### PR TITLE
feat: Phase 5-6 — Architecture fixes, unit tests, remote edge agent deployment

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -205,6 +205,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astra-edge"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "futures-util",
+ "hostname",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "astra-runtime"
 version = "0.1.0"
 dependencies = [
@@ -2432,6 +2448,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite 0.26.2",
  "tokio-util",
  "toml",
  "tower",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/astra-cli",
     "crates/astra-admin",
     "crates/astra-thin-client",
+    "crates/astra-edge",
 ]
 resolver = "2"
 
@@ -51,6 +52,9 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
     "std",
 ] }
 http-body-util = "0.1"
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
+clap = { version = "4", features = ["derive", "env"] }
+hostname = "0.4"
 
 [profile.dev]
 debug = "line-tables-only"

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -9,6 +9,7 @@ use astra_runtime::turn::tool_argument_hints::{
     command_hint_from_args, path_hint_from_args, permission_prompt_primary_detail,
 };
 use astra_runtime::{compensation_prompt_note, explicit_approval_reason};
+use astra_thin_client::ApprovalKind;
 
 /// Permission mode controls how tool approval decisions are handled.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -208,8 +209,8 @@ pub(super) struct PermissionManager {
 }
 
 impl PermissionManager {
-    fn cloud_detail_requires_explicit_approval(detail: Option<&str>) -> bool {
-        detail.is_some_and(|detail| detail.contains("Explicit approval required:"))
+    fn cloud_approval_is_explicit(approval_kind: ApprovalKind) -> bool {
+        matches!(approval_kind, ApprovalKind::Explicit)
     }
 
     /// Return the current permission mode (for propagation to sub-runs).
@@ -417,10 +418,11 @@ impl PermissionManager {
         &mut self,
         tool: &str,
         detail: Option<&str>,
+        approval_kind: ApprovalKind,
         quiet: bool,
     ) -> astra_thin_client::ApprovalDecision {
         use astra_thin_client::ApprovalDecision;
-        let explicit = Self::cloud_detail_requires_explicit_approval(detail);
+        let explicit = Self::cloud_approval_is_explicit(approval_kind);
         if quiet {
             return if self.mode == PermissionMode::Auto && !explicit {
                 ApprovalDecision::Allow
@@ -479,10 +481,11 @@ impl PermissionManager {
         &mut self,
         tool: &str,
         detail: Option<&str>,
+        approval_kind: ApprovalKind,
         quiet: bool,
     ) -> astra_thin_client::ApprovalDecision {
         use astra_thin_client::ApprovalDecision;
-        let explicit = Self::cloud_detail_requires_explicit_approval(detail);
+        let explicit = Self::cloud_approval_is_explicit(approval_kind);
         if quiet {
             return if self.mode == PermissionMode::Auto && !explicit {
                 ApprovalDecision::Allow
@@ -1322,7 +1325,7 @@ mod tests {
     fn resolve_cloud_approval_quiet_denies_without_auto() {
         let mut pm = PermissionManager::new(false);
         assert!(matches!(
-            pm.resolve_cloud_approval("write_file", Some("x.rs"), true),
+            pm.resolve_cloud_approval("write_file", Some("x.rs"), ApprovalKind::Standard, true),
             astra_thin_client::ApprovalDecision::Deny
         ));
     }
@@ -1331,7 +1334,7 @@ mod tests {
     fn resolve_cloud_approval_quiet_allows_when_auto() {
         let mut pm = PermissionManager::new(true);
         assert!(matches!(
-            pm.resolve_cloud_approval("write_file", Some("x.rs"), true),
+            pm.resolve_cloud_approval("write_file", Some("x.rs"), ApprovalKind::Standard, true),
             astra_thin_client::ApprovalDecision::Allow
         ));
     }
@@ -1726,7 +1729,8 @@ mod tests {
     fn deny_mode_cloud_approval_denied() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Deny, dir.path());
-        let decision = pm.resolve_cloud_approval("bash", Some("/tmp"), false);
+        let decision =
+            pm.resolve_cloud_approval("bash", Some("/tmp"), ApprovalKind::Standard, false);
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
     }
 
@@ -1734,7 +1738,8 @@ mod tests {
     fn auto_mode_cloud_approval_allowed() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
-        let decision = pm.resolve_cloud_approval("bash", Some("/tmp"), false);
+        let decision =
+            pm.resolve_cloud_approval("bash", Some("/tmp"), ApprovalKind::Standard, false);
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
     }
 
@@ -1742,12 +1747,22 @@ mod tests {
     fn auto_mode_cloud_explicit_approval_is_not_auto_allowed() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
+        let decision =
+            pm.resolve_cloud_approval("bash", Some("/tmp"), ApprovalKind::Explicit, true);
+        assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
+    }
+
+    #[test]
+    fn cloud_approval_detail_text_no_longer_drives_explicit_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
         let decision = pm.resolve_cloud_approval(
             "bash",
             Some("Explicit approval required: action scope is unbounded."),
+            ApprovalKind::Standard,
             true,
         );
-        assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
+        assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
     }
 
     #[test]
@@ -2232,7 +2247,7 @@ mod tests {
     async fn cloud_approval_async_quiet_denies_without_auto() {
         let mut pm = PermissionManager::new(false);
         let decision = pm
-            .resolve_cloud_approval_async("write_file", Some("x.rs"), true)
+            .resolve_cloud_approval_async("write_file", Some("x.rs"), ApprovalKind::Standard, true)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
     }
@@ -2241,7 +2256,7 @@ mod tests {
     async fn cloud_approval_async_quiet_allows_when_auto() {
         let mut pm = PermissionManager::new(true);
         let decision = pm
-            .resolve_cloud_approval_async("write_file", Some("x.rs"), true)
+            .resolve_cloud_approval_async("write_file", Some("x.rs"), ApprovalKind::Standard, true)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
     }
@@ -2251,7 +2266,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
         let decision = pm
-            .resolve_cloud_approval_async("bash", Some("/tmp"), false)
+            .resolve_cloud_approval_async("bash", Some("/tmp"), ApprovalKind::Standard, false)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
     }
@@ -2261,7 +2276,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Deny, dir.path());
         let decision = pm
-            .resolve_cloud_approval_async("bash", Some("/tmp"), false)
+            .resolve_cloud_approval_async("bash", Some("/tmp"), ApprovalKind::Standard, false)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
     }
@@ -2272,7 +2287,7 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
         pm.session_overrides.insert("bash".to_string(), true);
         let decision = pm
-            .resolve_cloud_approval_async("bash", Some("/tmp"), false)
+            .resolve_cloud_approval_async("bash", Some("/tmp"), ApprovalKind::Standard, false)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
     }
@@ -2283,7 +2298,7 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
         pm.session_overrides.insert("bash".to_string(), false);
         let decision = pm
-            .resolve_cloud_approval_async("bash", Some("/tmp"), false)
+            .resolve_cloud_approval_async("bash", Some("/tmp"), ApprovalKind::Standard, false)
             .await;
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
     }
@@ -2353,7 +2368,12 @@ mod tests {
 
         // 2nd call: cloud approval must auto-allow (session override)
         let decision2 = pm
-            .resolve_cloud_approval_async("write_file", Some("src/main.rs"), false)
+            .resolve_cloud_approval_async(
+                "write_file",
+                Some("src/main.rs"),
+                ApprovalKind::Standard,
+                false,
+            )
             .await;
         assert_eq!(decision2, astra_thin_client::ApprovalDecision::Allow);
 
@@ -2369,17 +2389,66 @@ mod tests {
     /// behavior for all non-interactive paths.
     #[tokio::test]
     async fn async_sync_parity_all_early_returns() {
-        let cases: Vec<(PermissionMode, bool, &str, Option<bool>)> = vec![
+        let cases: Vec<(PermissionMode, bool, &str, Option<bool>, ApprovalKind)> = vec![
             // (mode, quiet, tool, session_override) → expected same result
-            (PermissionMode::Auto, true, "bash", None),
-            (PermissionMode::Auto, false, "bash", None),
-            (PermissionMode::Deny, true, "bash", None),
-            (PermissionMode::Deny, false, "bash", None),
-            (PermissionMode::Prompt, true, "bash", None),
-            (PermissionMode::Prompt, false, "bash", Some(true)),
-            (PermissionMode::Prompt, false, "bash", Some(false)),
+            (
+                PermissionMode::Auto,
+                true,
+                "bash",
+                None,
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Auto,
+                false,
+                "bash",
+                None,
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Auto,
+                true,
+                "bash",
+                None,
+                ApprovalKind::Explicit,
+            ),
+            (
+                PermissionMode::Deny,
+                true,
+                "bash",
+                None,
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Deny,
+                false,
+                "bash",
+                None,
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Prompt,
+                true,
+                "bash",
+                None,
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Prompt,
+                false,
+                "bash",
+                Some(true),
+                ApprovalKind::Standard,
+            ),
+            (
+                PermissionMode::Prompt,
+                false,
+                "bash",
+                Some(false),
+                ApprovalKind::Standard,
+            ),
         ];
-        for (mode, quiet, tool, override_val) in cases {
+        for (mode, quiet, tool, override_val, approval_kind) in cases {
             let dir = tempfile::tempdir().unwrap();
             let mut pm_sync = PermissionManager::with_project_mode(mode, dir.path());
             let mut pm_async = PermissionManager::with_project_mode(mode, dir.path());
@@ -2387,9 +2456,10 @@ mod tests {
                 pm_sync.session_overrides.insert(tool.to_string(), v);
                 pm_async.session_overrides.insert(tool.to_string(), v);
             }
-            let sync_result = pm_sync.resolve_cloud_approval(tool, Some("detail"), quiet);
+            let sync_result =
+                pm_sync.resolve_cloud_approval(tool, Some("detail"), approval_kind, quiet);
             let async_result = pm_async
-                .resolve_cloud_approval_async(tool, Some("detail"), quiet)
+                .resolve_cloud_approval_async(tool, Some("detail"), approval_kind, quiet)
                 .await;
             assert_eq!(
                 sync_result, async_result,

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -1740,6 +1740,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
         &mut self,
         request_id: &str,
         tool: &str,
+        approval_kind: astra_thin_client::ApprovalKind,
         detail: Option<&str>,
     ) -> EdgeApprovalResult {
         // `resolve_cloud_approval` writes to stderr only. Never bump `lines_written` here:
@@ -1753,8 +1754,13 @@ impl SseStreamHost for CliSseStreamHost<'_> {
         self.render.stop_thinking();
         let decision = match &mut self.perm_manager {
             Some(pm) => {
-                pm.resolve_cloud_approval_async(tool, detail, self.render_policy.is_silent())
-                    .await
+                pm.resolve_cloud_approval_async(
+                    tool,
+                    detail,
+                    approval_kind,
+                    self.render_policy.is_silent(),
+                )
+                .await
             }
             None => astra_thin_client::ApprovalDecision::Deny,
         };
@@ -3735,17 +3741,19 @@ mod tests {
         let mut r = TurnResult::new();
         let mut s = StreamRenderState::new();
         let mut pending = Vec::new();
-        let block = "data: {\"type\":\"approval_required\",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"}\n\n";
+        let block = "data: {\"type\":\"approval_required\",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"approval_kind\":\"standard\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"}\n\n";
         dispatch_turn_event_block(block, &mut r, &mut s, RenderPolicy::Silent, &mut pending);
         assert_eq!(pending.len(), 1);
         match &pending[0] {
             ChatTurnEdgePending::ApprovalRequired {
                 request_id,
                 tool,
+                approval_kind,
                 detail,
             } => {
                 assert_eq!(request_id, "ap-1");
                 assert_eq!(tool, "write_file");
+                assert_eq!(*approval_kind, astra_thin_client::ApprovalKind::Standard);
                 assert_eq!(detail.as_deref(), Some("src/x.rs"));
             }
             _ => panic!("expected ApprovalRequired"),

--- a/rust/crates/astra-edge/Cargo.toml
+++ b/rust/crates/astra-edge/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "astra-edge"
+version.workspace = true
+edition.workspace = true
+description = "Lightweight remote edge agent that connects to an Astra server via WebSocket for local tool execution"
+
+[[bin]]
+name = "astra-edge"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+futures-util = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
+tokio-tungstenite = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
+hostname = { workspace = true }

--- a/rust/crates/astra-edge/src/main.rs
+++ b/rust/crates/astra-edge/src/main.rs
@@ -1,0 +1,624 @@
+//! `astra-edge` — lightweight remote tool execution agent.
+//!
+//! Connects to an Astra server via WebSocket, authenticates, and executes
+//! tool calls locally on the user's machine. Results are sent back over the
+//! same WebSocket connection.
+//!
+//! ## Usage
+//! ```bash
+//! astra-edge --server-url wss://astra.example.com --token <jwt> --workspace-dir ~/projects/my-app
+//! ```
+
+use clap::Parser;
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+/// Astra remote edge agent — execute tool calls locally for web sessions.
+#[derive(Parser, Debug)]
+#[command(name = "astra-edge", version, about)]
+struct Args {
+    /// WebSocket URL of the Astra server (e.g., wss://astra.example.com/edge/ws)
+    #[arg(long, env = "ASTRA_SERVER_URL")]
+    server_url: String,
+
+    /// Authentication token (JWT)
+    #[arg(long, env = "ASTRA_TOKEN")]
+    token: String,
+
+    /// Local workspace directory for file operations
+    #[arg(long, env = "ASTRA_WORKSPACE_DIR", default_value = ".")]
+    workspace_dir: PathBuf,
+
+    /// Edge agent identifier
+    #[arg(long, env = "ASTRA_EDGE_ID", default_value_t = default_edge_id())]
+    edge_id: String,
+
+    /// Auto-reconnect on disconnect
+    #[arg(long, default_value_t = true)]
+    reconnect: bool,
+}
+
+fn default_edge_id() -> String {
+    let hostname = hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".into());
+    format!("edge-{hostname}-{}", &uuid::Uuid::new_v4().to_string()[..8])
+}
+
+// ─── Protocol types (mirroring server edge_ws_protocol.rs) ───────────────────
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum EdgeToServer {
+    #[serde(rename = "edge_auth")]
+    Auth {
+        token: String,
+        edge_agent_id: String,
+        hostname: Option<String>,
+        workspace_dir: Option<String>,
+    },
+    #[serde(rename = "edge_tool_result")]
+    ToolResult {
+        request_id: String,
+        output: String,
+        is_error: bool,
+        duration_ms: u64,
+    },
+    #[serde(rename = "edge_ping")]
+    Ping,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum ServerToEdge {
+    #[serde(rename = "edge_auth_ok")]
+    AuthOk { user_id: String },
+    #[serde(rename = "edge_auth_error")]
+    AuthError { message: String },
+    #[serde(rename = "edge_tool_request")]
+    ToolRequest {
+        request_id: String,
+        tool: String,
+        args: serde_json::Value,
+        #[serde(default = "default_timeout")]
+        timeout_secs: u64,
+    },
+    #[serde(rename = "edge_pong")]
+    Pong,
+    #[serde(rename = "edge_closing")]
+    Closing { reason: String },
+}
+
+fn default_timeout() -> u64 {
+    300
+}
+
+// ─── Local tool executor ─────────────────────────────────────────────────────
+
+struct LocalToolExecutor {
+    workspace: PathBuf,
+}
+
+impl LocalToolExecutor {
+    fn new(workspace: PathBuf) -> Self {
+        Self { workspace }
+    }
+
+    fn resolve_path(&self, path_str: &str) -> Result<PathBuf, String> {
+        let path = Path::new(path_str);
+        let resolved = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.workspace.join(path)
+        };
+        let canonical_ws = self
+            .workspace
+            .canonicalize()
+            .unwrap_or_else(|_| self.workspace.clone());
+        // Normalize by resolving .. components
+        let mut normalized = PathBuf::new();
+        for component in resolved.components() {
+            match component {
+                std::path::Component::ParentDir => {
+                    normalized.pop();
+                }
+                _ => normalized.push(component.as_os_str()),
+            }
+        }
+        if !normalized.starts_with(&canonical_ws) {
+            return Err(format!("SANDBOX_DENIED: path escapes workspace: {path_str}"));
+        }
+        Ok(normalized)
+    }
+
+    async fn execute(&self, tool: &str, args: &serde_json::Value) -> (String, bool) {
+        match tool {
+            "read_file" => self.read_file(args),
+            "write_file" => self.write_file(args),
+            "str_replace" => self.str_replace(args),
+            "delete_file" => self.delete_file(args),
+            "list_dir" => self.list_dir(args),
+            "bash" => self.bash(args).await,
+            "grep" => self.grep(args),
+            "glob" => self.glob_tool(args),
+            "git_status" => self.git_cmd(&["status", "--porcelain"]),
+            "git_diff" => self.git_diff(args),
+            "git_log" => self.git_log(args),
+            _ => (format!("Tool '{tool}' not available on this edge agent"), true),
+        }
+    }
+
+    fn read_file(&self, args: &serde_json::Value) -> (String, bool) {
+        let path_str = match args.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ("Error: Missing 'path' parameter".into(), true),
+        };
+        let path = match self.resolve_path(path_str) {
+            Ok(p) => p,
+            Err(e) => return (e, true),
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(content) => {
+                let start = args.get("start_line").and_then(|v| v.as_u64()).unwrap_or(1) as usize;
+                let end = args.get("end_line").and_then(|v| v.as_u64()).map(|v| v as usize);
+                let lines: Vec<&str> = content.lines().collect();
+                let start_idx = start.saturating_sub(1);
+                let end_idx = end.unwrap_or(lines.len()).min(lines.len());
+                let numbered: Vec<String> = lines[start_idx..end_idx]
+                    .iter()
+                    .enumerate()
+                    .map(|(i, line)| format!("{}\t{line}", start_idx + i + 1))
+                    .collect();
+                (numbered.join("\n"), false)
+            }
+            Err(e) => (format!("Error: {e}"), true),
+        }
+    }
+
+    fn write_file(&self, args: &serde_json::Value) -> (String, bool) {
+        let path_str = match args.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ("Error: Missing 'path' parameter".into(), true),
+        };
+        let content = match args.get("content").and_then(|v| v.as_str()) {
+            Some(c) => c,
+            None => return ("Error: Missing 'content' parameter".into(), true),
+        };
+        let path = match self.resolve_path(path_str) {
+            Ok(p) => p,
+            Err(e) => return (e, true),
+        };
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        match std::fs::write(&path, content) {
+            Ok(_) => (
+                format!("Successfully wrote {} bytes to {path_str}", content.len()),
+                false,
+            ),
+            Err(e) => (format!("Error: {e}"), true),
+        }
+    }
+
+    fn str_replace(&self, args: &serde_json::Value) -> (String, bool) {
+        let path_str = match args.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ("Error: Missing 'path' parameter".into(), true),
+        };
+        let old_str = match args.get("old_str").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => return ("Error: Missing 'old_str' parameter".into(), true),
+        };
+        let new_str = args
+            .get("new_str")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let path = match self.resolve_path(path_str) {
+            Ok(p) => p,
+            Err(e) => return (e, true),
+        };
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => return (format!("Error: {e}"), true),
+        };
+        let count = content.matches(old_str).count();
+        if count == 0 {
+            return (format!("Error: old_str not found in {path_str}"), true);
+        }
+        if count > 1 {
+            return (
+                format!("Error: old_str found {count} times in {path_str} — must be unique"),
+                true,
+            );
+        }
+        let new_content = content.replacen(old_str, new_str, 1);
+        match std::fs::write(&path, new_content) {
+            Ok(_) => (format!("Successfully replaced in {path_str}"), false),
+            Err(e) => (format!("Error writing: {e}"), true),
+        }
+    }
+
+    fn delete_file(&self, args: &serde_json::Value) -> (String, bool) {
+        let path_str = match args.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ("Error: Missing 'path' parameter".into(), true),
+        };
+        let path = match self.resolve_path(path_str) {
+            Ok(p) => p,
+            Err(e) => return (e, true),
+        };
+        if !path.exists() {
+            return (format!("File not found: {path_str}"), true);
+        }
+        match std::fs::remove_file(&path) {
+            Ok(_) => (format!("Successfully deleted {path_str}"), false),
+            Err(e) => (format!("Error: {e}"), true),
+        }
+    }
+
+    fn list_dir(&self, args: &serde_json::Value) -> (String, bool) {
+        let path_str = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .unwrap_or(".");
+        let path = match self.resolve_path(path_str) {
+            Ok(p) => p,
+            Err(e) => return (e, true),
+        };
+        match std::fs::read_dir(&path) {
+            Ok(entries) => {
+                let mut items: Vec<String> = entries
+                    .filter_map(|e| e.ok())
+                    .map(|e| {
+                        let name = e.file_name().to_string_lossy().to_string();
+                        if e.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                            format!("{name}/")
+                        } else {
+                            name
+                        }
+                    })
+                    .collect();
+                items.sort();
+                (items.join("\n"), false)
+            }
+            Err(e) => (format!("Error: {e}"), true),
+        }
+    }
+
+    async fn bash(&self, args: &serde_json::Value) -> (String, bool) {
+        let command = match args.get("command").and_then(|v| v.as_str()) {
+            Some(c) => c,
+            None => return ("Error: Missing 'command' parameter".into(), true),
+        };
+        let timeout_secs = args
+            .get("timeout")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(120);
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(timeout_secs),
+            tokio::process::Command::new("bash")
+                .arg("-c")
+                .arg(command)
+                .current_dir(&self.workspace)
+                .output(),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(output)) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                let code = output.status.code().unwrap_or(-1);
+                if code == 0 {
+                    if stderr.is_empty() {
+                        (stdout, false)
+                    } else {
+                        (format!("{stdout}\nstderr:\n{stderr}"), false)
+                    }
+                } else {
+                    let mut out = stdout;
+                    if !stderr.is_empty() {
+                        out.push_str(&format!("\nstderr:\n{stderr}"));
+                    }
+                    out.push_str(&format!("\n(exit code: {code})"));
+                    (out, true)
+                }
+            }
+            Ok(Err(e)) => (format!("Error: {e}"), true),
+            Err(_) => ("Error: command timed out".into(), true),
+        }
+    }
+
+    fn grep(&self, args: &serde_json::Value) -> (String, bool) {
+        let pattern = match args.get("pattern").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ("Error: Missing 'pattern' parameter".into(), true),
+        };
+        let path = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .unwrap_or(".");
+        let resolved = match self.resolve_path(path) {
+            Ok(p) => p,
+            Err(e) => return (e, true),
+        };
+
+        let output = std::process::Command::new("rg")
+            .args(["--no-heading", "--line-number", "--max-count", "100", pattern])
+            .current_dir(&resolved)
+            .output();
+
+        match output {
+            Ok(o) => {
+                let stdout = String::from_utf8_lossy(&o.stdout).to_string();
+                if stdout.trim().is_empty() {
+                    ("No matches found".into(), false)
+                } else {
+                    (stdout, false)
+                }
+            }
+            Err(_) => {
+                // Fallback to grep if rg not available
+                let output = std::process::Command::new("grep")
+                    .args(["-rn", "--max-count=100", pattern, "."])
+                    .current_dir(&resolved)
+                    .output();
+                match output {
+                    Ok(o) => {
+                        let stdout = String::from_utf8_lossy(&o.stdout).to_string();
+                        if stdout.trim().is_empty() {
+                            ("No matches found".into(), false)
+                        } else {
+                            (stdout, false)
+                        }
+                    }
+                    Err(e) => (format!("Error: {e}"), true),
+                }
+            }
+        }
+    }
+
+    fn glob_tool(&self, args: &serde_json::Value) -> (String, bool) {
+        let pattern = match args.get("pattern").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ("Error: Missing 'pattern' parameter".into(), true),
+        };
+        // Use `find` as a simple glob approximation
+        let output = std::process::Command::new("find")
+            .args([".", "-name", pattern, "-maxdepth", "5"])
+            .current_dir(&self.workspace)
+            .output();
+        match output {
+            Ok(o) => {
+                let stdout = String::from_utf8_lossy(&o.stdout).to_string();
+                if stdout.trim().is_empty() {
+                    ("No files matched".into(), false)
+                } else {
+                    (stdout, false)
+                }
+            }
+            Err(e) => (format!("Error: {e}"), true),
+        }
+    }
+
+    fn git_cmd(&self, args: &[&str]) -> (String, bool) {
+        match std::process::Command::new("git")
+            .args(args)
+            .current_dir(&self.workspace)
+            .output()
+        {
+            Ok(o) => {
+                let stdout = String::from_utf8_lossy(&o.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&o.stderr).to_string();
+                if o.status.success() {
+                    (stdout, false)
+                } else {
+                    (format!("Error: {stderr}"), true)
+                }
+            }
+            Err(e) => (format!("Error: {e}"), true),
+        }
+    }
+
+    fn git_diff(&self, args: &serde_json::Value) -> (String, bool) {
+        let mut cmd_args = vec!["diff"];
+        let cached = args
+            .get("staged")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if cached {
+            cmd_args.push("--cached");
+        }
+        self.git_cmd(&cmd_args)
+    }
+
+    fn git_log(&self, args: &serde_json::Value) -> (String, bool) {
+        let n = args.get("n").and_then(|v| v.as_u64()).unwrap_or(20).min(100);
+        let n_str = format!("-{n}");
+        self.git_cmd(&["log", "--oneline", &n_str])
+    }
+}
+
+// ─── Connection loop ─────────────────────────────────────────────────────────
+
+async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
+    let url = if args.server_url.ends_with("/edge/ws") {
+        args.server_url.clone()
+    } else {
+        format!("{}/edge/ws", args.server_url.trim_end_matches('/'))
+    };
+
+    tracing::info!(url = %url, edge_id = %args.edge_id, "Connecting to server...");
+
+    let (ws_stream, _) = connect_async(&url).await?;
+    let (mut write, mut read) = ws_stream.split();
+
+    tracing::info!("WebSocket connected, authenticating...");
+
+    // Send auth
+    let hostname = hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok());
+    let auth_msg = EdgeToServer::Auth {
+        token: args.token.clone(),
+        edge_agent_id: args.edge_id.clone(),
+        hostname,
+        workspace_dir: Some(
+            args.workspace_dir
+                .canonicalize()
+                .unwrap_or_else(|_| args.workspace_dir.clone())
+                .to_string_lossy()
+                .to_string(),
+        ),
+    };
+    write
+        .send(Message::Text(serde_json::to_string(&auth_msg)?.into()))
+        .await?;
+
+    // Wait for auth response
+    let auth_timeout = Duration::from_secs(30);
+    let auth_response = tokio::time::timeout(auth_timeout, read.next()).await;
+
+    match auth_response {
+        Ok(Some(Ok(Message::Text(text)))) => match serde_json::from_str::<ServerToEdge>(&text) {
+            Ok(ServerToEdge::AuthOk { user_id }) => {
+                tracing::info!(user_id = %user_id, "Authenticated successfully");
+            }
+            Ok(ServerToEdge::AuthError { message }) => {
+                return Err(format!("Authentication failed: {message}").into());
+            }
+            _ => {
+                return Err("Unexpected auth response".into());
+            }
+        },
+        _ => {
+            return Err("Auth timeout or connection closed".into());
+        }
+    }
+
+    let executor = LocalToolExecutor::new(
+        args.workspace_dir
+            .canonicalize()
+            .unwrap_or_else(|_| args.workspace_dir.clone()),
+    );
+
+    // Heartbeat ticker
+    let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    tracing::info!(
+        workspace = %args.workspace_dir.display(),
+        "Edge agent ready — waiting for tool calls"
+    );
+
+    loop {
+        tokio::select! {
+            msg = read.next() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        match serde_json::from_str::<ServerToEdge>(&text) {
+                            Ok(ServerToEdge::ToolRequest { request_id, tool, args: tool_args, timeout_secs: _ }) => {
+                                tracing::info!(tool = %tool, request_id = %request_id, "Executing tool");
+                                let start = Instant::now();
+                                let (output, is_error) = executor.execute(&tool, &tool_args).await;
+                                let duration_ms = start.elapsed().as_millis() as u64;
+                                tracing::info!(
+                                    tool = %tool,
+                                    request_id = %request_id,
+                                    duration_ms = duration_ms,
+                                    is_error = is_error,
+                                    output_len = output.len(),
+                                    "Tool execution complete"
+                                );
+                                let result_msg = EdgeToServer::ToolResult {
+                                    request_id,
+                                    output,
+                                    is_error,
+                                    duration_ms,
+                                };
+                                write.send(Message::Text(serde_json::to_string(&result_msg)?.into())).await?;
+                            }
+                            Ok(ServerToEdge::Pong) => {
+                                // heartbeat ack
+                            }
+                            Ok(ServerToEdge::Closing { reason }) => {
+                                tracing::info!(reason = %reason, "Server closing connection");
+                                break;
+                            }
+                            Ok(ServerToEdge::AuthOk { .. } | ServerToEdge::AuthError { .. }) => {
+                                // ignore duplicate auth
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "Failed to parse server message");
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Ping(data))) => {
+                        let _ = write.send(Message::Pong(data)).await;
+                    }
+                    Some(Ok(Message::Close(_))) | None => {
+                        tracing::info!("Connection closed");
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            _ = heartbeat.tick() => {
+                let ping = EdgeToServer::Ping;
+                if write.send(Message::Text(serde_json::to_string(&ping)?.into())).await.is_err() {
+                    tracing::warn!("Failed to send heartbeat");
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    eprintln!(
+        "astra-edge v{} — remote tool execution agent",
+        env!("CARGO_PKG_VERSION")
+    );
+    eprintln!("  server:    {}", args.server_url);
+    eprintln!("  edge-id:   {}", args.edge_id);
+    eprintln!("  workspace: {}", args.workspace_dir.display());
+    eprintln!();
+
+    loop {
+        match run_edge_connection(&args).await {
+            Ok(()) => {
+                if !args.reconnect {
+                    break;
+                }
+                tracing::info!("Disconnected, reconnecting in 5s...");
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Connection error");
+                if !args.reconnect {
+                    std::process::exit(1);
+                }
+                tracing::info!("Reconnecting in 5s...");
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}

--- a/rust/crates/astra-edge/src/main.rs
+++ b/rust/crates/astra-edge/src/main.rs
@@ -84,6 +84,7 @@ enum ServerToEdge {
         request_id: String,
         tool: String,
         args: serde_json::Value,
+        #[allow(dead_code)]
         #[serde(default = "default_timeout")]
         timeout_secs: u64,
     },

--- a/rust/crates/astra-thin-client/src/lib.rs
+++ b/rust/crates/astra-thin-client/src/lib.rs
@@ -23,9 +23,9 @@ pub use edge::{
 };
 pub use error::ThinClientError;
 pub use protocol::{
-    ApprovalDecision, ApprovalRespondRequest, ChatStreamRequest, EdgeHeartbeatRequest,
-    EdgeRegisterRequest, SessionCreateRequest, SessionUpdateRequest, StreamEvent,
-    TaskLeaseMutationRequest, ToolResultRequest, classify_stream_event,
+    ApprovalDecision, ApprovalKind, ApprovalRespondRequest, ChatStreamRequest,
+    EdgeHeartbeatRequest, EdgeRegisterRequest, SessionCreateRequest, SessionUpdateRequest,
+    StreamEvent, TaskLeaseMutationRequest, ToolResultRequest, classify_stream_event,
 };
 /// SSE / buffered HTTP response from [`ThinClient::post_chat_turn`] (transport type for consumers like CLI stream rendering).
 pub use reqwest::Response as HttpResponse;

--- a/rust/crates/astra-thin-client/src/protocol.rs
+++ b/rust/crates/astra-thin-client/src/protocol.rs
@@ -107,6 +107,13 @@ pub enum ApprovalDecision {
     AllowSession,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalKind {
+    Standard,
+    Explicit,
+}
+
 /// `POST /agents/edge` — matches server `EdgeRegisterRequest` (Phase 3 registry).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EdgeRegisterRequest {
@@ -273,6 +280,7 @@ pub enum StreamEvent {
     ApprovalRequired {
         request_id: String,
         tool: String,
+        approval_kind: ApprovalKind,
         path: Option<String>,
         detail: Option<String>,
         raw: Value,
@@ -445,6 +453,11 @@ pub fn classify_stream_event(value: Value) -> Result<StreamEvent, crate::error::
         "approval_required" => StreamEvent::ApprovalRequired {
             request_id: get_str(&obj, "request_id"),
             tool: get_str(&obj, "tool"),
+            approval_kind: obj
+                .get("approval_kind")
+                .cloned()
+                .and_then(|value| serde_json::from_value::<ApprovalKind>(value).ok())
+                .unwrap_or(ApprovalKind::Explicit),
             path: obj
                 .get("path")
                 .and_then(|v| v.as_str())
@@ -574,6 +587,53 @@ mod tests {
                 assert_eq!(args["command"], "ls");
             }
             e => panic!("unexpected {e:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_approval_required_preserves_approval_kind() {
+        let v = serde_json::json!({
+            "type": "approval_required",
+            "request_id": "ap-1",
+            "tool": "bash",
+            "approval_kind": "explicit",
+            "detail": "rm -rf tmp"
+        });
+        match classify_stream_event(v).unwrap() {
+            StreamEvent::ApprovalRequired {
+                request_id,
+                tool,
+                approval_kind,
+                detail,
+                ..
+            } => {
+                assert_eq!(request_id, "ap-1");
+                assert_eq!(tool, "bash");
+                assert_eq!(approval_kind, ApprovalKind::Explicit);
+                assert_eq!(detail.as_deref(), Some("rm -rf tmp"));
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_approval_required_without_kind_defaults_to_explicit() {
+        let v = serde_json::json!({
+            "type": "approval_required",
+            "request_id": "ap-legacy",
+            "tool": "write_file",
+            "path": "src/lib.rs"
+        });
+        match classify_stream_event(v).unwrap() {
+            StreamEvent::ApprovalRequired {
+                approval_kind,
+                detail,
+                ..
+            } => {
+                assert_eq!(approval_kind, ApprovalKind::Explicit);
+                assert_eq!(detail.as_deref(), Some("src/lib.rs"));
+            }
+            other => panic!("unexpected {other:?}"),
         }
     }
 

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -436,3 +436,264 @@ pub mod git_status_codes {
     pub const RENAMED: char = 'R';
     pub const UNTRACKED_PREFIX: &str = "??";
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── ToolResult ─────────────────────────────────────────────────────
+
+    #[test]
+    fn tool_result_text() {
+        let r = ToolResult::text("hello".into());
+        assert_eq!(r.output, "hello");
+        assert!(!r.is_error);
+        assert!(r.metadata.is_none());
+    }
+
+    #[test]
+    fn tool_result_error() {
+        let r = ToolResult::error("boom".into());
+        assert_eq!(r.output, "boom");
+        assert!(r.is_error);
+    }
+
+    #[test]
+    fn tool_result_default_is_empty() {
+        let r = ToolResult::default();
+        assert!(r.output.is_empty());
+        assert!(!r.is_error);
+        assert!(r.metadata.is_none());
+    }
+
+    // ── SandboxConfig ──────────────────────────────────────────────────
+
+    #[test]
+    fn sandbox_standard_defaults() {
+        let cfg = SandboxConfig::standard("/projects/foo");
+        assert_eq!(cfg.project_root, PathBuf::from("/projects/foo"));
+        assert_eq!(cfg.mode, SandboxMode::Standard);
+        assert!(cfg.network_allowed);
+        assert_eq!(cfg.max_output_bytes, 200_000);
+        assert_eq!(cfg.command_timeout, Duration::from_secs(120));
+        assert!(cfg.allowed_paths.contains(&PathBuf::from("/tmp")));
+    }
+
+    #[test]
+    fn sandbox_strict_defaults() {
+        let cfg = SandboxConfig::strict("/srv/workspace");
+        assert_eq!(cfg.mode, SandboxMode::Strict);
+        assert!(!cfg.network_allowed);
+        assert_eq!(cfg.allowed_paths, vec![PathBuf::from("/tmp")]);
+    }
+
+    #[test]
+    fn sandbox_mode_ordering() {
+        assert!(SandboxMode::Permissive < SandboxMode::Standard);
+        assert!(SandboxMode::Standard < SandboxMode::Strict);
+        assert!(SandboxMode::Strict < SandboxMode::ReadOnly);
+    }
+
+    // ── Output utilities ───────────────────────────────────────────────
+
+    #[test]
+    fn truncate_output_short_stays_intact() {
+        let s = "short output".to_string();
+        assert_eq!(truncate_output(s.clone(), 1000), s);
+    }
+
+    #[test]
+    fn truncate_output_long_gets_cut() {
+        let s = "a\n".repeat(5000); // 10000 chars
+        let result = truncate_output(s, 100);
+        assert!(result.len() < 200);
+        assert!(result.ends_with("[truncated]"));
+    }
+
+    #[test]
+    fn truncate_output_prefers_newline_boundary() {
+        let s = "line one\nline two\nline three that is quite long\n".to_string();
+        let result = truncate_output(s, 30);
+        // Should cut at a newline
+        assert!(result.ends_with("[truncated]"));
+        assert!(!result.contains("line three"));
+    }
+
+    #[test]
+    fn normalize_empty_output_replaces_blank() {
+        let result = normalize_empty_output("".into(), "bash");
+        assert_eq!(result, "(bash completed with no output)");
+    }
+
+    #[test]
+    fn normalize_empty_output_replaces_whitespace() {
+        let result = normalize_empty_output("   \n\t  ".into(), "grep");
+        assert_eq!(result, "(grep completed with no output)");
+    }
+
+    #[test]
+    fn normalize_empty_output_keeps_real_content() {
+        let result = normalize_empty_output("hello".into(), "bash");
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn per_tool_output_limit_grep_is_capped() {
+        let base = tool_output_limit();
+        let grep_limit = per_tool_output_limit("grep");
+        assert!(grep_limit <= 10_000);
+        assert!(grep_limit <= base);
+    }
+
+    #[test]
+    fn per_tool_output_limit_bash_uses_base() {
+        let base = tool_output_limit();
+        assert_eq!(per_tool_output_limit("bash"), base);
+    }
+
+    // ── Utility functions ──────────────────────────────────────────────
+
+    #[test]
+    fn utf16_col_ascii() {
+        assert_eq!(utf16_col_to_char_idx("hello world", 5), 5);
+    }
+
+    #[test]
+    fn utf16_col_beyond_line_end() {
+        let idx = utf16_col_to_char_idx("hi", 999);
+        assert_eq!(idx, 2); // line.chars().count()
+    }
+
+    #[test]
+    fn parse_grep_file_line_valid() {
+        let (file, line) = parse_grep_file_line("src/main.rs:42:fn main()").unwrap();
+        assert_eq!(file, "src/main.rs");
+        assert_eq!(line, 42);
+    }
+
+    #[test]
+    fn parse_grep_file_line_invalid() {
+        assert!(parse_grep_file_line("no colons here").is_none());
+        assert!(parse_grep_file_line("file:notanum:text").is_none());
+    }
+
+    #[test]
+    fn categorize_reference_import() {
+        assert_eq!(categorize_reference("f.rs:1:use std::io;", "io"), "import");
+        assert_eq!(categorize_reference("f.rs:1:import React from 'react';", "React"), "import");
+        assert_eq!(categorize_reference("f.rs:1:from os import path", "path"), "import");
+    }
+
+    #[test]
+    fn categorize_reference_definition() {
+        assert_eq!(categorize_reference("f.rs:1:fn my_func() {}", "my_func"), "definition");
+        assert_eq!(categorize_reference("f.rs:1:pub fn my_func() {}", "my_func"), "definition");
+        assert_eq!(categorize_reference("f.rs:1:struct Foo {}", "Foo"), "definition");
+        assert_eq!(categorize_reference("f.rs:1:class MyClass:", "MyClass"), "definition");
+    }
+
+    #[test]
+    fn categorize_reference_usage() {
+        assert_eq!(categorize_reference("f.rs:1:    my_func();", "my_func"), "usage");
+        assert_eq!(categorize_reference("f.rs:1:    x = foo.bar();", "bar"), "usage");
+        // Note: "let x = ..." is categorized as "definition" by design (it starts with "let ")
+        assert_eq!(categorize_reference("f.rs:1:let x = foo.bar();", "bar"), "definition");
+    }
+
+    // ── APPROVAL_REQUIRED_TOOLS ────────────────────────────────────────
+
+    #[test]
+    fn approval_required_tools_includes_dangerous_ops() {
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"bash"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"write_file"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"delete_file"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_commit"));
+        assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"read_file"));
+        assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"grep"));
+    }
+
+    // ── ApprovalDecision ───────────────────────────────────────────────
+
+    #[test]
+    fn approval_decision_variants_debug() {
+        let _ = format!("{:?}", ApprovalDecision::Approved);
+        let _ = format!("{:?}", ApprovalDecision::Denied { reason: Some("nope".into()) });
+        let _ = format!("{:?}", ApprovalDecision::Timeout);
+    }
+
+    // ── Schemas ────────────────────────────────────────────────────────
+
+    #[test]
+    fn all_tool_schemas_has_expected_tools() {
+        let schemas = schemas::all_tool_schemas();
+        let names: Vec<String> = schemas
+            .iter()
+            .filter_map(|s| {
+                s.get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|n| n.as_str())
+                    .map(String::from)
+            })
+            .collect();
+        // Core tools that must be present
+        assert!(names.contains(&"bash".into()));
+        assert!(names.contains(&"read_file".into()));
+        assert!(names.contains(&"write_file".into()));
+        assert!(names.contains(&"str_replace".into()));
+        assert!(names.contains(&"grep".into()));
+        assert!(names.contains(&"glob".into()));
+        assert!(names.contains(&"memory_store".into()));
+        assert!(names.contains(&"memory_search".into()));
+        assert!(names.contains(&"memory_profile".into()));
+    }
+
+    #[test]
+    fn all_tool_schemas_valid_structure() {
+        let schemas = schemas::all_tool_schemas();
+        assert!(!schemas.is_empty());
+        for schema in &schemas {
+            // Each schema must have type: "function" and function.name
+            assert_eq!(schema.get("type").and_then(|v| v.as_str()), Some("function"));
+            let func = schema.get("function").expect("missing 'function' key");
+            assert!(func.get("name").and_then(|n| n.as_str()).is_some());
+            assert!(func.get("description").and_then(|d| d.as_str()).is_some());
+        }
+    }
+
+    // ── Persist large output ───────────────────────────────────────────
+
+    #[test]
+    fn maybe_persist_small_output_passes_through() {
+        let out = "small output".to_string();
+        let result = maybe_persist_large_output(out.clone(), 0, "bash");
+        assert_eq!(result, out);
+    }
+
+    #[test]
+    fn maybe_persist_under_soft_limit_passes_through() {
+        let out = "x".repeat(PERSIST_THRESHOLD + 1);
+        let result = maybe_persist_large_output(out.clone(), 0, "bash");
+        // Under AGGREGATE_SOFT_LIMIT, even large output passes through
+        assert_eq!(result, out);
+    }
+
+    #[test]
+    fn maybe_persist_error_output_passes_through() {
+        let out = format!("Error: {}", "x".repeat(PERSIST_THRESHOLD + 1));
+        let result = maybe_persist_large_output(out.clone(), AGGREGATE_SOFT_LIMIT + 1, "bash");
+        // Error output is never persisted
+        assert_eq!(result, out);
+    }
+
+    // ── git_status_codes ───────────────────────────────────────────────
+
+    #[test]
+    fn git_status_codes_constants() {
+        assert_eq!(git_status_codes::MODIFIED, 'M');
+        assert_eq!(git_status_codes::ADDED, 'A');
+        assert_eq!(git_status_codes::DELETED, 'D');
+        assert_eq!(git_status_codes::RENAMED, 'R');
+        assert_eq!(git_status_codes::UNTRACKED_PREFIX, "??");
+    }
+}

--- a/rust/crates/astra-tools/src/memoria.rs
+++ b/rust/crates/astra-tools/src/memoria.rs
@@ -271,6 +271,18 @@ impl MemoriaClient {
     }
 
     fn build_direct_request(base: &str, op: &str, args: &Value) -> (String, Value) {
+        // Helper: propagate session_id and user_id when present in args
+        // so Memoria can scope operations to the correct user.
+        let inject_identity = |pl: &mut Value| {
+            if let Some(obj) = pl.as_object_mut() {
+                if let Some(sid) = args.get("session_id").and_then(Value::as_str) {
+                    obj.insert("session_id".to_string(), json!(sid));
+                }
+                if let Some(uid) = args.get("user_id").and_then(Value::as_str) {
+                    obj.insert("user_id".to_string(), json!(uid));
+                }
+            }
+        };
         match op {
             "retrieve" => {
                 let query = args.get("query").and_then(Value::as_str).unwrap_or("");
@@ -279,6 +291,7 @@ impl MemoriaClient {
                 if let Some(mc) = args.get("min_confidence").and_then(Value::as_f64) {
                     pl["min_confidence"] = json!(mc);
                 }
+                inject_identity(&mut pl);
                 (format!("{base}/v1/memories/retrieve"), pl)
             }
             "store" => {
@@ -291,9 +304,7 @@ impl MemoriaClient {
                 if let Some(tier) = args.get("trust_tier").and_then(Value::as_str) {
                     payload["trust_tier"] = json!(tier);
                 }
-                if let Some(sid) = args.get("session_id").and_then(Value::as_str) {
-                    payload["session_id"] = json!(sid);
-                }
+                inject_identity(&mut payload);
                 (format!("{base}/v1/memories"), payload)
             }
             "search" => {
@@ -303,6 +314,7 @@ impl MemoriaClient {
                 if let Some(mc) = args.get("min_confidence").and_then(Value::as_f64) {
                     pl["min_confidence"] = json!(mc);
                 }
+                inject_identity(&mut pl);
                 (format!("{base}/v1/memories/search"), pl)
             }
             "purge" => {
@@ -311,10 +323,9 @@ impl MemoriaClient {
                     .get("reason")
                     .and_then(Value::as_str)
                     .unwrap_or("user request");
-                (
-                    format!("{base}/v1/memories/purge"),
-                    json!({"topic": topic, "reason": reason}),
-                )
+                let mut pl = json!({"topic": topic, "reason": reason});
+                inject_identity(&mut pl);
+                (format!("{base}/v1/memories/purge"), pl)
             }
             "correct" => {
                 let memory_id = args.get("memory_id").and_then(Value::as_str).unwrap_or("");
@@ -326,12 +337,16 @@ impl MemoriaClient {
                     .get("reason")
                     .and_then(Value::as_str)
                     .unwrap_or("correction");
-                (
-                    format!("{base}/v1/memories/correct"),
-                    json!({"memory_id": memory_id, "new_content": new_content, "reason": reason}),
-                )
+                let mut pl =
+                    json!({"memory_id": memory_id, "new_content": new_content, "reason": reason});
+                inject_identity(&mut pl);
+                (format!("{base}/v1/memories/correct"), pl)
             }
-            "profile" => (format!("{base}/v1/memories/profile"), json!({})),
+            "profile" => {
+                let mut pl = json!({});
+                inject_identity(&mut pl);
+                (format!("{base}/v1/memories/profile"), pl)
+            }
             _ => (
                 String::new(),
                 json!({"error": format!("Unknown memoria op: {op}")}),
@@ -379,4 +394,76 @@ pub async fn memoria_consolidate_fire_and_forget() {
         .json(&json!({"force": false}))
         .send()
         .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn build_direct_request_propagates_session_and_user_id() {
+        let args = json!({
+            "query": "rust patterns",
+            "top_k": 3,
+            "session_id": "user-42",
+            "user_id": "user-42"
+        });
+
+        // retrieve
+        let (_, pl) = MemoriaClient::build_direct_request("http://mem", "retrieve", &args);
+        assert_eq!(pl["session_id"], "user-42");
+        assert_eq!(pl["user_id"], "user-42");
+        assert_eq!(pl["query"], "rust patterns");
+
+        // search
+        let (_, pl) = MemoriaClient::build_direct_request("http://mem", "search", &args);
+        assert_eq!(pl["session_id"], "user-42");
+        assert_eq!(pl["user_id"], "user-42");
+
+        // store
+        let store_args = json!({
+            "content": "hello",
+            "session_id": "user-42",
+            "user_id": "user-42"
+        });
+        let (_, pl) = MemoriaClient::build_direct_request("http://mem", "store", &store_args);
+        assert_eq!(pl["session_id"], "user-42");
+        assert_eq!(pl["user_id"], "user-42");
+
+        // purge
+        let purge_args = json!({
+            "topic": "old",
+            "session_id": "user-42",
+            "user_id": "user-42"
+        });
+        let (_, pl) = MemoriaClient::build_direct_request("http://mem", "purge", &purge_args);
+        assert_eq!(pl["session_id"], "user-42");
+        assert_eq!(pl["user_id"], "user-42");
+
+        // correct
+        let correct_args = json!({
+            "memory_id": "m1",
+            "new_content": "fixed",
+            "session_id": "user-42",
+            "user_id": "user-42"
+        });
+        let (_, pl) = MemoriaClient::build_direct_request("http://mem", "correct", &correct_args);
+        assert_eq!(pl["session_id"], "user-42");
+        assert_eq!(pl["user_id"], "user-42");
+
+        // profile
+        let profile_args = json!({"session_id": "user-42", "user_id": "user-42"});
+        let (_, pl) = MemoriaClient::build_direct_request("http://mem", "profile", &profile_args);
+        assert_eq!(pl["session_id"], "user-42");
+        assert_eq!(pl["user_id"], "user-42");
+    }
+
+    #[test]
+    fn build_direct_request_omits_identity_when_absent() {
+        let args = json!({"query": "test"});
+        let (_, pl) = MemoriaClient::build_direct_request("http://mem", "retrieve", &args);
+        assert!(pl.get("session_id").is_none());
+        assert!(pl.get("user_id").is_none());
+    }
 }

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -69,6 +69,7 @@ criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 futures-util.workspace = true
 sqlx.workspace = true
 tempfile = "3"
+tokio-tungstenite.workspace = true
 tokio-util.workspace = true
 tower.workspace = true
 proptest = "1"

--- a/rust/crates/runtime/src/app_state.rs
+++ b/rust/crates/runtime/src/app_state.rs
@@ -95,6 +95,8 @@ pub struct AppState {
     /// Team persistence store — CRUD for team definitions and execution history.
     pub(crate) team_store:
         Option<Arc<dyn astra_services::team_persistence::TeamPersistenceService>>,
+    /// Live edge agent WebSocket connections for remote tool execution (Phase 6).
+    pub edge_connection_pool: crate::server::edge_connection_pool::EdgeConnectionPool,
 }
 
 impl AppState {
@@ -178,6 +180,7 @@ impl AppState {
             agent_profile_registry: Arc::new(astra_services::AgentProfileRegistry::new()),
             delegation_engine: None,
             team_store: None,
+            edge_connection_pool: crate::server::edge_connection_pool::EdgeConnectionPool::new(),
         }
     }
 

--- a/rust/crates/runtime/src/server/edge_connection_pool.rs
+++ b/rust/crates/runtime/src/server/edge_connection_pool.rs
@@ -1,0 +1,335 @@
+//! In-memory pool of live edge agent WebSocket connections.
+//!
+//! Each entry maps `{user_id}:{edge_agent_id}` to a channel sender that can
+//! push [`EdgeServerMessage`] frames to the connected edge agent. The pool is
+//! stored in [`AppState`] and queried by the tool routing layer to decide
+//! whether to route tool calls to a remote edge or fall back to the server.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use tokio::sync::{mpsc, oneshot};
+use uuid::Uuid;
+
+use super::edge_ws_protocol::{EdgeServerMessage, EDGE_TOOL_TIMEOUT_SECS};
+
+/// Sender half that pushes frames into an edge agent's WebSocket write loop.
+pub type EdgeWsSender = mpsc::UnboundedSender<EdgeServerMessage>;
+
+/// Metadata about a connected edge agent.
+#[derive(Debug, Clone)]
+pub struct EdgeConnection {
+    pub user_id: String,
+    pub edge_agent_id: String,
+    pub hostname: Option<String>,
+    pub workspace_dir: Option<String>,
+    pub sender: EdgeWsSender,
+    pub connected_at: std::time::Instant,
+    /// Pending tool call responses: request_id → oneshot sender.
+    pending_results: Arc<DashMap<String, oneshot::Sender<EdgeToolResult>>>,
+}
+
+/// Result from an edge tool execution.
+#[derive(Debug, Clone)]
+pub struct EdgeToolResult {
+    pub output: String,
+    pub is_error: bool,
+    pub duration_ms: Option<u64>,
+}
+
+/// Pool key: `{user_id}:{edge_agent_id}`.
+fn pool_key(user_id: &str, edge_agent_id: &str) -> String {
+    format!("{user_id}:{edge_agent_id}")
+}
+
+/// Thread-safe pool of live edge WebSocket connections.
+#[derive(Debug, Clone, Default)]
+pub struct EdgeConnectionPool {
+    connections: Arc<DashMap<String, EdgeConnection>>,
+}
+
+impl EdgeConnectionPool {
+    pub fn new() -> Self {
+        Self {
+            connections: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Register a new edge connection. Replaces any existing connection for the same key.
+    pub fn register(
+        &self,
+        user_id: &str,
+        edge_agent_id: &str,
+        hostname: Option<String>,
+        workspace_dir: Option<String>,
+        sender: EdgeWsSender,
+    ) {
+        let key = pool_key(user_id, edge_agent_id);
+        self.connections.insert(
+            key,
+            EdgeConnection {
+                user_id: user_id.to_string(),
+                edge_agent_id: edge_agent_id.to_string(),
+                hostname,
+                workspace_dir,
+                sender,
+                connected_at: std::time::Instant::now(),
+                pending_results: Arc::new(DashMap::new()),
+            },
+        );
+    }
+
+    /// Remove an edge connection.
+    pub fn unregister(&self, user_id: &str, edge_agent_id: &str) {
+        let key = pool_key(user_id, edge_agent_id);
+        self.connections.remove(&key);
+    }
+
+    /// Check if a user has any connected edge agent.
+    pub fn has_connected_edge(&self, user_id: &str) -> bool {
+        self.connections
+            .iter()
+            .any(|entry| entry.value().user_id == user_id && !entry.value().sender.is_closed())
+    }
+
+    /// Get all connected edge agents for a user.
+    pub fn get_user_edges(&self, user_id: &str) -> Vec<EdgeConnectionInfo> {
+        self.connections
+            .iter()
+            .filter(|entry| entry.value().user_id == user_id && !entry.value().sender.is_closed())
+            .map(|entry| {
+                let conn = entry.value();
+                EdgeConnectionInfo {
+                    edge_agent_id: conn.edge_agent_id.clone(),
+                    hostname: conn.hostname.clone(),
+                    workspace_dir: conn.workspace_dir.clone(),
+                    connected_at: conn.connected_at,
+                }
+            })
+            .collect()
+    }
+
+    /// Send a tool execution request to an edge agent and await the result.
+    ///
+    /// Returns `None` if the edge is not connected or the request times out.
+    pub async fn execute_tool(
+        &self,
+        user_id: &str,
+        edge_agent_id: &str,
+        tool: &str,
+        args: &serde_json::Value,
+    ) -> Option<EdgeToolResult> {
+        let key = pool_key(user_id, edge_agent_id);
+        let (pending_results, sender) = {
+            let entry = self.connections.get(&key)?;
+            let conn = entry.value();
+            if conn.sender.is_closed() {
+                drop(entry);
+                self.connections.remove(&key);
+                return None;
+            }
+            (conn.pending_results.clone(), conn.sender.clone())
+        };
+
+        let request_id = Uuid::new_v4().to_string();
+        let (tx, rx) = oneshot::channel();
+        pending_results.insert(request_id.clone(), tx);
+
+        let msg = EdgeServerMessage::ToolRequest {
+            request_id: request_id.clone(),
+            tool: tool.to_string(),
+            args: args.clone(),
+            timeout_secs: EDGE_TOOL_TIMEOUT_SECS,
+        };
+
+        if sender.send(msg).is_err() {
+            pending_results.remove(&request_id);
+            return None;
+        }
+
+        let timeout_dur = Duration::from_secs(EDGE_TOOL_TIMEOUT_SECS);
+        match tokio::time::timeout(timeout_dur, rx).await {
+            Ok(Ok(result)) => Some(result),
+            _ => {
+                pending_results.remove(&request_id);
+                None
+            }
+        }
+    }
+
+    /// Send a tool execution request to the first available edge for a user.
+    pub async fn execute_tool_any_edge(
+        &self,
+        user_id: &str,
+        tool: &str,
+        args: &serde_json::Value,
+    ) -> Option<EdgeToolResult> {
+        // Find the first connected edge for this user
+        let edge_agent_id = self
+            .connections
+            .iter()
+            .find(|entry| entry.value().user_id == user_id && !entry.value().sender.is_closed())
+            .map(|entry| entry.value().edge_agent_id.clone())?;
+
+        self.execute_tool(user_id, &edge_agent_id, tool, args).await
+    }
+
+    /// Deliver a tool result from an edge agent (called from the edge WS read loop).
+    pub fn deliver_tool_result(
+        &self,
+        user_id: &str,
+        edge_agent_id: &str,
+        request_id: &str,
+        result: EdgeToolResult,
+    ) -> bool {
+        let key = pool_key(user_id, edge_agent_id);
+        if let Some(entry) = self.connections.get(&key) {
+            if let Some((_, tx)) = entry.value().pending_results.remove(request_id) {
+                return tx.send(result).is_ok();
+            }
+        }
+        false
+    }
+
+    /// Remove stale connections (sender closed).
+    pub fn cleanup_stale(&self) {
+        self.connections
+            .retain(|_, conn| !conn.sender.is_closed());
+    }
+
+    /// Number of active connections.
+    pub fn connection_count(&self) -> usize {
+        self.connections.len()
+    }
+}
+
+/// Public info about a connected edge (no sender exposed).
+#[derive(Debug, Clone)]
+pub struct EdgeConnectionInfo {
+    pub edge_agent_id: String,
+    pub hostname: Option<String>,
+    pub workspace_dir: Option<String>,
+    pub connected_at: std::time::Instant,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn register_and_check_connected() {
+        let pool = EdgeConnectionPool::new();
+        assert!(!pool.has_connected_edge("user-1"));
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        pool.register("user-1", "edge-a", Some("laptop".into()), None, tx);
+
+        assert!(pool.has_connected_edge("user-1"));
+        assert!(!pool.has_connected_edge("user-2"));
+        assert_eq!(pool.connection_count(), 1);
+    }
+
+    #[test]
+    fn unregister_removes_connection() {
+        let pool = EdgeConnectionPool::new();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        pool.register("user-1", "edge-a", None, None, tx);
+        assert!(pool.has_connected_edge("user-1"));
+
+        pool.unregister("user-1", "edge-a");
+        assert!(!pool.has_connected_edge("user-1"));
+        assert_eq!(pool.connection_count(), 0);
+    }
+
+    #[test]
+    fn get_user_edges_returns_info() {
+        let pool = EdgeConnectionPool::new();
+        let (tx1, _rx1) = mpsc::unbounded_channel();
+        let (tx2, _rx2) = mpsc::unbounded_channel();
+        pool.register("user-1", "edge-a", Some("laptop".into()), None, tx1);
+        pool.register("user-1", "edge-b", Some("desktop".into()), None, tx2);
+
+        let edges = pool.get_user_edges("user-1");
+        assert_eq!(edges.len(), 2);
+        let names: Vec<&str> = edges.iter().map(|e| e.edge_agent_id.as_str()).collect();
+        assert!(names.contains(&"edge-a"));
+        assert!(names.contains(&"edge-b"));
+    }
+
+    #[test]
+    fn closed_sender_detected_as_disconnected() {
+        let pool = EdgeConnectionPool::new();
+        let (tx, rx) = mpsc::unbounded_channel();
+        pool.register("user-1", "edge-a", None, None, tx);
+        drop(rx); // close the receiver, which closes the sender
+        assert!(!pool.has_connected_edge("user-1"));
+    }
+
+    #[test]
+    fn cleanup_stale_removes_closed() {
+        let pool = EdgeConnectionPool::new();
+        let (tx, rx) = mpsc::unbounded_channel();
+        pool.register("user-1", "edge-stale", None, None, tx);
+        drop(rx);
+        assert_eq!(pool.connection_count(), 1);
+        pool.cleanup_stale();
+        assert_eq!(pool.connection_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn deliver_tool_result_completes_pending() {
+        let pool = EdgeConnectionPool::new();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        pool.register("user-1", "edge-a", None, None, tx);
+
+        // Spawn a task that will call execute_tool
+        let pool_clone = pool.clone();
+        let handle = tokio::spawn(async move {
+            pool_clone
+                .execute_tool("user-1", "edge-a", "bash", &json!({"command": "ls"}))
+                .await
+        });
+
+        // Wait a bit for the request to be sent
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Read the tool request from the receiver
+        let msg = rx.recv().await.unwrap();
+        let request_id = match msg {
+            EdgeServerMessage::ToolRequest { request_id, .. } => request_id,
+            _ => panic!("expected ToolRequest"),
+        };
+
+        // Deliver the result
+        let delivered = pool.deliver_tool_result(
+            "user-1",
+            "edge-a",
+            &request_id,
+            EdgeToolResult {
+                output: "file1.txt\nfile2.txt".into(),
+                is_error: false,
+                duration_ms: Some(10),
+            },
+        );
+        assert!(delivered);
+
+        // The execute_tool should now complete
+        let result = handle.await.unwrap();
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.output, "file1.txt\nfile2.txt");
+        assert!(!result.is_error);
+    }
+
+    #[tokio::test]
+    async fn execute_tool_returns_none_for_missing_edge() {
+        let pool = EdgeConnectionPool::new();
+        let result = pool
+            .execute_tool("user-1", "nonexistent", "bash", &json!({}))
+            .await;
+        assert!(result.is_none());
+    }
+}

--- a/rust/crates/runtime/src/server/edge_connection_pool.rs
+++ b/rust/crates/runtime/src/server/edge_connection_pool.rs
@@ -5,7 +5,6 @@
 //! stored in [`AppState`] and queried by the tool routing layer to decide
 //! whether to route tool calls to a remote edge or fall back to the server.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/rust/crates/runtime/src/server/edge_connection_pool.rs
+++ b/rust/crates/runtime/src/server/edge_connection_pool.rs
@@ -80,10 +80,13 @@ impl EdgeConnectionPool {
         );
     }
 
-    /// Remove an edge connection.
+    /// Remove an edge connection. Cancels any pending tool requests.
     pub fn unregister(&self, user_id: &str, edge_agent_id: &str) {
         let key = pool_key(user_id, edge_agent_id);
-        self.connections.remove(&key);
+        if let Some((_, conn)) = self.connections.remove(&key) {
+            // Drop all pending oneshot senders so execute_tool callers get None
+            conn.pending_results.clear();
+        }
     }
 
     /// Check if a user has any connected edge agent.

--- a/rust/crates/runtime/src/server/edge_status_handler.rs
+++ b/rust/crates/runtime/src/server/edge_status_handler.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+/// Response for `GET /edges/status`.
+#[derive(Serialize)]
+pub(super) struct EdgeStatusResponse {
+    pub(super) edges: Vec<EdgeInfo>,
+}
+
+#[derive(Serialize)]
+pub(super) struct EdgeInfo {
+    pub(super) edge_agent_id: String,
+    pub(super) hostname: Option<String>,
+    pub(super) workspace_dir: Option<String>,
+    pub(super) connected_secs: u64,
+}
+
+pub(super) async fn edge_status_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<EdgeStatusResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let user = state.auth_service.current_user(&headers).await?;
+
+    let infos = state.edge_connection_pool.get_user_edges(&user.user_id);
+    let edges = infos
+        .into_iter()
+        .map(|info| EdgeInfo {
+            edge_agent_id: info.edge_agent_id,
+            hostname: info.hostname,
+            workspace_dir: info.workspace_dir,
+            connected_secs: info.connected_at.elapsed().as_secs(),
+        })
+        .collect();
+
+    Ok(Json(EdgeStatusResponse { edges }))
+}

--- a/rust/crates/runtime/src/server/edge_ws_handler.rs
+++ b/rust/crates/runtime/src/server/edge_ws_handler.rs
@@ -1,0 +1,232 @@
+//! WebSocket handler for remote edge agent connections.
+//!
+//! Provides the `GET /edge/ws` endpoint where edge agent binaries connect,
+//! authenticate, and then receive tool execution requests from the server.
+//! Results are sent back over the same WebSocket.
+
+use super::edge_connection_pool::EdgeToolResult;
+use super::edge_ws_protocol::*;
+use super::*;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use futures_util::stream::SplitSink;
+use futures_util::StreamExt;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+/// Axum handler for edge WebSocket upgrade.
+pub(super) async fn edge_ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    ws.max_message_size(256 * 1024)
+        .on_upgrade(move |socket| handle_edge_connection(socket, state))
+}
+
+/// Main edge WebSocket connection loop.
+async fn handle_edge_connection(socket: WebSocket, state: AppState) {
+    let (ws_sink, mut ws_stream) = socket.split();
+    let ws_sink = Arc::new(tokio::sync::Mutex::new(ws_sink));
+
+    // ── Phase 1: Authenticate ────────────────────────────────────────
+    let auth_timeout = Duration::from_secs(EDGE_AUTH_TIMEOUT_SECS);
+    let auth_result = tokio::time::timeout(auth_timeout, async {
+        while let Some(Ok(msg)) = ws_stream.next().await {
+            if let Message::Text(text) = msg {
+                match serde_json::from_str::<EdgeClientMessage>(&text) {
+                    Ok(EdgeClientMessage::Auth {
+                        token,
+                        edge_agent_id,
+                        hostname,
+                        workspace_dir,
+                        capabilities: _,
+                    }) => {
+                        return Some((token, edge_agent_id, hostname, workspace_dir));
+                    }
+                    _ => {
+                        let _ = send_edge_msg(
+                            &ws_sink,
+                            EdgeServerMessage::AuthError {
+                                message: "first message must be edge_auth".into(),
+                            },
+                        )
+                        .await;
+                        return None;
+                    }
+                }
+            }
+        }
+        None
+    })
+    .await;
+
+    let (token, edge_agent_id, hostname, workspace_dir) = match auth_result {
+        Ok(Some(auth)) => auth,
+        _ => {
+            let _ = send_edge_msg(
+                &ws_sink,
+                EdgeServerMessage::AuthError {
+                    message: "auth timeout or connection closed".into(),
+                },
+            )
+            .await;
+            return;
+        }
+    };
+
+    // Validate token
+    let mut headers = HeaderMap::new();
+    if let Ok(hv) = axum::http::HeaderValue::from_str(&format!("Bearer {token}")) {
+        headers.insert(axum::http::header::AUTHORIZATION, hv);
+    }
+    let user = match state.auth_service.current_user(&headers).await {
+        Ok(user) => user,
+        Err(_) => {
+            let _ = send_edge_msg(
+                &ws_sink,
+                EdgeServerMessage::AuthError {
+                    message: "invalid token".into(),
+                },
+            )
+            .await;
+            return;
+        }
+    };
+
+    let user_id = user.user_id.clone();
+
+    // Send auth success
+    let _ = send_edge_msg(
+        &ws_sink,
+        EdgeServerMessage::AuthOk {
+            user_id: user_id.clone(),
+        },
+    )
+    .await;
+
+    tracing::info!(
+        user_id = %user_id,
+        edge_agent_id = %edge_agent_id,
+        hostname = ?hostname,
+        "Edge agent connected"
+    );
+
+    // ── Phase 2: Register in pool ────────────────────────────────────
+    let (pool_tx, mut pool_rx) = mpsc::unbounded_channel::<EdgeServerMessage>();
+    state.edge_connection_pool.register(
+        &user_id,
+        &edge_agent_id,
+        hostname.clone(),
+        workspace_dir.clone(),
+        pool_tx,
+    );
+
+    // ── Phase 3: Bidirectional message loop ──────────────────────────
+    let heartbeat_interval = Duration::from_secs(EDGE_HEARTBEAT_INTERVAL_SECS);
+
+    let ws_sink_write = ws_sink.clone();
+    let pool_for_cleanup = state.edge_connection_pool.clone();
+    let user_id_cleanup = user_id.clone();
+    let edge_agent_id_cleanup = edge_agent_id.clone();
+
+    // Task: forward server → edge messages from the pool channel
+    let ws_sink_fwd = ws_sink.clone();
+    let forward_task = tokio::spawn(async move {
+        while let Some(msg) = pool_rx.recv().await {
+            if send_edge_msg(&ws_sink_fwd, msg).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Task: read edge → server messages + heartbeat
+    let read_loop = async {
+        let mut heartbeat = tokio::time::interval(heartbeat_interval);
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                msg = ws_stream.next() => {
+                    match msg {
+                        Some(Ok(Message::Text(text))) => {
+                            match serde_json::from_str::<EdgeClientMessage>(&text) {
+                                Ok(EdgeClientMessage::ToolResult {
+                                    request_id,
+                                    output,
+                                    is_error,
+                                    duration_ms,
+                                }) => {
+                                    state.edge_connection_pool.deliver_tool_result(
+                                        &user_id,
+                                        &edge_agent_id,
+                                        &request_id,
+                                        EdgeToolResult {
+                                            output,
+                                            is_error,
+                                            duration_ms,
+                                        },
+                                    );
+                                }
+                                Ok(EdgeClientMessage::Ping) => {
+                                    let _ = send_edge_msg(&ws_sink_write, EdgeServerMessage::Pong).await;
+                                }
+                                Ok(EdgeClientMessage::Auth { .. }) => {
+                                    // Already authenticated, ignore duplicate auth
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        user_id = %user_id,
+                                        edge_agent_id = %edge_agent_id,
+                                        error = %e,
+                                        "Edge: invalid message"
+                                    );
+                                }
+                            }
+                        }
+                        Some(Ok(Message::Close(_))) | None => break,
+                        Some(Ok(Message::Ping(data))) => {
+                            use futures_util::SinkExt;
+                            let _ = ws_sink_write.lock().await
+                                .send(Message::Pong(data))
+                                .await;
+                        }
+                        _ => {} // ignore binary, pong
+                    }
+                }
+                _ = heartbeat.tick() => {
+                    if send_edge_msg(&ws_sink_write, EdgeServerMessage::Pong).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    };
+
+    read_loop.await;
+
+    // ── Cleanup ──────────────────────────────────────────────────────
+    forward_task.abort();
+    pool_for_cleanup.unregister(&user_id_cleanup, &edge_agent_id_cleanup);
+
+    tracing::info!(
+        user_id = %user_id_cleanup,
+        edge_agent_id = %edge_agent_id_cleanup,
+        "Edge agent disconnected"
+    );
+}
+
+/// Helper: serialize and send an EdgeServerMessage over the WebSocket.
+async fn send_edge_msg(
+    sink: &Arc<tokio::sync::Mutex<SplitSink<WebSocket, Message>>>,
+    msg: EdgeServerMessage,
+) -> Result<(), ()> {
+    use futures_util::SinkExt;
+    let text = serde_json::to_string(&msg).map_err(|_| ())?;
+    sink.lock()
+        .await
+        .send(Message::Text(text.into()))
+        .await
+        .map_err(|_| ())
+}

--- a/rust/crates/runtime/src/server/edge_ws_protocol.rs
+++ b/rust/crates/runtime/src/server/edge_ws_protocol.rs
@@ -1,0 +1,205 @@
+//! Edge WebSocket protocol types for remote tool execution.
+//!
+//! Defines the bidirectional message protocol between the Astra server and
+//! remote edge agents. Edge agents connect via `GET /edge/ws`, authenticate,
+//! and then receive tool execution requests and return results.
+//!
+//! ## Protocol
+//!
+//! **Edge → Server** (JSON text frames):
+//! ```text
+//! {"type": "edge_auth", "token": "Bearer ...", "edge_agent_id": "...", "hostname": "...", "workspace_dir": "..."}
+//! {"type": "edge_tool_result", "request_id": "...", "output": "...", "is_error": false}
+//! {"type": "edge_ping"}
+//! ```
+//!
+//! **Server → Edge** (JSON text frames):
+//! ```text
+//! {"type": "edge_auth_ok", "user_id": "..."}
+//! {"type": "edge_auth_error", "message": "..."}
+//! {"type": "edge_tool_request", "request_id": "...", "tool": "...", "args": {...}}
+//! {"type": "edge_pong"}
+//! {"type": "edge_closing", "reason": "..."}
+//! ```
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Timeout for tool execution on the edge agent.
+pub const EDGE_TOOL_TIMEOUT_SECS: u64 = 300; // 5 minutes
+
+/// Timeout for the initial auth message after WebSocket upgrade.
+pub const EDGE_AUTH_TIMEOUT_SECS: u64 = 30;
+
+/// Heartbeat interval for edge keep-alive.
+pub const EDGE_HEARTBEAT_INTERVAL_SECS: u64 = 30;
+
+// ─── Edge → Server Messages ─────────────────────────────────────────────────
+
+/// Messages sent from edge agent to server.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(tag = "type")]
+pub enum EdgeClientMessage {
+    /// Authenticate the edge agent (must be first message).
+    #[serde(rename = "edge_auth")]
+    Auth {
+        token: String,
+        edge_agent_id: String,
+        #[serde(default)]
+        hostname: Option<String>,
+        #[serde(default)]
+        workspace_dir: Option<String>,
+        #[serde(default)]
+        capabilities: Option<Vec<String>>,
+    },
+
+    /// Tool execution result from the edge.
+    #[serde(rename = "edge_tool_result")]
+    ToolResult {
+        request_id: String,
+        output: String,
+        #[serde(default)]
+        is_error: bool,
+        #[serde(default)]
+        duration_ms: Option<u64>,
+    },
+
+    /// Edge heartbeat.
+    #[serde(rename = "edge_ping")]
+    Ping,
+}
+
+// ─── Server → Edge Messages ─────────────────────────────────────────────────
+
+/// Messages sent from server to edge agent.
+#[derive(Serialize, Debug, Clone)]
+#[serde(tag = "type")]
+pub enum EdgeServerMessage {
+    /// Authentication succeeded.
+    #[serde(rename = "edge_auth_ok")]
+    AuthOk { user_id: String },
+
+    /// Authentication failed.
+    #[serde(rename = "edge_auth_error")]
+    AuthError { message: String },
+
+    /// Request the edge to execute a tool.
+    #[serde(rename = "edge_tool_request")]
+    ToolRequest {
+        request_id: String,
+        tool: String,
+        args: Value,
+        /// Maximum execution time in seconds.
+        timeout_secs: u64,
+    },
+
+    /// Server heartbeat response.
+    #[serde(rename = "edge_pong")]
+    Pong,
+
+    /// Server is closing the connection.
+    #[serde(rename = "edge_closing")]
+    Closing { reason: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn edge_auth_deserializes() {
+        let msg: EdgeClientMessage = serde_json::from_value(json!({
+            "type": "edge_auth",
+            "token": "Bearer abc",
+            "edge_agent_id": "my-edge",
+            "hostname": "laptop",
+            "workspace_dir": "/home/user/project"
+        }))
+        .unwrap();
+        match msg {
+            EdgeClientMessage::Auth {
+                token,
+                edge_agent_id,
+                hostname,
+                ..
+            } => {
+                assert_eq!(token, "Bearer abc");
+                assert_eq!(edge_agent_id, "my-edge");
+                assert_eq!(hostname.as_deref(), Some("laptop"));
+            }
+            _ => panic!("expected Auth"),
+        }
+    }
+
+    #[test]
+    fn edge_tool_result_deserializes() {
+        let msg: EdgeClientMessage = serde_json::from_value(json!({
+            "type": "edge_tool_result",
+            "request_id": "req-123",
+            "output": "file contents here",
+            "is_error": false,
+            "duration_ms": 42
+        }))
+        .unwrap();
+        match msg {
+            EdgeClientMessage::ToolResult {
+                request_id,
+                output,
+                is_error,
+                duration_ms,
+            } => {
+                assert_eq!(request_id, "req-123");
+                assert_eq!(output, "file contents here");
+                assert!(!is_error);
+                assert_eq!(duration_ms, Some(42));
+            }
+            _ => panic!("expected ToolResult"),
+        }
+    }
+
+    #[test]
+    fn edge_tool_request_serializes() {
+        let msg = EdgeServerMessage::ToolRequest {
+            request_id: "req-456".into(),
+            tool: "bash".into(),
+            args: json!({"command": "echo hello"}),
+            timeout_secs: 120,
+        };
+        let v = serde_json::to_value(&msg).unwrap();
+        assert_eq!(v["type"], "edge_tool_request");
+        assert_eq!(v["tool"], "bash");
+        assert_eq!(v["timeout_secs"], 120);
+    }
+
+    #[test]
+    fn edge_ping_deserializes() {
+        let msg: EdgeClientMessage =
+            serde_json::from_value(json!({"type": "edge_ping"})).unwrap();
+        assert!(matches!(msg, EdgeClientMessage::Ping));
+    }
+
+    #[test]
+    fn edge_pong_serializes() {
+        let msg = EdgeServerMessage::Pong;
+        let v = serde_json::to_value(&msg).unwrap();
+        assert_eq!(v["type"], "edge_pong");
+    }
+
+    #[test]
+    fn edge_auth_ok_serializes() {
+        let msg = EdgeServerMessage::AuthOk {
+            user_id: "u-123".into(),
+        };
+        let v = serde_json::to_value(&msg).unwrap();
+        assert_eq!(v["type"], "edge_auth_ok");
+        assert_eq!(v["user_id"], "u-123");
+    }
+
+    #[test]
+    fn constants_are_reasonable() {
+        assert!(EDGE_TOOL_TIMEOUT_SECS >= 60);
+        assert!(EDGE_AUTH_TIMEOUT_SECS >= 10);
+        assert!(EDGE_HEARTBEAT_INTERVAL_SECS >= 10);
+    }
+}

--- a/rust/crates/runtime/src/server/mod.rs
+++ b/rust/crates/runtime/src/server/mod.rs
@@ -53,6 +53,7 @@ mod ws_handler;
 pub mod edge_ws_protocol;
 pub mod edge_connection_pool;
 mod edge_ws_handler;
+mod edge_status_handler;
 
 use self::{
     bridge_prep::prepare_chat_turn_bridge_body,

--- a/rust/crates/runtime/src/server/mod.rs
+++ b/rust/crates/runtime/src/server/mod.rs
@@ -41,6 +41,7 @@ pub mod run_engine;
 mod run_handlers;
 pub mod run_lifecycle;
 pub mod server_loop_host;
+pub mod server_skill_subrun;
 pub mod server_tool_executor;
 mod session_handlers;
 mod state_builder;

--- a/rust/crates/runtime/src/server/mod.rs
+++ b/rust/crates/runtime/src/server/mod.rs
@@ -50,6 +50,9 @@ mod team_handlers;
 pub mod team_orchestrator;
 pub mod worktree_isolation;
 mod ws_handler;
+pub mod edge_ws_protocol;
+pub mod edge_connection_pool;
+mod edge_ws_handler;
 
 use self::{
     bridge_prep::prepare_chat_turn_bridge_body,

--- a/rust/crates/runtime/src/server/router_builder.rs
+++ b/rust/crates/runtime/src/server/router_builder.rs
@@ -48,6 +48,8 @@ pub(super) fn build_router(state: AppState) -> Router {
         .route("/chat/ws", get(ws_handler::ws_chat_handler))
         // WebSocket endpoint for remote edge agent connections (Phase 6)
         .route("/edge/ws", get(edge_ws_handler::edge_ws_handler))
+        // Edge connection status (authenticated, returns user's connected edges)
+        .route("/edges/status", get(edge_status_handler::edge_status_handler))
         .route(
             "/chat/runs/{run_id}",
             get(run_handlers::get_run_status_handler).delete(run_handlers::cancel_run_handler),

--- a/rust/crates/runtime/src/server/router_builder.rs
+++ b/rust/crates/runtime/src/server/router_builder.rs
@@ -46,6 +46,8 @@ pub(super) fn build_router(state: AppState) -> Router {
         )
         // WebSocket endpoint for browser-based agent access
         .route("/chat/ws", get(ws_handler::ws_chat_handler))
+        // WebSocket endpoint for remote edge agent connections (Phase 6)
+        .route("/edge/ws", get(edge_ws_handler::edge_ws_handler))
         .route(
             "/chat/runs/{run_id}",
             get(run_handlers::get_run_status_handler).delete(run_handlers::cancel_run_handler),

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -56,8 +56,7 @@ use super::server_loop_host::ServerAgenticLoopHostBuilder;
 /// Build skill registry + resolver for server-side agentic loops.
 ///
 /// Returns `(registry_for_activation, resolver)` using the global default
-/// registry (Local + Bundled providers). Fork-context skills require a
-/// `skill_executor` which is CLI-only; the server gets inline resolution only.
+/// registry (Local + Bundled providers).
 fn build_server_skill_resolver() -> (
     Option<Arc<crate::skills::UnifiedSkillRegistry>>,
     Option<Arc<dyn crate::turn::skill_tool::SkillResolver>>,
@@ -79,6 +78,37 @@ fn build_server_skill_resolver() -> (
         Some(Arc::new(adapter))
     };
     (Some(registry), resolver)
+}
+
+/// Build a server-side skill executor that supports both Inline and Fork
+/// execution contexts via [`SkillExecutionRouter`].
+fn build_server_skill_executor(
+    matrixone: &MatrixOneSettings,
+    encryptor: &Arc<FernetTokenEncryptor>,
+    shared_pool: Option<&SharedPool>,
+    model_override: Option<&str>,
+    edge_tools: &[Value],
+    edge_profile: &Map<String, Value>,
+    skill_resolver: Option<Arc<dyn crate::turn::skill_tool::SkillResolver>>,
+    session_id: &str,
+) -> Option<Arc<dyn crate::skills::traits::SkillExecutor>> {
+    use super::server_skill_subrun::ServerSkillSubRunExecutor;
+    use crate::skills::executor::isolated::{IsolatedSkillExecutor, SkillExecutionRouter};
+
+    let subrun_executor = ServerSkillSubRunExecutor::new(
+        matrixone.clone(),
+        Arc::clone(encryptor),
+        session_id.to_string(),
+    )
+    .with_pool(shared_pool.cloned())
+    .with_default_model(model_override.map(String::from))
+    .with_edge_tools(edge_tools.to_vec())
+    .with_edge_profile(edge_profile.clone())
+    .with_skill_resolver(skill_resolver);
+
+    let isolated = Arc::new(IsolatedSkillExecutor::new(Arc::new(subrun_executor)));
+    let router = SkillExecutionRouter::new(Some(isolated));
+    Some(Arc::new(router))
 }
 
 fn skill_search_from_context(
@@ -666,6 +696,21 @@ impl AgenticRunLifecycleService {
             .map(|root| crate::skills::hooks::load_all_hooks(std::path::Path::new(root)))
             .unwrap_or_default();
 
+        // Build the server-side skill fork executor so skills with
+        // execution_context: Fork can run in isolated sub-agent loops.
+        let edge_tools = Self::extract_edge_tools(request);
+        let edge_profile = Self::extract_edge_profile(request);
+        let skill_executor = build_server_skill_executor(
+            &self.matrixone,
+            &self.encryptor,
+            self.shared_pool.as_ref(),
+            request.model.as_deref(),
+            &edge_tools,
+            &edge_profile,
+            skill_resolver.clone(),
+            session_id,
+        );
+
         AgenticLoopState {
             messages: vec![user_message],
             tool_results: Vec::new(),
@@ -699,6 +744,7 @@ impl AgenticRunLifecycleService {
             skills: SkillState {
                 registry_for_activation: skill_registry,
                 resolver: skill_resolver,
+                executor: skill_executor,
                 quality_tracker: crate::skills::quality::SkillQualityTracker::new(),
                 improvement_tracker: crate::skills::improvement::ImprovementTracker::new(),
                 search: skill_search,

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -654,11 +654,16 @@ impl AgenticRunLifecycleService {
     }
 
     /// Build the initial [`AgenticLoopState`] from a chat request.
+    ///
+    /// `workspace_override` — when the server provisions a workspace (web-agent
+    /// mode, no CLI edge), pass it here so stop hooks and skill hooks are loaded
+    /// from the provisioned directory instead of requiring `edge_profile.cwd`.
     fn build_initial_state(
         &self,
         request: &ChatRequestData,
         session_id: &str,
         run_id: &str,
+        workspace_override: Option<&std::path::Path>,
     ) -> AgenticLoopState {
         use crate::pipeline::step_protocol::InMemoryIdempotencyCache;
         use crate::semantic_dedup::SemanticDedup;
@@ -678,7 +683,10 @@ impl AgenticRunLifecycleService {
         let max_turns = request.max_candidates.max(1) as usize;
         let task_profile = infer_task_execution_profile(&request.message);
         let edge_ctx = Self::extract_edge_context(request);
-        let project_root_buf = project_root_for_stop_hooks(&edge_ctx);
+        // Use edge profile's git_root/cwd if available; fall back to provisioned
+        // server workspace so web-agent sessions still load stop-hooks.yaml.
+        let project_root_buf = project_root_for_stop_hooks(&edge_ctx)
+            .or_else(|| workspace_override.map(|p| p.to_path_buf()));
         let hook_sets = project_root_buf
             .as_ref()
             .map(|root| {
@@ -959,8 +967,18 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         // Spawn background agentic loop.
         let edge_tools = Self::extract_edge_tools(&request);
         let edge_profile = Self::extract_edge_profile(&request);
+
+        // Provision workspace early so build_initial_state can load stop hooks
+        // from the provisioned directory when no edge profile supplies cwd.
+        let server_workspace = if edge_tools.is_empty() {
+            Some(self.provision_server_workspace(&session_id))
+        } else {
+            None
+        };
+
         let mut host = self.build_host(&user_id, &session_id, &request, edge_tools, edge_profile);
-        let mut loop_state = self.build_initial_state(&request, &session_id, &run_id);
+        let mut loop_state =
+            self.build_initial_state(&request, &session_id, &run_id, server_workspace.as_deref());
         self.configure_loop_state_runtime_controls(
             &mut loop_state,
             &cancel_flag,
@@ -977,10 +995,9 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         .await;
 
         // ── Server-side tool execution (web-only mode) ─────────────────
-        // When no edge tools are provided (no CLI connected), provision a
-        // ServerToolExecutor so tools execute directly on the server.
-        if host.edge_tools_empty() {
-            let workspace = self.provision_server_workspace(&session_id);
+        // When no edge tools are provided (no CLI connected), use the
+        // already-provisioned workspace for the ServerToolExecutor.
+        if let Some(workspace) = server_workspace {
             let memoria_base = std::env::var("MEMORIA_BASE_URL").ok();
             let executor = super::server_tool_executor::ServerToolExecutor::new(
                 workspace,
@@ -1111,10 +1128,19 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         let edge_tools = Self::extract_edge_tools(&request);
         let edge_profile = Self::extract_edge_profile(&request);
 
+        // Provision workspace early for web-agent mode (no edge tools) so
+        // build_initial_state loads stop hooks from the provisioned directory.
+        let server_workspace = if edge_tools.is_empty() {
+            Some(self.provision_server_workspace(&session_id))
+        } else {
+            None
+        };
+
         // If no edge tools are provided, return a minimal "no tools" response.
         // The client (CLI thin-client) is expected to provide edge_tools in context.
         let mut host = self.build_host(&user_id, &session_id, &request, edge_tools, edge_profile);
-        let mut state = self.build_initial_state(&request, &session_id, &run_id);
+        let mut state =
+            self.build_initial_state(&request, &session_id, &run_id, server_workspace.as_deref());
         let (run_state, cancel_flag, pause_flag, llm_cancel_token) =
             Self::build_tracked_run_state(run_id.clone(), session_id.clone(), user_id.clone());
         self.runs.write().await.insert(run_id.clone(), run_state);
@@ -1864,7 +1890,7 @@ mod tests {
     fn seed_restricted_tools_from_blocked_patterns_adds_blocked_tools() {
         let svc = test_service();
         let request = test_request("inspect blocked tools");
-        let mut state = svc.build_initial_state(&request, "session-1", "run-1");
+        let mut state = svc.build_initial_state(&request, "session-1", "run-1", None);
         let mut pattern_library = crate::pipeline::pattern::PatternLibrary::new();
 
         for _ in 0..3 {
@@ -1889,7 +1915,7 @@ mod tests {
     fn finalize_run_events_appends_run_finished_for_failures() {
         let svc = test_service();
         let request = test_request("boom");
-        let state = svc.build_initial_state(&request, "session-1", "run-1");
+        let state = svc.build_initial_state(&request, "session-1", "run-1", None);
 
         let (events, status, error) = AgenticRunLifecycleService::finalize_run_events(
             Ok(AgenticLoopOutcome::Error("boom".into())),
@@ -1908,7 +1934,7 @@ mod tests {
     fn finalize_run_events_cancellation_beats_completed_outcome() {
         let svc = test_service();
         let request = test_request("done");
-        let mut state = svc.build_initial_state(&request, "session-1", "run-1");
+        let mut state = svc.build_initial_state(&request, "session-1", "run-1", None);
         let cancel_flag = Arc::new(AtomicBool::new(true));
         let cancel_token = Arc::new(CancellationToken::new());
         cancel_token.cancel();
@@ -2270,7 +2296,7 @@ mod tests {
     fn build_initial_state_sets_user_message() {
         let svc = test_service();
         let req = test_request("write a test");
-        let state = svc.build_initial_state(&req, "sess-1", "run-1");
+        let state = svc.build_initial_state(&req, "sess-1", "run-1", None);
         assert_eq!(state.messages.len(), 1);
         assert_eq!(state.messages[0]["role"], "user");
         assert_eq!(state.messages[0]["content"], "write a test");
@@ -2287,7 +2313,7 @@ mod tests {
         let svc = test_service();
         let mut req = test_request("go");
         req.max_candidates = 0;
-        let state = svc.build_initial_state(&req, "s", "r");
+        let state = svc.build_initial_state(&req, "s", "r", None);
         assert_eq!(state.max_turns, 1);
     }
 
@@ -2313,12 +2339,77 @@ mod tests {
             .clone(),
         );
 
-        let state = svc.build_initial_state(&req, "s", "r");
+        let state = svc.build_initial_state(&req, "s", "r", None);
         assert_eq!(state.hooks.stop_hooks.len(), 1);
         assert_eq!(state.hooks.stop_hooks[0].label, "cloud_hook");
         assert_eq!(
             state.hooks.workspace_root_hint.as_deref(),
             Some(dir.path().to_str().unwrap())
+        );
+    }
+
+    #[test]
+    fn build_initial_state_uses_workspace_override_when_no_edge_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let mo = dir.path().join(".astra");
+        std::fs::create_dir_all(&mo).unwrap();
+        std::fs::write(
+            mo.join("stop-hooks.yaml"),
+            "version: 1\nauto_detect: false\nhooks:\n  - label: server_hook\n    command: echo ok\n",
+        )
+        .unwrap();
+
+        let svc = test_service();
+        // Request with NO edge_profile.cwd — simulates web-agent mode.
+        let req = test_request("fix a bug");
+        let state = svc.build_initial_state(&req, "s", "r", Some(dir.path()));
+        assert_eq!(state.hooks.stop_hooks.len(), 1);
+        assert_eq!(state.hooks.stop_hooks[0].label, "server_hook");
+        assert_eq!(
+            state.hooks.workspace_root_hint.as_deref(),
+            Some(dir.path().to_str().unwrap())
+        );
+    }
+
+    #[test]
+    fn build_initial_state_edge_cwd_takes_priority_over_workspace_override() {
+        // Edge profile with cwd set — workspace_override should be ignored.
+        let edge_dir = tempfile::tempdir().unwrap();
+        let mo = edge_dir.path().join(".astra");
+        std::fs::create_dir_all(&mo).unwrap();
+        std::fs::write(
+            mo.join("stop-hooks.yaml"),
+            "version: 1\nauto_detect: false\nhooks:\n  - label: edge_hook\n    command: true\n",
+        )
+        .unwrap();
+
+        let override_dir = tempfile::tempdir().unwrap();
+        let mo2 = override_dir.path().join(".astra");
+        std::fs::create_dir_all(&mo2).unwrap();
+        std::fs::write(
+            mo2.join("stop-hooks.yaml"),
+            "version: 1\nauto_detect: false\nhooks:\n  - label: override_hook\n    command: true\n",
+        )
+        .unwrap();
+
+        let svc = test_service();
+        let mut req = test_request("deploy");
+        req.context = Some(
+            serde_json::json!({
+                "edge_profile": { "cwd": edge_dir.path().to_str().unwrap() }
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+        );
+
+        let state = svc.build_initial_state(&req, "s", "r", Some(override_dir.path()));
+        // Edge profile's cwd wins over the workspace override.
+        assert_eq!(state.hooks.stop_hooks.len(), 1);
+        assert_eq!(state.hooks.stop_hooks[0].label, "edge_hook");
+        assert_eq!(
+            state.hooks.workspace_root_hint.as_deref(),
+            Some(edge_dir.path().to_str().unwrap())
         );
     }
 

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -426,6 +426,8 @@ pub struct AgenticRunLifecycleService {
     run_engine: Option<RunEngine>,
     /// Optional delegation engine for multi-agent coordination.
     delegation_engine: Option<Arc<crate::server::delegation_engine::DelegationEngine>>,
+    /// Live edge WebSocket connection pool (Phase 6).
+    edge_connection_pool: Option<super::edge_connection_pool::EdgeConnectionPool>,
 }
 
 impl AgenticRunLifecycleService {
@@ -442,6 +444,7 @@ impl AgenticRunLifecycleService {
             edge_callback_ledger,
             run_engine: None,
             delegation_engine: None,
+            edge_connection_pool: None,
         }
     }
 
@@ -460,6 +463,14 @@ impl AgenticRunLifecycleService {
         engine: Arc<crate::server::delegation_engine::DelegationEngine>,
     ) -> Self {
         self.delegation_engine = Some(engine);
+        self
+    }
+
+    pub fn with_edge_connection_pool(
+        mut self,
+        pool: super::edge_connection_pool::EdgeConnectionPool,
+    ) -> Self {
+        self.edge_connection_pool = Some(pool);
         self
     }
 
@@ -999,13 +1010,16 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         // already-provisioned workspace for the ServerToolExecutor.
         if let Some(workspace) = server_workspace {
             let memoria_base = std::env::var("MEMORIA_BASE_URL").ok();
-            let executor = super::server_tool_executor::ServerToolExecutor::new(
+            let mut executor = super::server_tool_executor::ServerToolExecutor::new(
                 workspace,
                 user_id.clone(),
                 session_id.clone(),
                 memoria_base,
                 None,
             );
+            if let Some(pool) = &self.edge_connection_pool {
+                executor.set_edge_connection_pool(pool.clone());
+            }
             loop_state.server_tool_executor = Some(std::sync::Arc::new(executor));
         }
 

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -28,6 +28,10 @@ use crate::turn::agentic_loop_host::{
     AgenticLoopHost, AgenticLoopState, HostReflectionRequest, HostReflectionResult, HostTurnResult,
     TurnInteractionMode, TurnInteractionPolicy, interaction_scoped_tool_restrictions,
 };
+use crate::turn::bridge_inprocess::{
+    PromptCacheConfig, add_message_cache_breakpoint, annotate_tool_schemas_for_caching,
+    build_system_message,
+};
 use crate::turn::chat_turn_sse_dispatch::ChatTurnSseAccum;
 use crate::turn::llm_client::{
     LlmCallResult, LlmCancel, cached_system_prompt, call_llm_and_collect, classify_llm_error,
@@ -251,7 +255,17 @@ impl ServerAgenticLoopHost {
 
     /// Build the system prompt from edge context and the tool schemas visible
     /// to the current turn.
-    fn build_system_prompt(&self, user_content: &str, tools: &[Value]) -> String {
+    ///
+    /// Returns `(structured_system_messages, plain_text_for_estimates)`.
+    /// The structured messages include Anthropic cache_control annotations when
+    /// applicable, enabling prompt caching on the runs path.
+    fn build_system_messages_cached(
+        &self,
+        user_content: &str,
+        tools: &[Value],
+        state: &AgenticLoopState,
+        cache_cfg: &PromptCacheConfig,
+    ) -> (Vec<Value>, String) {
         let tool_names: Vec<&str> = tools
             .iter()
             .filter_map(|t| {
@@ -308,12 +322,19 @@ impl ServerAgenticLoopHost {
         };
         let profile_with_hints = format!("{profile_desc}{skill_hint}{learned_context_hint}");
 
-        let base = cached_system_prompt(
-            &tool_names,
-            &profile_with_hints,
-            self.selection_confidence,
-            task_type,
-        );
+        // Skill effort/agent_type hints (dynamic per-turn)
+        let mut extra_dynamic = String::new();
+        if let Some(ref effort) = state.skills.effort {
+            extra_dynamic.push_str(&format!(
+                "\n\n## Effort Level\nThe active skill requests effort level: **{effort}**. \
+                 Adjust thoroughness accordingly.",
+            ));
+        }
+        if let Some(ref agent_type) = state.skills.agent_type {
+            extra_dynamic.push_str(&format!(
+                "\n\n## Agent Type\nYou are acting as a **{agent_type}** agent for this skill.",
+            ));
+        }
 
         // Memory signal detection
         let memory_signal_hint = if let Some(category) =
@@ -337,7 +358,33 @@ impl ServerAgenticLoopHost {
             .map(|s| format!("\n\n{s}"))
             .unwrap_or_default();
 
-        format!("{base}{memory_signal_hint}{system_override}")
+        // All dynamic per-turn content (not cached)
+        let full_dynamic =
+            format!("{profile_with_hints}{extra_dynamic}{memory_signal_hint}{system_override}");
+
+        // Build structured system messages with Anthropic cache annotations.
+        // Stable sections (Global/Session) get cache_control; dynamic content does not.
+        let (sys_msg, dynamic_msg, _sections) = build_system_message(
+            &tool_names,
+            &full_dynamic,
+            self.selection_confidence,
+            task_type,
+            cache_cfg,
+        );
+        let mut system_messages = vec![sys_msg];
+        if let Some(dm) = dynamic_msg {
+            system_messages.push(dm);
+        }
+
+        // Plain text for token estimation (no cache annotations)
+        let plain = cached_system_prompt(
+            &tool_names,
+            &full_dynamic,
+            self.selection_confidence,
+            task_type,
+        );
+
+        (system_messages, plain)
     }
 
     /// Compute the tool schemas visible for the current turn after applying
@@ -356,21 +403,91 @@ impl ServerAgenticLoopHost {
         self.filtered_turn_tools(&state.restricted_tools)
     }
 
+    /// Test-only: returns the plain-text system prompt (no cache annotations).
+    #[cfg(test)]
+    fn build_system_prompt(&self, user_content: &str, visible_tools: &[Value]) -> String {
+        let tool_names: Vec<&str> = visible_tools
+            .iter()
+            .filter_map(|t| {
+                t.get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(Value::as_str)
+            })
+            .collect();
+
+        // Replicate the dynamic section assembly from build_system_messages_cached.
+        let mut profile_parts = Vec::new();
+        if let Some(cwd) = self.edge_profile.get("cwd").and_then(Value::as_str) {
+            profile_parts.push(format!("cwd: {cwd}"));
+        }
+        if let Some(branch) = self.edge_profile.get("git_branch").and_then(Value::as_str) {
+            profile_parts.push(format!("git_branch: {branch}"));
+        }
+        let skill_hint = self
+            .edge_profile
+            .get("active_skills")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                let names: Vec<&str> = arr.iter().filter_map(Value::as_str).collect();
+                if names.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        "\n\n## Active Output Skills\nThe user has enabled these output constraints: {}. \
+                         Follow their formatting rules strictly.",
+                        names.join(", ")
+                    )
+                }
+            })
+            .unwrap_or_default();
+        let learned_context_hint = self
+            .edge_profile
+            .get("learned_context_hint")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(|hint| format!("\n\n## Learned Runtime Context\n{hint}"))
+            .unwrap_or_default();
+        let task_type = crate::prompts::detect_task_type(user_content);
+        let profile_desc = if profile_parts.is_empty() {
+            String::new()
+        } else {
+            format!("\n\n# Project Profile\n{}", profile_parts.join("\n"))
+        };
+        let memory_signal_hint = if let Some(category) =
+            crate::prompts::memory_lifecycle::detect_store_signal(user_content)
+        {
+            let ns = crate::prompts::memory_lifecycle::suggest_namespace(category);
+            format!(
+                "\n\n⚡ MEMORY SIGNAL DETECTED: category=\"{category}\", namespace=\"{ns}\". \
+                 Store the user's intent with memory_store BEFORE doing anything else."
+            )
+        } else {
+            String::new()
+        };
+        let full_dynamic =
+            format!("{profile_desc}{skill_hint}{learned_context_hint}{memory_signal_hint}");
+
+        cached_system_prompt(
+            &tool_names,
+            &full_dynamic,
+            self.selection_confidence,
+            task_type,
+        )
+    }
+
     /// Build the LLM message array from loop state.
     async fn build_llm_messages(
         &self,
-        system_prompt: &str,
+        system_messages: Vec<Value>,
         state: &AgenticLoopState,
         visible_tools: &[Value],
         model_name: &str,
         api_key: &str,
         base_url: &str,
         provider: &str,
+        cache_cfg: &PromptCacheConfig,
     ) -> Vec<Value> {
-        let mut llm_messages = vec![json!({
-            "role": "system",
-            "content": system_prompt
-        })];
+        let mut llm_messages = system_messages;
 
         // Compute compaction tier
         let budget = crate::prompts::budget_for_model(Some(model_name));
@@ -478,6 +595,9 @@ impl ServerAgenticLoopHost {
             llm_messages.push(listing.clone());
         }
 
+        // Add cache breakpoint on the last conversation message for Anthropic.
+        add_message_cache_breakpoint(&mut llm_messages, cache_cfg);
+
         llm_messages
     }
 
@@ -493,6 +613,16 @@ impl ServerAgenticLoopHost {
             .get("completion")
             .and_then(Value::as_u64)
             .unwrap_or(0);
+        let cache_read_tokens = result
+            .usage
+            .get("cache_read_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let cache_creation_tokens = result
+            .usage
+            .get("cache_creation_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
 
         ChatTurnSseAccum {
             full_text: result.full_text.clone(),
@@ -501,8 +631,8 @@ impl ServerAgenticLoopHost {
             has_tool_calls: !result.tool_calls.is_empty(),
             prompt_tokens,
             completion_tokens,
-            cache_read_tokens: 0,
-            cache_creation_tokens: 0,
+            cache_read_tokens,
+            cache_creation_tokens,
             has_usage: !result.usage.is_empty(),
             session_id: None,
             run_id: None,
@@ -631,31 +761,24 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
             TurnInteractionMode::Headless,
         ));
         let visible_tools = self.filtered_turn_tools(&effective_restricted);
-        let system_prompt = self.build_system_prompt(&user_content, &visible_tools);
 
-        // Append skill-level hints (effort, agent_type) when active.
-        let mut system_prompt = system_prompt;
-        if let Some(ref effort) = state.skills.effort {
-            system_prompt.push_str(&format!(
-                "\n\n## Effort Level\nThe active skill requests effort level: **{effort}**. \
-                 Adjust thoroughness accordingly.",
-            ));
-        }
-        if let Some(ref agent_type) = state.skills.agent_type {
-            system_prompt.push_str(&format!(
-                "\n\n## Agent Type\nYou are acting as a **{agent_type}** agent for this skill.",
-            ));
-        }
+        // Latch prompt cache config from provider info (once per turn is fine;
+        // provider doesn't change within a turn).
+        let cache_cfg = PromptCacheConfig::latch(&provider, &model_name);
+
+        let (system_messages, system_prompt_plain) =
+            self.build_system_messages_cached(&user_content, &visible_tools, state, &cache_cfg);
 
         let llm_messages = self
             .build_llm_messages(
-                &system_prompt,
+                system_messages,
                 state,
                 &visible_tools,
                 &model_name,
                 &api_key,
                 &base_url,
                 &provider,
+                &cache_cfg,
             )
             .await;
 
@@ -671,7 +794,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                     .unwrap_or(50)
             })
             .sum();
-        let mut est_msgs = vec![json!({"role": "system", "content": system_prompt})];
+        let mut est_msgs = vec![json!({"role": "system", "content": system_prompt_plain})];
         est_msgs.extend(state.messages.iter().cloned());
         let cache_est = crate::prompts::estimate_tokens_cache_aware(&est_msgs, tool_schema_tokens);
         let tier = crate::prompts::compaction_tier_calibrated(
@@ -680,7 +803,9 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
             state.last_measured_prompt_tokens,
             state.consecutive_context_window_errors,
         );
-        let final_tools = prune_tool_schemas(&visible_tools, tier);
+        let mut final_tools = prune_tool_schemas(&visible_tools, tier);
+        // Annotate tool schemas with cache_control for Anthropic.
+        annotate_tool_schemas_for_caching(&mut final_tools, &cache_cfg);
         state.last_turn_policy =
             TurnInteractionPolicy::from_tool_schemas(TurnInteractionMode::Headless, &final_tools);
 
@@ -1300,13 +1425,14 @@ mod tests {
 
         let msgs = host
             .build_llm_messages(
-                "system prompt text",
+                vec![json!({"role": "system", "content": "system prompt text"})],
                 &state,
                 &host.edge_tools,
                 "gpt-4",
                 "sk-test",
                 "https://api.test.com",
                 "openai",
+                &PromptCacheConfig::latch("openai", "gpt-4"),
             )
             .await;
         assert!(msgs.len() >= 2, "should have system + user messages");

--- a/rust/crates/runtime/src/server/server_skill_subrun.rs
+++ b/rust/crates/runtime/src/server/server_skill_subrun.rs
@@ -1,0 +1,371 @@
+//! Server-side skill fork (sub-run) executor.
+//!
+//! Enables skills with `execution_context: Fork` to run in isolated sub-agent
+//! loops on the server, matching the CLI's `CliSkillSubRunExecutor` behavior.
+//!
+//! Each sub-run creates a fresh [`ServerAgenticLoopHost`] +
+//! [`AgenticLoopState`] pair and runs [`run_agentic_loop_with_host`] to
+//! completion, inheriting the parent's LLM credentials, skill resolver,
+//! and cancellation token.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Map, Value, json};
+use tokio::sync::Mutex as TokioMutex;
+
+use astra_core::SharedPool;
+
+use crate::FernetTokenEncryptor;
+use crate::MatrixOneSettings;
+use crate::pipeline::step_protocol::InMemoryIdempotencyCache;
+use crate::pipeline::step_recorder::StepRecorder;
+use crate::semantic_dedup::SemanticDedup;
+use crate::skills::executor::isolated::{SkillSubRunExecutor, SubRunResult};
+use crate::turn::agentic_loop_host::{
+    AgenticLoopHost as _, AgenticLoopState, CancellationState, SkillState, StopHookState,
+    TurnInteractionPolicy, run_agentic_loop_with_host,
+};
+use crate::turn::chat_turn_heuristics::infer_task_execution_profile;
+use crate::turn::turn_guard::TurnGuard;
+
+use super::server_loop_host::ServerAgenticLoopHostBuilder;
+
+/// Maximum turns for a skill sub-run (matches CLI's SUBRUN_MAX_TURNS).
+const SUBRUN_MAX_TURNS: usize = 30;
+
+/// Maximum cumulative tokens for a skill sub-run.
+const SUBRUN_MAX_CUMULATIVE_TOKENS: u64 = 500_000;
+
+/// Server-side implementation of [`SkillSubRunExecutor`].
+///
+/// Creates a [`ServerAgenticLoopHost`] for each sub-run with isolated context
+/// but shared LLM credentials and skill resolver.
+pub struct ServerSkillSubRunExecutor {
+    matrixone: MatrixOneSettings,
+    encryptor: Arc<FernetTokenEncryptor>,
+    shared_pool: Option<SharedPool>,
+    /// Default model to use when the skill manifest doesn't specify one.
+    default_model: Option<String>,
+    /// Edge tools available to sub-runs (inherited from parent host).
+    edge_tools: Vec<Value>,
+    /// Edge profile (cwd, git_branch, etc.) inherited from parent.
+    edge_profile: Map<String, Value>,
+    /// Skill resolver inherited from parent — enables nested inline skills.
+    skill_resolver: Option<Arc<dyn crate::turn::skill_tool::SkillResolver>>,
+    /// Parent cancellation token — propagated so stop/cancel interrupts sub-runs.
+    cancel_token: Option<Arc<tokio_util::sync::CancellationToken>>,
+    /// Session ID for the parent run.
+    session_id: String,
+}
+
+impl ServerSkillSubRunExecutor {
+    pub fn new(
+        matrixone: MatrixOneSettings,
+        encryptor: Arc<FernetTokenEncryptor>,
+        session_id: String,
+    ) -> Self {
+        Self {
+            matrixone,
+            encryptor,
+            shared_pool: None,
+            default_model: None,
+            edge_tools: Vec::new(),
+            edge_profile: Map::new(),
+            skill_resolver: None,
+            cancel_token: None,
+            session_id,
+        }
+    }
+
+    pub fn with_pool(mut self, pool: Option<SharedPool>) -> Self {
+        self.shared_pool = pool;
+        self
+    }
+
+    pub fn with_default_model(mut self, model: Option<String>) -> Self {
+        self.default_model = model;
+        self
+    }
+
+    pub fn with_edge_tools(mut self, tools: Vec<Value>) -> Self {
+        self.edge_tools = tools;
+        self
+    }
+
+    pub fn with_edge_profile(mut self, profile: Map<String, Value>) -> Self {
+        self.edge_profile = profile;
+        self
+    }
+
+    pub fn with_skill_resolver(
+        mut self,
+        resolver: Option<Arc<dyn crate::turn::skill_tool::SkillResolver>>,
+    ) -> Self {
+        self.skill_resolver = resolver;
+        self
+    }
+
+    pub fn with_cancel_token(
+        mut self,
+        token: Option<Arc<tokio_util::sync::CancellationToken>>,
+    ) -> Self {
+        self.cancel_token = token;
+        self
+    }
+}
+
+#[async_trait]
+impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
+    async fn execute_skill_subrun(
+        &self,
+        skill_name: &str,
+        instructions: &str,
+        task_context: &str,
+        model: Option<&str>,
+        _max_tokens: Option<u32>,
+        allowed_tools: &[String],
+        parent_recursion_depth: u8,
+        effort: Option<&str>,
+        agent_type: Option<&str>,
+    ) -> Result<SubRunResult, String> {
+        let child_recursion_depth =
+            crate::turn::agentic_recursion_guard::checked_child_recursion_depth(
+                parent_recursion_depth,
+            )?;
+
+        let effective_model = model
+            .map(String::from)
+            .or_else(|| self.default_model.clone());
+
+        // Build a sub-run session ID for isolation.
+        let safe_name = crate::skills::loader::sanitize_for_path(skill_name);
+        let subrun_session_id = format!(
+            "subrun-{}-{}",
+            safe_name,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_micros()
+        );
+
+        // Build the host for the sub-run.
+        let mut builder = ServerAgenticLoopHostBuilder::new(
+            self.matrixone.clone(),
+            self.encryptor.clone(),
+            String::new(), // sub-runs don't need user_id for LLM calls
+            subrun_session_id.clone(),
+        )
+        .with_model(effective_model)
+        .with_edge_tools(self.edge_tools.clone())
+        .with_edge_profile(self.edge_profile.clone())
+        .with_edge_callback_ledger(Arc::new(TokioMutex::new(HashMap::new())));
+
+        if let Some(pool) = &self.shared_pool {
+            builder = builder.with_pool(pool.clone());
+        }
+
+        let mut host = builder.build();
+
+        // Build tool restriction set: if allowed_tools is non-empty, only those
+        // tools (plus skill discovery) are permitted.
+        let valid_tool_names = host.valid_tool_names();
+        let restricted_tools: HashSet<String> = if allowed_tools.is_empty() {
+            HashSet::new()
+        } else {
+            let allowed: HashSet<&str> = allowed_tools.iter().map(|s| s.as_str()).collect();
+            valid_tool_names
+                .iter()
+                .filter(|name: &&String| {
+                    !allowed.contains(name.as_str())
+                        && name.as_str() != crate::turn::skill_tool::SKILL_TOOL_NAME
+                        && name.as_str() != crate::turn::skill_tool::DISCOVER_SKILLS_TOOL_NAME
+                })
+                .cloned()
+                .collect()
+        };
+
+        // Build initial messages: system = skill instructions, user = task context.
+        let messages = vec![
+            json!({
+                "role": "system",
+                "content": instructions,
+            }),
+            json!({
+                "role": "user",
+                "content": if task_context.is_empty() {
+                    format!("Execute the skill '{skill_name}' according to the instructions above.")
+                } else {
+                    task_context.to_string()
+                },
+            }),
+        ];
+
+        let task_profile = infer_task_execution_profile(task_context);
+        let workspace_root_hint = self
+            .edge_profile
+            .get("cwd")
+            .and_then(Value::as_str)
+            .map(String::from);
+
+        let (tool_event_hooks, session_event_hooks) = workspace_root_hint
+            .as_ref()
+            .map(|root| crate::skills::hooks::load_all_hooks(std::path::Path::new(root)))
+            .unwrap_or_default();
+
+        let step_recorder = StepRecorder::new(&subrun_session_id, &subrun_session_id);
+
+        let mut state = AgenticLoopState {
+            messages,
+            tool_results: Vec::new(),
+            current_session_id: Some(self.session_id.clone()),
+            current_run_id: None,
+            recursion_depth: child_recursion_depth,
+            final_text: String::new(),
+            total_prompt: 0,
+            total_completion: 0,
+            total_cache_read: 0,
+            total_cache_creation: 0,
+            total_tool_calls: 0,
+            total_evidence_tool_calls: 0,
+            has_any_usage: false,
+            max_turns: SUBRUN_MAX_TURNS,
+            remaining_turns: SUBRUN_MAX_TURNS,
+            turn_guard: TurnGuard::with_profile(task_profile),
+            restricted_tools,
+            step_recorder,
+            idempotency_cache: InMemoryIdempotencyCache::new(),
+            semantic_dedup: SemanticDedup::new(crate::semantic_dedup::DEFAULT_SIMILARITY_THRESHOLD),
+            call_counts: HashMap::new(),
+            max_identical_tool_calls: crate::runtime_config::RuntimeConfig::load()
+                .tool_selection
+                .effective_max_identical_calls(),
+            max_tools_per_turn: crate::runtime_config::RuntimeConfig::load()
+                .tool_selection
+                .effective_max_tools_per_turn(),
+            stall: Default::default(),
+            telemetry: Default::default(),
+            skills: SkillState {
+                // Inherit resolver for nested inline skills, but NO executor
+                // to prevent Fork→Fork recursion (same as CLI design).
+                resolver: self.skill_resolver.clone(),
+                quality_tracker: crate::skills::quality::SkillQualityTracker::new(),
+                improvement_tracker: crate::skills::improvement::ImprovementTracker::new(),
+                tool_event_hooks,
+                session_event_hooks,
+                // Skill-level effort/agent_type from manifest
+                effort: effort.and_then(crate::skills::manifest::EffortLevel::parse),
+                agent_type: agent_type.map(String::from),
+                ..Default::default()
+            },
+            hooks: StopHookState {
+                workspace_root_hint,
+                ..Default::default()
+            },
+            cancellation: CancellationState {
+                flag: None,
+                pause_flag: None,
+                token: self.cancel_token.clone(),
+            },
+            messaging: Default::default(),
+            error_recovery: Default::default(),
+            message: task_context.to_string(),
+            recent_tools: Vec::new(),
+            task_profile: infer_task_execution_profile(task_context),
+            last_turn_policy: TurnInteractionPolicy::default(),
+            api: astra_thin_client::ThinClient::new("http://127.0.0.1:1", None)
+                .expect("valid dummy URL"),
+            api_token: String::new(),
+            delegation_engine: None,
+            project_context: None,
+            checkpoint_gate: None,
+            evolution_service: None,
+            rate_limit_cooldown: Default::default(),
+            data_snapshot_provider: None,
+            last_composite_snapshot: None,
+            last_measured_prompt_tokens: None,
+            consecutive_context_window_errors: 0,
+            max_turn_input_tokens: astra_core::RuntimeLimits::global().max_turn_input_tokens,
+            budget_wrapup_injected: false,
+            skill_produced_output: false,
+            max_cumulative_tokens: SUBRUN_MAX_CUMULATIVE_TOKENS,
+            thinking_budget_tokens: None,
+            recent_file_reads: Vec::new(),
+            permission_context: None,
+            permission_handler: None,
+            tactical_adapter: None,
+            step_signal_collector: None,
+            tool_budget_override: None,
+            pending_reflection_signals: Vec::new(),
+            recent_tactical_actions: Vec::new(),
+            server_tool_executor: None,
+        };
+
+        if let Err(err) = run_agentic_loop_with_host(&mut host, &mut state).await {
+            return Err(format!(
+                "Skill sub-run '{}' failed after {} turns: {}",
+                skill_name,
+                SUBRUN_MAX_TURNS - state.remaining_turns,
+                err
+            ));
+        }
+
+        let turns = (SUBRUN_MAX_TURNS - state.remaining_turns) as u32;
+        let tokens_used = (state.total_prompt + state.total_completion) as u32;
+
+        Ok(SubRunResult {
+            output: state.final_text,
+            tokens_used,
+            turns,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_matrixone() -> MatrixOneSettings {
+        MatrixOneSettings {
+            host: "127.0.0.1".to_string(),
+            port: 6001,
+            user: "test".to_string(),
+            password: "test".to_string(),
+            database: "test".to_string(),
+        }
+    }
+
+    fn mock_encryptor() -> Arc<FernetTokenEncryptor> {
+        Arc::new(FernetTokenEncryptor::new("cJ8pxr3t6iJmSYqe6wD7vu2rN_C3ovGUxkC5H3NXFNY=").unwrap())
+    }
+
+    #[test]
+    fn server_skill_subrun_executor_builds() {
+        let executor = ServerSkillSubRunExecutor::new(
+            mock_matrixone(),
+            mock_encryptor(),
+            "test-session".to_string(),
+        );
+        assert!(executor.cancel_token.is_none());
+        assert!(executor.skill_resolver.is_none());
+    }
+
+    #[test]
+    fn server_skill_subrun_executor_with_builders() {
+        let executor = ServerSkillSubRunExecutor::new(
+            mock_matrixone(),
+            mock_encryptor(),
+            "test-session".to_string(),
+        )
+        .with_default_model(Some("claude-sonnet-4-20250514".to_string()))
+        .with_edge_tools(vec![
+            json!({"type": "function", "function": {"name": "bash"}}),
+        ])
+        .with_cancel_token(Some(Arc::new(tokio_util::sync::CancellationToken::new())));
+
+        assert!(executor.default_model.is_some());
+        assert_eq!(executor.edge_tools.len(), 1);
+        assert!(executor.cancel_token.is_some());
+    }
+}

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -64,6 +64,8 @@ pub struct ServerToolExecutor {
     approval_gate: Option<Arc<dyn astra_tools::ToolApprovalGate>>,
     /// Optional progress callback for streaming tool output.
     progress_callback: Option<Arc<dyn astra_tools::ToolProgressCallback>>,
+    /// Optional edge connection pool for routing to remote edge agents.
+    edge_connection_pool: Option<super::edge_connection_pool::EdgeConnectionPool>,
 }
 
 impl ServerToolExecutor {
@@ -108,6 +110,7 @@ impl ServerToolExecutor {
             url_cache: Mutex::new(HashMap::new()),
             approval_gate: None,
             progress_callback: None,
+            edge_connection_pool: None,
         }
     }
 
@@ -121,11 +124,31 @@ impl ServerToolExecutor {
         self.progress_callback = Some(cb);
     }
 
+    /// Set the edge connection pool for remote tool routing.
+    pub fn set_edge_connection_pool(
+        &mut self,
+        pool: super::edge_connection_pool::EdgeConnectionPool,
+    ) {
+        self.edge_connection_pool = Some(pool);
+    }
+
     /// Execute a tool call and return the result string.
     ///
-    /// This is the main entry point called by the headless round when
-    /// no edge agent is available.
+    /// Routing order:
+    /// 1. Try remote edge agent (if connected via WebSocket)
+    /// 2. Fall back to local server-side execution
     pub async fn execute(&self, name: &str, args: &Value) -> String {
+        // ── Try remote edge agent first ──────────────────────────────
+        if let Some(pool) = &self.edge_connection_pool {
+            if let Some(result) = pool.execute_tool_any_edge(&self.user_id, name, args).await {
+                return result.output;
+            }
+        }
+        self.execute_local(name, args).await
+    }
+
+    /// Execute a tool locally on the server (no edge routing).
+    async fn execute_local(&self, name: &str, args: &Value) -> String {
         // ── Approval gate check ──────────────────────────────────────
         if let Some(gate) = &self.approval_gate {
             if gate.requires_approval(name) {

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -31,8 +31,7 @@ use crate::turn::file_edit_journal::FileEditJournal;
 pub struct ServerToolExecutor {
     /// Workspace root for this session.
     workspace_root: PathBuf,
-    /// User ID owning this session.
-    #[allow(dead_code)] // Phase 5: used for audit logging and multi-tenant isolation
+    /// User ID owning this session (used for Memoria isolation).
     user_id: String,
     /// Session ID for isolation.
     session_id: String,
@@ -156,7 +155,17 @@ impl ServerToolExecutor {
             "memory_retrieve" | "memory_store" | "memory_search" | "memory_purge"
             | "memory_correct" | "memory_profile" => {
                 let op = name.strip_prefix("memory_").unwrap_or(name);
-                self.memoria_client.call(op, args).await
+                // Force-inject user_id and session_id for per-user isolation,
+                // mirroring the server's /memory/* proxy in auth_handlers.rs.
+                let mut isolated_args = args.clone();
+                if let Some(obj) = isolated_args.as_object_mut() {
+                    obj.insert(
+                        "session_id".to_string(),
+                        Value::String(self.user_id.clone()),
+                    );
+                    obj.insert("user_id".to_string(), Value::String(self.user_id.clone()));
+                }
+                self.memoria_client.call(op, &isolated_args).await
             }
             // ── Web search (standalone function) ───────────────────────
             "web_search" => astra_tools::web_search::web_search(args),

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -679,3 +679,374 @@ fn uuid_v4_short() -> String {
         .as_nanos();
     format!("{:08x}", (ts & 0xFFFF_FFFF) as u32)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn test_executor() -> (ServerToolExecutor, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let exec = ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            "test-session".into(),
+            None,
+            None,
+        );
+        (exec, dir)
+    }
+
+    // ── Path traversal security ────────────────────────────────────────
+
+    #[test]
+    fn resolve_path_allows_relative_inside_workspace() {
+        let (exec, _dir) = test_executor();
+        let result = exec.resolve_path("src/main.rs");
+        assert!(result.is_ok());
+        assert!(result.unwrap().starts_with(exec.workspace_root()));
+    }
+
+    #[test]
+    fn resolve_path_blocks_parent_traversal() {
+        let (exec, _dir) = test_executor();
+        let result = exec.resolve_path("../../etc/passwd");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("SANDBOX_DENIED"));
+    }
+
+    #[test]
+    fn resolve_path_blocks_absolute_outside_workspace() {
+        let (exec, _dir) = test_executor();
+        let result = exec.resolve_path("/etc/passwd");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("SANDBOX_DENIED"));
+    }
+
+    #[test]
+    fn resolve_path_allows_absolute_inside_workspace() {
+        let (exec, dir) = test_executor();
+        let inner = dir.path().join("foo.txt");
+        let result = exec.resolve_path(inner.to_str().unwrap());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn resolve_path_normalizes_dot_dot_in_middle() {
+        let (exec, _dir) = test_executor();
+        // src/../../../etc/passwd should be blocked
+        let result = exec.resolve_path("src/../../../etc/passwd");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("SANDBOX_DENIED"));
+    }
+
+    #[test]
+    fn resolve_path_allows_dot_dot_within_workspace() {
+        let (exec, dir) = test_executor();
+        // Create nested dir so the path stays inside workspace
+        std::fs::create_dir_all(dir.path().join("a/b")).unwrap();
+        let result = exec.resolve_path("a/b/../c.txt");
+        assert!(result.is_ok());
+        let resolved = result.unwrap();
+        assert!(resolved.starts_with(exec.workspace_root()));
+    }
+
+    // ── File operations ────────────────────────────────────────────────
+
+    #[test]
+    fn read_file_returns_content_with_line_numbers() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("hello.txt"), "line1\nline2\nline3\n").unwrap();
+        let result = exec.server_read_file(&json!({"path": "hello.txt"}));
+        assert!(result.contains("1\tline1"));
+        assert!(result.contains("2\tline2"));
+        assert!(result.contains("3\tline3"));
+    }
+
+    #[test]
+    fn read_file_respects_start_and_end_line() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("f.txt"), "a\nb\nc\nd\ne\n").unwrap();
+        let result = exec.server_read_file(&json!({"path": "f.txt", "start_line": 2, "end_line": 4}));
+        assert!(!result.contains("1\ta"));
+        assert!(result.contains("2\tb"));
+        assert!(result.contains("3\tc"));
+        assert!(result.contains("4\td"));
+        assert!(!result.contains("5\te"));
+    }
+
+    #[test]
+    fn read_file_missing_file_returns_error() {
+        let (exec, _dir) = test_executor();
+        let result = exec.server_read_file(&json!({"path": "nonexistent.txt"}));
+        assert!(result.starts_with("Error:"));
+    }
+
+    #[test]
+    fn read_file_missing_path_param_returns_error() {
+        let (exec, _dir) = test_executor();
+        let result = exec.server_read_file(&json!({}));
+        assert!(result.contains("Missing 'path'"));
+    }
+
+    #[test]
+    fn read_file_blocks_path_traversal() {
+        let (exec, _dir) = test_executor();
+        let result = exec.server_read_file(&json!({"path": "../../etc/passwd"}));
+        assert!(result.contains("SANDBOX_DENIED"));
+    }
+
+    #[test]
+    fn write_file_creates_and_writes() {
+        let (exec, dir) = test_executor();
+        let result = exec.server_write_file(&json!({"path": "out.txt", "content": "hello world"}));
+        assert!(result.contains("Successfully wrote"));
+        let content = std::fs::read_to_string(dir.path().join("out.txt")).unwrap();
+        assert_eq!(content, "hello world");
+    }
+
+    #[test]
+    fn write_file_creates_parent_dirs() {
+        let (exec, dir) = test_executor();
+        let result = exec.server_write_file(&json!({
+            "path": "deep/nested/dir/file.txt",
+            "content": "deep content"
+        }));
+        assert!(result.contains("Successfully wrote"));
+        assert!(dir.path().join("deep/nested/dir/file.txt").exists());
+    }
+
+    #[test]
+    fn write_file_blocks_path_traversal() {
+        let (exec, _dir) = test_executor();
+        let result = exec.server_write_file(&json!({
+            "path": "../../evil.txt",
+            "content": "pwned"
+        }));
+        assert!(result.contains("SANDBOX_DENIED"));
+    }
+
+    #[test]
+    fn str_replace_single_occurrence() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("code.rs"), "fn old_name() {}").unwrap();
+        let result = exec.server_str_replace(&json!({
+            "path": "code.rs",
+            "old_str": "old_name",
+            "new_str": "new_name"
+        }));
+        assert!(result.contains("Successfully replaced"));
+        let content = std::fs::read_to_string(dir.path().join("code.rs")).unwrap();
+        assert_eq!(content, "fn new_name() {}");
+    }
+
+    #[test]
+    fn str_replace_rejects_multiple_matches() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("dup.txt"), "foo bar foo").unwrap();
+        let result = exec.server_str_replace(&json!({
+            "path": "dup.txt",
+            "old_str": "foo",
+            "new_str": "baz"
+        }));
+        assert!(result.contains("found 2 times"));
+    }
+
+    #[test]
+    fn str_replace_not_found() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("nope.txt"), "hello").unwrap();
+        let result = exec.server_str_replace(&json!({
+            "path": "nope.txt",
+            "old_str": "missing",
+            "new_str": "x"
+        }));
+        assert!(result.contains("not found"));
+    }
+
+    #[test]
+    fn delete_file_removes_existing() {
+        let (exec, dir) = test_executor();
+        let target = dir.path().join("to_delete.txt");
+        std::fs::write(&target, "temp").unwrap();
+        assert!(target.exists());
+        let result = exec.server_delete_file(&json!({"path": "to_delete.txt"}));
+        assert!(result.contains("Successfully deleted"));
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn delete_file_nonexistent_returns_error() {
+        let (exec, _dir) = test_executor();
+        let result = exec.server_delete_file(&json!({"path": "ghost.txt"}));
+        assert!(result.contains("File not found"));
+    }
+
+    #[test]
+    fn list_dir_shows_files_and_dirs() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("a.txt"), "").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "").unwrap();
+        std::fs::create_dir(dir.path().join("subdir")).unwrap();
+        let result = exec.server_list_dir(&json!({"path": "."}));
+        assert!(result.contains("a.txt"));
+        assert!(result.contains("b.rs"));
+        assert!(result.contains("subdir/"));
+    }
+
+    #[test]
+    fn list_dir_sorted_output() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("z.txt"), "").unwrap();
+        std::fs::write(dir.path().join("a.txt"), "").unwrap();
+        std::fs::write(dir.path().join("m.txt"), "").unwrap();
+        let result = exec.server_list_dir(&json!({"path": "."}));
+        let lines: Vec<&str> = result.lines().collect();
+        assert_eq!(lines, vec!["a.txt", "m.txt", "z.txt"]);
+    }
+
+    // ── Unknown tool ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn unknown_tool_returns_error_message() {
+        let (exec, _dir) = test_executor();
+        let result = exec.execute("nonexistent_tool", &json!({})).await;
+        assert!(result.contains("not available"));
+    }
+
+    // ── Bash execution ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn bash_echo_returns_output() {
+        let (exec, _dir) = test_executor();
+        let result = exec.server_bash(&json!({"command": "echo hello"})).await;
+        assert_eq!(result.trim(), "hello");
+    }
+
+    #[tokio::test]
+    async fn bash_missing_command_returns_error() {
+        let (exec, _dir) = test_executor();
+        let result = exec.server_bash(&json!({})).await;
+        assert!(result.contains("Missing 'command'"));
+    }
+
+    #[tokio::test]
+    async fn bash_nonzero_exit_includes_exit_code() {
+        let (exec, _dir) = test_executor();
+        let result = exec.server_bash(&json!({"command": "exit 42"})).await;
+        assert!(result.contains("exit code: 42"));
+    }
+
+    #[tokio::test]
+    async fn bash_stderr_is_captured() {
+        let (exec, _dir) = test_executor();
+        let result = exec
+            .server_bash(&json!({"command": "echo err >&2"}))
+            .await;
+        assert!(result.contains("stderr:"));
+        assert!(result.contains("err"));
+    }
+
+    #[tokio::test]
+    async fn bash_runs_in_workspace_dir() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("marker.txt"), "found").unwrap();
+        let result = exec
+            .server_bash(&json!({"command": "cat marker.txt"}))
+            .await;
+        assert_eq!(result.trim(), "found");
+    }
+
+    // ── Grep ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn grep_finds_pattern_in_files() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("test.rs"), "fn main() {}\nfn helper() {}").unwrap();
+        let result = exec.server_grep(&json!({"pattern": "fn main"}));
+        assert!(result.contains("fn main"));
+    }
+
+    #[test]
+    fn grep_no_matches_returns_message() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("empty.rs"), "nothing here").unwrap();
+        let result = exec.server_grep(&json!({"pattern": "ZZZZNOTFOUND"}));
+        assert!(result.contains("No matches found"));
+    }
+
+    // ── Git operations ─────────────────────────────────────────────────
+
+    #[test]
+    fn git_status_in_non_git_dir_returns_error() {
+        let (exec, _dir) = test_executor();
+        let result = exec.server_git_status();
+        assert!(result.contains("Error:") || result.contains("fatal"));
+    }
+
+    #[test]
+    fn git_log_caps_at_100() {
+        let (exec, dir) = test_executor();
+        // Initialize a git repo
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::fs::write(dir.path().join("f.txt"), "x").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        // Request 999 — should be capped at 100
+        let result = exec.server_git_log(&json!({"n": 999}));
+        assert!(result.contains("initial"));
+    }
+
+    // ── Memory tool user isolation ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn memory_tool_injects_user_id() {
+        let (exec, _dir) = test_executor();
+        // We can't actually call Memoria, but we can verify the execute path
+        // doesn't panic and returns a reasonable error (no MEMORIA_BASE_URL set).
+        let result = exec.execute("memory_store", &json!({"content": "test"})).await;
+        // Should attempt the call (may fail due to no server, but shouldn't crash)
+        assert!(!result.is_empty());
+    }
+
+    // ── Output management ──────────────────────────────────────────────
+
+    #[test]
+    fn set_turn_index_and_reset_aggregate() {
+        let (exec, _dir) = test_executor();
+        exec.set_turn_index(5);
+        assert_eq!(exec.journal_turn_index.load(Ordering::Relaxed), 5);
+        exec.aggregate_output_bytes.store(999, Ordering::Relaxed);
+        exec.reset_aggregate_output();
+        assert_eq!(exec.aggregate_output_bytes.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn workspace_root_returns_correct_path() {
+        let (exec, dir) = test_executor();
+        assert_eq!(exec.workspace_root(), dir.path());
+    }
+}

--- a/rust/crates/runtime/src/server/state_builder.rs
+++ b/rust/crates/runtime/src/server/state_builder.rs
@@ -265,7 +265,8 @@ pub async fn build_server_state(
     )
     .with_pool(shared_pool.clone())
     .with_run_engine(run_engine)
-    .with_delegation_engine(Arc::clone(&delegation_engine));
+    .with_delegation_engine(Arc::clone(&delegation_engine))
+    .with_edge_connection_pool(state.edge_connection_pool.clone());
     // Wire team persistence store backed by MatrixOne.
     let team_store =
         astra_services::team_persistence::MatrixOneTeamStore::new(shared_pool.get().clone());

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -497,7 +497,7 @@ fn section_cache_key(tool_names: &[&str], task_type: Option<&str>, confidence: f
 ///   `dynamic` holds a second system message with the per-turn profile/hints, or `None`
 ///   if there is nothing dynamic. This split enables OpenAI's automatic prefix caching:
 ///   the stable message stays identical across turns so the provider can reuse the KV cache.
-fn build_system_message(
+pub(crate) fn build_system_message(
     tool_names: &[&str],
     profile_desc: &str,
     confidence: f64,
@@ -646,7 +646,10 @@ fn build_system_message(
 ///
 /// This matches Claude Code's strategy of prioritizing message history caching
 /// for multi-turn conversations while still caching the stable tool prefix.
-fn annotate_tool_schemas_for_caching(tools: &mut [Value], cache_cfg: &PromptCacheConfig) {
+pub(crate) fn annotate_tool_schemas_for_caching(
+    tools: &mut [Value],
+    cache_cfg: &PromptCacheConfig,
+) {
     if !cache_cfg.should_annotate() || tools.is_empty() {
         return;
     }
@@ -658,7 +661,7 @@ fn annotate_tool_schemas_for_caching(tools: &mut [Value], cache_cfg: &PromptCach
 
 /// Add a cache breakpoint on the last conversation message for Anthropic.
 /// This enables turn-to-turn KV cache reuse for the conversation prefix.
-fn add_message_cache_breakpoint(messages: &mut [Value], cache_cfg: &PromptCacheConfig) {
+pub(crate) fn add_message_cache_breakpoint(messages: &mut [Value], cache_cfg: &PromptCacheConfig) {
     if !cache_cfg.should_annotate() || messages.is_empty() {
         return;
     }

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -69,8 +69,9 @@ use crate::{
     },
     turn::cloud_tool_delivery::{
         cloud_tool_requires_approval_for_delivery, sse_maps_through_tool_request,
-        tool_approval_detail_for_delivery, tool_path_hint_for_delivery,
-        wait_approval_ledger_for_tool, wait_tool_result_ledger_for_tool,
+        tool_approval_detail_for_delivery, tool_approval_kind_for_delivery,
+        tool_path_hint_for_delivery, wait_approval_ledger_for_tool,
+        wait_tool_result_ledger_for_tool,
     },
     turn::edge_ledger::{
         assistant_message_with_tool_calls_and_reasoning, ensure_tool_call_ids,
@@ -2128,9 +2129,11 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                         .unwrap_or("");
                     let path = tool_path_hint_for_delivery(tc);
                     let detail = tool_approval_detail_for_delivery(tc);
+                    let approval_kind = tool_approval_kind_for_delivery(tc);
                     yield render_sse_map(&build_approval_required_event(
                         id,
                         tool_name,
+                        approval_kind,
                         path.as_deref(),
                         detail.as_deref(),
                     ));

--- a/rust/crates/runtime/src/turn/chat_turn_sse_dispatch.rs
+++ b/rust/crates/runtime/src/turn/chat_turn_sse_dispatch.rs
@@ -4,6 +4,7 @@
 //! accumulator and returns terminal UI hints. [`ChatTurnSseFramer`] turns arbitrary byte chunks
 //! into complete event blocks via [`super::sse_blocks`] and records time-to-first-token.
 
+use astra_thin_client::ApprovalKind;
 use serde_json::Value;
 use std::time::Instant;
 
@@ -45,6 +46,7 @@ pub enum ChatTurnEdgePending {
     ApprovalRequired {
         request_id: String,
         tool: String,
+        approval_kind: ApprovalKind,
         detail: Option<String>,
     },
 }
@@ -113,6 +115,14 @@ fn normalize_tool_call_for_accum(event: &Value) -> Option<Value> {
             "arguments": arguments,
         }
     }))
+}
+
+fn approval_kind_from_event(event: &Value) -> ApprovalKind {
+    event
+        .get("approval_kind")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<ApprovalKind>(value).ok())
+        .unwrap_or(ApprovalKind::Explicit)
 }
 
 fn apply_one_event(
@@ -214,6 +224,7 @@ fn apply_one_event(
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
+            let approval_kind = approval_kind_from_event(event);
             let detail = event
                 .get("detail")
                 .and_then(|v| v.as_str())
@@ -228,6 +239,7 @@ fn apply_one_event(
                 edge_pending.push(ChatTurnEdgePending::ApprovalRequired {
                     request_id,
                     tool,
+                    approval_kind,
                     detail,
                 });
             }
@@ -655,20 +667,36 @@ mod tests {
     fn approval_required_enqueues_pending() {
         let mut a = ChatTurnSseAccum::default();
         let mut pending = Vec::new();
-        let block = "data: {\"type\":\"approval_required\",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"}\n\n";
+        let block = "data: {\"type\":\"approval_required\",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"approval_kind\":\"standard\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"}\n\n";
         dispatch_chat_turn_sse_event_block(block, &mut a, &mut pending);
         assert_eq!(pending.len(), 1);
         match &pending[0] {
             ChatTurnEdgePending::ApprovalRequired {
                 request_id,
                 tool,
+                approval_kind,
                 detail,
             } => {
                 assert_eq!(request_id, "ap-1");
                 assert_eq!(tool, "write_file");
+                assert_eq!(*approval_kind, ApprovalKind::Standard);
                 assert_eq!(detail.as_deref(), Some("src/x.rs"));
             }
             _ => panic!("expected ApprovalRequired"),
+        }
+    }
+
+    #[test]
+    fn approval_required_without_kind_defaults_to_explicit() {
+        let mut a = ChatTurnSseAccum::default();
+        let mut pending = Vec::new();
+        let block = "data: {\"type\":\"approval_required\",\"request_id\":\"ap-1\",\"tool\":\"bash\",\"detail\":\"rm -rf tmp\"}\n\n";
+        dispatch_chat_turn_sse_event_block(block, &mut a, &mut pending);
+        match &pending[0] {
+            ChatTurnEdgePending::ApprovalRequired { approval_kind, .. } => {
+                assert_eq!(*approval_kind, ApprovalKind::Explicit);
+            }
+            other => panic!("expected ApprovalRequired, got {other:?}"),
         }
     }
 

--- a/rust/crates/runtime/src/turn/cloud_tool_delivery.rs
+++ b/rust/crates/runtime/src/turn/cloud_tool_delivery.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use astra_thin_client::ApprovalRespondRequest;
+use astra_thin_client::{ApprovalKind, ApprovalRespondRequest};
 use serde_json::{Map, Value, json};
 
 #[cfg(test)]
@@ -90,6 +90,21 @@ fn tool_approval_detail(tool_call: &Value) -> Option<String> {
         .collect::<Vec<_>>()
         .join("\n");
     (!detail.is_empty()).then_some(detail)
+}
+
+fn tool_approval_kind(tool_call: &Value) -> ApprovalKind {
+    let tool_name = tool_call
+        .get("function")
+        .and_then(|f| f.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let raw = raw_tool_arguments(tool_call);
+    let parsed = normalize_llm_function_arguments(&raw);
+    if explicit_approval_reason(tool_name, &parsed).is_some() {
+        ApprovalKind::Explicit
+    } else {
+        ApprovalKind::Standard
+    }
 }
 
 pub fn parse_cloud_approval_outcome(entry: Option<&Value>) -> CloudApprovalResult {
@@ -277,6 +292,10 @@ pub(crate) fn tool_approval_detail_for_delivery(tool_call: &Value) -> Option<Str
     tool_approval_detail(tool_call)
 }
 
+pub(crate) fn tool_approval_kind_for_delivery(tool_call: &Value) -> ApprovalKind {
+    tool_approval_kind(tool_call)
+}
+
 pub async fn deliver_tool_calls_through_edge_ledger(
     ledger: &Arc<tokio::sync::Mutex<HashMap<String, Value>>>,
     user_id: &str,
@@ -300,9 +319,11 @@ pub async fn deliver_tool_calls_through_edge_ledger(
         if cloud_tool_requires_approval(tc) {
             let path = tool_path_hint(tc);
             let detail = tool_approval_detail(tc);
+            let approval_kind = tool_approval_kind(tc);
             out.sse_maps.push(build_approval_required_event(
                 id,
                 tool_name,
+                approval_kind,
                 path.as_deref(),
                 detail.as_deref(),
             ));
@@ -363,9 +384,11 @@ pub async fn deliver_tool_calls_concurrent(
             .unwrap_or("");
         let path = tool_path_hint(tc);
         let detail = tool_approval_detail(tc);
+        let approval_kind = tool_approval_kind(tc);
         out.sse_maps.push(build_approval_required_event(
             id,
             tool_name,
+            approval_kind,
             path.as_deref(),
             detail.as_deref(),
         ));

--- a/rust/crates/runtime/src/turn/sse_stream_host.rs
+++ b/rust/crates/runtime/src/turn/sse_stream_host.rs
@@ -19,6 +19,7 @@ use crate::turn::chat_turn_sse_dispatch::{
     ChatTurnEdgePending, ChatTurnSseAccum, ChatTurnSseFramer, SseRenderEffect,
     dispatch_chat_turn_sse_event_block,
 };
+use astra_thin_client::ApprovalKind;
 use async_trait::async_trait;
 use serde_json::Value;
 
@@ -218,6 +219,7 @@ pub trait SseStreamHost: Send {
         &mut self,
         request_id: &str,
         tool: &str,
+        approval_kind: ApprovalKind,
         detail: Option<&str>,
     ) -> EdgeApprovalResult;
 
@@ -463,6 +465,7 @@ async fn flush_pending_via_host<H: SseStreamHost>(
         if let ChatTurnEdgePending::ApprovalRequired {
             request_id,
             tool,
+            approval_kind,
             detail,
         } = item
         {
@@ -470,7 +473,7 @@ async fn flush_pending_via_host<H: SseStreamHost>(
                 continue;
             }
             let result = host
-                .resolve_approval(&request_id, &tool, detail.as_deref())
+                .resolve_approval(&request_id, &tool, approval_kind, detail.as_deref())
                 .await;
             approval_results.push(result);
         }
@@ -513,6 +516,7 @@ impl SseStreamHost for NoopSseStreamHost {
         &mut self,
         request_id: &str,
         _tool: &str,
+        _approval_kind: ApprovalKind,
         _detail: Option<&str>,
     ) -> EdgeApprovalResult {
         EdgeApprovalResult {
@@ -530,6 +534,7 @@ impl SseStreamHost for NoopSseStreamHost {
 struct RecordingSseStreamHost {
     render_effects: Vec<SseRenderEffect>,
     tool_outputs: std::collections::HashMap<String, String>,
+    approval_kinds: Vec<ApprovalKind>,
     stream_completed: bool,
 }
 
@@ -539,6 +544,7 @@ impl RecordingSseStreamHost {
         Self {
             render_effects: Vec::new(),
             tool_outputs: std::collections::HashMap::new(),
+            approval_kinds: Vec::new(),
             stream_completed: false,
         }
     }
@@ -587,8 +593,10 @@ impl SseStreamHost for RecordingSseStreamHost {
         &mut self,
         request_id: &str,
         _tool: &str,
+        approval_kind: ApprovalKind,
         _detail: Option<&str>,
     ) -> EdgeApprovalResult {
+        self.approval_kinds.push(approval_kind);
         EdgeApprovalResult {
             request_id: request_id.to_string(),
             decision: "allow".to_string(),
@@ -717,7 +725,7 @@ mod tests {
     async fn recording_host_approval_resolved() {
         let events = sse_event(
             "approval_required",
-            ",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"",
+            ",\"request_id\":\"ap-1\",\"tool\":\"write_file\",\"approval_kind\":\"standard\",\"path\":\"src/x.rs\",\"detail\":\"src/x.rs\"",
         );
         let chunks = chunks_from_sse(&events);
         let mut stream = stream::iter(chunks);
@@ -733,6 +741,7 @@ mod tests {
         assert_eq!(result.approval_results.len(), 1);
         assert_eq!(result.approval_results[0].request_id, "ap-1");
         assert_eq!(result.approval_results[0].decision, "allow");
+        assert_eq!(host.approval_kinds, vec![ApprovalKind::Standard]);
     }
 
     #[tokio::test]
@@ -1269,6 +1278,7 @@ mod tests {
                 &mut self,
                 rid: &str,
                 _: &str,
+                _: ApprovalKind,
                 _: Option<&str>,
             ) -> EdgeApprovalResult {
                 EdgeApprovalResult {

--- a/rust/crates/runtime/src/turn/stream_events.rs
+++ b/rust/crates/runtime/src/turn/stream_events.rs
@@ -1,5 +1,7 @@
 use serde_json::{Map, Value};
 
+use astra_thin_client::ApprovalKind;
+
 use crate::try_repair_tool_args;
 
 pub fn build_stream_error_event(message: &str, code: &str, retryable: bool) -> Map<String, Value> {
@@ -157,6 +159,7 @@ pub fn build_edge_tool_call_event(tool_call: &Map<String, Value>) -> Map<String,
 pub fn build_approval_required_event(
     request_id: &str,
     tool_name: &str,
+    approval_kind: ApprovalKind,
     path: Option<&str>,
     detail: Option<&str>,
 ) -> Map<String, Value> {
@@ -170,6 +173,10 @@ pub fn build_approval_required_event(
             Value::String(request_id.to_string()),
         ),
         ("tool".to_string(), Value::String(tool_name.to_string())),
+        (
+            "approval_kind".to_string(),
+            serde_json::to_value(approval_kind).unwrap_or(Value::String("explicit".to_string())),
+        ),
     ]);
     if let Some(p) = path.filter(|s| !s.is_empty()) {
         m.insert("path".to_string(), Value::String(p.to_string()));
@@ -222,19 +229,35 @@ mod tests {
 
     #[test]
     fn approval_required_includes_optional_path() {
-        let ev = build_approval_required_event("a1", "write_file", Some("p/x.rs"), None);
+        let ev = build_approval_required_event(
+            "a1",
+            "write_file",
+            ApprovalKind::Standard,
+            Some("p/x.rs"),
+            None,
+        );
         assert_eq!(
             ev.get("type").and_then(Value::as_str),
             Some("approval_required")
         );
         assert_eq!(ev.get("request_id").and_then(Value::as_str), Some("a1"));
         assert_eq!(ev.get("tool").and_then(Value::as_str), Some("write_file"));
+        assert_eq!(
+            ev.get("approval_kind").and_then(Value::as_str),
+            Some("standard")
+        );
         assert_eq!(ev.get("path").and_then(Value::as_str), Some("p/x.rs"));
     }
 
     #[test]
     fn approval_required_includes_optional_detail() {
-        let ev = build_approval_required_event("a1", "bash", None, Some("git status"));
+        let ev = build_approval_required_event(
+            "a1",
+            "bash",
+            ApprovalKind::Explicit,
+            None,
+            Some("git status"),
+        );
         assert_eq!(ev.get("detail").and_then(Value::as_str), Some("git status"));
     }
 
@@ -474,14 +497,15 @@ mod tests {
 
     #[test]
     fn approval_required_omits_empty_path() {
-        let ev = build_approval_required_event("r1", "bash", Some(""), Some(""));
+        let ev =
+            build_approval_required_event("r1", "bash", ApprovalKind::Explicit, Some(""), Some(""));
         assert!(ev.get("path").is_none());
         assert!(ev.get("detail").is_none());
     }
 
     #[test]
     fn approval_required_omits_none_path() {
-        let ev = build_approval_required_event("r1", "bash", None, None);
+        let ev = build_approval_required_event("r1", "bash", ApprovalKind::Explicit, None, None);
         assert!(ev.get("path").is_none());
         assert!(ev.get("detail").is_none());
     }

--- a/rust/crates/runtime/tests/edge_5_5_http_e2e.rs
+++ b/rust/crates/runtime/tests/edge_5_5_http_e2e.rs
@@ -196,10 +196,14 @@ async fn http_handler_payload_matches_delivery_parser() {
     let d =
         deliver_tool_calls_through_edge_ledger(&ledger, "e2e-user", &[tc], Duration::from_secs(2))
             .await;
-    assert!(
-        d.sse_maps
-            .iter()
-            .any(|m| m.get("type").and_then(|v| v.as_str()) == Some("approval_required"))
+    let approval = d
+        .sse_maps
+        .iter()
+        .find(|m| m.get("type").and_then(|v| v.as_str()) == Some("approval_required"))
+        .expect("approval_required event");
+    assert_eq!(
+        approval.get("approval_kind").and_then(|v| v.as_str()),
+        Some("standard")
     );
     assert!(
         d.sse_maps

--- a/rust/crates/runtime/tests/edge_cloud_round_trip_e2e.rs
+++ b/rust/crates/runtime/tests/edge_cloud_round_trip_e2e.rs
@@ -542,6 +542,7 @@ async fn approval_gate_allow_then_tool_request() {
         .iter()
         .position(|e| e["type"] == "approval_required")
         .unwrap();
+    assert_eq!(events[approval_idx]["approval_kind"], "standard");
     let request_idx = events
         .iter()
         .position(|e| e["type"] == "tool_request" && e.to_string().contains("tc-wf-1"))
@@ -620,6 +621,11 @@ async fn approval_denied_skips_tool_execution() {
 
     // tool_request should NOT appear for a denied tool
     let events = parse_sse_events(&full);
+    let approval_event = events
+        .iter()
+        .find(|e| e["type"] == "approval_required" && e.to_string().contains("tc-deny-1"))
+        .expect("approval_required event for denied bash");
+    assert_eq!(approval_event["approval_kind"], "explicit");
     let tool_requests: Vec<_> = events
         .iter()
         .filter(|e| e["type"] == "tool_request" && e.to_string().contains("tc-deny-1"))

--- a/rust/crates/runtime/tests/edge_ws_e2e.rs
+++ b/rust/crates/runtime/tests/edge_ws_e2e.rs
@@ -295,3 +295,220 @@ async fn edge_ws_multiple_edges_per_user() {
 
     server.abort();
 }
+
+#[tokio::test]
+async fn edge_tool_error_result_propagated() {
+    let (addr, state, server) = spawn_test_server().await;
+
+    let ws = ws_auth(addr, "edge-err", "err-host").await;
+    let (mut write, mut read) = ws.split();
+
+    let pool = state.edge_connection_pool.clone();
+    let tool_task = tokio::spawn(async move {
+        let args = serde_json::json!({ "command": "fail-cmd" });
+        pool.execute_tool("test-user-1", "edge-err", "bash", &args)
+            .await
+    });
+
+    // Receive the tool request
+    let req = read.next().await.unwrap().unwrap();
+    let req_json: serde_json::Value =
+        serde_json::from_str(&req.into_text().unwrap()).unwrap();
+    let request_id = req_json["request_id"].as_str().unwrap().to_string();
+
+    // Edge reports an error result
+    let result_msg = json!({
+        "type": "edge_tool_result",
+        "request_id": request_id,
+        "output": "command not found: fail-cmd",
+        "is_error": true,
+        "duration_ms": 5
+    });
+    write
+        .send(Message::Text(result_msg.to_string().into()))
+        .await
+        .unwrap();
+
+    let result = tool_task.await.unwrap().expect("should get error result");
+    assert!(result.is_error);
+    assert_eq!(result.output, "command not found: fail-cmd");
+
+    write.close().await.ok();
+    server.abort();
+}
+
+#[tokio::test]
+async fn edge_tool_disconnect_during_request_returns_none() {
+    let (addr, state, server) = spawn_test_server().await;
+
+    let ws = ws_auth(addr, "edge-slow", "slow-host").await;
+    let (write, mut read) = ws.split();
+
+    let pool = state.edge_connection_pool.clone();
+
+    // Start a tool request in background
+    let tool_task = tokio::spawn(async move {
+        let args = serde_json::json!({ "command": "slow" });
+        pool.execute_tool("test-user-1", "edge-slow", "bash", &args)
+            .await
+    });
+
+    // Wait for the tool request to arrive at the edge
+    let req = read.next().await.unwrap().unwrap();
+    let req_json: serde_json::Value =
+        serde_json::from_str(&req.into_text().unwrap()).unwrap();
+    assert_eq!(req_json["type"], "edge_tool_request");
+
+    // Drop both halves — this closes the WS, triggering server cleanup
+    drop(write);
+    drop(read);
+
+    // The tool_task should resolve with None after the server detects
+    // the disconnect and unregisters the edge (drops pending oneshots)
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        tool_task,
+    )
+    .await
+    .expect("task should complete within 10s")
+    .expect("task should not panic");
+
+    assert!(result.is_none(), "disconnected edge should return None");
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn edge_reconnect_after_disconnect() {
+    let (addr, state, server) = spawn_test_server().await;
+
+    // First connection
+    let ws1 = ws_auth(addr, "edge-rc", "rc-host").await;
+    assert!(state.edge_connection_pool.has_connected_edge("test-user-1"));
+
+    // Disconnect
+    drop(ws1);
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert!(!state.edge_connection_pool.has_connected_edge("test-user-1"));
+
+    // Reconnect with same edge_agent_id
+    let ws2 = ws_auth(addr, "edge-rc", "rc-host").await;
+    assert!(state.edge_connection_pool.has_connected_edge("test-user-1"));
+    let edges = state.edge_connection_pool.get_user_edges("test-user-1");
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].edge_agent_id, "edge-rc");
+
+    // Tool request should work on the new connection
+    let pool = state.edge_connection_pool.clone();
+    let (mut write, mut read) = ws2.split();
+
+    let tool_task = tokio::spawn(async move {
+        let args = serde_json::json!({ "path": "." });
+        pool.execute_tool("test-user-1", "edge-rc", "list_dir", &args)
+            .await
+    });
+
+    let req = read.next().await.unwrap().unwrap();
+    let req_json: serde_json::Value =
+        serde_json::from_str(&req.into_text().unwrap()).unwrap();
+    assert_eq!(req_json["tool"], "list_dir");
+    let request_id = req_json["request_id"].as_str().unwrap().to_string();
+
+    let result_msg = json!({
+        "type": "edge_tool_result",
+        "request_id": request_id,
+        "output": "file1.txt\nfile2.txt",
+        "is_error": false
+    });
+    write
+        .send(Message::Text(result_msg.to_string().into()))
+        .await
+        .unwrap();
+
+    let result = tool_task.await.unwrap().expect("should get result");
+    assert_eq!(result.output, "file1.txt\nfile2.txt");
+    assert!(!result.is_error);
+
+    write.close().await.ok();
+    server.abort();
+}
+
+#[tokio::test]
+async fn edge_invalid_first_message_rejected() {
+    let (addr, _state, server) = spawn_test_server().await;
+
+    let url = format!("ws://{addr}/edge/ws");
+    let (mut ws, _) = connect_async(&url).await.expect("WS connect");
+
+    // Send a non-auth message first
+    let bad_msg = json!({ "type": "edge_ping" });
+    ws.send(Message::Text(bad_msg.to_string().into()))
+        .await
+        .unwrap();
+
+    let resp = ws.next().await.unwrap().unwrap();
+    let resp_json: serde_json::Value =
+        serde_json::from_str(&resp.into_text().unwrap()).unwrap();
+    assert_eq!(resp_json["type"], "edge_auth_error");
+    assert!(resp_json["message"]
+        .as_str()
+        .unwrap()
+        .contains("first message must be edge_auth"));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn edge_malformed_json_handled_gracefully() {
+    let (addr, state, server) = spawn_test_server().await;
+
+    let ws = ws_auth(addr, "edge-mal", "mal-host").await;
+    let (mut write, mut read) = ws.split();
+
+    // Send malformed JSON — should not crash the server
+    write
+        .send(Message::Text("not valid json {{{".into()))
+        .await
+        .unwrap();
+
+    // Connection should still work — try a ping
+    let ping = json!({ "type": "edge_ping" });
+    write
+        .send(Message::Text(ping.to_string().into()))
+        .await
+        .unwrap();
+
+    let pong = read.next().await.unwrap().unwrap();
+    let pong_json: serde_json::Value =
+        serde_json::from_str(&pong.into_text().unwrap()).unwrap();
+    assert_eq!(pong_json["type"], "edge_pong");
+
+    // Edge is still in pool
+    assert!(state.edge_connection_pool.has_connected_edge("test-user-1"));
+
+    write.close().await.ok();
+    server.abort();
+}
+
+#[tokio::test]
+async fn edge_deliver_result_for_unknown_request_returns_false() {
+    let (addr, state, server) = spawn_test_server().await;
+
+    let _ws = ws_auth(addr, "edge-unk", "unk-host").await;
+
+    // Try to deliver a result for a request that doesn't exist
+    use astra_runtime::server::edge_connection_pool::EdgeToolResult;
+    let delivered = state.edge_connection_pool.deliver_tool_result(
+        "test-user-1",
+        "edge-unk",
+        "nonexistent-request-id",
+        EdgeToolResult {
+            output: "orphaned".into(),
+            is_error: false,
+            duration_ms: None,
+        },
+    );
+    assert!(!delivered);
+
+    server.abort();
+}

--- a/rust/crates/runtime/tests/edge_ws_e2e.rs
+++ b/rust/crates/runtime/tests/edge_ws_e2e.rs
@@ -1,0 +1,297 @@
+//! End-to-end integration test for the edge WebSocket agent infrastructure.
+//!
+//! Verifies:
+//! 1. Edge agent connects to `GET /edge/ws` and authenticates
+//! 2. Edge appears in the connection pool for the authenticated user
+//! 3. Tool request → result roundtrip works via pool + WS
+//! 4. After edge disconnects, it disappears from the pool
+//! 5. Multiple edges per user tracked correctly
+
+use std::sync::Arc;
+
+use astra_runtime::{
+    AppState, AuthLoginRequestData, AuthRefreshRequestData, AuthRegisterRequestData, AuthService,
+    AuthUserRecord, ErrorResponse, HealthChecker, ServiceInfo, build_app,
+};
+use async_trait::async_trait;
+use axum::http::{HeaderMap, StatusCode};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+// ── Stubs ────────────────────────────────────────────────────────────
+
+struct StubHealthChecker;
+
+#[async_trait]
+impl HealthChecker for StubHealthChecker {
+    async fn database_healthy(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Clone)]
+struct StubAuthService;
+
+#[async_trait]
+impl AuthService for StubAuthService {
+    async fn register(
+        &self,
+        _req: AuthRegisterRequestData,
+    ) -> Result<AuthUserRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+        unreachable!()
+    }
+    async fn login(
+        &self,
+        _req: AuthLoginRequestData,
+    ) -> Result<astra_runtime::AuthTokenRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+        unreachable!()
+    }
+    async fn refresh(
+        &self,
+        _req: AuthRefreshRequestData,
+    ) -> Result<astra_runtime::AuthTokenRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+        unreachable!()
+    }
+    async fn logout(
+        &self,
+        _req: AuthRefreshRequestData,
+    ) -> Result<(), (StatusCode, axum::Json<ErrorResponse>)> {
+        unreachable!()
+    }
+    async fn current_user(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthUserRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+        match headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+        {
+            Some("Bearer test-edge-token") => Ok(AuthUserRecord {
+                user_id: "test-user-1".to_string(),
+                username: "edgeuser".to_string(),
+                email: "edge@test.local".to_string(),
+                display_name: None,
+            }),
+            _ => Err((
+                StatusCode::UNAUTHORIZED,
+                axum::Json(ErrorResponse::new("bad token".to_string())),
+            )),
+        }
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/// Spawn a minimal server, return address + shared state + handle.
+async fn spawn_test_server() -> (std::net::SocketAddr, AppState, tokio::task::JoinHandle<()>) {
+    let state = AppState::new(
+        ServiceInfo::new("edge-e2e-test", "0.0.0-test", ""),
+        Arc::new(StubHealthChecker),
+    )
+    .with_auth_service(Arc::new(StubAuthService));
+
+    let state_clone = state.clone();
+    let app = build_app(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind to ephemeral port");
+    let addr = listener.local_addr().unwrap();
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Give server a moment to start accepting connections
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    (addr, state_clone, handle)
+}
+
+/// Perform WS auth and return the authenticated connection.
+async fn ws_auth(
+    addr: std::net::SocketAddr,
+    edge_id: &str,
+    hostname: &str,
+) -> tokio_tungstenite::WebSocketStream<
+    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+> {
+    let url = format!("ws://{addr}/edge/ws");
+    let (mut ws, _) = connect_async(&url).await.expect("WS connect");
+
+    let auth_msg = json!({
+        "type": "edge_auth",
+        "token": "test-edge-token",
+        "edge_agent_id": edge_id,
+        "hostname": hostname,
+        "workspace_dir": "/home/test/project"
+    });
+    ws.send(Message::Text(auth_msg.to_string().into()))
+        .await
+        .unwrap();
+
+    let resp = ws.next().await.unwrap().unwrap();
+    let resp_json: serde_json::Value =
+        serde_json::from_str(&resp.into_text().unwrap()).unwrap();
+    assert_eq!(resp_json["type"], "edge_auth_ok");
+    assert_eq!(resp_json["user_id"], "test-user-1");
+
+    ws
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn edge_ws_auth_and_pool_registration() {
+    let (addr, state, server) = spawn_test_server().await;
+
+    // Before: no edges
+    assert!(!state.edge_connection_pool.has_connected_edge("test-user-1"));
+
+    // Connect and auth
+    let ws = ws_auth(addr, "edge-001", "dev-laptop").await;
+
+    // Pool should have 1 edge
+    assert!(state.edge_connection_pool.has_connected_edge("test-user-1"));
+    let edges = state.edge_connection_pool.get_user_edges("test-user-1");
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].edge_agent_id, "edge-001");
+    assert_eq!(edges[0].hostname.as_deref(), Some("dev-laptop"));
+    assert_eq!(
+        edges[0].workspace_dir.as_deref(),
+        Some("/home/test/project")
+    );
+
+    // Disconnect
+    drop(ws);
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Pool should be empty
+    assert!(!state.edge_connection_pool.has_connected_edge("test-user-1"));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn edge_ws_bad_token_rejected() {
+    let (addr, _state, server) = spawn_test_server().await;
+
+    let url = format!("ws://{addr}/edge/ws");
+    let (mut ws, _resp) = connect_async(&url).await.expect("WS connect");
+
+    let auth_msg = json!({
+        "type": "edge_auth",
+        "token": "wrong-token",
+        "edge_agent_id": "edge-bad"
+    });
+    ws.send(Message::Text(auth_msg.to_string().into()))
+        .await
+        .unwrap();
+
+    let resp = ws.next().await.expect("msg").expect("ok");
+    let resp_json: serde_json::Value =
+        serde_json::from_str(&resp.into_text().unwrap()).unwrap();
+    assert_eq!(resp_json["type"], "edge_auth_error");
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn edge_ws_ping_pong() {
+    let (addr, _state, server) = spawn_test_server().await;
+
+    let ws = ws_auth(addr, "edge-pp", "test-host").await;
+    let (mut write, mut read) = ws.split();
+
+    // Send ping
+    let ping_msg = json!({ "type": "edge_ping" });
+    write
+        .send(Message::Text(ping_msg.to_string().into()))
+        .await
+        .unwrap();
+
+    // Should receive edge_pong
+    let pong = read.next().await.unwrap().unwrap();
+    let pong_json: serde_json::Value =
+        serde_json::from_str(&pong.into_text().unwrap()).unwrap();
+    assert_eq!(pong_json["type"], "edge_pong");
+
+    write.close().await.ok();
+    server.abort();
+}
+
+#[tokio::test]
+async fn edge_ws_tool_request_roundtrip() {
+    let (addr, state, server) = spawn_test_server().await;
+
+    let ws = ws_auth(addr, "edge-tool", "tool-host").await;
+    let (mut write, mut read) = ws.split();
+
+    // Spawn a task that sends a tool request through the pool and awaits the result
+    let pool = state.edge_connection_pool.clone();
+    let tool_task = tokio::spawn(async move {
+        let args = serde_json::json!({ "command": "echo hello" });
+        pool.execute_tool("test-user-1", "edge-tool", "bash", &args)
+            .await
+    });
+
+    // Edge should receive a tool_request via WS
+    let tool_req = read.next().await.unwrap().unwrap();
+    let req_json: serde_json::Value =
+        serde_json::from_str(&tool_req.into_text().unwrap()).unwrap();
+    assert_eq!(req_json["type"], "edge_tool_request");
+    assert_eq!(req_json["tool"], "bash");
+    let request_id = req_json["request_id"].as_str().unwrap().to_string();
+
+    // Edge sends back the result
+    let result_msg = json!({
+        "type": "edge_tool_result",
+        "request_id": request_id,
+        "output": "hello\n",
+        "is_error": false,
+        "duration_ms": 42
+    });
+    write
+        .send(Message::Text(result_msg.to_string().into()))
+        .await
+        .unwrap();
+
+    // The pool task should resolve with the result
+    let result = tool_task.await.unwrap();
+    let result = result.expect("tool result should arrive");
+    assert_eq!(result.output, "hello\n");
+    assert!(!result.is_error);
+    assert_eq!(result.duration_ms, Some(42));
+
+    write.close().await.ok();
+    server.abort();
+}
+
+#[tokio::test]
+async fn edge_ws_multiple_edges_per_user() {
+    let (addr, state, server) = spawn_test_server().await;
+
+    // Connect two edges
+    let ws1 = ws_auth(addr, "edge-a", "host-a").await;
+    let ws2 = ws_auth(addr, "edge-b", "host-b").await;
+
+    // Pool should show 2
+    let edges = state.edge_connection_pool.get_user_edges("test-user-1");
+    assert_eq!(edges.len(), 2);
+
+    // Disconnect first
+    drop(ws1);
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Should have 1 left
+    let edges = state.edge_connection_pool.get_user_edges("test-user-1");
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].edge_agent_id, "edge-b");
+
+    drop(ws2);
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert!(!state.edge_connection_pool.has_connected_edge("test-user-1"));
+
+    server.abort();
+}

--- a/web/components/workspace/edge-connection-badge.tsx
+++ b/web/components/workspace/edge-connection-badge.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import type { EdgeConnection } from '@/hooks/use-edge-connections';
+
+function formatDuration(secs: number): string {
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m`;
+  return `${Math.floor(secs / 3600)}h ${Math.floor((secs % 3600) / 60)}m`;
+}
+
+export function EdgeConnectionBadge({
+  edges,
+  hasEdge,
+}: {
+  edges: EdgeConnection[];
+  hasEdge: boolean;
+}) {
+  if (!hasEdge) return null;
+
+  const first = edges[0];
+  const label = first.hostname ?? first.edge_agent_id.slice(0, 8);
+
+  return (
+    <div className="group relative flex items-center gap-1.5">
+      <span className="inline-block h-2 w-2 rounded-full bg-violet-400" />
+      <span className="text-xs font-medium text-violet-300">
+        Edge: {label}
+        {edges.length > 1 ? ` +${edges.length - 1}` : ''}
+      </span>
+
+      {/* Hover tooltip with details */}
+      <div className="pointer-events-none absolute left-0 top-full z-50 mt-2 hidden w-64 rounded-lg border border-slate-700 bg-slate-900 p-3 shadow-xl group-hover:block">
+        <p className="mb-2 text-xs font-semibold text-slate-300">
+          Connected Edge Agents ({edges.length})
+        </p>
+        <div className="space-y-2">
+          {edges.map((edge) => (
+            <div
+              key={edge.edge_agent_id}
+              className="rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5"
+            >
+              <p className="text-xs font-medium text-white">
+                {edge.hostname ?? 'Unknown host'}
+              </p>
+              <div className="mt-0.5 flex items-center gap-2 text-[10px] text-slate-500">
+                <span title={edge.edge_agent_id}>
+                  {edge.edge_agent_id.slice(0, 12)}…
+                </span>
+                <span>·</span>
+                <span>{formatDuration(edge.connected_secs)}</span>
+                {edge.workspace_dir ? (
+                  <>
+                    <span>·</span>
+                    <span className="truncate" title={edge.workspace_dir}>
+                      {edge.workspace_dir}
+                    </span>
+                  </>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/components/workspace/workspace-shell.tsx
+++ b/web/components/workspace/workspace-shell.tsx
@@ -11,8 +11,10 @@ import { TokenUsageBar } from './token-usage-bar';
 import type { ChatConfig } from '@/lib/workspace/types';
 import type { SessionSummary, EventSummary } from '@/lib/models/platform';
 import { ConnectionStatus } from '@/components/streaming/connection-status';
+import { EdgeConnectionBadge } from '@/components/workspace/edge-connection-badge';
 import { EventLogViewer } from '@/components/events/event-log-viewer';
 import { AgentTree } from '@/components/agents/agent-tree';
+import { useEdgeConnections } from '@/hooks/use-edge-connections';
 
 type SidePanel = 'tools' | 'plan' | 'agents' | 'events' | 'context';
 
@@ -29,6 +31,7 @@ export function WorkspaceShell({
 }) {
   const [activeConfig, setActiveConfig] = useState<ChatConfig>(config);
   const chat = useChatStream(activeConfig);
+  const edge = useEdgeConnections();
   const [sidePanel, setSidePanel] = useState<SidePanel>('tools');
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
@@ -88,6 +91,7 @@ export function WorkspaceShell({
                     : 'disconnected'
               }
             />
+            <EdgeConnectionBadge edges={edge.edges} hasEdge={edge.hasEdge} />
           </div>
           <div className="flex items-center gap-3 text-xs text-slate-500">
             {displaySessionId ? (

--- a/web/hooks/use-edge-connections.ts
+++ b/web/hooks/use-edge-connections.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCallback } from 'react';
+import { usePolling } from './use-polling';
+
+export type EdgeConnection = {
+  edge_agent_id: string;
+  hostname: string | null;
+  workspace_dir: string | null;
+  connected_secs: number;
+};
+
+type EdgeStatusResponse = {
+  edges: EdgeConnection[];
+};
+
+/**
+ * Polls the backend for connected edge agents.
+ * Uses the catch-all proxy route: /api/backend/edges/status → GET /edges/status
+ */
+export function useEdgeConnections({ enabled = true, intervalMs = 10000 } = {}) {
+  const fetcher = useCallback(async (): Promise<EdgeConnection[]> => {
+    const res = await fetch('/api/backend/edges/status');
+    if (!res.ok) return [];
+    const data: EdgeStatusResponse = await res.json();
+    return data.edges;
+  }, []);
+
+  const { data, error, isLoading, refresh } = usePolling<EdgeConnection[]>({
+    fetcher,
+    intervalMs,
+    enabled,
+  });
+
+  return {
+    edges: data ?? [],
+    hasEdge: (data?.length ?? 0) > 0,
+    error,
+    isLoading,
+    refresh,
+  };
+}


### PR DESCRIPTION
## Summary

Phases 5-6 of the web-agent tool extraction plan: architecture hardening, comprehensive unit tests, and full remote edge agent deployment.

### Architecture Fixes
- **Prompt caching** on runs path for 30-50% Anthropic token savings
- **Server-side skill fork execution** for web-agent mode
- **Stop hooks loading** from provisioned workspace in web-agent mode
- **Per-user memory isolation** for memoria tools

### Unit Tests (Phase 5)
- 31 tests for `astra-tools` crate (tool schemas, tool calls, error handling)
- 34 tests for `ServerToolExecutor` (all tool types, security boundaries)

### Remote Edge Agent (Phase 6)
Lets users connect their own machine as a remote tool executor via WebSocket.

**Components:**
- **Edge WS Protocol** — auth, tool request/result, heartbeat messages + 8 unit tests
- **EdgeConnectionPool** — DashMap-backed pool with pending request tracking + 8 unit tests
- **Edge WS Handler** — `GET /edge/ws` endpoint with auth timeout, bidirectional message loop
- **Tool Routing** — `ServerToolExecutor.execute()` checks edge pool first, falls back to local
- **`astra-edge` binary** — standalone CLI, connects to server, executes tools locally, auto-reconnects
- **Frontend UI** — `EdgeConnectionBadge` component + `useEdgeConnections` hook
- **Edge Status API** — `GET /edges/status` REST endpoint

**Bug fix found during testing:**
- `unregister()` now clears `pending_results` so in-flight `execute_tool()` callers return `None` immediately instead of hanging for 300s

### E2E Integration Tests (11 tests)
Auth, bad token, ping/pong, tool roundtrip, multi-edge, error propagation, disconnect-during-request, reconnect, invalid message, malformed JSON, unknown result delivery.

### Test Results
- All Rust tests pass (astra-tools, astra-runtime unit + integration)
- All 132 web tests pass
