### PR TITLE
fix(core): detect wrapped MatrixOne duplicate-key errors

### DIFF
--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -273,10 +273,22 @@ pub fn internal_error_coded(
     )
 }
 
-/// MySQL/MatrixOne error code 1062 = `ER_DUP_ENTRY`.
+/// MySQL/MatrixOne duplicate-key errors may surface as vendor code 1062,
+/// SQLSTATE 23000, or wrapped message-only errors.
 pub fn is_duplicate_key_error(err: &sqlx::Error) -> bool {
-    matches!(err, sqlx::Error::Database(db_err) if db_err.code().as_deref() == Some("23000")
-        || db_err.message().contains("Duplicate entry"))
+    match err {
+        sqlx::Error::Database(db_err) => {
+            let message = db_err.message();
+            matches!(db_err.code().as_deref(), Some("1062") | Some("23000"))
+                || message.contains("Duplicate entry")
+                || message.contains("ER_DUP_ENTRY")
+        }
+        _ => {
+            let message = err.to_string();
+            message.contains("Duplicate entry")
+                && (message.contains("1062") || message.contains("ER_DUP_ENTRY"))
+        }
+    }
 }
 
 pub fn current_unix_seconds() -> f64 {
@@ -351,6 +363,18 @@ mod tests {
         let err = std::io::Error::new(std::io::ErrorKind::NotFound, "file gone");
         let (status, _) = internal_error(err);
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn duplicate_key_error_detects_protocol_wrappers() {
+        let err = sqlx::Error::Protocol("1062: Duplicate entry 'test' for key".into());
+        assert!(is_duplicate_key_error(&err));
+    }
+
+    #[test]
+    fn duplicate_key_error_rejects_unrelated_protocol_wrappers() {
+        let err = sqlx::Error::Protocol("connection reset by peer".into());
+        assert!(!is_duplicate_key_error(&err));
     }
 
     // --- current_unix_seconds ---

--- a/rust/crates/services/src/session_restore.rs
+++ b/rust/crates/services/src/session_restore.rs
@@ -1652,10 +1652,9 @@ mod tests {
     }
 
     #[test]
-    fn is_duplicate_key_error_rejects_protocol_error() {
-        // Protocol errors should NOT be treated as duplicate key, even if message contains "1062"
+    fn is_duplicate_key_error_detects_protocol_duplicate_wrapper() {
         let fake_err = sqlx::Error::Protocol("1062: Duplicate entry 'test' for key".into());
-        assert!(!astra_core::is_duplicate_key_error(&fake_err));
+        assert!(astra_core::is_duplicate_key_error(&fake_err));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend the shared `astra_core::is_duplicate_key_error` helper to recognize wrapped duplicate-entry failures
- keep support for SQLSTATE `23000` and vendor code `1062`, plus `ER_DUP_ENTRY` message forms
- align session restore regression coverage with the shared helper behavior

## Testing
- cargo test -p astra-core duplicate_key_error --lib
- cargo test -p astra-services detects_protocol_duplicate_wrapper --lib