### PR TITLE
feat(protocol): structure approval kind in edge events

### DIFF
--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -9,6 +9,7 @@ use astra_runtime::turn::tool_argument_hints::{
     command_hint_from_args, path_hint_from_args, permission_prompt_primary_detail,
 };
 use astra_runtime::{compensation_prompt_note, explicit_approval_reason};
+use astra_thin_client::ApprovalKind;
 
 /// Permission mode controls how tool approval decisions are handled.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -208,8 +209,8 @@ pub(super) struct PermissionManager {
 }
 
 impl PermissionManager {
-    fn cloud_detail_requires_explicit_approval(detail: Option<&str>) -> bool {
-        detail.is_some_and(|detail| detail.contains("Explicit approval required:"))
+    fn cloud_approval_is_explicit(approval_kind: ApprovalKind) -> bool {
+        matches!(approval_kind, ApprovalKind::Explicit)
     }
 
     /// Return the current permission mode (for propagation to sub-runs).
@@ -417,10 +418,11 @@ impl PermissionManager {
         &mut self,
         tool: &str,
         detail: Option<&str>,
+        approval_kind: ApprovalKind,
         quiet: bool,
     ) -> astra_thin_client::ApprovalDecision {
         use astra_thin_client::ApprovalDecision;
-        let explicit = Self::cloud_detail_requires_explicit_approval(detail);
+        let explicit = Self::cloud_approval_is_explicit(approval_kind);
         if quiet {
             return if self.mode == PermissionMode::Auto && !explicit {
                 ApprovalDecision::Allow
@@ -479,10 +481,11 @@ impl PermissionManager {
         &mut self,
         tool: &str,
         detail: Option<&str>,
+        approval_kind: ApprovalKind,
         quiet: bool,
     ) -> astra_thin_client::ApprovalDecision {
         use astra_thin_client::ApprovalDecision;
-        let explicit = Self::cloud_detail_requires_explicit_approval(detail);
+        let explicit = Self::cloud_approval_is_explicit(approval_kind);
         if quiet {
             return if self.mode == PermissionMode::Auto && !explicit {
                 ApprovalDecision::Allow
@@ -1322,7 +1325,7 @@ mod tests {
     fn resolve_cloud_approval_quiet_denies_without_auto() {
         let mut pm = PermissionManager::new(false);
         assert!(matches!(
-            pm.resolve_cloud_approval("write_file", Some("x.rs"), true),
+            pm.resolve_cloud_approval("write_file", Some("x.rs"), ApprovalKind::Standard, true),
             astra_thin_client::ApprovalDecision::Deny
         ));
     }
@@ -1331,7 +1334,7 @@ mod tests {
     fn resolve_cloud_approval_quiet_allows_when_auto() {
         let mut pm = PermissionManager::new(true);
         assert!(matches!(
-            pm.resolve_cloud_approval("write_file", Some("x.rs"), true),
+            pm.resolve_cloud_approval("write_file", Some("x.rs"), ApprovalKind::Standard, true),
             astra_thin_client::ApprovalDecision::Allow
         ));
     }
@@ -1726,7 +1729,8 @@ mod tests {
     fn deny_mode_cloud_approval_denied() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Deny, dir.path());
-        let decision = pm.resolve_cloud_approval("bash", Some("/tmp"), false);
+        let decision =
+            pm.resolve_cloud_approval("bash", Some("/tmp"), ApprovalKind::Standard, false);
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
     }
 
@@ -1734,7 +1738,8 @@ mod tests {
     fn auto_mode_cloud_approval_allowed() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
-        let decision = pm.resolve_cloud_approval("bash", Some("/tmp"), false);
+        let decision =
+            pm.resolve_cloud_approval("bash", Some("/tmp"), ApprovalKind::Standard, false);
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
     }
 
@@ -1742,12 +1747,22 @@ mod tests {
     fn auto_mode_cloud_explicit_approval_is_not_auto_allowed() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
+        let decision =
+            pm.resolve_cloud_approval("bash", Some("/tmp"), ApprovalKind::Explicit, true);
+        assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
+    }
+
+    #[test]
+    fn cloud_approval_detail_text_no_longer_drives_explicit_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
         let decision = pm.resolve_cloud_approval(
             "bash",
             Some("Explicit approval required: action scope is unbounded."),
+            ApprovalKind::Standard,
             true,
         );
-        assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
+        assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
     }
 
     #[test]
@@ -2232,7 +2247,7 @@ mod tests {
     async fn cloud_approval_async_quiet_denies_without_auto() {
         let mut pm = PermissionManager::new(false);
         let decision = pm
-            .resolve_cloud_approval_async("write_file", Some("x.rs"), true)
+            .resolve_cloud_approval_async("write_file", Some("x.rs"), ApprovalKind::Standard, true)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
     }
@@ -2241,7 +2256,7 @@ mod tests {
     async fn cloud_approval_async_quiet_allows_when_auto() {
         let mut pm = PermissionManager::new(true);
         let decision = pm
-            .resolve_cloud_approval_async("write_file", Some("x.rs"), true)
+            .resolve_cloud_approval_async("write_file", Some("x.rs"), ApprovalKind::Standard, true)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
     }
@@ -2251,7 +2266,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
         let decision = pm
-            .resolve_cloud_approval_async("bash", Some("/tmp"), false)
+            .resolve_cloud_approval_async("bash", Some("/tmp"), ApprovalKind::Standard, false)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
     }
@@ -2261,7 +2276,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Deny, dir.path());
         let decision = pm
-            .resolve_cloud_approval_async("bash", Some("/tmp"), false)
+            .resolve_cloud_approval_async("bash", Some("/tmp"), ApprovalKind::Standard, false)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
     }
@@ -2272,7 +2287,7 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
         pm.session_overrides.insert("bash".to_string(), true);
         let decision = pm
-            .resolve_cloud_approval_async("bash", Some("/tmp"), false)
+            .resolve_cloud_approval_async("bash", Some("/tmp"), ApprovalKind::Standard, false)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
     }
@@ -2283,7 +2298,7 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
         pm.session_overrides.insert("bash".to_string(), false);
         let decision = pm
-            .resolve_cloud_approval_async("bash", Some("/tmp"), false)
+            .resolve_cloud_approval_async("bash", Some("/tmp"), ApprovalKind::Standard, false)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
     }
@@ -2353,7 +2368,12 @@ mod tests {
 
         // 2nd call: cloud approval must auto-allow (session override)
         let decision2 = pm
-            .resolve_cloud_approval_async("write_file", Some("src/main.rs"), false)
+            .resolve_cloud_approval_async(
+                "write_file",
+                Some("src/main.rs"),
+                ApprovalKind::Standard,
+                false,
+            )
             .await;
         assert_eq!(decision2, astra_thin_client::ApprovalDecision::Allow);
 
@@ -2369,17 +2389,66 @@ mod tests {
     /// behavior for all non-interactive paths.
     #[tokio::test]
     async fn async_sync_parity_all_early_returns() {
-        let cases: Vec<(PermissionMode, bool, &str, Option<bool>)> = vec![
+        let cases: Vec<(PermissionMode, bool, &str, Option<bool>, ApprovalKind)> = vec![
             // (mode, quiet, tool, session_override) → expected same result
-            (PermissionMode::Auto, true, "bash", None),
-            (PermissionMode::Auto, false, "bash", None),
-            (PermissionMode::Deny, true, "bash", None),
-            (PermissionMode::Deny, false, "bash", None),
-            (PermissionMode::Prompt, true, "bash", None),
-            (PermissionMode::Prompt, false, "bash", Some(true)),
-            (PermissionMode::Prompt, false, "bash", Some(false)),
+            (
+                PermissionMode::Auto,
+                true,
+                "bash",
+                None,
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Auto,
+                false,
+                "bash",
+                None,
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Auto,
+                true,
+                "bash",
+                None,
+                ApprovalKind::Explicit,
+            ),
+            (
+                PermissionMode::Deny,
+                true,
+                "bash",
+                None,
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Deny,
+                false,
+                "bash",
+                None,
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Prompt,
+                true,
+                "bash",
+                None,
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Prompt,
+                false,
+                "bash",
+                Some(true),
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Prompt,
+                false,
+                "bash",
+                Some(false),
+                ApprovalKind::Standard,
+            ),
         ];
-        for (mode, quiet, tool, override_val) in cases {
+        for (mode, quiet, tool, override_val, approval_kind) in cases {
             let dir = tempfile::tempdir().unwrap();
             let mut pm_sync = PermissionManager::with_project_mode(mode, dir.path());
             let mut pm_async = PermissionManager::with_project_mode(mode, dir.path());
@@ -2387,9 +2456,10 @@ mod tests {
                 pm_sync.session_overrides.insert(tool.to_string(), v);
                 pm_async.session_overrides.insert(tool.to_string(), v);
             }
-            let sync_result = pm_sync.resolve_cloud_approval(tool, Some("detail"), quiet);
+            let sync_result =
+                pm_sync.resolve_cloud_approval(tool, Some("detail"), approval_kind, quiet);
             let async_result = pm_async
-                .resolve_cloud_approval_async(tool, Some("detail"), quiet)
+                .resolve_cloud_approval_async(tool, Some("detail"), approval_kind, quiet)
                 .await;
             assert_eq!(
                 sync_result, async_result,

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -1740,6 +1740,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
         &mut self,
         request_id: &str,
         tool: &str,
+        approval_kind: astra_thin_client::ApprovalKind,
         detail: Option<&str>,
     ) -> EdgeApprovalResult {
         // `resolve_cloud_approval` writes to stderr only. Never bump `lines_written` here:
@@ -1753,8 +1754,13 @@ impl SseStreamHost for CliSseStreamHost<'_> {
         self.render.stop_thinking();
         let decision = match &mut self.perm_manager {
             Some(pm) => {
-                pm.resolve_cloud_approval_async(tool, detail, self.render_policy.is_silent())
-                    .await
+                pm.resolve_cloud_approval_async(
+                    tool,
+                    detail,
+                    approval_kind,
+                    self.render_policy.is_silent(),
+                )
+                .await
             }
             None => astra_thin_client::ApprovalDecision::Deny,
         };
@@ -3735,17 +3741,19 @@ mod tests {
         let mut r = TurnResult::new();
         let mut s = StreamRenderState::new();
         let mut pending = Vec::new();
-        let block = "data: {\"type\":\"approval_required\",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"}\n\n";
+        let block = "data: {\"type\":\"approval_required\",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"approval_kind\":\"standard\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"}\n\n";
         dispatch_turn_event_block(block, &mut r, &mut s, RenderPolicy::Silent, &mut pending);
         assert_eq!(pending.len(), 1);
         match &pending[0] {
             ChatTurnEdgePending::ApprovalRequired {
                 request_id,
                 tool,
+                approval_kind,
                 detail,
             } => {
                 assert_eq!(request_id, "ap-1");
                 assert_eq!(tool, "write_file");
+                assert_eq!(*approval_kind, astra_thin_client::ApprovalKind::Standard);
                 assert_eq!(detail.as_deref(), Some("src/x.rs"));
             }
             _ => panic!("expected ApprovalRequired"),

--- a/rust/crates/astra-thin-client/src/lib.rs
+++ b/rust/crates/astra-thin-client/src/lib.rs
@@ -23,9 +23,9 @@ pub use edge::{
 };
 pub use error::ThinClientError;
 pub use protocol::{
-    ApprovalDecision, ApprovalRespondRequest, ChatStreamRequest, EdgeHeartbeatRequest,
-    EdgeRegisterRequest, SessionCreateRequest, SessionUpdateRequest, StreamEvent,
-    TaskLeaseMutationRequest, ToolResultRequest, classify_stream_event,
+    ApprovalDecision, ApprovalKind, ApprovalRespondRequest, ChatStreamRequest,
+    EdgeHeartbeatRequest, EdgeRegisterRequest, SessionCreateRequest, SessionUpdateRequest,
+    StreamEvent, TaskLeaseMutationRequest, ToolResultRequest, classify_stream_event,
 };
 /// SSE / buffered HTTP response from [`ThinClient::post_chat_turn`] (transport type for consumers like CLI stream rendering).
 pub use reqwest::Response as HttpResponse;

--- a/rust/crates/astra-thin-client/src/protocol.rs
+++ b/rust/crates/astra-thin-client/src/protocol.rs
@@ -107,6 +107,13 @@ pub enum ApprovalDecision {
     AllowSession,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalKind {
+    Standard,
+    Explicit,
+}
+
 /// `POST /agents/edge` — matches server `EdgeRegisterRequest` (Phase 3 registry).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EdgeRegisterRequest {
@@ -273,6 +280,7 @@ pub enum StreamEvent {
     ApprovalRequired {
         request_id: String,
         tool: String,
+        approval_kind: ApprovalKind,
         path: Option<String>,
         detail: Option<String>,
         raw: Value,
@@ -445,6 +453,11 @@ pub fn classify_stream_event(value: Value) -> Result<StreamEvent, crate::error::
         "approval_required" => StreamEvent::ApprovalRequired {
             request_id: get_str(&obj, "request_id"),
             tool: get_str(&obj, "tool"),
+            approval_kind: obj
+                .get("approval_kind")
+                .cloned()
+                .and_then(|value| serde_json::from_value::<ApprovalKind>(value).ok())
+                .unwrap_or(ApprovalKind::Explicit),
             path: obj
                 .get("path")
                 .and_then(|v| v.as_str())
@@ -574,6 +587,53 @@ mod tests {
                 assert_eq!(args["command"], "ls");
             }
             e => panic!("unexpected {e:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_approval_required_preserves_approval_kind() {
+        let v = serde_json::json!({
+            "type": "approval_required",
+            "request_id": "ap-1",
+            "tool": "bash",
+            "approval_kind": "explicit",
+            "detail": "rm -rf tmp"
+        });
+        match classify_stream_event(v).unwrap() {
+            StreamEvent::ApprovalRequired {
+                request_id,
+                tool,
+                approval_kind,
+                detail,
+                ..
+            } => {
+                assert_eq!(request_id, "ap-1");
+                assert_eq!(tool, "bash");
+                assert_eq!(approval_kind, ApprovalKind::Explicit);
+                assert_eq!(detail.as_deref(), Some("rm -rf tmp"));
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_approval_required_without_kind_defaults_to_explicit() {
+        let v = serde_json::json!({
+            "type": "approval_required",
+            "request_id": "ap-legacy",
+            "tool": "write_file",
+            "path": "src/lib.rs"
+        });
+        match classify_stream_event(v).unwrap() {
+            StreamEvent::ApprovalRequired {
+                approval_kind,
+                detail,
+                ..
+            } => {
+                assert_eq!(approval_kind, ApprovalKind::Explicit);
+                assert_eq!(detail.as_deref(), Some("src/lib.rs"));
+            }
+            other => panic!("unexpected {other:?}"),
         }
     }
 

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -69,8 +69,9 @@ use crate::{
     },
     turn::cloud_tool_delivery::{
         cloud_tool_requires_approval_for_delivery, sse_maps_through_tool_request,
-        tool_approval_detail_for_delivery, tool_path_hint_for_delivery,
-        wait_approval_ledger_for_tool, wait_tool_result_ledger_for_tool,
+        tool_approval_detail_for_delivery, tool_approval_kind_for_delivery,
+        tool_path_hint_for_delivery, wait_approval_ledger_for_tool,
+        wait_tool_result_ledger_for_tool,
     },
     turn::edge_ledger::{
         assistant_message_with_tool_calls_and_reasoning, ensure_tool_call_ids,
@@ -2125,9 +2126,11 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                         .unwrap_or("");
                     let path = tool_path_hint_for_delivery(tc);
                     let detail = tool_approval_detail_for_delivery(tc);
+                    let approval_kind = tool_approval_kind_for_delivery(tc);
                     yield render_sse_map(&build_approval_required_event(
                         id,
                         tool_name,
+                        approval_kind,
                         path.as_deref(),
                         detail.as_deref(),
                     ));

--- a/rust/crates/runtime/src/turn/chat_turn_sse_dispatch.rs
+++ b/rust/crates/runtime/src/turn/chat_turn_sse_dispatch.rs
@@ -4,6 +4,7 @@
 //! accumulator and returns terminal UI hints. [`ChatTurnSseFramer`] turns arbitrary byte chunks
 //! into complete event blocks via [`super::sse_blocks`] and records time-to-first-token.
 
+use astra_thin_client::ApprovalKind;
 use serde_json::Value;
 use std::time::Instant;
 
@@ -45,6 +46,7 @@ pub enum ChatTurnEdgePending {
     ApprovalRequired {
         request_id: String,
         tool: String,
+        approval_kind: ApprovalKind,
         detail: Option<String>,
     },
 }
@@ -113,6 +115,14 @@ fn normalize_tool_call_for_accum(event: &Value) -> Option<Value> {
             "arguments": arguments,
         }
     }))
+}
+
+fn approval_kind_from_event(event: &Value) -> ApprovalKind {
+    event
+        .get("approval_kind")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<ApprovalKind>(value).ok())
+        .unwrap_or(ApprovalKind::Explicit)
 }
 
 fn apply_one_event(
@@ -214,6 +224,7 @@ fn apply_one_event(
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
+            let approval_kind = approval_kind_from_event(event);
             let detail = event
                 .get("detail")
                 .and_then(|v| v.as_str())
@@ -228,6 +239,7 @@ fn apply_one_event(
                 edge_pending.push(ChatTurnEdgePending::ApprovalRequired {
                     request_id,
                     tool,
+                    approval_kind,
                     detail,
                 });
             }
@@ -655,20 +667,36 @@ mod tests {
     fn approval_required_enqueues_pending() {
         let mut a = ChatTurnSseAccum::default();
         let mut pending = Vec::new();
-        let block = "data: {\"type\":\"approval_required\",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"}\n\n";
+        let block = "data: {\"type\":\"approval_required\",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"approval_kind\":\"standard\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"}\n\n";
         dispatch_chat_turn_sse_event_block(block, &mut a, &mut pending);
         assert_eq!(pending.len(), 1);
         match &pending[0] {
             ChatTurnEdgePending::ApprovalRequired {
                 request_id,
                 tool,
+                approval_kind,
                 detail,
             } => {
                 assert_eq!(request_id, "ap-1");
                 assert_eq!(tool, "write_file");
+                assert_eq!(*approval_kind, ApprovalKind::Standard);
                 assert_eq!(detail.as_deref(), Some("src/x.rs"));
             }
             _ => panic!("expected ApprovalRequired"),
+        }
+    }
+
+    #[test]
+    fn approval_required_without_kind_defaults_to_explicit() {
+        let mut a = ChatTurnSseAccum::default();
+        let mut pending = Vec::new();
+        let block = "data: {\"type\":\"approval_required\",\"request_id\":\"ap-1\",\"tool\":\"bash\",\"detail\":\"rm -rf tmp\"}\n\n";
+        dispatch_chat_turn_sse_event_block(block, &mut a, &mut pending);
+        match &pending[0] {
+            ChatTurnEdgePending::ApprovalRequired { approval_kind, .. } => {
+                assert_eq!(*approval_kind, ApprovalKind::Explicit);
+            }
+            other => panic!("expected ApprovalRequired, got {other:?}"),
         }
     }
 

--- a/rust/crates/runtime/src/turn/cloud_tool_delivery.rs
+++ b/rust/crates/runtime/src/turn/cloud_tool_delivery.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use astra_thin_client::ApprovalRespondRequest;
+use astra_thin_client::{ApprovalKind, ApprovalRespondRequest};
 use serde_json::{Map, Value, json};
 
 #[cfg(test)]
@@ -90,6 +90,21 @@ fn tool_approval_detail(tool_call: &Value) -> Option<String> {
         .collect::<Vec<_>>()
         .join("\n");
     (!detail.is_empty()).then_some(detail)
+}
+
+fn tool_approval_kind(tool_call: &Value) -> ApprovalKind {
+    let tool_name = tool_call
+        .get("function")
+        .and_then(|f| f.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let raw = raw_tool_arguments(tool_call);
+    let parsed = normalize_llm_function_arguments(&raw);
+    if explicit_approval_reason(tool_name, &parsed).is_some() {
+        ApprovalKind::Explicit
+    } else {
+        ApprovalKind::Standard
+    }
 }
 
 pub fn parse_cloud_approval_outcome(entry: Option<&Value>) -> CloudApprovalResult {
@@ -277,6 +292,10 @@ pub(crate) fn tool_approval_detail_for_delivery(tool_call: &Value) -> Option<Str
     tool_approval_detail(tool_call)
 }
 
+pub(crate) fn tool_approval_kind_for_delivery(tool_call: &Value) -> ApprovalKind {
+    tool_approval_kind(tool_call)
+}
+
 pub async fn deliver_tool_calls_through_edge_ledger(
     ledger: &Arc<tokio::sync::Mutex<HashMap<String, Value>>>,
     user_id: &str,
@@ -300,9 +319,11 @@ pub async fn deliver_tool_calls_through_edge_ledger(
         if cloud_tool_requires_approval(tc) {
             let path = tool_path_hint(tc);
             let detail = tool_approval_detail(tc);
+            let approval_kind = tool_approval_kind(tc);
             out.sse_maps.push(build_approval_required_event(
                 id,
                 tool_name,
+                approval_kind,
                 path.as_deref(),
                 detail.as_deref(),
             ));
@@ -363,9 +384,11 @@ pub async fn deliver_tool_calls_concurrent(
             .unwrap_or("");
         let path = tool_path_hint(tc);
         let detail = tool_approval_detail(tc);
+        let approval_kind = tool_approval_kind(tc);
         out.sse_maps.push(build_approval_required_event(
             id,
             tool_name,
+            approval_kind,
             path.as_deref(),
             detail.as_deref(),
         ));

--- a/rust/crates/runtime/src/turn/sse_stream_host.rs
+++ b/rust/crates/runtime/src/turn/sse_stream_host.rs
@@ -19,6 +19,7 @@ use crate::turn::chat_turn_sse_dispatch::{
     ChatTurnEdgePending, ChatTurnSseAccum, ChatTurnSseFramer, SseRenderEffect,
     dispatch_chat_turn_sse_event_block,
 };
+use astra_thin_client::ApprovalKind;
 use async_trait::async_trait;
 use serde_json::Value;
 
@@ -218,6 +219,7 @@ pub trait SseStreamHost: Send {
         &mut self,
         request_id: &str,
         tool: &str,
+        approval_kind: ApprovalKind,
         detail: Option<&str>,
     ) -> EdgeApprovalResult;
 
@@ -463,6 +465,7 @@ async fn flush_pending_via_host<H: SseStreamHost>(
         if let ChatTurnEdgePending::ApprovalRequired {
             request_id,
             tool,
+            approval_kind,
             detail,
         } = item
         {
@@ -470,7 +473,7 @@ async fn flush_pending_via_host<H: SseStreamHost>(
                 continue;
             }
             let result = host
-                .resolve_approval(&request_id, &tool, detail.as_deref())
+                .resolve_approval(&request_id, &tool, approval_kind, detail.as_deref())
                 .await;
             approval_results.push(result);
         }
@@ -513,6 +516,7 @@ impl SseStreamHost for NoopSseStreamHost {
         &mut self,
         request_id: &str,
         _tool: &str,
+        _approval_kind: ApprovalKind,
         _detail: Option<&str>,
     ) -> EdgeApprovalResult {
         EdgeApprovalResult {
@@ -530,6 +534,7 @@ impl SseStreamHost for NoopSseStreamHost {
 struct RecordingSseStreamHost {
     render_effects: Vec<SseRenderEffect>,
     tool_outputs: std::collections::HashMap<String, String>,
+    approval_kinds: Vec<ApprovalKind>,
     stream_completed: bool,
 }
 
@@ -539,6 +544,7 @@ impl RecordingSseStreamHost {
         Self {
             render_effects: Vec::new(),
             tool_outputs: std::collections::HashMap::new(),
+            approval_kinds: Vec::new(),
             stream_completed: false,
         }
     }
@@ -587,8 +593,10 @@ impl SseStreamHost for RecordingSseStreamHost {
         &mut self,
         request_id: &str,
         _tool: &str,
+        approval_kind: ApprovalKind,
         _detail: Option<&str>,
     ) -> EdgeApprovalResult {
+        self.approval_kinds.push(approval_kind);
         EdgeApprovalResult {
             request_id: request_id.to_string(),
             decision: "allow".to_string(),
@@ -717,7 +725,7 @@ mod tests {
     async fn recording_host_approval_resolved() {
         let events = sse_event(
             "approval_required",
-            ",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"",
+            ",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"approval_kind\":\"standard\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"",
         );
         let chunks = chunks_from_sse(&events);
         let mut stream = stream::iter(chunks);
@@ -733,6 +741,7 @@ mod tests {
         assert_eq!(result.approval_results.len(), 1);
         assert_eq!(result.approval_results[0].request_id, "ap-1");
         assert_eq!(result.approval_results[0].decision, "allow");
+        assert_eq!(host.approval_kinds, vec![ApprovalKind::Standard]);
     }
 
     #[tokio::test]
@@ -1269,6 +1278,7 @@ mod tests {
                 &mut self,
                 rid: &str,
                 _: &str,
+                _: ApprovalKind,
                 _: Option<&str>,
             ) -> EdgeApprovalResult {
                 EdgeApprovalResult {

--- a/rust/crates/runtime/src/turn/stream_events.rs
+++ b/rust/crates/runtime/src/turn/stream_events.rs
@@ -1,5 +1,7 @@
 use serde_json::{Map, Value};
 
+use astra_thin_client::ApprovalKind;
+
 use crate::try_repair_tool_args;
 
 pub fn build_stream_error_event(message: &str, code: &str, retryable: bool) -> Map<String, Value> {
@@ -157,6 +159,7 @@ pub fn build_edge_tool_call_event(tool_call: &Map<String, Value>) -> Map<String,
 pub fn build_approval_required_event(
     request_id: &str,
     tool_name: &str,
+    approval_kind: ApprovalKind,
     path: Option<&str>,
     detail: Option<&str>,
 ) -> Map<String, Value> {
@@ -170,6 +173,10 @@ pub fn build_approval_required_event(
             Value::String(request_id.to_string()),
         ),
         ("tool".to_string(), Value::String(tool_name.to_string())),
+        (
+            "approval_kind".to_string(),
+            serde_json::to_value(approval_kind).unwrap_or(Value::String("explicit".to_string())),
+        ),
     ]);
     if let Some(p) = path.filter(|s| !s.is_empty()) {
         m.insert("path".to_string(), Value::String(p.to_string()));
@@ -222,19 +229,35 @@ mod tests {
 
     #[test]
     fn approval_required_includes_optional_path() {
-        let ev = build_approval_required_event("a1", "write_file", Some("p/x.rs"), None);
+        let ev = build_approval_required_event(
+            "a1",
+            "write_file",
+            ApprovalKind::Standard,
+            Some("p/x.rs"),
+            None,
+        );
         assert_eq!(
             ev.get("type").and_then(Value::as_str),
             Some("approval_required")
         );
         assert_eq!(ev.get("request_id").and_then(Value::as_str), Some("a1"));
         assert_eq!(ev.get("tool").and_then(Value::as_str), Some("write_file"));
+        assert_eq!(
+            ev.get("approval_kind").and_then(Value::as_str),
+            Some("standard")
+        );
         assert_eq!(ev.get("path").and_then(Value::as_str), Some("p/x.rs"));
     }
 
     #[test]
     fn approval_required_includes_optional_detail() {
-        let ev = build_approval_required_event("a1", "bash", None, Some("git status"));
+        let ev = build_approval_required_event(
+            "a1",
+            "bash",
+            ApprovalKind::Explicit,
+            None,
+            Some("git status"),
+        );
         assert_eq!(ev.get("detail").and_then(Value::as_str), Some("git status"));
     }
 
@@ -474,14 +497,15 @@ mod tests {
 
     #[test]
     fn approval_required_omits_empty_path() {
-        let ev = build_approval_required_event("r1", "bash", Some(""), Some(""));
+        let ev =
+            build_approval_required_event("r1", "bash", ApprovalKind::Explicit, Some(""), Some(""));
         assert!(ev.get("path").is_none());
         assert!(ev.get("detail").is_none());
     }
 
     #[test]
     fn approval_required_omits_none_path() {
-        let ev = build_approval_required_event("r1", "bash", None, None);
+        let ev = build_approval_required_event("r1", "bash", ApprovalKind::Explicit, None, None);
         assert!(ev.get("path").is_none());
         assert!(ev.get("detail").is_none());
     }

--- a/rust/crates/runtime/tests/edge_5_5_http_e2e.rs
+++ b/rust/crates/runtime/tests/edge_5_5_http_e2e.rs
@@ -196,10 +196,14 @@ async fn http_handler_payload_matches_delivery_parser() {
     let d =
         deliver_tool_calls_through_edge_ledger(&ledger, "e2e-user", &[tc], Duration::from_secs(2))
             .await;
-    assert!(
-        d.sse_maps
-            .iter()
-            .any(|m| m.get("type").and_then(|v| v.as_str()) == Some("approval_required"))
+    let approval = d
+        .sse_maps
+        .iter()
+        .find(|m| m.get("type").and_then(|v| v.as_str()) == Some("approval_required"))
+        .expect("approval_required event");
+    assert_eq!(
+        approval.get("approval_kind").and_then(|v| v.as_str()),
+        Some("standard")
     );
     assert!(
         d.sse_maps

--- a/rust/crates/runtime/tests/edge_cloud_round_trip_e2e.rs
+++ b/rust/crates/runtime/tests/edge_cloud_round_trip_e2e.rs
@@ -542,6 +542,7 @@ async fn approval_gate_allow_then_tool_request() {
         .iter()
         .position(|e| e["type"] == "approval_required")
         .unwrap();
+    assert_eq!(events[approval_idx]["approval_kind"], "standard");
     let request_idx = events
         .iter()
         .position(|e| e["type"] == "tool_request" && e.to_string().contains("tc-wf-1"))
@@ -620,6 +621,11 @@ async fn approval_denied_skips_tool_execution() {
 
     // tool_request should NOT appear for a denied tool
     let events = parse_sse_events(&full);
+    let approval_event = events
+        .iter()
+        .find(|e| e["type"] == "approval_required" && e.to_string().contains("tc-deny-1"))
+        .expect("approval_required event for denied bash");
+    assert_eq!(approval_event["approval_kind"], "explicit");
     let tool_requests: Vec<_> = events
         .iter()
         .filter(|e| e["type"] == "tool_request" && e.to_string().contains("tc-deny-1"))


### PR DESCRIPTION
## Summary
- add structured `approval_kind` to `approval_required` events in the thin-client/runtime protocol
- thread the new field through runtime delivery, SSE host handling, and CLI approval resolution
- replace CLI detail-string parsing with structured approval-kind handling and add E2E coverage

## Validation
- make check
- cargo test -p astra-runtime --features bridge-e2e-hooks --test edge_cloud_round_trip_e2e approval_gate_allow_then_tool_request --quiet
- cargo test -p astra-runtime --features bridge-e2e-hooks --test edge_cloud_round_trip_e2e approval_denied_skips_tool_execution --quiet
- cargo test -p astra-runtime --test edge_5_5_http_e2e http_handler_payload_matches_delivery_parser --quiet