### PR TITLE
feat: B.2-B.9 tool module extraction to astra-tools

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "sha2",
  "tempfile",
  "thiserror 1.0.69",

--- a/rust/crates/astra-tools/Cargo.toml
+++ b/rust/crates/astra-tools/Cargo.toml
@@ -42,6 +42,7 @@ dirs = "6.0.0"
 [dev-dependencies]
 tempfile = "3"
 serde_json.workspace = true
+serial_test = "3"
 
 [features]
 default = []

--- a/rust/crates/astra-tools/src/build_test.rs
+++ b/rust/crates/astra-tools/src/build_test.rs
@@ -1,0 +1,3888 @@
+//! Structured parsing of build and test output.
+//!
+//! Detects framework (cargo, pytest, jest, go test, etc.) and extracts:
+//! - Pass/fail status
+//! - Error count and messages
+//! - Error locations (file:line:col) for direct navigation
+//! - Test summary (passed, failed, skipped counts)
+//!
+//! Enables automated change→test→fix cycles by providing structured feedback.
+
+#![allow(dead_code)]
+use regex::Regex;
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+/// A precise error location extracted from compiler/test output.
+#[derive(Debug, Clone)]
+pub struct ErrorLocation {
+    /// File path (relative to project root)
+    pub file: String,
+    /// Line number (1-based)
+    pub line: usize,
+    /// Column number (1-based, 0 = unknown)
+    pub col: usize,
+    /// Error code (e.g., "E0425") if available
+    pub error_code: String,
+    /// Error message
+    pub message: String,
+    /// Severity: "error", "warning", "note"
+    #[allow(dead_code)]
+    pub severity: String,
+    /// Classification for auto-fix prioritization
+    pub class: ErrorClass,
+    /// Quick-fix hint for the LLM (empty if no suggestion)
+    pub hint: String,
+    /// Containing function/class scope (from tree-sitter, empty if unavailable)
+    pub scope: String,
+}
+
+/// A concrete, applicable fix suggestion for an error.
+#[derive(Debug, Clone)]
+pub struct FixSuggestion {
+    /// The file to edit
+    pub file: String,
+    /// What to do: "insert_line", "replace", "delete_line", "add_import"
+    pub action: String,
+    /// Target line number (for insert: where to insert before)
+    pub line: usize,
+    /// Text to insert or replace with (empty for delete)
+    pub new_text: String,
+    /// Human-readable explanation of the fix
+    pub explanation: String,
+    /// Confidence: 0.0-1.0 (1.0 = certain, 0.5 = likely, below 0.3 = speculative)
+    pub confidence: f64,
+}
+
+impl FixSuggestion {
+    fn new(
+        file: &str,
+        action: &str,
+        line: usize,
+        new_text: &str,
+        explanation: &str,
+        confidence: f64,
+    ) -> Self {
+        Self {
+            file: file.to_string(),
+            action: action.to_string(),
+            line,
+            new_text: new_text.to_string(),
+            explanation: explanation.to_string(),
+            confidence,
+        }
+    }
+}
+
+/// Minimum confidence threshold for auto-fix application.
+pub const AUTO_FIX_CONFIDENCE_THRESHOLD: f64 = 0.8;
+/// Maximum number of auto-fix iterations to prevent infinite loops.
+pub const AUTO_FIX_MAX_ITERATIONS: usize = 3;
+
+/// Result of applying a single fix.
+#[derive(Debug, Clone)]
+pub struct AppliedFix {
+    pub file: String,
+    pub action: String,
+    pub line: usize,
+    pub explanation: String,
+}
+
+/// Apply a single fix to a file. Returns Ok(description) on success.
+pub fn apply_fix(
+    fix: &FixSuggestion,
+    project_root: &std::path::Path,
+) -> Result<AppliedFix, String> {
+    let file_path = if std::path::Path::new(&fix.file).is_absolute() {
+        std::path::PathBuf::from(&fix.file)
+    } else {
+        project_root.join(&fix.file)
+    };
+
+    let content = std::fs::read_to_string(&file_path)
+        .map_err(|e| format!("Failed to read {}: {}", fix.file, e))?;
+    let lines: Vec<&str> = content.lines().collect();
+
+    let new_content = match fix.action.as_str() {
+        "delete_line" => {
+            if fix.line == 0 || fix.line > lines.len() {
+                return Err(format!(
+                    "Line {} out of range (file has {} lines)",
+                    fix.line,
+                    lines.len()
+                ));
+            }
+            let mut result: Vec<&str> = Vec::with_capacity(lines.len());
+            for (i, line) in lines.iter().enumerate() {
+                if i + 1 != fix.line {
+                    result.push(line);
+                }
+            }
+            result.join("\n") + if content.ends_with('\n') { "\n" } else { "" }
+        }
+        "replace" => {
+            if fix.line == 0 || fix.line > lines.len() {
+                return Err(format!(
+                    "Line {} out of range (file has {} lines)",
+                    fix.line,
+                    lines.len()
+                ));
+            }
+            let mut result: Vec<String> = Vec::with_capacity(lines.len());
+            for (i, line) in lines.iter().enumerate() {
+                if i + 1 == fix.line {
+                    result.push(fix.new_text.clone());
+                } else {
+                    result.push(line.to_string());
+                }
+            }
+            result.join("\n") + if content.ends_with('\n') { "\n" } else { "" }
+        }
+        "insert_line" => {
+            if fix.line == 0 || fix.line > lines.len() + 1 {
+                return Err(format!(
+                    "Insert line {} out of range (file has {} lines)",
+                    fix.line,
+                    lines.len()
+                ));
+            }
+            let mut result: Vec<String> = Vec::with_capacity(lines.len() + 1);
+            for (i, line) in lines.iter().enumerate() {
+                if i + 1 == fix.line {
+                    result.push(fix.new_text.clone());
+                }
+                result.push(line.to_string());
+            }
+            // insert after last line
+            if fix.line == lines.len() + 1 {
+                result.push(fix.new_text.clone());
+            }
+            result.join("\n") + if content.ends_with('\n') { "\n" } else { "" }
+        }
+        "add_import" => {
+            // Insert at top of file (line 1) or after existing use/import block
+            let insert_at = find_import_insertion_point(&lines);
+            let mut result: Vec<String> = Vec::with_capacity(lines.len() + 1);
+            for (i, line) in lines.iter().enumerate() {
+                if i == insert_at {
+                    result.push(fix.new_text.clone());
+                }
+                result.push(line.to_string());
+            }
+            if insert_at >= lines.len() {
+                result.push(fix.new_text.clone());
+            }
+            result.join("\n") + if content.ends_with('\n') { "\n" } else { "" }
+        }
+        other => {
+            return Err(format!("Unknown fix action: {}", other));
+        }
+    };
+
+    std::fs::write(&file_path, new_content)
+        .map_err(|e| format!("Failed to write {}: {}", fix.file, e))?;
+
+    Ok(AppliedFix {
+        file: fix.file.clone(),
+        action: fix.action.clone(),
+        line: fix.line,
+        explanation: fix.explanation.clone(),
+    })
+}
+
+/// Find the best insertion point for a new import/use statement.
+/// Returns the line index (0-based) where the new import should be inserted.
+fn find_import_insertion_point(lines: &[&str]) -> usize {
+    let mut last_import = 0;
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("use ")
+            || trimmed.starts_with("import ")
+            || trimmed.starts_with("from ")
+            || trimmed.starts_with("require(")
+            || trimmed.starts_with("const ") && trimmed.contains("require(")
+        {
+            last_import = i + 1; // insert after this line
+        }
+    }
+    last_import
+}
+
+/// Apply all high-confidence fixes from a list. Returns applied fixes.
+/// Fixes are applied in reverse line order within each file to preserve line numbers.
+pub fn apply_auto_fixes(
+    fixes: &[FixSuggestion],
+    project_root: &std::path::Path,
+) -> (Vec<AppliedFix>, Vec<String>) {
+    let mut applied = Vec::new();
+    let mut errors = Vec::new();
+
+    // Filter to high-confidence only
+    let mut eligible: Vec<&FixSuggestion> = fixes
+        .iter()
+        .filter(|f| f.confidence >= AUTO_FIX_CONFIDENCE_THRESHOLD)
+        .collect();
+
+    // Sort by file, then by line descending (so deletions don't shift later lines)
+    eligible.sort_by(|a, b| a.file.cmp(&b.file).then(b.line.cmp(&a.line)));
+
+    for fix in eligible {
+        match apply_fix(fix, project_root) {
+            Ok(af) => applied.push(af),
+            Err(e) => errors.push(e),
+        }
+    }
+
+    (applied, errors)
+}
+
+/// Format applied fixes into a human-readable report section.
+pub fn format_auto_fix_report(
+    applied: &[AppliedFix],
+    errors: &[String],
+    iteration: usize,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("\n── Auto-Fix Iteration {} ──\n", iteration));
+    if applied.is_empty() {
+        out.push_str("  No fixes applied.\n");
+    } else {
+        for af in applied {
+            out.push_str(&format!(
+                "  ✓ {} L{}: {} ({})\n",
+                af.file, af.line, af.explanation, af.action
+            ));
+        }
+    }
+    for e in errors {
+        out.push_str(&format!("  ✗ {}\n", e));
+    }
+    out
+}
+
+/// Generate concrete fix suggestions for an error, given source context.
+///
+/// Returns zero or more suggestions ranked by confidence. The source_lines
+/// parameter should contain the relevant file content for context.
+pub fn suggest_fix(error: &ErrorLocation, source_lines: &[&str]) -> Vec<FixSuggestion> {
+    let mut fixes = Vec::new();
+
+    match error.error_code.as_str() {
+        // ── Rust: Missing import (E0425, E0433, E0412) ──
+        "E0425" | "E0433" | "E0412" => {
+            if let Some(name) = extract_identifier(&error.message) {
+                // Suggest common std imports
+                if let Some(import) = suggest_rust_import(name) {
+                    fixes.push(FixSuggestion::new(
+                        &error.file,
+                        "add_import",
+                        1,
+                        &format!("use {};", import),
+                        &format!("Add missing import for `{}`", name),
+                        0.8,
+                    ));
+                }
+            }
+        }
+
+        // ── Rust: Missing field (E0063) ──
+        "E0063" => {
+            if let Some(field) = extract_identifier(&error.message) {
+                let err_line = error.line.saturating_sub(1);
+                if err_line < source_lines.len() {
+                    fixes.push(FixSuggestion::new(
+                        &error.file,
+                        "insert_line",
+                        error.line,
+                        &format!("            {}: Default::default(),", field),
+                        &format!("Add missing field `{}` with default value", field),
+                        0.6,
+                    ));
+                }
+            }
+        }
+
+        // ── Rust: Unused variable ──
+        _ if error.message.contains("unused variable") => {
+            if let Some(name) = extract_identifier(&error.message) {
+                let err_idx = error.line.saturating_sub(1);
+                if err_idx < source_lines.len() {
+                    let line = source_lines[err_idx];
+                    let new_line = line.replace(name, &format!("_{}", name));
+                    fixes.push(FixSuggestion::new(
+                        &error.file,
+                        "replace",
+                        error.line,
+                        &new_line,
+                        &format!("Prefix unused variable `{}` with underscore", name),
+                        0.9,
+                    ));
+                }
+            }
+        }
+
+        // ── Rust: Unused import ──
+        _ if error.message.contains("unused import") => {
+            fixes.push(FixSuggestion::new(
+                &error.file,
+                "delete_line",
+                error.line,
+                "",
+                "Remove unused import",
+                0.9,
+            ));
+        }
+
+        // ── Rust: String/&str mismatch (E0308) ──
+        "E0308" if error.message.contains("&str") && error.message.contains("String") => {
+            let err_idx = error.line.saturating_sub(1);
+            if err_idx < source_lines.len() {
+                let line = source_lines[err_idx];
+                if error.message.contains("expected `String`")
+                    || error.message.contains("expected struct `String`")
+                {
+                    // Need String, got &str → add .to_string()
+                    fixes.push(FixSuggestion::new(
+                        &error.file,
+                        "replace",
+                        error.line,
+                        &format!("{}  // consider adding .to_string()", line.trim_end()),
+                        "Add .to_string() to convert &str to String",
+                        0.5,
+                    ));
+                } else {
+                    // Need &str, got String → add .as_str() or &
+                    fixes.push(FixSuggestion::new(
+                        &error.file,
+                        "replace",
+                        error.line,
+                        &format!("{}  // consider adding .as_str() or &", line.trim_end()),
+                        "Add .as_str() or & to convert String to &str",
+                        0.5,
+                    ));
+                }
+            }
+        }
+
+        // ── Rust: Missing trait method (E0046) ──
+        "E0046" => {
+            if let Some(method) = extract_identifier(&error.message) {
+                fixes.push(FixSuggestion::new(
+                    &error.file,
+                    "insert_line",
+                    error.line,
+                    &format!("    fn {}(&self) {{ todo!() }}", method),
+                    &format!("Add stub for missing trait method `{}`", method),
+                    0.6,
+                ));
+            }
+        }
+
+        // ── TypeScript/JavaScript: Cannot find name (TS2304) ──
+        "TS2304" => {
+            if let Some(name) = extract_identifier(&error.message) {
+                fixes.push(FixSuggestion::new(
+                    &error.file,
+                    "add_import",
+                    1,
+                    &format!(
+                        "import {{ {} }} from './';  // TODO: specify module path",
+                        name
+                    ),
+                    &format!("Add import for `{}`", name),
+                    0.4,
+                ));
+            }
+        }
+
+        _ => {}
+    }
+
+    // Sort by confidence descending
+    fixes.sort_by(|a, b| {
+        b.confidence
+            .partial_cmp(&a.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    fixes
+}
+
+/// Suggest a Rust import path for common standard library types.
+fn suggest_rust_import(name: &str) -> Option<&'static str> {
+    match name {
+        "HashMap" => Some("std::collections::HashMap"),
+        "HashSet" => Some("std::collections::HashSet"),
+        "BTreeMap" => Some("std::collections::BTreeMap"),
+        "BTreeSet" => Some("std::collections::BTreeSet"),
+        "VecDeque" => Some("std::collections::VecDeque"),
+        "BinaryHeap" => Some("std::collections::BinaryHeap"),
+        "Arc" => Some("std::sync::Arc"),
+        "Mutex" => Some("std::sync::Mutex"),
+        "RwLock" => Some("std::sync::RwLock"),
+        "Rc" => Some("std::rc::Rc"),
+        "RefCell" => Some("std::cell::RefCell"),
+        "Cell" => Some("std::cell::Cell"),
+        "Pin" => Some("std::pin::Pin"),
+        "Path" => Some("std::path::Path"),
+        "PathBuf" => Some("std::path::PathBuf"),
+        "File" => Some("std::fs::File"),
+        "Read" | "Write" | "BufReader" | "BufWriter" => Some("std::io"),
+        "Sender" | "Receiver" => Some("std::sync::mpsc"),
+        "Duration" | "Instant" | "SystemTime" => Some("std::time"),
+        "Display" | "Formatter" => Some("std::fmt"),
+        "Error" => Some("std::error::Error"),
+        "Cow" => Some("std::borrow::Cow"),
+        "NonZeroU32" | "NonZeroU64" | "NonZeroUsize" => Some("std::num"),
+        _ => None,
+    }
+}
+
+/// Error classification for auto-fix prioritization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorClass {
+    /// Trivial: can be fixed mechanically (missing import, unused var prefix)
+    Trivial,
+    /// Fixable: LLM can likely fix with context (type mismatch, wrong args)
+    Fixable,
+    /// Complex: requires deep understanding (borrow checker, trait bounds, logic)
+    Complex,
+}
+
+impl ErrorLocation {
+    /// Create a new ErrorLocation with automatic classification and hints.
+    fn new(
+        file: String,
+        line: usize,
+        col: usize,
+        error_code: String,
+        message: String,
+        severity: String,
+    ) -> Self {
+        let (class, hint) = classify_and_hint(&error_code, &message);
+        Self {
+            file,
+            line,
+            col,
+            error_code,
+            message,
+            severity,
+            class,
+            hint,
+            scope: String::new(),
+        }
+    }
+}
+
+/// A group of related errors (same file or cascading from a root cause).
+#[derive(Debug)]
+pub struct ErrorGroup {
+    /// The root-cause error (first/most upstream in the cascade)
+    pub root_index: usize,
+    /// Indices of all errors in this group (including root)
+    pub member_indices: Vec<usize>,
+    /// Whether this is a suspected cascade (many errors from one root)
+    pub is_cascade: bool,
+    /// Description of the cascade pattern (e.g., "missing import causes 4 not-found errors")
+    pub cascade_hint: String,
+}
+
+/// Parsed result from a build or test command.
+#[derive(Debug, Clone, Default)]
+pub struct BuildTestResult {
+    /// Overall pass/fail status
+    pub passed: bool,
+    /// Command exit code (if available)
+    pub exit_code: Option<i32>,
+    /// Detected framework (cargo, pytest, jest, go, npm, make, etc.)
+    pub framework: String,
+    /// Number of errors/failures
+    pub error_count: usize,
+    /// Top error messages (max 5)
+    pub error_messages: Vec<String>,
+    /// Precise error locations (file:line:col) for navigation
+    pub error_locations: Vec<ErrorLocation>,
+    /// Tests passed (if test command)
+    pub tests_passed: usize,
+    /// Tests failed (if test command)
+    pub tests_failed: usize,
+    /// Tests skipped/ignored (if test command)
+    pub tests_skipped: usize,
+    /// One-line summary
+    pub summary: String,
+    /// Whether output was truncated
+    pub truncated: bool,
+}
+
+impl BuildTestResult {
+    /// Analyze error locations and group cascading errors by root cause.
+    ///
+    /// Cascade patterns detected:
+    /// 1. **Import cascade**: E0425/E0433/E0412 (not found) in same file from one missing import
+    /// 2. **Type cascade**: E0308 (type mismatch) following E0412/E0425 in same scope
+    /// 3. **Same-file cluster**: 3+ errors in one file → suggest fixing first
+    /// 4. **Trait cascade**: E0599 (method not found) following E0277 (trait not satisfied)
+    pub fn analyze_error_groups(&self) -> Vec<ErrorGroup> {
+        use std::collections::HashMap;
+
+        if self.error_locations.is_empty() {
+            return Vec::new();
+        }
+
+        // Group by file
+        let mut by_file: HashMap<&str, Vec<usize>> = HashMap::new();
+        for (i, loc) in self.error_locations.iter().enumerate() {
+            by_file.entry(&loc.file).or_default().push(i);
+        }
+
+        let mut groups = Vec::new();
+        for indices in by_file.values() {
+            if indices.len() < 2 {
+                // Single error in file — trivial group, no cascade
+                groups.push(ErrorGroup {
+                    root_index: indices[0],
+                    member_indices: indices.clone(),
+                    is_cascade: false,
+                    cascade_hint: String::new(),
+                });
+                continue;
+            }
+
+            // Look for cascade patterns within this file
+            let locs: Vec<&ErrorLocation> =
+                indices.iter().map(|&i| &self.error_locations[i]).collect();
+
+            // Pattern 1: Import cascade — one missing import causes multiple "not found"
+            let import_codes = ["E0425", "E0433", "E0412", "E0432"];
+            let import_errors: Vec<usize> = indices
+                .iter()
+                .filter(|&&i| import_codes.contains(&self.error_locations[i].error_code.as_str()))
+                .copied()
+                .collect();
+
+            if import_errors.len() >= 2 {
+                // Check if they reference the same identifier
+                let identifiers: Vec<Option<&str>> = import_errors
+                    .iter()
+                    .map(|&i| extract_identifier(&self.error_locations[i].message))
+                    .collect();
+                let first_id = identifiers[0];
+                let same_id_count = identifiers
+                    .iter()
+                    .filter(|id| **id == first_id && id.is_some())
+                    .count();
+
+                if same_id_count >= 2 {
+                    let id_name = first_id.unwrap_or("unknown");
+                    groups.push(ErrorGroup {
+                        root_index: import_errors[0],
+                        member_indices: import_errors,
+                        is_cascade: true,
+                        cascade_hint: format!(
+                            "Missing import for `{}` causes {} cascading errors — add the import to fix all",
+                            id_name, same_id_count
+                        ),
+                    });
+                    continue;
+                }
+            }
+
+            // Pattern 2: First error is trivial/import, rest are downstream
+            let first = &locs[0];
+            if first.class == ErrorClass::Trivial && locs.len() >= 3 {
+                groups.push(ErrorGroup {
+                    root_index: indices[0],
+                    member_indices: indices.clone(),
+                    is_cascade: true,
+                    cascade_hint: format!(
+                        "{} errors likely cascade from line {} — fix `{}` first",
+                        indices.len(),
+                        first.line,
+                        first.message.chars().take(50).collect::<String>()
+                    ),
+                });
+                continue;
+            }
+
+            // Pattern 3: Same scope cascade — errors in the same function
+            if !locs[0].scope.is_empty() {
+                let same_scope: Vec<usize> = indices
+                    .iter()
+                    .filter(|&&i| self.error_locations[i].scope == locs[0].scope)
+                    .copied()
+                    .collect();
+                if same_scope.len() >= 3 {
+                    groups.push(ErrorGroup {
+                        root_index: same_scope[0],
+                        member_indices: same_scope.clone(),
+                        is_cascade: true,
+                        cascade_hint: format!(
+                            "{} errors in `{}` — fix earliest (line {}) first",
+                            same_scope.len(),
+                            locs[0].scope,
+                            self.error_locations[same_scope[0]].line
+                        ),
+                    });
+                    continue;
+                }
+            }
+
+            // Generic cluster: 3+ errors in same file
+            groups.push(ErrorGroup {
+                root_index: indices[0],
+                member_indices: indices.clone(),
+                is_cascade: indices.len() >= 3,
+                cascade_hint: if indices.len() >= 3 {
+                    format!(
+                        "{} errors in file — fix line {} first, others may resolve",
+                        indices.len(),
+                        locs[0].line
+                    )
+                } else {
+                    String::new()
+                },
+            });
+        }
+
+        // Sort groups: cascades first (most impactful), then by member count desc
+        groups.sort_by(|a, b| {
+            b.is_cascade
+                .cmp(&a.is_cascade)
+                .then(b.member_indices.len().cmp(&a.member_indices.len()))
+        });
+
+        groups
+    }
+
+    /// Generate a fix ordering: returns error indices sorted by dependency.
+    /// Root-cause errors come first, downstream/cascading errors come last.
+    pub fn fix_order(&self) -> Vec<usize> {
+        let groups = self.analyze_error_groups();
+        let mut ordered = Vec::new();
+        let mut seen = HashSet::new();
+
+        // First: root causes from cascade groups
+        for g in &groups {
+            if g.is_cascade && !seen.contains(&g.root_index) {
+                ordered.push(g.root_index);
+                seen.insert(g.root_index);
+            }
+        }
+
+        // Then: trivial non-cascade errors
+        for (i, loc) in self.error_locations.iter().enumerate() {
+            if !seen.contains(&i) && loc.class == ErrorClass::Trivial {
+                ordered.push(i);
+                seen.insert(i);
+            }
+        }
+
+        // Then: fixable
+        for (i, loc) in self.error_locations.iter().enumerate() {
+            if !seen.contains(&i) && loc.class == ErrorClass::Fixable {
+                ordered.push(i);
+                seen.insert(i);
+            }
+        }
+
+        // Finally: complex
+        for i in 0..self.error_locations.len() {
+            if !seen.contains(&i) {
+                ordered.push(i);
+                seen.insert(i);
+            }
+        }
+
+        ordered
+    }
+    /// Format as enhanced output with summary at top.
+    pub fn to_enhanced_output(&self, raw_output: &str) -> String {
+        let status_icon = if self.passed { "✓" } else { "✗" };
+        let mut parts = Vec::new();
+
+        // Summary line with exit code if non-zero
+        let exit_suffix = if let Some(code) = self.exit_code {
+            if code != 0 {
+                format!(" (exit {})", code)
+            } else {
+                String::new()
+            }
+        } else {
+            String::new()
+        };
+
+        if self.tests_passed > 0 || self.tests_failed > 0 {
+            parts.push(format!(
+                "{} {} | {} passed, {} failed{}{}",
+                status_icon,
+                self.framework,
+                self.tests_passed,
+                self.tests_failed,
+                if self.tests_skipped > 0 {
+                    format!(", {} skipped", self.tests_skipped)
+                } else {
+                    String::new()
+                },
+                exit_suffix,
+            ));
+        } else if !self.summary.is_empty() {
+            parts.push(format!(
+                "{} {} | {}{}",
+                status_icon, self.framework, self.summary, exit_suffix
+            ));
+        } else {
+            parts.push(format!(
+                "{} {} | {}{}",
+                status_icon,
+                self.framework,
+                if self.passed { "success" } else { "failed" },
+                exit_suffix,
+            ));
+        }
+
+        // Truncation warning
+        if self.truncated {
+            parts.push("⚠ Output was truncated".to_string());
+        }
+
+        // Error messages (top 5)
+        if !self.error_messages.is_empty() {
+            parts.push(String::new());
+            parts.push("Errors:".to_string());
+            for (i, msg) in self.error_messages.iter().take(5).enumerate() {
+                parts.push(format!("  {}. {}", i + 1, msg));
+            }
+            if self.error_messages.len() > 5 {
+                parts.push(format!("  ... and {} more", self.error_messages.len() - 5));
+            }
+        }
+
+        // Error locations for direct navigation
+        if !self.error_locations.is_empty() {
+            parts.push(String::new());
+
+            // Classify errors for the LLM: show fixable count
+            let trivial_count = self
+                .error_locations
+                .iter()
+                .filter(|l| l.class == ErrorClass::Trivial)
+                .count();
+            let fixable_count = self
+                .error_locations
+                .iter()
+                .filter(|l| l.class == ErrorClass::Fixable)
+                .count();
+            let complex_count = self
+                .error_locations
+                .iter()
+                .filter(|l| l.class == ErrorClass::Complex)
+                .count();
+
+            if trivial_count + fixable_count > 0 {
+                parts.push(format!(
+                    "Fix priority: {} trivial, {} fixable, {} complex",
+                    trivial_count, fixable_count, complex_count
+                ));
+            }
+
+            // Cascading error analysis — detect root causes and group related errors
+            let groups = self.analyze_error_groups();
+            let cascades: Vec<&ErrorGroup> = groups.iter().filter(|g| g.is_cascade).collect();
+            if !cascades.is_empty() {
+                parts.push(String::new());
+                parts.push("⚡ Cascading errors — fix root cause FIRST:".to_string());
+                for g in cascades.iter().take(3) {
+                    let root = &self.error_locations[g.root_index];
+                    parts.push(format!(
+                        "  → {}:{} — {} ({} downstream errors will likely resolve)",
+                        root.file,
+                        root.line,
+                        g.cascade_hint,
+                        g.member_indices.len().saturating_sub(1)
+                    ));
+                }
+            }
+
+            // Show errors in fix order (root causes first)
+            let fix_order = self.fix_order();
+            parts.push("Locations (fix order):".to_string());
+            for (rank, &idx) in fix_order.iter().take(10).enumerate() {
+                let loc = &self.error_locations[idx];
+                let code_part = if loc.error_code.is_empty() {
+                    String::new()
+                } else {
+                    format!(" [{}]", loc.error_code)
+                };
+                let col_part = if loc.col > 0 {
+                    format!(":{}", loc.col)
+                } else {
+                    String::new()
+                };
+                let class_tag = match loc.class {
+                    ErrorClass::Trivial => " 🔧",
+                    ErrorClass::Fixable => " 🔨",
+                    ErrorClass::Complex => "",
+                };
+                let scope_part = if loc.scope.is_empty() {
+                    String::new()
+                } else {
+                    format!(" (in {})", loc.scope)
+                };
+                let root_marker = if cascades.iter().any(|g| g.root_index == idx) {
+                    " ← ROOT CAUSE"
+                } else {
+                    ""
+                };
+                parts.push(format!(
+                    "  {}. {}:{}{}{} {}{}{}{}",
+                    rank + 1,
+                    loc.file,
+                    loc.line,
+                    col_part,
+                    code_part,
+                    loc.message,
+                    class_tag,
+                    scope_part,
+                    root_marker
+                ));
+                if !loc.hint.is_empty() {
+                    parts.push(format!("     💡 {}", loc.hint));
+                }
+            }
+            if self.error_locations.len() > 10 {
+                parts.push(format!(
+                    "  ... and {} more locations",
+                    self.error_locations.len() - 10
+                ));
+            }
+        }
+
+        // Include raw output for failed builds (full tail) and successful builds
+        // (compact tail with warnings). Without this, successful `cargo check`
+        // returns only "✓ unknown | completed" — the agent can't see warnings
+        // or verify what was compiled.
+        if !self.passed && raw_output.len() > 200 {
+            parts.push(String::new());
+            parts.push("─── Raw output (last 2000 chars) ───".to_string());
+            let tail = if raw_output.len() > 2000 {
+                &raw_output[raw_output.len() - 2000..]
+            } else {
+                raw_output
+            };
+            parts.push(tail.to_string());
+        } else if !self.passed {
+            parts.push(String::new());
+            parts.push(raw_output.to_string());
+        } else if !raw_output.is_empty() && self.error_messages.is_empty() {
+            // Successful build/test — include compact tail so agent can see
+            // warnings, compilation summary, and "Finished ..." line.
+            let tail = if raw_output.len() > 500 {
+                &raw_output[raw_output.len() - 500..]
+            } else {
+                raw_output
+            };
+            // Only include if there's something beyond whitespace
+            let trimmed = tail.trim();
+            if !trimmed.is_empty() {
+                parts.push(String::new());
+                parts.push(trimmed.to_string());
+            }
+        }
+
+        parts.join("\n")
+    }
+
+    /// Enrich error locations with tree-sitter scope context.
+    ///
+    /// For each error location, reads the source file and uses tree-sitter's
+    /// `scope_at_line()` to find the containing function/class. This adds
+    /// context like "in fn process_data" or "in impl Foo > fn bar" to each error.
+    pub fn enrich_with_scope(&mut self, project_root: &std::path::Path) {
+        use crate::code_intel::{detect_language, scope_at_line};
+        use std::collections::HashMap;
+
+        // Cache file contents to avoid re-reading for multiple errors in same file
+        let mut file_cache: HashMap<String, Option<(String, crate::code_intel::Language)>> =
+            HashMap::new();
+
+        for loc in self.error_locations.iter_mut() {
+            let file_path = project_root.join(&loc.file);
+            let key = loc.file.clone();
+
+            let cached = file_cache.entry(key).or_insert_with(|| {
+                let lang = detect_language(&file_path)?;
+                let source = std::fs::read_to_string(&file_path).ok()?;
+                Some((source, lang))
+            });
+
+            if let Some((source, lang)) = cached {
+                let ctx = scope_at_line(source, *lang, loc.line);
+                loc.scope = if ctx.breadcrumbs.len() > 1 {
+                    ctx.breadcrumbs.join(" > ")
+                } else if let Some(ref sym) = ctx.symbol {
+                    sym.name.clone()
+                } else {
+                    String::new()
+                };
+            }
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Build/Test Iteration Tracker — delta analysis across fix cycles
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Signature for an error location (fuzzy enough to survive line shifts).
+/// Format: "file::error_code::message_prefix" — ignores line numbers
+/// so that fixing above the error doesn't cause a false "new error".
+fn error_signature(loc: &ErrorLocation) -> String {
+    let msg_prefix: String = loc.message.chars().take(60).collect();
+    format!("{}::{}::{}", loc.file, loc.error_code, msg_prefix)
+}
+
+/// Delta between two build/test iterations.
+#[derive(Debug, Clone)]
+pub struct BuildTestDelta {
+    /// Which iteration this is (0 = first run)
+    pub iteration: usize,
+    /// Errors that are new since last run
+    pub new_errors: Vec<String>,
+    /// Errors that were fixed since last run
+    pub fixed_errors: Vec<String>,
+    /// Errors that persist from last run
+    pub persistent_errors: Vec<String>,
+    /// True if error count increased (regression)
+    pub regressed: bool,
+    /// Overall progress: errors fixed vs original count
+    pub progress_pct: f64,
+    /// Command that was run
+    #[allow(dead_code)]
+    pub command: String,
+}
+
+impl BuildTestDelta {
+    /// Format the delta as a compact summary for the LLM.
+    pub fn to_summary(&self) -> String {
+        if self.iteration == 0 {
+            return String::new(); // First run, no delta to show
+        }
+        let mut parts = Vec::new();
+
+        // Compact header: iteration N: prev_count → current_count
+        let prev = self.fixed_errors.len() + self.persistent_errors.len();
+        let cur = self.new_errors.len() + self.persistent_errors.len();
+        parts.push(format!(
+            "─── Iteration {} ({} → {} errors) ───",
+            self.iteration, prev, cur
+        ));
+
+        if !self.fixed_errors.is_empty() {
+            parts.push(format!("✅ Fixed {} error(s)", self.fixed_errors.len()));
+        }
+        if !self.new_errors.is_empty() {
+            parts.push(format!("🆕 {} new error(s)", self.new_errors.len()));
+        }
+        if !self.persistent_errors.is_empty() {
+            parts.push(format!("⏳ {} still present", self.persistent_errors.len()));
+        }
+        if self.regressed {
+            parts.push(
+                "⚠ REGRESSION — more errors than before. Revert your last change and try a different approach.".into(),
+            );
+        }
+        if self.progress_pct > 0.0 {
+            parts.push(format!(
+                "Progress: {:.0}% of original errors resolved",
+                self.progress_pct
+            ));
+        }
+        parts.join("\n")
+    }
+}
+
+/// Tracks build/test results across iterations within a session.
+///
+/// Provides delta analysis: which errors were fixed, which are new,
+/// which persist. Helps the LLM understand the impact of each fix
+/// and avoid chasing regressions.
+#[derive(Debug)]
+pub struct BuildTestTracker {
+    /// Previous result's error signatures
+    previous_sigs: HashSet<String>,
+    /// Original error signatures from the very first failed run
+    original_sigs: HashSet<String>,
+    /// Current iteration count
+    iteration: usize,
+    /// Last command that was run
+    last_command: String,
+}
+
+impl BuildTestTracker {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            previous_sigs: HashSet::new(),
+            original_sigs: HashSet::new(),
+            iteration: 0,
+            last_command: String::new(),
+        }
+    }
+
+    /// Record a new build/test result and compute the delta.
+    ///
+    /// Call this each time `run_build_test` completes. The returned
+    /// `BuildTestDelta` should be prepended to the tool output so the
+    /// LLM can see what changed since its last fix attempt.
+    pub fn record(&mut self, result: &BuildTestResult, command: &str) -> BuildTestDelta {
+        let current_sigs: HashSet<String> =
+            result.error_locations.iter().map(error_signature).collect();
+
+        let delta = if self.iteration == 0 && !self.previous_sigs.is_empty() || self.iteration > 0 {
+            // Subsequent run — compute delta
+            let new_errors: Vec<String> = current_sigs
+                .difference(&self.previous_sigs)
+                .cloned()
+                .collect();
+            let fixed_errors: Vec<String> = self
+                .previous_sigs
+                .difference(&current_sigs)
+                .cloned()
+                .collect();
+            let persistent_errors: Vec<String> = current_sigs
+                .intersection(&self.previous_sigs)
+                .cloned()
+                .collect();
+            let regressed = current_sigs.len() > self.previous_sigs.len();
+
+            // Progress vs original errors
+            let progress_pct = if self.original_sigs.is_empty() {
+                0.0
+            } else {
+                let fixed_from_original = self.original_sigs.difference(&current_sigs).count();
+                (fixed_from_original as f64 / self.original_sigs.len() as f64) * 100.0
+            };
+
+            BuildTestDelta {
+                iteration: self.iteration,
+                new_errors,
+                fixed_errors,
+                persistent_errors,
+                regressed,
+                progress_pct,
+                command: command.to_string(),
+            }
+        } else {
+            // First run — store baseline
+            self.original_sigs = current_sigs.clone();
+            BuildTestDelta {
+                iteration: 0,
+                new_errors: Vec::new(),
+                fixed_errors: Vec::new(),
+                persistent_errors: Vec::new(),
+                regressed: false,
+                progress_pct: 0.0,
+                command: command.to_string(),
+            }
+        };
+
+        self.previous_sigs = current_sigs;
+        self.last_command = command.to_string();
+        self.iteration += 1;
+        delta
+    }
+
+    /// How many iterations have been recorded.
+    #[allow(dead_code)]
+    pub fn iterations(&self) -> usize {
+        self.iteration
+    }
+
+    /// Reset tracker (e.g., when switching to a different command).
+    pub fn reset(&mut self) {
+        self.previous_sigs.clear();
+        self.original_sigs.clear();
+        self.iteration = 0;
+        self.last_command.clear();
+    }
+
+    /// Whether the command changed since last run (triggers a reset).
+    pub fn command_changed(&self, command: &str) -> bool {
+        !self.last_command.is_empty() && self.last_command != command
+    }
+}
+
+/// Classify an error and generate a quick-fix hint for the LLM.
+fn classify_and_hint(error_code: &str, message: &str) -> (ErrorClass, String) {
+    // Rust error codes
+    match error_code {
+        // Trivial: mechanical fixes
+        "E0425" => {
+            // cannot find value — usually missing import
+            if let Some(name) = extract_identifier(message) {
+                return (
+                    ErrorClass::Trivial,
+                    format!("Add `use` import for `{name}`, or check spelling"),
+                );
+            }
+            (
+                ErrorClass::Trivial,
+                "Add missing import or check spelling".into(),
+            )
+        }
+        "E0433" => (
+            ErrorClass::Trivial,
+            "Add missing `use` or crate dependency in Cargo.toml".into(),
+        ),
+        "E0432" => (
+            ErrorClass::Trivial,
+            "Fix import path — module or item doesn't exist at that path".into(),
+        ),
+        "E0412" => (
+            ErrorClass::Trivial,
+            "Type not found — add missing `use` import".into(),
+        ),
+        "E0603" => (
+            ErrorClass::Trivial,
+            "Item is private — add `pub` to definition or use a public re-export".into(),
+        ),
+
+        // Fixable: LLM can reason about these
+        "E0308" => {
+            // Mismatched types
+            if message.contains("&str") && message.contains("String") {
+                (
+                    ErrorClass::Fixable,
+                    "String/&str mismatch — use `.to_string()` or `&*s` / `.as_str()`".into(),
+                )
+            } else if message.contains("Option") {
+                (
+                    ErrorClass::Fixable,
+                    "Wrap in Some() or unwrap with .unwrap_or()".into(),
+                )
+            } else {
+                (
+                    ErrorClass::Fixable,
+                    "Check expected vs actual type — may need conversion or different return"
+                        .into(),
+                )
+            }
+        }
+        "E0277" => (
+            ErrorClass::Fixable,
+            "Trait not satisfied — implement the trait or add a bound".into(),
+        ),
+        "E0599" => (
+            ErrorClass::Fixable,
+            "Method not found — check spelling, or the type may need a different impl/import"
+                .into(),
+        ),
+        "E0061" => (
+            ErrorClass::Fixable,
+            "Wrong number of arguments — check function signature".into(),
+        ),
+        "E0063" => (
+            ErrorClass::Fixable,
+            "Missing struct fields — add the required fields".into(),
+        ),
+        "E0609" => (
+            ErrorClass::Fixable,
+            "No field on type — check struct definition for correct field name".into(),
+        ),
+        "E0107" => (
+            ErrorClass::Fixable,
+            "Wrong number of type arguments — check generic parameters".into(),
+        ),
+        "E0369" => (
+            ErrorClass::Fixable,
+            "Operator not implemented — derive trait or implement manually".into(),
+        ),
+        "E0046" => (
+            ErrorClass::Fixable,
+            "Missing trait method — implement the required method".into(),
+        ),
+
+        // Complex: requires deep understanding
+        "E0382" | "E0505" | "E0502" => (
+            ErrorClass::Complex,
+            "Borrow/move error — restructure ownership or use .clone()".into(),
+        ),
+        "E0597" => (
+            ErrorClass::Complex,
+            "Value doesn't live long enough — restructure lifetimes".into(),
+        ),
+        "E0106" => (
+            ErrorClass::Complex,
+            "Missing lifetime — add explicit lifetime annotations".into(),
+        ),
+        "E0495" => (
+            ErrorClass::Complex,
+            "Conflicting lifetime requirements — simplify borrowing structure".into(),
+        ),
+
+        _ => {
+            // Fallback: classify by message patterns
+            classify_by_message(message)
+        }
+    }
+}
+
+/// Classify non-Rust errors or errors without codes by message content.
+fn classify_by_message(message: &str) -> (ErrorClass, String) {
+    let lower = message.to_lowercase();
+
+    // Python / TypeScript / Go common patterns
+    if lower.contains("import")
+        && (lower.contains("not found")
+            || lower.contains("cannot find")
+            || lower.contains("no module"))
+    {
+        return (
+            ErrorClass::Trivial,
+            "Missing import — add the correct import statement".into(),
+        );
+    }
+    if lower.contains("undefined") || lower.contains("is not defined") {
+        return (
+            ErrorClass::Fixable,
+            "Undefined variable/function — check spelling or add import".into(),
+        );
+    }
+    if lower.contains("type") && lower.contains("not assignable") {
+        return (
+            ErrorClass::Fixable,
+            "Type mismatch — check expected vs actual type".into(),
+        );
+    }
+    if lower.contains("unused") {
+        return (
+            ErrorClass::Trivial,
+            "Unused variable — prefix with _ or remove".into(),
+        );
+    }
+    if lower.contains("syntax error") || lower.contains("unexpected token") {
+        return (
+            ErrorClass::Fixable,
+            "Syntax error — check for missing brackets, semicolons, or typos".into(),
+        );
+    }
+    if lower.contains("assertion") || lower.contains("expected") && lower.contains("got") {
+        return (
+            ErrorClass::Complex,
+            "Test assertion failure — check logic and expected values".into(),
+        );
+    }
+
+    (ErrorClass::Fixable, String::new())
+}
+
+/// Extract an identifier name from an error message like "cannot find value `foo`".
+fn extract_identifier(message: &str) -> Option<&str> {
+    // Try backtick-quoted (Rust), then single-quoted (TypeScript/Go)
+    for quote in ['`', '\''] {
+        if let Some(start_pos) = message.find(quote) {
+            let start = start_pos + 1;
+            if let Some(end_offset) = message[start..].find(quote) {
+                let end = start + end_offset;
+                let candidate = &message[start..end];
+                if !candidate.is_empty() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Detect if a command is a build or test command.
+pub fn is_build_test_command(command: &str) -> bool {
+    let lower = command.to_lowercase();
+
+    // Cargo
+    if lower.contains("cargo build")
+        || lower.contains("cargo test")
+        || lower.contains("cargo check")
+        || lower.contains("cargo clippy")
+    {
+        return true;
+    }
+
+    // Python
+    if lower.contains("pytest")
+        || lower.contains("python -m pytest")
+        || lower.contains("python -m unittest")
+    {
+        return true;
+    }
+
+    // Node/JS
+    if lower.contains("npm test")
+        || lower.contains("npm run test")
+        || lower.contains("yarn test")
+        || lower.contains("jest")
+        || lower.contains("vitest")
+        || lower.contains("mocha")
+    {
+        return true;
+    }
+
+    // Go
+    if lower.contains("go build") || lower.contains("go test") {
+        return true;
+    }
+
+    // Make
+    if lower.contains("make test") || lower.contains("make check") {
+        return true;
+    }
+
+    // Generic
+    lower.contains("npm run build") || lower.contains("yarn build")
+}
+
+/// Parse build/test output and return structured result.
+pub fn parse_build_test_output(output: &str, exit_code: Option<i32>) -> BuildTestResult {
+    let lower = output.to_lowercase();
+    let truncated = output.contains("[truncated]");
+
+    // Detect framework
+    let framework = detect_framework(output);
+
+    // Default passed status from exit code
+    let passed_from_exit = exit_code.map(|c| c == 0).unwrap_or(true);
+
+    match framework.as_str() {
+        "cargo" => parse_cargo_output(output, exit_code, truncated),
+        "pytest" => parse_pytest_output(output, exit_code, truncated),
+        "jest" | "vitest" => parse_jest_output(output, exit_code, truncated),
+        "go" => parse_go_output(output, exit_code, truncated),
+        _ => {
+            // Generic fallback
+            let error_count = count_generic_errors(&lower);
+            let (error_messages, error_locations) = extract_generic_errors(output);
+            let passed = passed_from_exit && error_count == 0;
+            BuildTestResult {
+                passed,
+                exit_code,
+                framework,
+                error_count,
+                error_messages,
+                error_locations,
+                summary: if passed {
+                    "completed".to_string()
+                } else {
+                    format!("{} error(s)", error_count)
+                },
+                truncated,
+                ..Default::default()
+            }
+        }
+    }
+}
+
+fn detect_framework(output: &str) -> String {
+    let lower = output.to_lowercase();
+
+    if lower.contains("compiling") && lower.contains("cargo")
+        || lower.contains("error[e")
+        || lower.contains("test result:")
+        || lower.contains("running ")
+            && (lower.contains(" tests") || lower.contains(" test"))
+            && lower.contains("passed")
+    {
+        return "cargo".to_string();
+    }
+
+    if lower.contains("pytest") || lower.contains("===") && lower.contains("passed") {
+        return "pytest".to_string();
+    }
+
+    if lower.contains("jest") || lower.contains("test suites:") {
+        return "jest".to_string();
+    }
+
+    if lower.contains("vitest") {
+        return "vitest".to_string();
+    }
+
+    if lower.contains("--- pass:") || lower.contains("--- fail:") || lower.contains("ok  \t") {
+        return "go".to_string();
+    }
+
+    if lower.contains("mocha") {
+        return "mocha".to_string();
+    }
+
+    "unknown".to_string()
+}
+
+// ─── Cargo Parser ────────────────────────────────────────────────────────────
+
+static CARGO_ERROR_CODE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"error\[(E\d+)\]: (.+)").expect("valid regex"));
+
+static CARGO_LOCATION_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*--> (.+):(\d+):(\d+)").expect("valid regex"));
+
+static CARGO_TEST_RESULT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"test result: (ok|FAILED)\. (\d+) passed; (\d+) failed; (\d+) ignored")
+        .expect("valid regex")
+});
+
+fn parse_cargo_output(output: &str, exit_code: Option<i32>, truncated: bool) -> BuildTestResult {
+    let mut result = BuildTestResult {
+        framework: "cargo".to_string(),
+        exit_code,
+        truncated,
+        ..Default::default()
+    };
+
+    let lines: Vec<&str> = output.lines().collect();
+
+    // Extract compilation errors with locations
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+
+        // Match error[EXXXX]: message
+        if let Some(cap) = CARGO_ERROR_CODE_RE.captures(line) {
+            let code = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+            let msg = cap.get(2).map(|m| m.as_str().trim()).unwrap_or("");
+
+            if !msg.is_empty() && result.error_messages.len() < 10 {
+                result.error_messages.push(msg.to_string());
+            }
+
+            // Look for location on the next few lines (usually line i+1)
+            for line in lines.iter().take(lines.len().min(i + 4)).skip(i + 1) {
+                if let Some(loc_cap) = CARGO_LOCATION_RE.captures(line) {
+                    let file = loc_cap.get(1).map(|m| m.as_str()).unwrap_or("");
+                    let line_num: usize = loc_cap
+                        .get(2)
+                        .and_then(|m| m.as_str().parse().ok())
+                        .unwrap_or(0);
+                    let col: usize = loc_cap
+                        .get(3)
+                        .and_then(|m| m.as_str().parse().ok())
+                        .unwrap_or(0);
+
+                    if !file.is_empty() && line_num > 0 && result.error_locations.len() < 20 {
+                        result.error_locations.push(ErrorLocation::new(
+                            file.to_string(),
+                            line_num,
+                            col,
+                            code.to_string(),
+                            msg.to_string(),
+                            "error".to_string(),
+                        ));
+                    }
+                    break;
+                }
+            }
+        } else if line.starts_with("error:")
+            && !line.contains("could not compile")
+            && !line.contains("aborting due to")
+        {
+            // Plain error: without code
+            let msg = line.strip_prefix("error:").unwrap_or(line).trim();
+            if !msg.is_empty() && result.error_messages.len() < 10 {
+                result.error_messages.push(msg.to_string());
+            }
+            // Check for location
+            for line in lines.iter().take(lines.len().min(i + 4)).skip(i + 1) {
+                if let Some(loc_cap) = CARGO_LOCATION_RE.captures(line) {
+                    let file = loc_cap.get(1).map(|m| m.as_str()).unwrap_or("");
+                    let line_num: usize = loc_cap
+                        .get(2)
+                        .and_then(|m| m.as_str().parse().ok())
+                        .unwrap_or(0);
+                    let col: usize = loc_cap
+                        .get(3)
+                        .and_then(|m| m.as_str().parse().ok())
+                        .unwrap_or(0);
+                    if !file.is_empty() && line_num > 0 && result.error_locations.len() < 20 {
+                        result.error_locations.push(ErrorLocation::new(
+                            file.to_string(),
+                            line_num,
+                            col,
+                            String::new(),
+                            msg.to_string(),
+                            "error".to_string(),
+                        ));
+                    }
+                    break;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    result.error_count = result.error_messages.len();
+
+    // Check for test results
+    if let Some(cap) = CARGO_TEST_RESULT_RE.captures(output) {
+        let status = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        result.tests_passed = cap
+            .get(2)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0);
+        result.tests_failed = cap
+            .get(3)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0);
+        result.tests_skipped = cap
+            .get(4)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0);
+
+        result.passed = status == "ok";
+        result.summary = format!(
+            "{} passed, {} failed",
+            result.tests_passed, result.tests_failed
+        );
+
+        // Extract failed test names with panic locations
+        if result.tests_failed > 0 {
+            let mut failed_tests = extract_cargo_failed_tests(output, &mut result.error_locations);
+            result.error_messages.append(&mut failed_tests);
+            result.error_count = result.tests_failed;
+        }
+    } else {
+        // Build-only (no test result line)
+        result.passed = result.error_count == 0 && exit_code.map(|c| c == 0).unwrap_or(true);
+
+        if output.contains("Finished") {
+            result.summary = "build succeeded".to_string();
+            result.passed = true;
+        } else if result.error_count > 0 {
+            result.summary = format!("{} compilation error(s)", result.error_count);
+        } else if !result.passed {
+            result.summary = "build failed".to_string();
+        } else {
+            result.summary = "completed".to_string();
+        }
+    }
+
+    result
+}
+
+static PANIC_LOCATION_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"panicked at .+,?\s+(.+):(\d+):(\d+)"#).expect("valid regex"));
+
+fn extract_cargo_failed_tests(output: &str, locations: &mut Vec<ErrorLocation>) -> Vec<String> {
+    let mut failed = Vec::new();
+    let lines: Vec<&str> = output.lines().collect();
+
+    for (i, line) in lines.iter().enumerate() {
+        // Look for "---- test_name stdout ----" pattern
+        if line.contains("---- ")
+            && line.contains(" stdout ----")
+            && let Some(name) = line
+                .strip_prefix("---- ")
+                .and_then(|s| s.strip_suffix(" stdout ----"))
+        {
+            let mut msg = name.to_string();
+            // Scan next lines for assertion/panic details
+            for next_line in lines.iter().skip(i + 1).take(10) {
+                if next_line.contains("assertion") || next_line.contains("panicked at") {
+                    msg = format!("{}: {}", name, next_line.trim());
+
+                    // Extract panic location
+                    if let Some(pcap) = PANIC_LOCATION_RE.captures(next_line) {
+                        let file = pcap.get(1).map(|m| m.as_str()).unwrap_or("");
+                        let line_num: usize = pcap
+                            .get(2)
+                            .and_then(|m| m.as_str().parse().ok())
+                            .unwrap_or(0);
+                        let col: usize = pcap
+                            .get(3)
+                            .and_then(|m| m.as_str().parse().ok())
+                            .unwrap_or(0);
+                        if !file.is_empty() && line_num > 0 && locations.len() < 20 {
+                            locations.push(ErrorLocation::new(
+                                file.to_string(),
+                                line_num,
+                                col,
+                                String::new(),
+                                format!("test {name} panicked"),
+                                "error".to_string(),
+                            ));
+                        }
+                    }
+                    break;
+                }
+            }
+            if failed.len() < 10 {
+                failed.push(msg);
+            }
+        }
+    }
+
+    failed
+}
+
+// ─── Pytest Parser ───────────────────────────────────────────────────────────
+
+static PYTEST_SUMMARY_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(\d+) passed.*?(\d+) failed|(\d+) passed").expect("valid regex"));
+
+// Matches Python tracebacks: "  File "path.py", line 42, in func"
+static PYTHON_TRACEBACK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"File "(.+?)", line (\d+)(?:, in (.+))?"#).expect("valid regex"));
+
+fn parse_pytest_output(output: &str, exit_code: Option<i32>, truncated: bool) -> BuildTestResult {
+    let mut result = BuildTestResult {
+        framework: "pytest".to_string(),
+        exit_code,
+        truncated,
+        ..Default::default()
+    };
+
+    // Parse summary line
+    if let Some(cap) = PYTEST_SUMMARY_RE.captures(output) {
+        if let Some(p) = cap.get(1) {
+            result.tests_passed = p.as_str().parse().unwrap_or(0);
+        } else if let Some(p) = cap.get(3) {
+            result.tests_passed = p.as_str().parse().unwrap_or(0);
+        }
+        if let Some(f) = cap.get(2) {
+            result.tests_failed = f.as_str().parse().unwrap_or(0);
+        }
+    }
+
+    result.passed = result.tests_failed == 0 && exit_code.map(|c| c == 0).unwrap_or(true);
+    result.error_count = result.tests_failed;
+
+    // Extract failed test names and traceback locations
+    let lines: Vec<&str> = output.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if line.starts_with("FAILED ") {
+            let test_name = line.trim_start_matches("FAILED ").trim();
+            if result.error_messages.len() < 10 {
+                result.error_messages.push(test_name.to_string());
+            }
+        }
+
+        // Extract traceback file locations (last File line before assertion error)
+        if let Some(cap) = PYTHON_TRACEBACK_RE.captures(line) {
+            let file = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+            let line_num: usize = cap
+                .get(2)
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(0);
+            let func = cap.get(3).map(|m| m.as_str()).unwrap_or("");
+
+            // Only include if the next few lines contain an assertion or error
+            let is_relevant = lines.iter().skip(i + 1).take(3).any(|l| {
+                l.contains("AssertionError")
+                    || l.contains("assert ")
+                    || l.contains("Error")
+                    || l.contains("raise ")
+            });
+
+            if is_relevant && !file.is_empty() && line_num > 0 && result.error_locations.len() < 20
+            {
+                result.error_locations.push(ErrorLocation::new(
+                    file.to_string(),
+                    line_num,
+                    0,
+                    String::new(),
+                    if func.is_empty() {
+                        String::new()
+                    } else {
+                        format!("in {func}")
+                    },
+                    "error".to_string(),
+                ));
+            }
+        }
+    }
+
+    result.summary = format!(
+        "{} passed, {} failed",
+        result.tests_passed, result.tests_failed
+    );
+
+    result
+}
+
+// ─── Jest/Vitest Parser ──────────────────────────────────────────────────────
+
+static JEST_SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"Tests:\s+(\d+) failed.*?(\d+) passed|Tests:\s+(\d+) passed").expect("valid regex")
+});
+
+fn parse_jest_output(output: &str, exit_code: Option<i32>, truncated: bool) -> BuildTestResult {
+    let mut result = BuildTestResult {
+        framework: if output.to_lowercase().contains("vitest") {
+            "vitest"
+        } else {
+            "jest"
+        }
+        .to_string(),
+        exit_code,
+        truncated,
+        ..Default::default()
+    };
+
+    if let Some(cap) = JEST_SUMMARY_RE.captures(output) {
+        if let Some(f) = cap.get(1) {
+            result.tests_failed = f.as_str().parse().unwrap_or(0);
+        }
+        if let Some(p) = cap.get(2) {
+            result.tests_passed = p.as_str().parse().unwrap_or(0);
+        } else if let Some(p) = cap.get(3) {
+            result.tests_passed = p.as_str().parse().unwrap_or(0);
+        }
+    }
+
+    result.passed = result.tests_failed == 0 && exit_code.map(|c| c == 0).unwrap_or(true);
+    result.error_count = result.tests_failed;
+
+    // Extract failed test descriptions
+    for line in output.lines() {
+        if (line.trim().starts_with("✕") || line.trim().starts_with("×"))
+            && result.error_messages.len() < 10
+        {
+            result.error_messages.push(line.trim().to_string());
+        }
+    }
+
+    result.summary = format!(
+        "{} passed, {} failed",
+        result.tests_passed, result.tests_failed
+    );
+
+    result
+}
+
+// ─── Go Test Parser ──────────────────────────────────────────────────────────
+
+// Matches go test failure locations: "    main_test.go:25: expected true, got false"
+static GO_TEST_LOCATION_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s+(\S+\.go):(\d+): (.+)").expect("valid regex"));
+
+fn parse_go_output(output: &str, exit_code: Option<i32>, truncated: bool) -> BuildTestResult {
+    let mut result = BuildTestResult {
+        framework: "go".to_string(),
+        exit_code,
+        truncated,
+        ..Default::default()
+    };
+
+    let mut current_test = String::new();
+    for line in output.lines() {
+        if line.starts_with("--- PASS:") {
+            result.tests_passed += 1;
+        } else if line.starts_with("--- FAIL:") {
+            result.tests_failed += 1;
+            current_test = line
+                .trim_start_matches("--- FAIL: ")
+                .split(' ')
+                .next()
+                .unwrap_or("")
+                .to_string();
+            if result.error_messages.len() < 10 {
+                result.error_messages.push(line.trim().to_string());
+            }
+        } else if line.starts_with("--- SKIP:") {
+            result.tests_skipped += 1;
+        } else if let Some(cap) = GO_TEST_LOCATION_RE.captures(line) {
+            let file = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+            let line_num: usize = cap
+                .get(2)
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(0);
+            let msg = cap.get(3).map(|m| m.as_str()).unwrap_or("");
+            if !file.is_empty() && line_num > 0 && result.error_locations.len() < 20 {
+                let full_msg = if current_test.is_empty() {
+                    msg.to_string()
+                } else {
+                    format!("{}: {}", current_test, msg)
+                };
+                result.error_locations.push(ErrorLocation::new(
+                    file.to_string(),
+                    line_num,
+                    0,
+                    String::new(),
+                    full_msg,
+                    "error".to_string(),
+                ));
+            }
+        }
+    }
+
+    result.passed = result.tests_failed == 0 && exit_code.map(|c| c == 0).unwrap_or(true);
+    result.error_count = result.tests_failed;
+    result.summary = format!(
+        "{} passed, {} failed",
+        result.tests_passed, result.tests_failed
+    );
+
+    result
+}
+
+// ─── Generic Fallback ────────────────────────────────────────────────────────
+
+// Matches TypeScript errors: "src/app.ts(10,5): error TS2304: Cannot find name 'foo'"
+static TS_ERROR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(.+)\((\d+),(\d+)\): error (TS\d+): (.+)").expect("valid regex"));
+
+// Matches generic file:line:col: error patterns
+static GENERIC_LOCATION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(.+?):(\d+):(\d+):\s*(error|warning):\s*(.+)").expect("valid regex")
+});
+
+fn count_generic_errors(lower: &str) -> usize {
+    let mut count = 0;
+    count += lower.matches("error:").count();
+    count += lower.matches("error[").count();
+    count += lower.matches("failed").count().min(5);
+    count += lower.matches("exception").count();
+    count
+}
+
+fn extract_generic_errors(output: &str) -> (Vec<String>, Vec<ErrorLocation>) {
+    let mut errors = Vec::new();
+    let mut locations = Vec::new();
+
+    for line in output.lines() {
+        let lower = line.to_lowercase();
+
+        // Try TypeScript error format first
+        if let Some(cap) = TS_ERROR_RE.captures(line) {
+            let file = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+            let line_num: usize = cap
+                .get(2)
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(0);
+            let col: usize = cap
+                .get(3)
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(0);
+            let code = cap.get(4).map(|m| m.as_str()).unwrap_or("");
+            let msg = cap.get(5).map(|m| m.as_str()).unwrap_or("");
+            if errors.len() < 10 {
+                errors.push(format!("[{code}] {msg}"));
+            }
+            if locations.len() < 20 {
+                locations.push(ErrorLocation::new(
+                    file.to_string(),
+                    line_num,
+                    col,
+                    code.to_string(),
+                    msg.to_string(),
+                    "error".to_string(),
+                ));
+            }
+            continue;
+        }
+
+        // Try generic file:line:col: error format
+        if let Some(cap) = GENERIC_LOCATION_RE.captures(line) {
+            let file = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+            let line_num: usize = cap
+                .get(2)
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(0);
+            let col: usize = cap
+                .get(3)
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(0);
+            let severity = cap.get(4).map(|m| m.as_str()).unwrap_or("error");
+            let msg = cap.get(5).map(|m| m.as_str()).unwrap_or("");
+            if errors.len() < 10 {
+                errors.push(msg.to_string());
+            }
+            if locations.len() < 20 {
+                locations.push(ErrorLocation::new(
+                    file.to_string(),
+                    line_num,
+                    col,
+                    String::new(),
+                    msg.to_string(),
+                    severity.to_string(),
+                ));
+            }
+            continue;
+        }
+
+        // Fall through to simple text-matching
+        if lower.contains("error:") || lower.contains("failed:") || lower.contains("exception:") {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() && errors.len() < 10 {
+                if trimmed.len() > 200 {
+                    let mut end = 200;
+                    while !trimmed.is_char_boundary(end) && end > 0 {
+                        end -= 1;
+                    }
+                    errors.push(format!("{}...", &trimmed[..end]));
+                } else {
+                    errors.push(trimmed.to_string());
+                }
+            }
+        }
+    }
+
+    (errors, locations)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn detect_cargo_build() {
+        assert!(is_build_test_command("cargo build"));
+        assert!(is_build_test_command("cargo test --workspace"));
+        assert!(is_build_test_command("RUST_BACKTRACE=1 cargo test"));
+    }
+
+    #[test]
+    fn detect_pytest() {
+        assert!(is_build_test_command("pytest tests/"));
+        assert!(is_build_test_command("python -m pytest -v"));
+    }
+
+    #[test]
+    fn detect_npm() {
+        assert!(is_build_test_command("npm test"));
+        assert!(is_build_test_command("npm run test"));
+        assert!(is_build_test_command("yarn test"));
+    }
+
+    #[test]
+    fn parse_cargo_test_success() {
+        let output = r#"
+   Compiling myproject v0.1.0
+    Finished test [unoptimized + debuginfo] target(s) in 2.34s
+     Running unittests src/lib.rs
+
+running 10 tests
+test tests::test_one ... ok
+test tests::test_two ... ok
+test result: ok. 10 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
+"#;
+        let result = parse_build_test_output(output, Some(0));
+        assert!(result.passed);
+        assert_eq!(result.framework, "cargo");
+        assert_eq!(result.tests_passed, 10);
+        assert_eq!(result.tests_failed, 0);
+        assert_eq!(result.tests_skipped, 2);
+    }
+
+    #[test]
+    fn parse_cargo_test_failure() {
+        let output = r#"
+running 3 tests
+test tests::test_one ... ok
+test tests::test_two ... FAILED
+test tests::test_three ... ok
+
+failures:
+
+---- tests::test_two stdout ----
+thread 'tests::test_two' panicked at 'assertion failed: false'
+
+test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+"#;
+        let result = parse_build_test_output(output, Some(101));
+        assert!(!result.passed);
+        assert_eq!(result.tests_passed, 2);
+        assert_eq!(result.tests_failed, 1);
+        assert!(result.error_messages.iter().any(|m| m.contains("test_two")));
+    }
+
+    #[test]
+    fn parse_cargo_build_error() {
+        let output = r#"
+   Compiling myproject v0.1.0
+error[E0425]: cannot find value `foo` in this scope
+ --> src/main.rs:10:5
+  |
+10 |     foo
+  |     ^^^ not found in this scope
+
+error[E0308]: mismatched types
+ --> src/lib.rs:20:10
+  |
+20 |     return "hello";
+  |            ^^^^^^^ expected i32, found &str
+
+error: could not compile `myproject` due to 2 previous errors
+"#;
+        let result = parse_build_test_output(output, Some(101));
+        assert!(!result.passed);
+        assert_eq!(result.framework, "cargo");
+        assert_eq!(result.error_count, 2);
+        assert!(
+            result
+                .error_messages
+                .iter()
+                .any(|m| m.contains("cannot find value"))
+        );
+
+        // Verify error locations extracted
+        assert_eq!(
+            result.error_locations.len(),
+            2,
+            "should extract 2 error locations"
+        );
+        let loc0 = &result.error_locations[0];
+        assert_eq!(loc0.file, "src/main.rs");
+        assert_eq!(loc0.line, 10);
+        assert_eq!(loc0.col, 5);
+        assert_eq!(loc0.error_code, "E0425");
+        assert!(loc0.message.contains("cannot find value"));
+
+        let loc1 = &result.error_locations[1];
+        assert_eq!(loc1.file, "src/lib.rs");
+        assert_eq!(loc1.line, 20);
+        assert_eq!(loc1.col, 10);
+        assert_eq!(loc1.error_code, "E0308");
+    }
+
+    #[test]
+    fn parse_pytest_success() {
+        let output = r#"
+============================= test session starts ==============================
+collected 5 items
+
+tests/test_main.py .....                                                  [100%]
+
+============================== 5 passed in 0.12s ===============================
+"#;
+        let result = parse_build_test_output(output, Some(0));
+        assert!(result.passed);
+        assert_eq!(result.framework, "pytest");
+        assert_eq!(result.tests_passed, 5);
+        assert_eq!(result.tests_failed, 0);
+    }
+
+    #[test]
+    fn parse_jest_output() {
+        let output = r#"
+PASS  src/__tests__/app.test.js
+  ✓ should render (5 ms)
+  ✓ should handle click (3 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       2 passed, 2 total
+"#;
+        let result = parse_build_test_output(output, Some(0));
+        assert!(result.passed);
+        assert_eq!(result.tests_passed, 2);
+    }
+
+    #[test]
+    fn parse_go_test() {
+        let output = r#"
+=== RUN   TestMain
+--- PASS: TestMain (0.00s)
+=== RUN   TestHelper
+--- PASS: TestHelper (0.01s)
+=== RUN   TestError
+--- FAIL: TestError (0.00s)
+    main_test.go:25: expected true, got false
+FAIL
+exit status 1
+"#;
+        let result = parse_build_test_output(output, Some(1));
+        assert!(!result.passed);
+        assert_eq!(result.framework, "go");
+        assert_eq!(result.tests_passed, 2);
+        assert_eq!(result.tests_failed, 1);
+    }
+
+    #[test]
+    fn enhanced_output_format() {
+        let result = BuildTestResult {
+            passed: false,
+            framework: "cargo".to_string(),
+            tests_passed: 45,
+            tests_failed: 2,
+            error_messages: vec![
+                "test_auth: assertion failed".to_string(),
+                "test_db: timeout".to_string(),
+            ],
+            ..Default::default()
+        };
+        let enhanced = result.to_enhanced_output("");
+        assert!(enhanced.contains("✗"));
+        assert!(enhanced.contains("45 passed"));
+        assert!(enhanced.contains("2 failed"));
+        assert!(enhanced.contains("Errors:"));
+    }
+
+    #[test]
+    fn framework_detection() {
+        assert_eq!(detect_framework("error[E0425]: cannot find"), "cargo");
+        assert_eq!(detect_framework("test result: ok. 5 passed"), "cargo");
+        assert_eq!(detect_framework("===== 5 passed ====="), "pytest");
+        assert_eq!(detect_framework("Test Suites: 1 passed"), "jest");
+        assert_eq!(detect_framework("--- PASS: TestMain"), "go");
+    }
+
+    // ─── Error Location Tests ─────────────────────────────────────────────
+
+    #[test]
+    fn cargo_error_locations_in_enhanced_output() {
+        let result = BuildTestResult {
+            passed: false,
+            framework: "cargo".to_string(),
+            error_count: 1,
+            error_messages: vec!["cannot find value `foo`".to_string()],
+            error_locations: vec![ErrorLocation::new(
+                "src/main.rs".to_string(),
+                10,
+                5,
+                "E0425".to_string(),
+                "cannot find value `foo`".to_string(),
+                "error".to_string(),
+            )],
+            summary: "1 compilation error(s)".to_string(),
+            ..Default::default()
+        };
+        let output = result.to_enhanced_output("");
+        assert!(
+            output.contains("Locations"),
+            "should have Locations section: {output}"
+        );
+        assert!(
+            output.contains("src/main.rs:10:5"),
+            "should show file:line:col: {output}"
+        );
+        assert!(
+            output.contains("[E0425]"),
+            "should show error code: {output}"
+        );
+    }
+
+    #[test]
+    fn go_test_extracts_locations() {
+        let output = r#"
+=== RUN   TestMain
+--- PASS: TestMain (0.00s)
+=== RUN   TestHelper
+--- PASS: TestHelper (0.01s)
+=== RUN   TestError
+    main_test.go:25: expected true, got false
+    main_test.go:30: another assertion failed
+--- FAIL: TestError (0.00s)
+FAIL
+exit status 1
+"#;
+        let result = parse_build_test_output(output, Some(1));
+        assert!(!result.passed);
+        assert_eq!(result.framework, "go");
+        assert_eq!(result.tests_failed, 1);
+        assert!(
+            !result.error_locations.is_empty(),
+            "should extract go test locations"
+        );
+        assert_eq!(result.error_locations[0].file, "main_test.go");
+        assert_eq!(result.error_locations[0].line, 25);
+    }
+
+    #[test]
+    fn typescript_error_locations() {
+        let output = r#"
+src/app.ts(10,5): error TS2304: Cannot find name 'foo'
+src/utils.ts(20,15): error TS2345: Argument of type 'string' is not assignable
+"#;
+        let result = parse_build_test_output(output, Some(1));
+        assert!(!result.passed);
+        assert_eq!(result.error_locations.len(), 2);
+        assert_eq!(result.error_locations[0].file, "src/app.ts");
+        assert_eq!(result.error_locations[0].line, 10);
+        assert_eq!(result.error_locations[0].col, 5);
+        assert_eq!(result.error_locations[0].error_code, "TS2304");
+        assert_eq!(result.error_locations[1].file, "src/utils.ts");
+        assert_eq!(result.error_locations[1].line, 20);
+    }
+
+    #[test]
+    fn generic_file_line_col_error_locations() {
+        let output = r#"
+src/main.c:42:10: error: use of undeclared identifier 'x'
+src/helper.c:15:3: warning: implicit conversion
+"#;
+        let result = parse_build_test_output(output, Some(1));
+        assert_eq!(result.error_locations.len(), 2);
+        assert_eq!(result.error_locations[0].file, "src/main.c");
+        assert_eq!(result.error_locations[0].line, 42);
+        assert_eq!(result.error_locations[0].severity, "error");
+        assert_eq!(result.error_locations[1].severity, "warning");
+    }
+
+    #[test]
+    fn enhanced_output_no_locations_when_empty() {
+        let result = BuildTestResult {
+            passed: true,
+            framework: "cargo".to_string(),
+            tests_passed: 10,
+            summary: "10 passed, 0 failed".to_string(),
+            ..Default::default()
+        };
+        let output = result.to_enhanced_output("");
+        assert!(
+            !output.contains("Locations"),
+            "should not show Locations when empty"
+        );
+    }
+
+    #[test]
+    fn parse_cargo_panic_location_extraction() {
+        let output = r#"
+running 1 test
+test tests::my_test ... FAILED
+
+failures:
+
+---- tests::my_test stdout ----
+thread 'tests::my_test' panicked at 'assertion failed: x > 0', src/lib.rs:42:9
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored
+"#;
+        let result = parse_build_test_output(output, None);
+        assert!(!result.passed);
+        assert_eq!(result.tests_failed, 1);
+        // Verify panic location was correctly extracted
+        assert!(
+            !result.error_locations.is_empty(),
+            "should extract panic location, got: {:?}",
+            result.error_locations
+        );
+        let loc = &result.error_locations[0];
+        assert_eq!(loc.file, "src/lib.rs", "file should be src/lib.rs");
+        assert_eq!(loc.line, 42, "line should be 42");
+        assert_eq!(loc.col, 9, "col should be 9");
+        assert!(
+            loc.message.contains("my_test"),
+            "message should reference test name"
+        );
+    }
+
+    // ─── Error classification tests ────────────────────────────────────
+
+    #[test]
+    fn classify_rust_trivial_missing_import() {
+        let (class, hint) = classify_and_hint("E0425", "cannot find value `HashMap` in this scope");
+        assert_eq!(class, ErrorClass::Trivial);
+        assert!(
+            hint.contains("HashMap"),
+            "hint should mention the identifier: {hint}"
+        );
+        assert!(
+            hint.contains("import"),
+            "hint should suggest import: {hint}"
+        );
+    }
+
+    #[test]
+    fn classify_rust_trivial_missing_crate() {
+        let (class, hint) = classify_and_hint(
+            "E0433",
+            "failed to resolve: use of undeclared crate or module `serde`",
+        );
+        assert_eq!(class, ErrorClass::Trivial);
+        assert!(
+            hint.contains("Cargo.toml"),
+            "hint should mention Cargo.toml: {hint}"
+        );
+    }
+
+    #[test]
+    fn classify_rust_fixable_type_mismatch() {
+        let (class, hint) =
+            classify_and_hint("E0308", "mismatched types: expected &str, found String");
+        assert_eq!(class, ErrorClass::Fixable);
+        assert!(
+            hint.contains("to_string") || hint.contains("as_str"),
+            "hint should suggest conversion: {hint}"
+        );
+    }
+
+    #[test]
+    fn classify_rust_fixable_option_mismatch() {
+        let (class, hint) = classify_and_hint("E0308", "expected Option<i32>, found i32");
+        assert_eq!(class, ErrorClass::Fixable);
+        assert!(hint.contains("Some"), "hint should suggest Some: {hint}");
+    }
+
+    #[test]
+    fn classify_rust_complex_borrow() {
+        for code in &["E0382", "E0505", "E0502"] {
+            let (class, _hint) = classify_and_hint(code, "value moved here");
+            assert_eq!(class, ErrorClass::Complex, "code {code} should be Complex");
+        }
+    }
+
+    #[test]
+    fn classify_rust_complex_lifetime() {
+        let (class, hint) = classify_and_hint("E0597", "borrowed value does not live long enough");
+        assert_eq!(class, ErrorClass::Complex);
+        assert!(
+            hint.contains("lifetime"),
+            "hint should mention lifetime: {hint}"
+        );
+    }
+
+    #[test]
+    fn classify_unknown_code_by_message() {
+        let (class, _) = classify_and_hint("", "unused variable: `x`");
+        assert_eq!(class, ErrorClass::Trivial);
+
+        let (class, _) = classify_and_hint("", "import 'foo' not found");
+        assert_eq!(class, ErrorClass::Trivial);
+
+        let (class, _) = classify_and_hint("", "syntax error: unexpected token '}'");
+        assert_eq!(class, ErrorClass::Fixable);
+
+        let (class, _) = classify_and_hint("", "assertion failed: expected 5, got 3");
+        assert_eq!(class, ErrorClass::Complex);
+    }
+
+    #[test]
+    fn classify_extract_identifier() {
+        assert_eq!(
+            extract_identifier("cannot find value `foo` in scope"),
+            Some("foo")
+        );
+        assert_eq!(extract_identifier("no backticks here"), None);
+        assert_eq!(extract_identifier("found `Bar` not defined"), Some("Bar"));
+    }
+
+    #[test]
+    fn enhanced_output_shows_classification_summary() {
+        let result = BuildTestResult {
+            passed: false,
+            error_count: 3,
+            error_messages: vec!["E0425".into(), "E0308".into(), "E0382".into()],
+            error_locations: vec![
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    1,
+                    0,
+                    "E0425".into(),
+                    "cannot find value `x`".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/b.rs".into(),
+                    2,
+                    0,
+                    "E0308".into(),
+                    "mismatched types".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/c.rs".into(),
+                    3,
+                    0,
+                    "E0382".into(),
+                    "value moved".into(),
+                    "error".into(),
+                ),
+            ],
+            summary: "3 errors".into(),
+            ..Default::default()
+        };
+        let output = result.to_enhanced_output("");
+        assert!(
+            output.contains("trivial"),
+            "should show trivial count: {output}"
+        );
+        assert!(
+            output.contains("fixable"),
+            "should show fixable count: {output}"
+        );
+        assert!(
+            output.contains("complex"),
+            "should show complex count: {output}"
+        );
+    }
+
+    #[test]
+    fn enhanced_output_shows_hints() {
+        let result = BuildTestResult {
+            passed: false,
+            error_count: 1,
+            error_messages: vec!["cannot find value `foo`".into()],
+            error_locations: vec![ErrorLocation::new(
+                "src/main.rs".into(),
+                10,
+                5,
+                "E0425".into(),
+                "cannot find value `foo`".into(),
+                "error".into(),
+            )],
+            summary: "1 error".into(),
+            ..Default::default()
+        };
+        let output = result.to_enhanced_output("");
+        assert!(output.contains("💡"), "should show hint icon: {output}");
+        assert!(
+            output.contains("import"),
+            "hint should mention import: {output}"
+        );
+        assert!(
+            output.contains("🔧"),
+            "trivial should get wrench icon: {output}"
+        );
+    }
+
+    #[test]
+    fn enhanced_output_cascading_detection() {
+        let result = BuildTestResult {
+            passed: false,
+            error_count: 4,
+            error_messages: vec!["err1".into(), "err2".into(), "err3".into(), "err4".into()],
+            error_locations: vec![
+                ErrorLocation::new(
+                    "src/same.rs".into(),
+                    10,
+                    0,
+                    "E0425".into(),
+                    "err1".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/same.rs".into(),
+                    20,
+                    0,
+                    "E0308".into(),
+                    "err2".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/same.rs".into(),
+                    30,
+                    0,
+                    "E0599".into(),
+                    "err3".into(),
+                    "error".into(),
+                ),
+            ],
+            summary: "3 errors in same file".into(),
+            ..Default::default()
+        };
+        let output = result.to_enhanced_output("");
+        assert!(
+            output.contains("Cascading") || output.contains("cascade"),
+            "should detect cascading errors in same file: {output}"
+        );
+        assert!(
+            output.contains("ROOT CAUSE"),
+            "should mark root cause: {output}"
+        );
+    }
+
+    #[test]
+    fn errorlocation_new_auto_classifies() {
+        let loc = ErrorLocation::new(
+            "f.rs".into(),
+            1,
+            0,
+            "E0425".into(),
+            "cannot find value `x`".into(),
+            "error".into(),
+        );
+        assert_eq!(loc.class, ErrorClass::Trivial);
+        assert!(!loc.hint.is_empty());
+
+        let loc2 = ErrorLocation::new(
+            "f.rs".into(),
+            1,
+            0,
+            "E0382".into(),
+            "value moved".into(),
+            "error".into(),
+        );
+        assert_eq!(loc2.class, ErrorClass::Complex);
+
+        let loc3 = ErrorLocation::new(
+            "f.rs".into(),
+            1,
+            0,
+            "".into(),
+            "random error".into(),
+            "error".into(),
+        );
+        assert_eq!(loc3.class, ErrorClass::Fixable);
+    }
+
+    #[test]
+    fn rust_error_gets_classified_in_parse() {
+        let output = r#"
+error[E0425]: cannot find value `nonexistent` in this scope
+  --> src/main.rs:10:5
+   |
+10 |     nonexistent;
+   |     ^^^^^^^^^^^ not found in this scope
+"#;
+        let result = parse_build_test_output(output, Some(101));
+        assert!(!result.error_locations.is_empty());
+        let loc = &result.error_locations[0];
+        assert_eq!(loc.error_code, "E0425");
+        assert_eq!(loc.class, ErrorClass::Trivial, "E0425 should be trivial");
+        assert!(!loc.hint.is_empty(), "should have a hint");
+    }
+
+    #[test]
+    fn enrich_with_scope_fills_scope_field() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let mut result = BuildTestResult {
+            error_locations: vec![ErrorLocation::new(
+                "src/code_intel.rs".into(),
+                138,
+                5,
+                "E0425".into(),
+                "cannot find value".into(),
+                "error".into(),
+            )],
+            ..Default::default()
+        };
+        // Scope should be empty initially
+        assert!(result.error_locations[0].scope.is_empty());
+        // Enrich
+        result.enrich_with_scope(root);
+        // After enrichment, scope should have the containing function
+        let scope = &result.error_locations[0].scope;
+        assert!(
+            !scope.is_empty(),
+            "scope should be filled after enrichment for a valid Rust file"
+        );
+    }
+
+    #[test]
+    fn enrich_with_scope_handles_nonexistent_file() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let mut result = BuildTestResult {
+            error_locations: vec![ErrorLocation::new(
+                "nonexistent_file.rs".into(),
+                10,
+                0,
+                "".into(),
+                "some error".into(),
+                "error".into(),
+            )],
+            ..Default::default()
+        };
+        result.enrich_with_scope(root);
+        // Should not crash, scope should remain empty
+        assert!(result.error_locations[0].scope.is_empty());
+    }
+
+    #[test]
+    fn scope_field_appears_in_enhanced_output() {
+        let result = BuildTestResult {
+            passed: false,
+            framework: "cargo".into(),
+            error_count: 1,
+            error_locations: vec![ErrorLocation {
+                file: "src/lib.rs".into(),
+                line: 42,
+                col: 5,
+                error_code: "E0308".into(),
+                message: "type mismatch".into(),
+                severity: "error".into(),
+                class: ErrorClass::Fixable,
+                hint: "check types".into(),
+                scope: "impl Foo > fn process".into(),
+            }],
+            summary: "Build failed".into(),
+            ..Default::default()
+        };
+        let output = result.to_enhanced_output("");
+        assert!(
+            output.contains("(in impl Foo > fn process)"),
+            "scope should appear in enhanced output: {output}"
+        );
+    }
+
+    // ═══════════════════════ Cascading Analysis Tests ═══════════════════════
+
+    #[test]
+    fn analyze_import_cascade_same_identifier() {
+        let result = BuildTestResult {
+            error_locations: vec![
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    10,
+                    1,
+                    "E0425".into(),
+                    "cannot find value `Foo`".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    20,
+                    1,
+                    "E0425".into(),
+                    "cannot find value `Foo`".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    30,
+                    1,
+                    "E0433".into(),
+                    "cannot find `Foo` in this scope".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let groups = result.analyze_error_groups();
+        assert!(!groups.is_empty());
+        let cascade = groups.iter().find(|g| g.is_cascade);
+        assert!(cascade.is_some(), "should detect import cascade");
+        let c = cascade.unwrap();
+        assert!(
+            c.cascade_hint.contains("Foo"),
+            "hint should mention the identifier: {}",
+            c.cascade_hint
+        );
+    }
+
+    #[test]
+    fn analyze_trivial_first_cascade() {
+        let result = BuildTestResult {
+            error_locations: vec![
+                ErrorLocation::new(
+                    "src/b.rs".into(),
+                    5,
+                    1,
+                    "E0432".into(),
+                    "unresolved import".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/b.rs".into(),
+                    15,
+                    1,
+                    "E0308".into(),
+                    "mismatched types".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/b.rs".into(),
+                    25,
+                    1,
+                    "E0599".into(),
+                    "method not found".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let groups = result.analyze_error_groups();
+        let cascade = groups.iter().find(|g| g.is_cascade);
+        assert!(
+            cascade.is_some(),
+            "trivial-first with 3 errors should cascade"
+        );
+        let c = cascade.unwrap();
+        assert_eq!(c.root_index, 0, "root should be the first (trivial) error");
+    }
+
+    #[test]
+    fn analyze_no_cascade_two_errors() {
+        let result = BuildTestResult {
+            error_locations: vec![
+                ErrorLocation::new(
+                    "src/c.rs".into(),
+                    10,
+                    1,
+                    "E0308".into(),
+                    "type mismatch".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/c.rs".into(),
+                    20,
+                    1,
+                    "E0277".into(),
+                    "trait not satisfied".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let groups = result.analyze_error_groups();
+        // 2 errors, first is Fixable (not Trivial), so no cascade
+        assert!(
+            groups.iter().all(|g| !g.is_cascade),
+            "2 non-trivial errors should not be cascade"
+        );
+    }
+
+    #[test]
+    fn analyze_multi_file_groups() {
+        let result = BuildTestResult {
+            error_locations: vec![
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    10,
+                    1,
+                    "E0425".into(),
+                    "not found".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/b.rs".into(),
+                    20,
+                    1,
+                    "E0308".into(),
+                    "type mismatch".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/c.rs".into(),
+                    30,
+                    1,
+                    "E0599".into(),
+                    "method not found".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let groups = result.analyze_error_groups();
+        assert_eq!(groups.len(), 3, "each file should be its own group");
+        assert!(
+            groups.iter().all(|g| !g.is_cascade),
+            "single error per file = no cascade"
+        );
+    }
+
+    #[test]
+    fn fix_order_root_causes_first() {
+        let result = BuildTestResult {
+            error_locations: vec![
+                // File A: cascade (trivial root)
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    5,
+                    1,
+                    "E0425".into(),
+                    "cannot find value `X`".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    15,
+                    1,
+                    "E0308".into(),
+                    "type mismatch".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    25,
+                    1,
+                    "E0599".into(),
+                    "method not found".into(),
+                    "error".into(),
+                ),
+                // File B: standalone complex error
+                ErrorLocation::new(
+                    "src/b.rs".into(),
+                    10,
+                    1,
+                    "E0382".into(),
+                    "value moved".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let order = result.fix_order();
+        assert_eq!(order.len(), 4);
+        // Root cause (index 0, E0425 cascade root) should be first
+        assert_eq!(order[0], 0, "cascade root should be first");
+        // Complex error should be last
+        assert_eq!(*order.last().unwrap(), 3, "complex error should be last");
+    }
+
+    #[test]
+    fn fix_order_trivial_before_fixable() {
+        let result = BuildTestResult {
+            error_locations: vec![
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    10,
+                    1,
+                    "E0308".into(),
+                    "type mismatch".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/b.rs".into(),
+                    20,
+                    1,
+                    "E0425".into(),
+                    "not found".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/c.rs".into(),
+                    30,
+                    1,
+                    "E0382".into(),
+                    "value moved".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let order = result.fix_order();
+        // Index 1 (Trivial E0425) should come before index 0 (Fixable E0308)
+        let trivial_pos = order.iter().position(|&i| i == 1).unwrap();
+        let fixable_pos = order.iter().position(|&i| i == 0).unwrap();
+        let complex_pos = order.iter().position(|&i| i == 2).unwrap();
+        assert!(
+            trivial_pos < fixable_pos,
+            "trivial should be before fixable"
+        );
+        assert!(
+            fixable_pos < complex_pos,
+            "fixable should be before complex"
+        );
+    }
+
+    #[test]
+    fn enhanced_output_shows_fix_order_numbers() {
+        let result = BuildTestResult {
+            passed: false,
+            error_locations: vec![
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    10,
+                    5,
+                    "E0308".into(),
+                    "type mismatch".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/b.rs".into(),
+                    20,
+                    1,
+                    "E0425".into(),
+                    "not found".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let output = result.to_enhanced_output("");
+        // Should show numbered list
+        assert!(
+            output.contains("1."),
+            "should have numbered errors: {output}"
+        );
+        assert!(output.contains("2."), "should have second error: {output}");
+    }
+
+    #[test]
+    fn enhanced_output_marks_root_cause() {
+        let result = BuildTestResult {
+            passed: false,
+            error_locations: vec![
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    5,
+                    1,
+                    "E0425".into(),
+                    "cannot find `X`".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    15,
+                    1,
+                    "E0308".into(),
+                    "type mismatch".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/a.rs".into(),
+                    25,
+                    1,
+                    "E0599".into(),
+                    "method not found".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let output = result.to_enhanced_output("");
+        assert!(
+            output.contains("ROOT CAUSE"),
+            "should mark root cause in cascade: {output}"
+        );
+        assert!(
+            output.contains("cascade"),
+            "should show cascade hint: {output}"
+        );
+    }
+
+    // ═══════════════════════ BuildTestTracker Tests ═══════════════════════
+
+    fn make_errors(specs: &[(&str, &str, &str)]) -> Vec<ErrorLocation> {
+        specs
+            .iter()
+            .map(|(file, code, msg)| {
+                ErrorLocation::new(
+                    file.to_string(),
+                    10,
+                    1,
+                    code.to_string(),
+                    msg.to_string(),
+                    "error".into(),
+                )
+            })
+            .collect()
+    }
+
+    fn make_result(errors: Vec<ErrorLocation>) -> BuildTestResult {
+        BuildTestResult {
+            passed: errors.is_empty(),
+            error_count: errors.len(),
+            error_locations: errors,
+            framework: "cargo".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn tracker_first_run_no_delta() {
+        let mut tracker = BuildTestTracker::new();
+        let result = make_result(make_errors(&[
+            ("src/a.rs", "E0425", "cannot find value `foo`"),
+            ("src/b.rs", "E0308", "mismatched types"),
+        ]));
+        let delta = tracker.record(&result, "cargo build");
+        assert_eq!(delta.iteration, 0);
+        assert!(delta.new_errors.is_empty());
+        assert!(delta.fixed_errors.is_empty());
+        assert!(!delta.regressed);
+        assert_eq!(delta.to_summary(), ""); // No summary for first run
+    }
+
+    #[test]
+    fn tracker_detects_fixed_errors() {
+        let mut tracker = BuildTestTracker::new();
+        // First run: 2 errors
+        let r1 = make_result(make_errors(&[
+            ("src/a.rs", "E0425", "cannot find value `foo`"),
+            ("src/b.rs", "E0308", "mismatched types"),
+        ]));
+        tracker.record(&r1, "cargo build");
+
+        // Second run: only 1 error (fixed E0425)
+        let r2 = make_result(make_errors(&[("src/b.rs", "E0308", "mismatched types")]));
+        let delta = tracker.record(&r2, "cargo build");
+
+        assert_eq!(delta.iteration, 1);
+        assert_eq!(delta.fixed_errors.len(), 1);
+        assert!(delta.fixed_errors[0].contains("E0425"));
+        assert!(delta.persistent_errors.len() == 1);
+        assert!(!delta.regressed);
+        assert!(delta.progress_pct > 0.0);
+    }
+
+    #[test]
+    fn tracker_detects_new_errors() {
+        let mut tracker = BuildTestTracker::new();
+        let r1 = make_result(make_errors(&[(
+            "src/a.rs",
+            "E0425",
+            "cannot find value `foo`",
+        )]));
+        tracker.record(&r1, "cargo build");
+
+        // Fixed old error but introduced a new one
+        let r2 = make_result(make_errors(&[("src/c.rs", "E0277", "trait not satisfied")]));
+        let delta = tracker.record(&r2, "cargo build");
+
+        assert_eq!(delta.new_errors.len(), 1);
+        assert_eq!(delta.fixed_errors.len(), 1);
+        assert!(delta.persistent_errors.is_empty());
+        assert!(!delta.regressed); // Same count, not regression
+    }
+
+    #[test]
+    fn tracker_detects_regression() {
+        let mut tracker = BuildTestTracker::new();
+        let r1 = make_result(make_errors(&[(
+            "src/a.rs",
+            "E0425",
+            "cannot find value `foo`",
+        )]));
+        tracker.record(&r1, "cargo build");
+
+        // Introduced MORE errors than before
+        let r2 = make_result(make_errors(&[
+            ("src/a.rs", "E0425", "cannot find value `foo`"),
+            ("src/b.rs", "E0308", "mismatched types"),
+            ("src/c.rs", "E0277", "trait not satisfied"),
+        ]));
+        let delta = tracker.record(&r2, "cargo build");
+
+        assert!(delta.regressed);
+        assert_eq!(delta.new_errors.len(), 2);
+        assert_eq!(delta.persistent_errors.len(), 1);
+        let summary = delta.to_summary();
+        assert!(
+            summary.contains("REGRESSION"),
+            "should warn about regression: {summary}"
+        );
+    }
+
+    #[test]
+    fn tracker_full_resolution_shows_100_percent() {
+        let mut tracker = BuildTestTracker::new();
+        let r1 = make_result(make_errors(&[
+            ("src/a.rs", "E0425", "cannot find value `foo`"),
+            ("src/b.rs", "E0308", "mismatched types"),
+        ]));
+        tracker.record(&r1, "cargo build");
+
+        // All errors fixed!
+        let r2 = make_result(Vec::new());
+        let delta = tracker.record(&r2, "cargo build");
+
+        assert_eq!(delta.fixed_errors.len(), 2);
+        assert!(delta.new_errors.is_empty());
+        assert!((delta.progress_pct - 100.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn tracker_command_change_resets() {
+        let mut tracker = BuildTestTracker::new();
+        let r1 = make_result(make_errors(&[(
+            "src/a.rs",
+            "E0425",
+            "cannot find value `foo`",
+        )]));
+        tracker.record(&r1, "cargo build");
+        assert_eq!(tracker.iterations(), 1);
+
+        // Different command — should reset
+        assert!(tracker.command_changed("cargo test"));
+        tracker.reset();
+        let r2 = make_result(make_errors(&[(
+            "src/a.rs",
+            "E0425",
+            "cannot find value `foo`",
+        )]));
+        let delta = tracker.record(&r2, "cargo test");
+        assert_eq!(delta.iteration, 0); // Fresh start
+    }
+
+    #[test]
+    fn tracker_multi_iteration_progress() {
+        let mut tracker = BuildTestTracker::new();
+        // 4 errors initially
+        let r1 = make_result(make_errors(&[
+            ("src/a.rs", "E0425", "cannot find value `foo`"),
+            ("src/b.rs", "E0308", "mismatched types"),
+            ("src/c.rs", "E0277", "trait not satisfied"),
+            ("src/d.rs", "E0599", "method not found"),
+        ]));
+        tracker.record(&r1, "cargo build");
+
+        // Fix 2
+        let r2 = make_result(make_errors(&[
+            ("src/c.rs", "E0277", "trait not satisfied"),
+            ("src/d.rs", "E0599", "method not found"),
+        ]));
+        let d2 = tracker.record(&r2, "cargo build");
+        assert_eq!(d2.fixed_errors.len(), 2);
+        assert!((d2.progress_pct - 50.0).abs() < 0.001);
+
+        // Fix 1 more
+        let r3 = make_result(make_errors(&[("src/d.rs", "E0599", "method not found")]));
+        let d3 = tracker.record(&r3, "cargo build");
+        assert_eq!(d3.fixed_errors.len(), 1);
+        assert!((d3.progress_pct - 75.0).abs() < 0.001);
+        assert_eq!(d3.iteration, 2);
+    }
+
+    #[test]
+    fn tracker_error_signature_ignores_line_number() {
+        let loc1 = ErrorLocation::new(
+            "src/a.rs".into(),
+            10,
+            1,
+            "E0425".into(),
+            "cannot find value `foo`".into(),
+            "error".into(),
+        );
+        let loc2 = ErrorLocation::new(
+            "src/a.rs".into(),
+            20,
+            1,
+            "E0425".into(),
+            "cannot find value `foo`".into(),
+            "error".into(),
+        );
+        assert_eq!(error_signature(&loc1), error_signature(&loc2));
+    }
+
+    #[test]
+    fn delta_summary_format() {
+        let delta = BuildTestDelta {
+            iteration: 2,
+            new_errors: vec!["new1".into()],
+            fixed_errors: vec!["fix1".into(), "fix2".into()],
+            persistent_errors: vec!["persist1".into()],
+            regressed: false,
+            progress_pct: 66.7,
+            command: "cargo build".into(),
+        };
+        let summary = delta.to_summary();
+        assert!(summary.contains("Iteration 2"));
+        assert!(summary.contains("Fixed 2"));
+        assert!(summary.contains("1 new"));
+        assert!(summary.contains("1 still present"));
+        assert!(summary.contains("67%")); // 66.7 rounds to 67
+    }
+
+    // ────────────────────────────────────────────────────────
+    // suggest_fix tests
+    // ────────────────────────────────────────────────────────
+
+    fn make_error(file: &str, line: usize, code: &str, msg: &str) -> ErrorLocation {
+        ErrorLocation {
+            file: file.to_string(),
+            line,
+            col: 0,
+            error_code: code.to_string(),
+            message: msg.to_string(),
+            severity: "error".to_string(),
+            class: ErrorClass::Fixable,
+            hint: String::new(),
+            scope: String::new(),
+        }
+    }
+
+    #[test]
+    fn fix_unused_variable() {
+        let err = make_error("src/main.rs", 3, "", "unused variable: `count`");
+        let source = vec!["fn main() {", "    let x = 1;", "    let count = 42;", "}"];
+        let fixes = suggest_fix(&err, &source);
+        assert_eq!(fixes.len(), 1);
+        assert_eq!(fixes[0].action, "replace");
+        assert!(fixes[0].new_text.contains("_count"));
+        assert!(fixes[0].confidence >= 0.9);
+    }
+
+    #[test]
+    fn fix_unused_import() {
+        let err = make_error("src/lib.rs", 2, "", "unused import: `HashMap`");
+        let source = vec![
+            "use std::io;",
+            "use std::collections::HashMap;",
+            "",
+            "fn main() {}",
+        ];
+        let fixes = suggest_fix(&err, &source);
+        assert_eq!(fixes.len(), 1);
+        assert_eq!(fixes[0].action, "delete_line");
+        assert_eq!(fixes[0].line, 2);
+        assert!(fixes[0].confidence >= 0.9);
+    }
+
+    #[test]
+    fn fix_missing_import_hashmap() {
+        let err = make_error(
+            "src/main.rs",
+            5,
+            "E0425",
+            "cannot find value `HashMap` in this scope",
+        );
+        let source = vec!["fn main() {", "    let m = HashMap::new();", "}"];
+        let fixes = suggest_fix(&err, &source);
+        assert_eq!(fixes.len(), 1);
+        assert_eq!(fixes[0].action, "add_import");
+        assert!(fixes[0].new_text.contains("std::collections::HashMap"));
+        assert!(fixes[0].confidence >= 0.7);
+    }
+
+    #[test]
+    fn fix_missing_import_arc() {
+        let err = make_error(
+            "src/lib.rs",
+            1,
+            "E0433",
+            "failed to resolve: use of undeclared type `Arc`",
+        );
+        let source = vec!["let a = Arc::new(42);"];
+        let fixes = suggest_fix(&err, &source);
+        assert_eq!(fixes.len(), 1);
+        assert!(fixes[0].new_text.contains("std::sync::Arc"));
+    }
+
+    #[test]
+    fn fix_missing_field() {
+        let err = make_error(
+            "src/config.rs",
+            10,
+            "E0063",
+            "missing field `name` in initializer",
+        );
+        let source = vec![""; 20];
+        let fixes = suggest_fix(&err, &source);
+        assert_eq!(fixes.len(), 1);
+        assert_eq!(fixes[0].action, "insert_line");
+        assert!(fixes[0].new_text.contains("name"));
+        assert!(fixes[0].new_text.contains("Default::default()"));
+    }
+
+    #[test]
+    fn fix_string_str_mismatch_need_string() {
+        let err = make_error(
+            "src/lib.rs",
+            3,
+            "E0308",
+            "mismatched types: expected `String`, found `&str`",
+        );
+        let source = vec![
+            "fn f() {",
+            "    let s: &str = \"hi\";",
+            "    takes_string(s);",
+            "}",
+        ];
+        let fixes = suggest_fix(&err, &source);
+        assert_eq!(fixes.len(), 1);
+        assert!(fixes[0].new_text.contains(".to_string()"));
+    }
+
+    #[test]
+    fn fix_string_str_mismatch_need_ref() {
+        let err = make_error(
+            "src/lib.rs",
+            3,
+            "E0308",
+            "mismatched types: expected `&str`, found struct `String`",
+        );
+        let source = vec![
+            "fn f() {",
+            "    let s = String::new();",
+            "    takes_ref(s);",
+            "}",
+        ];
+        let fixes = suggest_fix(&err, &source);
+        assert_eq!(fixes.len(), 1);
+        assert!(fixes[0].new_text.contains(".as_str()"));
+    }
+
+    #[test]
+    fn fix_missing_trait_method() {
+        let err = make_error(
+            "src/impl.rs",
+            5,
+            "E0046",
+            "not all trait items implemented, missing: `process`",
+        );
+        let source = vec!["impl Handler for MyType {", "}"];
+        let fixes = suggest_fix(&err, &source);
+        assert_eq!(fixes.len(), 1);
+        assert!(fixes[0].new_text.contains("fn process"));
+        assert!(fixes[0].new_text.contains("todo!()"));
+    }
+
+    #[test]
+    fn fix_ts_missing_name() {
+        let err = make_error("src/app.ts", 3, "TS2304", "Cannot find name 'Router'");
+        let source = vec!["const app = new Router();"];
+        let fixes = suggest_fix(&err, &source);
+        assert_eq!(fixes.len(), 1);
+        assert!(fixes[0].new_text.contains("import { Router }"));
+    }
+
+    #[test]
+    fn fix_unknown_error_no_suggestion() {
+        let err = make_error("src/main.rs", 1, "E9999", "something weird happened");
+        let source = vec!["fn main() {}"];
+        let fixes = suggest_fix(&err, &source);
+        assert!(fixes.is_empty());
+    }
+
+    #[test]
+    fn fix_sorted_by_confidence() {
+        // The unused variable fix should have high confidence
+        let err = make_error("src/main.rs", 1, "", "unused variable: `x`");
+        let source = vec!["let x = 1;"];
+        let fixes = suggest_fix(&err, &source);
+        if fixes.len() > 1 {
+            for w in fixes.windows(2) {
+                assert!(w[0].confidence >= w[1].confidence);
+            }
+        }
+    }
+
+    #[test]
+    fn fix_suggest_rust_import_coverage() {
+        // Check several common types have import suggestions
+        for name in &[
+            "HashMap", "HashSet", "Arc", "Mutex", "PathBuf", "File", "Cow", "Rc",
+        ] {
+            assert!(
+                suggest_rust_import(name).is_some(),
+                "Expected import suggestion for {}",
+                name
+            );
+        }
+        // Unknown type returns None
+        assert!(suggest_rust_import("MyCustomType").is_none());
+    }
+
+    // ── Auto-Fix Application Tests ────────────────────────────────────
+
+    #[test]
+    fn apply_fix_delete_line() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.rs");
+        std::fs::write(&file, "use std::io;\nuse std::fs;\nfn main() {}\n").unwrap();
+
+        let fix = FixSuggestion::new("test.rs", "delete_line", 1, "", "Remove unused import", 0.9);
+        let result = apply_fix(&fix, dir.path());
+        assert!(result.is_ok());
+        let content = std::fs::read_to_string(&file).unwrap();
+        assert!(!content.contains("use std::io;"));
+        assert!(content.contains("use std::fs;"));
+        assert!(content.contains("fn main()"));
+    }
+
+    #[test]
+    fn apply_fix_replace_line() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.rs");
+        std::fs::write(
+            &file,
+            "fn main() {\n    let x = 42;\n    println!(\"{}\", x);\n}\n",
+        )
+        .unwrap();
+
+        let fix = FixSuggestion::new(
+            "test.rs",
+            "replace",
+            2,
+            "    let _x = 42;",
+            "Prefix unused var",
+            0.9,
+        );
+        let result = apply_fix(&fix, dir.path());
+        assert!(result.is_ok());
+        let content = std::fs::read_to_string(&file).unwrap();
+        assert!(content.contains("let _x = 42;"));
+        assert!(!content.contains("let x = 42;"));
+    }
+
+    #[test]
+    fn apply_fix_insert_line() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.rs");
+        std::fs::write(&file, "fn main() {\n    let x = HashMap::new();\n}\n").unwrap();
+
+        let fix = FixSuggestion::new(
+            "test.rs",
+            "insert_line",
+            1,
+            "use std::collections::HashMap;",
+            "Add missing import",
+            0.8,
+        );
+        let result = apply_fix(&fix, dir.path());
+        assert!(result.is_ok());
+        let content = std::fs::read_to_string(&file).unwrap();
+        assert!(content.starts_with("use std::collections::HashMap;\nfn main()"));
+    }
+
+    #[test]
+    fn apply_fix_add_import_after_existing() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.rs");
+        std::fs::write(
+            &file,
+            "use std::io;\n\nfn main() {\n    let x = HashMap::new();\n}\n",
+        )
+        .unwrap();
+
+        let fix = FixSuggestion::new(
+            "test.rs",
+            "add_import",
+            0,
+            "use std::collections::HashMap;",
+            "Add HashMap import",
+            0.8,
+        );
+        let result = apply_fix(&fix, dir.path());
+        assert!(result.is_ok());
+        let content = std::fs::read_to_string(&file).unwrap();
+        // New import should be after existing import
+        let io_pos = content.find("use std::io;").unwrap();
+        let hm_pos = content.find("use std::collections::HashMap;").unwrap();
+        assert!(
+            hm_pos > io_pos,
+            "New import should be after existing imports"
+        );
+    }
+
+    #[test]
+    fn apply_fix_line_out_of_range() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.rs");
+        std::fs::write(&file, "line1\nline2\n").unwrap();
+
+        let fix = FixSuggestion::new("test.rs", "delete_line", 99, "", "Bad line", 0.9);
+        let result = apply_fix(&fix, dir.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("out of range"));
+    }
+
+    #[test]
+    fn apply_fix_unknown_action() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.rs");
+        std::fs::write(&file, "line1\n").unwrap();
+
+        let fix = FixSuggestion::new("test.rs", "magic", 1, "x", "Bad action", 0.9);
+        let result = apply_fix(&fix, dir.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown fix action"));
+    }
+
+    #[test]
+    fn apply_fix_missing_file() {
+        let dir = tempdir().unwrap();
+        let fix = FixSuggestion::new("nonexistent.rs", "delete_line", 1, "", "Bad file", 0.9);
+        let result = apply_fix(&fix, dir.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to read"));
+    }
+
+    #[test]
+    fn apply_auto_fixes_filters_low_confidence() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.rs");
+        std::fs::write(&file, "use std::io;\nuse std::fs;\nfn main() {}\n").unwrap();
+
+        let fixes = vec![
+            FixSuggestion::new("test.rs", "delete_line", 1, "", "High confidence", 0.9),
+            FixSuggestion::new("test.rs", "delete_line", 2, "", "Low confidence", 0.5),
+        ];
+
+        let (applied, errors) = apply_auto_fixes(&fixes, dir.path());
+        assert_eq!(
+            applied.len(),
+            1,
+            "Only high-confidence fix should be applied"
+        );
+        assert!(errors.is_empty());
+        let content = std::fs::read_to_string(&file).unwrap();
+        assert!(
+            !content.contains("use std::io;"),
+            "High-confidence fix should delete line 1"
+        );
+        assert!(
+            content.contains("use std::fs;"),
+            "Low-confidence line 2 should remain"
+        );
+    }
+
+    #[test]
+    fn apply_auto_fixes_reverse_line_order() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.rs");
+        std::fs::write(
+            &file,
+            "use std::io;\nuse std::fs;\nuse std::net;\nfn main() {}\n",
+        )
+        .unwrap();
+
+        let fixes = vec![
+            FixSuggestion::new("test.rs", "delete_line", 1, "", "Delete line 1", 0.9),
+            FixSuggestion::new("test.rs", "delete_line", 3, "", "Delete line 3", 0.9),
+        ];
+
+        let (applied, errors) = apply_auto_fixes(&fixes, dir.path());
+        assert_eq!(applied.len(), 2);
+        assert!(errors.is_empty());
+        let content = std::fs::read_to_string(&file).unwrap();
+        assert!(!content.contains("use std::io;"));
+        assert!(content.contains("use std::fs;"));
+        assert!(!content.contains("use std::net;"));
+    }
+
+    #[test]
+    fn apply_auto_fixes_empty_when_all_low_confidence() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.rs");
+        std::fs::write(&file, "fn main() {}\n").unwrap();
+
+        let fixes = vec![FixSuggestion::new(
+            "test.rs",
+            "replace",
+            1,
+            "fn main() { todo!() }",
+            "Low",
+            0.3,
+        )];
+
+        let (applied, _) = apply_auto_fixes(&fixes, dir.path());
+        assert!(applied.is_empty());
+        // File unchanged
+        let content = std::fs::read_to_string(&file).unwrap();
+        assert!(content.contains("fn main() {}"));
+    }
+
+    #[test]
+    fn format_auto_fix_report_applied() {
+        let applied = vec![AppliedFix {
+            file: "src/main.rs".to_string(),
+            action: "delete_line".to_string(),
+            line: 3,
+            explanation: "Remove unused import".to_string(),
+        }];
+        let report = format_auto_fix_report(&applied, &[], 1);
+        assert!(report.contains("Auto-Fix Iteration 1"));
+        assert!(report.contains("✓ src/main.rs L3"));
+        assert!(report.contains("Remove unused import"));
+    }
+
+    #[test]
+    fn format_auto_fix_report_no_fixes() {
+        let report = format_auto_fix_report(&[], &[], 1);
+        assert!(report.contains("No fixes applied"));
+    }
+
+    #[test]
+    fn format_auto_fix_report_with_errors() {
+        let errors = vec!["Failed to read foo.rs: not found".to_string()];
+        let report = format_auto_fix_report(&[], &errors, 2);
+        assert!(report.contains("Auto-Fix Iteration 2"));
+        assert!(report.contains("✗ Failed to read foo.rs"));
+    }
+
+    #[test]
+    fn find_import_insertion_point_after_use() {
+        let lines = vec!["use std::io;", "use std::fs;", "", "fn main() {}"];
+        assert_eq!(find_import_insertion_point(&lines), 2);
+    }
+
+    #[test]
+    fn find_import_insertion_point_no_imports() {
+        let lines = vec!["fn main() {}", "  println!(\"hi\");", "}"];
+        assert_eq!(find_import_insertion_point(&lines), 0);
+    }
+
+    #[test]
+    fn find_import_insertion_point_python() {
+        let lines = vec!["import os", "from pathlib import Path", "", "def main():"];
+        assert_eq!(find_import_insertion_point(&lines), 2);
+    }
+
+    #[test]
+    fn auto_fix_constants_are_sane() {
+        let threshold = std::hint::black_box(AUTO_FIX_CONFIDENCE_THRESHOLD);
+        let max_iterations = std::hint::black_box(AUTO_FIX_MAX_ITERATIONS);
+        assert!(threshold >= 0.7);
+        assert!(threshold <= 1.0);
+        assert!(max_iterations >= 1);
+        assert!(max_iterations <= 5);
+    }
+
+    #[test]
+    fn apply_fix_preserves_trailing_newline() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.rs");
+        std::fs::write(&file, "use std::io;\nfn main() {}\n").unwrap();
+
+        let fix = FixSuggestion::new("test.rs", "delete_line", 1, "", "Remove import", 0.9);
+        apply_fix(&fix, dir.path()).unwrap();
+        let content = std::fs::read_to_string(&file).unwrap();
+        assert!(content.ends_with('\n'), "Should preserve trailing newline");
+    }
+
+    // ── C2 Enhancement Tests: Build/Test Loop ────────────────────────────
+
+    #[test]
+    fn delta_summary_shows_error_count_transition() {
+        let delta = BuildTestDelta {
+            iteration: 2,
+            new_errors: vec!["new1".into()],
+            fixed_errors: vec!["fix1".into(), "fix2".into()],
+            persistent_errors: vec!["persist1".into()],
+            regressed: false,
+            progress_pct: 40.0,
+            command: "cargo test".into(),
+        };
+        let summary = delta.to_summary();
+        // Should show prev→cur error count: prev = fixed + persistent = 3, cur = new + persistent = 2
+        assert!(summary.contains("3 → 2 errors"), "got: {summary}");
+        assert!(summary.contains("✅ Fixed 2"));
+        assert!(summary.contains("🆕 1 new"));
+        assert!(summary.contains("⏳ 1 still present"));
+        assert!(summary.contains("40%"));
+    }
+
+    #[test]
+    fn delta_summary_regression_directive() {
+        let delta = BuildTestDelta {
+            iteration: 1,
+            new_errors: vec!["a".into(), "b".into(), "c".into()],
+            fixed_errors: vec![],
+            persistent_errors: vec!["p1".into()],
+            regressed: true,
+            progress_pct: 0.0,
+            command: "cargo test".into(),
+        };
+        let summary = delta.to_summary();
+        assert!(summary.contains("REGRESSION"), "got: {summary}");
+        assert!(
+            summary.contains("Revert"),
+            "Should tell LLM to revert: {summary}"
+        );
+    }
+
+    #[test]
+    fn cascade_output_includes_root_cause_directive() {
+        // Build a result with import-cascade pattern
+        let result = BuildTestResult {
+            passed: false,
+            exit_code: Some(1),
+            framework: "cargo".into(),
+            error_count: 4,
+            error_messages: vec![],
+            error_locations: vec![
+                ErrorLocation::new(
+                    "src/main.rs".into(),
+                    5,
+                    0,
+                    "E0425".into(),
+                    "cannot find value `Foo`".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/main.rs".into(),
+                    10,
+                    0,
+                    "E0425".into(),
+                    "cannot find value `Foo`".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/main.rs".into(),
+                    15,
+                    0,
+                    "E0425".into(),
+                    "cannot find value `Foo`".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "src/main.rs".into(),
+                    20,
+                    0,
+                    "E0308".into(),
+                    "type mismatch".into(),
+                    "error".into(),
+                ),
+            ],
+            tests_passed: 0,
+            tests_failed: 0,
+            tests_skipped: 0,
+            summary: "4 errors".into(),
+            truncated: false,
+        };
+        let output = result.to_enhanced_output("");
+        assert!(
+            output.contains("fix root cause FIRST"),
+            "Should include root-cause directive: {output}"
+        );
+        assert!(
+            output.contains("downstream errors"),
+            "Should mention downstream: {output}"
+        );
+    }
+
+    #[test]
+    fn tracker_records_error_count_in_delta() {
+        let mut tracker = BuildTestTracker::new();
+
+        // First run: 3 errors
+        let r1 = BuildTestResult {
+            error_count: 3,
+            error_locations: vec![
+                ErrorLocation::new(
+                    "a.rs".into(),
+                    1,
+                    0,
+                    "E0425".into(),
+                    "err1".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "a.rs".into(),
+                    2,
+                    0,
+                    "E0308".into(),
+                    "err2".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "b.rs".into(),
+                    1,
+                    0,
+                    "E0599".into(),
+                    "err3".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let d1 = tracker.record(&r1, "cargo test");
+        assert_eq!(d1.iteration, 0); // baseline
+
+        // Second run: 2 errors (one fixed, one new)
+        let r2 = BuildTestResult {
+            error_count: 2,
+            error_locations: vec![
+                ErrorLocation::new(
+                    "a.rs".into(),
+                    1,
+                    0,
+                    "E0425".into(),
+                    "err1".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "c.rs".into(),
+                    5,
+                    0,
+                    "E0277".into(),
+                    "err4".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let d2 = tracker.record(&r2, "cargo test");
+        assert_eq!(d2.iteration, 1);
+        assert_eq!(d2.fixed_errors.len(), 2); // err2 and err3 gone
+        assert_eq!(d2.new_errors.len(), 1); // err4 is new
+        assert!(!d2.regressed); // 2 < 3
+
+        // Third run: regression (4 errors)
+        let r3 = BuildTestResult {
+            error_count: 4,
+            error_locations: vec![
+                ErrorLocation::new(
+                    "a.rs".into(),
+                    1,
+                    0,
+                    "E0425".into(),
+                    "err1".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "c.rs".into(),
+                    5,
+                    0,
+                    "E0277".into(),
+                    "err4".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "d.rs".into(),
+                    1,
+                    0,
+                    "E0412".into(),
+                    "err5".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "d.rs".into(),
+                    2,
+                    0,
+                    "E0433".into(),
+                    "err6".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let d3 = tracker.record(&r3, "cargo test");
+        assert!(d3.regressed, "Should detect regression");
+        assert_eq!(d3.new_errors.len(), 2);
+    }
+
+    #[test]
+    fn fix_order_root_cause_first() {
+        let result = BuildTestResult {
+            passed: false,
+            error_count: 5,
+            error_locations: vec![
+                // Complex error
+                ErrorLocation::new(
+                    "a.rs".into(),
+                    100,
+                    0,
+                    "E0277".into(),
+                    "trait not satisfied".into(),
+                    "error".into(),
+                ),
+                // Trivial import errors (cascade root at index 1)
+                ErrorLocation::new(
+                    "b.rs".into(),
+                    1,
+                    0,
+                    "E0425".into(),
+                    "cannot find `Vec`".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "b.rs".into(),
+                    5,
+                    0,
+                    "E0425".into(),
+                    "cannot find `Vec`".into(),
+                    "error".into(),
+                ),
+                ErrorLocation::new(
+                    "b.rs".into(),
+                    10,
+                    0,
+                    "E0425".into(),
+                    "cannot find `Vec`".into(),
+                    "error".into(),
+                ),
+                // Fixable error
+                ErrorLocation::new(
+                    "c.rs".into(),
+                    20,
+                    0,
+                    "E0308".into(),
+                    "type mismatch".into(),
+                    "error".into(),
+                ),
+            ],
+            ..Default::default()
+        };
+        let order = result.fix_order();
+        // Root cause (cascade root in b.rs) should come before complex error
+        assert_eq!(order[0], 1, "Cascade root (b.rs:1) should be first");
+        // Complex error should be last
+        let complex_pos = order.iter().position(|&i| i == 0).unwrap();
+        assert!(
+            complex_pos > 2,
+            "Complex error should come after trivial/fixable"
+        );
+    }
+}

--- a/rust/crates/astra-tools/src/code_intel.rs
+++ b/rust/crates/astra-tools/src/code_intel.rs
@@ -1,0 +1,2968 @@
+//! Code intelligence via Tree-sitter — symbol extraction and outlines.
+//!
+//! Provides:
+//! - Function/method/class extraction
+//! - Module outlines (function signatures without bodies)
+//! - Symbol search by name
+//!
+//! Supports: Rust, Python, TypeScript/JavaScript, Go
+
+#![allow(dead_code)] // Symbol/find_symbols are exported for future tools
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Extracted symbol from source code.
+#[derive(Debug, Clone)]
+pub struct Symbol {
+    /// Symbol name (e.g., "parse_config", "UserService")
+    pub name: String,
+    /// Symbol kind (function, method, class, struct, interface, etc.)
+    pub kind: SymbolKind,
+    /// Start line (1-indexed)
+    pub start_line: usize,
+    /// End line (1-indexed)
+    pub end_line: usize,
+    /// Signature (e.g., "fn parse_config(path: &str) -> Result<Config>")
+    pub signature: String,
+    /// Parent symbol name (for methods, nested items)
+    pub parent: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymbolKind {
+    Function,
+    Method,
+    Constructor,
+    Class,
+    Struct,
+    Interface,
+    Trait,
+    Enum,
+    Constant,
+    Variable,
+    Module,
+    Import,
+    Type,
+}
+
+impl SymbolKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Function => "fn",
+            Self::Method => "method",
+            Self::Constructor => "ctor",
+            Self::Class => "class",
+            Self::Struct => "struct",
+            Self::Interface => "interface",
+            Self::Trait => "trait",
+            Self::Enum => "enum",
+            Self::Constant => "const",
+            Self::Variable => "var",
+            Self::Module => "mod",
+            Self::Import => "import",
+            Self::Type => "type",
+        }
+    }
+}
+
+/// Detect language from file extension.
+pub fn detect_language(path: &Path) -> Option<Language> {
+    let ext = path.extension()?.to_str()?;
+    match ext {
+        "rs" => Some(Language::Rust),
+        "py" => Some(Language::Python),
+        "ts" | "tsx" => Some(Language::TypeScript),
+        "js" | "jsx" => Some(Language::JavaScript),
+        "go" => Some(Language::Go),
+        "java" => Some(Language::Java),
+        "c" | "h" => Some(Language::C),
+        "cpp" | "cc" | "cxx" | "hpp" | "hxx" | "hh" => Some(Language::Cpp),
+        "rb" => Some(Language::Ruby),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Language {
+    Rust,
+    Python,
+    TypeScript,
+    JavaScript,
+    Go,
+    Java,
+    C,
+    Cpp,
+    Ruby,
+}
+
+thread_local! {
+    static PARSER_CACHE: RefCell<HashMap<u8, tree_sitter::Parser>> = RefCell::new(HashMap::new());
+}
+
+/// Get a tree-sitter Language grammar for our Language enum.
+fn ts_language(lang: Language) -> tree_sitter::Language {
+    match lang {
+        Language::Rust => tree_sitter_rust::LANGUAGE.into(),
+        Language::Python => tree_sitter_python::LANGUAGE.into(),
+        Language::TypeScript | Language::JavaScript => {
+            tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+        }
+        Language::Go => tree_sitter_go::LANGUAGE.into(),
+        Language::Java => tree_sitter_java::LANGUAGE.into(),
+        Language::C | Language::Cpp => tree_sitter_cpp::LANGUAGE.into(),
+        Language::Ruby => tree_sitter_ruby::LANGUAGE.into(),
+    }
+}
+
+/// Parse source code using a cached thread-local parser.
+/// Returns None if parsing fails.
+fn cached_parse(source: &str, lang: Language) -> Option<tree_sitter::Tree> {
+    let key = lang as u8;
+    PARSER_CACHE.with(|cache| {
+        let mut map = cache.borrow_mut();
+        let parser = map.entry(key).or_insert_with(|| {
+            let mut p = tree_sitter::Parser::new();
+            let _ = p.set_language(&ts_language(lang));
+            p
+        });
+        // Ensure the right language is set (in case of C/Cpp sharing)
+        let _ = parser.set_language(&ts_language(lang));
+        parser.parse(source, None)
+    })
+}
+
+/// Extract symbols from source code.
+pub fn extract_symbols(source: &str, lang: Language) -> Vec<Symbol> {
+    let tree = match cached_parse(source, lang) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+
+    let root = tree.root_node();
+    let mut symbols = Vec::new();
+
+    match lang {
+        Language::Rust => extract_rust_symbols(root, source, &mut symbols, None),
+        Language::Python => extract_python_symbols(root, source, &mut symbols, None),
+        Language::TypeScript | Language::JavaScript => {
+            extract_ts_symbols(root, source, &mut symbols, None)
+        }
+        Language::Go => extract_go_symbols(root, source, &mut symbols, None),
+        Language::Java => extract_java_symbols(root, source, &mut symbols, None),
+        Language::C | Language::Cpp => extract_cpp_symbols(root, source, &mut symbols, None),
+        Language::Ruby => extract_ruby_symbols(root, source, &mut symbols, None),
+    }
+
+    symbols
+}
+
+/// Generate a module outline (signatures only, no bodies).
+pub fn generate_outline(source: &str, lang: Language) -> String {
+    let symbols = extract_symbols(source, lang);
+    let mut lines = Vec::new();
+
+    for sym in symbols {
+        let indent = if sym.parent.is_some() { "  " } else { "" };
+        lines.push(format!(
+            "{}L{}: {} {}",
+            indent,
+            sym.start_line,
+            sym.kind.as_str(),
+            sym.signature
+        ));
+    }
+
+    lines.join("\n")
+}
+
+/// Find symbols matching a name pattern.
+pub fn find_symbols(source: &str, lang: Language, pattern: &str) -> Vec<Symbol> {
+    let lower_pattern = pattern.to_lowercase();
+    extract_symbols(source, lang)
+        .into_iter()
+        .filter(|s| s.name.to_lowercase().contains(&lower_pattern))
+        .collect()
+}
+
+// ─── Rust Symbol Extraction ──────────────────────────────────────────────────
+
+fn extract_rust_symbols(
+    node: tree_sitter::Node,
+    source: &str,
+    symbols: &mut Vec<Symbol>,
+    parent: Option<&str>,
+) {
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "function_item" => {
+                if let Some(sym) = parse_rust_function(child, source, parent) {
+                    symbols.push(sym);
+                }
+            }
+            "struct_item" => {
+                if let Some(name) = get_child_text(child, "type_identifier", source) {
+                    let sig = get_signature_line(child, source);
+                    symbols.push(Symbol {
+                        name: name.clone(),
+                        kind: SymbolKind::Struct,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: sig,
+                        parent: parent.map(String::from),
+                    });
+                    // Extract methods inside impl blocks referencing this struct
+                }
+            }
+            "enum_item" => {
+                if let Some(name) = get_child_text(child, "type_identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Enum,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "trait_item" => {
+                if let Some(name) = get_child_text(child, "type_identifier", source) {
+                    symbols.push(Symbol {
+                        name: name.clone(),
+                        kind: SymbolKind::Trait,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                    // Recurse into trait body for method signatures
+                    extract_rust_symbols(child, source, symbols, Some(&name));
+                }
+            }
+            "impl_item" => {
+                // Get the type being implemented
+                let impl_type = get_impl_type(child, source);
+                extract_rust_symbols(child, source, symbols, impl_type.as_deref());
+            }
+            "mod_item" => {
+                if let Some(name) = get_child_text(child, "identifier", source) {
+                    symbols.push(Symbol {
+                        name: name.clone(),
+                        kind: SymbolKind::Module,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: format!("mod {}", name),
+                        parent: parent.map(String::from),
+                    });
+                    extract_rust_symbols(child, source, symbols, Some(&name));
+                }
+            }
+            "const_item" | "static_item" => {
+                if let Some(name) = get_child_text(child, "identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Constant,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "type_item" => {
+                if let Some(name) = get_child_text(child, "type_identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Type,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            _ => {
+                // Recurse into other nodes (e.g., blocks)
+                extract_rust_symbols(child, source, symbols, parent);
+            }
+        }
+    }
+}
+
+fn parse_rust_function(
+    node: tree_sitter::Node,
+    source: &str,
+    parent: Option<&str>,
+) -> Option<Symbol> {
+    let name = get_child_text(node, "identifier", source)?;
+    let sig = get_signature_line(node, source);
+
+    Some(Symbol {
+        name,
+        kind: if parent.is_some() {
+            SymbolKind::Method
+        } else {
+            SymbolKind::Function
+        },
+        start_line: node.start_position().row + 1,
+        end_line: node.end_position().row + 1,
+        signature: sig,
+        parent: parent.map(String::from),
+    })
+}
+
+fn get_impl_type(node: tree_sitter::Node, source: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "type_identifier" || child.kind() == "generic_type" {
+            return Some(child.utf8_text(source.as_bytes()).ok()?.to_string());
+        }
+    }
+    None
+}
+
+// ─── Python Symbol Extraction ────────────────────────────────────────────────
+
+fn extract_python_symbols(
+    node: tree_sitter::Node,
+    source: &str,
+    symbols: &mut Vec<Symbol>,
+    parent: Option<&str>,
+) {
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "function_definition" => {
+                if let Some(name) = get_child_text(child, "identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: if parent.is_some() {
+                            SymbolKind::Method
+                        } else {
+                            SymbolKind::Function
+                        },
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "class_definition" => {
+                if let Some(name) = get_child_text(child, "identifier", source) {
+                    symbols.push(Symbol {
+                        name: name.clone(),
+                        kind: SymbolKind::Class,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                    // Recurse into class body
+                    extract_python_symbols(child, source, symbols, Some(&name));
+                }
+            }
+            _ => {
+                extract_python_symbols(child, source, symbols, parent);
+            }
+        }
+    }
+}
+
+// ─── TypeScript/JavaScript Symbol Extraction ─────────────────────────────────
+
+fn extract_ts_symbols(
+    node: tree_sitter::Node,
+    source: &str,
+    symbols: &mut Vec<Symbol>,
+    parent: Option<&str>,
+) {
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "function_declaration" => {
+                if let Some(name) = get_child_text(child, "identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Function,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "method_definition" => {
+                if let Some(name) = get_child_text(child, "property_identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Method,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "class_declaration" => {
+                if let Some(name) = get_child_text(child, "type_identifier", source)
+                    .or_else(|| get_child_text(child, "identifier", source))
+                {
+                    symbols.push(Symbol {
+                        name: name.clone(),
+                        kind: SymbolKind::Class,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                    extract_ts_symbols(child, source, symbols, Some(&name));
+                }
+            }
+            "interface_declaration" => {
+                if let Some(name) = get_child_text(child, "type_identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Interface,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "type_alias_declaration" => {
+                if let Some(name) = get_child_text(child, "type_identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Type,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "lexical_declaration" | "variable_declaration" => {
+                // const/let/var declarations
+                if let Some(decl) = child.child_by_field_name("declarator")
+                    && let Some(name) = get_child_text(decl, "identifier", source)
+                {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Variable,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            _ => {
+                extract_ts_symbols(child, source, symbols, parent);
+            }
+        }
+    }
+}
+
+// ─── Go Symbol Extraction ────────────────────────────────────────────────────
+
+fn extract_go_symbols(
+    node: tree_sitter::Node,
+    source: &str,
+    symbols: &mut Vec<Symbol>,
+    parent: Option<&str>,
+) {
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "function_declaration" => {
+                if let Some(name) = get_child_text(child, "identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Function,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "method_declaration" => {
+                if let Some(name) = get_child_text(child, "field_identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Method,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "type_declaration" => {
+                // Could be struct, interface, or type alias
+                if let Some(spec) = child.child(1)
+                    && let Some(name) = get_child_text(spec, "type_identifier", source)
+                {
+                    let kind = if spec.kind() == "struct_type" {
+                        SymbolKind::Struct
+                    } else if spec.kind() == "interface_type" {
+                        SymbolKind::Interface
+                    } else {
+                        SymbolKind::Type
+                    };
+                    symbols.push(Symbol {
+                        name,
+                        kind,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "const_declaration" | "var_declaration" => {
+                // Extract const/var names
+                extract_go_symbols(child, source, symbols, parent);
+            }
+            "const_spec" | "var_spec" => {
+                if let Some(name) = get_child_text(child, "identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Constant,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            _ => {
+                extract_go_symbols(child, source, symbols, parent);
+            }
+        }
+    }
+}
+
+// ─── Java extraction ─────────────────────────────────────────────────────────
+
+fn extract_java_symbols(
+    node: tree_sitter::Node,
+    source: &str,
+    symbols: &mut Vec<Symbol>,
+    parent: Option<&str>,
+) {
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "class_declaration" => {
+                if let Some(name) = get_child_text(child, "identifier", source) {
+                    symbols.push(Symbol {
+                        name: name.clone(),
+                        kind: SymbolKind::Class,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                    // Recurse into class body
+                    if let Some(body) = child.child_by_field_name("body") {
+                        extract_java_symbols(body, source, symbols, Some(&name));
+                    }
+                }
+            }
+            "interface_declaration" => {
+                if let Some(name) = get_child_text(child, "identifier", source) {
+                    symbols.push(Symbol {
+                        name: name.clone(),
+                        kind: SymbolKind::Interface,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                    if let Some(body) = child.child_by_field_name("body") {
+                        extract_java_symbols(body, source, symbols, Some(&name));
+                    }
+                }
+            }
+            "enum_declaration" => {
+                if let Some(name) = get_child_text(child, "identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Enum,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "method_declaration" | "constructor_declaration" => {
+                if let Some(name) = get_child_text(child, "identifier", source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: if child.kind() == "constructor_declaration" {
+                            SymbolKind::Constructor
+                        } else {
+                            SymbolKind::Method
+                        },
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "field_declaration" => {
+                // Extract field names (may have multiple declarators)
+                let mut decl_cursor = child.walk();
+                for decl_child in child.children(&mut decl_cursor) {
+                    if decl_child.kind() == "variable_declarator"
+                        && let Some(name) = get_child_text(decl_child, "identifier", source)
+                    {
+                        symbols.push(Symbol {
+                            name,
+                            kind: SymbolKind::Variable,
+                            start_line: child.start_position().row + 1,
+                            end_line: child.end_position().row + 1,
+                            signature: get_signature_line(child, source),
+                            parent: parent.map(String::from),
+                        });
+                    }
+                }
+            }
+            _ => {
+                extract_java_symbols(child, source, symbols, parent);
+            }
+        }
+    }
+}
+
+// ─── C/C++ extraction ────────────────────────────────────────────────────────
+
+fn extract_cpp_symbols(
+    node: tree_sitter::Node,
+    source: &str,
+    symbols: &mut Vec<Symbol>,
+    parent: Option<&str>,
+) {
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "function_definition" => {
+                // Try to get function name from declarator
+                if let Some(decl) = child.child_by_field_name("declarator")
+                    && let Some(name) = extract_cpp_declarator_name(decl, source)
+                {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Function,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "declaration" => {
+                // Could be function declaration, variable, etc.
+                if let Some(decl) = child.child_by_field_name("declarator") {
+                    // Check if it's a function declaration (has parameter list)
+                    let is_func = decl.kind() == "function_declarator"
+                        || has_child_kind(decl, "parameter_list");
+                    if let Some(name) = extract_cpp_declarator_name(decl, source) {
+                        symbols.push(Symbol {
+                            name,
+                            kind: if is_func {
+                                SymbolKind::Function
+                            } else {
+                                SymbolKind::Variable
+                            },
+                            start_line: child.start_position().row + 1,
+                            end_line: child.end_position().row + 1,
+                            signature: get_signature_line(child, source),
+                            parent: parent.map(String::from),
+                        });
+                    }
+                }
+            }
+            "struct_specifier" | "class_specifier" => {
+                if let Some(name) = child.child_by_field_name("name") {
+                    let name_str = name.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+                    if !name_str.is_empty() {
+                        symbols.push(Symbol {
+                            name: name_str.clone(),
+                            kind: if child.kind() == "class_specifier" {
+                                SymbolKind::Class
+                            } else {
+                                SymbolKind::Struct
+                            },
+                            start_line: child.start_position().row + 1,
+                            end_line: child.end_position().row + 1,
+                            signature: get_signature_line(child, source),
+                            parent: parent.map(String::from),
+                        });
+                        // Recurse into body
+                        if let Some(body) = child.child_by_field_name("body") {
+                            extract_cpp_symbols(body, source, symbols, Some(&name_str));
+                        }
+                    }
+                }
+            }
+            "enum_specifier" => {
+                if let Some(name) = child.child_by_field_name("name") {
+                    let name_str = name.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+                    if !name_str.is_empty() {
+                        symbols.push(Symbol {
+                            name: name_str,
+                            kind: SymbolKind::Enum,
+                            start_line: child.start_position().row + 1,
+                            end_line: child.end_position().row + 1,
+                            signature: get_signature_line(child, source),
+                            parent: parent.map(String::from),
+                        });
+                    }
+                }
+            }
+            "namespace_definition" => {
+                if let Some(name) = child.child_by_field_name("name") {
+                    let name_str = name.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+                    symbols.push(Symbol {
+                        name: name_str.clone(),
+                        kind: SymbolKind::Module,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                    if let Some(body) = child.child_by_field_name("body") {
+                        extract_cpp_symbols(body, source, symbols, Some(&name_str));
+                    }
+                }
+            }
+            _ => {
+                extract_cpp_symbols(child, source, symbols, parent);
+            }
+        }
+    }
+}
+
+fn extract_cpp_declarator_name(node: tree_sitter::Node, source: &str) -> Option<String> {
+    match node.kind() {
+        "identifier" | "field_identifier" => {
+            Some(node.utf8_text(source.as_bytes()).ok()?.to_string())
+        }
+        "function_declarator" | "pointer_declarator" | "reference_declarator" => {
+            // Recurse into nested declarator
+            if let Some(inner) = node.child_by_field_name("declarator") {
+                extract_cpp_declarator_name(inner, source)
+            } else {
+                // Try first child as fallback
+                node.child(0)
+                    .and_then(|c| extract_cpp_declarator_name(c, source))
+            }
+        }
+        "qualified_identifier" => {
+            // For things like ClassName::method
+            let text = node.utf8_text(source.as_bytes()).ok()?;
+            Some(text.to_string())
+        }
+        _ => {
+            // Try to find an identifier child
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if child.kind() == "identifier" || child.kind() == "field_identifier" {
+                    return Some(child.utf8_text(source.as_bytes()).ok()?.to_string());
+                }
+            }
+            None
+        }
+    }
+}
+
+fn has_child_kind(node: tree_sitter::Node, kind: &str) -> bool {
+    let mut cursor = node.walk();
+    node.children(&mut cursor).any(|c| c.kind() == kind)
+}
+
+// ─── Ruby extraction ─────────────────────────────────────────────────────────
+
+fn extract_ruby_symbols(
+    node: tree_sitter::Node,
+    source: &str,
+    symbols: &mut Vec<Symbol>,
+    parent: Option<&str>,
+) {
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "class" => {
+                if let Some(name) = child.child_by_field_name("name") {
+                    let name_str = name.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+                    if !name_str.is_empty() {
+                        symbols.push(Symbol {
+                            name: name_str.clone(),
+                            kind: SymbolKind::Class,
+                            start_line: child.start_position().row + 1,
+                            end_line: child.end_position().row + 1,
+                            signature: get_signature_line(child, source),
+                            parent: parent.map(String::from),
+                        });
+                        // Recurse into class body
+                        extract_ruby_symbols(child, source, symbols, Some(&name_str));
+                    }
+                }
+            }
+            "module" => {
+                if let Some(name) = child.child_by_field_name("name") {
+                    let name_str = name.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+                    if !name_str.is_empty() {
+                        symbols.push(Symbol {
+                            name: name_str.clone(),
+                            kind: SymbolKind::Module,
+                            start_line: child.start_position().row + 1,
+                            end_line: child.end_position().row + 1,
+                            signature: get_signature_line(child, source),
+                            parent: parent.map(String::from),
+                        });
+                        extract_ruby_symbols(child, source, symbols, Some(&name_str));
+                    }
+                }
+            }
+            "method" | "singleton_method" => {
+                if let Some(name) = child.child_by_field_name("name") {
+                    let name_str = name.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+                    symbols.push(Symbol {
+                        name: name_str,
+                        kind: SymbolKind::Method,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: parent.map(String::from),
+                    });
+                }
+            }
+            "constant" => {
+                // Top-level constants
+                let name_str = child.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+                if !name_str.is_empty() && parent.is_none() {
+                    symbols.push(Symbol {
+                        name: name_str,
+                        kind: SymbolKind::Constant,
+                        start_line: child.start_position().row + 1,
+                        end_line: child.end_position().row + 1,
+                        signature: get_signature_line(child, source),
+                        parent: None,
+                    });
+                }
+            }
+            _ => {
+                extract_ruby_symbols(child, source, symbols, parent);
+            }
+        }
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn get_child_text(node: tree_sitter::Node, kind: &str, source: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == kind {
+            return Some(child.utf8_text(source.as_bytes()).ok()?.to_string());
+        }
+    }
+    None
+}
+
+fn get_signature_line(node: tree_sitter::Node, source: &str) -> String {
+    let start = node.start_position();
+    let end = node.end_position();
+
+    // Get the first line of the node
+    let lines: Vec<&str> = source.lines().collect();
+    if start.row < lines.len() {
+        let first_line = lines[start.row].trim();
+        // Truncate at opening brace for multi-line signatures
+        if let Some(brace_pos) = first_line.find('{') {
+            return first_line[..brace_pos].trim().to_string();
+        }
+        // If no brace on first line, might be a multi-line sig — take first line
+        if first_line.len() > 100 {
+            // Find a valid char boundary at or before byte 100
+            let mut end = 100;
+            while !first_line.is_char_boundary(end) && end > 0 {
+                end -= 1;
+            }
+            return format!("{}...", &first_line[..end]);
+        }
+        return first_line.to_string();
+    }
+
+    format!("(lines {}-{})", start.row + 1, end.row + 1)
+}
+
+// ─── Call Graph Extraction ───────────────────────────────────────────────────
+
+/// A function call found within a symbol's body.
+#[derive(Debug, Clone)]
+pub struct CallSite {
+    /// Name of the function/method being called
+    pub callee: String,
+    /// Line number of the call (1-indexed)
+    pub line: usize,
+    /// Optional receiver (e.g., "self", "config", "Vec")
+    pub receiver: Option<String>,
+}
+
+/// Extract function/method calls within the body of a given symbol range.
+/// Returns a list of call sites found between `start_line` and `end_line`.
+pub fn extract_calls(
+    source: &str,
+    lang: Language,
+    start_line: usize,
+    end_line: usize,
+) -> Vec<CallSite> {
+    let tree = match cached_parse(source, lang) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+
+    let mut calls = Vec::new();
+    collect_calls(
+        tree.root_node(),
+        source,
+        start_line,
+        end_line,
+        lang,
+        &mut calls,
+    );
+    // Deduplicate by (callee, line)
+    calls.sort_by(|a, b| a.line.cmp(&b.line).then(a.callee.cmp(&b.callee)));
+    calls.dedup_by(|a, b| a.line == b.line && a.callee == b.callee);
+    calls
+}
+
+fn collect_calls(
+    node: tree_sitter::Node,
+    source: &str,
+    start_line: usize,
+    end_line: usize,
+    lang: Language,
+    calls: &mut Vec<CallSite>,
+) {
+    let node_start = node.start_position().row + 1;
+    let node_end = node.end_position().row + 1;
+
+    // Skip nodes entirely outside our range
+    if node_end < start_line || node_start > end_line {
+        return;
+    }
+
+    let kind = node.kind();
+
+    // Match call expressions based on language
+    let is_call = match lang {
+        Language::Rust => kind == "call_expression" || kind == "macro_invocation",
+        Language::Python => kind == "call",
+        Language::TypeScript | Language::JavaScript => {
+            kind == "call_expression" || kind == "new_expression"
+        }
+        Language::Go => kind == "call_expression",
+        Language::Java => kind == "method_invocation" || kind == "object_creation_expression",
+        Language::C | Language::Cpp => kind == "call_expression",
+        Language::Ruby => kind == "call" || kind == "method_call",
+    };
+
+    if is_call
+        && let Some(cs) = parse_call_site(node, source, lang)
+        && cs.line >= start_line
+        && cs.line <= end_line
+    {
+        calls.push(cs);
+    }
+
+    // Recurse into children
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_calls(child, source, start_line, end_line, lang, calls);
+    }
+}
+
+fn parse_call_site(node: tree_sitter::Node, source: &str, lang: Language) -> Option<CallSite> {
+    let line = node.start_position().row + 1;
+
+    match lang {
+        Language::Rust => {
+            // call_expression: function child is the callee
+            if node.kind() == "macro_invocation" {
+                // macro!(...) — first child is the macro name
+                let name_node = node.child(0)?;
+                let name = node_text(name_node, source);
+                return Some(CallSite {
+                    callee: format!("{name}!"),
+                    line,
+                    receiver: None,
+                });
+            }
+            let func = node.child(0)?;
+            if func.kind() == "field_expression" {
+                // receiver.method() form
+                let receiver_node = func.child(0)?;
+                let method_node = func.child_by_field_name("field")?;
+                Some(CallSite {
+                    callee: node_text(method_node, source),
+                    line,
+                    receiver: Some(node_text(receiver_node, source)),
+                })
+            } else if func.kind() == "scoped_identifier" {
+                // Path::method() form
+                Some(CallSite {
+                    callee: node_text(func, source),
+                    line,
+                    receiver: None,
+                })
+            } else {
+                Some(CallSite {
+                    callee: node_text(func, source),
+                    line,
+                    receiver: None,
+                })
+            }
+        }
+        Language::Python => {
+            let func = node.child_by_field_name("function")?;
+            if func.kind() == "attribute" {
+                let obj = func.child_by_field_name("object")?;
+                let attr = func.child_by_field_name("attribute")?;
+                Some(CallSite {
+                    callee: node_text(attr, source),
+                    line,
+                    receiver: Some(node_text(obj, source)),
+                })
+            } else {
+                Some(CallSite {
+                    callee: node_text(func, source),
+                    line,
+                    receiver: None,
+                })
+            }
+        }
+        Language::TypeScript | Language::JavaScript => {
+            if node.kind() == "new_expression" {
+                let ctor = node.child(1)?;
+                return Some(CallSite {
+                    callee: format!("new {}", node_text(ctor, source)),
+                    line,
+                    receiver: None,
+                });
+            }
+            let func = node.child_by_field_name("function")?;
+            if func.kind() == "member_expression" {
+                let obj = func.child_by_field_name("object")?;
+                let prop = func.child_by_field_name("property")?;
+                Some(CallSite {
+                    callee: node_text(prop, source),
+                    line,
+                    receiver: Some(node_text(obj, source)),
+                })
+            } else {
+                Some(CallSite {
+                    callee: node_text(func, source),
+                    line,
+                    receiver: None,
+                })
+            }
+        }
+        Language::Go => {
+            let func = node.child_by_field_name("function")?;
+            if func.kind() == "selector_expression" {
+                let obj = func.child_by_field_name("operand")?;
+                let sel = func.child_by_field_name("field")?;
+                Some(CallSite {
+                    callee: node_text(sel, source),
+                    line,
+                    receiver: Some(node_text(obj, source)),
+                })
+            } else {
+                Some(CallSite {
+                    callee: node_text(func, source),
+                    line,
+                    receiver: None,
+                })
+            }
+        }
+        Language::Java => {
+            if node.kind() == "method_invocation" {
+                let name = node.child_by_field_name("name")?;
+                let obj = node.child_by_field_name("object");
+                Some(CallSite {
+                    callee: node_text(name, source),
+                    line,
+                    receiver: obj.map(|o| node_text(o, source)),
+                })
+            } else {
+                // object_creation_expression
+                let typ = node.child_by_field_name("type")?;
+                Some(CallSite {
+                    callee: format!("new {}", node_text(typ, source)),
+                    line,
+                    receiver: None,
+                })
+            }
+        }
+        Language::C | Language::Cpp => {
+            let func = node.child_by_field_name("function")?;
+            if func.kind() == "field_expression" {
+                let obj = func.child_by_field_name("argument")?;
+                let field = func.child_by_field_name("field")?;
+                Some(CallSite {
+                    callee: node_text(field, source),
+                    line,
+                    receiver: Some(node_text(obj, source)),
+                })
+            } else {
+                Some(CallSite {
+                    callee: node_text(func, source),
+                    line,
+                    receiver: None,
+                })
+            }
+        }
+        Language::Ruby => {
+            let method = node.child_by_field_name("method")?;
+            let recv = node.child_by_field_name("receiver");
+            Some(CallSite {
+                callee: node_text(method, source),
+                line,
+                receiver: recv.map(|r| node_text(r, source)),
+            })
+        }
+    }
+}
+
+// ─── Scope Context ──────────────────────────────────────────────────────────
+
+/// The enclosing scope at a given line.
+#[derive(Debug, Clone)]
+pub struct ScopeContext {
+    /// Breadcrumb path from outermost to innermost scope
+    /// e.g., ["impl ToolExecutor", "fn str_replace"]
+    pub breadcrumbs: Vec<String>,
+    /// The innermost symbol containing the target line
+    pub symbol: Option<Symbol>,
+}
+
+/// Identify the symbol/identifier at exact (line, column) using tree-sitter AST.
+/// Returns (identifier_text, node_kind) or None if not on an identifier.
+pub fn identifier_at_position(
+    source: &str,
+    lang: Language,
+    line: usize,
+    column: usize,
+) -> Option<(String, String)> {
+    let tree = cached_parse(source, lang)?;
+
+    let point = tree_sitter::Point {
+        row: line.saturating_sub(1),
+        column,
+    };
+
+    let node = tree.root_node().descendant_for_point_range(point, point)?;
+
+    // Walk up to find an identifier or type_identifier node
+    let mut current = node;
+    for _ in 0..5 {
+        let kind = current.kind();
+        if kind == "identifier"
+            || kind == "type_identifier"
+            || kind == "field_identifier"
+            || kind == "property_identifier"
+            || kind == "method_name"
+            || kind == "name"
+        {
+            let text = current.utf8_text(source.as_bytes()).ok()?.to_string();
+            return Some((text, kind.to_string()));
+        }
+        match current.parent() {
+            Some(p) => current = p,
+            None => break,
+        }
+    }
+
+    // If we landed on a leaf node with content, use it directly
+    let text = node.utf8_text(source.as_bytes()).ok()?.to_string();
+    if !text.is_empty() && text.len() < 100 && !text.contains('\n') {
+        Some((text, node.kind().to_string()))
+    } else {
+        None
+    }
+}
+
+/// Find the enclosing scope at a given line (1-indexed).
+pub fn scope_at_line(source: &str, lang: Language, line: usize) -> ScopeContext {
+    let symbols = extract_symbols(source, lang);
+
+    // Find all symbols that contain this line, sorted by specificity (smaller range = more specific)
+    let mut containing: Vec<&Symbol> = symbols
+        .iter()
+        .filter(|s| s.start_line <= line && s.end_line >= line)
+        .collect();
+
+    // Sort by range size ascending (most specific first)
+    containing.sort_by_key(|s| s.end_line - s.start_line);
+
+    let innermost = containing.first().copied().cloned();
+
+    // Build breadcrumb trail from outermost to innermost
+    // We reverse to go from outermost to innermost
+    containing.reverse();
+    let breadcrumbs: Vec<String> = containing
+        .iter()
+        .map(|s| {
+            if s.signature.len() > 80 {
+                format!("{} {}...", s.kind.as_str(), s.name)
+            } else {
+                format!("{} {}", s.kind.as_str(), s.signature)
+            }
+        })
+        .collect();
+
+    ScopeContext {
+        breadcrumbs,
+        symbol: innermost,
+    }
+}
+
+fn node_text(node: tree_sitter::Node, source: &str) -> String {
+    let start = node.start_byte();
+    let end = node.end_byte();
+    if start <= end && end <= source.len() {
+        source[start..end].to_string()
+    } else {
+        String::new()
+    }
+}
+
+/// Extract the doc comment block immediately preceding a given line.
+///
+/// Walks backward from `symbol_line - 1` collecting contiguous comment lines.
+/// Handles language-specific doc comment styles:
+/// - Rust: `///`, `//!`, `/** ... */`
+/// - Python: `"""..."""` docstring (first expression in function body at symbol_line + 1)
+/// - TypeScript/JavaScript/Go/Java/C/C++: `/** ... */`, `///`, `//`
+/// - Ruby: `#` comment blocks
+///
+/// Returns the cleaned doc text (comment markers stripped) or empty string if no doc found.
+pub fn extract_doc_comment(source: &str, lang: Language, symbol_line: usize) -> String {
+    let lines: Vec<&str> = source.lines().collect();
+    if symbol_line == 0 || symbol_line > lines.len() {
+        return String::new();
+    }
+
+    // For Python, check for docstring INSIDE the function body
+    if lang == Language::Python
+        && let Some(docstring) = extract_python_docstring(&lines, symbol_line)
+    {
+        return docstring;
+    }
+
+    // Walk backward collecting comment lines
+    let mut doc_lines: Vec<String> = Vec::new();
+    let mut i = symbol_line.saturating_sub(1); // 0-indexed line before symbol (symbol_line is 1-indexed)
+    if i == 0 && symbol_line > 1 {
+        // symbol_line is 1-indexed, so line before it is at index symbol_line - 2
+    }
+    // Convert to 0-indexed
+    let start_idx = symbol_line.saturating_sub(2);
+
+    // Check for block comment first (/** ... */)
+    if start_idx < lines.len() {
+        let trimmed = lines[start_idx].trim();
+        if trimmed.ends_with("*/") {
+            // Walk back to find the opening `/**` or `/*`
+            let mut block_lines: Vec<String> = Vec::new();
+            i = start_idx;
+            loop {
+                let line = lines[i].trim();
+                if line.starts_with("/**") || line.starts_with("/*") {
+                    // Strip the opening marker
+                    let content = line
+                        .trim_start_matches("/**")
+                        .trim_start_matches("/*")
+                        .trim();
+                    let content = content.trim_end_matches("*/").trim();
+                    if !content.is_empty() {
+                        block_lines.push(content.to_string());
+                    }
+                    block_lines.reverse();
+                    return block_lines.join("\n");
+                }
+                // Strip leading * and trailing */
+                let content = line.trim_start_matches('*').trim_end_matches("*/").trim();
+                block_lines.push(content.to_string());
+                if i == 0 {
+                    break;
+                }
+                i -= 1;
+            }
+        }
+    }
+
+    // Walk backward collecting single-line comments
+    i = start_idx;
+    loop {
+        if i >= lines.len() {
+            break;
+        }
+        let line = lines[i].trim();
+
+        // Check for doc comment patterns by language
+        let (is_doc, content) = match lang {
+            Language::Rust => {
+                if let Some(rest) = line.strip_prefix("///") {
+                    (true, rest.trim().to_string())
+                } else if let Some(rest) = line.strip_prefix("//!") {
+                    (true, rest.trim().to_string())
+                } else {
+                    (false, String::new())
+                }
+            }
+            Language::Go => {
+                if let Some(rest) = line.strip_prefix("//") {
+                    (true, rest.trim().to_string())
+                } else {
+                    (false, String::new())
+                }
+            }
+            Language::Ruby => {
+                if let Some(rest) = line.strip_prefix('#') {
+                    (true, rest.trim().to_string())
+                } else {
+                    (false, String::new())
+                }
+            }
+            _ => {
+                // JS/TS/Java/C/C++: accept // and ///
+                if let Some(rest) = line.strip_prefix("///") {
+                    (true, rest.trim().to_string())
+                } else if let Some(rest) = line.strip_prefix("//") {
+                    (true, rest.trim().to_string())
+                } else {
+                    (false, String::new())
+                }
+            }
+        };
+
+        if is_doc {
+            doc_lines.push(content);
+        } else if line.is_empty() && !doc_lines.is_empty() {
+            // Allow one blank line in the middle of a doc block
+            doc_lines.push(String::new());
+        } else {
+            break;
+        }
+
+        if i == 0 {
+            break;
+        }
+        i -= 1;
+    }
+
+    doc_lines.reverse();
+    // Trim leading/trailing blank lines
+    while doc_lines.first().is_some_and(|l| l.is_empty()) {
+        doc_lines.remove(0);
+    }
+    while doc_lines.last().is_some_and(|l| l.is_empty()) {
+        doc_lines.pop();
+    }
+    doc_lines.join("\n")
+}
+
+/// Extract Python docstring: the first string literal in the function body.
+fn extract_python_docstring(lines: &[&str], symbol_line: usize) -> Option<String> {
+    // Look at lines after the def/class line for a triple-quoted string
+    let body_start = symbol_line; // 0-indexed line after the symbol (symbol_line is 1-indexed)
+    if body_start >= lines.len() {
+        return None;
+    }
+
+    let first_body = lines[body_start].trim();
+    if first_body.starts_with("\"\"\"") || first_body.starts_with("'''") {
+        let quote = if first_body.starts_with("\"\"\"") {
+            "\"\"\""
+        } else {
+            "'''"
+        };
+        // Single-line docstring
+        if first_body.ends_with(quote) && first_body.len() > 6 {
+            let content = first_body
+                .trim_start_matches(quote)
+                .trim_end_matches(quote)
+                .trim();
+            return Some(content.to_string());
+        }
+        // Multi-line docstring
+        let mut doc_lines = Vec::new();
+        let first_content = first_body.trim_start_matches(quote).trim();
+        if !first_content.is_empty() {
+            doc_lines.push(first_content.to_string());
+        }
+        for line in lines.iter().skip(body_start + 1) {
+            let line = line.trim();
+            if line.contains(quote) {
+                let content = line.trim_end_matches(quote).trim();
+                if !content.is_empty() {
+                    doc_lines.push(content.to_string());
+                }
+                return Some(doc_lines.join("\n"));
+            }
+            doc_lines.push(line.to_string());
+        }
+    }
+    None
+}
+
+/// Check if a position in source code falls inside a comment or string literal.
+///
+/// Parses the source with tree-sitter and walks ancestors of the node at
+/// the given (line, column) position. Returns true if ANY ancestor is a
+/// comment, string, or doc-comment node.
+///
+/// Used by find_references to filter out false-positive grep matches that
+/// appear in comments or string literals.
+pub fn is_in_comment_or_string(source: &str, lang: Language, line: usize, column: usize) -> bool {
+    let tree = match cached_parse(source, lang) {
+        Some(t) => t,
+        None => return false,
+    };
+
+    // tree-sitter uses 0-indexed rows
+    let point = tree_sitter::Point {
+        row: line.saturating_sub(1),
+        column,
+    };
+
+    let Some(node) = tree.root_node().descendant_for_point_range(point, point) else {
+        return false;
+    };
+
+    // Walk up from the node to check if any ancestor is a comment or string
+    let mut current = Some(node);
+    while let Some(n) = current {
+        let kind = n.kind();
+        if is_non_code_node(kind) {
+            return true;
+        }
+        current = n.parent();
+    }
+
+    false
+}
+
+/// Check if a tree-sitter node kind represents non-code content (comments, strings, etc.)
+fn is_non_code_node(kind: &str) -> bool {
+    // Comments (across all languages)
+    kind == "line_comment"
+        || kind == "block_comment"
+        || kind == "comment"
+        || kind == "doc_comment"
+        // Rust-specific
+        || kind == "inner_line_doc_comment"
+        || kind == "outer_line_doc_comment"
+        || kind == "inner_block_doc_comment"
+        || kind == "outer_block_doc_comment"
+        // String literals
+        || kind == "string_literal"
+        || kind == "raw_string_literal"
+        || kind == "string"
+        || kind == "raw_string"
+        || kind == "string_content"
+        || kind == "interpreted_string_literal"  // Go
+        || kind == "raw_string_literal"
+        || kind == "template_string"  // JS/TS
+        || kind == "string_fragment"
+        || kind == "heredoc_body"  // Ruby
+        // Python specific
+        || kind == "concatenated_string"
+}
+
+// ─── Type Member Extraction ─────────────────────────────────────────────────
+
+/// A field, property, or variant belonging to a type definition.
+#[derive(Debug, Clone)]
+pub struct Member {
+    /// Member name (e.g., "name", "age", "Variant")
+    pub name: String,
+    /// Member kind: "field", "method", "variant", "property"
+    pub kind: String,
+    /// Type annotation if available (e.g., "String", "usize", "Option<i32>")
+    pub type_annotation: String,
+    /// Line number (1-indexed)
+    pub line: usize,
+    /// Visibility/access (e.g., "pub", "pub(crate)", "private", "protected")
+    pub visibility: String,
+    /// Default value or initializer if present
+    pub default_value: String,
+}
+
+/// Extract members (fields, methods, variants) from a type definition at a
+/// specific line in the source. Finds the enclosing struct/class/enum/interface
+/// and returns its members.
+pub fn extract_members(source: &str, lang: Language, type_line: usize) -> Vec<Member> {
+    let tree = match cached_parse(source, lang) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+
+    // Find the type node at the given line
+    let target_row = type_line.saturating_sub(1);
+    let root = tree.root_node();
+    let type_node = find_type_node_at_line(root, target_row, lang);
+
+    match type_node {
+        Some(node) => match lang {
+            Language::Rust => extract_rust_members(node, source),
+            Language::Python => extract_python_members(node, source),
+            Language::TypeScript | Language::JavaScript => extract_ts_members(node, source),
+            Language::Go => extract_go_members(node, source),
+            _ => Vec::new(),
+        },
+        None => Vec::new(),
+    }
+}
+
+fn find_type_node_at_line(
+    root: tree_sitter::Node,
+    target_row: usize,
+    lang: Language,
+) -> Option<tree_sitter::Node> {
+    let type_kinds: &[&str] = match lang {
+        Language::Rust => &["struct_item", "enum_item", "trait_item"],
+        Language::Python => &["class_definition"],
+        Language::TypeScript | Language::JavaScript => &[
+            "class_declaration",
+            "interface_declaration",
+            "type_alias_declaration",
+        ],
+        Language::Go => &["type_declaration", "type_spec"],
+        Language::Java => &[
+            "class_declaration",
+            "interface_declaration",
+            "enum_declaration",
+        ],
+        _ => &[],
+    };
+
+    find_node_at_line_by_kinds(root, target_row, type_kinds)
+}
+
+fn find_node_at_line_by_kinds<'a>(
+    node: tree_sitter::Node<'a>,
+    target_row: usize,
+    kinds: &[&str],
+) -> Option<tree_sitter::Node<'a>> {
+    if kinds.contains(&node.kind()) && node.start_position().row == target_row {
+        return Some(node);
+    }
+    // Also match if target is within the node's range (user points at any line)
+    if kinds.contains(&node.kind())
+        && target_row >= node.start_position().row
+        && target_row <= node.end_position().row
+    {
+        return Some(node);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(found) = find_node_at_line_by_kinds(child, target_row, kinds) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn extract_rust_members(node: tree_sitter::Node, source: &str) -> Vec<Member> {
+    let mut members = Vec::new();
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "field_declaration_list" => {
+                let mut fc = child.walk();
+                for field in child.children(&mut fc) {
+                    if field.kind() == "field_declaration" {
+                        let vis = extract_rust_visibility(field, source);
+                        let name =
+                            get_child_text(field, "field_identifier", source).unwrap_or_default();
+                        let type_ann = get_child_text(field, "type_identifier", source)
+                            .or_else(|| get_child_by_kind_text(field, source))
+                            .unwrap_or_default();
+                        members.push(Member {
+                            name,
+                            kind: "field".to_string(),
+                            type_annotation: type_ann,
+                            line: field.start_position().row + 1,
+                            visibility: vis,
+                            default_value: String::new(),
+                        });
+                    }
+                }
+            }
+            "enum_variant_list" => {
+                let mut vc = child.walk();
+                for variant in child.children(&mut vc) {
+                    if variant.kind() == "enum_variant" {
+                        let name =
+                            get_child_text(variant, "identifier", source).unwrap_or_default();
+                        members.push(Member {
+                            name,
+                            kind: "variant".to_string(),
+                            type_annotation: String::new(),
+                            line: variant.start_position().row + 1,
+                            visibility: "pub".to_string(),
+                            default_value: String::new(),
+                        });
+                    }
+                }
+            }
+            "declaration_list" => {
+                // Trait items (method signatures)
+                let mut dc = child.walk();
+                for item in child.children(&mut dc) {
+                    if item.kind() == "function_item" || item.kind() == "function_signature_item" {
+                        let name = get_child_text(item, "identifier", source).unwrap_or_default();
+                        let sig = get_signature_line(item, source);
+                        members.push(Member {
+                            name,
+                            kind: "method".to_string(),
+                            type_annotation: sig,
+                            line: item.start_position().row + 1,
+                            visibility: String::new(),
+                            default_value: String::new(),
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    members
+}
+
+fn extract_rust_visibility(node: tree_sitter::Node, source: &str) -> String {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "visibility_modifier" {
+            return child
+                .utf8_text(source.as_bytes())
+                .unwrap_or("pub")
+                .to_string();
+        }
+    }
+    String::new()
+}
+
+fn get_child_by_kind_text(node: tree_sitter::Node, source: &str) -> Option<String> {
+    // For complex types (generic_type, reference_type, etc.), get the full text
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let k = child.kind();
+        if k.ends_with("_type") || k == "generic_type" || k == "scoped_type_identifier" {
+            return Some(child.utf8_text(source.as_bytes()).ok()?.to_string());
+        }
+    }
+    None
+}
+
+fn extract_python_members(node: tree_sitter::Node, source: &str) -> Vec<Member> {
+    let mut members = Vec::new();
+    // Look at the class body for assignments and methods
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "block" {
+            let mut bc = child.walk();
+            for stmt in child.children(&mut bc) {
+                match stmt.kind() {
+                    "function_definition" => {
+                        let name = get_child_text(stmt, "identifier", source).unwrap_or_default();
+                        let sig = get_signature_line(stmt, source);
+                        members.push(Member {
+                            name,
+                            kind: "method".to_string(),
+                            type_annotation: sig,
+                            line: stmt.start_position().row + 1,
+                            visibility: String::new(),
+                            default_value: String::new(),
+                        });
+                    }
+                    "expression_statement" => {
+                        // Class-level assignments like: name: str = "default"
+                        let text = stmt
+                            .utf8_text(source.as_bytes())
+                            .unwrap_or_default()
+                            .trim()
+                            .to_string();
+                        if let Some(colon_pos) = text.find(':') {
+                            let name = text[..colon_pos].trim().to_string();
+                            let rest = text[colon_pos + 1..].trim();
+                            let (type_ann, default) = if let Some(eq_pos) = rest.find('=') {
+                                (
+                                    rest[..eq_pos].trim().to_string(),
+                                    rest[eq_pos + 1..].trim().to_string(),
+                                )
+                            } else {
+                                (rest.to_string(), String::new())
+                            };
+                            if !name.is_empty() && !name.contains(' ') && !name.starts_with('#') {
+                                members.push(Member {
+                                    name,
+                                    kind: "property".to_string(),
+                                    type_annotation: type_ann,
+                                    line: stmt.start_position().row + 1,
+                                    visibility: String::new(),
+                                    default_value: default,
+                                });
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    members
+}
+
+fn extract_ts_members(node: tree_sitter::Node, source: &str) -> Vec<Member> {
+    let mut members = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "class_body"
+            || child.kind() == "interface_body"
+            || child.kind() == "object_type"
+        {
+            let mut bc = child.walk();
+            for item in child.children(&mut bc) {
+                match item.kind() {
+                    "method_definition" | "method_signature" => {
+                        let name =
+                            get_child_text(item, "property_identifier", source).unwrap_or_default();
+                        let sig = get_signature_line(item, source);
+                        members.push(Member {
+                            name,
+                            kind: "method".to_string(),
+                            type_annotation: sig,
+                            line: item.start_position().row + 1,
+                            visibility: extract_ts_visibility(item, source),
+                            default_value: String::new(),
+                        });
+                    }
+                    "public_field_definition" | "property_signature" => {
+                        let name =
+                            get_child_text(item, "property_identifier", source).unwrap_or_default();
+                        let type_ann = get_child_text(item, "type_annotation", source)
+                            .map(|t| t.trim_start_matches(':').trim().to_string())
+                            .unwrap_or_default();
+                        members.push(Member {
+                            name,
+                            kind: "property".to_string(),
+                            type_annotation: type_ann,
+                            line: item.start_position().row + 1,
+                            visibility: extract_ts_visibility(item, source),
+                            default_value: String::new(),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    members
+}
+
+fn extract_ts_visibility(node: tree_sitter::Node, source: &str) -> String {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "accessibility_modifier" {
+            return child
+                .utf8_text(source.as_bytes())
+                .unwrap_or("public")
+                .to_string();
+        }
+    }
+    String::new()
+}
+
+fn extract_go_members(node: tree_sitter::Node, source: &str) -> Vec<Member> {
+    let mut members = Vec::new();
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        if child.kind() == "type_spec" {
+            // Recurse into the type_spec to find struct_type or interface_type
+            let mut tc = child.walk();
+            for type_child in child.children(&mut tc) {
+                match type_child.kind() {
+                    "struct_type" => {
+                        let mut fc = type_child.walk();
+                        for field_list in type_child.children(&mut fc) {
+                            if field_list.kind() == "field_declaration_list" {
+                                let mut flc = field_list.walk();
+                                for field in field_list.children(&mut flc) {
+                                    if field.kind() == "field_declaration" {
+                                        let name =
+                                            get_child_text(field, "field_identifier", source)
+                                                .unwrap_or_default();
+                                        let type_ann = field
+                                            .utf8_text(source.as_bytes())
+                                            .unwrap_or_default()
+                                            .trim()
+                                            .to_string();
+                                        // Remove the name from front to get type
+                                        let type_part = type_ann
+                                            .strip_prefix(&name)
+                                            .unwrap_or(&type_ann)
+                                            .trim()
+                                            .to_string();
+                                        members.push(Member {
+                                            name,
+                                            kind: "field".to_string(),
+                                            type_annotation: type_part,
+                                            line: field.start_position().row + 1,
+                                            visibility: String::new(),
+                                            default_value: String::new(),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    "interface_type" => {
+                        let mut ic = type_child.walk();
+                        for method_list in type_child.children(&mut ic) {
+                            if method_list.kind() == "method_spec_list"
+                                || method_list.kind() == "method_spec"
+                            {
+                                let text = method_list
+                                    .utf8_text(source.as_bytes())
+                                    .unwrap_or_default()
+                                    .trim()
+                                    .to_string();
+                                if !text.is_empty()
+                                    && !text.starts_with('{')
+                                    && !text.starts_with('}')
+                                {
+                                    members.push(Member {
+                                        name: text
+                                            .split('(')
+                                            .next()
+                                            .unwrap_or("")
+                                            .trim()
+                                            .to_string(),
+                                        kind: "method".to_string(),
+                                        type_annotation: text,
+                                        line: method_list.start_position().row + 1,
+                                        visibility: String::new(),
+                                        default_value: String::new(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    members
+}
+
+// ─── Implementation / Type Hierarchy ────────────────────────────────────────
+
+/// An implementation relationship found in source code.
+#[derive(Debug, Clone)]
+pub struct ImplRelation {
+    /// The trait/interface being implemented
+    pub trait_name: String,
+    /// The type implementing it
+    pub type_name: String,
+    /// File where the impl was found
+    pub file: String,
+    /// Line number of the impl block
+    pub line: usize,
+}
+
+/// Find impl blocks in a Rust source file.
+/// Returns all `impl Trait for Type` relationships.
+pub fn find_rust_impls(source: &str, file_path: &str) -> Vec<ImplRelation> {
+    let tree = match cached_parse(source, Language::Rust) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+
+    let mut impls = Vec::new();
+    collect_rust_impls(tree.root_node(), source, file_path, &mut impls);
+    impls
+}
+
+fn collect_rust_impls(
+    node: tree_sitter::Node,
+    source: &str,
+    file_path: &str,
+    impls: &mut Vec<ImplRelation>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "impl_item" {
+            // Check if this is `impl Trait for Type`
+            let text = child.utf8_text(source.as_bytes()).unwrap_or_default();
+            let first_line = text.lines().next().unwrap_or("");
+
+            if let Some(for_pos) = first_line.find(" for ") {
+                // impl TRAIT for TYPE
+                let before_for = &first_line[..for_pos];
+                let after_for = &first_line[for_pos + 5..];
+
+                let trait_name = before_for
+                    .strip_prefix("impl ")
+                    .unwrap_or(before_for)
+                    .trim()
+                    .split('<')
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+
+                let type_name = after_for
+                    .split('{')
+                    .next()
+                    .unwrap_or(after_for)
+                    .split('<')
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+
+                if !trait_name.is_empty() && !type_name.is_empty() {
+                    impls.push(ImplRelation {
+                        trait_name,
+                        type_name,
+                        file: file_path.to_string(),
+                        line: child.start_position().row + 1,
+                    });
+                }
+            }
+        }
+        collect_rust_impls(child, source, file_path, impls);
+    }
+}
+
+// ─── Import / Use Statement Extraction ──────────────────────────────────────
+
+/// An import/use statement extracted from source code.
+#[derive(Debug, Clone)]
+pub struct ImportStatement {
+    /// The full import path (e.g., "std::collections::HashMap", "os.path")
+    pub path: String,
+    /// The imported name(s) — the leaf items being imported
+    pub names: Vec<String>,
+    /// Line number (1-indexed)
+    pub line: usize,
+    /// Whether it's a wildcard import (e.g., `use foo::*`, `from foo import *`)
+    pub is_wildcard: bool,
+}
+
+/// Extract import/use statements from source code.
+pub fn extract_imports(source: &str, lang: Language) -> Vec<ImportStatement> {
+    let tree = match cached_parse(source, lang) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+    let root = tree.root_node();
+    match lang {
+        Language::Rust => extract_rust_imports(root, source),
+        Language::Python => extract_python_imports(root, source),
+        Language::TypeScript | Language::JavaScript => extract_ts_imports(root, source),
+        Language::Go => extract_go_imports(root, source),
+        _ => Vec::new(), // Java, C, Cpp, Ruby: not yet implemented
+    }
+}
+
+fn extract_rust_imports(node: tree_sitter::Node, source: &str) -> Vec<ImportStatement> {
+    let mut imports = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "use_declaration" {
+            let line = child.start_position().row + 1;
+            let text = child.utf8_text(source.as_bytes()).unwrap_or_default();
+            // Remove `use ` prefix and `;` suffix
+            let path_str = text
+                .trim_start_matches("use ")
+                .trim_start_matches("pub use ")
+                .trim_end_matches(';')
+                .trim();
+
+            let is_wildcard = path_str.ends_with("::*");
+
+            // Extract names from use tree
+            let names = extract_rust_use_names(path_str);
+            let path = path_str
+                .split("::{")
+                .next()
+                .unwrap_or(path_str)
+                .trim_end_matches("::*")
+                .to_string();
+
+            imports.push(ImportStatement {
+                path,
+                names,
+                line,
+                is_wildcard,
+            });
+        }
+    }
+    imports
+}
+
+fn extract_rust_use_names(path: &str) -> Vec<String> {
+    // Handle `use std::collections::{HashMap, HashSet};`
+    if let Some(brace_start) = path.find("::{") {
+        let names_str = &path[brace_start + 3..];
+        let names_str = names_str.trim_end_matches('}');
+        return names_str
+            .split(',')
+            .map(|n| {
+                let n = n.trim();
+                // Handle `self` and `as Alias`
+                n.split(" as ").next().unwrap_or(n).trim().to_string()
+            })
+            .filter(|n| !n.is_empty())
+            .collect();
+    }
+    // Handle `use std::collections::HashMap;`
+    if let Some(last) = path.rsplit("::").next()
+        && last != "*"
+    {
+        return vec![last.split(" as ").next().unwrap_or(last).trim().to_string()];
+    }
+    Vec::new()
+}
+
+fn extract_python_imports(node: tree_sitter::Node, source: &str) -> Vec<ImportStatement> {
+    let mut imports = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "import_statement" => {
+                // `import os.path`
+                let line = child.start_position().row + 1;
+                let text = child.utf8_text(source.as_bytes()).unwrap_or_default();
+                let path = text.trim_start_matches("import ").trim();
+                let names: Vec<String> = path
+                    .split(',')
+                    .map(|p| {
+                        let p = p.trim();
+                        p.split(" as ")
+                            .next()
+                            .unwrap_or(p)
+                            .trim()
+                            .rsplit('.')
+                            .next()
+                            .unwrap_or(p)
+                            .to_string()
+                    })
+                    .collect();
+                imports.push(ImportStatement {
+                    path: path
+                        .split(',')
+                        .next()
+                        .unwrap_or(path)
+                        .split(" as ")
+                        .next()
+                        .unwrap_or(path)
+                        .trim()
+                        .to_string(),
+                    names,
+                    line,
+                    is_wildcard: false,
+                });
+            }
+            "import_from_statement" => {
+                // `from os.path import join, exists`
+                let line = child.start_position().row + 1;
+                let text = child.utf8_text(source.as_bytes()).unwrap_or_default();
+                let is_wildcard = text.contains("import *");
+
+                // Parse "from MODULE import NAMES"
+                let after_from = text.trim_start_matches("from ").trim();
+                let parts: Vec<&str> = after_from.splitn(2, " import ").collect();
+                let module = parts.first().map(|s| s.trim()).unwrap_or("").to_string();
+                let names = if parts.len() > 1 {
+                    parts[1]
+                        .split(',')
+                        .map(|n| {
+                            n.trim()
+                                .split(" as ")
+                                .next()
+                                .unwrap_or("")
+                                .trim()
+                                .to_string()
+                        })
+                        .filter(|n| !n.is_empty() && n != "*")
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+
+                imports.push(ImportStatement {
+                    path: module,
+                    names,
+                    line,
+                    is_wildcard,
+                });
+            }
+            _ => {}
+        }
+    }
+    imports
+}
+
+fn extract_ts_imports(node: tree_sitter::Node, source: &str) -> Vec<ImportStatement> {
+    let mut imports = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "import_statement" {
+            let line = child.start_position().row + 1;
+            let text = child.utf8_text(source.as_bytes()).unwrap_or_default();
+
+            // Extract module path from string literal
+            let path = text
+                .split('\'')
+                .nth(1)
+                .or_else(|| text.split('"').nth(1))
+                .unwrap_or("")
+                .to_string();
+
+            // Extract imported names
+            let mut names = Vec::new();
+            let is_wildcard = text.contains("* as ");
+
+            if let Some(brace_start) = text.find('{')
+                && let Some(brace_end) = text.find('}')
+            {
+                let inner = &text[brace_start + 1..brace_end];
+                for name in inner.split(',') {
+                    let n = name.trim().split(" as ").next().unwrap_or("").trim();
+                    if !n.is_empty() {
+                        names.push(n.to_string());
+                    }
+                }
+            }
+            // Default import: `import Foo from '...'`
+            if names.is_empty() && !is_wildcard {
+                let after_import = text.trim_start_matches("import ").trim();
+                if let Some(name) = after_import.split_whitespace().next()
+                    && name != "{"
+                    && name != "*"
+                    && name != "type"
+                {
+                    names.push(name.to_string());
+                }
+            }
+
+            imports.push(ImportStatement {
+                path,
+                names,
+                line,
+                is_wildcard,
+            });
+        }
+    }
+    imports
+}
+
+fn extract_go_imports(node: tree_sitter::Node, source: &str) -> Vec<ImportStatement> {
+    let mut imports = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "import_declaration" {
+            let line = child.start_position().row + 1;
+            // Can be single: `import "fmt"` or grouped: `import ("fmt" \n "os")`
+            let text = child.utf8_text(source.as_bytes()).unwrap_or_default();
+
+            for import_line in text.lines() {
+                let trimmed = import_line.trim();
+                if trimmed == "import"
+                    || trimmed == "import ("
+                    || trimmed == ")"
+                    || trimmed.is_empty()
+                {
+                    continue;
+                }
+                let path_str = trimmed
+                    .trim_start_matches("import ")
+                    .trim()
+                    .trim_matches('"')
+                    .trim_matches('(')
+                    .trim_matches(')')
+                    .trim()
+                    .trim_matches('"');
+
+                if path_str.is_empty() {
+                    continue;
+                }
+
+                let name = path_str.rsplit('/').next().unwrap_or(path_str).to_string();
+                imports.push(ImportStatement {
+                    path: path_str.to_string(),
+                    names: vec![name],
+                    line,
+                    is_wildcard: false,
+                });
+            }
+        }
+    }
+    imports
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_rust_language() {
+        assert_eq!(
+            detect_language(Path::new("src/main.rs")),
+            Some(Language::Rust)
+        );
+    }
+
+    #[test]
+    fn detect_python_language() {
+        assert_eq!(detect_language(Path::new("app.py")), Some(Language::Python));
+    }
+
+    #[test]
+    fn detect_typescript_language() {
+        assert_eq!(
+            detect_language(Path::new("index.ts")),
+            Some(Language::TypeScript)
+        );
+        assert_eq!(
+            detect_language(Path::new("App.tsx")),
+            Some(Language::TypeScript)
+        );
+    }
+
+    #[test]
+    fn extract_rust_functions() {
+        let source = r#"
+pub fn main() {
+    println!("hello");
+}
+
+fn helper(x: i32) -> i32 {
+    x + 1
+}
+"#;
+        let symbols = extract_symbols(source, Language::Rust);
+        assert_eq!(symbols.len(), 2);
+        assert_eq!(symbols[0].name, "main");
+        assert_eq!(symbols[0].kind, SymbolKind::Function);
+        assert_eq!(symbols[1].name, "helper");
+    }
+
+    #[test]
+    fn extract_rust_struct_and_impl() {
+        let source = r#"
+pub struct Config {
+    path: String,
+}
+
+impl Config {
+    pub fn new(path: &str) -> Self {
+        Self { path: path.to_string() }
+    }
+
+    fn validate(&self) -> bool {
+        true
+    }
+}
+"#;
+        let symbols = extract_symbols(source, Language::Rust);
+        // Should find: struct Config, method new, method validate
+        let struct_sym = symbols.iter().find(|s| s.name == "Config");
+        assert!(struct_sym.is_some());
+        assert_eq!(struct_sym.unwrap().kind, SymbolKind::Struct);
+
+        let new_sym = symbols.iter().find(|s| s.name == "new");
+        assert!(new_sym.is_some());
+        assert_eq!(new_sym.unwrap().kind, SymbolKind::Method);
+        assert_eq!(new_sym.unwrap().parent, Some("Config".to_string()));
+    }
+
+    #[test]
+    fn extract_python_class() {
+        let source = r#"
+class UserService:
+    def __init__(self, db):
+        self.db = db
+
+    def get_user(self, user_id: int) -> dict:
+        return self.db.find(user_id)
+
+def helper():
+    pass
+"#;
+        let symbols = extract_symbols(source, Language::Python);
+
+        let class_sym = symbols.iter().find(|s| s.name == "UserService");
+        assert!(class_sym.is_some());
+        assert_eq!(class_sym.unwrap().kind, SymbolKind::Class);
+
+        let method_sym = symbols.iter().find(|s| s.name == "get_user");
+        assert!(method_sym.is_some());
+        assert_eq!(method_sym.unwrap().kind, SymbolKind::Method);
+        assert_eq!(method_sym.unwrap().parent, Some("UserService".to_string()));
+
+        let func_sym = symbols.iter().find(|s| s.name == "helper");
+        assert!(func_sym.is_some());
+        assert_eq!(func_sym.unwrap().kind, SymbolKind::Function);
+    }
+
+    #[test]
+    fn extract_go_functions() {
+        let source = r#"
+package main
+
+func main() {
+    fmt.Println("hello")
+}
+
+func (s *Server) Start() error {
+    return nil
+}
+"#;
+        let symbols = extract_symbols(source, Language::Go);
+
+        let main_sym = symbols.iter().find(|s| s.name == "main");
+        assert!(main_sym.is_some());
+        assert_eq!(main_sym.unwrap().kind, SymbolKind::Function);
+
+        let method_sym = symbols.iter().find(|s| s.name == "Start");
+        assert!(method_sym.is_some());
+        assert_eq!(method_sym.unwrap().kind, SymbolKind::Method);
+    }
+
+    #[test]
+    fn generate_rust_outline() {
+        let source = r#"
+pub fn parse_config(path: &str) -> Result<Config, Error> {
+    // ...
+}
+
+pub struct Config {
+    name: String,
+}
+"#;
+        let outline = generate_outline(source, Language::Rust);
+        assert!(outline.contains("fn parse_config"));
+        assert!(outline.contains("struct Config"));
+    }
+
+    #[test]
+    fn find_symbols_by_name() {
+        let source = r#"
+fn get_user() {}
+fn get_config() {}
+fn set_user() {}
+"#;
+        let matches = find_symbols(source, Language::Rust, "user");
+        assert_eq!(matches.len(), 2);
+        assert!(matches.iter().any(|s| s.name == "get_user"));
+        assert!(matches.iter().any(|s| s.name == "set_user"));
+    }
+
+    // ─── New language tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn detect_java_language() {
+        assert_eq!(
+            detect_language(Path::new("Main.java")),
+            Some(Language::Java)
+        );
+    }
+
+    #[test]
+    fn detect_cpp_language() {
+        assert_eq!(detect_language(Path::new("main.cpp")), Some(Language::Cpp));
+        assert_eq!(detect_language(Path::new("main.cc")), Some(Language::Cpp));
+        assert_eq!(
+            detect_language(Path::new("header.hpp")),
+            Some(Language::Cpp)
+        );
+    }
+
+    #[test]
+    fn detect_c_language() {
+        assert_eq!(detect_language(Path::new("main.c")), Some(Language::C));
+        assert_eq!(detect_language(Path::new("header.h")), Some(Language::C));
+    }
+
+    #[test]
+    fn detect_ruby_language() {
+        assert_eq!(detect_language(Path::new("app.rb")), Some(Language::Ruby));
+    }
+
+    #[test]
+    fn extract_java_class_and_methods() {
+        let source = r#"
+public class UserService {
+    private String name;
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+}
+"#;
+        let symbols = extract_symbols(source, Language::Java);
+
+        let class_sym = symbols.iter().find(|s| s.name == "UserService");
+        assert!(class_sym.is_some(), "symbols: {:?}", symbols);
+        assert_eq!(class_sym.unwrap().kind, SymbolKind::Class);
+
+        let set_method = symbols.iter().find(|s| s.name == "setName");
+        assert!(set_method.is_some(), "symbols: {:?}", symbols);
+        assert_eq!(set_method.unwrap().kind, SymbolKind::Method);
+
+        let get_method = symbols.iter().find(|s| s.name == "getName");
+        assert!(get_method.is_some(), "symbols: {:?}", symbols);
+    }
+
+    #[test]
+    fn extract_cpp_functions_and_classes() {
+        let source = r#"
+#include <iostream>
+
+class Calculator {
+public:
+    int add(int a, int b) {
+        return a + b;
+    }
+};
+
+int main() {
+    Calculator calc;
+    return 0;
+}
+"#;
+        let symbols = extract_symbols(source, Language::Cpp);
+
+        let class_sym = symbols.iter().find(|s| s.name == "Calculator");
+        assert!(class_sym.is_some(), "symbols: {:?}", symbols);
+        assert_eq!(class_sym.unwrap().kind, SymbolKind::Class);
+
+        let main_sym = symbols.iter().find(|s| s.name == "main");
+        assert!(main_sym.is_some(), "symbols: {:?}", symbols);
+        assert_eq!(main_sym.unwrap().kind, SymbolKind::Function);
+    }
+
+    #[test]
+    fn extract_ruby_class_and_methods() {
+        let source = r#"
+class UserController
+  def index
+    @users = User.all
+  end
+
+  def show
+    @user = User.find(params[:id])
+  end
+end
+"#;
+        let symbols = extract_symbols(source, Language::Ruby);
+
+        let class_sym = symbols.iter().find(|s| s.name == "UserController");
+        assert!(class_sym.is_some(), "symbols: {:?}", symbols);
+        assert_eq!(class_sym.unwrap().kind, SymbolKind::Class);
+
+        let index_method = symbols.iter().find(|s| s.name == "index");
+        assert!(index_method.is_some(), "symbols: {:?}", symbols);
+        assert_eq!(index_method.unwrap().kind, SymbolKind::Method);
+
+        let show_method = symbols.iter().find(|s| s.name == "show");
+        assert!(show_method.is_some(), "symbols: {:?}", symbols);
+    }
+
+    // ─── Call graph extraction tests ────────────────────────────────────
+
+    #[test]
+    fn extract_calls_rust_function() {
+        let source = r#"
+fn process(items: &[Item]) -> Result<()> {
+    let config = Config::load("default")?;
+    let mut results = Vec::new();
+    for item in items {
+        let val = item.transform();
+        results.push(val);
+    }
+    println!("done: {}", results.len());
+    save_results(&results)?;
+    Ok(())
+}
+"#;
+        let calls = extract_calls(source, Language::Rust, 2, 12);
+        assert!(!calls.is_empty(), "should find calls");
+
+        let names: Vec<&str> = calls.iter().map(|c| c.callee.as_str()).collect();
+        assert!(
+            names.contains(&"Config::load"),
+            "should find Config::load: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"transform"),
+            "should find item.transform: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"push"),
+            "should find results.push: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"println!"),
+            "should find println!: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"save_results"),
+            "should find save_results: {:?}",
+            names
+        );
+
+        // Check receiver on method calls
+        let transform_call = calls.iter().find(|c| c.callee == "transform").unwrap();
+        assert_eq!(transform_call.receiver.as_deref(), Some("item"));
+    }
+
+    #[test]
+    fn extract_calls_python() {
+        let source = r#"
+def process_data(df):
+    result = df.groupby("category").agg({"value": "sum"})
+    print(f"Groups: {len(result)}")
+    save_to_csv(result, "output.csv")
+    return result
+"#;
+        let calls = extract_calls(source, Language::Python, 2, 6);
+        let names: Vec<&str> = calls.iter().map(|c| c.callee.as_str()).collect();
+        assert!(
+            names.contains(&"groupby"),
+            "should find df.groupby: {:?}",
+            names
+        );
+        assert!(names.contains(&"print"), "should find print: {:?}", names);
+        assert!(
+            names.contains(&"save_to_csv"),
+            "should find save_to_csv: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn extract_calls_typescript() {
+        let source = r#"
+function handleRequest(req: Request): Response {
+    const user = authenticateUser(req.headers);
+    const data = db.query("SELECT * FROM users");
+    console.log("processed", user.id);
+    return new Response(JSON.stringify(data));
+}
+"#;
+        let calls = extract_calls(source, Language::TypeScript, 2, 7);
+        let names: Vec<&str> = calls.iter().map(|c| c.callee.as_str()).collect();
+        assert!(
+            names.contains(&"authenticateUser"),
+            "should find authenticateUser: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"query"),
+            "should find db.query: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"log"),
+            "should find console.log: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn extract_calls_go() {
+        let source = r#"
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+    body, err := ioutil.ReadAll(r.Body)
+    if err != nil {
+        http.Error(w, "bad request", 400)
+        return
+    }
+    fmt.Fprintf(w, "OK: %d bytes", len(body))
+}
+"#;
+        let calls = extract_calls(source, Language::Go, 2, 9);
+        let names: Vec<&str> = calls.iter().map(|c| c.callee.as_str()).collect();
+        assert!(
+            names.contains(&"ReadAll"),
+            "should find ioutil.ReadAll: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"Error"),
+            "should find http.Error: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"Fprintf"),
+            "should find fmt.Fprintf: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn extract_calls_empty_function() {
+        let source = "fn noop() {}\n";
+        let calls = extract_calls(source, Language::Rust, 1, 1);
+        assert!(calls.is_empty(), "should find no calls in empty function");
+    }
+
+    #[test]
+    fn extract_calls_respects_line_range() {
+        let source = r#"
+fn first() {
+    a();
+}
+fn second() {
+    b();
+}
+"#;
+        // Only analyze first function (lines 2-4)
+        let calls = extract_calls(source, Language::Rust, 2, 4);
+        let names: Vec<&str> = calls.iter().map(|c| c.callee.as_str()).collect();
+        assert!(names.contains(&"a"), "should find a(): {:?}", names);
+        assert!(!names.contains(&"b"), "should NOT find b(): {:?}", names);
+    }
+
+    // ─── Scope context tests ────────────────────────────────────────────
+
+    #[test]
+    fn scope_at_line_rust_nested() {
+        let source = r#"
+mod utils {
+    pub struct Config {
+        pub name: String,
+    }
+
+    impl Config {
+        pub fn new(name: &str) -> Self {
+            Config { name: name.to_string() }
+        }
+    }
+}
+"#;
+        // Line 9 is inside Config::new, inside impl Config, inside mod utils
+        let scope = scope_at_line(source, Language::Rust, 9);
+        assert!(
+            !scope.breadcrumbs.is_empty(),
+            "should have scope breadcrumbs"
+        );
+        assert!(scope.symbol.is_some(), "should have innermost symbol");
+        let inner = scope.symbol.unwrap();
+        assert_eq!(inner.name, "new");
+    }
+
+    #[test]
+    fn scope_at_line_outside_any_symbol() {
+        let source = "// just a comment\nlet x = 1;\n";
+        let scope = scope_at_line(source, Language::Rust, 1);
+        assert!(
+            scope.breadcrumbs.is_empty(),
+            "should be empty for comment-only line"
+        );
+        assert!(scope.symbol.is_none());
+    }
+
+    #[test]
+    fn scope_at_line_python_class_method() {
+        let source = r#"
+class UserService:
+    def __init__(self, db):
+        self.db = db
+
+    def get_user(self, user_id):
+        return self.db.query(user_id)
+"#;
+        let scope = scope_at_line(source, Language::Python, 7);
+        assert!(scope.symbol.is_some());
+        let sym = scope.symbol.unwrap();
+        assert_eq!(sym.name, "get_user");
+        // Breadcrumbs should include the class
+        let crumbs_str = scope.breadcrumbs.join(" > ");
+        assert!(
+            crumbs_str.contains("UserService"),
+            "breadcrumbs: {crumbs_str}"
+        );
+    }
+
+    // ── extract_members tests ────────────────────────────────────────────────
+
+    #[test]
+    fn extract_members_rust_struct_fields() {
+        let source = "pub struct Config {\n    pub name: String,\n    port: u16,\n}\n";
+        let members = extract_members(source, Language::Rust, 1);
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0].name, "name");
+        assert_eq!(members[0].kind, "field");
+        assert!(members[0].visibility.contains("pub"));
+        assert_eq!(members[1].name, "port");
+        assert!(members[1].visibility.is_empty());
+    }
+
+    #[test]
+    fn extract_members_rust_enum_variants() {
+        let source = "enum Direction {\n    North,\n    South,\n    East,\n    West,\n}\n";
+        let members = extract_members(source, Language::Rust, 1);
+        assert_eq!(members.len(), 4);
+        assert!(members.iter().all(|m| m.kind == "variant"));
+        assert_eq!(members[0].name, "North");
+        assert_eq!(members[3].name, "West");
+    }
+
+    #[test]
+    fn extract_members_python_class() {
+        let source =
+            "class User:\n    name: str\n    age: int = 25\n    def greet(self):\n        pass\n";
+        let members = extract_members(source, Language::Python, 1);
+        assert!(
+            members.len() >= 2,
+            "should have at least name and greet: {:?}",
+            members
+        );
+        let props: Vec<_> = members.iter().filter(|m| m.kind == "property").collect();
+        assert!(!props.is_empty(), "should have properties");
+        let methods: Vec<_> = members.iter().filter(|m| m.kind == "method").collect();
+        assert!(!methods.is_empty(), "should have methods");
+    }
+
+    #[test]
+    fn extract_members_empty_for_non_type() {
+        let source = "fn main() {\n    println!(\"hello\");\n}\n";
+        let members = extract_members(source, Language::Rust, 1);
+        assert!(members.is_empty());
+    }
+
+    #[test]
+    fn find_rust_impls_basic() {
+        let source = "trait A {}\nstruct B;\nimpl A for B {}\n";
+        let impls = find_rust_impls(source, "test.rs");
+        assert_eq!(impls.len(), 1);
+        assert_eq!(impls[0].trait_name, "A");
+        assert_eq!(impls[0].type_name, "B");
+        assert_eq!(impls[0].file, "test.rs");
+    }
+
+    #[test]
+    fn find_rust_impls_skips_inherent() {
+        let source = "struct Foo;\nimpl Foo {\n    fn new() -> Self { Self }\n}\n";
+        let impls = find_rust_impls(source, "test.rs");
+        assert!(impls.is_empty(), "inherent impls should not be listed");
+    }
+
+    #[test]
+    fn find_rust_impls_multiple() {
+        let source = r#"trait X {}
+trait Y {}
+struct Z;
+impl X for Z {}
+impl Y for Z {}
+"#;
+        let impls = find_rust_impls(source, "multi.rs");
+        assert_eq!(impls.len(), 2);
+    }
+
+    // ─── Parser cache tests ─────────────────────────────────────────────
+
+    #[test]
+    fn cached_parse_returns_valid_tree() {
+        let source = "fn main() {}\n";
+        let tree = cached_parse(source, Language::Rust);
+        assert!(tree.is_some(), "should parse simple Rust");
+        let tree = tree.unwrap();
+        let root = tree.root_node();
+        assert_eq!(root.kind(), "source_file");
+    }
+
+    #[test]
+    fn cached_parse_works_across_languages() {
+        // Parse with different languages sequentially
+        let rust_tree = cached_parse("fn main() {}\n", Language::Rust);
+        assert!(rust_tree.is_some());
+
+        let py_tree = cached_parse("def main(): pass\n", Language::Python);
+        assert!(py_tree.is_some());
+
+        let ts_tree = cached_parse("function main() {}\n", Language::TypeScript);
+        assert!(ts_tree.is_some());
+
+        let go_tree = cached_parse("package main\nfunc main() {}\n", Language::Go);
+        assert!(go_tree.is_some());
+
+        // Re-parse Rust to verify cache still works
+        let rust_tree2 = cached_parse("struct Foo {}\n", Language::Rust);
+        assert!(rust_tree2.is_some());
+    }
+
+    #[test]
+    fn cached_parse_handles_invalid_source_gracefully() {
+        // Empty source should still parse (tree-sitter is lenient)
+        let tree = cached_parse("", Language::Rust);
+        assert!(tree.is_some());
+    }
+
+    // ─── Import extraction tests ────────────────────────────────────────
+
+    #[test]
+    fn extract_rust_imports_simple() {
+        let source = r#"
+use std::collections::HashMap;
+use std::io::{self, Read, Write};
+use crate::utils::*;
+pub use super::config::Config;
+"#;
+        let imports = extract_imports(source, Language::Rust);
+        assert!(imports.len() >= 4, "found: {:?}", imports);
+
+        let hashmap = imports
+            .iter()
+            .find(|i| i.names.contains(&"HashMap".to_string()));
+        assert!(hashmap.is_some(), "should find HashMap import");
+        assert_eq!(hashmap.unwrap().path, "std::collections::HashMap");
+
+        let io = imports.iter().find(|i| i.path.contains("std::io"));
+        assert!(io.is_some(), "should find io import");
+        assert!(io.unwrap().names.contains(&"Read".to_string()));
+        assert!(io.unwrap().names.contains(&"Write".to_string()));
+
+        let wildcard = imports.iter().find(|i| i.is_wildcard);
+        assert!(wildcard.is_some(), "should find wildcard import");
+    }
+
+    #[test]
+    fn extract_python_imports_basic() {
+        let source = r#"
+import os
+import os.path
+from collections import OrderedDict, defaultdict
+from typing import List, Optional
+from module import *
+"#;
+        let imports = extract_imports(source, Language::Python);
+        assert!(imports.len() >= 4, "found: {:?}", imports);
+
+        let os_import = imports.iter().find(|i| i.path == "os");
+        assert!(os_import.is_some(), "should find 'import os'");
+
+        let collections = imports.iter().find(|i| i.path == "collections");
+        assert!(collections.is_some(), "should find collections import");
+        assert!(
+            collections
+                .unwrap()
+                .names
+                .contains(&"OrderedDict".to_string())
+        );
+
+        let wildcard = imports.iter().find(|i| i.is_wildcard);
+        assert!(wildcard.is_some(), "should find wildcard import");
+    }
+
+    #[test]
+    fn extract_typescript_imports_basic() {
+        let source = r#"
+import React from 'react';
+import { useState, useEffect } from 'react';
+import * as path from 'path';
+import type { Config } from './config';
+"#;
+        let imports = extract_imports(source, Language::TypeScript);
+        assert!(imports.len() >= 3, "found: {:?}", imports);
+
+        let react = imports
+            .iter()
+            .find(|i| i.path == "react" && i.names.contains(&"React".to_string()));
+        assert!(react.is_some(), "should find default React import");
+
+        let hooks = imports
+            .iter()
+            .find(|i| i.path == "react" && i.names.contains(&"useState".to_string()));
+        assert!(hooks.is_some(), "should find named React imports");
+
+        let wildcard = imports.iter().find(|i| i.is_wildcard);
+        assert!(wildcard.is_some(), "should find wildcard import");
+    }
+
+    #[test]
+    fn extract_go_imports_basic() {
+        let source = r#"
+package main
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+)
+"#;
+        let imports = extract_imports(source, Language::Go);
+        assert!(imports.len() >= 3, "found: {:?}", imports);
+
+        let fmt_import = imports.iter().find(|i| i.path == "fmt");
+        assert!(fmt_import.is_some(), "should find fmt import");
+        assert!(fmt_import.unwrap().names.contains(&"fmt".to_string()));
+
+        let filepath = imports.iter().find(|i| i.path == "path/filepath");
+        assert!(filepath.is_some(), "should find path/filepath import");
+        assert!(filepath.unwrap().names.contains(&"filepath".to_string()));
+    }
+
+    #[test]
+    fn extract_imports_unsupported_language_returns_empty() {
+        let source = "class Foo { void bar() {} }";
+        let imports = extract_imports(source, Language::Java);
+        assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn extract_imports_empty_source() {
+        let imports = extract_imports("", Language::Rust);
+        assert!(imports.is_empty());
+    }
+}

--- a/rust/crates/astra-tools/src/config_tool.rs
+++ b/rust/crates/astra-tools/src/config_tool.rs
@@ -1,0 +1,200 @@
+#![allow(dead_code)]
+//! Config tool: get/set configuration settings.
+//!
+//! Reads/writes environment-based configuration. Extracted from edge_tools
+//! as a standalone function taking output limits as parameters.
+
+use serde_json::{Value, json};
+
+/// Configuration query/set handler.
+///
+/// `global_limit` and `tool_limit` are the current output limits in bytes.
+pub fn config_tool(global_limit: usize, tool_limit: usize, args: &Value) -> String {
+    let setting = match args.get("setting").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => return json!({ "error": "Missing required parameter: setting" }).to_string(),
+    };
+    let value = args.get("value").and_then(|v| v.as_str());
+
+    let available = [
+        ("model", "Current model (env: MO_MODEL)"),
+        (
+            "api_key",
+            "API key status (env: MO_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY)",
+        ),
+        (
+            "output_limit",
+            "Global output limit in bytes (env: MO_GLOBAL_OUTPUT_LIMIT)",
+        ),
+        (
+            "tool_output_limit",
+            "Per-tool output limit (env: MO_TOOL_OUTPUT_LIMIT)",
+        ),
+        (
+            "sandbox_mode",
+            "Sandbox mode: off, permissive, strict (env: MO_SANDBOX_MODE)",
+        ),
+        ("auto_approve", "Auto-approve tools (env: MO_AUTO_APPROVE)"),
+        (
+            "turn_limit",
+            "Max turns per conversation (env: MO_MAX_TURNS)",
+        ),
+        (
+            "plan_subtask_turn_limit",
+            "Max turns per plan subtask, 0=use turn_limit (env: MO_PLAN_SUBTASK_MAX_TURNS)",
+        ),
+        ("list", "Show all available settings"),
+    ];
+
+    if setting == "list" {
+        let settings: Vec<Value> = available
+            .iter()
+            .take(available.len() - 1)
+            .map(|(k, desc)| json!({ "setting": k, "description": desc }))
+            .collect();
+        return json!({ "available_settings": settings }).to_string();
+    }
+
+    match setting {
+        "model" => {
+            if let Some(v) = value {
+                json!({
+                    "note": format!("To change model, set MO_MODEL={} environment variable", v),
+                    "setting": "model",
+                    "hint": "Use env tool to set MO_MODEL"
+                })
+                .to_string()
+            } else {
+                let current = std::env::var("MO_MODEL").unwrap_or_else(|_| "default".to_string());
+                json!({ "setting": "model", "value": current }).to_string()
+            }
+        }
+        "api_key" => {
+            let has_mo = std::env::var("MO_API_KEY").is_ok();
+            let has_openai = std::env::var("OPENAI_API_KEY").is_ok();
+            let has_anthropic = std::env::var("ANTHROPIC_API_KEY").is_ok();
+            json!({
+                "setting": "api_key",
+                "status": {
+                    "MO_API_KEY": if has_mo { "set" } else { "not set" },
+                    "OPENAI_API_KEY": if has_openai { "set" } else { "not set" },
+                    "ANTHROPIC_API_KEY": if has_anthropic { "set" } else { "not set" }
+                }
+            })
+            .to_string()
+        }
+        "output_limit" => {
+            if value.is_some() {
+                json!({
+                    "note": "To change output limit, set MO_GLOBAL_OUTPUT_LIMIT environment variable",
+                    "setting": "output_limit"
+                })
+                .to_string()
+            } else {
+                json!({
+                    "setting": "output_limit",
+                    "value": global_limit,
+                    "env_var": "MO_GLOBAL_OUTPUT_LIMIT"
+                })
+                .to_string()
+            }
+        }
+        "tool_output_limit" => json!({
+            "setting": "tool_output_limit",
+            "value": tool_limit,
+            "env_var": "MO_TOOL_OUTPUT_LIMIT"
+        })
+        .to_string(),
+        "sandbox_mode" => {
+            let current =
+                std::env::var("MO_SANDBOX_MODE").unwrap_or_else(|_| "permissive".to_string());
+            if let Some(v) = value {
+                if !["off", "permissive", "strict"].contains(&v) {
+                    return json!({ "error": "sandbox_mode must be: off, permissive, or strict" })
+                        .to_string();
+                }
+                json!({
+                    "note": format!("To change sandbox mode, set MO_SANDBOX_MODE={}", v),
+                    "setting": "sandbox_mode",
+                    "current": current
+                })
+                .to_string()
+            } else {
+                json!({
+                    "setting": "sandbox_mode",
+                    "value": current,
+                    "options": ["off", "permissive", "strict"]
+                })
+                .to_string()
+            }
+        }
+        "auto_approve" => {
+            let current = std::env::var("MO_AUTO_APPROVE").unwrap_or_else(|_| "false".to_string());
+            json!({
+                "setting": "auto_approve",
+                "value": current,
+                "env_var": "MO_AUTO_APPROVE"
+            })
+            .to_string()
+        }
+        "turn_limit" => {
+            let current = std::env::var("MO_MAX_TURNS").unwrap_or_else(|_| "50".to_string());
+            json!({
+                "setting": "turn_limit",
+                "value": current,
+                "env_var": "MO_MAX_TURNS"
+            })
+            .to_string()
+        }
+        "plan_subtask_turn_limit" => {
+            let current =
+                std::env::var("MO_PLAN_SUBTASK_MAX_TURNS").unwrap_or_else(|_| "0".to_string());
+            let effective = astra_core::RuntimeLimits::global().effective_plan_subtask_turns();
+            json!({
+                "setting": "plan_subtask_turn_limit",
+                "value": current,
+                "effective": effective,
+                "env_var": "MO_PLAN_SUBTASK_MAX_TURNS"
+            })
+            .to_string()
+        }
+        _ => json!({
+            "error": format!(
+                "Unknown setting: {}. Use setting='list' to see available settings.",
+                setting
+            )
+        })
+        .to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_settings() {
+        let result = config_tool(100_000, 50_000, &json!({"setting": "list"}));
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert!(!parsed["available_settings"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn get_output_limit() {
+        let result = config_tool(100_000, 50_000, &json!({"setting": "output_limit"}));
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["value"], 100_000);
+    }
+
+    #[test]
+    fn unknown_setting() {
+        let result = config_tool(100_000, 50_000, &json!({"setting": "nonexistent"}));
+        assert!(result.contains("Unknown setting"));
+    }
+
+    #[test]
+    fn missing_setting() {
+        let result = config_tool(100_000, 50_000, &json!({}));
+        assert!(result.contains("Missing required parameter"));
+    }
+}

--- a/rust/crates/astra-tools/src/env_tools.rs
+++ b/rust/crates/astra-tools/src/env_tools.rs
@@ -1,0 +1,355 @@
+//! Thread-safe environment variable overlay and env tool implementation.
+//!
+//! Instead of calling unsafe `std::env::set_var` (which is unsound in
+//! multi-threaded programs under Rust 2024 edition), the env tool writes to
+//! an in-process overlay. Reads merge overlay values with the real environment.
+//! Child processes receive overlay values via `Command::envs()`.
+//!
+//! **Visibility caveat**: overlay values are visible to [`overlay_get`],
+//! [`overlay_all`], and child processes (via [`apply_overlay`]), but
+//! NOT to `std::env::var` calls elsewhere in the current process. Code
+//! outside this module that reads env vars directly will see the real
+//! environment, not the overlay. This is intentional — mutating the real
+//! process env is unsound under Rust 2024 edition.
+
+#![allow(dead_code)]
+use std::collections::HashMap;
+use std::process::Command;
+use std::sync::RwLock;
+
+use serde_json::{Value, json};
+
+// ─── Overlay storage ─────────────────────────────────────────────────────────
+
+static ENV_OVERLAY: RwLock<Option<HashMap<String, Option<String>>>> = RwLock::new(None);
+
+/// Acquire the overlay read lock, logging a warning on poison recovery.
+fn overlay_read() -> std::sync::RwLockReadGuard<'static, Option<HashMap<String, Option<String>>>> {
+    ENV_OVERLAY.read().unwrap_or_else(|p| {
+        astra_core::agent_warn!("edge_tools", "ENV_OVERLAY read lock poisoned, recovering");
+        p.into_inner()
+    })
+}
+
+/// Acquire the overlay write lock, logging a warning on poison recovery.
+fn overlay_write() -> std::sync::RwLockWriteGuard<'static, Option<HashMap<String, Option<String>>>>
+{
+    ENV_OVERLAY.write().unwrap_or_else(|p| {
+        astra_core::agent_warn!("edge_tools", "ENV_OVERLAY write lock poisoned, recovering");
+        p.into_inner()
+    })
+}
+
+// ─── Public overlay API ──────────────────────────────────────────────────────
+
+/// Read an env var, checking the overlay first then falling back to real env.
+pub(crate) fn overlay_get(name: &str) -> Option<String> {
+    let guard = overlay_read();
+    if let Some(ref map) = *guard
+        && let Some(entry) = map.get(name)
+    {
+        return entry.clone(); // Some(val) = set, None = removed
+    }
+    std::env::var(name).ok()
+}
+
+/// Set an env var in the overlay (does NOT touch the real process env).
+pub(crate) fn overlay_set(name: &str, value: &str) {
+    overlay_write()
+        .get_or_insert_with(HashMap::new)
+        .insert(name.to_string(), Some(value.to_string()));
+}
+
+/// Remove an env var in the overlay (marks it as deleted without touching real env).
+pub(crate) fn overlay_remove(name: &str) {
+    overlay_write()
+        .get_or_insert_with(HashMap::new)
+        .insert(name.to_string(), None);
+}
+
+/// Collect all env vars: real env merged with overlay (overlay wins).
+///
+/// Acquires the read lock first, then snapshots both sources under the lock
+/// to avoid TOCTOU inconsistency between `std::env::vars()` and the overlay.
+pub(crate) fn overlay_all() -> Vec<(String, String)> {
+    let guard = overlay_read();
+    let mut result: HashMap<String, String> = std::env::vars().collect();
+    if let Some(ref map) = *guard {
+        for (k, v) in map {
+            match v {
+                Some(val) => {
+                    result.insert(k.clone(), val.clone());
+                }
+                None => {
+                    result.remove(k);
+                }
+            }
+        }
+    }
+    let mut pairs: Vec<_> = result.into_iter().collect();
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    pairs
+}
+
+/// Apply overlay env vars to a `Command` so child processes inherit them.
+pub fn apply_overlay(cmd: &mut Command) {
+    let guard = overlay_read();
+    if let Some(ref map) = *guard {
+        for (k, v) in map {
+            match v {
+                Some(val) => {
+                    cmd.env(k, val);
+                }
+                None => {
+                    cmd.env_remove(k);
+                }
+            }
+        }
+    }
+}
+
+// ─── Env tool functions ──────────────────────────────────────────────────────
+
+/// Dispatch an env tool call to the appropriate sub-command.
+pub(crate) fn env_tool(args: &Value) -> String {
+    let operation = args
+        .get("operation")
+        .and_then(|v| v.as_str())
+        .unwrap_or("list");
+
+    match operation {
+        "list" => env_list(args),
+        "get" => env_get(args),
+        "set" => env_set(args),
+        "unset" => env_unset(args),
+        "search" => env_search(args),
+        _ => json!({
+            "error": format!("Unknown env operation: {}. Use: list, get, set, unset, search", operation)
+        })
+        .to_string(),
+    }
+}
+
+/// List all environment variables (values masked by default for security).
+fn env_list(args: &Value) -> String {
+    let show_values = args
+        .get("show_values")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let vars = overlay_all();
+
+    let entries: Vec<Value> = vars
+        .into_iter()
+        .map(|(name, value)| {
+            let display_value = if is_sensitive_var(&name) {
+                format!("***MASKED*** ({} chars)", value.len())
+            } else if show_values {
+                value
+            } else {
+                format!("({} chars)", value.len())
+            };
+            json!({
+                "name": name,
+                "value": display_value
+            })
+        })
+        .collect();
+
+    json!({
+        "count": entries.len(),
+        "variables": entries
+    })
+    .to_string()
+}
+
+/// Get a specific environment variable.
+fn env_get(args: &Value) -> String {
+    let name = match args.get("name").and_then(|v| v.as_str()) {
+        Some(n) => n,
+        None => return json!({ "error": "Missing required parameter: name" }).to_string(),
+    };
+
+    match overlay_get(name) {
+        Some(value) => {
+            let display_value = if is_sensitive_var(name) {
+                format!("***MASKED*** ({} chars)", value.len())
+            } else {
+                value
+            };
+            json!({
+                "name": name,
+                "value": display_value,
+                "exists": true
+            })
+            .to_string()
+        }
+        None => json!({
+            "name": name,
+            "exists": false
+        })
+        .to_string(),
+    }
+}
+
+/// Set an environment variable (for this session only).
+fn env_set(args: &Value) -> String {
+    let name = match args.get("name").and_then(|v| v.as_str()) {
+        Some(n) => n,
+        None => return json!({ "error": "Missing required parameter: name" }).to_string(),
+    };
+    let value = match args.get("value").and_then(|v| v.as_str()) {
+        Some(v) => v,
+        None => return json!({ "error": "Missing required parameter: value" }).to_string(),
+    };
+
+    // Validate variable name (alphanumeric + underscore, not starting with digit)
+    if name.is_empty()
+        || name
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+    {
+        return json!({ "error": "Invalid variable name: cannot be empty or start with a digit" })
+            .to_string();
+    }
+    if !name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        return json!({ "error": "Invalid variable name: must contain only alphanumeric characters and underscores" }).to_string();
+    }
+
+    // Store in thread-safe overlay (no unsafe set_var needed).
+    // Child processes receive overlay values via apply_overlay().
+    overlay_set(name, value);
+
+    let display_value = if is_sensitive_var(name) {
+        format!("***MASKED*** ({} chars)", value.len())
+    } else {
+        value.to_string()
+    };
+
+    json!({
+        "success": true,
+        "name": name,
+        "value": display_value,
+        "note": "Variable set for this session only"
+    })
+    .to_string()
+}
+
+/// Unset (remove) an environment variable.
+fn env_unset(args: &Value) -> String {
+    let name = match args.get("name").and_then(|v| v.as_str()) {
+        Some(n) => n,
+        None => return json!({ "error": "Missing required parameter: name" }).to_string(),
+    };
+
+    let existed = overlay_get(name).is_some();
+
+    // Mark as removed in thread-safe overlay (no unsafe remove_var needed).
+    overlay_remove(name);
+
+    json!({
+        "success": true,
+        "name": name,
+        "existed": existed,
+        "note": "Variable unset for this session only"
+    })
+    .to_string()
+}
+
+/// Search environment variables by regex pattern.
+fn env_search(args: &Value) -> String {
+    let pattern = match args.get("pattern").and_then(|v| v.as_str()) {
+        Some(p) => p,
+        None => return json!({ "error": "Missing required parameter: pattern" }).to_string(),
+    };
+    let show_values = args
+        .get("show_values")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    // ReDoS protection: limit pattern length
+    if pattern.len() > 500 {
+        return json!({ "error": "Pattern too long (max 500 characters)" }).to_string();
+    }
+
+    let regex = match regex::Regex::new(&format!("(?i){}", pattern)) {
+        Ok(r) => r,
+        Err(e) => return json!({ "error": format!("Invalid regex pattern: {}", e) }).to_string(),
+    };
+
+    let vars = overlay_all();
+    let mut matches: Vec<Value> = Vec::new();
+
+    for (name, value) in vars {
+        if regex.is_match(&name) || regex.is_match(&value) {
+            let display_value = if is_sensitive_var(&name) {
+                format!("***MASKED*** ({} chars)", value.len())
+            } else if show_values {
+                value
+            } else {
+                format!("({} chars)", value.len())
+            };
+            matches.push(json!({
+                "name": name,
+                "value": display_value
+            }));
+        }
+    }
+
+    matches.sort_by(|a, b| {
+        let a_name = a.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let b_name = b.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        a_name.cmp(b_name)
+    });
+
+    json!({
+        "pattern": pattern,
+        "count": matches.len(),
+        "matches": matches
+    })
+    .to_string()
+}
+
+/// Check if a variable name suggests it contains sensitive data.
+pub(crate) fn is_sensitive_var(name: &str) -> bool {
+    let upper = name.to_uppercase();
+    // Core patterns
+    upper.contains("KEY")
+        || upper.contains("TOKEN")
+        || upper.contains("SECRET")
+        || upper.contains("PASSWORD")
+        || upper.contains("PASSWD")
+        || upper.contains("CREDENTIAL")
+        || upper.contains("PRIVATE")
+        || upper.starts_with("API_")
+        || upper.ends_with("_API")
+        || upper.contains("AUTH")
+        || upper.contains("BEARER")
+        || upper.contains("JWT")
+        // Cloud providers
+        || upper.starts_with("AWS_")
+        || upper.starts_with("AZURE_")
+        || upper.starts_with("GCP_")
+        || upper.starts_with("GOOGLE_")
+        // AI providers
+        || upper.contains("OPENAI")
+        || upper.contains("ANTHROPIC")
+        || upper.contains("CLAUDE")
+        || upper.contains("GEMINI")
+        // Code hosting
+        || upper.starts_with("GITHUB_")
+        || upper.starts_with("GITLAB_")
+        || upper.starts_with("GH_")
+        // Databases
+        || upper.contains("DATABASE_URL")
+        || upper.contains("DB_PASS")
+        || upper.starts_with("REDIS_")
+        || upper.starts_with("MONGO")
+        // Other services
+        || upper.starts_with("SLACK_")
+        || upper.starts_with("STRIPE_")
+        || upper.starts_with("SENDGRID")
+        || upper.starts_with("TWILIO")
+}

--- a/rust/crates/astra-tools/src/fuzzy_replacer.rs
+++ b/rust/crates/astra-tools/src/fuzzy_replacer.rs
@@ -1,0 +1,990 @@
+//! Fuzzy replacer strategies for str_replace.
+//!
+//! When LLMs produce `old_str` that doesn't exactly match the file content
+//! (wrong indentation, extra whitespace, escape chars, etc.), these replacers
+//! try progressively looser matching to auto-fix the replacement.
+//!
+//! Cascade order:
+//!   0. LineNumberStrippedReplacer — strip read_file-style line-number prefixes
+//!   0.5 QuoteNormalizedReplacer — normalize curly quotes to ASCII
+//!   1. LineTrimmedReplacer — trim each line before comparing
+//!   2. BlockAnchorReplacer — anchor first+last line, Levenshtein middle
+//!   3. WhitespaceNormalizedReplacer — collapse all whitespace
+//!   4. IndentationFlexibleReplacer — remove common indent, compare dedented
+//!   5. EscapeNormalizedReplacer — handle \n \t \' \" etc.
+//!   6. SequenceSimilarityReplacer — sliding-window similarity fallback
+//!
+//! Each replacer returns the *actual* substring from the file content that
+//! should be replaced, so the caller can do `content.replacen(actual, new_str, 1)`.
+//!
+//! Inspired by opencode (anomalyco/opencode) and Cline's replacer strategies.
+
+#![allow(dead_code)]
+/// Result of a fuzzy match: the actual content substring and which strategy matched.
+pub(crate) struct FuzzyMatch<'a> {
+    /// The actual substring from the file content to replace.
+    pub actual: &'a str,
+    /// Human-readable name of the strategy that matched.
+    pub strategy: &'static str,
+}
+
+/// Try all fuzzy replacer strategies in cascade order.
+/// Returns the first unique match, or None if no strategy finds exactly one match.
+pub(crate) fn fuzzy_find_replacement<'a>(
+    content: &'a str,
+    old_str: &str,
+    replace_all: bool,
+) -> Option<FuzzyMatch<'a>> {
+    // Cascade through strategies in priority order.
+    // Each returns Vec of actual content substrings that match.
+    type Strategy = (&'static str, fn(&str, &str) -> Vec<String>);
+    let strategies: &[Strategy] = &[
+        ("line-number-stripped", |c, s| {
+            line_number_stripped_find(c, s)
+        }),
+        ("quote-normalized", |c, s| quote_normalized_find(c, s)),
+        ("line-trimmed", |c, s| line_trimmed_find(c, s)),
+        ("block-anchor", |c, s| block_anchor_find(c, s)),
+        ("whitespace-normalized", |c, s| {
+            whitespace_normalized_find(c, s)
+        }),
+        ("indentation-flexible", |c, s| {
+            indentation_flexible_find(c, s)
+        }),
+        ("escape-normalized", |c, s| escape_normalized_find(c, s)),
+        ("sequence-similarity", |c, s| sequence_similarity_find(c, s)),
+    ];
+
+    for (name, strategy_fn) in strategies {
+        let matches = strategy_fn(content, old_str);
+        if replace_all && !matches.is_empty() {
+            // For replace_all, verify the match exists in content
+            if content.contains(&matches[0]) {
+                // Find the actual slice in content
+                if let Some(pos) = content.find(&matches[0]) {
+                    return Some(FuzzyMatch {
+                        actual: &content[pos..pos + matches[0].len()],
+                        strategy: name,
+                    });
+                }
+            }
+        }
+        if matches.len() == 1 {
+            // Verify uniqueness: the matched string should appear exactly once
+            if let Some(pos) = content.find(&matches[0]) {
+                let remaining = &content[pos + matches[0].len()..];
+                let is_unique = !remaining.contains(&matches[0]);
+                if is_unique || replace_all {
+                    return Some(FuzzyMatch {
+                        actual: &content[pos..pos + matches[0].len()],
+                        strategy: name,
+                    });
+                }
+            }
+        }
+        // 0 matches → try next; >1 matches → ambiguous, try next
+    }
+    None
+}
+
+// ─── Strategy 0: LineNumberStrippedReplacer ──────────────────────────────────
+
+/// Match after stripping line-number prefixes from old_str lines.
+/// Handles: LLM copying `read_file` output that includes `123. ` or `42: ` prefixes.
+/// Only activates if ≥50% of non-empty old_str lines have a line-number prefix.
+fn line_number_stripped_find(content: &str, old_str: &str) -> Vec<String> {
+    let search_lines: Vec<&str> = old_str.lines().collect();
+    if search_lines.is_empty() {
+        return vec![];
+    }
+
+    // Count how many non-empty lines have a line-number prefix
+    let non_empty: Vec<&&str> = search_lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+    if non_empty.is_empty() {
+        return vec![];
+    }
+
+    let prefixed_count = non_empty
+        .iter()
+        .filter(|l| has_line_number_prefix(l))
+        .count();
+
+    // Only activate if ≥50% of non-empty lines have prefixes
+    if prefixed_count * 2 < non_empty.len() {
+        return vec![];
+    }
+
+    // Strip prefixes and reconstruct
+    let stripped: String = search_lines
+        .iter()
+        .map(|l| strip_line_number_prefix(l))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Try exact match with stripped version
+    let mut results = Vec::new();
+    let mut search_start = 0;
+    while let Some(pos) = content[search_start..].find(&stripped) {
+        let abs_pos = search_start + pos;
+        results.push(content[abs_pos..abs_pos + stripped.len()].to_string());
+        search_start = abs_pos + 1;
+        if results.len() > 2 {
+            break;
+        }
+    }
+    results
+}
+
+/// Check if a line starts with a line-number prefix pattern.
+/// Matches: `123. `, `42: `, `100| `, `  7. `, `15.` (with optional trailing space)
+fn has_line_number_prefix(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let mut chars = trimmed.chars().peekable();
+
+    // Must start with a digit
+    if !chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+        return false;
+    }
+
+    // Consume digits
+    while chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+        chars.next();
+    }
+
+    // Must be followed by one of: . : |
+    matches!(chars.peek(), Some('.' | ':' | '|'))
+}
+
+/// Strip the line-number prefix from a line, preserving remaining content.
+fn strip_line_number_prefix(line: &str) -> &str {
+    let leading_ws = line.len() - line.trim_start().len();
+    let trimmed = &line[leading_ws..];
+
+    let mut idx = 0;
+    let bytes = trimmed.as_bytes();
+
+    // Skip digits
+    while idx < bytes.len() && bytes[idx].is_ascii_digit() {
+        idx += 1;
+    }
+
+    // Skip delimiter (. : |)
+    if idx < bytes.len() && matches!(bytes[idx], b'.' | b':' | b'|') {
+        idx += 1;
+    } else {
+        // No delimiter found — return original
+        return line;
+    }
+
+    // Skip optional single space after delimiter
+    if idx < bytes.len() && bytes[idx] == b' ' {
+        idx += 1;
+    }
+
+    &trimmed[idx..]
+}
+
+// ─── Strategy 0.5: QuoteNormalizedReplacer ──────────────────────────────────
+
+/// Match after normalizing curly/smart quotes to ASCII quotes.
+/// Handles: LLMs and copy-paste from docs/web often producing U+2018/2019/201C/201D.
+fn quote_normalized_find(content: &str, old_str: &str) -> Vec<String> {
+    if quote_normalized_match_count(content, old_str) != 1 {
+        return vec![];
+    }
+
+    quote_normalized_actual(content, old_str)
+        .map(|actual| vec![actual.to_string()])
+        .unwrap_or_default()
+}
+
+// ─── Strategy 1: LineTrimmedReplacer ────────────────────────────────────────
+
+/// Match by trimming each line before comparing.
+/// Handles: LLM adding/removing leading/trailing whitespace per line.
+fn line_trimmed_find(content: &str, old_str: &str) -> Vec<String> {
+    let content_lines: Vec<&str> = content.lines().collect();
+    let mut search_lines: Vec<&str> = old_str.lines().collect();
+
+    // Need at least 2 lines for line-trimmed matching to be meaningful
+    if search_lines.len() < 2 {
+        return vec![];
+    }
+
+    // Remove trailing empty line (common in LLM output)
+    if search_lines.last().is_some_and(|l| l.trim().is_empty()) {
+        search_lines.pop();
+    }
+    if search_lines.is_empty() {
+        return vec![];
+    }
+
+    let mut results = Vec::new();
+
+    if content_lines.len() < search_lines.len() {
+        return results;
+    }
+
+    for i in 0..=content_lines.len() - search_lines.len() {
+        let mut all_match = true;
+        for (j, search_line) in search_lines.iter().enumerate() {
+            if content_lines[i + j].trim() != search_line.trim() {
+                all_match = false;
+                break;
+            }
+        }
+        if all_match {
+            let block: String = content_lines[i..i + search_lines.len()].join("\n");
+            results.push(block);
+        }
+    }
+    results
+}
+
+// ─── Strategy 2: BlockAnchorReplacer ────────────────────────────────────────
+
+/// Match by anchoring first and last lines, then scoring middle via Levenshtein.
+/// Handles: LLM modifying middle lines slightly while keeping boundaries correct.
+fn block_anchor_find(content: &str, old_str: &str) -> Vec<String> {
+    let content_lines: Vec<&str> = content.lines().collect();
+    let mut search_lines: Vec<&str> = old_str.lines().collect();
+
+    // Need at least 3 lines (first + middle + last)
+    if search_lines.len() < 3 {
+        return vec![];
+    }
+
+    // Remove trailing empty line
+    if search_lines.last().is_some_and(|l| l.trim().is_empty()) {
+        search_lines.pop();
+    }
+    if search_lines.len() < 3 {
+        return vec![];
+    }
+
+    let first_search = search_lines[0].trim();
+    let last_search = search_lines
+        .last()
+        .expect("search_lines has >= 3 elements")
+        .trim();
+
+    if first_search.is_empty() || last_search.is_empty() {
+        return vec![];
+    }
+
+    // Find candidate blocks: first line matches at position i, last line matches at j
+    struct Candidate {
+        start: usize,
+        end: usize, // inclusive
+        similarity: f64,
+    }
+
+    let mut candidates: Vec<Candidate> = Vec::new();
+
+    for i in 0..content_lines.len() {
+        if content_lines[i].trim() != first_search {
+            continue;
+        }
+        // Look for matching last line
+        for j in (i + 2)..content_lines.len() {
+            if content_lines[j].trim() == last_search {
+                // Score middle lines
+                let actual_block_size = j - i + 1;
+                let lines_to_check =
+                    (search_lines.len() - 2).min(actual_block_size.saturating_sub(2));
+
+                let similarity = if lines_to_check > 0 {
+                    let mut total = 0.0;
+                    for k in 1..=lines_to_check.min(search_lines.len() - 1) {
+                        if i + k >= content_lines.len() {
+                            break;
+                        }
+                        let orig = content_lines[i + k].trim();
+                        let search = search_lines[k].trim();
+                        let max_len = orig.len().max(search.len());
+                        if max_len == 0 {
+                            continue;
+                        }
+                        let dist = levenshtein(orig, search);
+                        total += 1.0 - (dist as f64 / max_len as f64);
+                    }
+                    total / lines_to_check as f64
+                } else {
+                    1.0 // No middle lines → anchors are enough
+                };
+
+                candidates.push(Candidate {
+                    start: i,
+                    end: j,
+                    similarity,
+                });
+                break; // First matching last-line per start position
+            }
+        }
+    }
+
+    if candidates.is_empty() {
+        return vec![];
+    }
+
+    // Thresholds: relaxed for single candidate, stricter for multiple
+    let threshold = if candidates.len() == 1 { 0.0 } else { 0.3 };
+
+    let best = candidates
+        .iter()
+        .filter(|c| c.similarity >= threshold)
+        .max_by(|a, b| {
+            a.similarity
+                .partial_cmp(&b.similarity)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+    match best {
+        Some(c) => {
+            let block: String = content_lines[c.start..=c.end].join("\n");
+            vec![block]
+        }
+        None => vec![],
+    }
+}
+
+// ─── Strategy 3: WhitespaceNormalizedReplacer ───────────────────────────────
+
+/// Match after collapsing all whitespace to single spaces.
+/// Handles: tabs vs spaces, multiple spaces, trailing whitespace.
+fn whitespace_normalized_find(content: &str, old_str: &str) -> Vec<String> {
+    let content_lines: Vec<&str> = content.lines().collect();
+    let search_lines: Vec<&str> = old_str.lines().collect();
+
+    // Single-line: find lines whose normalized form matches
+    if search_lines.len() <= 1 {
+        let norm_search = normalize_ws(old_str);
+        if norm_search.is_empty() {
+            return vec![];
+        }
+        let mut results = Vec::new();
+        for line in content_lines.iter() {
+            if normalize_ws(line) == norm_search {
+                results.push(line.to_string());
+            }
+        }
+        return results;
+    }
+
+    // Multi-line: sliding window with normalized comparison
+    let mut results = Vec::new();
+    let norm_search = normalize_ws(old_str);
+
+    if content_lines.len() < search_lines.len() {
+        return results;
+    }
+
+    for i in 0..=content_lines.len() - search_lines.len() {
+        let block: String = content_lines[i..i + search_lines.len()].join("\n");
+        if normalize_ws(&block) == norm_search {
+            results.push(block);
+        }
+    }
+    results
+}
+
+// ─── Strategy 4: IndentationFlexibleReplacer ────────────────────────────────
+
+/// Match after removing common indentation from both content block and search.
+/// Handles: LLM producing code at wrong indentation level.
+fn indentation_flexible_find(content: &str, old_str: &str) -> Vec<String> {
+    let content_lines: Vec<&str> = content.lines().collect();
+    let search_lines: Vec<&str> = old_str.lines().collect();
+
+    if search_lines.len() < 2 {
+        return vec![];
+    }
+
+    let dedented_search = remove_common_indent(old_str);
+    let mut results = Vec::new();
+
+    if content_lines.len() < search_lines.len() {
+        return results;
+    }
+
+    for i in 0..=content_lines.len() - search_lines.len() {
+        let block: String = content_lines[i..i + search_lines.len()].join("\n");
+        if remove_common_indent(&block) == dedented_search {
+            results.push(block);
+        }
+    }
+    results
+}
+
+// ─── Strategy 5: EscapeNormalizedReplacer ───────────────────────────────────
+
+/// Match after unescaping common escape sequences in the search string.
+/// Handles: LLM using literal \n instead of newline, \t instead of tab, etc.
+fn escape_normalized_find(content: &str, old_str: &str) -> Vec<String> {
+    let unescaped = unescape_str(old_str);
+    if unescaped == old_str {
+        return vec![]; // No escape sequences found, skip
+    }
+
+    // Direct substring match
+    let mut results = Vec::new();
+    let mut search_start = 0;
+    while let Some(pos) = content[search_start..].find(&unescaped) {
+        let abs_pos = search_start + pos;
+        results.push(content[abs_pos..abs_pos + unescaped.len()].to_string());
+        search_start = abs_pos + 1;
+        if results.len() > 2 {
+            break; // Too many matches, won't be unique
+        }
+    }
+    results
+}
+
+// ─── Strategy 6: SequenceSimilarityReplacer ──────────────────────────────────
+
+/// Match by scoring line-by-line similarity across a sliding window.
+/// Handles: LLM hallucinating small changes across multiple lines (variable names,
+/// values, comments) where no single structural anchor matches exactly.
+/// This is the broadest and most expensive strategy — runs last in the cascade.
+fn sequence_similarity_find(content: &str, old_str: &str) -> Vec<String> {
+    const SIMILARITY_THRESHOLD: f64 = 0.85;
+
+    let content_lines: Vec<&str> = content.lines().collect();
+    let mut search_lines: Vec<&str> = old_str.lines().collect();
+
+    // Need at least 2 lines for meaningful similarity
+    if search_lines.len() < 2 {
+        return vec![];
+    }
+
+    // Remove trailing empty line (common in LLM output)
+    if search_lines.last().is_some_and(|l| l.trim().is_empty()) {
+        search_lines.pop();
+    }
+    if search_lines.len() < 2 || content_lines.len() < search_lines.len() {
+        return vec![];
+    }
+
+    struct ScoredBlock {
+        start: usize,
+        similarity: f64,
+    }
+
+    let mut candidates: Vec<ScoredBlock> = Vec::new();
+
+    for i in 0..=content_lines.len() - search_lines.len() {
+        let mut total_sim = 0.0;
+        let mut scored_lines = 0;
+
+        for (j, search_line) in search_lines.iter().enumerate() {
+            let content_line = content_lines[i + j];
+            let a = content_line.trim();
+            let b = search_line.trim();
+
+            // Empty line matches empty line perfectly
+            if a.is_empty() && b.is_empty() {
+                total_sim += 1.0;
+                scored_lines += 1;
+                continue;
+            }
+
+            let max_len = a.len().max(b.len());
+            if max_len == 0 {
+                total_sim += 1.0;
+                scored_lines += 1;
+                continue;
+            }
+
+            let dist = levenshtein(a, b);
+            let sim = 1.0 - (dist as f64 / max_len as f64);
+            total_sim += sim;
+            scored_lines += 1;
+        }
+
+        if scored_lines == 0 {
+            continue;
+        }
+
+        let avg_sim = total_sim / scored_lines as f64;
+        if avg_sim >= SIMILARITY_THRESHOLD {
+            candidates.push(ScoredBlock {
+                start: i,
+                similarity: avg_sim,
+            });
+        }
+    }
+
+    if candidates.is_empty() {
+        return vec![];
+    }
+
+    // Return best match only if it's clearly the winner
+    candidates.sort_by(|a, b| {
+        b.similarity
+            .partial_cmp(&a.similarity)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // If multiple candidates are very close in score (within 0.02), it's ambiguous
+    if candidates.len() > 1 && (candidates[0].similarity - candidates[1].similarity) < 0.02 {
+        return vec![];
+    }
+
+    let best = &candidates[0];
+    let block: String = content_lines[best.start..best.start + search_lines.len()].join("\n");
+    vec![block]
+}
+
+// ─── Helper functions ───────────────────────────────────────────────────────
+
+fn normalize_quotes(s: &str) -> String {
+    s.replace(['\u{2018}', '\u{2019}'], "'")
+        .replace(['\u{201C}', '\u{201D}'], "\"")
+}
+
+fn quote_normalized_actual<'a>(content: &'a str, search: &str) -> Option<&'a str> {
+    let norm_search = normalize_quotes(search);
+    let norm_content = normalize_quotes(content);
+    let pos = norm_content.find(&norm_search)?;
+
+    let mut content_indices: Vec<usize> = content.char_indices().map(|(i, _)| i).collect();
+    content_indices.push(content.len());
+    let mut norm_indices: Vec<usize> = norm_content.char_indices().map(|(i, _)| i).collect();
+    norm_indices.push(norm_content.len());
+    let start_char = norm_indices
+        .partition_point(|&i| i <= pos)
+        .saturating_sub(1);
+    let end_pos = pos + norm_search.len();
+    let end_char = norm_indices.partition_point(|&i| i < end_pos);
+    let content_start = *content_indices.get(start_char)?;
+    let content_end = *content_indices.get(end_char)?;
+    Some(&content[content_start..content_end])
+}
+
+pub(crate) fn quote_normalized_match_count(content: &str, search: &str) -> usize {
+    let norm_search = normalize_quotes(search);
+    let norm_content = normalize_quotes(content);
+    norm_content.matches(&norm_search).count()
+}
+
+/// Collapse all whitespace to single spaces and trim.
+fn normalize_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Remove common leading indentation from all non-empty lines.
+fn remove_common_indent(text: &str) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    let min_indent = lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    if min_indent == 0 {
+        return text.to_string();
+    }
+
+    lines
+        .iter()
+        .map(|l| {
+            if l.trim().is_empty() {
+                *l
+            } else {
+                &l[min_indent..]
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Unescape common escape sequences: \n → newline, \t → tab, etc.
+fn unescape_str(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            match chars.peek() {
+                Some('n') => {
+                    chars.next();
+                    result.push('\n');
+                }
+                Some('t') => {
+                    chars.next();
+                    result.push('\t');
+                }
+                Some('r') => {
+                    chars.next();
+                    result.push('\r');
+                }
+                Some('\'') => {
+                    chars.next();
+                    result.push('\'');
+                }
+                Some('"') => {
+                    chars.next();
+                    result.push('"');
+                }
+                Some('\\') => {
+                    chars.next();
+                    result.push('\\');
+                }
+                _ => result.push(ch),
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+/// Levenshtein edit distance between two strings.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a_len = a.len();
+    let b_len = b.len();
+
+    if a_len == 0 {
+        return b_len;
+    }
+    if b_len == 0 {
+        return a_len;
+    }
+
+    // Use single-row optimization: O(min(a,b)) space
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+    let mut prev: Vec<usize> = (0..=b_len).collect();
+    let mut curr = vec![0usize; b_len + 1];
+
+    for i in 1..=a_len {
+        curr[0] = i;
+        for j in 1..=b_len {
+            let cost = if a_bytes[i - 1] == b_bytes[j - 1] {
+                0
+            } else {
+                1
+            };
+            curr[j] = (prev[j] + 1) // deletion
+                .min(curr[j - 1] + 1) // insertion
+                .min(prev[j - 1] + cost); // substitution
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b_len]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── Levenshtein ────────────────────────────────────────────────────────
+
+    #[test]
+    fn levenshtein_identical() {
+        assert_eq!(levenshtein("hello", "hello"), 0);
+    }
+
+    #[test]
+    fn levenshtein_basic() {
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+    }
+
+    #[test]
+    fn levenshtein_empty() {
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("abc", ""), 3);
+    }
+
+    // ─── LineNumberStrippedReplacer ────────────────────────────────────────
+
+    #[test]
+    fn has_line_number_prefix_recognizes_supported_prefixes() {
+        assert!(has_line_number_prefix("1. hello"));
+        assert!(has_line_number_prefix("42: world"));
+        assert!(has_line_number_prefix("  7| test"));
+        assert!(has_line_number_prefix("15."));
+    }
+
+    #[test]
+    fn has_line_number_prefix_rejects_non_prefixes() {
+        assert!(!has_line_number_prefix("hello"));
+        assert!(!has_line_number_prefix("v1.2.3"));
+        assert!(!has_line_number_prefix("  abc: test"));
+    }
+
+    #[test]
+    fn strip_line_number_prefix_removes_prefix() {
+        assert_eq!(strip_line_number_prefix("12. hello"), "hello");
+        assert_eq!(strip_line_number_prefix("  42: world"), "world");
+        assert_eq!(strip_line_number_prefix("7| value"), "value");
+        assert_eq!(strip_line_number_prefix("no prefix"), "no prefix");
+    }
+
+    #[test]
+    fn line_number_stripped_finds_exact_match() {
+        let content = "fn demo() {\n    println!(\"hi\");\n}";
+        let search = "1. fn demo() {\n2.     println!(\"hi\");\n3. }";
+        let matches = line_number_stripped_find(content, search);
+        assert_eq!(matches, vec![content.to_string()]);
+    }
+
+    #[test]
+    fn line_number_stripped_requires_majority_prefixed_lines() {
+        let content = "fn demo() {\n    println!(\"hi\");\n}";
+        let search = "1. fn demo() {\n    println!(\"hi\");\n}";
+        let matches = line_number_stripped_find(content, search);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn line_number_stripped_handles_colon_and_pipe_prefixes() {
+        let content = "alpha\nbeta\ngamma";
+        let search = "10: alpha\n11| beta\n12: gamma";
+        let matches = line_number_stripped_find(content, search);
+        assert_eq!(matches, vec![content.to_string()]);
+    }
+
+    #[test]
+    fn normalize_quotes_curly_to_straight() {
+        assert_eq!(
+            normalize_quotes("say \u{201C}hello\u{201D}"),
+            "say \"hello\""
+        );
+        assert_eq!(normalize_quotes("it\u{2019}s"), "it's");
+    }
+
+    #[test]
+    fn quote_normalized_actual_returns_original_slice() {
+        let content = "let x = \u{201C}hello\u{201D};";
+        let search = "\"hello\"";
+        let found = quote_normalized_actual(content, search);
+        assert_eq!(found, Some("\u{201C}hello\u{201D}"));
+    }
+
+    #[test]
+    fn quote_normalized_match_count_handles_curly_quotes() {
+        let content = "let x = \"hello\";\nlet y = \"hello\";";
+        let search = "let x = \u{201C}hello\u{201D};";
+        assert_eq!(quote_normalized_match_count(content, search), 1);
+    }
+
+    // ─── LineTrimmedReplacer ────────────────────────────────────────────────
+
+    #[test]
+    fn line_trimmed_ignores_leading_whitespace() {
+        let content = "    fn foo() {\n        bar();\n    }";
+        let search = "fn foo() {\n    bar();\n}";
+        let matches = line_trimmed_find(content, search);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0], content);
+    }
+
+    #[test]
+    fn line_trimmed_no_match() {
+        let content = "fn foo() {\n    bar();\n}";
+        let search = "fn baz() {\n    bar();\n}";
+        let matches = line_trimmed_find(content, search);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn line_trimmed_trailing_empty_line() {
+        let content = "  a\n  b";
+        let search = "a\nb\n";
+        let matches = line_trimmed_find(content, search);
+        assert_eq!(matches.len(), 1);
+    }
+
+    // ─── BlockAnchorReplacer ────────────────────────────────────────────────
+
+    #[test]
+    fn block_anchor_matching_anchors_fuzzy_middle() {
+        let content = "fn foo() {\n    let x = 1;\n    let y = 2;\n}";
+        // LLM changed middle line slightly
+        let search = "fn foo() {\n    let x = 10;\n    let y = 20;\n}";
+        let matches = block_anchor_find(content, search);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0], content);
+    }
+
+    #[test]
+    fn block_anchor_no_last_line_match() {
+        let content = "fn foo() {\n    bar();\n}";
+        let search = "fn foo() {\n    bar();\nend";
+        let matches = block_anchor_find(content, search);
+        assert!(matches.is_empty());
+    }
+
+    // ─── WhitespaceNormalizedReplacer ───────────────────────────────────────
+
+    #[test]
+    fn whitespace_normalized_single_line() {
+        let content = "    let   x  =   42;";
+        let search = "let x = 42;";
+        let matches = whitespace_normalized_find(content, search);
+        assert_eq!(matches.len(), 1);
+    }
+
+    #[test]
+    fn whitespace_normalized_multiline() {
+        let content = "  fn foo()  {\n    bar() ; \n  }";
+        let search = "fn foo() {\nbar() ;\n}";
+        let matches = whitespace_normalized_find(content, search);
+        assert_eq!(matches.len(), 1);
+    }
+
+    // ─── IndentationFlexibleReplacer ────────────────────────────────────────
+
+    #[test]
+    fn indentation_flexible_different_indent() {
+        let content = "        fn foo() {\n            bar();\n        }";
+        let search = "    fn foo() {\n        bar();\n    }";
+        let matches = indentation_flexible_find(content, search);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0], content);
+    }
+
+    #[test]
+    fn indentation_flexible_no_match() {
+        let content = "    fn foo() {\n        bar();\n    }";
+        let search = "    fn baz() {\n        bar();\n    }";
+        let matches = indentation_flexible_find(content, search);
+        assert!(matches.is_empty());
+    }
+
+    // ─── EscapeNormalizedReplacer ───────────────────────────────────────────
+
+    #[test]
+    fn escape_normalized_newline() {
+        let content = "hello\nworld";
+        let search = "hello\\nworld";
+        let matches = escape_normalized_find(content, search);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0], content);
+    }
+
+    #[test]
+    fn escape_normalized_tab() {
+        let content = "col1\tcol2";
+        let search = "col1\\tcol2";
+        let matches = escape_normalized_find(content, search);
+        assert_eq!(matches.len(), 1);
+    }
+
+    #[test]
+    fn escape_normalized_no_escapes() {
+        let content = "hello world";
+        let search = "hello world";
+        let matches = escape_normalized_find(content, search);
+        assert!(matches.is_empty()); // No escapes → skip strategy
+    }
+
+    // ─── SequenceSimilarityReplacer ────────────────────────────────────────
+
+    #[test]
+    fn sequence_similarity_matches_near_block_without_exact_anchors() {
+        let content = "let count = 1;\nprintln!(\"hello\");";
+        let search = "let count = 2;\nprintln!(\"hullo\");";
+        let matches = sequence_similarity_find(content, search);
+        assert_eq!(matches, vec![content.to_string()]);
+    }
+
+    #[test]
+    fn sequence_similarity_below_threshold_returns_none() {
+        let content = "let count = 1;\nprintln!(\"hello\");";
+        let search = "totally different\ncompletely unrelated";
+        let matches = sequence_similarity_find(content, search);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn sequence_similarity_ambiguous_returns_none() {
+        let content =
+            "let count = 1;\nprintln!(\"hello\");\n\nlet count = 1;\nprintln!(\"hello\");";
+        let search = "let count = 2;\nprintln!(\"hullo\");";
+        let matches = sequence_similarity_find(content, search);
+        assert!(matches.is_empty());
+    }
+
+    // ─── unescape_str ──────────────────────────────────────────────────────
+
+    #[test]
+    fn unescape_basic() {
+        assert_eq!(unescape_str("a\\nb"), "a\nb");
+        assert_eq!(unescape_str("a\\tb"), "a\tb");
+        assert_eq!(unescape_str("a\\\\b"), "a\\b");
+        assert_eq!(unescape_str("a\\'b"), "a'b");
+        assert_eq!(unescape_str("no escapes"), "no escapes");
+    }
+
+    // ─── remove_common_indent ───────────────────────────────────────────────
+
+    #[test]
+    fn remove_indent_basic() {
+        assert_eq!(remove_common_indent("    a\n    b\n    c"), "a\nb\nc");
+    }
+
+    #[test]
+    fn remove_indent_mixed() {
+        assert_eq!(remove_common_indent("    a\n      b\n    c"), "a\n  b\nc");
+    }
+
+    #[test]
+    fn remove_indent_with_empty_lines() {
+        assert_eq!(remove_common_indent("    a\n\n    c"), "a\n\nc");
+    }
+
+    // ─── fuzzy_find_replacement (integration) ───────────────────────────────
+
+    #[test]
+    fn cascade_prefers_earlier_strategy() {
+        // LineTrimmed should match before BlockAnchor
+        let content = "  fn foo() {\n    bar();\n  }";
+        let search = "fn foo() {\n  bar();\n}";
+        let result = fuzzy_find_replacement(content, search, false);
+        assert!(result.is_some());
+        let m = result.unwrap();
+        assert_eq!(m.strategy, "line-trimmed");
+        assert_eq!(m.actual, content);
+    }
+
+    #[test]
+    fn cascade_no_match_returns_none() {
+        let content = "completely different content";
+        let search = "fn foo() {\n    bar();\n}";
+        let result = fuzzy_find_replacement(content, search, false);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn cascade_ambiguous_skips_to_next() {
+        // Two identical blocks → LineTrimmed finds 2 → skips to next strategies
+        let content = "  foo\n  bar\n\n  foo\n  bar";
+        let search = "foo\nbar";
+        let result = fuzzy_find_replacement(content, search, false);
+        // All strategies should find 2 matches → None
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn cascade_uses_line_number_stripped_before_other_strategies() {
+        let content = "fn demo() {\n    println!(\"hi\");\n}";
+        let search = "1. fn demo() {\n2.     println!(\"hi\");\n3. }";
+        let result = fuzzy_find_replacement(content, search, false).unwrap();
+        assert_eq!(result.strategy, "line-number-stripped");
+        assert_eq!(result.actual, content);
+    }
+
+    #[test]
+    fn cascade_uses_sequence_similarity_as_last_resort() {
+        let content = "let count = 1;\nprintln!(\"hello\");";
+        let search = "let count = 2;\nprintln!(\"hullo\");";
+        let result = fuzzy_find_replacement(content, search, false).unwrap();
+        assert_eq!(result.strategy, "sequence-similarity");
+        assert_eq!(result.actual, content);
+    }
+}

--- a/rust/crates/astra-tools/src/git_gix.rs
+++ b/rust/crates/astra-tools/src/git_gix.rs
@@ -1,0 +1,3778 @@
+#![allow(dead_code)]
+#![allow(clippy::collapsible_if)]
+//! Pure-Rust git implementations using the `gix` crate.
+//!
+//! Replaces shell `git` subprocess calls with in-process operations for:
+//! - git_status, git_diff, git_log, git_show, git_blame, git_file_history
+//!
+//! Benefits: no subprocess overhead, no shell injection risk, no `git` binary dependency.
+
+use std::path::Path;
+use std::time::SystemTime;
+
+use gix::bstr::{BString, ByteSlice};
+use serde_json::Value;
+
+const DIFF_LIMIT: usize = 40_000; // ~10K tokens — diff is the primary input for code review
+const SHOW_LIMIT: usize = 16_000;
+
+/// Outcome of a tool execution with optional metadata fields.
+pub struct ToolExecutionOutcome {
+    pub output: String,
+    pub tool_result_fields: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+impl ToolExecutionOutcome {
+    pub fn text(output: String) -> Self {
+        Self {
+            output,
+            tool_result_fields: None,
+        }
+    }
+}
+
+/// Simple word tokenizer for search scoring.
+/// Splits on non-alphanumeric boundaries and lowercases.
+fn estimate_tokens(text: &str) -> Vec<String> {
+    let lower = text.to_lowercase();
+    lower
+        .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|w| w.len() >= 2)
+        .map(|w| w.to_string())
+        .collect()
+}
+
+/// Truncate output to a byte limit, preferring line boundaries.
+fn truncate_output(mut output: String, max_bytes: usize) -> String {
+    if output.len() > max_bytes {
+        let end = output.floor_char_boundary(max_bytes);
+        let cut = output[..end]
+            .rfind('\n')
+            .filter(|&pos| pos > end / 2)
+            .map(|pos| pos + 1)
+            .unwrap_or(end);
+        output.truncate(cut);
+        output.push_str("\n[truncated]");
+    }
+    output
+}
+
+// ~4K tokens; was 30K
+
+/// Reject file paths with `..` components that could escape the repository tree.
+fn reject_path_traversal(file: &str) -> Result<(), String> {
+    if file.contains("..") {
+        Err("Error: path traversal ('..') not allowed in file parameter".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+/// Reject git ref strings containing shell metacharacters.
+fn reject_shell_meta(ref_str: &str) -> Result<(), String> {
+    if ref_str.chars().any(|c| {
+        matches!(
+            c,
+            ';' | '|' | '&' | '$' | '`' | '(' | ')' | '{' | '}' | '<' | '>' | '!' | '\n'
+        )
+    }) {
+        Err(format!(
+            "Error: git ref contains disallowed characters: {ref_str}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn reject_stash_selector(selector: &str) -> Result<(), String> {
+    let trimmed = selector.trim();
+    if trimmed.is_empty() {
+        return Err("Error: stash_ref must not be empty".to_string());
+    }
+    if trimmed.chars().any(|c| {
+        matches!(
+            c,
+            ';' | '|' | '&' | '$' | '`' | '(' | ')' | '<' | '>' | '\n'
+        )
+    }) {
+        Err(format!(
+            "Error: stash selector contains disallowed characters: {selector}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_commit_ref(commit_ref: &str, param_name: &str) -> Result<String, String> {
+    let trimmed = commit_ref.trim();
+    if trimmed.is_empty() {
+        return Err(format!("Error: {param_name} must not be empty"));
+    }
+    if trimmed.starts_with('-') {
+        return Err(format!("Error: {param_name} must not start with '-'"));
+    }
+    reject_shell_meta(trimmed)?;
+    Ok(trimmed.to_string())
+}
+
+fn resolve_commit_ref(project_root: &Path, commit_ref: &str) -> Option<String> {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--verify", commit_ref])
+        .current_dir(project_root)
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn short_commit_sha(commit_sha: &str) -> String {
+    commit_sha[..7.min(commit_sha.len())].to_string()
+}
+
+fn head_first_parent_tail(project_root: &Path, count: usize) -> Option<Vec<String>> {
+    if count == 0 {
+        return Some(Vec::new());
+    }
+    std::process::Command::new("git")
+        .args([
+            "rev-list",
+            "--first-parent",
+            "--max-count",
+            &count.to_string(),
+            "HEAD",
+        ])
+        .current_dir(project_root)
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| {
+            String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(ToString::to_string)
+                .collect()
+        })
+}
+
+fn git_worktree_is_clean(project_root: &Path) -> Result<bool, String> {
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(project_root)
+        .output()
+        .map_err(|error| format!("Error: git status failed: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Error: git status failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
+fn abort_git_revert(project_root: &Path) -> Result<bool, String> {
+    let output = std::process::Command::new("git")
+        .args(["revert", "--abort"])
+        .current_dir(project_root)
+        .output()
+        .map_err(|error| format!("Error: git revert --abort failed: {error}"))?;
+    if output.status.success() {
+        Ok(true)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("no cherry-pick or revert in progress") {
+            Ok(false)
+        } else {
+            Err(format!(
+                "Error: git revert --abort failed: {}",
+                stderr.trim()
+            ))
+        }
+    }
+}
+
+fn apply_stash_selector(args: &Value) -> Result<String, String> {
+    if let Some(selector) = args.get("stash_ref").and_then(Value::as_str) {
+        reject_stash_selector(selector)?;
+        return Ok(selector.trim().to_string());
+    }
+    Ok(stash_index_selector(args))
+}
+
+fn stash_index_selector(args: &Value) -> String {
+    let idx = args.get("index").and_then(Value::as_u64).unwrap_or(0);
+    format!("stash@{{{idx}}}")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitStashRollbackEntry {
+    sequence: u64,
+    pub stash_ref: String,
+    pub turn_index: u32,
+    pub timestamp: SystemTime,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct GitStashRollbackJournal {
+    entries: Vec<GitStashRollbackEntry>,
+    next_sequence: u64,
+}
+
+impl GitStashRollbackJournal {
+    fn record(&mut self, stash_ref: impl Into<String>, turn_index: u32, message: Option<String>) {
+        self.entries.push(GitStashRollbackEntry {
+            sequence: self.next_sequence,
+            stash_ref: stash_ref.into(),
+            turn_index,
+            timestamp: SystemTime::now(),
+            message,
+        });
+        self.next_sequence = self.next_sequence.saturating_add(1);
+    }
+
+    fn list(&self) -> Vec<GitStashRollbackEntry> {
+        self.entries.iter().rev().cloned().collect()
+    }
+
+    fn restore_plan_for_turn(&self, turn_index: u32) -> Vec<GitStashRollbackEntry> {
+        self.restore_plan_for_turn_since(turn_index, 0)
+    }
+
+    fn restore_plan_for_turn_since(
+        &self,
+        turn_index: u32,
+        checkpoint: u64,
+    ) -> Vec<GitStashRollbackEntry> {
+        self.entries
+            .iter()
+            .find(|entry| entry.turn_index == turn_index && entry.sequence >= checkpoint)
+            .cloned()
+            .into_iter()
+            .collect()
+    }
+
+    fn checkpoint(&self) -> u64 {
+        self.next_sequence
+    }
+
+    fn remove_stash(&mut self, stash_ref: &str) -> bool {
+        if let Some(index) = self
+            .entries
+            .iter()
+            .rposition(|entry| entry.stash_ref == stash_ref)
+        {
+            self.entries.remove(index);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitCommitRollbackEntry {
+    sequence: u64,
+    pub commit_sha: String,
+    pub turn_index: u32,
+    pub timestamp: SystemTime,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct GitCommitRollbackJournal {
+    entries: Vec<GitCommitRollbackEntry>,
+    next_sequence: u64,
+}
+
+impl GitCommitRollbackJournal {
+    fn record(&mut self, commit_sha: impl Into<String>, turn_index: u32, message: Option<String>) {
+        self.entries.push(GitCommitRollbackEntry {
+            sequence: self.next_sequence,
+            commit_sha: commit_sha.into(),
+            turn_index,
+            timestamp: SystemTime::now(),
+            message,
+        });
+        self.next_sequence = self.next_sequence.saturating_add(1);
+    }
+
+    fn list(&self) -> Vec<GitCommitRollbackEntry> {
+        self.entries.iter().rev().cloned().collect()
+    }
+
+    fn restore_plan_for_turn(&self, turn_index: u32) -> Vec<GitCommitRollbackEntry> {
+        self.restore_plan_for_turn_since(turn_index, 0)
+    }
+
+    fn restore_plan_for_turn_since(
+        &self,
+        turn_index: u32,
+        checkpoint: u64,
+    ) -> Vec<GitCommitRollbackEntry> {
+        self.entries
+            .iter()
+            .rev()
+            .filter(|entry| entry.turn_index == turn_index && entry.sequence >= checkpoint)
+            .cloned()
+            .collect()
+    }
+
+    fn checkpoint(&self) -> u64 {
+        self.next_sequence
+    }
+
+    fn remove_commit(&mut self, commit_sha: &str) -> bool {
+        if let Some(index) = self
+            .entries
+            .iter()
+            .rposition(|entry| entry.commit_sha == commit_sha)
+        {
+            self.entries.remove(index);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fn tool_output_limit() -> usize {
+    super::tool_output_limit()
+}
+
+/// Scale a base output limit by budget pressure.
+/// pressure=0.0 → 100% of base, pressure=0.6 → 70%, pressure=0.9 → 46%.
+/// Never goes below 40% of base — aggressive truncation on git diffs
+/// forces bash fallbacks which waste a tool round.
+fn pressure_scaled_limit(base: usize, pressure: f64) -> usize {
+    let scale = (1.0 - pressure * 0.6).max(0.4);
+    (base as f64 * scale) as usize
+}
+
+fn open_repo(project_root: &Path) -> Result<gix::Repository, String> {
+    gix::discover(project_root).map_err(|e| format!("Error: cannot open git repo: {e}"))
+}
+
+/// Return the current branch name (like `git branch --show-current`).
+pub fn current_branch(project_root: &Path) -> String {
+    let repo = match open_repo(project_root) {
+        Ok(r) => r,
+        Err(_) => return String::new(),
+    };
+    match repo.head_ref() {
+        Ok(Some(reference)) => reference.name().shorten().to_string(),
+        _ => String::new(),
+    }
+}
+
+/// Return the short HEAD commit hash (like `git rev-parse --short HEAD`).
+pub fn head_short(project_root: &Path) -> String {
+    let repo = match open_repo(project_root) {
+        Ok(r) => r,
+        Err(_) => return String::new(),
+    };
+    match repo.head_id() {
+        Ok(id) => id.to_hex_with_len(7).to_string(),
+        Err(_) => String::new(),
+    }
+}
+
+/// Format author time as YYYY-MM-DD from a SignatureRef.
+fn format_author_date(sig: &gix::actor::SignatureRef<'_>) -> String {
+    sig.time()
+        .ok()
+        .and_then(|t| t.format(gix::date::time::format::SHORT).ok())
+        .unwrap_or_else(|| "?".to_string())
+}
+
+// ─── git_status ─────────────────────────────────────────────────────────────
+
+pub fn git_status(project_root: &Path) -> String {
+    let repo = match open_repo(project_root) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+
+    let mut out = String::new();
+
+    // Branch info
+    if let Ok(head_ref) = repo.head_ref() {
+        if let Some(r) = head_ref {
+            let name = r.name().shorten().to_string();
+            out.push_str(&format!("## {name}\n"));
+        } else if let Ok(head) = repo.head_id() {
+            out.push_str(&format!(
+                "## HEAD detached at {}\n",
+                head.to_hex_with_len(8)
+            ));
+        }
+    }
+
+    // Status entries
+    let platform = match repo.status(gix::progress::Discard) {
+        Ok(p) => p,
+        Err(e) => return format!("{out}Error getting status: {e}"),
+    };
+
+    let iter = match platform.into_index_worktree_iter(Vec::<BString>::new()) {
+        Ok(i) => i,
+        Err(e) => return format!("{out}Error iterating status: {e}"),
+    };
+
+    use gix::status::index_worktree::iter::Summary;
+    let mut count = 0;
+    for entry in iter {
+        match entry {
+            Ok(item) => {
+                let path = item.rela_path().to_string();
+                let status_char = match item.summary() {
+                    Some(Summary::Removed) => "D ",
+                    Some(Summary::Added) => "? ",
+                    Some(Summary::Modified) => "M ",
+                    Some(Summary::TypeChange) => "T ",
+                    Some(Summary::Renamed) => "R ",
+                    Some(Summary::Copied) => "C ",
+                    Some(Summary::IntentToAdd) => "A ",
+                    Some(Summary::Conflict) => "U ",
+                    None => "? ",
+                };
+                out.push_str(&format!("{status_char}{path}\n"));
+                count += 1;
+                if count >= 200 {
+                    out.push_str("[truncated — 200+ changes]\n");
+                    break;
+                }
+            }
+            Err(e) => {
+                out.push_str(&format!("Error: {e}\n"));
+                break;
+            }
+        }
+    }
+
+    if out.trim().is_empty() {
+        "nothing to commit, working tree clean".to_string()
+    } else {
+        truncate_output(out, tool_output_limit())
+    }
+}
+
+// ─── git_log ────────────────────────────────────────────────────────────────
+
+pub fn git_log(project_root: &Path, args: &Value) -> String {
+    let repo = match open_repo(project_root) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+
+    let n = args.get("n").and_then(Value::as_u64).unwrap_or(10).min(500) as usize;
+
+    let head = match repo.head_id() {
+        Ok(h) => h,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    let walk = match head
+        .ancestors()
+        .sorting(gix::revision::walk::Sorting::ByCommitTime(
+            gix::traverse::commit::simple::CommitTimeOrder::NewestFirst,
+        ))
+        .all()
+    {
+        Ok(w) => w,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    let mut out = String::new();
+    let mut count = 0;
+    for info in walk {
+        if count >= n {
+            break;
+        }
+        match info {
+            Ok(info) => {
+                let id = info.id.to_string();
+                let short = &id[..7.min(id.len())];
+                match info.object() {
+                    Ok(commit) => {
+                        let raw = commit.message_raw_sloppy();
+                        let summary = raw
+                            .lines()
+                            .next()
+                            .map(|l| String::from_utf8_lossy(l).to_string())
+                            .unwrap_or_default();
+                        out.push_str(&format!("{short} {summary}\n"));
+                    }
+                    Err(_) => out.push_str(&format!("{short} <object error>\n")),
+                }
+                count += 1;
+            }
+            Err(e) => {
+                out.push_str(&format!("Error walking commits: {e}\n"));
+                break;
+            }
+        }
+    }
+
+    if out.is_empty() {
+        "No commits found".to_string()
+    } else {
+        truncate_output(out, tool_output_limit())
+    }
+}
+
+// ─── git_show ───────────────────────────────────────────────────────────────
+
+pub fn git_show(
+    project_root: &Path,
+    args: &Value,
+    pressure: f64,
+    aggregate_bytes: usize,
+) -> String {
+    let mut limit = pressure_scaled_limit(SHOW_LIMIT, pressure);
+    // Further reduce limit when aggregate output is already high
+    if aggregate_bytes > super::AGGREGATE_SOFT_LIMIT {
+        let remaining = super::AGGREGATE_OUTPUT_BUDGET.saturating_sub(aggregate_bytes);
+        limit = limit.min(remaining).max(2048);
+    }
+    let repo = match open_repo(project_root) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+
+    let commit_ref = match args.get("commit").and_then(Value::as_str) {
+        Some(c) => c,
+        None => return "Error: missing 'commit' (SHA, branch, or tag)".to_string(),
+    };
+
+    // Allow valid git ref characters including reflog (@{}) and tree-object (:)
+    if commit_ref.contains(|c: char| {
+        !c.is_alphanumeric()
+            && c != '-'
+            && c != '_'
+            && c != '.'
+            && c != '/'
+            && c != '~'
+            && c != '^'
+            && c != '@'
+            && c != ':'
+            && c != '{'
+            && c != '}'
+    }) {
+        return "Error: invalid commit reference".to_string();
+    }
+
+    let stat_only = args
+        .get("stat_only")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let file_filter = args.get("file").and_then(Value::as_str);
+
+    // Resolve reference to commit
+    let id = match repo.rev_parse_single(commit_ref) {
+        Ok(id) => id,
+        Err(e) => return format!("Error: cannot resolve '{commit_ref}': {e}"),
+    };
+
+    let commit = match id.object() {
+        Ok(o) => match o.try_into_commit() {
+            Ok(c) => c,
+            Err(_) => return format!("Error: '{commit_ref}' is not a commit"),
+        },
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    let mut out = String::new();
+
+    // Header
+    out.push_str(&format!("commit {}\n", commit.id));
+    if let Ok(author) = commit.author() {
+        let name = String::from_utf8_lossy(author.name).to_string();
+        let email = String::from_utf8_lossy(author.email).to_string();
+        let date = format_author_date(&author);
+        out.push_str(&format!("Author: {name} <{email}>\nDate:   {date}\n"));
+    }
+
+    let message = String::from_utf8_lossy(commit.message_raw_sloppy()).to_string();
+    out.push_str(&format!("\n    {}\n", message.trim()));
+
+    // Merge commits: gix first-parent diff produces useless tree-level output,
+    // and `git show --first-parent` can legitimately return only the commit
+    // header when the merge tree matches the first parent. Ask git for the
+    // per-parent tree diff instead so merge commits still show meaningful
+    // stats/patches.
+    let is_merge = commit.parent_ids().count() > 1;
+    if is_merge {
+        let mut cli_args = vec![
+            "diff-tree",
+            "-m",
+            "-r",
+            "--no-commit-id",
+            "--no-ext-diff",
+            "--no-color",
+        ];
+        if stat_only {
+            cli_args.push("--stat");
+        } else {
+            cli_args.push("-p");
+        }
+        cli_args.push(commit_ref);
+        if let Some(f) = file_filter {
+            cli_args.push("--");
+            cli_args.push(f);
+        }
+        let cli_out = std::process::Command::new("git")
+            .args(&cli_args)
+            .current_dir(project_root)
+            .output()
+            .ok();
+        if let Some(output) = cli_out {
+            if output.status.success() {
+                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !stdout.is_empty() {
+                    out.push('\n');
+                    out.push_str(&stdout);
+                    out.push('\n');
+                    return truncate_show_at(out, limit);
+                }
+                // Empty output with file filter means the file wasn't changed.
+                // Fall through to gix to at least show the commit header.
+            }
+        }
+        // CLI failed or empty — fall through to gix (best effort)
+    }
+
+    // Diff: use tree changes API
+    let new_tree = match commit.tree() {
+        Ok(t) => t,
+        Err(_) => return out,
+    };
+
+    let parent_tree = commit
+        .parent_ids()
+        .next()
+        .and_then(|pid| pid.object().ok())
+        .and_then(|o| o.try_into_commit().ok())
+        .and_then(|pc| pc.tree().ok());
+
+    let old_tree = match parent_tree {
+        Some(t) => t,
+        None => {
+            // Root commit — show added files recursively
+            out.push_str("\n[root commit]\n");
+            fn list_tree_entries(tree: &gix::Tree<'_>, prefix: &str, out: &mut String) {
+                for e in tree.iter().flatten() {
+                    let name = e.filename().to_string();
+                    let full = if prefix.is_empty() {
+                        name
+                    } else {
+                        format!("{prefix}/{name}")
+                    };
+                    if e.mode().is_tree() {
+                        if let Ok(obj) = e.object()
+                            && let Ok(sub) = obj.try_into_tree()
+                        {
+                            list_tree_entries(&sub, &full, out);
+                        }
+                    } else {
+                        out.push_str(&format!("A {full}\n"));
+                    }
+                }
+            }
+            list_tree_entries(&new_tree, "", &mut out);
+            return truncate_show_at(out, limit);
+        }
+    };
+
+    if stat_only {
+        // stat_only: compute stats in a single pass
+        let mut changes_platform = match old_tree.changes() {
+            Ok(p) => p,
+            Err(e) => {
+                out.push_str(&format!("\n[diff error: {e}]\n"));
+                return truncate_show_at(out, limit);
+            }
+        };
+
+        if let Ok(stats) = changes_platform.stats(&new_tree) {
+            out.push_str(&format!(
+                "\n {} files changed, {} insertions(+), {} deletions(-)\n",
+                stats.files_changed, stats.lines_added, stats.lines_removed
+            ));
+        }
+
+        // Also list file names
+        let mut changes_platform2 = match old_tree.changes() {
+            Ok(p) => p,
+            Err(_) => return truncate_show_at(out, limit),
+        };
+        let _ = changes_platform2.for_each_to_obtain_tree(&new_tree, |change| {
+            use gix::object::tree::diff::Change;
+            let (location, ct) = match &change {
+                Change::Addition { location, .. } => (location.to_string(), "A"),
+                Change::Deletion { location, .. } => (location.to_string(), "D"),
+                Change::Modification { location, .. } => (location.to_string(), "M"),
+                Change::Rewrite { location, .. } => (location.to_string(), "R"),
+            };
+            if file_filter.is_none() || location.contains(file_filter.unwrap_or("")) {
+                out.push_str(&format!(" {ct} {location}\n"));
+            }
+            Ok::<_, std::convert::Infallible>(std::ops::ControlFlow::Continue(()))
+        });
+    } else {
+        // Full diff with line content
+        let mut cache = match repo.diff_resource_cache_for_tree_diff() {
+            Ok(c) => c,
+            Err(e) => {
+                out.push_str(&format!("\n[diff cache error: {e}]\n"));
+                return truncate_show_at(out, limit);
+            }
+        };
+
+        let mut changes_platform = match old_tree.changes() {
+            Ok(p) => p,
+            Err(e) => {
+                out.push_str(&format!("\n[diff error: {e}]\n"));
+                return truncate_show_at(out, limit);
+            }
+        };
+
+        let _ = changes_platform.for_each_to_obtain_tree(&new_tree, |change| {
+            use gix::object::tree::diff::Change;
+            let location = match &change {
+                Change::Addition { location, .. }
+                | Change::Deletion { location, .. }
+                | Change::Modification { location, .. }
+                | Change::Rewrite { location, .. } => location.to_string(),
+            };
+
+            if let Some(filter) = file_filter
+                && !location.contains(filter)
+            {
+                return Ok::<_, std::convert::Infallible>(std::ops::ControlFlow::Continue(()));
+            }
+
+            out.push_str(&format!("--- a/{location}\n+++ b/{location}\n"));
+
+            if let Ok(mut platform) = change.diff(&mut cache) {
+                let _ = platform.lines(|hunk| {
+                    use gix::object::blob::diff::lines::Change as HC;
+                    match hunk {
+                        HC::Addition { lines } => {
+                            for l in lines {
+                                out.push_str(&format!("+{}\n", l));
+                            }
+                        }
+                        HC::Deletion { lines } => {
+                            for l in lines {
+                                out.push_str(&format!("-{}\n", l));
+                            }
+                        }
+                        HC::Modification {
+                            lines_before,
+                            lines_after,
+                        } => {
+                            for l in lines_before {
+                                out.push_str(&format!("-{}\n", l));
+                            }
+                            for l in lines_after {
+                                out.push_str(&format!("+{}\n", l));
+                            }
+                        }
+                    }
+                    Ok::<_, std::convert::Infallible>(())
+                });
+            }
+
+            out.push('\n');
+
+            if out.len() > limit {
+                return Ok(std::ops::ControlFlow::Break(()));
+            }
+            Ok(std::ops::ControlFlow::Continue(()))
+        });
+    }
+
+    truncate_show_at(out, limit)
+}
+
+fn truncate_show_at(out: String, limit: usize) -> String {
+    if out.len() > limit {
+        let end = out.floor_char_boundary(limit);
+        let mut t = out[..end].to_string();
+        t.push_str("\n[truncated — use stat_only:true or file param to narrow]");
+        t
+    } else {
+        out
+    }
+}
+
+// ─── git_blame ──────────────────────────────────────────────────────────────
+
+pub fn git_blame(project_root: &Path, args: &Value) -> String {
+    let repo = match open_repo(project_root) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+
+    let file = match args.get("file").and_then(Value::as_str) {
+        Some(f) => f,
+        None => return "Error: missing 'file' parameter".to_string(),
+    };
+    if let Err(e) = reject_path_traversal(file) {
+        return e;
+    }
+
+    let line_start = args.get("line_start").and_then(Value::as_u64);
+    let line_end = args.get("line_end").and_then(Value::as_u64);
+
+    let head = match repo.head_id() {
+        Ok(h) => h,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    // Build blame options with optional line range
+    let mut options = gix::repository::blame_file::Options::default();
+    if let Some(start) = line_start {
+        let end = line_end.unwrap_or(start);
+        match gix::blame::BlameRanges::from_one_based_inclusive_ranges(vec![
+            (start as u32)..=(end as u32),
+        ]) {
+            Ok(ranges) => options.ranges = ranges,
+            Err(e) => return format!("Error: invalid line range: {e}"),
+        }
+    }
+
+    let file_bstr: &gix::bstr::BStr = file.as_bytes().as_ref();
+    let outcome = match repo.blame_file(file_bstr, head.detach(), options) {
+        Ok(o) => o,
+        Err(e) => return format!("Error: blame failed for '{file}': {e}"),
+    };
+
+    // Format using entries_with_lines for correct line content
+    let mut out = String::new();
+    let mut unique_authors = std::collections::HashSet::new();
+    let mut unique_commits = std::collections::HashSet::new();
+    let mut total_lines = 0u32;
+
+    for (entry, lines) in outcome.entries_with_lines() {
+        let commit_id_str = entry.commit_id.to_string();
+        let short_commit = &commit_id_str[..8.min(commit_id_str.len())];
+
+        // Look up author/date from commit
+        let (author_name, date_str): (String, String) = repo
+            .find_object(entry.commit_id)
+            .ok()
+            .and_then(|obj| obj.try_into_commit().ok())
+            .and_then(|c: gix::Commit<'_>| {
+                c.author().ok().map(|a| {
+                    let name = String::from_utf8_lossy(a.name).to_string();
+                    let date = format_author_date(&a);
+                    (name, date)
+                })
+            })
+            .unwrap_or_else(|| ("?".to_string(), "?".to_string()));
+
+        let start_line = entry.start_in_blamed_file as u64 + 1;
+
+        for (offset, line_content) in lines.iter().enumerate() {
+            let line_no = start_line + offset as u64;
+
+            // Apply line range filter (in case blame ranges weren't exact)
+            if let Some(s) = line_start
+                && line_no < s
+            {
+                continue;
+            }
+            if let Some(e) = line_end
+                && line_no > e
+            {
+                continue;
+            }
+
+            let content = String::from_utf8_lossy(line_content);
+            let content = content.trim_end();
+            out.push_str(&format!(
+                "L{line_no} {short_commit} {date_str} [{author_name}] {content}\n"
+            ));
+
+            unique_authors.insert(author_name.clone());
+            unique_commits.insert(short_commit.to_string());
+            total_lines += 1;
+        }
+    }
+
+    if total_lines == 0 {
+        return format!("No blame data for '{file}'");
+    }
+
+    out.push_str(&format!(
+        "\n--- {} lines, {} authors, {} commits ---",
+        total_lines,
+        unique_authors.len(),
+        unique_commits.len(),
+    ));
+
+    truncate_output(out, tool_output_limit())
+}
+
+// ─── git_diff ───────────────────────────────────────────────────────────────
+
+/// `git diff … --stat` via the real `git` CLI (same sources as full diff, no bash).
+fn git_diff_stat_cli(project_root: &Path, args: &Value, limit: usize) -> String {
+    let staged = args.get("staged").and_then(Value::as_bool).unwrap_or(false);
+    let git_ref = args.get("ref").and_then(Value::as_str);
+    let base_ref = args.get("base_ref").and_then(Value::as_str);
+    let path_filter = args.get("path").and_then(Value::as_str);
+
+    if staged && git_ref.is_some() {
+        return "Error: git_diff: use either staged:true or ref, not both".to_string();
+    }
+
+    let mut parts: Vec<String> = vec!["diff".into()];
+    if let Some(base) = base_ref {
+        if let Err(e) = reject_shell_meta(base) {
+            return e;
+        }
+        let tip = git_ref.unwrap_or("HEAD");
+        if let Err(e) = reject_shell_meta(tip) {
+            return e;
+        }
+        parts.push(format!("{base}..{tip}"));
+    } else if staged {
+        parts.push("--cached".into());
+    } else if let Some(r) = git_ref {
+        parts.push(r.to_string());
+        if path_filter.is_none() {
+            parts.push("HEAD".into());
+        }
+    } else {
+        parts.push("HEAD".into());
+    }
+    parts.extend(["--stat".into(), "--no-color".into()]);
+    if let Some(p) = path_filter {
+        parts.push("--".into());
+        parts.push(p.to_string());
+    }
+
+    let cmd_refs: Vec<&str> = parts.iter().map(|s| s.as_str()).collect();
+    diff_via_git_cli(project_root, &cmd_refs, limit).unwrap_or_else(|| "No changes".to_string())
+}
+
+pub fn git_diff(
+    project_root: &Path,
+    args: &Value,
+    pressure: f64,
+    aggregate_bytes: usize,
+) -> String {
+    let mut limit = pressure_scaled_limit(DIFF_LIMIT, pressure);
+    // Further reduce limit when aggregate output is already high
+    if aggregate_bytes > super::AGGREGATE_SOFT_LIMIT {
+        let remaining = super::AGGREGATE_OUTPUT_BUDGET.saturating_sub(aggregate_bytes);
+        limit = limit.min(remaining).max(2048);
+    }
+    let stat_only = args
+        .get("stat_only")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if stat_only {
+        return git_diff_stat_cli(project_root, args, limit);
+    }
+
+    let repo = match open_repo(project_root) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+
+    let staged = args.get("staged").and_then(Value::as_bool).unwrap_or(false);
+    let git_ref = args.get("ref").and_then(Value::as_str);
+    let base_ref = args.get("base_ref").and_then(Value::as_str);
+    let path_filter = args.get("path").and_then(Value::as_str);
+    if let Some(p) = path_filter {
+        if let Err(e) = reject_path_traversal(p) {
+            return e;
+        }
+    }
+
+    // Range diff: base_ref..ref (e.g., HEAD~5..HEAD)
+    if let Some(base) = base_ref {
+        if let Err(e) = reject_shell_meta(base) {
+            return e;
+        }
+        let tip = git_ref.unwrap_or("HEAD");
+        if let Err(e) = reject_shell_meta(tip) {
+            return e;
+        }
+        let range = format!("{base}..{tip}");
+        let mut cli_args = vec!["diff", &range, "--no-ext-diff", "--no-color"];
+        let path_owned;
+        if let Some(p) = path_filter {
+            cli_args.push("--");
+            path_owned = p.to_string();
+            cli_args.push(&path_owned);
+        }
+        return diff_via_git_cli(project_root, &cli_args, limit)
+            .unwrap_or_else(|| "No changes".to_string());
+    }
+
+    // If a ref is given, do a tree-to-tree diff (HEAD vs ref)
+    if let Some(ref_str) = git_ref {
+        // With path filter, use CLI for tree-to-tree as well
+        if let Some(p) = path_filter
+            && let Some(result) = diff_via_git_cli(
+                project_root,
+                &["diff", ref_str, "--no-ext-diff", "--no-color", "--", p],
+                limit,
+            )
+        {
+            return result;
+        }
+        return diff_tree_to_tree_str(&repo, ref_str, limit);
+    }
+
+    // If staged, do index-to-HEAD diff
+    if staged {
+        let cli_args: Vec<&str> = if let Some(p) = path_filter {
+            vec!["diff", "--cached", "--no-ext-diff", "--no-color", "--", p]
+        } else {
+            vec!["diff", "--cached", "--no-ext-diff", "--no-color"]
+        };
+        let result = diff_via_git_cli(project_root, &cli_args, limit)
+            .unwrap_or_else(|| diff_index_to_head(&repo, limit));
+        if result == "No changes" {
+            return "No staged changes".to_string();
+        }
+        return result;
+    }
+
+    // Default: show full local patch vs HEAD so review flows don't need to fall
+    // back to bash just to recover actual diff hunks from summary-only output.
+    let cli_args: Vec<&str> = if let Some(p) = path_filter {
+        vec!["diff", "HEAD", "--no-ext-diff", "--no-color", "--", p]
+    } else {
+        vec!["diff", "HEAD", "--no-ext-diff", "--no-color"]
+    };
+    diff_via_git_cli(project_root, &cli_args, limit).unwrap_or_else(|| diff_worktree(&repo, limit))
+}
+
+fn diff_via_git_cli(project_root: &Path, args: &[&str], limit: usize) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(project_root)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    if stdout.trim().is_empty() {
+        return Some("No changes".to_string());
+    }
+    Some(truncate_diff_at(stdout, limit.min(tool_output_limit())))
+}
+
+/// Diff between two tree-ish refs (e.g., HEAD vs a branch/commit).
+fn diff_tree_to_tree_str(repo: &gix::Repository, ref_str: &str, limit: usize) -> String {
+    let head_tree = match resolve_tree(repo, "HEAD") {
+        Ok(t) => t,
+        Err(e) => return e,
+    };
+    let other_tree = match resolve_tree(repo, ref_str) {
+        Ok(t) => t,
+        Err(e) => return e,
+    };
+
+    let mut cache = match repo.diff_resource_cache_for_tree_diff() {
+        Ok(c) => c,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    let mut out = String::new();
+    let mut count = 0u32;
+
+    let mut changes_platform = match other_tree.changes() {
+        Ok(p) => p,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    let result = changes_platform.for_each_to_obtain_tree(
+        &head_tree,
+        |change: gix::object::tree::diff::Change<'_, '_, '_>| {
+            use gix::object::tree::diff::Change;
+            let location = match &change {
+                Change::Addition { location, .. }
+                | Change::Deletion { location, .. }
+                | Change::Modification { location, .. }
+                | Change::Rewrite { location, .. } => location.to_string(),
+            };
+            let change_type = match &change {
+                Change::Addition { .. } => "new file",
+                Change::Deletion { .. } => "deleted",
+                Change::Modification { .. } => "modified",
+                Change::Rewrite { .. } => "renamed",
+            };
+
+            out.push_str(&format!(
+                "diff --git a/{location} b/{location}\n--- a/{location}\n+++ b/{location}\n"
+            ));
+
+            // Try to get line-level diff
+            if let Ok(mut platform) = change.diff(&mut cache) {
+                let _ = platform.lines(|hunk| {
+                    use gix::object::blob::diff::lines::Change as HC;
+                    match hunk {
+                        HC::Addition { lines } => {
+                            for l in lines {
+                                out.push_str(&format!("+{}\n", l));
+                            }
+                        }
+                        HC::Deletion { lines } => {
+                            for l in lines {
+                                out.push_str(&format!("-{}\n", l));
+                            }
+                        }
+                        HC::Modification {
+                            lines_before,
+                            lines_after,
+                        } => {
+                            for l in lines_before {
+                                out.push_str(&format!("-{}\n", l));
+                            }
+                            for l in lines_after {
+                                out.push_str(&format!("+{}\n", l));
+                            }
+                        }
+                    }
+                    Ok::<_, std::convert::Infallible>(())
+                });
+            } else {
+                out.push_str(&format!("# {change_type}: {location}\n"));
+            }
+            out.push('\n');
+            count += 1;
+
+            if out.len() > limit {
+                return Ok(std::ops::ControlFlow::Break(()));
+            }
+            Ok::<_, std::convert::Infallible>(std::ops::ControlFlow::Continue(()))
+        },
+    );
+
+    if let Err(e) = result {
+        out.push_str(&format!("\n[diff error: {e}]\n"));
+    }
+
+    if out.is_empty() {
+        "No changes".to_string()
+    } else {
+        out.push_str(&format!(
+            "\n{count} file(s) changed (summary only — use `git diff` for full patch)"
+        ));
+        truncate_diff_at(out, limit)
+    }
+}
+
+/// Diff staged (index) changes against HEAD.
+fn diff_index_to_head(repo: &gix::Repository, limit: usize) -> String {
+    let head_tree = match resolve_tree(repo, "HEAD") {
+        Ok(t) => t,
+        Err(e) => return e,
+    };
+
+    // Get the index and convert to a tree for comparison
+    let index = match repo.index() {
+        Ok(i) => i,
+        Err(e) => return format!("Error reading index: {e}"),
+    };
+
+    // Build changes by comparing HEAD tree entries with index entries
+    let mut out = String::new();
+    let mut count = 0u32;
+
+    for entry in index.entries() {
+        let path = entry.path(&index);
+        let path_str = path.to_string();
+
+        // Check if HEAD has this file and whether it differs
+        let head_entry = head_tree.lookup_entry_by_path(&path_str);
+        let in_head: Option<gix::ObjectId> = match &head_entry {
+            Ok(Some(he)) => Some(he.object_id()),
+            _ => None,
+        };
+
+        let idx_oid = entry.id;
+
+        match in_head {
+            Some(head_oid) if head_oid == idx_oid => continue, // unchanged
+            Some(_head_oid) => {
+                out.push_str(&format!(
+                    "diff --git a/{path_str} b/{path_str}\n--- a/{path_str}\n+++ b/{path_str}\n"
+                ));
+                out.push_str("# modified (staged)\n\n");
+                count += 1;
+            }
+            None => {
+                out.push_str(&format!(
+                    "diff --git a/{path_str} b/{path_str}\n--- /dev/null\n+++ b/{path_str}\n"
+                ));
+                out.push_str("# new file (staged)\n\n");
+                count += 1;
+            }
+        }
+
+        if out.len() > limit {
+            out.push_str("[truncated]\n");
+            break;
+        }
+    }
+
+    // Detect staged deletions: files in HEAD tree but absent from index
+    {
+        fn collect_tree_paths(
+            tree: &gix::Tree<'_>,
+            prefix: &str,
+            paths: &mut std::collections::HashSet<String>,
+        ) {
+            for e in tree.iter().flatten() {
+                let name = e.filename().to_string();
+                let full = if prefix.is_empty() {
+                    name
+                } else {
+                    format!("{prefix}/{name}")
+                };
+                if e.mode().is_tree() {
+                    if let Ok(obj) = e.object()
+                        && let Ok(sub) = obj.try_into_tree()
+                    {
+                        collect_tree_paths(&sub, &full, paths);
+                    }
+                } else {
+                    paths.insert(full);
+                }
+            }
+        }
+
+        let mut head_paths = std::collections::HashSet::new();
+        collect_tree_paths(&head_tree, "", &mut head_paths);
+
+        let index_paths: std::collections::HashSet<String> = index
+            .entries()
+            .iter()
+            .map(|e| e.path(&index).to_string())
+            .collect();
+
+        for deleted_path in head_paths.difference(&index_paths) {
+            out.push_str(&format!(
+                "diff --git a/{deleted_path} b/{deleted_path}\n--- a/{deleted_path}\n+++ /dev/null\n"
+            ));
+            out.push_str("# deleted (staged)\n\n");
+            count += 1;
+            if out.len() > limit {
+                out.push_str("[truncated]\n");
+                break;
+            }
+        }
+    }
+
+    if out.is_empty() {
+        "No staged changes".to_string()
+    } else {
+        out.push_str(&format!("\n{count} file(s) staged"));
+        truncate_diff_at(out, limit)
+    }
+}
+
+/// Diff worktree (unstaged) changes.
+fn diff_worktree(repo: &gix::Repository, limit: usize) -> String {
+    let platform = match repo.status(gix::progress::Discard) {
+        Ok(p) => p,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    let iter = match platform.into_index_worktree_iter(Vec::<BString>::new()) {
+        Ok(i) => i,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    use gix::status::index_worktree::iter::Summary;
+    let mut out = String::new();
+    let mut count = 0;
+
+    for entry in iter {
+        match entry {
+            Ok(item) => {
+                let path = item.rela_path().to_string();
+                let summary = match item.summary() {
+                    Some(s) => s,
+                    None => continue,
+                };
+
+                let status_str = match summary {
+                    Summary::Modified => "modified",
+                    Summary::Added | Summary::IntentToAdd => "new file",
+                    Summary::Removed => "deleted",
+                    Summary::Renamed => "renamed",
+                    Summary::TypeChange => "typechange",
+                    _ => "changed",
+                };
+
+                out.push_str(&format!(
+                    "diff --git a/{path} b/{path}\n# {status_str}: {path}\n\n"
+                ));
+                count += 1;
+
+                if out.len() > limit {
+                    out.push_str("[truncated]\n");
+                    break;
+                }
+            }
+            Err(e) => {
+                out.push_str(&format!("Error: {e}\n"));
+                break;
+            }
+        }
+    }
+
+    if out.is_empty() {
+        "No changes".to_string()
+    } else {
+        out.push_str(&format!(
+            "\n{count} file(s) changed (summary only — use `git diff` for full patch)"
+        ));
+        truncate_diff_at(out, limit)
+    }
+}
+
+fn resolve_tree<'r>(repo: &'r gix::Repository, ref_str: &str) -> Result<gix::Tree<'r>, String> {
+    let id = repo
+        .rev_parse_single(ref_str)
+        .map_err(|e| format!("Error: cannot resolve '{ref_str}': {e}"))?;
+    let obj = id.object().map_err(|e| format!("Error: {e}"))?;
+    let commit = obj
+        .try_into_commit()
+        .map_err(|_| format!("Error: '{ref_str}' is not a commit"))?;
+    commit
+        .tree()
+        .map_err(|e| format!("Error: cannot get tree: {e}"))
+}
+
+fn truncate_diff_at(out: String, limit: usize) -> String {
+    if out.len() > limit {
+        let end = out.floor_char_boundary(limit);
+        let mut t = out[..end].to_string();
+        t.push_str("\n[truncated]");
+        t
+    } else {
+        out
+    }
+}
+
+// ─── git_file_history ───────────────────────────────────────────────────────
+
+pub fn git_file_history(project_root: &Path, args: &Value) -> String {
+    let repo = match open_repo(project_root) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+
+    let file = match args.get("file").and_then(Value::as_str) {
+        Some(f) => f,
+        None => return "Error: missing 'file' parameter".to_string(),
+    };
+    if let Err(e) = reject_path_traversal(file) {
+        return e;
+    }
+
+    let n = args.get("n").and_then(Value::as_u64).unwrap_or(10) as usize;
+
+    let head = match repo.head_id() {
+        Ok(h) => h,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    let walk = match head
+        .ancestors()
+        .sorting(gix::revision::walk::Sorting::ByCommitTime(
+            gix::traverse::commit::simple::CommitTimeOrder::NewestFirst,
+        ))
+        .all()
+    {
+        Ok(w) => w,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    let mut lines = Vec::new();
+    let mut walked = 0usize;
+    const MAX_WALK: usize = 50_000;
+    #[allow(clippy::explicit_counter_loop)]
+    for info in walk {
+        if lines.len() >= n || walked >= MAX_WALK {
+            break;
+        }
+        walked += 1;
+        let info = match info {
+            Ok(i) => i,
+            Err(_) => break,
+        };
+
+        let commit = match info.object() {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        // Check if this commit touches our file by comparing tree entries
+        let tree = match commit.tree() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+
+        // Check if file exists in this commit's tree
+        let cur_entry = match tree.lookup_entry_by_path(file) {
+            Ok(Some(e)) => e,
+            _ => continue,
+        };
+
+        // Check if parent had different content (file actually changed)
+        let parent_has_same = commit.parent_ids().next().is_some_and(|pid| {
+            pid.object()
+                .ok()
+                .and_then(|o| o.try_into_commit().ok())
+                .and_then(|pc| pc.tree().ok())
+                .map(|pt| match pt.lookup_entry_by_path(file) {
+                    Ok(Some(parent_entry)) => parent_entry.object_id() == cur_entry.object_id(),
+                    _ => false,
+                })
+                .unwrap_or(false)
+        });
+
+        if parent_has_same {
+            continue;
+        }
+
+        let id = info.id.to_string();
+        let short = &id[..8.min(id.len())];
+        let author = commit
+            .author()
+            .ok()
+            .map(|a| String::from_utf8_lossy(a.name).to_string())
+            .unwrap_or_else(|| "?".to_string());
+        let date = commit
+            .author()
+            .ok()
+            .map(|a| format_author_date(&a))
+            .unwrap_or_else(|| "?".to_string());
+        let summary = {
+            let raw = commit.message_raw_sloppy();
+            raw.lines()
+                .next()
+                .map(|l| String::from_utf8_lossy(l).to_string())
+                .unwrap_or_default()
+        };
+
+        lines.push(format!("{short} {date} [{author}] {summary}"));
+    }
+
+    if lines.is_empty() {
+        return format!("No history found for '{file}'");
+    }
+
+    truncate_output(
+        format!(
+            "File: {file}\nCommits: {}\n\n{}",
+            lines.len(),
+            lines.join("\n")
+        ),
+        tool_output_limit(),
+    )
+}
+
+// ─── git_log_search (TF-IDF semantic search) ────────────────────────────────
+
+/// A parsed commit with pre-computed tokens for TF-IDF scoring.
+struct CommitDoc {
+    hash: String,
+    author: String,
+    date: String,
+    message: String,
+    tokens: Vec<String>,
+}
+
+/// Score commit messages against a query using TF-IDF cosine similarity.
+fn score_commits(query: &str, commits: &[CommitDoc]) -> Vec<(usize, f64)> {
+    let query_tokens = estimate_tokens(query);
+    if query_tokens.is_empty() || commits.is_empty() {
+        return Vec::new();
+    }
+
+    let n = commits.len() as f64;
+
+    // Build IDF from the commit corpus
+    let mut doc_freq: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for doc in commits {
+        let unique: std::collections::HashSet<&String> = doc.tokens.iter().collect();
+        for t in unique {
+            *doc_freq.entry(t.clone()).or_default() += 1;
+        }
+    }
+    let idf: std::collections::HashMap<String, f64> = doc_freq
+        .into_iter()
+        .map(|(term, df)| (term, (n / df as f64).ln().max(0.1)))
+        .collect();
+
+    let mut scores: Vec<(usize, f64)> = commits
+        .iter()
+        .enumerate()
+        .map(|(i, doc)| {
+            let total = doc.tokens.len().max(1) as f64;
+            let mut doc_tf: std::collections::HashMap<&str, f64> = std::collections::HashMap::new();
+            for t in &doc.tokens {
+                *doc_tf.entry(t.as_str()).or_default() += 1.0;
+            }
+            for v in doc_tf.values_mut() {
+                *v /= total;
+            }
+
+            let mut dot = 0.0;
+            let mut q_norm_sq = 0.0;
+            let mut d_norm_sq = 0.0;
+
+            for qt in &query_tokens {
+                let idf_val = idf.get(qt.as_str()).copied().unwrap_or(0.0);
+                let q_w = idf_val;
+                q_norm_sq += q_w * q_w;
+                if let Some(&tf) = doc_tf.get(qt.as_str()) {
+                    let d_w = tf * idf_val;
+                    dot += q_w * d_w;
+                }
+            }
+            for (term, &tf) in &doc_tf {
+                let idf_val = idf.get(*term).copied().unwrap_or(0.0);
+                let d_w = tf * idf_val;
+                d_norm_sq += d_w * d_w;
+            }
+
+            let denom = q_norm_sq.sqrt() * d_norm_sq.sqrt();
+            let score = if denom > 0.0 { dot / denom } else { 0.0 };
+            (i, score)
+        })
+        .filter(|(_, s)| *s > 0.01)
+        .collect();
+
+    scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scores
+}
+
+pub fn git_log_search(project_root: &Path, args: &Value) -> String {
+    let query = match args.get("query").and_then(Value::as_str) {
+        Some(q) if !q.trim().is_empty() => q,
+        _ => return "Error: missing or empty 'query' parameter".to_string(),
+    };
+
+    let repo = match open_repo(project_root) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+
+    let n = args.get("n").and_then(Value::as_u64).unwrap_or(200) as usize;
+
+    let head = match repo.head_id() {
+        Ok(h) => h,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    let walk = match head
+        .ancestors()
+        .sorting(gix::revision::walk::Sorting::ByCommitTime(
+            gix::traverse::commit::simple::CommitTimeOrder::NewestFirst,
+        ))
+        .all()
+    {
+        Ok(w) => w,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    // Collect commits
+    let mut commits = Vec::new();
+    for info in walk {
+        if commits.len() >= n {
+            break;
+        }
+        let info = match info {
+            Ok(i) => i,
+            Err(_) => break,
+        };
+        let commit = match info.object() {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let hash = info.id.to_string();
+        let author = commit
+            .author()
+            .ok()
+            .map(|a| String::from_utf8_lossy(a.name).to_string())
+            .unwrap_or_else(|| "?".to_string());
+        let date = commit
+            .author()
+            .ok()
+            .map(|a| format_author_date(&a))
+            .unwrap_or_else(|| "?".to_string());
+        let message = {
+            let raw = commit.message_raw_sloppy();
+            raw.lines()
+                .next()
+                .map(|l| String::from_utf8_lossy(l).to_string())
+                .unwrap_or_default()
+        };
+        let tokens = estimate_tokens(&message);
+
+        commits.push(CommitDoc {
+            hash,
+            author,
+            date,
+            message,
+            tokens,
+        });
+    }
+
+    if commits.is_empty() {
+        return "No commits found".to_string();
+    }
+
+    let ranked = score_commits(query, &commits);
+    if ranked.is_empty() {
+        return format!(
+            "No commits matching '{}' found in last {} commits",
+            query,
+            commits.len()
+        );
+    }
+
+    let top_k = 10.min(ranked.len());
+    let mut result = format!(
+        "Search: '{}' ({} commits searched, {} matches)\n\n",
+        query,
+        commits.len(),
+        ranked.len()
+    );
+    for (i, &(idx, score)) in ranked.iter().take(top_k).enumerate() {
+        let c = &commits[idx];
+        result.push_str(&format!(
+            "{}. [score:{:.2}] {} {} [{}] {}\n",
+            i + 1,
+            score,
+            &c.hash[..8.min(c.hash.len())],
+            c.date,
+            c.author,
+            c.message,
+        ));
+    }
+
+    truncate_output(result, tool_output_limit())
+}
+
+// ─── git_contributors ───────────────────────────────────────────────────────
+
+pub fn git_contributors(project_root: &Path, args: &Value) -> String {
+    let repo = match open_repo(project_root) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+
+    let path_filter = args.get("path").and_then(Value::as_str);
+    if let Some(p) = path_filter {
+        if let Err(e) = reject_path_traversal(p) {
+            return e;
+        }
+    }
+    let since_str = args.get("since").and_then(Value::as_str);
+
+    // Parse --since into a unix timestamp cutoff
+    let since_cutoff: Option<i64> = since_str.and_then(parse_since_to_epoch);
+
+    let head = match repo.head_id() {
+        Ok(h) => h,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    let walk = match head
+        .ancestors()
+        .sorting(gix::revision::walk::Sorting::ByCommitTime(
+            gix::traverse::commit::simple::CommitTimeOrder::NewestFirst,
+        ))
+        .all()
+    {
+        Ok(w) => w,
+        Err(e) => return format!("Error: {e}"),
+    };
+
+    let mut author_counts: std::collections::HashMap<String, u32> =
+        std::collections::HashMap::new();
+    let mut file_freq: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+    let mut recent_lines: Vec<String> = Vec::new();
+    let mut total_commits = 0u32;
+    let mut walked = 0u32;
+    const MAX_WALK: u32 = 50_000;
+
+    #[allow(clippy::explicit_counter_loop)]
+    for info in walk {
+        if walked >= MAX_WALK {
+            break;
+        }
+        walked += 1;
+        let info = match info {
+            Ok(i) => i,
+            Err(_) => break,
+        };
+
+        let commit = match info.object() {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        // Date cutoff
+        if let Some(cutoff) = since_cutoff
+            && let Ok(author) = commit.author()
+            && let Ok(time) = author.time()
+            && time.seconds < cutoff
+        {
+            break; // Commits are sorted newest-first, so stop early
+        }
+
+        // Skip merges (2+ parents)
+        if commit.parent_ids().count() > 1 {
+            continue;
+        }
+
+        let author_name = commit
+            .author()
+            .ok()
+            .map(|a| String::from_utf8_lossy(a.name).to_string())
+            .unwrap_or_else(|| "?".to_string());
+
+        // Path filter: check if commit touches the target path
+        if let Some(path) = path_filter {
+            let tree = match commit.tree() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            let cur_entry = match tree.lookup_entry_by_path(path) {
+                Ok(Some(e)) => e,
+                _ => continue,
+            };
+            // Check parent differs
+            let parent_same = commit.parent_ids().next().is_some_and(|pid| {
+                pid.object()
+                    .ok()
+                    .and_then(|o| o.try_into_commit().ok())
+                    .and_then(|pc| pc.tree().ok())
+                    .map(|pt| match pt.lookup_entry_by_path(path) {
+                        Ok(Some(pe)) => pe.object_id() == cur_entry.object_id(),
+                        _ => false,
+                    })
+                    .unwrap_or(false)
+            });
+            if parent_same {
+                continue;
+            }
+        }
+
+        *author_counts.entry(author_name).or_default() += 1;
+
+        // Collect changed files for hot-files (up to 500 commits)
+        if total_commits < 500 {
+            let tree = commit.tree().ok();
+            let parent_tree = commit
+                .parent_ids()
+                .next()
+                .and_then(|pid| pid.object().ok())
+                .and_then(|o| o.try_into_commit().ok())
+                .and_then(|pc| pc.tree().ok());
+
+            if let (Some(new_tree), Some(old_tree)) = (tree, parent_tree)
+                && let Ok(mut changes) = old_tree.changes()
+            {
+                let _ = changes.for_each_to_obtain_tree(&new_tree, |change| {
+                    use gix::object::tree::diff::Change;
+                    let location = match &change {
+                        Change::Addition { location, .. }
+                        | Change::Deletion { location, .. }
+                        | Change::Modification { location, .. }
+                        | Change::Rewrite { location, .. } => location.to_string(),
+                    };
+
+                    if let Some(pf) = path_filter
+                        && !location.starts_with(pf)
+                    {
+                        return Ok::<_, std::convert::Infallible>(std::ops::ControlFlow::Continue(
+                            (),
+                        ));
+                    }
+
+                    *file_freq.entry(location).or_default() += 1;
+                    Ok(std::ops::ControlFlow::Continue(()))
+                });
+            }
+        }
+
+        // Recent activity (first 5)
+        if recent_lines.len() < 5 {
+            let id_str = info.id.to_string();
+            let short = &id_str[..7.min(id_str.len())];
+            let msg = {
+                let raw = commit.message_raw_sloppy();
+                raw.lines()
+                    .next()
+                    .map(|l| String::from_utf8_lossy(l).to_string())
+                    .unwrap_or_default()
+            };
+            recent_lines.push(format!("{short} {msg}"));
+        }
+
+        total_commits += 1;
+
+        // Safety cap
+        if total_commits >= 10_000 {
+            break;
+        }
+    }
+
+    // Format output
+    let mut parts = Vec::new();
+
+    // Top contributors
+    if !author_counts.is_empty() {
+        let mut sorted: Vec<_> = author_counts.into_iter().collect();
+        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        let top: Vec<String> = sorted
+            .iter()
+            .take(10)
+            .map(|(name, count)| format!("  {:>4}  {}", count, name))
+            .collect();
+        parts.push(format!("## Top Contributors\n{}", top.join("\n")));
+    }
+
+    // Hot files
+    if !file_freq.is_empty() {
+        let mut sorted: Vec<_> = file_freq.into_iter().collect();
+        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        let top_files: Vec<String> = sorted
+            .iter()
+            .take(10)
+            .map(|(f, c)| format!("  {:>3}× {}", c, f))
+            .collect();
+        parts.push(format!(
+            "## Hot Files (most changed)\n{}",
+            top_files.join("\n")
+        ));
+    }
+
+    // Recent activity
+    if !recent_lines.is_empty() {
+        parts.push(format!("## Recent Activity\n{}", recent_lines.join("\n")));
+    }
+
+    if parts.is_empty() {
+        "No git history found".to_string()
+    } else {
+        truncate_output(parts.join("\n\n"), tool_output_limit())
+    }
+}
+
+/// Parse a "since" string into a unix epoch timestamp.
+/// Supports ISO dates like "2024-01-01" and relative like "2 weeks ago".
+fn parse_since_to_epoch(since: &str) -> Option<i64> {
+    // Try ISO date (YYYY-MM-DD)
+    if since.len() == 10 && since.chars().nth(4) == Some('-') {
+        let parts: Vec<&str> = since.split('-').collect();
+        if parts.len() == 3 {
+            let y: i64 = parts[0].parse().ok()?;
+            let m: i64 = parts[1].parse().ok()?;
+            let d: i64 = parts[2].parse().ok()?;
+            if !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+                return None;
+            }
+            // Rough epoch calculation (not leap-second accurate, good enough for filtering)
+            let days_since_epoch = (y - 1970) * 365 + (y - 1969) / 4 - (y - 1901) / 100
+                + (y - 1601) / 400
+                + [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334][(m - 1) as usize]
+                + d
+                - 1;
+            return Some(days_since_epoch * 86400);
+        }
+    }
+    // Relative dates: just skip filtering for unsupported formats
+    None
+}
+
+// ─── Git Mutation Tools ─────────────────────────────────────────────────────
+// These use git subprocess (not gix) because gix's write operations are
+// complex and the git binary is universally available. Read tools stay pure-Rust.
+
+/// Stage files and create a commit.
+///
+/// Parameters:
+/// - `message` (required): commit message
+/// - `files` (optional): list of file paths to stage; if omitted, stages all changes
+/// - `all` (optional): if true, stages all tracked changes (like `git commit -a`)
+pub fn git_commit(project_root: &Path, args: &Value) -> String {
+    git_commit_with_metadata(project_root, args).output
+}
+
+pub fn git_commit_with_metadata(project_root: &Path, args: &Value) -> ToolExecutionOutcome {
+    let message = match args.get("message").and_then(Value::as_str) {
+        Some(m) if !m.trim().is_empty() => m.trim(),
+        _ => {
+            return ToolExecutionOutcome::text(
+                "Error: 'message' is required and must not be empty".to_string(),
+            );
+        }
+    };
+
+    // Validate message length (prevent absurdly long messages)
+    if message.len() > 5000 {
+        return ToolExecutionOutcome::text(
+            "Error: commit message too long (max 5000 chars)".to_string(),
+        );
+    }
+
+    // Stage files
+    let files: Vec<&str> = args
+        .get("files")
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    let stage_all = args.get("all").and_then(Value::as_bool).unwrap_or(false);
+
+    if files.is_empty() && !stage_all {
+        // Default: stage all changes
+        let add_out = std::process::Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(project_root)
+            .output();
+        match add_out {
+            Err(e) => {
+                return ToolExecutionOutcome::text(format!("Error: git add failed: {e}"));
+            }
+            Ok(ref out) if !out.status.success() => {
+                return ToolExecutionOutcome::text(format!(
+                    "Error: git add -A failed: {}",
+                    String::from_utf8_lossy(&out.stderr).trim()
+                ));
+            }
+            Ok(_) => {}
+        }
+    } else if !files.is_empty() {
+        // Stage specific files
+        let mut cmd = std::process::Command::new("git");
+        cmd.arg("add").args(&files).current_dir(project_root);
+        let add_out = cmd.output();
+        match add_out {
+            Err(e) => {
+                return ToolExecutionOutcome::text(format!("Error: git add failed: {e}"));
+            }
+            Ok(ref out) if !out.status.success() => {
+                return ToolExecutionOutcome::text(format!(
+                    "Error: git add failed: {}",
+                    String::from_utf8_lossy(&out.stderr).trim()
+                ));
+            }
+            Ok(_) => {}
+        }
+    }
+
+    // Commit
+    let mut commit_args = vec!["commit", "-m", message];
+    if stage_all && files.is_empty() {
+        commit_args.insert(1, "-a");
+    }
+    let commit_out = std::process::Command::new("git")
+        .args(&commit_args)
+        .current_dir(project_root)
+        .output();
+
+    match commit_out {
+        Ok(out) if out.status.success() => {
+            let commit_sha = resolve_commit_ref(project_root, "HEAD");
+            let short_hash = commit_sha
+                .as_deref()
+                .map(short_commit_sha)
+                .unwrap_or_else(|| {
+                    String::from_utf8_lossy(&out.stdout)
+                        .lines()
+                        .next()
+                        .unwrap_or("")
+                        .split_whitespace()
+                        .nth(1)
+                        .unwrap_or("???")
+                        .to_string()
+                });
+            let tool_result_fields = commit_sha.map(|commit_sha| {
+                serde_json::Map::from_iter([
+                    ("commit_sha".to_string(), Value::String(commit_sha.clone())),
+                    (
+                        "commit_short_sha".to_string(),
+                        Value::String(short_commit_sha(&commit_sha)),
+                    ),
+                ])
+            });
+            ToolExecutionOutcome {
+                output: format!("✓ Committed: {short_hash} {message}"),
+                tool_result_fields,
+            }
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if stderr.contains("nothing to commit") {
+                ToolExecutionOutcome::text("Nothing to commit — working tree clean".to_string())
+            } else {
+                ToolExecutionOutcome::text(format!("Error: git commit failed: {}", stderr.trim()))
+            }
+        }
+        Err(e) => ToolExecutionOutcome::text(format!("Error: git commit failed: {e}")),
+    }
+}
+
+/// Create a compensating revert commit for an earlier git commit.
+///
+/// Parameters:
+/// - `commit_sha` (required): full commit SHA or git revision to revert
+pub fn git_revert_commit(project_root: &Path, args: &Value) -> String {
+    git_revert_commit_with_metadata(project_root, args).output
+}
+
+pub fn git_revert_commit_with_metadata(project_root: &Path, args: &Value) -> ToolExecutionOutcome {
+    let commit_ref = match args.get("commit_sha").and_then(Value::as_str) {
+        Some(commit_ref) => match validate_commit_ref(commit_ref, "commit_sha") {
+            Ok(commit_ref) => commit_ref,
+            Err(error) => return ToolExecutionOutcome::text(error),
+        },
+        None => {
+            return ToolExecutionOutcome::text("Error: 'commit_sha' is required".to_string());
+        }
+    };
+    let target_commit_sha = match resolve_commit_ref(project_root, &commit_ref) {
+        Some(commit_sha) => commit_sha,
+        None => {
+            return ToolExecutionOutcome::text(format!("Error: unknown commit '{commit_ref}'"));
+        }
+    };
+
+    match std::process::Command::new("git")
+        .args(["revert", "--no-edit", target_commit_sha.as_str()])
+        .current_dir(project_root)
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            let revert_commit_sha = resolve_commit_ref(project_root, "HEAD");
+            let revert_short_sha = revert_commit_sha
+                .as_deref()
+                .map(short_commit_sha)
+                .unwrap_or_else(|| "???".to_string());
+            let tool_result_fields = revert_commit_sha.map(|revert_commit_sha| {
+                serde_json::Map::from_iter([
+                    (
+                        "reverted_commit_sha".to_string(),
+                        Value::String(target_commit_sha.clone()),
+                    ),
+                    (
+                        "reverted_commit_short_sha".to_string(),
+                        Value::String(short_commit_sha(&target_commit_sha)),
+                    ),
+                    (
+                        "revert_commit_sha".to_string(),
+                        Value::String(revert_commit_sha.clone()),
+                    ),
+                    (
+                        "revert_commit_short_sha".to_string(),
+                        Value::String(short_commit_sha(&revert_commit_sha)),
+                    ),
+                ])
+            });
+            ToolExecutionOutcome {
+                output: format!(
+                    "✓ Reverted commit: {} via {}",
+                    short_commit_sha(&target_commit_sha),
+                    revert_short_sha
+                ),
+                tool_result_fields,
+            }
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let mut message = format!("Error: git revert failed: {}", stderr.trim());
+            match abort_git_revert(project_root) {
+                Ok(true) => {
+                    message.push_str(" (aborted in-progress revert)");
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    message.push_str(&format!(" ({error})"));
+                }
+            }
+            ToolExecutionOutcome::text(message)
+        }
+        Err(e) => ToolExecutionOutcome::text(format!("Error: git revert failed: {e}")),
+    }
+}
+
+/// Stash working tree changes.
+///
+/// Parameters:
+/// - `action` (required): "push" (save), "apply", "pop" (restore + drop), "list", "drop"
+/// - `message` (optional): description for push
+/// - `index` (optional): stash index for apply/pop/drop (default 0)
+/// - `stash_ref` (optional): exact stash selector or OID for apply
+pub fn git_stash(project_root: &Path, args: &Value) -> String {
+    git_stash_with_metadata(project_root, args).output
+}
+
+pub fn git_stash_with_metadata(project_root: &Path, args: &Value) -> ToolExecutionOutcome {
+    let action = match args.get("action").and_then(Value::as_str) {
+        Some(a) => a,
+        None => {
+            return ToolExecutionOutcome::text(
+                "Error: 'action' is required (push, apply, pop, list, drop)".to_string(),
+            );
+        }
+    };
+
+    let mut cmd = std::process::Command::new("git");
+    cmd.current_dir(project_root);
+    let before_stash_oid = matches!(action, "push" | "save")
+        .then(|| {
+            std::process::Command::new("git")
+                .args(["rev-parse", "--verify", "refs/stash"])
+                .current_dir(project_root)
+                .output()
+                .ok()
+                .filter(|out| out.status.success())
+                .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        })
+        .flatten();
+
+    match action {
+        "push" | "save" => {
+            cmd.arg("stash").arg("push");
+            if let Some(msg) = args.get("message").and_then(Value::as_str) {
+                cmd.arg("-m").arg(msg);
+            }
+        }
+        "apply" => {
+            let selector = match apply_stash_selector(args) {
+                Ok(selector) => selector,
+                Err(error) => return ToolExecutionOutcome::text(error),
+            };
+            cmd.arg("stash").arg("apply").arg(selector);
+        }
+        "pop" => {
+            let selector = stash_index_selector(args);
+            cmd.arg("stash").arg("pop").arg(selector);
+        }
+        "list" => {
+            cmd.arg("stash").arg("list");
+        }
+        "drop" => {
+            let selector = stash_index_selector(args);
+            cmd.arg("stash").arg("drop").arg(selector);
+        }
+        _ => {
+            return ToolExecutionOutcome::text(format!(
+                "Error: unknown stash action '{action}'. Use: push, apply, pop, list, drop"
+            ));
+        }
+    }
+
+    match cmd.output() {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if out.status.success() {
+                let result = stdout.trim();
+                let output = if result.is_empty() {
+                    match action {
+                        "push" | "save" => "✓ Changes stashed".to_string(),
+                        "list" => "No stashes found".to_string(),
+                        _ => format!("✓ Stash {action} done"),
+                    }
+                } else {
+                    result.to_string()
+                };
+                let mut tool_result_fields = None;
+                if matches!(action, "push" | "save") {
+                    let after_stash_oid = std::process::Command::new("git")
+                        .args(["rev-parse", "--verify", "refs/stash"])
+                        .current_dir(project_root)
+                        .output()
+                        .ok()
+                        .filter(|out| out.status.success())
+                        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string());
+                    if let Some(stash_ref) = after_stash_oid
+                        && before_stash_oid.as_deref() != Some(stash_ref.as_str())
+                    {
+                        tool_result_fields = Some(serde_json::Map::from_iter([(
+                            "stash_ref".to_string(),
+                            Value::String(stash_ref),
+                        )]));
+                    }
+                }
+                ToolExecutionOutcome {
+                    output,
+                    tool_result_fields,
+                }
+            } else {
+                let err = stderr.trim();
+                if err.contains("No local changes") || err.contains("No stash entries") {
+                    ToolExecutionOutcome::text(err.to_string())
+                } else {
+                    ToolExecutionOutcome::text(format!("Error: git stash {action} failed: {err}"))
+                }
+            }
+        }
+        Err(e) => ToolExecutionOutcome::text(format!("Error: git stash failed: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    /// Take first n chars from a string.
+    fn prefix_chars(s: &str, n: usize) -> String {
+        s.chars().take(n).collect()
+    }
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn repo_root() -> std::path::PathBuf {
+        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.pop(); // crates/
+        path.pop(); // rust/
+        path
+    }
+
+    fn init_temp_repo() -> TempDir {
+        let dir = TempDir::new().expect("temp repo");
+        std::process::Command::new("git")
+            .arg("init")
+            .current_dir(dir.path())
+            .output()
+            .expect("git init");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git config user.name");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git config user.email");
+        std::fs::write(dir.path().join("tracked.txt"), "one\n").expect("seed tracked file");
+        std::process::Command::new("git")
+            .args(["add", "tracked.txt"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git add");
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git commit");
+        dir
+    }
+
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_stdout(dir: &std::path::Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn init_temp_repo_with_ours_merge() -> TempDir {
+        let dir = init_temp_repo();
+        let root = dir.path();
+        let default_branch = git_stdout(root, &["branch", "--show-current"]);
+        run_git(root, &["checkout", "-b", "feature"]);
+        std::fs::write(root.join("tracked.txt"), "feature branch change\n").expect("write feature");
+        run_git(root, &["add", "tracked.txt"]);
+        run_git(root, &["commit", "-m", "feature change"]);
+        run_git(root, &["checkout", &default_branch]);
+        run_git(
+            root,
+            &[
+                "merge",
+                "--no-ff",
+                "-s",
+                "ours",
+                "feature",
+                "-m",
+                "merge feature",
+            ],
+        );
+        dir
+    }
+
+    #[test]
+    fn git_status_returns_output() {
+        let root = repo_root();
+        let result = git_status(&root);
+        assert!(
+            result.contains("##")
+                || result.contains("nothing to commit")
+                || result.contains("Error"),
+            "unexpected status: {result}"
+        );
+    }
+
+    #[test]
+    fn git_log_returns_commits() {
+        let root = repo_root();
+        let result = git_log(&root, &json!({"n": 5}));
+        let lines: Vec<&str> = result.lines().collect();
+        assert!(!lines.is_empty(), "log should return commits");
+        let first = lines[0];
+        let hash_prefix = prefix_chars(first, 7);
+        assert!(
+            hash_prefix.chars().count() == 7 && hash_prefix.chars().all(|c| c.is_ascii_hexdigit()),
+            "first log line should start with hash: {first}"
+        );
+    }
+
+    #[test]
+    fn git_log_default_n() {
+        let root = repo_root();
+        let result = git_log(&root, &json!({}));
+        let lines: Vec<&str> = result.lines().filter(|l| !l.is_empty()).collect();
+        assert!(lines.len() <= 10, "default should be at most 10 commits");
+    }
+
+    #[test]
+    fn git_show_missing_commit() {
+        let root = repo_root();
+        let result = git_show(&root, &json!({}), 0.0, 0);
+        assert!(result.contains("Error: missing"));
+    }
+
+    #[test]
+    fn git_show_invalid_ref() {
+        let root = repo_root();
+        let result = git_show(&root, &json!({"commit": "abc;rm -rf /"}), 0.0, 0);
+        assert!(result.contains("Error: invalid commit reference"));
+    }
+
+    #[test]
+    fn git_show_head() {
+        let root = repo_root();
+        let result = git_show(&root, &json!({"commit": "HEAD"}), 0.0, 0);
+        assert!(result.contains("commit "), "should show commit: {result}");
+        assert!(result.contains("Author:"), "should show author");
+    }
+
+    #[test]
+    fn git_show_stat_only() {
+        let root = repo_root();
+        let result = git_show(&root, &json!({"commit": "HEAD", "stat_only": true}), 0.0, 0);
+        assert!(result.contains("commit "));
+        assert!(
+            result.contains("files changed") || result.contains("root commit"),
+            "should show stats: {result}"
+        );
+    }
+
+    #[test]
+    fn git_blame_missing_file_param() {
+        let root = repo_root();
+        let result = git_blame(&root, &json!({}));
+        assert!(result.contains("Error: missing 'file'"));
+    }
+
+    #[test]
+    fn git_blame_known_file() {
+        let root = repo_root();
+        let result = git_blame(&root, &json!({"file": "README.md"}));
+        assert!(
+            result.contains("L1") || result.contains("Error") || result.contains("No blame"),
+            "unexpected blame: {result}"
+        );
+    }
+
+    #[test]
+    fn git_blame_with_line_range() {
+        let root = repo_root();
+        let result = git_blame(
+            &root,
+            &json!({"file": "README.md", "line_start": 1, "line_end": 3}),
+        );
+        if result.contains("L1") {
+            let blame_lines: Vec<&str> = result.lines().filter(|l| l.starts_with('L')).collect();
+            assert!(
+                blame_lines.len() <= 3,
+                "should have at most 3 lines: {blame_lines:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn git_diff_no_crash() {
+        let root = repo_root();
+        let result = git_diff(&root, &json!({}), 0.0, 0);
+        assert!(
+            !result.contains("Error: cannot open"),
+            "should open repo: {result}"
+        );
+    }
+
+    #[test]
+    fn git_file_history_missing_file() {
+        let root = repo_root();
+        let result = git_file_history(&root, &json!({}));
+        assert!(result.contains("Error: missing 'file'"));
+    }
+
+    #[test]
+    fn git_file_history_known_file() {
+        let root = repo_root();
+        let result = git_file_history(&root, &json!({"file": "README.md"}));
+        assert!(
+            result.contains("File: README.md") || result.contains("No history"),
+            "unexpected: {result}"
+        );
+    }
+
+    #[test]
+    fn git_file_history_limits_n() {
+        let root = repo_root();
+        let result = git_file_history(&root, &json!({"file": "README.md", "n": 3}));
+        if result.contains("Commits:")
+            && let Some(line) = result.lines().find(|l| l.starts_with("Commits:"))
+        {
+            let count: usize = line
+                .trim_start_matches("Commits: ")
+                .trim()
+                .parse()
+                .unwrap_or(0);
+            assert!(count <= 3, "should respect n limit: {count}");
+        }
+    }
+
+    // ─── git_diff enhanced tests ────────────────────────────────────────────
+
+    #[test]
+    fn git_diff_staged_param_accepted() {
+        let root = repo_root();
+        // staged=true should not crash (may return "No staged changes" or file list)
+        let result = git_diff(&root, &json!({"staged": true}), 0.0, 0);
+        assert!(
+            !result.contains("Error: cannot open"),
+            "staged diff should not fail to open repo: {result}"
+        );
+    }
+
+    #[test]
+    fn git_diff_ref_param_uses_tree_diff() {
+        let root = repo_root();
+        // Diff HEAD against HEAD~1 should produce actual file changes
+        let result = git_diff(&root, &json!({"ref": "HEAD~1"}), 0.0, 0);
+        assert!(
+            result.contains("diff --git")
+                || result.contains("No changes")
+                || result.contains("Error: cannot resolve"),
+            "ref diff should produce diff output or error: {result}"
+        );
+    }
+
+    #[test]
+    fn git_diff_default_shows_worktree() {
+        let root = repo_root();
+        let result = git_diff(&root, &json!({}), 0.0, 0);
+        // Should not error — either shows changes or "No changes"
+        assert!(
+            !result.starts_with("Error:"),
+            "default diff should work: {result}"
+        );
+    }
+
+    #[test]
+    fn git_diff_stat_only_smoke() {
+        let root = repo_root();
+        let result = git_diff(&root, &json!({"stat_only": true}), 0.0, 0);
+        assert!(
+            !result.starts_with("Error:"),
+            "stat_only should use git CLI without repo open errors: {result}"
+        );
+        assert!(
+            result.contains('|')
+                || result.to_lowercase().contains("file")
+                || result == "No changes",
+            "expected stat-style summary: {result}"
+        );
+    }
+
+    #[test]
+    fn git_diff_stat_only_rejects_staged_with_ref() {
+        let root = repo_root();
+        let result = git_diff(
+            &root,
+            &json!({"stat_only": true, "staged": true, "ref": "HEAD~1"}),
+            0.0,
+            0,
+        );
+        assert!(result.contains("not both"), "{result}");
+    }
+
+    #[test]
+    fn git_diff_base_ref_range() {
+        let root = repo_root();
+        let result = git_diff(&root, &json!({"base_ref": "HEAD~3", "ref": "HEAD"}), 0.0, 0);
+        assert!(
+            result.contains("diff --git") || result == "No changes",
+            "range diff should produce output: {result}"
+        );
+    }
+
+    #[test]
+    fn git_diff_base_ref_defaults_tip_to_head() {
+        let root = repo_root();
+        let result = git_diff(&root, &json!({"base_ref": "HEAD~1"}), 0.0, 0);
+        assert!(
+            !result.starts_with("Error:"),
+            "base_ref without ref should default tip to HEAD: {result}"
+        );
+    }
+
+    #[test]
+    fn git_diff_base_ref_with_path() {
+        let root = repo_root();
+        let result = git_diff(
+            &root,
+            &json!({"base_ref": "HEAD~2", "ref": "HEAD", "path": "Cargo.toml"}),
+            0.0,
+            0,
+        );
+        assert!(
+            !result.starts_with("Error:"),
+            "range diff with path filter should work: {result}"
+        );
+    }
+
+    #[test]
+    fn git_diff_base_ref_stat_only() {
+        let root = repo_root();
+        let result = git_diff(
+            &root,
+            &json!({"base_ref": "HEAD~3", "ref": "HEAD", "stat_only": true}),
+            0.0,
+            0,
+        );
+        assert!(
+            !result.starts_with("Error:"),
+            "range stat diff should work: {result}"
+        );
+    }
+
+    #[test]
+    fn git_diff_base_ref_rejects_shell_injection() {
+        let root = repo_root();
+        let result = git_diff(&root, &json!({"base_ref": "HEAD; rm -rf /"}), 0.0, 0);
+        assert!(
+            result.contains("disallowed"),
+            "shell meta in base_ref should be rejected: {result}"
+        );
+    }
+
+    #[test]
+    fn reject_shell_meta_allows_valid_refs() {
+        assert!(super::reject_shell_meta("HEAD~5").is_ok());
+        assert!(super::reject_shell_meta("main").is_ok());
+        assert!(super::reject_shell_meta("v1.0.0").is_ok());
+        assert!(super::reject_shell_meta("feature/my-branch").is_ok());
+        assert!(super::reject_shell_meta("HEAD^2").is_ok());
+    }
+
+    #[test]
+    fn reject_shell_meta_blocks_injection() {
+        assert!(super::reject_shell_meta("HEAD; echo pwned").is_err());
+        assert!(super::reject_shell_meta("HEAD|cat /etc/passwd").is_err());
+        assert!(super::reject_shell_meta("$(whoami)").is_err());
+        assert!(super::reject_shell_meta("HEAD`id`").is_err());
+    }
+
+    // ─── git_show enhanced tests ────────────────────────────────────────────
+
+    #[test]
+    fn git_show_allows_reflog_syntax() {
+        let root = repo_root();
+        // HEAD@{0} should not be rejected by validation — it should reach rev_parse
+        let result = git_show(&root, &json!({"commit": "HEAD@{0}"}), 0.0, 0);
+        // Should show a commit (passes validation), not be rejected outright
+        assert!(
+            result.starts_with("commit ") || result.starts_with("Error: cannot resolve"),
+            "HEAD@{{0}} should pass validation and reach parsing: {result}"
+        );
+    }
+
+    #[test]
+    fn git_show_rejects_shell_metachar() {
+        let root = repo_root();
+        let result = git_show(&root, &json!({"commit": "HEAD;rm -rf /"}), 0.0, 0);
+        assert!(result.contains("Error: invalid commit reference"));
+    }
+
+    #[test]
+    fn git_show_head_has_diff_content() {
+        let root = repo_root();
+        let result = git_show(&root, &json!({"commit": "HEAD"}), 0.0, 0);
+        assert!(result.contains("commit "), "should show commit header");
+        assert!(result.contains("Author:"), "should show author");
+        // Should contain actual diff markers or root commit marker
+        assert!(
+            result.contains("---") || result.contains("[root commit]") || result.contains("+"),
+            "should contain diff content: {result}"
+        );
+    }
+
+    #[test]
+    fn git_show_stat_only_has_stats() {
+        let root = repo_root();
+        let result = git_show(&root, &json!({"commit": "HEAD", "stat_only": true}), 0.0, 0);
+        assert!(result.contains("commit "));
+        assert!(
+            result.contains("files changed") || result.contains("[root commit]"),
+            "should show stats or root: {result}"
+        );
+    }
+
+    #[test]
+    fn git_show_merge_commit_stat_only_has_stats() {
+        let dir = init_temp_repo_with_ours_merge();
+        let result = git_show(
+            dir.path(),
+            &json!({"commit": "HEAD", "stat_only": true}),
+            0.0,
+            0,
+        );
+        assert!(
+            result.contains("commit "),
+            "should show commit header: {result}"
+        );
+        assert!(
+            result.contains(" file changed") || result.contains(" files changed"),
+            "merge commit stat_only should show stats: {result}"
+        );
+        assert!(
+            result.contains("tracked.txt"),
+            "merge commit stat_only should mention changed file: {result}"
+        );
+    }
+
+    #[test]
+    fn git_show_merge_commit_has_diff_content() {
+        let dir = init_temp_repo_with_ours_merge();
+        let result = git_show(dir.path(), &json!({"commit": "HEAD"}), 0.0, 0);
+        assert!(
+            result.contains("commit "),
+            "should show commit header: {result}"
+        );
+        assert!(
+            result.contains("diff --git") || result.contains("--- a/tracked.txt"),
+            "merge commit should include diff output: {result}"
+        );
+    }
+
+    #[test]
+    fn git_show_file_filter() {
+        let root = repo_root();
+        let result = git_show(
+            &root,
+            &json!({"commit": "HEAD", "file": "README.md"}),
+            0.0,
+            0,
+        );
+        // If README.md was changed in HEAD, it should appear; otherwise no diff lines
+        assert!(result.contains("commit "), "should show header: {result}");
+    }
+
+    // ─── git_blame enhanced tests ───────────────────────────────────────────
+
+    #[test]
+    fn git_blame_nonexistent_file() {
+        let root = repo_root();
+        let result = git_blame(&root, &json!({"file": "nonexistent_file_xyz.rs"}));
+        assert!(
+            result.contains("Error"),
+            "should error on nonexistent file: {result}"
+        );
+    }
+
+    #[test]
+    fn git_blame_output_format() {
+        let root = repo_root();
+        let result = git_blame(&root, &json!({"file": "README.md"}));
+        if result.contains("L1") {
+            // Should have structured format: L<n> <commit> <date> [<author>] <content>
+            let first_line = result.lines().next().unwrap_or("");
+            assert!(
+                first_line.starts_with("L1 "),
+                "blame line should start with L1: {first_line}"
+            );
+            assert!(
+                first_line.contains('[') && first_line.contains(']'),
+                "blame line should have [author]: {first_line}"
+            );
+        }
+    }
+
+    #[test]
+    fn git_blame_summary_footer() {
+        let root = repo_root();
+        let result = git_blame(&root, &json!({"file": "README.md"}));
+        if !result.contains("Error") && !result.contains("No blame") {
+            assert!(
+                result.contains("lines,")
+                    && result.contains("authors,")
+                    && result.contains("commits"),
+                "should have summary footer: {result}"
+            );
+        }
+    }
+
+    // ─── git_status enhanced tests ──────────────────────────────────────────
+
+    #[test]
+    fn git_status_shows_branch() {
+        let root = repo_root();
+        let result = git_status(&root);
+        // Should show branch info or be clean
+        assert!(
+            result.contains("##")
+                || result.contains("nothing to commit")
+                || result.contains("HEAD detached"),
+            "status should show branch: {result}"
+        );
+    }
+
+    // ─── git_log enhanced tests ─────────────────────────────────────────────
+
+    #[test]
+    fn git_log_custom_n() {
+        let root = repo_root();
+        let result = git_log(&root, &json!({"n": 3}));
+        let lines: Vec<&str> = result.lines().filter(|l| !l.is_empty()).collect();
+        assert!(
+            lines.len() <= 3,
+            "should respect n=3: got {} lines",
+            lines.len()
+        );
+        assert!(!lines.is_empty(), "should have at least 1 commit");
+    }
+
+    #[test]
+    fn git_log_format_consistent() {
+        let root = repo_root();
+        let result = git_log(&root, &json!({"n": 5}));
+        for line in result.lines().filter(|l| !l.is_empty()) {
+            // Each line should start with a 7-char hex hash
+            let hash_prefix = prefix_chars(line, 7);
+            assert!(
+                hash_prefix.chars().count() == 7
+                    && hash_prefix.chars().all(|c| c.is_ascii_hexdigit()),
+                "log line should start with hash: {line}"
+            );
+            // Should have a space after the hash
+            assert!(
+                line.chars().nth(7) == Some(' '),
+                "log line should have space after hash: {line}"
+            );
+        }
+    }
+
+    // ─── Diff with actual content verification ──────────────────────────────
+
+    #[test]
+    fn git_diff_ref_produces_line_content() {
+        let root = repo_root();
+        let result = git_diff(&root, &json!({"ref": "HEAD~1"}), 0.0, 0);
+        if result.contains("diff --git") {
+            // If there are changes, we should see actual +/- lines
+            assert!(
+                result.contains('+') || result.contains('-') || result.contains("# "),
+                "ref diff should have content markers: {result}"
+            );
+        }
+    }
+
+    // ─── Edge cases ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn git_file_history_nonexistent_file() {
+        let root = repo_root();
+        let result = git_file_history(&root, &json!({"file": "this/does/not/exist.xyz"}));
+        assert!(
+            result.contains("No history"),
+            "should say no history: {result}"
+        );
+    }
+
+    #[test]
+    fn git_show_parent_ref() {
+        let root = repo_root();
+        let result = git_show(&root, &json!({"commit": "HEAD~1"}), 0.0, 0);
+        assert!(
+            result.contains("commit ") || result.contains("Error: cannot resolve"),
+            "HEAD~1 should work: {result}"
+        );
+    }
+
+    // ─── git_log_search tests ───────────────────────────────────────────────
+
+    #[test]
+    fn git_log_search_missing_query() {
+        let root = repo_root();
+        let result = git_log_search(&root, &json!({}));
+        assert!(result.contains("Error: missing or empty"));
+    }
+
+    #[test]
+    fn git_log_search_empty_query() {
+        let root = repo_root();
+        let result = git_log_search(&root, &json!({"query": "  "}));
+        assert!(result.contains("Error: missing or empty"));
+    }
+
+    #[test]
+    fn git_log_search_finds_commits() {
+        let root = repo_root();
+        let result = git_log_search(&root, &json!({"query": "fix"}));
+        // Should find some commits with "fix" in the message
+        assert!(
+            result.contains("Search:") || result.contains("No commits matching"),
+            "should produce search result: {result}"
+        );
+    }
+
+    #[test]
+    fn git_log_search_respects_n() {
+        let root = repo_root();
+        let result = git_log_search(&root, &json!({"query": "fix", "n": 10}));
+        if result.contains("commits searched") {
+            // Extract the number of commits searched
+            if let Some(start) = result.find('(')
+                && let Some(end) = result.find(" commits searched")
+            {
+                let num_str = &result[start + 1..end];
+                let count: usize = num_str.parse().unwrap_or(0);
+                assert!(count <= 10, "should search at most 10: {count}");
+            }
+        }
+    }
+
+    #[test]
+    fn git_log_search_score_format() {
+        let root = repo_root();
+        let result = git_log_search(&root, &json!({"query": "feat"}));
+        if result.contains("[score:") {
+            // Scores should be between 0 and 1
+            for line in result.lines() {
+                if let Some(start) = line.find("[score:")
+                    && let Some(end) = line[start..].find(']')
+                {
+                    let score_str = &line[start + 7..start + end];
+                    let score: f64 = score_str.parse().unwrap_or(0.0);
+                    assert!(score > 0.0 && score <= 1.0, "score should be 0-1: {score}");
+                }
+            }
+        }
+    }
+
+    // ─── git_contributors tests ─────────────────────────────────────────────
+
+    #[test]
+    fn git_contributors_shows_authors() {
+        let root = repo_root();
+        let result = git_contributors(&root, &json!({}));
+        assert!(
+            result.contains("## Top Contributors") || result.contains("No git history"),
+            "should show contributors: {result}"
+        );
+    }
+
+    #[test]
+    fn git_contributors_shows_hot_files() {
+        let root = repo_root();
+        let result = git_contributors(&root, &json!({}));
+        if result.contains("## Top Contributors") {
+            assert!(
+                result.contains("## Hot Files") || result.contains("## Recent"),
+                "should have hot files or recent activity: {result}"
+            );
+        }
+    }
+
+    #[test]
+    fn git_contributors_shows_recent() {
+        let root = repo_root();
+        let result = git_contributors(&root, &json!({}));
+        if !result.contains("No git history") {
+            assert!(
+                result.contains("## Recent Activity"),
+                "should show recent activity: {result}"
+            );
+        }
+    }
+
+    #[test]
+    fn git_contributors_with_path_filter() {
+        let root = repo_root();
+        let result = git_contributors(&root, &json!({"path": "README.md"}));
+        // Either shows filtered results or no history
+        assert!(
+            result.contains("## Top Contributors") || result.contains("No git history"),
+            "path filter should work: {result}"
+        );
+    }
+
+    #[test]
+    fn git_contributors_with_since() {
+        let root = repo_root();
+        let result = git_contributors(&root, &json!({"since": "2020-01-01"}));
+        assert!(
+            result.contains("## Top Contributors") || result.contains("No git history"),
+            "since filter should work: {result}"
+        );
+    }
+
+    // ─── Score function unit tests ──────────────────────────────────────────
+
+    #[test]
+    fn score_commits_empty_corpus() {
+        let result = score_commits("test", &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn score_commits_empty_query() {
+        let commits = vec![CommitDoc {
+            hash: "abc".into(),
+            author: "test".into(),
+            date: "2024".into(),
+            message: "hello".into(),
+            tokens: vec!["hello".into()],
+        }];
+        let result = score_commits("", &commits);
+        assert!(result.is_empty());
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn score_commits_exact_match_ranks_higher() {
+        let commits = vec![
+            CommitDoc {
+                hash: "a".into(),
+                author: "test".into(),
+                date: "2024".into(),
+                message: "fix bug in parser".into(),
+                tokens: astra_runtime::text_tokenize::tokenize("fix bug in parser"),
+            },
+            CommitDoc {
+                hash: "b".into(),
+                author: "test".into(),
+                date: "2024".into(),
+                message: "add new feature".into(),
+                tokens: astra_runtime::text_tokenize::tokenize("add new feature"),
+            },
+        ];
+        let result = score_commits("fix", &commits);
+        assert!(!result.is_empty(), "should find 'fix'");
+        assert_eq!(result[0].0, 0, "commit about 'fix' should rank first");
+    }
+
+    // ─── parse_since_to_epoch tests ─────────────────────────────────────────
+
+    #[test]
+    fn parse_since_iso_date() {
+        let epoch = parse_since_to_epoch("2024-01-01");
+        assert!(epoch.is_some());
+        let ts = epoch.unwrap();
+        // 2024-01-01 should be > 2023 in epoch seconds
+        assert!(ts > 1_672_000_000, "should be a valid epoch: {ts}");
+    }
+
+    #[test]
+    fn parse_since_invalid() {
+        assert!(parse_since_to_epoch("not a date").is_none());
+        assert!(parse_since_to_epoch("").is_none());
+    }
+
+    #[test]
+    fn parse_since_invalid_month_day() {
+        // Month 0 and 13 must not panic (was an array OOB bug)
+        assert!(parse_since_to_epoch("2024-00-15").is_none());
+        assert!(parse_since_to_epoch("2024-13-01").is_none());
+        // Day 0 and 32
+        assert!(parse_since_to_epoch("2024-01-00").is_none());
+        assert!(parse_since_to_epoch("2024-01-32").is_none());
+    }
+
+    // ─── current_branch / head_short tests ──────────────────────────────────
+
+    #[test]
+    fn current_branch_returns_nonempty_in_repo() {
+        let root = repo_root();
+        let branch = current_branch(&root);
+        // In a git repo we should get a branch name (or empty if detached HEAD)
+        // Just verify no panic and reasonable output
+        assert!(!branch.contains("Error"), "should not error: {branch}");
+    }
+
+    #[test]
+    fn head_short_returns_hex() {
+        let root = repo_root();
+        let short = head_short(&root);
+        assert!(!short.is_empty(), "should return a short hash");
+        assert_eq!(
+            short.len(),
+            7,
+            "to_hex_with_len(7) yields 7 hex chars: {short}"
+        );
+        assert!(
+            short.chars().all(|c| c.is_ascii_hexdigit()),
+            "should be hex: {short}"
+        );
+    }
+
+    #[test]
+    fn current_branch_bad_path_returns_empty() {
+        let branch = current_branch(Path::new("/nonexistent/repo"));
+        assert!(branch.is_empty());
+    }
+
+    #[test]
+    fn head_short_bad_path_returns_empty() {
+        let short = head_short(Path::new("/nonexistent/repo"));
+        assert!(short.is_empty());
+    }
+
+    // ─── Robustness regression tests ────────────────────────────────────────
+
+    #[test]
+    fn git_diff_staged_detects_no_staged() {
+        // In a clean repo, staged diff should say "No staged changes"
+        let root = repo_root();
+        let result = git_diff(&root, &json!({"staged": true}), 0.0, 0);
+        // Either "No staged changes" or actual staged content — no panic/error
+        assert!(
+            result.contains("staged") || result.contains("diff --git"),
+            "should handle staged query: {result}"
+        );
+    }
+
+    #[test]
+    fn git_log_n_capped_at_500() {
+        // Even with n=99999, should not produce huge output
+        let root = repo_root();
+        let result = git_log(&root, &json!({"n": 99999}));
+        let line_count = result.lines().count();
+        assert!(
+            line_count <= 501,
+            "n should be capped at 500: got {line_count} lines"
+        );
+    }
+
+    #[test]
+    fn git_log_output_truncated() {
+        // git_log should apply truncation
+        let root = repo_root();
+        let result = git_log(&root, &json!({"n": 500}));
+        // Just verify it doesn't panic and produces output
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn git_file_history_nonexistent_file_bounded() {
+        // For a nonexistent file, the walk should be bounded (not traverse all history)
+        let root = repo_root();
+        let start = std::time::Instant::now();
+        let result = git_file_history(&root, &json!({"file": "this/does/not/exist.xyz"}));
+        let elapsed = start.elapsed();
+        assert!(
+            result.contains("No history"),
+            "should say no history: {result}"
+        );
+        // Walk cap should prevent this from taking too long (50K cap)
+        // In a typical dev repo this should be well under 5 seconds
+        assert!(
+            elapsed.as_secs() < 30,
+            "walk should be bounded, took: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn git_contributors_bounded_walk() {
+        // Even without path filter, walk should complete in bounded time
+        let root = repo_root();
+        let start = std::time::Instant::now();
+        let result = git_contributors(&root, &json!({}));
+        let elapsed = start.elapsed();
+        assert!(
+            !result.contains("Error: cannot open"),
+            "should open repo: {result}"
+        );
+        assert!(
+            elapsed.as_secs() < 30,
+            "walk should be bounded, took: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn git_contributors_path_filter_bounded() {
+        // Path filter with nonexistent file should still be bounded
+        let root = repo_root();
+        let start = std::time::Instant::now();
+        let _result = git_contributors(
+            &root,
+            &json!({"path": "nonexistent/deeply/nested/file.xyz"}),
+        );
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed.as_secs() < 30,
+            "path-filtered walk should be bounded, took: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn git_show_root_commit_lists_files() {
+        // Find the root commit and verify it lists actual file paths
+        let root = repo_root();
+        let repo = gix::discover(&root).unwrap();
+        // Walk to find root commit (no parents)
+        let head = repo.head_id().unwrap();
+        let mut root_oid = None;
+        if let Ok(walk) = head.ancestors().all() {
+            for info in walk.flatten() {
+                if let Ok(c) = info.object()
+                    && c.parent_ids().count() == 0
+                {
+                    root_oid = Some(info.id.to_string());
+                    break;
+                }
+            }
+        }
+        if let Some(oid) = root_oid {
+            let result = git_show(&root, &json!({"commit": oid}), 0.0, 0);
+            assert!(
+                result.contains("[root commit]"),
+                "should mark as root: {result}"
+            );
+            // Should list files with full paths, not just top-level dirs
+            // (regression: previously only listed directory names)
+            assert!(
+                result.contains('/') || result.lines().filter(|l| l.starts_with("A ")).count() > 0,
+                "root commit should list files: {result}"
+            );
+        }
+    }
+
+    // ── Pressure-aware output limit tests ──
+
+    #[test]
+    fn pressure_scaled_limit_zero_pressure_returns_base() {
+        assert_eq!(super::pressure_scaled_limit(12_000, 0.0), 12_000);
+        assert_eq!(super::pressure_scaled_limit(16_000, 0.0), 16_000);
+    }
+
+    #[test]
+    fn pressure_scaled_limit_moderate_pressure_reduces() {
+        let limit = super::pressure_scaled_limit(12_000, 0.6);
+        assert!(limit < 12_000, "moderate pressure should reduce limit");
+        assert!(limit > 4_800, "should stay above 40% minimum");
+        // scale = 1.0 - 0.6*0.6 = 0.64 → 12000 * 0.64 = 7680
+        assert_eq!(limit, 7_680);
+    }
+
+    #[test]
+    fn pressure_scaled_limit_max_pressure_reaches_floor() {
+        let limit = super::pressure_scaled_limit(12_000, 1.0);
+        // scale = 1.0 - 1.0*0.6 = 0.4 → 12000 * 0.4 = 4800
+        assert_eq!(limit, 4_800);
+    }
+
+    #[test]
+    fn pressure_scaled_limit_never_goes_below_forty_percent() {
+        let limit = super::pressure_scaled_limit(10_000, 1.5);
+        // scale = max(1.0 - 1.5*0.6, 0.4) = max(0.1, 0.4) = 0.4 → 4000
+        assert_eq!(limit, 4_000);
+    }
+
+    #[test]
+    fn git_show_under_pressure_truncates_earlier() {
+        let root = std::env::current_dir().unwrap();
+        let normal = git_show(&root, &json!({"commit": "HEAD"}), 0.0, 0);
+        let pressed = git_show(&root, &json!({"commit": "HEAD"}), 0.9, 0);
+        assert!(
+            pressed.len() <= normal.len(),
+            "high-pressure output ({}) should not exceed normal ({})",
+            pressed.len(),
+            normal.len()
+        );
+    }
+
+    #[test]
+    fn git_diff_under_pressure_truncates_earlier() {
+        let root = std::env::current_dir().unwrap();
+        let normal = git_diff(&root, &json!({}), 0.0, 0);
+        let pressed = git_diff(&root, &json!({}), 0.9, 0);
+        assert!(
+            pressed.len() <= normal.len(),
+            "high-pressure diff ({}) should not exceed normal ({})",
+            pressed.len(),
+            normal.len()
+        );
+    }
+
+    // ─── git_commit tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn git_commit_rejects_empty_message() {
+        let root = repo_root();
+        let result = git_commit(&root, &json!({}));
+        assert!(
+            result.starts_with("Error:"),
+            "should reject missing message: {result}"
+        );
+
+        let result2 = git_commit(&root, &json!({"message": "  "}));
+        assert!(
+            result2.starts_with("Error:"),
+            "should reject blank message: {result2}"
+        );
+    }
+
+    #[test]
+    fn git_commit_rejects_long_message() {
+        let root = repo_root();
+        let long_msg = "x".repeat(5001);
+        let result = git_commit(&root, &json!({"message": long_msg}));
+        assert!(
+            result.contains("too long"),
+            "should reject over-long message: {result}"
+        );
+    }
+
+    #[test]
+    fn git_commit_clean_tree_says_nothing() {
+        // In a clean repo with nothing staged, commit should say "Nothing to commit"
+        // or succeed if there are pending changes — either is fine, just no panic
+        let root = repo_root();
+        let result = git_commit(
+            &root,
+            &json!({"message": "test commit", "files": ["nonexistent_file_xyz.txt"]}),
+        );
+        // Should either succeed or report a meaningful error
+        assert!(!result.is_empty(), "should return some output");
+    }
+
+    #[test]
+    fn git_commit_with_metadata_returns_commit_sha_and_revert_tool_restores_state() {
+        let repo = init_temp_repo();
+        let tracked_path = repo.path().join("tracked.txt");
+        std::fs::write(&tracked_path, "two\n").expect("update tracked file");
+
+        let outcome = git_commit_with_metadata(repo.path(), &json!({"message": "update tracked"}));
+        assert!(
+            !outcome.output.starts_with("Error:"),
+            "commit should succeed: {}",
+            outcome.output
+        );
+        let commit_fields = outcome
+            .tool_result_fields
+            .as_ref()
+            .expect("git_commit should return commit metadata");
+        let commit_sha = commit_fields
+            .get("commit_sha")
+            .and_then(Value::as_str)
+            .expect("commit_sha");
+        let commit_short_sha = commit_fields
+            .get("commit_short_sha")
+            .and_then(Value::as_str)
+            .expect("commit_short_sha");
+        assert_eq!(commit_short_sha, short_commit_sha(commit_sha));
+        assert_eq!(
+            std::fs::read_to_string(&tracked_path).expect("read committed file"),
+            "two\n"
+        );
+
+        let revert_outcome =
+            git_revert_commit_with_metadata(repo.path(), &json!({"commit_sha": commit_sha}));
+        assert!(
+            !revert_outcome.output.starts_with("Error:"),
+            "revert should succeed: {}",
+            revert_outcome.output
+        );
+        let revert_fields = revert_outcome
+            .tool_result_fields
+            .as_ref()
+            .expect("git_revert_commit should return metadata");
+        assert_eq!(
+            revert_fields
+                .get("reverted_commit_sha")
+                .and_then(Value::as_str),
+            Some(commit_sha)
+        );
+        assert!(
+            revert_fields
+                .get("revert_commit_sha")
+                .and_then(Value::as_str)
+                .is_some(),
+            "revert should report the compensating commit"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&tracked_path).expect("read reverted file"),
+            "one\n"
+        );
+    }
+
+    #[test]
+    fn git_revert_commit_conflict_is_aborted() {
+        let repo = init_temp_repo();
+        let tracked_path = repo.path().join("tracked.txt");
+        std::fs::write(&tracked_path, "two\n").expect("write second version");
+        let second = git_commit_with_metadata(repo.path(), &json!({"message": "second"}));
+        let second_sha = second
+            .tool_result_fields
+            .as_ref()
+            .and_then(|fields| fields.get("commit_sha"))
+            .and_then(Value::as_str)
+            .expect("second commit sha")
+            .to_string();
+
+        std::fs::write(&tracked_path, "three\n").expect("write third version");
+        let third = git_commit_with_metadata(repo.path(), &json!({"message": "third"}));
+        assert!(
+            !third.output.starts_with("Error:"),
+            "third commit should succeed: {}",
+            third.output
+        );
+
+        let revert =
+            git_revert_commit_with_metadata(repo.path(), &json!({"commit_sha": second_sha}));
+        assert!(
+            revert.output.starts_with("Error:"),
+            "reverting a non-HEAD conflicting commit should fail: {}",
+            revert.output
+        );
+        assert!(
+            revert.output.contains("aborted in-progress revert"),
+            "failure should clean up revert state: {}",
+            revert.output
+        );
+        assert_eq!(
+            std::fs::read_to_string(&tracked_path).expect("read file after aborted revert"),
+            "three\n"
+        );
+        assert!(
+            !repo.path().join(".git/REVERT_HEAD").exists(),
+            "revert conflict should not leave REVERT_HEAD behind"
+        );
+    }
+
+    // ─── git_stash tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn git_stash_requires_action() {
+        let root = repo_root();
+        let result = git_stash(&root, &json!({}));
+        assert!(
+            result.starts_with("Error:"),
+            "should require action: {result}"
+        );
+    }
+
+    #[test]
+    fn git_stash_rejects_unknown_action() {
+        let root = repo_root();
+        let result = git_stash(&root, &json!({"action": "fly"}));
+        assert!(
+            result.contains("unknown stash action"),
+            "should reject unknown: {result}"
+        );
+    }
+
+    #[test]
+    fn git_stash_list_works() {
+        let root = repo_root();
+        let result = git_stash(&root, &json!({"action": "list"}));
+        // Should return stash list or "No stashes found"
+        assert!(
+            result.contains("stash@") || result.contains("No stashes") || result.is_empty(),
+            "unexpected stash list output: {result}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[tokio::test]
+    async fn execute_with_metadata_returns_stash_ref_for_push_and_apply_accepts_it() {
+        let repo = init_temp_repo();
+        let tracked = repo.path().join("tracked.txt");
+        std::fs::write(&tracked, "two\n").expect("modify tracked file");
+        let executor = ToolExecutor::new(repo.path());
+
+        let outcome = executor
+            .execute_with_metadata("git_stash", &json!({"action": "push", "message": "demo"}))
+            .await;
+        assert!(
+            !outcome.output.starts_with("Error:"),
+            "stash push failed: {}",
+            outcome.output
+        );
+        let stash_ref = outcome
+            .tool_result_fields
+            .as_ref()
+            .and_then(|fields| fields.get("stash_ref"))
+            .and_then(Value::as_str)
+            .expect("stash_ref");
+        assert_eq!(
+            std::fs::read_to_string(&tracked).expect("clean worktree after stash"),
+            "one\n"
+        );
+
+        let apply = git_stash(
+            repo.path(),
+            &json!({"action": "apply", "stash_ref": stash_ref}),
+        );
+        assert!(!apply.starts_with("Error:"), "stash apply failed: {apply}");
+        assert_eq!(
+            std::fs::read_to_string(&tracked).expect("restored working tree"),
+            "two\n"
+        );
+    }
+
+    // ─── git_checkout_file tests ────────────────────────────────────────────
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_checkout_file_requires_path() {
+        let root = repo_root();
+        let result = git_checkout_file(&root, &json!({}));
+        assert!(
+            result.starts_with("Error:"),
+            "should require path: {result}"
+        );
+
+        let result2 = git_checkout_file(&root, &json!({"path": ""}));
+        assert!(
+            result2.starts_with("Error:"),
+            "should reject empty path: {result2}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_checkout_file_rejects_path_traversal() {
+        let root = repo_root();
+        let result = git_checkout_file(&root, &json!({"path": "../../../etc/passwd"}));
+        assert!(
+            result.contains("path traversal"),
+            "should reject traversal: {result}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_checkout_file_rejects_dangerous_ref() {
+        let root = repo_root();
+        let result = git_checkout_file(
+            &root,
+            &json!({"path": "README.md", "ref": "HEAD; rm -rf /"}),
+        );
+        assert!(
+            result.contains("invalid ref"),
+            "should reject dangerous ref: {result}"
+        );
+
+        let result2 = git_checkout_file(
+            &root,
+            &json!({"path": "README.md", "ref": "main|cat /etc/passwd"}),
+        );
+        assert!(
+            result2.contains("invalid ref"),
+            "should reject pipe ref: {result2}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_checkout_file_known_file() {
+        let root = repo_root();
+        // Checkout a known file at HEAD — should succeed (idempotent)
+        let result = git_checkout_file(&root, &json!({"path": "README.md"}));
+        assert!(
+            result.contains("Restored") || result.contains("Error"),
+            "should restore or report error: {result}"
+        );
+    }
+
+    // ─── git CLI fallback behavior tests ────────────────────────────────────
+
+    #[test]
+    fn diff_via_git_cli_returns_none_for_bad_args() {
+        let root = repo_root();
+        // Invalid ref should make git fail → returns None
+        let result = diff_via_git_cli(
+            &root,
+            &["diff", "not_a_valid_ref_xyzzy", "--no-ext-diff"],
+            8000,
+        );
+        assert!(result.is_none(), "bad ref should return None for fallback");
+    }
+
+    #[test]
+    fn diff_via_git_cli_returns_no_changes_for_empty_diff() {
+        let root = repo_root();
+        // HEAD vs HEAD has no diff
+        let result = diff_via_git_cli(
+            &root,
+            &["diff", "HEAD", "HEAD", "--no-ext-diff", "--no-color"],
+            8000,
+        );
+        assert_eq!(
+            result,
+            Some("No changes".to_string()),
+            "HEAD vs HEAD should be empty diff"
+        );
+    }
+
+    #[test]
+    fn gix_worktree_fallback_annotates_summary_only() {
+        // diff_worktree output (when it has entries) should tell the user
+        // that it's summary-only so the LLM knows to call bash git diff.
+        let root = repo_root();
+        let repo = open_repo(&root).expect("repo should open");
+        let result = diff_worktree(&repo, 100_000);
+        if result != "No changes" {
+            assert!(
+                result.contains("summary only"),
+                "gix fallback should annotate summary-only output: {result}"
+            );
+        }
+    }
+
+    #[test]
+    fn diff_via_git_cli_returns_none_for_nonexistent_dir() {
+        let result = diff_via_git_cli(
+            Path::new("/nonexistent_dir_xyz"),
+            &["diff", "--no-ext-diff"],
+            8000,
+        );
+        assert!(
+            result.is_none(),
+            "nonexistent dir should return None for fallback"
+        );
+    }
+
+    // ── Git Worktree Tests ──────────────────────────────────────────────
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_worktree_missing_action() {
+        let root = repo_root();
+        let result = git_worktree(&root, &json!({}));
+        assert!(
+            result.contains("Error") && result.contains("action"),
+            "should require action: {result}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_worktree_unknown_action() {
+        let root = repo_root();
+        let result = git_worktree(&root, &json!({"action": "teleport"}));
+        assert!(
+            result.contains("Error") && result.contains("unknown"),
+            "should reject unknown action: {result}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_worktree_add_missing_branch() {
+        let root = repo_root();
+        let result = git_worktree(&root, &json!({"action": "add"}));
+        assert!(
+            result.contains("Error") && result.contains("branch"),
+            "should require branch: {result}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_worktree_add_rejects_shell_injection() {
+        let root = repo_root();
+        for dangerous in &[
+            "test;rm -rf /",
+            "test|cat /etc/passwd",
+            "test&whoami",
+            "test`id`",
+            "test$(whoami)",
+            "test()",
+            "test{}",
+        ] {
+            let result = git_worktree(&root, &json!({"action": "add", "branch": dangerous}));
+            assert!(
+                result.contains("Error") && result.contains("invalid branch name"),
+                "should reject '{dangerous}': {result}"
+            );
+        }
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_worktree_list_runs() {
+        let root = repo_root();
+        let result = git_worktree(&root, &json!({"action": "list"}));
+        // Should contain at least the main worktree path
+        assert!(
+            !result.contains("Error: git") || result.contains("worktree"),
+            "list should succeed or show worktree info: {result}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_worktree_list_alias_ls() {
+        let root = repo_root();
+        let result = git_worktree(&root, &json!({"action": "ls"}));
+        assert!(
+            !result.contains("unknown"),
+            "ls should be accepted as alias for list: {result}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_worktree_remove_missing_path() {
+        let root = repo_root();
+        let result = git_worktree(&root, &json!({"action": "remove"}));
+        assert!(
+            result.contains("Error") && result.contains("path"),
+            "should require path for remove: {result}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_worktree_remove_nonexistent() {
+        let root = repo_root();
+        let result = git_worktree(
+            &root,
+            &json!({"action": "remove", "path": "/tmp/nonexistent-worktree-xyz"}),
+        );
+        assert!(
+            result.contains("Error") || result.contains("error"),
+            "removing nonexistent worktree should fail: {result}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_worktree_add_existing_path_fails() {
+        let root = repo_root();
+        // Use /tmp which always exists — should fail with "already exists"
+        let result = git_worktree(
+            &root,
+            &json!({"action": "add", "branch": "test-existing", "path": "/tmp"}),
+        );
+        assert!(
+            result.contains("Error") && result.contains("already exists"),
+            "should reject existing path: {result}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn worktree_add_with_metadata_returns_rollback_fields() {
+        let dir = init_temp_repo();
+        let worktree_path = dir.path().join("meta-worktree");
+        let outcome = worktree_add_with_metadata(
+            dir.path(),
+            &json!({
+                "branch": "meta-worktree",
+                "path": worktree_path,
+            }),
+        );
+        assert!(
+            !outcome.output.starts_with("Error:"),
+            "worktree add failed: {}",
+            outcome.output
+        );
+        let fields = outcome.tool_result_fields.expect("metadata fields");
+        assert_eq!(
+            fields.get("branch").and_then(Value::as_str),
+            Some("meta-worktree")
+        );
+        assert_eq!(
+            fields
+                .get("worktree_path")
+                .and_then(Value::as_str)
+                .map(std::path::PathBuf::from)
+                .as_deref(),
+            Some(worktree_path.as_path())
+        );
+        assert_eq!(
+            fields
+                .get("delete_branch_on_rollback")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        let cleanup = worktree_remove(
+            dir.path(),
+            &json!({
+                "path": worktree_path,
+                "force": true,
+                "delete_branch": true,
+            }),
+        );
+        assert!(
+            !cleanup.starts_with("Error:"),
+            "cleanup remove failed: {cleanup}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn git_worktree_action_aliases() {
+        let root = repo_root();
+        // "create" should alias to "add" (needs branch param, so will error on missing branch)
+        let r1 = git_worktree(&root, &json!({"action": "create"}));
+        assert!(r1.contains("branch"), "create should route to add: {r1}");
+
+        // "rm" and "delete" should alias to "remove" (needs path param)
+        let r2 = git_worktree(&root, &json!({"action": "rm"}));
+        assert!(r2.contains("path"), "rm should route to remove: {r2}");
+
+        let r3 = git_worktree(&root, &json!({"action": "delete"}));
+        assert!(r3.contains("path"), "delete should route to remove: {r3}");
+    }
+}

--- a/rust/crates/astra-tools/src/github.rs
+++ b/rust/crates/astra-tools/src/github.rs
@@ -1,0 +1,2254 @@
+#![allow(dead_code)]
+//! GitHub API tool implementations.
+//!
+//! Extracted from edge_tools as a standalone `GitHubClient` struct.
+//! Both CLI and server executors can instantiate this with their own
+//! reqwest::Client and token.
+
+use chrono::{DateTime, Utc};
+use reqwest::{Client, Method, StatusCode};
+use serde_json::{Value, json};
+use std::sync::Mutex;
+
+/// GitHub API client for tool operations.
+///
+/// Wraps a reqwest::Client with optional auth token and a list of
+/// preferred repositories (learned from user interactions).
+pub struct GitHubClient {
+    client: Client,
+    token: Option<String>,
+    preferred_repos: Mutex<Vec<String>>,
+}
+
+impl GitHubClient {
+    pub fn new(client: Client, token: Option<String>, preferred_repos: Vec<String>) -> Self {
+        Self {
+            client,
+            token,
+            preferred_repos: Mutex::new(preferred_repos),
+        }
+    }
+
+    /// Record a repo as preferred for future bare-name resolution.
+    pub fn add_preferred_repo(&self, owner_repo: &str) {
+        let normalized = owner_repo.to_lowercase();
+        match self.preferred_repos.lock() {
+            Ok(mut repos) => {
+                if !repos.contains(&normalized) {
+                    repos.push(normalized);
+                }
+            }
+            Err(p) => {
+                let mut repos = p.into_inner();
+                if !repos.contains(&normalized) {
+                    repos.push(normalized);
+                }
+            }
+        }
+    }
+
+    /// Get the current list of preferred repos.
+    fn get_preferred_repos(&self) -> Vec<String> {
+        match self.preferred_repos.lock() {
+            Ok(repos) => repos.clone(),
+            Err(p) => p.into_inner().clone(),
+        }
+    }
+}
+
+const GITHUB_MISSING_REPO_ERROR: &str = "Error: missing 'repo' — infer repo from current user text or recent conversation; bare names like 'memoria' are allowed";
+
+impl GitHubClient {
+    async fn github_request(
+        &self,
+        method: Method,
+        url: &str,
+        payload: Option<&Value>,
+    ) -> Result<Value, String> {
+        let mut request = self
+            .client
+            .request(method, url)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28");
+        if let Some(token) = &self.token {
+            request = request.bearer_auth(token);
+        }
+        if let Some(payload) = payload {
+            request = request.json(payload);
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| format!("Error: GitHub request failed: {e}"))?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| format!("Error: failed reading GitHub response: {e}"))?;
+
+        if body.trim().is_empty() {
+            return Err(format!("Error: empty response from GitHub (HTTP {status})"));
+        }
+
+        let value: Value = serde_json::from_str(&body)
+            .map_err(|e| format!("Error: invalid GitHub response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(github_api_error_message(
+                status,
+                &value,
+                self.token.is_some(),
+            ));
+        }
+
+        Ok(value)
+    }
+
+    async fn github_resolve_repo(&self, repo: &str) -> Result<GithubRepoResolution, String> {
+        if repo.contains('/') {
+            // Learn from explicit owner/repo for future bare-name lookups
+            self.add_preferred_repo(repo);
+            return Ok(GithubRepoResolution {
+                resolved_repo: repo.to_string(),
+                resolved_by_search: false,
+            });
+        }
+
+        // Check preferred repos first — if any preferred repo's name matches,
+        // use it directly without hitting the GitHub search API.
+        let preferred = self.get_preferred_repos();
+        let repo_lower = repo.to_lowercase();
+        for pref in &preferred {
+            if let Some(name) = pref.rsplit('/').next()
+                && name == repo_lower
+            {
+                return Ok(GithubRepoResolution {
+                    resolved_repo: pref.clone(),
+                    resolved_by_search: false,
+                });
+            }
+        }
+
+        let response = self
+            .github_request(
+                Method::GET,
+                &format!(
+                    "https://api.github.com/search/repositories?q={repo}&sort=stars&per_page=5"
+                ),
+                None,
+            )
+            .await?;
+        let Some(items) = response.get("items").and_then(Value::as_array) else {
+            return Err(format!("Could not resolve repo '{repo}'"));
+        };
+
+        let resolved_repo = github_pick_resolved_repo(repo, items, &preferred)?;
+        // Learn from successful resolution
+        self.add_preferred_repo(&resolved_repo);
+        Ok(GithubRepoResolution {
+            resolved_repo,
+            resolved_by_search: true,
+        })
+    }
+
+    pub async fn github_list_prs(&self, args: &Value) -> String {
+        let repo = match args.get("repo").and_then(Value::as_str) {
+            Some(r) => r.to_string(),
+            None => {
+                return github_error_response(
+                    "github_list_prs",
+                    "pull_requests",
+                    Some(GithubDetail::Brief),
+                    None,
+                    None,
+                    GITHUB_MISSING_REPO_ERROR,
+                );
+            }
+        };
+        let detail = match GithubDetail::parse(args.get("detail").and_then(Value::as_str)) {
+            Ok(detail) => detail,
+            Err(error) => {
+                return github_error_response(
+                    "github_list_prs",
+                    "pull_requests",
+                    Some(GithubDetail::Brief),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+        let state = args.get("state").and_then(Value::as_str).unwrap_or("open");
+        let limit = github_requested_limit(args.get("limit").and_then(Value::as_u64), detail, 10);
+
+        let resolution = match self.github_resolve_repo(&repo).await {
+            Ok(resolution) => resolution,
+            Err(error) => {
+                return github_error_response(
+                    "github_list_prs",
+                    "pull_requests",
+                    Some(detail),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+
+        let response = match self
+            .github_request(
+                Method::GET,
+                &format!(
+                    "https://api.github.com/repos/{}/pulls?state={state}&per_page={limit}",
+                    resolution.resolved_repo
+                ),
+                None,
+            )
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return github_error_response(
+                    "github_list_prs",
+                    "pull_requests",
+                    Some(detail),
+                    Some(&repo),
+                    Some(&resolution),
+                    error,
+                );
+            }
+        };
+
+        let Some(prs) = response.as_array() else {
+            return github_error_response(
+                "github_list_prs",
+                "pull_requests",
+                Some(detail),
+                Some(&repo),
+                Some(&resolution),
+                "Error: unexpected GitHub response",
+            );
+        };
+
+        let items = prs
+            .iter()
+            .map(|pr| github_pr_list_item(pr, detail))
+            .collect::<Vec<_>>();
+
+        github_response_string(json!({
+            "ok": true,
+            "tool": "github_list_prs",
+            "detail": detail.as_str(),
+            "requested_repo": repo,
+            "resolved_repo": resolution_output_repo(&resolution),
+            "resolved_by_search": resolution.resolved_by_search,
+            "state": state,
+            "count": items.len(),
+            "pull_requests": items,
+            "error": Value::Null,
+        }))
+    }
+
+    pub async fn github_get_pr(&self, args: &Value) -> String {
+        let repo = match args.get("repo").and_then(Value::as_str) {
+            Some(r) => r.to_string(),
+            None => {
+                return github_error_response(
+                    "github_get_pr",
+                    "pull_request",
+                    Some(GithubDetail::Brief),
+                    None,
+                    None,
+                    GITHUB_MISSING_REPO_ERROR,
+                );
+            }
+        };
+        let pr_number = match args.get("pr_number").and_then(Value::as_u64) {
+            Some(n) => n,
+            None => {
+                return github_error_response(
+                    "github_get_pr",
+                    "pull_request",
+                    Some(GithubDetail::Brief),
+                    Some(&repo),
+                    None,
+                    "Error: missing 'pr_number'",
+                );
+            }
+        };
+        let detail = match GithubDetail::parse(args.get("detail").and_then(Value::as_str)) {
+            Ok(detail) => detail,
+            Err(error) => {
+                return github_error_response(
+                    "github_get_pr",
+                    "pull_request",
+                    Some(GithubDetail::Brief),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+
+        let resolution = match self.github_resolve_repo(&repo).await {
+            Ok(resolution) => resolution,
+            Err(error) => {
+                return github_error_response(
+                    "github_get_pr",
+                    "pull_request",
+                    Some(detail),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+
+        let response = match self
+            .github_request(
+                Method::GET,
+                &format!(
+                    "https://api.github.com/repos/{}/pulls/{pr_number}",
+                    resolution.resolved_repo
+                ),
+                None,
+            )
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return github_error_response(
+                    "github_get_pr",
+                    "pull_request",
+                    Some(detail),
+                    Some(&repo),
+                    Some(&resolution),
+                    error,
+                );
+            }
+        };
+
+        if !response.is_object() {
+            return github_error_response(
+                "github_get_pr",
+                "pull_request",
+                Some(detail),
+                Some(&repo),
+                Some(&resolution),
+                "Error: unexpected GitHub response",
+            );
+        }
+
+        let ci_conclusion =
+            match json_value_at_path(&response, &["head", "sha"]).and_then(Value::as_str) {
+                Some(sha) => match self
+                    .github_commit_ci_conclusion(&resolution.resolved_repo, sha)
+                    .await
+                {
+                    Ok(conclusion) => conclusion,
+                    Err(error) => {
+                        return github_error_response(
+                            "github_get_pr",
+                            "pull_request",
+                            Some(detail),
+                            Some(&repo),
+                            Some(&resolution),
+                            error,
+                        );
+                    }
+                },
+                None => "unknown".to_string(),
+            };
+
+        let key_changed_files = if detail.includes_detailed() {
+            match self
+                .github_pr_files(&resolution.resolved_repo, pr_number, detail)
+                .await
+            {
+                Ok(files) => files,
+                Err(error) => {
+                    return github_error_response(
+                        "github_get_pr",
+                        "pull_request",
+                        Some(detail),
+                        Some(&repo),
+                        Some(&resolution),
+                        error,
+                    );
+                }
+            }
+        } else {
+            Vec::new()
+        };
+
+        let review_comments = if detail == GithubDetail::Full {
+            match self
+                .github_pr_review_comments(&resolution.resolved_repo, pr_number, detail)
+                .await
+            {
+                Ok(comments) => comments,
+                Err(error) => {
+                    return github_error_response(
+                        "github_get_pr",
+                        "pull_request",
+                        Some(detail),
+                        Some(&repo),
+                        Some(&resolution),
+                        error,
+                    );
+                }
+            }
+        } else {
+            Vec::new()
+        };
+
+        let body = json_value_at_path(&response, &["body"])
+            .and_then(Value::as_str)
+            .unwrap_or("");
+
+        let item = json!({
+            "number": json_u64(&response, &["number"]),
+            "title": github_title_value(json_value_at_path(&response, &["title"]).and_then(Value::as_str), detail),
+            "author": json_value_at_path(&response, &["user", "login"]).and_then(Value::as_str).unwrap_or("?"),
+            "state": github_pr_state(&response),
+            "created_at": github_timestamp(json_value_at_path(&response, &["created_at"]).and_then(Value::as_str)),
+            "ci_conclusion": ci_conclusion,
+            "body_summary": if detail.includes_normal() {
+                github_excerpt(body, Some(detail.body_limit()))
+            } else {
+                String::new()
+            },
+            "labels": if detail.includes_normal() { github_label_names(&response) } else { Vec::<String>::new() },
+            "reviewers": if detail.includes_normal() { github_reviewer_names(&response) } else { Vec::<String>::new() },
+            "changed_files": if detail.includes_normal() { json_u64(&response, &["changed_files"]) } else { None::<u64> },
+            "additions": if detail.includes_detailed() { json_u64(&response, &["additions"]) } else { None::<u64> },
+            "deletions": if detail.includes_detailed() { json_u64(&response, &["deletions"]) } else { None::<u64> },
+            "key_changed_files": if detail.includes_detailed() { key_changed_files } else { Vec::<Value>::new() },
+            "review_comments_count": if detail.includes_detailed() { json_u64(&response, &["review_comments"]) } else { None::<u64> },
+            "merge_status": if detail.includes_detailed() {
+                json_value_at_path(&response, &["mergeable_state"]).and_then(Value::as_str).map(ToString::to_string)
+            } else {
+                None::<String>
+            },
+            "conflicts": if detail.includes_detailed() {
+                json_value_at_path(&response, &["mergeable_state"]).and_then(Value::as_str).map(|state| state == "dirty")
+            } else {
+                None::<bool>
+            },
+            "body": if detail == GithubDetail::Full {
+                github_excerpt(body, Some(detail.body_limit()))
+            } else {
+                String::new()
+            },
+            "review_comments": if detail == GithubDetail::Full { review_comments } else { Vec::<Value>::new() },
+            "url": json_value_at_path(&response, &["html_url"]).and_then(Value::as_str).unwrap_or(""),
+        });
+
+        github_response_string(json!({
+            "ok": true,
+            "tool": "github_get_pr",
+            "detail": detail.as_str(),
+            "requested_repo": repo,
+            "resolved_repo": resolution_output_repo(&resolution),
+            "resolved_by_search": resolution.resolved_by_search,
+            "count": 1,
+            "pull_request": item,
+            "error": Value::Null,
+        }))
+    }
+
+    pub async fn github_ci_status(&self, args: &Value) -> String {
+        let repo = match args.get("repo").and_then(Value::as_str) {
+            Some(r) => r.to_string(),
+            None => {
+                return github_error_response(
+                    "github_ci_status",
+                    "workflow_runs",
+                    Some(GithubDetail::Brief),
+                    None,
+                    None,
+                    GITHUB_MISSING_REPO_ERROR,
+                );
+            }
+        };
+        let detail = match GithubDetail::parse(args.get("detail").and_then(Value::as_str)) {
+            Ok(detail) => detail,
+            Err(error) => {
+                return github_error_response(
+                    "github_ci_status",
+                    "workflow_runs",
+                    Some(GithubDetail::Brief),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+        let limit = github_requested_limit(args.get("limit").and_then(Value::as_u64), detail, 1);
+
+        let resolution = match self.github_resolve_repo(&repo).await {
+            Ok(resolution) => resolution,
+            Err(error) => {
+                return github_error_response(
+                    "github_ci_status",
+                    "workflow_runs",
+                    Some(detail),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+
+        let response = match self
+            .github_request(
+                Method::GET,
+                &format!(
+                    "https://api.github.com/repos/{}/actions/runs?per_page={limit}",
+                    resolution.resolved_repo
+                ),
+                None,
+            )
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return github_error_response(
+                    "github_ci_status",
+                    "workflow_runs",
+                    Some(detail),
+                    Some(&repo),
+                    Some(&resolution),
+                    error,
+                );
+            }
+        };
+
+        let Some(runs) = response.get("workflow_runs").and_then(Value::as_array) else {
+            return github_error_response(
+                "github_ci_status",
+                "workflow_runs",
+                Some(detail),
+                Some(&repo),
+                Some(&resolution),
+                "Error: unexpected GitHub response",
+            );
+        };
+
+        let mut normalized_runs = Vec::with_capacity(runs.len());
+        for run in runs {
+            let run_id = json_u64(run, &["id"]);
+            let (failed_jobs, failed_steps, all_jobs) = if detail.includes_detailed() {
+                match run_id {
+                    Some(id) => match self
+                        .github_workflow_run_jobs(&resolution.resolved_repo, id, detail)
+                        .await
+                    {
+                        Ok(job_details) => job_details,
+                        Err(error) => {
+                            return github_error_response(
+                                "github_ci_status",
+                                "workflow_runs",
+                                Some(detail),
+                                Some(&repo),
+                                Some(&resolution),
+                                error,
+                            );
+                        }
+                    },
+                    None => (Vec::new(), Vec::new(), Vec::new()),
+                }
+            } else {
+                (Vec::new(), Vec::new(), Vec::new())
+            };
+
+            let pr_number = json_value_at_path(run, &["pull_requests"])
+                .and_then(Value::as_array)
+                .and_then(|prs| prs.first())
+                .and_then(|pr| pr.get("number"))
+                .and_then(Value::as_u64);
+            let display_title = json_value_at_path(run, &["display_title"]).and_then(Value::as_str);
+
+            normalized_runs.push(json!({
+                "id": run_id,
+                "name": github_title_value(json_value_at_path(run, &["name"]).and_then(Value::as_str), detail),
+                "conclusion": github_normalize_conclusion(
+                    json_value_at_path(run, &["conclusion"]).and_then(Value::as_str),
+                    json_value_at_path(run, &["status"]).and_then(Value::as_str),
+                ),
+                "branch": json_value_at_path(run, &["head_branch"]).and_then(Value::as_str).unwrap_or("?"),
+                "triggered_at": github_timestamp(json_value_at_path(run, &["created_at"]).and_then(Value::as_str)),
+                "duration_seconds": if detail.includes_normal() {
+                    github_duration_seconds(
+                        json_value_at_path(run, &["run_started_at"]).and_then(Value::as_str)
+                            .or_else(|| json_value_at_path(run, &["created_at"]).and_then(Value::as_str)),
+                        json_value_at_path(run, &["updated_at"]).and_then(Value::as_str),
+                    )
+                } else {
+                    None::<i64>
+                },
+                "pr_number": if detail.includes_normal() { pr_number } else { None::<u64> },
+                "pr_title": if detail.includes_normal() && pr_number.is_some() {
+                    display_title.map(|value| github_excerpt(value, Some(detail.title_limit())))
+                } else {
+                    None::<String>
+                },
+                "commit_message": if detail.includes_normal() {
+                    github_excerpt(display_title.unwrap_or(""), Some(80))
+                } else {
+                    String::new()
+                },
+                "failed_jobs": if detail.includes_detailed() { failed_jobs } else { Vec::<String>::new() },
+                "failed_steps": if detail.includes_detailed() { failed_steps } else { Vec::<Value>::new() },
+                "all_jobs": if detail == GithubDetail::Full { all_jobs } else { Vec::<Value>::new() },
+                "url": json_value_at_path(run, &["html_url"]).and_then(Value::as_str).unwrap_or(""),
+            }));
+        }
+
+        github_response_string(json!({
+            "ok": true,
+            "tool": "github_ci_status",
+            "detail": detail.as_str(),
+            "requested_repo": repo,
+            "resolved_repo": resolution_output_repo(&resolution),
+            "resolved_by_search": resolution.resolved_by_search,
+            "count": normalized_runs.len(),
+            "workflow_runs": normalized_runs,
+            "error": Value::Null,
+        }))
+    }
+
+    pub async fn github_list_issues(&self, args: &Value) -> String {
+        let repo = match args.get("repo").and_then(Value::as_str) {
+            Some(r) => r.to_string(),
+            None => {
+                return github_error_response(
+                    "github_list_issues",
+                    "issues",
+                    Some(GithubDetail::Brief),
+                    None,
+                    None,
+                    GITHUB_MISSING_REPO_ERROR,
+                );
+            }
+        };
+        let detail = match GithubDetail::parse(args.get("detail").and_then(Value::as_str)) {
+            Ok(detail) => detail,
+            Err(error) => {
+                return github_error_response(
+                    "github_list_issues",
+                    "issues",
+                    Some(GithubDetail::Brief),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+        let state = args.get("state").and_then(Value::as_str).unwrap_or("open");
+        let limit = github_requested_limit(args.get("limit").and_then(Value::as_u64), detail, 10);
+        let labels = args.get("labels").and_then(Value::as_str).unwrap_or("");
+
+        let resolution = match self.github_resolve_repo(&repo).await {
+            Ok(resolution) => resolution,
+            Err(error) => {
+                return github_error_response(
+                    "github_list_issues",
+                    "issues",
+                    Some(detail),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+
+        let labels_param = if labels.is_empty() {
+            String::new()
+        } else {
+            format!("&labels={labels}")
+        };
+        let response = match self
+            .github_request(
+            Method::GET,
+            &format!(
+                "https://api.github.com/repos/{}/issues?state={state}&per_page={limit}{labels_param}",
+                resolution.resolved_repo
+            ),
+            None,
+        )
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return github_error_response(
+                    "github_list_issues",
+                    "issues",
+                    Some(detail),
+                    Some(&repo),
+                    Some(&resolution),
+                    error,
+                );
+            }
+        };
+
+        let Some(issues) = response.as_array() else {
+            return github_error_response(
+                "github_list_issues",
+                "issues",
+                Some(detail),
+                Some(&repo),
+                Some(&resolution),
+                "Error: unexpected GitHub response",
+            );
+        };
+
+        let items = issues
+            .iter()
+            .filter(|issue| issue.get("pull_request").is_none())
+            .map(|issue| github_issue_list_item(issue, detail))
+            .collect::<Vec<_>>();
+
+        github_response_string(json!({
+            "ok": true,
+            "tool": "github_list_issues",
+            "detail": detail.as_str(),
+            "requested_repo": repo,
+            "resolved_repo": resolution_output_repo(&resolution),
+            "resolved_by_search": resolution.resolved_by_search,
+            "state": state,
+            "labels": labels,
+            "count": items.len(),
+            "issues": items,
+            "error": Value::Null,
+        }))
+    }
+
+    pub async fn github_get_issue(&self, args: &Value) -> String {
+        let repo = match args.get("repo").and_then(Value::as_str) {
+            Some(r) => r.to_string(),
+            None => {
+                return github_error_response(
+                    "github_get_issue",
+                    "issue",
+                    Some(GithubDetail::Brief),
+                    None,
+                    None,
+                    GITHUB_MISSING_REPO_ERROR,
+                );
+            }
+        };
+        let issue_number = match args.get("issue_number").and_then(Value::as_u64) {
+            Some(n) => n,
+            None => {
+                return github_error_response(
+                    "github_get_issue",
+                    "issue",
+                    Some(GithubDetail::Brief),
+                    Some(&repo),
+                    None,
+                    "Error: missing 'issue_number'",
+                );
+            }
+        };
+        let detail = match GithubDetail::parse(args.get("detail").and_then(Value::as_str)) {
+            Ok(detail) => detail,
+            Err(error) => {
+                return github_error_response(
+                    "github_get_issue",
+                    "issue",
+                    Some(GithubDetail::Brief),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+
+        let resolution = match self.github_resolve_repo(&repo).await {
+            Ok(resolution) => resolution,
+            Err(error) => {
+                return github_error_response(
+                    "github_get_issue",
+                    "issue",
+                    Some(detail),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+
+        let response = match self
+            .github_request(
+                Method::GET,
+                &format!(
+                    "https://api.github.com/repos/{}/issues/{issue_number}",
+                    resolution.resolved_repo
+                ),
+                None,
+            )
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return github_error_response(
+                    "github_get_issue",
+                    "issue",
+                    Some(detail),
+                    Some(&repo),
+                    Some(&resolution),
+                    error,
+                );
+            }
+        };
+
+        if !response.is_object() {
+            return github_error_response(
+                "github_get_issue",
+                "issue",
+                Some(detail),
+                Some(&repo),
+                Some(&resolution),
+                "Error: unexpected GitHub response",
+            );
+        }
+
+        if response.get("pull_request").is_some() {
+            return github_error_response(
+                "github_get_issue",
+                "issue",
+                Some(detail),
+                Some(&repo),
+                Some(&resolution),
+                format!("Error: #{issue_number} is a pull request, not an issue"),
+            );
+        }
+
+        let comments = if detail.includes_detailed() {
+            match self
+                .github_issue_comments(&resolution.resolved_repo, issue_number, detail)
+                .await
+            {
+                Ok(comments) => comments,
+                Err(error) => {
+                    return github_error_response(
+                        "github_get_issue",
+                        "issue",
+                        Some(detail),
+                        Some(&repo),
+                        Some(&resolution),
+                        error,
+                    );
+                }
+            }
+        } else {
+            Vec::new()
+        };
+
+        let body = json_value_at_path(&response, &["body"])
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let item = json!({
+            "number": json_u64(&response, &["number"]),
+            "title": github_title_value(json_value_at_path(&response, &["title"]).and_then(Value::as_str), detail),
+            "state": json_value_at_path(&response, &["state"]).and_then(Value::as_str).unwrap_or("?"),
+            "labels": github_label_names(&response),
+            "created_at": github_timestamp(json_value_at_path(&response, &["created_at"]).and_then(Value::as_str)),
+            "author": json_value_at_path(&response, &["user", "login"]).and_then(Value::as_str).unwrap_or("?"),
+            "body": if detail.includes_normal() { github_excerpt(body, Some(detail.body_limit())) } else { String::new() },
+            "assignee": if detail.includes_normal() { github_primary_assignee(&response) } else { None::<String> },
+            "milestone": if detail.includes_normal() { github_milestone_title(&response) } else { None::<String> },
+            "comment_count": if detail.includes_normal() { json_u64(&response, &["comments"]) } else { None::<u64> },
+            "comments": if detail.includes_detailed() { comments } else { Vec::<Value>::new() },
+            "linked_prs": Vec::<Value>::new(),
+            "url": json_value_at_path(&response, &["html_url"]).and_then(Value::as_str).unwrap_or(""),
+        });
+
+        github_response_string(json!({
+            "ok": true,
+            "tool": "github_get_issue",
+            "detail": detail.as_str(),
+            "requested_repo": repo,
+            "resolved_repo": resolution_output_repo(&resolution),
+            "resolved_by_search": resolution.resolved_by_search,
+            "count": 1,
+            "issue": item,
+            "error": Value::Null,
+        }))
+    }
+
+    pub async fn github_repo_stats(&self, args: &Value) -> String {
+        let repo = match args.get("repo").and_then(Value::as_str) {
+            Some(r) => r.to_string(),
+            None => {
+                return github_error_response(
+                    "github_repo_stats",
+                    "repository",
+                    Some(GithubDetail::Brief),
+                    None,
+                    None,
+                    GITHUB_MISSING_REPO_ERROR,
+                );
+            }
+        };
+        let detail = match GithubDetail::parse(args.get("detail").and_then(Value::as_str)) {
+            Ok(detail) => detail,
+            Err(error) => {
+                return github_error_response(
+                    "github_repo_stats",
+                    "repository",
+                    Some(GithubDetail::Brief),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+
+        let resolution = match self.github_resolve_repo(&repo).await {
+            Ok(resolution) => resolution,
+            Err(error) => {
+                return github_error_response(
+                    "github_repo_stats",
+                    "repository",
+                    Some(detail),
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+
+        let response = match self
+            .github_request(
+                Method::GET,
+                &format!("https://api.github.com/repos/{}", resolution.resolved_repo),
+                None,
+            )
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return github_error_response(
+                    "github_repo_stats",
+                    "repository",
+                    Some(detail),
+                    Some(&repo),
+                    Some(&resolution),
+                    error,
+                );
+            }
+        };
+
+        if !response.is_object() {
+            return github_error_response(
+                "github_repo_stats",
+                "repository",
+                Some(detail),
+                Some(&repo),
+                Some(&resolution),
+                "Error: unexpected GitHub response",
+            );
+        }
+
+        let mut repository = json!({
+            "name": json_value_at_path(&response, &["name"]).and_then(Value::as_str).unwrap_or(""),
+            "full_name": json_value_at_path(&response, &["full_name"]).and_then(Value::as_str).unwrap_or(""),
+            "owner": json_value_at_path(&response, &["owner", "login"]).and_then(Value::as_str).unwrap_or(""),
+            "description": github_excerpt(
+                json_value_at_path(&response, &["description"]).and_then(Value::as_str).unwrap_or(""),
+                Some(detail.body_limit().max(120)),
+            ),
+            "stars": json_u64(&response, &["stargazers_count"]),
+            "forks": json_u64(&response, &["forks_count"]),
+            "watchers": json_u64(&response, &["subscribers_count"])
+                .or_else(|| json_u64(&response, &["watchers_count"])),
+            "open_issues": json_u64(&response, &["open_issues_count"]),
+            "language": json_value_at_path(&response, &["language"]).and_then(Value::as_str),
+            "default_branch": json_value_at_path(&response, &["default_branch"]).and_then(Value::as_str),
+            "pushed_at": github_timestamp(json_value_at_path(&response, &["pushed_at"]).and_then(Value::as_str)),
+            "updated_at": github_timestamp(json_value_at_path(&response, &["updated_at"]).and_then(Value::as_str)),
+            "created_at": github_timestamp(json_value_at_path(&response, &["created_at"]).and_then(Value::as_str)),
+            "homepage": json_value_at_path(&response, &["homepage"]).and_then(Value::as_str),
+            "html_url": json_value_at_path(&response, &["html_url"]).and_then(Value::as_str).unwrap_or(""),
+            "archived": json_value_at_path(&response, &["archived"]).and_then(Value::as_bool).unwrap_or(false),
+            "fork": json_value_at_path(&response, &["fork"]).and_then(Value::as_bool).unwrap_or(false),
+        });
+
+        if !matches!(detail, GithubDetail::Brief) {
+            repository["topics"] = serde_json::Value::Array(
+                json_value_at_path(&response, &["topics"])
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default(),
+            );
+            repository["license"] = json_value_at_path(&response, &["license", "spdx_id"])
+                .or_else(|| json_value_at_path(&response, &["license", "name"]))
+                .cloned()
+                .unwrap_or(Value::Null);
+        }
+
+        github_response_string(json!({
+            "ok": true,
+            "tool": "github_repo_stats",
+            "detail": detail.as_str(),
+            "requested_repo": repo,
+            "resolved_repo": resolution_output_repo(&resolution),
+            "resolved_by_search": resolution.resolved_by_search,
+            "count": 1,
+            "repository": repository,
+            "error": Value::Null,
+        }))
+    }
+
+    pub async fn github_create_issue(&self, args: &Value) -> String {
+        let repo = match args.get("repo").and_then(Value::as_str) {
+            Some(r) => r.to_string(),
+            None => {
+                return github_error_response(
+                    "github_create_issue",
+                    "issue",
+                    None,
+                    None,
+                    None,
+                    GITHUB_MISSING_REPO_ERROR,
+                );
+            }
+        };
+        let title = match args.get("title").and_then(Value::as_str) {
+            Some(t) if !t.trim().is_empty() => t,
+            _ => {
+                return github_error_response(
+                    "github_create_issue",
+                    "issue",
+                    None,
+                    Some(&repo),
+                    None,
+                    "Error: missing or empty 'title'",
+                );
+            }
+        };
+        if !repo.contains('/') {
+            return github_error_response(
+                "github_create_issue",
+                "issue",
+                None,
+                Some(&repo),
+                None,
+                "Error: github_create_issue requires repo in 'owner/repo' form",
+            );
+        }
+        if self.token.is_none() {
+            return github_error_response(
+                "github_create_issue",
+                "issue",
+                None,
+                Some(&repo),
+                None,
+                "Error: GITHUB_TOKEN is required for github_create_issue",
+            );
+        }
+        let body = args.get("body").and_then(Value::as_str).unwrap_or("");
+        let labels = args.get("labels").and_then(Value::as_str).unwrap_or("");
+
+        let payload = serde_json::json!({
+            "title": title,
+            "body": body,
+            "labels": if labels.is_empty() { vec![] } else { labels.split(',').map(|s| s.trim()).collect::<Vec<_>>() }
+        });
+        let response = match self
+            .github_request(
+                Method::POST,
+                &format!("https://api.github.com/repos/{repo}/issues"),
+                Some(&payload),
+            )
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return github_error_response(
+                    "github_create_issue",
+                    "issue",
+                    None,
+                    Some(&repo),
+                    None,
+                    error,
+                );
+            }
+        };
+
+        if !response.is_object() {
+            return github_error_response(
+                "github_create_issue",
+                "issue",
+                None,
+                Some(&repo),
+                None,
+                "Error: unexpected GitHub response",
+            );
+        }
+
+        github_response_string(json!({
+            "ok": true,
+            "tool": "github_create_issue",
+            "detail": Value::Null,
+            "requested_repo": repo,
+            "resolved_repo": Value::Null,
+            "resolved_by_search": false,
+            "count": 1,
+            "issue": {
+                "number": json_u64(&response, &["number"]),
+                "title": json_value_at_path(&response, &["title"]).and_then(Value::as_str).unwrap_or(""),
+                "state": json_value_at_path(&response, &["state"]).and_then(Value::as_str).unwrap_or("?"),
+                "created_at": github_timestamp(json_value_at_path(&response, &["created_at"]).and_then(Value::as_str)),
+                "labels": github_label_names(&response),
+                "url": json_value_at_path(&response, &["html_url"]).and_then(Value::as_str).unwrap_or(""),
+            },
+            "error": Value::Null,
+        }))
+    }
+
+    pub async fn github_commit_ci_conclusion(
+        &self,
+        repo: &str,
+        sha: &str,
+    ) -> Result<String, String> {
+        // Use check-runs API (covers GitHub Actions) with fallback to legacy commit status API.
+        let check_response = self
+            .github_request(
+                Method::GET,
+                &format!(
+                    "https://api.github.com/repos/{repo}/commits/{sha}/check-runs?per_page=100"
+                ),
+                None,
+            )
+            .await;
+
+        if let Ok(ref response) = check_response
+            && let Some(runs) = response.get("check_runs").and_then(Value::as_array)
+            && !runs.is_empty()
+        {
+            let any_failure = runs.iter().any(|run| {
+                matches!(
+                    json_value_at_path(run, &["conclusion"]).and_then(Value::as_str),
+                    Some("failure") | Some("timed_out") | Some("action_required")
+                )
+            });
+            let any_pending = runs.iter().any(|run| {
+                json_value_at_path(run, &["status"])
+                    .and_then(Value::as_str)
+                    .is_some_and(|s| s != "completed")
+            });
+            return Ok(if any_failure {
+                "failure"
+            } else if any_pending {
+                "pending"
+            } else {
+                "success"
+            }
+            .to_string());
+        }
+
+        // Fallback: legacy commit status API
+        let response = self
+            .github_request(
+                Method::GET,
+                &format!("https://api.github.com/repos/{repo}/commits/{sha}/status"),
+                None,
+            )
+            .await?;
+        Ok(github_normalize_conclusion(
+            json_value_at_path(&response, &["state"]).and_then(Value::as_str),
+            None,
+        ))
+    }
+
+    async fn github_pr_files(
+        &self,
+        repo: &str,
+        pr_number: u64,
+        detail: GithubDetail,
+    ) -> Result<Vec<Value>, String> {
+        let response = self
+            .github_request(
+                Method::GET,
+                &format!(
+                    "https://api.github.com/repos/{repo}/pulls/{pr_number}/files?per_page={}",
+                    if detail == GithubDetail::Full { 20 } else { 10 }
+                ),
+                None,
+            )
+            .await?;
+        let Some(files) = response.as_array() else {
+            return Err("Error: unexpected GitHub files response".to_string());
+        };
+
+        let mut files = files.to_vec();
+        files.sort_by(|left, right| {
+            let left_changes = json_u64(left, &["changes"]).unwrap_or(0);
+            let right_changes = json_u64(right, &["changes"]).unwrap_or(0);
+            right_changes.cmp(&left_changes)
+        });
+
+        Ok(files
+            .into_iter()
+            .take(if detail == GithubDetail::Full { 20 } else { 10 })
+            .map(|file| github_pr_file_item(&file, detail))
+            .collect())
+    }
+
+    async fn github_pr_review_comments(
+        &self,
+        repo: &str,
+        pr_number: u64,
+        detail: GithubDetail,
+    ) -> Result<Vec<Value>, String> {
+        let response = self
+            .github_request(
+                Method::GET,
+                &format!(
+                    "https://api.github.com/repos/{repo}/pulls/{pr_number}/comments?per_page={}",
+                    if detail == GithubDetail::Full { 20 } else { 10 }
+                ),
+                None,
+            )
+            .await?;
+        let Some(comments) = response.as_array() else {
+            return Err("Error: unexpected GitHub review comments response".to_string());
+        };
+
+        Ok(comments
+            .iter()
+            .take(if detail == GithubDetail::Full { 20 } else { 10 })
+            .map(|comment| {
+                json!({
+                    "author": json_value_at_path(comment, &["user", "login"]).and_then(Value::as_str).unwrap_or("?"),
+                    "created_at": github_timestamp(json_value_at_path(comment, &["created_at"]).and_then(Value::as_str)),
+                    "body": github_excerpt(
+                        json_value_at_path(comment, &["body"]).and_then(Value::as_str).unwrap_or(""),
+                        Some(200),
+                    ),
+                    "url": json_value_at_path(comment, &["html_url"]).and_then(Value::as_str).unwrap_or(""),
+                })
+            })
+            .collect())
+    }
+
+    async fn github_issue_comments(
+        &self,
+        repo: &str,
+        issue_number: u64,
+        detail: GithubDetail,
+    ) -> Result<Vec<Value>, String> {
+        let response = self
+            .github_request(
+                Method::GET,
+                &format!(
+                    "https://api.github.com/repos/{repo}/issues/{issue_number}/comments?per_page={}",
+                    if detail == GithubDetail::Full { 20 } else { 3 }
+                ),
+                None,
+            )
+            .await?;
+        let Some(comments) = response.as_array() else {
+            return Err("Error: unexpected GitHub issue comments response".to_string());
+        };
+
+        Ok(comments
+            .iter()
+            .take(if detail == GithubDetail::Full { 20 } else { 3 })
+            .map(|comment| {
+                json!({
+                    "author": json_value_at_path(comment, &["user", "login"]).and_then(Value::as_str).unwrap_or("?"),
+                    "created_at": github_timestamp(json_value_at_path(comment, &["created_at"]).and_then(Value::as_str)),
+                    "body": github_excerpt(
+                        json_value_at_path(comment, &["body"]).and_then(Value::as_str).unwrap_or(""),
+                        Some(200),
+                    ),
+                    "url": json_value_at_path(comment, &["html_url"]).and_then(Value::as_str).unwrap_or(""),
+                })
+            })
+            .collect())
+    }
+
+    async fn github_workflow_run_jobs(
+        &self,
+        repo: &str,
+        run_id: u64,
+        detail: GithubDetail,
+    ) -> Result<(Vec<String>, Vec<Value>, Vec<Value>), String> {
+        let response = self
+            .github_request(
+                Method::GET,
+                &format!(
+                    "https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100"
+                ),
+                None,
+            )
+            .await?;
+        let Some(jobs) = response.get("jobs").and_then(Value::as_array) else {
+            return Err("Error: unexpected GitHub jobs response".to_string());
+        };
+
+        let mut failed_jobs = Vec::new();
+        let mut failed_steps = Vec::new();
+        let mut all_jobs = Vec::new();
+
+        for job in jobs {
+            let conclusion = github_normalize_conclusion(
+                json_value_at_path(job, &["conclusion"]).and_then(Value::as_str),
+                json_value_at_path(job, &["status"]).and_then(Value::as_str),
+            );
+            let job_name = json_value_at_path(job, &["name"])
+                .and_then(Value::as_str)
+                .unwrap_or("?")
+                .to_string();
+            if conclusion == "failure" {
+                failed_jobs.push(job_name.clone());
+            }
+
+            if detail == GithubDetail::Full {
+                all_jobs.push(json!({
+                    "name": job_name,
+                    "conclusion": conclusion,
+                    "started_at": github_timestamp(json_value_at_path(job, &["started_at"]).and_then(Value::as_str)),
+                    "completed_at": github_timestamp(json_value_at_path(job, &["completed_at"]).and_then(Value::as_str)),
+                }));
+            }
+
+            if detail.includes_detailed() {
+                let mut job_failed_steps = job
+                    .get("steps")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|step| {
+                        let step_conclusion = github_normalize_conclusion(
+                            json_value_at_path(step, &["conclusion"]).and_then(Value::as_str),
+                            json_value_at_path(step, &["status"]).and_then(Value::as_str),
+                        );
+                        if step_conclusion == "failure" {
+                            Some(json!({
+                                "job": job_name,
+                                "step": json_value_at_path(step, &["name"]).and_then(Value::as_str).unwrap_or("?"),
+                                "conclusion": step_conclusion,
+                                "number": json_u64(step, &["number"]),
+                                "log_snippet": Value::Null,
+                            }))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                if detail == GithubDetail::Detailed {
+                    if let Some(first) = job_failed_steps.into_iter().next() {
+                        failed_steps.push(first);
+                    }
+                } else {
+                    failed_steps.append(&mut job_failed_steps);
+                }
+            }
+        }
+
+        Ok((failed_jobs, failed_steps, all_jobs))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct GithubRepoResolution {
+    resolved_repo: String,
+    resolved_by_search: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GithubDetail {
+    Brief,
+    Normal,
+    Detailed,
+    Full,
+}
+
+impl GithubDetail {
+    pub(crate) fn parse(value: Option<&str>) -> Result<Self, String> {
+        match value.unwrap_or("brief") {
+            "brief" => Ok(Self::Brief),
+            "normal" => Ok(Self::Normal),
+            "detailed" => Ok(Self::Detailed),
+            "full" => Ok(Self::Full),
+            other => Err(format!(
+                "Error: invalid detail '{other}'. Use one of: brief, normal, detailed, full"
+            )),
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Brief => "brief",
+            Self::Normal => "normal",
+            Self::Detailed => "detailed",
+            Self::Full => "full",
+        }
+    }
+
+    pub(crate) fn includes_normal(self) -> bool {
+        matches!(self, Self::Normal | Self::Detailed | Self::Full)
+    }
+
+    pub(crate) fn includes_detailed(self) -> bool {
+        matches!(self, Self::Detailed | Self::Full)
+    }
+
+    pub(crate) fn title_limit(self) -> usize {
+        match self {
+            Self::Brief | Self::Normal => 80,
+            Self::Detailed | Self::Full => usize::MAX,
+        }
+    }
+
+    pub(crate) fn body_limit(self) -> usize {
+        match self {
+            Self::Brief => 0,
+            Self::Normal => 200,
+            Self::Detailed => 500,
+            Self::Full => 2000,
+        }
+    }
+
+    pub(crate) fn diff_limit(self) -> usize {
+        match self {
+            Self::Brief | Self::Normal => 0,
+            Self::Detailed => 500,
+            Self::Full => 2000,
+        }
+    }
+
+    pub(crate) fn list_cap(self) -> usize {
+        match self {
+            Self::Brief | Self::Normal => 10,
+            Self::Detailed => 20,
+            Self::Full => 50,
+        }
+    }
+}
+
+fn json_value_at_path<'a>(value: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    Some(current)
+}
+
+fn json_u64(value: &Value, path: &[&str]) -> Option<u64> {
+    json_value_at_path(value, path).and_then(Value::as_u64)
+}
+
+fn github_api_error_message(
+    status: StatusCode,
+    value: &Value,
+    github_token_present: bool,
+) -> String {
+    let message = value
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("GitHub request failed");
+    let mut details = vec![message.to_string()];
+
+    if let Some(errors) = value.get("errors").and_then(Value::as_array) {
+        let flattened = errors
+            .iter()
+            .take(3)
+            .map(|entry| {
+                let field = entry.get("field").and_then(Value::as_str).unwrap_or("");
+                let code = entry.get("code").and_then(Value::as_str).unwrap_or("");
+                let detail = entry.get("message").and_then(Value::as_str).unwrap_or("");
+                [field, code, detail]
+                    .into_iter()
+                    .filter(|part| !part.is_empty())
+                    .collect::<Vec<_>>()
+                    .join(": ")
+            })
+            .filter(|entry| !entry.is_empty())
+            .collect::<Vec<_>>();
+        if !flattened.is_empty() {
+            details.push(format!("details: {}", flattened.join("; ")));
+        }
+    }
+
+    if status == StatusCode::NOT_FOUND && !github_token_present {
+        details.push("repo may be missing, private, or require GITHUB_TOKEN".to_string());
+    }
+
+    if let Some(doc_url) = value.get("documentation_url").and_then(Value::as_str) {
+        details.push(format!("docs: {doc_url}"));
+    }
+
+    format!(
+        "Error: GitHub API HTTP {}: {}",
+        status.as_u16(),
+        details.join(" | ")
+    )
+}
+
+fn github_requested_limit(requested: Option<u64>, detail: GithubDetail, default: usize) -> usize {
+    requested
+        .map(|value| value as usize)
+        .unwrap_or(default)
+        .min(detail.list_cap())
+}
+
+fn github_response_string(value: Value) -> String {
+    serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+}
+
+fn resolution_output_repo(resolution: &GithubRepoResolution) -> Option<String> {
+    resolution
+        .resolved_by_search
+        .then(|| resolution.resolved_repo.clone())
+}
+
+fn github_error_response(
+    tool: &str,
+    payload_key: &str,
+    detail: Option<GithubDetail>,
+    requested_repo: Option<&str>,
+    resolution: Option<&GithubRepoResolution>,
+    error: impl Into<String>,
+) -> String {
+    let mut response = json!({
+        "ok": false,
+        "tool": tool,
+        "detail": detail.map(GithubDetail::as_str),
+        "requested_repo": requested_repo,
+        "resolved_repo": resolution.and_then(resolution_output_repo),
+        "resolved_by_search": resolution.map(|value| value.resolved_by_search).unwrap_or(false),
+        "count": 0,
+        "error": error.into(),
+    });
+    response
+        .as_object_mut()
+        .expect("github error response should be an object")
+        .insert(payload_key.to_string(), Value::Null);
+    github_response_string(response)
+}
+
+fn github_normalize_name(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn github_pick_resolved_repo(
+    repo: &str,
+    items: &[Value],
+    preferred_repos: &[String],
+) -> Result<String, String> {
+    let normalized_repo = github_normalize_name(repo);
+    let exact_name_matches = items
+        .iter()
+        .filter(|item| {
+            item.get("name")
+                .and_then(Value::as_str)
+                .map(|name| {
+                    name.eq_ignore_ascii_case(repo)
+                        || github_normalize_name(name) == normalized_repo
+                })
+                .unwrap_or(false)
+        })
+        .filter_map(|item| item.get("full_name").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+
+    if exact_name_matches.len() > 1 {
+        // Multiple exact matches — check if one is preferred
+        for candidate in &exact_name_matches {
+            if preferred_repos
+                .iter()
+                .any(|pref| pref.eq_ignore_ascii_case(candidate))
+            {
+                return Ok(candidate.to_string());
+            }
+        }
+        return Err(format!(
+            "Error: repo name '{repo}' is ambiguous. Use owner/repo, e.g. {}",
+            exact_name_matches.join(", ")
+        ));
+    }
+
+    if let Some(found) = exact_name_matches.first() {
+        return Ok((*found).to_string());
+    }
+
+    let candidates = items
+        .iter()
+        .take(3)
+        .filter_map(|item| item.get("full_name").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        Err(format!("Could not resolve repo '{repo}'"))
+    } else {
+        Err(format!(
+            "Error: repo name '{repo}' did not resolve safely. Use owner/repo, e.g. {}",
+            candidates.join(", ")
+        ))
+    }
+}
+
+fn github_normalize_conclusion(conclusion: Option<&str>, status: Option<&str>) -> String {
+    match conclusion.or(status) {
+        Some("success") => "success",
+        Some("failure")
+        | Some("timed_out")
+        | Some("action_required")
+        | Some("startup_failure")
+        | Some("stale")
+        | Some("error") => "failure",
+        Some("cancelled") => "cancelled",
+        Some("skipped") | Some("neutral") => "skipped",
+        Some("queued") | Some("in_progress") | Some("waiting") | Some("requested") | None => {
+            "pending"
+        }
+        Some(_) => "unknown",
+    }
+    .to_string()
+}
+
+fn github_timestamp(value: Option<&str>) -> String {
+    value
+        .and_then(|raw| DateTime::parse_from_rfc3339(raw).ok())
+        .map(|dt| dt.with_timezone(&Utc).format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "?".to_string())
+}
+
+fn github_duration_seconds(start: Option<&str>, end: Option<&str>) -> Option<i64> {
+    let start = DateTime::parse_from_rfc3339(start?).ok()?;
+    let end = DateTime::parse_from_rfc3339(end?).ok()?;
+    Some(end.signed_duration_since(start).num_seconds().max(0))
+}
+
+fn github_excerpt(value: &str, limit: Option<usize>) -> String {
+    let normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    match limit {
+        Some(0) => String::new(),
+        Some(max) => {
+            let char_count = normalized.chars().count();
+            if char_count > max {
+                format!(
+                    "{} [truncated]",
+                    normalized.chars().take(max).collect::<String>()
+                )
+            } else {
+                normalized
+            }
+        }
+        None => normalized,
+    }
+}
+
+fn github_title_value(value: Option<&str>, detail: GithubDetail) -> String {
+    github_excerpt(value.unwrap_or(""), Some(detail.title_limit()))
+}
+
+fn github_label_names(value: &Value) -> Vec<String> {
+    value
+        .get("labels")
+        .and_then(Value::as_array)
+        .map(|labels| {
+            labels
+                .iter()
+                .filter_map(|label| label.get("name").and_then(Value::as_str))
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn github_reviewer_names(value: &Value) -> Vec<String> {
+    value
+        .get("requested_reviewers")
+        .and_then(Value::as_array)
+        .map(|reviewers| {
+            reviewers
+                .iter()
+                .filter_map(|reviewer| reviewer.get("login").and_then(Value::as_str))
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn github_primary_assignee(value: &Value) -> Option<String> {
+    value
+        .get("assignee")
+        .and_then(|assignee| assignee.get("login"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .or_else(|| {
+            value
+                .get("assignees")
+                .and_then(Value::as_array)
+                .and_then(|assignees| assignees.first())
+                .and_then(|assignee| assignee.get("login"))
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+}
+
+fn github_milestone_title(value: &Value) -> Option<String> {
+    value
+        .get("milestone")
+        .and_then(|milestone| milestone.get("title"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn github_pr_state(value: &Value) -> String {
+    if value
+        .get("merged_at")
+        .is_some_and(|merged| !merged.is_null())
+    {
+        "merged".to_string()
+    } else {
+        json_value_at_path(value, &["state"])
+            .and_then(Value::as_str)
+            .unwrap_or("?")
+            .to_string()
+    }
+}
+
+fn github_pr_file_item(file: &Value, detail: GithubDetail) -> Value {
+    json!({
+        "path": json_value_at_path(file, &["filename"]).and_then(Value::as_str).unwrap_or(""),
+        "status": json_value_at_path(file, &["status"]).and_then(Value::as_str).unwrap_or("unknown"),
+        "changes": json_u64(file, &["changes"]),
+        "additions": json_u64(file, &["additions"]),
+        "deletions": json_u64(file, &["deletions"]),
+        "diff_summary": if detail == GithubDetail::Full {
+            github_excerpt(
+                json_value_at_path(file, &["patch"]).and_then(Value::as_str).unwrap_or(""),
+                Some(detail.diff_limit()),
+            )
+        } else {
+            String::new()
+        },
+    })
+}
+
+fn github_pr_list_item(pr: &Value, detail: GithubDetail) -> Value {
+    let body = json_value_at_path(pr, &["body"])
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    json!({
+        "number": json_u64(pr, &["number"]),
+        "title": github_title_value(json_value_at_path(pr, &["title"]).and_then(Value::as_str), detail),
+        "author": json_value_at_path(pr, &["user", "login"]).and_then(Value::as_str).unwrap_or("?"),
+        "state": github_pr_state(pr),
+        "created_at": github_timestamp(json_value_at_path(pr, &["created_at"]).and_then(Value::as_str)),
+        "body_summary": if detail.includes_normal() {
+            github_excerpt(body, Some(detail.body_limit()))
+        } else {
+            String::new()
+        },
+        "labels": if detail.includes_normal() { github_label_names(pr) } else { Vec::<String>::new() },
+        "reviewers": if detail.includes_normal() { github_reviewer_names(pr) } else { Vec::<String>::new() },
+        "changed_files": None::<u64>,
+        "additions": None::<u64>,
+        "deletions": None::<u64>,
+        "review_comments_count": if detail.includes_detailed() { json_u64(pr, &["review_comments"]) } else { None::<u64> },
+        "merge_status": None::<String>,
+        "conflicts": None::<bool>,
+        "url": json_value_at_path(pr, &["html_url"]).and_then(Value::as_str).unwrap_or(""),
+    })
+}
+
+fn github_issue_list_item(issue: &Value, detail: GithubDetail) -> Value {
+    let body = json_value_at_path(issue, &["body"])
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    json!({
+        "number": json_u64(issue, &["number"]),
+        "title": github_title_value(json_value_at_path(issue, &["title"]).and_then(Value::as_str), detail),
+        "state": json_value_at_path(issue, &["state"]).and_then(Value::as_str).unwrap_or("?"),
+        "labels": github_label_names(issue),
+        "created_at": github_timestamp(json_value_at_path(issue, &["created_at"]).and_then(Value::as_str)),
+        "author": json_value_at_path(issue, &["user", "login"]).and_then(Value::as_str).unwrap_or("?"),
+        "body": if detail.includes_normal() { github_excerpt(body, Some(detail.body_limit())) } else { String::new() },
+        "assignee": if detail.includes_normal() { github_primary_assignee(issue) } else { None::<String> },
+        "milestone": if detail.includes_normal() { github_milestone_title(issue) } else { None::<String> },
+        "comment_count": if detail.includes_normal() { json_u64(issue, &["comments"]) } else { None::<u64> },
+        "comments": Vec::<Value>::new(),
+        "linked_prs": Vec::<Value>::new(),
+        "url": json_value_at_path(issue, &["html_url"]).and_then(Value::as_str).unwrap_or(""),
+    })
+}
+
+/// Extract owner/repo from a git remote line.
+pub fn extract_github_owner_repo(remote_line: &str) -> Option<String> {
+    let parts: Vec<&str> = remote_line.split_whitespace().collect();
+    let url = parts.get(1)?;
+    let path = if let Some(rest) = url.strip_prefix("git@github.com:") {
+        rest
+    } else if url.contains("://github.com/") {
+        url.rsplit_once("github.com/")?.1
+    } else {
+        return None;
+    };
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    if path.contains('/') && !path.contains(' ') {
+        Some(path.to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    pub fn github_detail_defaults_to_brief() {
+        assert_eq!(GithubDetail::parse(None).unwrap(), GithubDetail::Brief);
+        assert_eq!(
+            GithubDetail::parse(Some("full")).unwrap(),
+            GithubDetail::Full
+        );
+    }
+
+    #[test]
+    pub fn github_timestamp_is_normalized() {
+        assert_eq!(
+            github_timestamp(Some("2026-03-04T06:47:17Z")),
+            "2026-03-04 06:47"
+        );
+    }
+
+    #[test]
+    pub fn github_excerpt_marks_truncation() {
+        assert_eq!(
+            github_excerpt("one two three four", Some(7)),
+            "one two [truncated]"
+        );
+    }
+
+    #[test]
+    pub fn github_conclusion_is_normalized() {
+        assert_eq!(github_normalize_conclusion(None, Some("queued")), "pending");
+        assert_eq!(
+            github_normalize_conclusion(Some("success"), None),
+            "success"
+        );
+        assert_eq!(
+            github_normalize_conclusion(Some("timed_out"), None),
+            "failure"
+        );
+    }
+
+    #[test]
+    pub fn github_repo_resolution_requires_safe_match() {
+        let items = vec![
+            json!({"name": "memoriax", "full_name": "someone/memoriax"}),
+            json!({"name": "Memoria", "full_name": "MatrixOrigin/Memoria"}),
+        ];
+        assert_eq!(
+            github_pick_resolved_repo("memoria", &items, &[]).unwrap(),
+            "MatrixOrigin/Memoria"
+        );
+
+        let unsafe_items = vec![
+            json!({"name": "memoriax", "full_name": "someone/memoriax"}),
+            json!({"name": "memory", "full_name": "else/memory"}),
+        ];
+        assert!(github_pick_resolved_repo("memoria", &unsafe_items, &[]).is_err());
+    }
+
+    #[test]
+    fn github_repo_resolution_prefers_preferred_repo_on_ambiguity() {
+        // Two exact name matches — normally ambiguous
+        let items = vec![
+            json!({"name": "Memoria", "full_name": "Albeoris/Memoria"}),
+            json!({"name": "Memoria", "full_name": "MatrixOrigin/Memoria"}),
+        ];
+        // Without preferred → ambiguous error
+        assert!(github_pick_resolved_repo("memoria", &items, &[]).is_err());
+
+        // With preferred → picks the preferred one
+        let preferred = vec!["matrixorigin/memoria".to_string()];
+        assert_eq!(
+            github_pick_resolved_repo("memoria", &items, &preferred).unwrap(),
+            "MatrixOrigin/Memoria"
+        );
+    }
+
+    #[test]
+    fn extract_github_owner_repo_ssh() {
+        let line = "origin\tgit@github.com:MatrixOrigin/Memoria.git (fetch)";
+        assert_eq!(
+            super::extract_github_owner_repo(line),
+            Some("MatrixOrigin/Memoria".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_github_owner_repo_https() {
+        let line = "origin\thttps://github.com/matrixorigin/mo-dev-agent.git (push)";
+        assert_eq!(
+            super::extract_github_owner_repo(line),
+            Some("matrixorigin/mo-dev-agent".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_github_owner_repo_non_github() {
+        let line = "origin\thttps://gitlab.com/someone/project.git (fetch)";
+        assert_eq!(super::extract_github_owner_repo(line), None);
+    }
+
+    // ── github_pick_resolved_repo edge cases ──
+
+    #[test]
+    fn pick_resolved_repo_empty_items() {
+        let result = github_pick_resolved_repo("something", &[], &[]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Could not resolve"));
+    }
+
+    #[test]
+    fn pick_resolved_repo_no_exact_name_match() {
+        let items = vec![
+            json!({"name": "memoria-fork", "full_name": "someone/memoria-fork"}),
+            json!({"name": "memoria-v2", "full_name": "other/memoria-v2"}),
+        ];
+        let result = github_pick_resolved_repo("memoria", &items, &[]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("did not resolve safely"));
+    }
+
+    #[test]
+    fn pick_resolved_repo_normalized_name_match() {
+        // "mo-dev-agent" normalized matches "modevagent"
+        let items = vec![json!({"name": "mo-dev-agent", "full_name": "org/mo-dev-agent"})];
+        assert_eq!(
+            github_pick_resolved_repo("mo_dev_agent", &items, &[]).unwrap(),
+            "org/mo-dev-agent"
+        );
+    }
+
+    #[test]
+    fn pick_resolved_repo_missing_full_name_field() {
+        // Malformed response — item without full_name
+        let items = vec![
+            json!({"name": "memoria"}), // no full_name
+        ];
+        let result = github_pick_resolved_repo("memoria", &items, &[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn pick_resolved_repo_case_insensitive_preference() {
+        let items = vec![
+            json!({"name": "Memoria", "full_name": "Albeoris/Memoria"}),
+            json!({"name": "Memoria", "full_name": "MatrixOrigin/Memoria"}),
+        ];
+        // Preference is lowercased
+        let preferred = vec!["MATRIXORIGIN/MEMORIA".to_lowercase()];
+        assert_eq!(
+            github_pick_resolved_repo("memoria", &items, &preferred).unwrap(),
+            "MatrixOrigin/Memoria"
+        );
+    }
+
+    #[test]
+    fn pick_resolved_repo_single_exact_match_ignores_preferences() {
+        // Only one exact match — preferences don't matter
+        let items = vec![json!({"name": "Memoria", "full_name": "Albeoris/Memoria"})];
+        let preferred = vec!["matrixorigin/memoria".to_string()];
+        // The single exact match wins regardless of preference
+        assert_eq!(
+            github_pick_resolved_repo("memoria", &items, &preferred).unwrap(),
+            "Albeoris/Memoria"
+        );
+    }
+
+    #[test]
+    pub fn github_missing_repo_error_guides_recovery() {
+        let response = github_error_response(
+            "github_ci_status",
+            "workflow_runs",
+            Some(GithubDetail::Brief),
+            None,
+            None,
+            GITHUB_MISSING_REPO_ERROR,
+        );
+        assert!(response.contains("missing 'repo'"));
+        assert!(response.contains("recent conversation"));
+        assert!(response.contains("memoria"));
+    }
+
+    // ── Helper function correctness ──
+
+    #[test]
+    fn github_detail_parse_all_valid_levels() {
+        assert_eq!(
+            GithubDetail::parse(Some("brief")).unwrap(),
+            GithubDetail::Brief
+        );
+        assert_eq!(
+            GithubDetail::parse(Some("normal")).unwrap(),
+            GithubDetail::Normal
+        );
+        assert_eq!(
+            GithubDetail::parse(Some("detailed")).unwrap(),
+            GithubDetail::Detailed
+        );
+        assert_eq!(
+            GithubDetail::parse(Some("full")).unwrap(),
+            GithubDetail::Full
+        );
+        assert_eq!(GithubDetail::parse(None).unwrap(), GithubDetail::Brief);
+    }
+
+    #[test]
+    fn github_detail_parse_invalid_returns_error() {
+        let err = GithubDetail::parse(Some("verbose")).unwrap_err();
+        assert!(err.contains("brief"), "should suggest valid options: {err}");
+    }
+
+    #[test]
+    fn github_detail_list_caps() {
+        // Brief should have tighter limits than Full
+        assert!(GithubDetail::Brief.list_cap() <= GithubDetail::Normal.list_cap());
+        assert!(GithubDetail::Normal.list_cap() <= GithubDetail::Full.list_cap());
+    }
+
+    #[test]
+    fn github_requested_limit_respects_cap() {
+        // Requesting 1000 but brief cap is much lower
+        let result = github_requested_limit(Some(1000), GithubDetail::Brief, 10);
+        assert!(result <= GithubDetail::Brief.list_cap());
+    }
+
+    #[test]
+    fn github_requested_limit_uses_default() {
+        assert_eq!(github_requested_limit(None, GithubDetail::Brief, 10), 10);
+        assert_eq!(github_requested_limit(None, GithubDetail::Brief, 5), 5);
+    }
+
+    #[test]
+    fn github_timestamp_valid_rfc3339() {
+        let result = github_timestamp(Some("2025-01-15T10:30:00Z"));
+        assert!(
+            result.contains("2025-01-15"),
+            "should format date: {result}"
+        );
+    }
+
+    #[test]
+    fn github_timestamp_invalid_returns_question_mark() {
+        assert_eq!(github_timestamp(Some("not-a-date")), "?");
+        assert_eq!(github_timestamp(None), "?");
+    }
+
+    #[test]
+    fn github_duration_seconds_valid() {
+        let d = github_duration_seconds(Some("2025-01-01T00:00:00Z"), Some("2025-01-01T00:05:00Z"));
+        assert_eq!(d, Some(300));
+    }
+
+    #[test]
+    fn github_duration_seconds_invalid_returns_none() {
+        assert_eq!(
+            github_duration_seconds(None, Some("2025-01-01T00:00:00Z")),
+            None
+        );
+        assert_eq!(
+            github_duration_seconds(Some("bad"), Some("2025-01-01T00:00:00Z")),
+            None
+        );
+    }
+
+    #[test]
+    fn github_excerpt_truncates_long_text() {
+        let long = "a ".repeat(100);
+        let result = github_excerpt(&long, Some(10));
+        assert!(result.contains("[truncated]"));
+        assert!(result.len() < long.len());
+    }
+
+    #[test]
+    fn github_excerpt_no_limit_preserves_all() {
+        let text = "hello world  foo   bar";
+        assert_eq!(github_excerpt(text, None), "hello world foo bar");
+    }
+
+    #[test]
+    fn github_normalize_name_strips_special_chars() {
+        assert_eq!(github_normalize_name("Mo-Dev-Agent"), "modevagent");
+        assert_eq!(github_normalize_name("Memoria"), "memoria");
+        assert_eq!(github_normalize_name("my_repo-v2.0"), "myrepov20");
+    }
+
+    #[test]
+    fn github_normalize_conclusion_all_states() {
+        assert_eq!(
+            github_normalize_conclusion(Some("success"), None),
+            "success"
+        );
+        assert_eq!(
+            github_normalize_conclusion(Some("failure"), None),
+            "failure"
+        );
+        assert_eq!(
+            github_normalize_conclusion(Some("timed_out"), None),
+            "failure"
+        );
+        assert_eq!(
+            github_normalize_conclusion(Some("cancelled"), None),
+            "cancelled"
+        );
+        assert_eq!(
+            github_normalize_conclusion(Some("skipped"), None),
+            "skipped"
+        );
+        assert_eq!(
+            github_normalize_conclusion(Some("neutral"), None),
+            "skipped"
+        );
+        assert_eq!(github_normalize_conclusion(Some("queued"), None), "pending");
+        assert_eq!(
+            github_normalize_conclusion(Some("in_progress"), None),
+            "pending"
+        );
+        assert_eq!(github_normalize_conclusion(None, None), "pending");
+        assert_eq!(
+            github_normalize_conclusion(Some("something_else"), None),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn github_normalize_conclusion_status_fallback() {
+        // When conclusion is None, falls back to status
+        assert_eq!(
+            github_normalize_conclusion(None, Some("success")),
+            "success"
+        );
+        assert_eq!(github_normalize_conclusion(None, Some("error")), "failure");
+    }
+
+    #[test]
+    fn github_pr_state_merged() {
+        let pr = json!({"state": "closed", "merged_at": "2025-01-01T00:00:00Z"});
+        assert_eq!(github_pr_state(&pr), "merged");
+    }
+
+    #[test]
+    fn github_pr_state_not_merged() {
+        let pr = json!({"state": "open", "merged_at": null});
+        assert_eq!(github_pr_state(&pr), "open");
+    }
+
+    // ── Error response format ──
+
+    #[test]
+    fn github_error_response_structure() {
+        let response = github_error_response(
+            "github_list_prs",
+            "pull_requests",
+            Some(GithubDetail::Brief),
+            Some("matrixorigin/memoria"),
+            None,
+            "some error message",
+        );
+        let parsed: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(parsed["ok"], json!(false));
+        assert_eq!(parsed["tool"], "github_list_prs");
+        assert_eq!(parsed["error"], "some error message");
+        assert_eq!(parsed["count"], 0);
+        assert!(
+            parsed["pull_requests"].is_null(),
+            "payload key should be null"
+        );
+    }
+
+    #[test]
+    fn github_error_response_with_resolution() {
+        let resolution = GithubRepoResolution {
+            resolved_repo: "MatrixOrigin/Memoria".into(),
+            resolved_by_search: true,
+        };
+        let response = github_error_response(
+            "github_ci_status",
+            "workflow_runs",
+            Some(GithubDetail::Normal),
+            Some("memoria"),
+            Some(&resolution),
+            "API failure",
+        );
+        let parsed: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(parsed["resolved_repo"], "MatrixOrigin/Memoria");
+        assert_eq!(parsed["resolved_by_search"], true);
+    }
+
+    // ── Item formatting ──
+
+    #[test]
+    fn github_pr_list_item_brief() {
+        let pr = json!({
+            "number": 42,
+            "title": "Fix bug in parser",
+            "user": {"login": "alice"},
+            "state": "open",
+            "merged_at": null,
+            "created_at": "2025-06-01T10:00:00Z",
+            "body": "This fixes the parser",
+            "html_url": "https://github.com/org/repo/pull/42"
+        });
+        let item = github_pr_list_item(&pr, GithubDetail::Brief);
+        assert_eq!(item["number"], 42);
+        assert_eq!(item["author"], "alice");
+        assert_eq!(item["state"], "open");
+        // Brief mode should not include body
+        assert_eq!(item["body_summary"], "");
+    }
+
+    #[test]
+    fn github_pr_list_item_normal_includes_body() {
+        let pr = json!({
+            "number": 1,
+            "title": "Feat",
+            "user": {"login": "bob"},
+            "state": "closed",
+            "merged_at": "2025-06-02T00:00:00Z",
+            "created_at": "2025-06-01T10:00:00Z",
+            "body": "Detailed description here",
+            "html_url": "https://github.com/org/repo/pull/1"
+        });
+        let item = github_pr_list_item(&pr, GithubDetail::Normal);
+        assert_eq!(item["state"], "merged"); // has merged_at
+        assert!(!item["body_summary"].as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn github_issue_list_item_structure() {
+        let issue = json!({
+            "number": 10,
+            "title": "Feature request",
+            "state": "open",
+            "user": {"login": "carol"},
+            "created_at": "2025-05-01T00:00:00Z",
+            "body": "Please add X",
+            "comments": 3,
+            "labels": [{"name": "enhancement"}],
+            "html_url": "https://github.com/org/repo/issues/10"
+        });
+        let item = github_issue_list_item(&issue, GithubDetail::Brief);
+        assert_eq!(item["number"], 10);
+        assert_eq!(item["state"], "open");
+        assert_eq!(item["author"], "carol");
+    }
+}

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -13,15 +13,19 @@ pub mod web_search;
 
 pub mod build_test;
 pub mod code_intel;
+pub mod config_tool;
 pub mod env_tools;
 pub mod executor;
 pub mod fs_ops;
 pub mod fuzzy_replacer;
+pub mod git_gix;
 pub mod git_ops;
+pub mod github;
 pub mod passive_cargo_check;
 pub mod passive_tsc_check;
 pub mod shell_ops;
 pub mod task_mgmt;
+pub mod tool_search;
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -11,10 +11,17 @@ pub mod memoria;
 pub mod schemas;
 pub mod web_search;
 
+pub mod build_test;
+pub mod code_intel;
+pub mod env_tools;
 pub mod executor;
 pub mod fs_ops;
+pub mod fuzzy_replacer;
 pub mod git_ops;
+pub mod passive_cargo_check;
+pub mod passive_tsc_check;
 pub mod shell_ops;
+pub mod task_mgmt;
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;

--- a/rust/crates/astra-tools/src/passive_cargo_check.rs
+++ b/rust/crates/astra-tools/src/passive_cargo_check.rs
@@ -1,0 +1,292 @@
+//! Passive `cargo check` after Rust source edits: run once before the next LLM turn
+//! that carries `tool_results`, then inject a user message wrapped in
+//! `<new-diagnostics>` when there are errors or the check fails.
+//!
+//! Kill switch: `ASTRA_PASSIVE_CARGO_CHECK=0|false|off`
+//! Timeout: `ASTRA_PASSIVE_CARGO_TIMEOUT_SECS` (default 45, max 300)
+
+#![allow(dead_code)]
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use crate::build_test;
+
+/// Max chars for injected diagnostic text (keeps `/chat` payload bounded).
+const MAX_PASSIVE_DIAG_CHARS: usize = 12_000;
+
+fn passive_cargo_check_enabled() -> bool {
+    match std::env::var("ASTRA_PASSIVE_CARGO_CHECK") {
+        Ok(v) => {
+            let v = v.trim().to_lowercase();
+            !(v.is_empty() || v == "0" || v == "false" || v == "off")
+        }
+        Err(_) => true,
+    }
+}
+
+fn passive_cargo_timeout() -> Duration {
+    let secs = std::env::var("ASTRA_PASSIVE_CARGO_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(45);
+    Duration::from_secs(secs.clamp(1, 300))
+}
+
+/// Whether a successful disk write to `edited_path` should schedule a passive check.
+#[must_use]
+pub(crate) fn should_schedule_passive_cargo(project_root: &Path, edited_path: &Path) -> bool {
+    if !passive_cargo_check_enabled() {
+        return false;
+    }
+    if edited_path.extension().and_then(|e| e.to_str()) != Some("rs") {
+        return false;
+    }
+    project_root.join("Cargo.toml").is_file()
+}
+
+fn truncate_diag_body(s: &str) -> String {
+    if s.chars().count() <= MAX_PASSIVE_DIAG_CHARS {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(MAX_PASSIVE_DIAG_CHARS).collect();
+    format!("{head}\n\n[truncated passive cargo diagnostics at {MAX_PASSIVE_DIAG_CHARS} chars]")
+}
+
+/// Drain pending flag, run `cargo check` if appropriate, return messages to append to `payload["messages"]`.
+pub(crate) async fn take_passive_cargo_messages(
+    pending: &AtomicBool,
+    project_root: &Path,
+    tool_results_nonempty: bool,
+) -> Vec<Value> {
+    if !passive_cargo_check_enabled() || !tool_results_nonempty {
+        return Vec::new();
+    }
+    if !pending.load(Ordering::SeqCst) {
+        return Vec::new();
+    }
+    if !project_root.join("Cargo.toml").is_file() {
+        pending.store(false, Ordering::SeqCst);
+        return Vec::new();
+    }
+    pending.store(false, Ordering::SeqCst);
+
+    let run = async {
+        Command::new("cargo")
+            .args(["check", "--message-format=short"])
+            .current_dir(project_root)
+            .kill_on_drop(true)
+            .output()
+            .await
+    };
+
+    let output = match timeout(passive_cargo_timeout(), run).await {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            return vec![diagnostic_message(format!(
+                "Passive `cargo check` could not run: {e}"
+            ))];
+        }
+        Err(_) => {
+            return vec![diagnostic_message(format!(
+                "Passive `cargo check` timed out after {:?}",
+                passive_cargo_timeout()
+            ))];
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let combined = format!("{stdout}\n{stderr}");
+    let code = output.status.code();
+    let mut result = build_test::parse_build_test_output(&combined, code);
+    if !result.error_locations.is_empty() {
+        result.enrich_with_scope(project_root);
+    }
+
+    let exit_fail = !matches!(code, Some(0));
+    let has_model_issues = !result.passed || result.error_count > 0;
+    if !exit_fail && !has_model_issues {
+        return Vec::new();
+    }
+
+    let body = truncate_diag_body(&result.to_enhanced_output(&combined));
+    let intro = if exit_fail && result.error_count == 0 {
+        "Workspace `cargo check` failed (non-zero exit) after recent Rust edits."
+    } else {
+        "Workspace `cargo check` reported issues after recent Rust edits."
+    };
+    vec![diagnostic_message(format!(
+        "<new-diagnostics>\n{intro}\n\n{body}\n</new-diagnostics>"
+    ))]
+}
+
+fn diagnostic_message(content: String) -> Value {
+    json!({
+        "role": "user",
+        "content": content,
+        "attachment_metadata": {
+            "kind": "passive_workspace_diagnostics",
+            "source": "cargo_check",
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // NOTE: ToolExecutor tests require CLI context, disabled in astra-tools
+    // use crate::edge_tools::ToolExecutor; // CLI-specific, not available here
+    #[cfg(feature = "cli")]
+    use serde_json::json;
+    use std::sync::atomic::AtomicBool;
+
+    #[test]
+    #[serial_test::serial]
+    fn should_schedule_requires_rs_and_cargo_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        assert!(!should_schedule_passive_cargo(
+            root,
+            Path::new("src/lib.rs")
+        ));
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname=\"x\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+        )
+        .unwrap();
+        assert!(should_schedule_passive_cargo(
+            root,
+            Path::new("src/main.rs")
+        ));
+        assert!(!should_schedule_passive_cargo(root, Path::new("src/x.go")));
+    }
+
+    #[tokio::test]
+    async fn pending_not_consumed_when_tool_results_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname=\"passive_t\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        let pending = AtomicBool::new(true);
+        let msgs = take_passive_cargo_messages(&pending, root, false).await;
+        assert!(msgs.is_empty());
+        assert!(pending.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn injects_on_compile_error_after_tool_round() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname=\"passive_t2\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src/main.rs"),
+            "fn main() { let x: String = 42; }\n",
+        )
+        .unwrap();
+
+        let pending = AtomicBool::new(true);
+        let msgs = take_passive_cargo_messages(&pending, root, true).await;
+        assert_eq!(msgs.len(), 1);
+        let content = msgs[0]["content"].as_str().unwrap();
+        assert!(content.contains("<new-diagnostics>"), "content={content:?}");
+        assert!(
+            content.contains("error") || content.contains("mismatch"),
+            "expected rustc hint, content={content:?}"
+        );
+        assert!(!pending.load(Ordering::SeqCst));
+    }
+
+    #[cfg(feature = "cli")]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn tool_executor_write_file_triggers_passive_flush() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname=\"passive_t4\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let exe = ToolExecutor::new(root);
+        let _ = exe
+            .execute("read_file", &json!({"path": "src/main.rs"}))
+            .await;
+        let r = exe
+            .execute(
+                "write_file",
+                &json!({"path": "src/main.rs", "content": "fn main() { let _: () = 1; }\n"}),
+            )
+            .await;
+        assert!(r.contains("\"success\":true"), "write_file: {r}");
+        let msgs = exe
+            .take_passive_workspace_diagnostic_messages(root, true)
+            .await;
+        assert_eq!(msgs.len(), 1);
+        let c = msgs[0]["content"].as_str().unwrap();
+        assert!(c.contains("<new-diagnostics>"), "{c}");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn no_message_when_check_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname=\"passive_t3\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let pending = AtomicBool::new(true);
+        let msgs = take_passive_cargo_messages(&pending, root, true).await;
+        assert!(msgs.is_empty());
+        assert!(!pending.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn disabled_via_env_skips_schedule() {
+        struct ClearPassiveEnv;
+        impl Drop for ClearPassiveEnv {
+            fn drop(&mut self) {
+                // SAFETY: `serial` test; no concurrent readers of this env var in other threads.
+                unsafe {
+                    std::env::remove_var("ASTRA_PASSIVE_CARGO_CHECK");
+                }
+            }
+        }
+        // SAFETY: `serial` test; no concurrent env access in other threads.
+        unsafe {
+            std::env::set_var("ASTRA_PASSIVE_CARGO_CHECK", "0");
+        }
+        let _clear = ClearPassiveEnv;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname=\"x\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+        )
+        .unwrap();
+        assert!(!should_schedule_passive_cargo(root, Path::new("a.rs")));
+    }
+}

--- a/rust/crates/astra-tools/src/passive_tsc_check.rs
+++ b/rust/crates/astra-tools/src/passive_tsc_check.rs
@@ -1,0 +1,282 @@
+//! Passive `tsc --noEmit` after TypeScript edits when `tsconfig.json` exists.
+//!
+//! Requires `tsc` on `PATH` (e.g. `npm i -D typescript`). If `tsc` is missing, the
+//! pending flag is cleared and nothing is injected (no noisy errors).
+//!
+//! Kill switch: `ASTRA_PASSIVE_TSC_CHECK=0|false|off`
+//! Timeout: `ASTRA_PASSIVE_TSC_TIMEOUT_SECS` (default 90, max 300)
+
+#![allow(dead_code)]
+use std::io::ErrorKind;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::process::Command;
+use tokio::time::timeout;
+
+/// Keep in sync with [`super::passive_cargo_check`] budget.
+const MAX_PASSIVE_DIAG_CHARS: usize = 12_000;
+
+fn passive_tsc_check_enabled() -> bool {
+    match std::env::var("ASTRA_PASSIVE_TSC_CHECK") {
+        Ok(v) => {
+            let v = v.trim().to_lowercase();
+            !(v.is_empty() || v == "0" || v == "false" || v == "off")
+        }
+        Err(_) => true,
+    }
+}
+
+fn passive_tsc_timeout() -> Duration {
+    let secs = std::env::var("ASTRA_PASSIVE_TSC_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(90);
+    Duration::from_secs(secs.clamp(1, 300))
+}
+
+fn is_ts_like_source(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("ts" | "tsx")
+    )
+}
+
+/// Whether a successful disk write should schedule passive `tsc --noEmit`.
+#[must_use]
+pub(crate) fn should_schedule_passive_tsc(project_root: &Path, edited_path: &Path) -> bool {
+    if !passive_tsc_check_enabled() {
+        return false;
+    }
+    if !is_ts_like_source(edited_path) {
+        return false;
+    }
+    project_root.join("tsconfig.json").is_file()
+}
+
+fn truncate_body(s: &str) -> String {
+    if s.chars().count() <= MAX_PASSIVE_DIAG_CHARS {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(MAX_PASSIVE_DIAG_CHARS).collect();
+    format!("{head}\n\n[truncated passive tsc diagnostics at {MAX_PASSIVE_DIAG_CHARS} chars]")
+}
+
+fn diagnostic_message(content: String) -> Value {
+    json!({
+        "role": "user",
+        "content": content,
+        "attachment_metadata": {
+            "kind": "passive_workspace_diagnostics",
+            "source": "tsc_no_emit",
+        }
+    })
+}
+
+/// Drain pending, run `tsc --noEmit -p tsconfig.json` when appropriate.
+pub(crate) async fn take_passive_tsc_messages(
+    pending: &AtomicBool,
+    project_root: &Path,
+    tool_results_nonempty: bool,
+) -> Vec<Value> {
+    if !passive_tsc_check_enabled() || !tool_results_nonempty {
+        return Vec::new();
+    }
+    if !pending.load(Ordering::SeqCst) {
+        return Vec::new();
+    }
+    if !project_root.join("tsconfig.json").is_file() {
+        pending.store(false, Ordering::SeqCst);
+        return Vec::new();
+    }
+    pending.store(false, Ordering::SeqCst);
+
+    let run = async {
+        Command::new("tsc")
+            .args(["--noEmit", "-p", "tsconfig.json"])
+            .current_dir(project_root)
+            .kill_on_drop(true)
+            .output()
+            .await
+    };
+
+    let output = match timeout(passive_tsc_timeout(), run).await {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) if e.kind() == ErrorKind::NotFound => {
+            // TypeScript not installed / not on PATH — skip silently.
+            return Vec::new();
+        }
+        Ok(Err(e)) => {
+            return vec![diagnostic_message(format!(
+                "Passive `tsc --noEmit` could not run: {e}"
+            ))];
+        }
+        Err(_) => {
+            return vec![diagnostic_message(format!(
+                "Passive `tsc --noEmit` timed out after {:?}",
+                passive_tsc_timeout()
+            ))];
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let combined = format!("{stdout}\n{stderr}");
+    let code = output.status.code();
+    if matches!(code, Some(0)) {
+        return Vec::new();
+    }
+
+    let body = truncate_body(combined.trim());
+    vec![diagnostic_message(format!(
+        "<new-diagnostics>\nTypeScript `tsc --noEmit` reported issues after recent edits:\n\n{body}\n</new-diagnostics>"
+    ))]
+}
+
+#[allow(dead_code)]
+fn tsc_available() -> bool {
+    std::process::Command::new("tsc")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // NOTE: ToolExecutor tests require CLI context, disabled in astra-tools
+    // use crate::edge_tools::ToolExecutor; // CLI-specific, not available here
+    #[cfg(feature = "cli")]
+    use serde_json::json;
+    use std::sync::atomic::AtomicBool;
+
+    #[test]
+    #[serial_test::serial]
+    fn should_schedule_requires_tsconfig_and_ts_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        assert!(!should_schedule_passive_tsc(root, Path::new("a.ts")));
+        std::fs::write(
+            root.join("tsconfig.json"),
+            "{\"compilerOptions\":{\"strict\":true}}\n",
+        )
+        .unwrap();
+        assert!(should_schedule_passive_tsc(root, Path::new("src/index.ts")));
+        assert!(should_schedule_passive_tsc(root, Path::new("src/App.tsx")));
+        assert!(!should_schedule_passive_tsc(root, Path::new("src/x.js")));
+    }
+
+    #[tokio::test]
+    async fn pending_not_consumed_when_tool_results_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("tsconfig.json"), "{\"compilerOptions\":{}}\n").unwrap();
+        let pending = AtomicBool::new(true);
+        let msgs = take_passive_tsc_messages(&pending, root, false).await;
+        assert!(msgs.is_empty());
+        assert!(pending.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn injects_on_type_error_when_tsc_available() {
+        if !tsc_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("tsconfig.json"),
+            r#"{"compilerOptions":{"strict":true,"noEmit":true},"include":["*.ts"]}"#,
+        )
+        .unwrap();
+        std::fs::write(root.join("bad.ts"), "const x: string = 42;\n").unwrap();
+
+        let pending = AtomicBool::new(true);
+        let msgs = take_passive_tsc_messages(&pending, root, true).await;
+        assert_eq!(msgs.len(), 1);
+        let c = msgs[0]["content"].as_str().unwrap();
+        assert!(c.contains("<new-diagnostics>"), "{c}");
+        assert!(c.contains("error TS") || c.contains("TypeScript"), "{c}");
+        assert!(!pending.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn no_message_when_types_clean() {
+        if !tsc_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("tsconfig.json"),
+            r#"{"compilerOptions":{"strict":true,"noEmit":true},"include":["*.ts"]}"#,
+        )
+        .unwrap();
+        std::fs::write(root.join("ok.ts"), "const x: string = 'hi';\n").unwrap();
+
+        let pending = AtomicBool::new(true);
+        let msgs = take_passive_tsc_messages(&pending, root, true).await;
+        assert!(msgs.is_empty());
+        assert!(!pending.load(Ordering::SeqCst));
+    }
+
+    #[cfg(feature = "cli")]
+    #[tokio::test]
+    async fn tool_executor_write_file_triggers_tsc_flush() {
+        if !tsc_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("tsconfig.json"),
+            r#"{"compilerOptions":{"strict":true,"noEmit":true},"include":["*.ts"]}"#,
+        )
+        .unwrap();
+        std::fs::write(root.join("ok.ts"), "export const n = 1;\n").unwrap();
+
+        let exe = ToolExecutor::new(root);
+        let _ = exe.execute("read_file", &json!({"path": "ok.ts"})).await;
+        let r = exe
+            .execute(
+                "write_file",
+                &json!({"path": "ok.ts", "content": "const bad: string = 99;\n"}),
+            )
+            .await;
+        assert!(r.contains("\"success\":true"), "{r}");
+        let msgs = exe
+            .take_passive_workspace_diagnostic_messages(root, true)
+            .await;
+        assert!(
+            msgs.iter()
+                .any(|m| m["attachment_metadata"]["source"] == "tsc_no_emit"),
+            "{msgs:?}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn disabled_via_env_skips_schedule() {
+        struct Clear;
+        impl Drop for Clear {
+            fn drop(&mut self) {
+                unsafe {
+                    std::env::remove_var("ASTRA_PASSIVE_TSC_CHECK");
+                }
+            }
+        }
+        unsafe {
+            std::env::set_var("ASTRA_PASSIVE_TSC_CHECK", "0");
+        }
+        let _c = Clear;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("tsconfig.json"), "{}").unwrap();
+        assert!(!should_schedule_passive_tsc(root, Path::new("a.ts")));
+    }
+}

--- a/rust/crates/astra-tools/src/task_mgmt.rs
+++ b/rust/crates/astra-tools/src/task_mgmt.rs
@@ -1,0 +1,351 @@
+//! Session-local task management for the CLI.
+//!
+//! Tasks are in-memory only — they survive across tool calls but not across
+//! CLI restarts. Each task can contain subtasks with dependency tracking.
+
+#![allow(dead_code)]
+use serde_json::{Value, json};
+use std::sync::{
+    Mutex,
+    atomic::{AtomicU32, Ordering},
+};
+
+/// A task tracked within the current CLI session.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionTask {
+    pub id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub status: String,
+    pub subtasks: Vec<SessionSubtask>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A subtask within a SessionTask.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionSubtask {
+    pub id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub status: String,
+    pub depends_on: Vec<String>,
+}
+
+/// In-memory task store for the current session.
+pub(crate) struct TaskManager {
+    tasks: Mutex<Vec<SessionTask>>,
+    id_counter: AtomicU32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskManagerSnapshot {
+    pub tasks: Vec<SessionTask>,
+    pub next_task_id: u32,
+}
+
+impl TaskManager {
+    pub fn new() -> Self {
+        Self {
+            tasks: Mutex::new(Vec::new()),
+            id_counter: AtomicU32::new(1),
+        }
+    }
+
+    /// Get a snapshot of all tasks (for brief/diagnostics).
+    pub fn snapshot(&self) -> Vec<SessionTask> {
+        self.tasks.lock().map(|g| g.clone()).unwrap_or_default()
+    }
+
+    pub fn snapshot_state(&self) -> TaskManagerSnapshot {
+        TaskManagerSnapshot {
+            tasks: self.snapshot(),
+            next_task_id: self.id_counter.load(Ordering::SeqCst),
+        }
+    }
+
+    pub fn restore_snapshot(&self, snapshot: &TaskManagerSnapshot) -> Result<(), String> {
+        let mut tasks = self
+            .tasks
+            .lock()
+            .map_err(|_| "failed to access task list".to_string())?;
+        *tasks = snapshot.tasks.clone();
+        self.id_counter
+            .store(snapshot.next_task_id, Ordering::SeqCst);
+        Ok(())
+    }
+
+    /// Create a new task in the session-local task list.
+    pub async fn create(&self, args: &Value) -> String {
+        let title = match args.get("title").and_then(Value::as_str) {
+            Some(t) if !t.is_empty() => t.to_string(),
+            _ => return "Error: 'title' is required".to_string(),
+        };
+
+        let description = args
+            .get("description")
+            .and_then(Value::as_str)
+            .map(String::from);
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let subtasks: Vec<SessionSubtask> = args
+            .get("subtasks")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|st| {
+                        let id = st.get("id").and_then(Value::as_str)?;
+                        let title = st.get("title").and_then(Value::as_str)?;
+                        Some(SessionSubtask {
+                            id: id.to_string(),
+                            title: title.to_string(),
+                            description: st
+                                .get("description")
+                                .and_then(Value::as_str)
+                                .map(String::from),
+                            status: "pending".to_string(),
+                            depends_on: st
+                                .get("depends_on")
+                                .and_then(Value::as_array)
+                                .map(|deps| {
+                                    deps.iter()
+                                        .filter_map(Value::as_str)
+                                        .map(String::from)
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let task_id = format!("task-{}", self.id_counter.fetch_add(1, Ordering::SeqCst));
+
+        let task = SessionTask {
+            id: task_id.clone(),
+            title: title.clone(),
+            description,
+            status: "pending".to_string(),
+            subtasks,
+            created_at: now.clone(),
+            updated_at: now,
+        };
+
+        if let Ok(mut tasks) = self.tasks.lock() {
+            tasks.push(task);
+        }
+
+        json!({
+            "success": true,
+            "task_id": task_id,
+            "message": format!("Task '{}' created successfully", title)
+        })
+        .to_string()
+    }
+
+    /// List tasks in the session, optionally filtered by status.
+    pub async fn list(&self, args: &Value) -> String {
+        let status_filter = args.get("status").and_then(Value::as_str).unwrap_or("all");
+
+        let tasks = match self.tasks.lock() {
+            Ok(guard) => guard.clone(),
+            Err(_) => return "Error: failed to access task list".to_string(),
+        };
+
+        let filtered: Vec<_> = tasks
+            .iter()
+            .filter(|t| match status_filter {
+                "all" => true,
+                "active" => t.status == "pending" || t.status == "in_progress",
+                s => t.status == s,
+            })
+            .map(|t| {
+                let subtask_summary = if t.subtasks.is_empty() {
+                    String::new()
+                } else {
+                    let done = t
+                        .subtasks
+                        .iter()
+                        .filter(|st| st.status == "completed")
+                        .count();
+                    format!(" [{}/{}]", done, t.subtasks.len())
+                };
+                json!({
+                    "id": t.id,
+                    "title": t.title,
+                    "status": t.status,
+                    "subtasks": subtask_summary,
+                    "updated_at": t.updated_at,
+                })
+            })
+            .collect();
+
+        if filtered.is_empty() {
+            return format!("No tasks found with status '{}'", status_filter);
+        }
+
+        json!({
+            "count": filtered.len(),
+            "tasks": filtered
+        })
+        .to_string()
+    }
+
+    /// Get full details of a task by ID.
+    pub async fn get(&self, args: &Value) -> String {
+        let task_id = match args.get("task_id").and_then(Value::as_str) {
+            Some(id) if !id.is_empty() => id,
+            _ => return "Error: 'task_id' is required".to_string(),
+        };
+
+        let tasks = match self.tasks.lock() {
+            Ok(guard) => guard.clone(),
+            Err(_) => return "Error: failed to access task list".to_string(),
+        };
+
+        match tasks.iter().find(|t| t.id == task_id) {
+            Some(task) => serde_json::to_string_pretty(task)
+                .unwrap_or_else(|_| "Error: serialization failed".to_string()),
+            None => format!("Error: task '{}' not found", task_id),
+        }
+    }
+
+    /// Update a task's status or a specific subtask's status.
+    pub async fn update(&self, args: &Value) -> String {
+        let task_id = match args.get("task_id").and_then(Value::as_str) {
+            Some(id) if !id.is_empty() => id,
+            _ => return "Error: 'task_id' is required".to_string(),
+        };
+
+        let new_status = args.get("status").and_then(Value::as_str);
+        let subtask_id = args.get("subtask_id").and_then(Value::as_str);
+        let error_message = args.get("error_message").and_then(Value::as_str);
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let mut tasks = match self.tasks.lock() {
+            Ok(guard) => guard,
+            Err(_) => return "Error: failed to access task list".to_string(),
+        };
+
+        let task = match tasks.iter_mut().find(|t| t.id == task_id) {
+            Some(t) => t,
+            None => return format!("Error: task '{}' not found", task_id),
+        };
+
+        if let Some(st_id) = subtask_id {
+            // Update subtask
+            match task.subtasks.iter_mut().find(|st| st.id == st_id) {
+                Some(subtask) => {
+                    let previous_status = subtask.status.clone();
+                    if let Some(status) = new_status {
+                        subtask.status = status.to_string();
+                    }
+                    task.updated_at = now;
+                    return json!({
+                        "success": true,
+                        "task_id": task_id,
+                        "subtask_id": st_id,
+                        "previous_status": previous_status,
+                        "status": subtask.status,
+                        "message": format!("Subtask '{}' updated to '{}'", st_id, subtask.status)
+                    })
+                    .to_string();
+                }
+                None => {
+                    return format!("Error: subtask '{}' not found in task '{}'", st_id, task_id);
+                }
+            }
+        }
+
+        // Update main task
+        let previous_status = task.status.clone();
+        if let Some(status) = new_status {
+            task.status = status.to_string();
+        }
+        if let Some(err) = error_message {
+            task.description = Some(format!(
+                "{}\n\nError: {}",
+                task.description.as_deref().unwrap_or(""),
+                err
+            ));
+        }
+        task.updated_at = now;
+
+        // Auto-complete task if all subtasks are completed
+        if !task.subtasks.is_empty() && task.subtasks.iter().all(|st| st.status == "completed") {
+            task.status = "completed".to_string();
+        }
+
+        json!({
+            "success": true,
+            "task_id": task_id,
+            "previous_status": previous_status,
+            "status": task.status,
+            "message": format!("Task '{}' updated to '{}'", task_id, task.status)
+        })
+        .to_string()
+    }
+
+    /// Stop/cancel a running task.
+    pub async fn stop(&self, args: &Value) -> String {
+        let task_id = match args.get("task_id").and_then(Value::as_str) {
+            Some(id) if !id.is_empty() => id,
+            _ => return "Error: 'task_id' is required".to_string(),
+        };
+
+        let reason = args
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or("user requested");
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let mut tasks = match self.tasks.lock() {
+            Ok(guard) => guard,
+            Err(_) => return "Error: failed to access task list".to_string(),
+        };
+
+        let task = match tasks.iter_mut().find(|t| t.id == task_id) {
+            Some(t) => t,
+            None => return format!("Error: task '{}' not found", task_id),
+        };
+
+        // Only allow stopping tasks that are running or pending
+        if task.status != "pending" && task.status != "in_progress" {
+            return json!({
+                "success": false,
+                "message": format!("Cannot stop task '{}': status is '{}' (only 'pending' or 'in_progress' can be stopped)", task_id, task.status)
+            })
+            .to_string();
+        }
+
+        let previous_status = task.status.clone();
+        task.status = "cancelled".to_string();
+        task.description = Some(format!(
+            "{}\n\nCancelled: {} (was: {})",
+            task.description.as_deref().unwrap_or(""),
+            reason,
+            previous_status
+        ));
+        task.updated_at = now;
+
+        // Also cancel any in-progress subtasks
+        let mut cancelled_subtasks = 0;
+        for subtask in &mut task.subtasks {
+            if subtask.status == "pending" || subtask.status == "in_progress" {
+                subtask.status = "cancelled".to_string();
+                cancelled_subtasks += 1;
+            }
+        }
+
+        json!({
+            "success": true,
+            "task_id": task_id,
+            "previous_status": previous_status,
+            "reason": reason,
+            "cancelled_subtasks": cancelled_subtasks,
+            "message": format!("Task '{}' cancelled (was: {})", task_id, previous_status)
+        })
+        .to_string()
+    }
+}

--- a/rust/crates/astra-tools/src/tool_search.rs
+++ b/rust/crates/astra-tools/src/tool_search.rs
@@ -1,0 +1,227 @@
+#![allow(dead_code)]
+//! Tool search — semantic search over available tool schemas.
+//!
+//! Takes a set of tool schemas and a query, returning ranked matches.
+//! Extracted from edge_tools as a standalone function.
+
+use serde_json::{Value, json};
+
+/// Search available tool schemas by keyword or exact name.
+///
+/// The `schemas` parameter should be a slice of tool schema JSON values,
+/// each with a `function.name` and `function.description` field.
+///
+/// Query modes:
+/// - `select:tool_name` or `select:a,b,c` — direct selection by name
+/// - Otherwise — keyword search with scoring
+pub fn tool_search(schemas: &[Value], args: &Value) -> String {
+    let query = match args.get("query").and_then(Value::as_str) {
+        Some(q) if !q.is_empty() => q.trim(),
+        _ => return "Error: 'query' is required".to_string(),
+    };
+
+    let max_results = args
+        .get("max_results")
+        .and_then(Value::as_u64)
+        .unwrap_or(5)
+        .min(20) as usize;
+
+    // Direct selection mode: select:tool_name or select:a,b,c
+    if let Some(tool_names) = query.strip_prefix("select:") {
+        let requested: Vec<&str> = tool_names
+            .split(',')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        let mut found = Vec::new();
+        let mut missing = Vec::new();
+
+        for name in requested {
+            let name_lower = name.to_lowercase();
+            if let Some(tool) = schemas.iter().find(|t| {
+                t.get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(Value::as_str)
+                    .map(|n| n.to_lowercase() == name_lower)
+                    .unwrap_or(false)
+            }) {
+                if let Some(func) = tool.get("function") {
+                    let tool_name = func.get("name").and_then(Value::as_str).unwrap_or("");
+                    let desc = func
+                        .get("description")
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    let short_desc: String = desc.chars().take(100).collect();
+                    found.push(json!({
+                        "name": tool_name,
+                        "description": if desc.len() > 100 { format!("{}...", short_desc) } else { desc.to_string() }
+                    }));
+                }
+            } else {
+                missing.push(name.to_string());
+            }
+        }
+
+        return json!({
+            "query": query,
+            "matches": found,
+            "missing": missing,
+            "total_tools": schemas.len()
+        })
+        .to_string();
+    }
+
+    // Keyword search mode
+    let query_lower = query.to_lowercase();
+    let query_terms: Vec<&str> = query_lower.split_whitespace().collect();
+
+    let mut scored: Vec<(usize, &Value)> = schemas
+        .iter()
+        .filter_map(|tool| {
+            let func = tool.get("function")?;
+            let name = func.get("name")?.as_str()?;
+            let desc = func
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+
+            let name_lower = name.to_lowercase();
+            let desc_lower = desc.to_lowercase();
+
+            let mut score = 0usize;
+
+            for term in &query_terms {
+                // Exact name match (high weight)
+                if name_lower == *term {
+                    score += 20;
+                } else if name_lower.contains(term) {
+                    score += 10;
+                }
+
+                // Split camelCase/snake_case for part matching
+                let name_parts: Vec<String> = name
+                    .replace('_', " ")
+                    .chars()
+                    .fold(String::new(), |mut acc, c| {
+                        if c.is_uppercase() && !acc.is_empty() {
+                            acc.push(' ');
+                        }
+                        acc.push(c);
+                        acc
+                    })
+                    .to_lowercase()
+                    .split_whitespace()
+                    .map(String::from)
+                    .collect();
+
+                for part in &name_parts {
+                    if part == *term {
+                        score += 8;
+                    } else if part.contains(term) {
+                        score += 4;
+                    }
+                }
+
+                // Description match (lower weight)
+                if desc_lower.contains(term) {
+                    score += 2;
+                }
+            }
+
+            if score > 0 { Some((score, tool)) } else { None }
+        })
+        .collect();
+
+    scored.sort_by(|a, b| b.0.cmp(&a.0));
+
+    let matches: Vec<Value> = scored
+        .into_iter()
+        .take(max_results)
+        .map(|(score, tool)| {
+            let func = tool.get("function").unwrap_or(tool);
+            let name = func.get("name").and_then(Value::as_str).unwrap_or("");
+            let desc = func
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let short_desc: String = desc.chars().take(100).collect();
+            json!({
+                "name": name,
+                "description": if desc.len() > 100 { format!("{}...", short_desc) } else { desc.to_string() },
+                "score": score
+            })
+        })
+        .collect();
+
+    json!({
+        "query": query,
+        "matches": matches,
+        "total_tools": schemas.len()
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_schemas() -> Vec<Value> {
+        vec![
+            json!({
+                "function": {
+                    "name": "read_file",
+                    "description": "Read file contents from the workspace"
+                }
+            }),
+            json!({
+                "function": {
+                    "name": "write_file",
+                    "description": "Write content to a file in the workspace"
+                }
+            }),
+            json!({
+                "function": {
+                    "name": "bash",
+                    "description": "Execute a bash command"
+                }
+            }),
+            json!({
+                "function": {
+                    "name": "github_list_prs",
+                    "description": "List pull requests on a GitHub repository"
+                }
+            }),
+        ]
+    }
+
+    #[test]
+    fn keyword_search_finds_file_tools() {
+        let schemas = sample_schemas();
+        let result = tool_search(&schemas, &json!({"query": "file"}));
+        assert!(result.contains("read_file"));
+        assert!(result.contains("write_file"));
+    }
+
+    #[test]
+    fn select_mode_finds_exact_tool() {
+        let schemas = sample_schemas();
+        let result = tool_search(&schemas, &json!({"query": "select:bash"}));
+        assert!(result.contains("bash"));
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed["missing"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn select_mode_reports_missing() {
+        let schemas = sample_schemas();
+        let result = tool_search(&schemas, &json!({"query": "select:nonexistent"}));
+        assert!(result.contains("nonexistent"));
+    }
+
+    #[test]
+    fn empty_query_returns_error() {
+        let schemas = sample_schemas();
+        let result = tool_search(&schemas, &json!({"query": ""}));
+        assert!(result.contains("Error"));
+    }
+}


### PR DESCRIPTION
## Summary

Extracts tool modules from `astra-cli/src/edge_tools/` to `astra-tools/src/` — the shared library that both CLI and server use.

### Tier 1: Standalone modules (9,100 LOC, 7 files)
- `build_test.rs` — structured build/test output parsing (cargo, pytest, jest, go test)
- `code_intel.rs` — tree-sitter symbol extraction, outlines, language detection
- `env_tools.rs` — environment variable get/set/list
- `fuzzy_replacer.rs` — fuzzy string replacement engine
- `passive_cargo_check.rs` — background cargo check diagnostics
- `passive_tsc_check.rs` — background TypeScript check diagnostics
- `task_mgmt.rs` — task/todo management

### Tier 2: Minor refactor (367 LOC, 2 files)
- `config_tool.rs` — configuration get/set (standalone function with limits as params)
- `tool_search.rs` — keyword/select search over tool schemas

### Tier 3: Major refactor (6,100 LOC, 2 files)
- `github.rs` — `GitHubClient` struct wrapping reqwest::Client + token + preferred repos. 8 GitHub API tools.
- `git_gix.rs` — All standalone gix-based git operations (status, diff, log, show, blame, etc.). Journal structs included for future `DefaultToolExecutor`.

### What remains in edge_tools (~24.8K LOC)
- **CLI-only (~8K)**: ask_user, lsp_stdio_session, mcp_dispatch, shell
- **Runtime-dependent (~1K)**: agent_messaging, agent_spawning, context_sharing
- **ToolExecutor-dependent (~15K)**: code_analysis, fs, lsp_tools, worktree, mo_tools, etc. — need Phase C (`DefaultToolExecutor`) for proper extraction

### Testing
- 350 tests pass in astra-tools
- `make check` clean (clippy, fmt, cargo check)
- All existing tests in other crates unaffected