### PR TITLE
fix(plan): per-subtask turn budget + resume after PlanError

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -292,7 +292,11 @@ pub(crate) async fn stream_chat_sse(
         TurnGuard::with_health_and_profile(health, task_profile)
     };
 
-    let max_turns = RuntimeLimits::global().max_turns;
+    let max_turns = if p.is_plan_subtask {
+        RuntimeLimits::global().effective_plan_subtask_turns()
+    } else {
+        RuntimeLimits::global().max_turns
+    };
     let step_recorder = StepRecorder::with_persistence(
         current_session_id.as_deref().unwrap_or("ephemeral"),
         step_recorder_chat_ephemeral_run_id(start.elapsed().as_millis()).as_str(),

--- a/rust/crates/astra-cli/src/cli/plan_interaction.rs
+++ b/rust/crates/astra-cli/src/cli/plan_interaction.rs
@@ -1038,6 +1038,42 @@ pub async fn handle_plan_mode_input(
     Ok(())
 }
 
+// ─── Plan Resume Recovery ────────────────────────────────────────────────────
+
+/// Result of attempting to recover a plan for resume after executor failure.
+#[derive(Debug)]
+enum PlanResumeRecovery {
+    /// Plan has work remaining — Failed subtasks reset to Pending. Contains the
+    /// recovered plan ready for a new executor.
+    Ready(astra_services::task_orchestrator::TaskPlan),
+    /// All subtasks are already Completed — nothing to resume.
+    NothingToDo,
+}
+
+/// Recover a plan for resume: reset Failed→Pending and return a clone if work remains.
+///
+/// Called when the executor is gone (PlanError) but `plan_mode` still holds the
+/// plan with up-to-date subtask statuses (via `SubtaskStatusSync`).
+fn recover_plan_for_resume(
+    plan: &mut astra_services::task_orchestrator::TaskPlan,
+) -> PlanResumeRecovery {
+    use astra_services::task_orchestrator::TaskStatus;
+
+    let has_work = plan
+        .subtasks
+        .iter()
+        .any(|s| s.status == TaskStatus::Pending || s.status == TaskStatus::Failed);
+    if !has_work {
+        return PlanResumeRecovery::NothingToDo;
+    }
+    for st in &mut plan.subtasks {
+        if st.status == TaskStatus::Failed {
+            st.status = TaskStatus::Pending;
+        }
+    }
+    PlanResumeRecovery::Ready(plan.clone())
+}
+
 /// Handle a parsed `PlanCommand`.
 async fn handle_plan_command(
     cmd: PlanCommand,
@@ -1336,6 +1372,7 @@ async fn handle_plan_command(
 
         PlanCommand::Resume => {
             if let Some(ref handle) = state.plan_handle {
+                // Executor is alive (paused) — send Resume command.
                 let corrections = if state.plan_execution_corrections.is_empty() {
                     None
                 } else {
@@ -1349,8 +1386,20 @@ async fn handle_plan_command(
                     }
                     Err(e) => eprintln!("  {} {}", theme::icon_err(), e),
                 }
-            } else if state.executing_plan.is_some() {
-                eprintln!("  {} Resuming plan execution...", "▶".cyan());
+            } else if let Some(ref mut ps) = state.plan_mode {
+                match recover_plan_for_resume(&mut ps.plan) {
+                    PlanResumeRecovery::Ready(plan) => {
+                        state.executing_plan = Some(plan);
+                        eprintln!("  {} Resuming plan execution...", "▶".cyan());
+                    }
+                    PlanResumeRecovery::NothingToDo => {
+                        eprintln!(
+                            "  {} {}",
+                            theme::icon_warn(),
+                            "All subtasks already completed — nothing to resume".yellow()
+                        );
+                    }
+                }
             } else {
                 eprintln!(
                     "  {} {}",
@@ -2050,5 +2099,102 @@ mod tests {
         assert!(plan::PlanModeState::is_execute_command("开始"));
         assert!(!plan::PlanModeState::is_execute_command("show"));
         assert!(!plan::PlanModeState::is_execute_command(""));
+    }
+
+    #[test]
+    fn recover_plan_for_resume_resets_failed_to_pending() {
+        use astra_services::task_orchestrator::TaskPlan;
+        let mut plan = TaskPlan {
+            subtasks: vec![
+                SubtaskPlan {
+                    id: "s1".into(),
+                    title: "done".into(),
+                    status: TaskStatus::Completed,
+                    ..Default::default()
+                },
+                SubtaskPlan {
+                    id: "s2".into(),
+                    title: "failed".into(),
+                    status: TaskStatus::Failed,
+                    ..Default::default()
+                },
+                SubtaskPlan {
+                    id: "s3".into(),
+                    title: "pending".into(),
+                    status: TaskStatus::Pending,
+                    ..Default::default()
+                },
+            ],
+            notes: None,
+        };
+        let result = super::recover_plan_for_resume(&mut plan);
+        match result {
+            super::PlanResumeRecovery::Ready(recovered) => {
+                assert_eq!(recovered.subtasks[0].status, TaskStatus::Completed);
+                assert_eq!(recovered.subtasks[1].status, TaskStatus::Pending);
+                assert_eq!(recovered.subtasks[2].status, TaskStatus::Pending);
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn recover_plan_for_resume_all_completed_returns_nothing() {
+        use astra_services::task_orchestrator::TaskPlan;
+        let mut plan = TaskPlan {
+            subtasks: vec![
+                SubtaskPlan {
+                    id: "s1".into(),
+                    title: "done".into(),
+                    status: TaskStatus::Completed,
+                    ..Default::default()
+                },
+                SubtaskPlan {
+                    id: "s2".into(),
+                    title: "also done".into(),
+                    status: TaskStatus::Completed,
+                    ..Default::default()
+                },
+            ],
+            notes: None,
+        };
+        assert!(matches!(
+            super::recover_plan_for_resume(&mut plan),
+            super::PlanResumeRecovery::NothingToDo
+        ));
+    }
+
+    #[test]
+    fn recover_plan_for_resume_preserves_completed_subtasks() {
+        use astra_services::task_orchestrator::TaskPlan;
+        let mut plan = TaskPlan {
+            subtasks: vec![
+                SubtaskPlan {
+                    id: "s1".into(),
+                    title: "done".into(),
+                    status: TaskStatus::Completed,
+                    ..Default::default()
+                },
+                SubtaskPlan {
+                    id: "s2".into(),
+                    title: "failed".into(),
+                    status: TaskStatus::Failed,
+                    ..Default::default()
+                },
+            ],
+            notes: None,
+        };
+        if let super::PlanResumeRecovery::Ready(recovered) =
+            super::recover_plan_for_resume(&mut plan)
+        {
+            // Completed subtask untouched
+            assert_eq!(recovered.subtasks[0].status, TaskStatus::Completed);
+            // ready_subtasks() should now return s2 (Pending, no deps)
+            let ready = recovered.ready_subtasks();
+            assert_eq!(ready.len(), 1);
+            assert_eq!(ready[0].id, "s2");
+        } else {
+            panic!("expected Ready");
+        }
     }
 }

--- a/rust/crates/astra-cli/src/cli/slash_bug.rs
+++ b/rust/crates/astra-cli/src/cli/slash_bug.rs
@@ -135,6 +135,7 @@ fn build_bug_report(state: &ReplState) -> String {
         ("MO_API_KEY", true),
         ("MO_MODEL", false),
         ("MO_MAX_TURNS", false),
+        ("MO_PLAN_SUBTASK_MAX_TURNS", false),
         ("MO_MAX_TOOL_RETRIES", false),
         ("MO_RETRY_BASE_MS", false),
         ("MO_BUDGET_LIMIT", false),

--- a/rust/crates/astra-cli/src/edge_tools/config_tool.rs
+++ b/rust/crates/astra-cli/src/edge_tools/config_tool.rs
@@ -39,6 +39,10 @@ impl ToolExecutor {
                 "turn_limit",
                 "Max turns per conversation (env: MO_MAX_TURNS)",
             ),
+            (
+                "plan_subtask_turn_limit",
+                "Max turns per plan subtask, 0=use turn_limit (env: MO_PLAN_SUBTASK_MAX_TURNS)",
+            ),
             ("list", "Show all available settings"),
         ];
 
@@ -140,6 +144,16 @@ impl ToolExecutor {
                     "setting": "turn_limit",
                     "value": current,
                     "env_var": "MO_MAX_TURNS"
+                }).to_string()
+            }
+            "plan_subtask_turn_limit" => {
+                let current = std::env::var("MO_PLAN_SUBTASK_MAX_TURNS").unwrap_or_else(|_| "0".to_string());
+                let effective = astra_core::RuntimeLimits::global().effective_plan_subtask_turns();
+                json!({
+                    "setting": "plan_subtask_turn_limit",
+                    "value": current,
+                    "effective": effective,
+                    "env_var": "MO_PLAN_SUBTASK_MAX_TURNS"
                 }).to_string()
             }
             _ => json!({

--- a/rust/crates/core/src/runtime_limits.rs
+++ b/rust/crates/core/src/runtime_limits.rs
@@ -5,6 +5,7 @@
 //!
 //! ```text
 //! MO_MAX_TURNS=50              # conversation turns per session
+//! MO_PLAN_SUBTASK_MAX_TURNS=0  # per-subtask turn budget (0 = use MO_MAX_TURNS)
 //! MO_MAX_TOOL_ROUNDS=15        # tool execution rounds per turn
 //! MO_TURN_TIMEOUT_S=300        # seconds before a turn is force-completed
 //! MO_GLOBAL_OUTPUT_LIMIT=80000 # combined tool output bytes
@@ -25,6 +26,9 @@ static LIMITS: OnceLock<RuntimeLimits> = OnceLock::new();
 pub struct RuntimeLimits {
     /// Maximum conversation turns per session.
     pub max_turns: usize,
+    /// Per-subtask turn budget for plan execution.
+    /// 0 means fall back to `max_turns`.
+    pub plan_subtask_max_turns: usize,
     /// Maximum tool execution rounds per turn.
     pub max_tool_rounds: i64,
     /// Per-turn hard timeout in seconds.
@@ -49,6 +53,7 @@ impl Default for RuntimeLimits {
     fn default() -> Self {
         Self {
             max_turns: 50,
+            plan_subtask_max_turns: 0,
             max_tool_rounds: 15,
             turn_timeout_s: 300.0,
             global_output_limit: 200_000,
@@ -67,6 +72,10 @@ impl RuntimeLimits {
         let d = Self::default();
         Self {
             max_turns: env_parse("MO_MAX_TURNS", d.max_turns),
+            plan_subtask_max_turns: env_parse(
+                "MO_PLAN_SUBTASK_MAX_TURNS",
+                d.plan_subtask_max_turns,
+            ),
             max_tool_rounds: env_parse("MO_MAX_TOOL_ROUNDS", d.max_tool_rounds),
             turn_timeout_s: env_parse("MO_TURN_TIMEOUT_S", d.turn_timeout_s),
             global_output_limit: env_parse("MO_GLOBAL_OUTPUT_LIMIT", d.global_output_limit),
@@ -81,6 +90,16 @@ impl RuntimeLimits {
     /// Get the global `RuntimeLimits` singleton (loaded from env on first call).
     pub fn global() -> &'static RuntimeLimits {
         LIMITS.get_or_init(Self::from_env)
+    }
+
+    /// Effective turn budget for a plan subtask.
+    /// Returns `plan_subtask_max_turns` if set (> 0), otherwise `max_turns`.
+    pub fn effective_plan_subtask_turns(&self) -> usize {
+        if self.plan_subtask_max_turns > 0 {
+            self.plan_subtask_max_turns
+        } else {
+            self.max_turns
+        }
     }
 }
 
@@ -119,6 +138,7 @@ mod tests {
     fn defaults_match_original_constants() {
         let d = RuntimeLimits::default();
         assert_eq!(d.max_turns, 50);
+        assert_eq!(d.plan_subtask_max_turns, 0);
         assert_eq!(d.max_tool_rounds, 15);
         assert!((d.turn_timeout_s - 300.0).abs() < f64::EPSILON);
         assert_eq!(d.global_output_limit, 200_000);
@@ -148,5 +168,25 @@ mod tests {
     #[test]
     fn dev_password_constant_matches_original() {
         assert_eq!(DEV_MATRIXONE_PASSWORD, "111");
+    }
+
+    #[test]
+    fn effective_plan_subtask_turns_falls_back_to_max_turns() {
+        let limits = RuntimeLimits {
+            plan_subtask_max_turns: 0,
+            max_turns: 50,
+            ..Default::default()
+        };
+        assert_eq!(limits.effective_plan_subtask_turns(), 50);
+    }
+
+    #[test]
+    fn effective_plan_subtask_turns_uses_explicit_value() {
+        let limits = RuntimeLimits {
+            plan_subtask_max_turns: 80,
+            max_turns: 50,
+            ..Default::default()
+        };
+        assert_eq!(limits.effective_plan_subtask_turns(), 80);
     }
 }

--- a/rust/crates/runtime/src/turn/stall.rs
+++ b/rust/crates/runtime/src/turn/stall.rs
@@ -10,9 +10,9 @@ use super::tool_call_shape::{tool_call_arguments_value, tool_call_name};
 /// (e.g. read_file with different args each turn) triggered false stalls.
 pub const SERVER_STALL_WINDOW: usize = 3;
 
-/// User-visible error when the agentic loop exhausts the per-request remaining-turn budget (stall guard).
-pub const CLI_AGENTIC_TURN_BUDGET_STALL_ABORT_MSG: &str =
-    "Turn budget exhausted. To increase, set MO_MAX_TURNS=100 (current default: 50).";
+/// User-visible error prefix when the agentic loop exhausts the per-request remaining-turn budget.
+/// Call sites append the actual budget number, e.g. `format!("{} (budget: {} turns)", MSG, n)`.
+pub const CLI_AGENTIC_TURN_BUDGET_STALL_ABORT_MSG: &str = "Turn budget exhausted. To increase, set MO_MAX_TURNS (interactive) or MO_PLAN_SUBTASK_MAX_TURNS (plan subtasks).";
 
 /// Tools considered "exploration" — low-value if used repeatedly without
 /// a "productive" tool call in between.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes plan executor turn budget exhaustion and broken resume after PlanError.

## What this PR does / why we need it:

Three systemic issues fixed:

### 1. Turn budget not isolated per subtask
All plan subtasks shared the global `MO_MAX_TURNS` budget. Added `MO_PLAN_SUBTASK_MAX_TURNS` env var (default 0 = use `MO_MAX_TURNS`) so plan subtasks can have independent turn budgets. `stream_chat_sse` now uses `effective_plan_subtask_turns()` when `is_plan_subtask` is true.

### 2. Resume broken after PlanError
`plan_monitor` cleared `executing_plan` on PlanError, and the resume handler had no fallback — showing recovery options that didn't work. Now the resume handler recovers from `plan_mode` (which has up-to-date subtask statuses via `SubtaskStatusSync`). It resets Failed subtasks to Pending and sets `executing_plan` so the main loop re-spawns the executor, which skips already-Completed subtasks via `ready_subtasks()`.

### 3. Misleading error message
Stall abort message only mentioned `MO_MAX_TURNS` with hardcoded default. Updated to mention both env vars; removed stale default number (actual budget is appended by call sites).

### Changes
- `runtime_limits.rs`: `plan_subtask_max_turns` field + `effective_plan_subtask_turns()` helper
- `sse_loop/mod.rs`: Use per-subtask budget when `is_plan_subtask`
- `plan_interaction.rs`: `recover_plan_for_resume()` helper + Resume handler recovery from `plan_mode`
- `stall.rs`: Updated error message
- `config_tool.rs` / `slash_bug.rs`: Observability additions

### Tests
5 new unit tests:
- `effective_plan_subtask_turns_falls_back_to_max_turns`
- `effective_plan_subtask_turns_uses_explicit_value`
- `recover_plan_for_resume_resets_failed_to_pending`
- `recover_plan_for_resume_all_completed_returns_nothing`
- `recover_plan_for_resume_preserves_completed_subtasks`
