### PR TITLE
fix(runtime): harden delegation closure and bridge turn evaluation

### DIFF
--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -853,6 +853,7 @@ fn commit_turn_journal_workspace_and_sidecars(
     state: &mut ReplState,
     line: &str,
     result: &StreamResult,
+    learning_snap: &ReplTurnLearningSnapshot,
     turn_start: Instant,
 ) {
     if let Some(journal) = state.journal.as_ref() {
@@ -1099,6 +1100,25 @@ fn commit_turn_journal_workspace_and_sidecars(
             enqueue_ingestion(state, &verdict_event);
         }
 
+        let turn_eval_event =
+            astra_runtime::pipeline::evaluation::build_turn_evaluation_journal_event(
+                state.session_id.as_deref(),
+                Some(state.turn),
+                "cli_repl",
+                line,
+                &state.recent_tools,
+                &result.tool_call_records,
+                result.stall_events.len(),
+                result.verdict_events.iter().any(|event| {
+                    event.severity.eq_ignore_ascii_case("warning")
+                        || event.severity.eq_ignore_ascii_case("critical")
+                }),
+                result.budget_pressure,
+                &learning_snap.eval,
+            );
+        let _ = journal.append(&turn_eval_event);
+        enqueue_ingestion(state, &turn_eval_event);
+
         // Step Protocol recorder summary: previously emitted as a second
         // checkpoint event, causing duplicate checkpoint entries with
         // inconsistent token counts. The summary is already captured in the
@@ -1119,34 +1139,21 @@ pub(super) fn analyze_repl_turn_learning(
     recent_tools: &[String],
     result: &StreamResult,
 ) -> ReplTurnLearningSnapshot {
-    use astra_runtime::pipeline::evaluation::{ToolCallInfo, evaluate_turn};
+    use astra_runtime::pipeline::evaluation::evaluate_tool_call_records;
     use astra_runtime::pipeline::routing::RoutingEngine;
     let routing = RoutingEngine::analyze(line, turn, recent_tools, &[], vec![]);
-    let is_live_query = looks_like_live_query_with_context(line, recent_tools);
 
-    let tool_infos: Vec<ToolCallInfo> = result
-        .tool_call_records
-        .iter()
-        .map(|r| ToolCallInfo {
-            name: r.name.clone(),
-            ok: r.ok,
-            ms: r.ms,
-            error: r.error.clone(),
-            output_bytes: r.output_bytes,
-        })
-        .collect();
+    let has_verdict_warning = result.verdict_events.iter().any(|v| {
+        v.severity.eq_ignore_ascii_case("warning") || v.severity.eq_ignore_ascii_case("critical")
+    });
 
-    let has_verdict_warning = result
-        .verdict_events
-        .iter()
-        .any(|v| v.severity == "Warning" || v.severity == "Critical");
-
-    let eval = evaluate_turn(
-        &tool_infos,
+    let eval = evaluate_tool_call_records(
+        line,
+        recent_tools,
+        &result.tool_call_records,
         result.stall_events.len(),
         has_verdict_warning,
         result.budget_pressure,
-        is_live_query,
     );
 
     ReplTurnLearningSnapshot { routing, eval }
@@ -1252,7 +1259,7 @@ fn apply_turn_success(
         && learning_snap.routing.domain_hint.is_none();
     result.set_repl_learning_journal_fields(routing_domain, entity_skipped);
 
-    commit_turn_journal_workspace_and_sidecars(state, line, &result, turn_start);
+    commit_turn_journal_workspace_and_sidecars(state, line, &result, &learning_snap, turn_start);
     record_selector_turn_outcome(selector, line, &result, &learning_snap);
 
     // ── Skill auto-improvement check ─────────────────────────────────────
@@ -3436,6 +3443,58 @@ mod tests {
         assert_eq!(persisted.tool_count, Some(1));
         assert_eq!(persisted.tools_used, Some(vec!["read_file".into()]));
         assert_eq!(persisted.tool_calls.as_ref().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn commit_turn_persists_turn_evaluation_event() {
+        let (_tmp, _g) = isolated_sessions_dir();
+        let sid = format!("test-turn-eval-{}", uuid::Uuid::new_v4());
+        let mut state = ReplState {
+            journal: Some(session_journal::JournalWriter::new(&sid).unwrap()),
+            session_id: Some(sid.clone()),
+            model: Some("gpt-5".into()),
+            turn: 1,
+            recent_tools: vec!["git_status".into()],
+            ..Default::default()
+        };
+        let mut result = stub_stream_result("Workspace is clean.");
+        result.tools_used = vec!["git_status".into()];
+        result.tool_calls_count = 1;
+        result.tool_call_records = vec![session_journal::ToolCallRecord {
+            name: "git_status".into(),
+            ok: true,
+            ms: 12,
+            error: None,
+            input_bytes: Some(16),
+            output_bytes: Some(240),
+            args_preview: None,
+            result_preview: Some("clean".into()),
+        }];
+
+        let learning =
+            analyze_repl_turn_learning("git status", state.turn, &state.recent_tools, &result);
+        commit_turn_journal_workspace_and_sidecars(
+            &mut state,
+            "git status",
+            &result,
+            &learning,
+            Instant::now(),
+        );
+
+        let events = session_journal::read_journal(&sid).unwrap();
+        let event = events
+            .iter()
+            .find(|event| event.event_type == session_journal::JournalEventType::TurnEvaluation)
+            .expect("turn evaluation event");
+        assert_eq!(event.turn, Some(1));
+        let metadata = event.metadata.as_ref().expect("turn evaluation metadata");
+        assert_eq!(metadata["source"], "cli_repl");
+        assert_eq!(metadata["live_query"], true);
+        assert_eq!(metadata["success"], true);
+        assert_eq!(metadata["tool_call_count"], 1);
+        assert_eq!(metadata["signal_count"], 2);
+        assert_eq!(metadata["signals"][0]["kind"], "tool_error_rate");
+        assert_eq!(metadata["signals"][1]["kind"], "all_tools_healthy");
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/self_command.rs
+++ b/rust/crates/astra-cli/src/cli/self_command.rs
@@ -2279,6 +2279,7 @@ fn event_type_name(event_type: &JournalEventType) -> String {
         JournalEventType::StallDetected => "stall_detected",
         JournalEventType::Checkpoint => "checkpoint",
         JournalEventType::TurnGuardVerdict => "turn_guard_verdict",
+        JournalEventType::TurnEvaluation => "turn_evaluation",
         JournalEventType::PlanProgress => "plan_progress",
         JournalEventType::SessionFork => "session_fork",
         JournalEventType::SyncMarker => "sync_marker",

--- a/rust/crates/astra-cli/src/cli/slash_session.rs
+++ b/rust/crates/astra-cli/src/cli/slash_session.rs
@@ -1018,6 +1018,55 @@ pub(super) fn handle_session_command(arg: &str, state: &mut ReplState) {
                                     details,
                                 );
                             }
+                            session_journal::JournalEventType::TurnEvaluation => {
+                                let metadata = evt.metadata.as_ref();
+                                let source = metadata
+                                    .and_then(|m| m.get("source"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("runtime");
+                                let quality = metadata
+                                    .and_then(|m| m.get("quality"))
+                                    .and_then(|v| v.as_f64())
+                                    .unwrap_or(0.0);
+                                let confidence = metadata
+                                    .and_then(|m| m.get("confidence"))
+                                    .and_then(|v| v.as_f64())
+                                    .unwrap_or(0.0);
+                                let success = metadata
+                                    .and_then(|m| m.get("success"))
+                                    .and_then(|v| v.as_bool())
+                                    .unwrap_or(false);
+                                let signals = metadata
+                                    .and_then(|m| m.get("signals"))
+                                    .and_then(|v| v.as_array())
+                                    .map(|signals| {
+                                        signals
+                                            .iter()
+                                            .filter_map(|signal| {
+                                                signal.get("kind").and_then(|kind| kind.as_str())
+                                            })
+                                            .take(2)
+                                            .collect::<Vec<_>>()
+                                            .join(", ")
+                                    })
+                                    .filter(|summary| !summary.is_empty())
+                                    .map(|summary| format!(" [{summary}]"))
+                                    .unwrap_or_default();
+                                eprintln!(
+                                    "  {} {} {}eval[{}]: q={:.2} conf={:.2}{}",
+                                    ts_short.dim(),
+                                    if success {
+                                        "◎".green().to_string()
+                                    } else {
+                                        theme::icon_warn().to_string()
+                                    },
+                                    evt.turn.map(|turn| format!("T{turn} ")).unwrap_or_default(),
+                                    source.dim(),
+                                    quality,
+                                    confidence,
+                                    signals,
+                                );
+                            }
                             session_journal::JournalEventType::PlanProgress => {
                                 let action = evt
                                     .metadata

--- a/rust/crates/runtime/src/messaging/in_process.rs
+++ b/rust/crates/runtime/src/messaging/in_process.rs
@@ -160,24 +160,15 @@ impl MessageTransport for InProcessTransport {
         };
 
         // Snapshot delegation membership while this subscribe still owns the
-        // direct-mailbox state; if the broadcast channel disappears afterward,
-        // fail fast instead of silently returning a stream with no broadcasts.
+        // direct-mailbox state. If the broadcast channel disappears before we
+        // subscribe, recreate it so a stale cleanup race does not abort mailbox
+        // registration for an otherwise live agent.
         let delegation_id = self.memberships.read().await.get(addr).cloned();
         drop(pending_receivers);
         drop(inboxes);
 
         let broadcast_rx = if let Some(did) = delegation_id {
-            let broadcasts = self.broadcasts.read().await;
-            Some(
-                broadcasts
-                    .get(&did)
-                    .ok_or_else(|| {
-                        MailboxError::Transport(format!(
-                            "broadcast group not found for registered agent: {did}"
-                        ))
-                    })?
-                    .subscribe(),
-            )
+            Some(self.ensure_broadcast(&did).await.subscribe())
         } else {
             None
         };
@@ -480,7 +471,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn subscribe_fails_when_membership_loses_broadcast_channel() {
+    async fn subscribe_recreates_missing_broadcast_channel_for_registered_agent() {
         let transport = InProcessTransport::new();
         let a = addr("r1", "a");
         let del = "del-missing";
@@ -491,11 +482,11 @@ mod tests {
             .unwrap();
         transport.broadcasts.write().await.remove(del);
 
-        let err = match transport.subscribe(&a).await {
-            Ok(_) => panic!("subscribe should fail when broadcast channel is missing"),
-            Err(err) => err,
-        };
-        assert!(matches!(err, MailboxError::Transport(_)));
+        let _stream = transport
+            .subscribe(&a)
+            .await
+            .expect("subscribe should heal a missing broadcast channel");
+        assert!(transport.broadcasts.read().await.contains_key(del));
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/pipeline/evaluation.rs
+++ b/rust/crates/runtime/src/pipeline/evaluation.rs
@@ -9,6 +9,11 @@
 //! - Repeated tool calls (retry loops)
 //! - Correction patterns in user follow-up
 
+use astra_services::session_journal::{JournalEvent, ToolCallRecord};
+use serde_json::json;
+
+use crate::turn::chat_turn_heuristics::looks_like_live_query_with_context;
+
 /// Signals detected during evaluation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum EvalSignal {
@@ -167,11 +172,111 @@ pub fn evaluate_turn(
     }
 }
 
+pub fn evaluate_tool_call_records(
+    input: &str,
+    recent_tools: &[String],
+    tool_call_records: &[ToolCallRecord],
+    stall_count: usize,
+    verdict_warning: bool,
+    budget_pressure: f64,
+) -> TurnEvaluation {
+    let tool_calls = tool_call_records
+        .iter()
+        .map(|record| ToolCallInfo {
+            name: record.name.clone(),
+            ok: record.ok,
+            ms: record.ms,
+            error: record.error.clone(),
+            output_bytes: record.output_bytes,
+        })
+        .collect::<Vec<_>>();
+    let is_live_query = looks_like_live_query_with_context(input, recent_tools);
+    evaluate_turn(
+        &tool_calls,
+        stall_count,
+        verdict_warning,
+        budget_pressure,
+        is_live_query,
+    )
+}
+
+pub fn eval_signal_to_json(signal: &EvalSignal) -> serde_json::Value {
+    match signal {
+        EvalSignal::ToolErrorRate(rate) => json!({
+            "kind": "tool_error_rate",
+            "weight": rate,
+        }),
+        EvalSignal::EmptyToolOutput => json!({
+            "kind": "empty_tool_output",
+            "message": "At least one successful tool call returned minimal output",
+        }),
+        EvalSignal::StallDetected => json!({
+            "kind": "stall_detected",
+            "message": "TurnGuard recorded a stall or divergence event",
+        }),
+        EvalSignal::HighBudgetPressure => json!({
+            "kind": "high_budget_pressure",
+            "message": "Budget pressure crossed the high-pressure threshold",
+        }),
+        EvalSignal::RepeatToolCall(name) => json!({
+            "kind": "repeat_tool_call",
+            "tool": name,
+            "message": format!("Repeated tool call pattern detected for `{name}`"),
+        }),
+        EvalSignal::VerdictWarning => json!({
+            "kind": "verdict_warning",
+            "message": "TurnGuard emitted a warning-or-higher verdict",
+        }),
+        EvalSignal::NoToolsNeeded => json!({
+            "kind": "missing_needed_tools",
+            "message": "The turn looked like a live query but completed without tool calls",
+        }),
+        EvalSignal::AllToolsHealthy => json!({
+            "kind": "all_tools_healthy",
+            "message": "All tool calls completed successfully with non-empty output",
+        }),
+    }
+}
+
+pub fn eval_signals_to_json(signals: &[EvalSignal]) -> Vec<serde_json::Value> {
+    signals.iter().map(eval_signal_to_json).collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_turn_evaluation_journal_event(
+    session_id: Option<&str>,
+    turn: Option<u32>,
+    source: &str,
+    input: &str,
+    recent_tools: &[String],
+    tool_call_records: &[ToolCallRecord],
+    stall_count: usize,
+    verdict_warning: bool,
+    budget_pressure: f64,
+    eval: &TurnEvaluation,
+) -> JournalEvent {
+    JournalEvent::turn_evaluation(
+        session_id,
+        turn,
+        source,
+        looks_like_live_query_with_context(input, recent_tools),
+        eval.success,
+        eval.quality,
+        eval.confidence,
+        budget_pressure,
+        stall_count,
+        verdict_warning,
+        tool_call_records.len(),
+        eval_signals_to_json(&eval.signals),
+    )
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use astra_services::session_journal::JournalEventType;
 
     fn ok_call(name: &str) -> ToolCallInfo {
         ToolCallInfo {
@@ -200,6 +305,19 @@ mod tests {
             ms: 100,
             error: None,
             output_bytes: Some(0),
+        }
+    }
+
+    fn journal_ok_call(name: &str) -> ToolCallRecord {
+        ToolCallRecord {
+            name: name.to_string(),
+            ok: true,
+            ms: 100,
+            error: None,
+            input_bytes: Some(12),
+            output_bytes: Some(500),
+            args_preview: None,
+            result_preview: Some("ok".to_string()),
         }
     }
 
@@ -331,5 +449,54 @@ mod tests {
         let simple = evaluate_turn(&[ok_call("bash")], 0, false, 0.3, false);
         let complex = evaluate_turn(&[err_call("bash"), err_call("grep")], 2, true, 0.9, false);
         assert!(complex.confidence > simple.confidence);
+    }
+
+    #[test]
+    fn evaluate_tool_call_records_reuses_live_query_heuristic() {
+        let eval = evaluate_tool_call_records(
+            "Check the latest git status",
+            &["git_status".to_string()],
+            &[],
+            0,
+            false,
+            0.2,
+        );
+        assert!(!eval.success);
+        assert!(eval.signals.contains(&EvalSignal::NoToolsNeeded));
+    }
+
+    #[test]
+    fn build_turn_evaluation_journal_event_serializes_normalized_signals() {
+        let records = vec![journal_ok_call("git_status")];
+        let eval = evaluate_tool_call_records(
+            "Check the latest git status",
+            &["git_status".to_string()],
+            &records,
+            0,
+            false,
+            0.2,
+        );
+
+        let event = build_turn_evaluation_journal_event(
+            Some("sess-1"),
+            Some(2),
+            "cli_repl",
+            "Check the latest git status",
+            &["git_status".to_string()],
+            &records,
+            0,
+            false,
+            0.2,
+            &eval,
+        );
+
+        assert_eq!(event.event_type, JournalEventType::TurnEvaluation);
+        let metadata = event.metadata.expect("turn evaluation metadata");
+        assert_eq!(metadata["source"], "cli_repl");
+        assert_eq!(metadata["live_query"], true);
+        assert_eq!(metadata["tool_call_count"], 1);
+        assert_eq!(metadata["signal_count"], 2);
+        assert_eq!(metadata["signals"][0]["kind"], "tool_error_rate");
+        assert_eq!(metadata["signals"][1]["kind"], "all_tools_healthy");
     }
 }

--- a/rust/crates/runtime/src/server/delegation_engine.rs
+++ b/rust/crates/runtime/src/server/delegation_engine.rs
@@ -453,15 +453,23 @@ impl DelegationTracker {
         let Some(ref sid) = self.session_id else {
             return;
         };
-        let writer = match astra_services::session_journal::JournalWriter::new(sid) {
-            Ok(w) => w,
-            Err(_) => return,
-        };
         let mut event = astra_services::session_journal::JournalEvent::base_public(
             event_type,
             Some(sid.as_str()),
         );
         event.metadata = Some(metadata);
+        self.persist_journal_entry(event);
+    }
+
+    /// Persist a fully constructed journal event (best-effort).
+    fn persist_journal_entry(&self, event: astra_services::session_journal::JournalEvent) {
+        let Some(ref sid) = self.session_id else {
+            return;
+        };
+        let writer = match astra_services::session_journal::JournalWriter::new(sid) {
+            Ok(w) => w,
+            Err(_) => return,
+        };
         if let Err(e) = writer.append(&event) {
             astra_core::agent_warn!("delegation", "Failed to write journal event: {e}");
         }
@@ -800,11 +808,24 @@ impl DelegationTracker {
     ///
     /// Cleans up resources and updates progress tracking.
     pub async fn complete_sub_run(&self, run_id: &str, terminal_state: SubRunState) {
+        self.complete_sub_run_with_result(run_id, terminal_state, None, None)
+            .await;
+    }
+
+    /// Mark a sub-run as complete and persist the terminal result metadata.
+    pub async fn complete_sub_run_with_result(
+        &self,
+        run_id: &str,
+        terminal_state: SubRunState,
+        error: Option<&str>,
+        output_preview: Option<&str>,
+    ) {
         debug_assert!(terminal_state.is_terminal());
 
         // Transition state in record
         let mut delegation_id = None;
         let mut agent_id = None;
+        let mut final_state = terminal_state;
         {
             let mut delegations = self.delegations.write().await;
             for records in delegations.values_mut() {
@@ -815,6 +836,7 @@ impl DelegationTracker {
                             .state
                             .try_transition(terminal_state)
                             .unwrap_or(terminal_state);
+                        final_state = record.state;
                         delegation_id = Some(record.delegation_id.clone());
                         agent_id = Some(record.agent_id.clone());
                         break;
@@ -831,13 +853,25 @@ impl DelegationTracker {
 
         // Update progress + emit SSE event
         if let (Some(did), Some(aid)) = (delegation_id, agent_id) {
-            self.update_progress(&did, &aid, terminal_state).await;
+            self.persist_journal_entry(
+                astra_services::session_journal::JournalEvent::delegation_sub_run_completed(
+                    self.session_id.as_deref(),
+                    &did,
+                    run_id,
+                    &aid,
+                    final_state.as_str(),
+                    error,
+                    output_preview,
+                ),
+            );
+
+            self.update_progress(&did, &aid, final_state).await;
 
             // Emit completion SSE event for web clients
             if let Some(ref broadcaster) = self.progress_broadcaster {
                 use crate::orchestration::{AgentProgressEvent, ProgressEventType};
-                let status_str = format!("{:?}", terminal_state);
-                let event_type = if terminal_state == SubRunState::Completed {
+                let status_str = format!("{:?}", final_state);
+                let event_type = if final_state == SubRunState::Completed {
                     ProgressEventType::Completed {
                         result_summary: format!("Sub-run {} finished", run_id),
                         total_tool_calls: 0,
@@ -866,9 +900,20 @@ impl DelegationTracker {
     /// Cleans up all tracking state for a completed delegation:
     /// progress entries, pause flags, parent mappings, and delegation records.
     /// Call after the delegation lifecycle is fully complete.
-    pub async fn cleanup_delegation(&self, delegation_id: &str) {
+    pub async fn cleanup_delegation(&self, delegation_id: &str) -> Result<(), String> {
         // Gather run_ids before cleanup
         let records = self.get_sub_runs(delegation_id).await;
+        let non_terminal: Vec<String> = records
+            .iter()
+            .filter(|record| !record.state.is_terminal())
+            .map(|record| format!("{}({})", record.run_id, record.state.as_str()))
+            .collect();
+        if !non_terminal.is_empty() {
+            return Err(format!(
+                "delegation {delegation_id} still has non-terminal sub-runs: {}",
+                non_terminal.join(", ")
+            ));
+        }
         let run_ids: Vec<String> = records.iter().map(|r| r.run_id.clone()).collect();
 
         // Acquire locks in consistent order: delegations → parents → pause_flags → progress
@@ -884,6 +929,7 @@ impl DelegationTracker {
             pause_flags.remove(rid);
         }
         progress_map.remove(delegation_id);
+        Ok(())
     }
 
     /// Get the full retry chain for a run: [original, retry1, retry2, ...]
@@ -1173,8 +1219,15 @@ impl DelegationEngine {
 
                     if attempt >= max_retries {
                         // Exhausted retries — mark as verification failure
+                        let verification_error =
+                            format!("verification gate failed after {attempt} attempts: {reason}");
                         self.tracker
-                            .complete_sub_run(&current.run_id, SubRunState::VerificationFailed)
+                            .complete_sub_run_with_result(
+                                &current.run_id,
+                                SubRunState::VerificationFailed,
+                                Some(verification_error.as_str()),
+                                current.output.as_deref(),
+                            )
                             .await;
                         astra_core::log_persist!(
                             self.run_engine
@@ -1191,9 +1244,7 @@ impl DelegationEngine {
                         );
                         return AgentResult {
                             status: STATUS_VERIFICATION_FAILED.to_string(),
-                            error: Some(format!(
-                                "verification gate failed after {attempt} attempts: {reason}"
-                            )),
+                            error: Some(verification_error),
                             ..current
                         };
                     }
@@ -1271,7 +1322,12 @@ impl DelegationEngine {
 
                     // Mark the original as verification-failed before retrying
                     self.tracker
-                        .complete_sub_run(&original_run_id, SubRunState::VerificationFailed)
+                        .complete_sub_run_with_result(
+                            &original_run_id,
+                            SubRunState::VerificationFailed,
+                            Some(reason.as_str()),
+                            current.output.as_deref(),
+                        )
                         .await;
 
                     // Transition retry to Running before execution
@@ -1316,14 +1372,17 @@ impl DelegationEngine {
                     } {
                         Ok(r) => {
                             // Transition retry to Running→Completed/Failed
+                            let terminal_state = if r.is_success() {
+                                SubRunState::Completed
+                            } else {
+                                SubRunState::Failed
+                            };
                             self.tracker
-                                .complete_sub_run(
+                                .complete_sub_run_with_result(
                                     &r.run_id,
-                                    if r.is_success() {
-                                        SubRunState::Completed
-                                    } else {
-                                        SubRunState::Failed
-                                    },
+                                    terminal_state,
+                                    r.error.as_deref(),
+                                    r.output.as_deref(),
                                 )
                                 .await;
                             astra_core::log_persist!(
@@ -1338,7 +1397,12 @@ impl DelegationEngine {
                         }
                         Err(e) => {
                             self.tracker
-                                .complete_sub_run(&retry_run_id, SubRunState::Failed)
+                                .complete_sub_run_with_result(
+                                    &retry_run_id,
+                                    SubRunState::Failed,
+                                    Some(e.as_str()),
+                                    None,
+                                )
                                 .await;
                             return AgentResult {
                                 status: STATUS_FAILED.to_string(),
@@ -1500,22 +1564,8 @@ impl DelegationEngine {
             }
         };
 
-        // Journal: sub-run completions + delegation completed
+        // Journal: delegation completed
         if let Ok(ref dr) = result {
-            for ar in &dr.agent_results {
-                Self::write_journal_event(
-                    session_id,
-                    astra_services::session_journal::JournalEvent::delegation_sub_run_completed(
-                        Some(session_id),
-                        &request.delegation_id,
-                        &ar.run_id,
-                        &ar.agent_id,
-                        &ar.status,
-                        ar.error.as_deref(),
-                        ar.output.as_deref(),
-                    ),
-                );
-            }
             let succeeded = dr.agent_results.iter().filter(|r| r.is_success()).count();
             let failed = dr.agent_results.len() - succeeded;
             Self::write_journal_event(
@@ -1816,7 +1866,13 @@ impl DelegationEngine {
                         SubRunState::Failed
                     }
                 };
-                tracker.complete_sub_run(&run_id, final_state).await;
+                let (error, output_preview) = match &result {
+                    Ok(r) => (r.error.as_deref(), r.output.as_deref()),
+                    Err(e) => (Some(e.as_str()), None),
+                };
+                tracker
+                    .complete_sub_run_with_result(&run_id, final_state, error, output_preview)
+                    .await;
                 (result, agent_id, run_id)
             });
             id_map.insert(abort_handle.id(), (captured_agent_id, captured_run_id));
@@ -1857,15 +1913,21 @@ impl DelegationEngine {
                         &panic_run_id,
                         "status"
                     );
+                    let panic_error = format!("task join error (panic): {e}");
                     self.tracker
-                        .complete_sub_run(&panic_run_id, SubRunState::Failed)
+                        .complete_sub_run_with_result(
+                            &panic_run_id,
+                            SubRunState::Failed,
+                            Some(panic_error.as_str()),
+                            None,
+                        )
                         .await;
                     results.push(AgentResult {
                         agent_id: panic_agent_id,
                         run_id: panic_run_id,
                         status: STATUS_FAILED.to_string(),
                         output: None,
-                        error: Some(format!("task join error (panic): {}", e)),
+                        error: Some(panic_error),
                         prompt_tokens: 0,
                         completion_tokens: 0,
                         tool_calls: 0,
@@ -2106,7 +2168,12 @@ impl DelegationEngine {
                     let final_state =
                         SubRunState::from_str(&r.status).unwrap_or(SubRunState::Failed);
                     self.tracker
-                        .complete_sub_run(&sub_run_id, final_state)
+                        .complete_sub_run_with_result(
+                            &sub_run_id,
+                            final_state,
+                            r.error.as_deref(),
+                            r.output.as_deref(),
+                        )
                         .await;
                     r
                 }
@@ -2120,7 +2187,12 @@ impl DelegationEngine {
                         "status"
                     );
                     self.tracker
-                        .complete_sub_run(&sub_run_id, SubRunState::Failed)
+                        .complete_sub_run_with_result(
+                            &sub_run_id,
+                            SubRunState::Failed,
+                            Some(e.as_str()),
+                            None,
+                        )
                         .await;
                     AgentResult {
                         agent_id: agent_id.clone(),
@@ -2376,7 +2448,12 @@ impl DelegationEngine {
                     let final_state =
                         SubRunState::from_str(&r.status).unwrap_or(SubRunState::Failed);
                     self.tracker
-                        .complete_sub_run(&prod_run_id, final_state)
+                        .complete_sub_run_with_result(
+                            &prod_run_id,
+                            final_state,
+                            r.error.as_deref(),
+                            r.output.as_deref(),
+                        )
                         .await;
                     r
                 }
@@ -2390,7 +2467,12 @@ impl DelegationEngine {
                         "status"
                     );
                     self.tracker
-                        .complete_sub_run(&prod_run_id, SubRunState::Failed)
+                        .complete_sub_run_with_result(
+                            &prod_run_id,
+                            SubRunState::Failed,
+                            Some(e.as_str()),
+                            None,
+                        )
                         .await;
                     AgentResult {
                         agent_id: producer_id.to_string(),
@@ -2564,7 +2646,12 @@ impl DelegationEngine {
                     let final_state =
                         SubRunState::from_str(&r.status).unwrap_or(SubRunState::Failed);
                     self.tracker
-                        .complete_sub_run(&rev_run_id, final_state)
+                        .complete_sub_run_with_result(
+                            &rev_run_id,
+                            final_state,
+                            r.error.as_deref(),
+                            r.output.as_deref(),
+                        )
                         .await;
                     r
                 }
@@ -2578,7 +2665,12 @@ impl DelegationEngine {
                         "status"
                     );
                     self.tracker
-                        .complete_sub_run(&rev_run_id, SubRunState::Failed)
+                        .complete_sub_run_with_result(
+                            &rev_run_id,
+                            SubRunState::Failed,
+                            Some(e.as_str()),
+                            None,
+                        )
                         .await;
                     AgentResult {
                         agent_id: reviewer_id.to_string(),
@@ -2830,7 +2922,13 @@ impl DelegationEngine {
                         SubRunState::Failed
                     }
                 };
-                tracker.complete_sub_run(&run_id, final_state).await;
+                let (error, output_preview) = match &result {
+                    Ok(r) => (r.error.as_deref(), r.output.as_deref()),
+                    Err(e) => (Some(e.as_str()), None),
+                };
+                tracker
+                    .complete_sub_run_with_result(&run_id, final_state, error, output_preview)
+                    .await;
                 (result, agent_id, run_id)
             });
             handles.push((handle, captured_agent_id, captured_run_id));
@@ -2868,15 +2966,21 @@ impl DelegationEngine {
                             "Fork: failed to persist panic status for {panic_run_id}: {e2}"
                         );
                     }
+                    let panic_error = format!("fork task panicked: {e}");
                     self.tracker
-                        .complete_sub_run(&panic_run_id, SubRunState::Failed)
+                        .complete_sub_run_with_result(
+                            &panic_run_id,
+                            SubRunState::Failed,
+                            Some(panic_error.as_str()),
+                            None,
+                        )
                         .await;
                     results.push(AgentResult {
                         agent_id: panic_agent_id,
                         run_id: panic_run_id,
                         status: "failed".to_string(),
                         output: None,
-                        error: Some(format!("fork task panicked: {}", e)),
+                        error: Some(panic_error),
                         prompt_tokens: 0,
                         completion_tokens: 0,
                         tool_calls: 0,
@@ -4234,6 +4338,62 @@ mod tests {
         let _ = std::fs::remove_dir_all(sessions_dir);
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn tracker_complete_sub_run_writes_sub_run_completed_event() {
+        let sessions_dir = std::env::temp_dir().join(format!(
+            "delegation-engine-subrun-complete-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let _guard = astra_services::session_journal::JournalDirGuard::new(&sessions_dir);
+        let tracker = DelegationTracker::with_session("sess-subrun-complete".into());
+
+        tracker
+            .record_sub_run(SubRunRecord {
+                run_id: "run-1".into(),
+                parent_run_id: "parent-1".into(),
+                delegation_id: "del-1".into(),
+                agent_id: "coder".into(),
+                depth: 1,
+                state: SubRunState::Running,
+                retry_of: None,
+            })
+            .await;
+        tracker
+            .complete_sub_run_with_result(
+                "run-1",
+                SubRunState::Failed,
+                Some("boom"),
+                Some("partial output"),
+            )
+            .await;
+
+        let journal_path = sessions_dir.join("sess-subrun-complete.jsonl");
+        let content = std::fs::read_to_string(&journal_path).unwrap();
+        let completed_events: Vec<astra_services::session_journal::JournalEvent> = content
+            .lines()
+            .map(|line| {
+                serde_json::from_str::<astra_services::session_journal::JournalEvent>(line).unwrap()
+            })
+            .filter(|evt| {
+                evt.event_type
+                    == astra_services::session_journal::JournalEventType::DelegationSubRunCompleted
+            })
+            .collect();
+
+        assert_eq!(completed_events.len(), 1);
+        let meta = completed_events[0].metadata.as_ref().unwrap();
+        assert_eq!(meta["delegation_id"], "del-1");
+        assert_eq!(meta["sub_run_id"], "run-1");
+        assert_eq!(meta["agent_id"], "coder");
+        assert_eq!(meta["status"], "failed");
+        assert_eq!(meta["error"], "boom");
+        assert_eq!(meta["output_preview"], "partial output");
+
+        let _ = std::fs::remove_file(journal_path);
+        let _ = std::fs::remove_dir_all(sessions_dir);
+    }
+
     #[tokio::test]
     async fn gate_exhausted_retries_sequential() {
         let (reg, engine, tracker, _) = setup_with_executor(Arc::new(EchoExecutor));
@@ -5124,7 +5284,7 @@ mod tests {
                 delegation_id: "d1".into(),
                 agent_id: "a1".into(),
                 depth: 1,
-                state: SubRunState::Running,
+                state: SubRunState::Completed,
                 retry_of: None,
             })
             .await;
@@ -5135,11 +5295,40 @@ mod tests {
         assert!(tracker.get_progress("d1").await.is_some());
         assert_eq!(tracker.get_sub_runs("d1").await.len(), 1);
 
-        tracker.cleanup_delegation("d1").await;
+        tracker.cleanup_delegation("d1").await.unwrap();
         assert!(tracker.get_pause_flag("r1").await.is_none());
         assert!(tracker.get_progress("d1").await.is_none());
         assert_eq!(tracker.get_sub_runs("d1").await.len(), 0);
         assert!(tracker.get_children("parent").await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn tracker_cleanup_delegation_rejects_nonterminal_sub_runs() {
+        let tracker = DelegationTracker::new();
+        tracker
+            .record_sub_run(SubRunRecord {
+                run_id: "r1".into(),
+                parent_run_id: "parent".into(),
+                delegation_id: "d1".into(),
+                agent_id: "a1".into(),
+                depth: 1,
+                state: SubRunState::Running,
+                retry_of: None,
+            })
+            .await;
+
+        let _f1 = tracker.register_pause_flag("r1").await;
+        tracker.init_progress("d1", &["a1".into()]).await;
+
+        let err = tracker
+            .cleanup_delegation("d1")
+            .await
+            .expect_err("non-terminal delegation should not be cleaned up");
+        assert!(err.contains("r1(running)"), "{err}");
+        assert!(tracker.get_pause_flag("r1").await.is_some());
+        assert!(tracker.get_progress("d1").await.is_some());
+        assert_eq!(tracker.get_sub_runs("d1").await.len(), 1);
+        assert_eq!(tracker.get_children("parent").await, vec!["r1".to_string()]);
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -111,6 +111,59 @@ fn build_server_skill_executor(
     Some(Arc::new(router))
 }
 
+fn has_turn_verdict_warning(
+    verdict_events: &[crate::turn::agentic_verdict_audit::AgenticVerdictAuditEvent],
+) -> bool {
+    verdict_events.iter().any(|event| {
+        event.severity.eq_ignore_ascii_case("warning")
+            || event.severity.eq_ignore_ascii_case("critical")
+    })
+}
+
+fn build_runtime_turn_evaluation_event(
+    session_id: &str,
+    source: &str,
+    state: &AgenticLoopState,
+) -> astra_services::session_journal::JournalEvent {
+    let verdict_warning = has_turn_verdict_warning(&state.stall.verdict_events);
+    let eval = crate::pipeline::evaluation::evaluate_tool_call_records(
+        &state.message,
+        &state.recent_tools,
+        &state.stall.tool_call_records,
+        state.stall.events.len(),
+        verdict_warning,
+        state.telemetry.first_budget_pressure,
+    );
+    crate::pipeline::evaluation::build_turn_evaluation_journal_event(
+        Some(session_id),
+        None,
+        source,
+        &state.message,
+        &state.recent_tools,
+        &state.stall.tool_call_records,
+        state.stall.events.len(),
+        verdict_warning,
+        state.telemetry.first_budget_pressure,
+        &eval,
+    )
+}
+
+fn persist_turn_evaluation_journal(session_id: &str, source: &str, state: &AgenticLoopState) {
+    if session_id.is_empty() {
+        return;
+    }
+
+    let event = build_runtime_turn_evaluation_event(session_id, source, state);
+    match astra_services::session_journal::JournalWriter::new(session_id) {
+        Ok(journal) => {
+            if let Err(err) = journal.append(&event) {
+                eprintln!("  ⚠ turn evaluation journal append failed: {err}");
+            }
+        }
+        Err(err) => eprintln!("  ⚠ turn evaluation journal init failed: {err}"),
+    }
+}
+
 fn skill_search_from_context(
     context: &std::collections::HashMap<String, serde_json::Value>,
 ) -> astra_core::SkillSearchSettings {
@@ -1141,6 +1194,10 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 }
             }
 
+            if persist_terminal_state {
+                persist_turn_evaluation_journal(&bg_session_id, "server_runtime", &loop_state);
+            }
+
             // Fire SessionEnd hooks (best-effort, non-blocking).
             crate::skills::hooks::fire_session_end(
                 &loop_state.skills.session_event_hooks,
@@ -1253,6 +1310,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
 
         let (mut final_events, final_status, error_msg) =
             Self::finalize_run_events(loop_result, host.take_emitted_events(), &state);
+        persist_turn_evaluation_journal(&session_id, "server_runtime", &state);
         let mut all_events = vec![json!({"event_type": "run_started", "data": {}})];
         all_events.append(&mut final_events);
 
@@ -1835,6 +1893,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
             &loop_state.telemetry.promotion_events,
         )
         .await;
+        persist_turn_evaluation_journal(&config.session_id, "server_subrun", &loop_state);
 
         // Persist cross-session learning state.
         let active_canary = match loop_state.evolution_service.as_ref() {
@@ -1909,6 +1968,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use astra_services::session_journal::{JournalEventType, ToolCallRecord};
 
     /// Unwrap a `Result<T, (StatusCode, Json<ErrorResponse>)>` in tests.
     fn ok<T>(result: Result<T, (StatusCode, Json<ErrorResponse>)>) -> T {
@@ -1961,6 +2021,56 @@ mod tests {
             max_candidates: 5,
             explain: false,
         }
+    }
+
+    #[test]
+    fn build_runtime_turn_evaluation_event_uses_loop_state_signals() {
+        let svc = test_service();
+        let request = test_request("git status");
+        let mut state = svc.build_initial_state(&request, "session-1", "run-1");
+        state.recent_tools = vec!["git_status".into()];
+        state.telemetry.first_budget_pressure = 0.27;
+        state.stall.events.push(("repetition_stall".into(), 1));
+        state.stall.verdict_events.push(
+            crate::turn::agentic_verdict_audit::AgenticVerdictAuditEvent {
+                turn: 1,
+                severity: "warning".into(),
+                injections: vec!["stall detected".into()],
+                avoid_tools: vec!["git_status".into()],
+                deprioritized_tools: vec![],
+                force_stop: false,
+                nudge_count: 1,
+                total_errors: 0,
+                deprioritized_count: 0,
+                total_timeouts: 0,
+                timeout_dominant_tools: vec![],
+                total_cache_hits: 0,
+                flaky_count: 0,
+            },
+        );
+        state.stall.tool_call_records.push(ToolCallRecord {
+            name: "git_status".into(),
+            ok: true,
+            ms: 14,
+            error: None,
+            input_bytes: Some(8),
+            output_bytes: Some(180),
+            args_preview: None,
+            result_preview: Some("clean".into()),
+        });
+
+        let event = build_runtime_turn_evaluation_event("session-1", "server_runtime", &state);
+
+        assert_eq!(event.event_type, JournalEventType::TurnEvaluation);
+        assert_eq!(event.turn, None);
+        let metadata = event.metadata.expect("turn evaluation metadata");
+        assert_eq!(metadata["source"], "server_runtime");
+        assert_eq!(metadata["live_query"], true);
+        assert_eq!(metadata["stall_count"], 1);
+        assert_eq!(metadata["verdict_warning"], true);
+        assert_eq!(metadata["tool_call_count"], 1);
+        assert!(metadata["quality"].as_f64().unwrap() < 0.8);
+        assert_eq!(metadata["signals"][0]["kind"], "tool_error_rate");
     }
 
     #[test]

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -2027,7 +2027,7 @@ mod tests {
     fn build_runtime_turn_evaluation_event_uses_loop_state_signals() {
         let svc = test_service();
         let request = test_request("git status");
-        let mut state = svc.build_initial_state(&request, "session-1", "run-1");
+        let mut state = svc.build_initial_state(&request, "session-1", "run-1", None);
         state.recent_tools = vec!["git_status".into()];
         state.telemetry.first_budget_pressure = 0.27;
         state.stall.events.push(("repetition_stall".into(), 1));

--- a/rust/crates/runtime/src/server/team_orchestrator.rs
+++ b/rust/crates/runtime/src/server/team_orchestrator.rs
@@ -492,15 +492,20 @@ impl TeamExecutionOrchestrator {
                     }
                 }
                 // Cleanup delegation state even on error path
-                self.delegation_tracker
+                let failure = match self
+                    .delegation_tracker
                     .cleanup_delegation(&delegation_id)
-                    .await;
-                return self.fail_report(
-                    team_name,
-                    &delegation_id,
-                    &parent_run_id,
-                    format!("delegation failed: {e}"),
-                );
+                    .await
+                {
+                    Ok(()) => format!("delegation failed: {e}"),
+                    Err(cleanup_err) => {
+                        eprintln!(
+                            "[team-orchestrator] delegation cleanup skipped after error: {cleanup_err}"
+                        );
+                        format!("delegation failed: {e}; cleanup skipped: {cleanup_err}")
+                    }
+                };
+                return self.fail_report(team_name, &delegation_id, &parent_run_id, failure);
             }
         };
 
@@ -687,9 +692,13 @@ impl TeamExecutionOrchestrator {
         }
 
         // Cleanup delegation pause flags and progress entries
-        self.delegation_tracker
+        if let Err(cleanup_err) = self
+            .delegation_tracker
             .cleanup_delegation(&delegation_id)
-            .await;
+            .await
+        {
+            eprintln!("[team-orchestrator] delegation cleanup skipped: {cleanup_err}");
+        }
 
         TeamExecutionReport {
             team_name: team_name.to_string(),

--- a/rust/crates/services/src/self_surface.rs
+++ b/rust/crates/services/src/self_surface.rs
@@ -1529,6 +1529,7 @@ fn evolution_record_from_event(event: &JournalEvent) -> Option<EvolutionRecord> 
     let (kind, status) = match event.event_type {
         JournalEventType::TurnError | JournalEventType::Error => ("failure", "observed"),
         JournalEventType::StallDetected => ("stall", "observed"),
+        JournalEventType::TurnEvaluation => ("evaluation", "recorded"),
         JournalEventType::DriftDetected => ("drift", "observed"),
         JournalEventType::AdaptiveScenarioApplied => ("scenario", "applied"),
         JournalEventType::AdaptivePerTurnApplied => ("adaptation", "applied"),
@@ -1884,7 +1885,7 @@ fn phase_for_event_type(event_type: &JournalEventType) -> &'static str {
         | JournalEventType::Error
         | JournalEventType::StallDetected
         | JournalEventType::DriftDetected => "reflect",
-        JournalEventType::VerificationCompleted => "evaluate",
+        JournalEventType::VerificationCompleted | JournalEventType::TurnEvaluation => "evaluate",
         JournalEventType::AdaptiveScenarioApplied
         | JournalEventType::AdaptivePerTurnApplied
         | JournalEventType::AdaptiveExperimentEnrolled
@@ -2012,6 +2013,25 @@ fn summarize_event(event: &JournalEvent) -> String {
                 .map(|kind| format!(" ({kind})"))
                 .unwrap_or_default()
         ),
+        JournalEventType::TurnEvaluation => event
+            .metadata
+            .as_ref()
+            .map(|metadata| {
+                let source = metadata
+                    .get("source")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("runtime");
+                let quality = metadata
+                    .get("quality")
+                    .and_then(|value| value.as_f64())
+                    .unwrap_or(0.0);
+                let confidence = metadata
+                    .get("confidence")
+                    .and_then(|value| value.as_f64())
+                    .unwrap_or(0.0);
+                format!("turn evaluation ({source}): q={quality:.2}, conf={confidence:.2}")
+            })
+            .unwrap_or_else(|| "turn evaluation recorded".to_string()),
         JournalEventType::DriftDetected => event
             .metadata
             .as_ref()
@@ -2087,6 +2107,7 @@ fn event_type_name(event_type: &JournalEventType) -> String {
         JournalEventType::StallDetected => "stall_detected",
         JournalEventType::Checkpoint => "checkpoint",
         JournalEventType::TurnGuardVerdict => "turn_guard_verdict",
+        JournalEventType::TurnEvaluation => "turn_evaluation",
         JournalEventType::PlanProgress => "plan_progress",
         JournalEventType::SessionFork => "session_fork",
         JournalEventType::SyncMarker => "sync_marker",

--- a/rust/crates/services/src/session_journal.rs
+++ b/rust/crates/services/src/session_journal.rs
@@ -680,6 +680,8 @@ pub enum JournalEventType {
     Checkpoint,
     /// TurnGuard verdict emitted (unified non-happy-path audit).
     TurnGuardVerdict,
+    /// Turn quality evaluation recorded for audit and replay surfaces.
+    TurnEvaluation,
     /// Plan execution progress (subtask started, completed, plan done).
     PlanProgress,
     /// Forked from another session — records lineage for audit and sync.
@@ -2094,6 +2096,39 @@ impl JournalEvent {
             "total_timeouts": total_timeouts,
             "total_cache_hits": total_cache_hits,
             "flaky_tools": flaky_count,
+        }));
+        evt
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn turn_evaluation(
+        session_id: Option<&str>,
+        turn: Option<u32>,
+        source: &str,
+        live_query: bool,
+        success: bool,
+        quality: f64,
+        confidence: f64,
+        budget_pressure: f64,
+        stall_count: usize,
+        verdict_warning: bool,
+        tool_call_count: usize,
+        signals: Vec<serde_json::Value>,
+    ) -> Self {
+        let mut evt = Self::base(JournalEventType::TurnEvaluation, session_id);
+        evt.turn = turn;
+        evt.metadata = Some(serde_json::json!({
+            "source": source,
+            "live_query": live_query,
+            "success": success,
+            "quality": quality,
+            "confidence": confidence,
+            "budget_pressure": budget_pressure,
+            "stall_count": stall_count,
+            "verdict_warning": verdict_warning,
+            "tool_call_count": tool_call_count,
+            "signal_count": signals.len(),
+            "signals": signals,
         }));
         evt
     }
@@ -3763,6 +3798,72 @@ mod tests {
         assert_eq!(meta["force_stop"], false);
         assert_eq!(meta["non_timeout_errors"], 1);
         assert_eq!(meta["avoid_tools_count"], 0);
+    }
+
+    #[test]
+    fn turn_evaluation_event_serializes() {
+        let evt = JournalEvent::turn_evaluation(
+            Some("sess-1"),
+            Some(4),
+            "cli_repl",
+            true,
+            true,
+            0.91,
+            0.72,
+            0.18,
+            1,
+            false,
+            2,
+            vec![serde_json::json!({
+                "kind": "all_tools_healthy",
+                "weight": 0.4,
+                "message": "All tool calls completed successfully"
+            })],
+        );
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains("\"type\":\"turn_evaluation\""));
+        assert!(json.contains("\"turn\":4"));
+
+        let parsed: JournalEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.event_type, JournalEventType::TurnEvaluation);
+        let meta = parsed.metadata.unwrap();
+        assert_eq!(meta["source"], "cli_repl");
+        assert_eq!(meta["live_query"], true);
+        assert_eq!(meta["success"], true);
+        assert_eq!(meta["quality"], 0.91);
+        assert_eq!(meta["confidence"], 0.72);
+        assert_eq!(meta["budget_pressure"], 0.18);
+        assert_eq!(meta["stall_count"], 1);
+        assert_eq!(meta["verdict_warning"], false);
+        assert_eq!(meta["tool_call_count"], 2);
+        assert_eq!(meta["signal_count"], 1);
+        assert_eq!(meta["signals"][0]["kind"], "all_tools_healthy");
+    }
+
+    #[test]
+    fn turn_evaluation_event_without_turn_is_allowed() {
+        let evt = JournalEvent::turn_evaluation(
+            Some("sess-2"),
+            None,
+            "server_runtime",
+            false,
+            false,
+            0.35,
+            0.81,
+            0.64,
+            2,
+            true,
+            0,
+            vec![],
+        );
+        let json = serde_json::to_string(&evt).unwrap();
+        let parsed: JournalEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.event_type, JournalEventType::TurnEvaluation);
+        assert_eq!(parsed.turn, None);
+        let meta = parsed.metadata.unwrap();
+        assert_eq!(meta["source"], "server_runtime");
+        assert_eq!(meta["signal_count"], 0);
+        assert_eq!(meta["signals"], serde_json::json!([]));
     }
 
     // ── stall_detected event ──


### PR DESCRIPTION
## Summary
- harden delegation lifecycle closure by durably journaling sub-run completion, guarding cleanup on non-terminal state, and self-healing missing in-process delegation broadcast channels
- add first-class turn-evaluation journaling and bridge it from CLI turns plus runtime run/sub-run completion paths
- surface turn-evaluation events in `/session` and self-surface naming/previews so the evaluation shell is inspectable
- supersede #24 by landing the delegation closure work together with the turn-evaluation bridge on a main-based branch

## Validation
- make format
- make check
