### PR TITLE
feat(runtime): close server rollback shell gaps

### DIFF
--- a/rust/crates/astra-tools/src/executor.rs
+++ b/rust/crates/astra-tools/src/executor.rs
@@ -30,6 +30,15 @@ fn string_to_result(output: String) -> ToolResult {
     }
 }
 
+fn outcome_to_result(outcome: crate::git_gix::ToolExecutionOutcome) -> ToolResult {
+    let is_error = outcome.output.starts_with("Error");
+    ToolResult {
+        output: outcome.output,
+        metadata: outcome.tool_result_fields,
+        is_error,
+    }
+}
+
 // ─── DefaultToolExecutor ────────────────────────────────────────────────────
 
 /// Default tool executor with the full shared tool set.
@@ -146,7 +155,7 @@ impl ToolExecutor for DefaultToolExecutor {
     }
 
     fn tool_schemas(&self) -> Vec<Value> {
-        crate::schemas::all_tool_schemas()
+        crate::schemas::default_executor_tool_schemas()
     }
 
     fn project_root(&self) -> &Path {
@@ -183,12 +192,14 @@ impl DefaultToolExecutor {
             "git_log" => string_to_result(crate::git_gix::git_log(pr, args)),
             "git_show" => string_to_result(crate::git_gix::git_show(pr, args, 0.0, 0)),
             "git_blame" => string_to_result(crate::git_gix::git_blame(pr, args)),
-            "git_commit" => string_to_result(crate::git_gix::git_commit(pr, args)),
+            "git_commit" => outcome_to_result(crate::git_gix::git_commit_with_metadata(pr, args)),
             "git_file_history" => string_to_result(crate::git_gix::git_file_history(pr, args)),
             "git_log_search" => string_to_result(crate::git_gix::git_log_search(pr, args)),
             "git_contributors" => string_to_result(crate::git_gix::git_contributors(pr, args)),
-            "git_revert_commit" => string_to_result(crate::git_gix::git_revert_commit(pr, args)),
-            "git_stash" => string_to_result(crate::git_gix::git_stash(pr, args)),
+            "git_revert_commit" => {
+                outcome_to_result(crate::git_gix::git_revert_commit_with_metadata(pr, args))
+            }
+            "git_stash" => outcome_to_result(crate::git_gix::git_stash_with_metadata(pr, args)),
 
             // ── GitHub API ───────────────────────────────────────────
             "github_list_prs"
@@ -408,7 +419,10 @@ impl DefaultToolExecutor {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
+    use serde_json::Value;
     use tempfile::TempDir;
 
     fn test_executor() -> (TempDir, DefaultToolExecutor) {
@@ -416,6 +430,24 @@ mod tests {
         let ctx = ToolContext::test(tmp.path());
         let exec = DefaultToolExecutor::new(ctx);
         (tmp, exec)
+    }
+
+    fn init_git_repo(dir: &Path) {
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
     }
 
     #[tokio::test]
@@ -631,5 +663,50 @@ mod tests {
             .await;
         assert!(result.is_error);
         assert!(result.output.contains("http"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_git_revert_commit() {
+        let (tmp, exec) = test_executor();
+        init_git_repo(tmp.path());
+
+        let tracked = tmp.path().join("tracked.txt");
+        std::fs::write(&tracked, "original\n").unwrap();
+        let initial = exec
+            .execute("git_commit", &serde_json::json!({"message": "initial"}))
+            .await;
+        assert!(!initial.is_error, "got: {}", initial.output);
+
+        std::fs::write(&tracked, "changed\n").unwrap();
+        let committed = exec
+            .execute(
+                "git_commit",
+                &serde_json::json!({"message": "change tracked"}),
+            )
+            .await;
+        assert!(!committed.is_error, "got: {}", committed.output);
+        let commit_sha = committed
+            .metadata
+            .as_ref()
+            .and_then(|fields| fields.get("commit_sha"))
+            .and_then(Value::as_str)
+            .expect("commit_sha metadata");
+
+        let reverted = exec
+            .execute(
+                "git_revert_commit",
+                &serde_json::json!({"commit_sha": commit_sha}),
+            )
+            .await;
+        assert!(!reverted.is_error, "got: {}", reverted.output);
+        assert_eq!(std::fs::read_to_string(&tracked).unwrap(), "original\n");
+        assert_eq!(
+            reverted
+                .metadata
+                .as_ref()
+                .and_then(|fields| fields.get("reverted_commit_sha"))
+                .and_then(Value::as_str),
+            Some(commit_sha)
+        );
     }
 }

--- a/rust/crates/astra-tools/src/git_ops.rs
+++ b/rust/crates/astra-tools/src/git_ops.rs
@@ -1,4 +1,4 @@
-//! Git operations: status, diff, log, show, blame, commit.
+//! Git operations: status, diff, log, show, blame, commit, revert.
 
 use std::path::Path;
 
@@ -23,6 +23,41 @@ fn git_command(workspace_root: &Path, git_args: &[&str]) -> ToolResult {
             }
         }
         Err(e) => ToolResult::error(format!("Error: git command failed: {e}")),
+    }
+}
+
+fn resolve_commit_ref(workspace_root: &Path, commit_ref: &str) -> Option<String> {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--verify", commit_ref])
+        .current_dir(workspace_root)
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn short_commit_sha(commit_sha: &str) -> String {
+    commit_sha[..7.min(commit_sha.len())].to_string()
+}
+
+fn abort_git_revert(workspace_root: &Path) -> Result<bool, String> {
+    let output = std::process::Command::new("git")
+        .args(["revert", "--abort"])
+        .current_dir(workspace_root)
+        .output()
+        .map_err(|error| format!("Error: git revert --abort failed: {error}"))?;
+    if output.status.success() {
+        Ok(true)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("no cherry-pick or revert in progress") {
+            Ok(false)
+        } else {
+            Err(format!(
+                "Error: git revert --abort failed: {}",
+                stderr.trim()
+            ))
+        }
     }
 }
 
@@ -89,7 +124,108 @@ pub fn commit(workspace_root: &Path, args: &Value) -> ToolResult {
         return stage_result;
     }
 
-    git_command(workspace_root, &["commit", "-m", message])
+    let output = std::process::Command::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(workspace_root)
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let commit_sha = resolve_commit_ref(workspace_root, "HEAD");
+            let short_hash = commit_sha
+                .as_deref()
+                .map(short_commit_sha)
+                .unwrap_or_else(|| "???".to_string());
+            let metadata = commit_sha.map(|commit_sha| {
+                serde_json::Map::from_iter([
+                    ("commit_sha".to_string(), Value::String(commit_sha.clone())),
+                    (
+                        "commit_short_sha".to_string(),
+                        Value::String(short_commit_sha(&commit_sha)),
+                    ),
+                ])
+            });
+            ToolResult {
+                output: format!("✓ Committed: {short_hash} {message}"),
+                metadata,
+                is_error: false,
+            }
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if stderr.contains("nothing to commit") {
+                ToolResult::text("Nothing to commit — working tree clean".to_string())
+            } else {
+                ToolResult::error(format!("Error: git commit failed: {}", stderr.trim()))
+            }
+        }
+        Err(error) => ToolResult::error(format!("Error: git commit failed: {error}")),
+    }
+}
+
+pub fn revert_commit(workspace_root: &Path, args: &Value) -> ToolResult {
+    let commit_ref = match args.get("commit_sha").and_then(|v| v.as_str()) {
+        Some(commit_ref) if !commit_ref.trim().is_empty() => commit_ref.trim().to_string(),
+        _ => return ToolResult::error("Error: Missing 'commit_sha' parameter".into()),
+    };
+    let target_commit_sha = match resolve_commit_ref(workspace_root, &commit_ref) {
+        Some(commit_sha) => commit_sha,
+        None => return ToolResult::error(format!("Error: unknown commit '{commit_ref}'")),
+    };
+
+    match std::process::Command::new("git")
+        .args(["revert", "--no-edit", target_commit_sha.as_str()])
+        .current_dir(workspace_root)
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            let revert_commit_sha = resolve_commit_ref(workspace_root, "HEAD");
+            let revert_short_sha = revert_commit_sha
+                .as_deref()
+                .map(short_commit_sha)
+                .unwrap_or_else(|| "???".to_string());
+            let metadata = revert_commit_sha.map(|revert_commit_sha| {
+                serde_json::Map::from_iter([
+                    (
+                        "reverted_commit_sha".to_string(),
+                        Value::String(target_commit_sha.clone()),
+                    ),
+                    (
+                        "reverted_commit_short_sha".to_string(),
+                        Value::String(short_commit_sha(&target_commit_sha)),
+                    ),
+                    (
+                        "revert_commit_sha".to_string(),
+                        Value::String(revert_commit_sha.clone()),
+                    ),
+                    (
+                        "revert_commit_short_sha".to_string(),
+                        Value::String(short_commit_sha(&revert_commit_sha)),
+                    ),
+                ])
+            });
+            ToolResult {
+                output: format!(
+                    "✓ Reverted commit: {} via {}",
+                    short_commit_sha(&target_commit_sha),
+                    revert_short_sha
+                ),
+                metadata,
+                is_error: false,
+            }
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let mut message = format!("Error: git revert failed: {}", stderr.trim());
+            match abort_git_revert(workspace_root) {
+                Ok(true) => message.push_str(" (aborted in-progress revert)"),
+                Ok(false) => {}
+                Err(error) => message.push_str(&format!(" ({error})")),
+            }
+            ToolResult::error(message)
+        }
+        Err(error) => ToolResult::error(format!("Error: git revert failed: {error}")),
+    }
 }
 
 #[cfg(test)]
@@ -114,5 +250,53 @@ mod tests {
             .unwrap();
         let result = status(tmp.path());
         assert!(!result.is_error);
+    }
+
+    #[test]
+    fn commit_returns_metadata_and_revert_restores_state() {
+        let tmp = TempDir::new().unwrap();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+
+        let tracked = tmp.path().join("tracked.txt");
+        std::fs::write(&tracked, "original\n").unwrap();
+        let initial = commit(tmp.path(), &serde_json::json!({"message": "initial"}));
+        assert!(!initial.is_error, "got: {}", initial.output);
+
+        std::fs::write(&tracked, "changed\n").unwrap();
+        let committed = commit(
+            tmp.path(),
+            &serde_json::json!({"message": "change tracked"}),
+        );
+        assert!(!committed.is_error, "got: {}", committed.output);
+        let commit_sha = committed
+            .metadata
+            .as_ref()
+            .and_then(|fields| fields.get("commit_sha"))
+            .and_then(Value::as_str)
+            .expect("commit_sha metadata");
+
+        let reverted = revert_commit(tmp.path(), &serde_json::json!({"commit_sha": commit_sha}));
+        assert!(!reverted.is_error, "got: {}", reverted.output);
+        assert_eq!(std::fs::read_to_string(&tracked).unwrap(), "original\n");
+        let revert_fields = reverted.metadata.as_ref().expect("revert metadata");
+        assert_eq!(
+            revert_fields["reverted_commit_sha"].as_str(),
+            Some(commit_sha)
+        );
+        assert!(revert_fields["revert_commit_sha"].as_str().is_some());
     }
 }

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -5,6 +5,85 @@
 
 use serde_json::{Value, json};
 
+pub const DEFAULT_EXECUTOR_TOOL_NAMES: &[&str] = &[
+    "bash",
+    "read_file",
+    "write_file",
+    "str_replace",
+    "delete_file",
+    "list_dir",
+    "grep",
+    "glob",
+    "git_status",
+    "git_diff",
+    "git_log",
+    "git_show",
+    "git_blame",
+    "git_commit",
+    "git_revert_commit",
+    "web_search",
+];
+
+pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
+    "bash",
+    "read_file",
+    "write_file",
+    "str_replace",
+    "delete_file",
+    "rollback_file_edits",
+    "list_dir",
+    "adjust_config",
+    "prioritize_tool",
+    "deprioritize_tool",
+    "set_goal",
+    "compress_context",
+    "rollback_session_state",
+    "task_create",
+    "task_list",
+    "task_get",
+    "task_update",
+    "task_stop",
+    "mo_query",
+    "rollback_database_snapshots",
+    "grep",
+    "glob",
+    "git_status",
+    "git_diff",
+    "git_log",
+    "git_show",
+    "git_blame",
+    "git_commit",
+    "git_revert_commit",
+    "web_search",
+    "memory_retrieve",
+    "memory_store",
+    "memory_search",
+    "memory_purge",
+    "memory_correct",
+    "memory_profile",
+];
+
+fn filter_tool_schemas_by_name(allowed_names: &[&str]) -> Vec<Value> {
+    all_tool_schemas()
+        .into_iter()
+        .filter(|schema| {
+            schema
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(Value::as_str)
+                .is_some_and(|name| allowed_names.contains(&name))
+        })
+        .collect()
+}
+
+pub fn default_executor_tool_schemas() -> Vec<Value> {
+    filter_tool_schemas_by_name(DEFAULT_EXECUTOR_TOOL_NAMES)
+}
+
+pub fn server_executor_tool_schemas() -> Vec<Value> {
+    filter_tool_schemas_by_name(SERVER_EXECUTOR_TOOL_NAMES)
+}
+
 pub fn all_tool_schemas() -> Vec<Value> {
     vec![
         json!({
@@ -1779,4 +1858,58 @@ pub fn all_tool_schemas() -> Vec<Value> {
             }
         }),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema_names(schemas: &[Value]) -> Vec<&str> {
+        schemas
+            .iter()
+            .filter_map(|schema| {
+                schema
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(Value::as_str)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn default_executor_tool_schemas_exclude_unsupported_tools() {
+        let schemas = default_executor_tool_schemas();
+        let names = schema_names(&schemas);
+        assert!(names.contains(&"git_revert_commit"));
+        assert!(!names.contains(&"rollback_file_edits"));
+        assert!(!names.contains(&"memory_store"));
+        assert!(!names.contains(&"powershell"));
+        assert!(!names.contains(&"multi_edit"));
+    }
+
+    #[test]
+    fn server_executor_tool_schemas_match_server_supported_surface() {
+        let schemas = server_executor_tool_schemas();
+        let names = schema_names(&schemas);
+        assert!(names.contains(&"rollback_file_edits"));
+        assert!(names.contains(&"adjust_config"));
+        assert!(names.contains(&"prioritize_tool"));
+        assert!(names.contains(&"deprioritize_tool"));
+        assert!(names.contains(&"set_goal"));
+        assert!(names.contains(&"compress_context"));
+        assert!(names.contains(&"rollback_session_state"));
+        assert!(names.contains(&"task_create"));
+        assert!(names.contains(&"task_list"));
+        assert!(names.contains(&"task_get"));
+        assert!(names.contains(&"task_update"));
+        assert!(names.contains(&"task_stop"));
+        assert!(names.contains(&"mo_query"));
+        assert!(names.contains(&"rollback_database_snapshots"));
+        assert!(names.contains(&"memory_store"));
+        assert!(names.contains(&"git_revert_commit"));
+        assert!(!names.contains(&"rollback_turn_actions"));
+        assert!(!names.contains(&"powershell"));
+        assert!(!names.contains(&"memory_feedback"));
+        assert!(!names.contains(&"multi_edit"));
+    }
 }

--- a/rust/crates/runtime/src/prompts/system.rs
+++ b/rust/crates/runtime/src/prompts/system.rs
@@ -198,6 +198,7 @@ fn tool_conditional_section(tool_names: &[&str], selection_confidence: f64) -> S
     let has_git_revert = tool_names.contains(&"git_revert_commit");
     let has_git_worktree = tool_names.contains(&"git_worktree");
     let has_session_state_rollback = tool_names.contains(&"rollback_session_state");
+    let has_turn_rollback = tool_names.contains(&"rollback_turn_actions");
 
     let mut s = String::new();
 
@@ -306,17 +307,24 @@ fn tool_conditional_section(tool_names: &[&str], selection_confidence: f64) -> S
             );
         }
         if has_git_worktree {
-            s.push_str(
-                "             - Use **git_worktree** for isolated parallel branch work; clean worktrees created by `enter`/`add` can participate in `rollback_turn_actions`, but explicit `remove` or `exit_action=remove` is still the destructive manual boundary once that worktree has diverged.\n",
-            );
+            if has_turn_rollback {
+                s.push_str(
+                    "             - Use **git_worktree** for isolated parallel branch work; clean worktrees created by `enter`/`add` can participate in `rollback_turn_actions`, but explicit `remove` or `exit_action=remove` is still the destructive manual boundary once that worktree has diverged.\n",
+                );
+            }
         }
     }
     if has_session_state_rollback {
         s.push_str(
             "\n## Session-State Rollback\n\
              - Use **rollback_session_state** to restore bounded self-mod or task mutations from the current turn (or inspect recorded handles with `scope=list`).\n\
-             - `rollback_turn_actions` now also includes recorded session-state mutations alongside file/database/git rollback journals for mixed-turn recovery.\n",
+",
         );
+        if has_turn_rollback {
+            s.push_str(
+                "             - `rollback_turn_actions` now also includes recorded session-state mutations alongside file/database/git rollback journals for mixed-turn recovery.\n",
+            );
+        }
     }
     if has_memory {
         s.push_str(
@@ -1743,6 +1751,42 @@ mod tests {
         assert!(
             !p.contains("Git Workflow"),
             "should NOT include git mutations without commit tool"
+        );
+    }
+
+    #[test]
+    fn session_state_rollback_guidance_omits_turn_rollback_when_unavailable() {
+        let p = build_main_system_prompt(
+            &["rollback_session_state", "adjust_config"],
+            "",
+            0.5,
+            Some("implementation"),
+        );
+        assert!(
+            p.contains("Session-State Rollback"),
+            "should include session rollback section"
+        );
+        assert!(
+            !p.contains("rollback_turn_actions"),
+            "should not mention unavailable mixed-surface rollback tool"
+        );
+    }
+
+    #[test]
+    fn session_state_rollback_guidance_mentions_turn_rollback_when_available() {
+        let p = build_main_system_prompt(
+            &[
+                "rollback_session_state",
+                "rollback_turn_actions",
+                "adjust_config",
+            ],
+            "",
+            0.5,
+            Some("implementation"),
+        );
+        assert!(
+            p.contains("rollback_turn_actions"),
+            "should mention mixed-surface rollback when tool is available"
         );
     }
 

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -1114,6 +1114,10 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             if let Some(pool) = &self.edge_connection_pool {
                 executor.set_edge_connection_pool(pool.clone());
             }
+            if let Some(observability_session) = loop_state.telemetry.observability_session.clone()
+            {
+                executor.set_observability_session(observability_session);
+            }
 
             // ── Phase E: Wire WebSocket approval gate ───────────────
             let (approval_tx, approval_rx) = mpsc::unbounded_channel();

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -184,7 +184,7 @@ impl ServerAgenticLoopHostBuilder {
         // server-side tool schemas from astra-tools so the LLM knows what's available.
         let server_side_tools = self.edge_tools.is_empty();
         let edge_tools = if server_side_tools {
-            astra_tools::schemas::all_tool_schemas()
+            astra_tools::schemas::server_executor_tool_schemas()
         } else {
             self.edge_tools
         };
@@ -1211,6 +1211,26 @@ mod tests {
         // When no edge tools are provided, server-side tool schemas are auto-populated
         assert!(host.server_side_tools);
         assert!(!host.valid_tool_names().is_empty());
+        assert!(host.valid_tool_names().contains("rollback_file_edits"));
+        assert!(host.valid_tool_names().contains("adjust_config"));
+        assert!(host.valid_tool_names().contains("prioritize_tool"));
+        assert!(host.valid_tool_names().contains("deprioritize_tool"));
+        assert!(host.valid_tool_names().contains("set_goal"));
+        assert!(host.valid_tool_names().contains("compress_context"));
+        assert!(host.valid_tool_names().contains("rollback_session_state"));
+        assert!(host.valid_tool_names().contains("task_create"));
+        assert!(host.valid_tool_names().contains("task_list"));
+        assert!(host.valid_tool_names().contains("task_get"));
+        assert!(host.valid_tool_names().contains("task_update"));
+        assert!(host.valid_tool_names().contains("task_stop"));
+        assert!(host.valid_tool_names().contains("mo_query"));
+        assert!(
+            host.valid_tool_names()
+                .contains("rollback_database_snapshots")
+        );
+        assert!(host.valid_tool_names().contains("memory_store"));
+        assert!(!host.valid_tool_names().contains("multi_edit"));
+        assert!(!host.valid_tool_names().contains("powershell"));
         assert!(host.emitted_events.is_empty());
     }
 

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -4,7 +4,7 @@
 //! tools directly using the shared `astra-tools` library. This module
 //! provides the `ServerToolExecutor` that wraps tool execution with:
 //! - Per-session workspace isolation (sandbox)
-//! - Per-session file and git journals
+//! - Per-session file journals with rollback support
 //! - Circuit-breaker for external services (Memoria)
 //!
 //! # Integration
@@ -15,11 +15,12 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use astra_tools::executor::DefaultToolExecutor;
 use astra_tools::{ToolContext, ToolExecutor};
@@ -28,7 +29,880 @@ use crate::tool_sandbox::{
     IsolationConfig, SandboxMode, SandboxPolicy, ToolTier, effective_tier, execute_isolated,
     filter_environment,
 };
-use crate::turn::file_edit_journal::FileEditJournal;
+use crate::turn::file_edit_journal::{EditType, FileEditJournal};
+
+const MO_CONNECT_TIMEOUT_SECS: u32 = 5;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DatabaseSnapshotRollbackEntry {
+    sequence: u64,
+    snapshot_id: String,
+    database: Option<String>,
+    turn_index: u32,
+}
+
+#[derive(Debug, Default)]
+struct DatabaseSnapshotRollbackJournal {
+    entries: Vec<DatabaseSnapshotRollbackEntry>,
+    next_sequence: u64,
+}
+
+impl DatabaseSnapshotRollbackJournal {
+    fn record(
+        &mut self,
+        snapshot_id: impl Into<String>,
+        database: Option<String>,
+        turn_index: u32,
+    ) {
+        self.entries.push(DatabaseSnapshotRollbackEntry {
+            sequence: self.next_sequence,
+            snapshot_id: snapshot_id.into(),
+            database,
+            turn_index,
+        });
+        self.next_sequence = self.next_sequence.saturating_add(1);
+    }
+
+    fn list(&self) -> Vec<DatabaseSnapshotRollbackEntry> {
+        self.entries.iter().rev().cloned().collect()
+    }
+
+    fn entry_for_snapshot(&self, snapshot_id: &str) -> Option<DatabaseSnapshotRollbackEntry> {
+        self.entries
+            .iter()
+            .rev()
+            .find(|entry| entry.snapshot_id == snapshot_id)
+            .cloned()
+    }
+
+    fn restore_plan_for_turn(&self, turn_index: u32) -> Vec<DatabaseSnapshotRollbackEntry> {
+        self.restore_plan_for_turn_since(turn_index, 0)
+    }
+
+    fn restore_plan_for_turn_since(
+        &self,
+        turn_index: u32,
+        checkpoint: u64,
+    ) -> Vec<DatabaseSnapshotRollbackEntry> {
+        let mut seen_databases = std::collections::HashSet::new();
+        let mut plan = Vec::new();
+        for entry in self
+            .entries
+            .iter()
+            .filter(|entry| entry.turn_index == turn_index && entry.sequence >= checkpoint)
+        {
+            if seen_databases.insert(entry.database.clone()) {
+                plan.push(entry.clone());
+            }
+        }
+        plan
+    }
+
+    fn remove_snapshot(&mut self, snapshot_id: &str) -> bool {
+        if let Some(index) = self
+            .entries
+            .iter()
+            .rposition(|entry| entry.snapshot_id == snapshot_id)
+        {
+            self.entries.remove(index);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct SessionTask {
+    id: String,
+    title: String,
+    description: Option<String>,
+    status: String,
+    subtasks: Vec<SessionSubtask>,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct SessionSubtask {
+    id: String,
+    title: String,
+    description: Option<String>,
+    status: String,
+    depends_on: Vec<String>,
+}
+
+#[derive(Debug)]
+struct ServerTaskManager {
+    tasks: Mutex<Vec<SessionTask>>,
+    id_counter: AtomicU32,
+}
+
+#[derive(Debug, Clone)]
+struct TaskManagerSnapshot {
+    tasks: Vec<SessionTask>,
+    next_task_id: u32,
+}
+
+impl ServerTaskManager {
+    fn new() -> Self {
+        Self {
+            tasks: Mutex::new(Vec::new()),
+            id_counter: AtomicU32::new(1),
+        }
+    }
+
+    fn snapshot(&self) -> Vec<SessionTask> {
+        self.tasks
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    fn snapshot_state(&self) -> TaskManagerSnapshot {
+        TaskManagerSnapshot {
+            tasks: self.snapshot(),
+            next_task_id: self.id_counter.load(Ordering::SeqCst),
+        }
+    }
+
+    fn restore_snapshot(&self, snapshot: &TaskManagerSnapshot) -> Result<(), String> {
+        let mut tasks = self
+            .tasks
+            .lock()
+            .map_err(|_| "failed to access task list".to_string())?;
+        *tasks = snapshot.tasks.clone();
+        self.id_counter
+            .store(snapshot.next_task_id, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn create(&self, args: &Value) -> String {
+        let title = match args.get("title").and_then(Value::as_str) {
+            Some(title) if !title.is_empty() => title.to_string(),
+            _ => return "Error: 'title' is required".to_string(),
+        };
+
+        let description = args
+            .get("description")
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let subtasks: Vec<SessionSubtask> = args
+            .get("subtasks")
+            .and_then(Value::as_array)
+            .map(|subtasks| {
+                subtasks
+                    .iter()
+                    .filter_map(|subtask| {
+                        let id = subtask.get("id").and_then(Value::as_str)?;
+                        let title = subtask.get("title").and_then(Value::as_str)?;
+                        Some(SessionSubtask {
+                            id: id.to_string(),
+                            title: title.to_string(),
+                            description: subtask
+                                .get("description")
+                                .and_then(Value::as_str)
+                                .map(ToString::to_string),
+                            status: "pending".to_string(),
+                            depends_on: subtask
+                                .get("depends_on")
+                                .and_then(Value::as_array)
+                                .map(|deps| {
+                                    deps.iter()
+                                        .filter_map(Value::as_str)
+                                        .map(ToString::to_string)
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let task_id = format!("task-{}", self.id_counter.fetch_add(1, Ordering::SeqCst));
+        let task = SessionTask {
+            id: task_id.clone(),
+            title: title.clone(),
+            description,
+            status: "pending".to_string(),
+            subtasks,
+            created_at: now.clone(),
+            updated_at: now,
+        };
+
+        if let Ok(mut tasks) = self.tasks.lock() {
+            tasks.push(task);
+        }
+
+        json!({
+            "success": true,
+            "task_id": task_id,
+            "message": format!("Task '{title}' created successfully"),
+        })
+        .to_string()
+    }
+
+    fn list(&self, args: &Value) -> String {
+        let status_filter = args.get("status").and_then(Value::as_str).unwrap_or("all");
+
+        let tasks = match self.tasks.lock() {
+            Ok(guard) => guard.clone(),
+            Err(_) => return "Error: failed to access task list".to_string(),
+        };
+
+        let filtered: Vec<_> = tasks
+            .iter()
+            .filter(|task| match status_filter {
+                "all" => true,
+                "active" => task.status == "pending" || task.status == "in_progress",
+                other => task.status == other,
+            })
+            .map(|task| {
+                let subtask_summary = if task.subtasks.is_empty() {
+                    String::new()
+                } else {
+                    let done = task
+                        .subtasks
+                        .iter()
+                        .filter(|subtask| subtask.status == "completed")
+                        .count();
+                    format!(" [{done}/{}]", task.subtasks.len())
+                };
+                json!({
+                    "id": task.id,
+                    "title": task.title,
+                    "status": task.status,
+                    "subtasks": subtask_summary,
+                    "updated_at": task.updated_at,
+                })
+            })
+            .collect();
+
+        if filtered.is_empty() {
+            return format!("No tasks found with status '{status_filter}'");
+        }
+
+        json!({
+            "count": filtered.len(),
+            "tasks": filtered,
+        })
+        .to_string()
+    }
+
+    fn get(&self, args: &Value) -> String {
+        let task_id = match args.get("task_id").and_then(Value::as_str) {
+            Some(task_id) if !task_id.is_empty() => task_id,
+            _ => return "Error: 'task_id' is required".to_string(),
+        };
+
+        let tasks = match self.tasks.lock() {
+            Ok(guard) => guard.clone(),
+            Err(_) => return "Error: failed to access task list".to_string(),
+        };
+
+        match tasks.iter().find(|task| task.id == task_id) {
+            Some(task) => serde_json::to_string_pretty(task)
+                .unwrap_or_else(|_| "Error: serialization failed".to_string()),
+            None => format!("Error: task '{task_id}' not found"),
+        }
+    }
+
+    fn update(&self, args: &Value) -> String {
+        let task_id = match args.get("task_id").and_then(Value::as_str) {
+            Some(task_id) if !task_id.is_empty() => task_id,
+            _ => return "Error: 'task_id' is required".to_string(),
+        };
+
+        let new_status = args.get("status").and_then(Value::as_str);
+        let subtask_id = args.get("subtask_id").and_then(Value::as_str);
+        let error_message = args.get("error_message").and_then(Value::as_str);
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let mut tasks = match self.tasks.lock() {
+            Ok(guard) => guard,
+            Err(_) => return "Error: failed to access task list".to_string(),
+        };
+
+        let task = match tasks.iter_mut().find(|task| task.id == task_id) {
+            Some(task) => task,
+            None => return format!("Error: task '{task_id}' not found"),
+        };
+
+        if let Some(subtask_id) = subtask_id {
+            match task
+                .subtasks
+                .iter_mut()
+                .find(|subtask| subtask.id == subtask_id)
+            {
+                Some(subtask) => {
+                    let previous_status = subtask.status.clone();
+                    if let Some(status) = new_status {
+                        subtask.status = status.to_string();
+                    }
+                    task.updated_at = now;
+                    return json!({
+                        "success": true,
+                        "task_id": task_id,
+                        "subtask_id": subtask_id,
+                        "previous_status": previous_status,
+                        "status": subtask.status,
+                        "message": format!("Subtask '{subtask_id}' updated to '{}'", subtask.status),
+                    })
+                    .to_string();
+                }
+                None => {
+                    return format!("Error: subtask '{subtask_id}' not found in task '{task_id}'");
+                }
+            }
+        }
+
+        let previous_status = task.status.clone();
+        if let Some(status) = new_status {
+            task.status = status.to_string();
+        }
+        if let Some(error_message) = error_message {
+            task.description = Some(format!(
+                "{}\n\nError: {error_message}",
+                task.description.as_deref().unwrap_or(""),
+            ));
+        }
+        task.updated_at = now;
+
+        if !task.subtasks.is_empty()
+            && task
+                .subtasks
+                .iter()
+                .all(|subtask| subtask.status == "completed")
+        {
+            task.status = "completed".to_string();
+        }
+
+        json!({
+            "success": true,
+            "task_id": task_id,
+            "previous_status": previous_status,
+            "status": task.status,
+            "message": format!("Task '{task_id}' updated to '{}'", task.status),
+        })
+        .to_string()
+    }
+
+    fn stop(&self, args: &Value) -> String {
+        let task_id = match args.get("task_id").and_then(Value::as_str) {
+            Some(task_id) if !task_id.is_empty() => task_id,
+            _ => return "Error: 'task_id' is required".to_string(),
+        };
+
+        let reason = args
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or("user requested");
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let mut tasks = match self.tasks.lock() {
+            Ok(guard) => guard,
+            Err(_) => return "Error: failed to access task list".to_string(),
+        };
+
+        let task = match tasks.iter_mut().find(|task| task.id == task_id) {
+            Some(task) => task,
+            None => return format!("Error: task '{task_id}' not found"),
+        };
+
+        if task.status != "pending" && task.status != "in_progress" {
+            return json!({
+                "success": false,
+                "message": format!(
+                    "Cannot stop task '{task_id}': status is '{}' (only 'pending' or 'in_progress' can be stopped)",
+                    task.status
+                ),
+            })
+            .to_string();
+        }
+
+        let previous_status = task.status.clone();
+        task.status = "cancelled".to_string();
+        task.description = Some(format!(
+            "{}\n\nCancelled: {reason} (was: {previous_status})",
+            task.description.as_deref().unwrap_or(""),
+        ));
+        task.updated_at = now;
+
+        let mut cancelled_subtasks = 0;
+        for subtask in &mut task.subtasks {
+            if subtask.status == "pending" || subtask.status == "in_progress" {
+                subtask.status = "cancelled".to_string();
+                cancelled_subtasks += 1;
+            }
+        }
+
+        json!({
+            "success": true,
+            "task_id": task_id,
+            "previous_status": previous_status,
+            "reason": reason,
+            "cancelled_subtasks": cancelled_subtasks,
+            "message": format!("Task '{task_id}' cancelled (was: {previous_status})"),
+        })
+        .to_string()
+    }
+}
+
+#[derive(Debug, Clone)]
+enum SessionStateRollbackAction {
+    ToolPreferences {
+        previous_pinned_tools: Vec<String>,
+        previous_deprioritized_tools: Vec<String>,
+    },
+    ConfigOverride {
+        path: String,
+        old_value: Value,
+        snapshot: crate::observability_integration::ObservabilitySessionRollbackSnapshot,
+    },
+    GoalOverride {
+        previous_goal: Option<String>,
+        snapshot: crate::observability_integration::ObservabilitySessionRollbackSnapshot,
+    },
+    Compression {
+        turn: u32,
+        snapshot: crate::observability_integration::ObservabilitySessionRollbackSnapshot,
+    },
+    TaskState {
+        snapshot: TaskManagerSnapshot,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct SessionStateRollbackEntry {
+    sequence: u64,
+    turn_index: u32,
+    timestamp: SystemTime,
+    label: String,
+    action: SessionStateRollbackAction,
+}
+
+#[derive(Debug, Default)]
+struct SessionStateRollbackJournal {
+    entries: Vec<SessionStateRollbackEntry>,
+    next_sequence: u64,
+}
+
+impl SessionStateRollbackJournal {
+    fn record(&mut self, turn_index: u32, label: String, action: SessionStateRollbackAction) {
+        self.entries.push(SessionStateRollbackEntry {
+            sequence: self.next_sequence,
+            turn_index,
+            timestamp: SystemTime::now(),
+            label,
+            action,
+        });
+        self.next_sequence = self.next_sequence.saturating_add(1);
+    }
+
+    fn list(&self) -> Vec<SessionStateRollbackEntry> {
+        self.entries.iter().rev().cloned().collect()
+    }
+
+    fn restore_plan_for_turn(&self, turn_index: u32) -> Vec<SessionStateRollbackEntry> {
+        self.restore_plan_for_turn_since(turn_index, 0)
+    }
+
+    fn restore_plan_for_turn_since(
+        &self,
+        turn_index: u32,
+        checkpoint: u64,
+    ) -> Vec<SessionStateRollbackEntry> {
+        self.entries
+            .iter()
+            .rev()
+            .filter(|entry| entry.turn_index == turn_index && entry.sequence >= checkpoint)
+            .cloned()
+            .collect()
+    }
+
+    fn checkpoint(&self) -> u64 {
+        self.next_sequence
+    }
+
+    fn remove_sequence(&mut self, sequence: u64) -> bool {
+        if let Some(index) = self
+            .entries
+            .iter()
+            .position(|entry| entry.sequence == sequence)
+        {
+            self.entries.remove(index);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fn action_kind(action: &SessionStateRollbackAction) -> &'static str {
+    match action {
+        SessionStateRollbackAction::ToolPreferences { .. } => "tool_preferences",
+        SessionStateRollbackAction::ConfigOverride { .. } => "config_override",
+        SessionStateRollbackAction::GoalOverride { .. } => "goal_override",
+        SessionStateRollbackAction::Compression { .. } => "compression",
+        SessionStateRollbackAction::TaskState { .. } => "task_state",
+    }
+}
+
+fn normalized_drift(old: f64, new: f64) -> Option<f64> {
+    let denom = old.abs();
+    if denom < f64::EPSILON {
+        return None;
+    }
+    Some((new - old).abs() / denom)
+}
+
+fn extract_tool_name(args: &Value) -> Option<String> {
+    args.get("tool")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|tool| !tool.is_empty())
+        .map(ToString::to_string)
+}
+
+fn effective_runtime_config(
+    workspace: Option<&astra_services::session_workspace::WorkspaceMetadata>,
+) -> Result<crate::runtime_config::RuntimeConfig, String> {
+    match workspace.and_then(|workspace| workspace.tuned_config_json.as_deref()) {
+        Some(json) => serde_json::from_str(json).map_err(|error| error.to_string()),
+        None => Ok(crate::runtime_config::RuntimeConfig::load()),
+    }
+}
+
+fn replace_json_path(root: &mut Value, path: &str, new_value: Value) -> Result<Value, String> {
+    let segments: Vec<&str> = path
+        .split('.')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    if segments.is_empty() {
+        return Err("mutation path cannot be empty".to_string());
+    }
+
+    let mut current = root;
+    for segment in &segments[..segments.len() - 1] {
+        current = current
+            .get_mut(*segment)
+            .ok_or_else(|| format!("unknown config path segment '{segment}'"))?;
+    }
+
+    let last = segments.last().expect("checked non-empty");
+    let object = current
+        .as_object_mut()
+        .ok_or_else(|| format!("config path '{path}' does not point to an object parent"))?;
+    let slot = object
+        .get_mut(*last)
+        .ok_or_else(|| format!("unknown config leaf '{last}'"))?;
+    let old_value = slot.clone();
+    *slot = new_value;
+    Ok(old_value)
+}
+
+fn append_config_change_event(
+    session_id: &str,
+    turn: u32,
+    key: &str,
+    new_value: &Value,
+    old_value: Option<Value>,
+    source: &str,
+) -> Result<(), String> {
+    let writer = astra_services::session_journal::JournalWriter::new(session_id)
+        .map_err(|e| e.to_string())?;
+    let mut event = astra_services::session_journal::JournalEvent::config_change(
+        Some(session_id),
+        key,
+        &new_value.to_string(),
+    );
+    event.turn = Some(turn);
+    let mut metadata =
+        serde_json::Map::from_iter([("source".to_string(), Value::String(source.to_string()))]);
+    if let Some(old_value) = old_value {
+        metadata.insert("old_value".to_string(), old_value);
+    }
+    event.metadata = Some(Value::Object(metadata));
+    writer.append(&event).map_err(|e| e.to_string())
+}
+
+fn persist_config_override(
+    session_id: &str,
+    path: &str,
+    new_value: Value,
+    source: &str,
+) -> Result<(), String> {
+    let mut workspace =
+        astra_services::session_workspace::read_workspace(session_id).map_err(|e| e.to_string())?;
+    let base_config = effective_runtime_config(Some(&workspace))?;
+    let mut value = serde_json::to_value(&base_config).map_err(|e| e.to_string())?;
+    let old_value = replace_json_path(&mut value, path, new_value.clone())?;
+    let candidate_config: crate::runtime_config::RuntimeConfig =
+        serde_json::from_value(value.clone()).map_err(|e| e.to_string())?;
+    let baseline_json = serde_json::to_value(crate::runtime_config::RuntimeConfig::load())
+        .map_err(|e| e.to_string())?;
+    workspace.tuned_config_json = if value == baseline_json {
+        None
+    } else {
+        Some(serde_json::to_string(&candidate_config).map_err(|e| e.to_string())?)
+    };
+    workspace.updated_at = chrono::Utc::now().to_rfc3339();
+    astra_services::session_workspace::write_workspace(&workspace).map_err(|e| e.to_string())?;
+    append_config_change_event(
+        session_id,
+        workspace.turn_count,
+        path,
+        &new_value,
+        Some(old_value),
+        source,
+    )
+}
+
+fn persist_goal_override(session_id: &str, goal: &str, source: &str) -> Result<(), String> {
+    let mut workspace =
+        astra_services::session_workspace::read_workspace(session_id).map_err(|e| e.to_string())?;
+    let previous_goal = workspace.session_goal.clone();
+    workspace.session_goal = Some(goal.to_string());
+    workspace.goal_progress = None;
+    workspace.updated_at = chrono::Utc::now().to_rfc3339();
+    astra_services::session_workspace::write_workspace(&workspace).map_err(|e| e.to_string())?;
+    append_config_change_event(
+        session_id,
+        workspace.turn_count,
+        "session_goal",
+        &Value::String(goal.to_string()),
+        previous_goal.clone().map(Value::String),
+        source,
+    )?;
+    if previous_goal.as_deref() != Some(goal) {
+        let writer = astra_services::session_journal::JournalWriter::new(session_id)
+            .map_err(|e| e.to_string())?;
+        writer
+            .append(
+                &astra_services::session_journal::JournalEvent::goal_steered(
+                    Some(session_id),
+                    workspace.turn_count,
+                    source,
+                    previous_goal.as_deref(),
+                    goal,
+                    None,
+                ),
+            )
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+fn clear_persisted_goal_override(session_id: &str) -> Result<(), String> {
+    let mut workspace =
+        astra_services::session_workspace::read_workspace(session_id).map_err(|e| e.to_string())?;
+    workspace.session_goal = None;
+    workspace.goal_progress = None;
+    workspace.updated_at = chrono::Utc::now().to_rfc3339();
+    astra_services::session_workspace::write_workspace(&workspace).map_err(|e| e.to_string())
+}
+
+fn persist_tool_preferences(
+    session_id: &str,
+    pinned_tools: &[String],
+    deprioritized_tools: &[String],
+    source: &str,
+) -> Result<(), String> {
+    let mut workspace =
+        astra_services::session_workspace::read_workspace(session_id).map_err(|e| e.to_string())?;
+    let mut pinned = pinned_tools.to_vec();
+    pinned.sort();
+    pinned.dedup();
+    let mut deprioritized = deprioritized_tools.to_vec();
+    deprioritized.sort();
+    deprioritized.dedup();
+
+    let old_pinned = workspace.pinned_tools.clone();
+    let old_deprioritized = workspace.deprioritized_tools.clone();
+    workspace.pinned_tools = pinned.clone();
+    workspace.deprioritized_tools = deprioritized.clone();
+    workspace.updated_at = chrono::Utc::now().to_rfc3339();
+    astra_services::session_workspace::write_workspace(&workspace).map_err(|e| e.to_string())?;
+
+    if old_pinned != pinned {
+        append_config_change_event(
+            session_id,
+            workspace.turn_count,
+            "pinned_tools",
+            &json!(pinned),
+            Some(json!(old_pinned)),
+            source,
+        )?;
+    }
+    if old_deprioritized != deprioritized {
+        append_config_change_event(
+            session_id,
+            workspace.turn_count,
+            "deprioritized_tools",
+            &json!(deprioritized),
+            Some(json!(old_deprioritized)),
+            source,
+        )?;
+    }
+    Ok(())
+}
+
+fn persist_manual_compression(
+    session_id: &str,
+    turn: u32,
+    reason: &str,
+    source: &str,
+) -> Result<(), String> {
+    let writer = astra_services::session_journal::JournalWriter::new(session_id)
+        .map_err(|e| e.to_string())?;
+    let mut event = astra_services::session_journal::JournalEvent::compact_with_summary(
+        Some(session_id),
+        turn,
+        1,
+        0,
+        Some(reason),
+    );
+    event.metadata = Some(json!({
+        "source": source,
+        "reason": reason,
+        "manual": true,
+    }));
+    writer.append(&event).map_err(|e| e.to_string())
+}
+
+fn supports_server_tool_name(tool: &str) -> bool {
+    astra_tools::schemas::SERVER_EXECUTOR_TOOL_NAMES.contains(&tool)
+}
+
+fn mo_current_account() -> &'static str {
+    use std::sync::OnceLock;
+
+    static ACCOUNT: OnceLock<String> = OnceLock::new();
+    ACCOUNT.get_or_init(|| {
+        let out = mo_execute_sql("SELECT current_account_name() AS name", None);
+        out.lines()
+            .filter(|line| !line.starts_with('+') && !line.contains("name"))
+            .find_map(|line| {
+                let trimmed = line.trim().trim_matches('|').trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            })
+            .unwrap_or_else(|| "sys".to_string())
+    })
+}
+
+fn mo_database() -> &'static str {
+    use std::sync::OnceLock;
+
+    static DB: OnceLock<String> = OnceLock::new();
+    DB.get_or_init(|| astra_core::resolve_matrixone_database_name(&|k| std::env::var(k).ok()))
+}
+
+fn resolved_mo_database(database: Option<&str>) -> String {
+    database
+        .map(str::trim)
+        .filter(|database| !database.is_empty())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| mo_database().to_string())
+}
+
+fn mo_create_snapshot_sql(name: &str, database: Option<&str>) -> String {
+    format!(
+        "CREATE SNAPSHOT `{name}` FOR DATABASE `{}`",
+        resolved_mo_database(database)
+    )
+}
+
+fn mo_restore_snapshot_sql(name: &str, database: Option<&str>) -> String {
+    let account = mo_current_account();
+    format!(
+        "RESTORE ACCOUNT `{account}` DATABASE `{}` FROM SNAPSHOT `{name}`",
+        resolved_mo_database(database)
+    )
+}
+
+fn mo_query_requires_pre_state_snapshot(sql: &str, allow_destructive: bool) -> bool {
+    match sql
+        .split_whitespace()
+        .next()
+        .map(|keyword| keyword.trim_matches(|c: char| c == '(' || c == ';'))
+        .map(str::to_ascii_uppercase)
+        .as_deref()
+    {
+        Some("INSERT" | "UPDATE" | "REPLACE" | "CREATE") => true,
+        Some("DROP" | "DELETE" | "TRUNCATE" | "ALTER" | "GRANT" | "REVOKE") => true,
+        _ => allow_destructive,
+    }
+}
+
+fn mo_pre_state_snapshot_name() -> String {
+    format!("moq_{}", uuid::Uuid::now_v7().simple())
+}
+
+fn is_valid_snapshot_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+}
+
+fn is_mo_error(output: &str) -> bool {
+    output.trim_start().starts_with("Error:")
+}
+
+fn mo_mysql_cmd(database: Option<&str>) -> Command {
+    astra_core::warn_default_credentials_once();
+    let host = std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".to_string());
+    let port = std::env::var("MATRIXONE_PORT").unwrap_or_else(|_| "6001".to_string());
+    let user = std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".to_string());
+    let password = std::env::var("MATRIXONE_PASSWORD")
+        .unwrap_or_else(|_| astra_core::DEV_MATRIXONE_PASSWORD.to_string());
+    let db = database
+        .map(ToString::to_string)
+        .unwrap_or_else(|| astra_core::resolve_matrixone_database_name(&|k| std::env::var(k).ok()));
+
+    let mut cmd = Command::new("mysql");
+    cmd.arg(format!("-h{host}"))
+        .arg(format!("-P{port}"))
+        .arg(format!("-u{user}"))
+        .env("MYSQL_PWD", &password)
+        .arg(db)
+        .arg(format!("--connect-timeout={MO_CONNECT_TIMEOUT_SECS}"))
+        .arg("--table");
+    cmd
+}
+
+fn mo_execute_sql(sql: &str, database: Option<&str>) -> String {
+    let mut cmd = mo_mysql_cmd(database);
+    cmd.arg("-e").arg(sql);
+
+    match cmd.output() {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if !out.status.success() {
+                let err = if stderr.is_empty() {
+                    stdout.to_string()
+                } else {
+                    stderr.to_string()
+                };
+                format!("Error: {}", err.trim())
+            } else if stdout.is_empty() {
+                "OK (no results)".to_string()
+            } else {
+                stdout.to_string()
+            }
+        }
+        Err(error) => format!("Error: failed to execute mysql client: {error}"),
+    }
+}
 
 /// Server-side tool executor for web agent sessions.
 ///
@@ -45,6 +919,12 @@ pub struct ServerToolExecutor {
     sandbox_policy: SandboxPolicy,
     /// File edit journal for undo support.
     file_journal: Arc<Mutex<FileEditJournal>>,
+    /// Database snapshot journal for MatrixOne rollback support.
+    database_snapshot_journal: Arc<Mutex<DatabaseSnapshotRollbackJournal>>,
+    /// Session-state rollback journal for bounded self-mod and task undo.
+    session_state_journal: Arc<Mutex<SessionStateRollbackJournal>>,
+    /// In-memory task manager for session-local task tools.
+    task_manager: Arc<ServerTaskManager>,
     /// Current turn index for journal entries.
     journal_turn_index: AtomicU32,
     /// Aggregate output bytes this turn.
@@ -75,6 +955,15 @@ pub struct ServerToolExecutor {
         Option<std::sync::Arc<dyn astra_services::resource_governor::ResourceGovernor>>,
     /// Optional edge connection pool for routing to remote edge agents.
     edge_connection_pool: Option<super::edge_connection_pool::EdgeConnectionPool>,
+    /// Optional observability session for self-mod and rollback-backed session state.
+    observability_session:
+        Option<Arc<std::sync::RwLock<crate::observability_integration::ObservabilitySession>>>,
+    /// Self-modification pinned tool preferences.
+    self_mod_pinned_tools: Mutex<Vec<String>>,
+    /// Self-modification deprioritized tool preferences.
+    self_mod_deprioritized_tools: Mutex<Vec<String>>,
+    /// Per-turn mutation accounting for adjust_config governor.
+    self_mod_mutation_counter: Mutex<(u32, u32)>,
     /// Shared default executor for delegating common tool logic.
     default_executor: DefaultToolExecutor,
 }
@@ -100,6 +989,10 @@ impl ServerToolExecutor {
 
         let memoria_client =
             astra_tools::memoria::MemoriaClient::new(cloud_base.clone(), cloud_token.clone());
+        let (pinned_tools, deprioritized_tools) =
+            astra_services::session_workspace::read_workspace(&session_id)
+                .map(|workspace| (workspace.pinned_tools, workspace.deprioritized_tools))
+                .unwrap_or_else(|_| (Vec::new(), Vec::new()));
 
         let http_client = reqwest::Client::builder()
             .timeout(Duration::from_secs(15))
@@ -136,6 +1029,11 @@ impl ServerToolExecutor {
             sandbox_policy,
             default_executor,
             file_journal: Arc::new(Mutex::new(FileEditJournal::new(500))),
+            database_snapshot_journal: Arc::new(Mutex::new(
+                DatabaseSnapshotRollbackJournal::default(),
+            )),
+            session_state_journal: Arc::new(Mutex::new(SessionStateRollbackJournal::default())),
+            task_manager: Arc::new(ServerTaskManager::new()),
             journal_turn_index: AtomicU32::new(0),
             aggregate_output_bytes: AtomicUsize::new(0),
             memoria_client,
@@ -148,6 +1046,10 @@ impl ServerToolExecutor {
             progress_callback: None,
             resource_governor: None,
             edge_connection_pool: None,
+            observability_session: None,
+            self_mod_pinned_tools: Mutex::new(pinned_tools),
+            self_mod_deprioritized_tools: Mutex::new(deprioritized_tools),
+            self_mod_mutation_counter: Mutex::new((0, 0)),
         }
     }
 
@@ -177,16 +1079,33 @@ impl ServerToolExecutor {
         self.resource_governor = Some(governor);
     }
 
+    /// Set the observability session for rollback-backed session-state tools.
+    pub fn set_observability_session(
+        &mut self,
+        session: Arc<std::sync::RwLock<crate::observability_integration::ObservabilitySession>>,
+    ) {
+        self.observability_session = Some(session);
+    }
+
     /// Execute a tool call and return the result string.
     ///
     /// Routing order:
     /// 1. Try remote edge agent (if connected via WebSocket)
     /// 2. Fall back to local server-side execution
     pub async fn execute(&self, name: &str, args: &Value) -> String {
+        self.execute_with_metadata(name, args).await.output
+    }
+
+    /// Execute a tool call and preserve structured metadata for server-side fallback paths.
+    pub async fn execute_with_metadata(&self, name: &str, args: &Value) -> astra_tools::ToolResult {
         // ── Try remote edge agent first ──────────────────────────────
         if let Some(pool) = &self.edge_connection_pool {
             if let Some(result) = pool.execute_tool_any_edge(&self.user_id, name, args).await {
-                return result.output;
+                return astra_tools::ToolResult {
+                    output: result.output,
+                    metadata: None,
+                    is_error: result.is_error,
+                };
             }
         }
         // ── Fire-and-forget resource usage recording (Phase 5) ────────
@@ -198,11 +1117,15 @@ impl ServerToolExecutor {
             });
         }
 
-        self.execute_local(name, args).await
+        self.execute_local_with_metadata(name, args).await
     }
 
     /// Execute a tool locally on the server (no edge routing).
-    async fn execute_local(&self, name: &str, args: &Value) -> String {
+    async fn execute_local_with_metadata(
+        &self,
+        name: &str,
+        args: &Value,
+    ) -> astra_tools::ToolResult {
         // ── Approval gate check ──────────────────────────────────────
         if let Some(gate) = &self.approval_gate {
             if gate.requires_approval(name) {
@@ -212,10 +1135,14 @@ impl ServerToolExecutor {
                     astra_tools::ApprovalDecision::Approved => { /* proceed */ }
                     astra_tools::ApprovalDecision::Denied { reason } => {
                         let msg = reason.unwrap_or_else(|| "User denied execution".into());
-                        return format!("Tool execution denied: {msg}");
+                        return astra_tools::ToolResult::error(format!(
+                            "Tool execution denied: {msg}"
+                        ));
                     }
                     astra_tools::ApprovalDecision::Timeout => {
-                        return "Tool execution denied: approval request timed out".into();
+                        return astra_tools::ToolResult::error(
+                            "Tool execution denied: approval request timed out".into(),
+                        );
                     }
                 }
             }
@@ -227,7 +1154,7 @@ impl ServerToolExecutor {
             cb.tool_started(&call_id, name, args).await;
         }
 
-        let output = match name {
+        let mut result = match name {
             // ── Memory tools (HTTP proxy) ──────────────────────────────
             "memory_retrieve" | "memory_store" | "memory_search" | "memory_purge"
             | "memory_correct" | "memory_profile" => {
@@ -242,78 +1169,98 @@ impl ServerToolExecutor {
                     );
                     obj.insert("user_id".to_string(), Value::String(self.user_id.clone()));
                 }
-                self.memoria_client.call(op, &isolated_args).await
+                let output = self.memoria_client.call(op, &isolated_args).await;
+                if output.starts_with("Error") {
+                    astra_tools::ToolResult::error(output)
+                } else {
+                    astra_tools::ToolResult::text(output)
+                }
             }
             // ── Web search (standalone function) ───────────────────────
-            "web_search" => astra_tools::web_search::web_search(args),
+            "web_search" => {
+                let output = astra_tools::web_search::web_search(args);
+                if output.starts_with("Error") {
+                    astra_tools::ToolResult::error(output)
+                } else {
+                    astra_tools::ToolResult::text(output)
+                }
+            }
             // ── File operations ─────────────────────────────────────────
             // Write operations use server-specific journal recording.
             // Read-only operations delegate to DefaultToolExecutor.
-            "read_file" => {
-                self.default_executor
-                    .execute("read_file", args)
-                    .await
-                    .output
+            "read_file" => self.default_executor.execute("read_file", args).await,
+            "write_file" => tool_result_from_output(self.server_write_file(args)),
+            "str_replace" => tool_result_from_output(self.server_str_replace(args)),
+            "delete_file" => tool_result_from_output(self.server_delete_file(args)),
+            "rollback_file_edits" => tool_result_from_output(self.rollback_file_edits(args)),
+            "list_dir" => self.default_executor.execute("list_dir", args).await,
+            // ── Session-state tools ─────────────────────────────────────
+            "adjust_config" => tool_result_from_output(self.adjust_config(args)),
+            "prioritize_tool" => tool_result_from_output(self.prioritize_tool(args)),
+            "deprioritize_tool" => tool_result_from_output(self.deprioritize_tool(args)),
+            "set_goal" => tool_result_from_output(self.set_goal(args)),
+            "compress_context" => tool_result_from_output(self.compress_context(args)),
+            "rollback_session_state" => tool_result_from_output(self.rollback_session_state(args)),
+            "task_create" => tool_result_from_output(self.task_create(args)),
+            "task_list" => tool_result_from_output(self.task_list(args)),
+            "task_get" => tool_result_from_output(self.task_get(args)),
+            "task_update" => tool_result_from_output(self.task_update(args)),
+            "task_stop" => tool_result_from_output(self.task_stop(args)),
+            // ── MatrixOne operations ────────────────────────────────────
+            "mo_query" => self.server_mo_query(args),
+            "rollback_database_snapshots" => {
+                tool_result_from_output(self.rollback_database_snapshots(args))
             }
-            "write_file" => self.server_write_file(args),
-            "str_replace" => self.server_str_replace(args),
-            "delete_file" => self.server_delete_file(args),
-            "list_dir" => self.default_executor.execute("list_dir", args).await.output,
             // ── Shell operations ───────────────────────────────────────
             // bash uses tiered process isolation (server-specific).
             // grep + glob delegate to DefaultToolExecutor.
-            "bash" => self.server_bash(args).await,
-            "grep" => self.default_executor.execute("grep", args).await.output,
-            "glob" => self.default_executor.execute("glob", args).await.output,
+            "bash" => tool_result_from_output(self.server_bash(args).await),
+            "grep" => self.default_executor.execute("grep", args).await,
+            "glob" => self.default_executor.execute("glob", args).await,
             // ── Git operations ─────────────────────────────────────────
             // All git ops delegate to DefaultToolExecutor.
-            "git_status" => {
+            "git_status" => self.default_executor.execute("git_status", args).await,
+            "git_diff" => self.default_executor.execute("git_diff", args).await,
+            "git_log" => self.default_executor.execute("git_log", args).await,
+            "git_show" => self.default_executor.execute("git_show", args).await,
+            "git_blame" => self.default_executor.execute("git_blame", args).await,
+            "git_commit" => self.default_executor.execute("git_commit", args).await,
+            "git_revert_commit" => {
                 self.default_executor
-                    .execute("git_status", args)
+                    .execute("git_revert_commit", args)
                     .await
-                    .output
-            }
-            "git_diff" => self.default_executor.execute("git_diff", args).await.output,
-            "git_log" => self.default_executor.execute("git_log", args).await.output,
-            "git_show" => self.default_executor.execute("git_show", args).await.output,
-            "git_blame" => {
-                self.default_executor
-                    .execute("git_blame", args)
-                    .await
-                    .output
-            }
-            "git_commit" => {
-                self.default_executor
-                    .execute("git_commit", args)
-                    .await
-                    .output
             }
             // ── Delegation placeholder ─────────────────────────────────
-            "delegate" => "Delegation request acknowledged. The delegation engine will execute \
-                this request and provide results in the next round."
-                .to_string(),
-            // ── Delegate to DefaultToolExecutor for all other tools ────
-            // Covers: git_file_history, git_log_search, git_contributors,
-            // git_revert_commit, git_stash, github_*, symbols, task_*,
-            // tool_search, env, config, multi_edit, sleep, web_fetch, etc.
-            _ => self.default_executor.execute(name, args).await.output,
+            "delegate" => astra_tools::ToolResult::text(
+                "Delegation request acknowledged. The delegation engine will execute \
+                 this request and provide results in the next round."
+                    .to_string(),
+            ),
+            // ── Unknown tool fallback ──────────────────────────────────
+            _ => astra_tools::ToolResult::error(format!(
+                "Error: Tool '{name}' is not available in server-side execution mode. \
+                     Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
+                     list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
+                     rollback_session_state, task_*, mo_query, rollback_database_snapshots, grep, glob, git_status, \
+                     git_diff, git_log, git_show, git_blame, git_commit, git_revert_commit, memory_*, web_search"
+            )),
         };
 
-        let output = astra_tools::normalize_empty_output(output, name);
+        result.output = astra_tools::normalize_empty_output(result.output, name);
         let limit = astra_tools::per_tool_output_limit(name);
-        let output = astra_tools::truncate_output(output, limit);
+        result.output = astra_tools::truncate_output(result.output, limit);
         let agg = self
             .aggregate_output_bytes
-            .fetch_add(output.len(), Ordering::Relaxed);
-        let output = astra_tools::maybe_persist_large_output(output, agg, name);
+            .fetch_add(result.output.len(), Ordering::Relaxed);
+        result.output = astra_tools::maybe_persist_large_output(result.output, agg, name);
 
         // ── Progress: tool completed ─────────────────────────────────
         if let Some(cb) = &self.progress_callback {
-            let success = !output.starts_with("Error:");
-            cb.tool_completed(&call_id, &output, success).await;
+            cb.tool_completed(&call_id, &result.output, !result.is_error)
+                .await;
         }
 
-        output
+        result
     }
 
     /// Set the current turn index for journal entries.
@@ -329,6 +1276,1279 @@ impl ServerToolExecutor {
     /// Get the workspace root path.
     pub fn workspace_root(&self) -> &Path {
         &self.workspace_root
+    }
+
+    pub(crate) fn file_journal_checkpoint(&self) -> u64 {
+        match self.file_journal.lock() {
+            Ok(journal) => journal.checkpoint(),
+            Err(poisoned) => poisoned.into_inner().checkpoint(),
+        }
+    }
+
+    fn record_database_snapshot_rollback(
+        &self,
+        snapshot_id: impl Into<String>,
+        database: Option<String>,
+    ) {
+        let turn_index = self.journal_turn_index.load(Ordering::Relaxed);
+        match self.database_snapshot_journal.lock() {
+            Ok(mut journal) => journal.record(snapshot_id, database, turn_index),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .record(snapshot_id, database, turn_index),
+        }
+    }
+
+    fn database_snapshot_entries(&self) -> Vec<DatabaseSnapshotRollbackEntry> {
+        match self.database_snapshot_journal.lock() {
+            Ok(journal) => journal.list(),
+            Err(poisoned) => poisoned.into_inner().list(),
+        }
+    }
+
+    fn database_snapshot_entry_for_snapshot(
+        &self,
+        snapshot_id: &str,
+    ) -> Option<DatabaseSnapshotRollbackEntry> {
+        match self.database_snapshot_journal.lock() {
+            Ok(journal) => journal.entry_for_snapshot(snapshot_id),
+            Err(poisoned) => poisoned.into_inner().entry_for_snapshot(snapshot_id),
+        }
+    }
+
+    fn database_snapshot_restore_plan_for_turn_since(
+        &self,
+        turn_index: u32,
+        checkpoint: u64,
+    ) -> Vec<DatabaseSnapshotRollbackEntry> {
+        match self.database_snapshot_journal.lock() {
+            Ok(journal) => journal.restore_plan_for_turn_since(turn_index, checkpoint),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .restore_plan_for_turn_since(turn_index, checkpoint),
+        }
+    }
+
+    fn remove_database_snapshot_rollback(&self, snapshot_id: &str) {
+        match self.database_snapshot_journal.lock() {
+            Ok(mut journal) => {
+                journal.remove_snapshot(snapshot_id);
+            }
+            Err(poisoned) => {
+                poisoned.into_inner().remove_snapshot(snapshot_id);
+            }
+        }
+    }
+
+    fn rollback_database_snapshot_entry_json(entry: &DatabaseSnapshotRollbackEntry) -> Value {
+        let mut value = serde_json::Map::from_iter([
+            (
+                "snapshot_id".to_string(),
+                Value::String(entry.snapshot_id.clone()),
+            ),
+            (
+                "turn_index".to_string(),
+                Value::Number(serde_json::Number::from(entry.turn_index)),
+            ),
+        ]);
+        if let Some(database) = entry.database.as_ref() {
+            value.insert("database".to_string(), Value::String(database.clone()));
+        }
+        Value::Object(value)
+    }
+
+    fn restore_database_snapshot_entry(
+        &self,
+        entry: &DatabaseSnapshotRollbackEntry,
+    ) -> Result<(), String> {
+        let output = mo_execute_sql(
+            &mo_restore_snapshot_sql(&entry.snapshot_id, entry.database.as_deref()),
+            None,
+        );
+        if is_mo_error(&output) {
+            Err(output)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn server_mo_query(&self, args: &Value) -> astra_tools::ToolResult {
+        let sql = match args.get("sql").and_then(Value::as_str) {
+            Some(sql) if !sql.trim().is_empty() => sql.trim(),
+            _ => return astra_tools::ToolResult::error("Error: Missing 'sql' parameter".into()),
+        };
+
+        let allow_destructive = args
+            .get("allow_destructive")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if !allow_destructive
+            && let Some(kind) = crate::turn::safety_middleware::check_sql_safety(sql)
+        {
+            return astra_tools::ToolResult::error(format!(
+                "Error: {kind} statements are blocked by default. Pass \"allow_destructive\": true to confirm execution."
+            ));
+        }
+
+        let database = args.get("database").and_then(Value::as_str);
+        let resolved_database = resolved_mo_database(database);
+        let mut metadata = None;
+        if mo_query_requires_pre_state_snapshot(sql, allow_destructive) {
+            let snapshot_id = mo_pre_state_snapshot_name();
+            let snapshot_output =
+                mo_execute_sql(&mo_create_snapshot_sql(&snapshot_id, database), None);
+            if is_mo_error(&snapshot_output) {
+                return astra_tools::ToolResult::error(format!(
+                    "Error: failed to capture pre-state snapshot `{snapshot_id}` before executing query.\n{snapshot_output}"
+                ));
+            }
+            self.record_database_snapshot_rollback(
+                snapshot_id.clone(),
+                Some(resolved_database.clone()),
+            );
+            metadata = Some(serde_json::Map::from_iter([
+                (
+                    "pre_state_snapshot_id".to_string(),
+                    Value::String(snapshot_id),
+                ),
+                (
+                    "pre_state_snapshot_database".to_string(),
+                    Value::String(resolved_database),
+                ),
+            ]));
+        }
+
+        let output = mo_execute_sql(sql, database);
+        astra_tools::ToolResult {
+            is_error: is_mo_error(&output),
+            output,
+            metadata,
+        }
+    }
+
+    pub(crate) fn rollback_database_snapshots(&self, args: &Value) -> String {
+        let scope = args
+            .get("scope")
+            .and_then(Value::as_str)
+            .or_else(|| {
+                if args.get("snapshot_id").is_some() {
+                    Some("snapshot")
+                } else {
+                    None
+                }
+            })
+            .unwrap_or("current_turn");
+
+        match scope {
+            "list" => {
+                let entries = self
+                    .database_snapshot_entries()
+                    .into_iter()
+                    .map(|entry| Self::rollback_database_snapshot_entry_json(&entry))
+                    .collect::<Vec<_>>();
+                json!({
+                    "success": true,
+                    "scope": "list",
+                    "total_entries": entries.len(),
+                    "entries": entries,
+                })
+                .to_string()
+            }
+            "snapshot" => {
+                let snapshot_id = match args.get("snapshot_id").and_then(Value::as_str) {
+                    Some(snapshot_id) if is_valid_snapshot_name(snapshot_id) => snapshot_id,
+                    Some(snapshot_id) => {
+                        return json!({
+                            "success": false,
+                            "scope": "snapshot",
+                            "error": format!("invalid snapshot_id `{snapshot_id}`"),
+                        })
+                        .to_string();
+                    }
+                    None => {
+                        return json!({
+                            "success": false,
+                            "scope": "snapshot",
+                            "error": "missing 'snapshot_id' for scope=snapshot",
+                        })
+                        .to_string();
+                    }
+                };
+                let journal_entry = self.database_snapshot_entry_for_snapshot(snapshot_id);
+                let database = args
+                    .get("database")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|database| !database.is_empty())
+                    .map(ToString::to_string)
+                    .or_else(|| {
+                        journal_entry
+                            .as_ref()
+                            .and_then(|entry| entry.database.clone())
+                    });
+                let entry = DatabaseSnapshotRollbackEntry {
+                    sequence: journal_entry.as_ref().map_or(0, |entry| entry.sequence),
+                    snapshot_id: snapshot_id.to_string(),
+                    database,
+                    turn_index: journal_entry.as_ref().map_or_else(
+                        || self.journal_turn_index.load(Ordering::Relaxed),
+                        |entry| entry.turn_index,
+                    ),
+                };
+                match self.restore_database_snapshot_entry(&entry) {
+                    Ok(()) => {
+                        self.remove_database_snapshot_rollback(snapshot_id);
+                        let database = entry.database.clone();
+                        json!({
+                            "success": true,
+                            "scope": "snapshot",
+                            "snapshot_id": snapshot_id,
+                            "database": database,
+                            "summary": format!(
+                                "Restored MatrixOne snapshot `{}`{}",
+                                snapshot_id,
+                                database
+                                    .as_deref()
+                                    .map(|database| format!(" for database `{database}`"))
+                                    .unwrap_or_default()
+                            ),
+                        })
+                        .to_string()
+                    }
+                    Err(error) => json!({
+                        "success": false,
+                        "scope": "snapshot",
+                        "snapshot_id": snapshot_id,
+                        "database": entry.database.clone(),
+                        "error": error,
+                    })
+                    .to_string(),
+                }
+            }
+            "turn" | "current_turn" => {
+                let turn_index = if scope == "turn" {
+                    match args.get("turn_index").and_then(Value::as_u64) {
+                        Some(turn_index) => turn_index as u32,
+                        None => {
+                            return json!({
+                                "success": false,
+                                "scope": "turn",
+                                "error": "missing 'turn_index' for scope=turn",
+                            })
+                            .to_string();
+                        }
+                    }
+                } else {
+                    self.journal_turn_index.load(Ordering::Relaxed)
+                };
+                let checkpoint = args
+                    .get("database_after_sequence")
+                    .or_else(|| args.get("after_sequence"))
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+                let plan = if checkpoint > 0 {
+                    self.database_snapshot_restore_plan_for_turn_since(turn_index, checkpoint)
+                } else {
+                    match self.database_snapshot_journal.lock() {
+                        Ok(journal) => journal.restore_plan_for_turn(turn_index),
+                        Err(poisoned) => poisoned.into_inner().restore_plan_for_turn(turn_index),
+                    }
+                };
+                let mut restored = Vec::new();
+                let mut failed = Vec::new();
+                for entry in &plan {
+                    match self.restore_database_snapshot_entry(entry) {
+                        Ok(()) => {
+                            self.remove_database_snapshot_rollback(&entry.snapshot_id);
+                            restored.push(Self::rollback_database_snapshot_entry_json(entry));
+                        }
+                        Err(error) => {
+                            let mut failed_entry =
+                                Self::rollback_database_snapshot_entry_json(entry)
+                                    .as_object()
+                                    .cloned()
+                                    .unwrap_or_default();
+                            failed_entry.insert("error".to_string(), Value::String(error));
+                            failed.push(Value::Object(failed_entry));
+                        }
+                    }
+                }
+                let success = !restored.is_empty() && failed.is_empty();
+                let summary = if plan.is_empty() {
+                    format!("No recorded MatrixOne snapshots found for turn {turn_index}")
+                } else if failed.is_empty() {
+                    format!(
+                        "Restored {} MatrixOne snapshot{} for turn {turn_index}",
+                        restored.len(),
+                        if restored.len() == 1 { "" } else { "s" }
+                    )
+                } else {
+                    format!(
+                        "Restored {} MatrixOne snapshot{} for turn {turn_index} with {} failure{}",
+                        restored.len(),
+                        if restored.len() == 1 { "" } else { "s" },
+                        failed.len(),
+                        if failed.len() == 1 { "" } else { "s" }
+                    )
+                };
+                json!({
+                    "success": success,
+                    "scope": scope,
+                    "turn_index": turn_index,
+                    "restored": restored,
+                    "failed": failed,
+                    "summary": summary,
+                })
+                .to_string()
+            }
+            other => json!({
+                "success": false,
+                "error": format!(
+                    "unknown scope `{other}`. Supported: current_turn, turn, snapshot, list"
+                ),
+            })
+            .to_string(),
+        }
+    }
+
+    pub(crate) fn session_state_journal_checkpoint(&self) -> u64 {
+        match self.session_state_journal.lock() {
+            Ok(journal) => journal.checkpoint(),
+            Err(poisoned) => poisoned.into_inner().checkpoint(),
+        }
+    }
+
+    fn record_session_state_rollback(&self, label: String, action: SessionStateRollbackAction) {
+        let turn_index = self.journal_turn_index.load(Ordering::Relaxed);
+        match self.session_state_journal.lock() {
+            Ok(mut journal) => journal.record(turn_index, label, action),
+            Err(poisoned) => poisoned.into_inner().record(turn_index, label, action),
+        }
+    }
+
+    fn record_tool_preferences_rollback(
+        &self,
+        previous_pinned_tools: Vec<String>,
+        previous_deprioritized_tools: Vec<String>,
+        label: impl Into<String>,
+    ) {
+        self.record_session_state_rollback(
+            label.into(),
+            SessionStateRollbackAction::ToolPreferences {
+                previous_pinned_tools,
+                previous_deprioritized_tools,
+            },
+        );
+    }
+
+    fn record_adjust_config_rollback(
+        &self,
+        path: impl Into<String>,
+        old_value: Value,
+        snapshot: crate::observability_integration::ObservabilitySessionRollbackSnapshot,
+    ) {
+        let path = path.into();
+        self.record_session_state_rollback(
+            format!("adjust_config:{path}"),
+            SessionStateRollbackAction::ConfigOverride {
+                path,
+                old_value,
+                snapshot,
+            },
+        );
+    }
+
+    fn record_goal_rollback(
+        &self,
+        previous_goal: Option<String>,
+        snapshot: crate::observability_integration::ObservabilitySessionRollbackSnapshot,
+    ) {
+        self.record_session_state_rollback(
+            "set_goal".to_string(),
+            SessionStateRollbackAction::GoalOverride {
+                previous_goal,
+                snapshot,
+            },
+        );
+    }
+
+    fn record_compression_rollback(
+        &self,
+        turn: u32,
+        snapshot: crate::observability_integration::ObservabilitySessionRollbackSnapshot,
+    ) {
+        self.record_session_state_rollback(
+            format!("compress_context:turn-{turn}"),
+            SessionStateRollbackAction::Compression { turn, snapshot },
+        );
+    }
+
+    fn record_task_state_rollback(&self, snapshot: TaskManagerSnapshot, label: impl Into<String>) {
+        self.record_session_state_rollback(
+            label.into(),
+            SessionStateRollbackAction::TaskState { snapshot },
+        );
+    }
+
+    fn session_state_entries(&self) -> Vec<SessionStateRollbackEntry> {
+        match self.session_state_journal.lock() {
+            Ok(journal) => journal.list(),
+            Err(poisoned) => poisoned.into_inner().list(),
+        }
+    }
+
+    fn session_state_restore_plan_for_turn(
+        &self,
+        turn_index: u32,
+    ) -> Vec<SessionStateRollbackEntry> {
+        match self.session_state_journal.lock() {
+            Ok(journal) => journal.restore_plan_for_turn(turn_index),
+            Err(poisoned) => poisoned.into_inner().restore_plan_for_turn(turn_index),
+        }
+    }
+
+    fn session_state_restore_plan_for_turn_since(
+        &self,
+        turn_index: u32,
+        checkpoint: u64,
+    ) -> Vec<SessionStateRollbackEntry> {
+        match self.session_state_journal.lock() {
+            Ok(journal) => journal.restore_plan_for_turn_since(turn_index, checkpoint),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .restore_plan_for_turn_since(turn_index, checkpoint),
+        }
+    }
+
+    fn remove_session_state_rollback(&self, sequence: u64) {
+        match self.session_state_journal.lock() {
+            Ok(mut journal) => {
+                journal.remove_sequence(sequence);
+            }
+            Err(poisoned) => {
+                poisoned.into_inner().remove_sequence(sequence);
+            }
+        }
+    }
+
+    fn restore_observability_snapshot(
+        &self,
+        snapshot: &crate::observability_integration::ObservabilitySessionRollbackSnapshot,
+    ) -> Result<(), String> {
+        let Some(observability_session) = self.observability_session.as_ref() else {
+            return Err("No observability session available".to_string());
+        };
+        let mut session = observability_session
+            .write()
+            .map_err(|_| "Failed to acquire observability session".to_string())?;
+        session.restore_rollback_snapshot(snapshot);
+        Ok(())
+    }
+
+    fn rollback_session_state_entry_json(entry: &SessionStateRollbackEntry) -> Value {
+        let timestamp_ms = entry
+            .timestamp
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .ok()
+            .map(|duration| duration.as_millis())
+            .and_then(|millis| u64::try_from(millis).ok());
+        let mut value = serde_json::Map::from_iter([
+            ("label".to_string(), Value::String(entry.label.clone())),
+            (
+                "kind".to_string(),
+                Value::String(action_kind(&entry.action).to_string()),
+            ),
+            (
+                "turn_index".to_string(),
+                Value::Number(serde_json::Number::from(entry.turn_index)),
+            ),
+        ]);
+        if let Some(timestamp_ms) = timestamp_ms {
+            value.insert(
+                "timestamp_ms".to_string(),
+                Value::Number(serde_json::Number::from(timestamp_ms)),
+            );
+        }
+        match &entry.action {
+            SessionStateRollbackAction::ConfigOverride { path, .. } => {
+                value.insert("path".to_string(), Value::String(path.clone()));
+            }
+            SessionStateRollbackAction::GoalOverride { previous_goal, .. } => {
+                value.insert(
+                    "previous_goal".to_string(),
+                    previous_goal
+                        .clone()
+                        .map(Value::String)
+                        .unwrap_or(Value::Null),
+                );
+            }
+            SessionStateRollbackAction::Compression { turn, .. } => {
+                value.insert(
+                    "turn".to_string(),
+                    Value::Number(serde_json::Number::from(*turn)),
+                );
+            }
+            SessionStateRollbackAction::ToolPreferences { .. }
+            | SessionStateRollbackAction::TaskState { .. } => {}
+        }
+        Value::Object(value)
+    }
+
+    fn rollback_session_state_entry(
+        &self,
+        entry: &SessionStateRollbackEntry,
+    ) -> Result<(), String> {
+        match &entry.action {
+            SessionStateRollbackAction::ToolPreferences {
+                previous_pinned_tools,
+                previous_deprioritized_tools,
+            } => {
+                let mut pinned = self
+                    .self_mod_pinned_tools
+                    .lock()
+                    .map_err(|_| "Failed to access pinned tools".to_string())?;
+                let mut deprioritized = self
+                    .self_mod_deprioritized_tools
+                    .lock()
+                    .map_err(|_| "Failed to access deprioritized tools".to_string())?;
+                let current_pinned = pinned.clone();
+                let current_deprioritized = deprioritized.clone();
+                *pinned = previous_pinned_tools.clone();
+                *deprioritized = previous_deprioritized_tools.clone();
+                if let Err(error) = persist_tool_preferences(
+                    &self.session_id,
+                    &pinned,
+                    &deprioritized,
+                    "server_tool_executor:rollback_session_state",
+                ) {
+                    *pinned = current_pinned;
+                    *deprioritized = current_deprioritized;
+                    return Err(format!(
+                        "failed to persist restored tool preferences: {error}"
+                    ));
+                }
+                Ok(())
+            }
+            SessionStateRollbackAction::ConfigOverride {
+                path,
+                old_value,
+                snapshot,
+            } => {
+                self.restore_observability_snapshot(snapshot)?;
+                persist_config_override(
+                    &self.session_id,
+                    path,
+                    old_value.clone(),
+                    "server_tool_executor:rollback_session_state",
+                )
+                .map_err(|error| {
+                    format!("failed to persist restored config override for {path}: {error}")
+                })
+            }
+            SessionStateRollbackAction::GoalOverride {
+                previous_goal,
+                snapshot,
+            } => {
+                self.restore_observability_snapshot(snapshot)?;
+                match previous_goal.as_deref() {
+                    Some(goal) => persist_goal_override(
+                        &self.session_id,
+                        goal,
+                        "server_tool_executor:rollback_session_state",
+                    )
+                    .map_err(|error| {
+                        format!("failed to persist restored goal override: {error}")
+                    })?,
+                    None => clear_persisted_goal_override(&self.session_id)?,
+                }
+                Ok(())
+            }
+            SessionStateRollbackAction::Compression { snapshot, .. } => {
+                self.restore_observability_snapshot(snapshot)
+            }
+            SessionStateRollbackAction::TaskState { snapshot } => {
+                self.task_manager.restore_snapshot(snapshot)
+            }
+        }
+    }
+
+    fn task_create(&self, args: &Value) -> String {
+        let snapshot = self.task_manager.snapshot_state();
+        let output = self.task_manager.create(args);
+        if !output.starts_with("Error:") {
+            self.record_task_state_rollback(
+                snapshot,
+                format!(
+                    "task_create:{}",
+                    args.get("title").and_then(Value::as_str).unwrap_or("task")
+                ),
+            );
+        }
+        output
+    }
+
+    fn task_list(&self, args: &Value) -> String {
+        self.task_manager.list(args)
+    }
+
+    fn task_get(&self, args: &Value) -> String {
+        self.task_manager.get(args)
+    }
+
+    fn task_update(&self, args: &Value) -> String {
+        let snapshot = self.task_manager.snapshot_state();
+        let output = self.task_manager.update(args);
+        if !output.starts_with("Error:")
+            && serde_json::from_str::<Value>(&output)
+                .ok()
+                .and_then(|value| value.get("success").and_then(Value::as_bool))
+                .unwrap_or(false)
+        {
+            self.record_task_state_rollback(
+                snapshot,
+                format!(
+                    "task_update:{}",
+                    args.get("task_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or("task")
+                ),
+            );
+        }
+        output
+    }
+
+    fn task_stop(&self, args: &Value) -> String {
+        let snapshot = self.task_manager.snapshot_state();
+        let output = self.task_manager.stop(args);
+        if !output.starts_with("Error:")
+            && serde_json::from_str::<Value>(&output)
+                .ok()
+                .and_then(|value| value.get("success").and_then(Value::as_bool))
+                .unwrap_or(false)
+        {
+            self.record_task_state_rollback(
+                snapshot,
+                format!(
+                    "task_stop:{}",
+                    args.get("task_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or("task")
+                ),
+            );
+        }
+        output
+    }
+
+    fn adjust_config(&self, args: &Value) -> String {
+        let path = match args.get("path").and_then(Value::as_str) {
+            Some(path) if !path.trim().is_empty() => path.trim(),
+            _ => return json!({"error": "Missing required parameter: path"}).to_string(),
+        };
+        let value = match args.get("value") {
+            Some(value) => value,
+            None => return json!({"error": "Missing required parameter: value"}).to_string(),
+        };
+        let force = args.get("force").and_then(Value::as_bool).unwrap_or(false);
+
+        let Some(observability_session) = self.observability_session.as_ref() else {
+            return json!({"error": "No observability session available"}).to_string();
+        };
+        let mut session = match observability_session.write() {
+            Ok(guard) => guard,
+            Err(_) => {
+                return json!({"error": "Failed to acquire observability session"}).to_string();
+            }
+        };
+
+        let turn = session.turn_number;
+        let constraints = crate::self_model::ConstraintSet::default();
+        let mut counter = match self.self_mod_mutation_counter.lock() {
+            Ok(counter) => counter,
+            Err(_) => return json!({"error": "Failed to access mutation counter"}).to_string(),
+        };
+        if counter.0 != turn {
+            *counter = (turn, 0);
+        }
+        if !force && counter.1 >= constraints.max_mutations_per_turn {
+            return json!({
+                "error": "mutation_limit_exceeded",
+                "turn": turn,
+                "max_mutations_per_turn": constraints.max_mutations_per_turn,
+                "hint": "Set force=true to override governor once.",
+            })
+            .to_string();
+        }
+
+        let parse_u32 =
+            |value: &Value| value.as_u64().and_then(|number| u32::try_from(number).ok());
+        let parse_f64 = |value: &Value| value.as_f64();
+        let ceiling = constraints.config_drift_ceiling;
+        let session_snapshot = session.rollback_snapshot();
+        let (old_value, new_value, drift) = match path {
+            "compression.compression_threshold" => {
+                let Some(new) = parse_f64(value) else {
+                    return json!({"error": "value must be a number"}).to_string();
+                };
+                if !(0.5..=0.98).contains(&new) {
+                    return json!({"error": "compression.compression_threshold must be within [0.5, 0.98]"}).to_string();
+                }
+                let old = session.config.compression.compression_threshold;
+                let drift = normalized_drift(old, new);
+                if let Some(drift_value) = drift
+                    && !force
+                    && drift_value > ceiling
+                {
+                    return json!({
+                        "error": "config_drift_ceiling_exceeded",
+                        "path": path,
+                        "old": old,
+                        "new": new,
+                        "drift": drift_value,
+                        "ceiling": ceiling,
+                    })
+                    .to_string();
+                }
+                session.config.compression.compression_threshold = new;
+                (json!(old), json!(new), drift)
+            }
+            "memory.retrieval_top_k" => {
+                let Some(new) = parse_u32(value) else {
+                    return json!({"error": "value must be an integer"}).to_string();
+                };
+                if !(1..=20).contains(&new) {
+                    return json!({"error": "memory.retrieval_top_k must be within [1, 20]"})
+                        .to_string();
+                }
+                let old = session.config.memory.retrieval_top_k;
+                let drift = normalized_drift(old as f64, new as f64);
+                if let Some(drift_value) = drift
+                    && !force
+                    && drift_value > ceiling
+                {
+                    return json!({
+                        "error": "config_drift_ceiling_exceeded",
+                        "path": path,
+                        "old": old,
+                        "new": new,
+                        "drift": drift_value,
+                        "ceiling": ceiling,
+                    })
+                    .to_string();
+                }
+                session.config.memory.retrieval_top_k = new;
+                (json!(old), json!(new), drift)
+            }
+            "tool_selection.max_tools" => {
+                let Some(new) = parse_u32(value) else {
+                    return json!({"error": "value must be an integer"}).to_string();
+                };
+                if !(5..=80).contains(&new) {
+                    return json!({"error": "tool_selection.max_tools must be within [5, 80]"})
+                        .to_string();
+                }
+                let old = session.config.tool_selection.max_tools;
+                let drift = normalized_drift(old as f64, new as f64);
+                if let Some(drift_value) = drift
+                    && !force
+                    && drift_value > ceiling
+                {
+                    return json!({
+                        "error": "config_drift_ceiling_exceeded",
+                        "path": path,
+                        "old": old,
+                        "new": new,
+                        "drift": drift_value,
+                        "ceiling": ceiling,
+                    })
+                    .to_string();
+                }
+                session.config.tool_selection.max_tools = new;
+                (json!(old), json!(new), drift)
+            }
+            "tool_selection.tool_budget_tokens" => {
+                let Some(new) = parse_u32(value) else {
+                    return json!({"error": "value must be an integer"}).to_string();
+                };
+                if new > 40_000 {
+                    return json!({"error": "tool_selection.tool_budget_tokens must be within [0, 40000]"}).to_string();
+                }
+                let old = session.config.tool_selection.tool_budget_tokens;
+                let drift = normalized_drift(old as f64, new as f64);
+                if let Some(drift_value) = drift
+                    && !force
+                    && drift_value > ceiling
+                {
+                    return json!({
+                        "error": "config_drift_ceiling_exceeded",
+                        "path": path,
+                        "old": old,
+                        "new": new,
+                        "drift": drift_value,
+                        "ceiling": ceiling,
+                    })
+                    .to_string();
+                }
+                session.config.tool_selection.tool_budget_tokens = new;
+                (json!(old), json!(new), drift)
+            }
+            "token_budget.max_turn_input_tokens" => {
+                let Some(new) = parse_u32(value) else {
+                    return json!({"error": "value must be an integer"}).to_string();
+                };
+                if !(8_000..=200_000).contains(&new) {
+                    return json!({"error": "token_budget.max_turn_input_tokens must be within [8000, 200000]"}).to_string();
+                }
+                let old = session.config.token_budget.max_turn_input_tokens;
+                let drift = normalized_drift(old as f64, new as f64);
+                if let Some(drift_value) = drift
+                    && !force
+                    && drift_value > ceiling
+                {
+                    return json!({
+                        "error": "config_drift_ceiling_exceeded",
+                        "path": path,
+                        "old": old,
+                        "new": new,
+                        "drift": drift_value,
+                        "ceiling": ceiling,
+                    })
+                    .to_string();
+                }
+                session.config.token_budget.max_turn_input_tokens = new;
+                (json!(old), json!(new), drift)
+            }
+            "token_budget.tools_reserve" => {
+                let Some(new) = parse_u32(value) else {
+                    return json!({"error": "value must be an integer"}).to_string();
+                };
+                if !(1_000..=40_000).contains(&new) {
+                    return json!({"error": "token_budget.tools_reserve must be within [1000, 40000]"}).to_string();
+                }
+                let old = session.config.token_budget.tools_reserve;
+                let drift = normalized_drift(old as f64, new as f64);
+                if let Some(drift_value) = drift
+                    && !force
+                    && drift_value > ceiling
+                {
+                    return json!({
+                        "error": "config_drift_ceiling_exceeded",
+                        "path": path,
+                        "old": old,
+                        "new": new,
+                        "drift": drift_value,
+                        "ceiling": ceiling,
+                    })
+                    .to_string();
+                }
+                session.config.token_budget.tools_reserve = new;
+                (json!(old), json!(new), drift)
+            }
+            "verification.strictness" => {
+                let Some(new) = parse_f64(value) else {
+                    return json!({"error": "value must be a number"}).to_string();
+                };
+                if !(0.2..=0.95).contains(&new) {
+                    return json!({"error": "verification.strictness must be within [0.2, 0.95]"})
+                        .to_string();
+                }
+                let old = session.config.verification.strictness;
+                let drift = normalized_drift(old, new);
+                if let Some(drift_value) = drift
+                    && !force
+                    && drift_value > ceiling
+                {
+                    return json!({
+                        "error": "config_drift_ceiling_exceeded",
+                        "path": path,
+                        "old": old,
+                        "new": new,
+                        "drift": drift_value,
+                        "ceiling": ceiling,
+                    })
+                    .to_string();
+                }
+                session.config.verification.strictness = new;
+                (json!(old), json!(new), drift)
+            }
+            _ => {
+                return json!({
+                    "error": "Unsupported config path",
+                    "path": path,
+                    "supported_paths": [
+                        "compression.compression_threshold",
+                        "memory.retrieval_top_k",
+                        "tool_selection.max_tools",
+                        "tool_selection.tool_budget_tokens",
+                        "token_budget.max_turn_input_tokens",
+                        "token_budget.tools_reserve",
+                        "verification.strictness",
+                    ],
+                })
+                .to_string();
+            }
+        };
+
+        if let Err(error) = persist_config_override(
+            &self.session_id,
+            path,
+            new_value.clone(),
+            "server_tool_executor:adjust_config",
+        ) {
+            session.restore_rollback_snapshot(&session_snapshot);
+            return json!({
+                "error": "failed_to_persist_config_override",
+                "path": path,
+                "detail": error,
+            })
+            .to_string();
+        }
+
+        counter.1 += 1;
+        self.record_adjust_config_rollback(path.to_string(), old_value.clone(), session_snapshot);
+        json!({
+            "status": "ok",
+            "path": path,
+            "old": old_value,
+            "new": new_value,
+            "turn": turn,
+            "mutations_this_turn": counter.1,
+            "max_mutations_per_turn": constraints.max_mutations_per_turn,
+            "drift": drift,
+            "drift_ceiling": ceiling,
+        })
+        .to_string()
+    }
+
+    fn prioritize_tool(&self, args: &Value) -> String {
+        let Some(tool) = extract_tool_name(args) else {
+            return json!({"error": "Missing required parameter: tool"}).to_string();
+        };
+        if !supports_server_tool_name(&tool) {
+            return json!({"error": format!("Unknown tool: {tool}")}).to_string();
+        }
+
+        let mut pinned = match self.self_mod_pinned_tools.lock() {
+            Ok(pinned) => pinned,
+            Err(_) => return json!({"error": "Failed to access pinned tools"}).to_string(),
+        };
+        let mut deprioritized = match self.self_mod_deprioritized_tools.lock() {
+            Ok(deprioritized) => deprioritized,
+            Err(_) => return json!({"error": "Failed to access deprioritized tools"}).to_string(),
+        };
+        let original_pinned = pinned.clone();
+        let original_deprioritized = deprioritized.clone();
+
+        if !pinned.contains(&tool) {
+            pinned.push(tool.clone());
+        }
+        pinned.sort();
+        deprioritized.retain(|entry| entry != &tool);
+
+        if let Err(error) = persist_tool_preferences(
+            &self.session_id,
+            &pinned,
+            &deprioritized,
+            "server_tool_executor:prioritize_tool",
+        ) {
+            *pinned = original_pinned;
+            *deprioritized = original_deprioritized;
+            return json!({
+                "error": "failed_to_persist_tool_preferences",
+                "detail": error,
+                "tool": tool,
+            })
+            .to_string();
+        }
+
+        let changed = original_pinned != *pinned || original_deprioritized != *deprioritized;
+        if changed {
+            self.record_tool_preferences_rollback(
+                original_pinned.clone(),
+                original_deprioritized.clone(),
+                format!("prioritize_tool:{tool}"),
+            );
+        }
+        json!({
+            "status": "ok",
+            "prioritized_tool": tool,
+            "previous_pinned_tools": original_pinned,
+            "previous_deprioritized_tools": original_deprioritized,
+            "pinned_tools": pinned.clone(),
+            "deprioritized_tools": deprioritized.clone(),
+        })
+        .to_string()
+    }
+
+    fn deprioritize_tool(&self, args: &Value) -> String {
+        let Some(tool) = extract_tool_name(args) else {
+            return json!({"error": "Missing required parameter: tool"}).to_string();
+        };
+        if !supports_server_tool_name(&tool) {
+            return json!({"error": format!("Unknown tool: {tool}")}).to_string();
+        }
+
+        let mut pinned = match self.self_mod_pinned_tools.lock() {
+            Ok(pinned) => pinned,
+            Err(_) => return json!({"error": "Failed to access pinned tools"}).to_string(),
+        };
+        let mut deprioritized = match self.self_mod_deprioritized_tools.lock() {
+            Ok(deprioritized) => deprioritized,
+            Err(_) => return json!({"error": "Failed to access deprioritized tools"}).to_string(),
+        };
+        let original_pinned = pinned.clone();
+        let original_deprioritized = deprioritized.clone();
+
+        if !deprioritized.contains(&tool) {
+            deprioritized.push(tool.clone());
+        }
+        deprioritized.sort();
+        pinned.retain(|entry| entry != &tool);
+
+        if let Err(error) = persist_tool_preferences(
+            &self.session_id,
+            &pinned,
+            &deprioritized,
+            "server_tool_executor:deprioritize_tool",
+        ) {
+            *pinned = original_pinned;
+            *deprioritized = original_deprioritized;
+            return json!({
+                "error": "failed_to_persist_tool_preferences",
+                "detail": error,
+                "tool": tool,
+            })
+            .to_string();
+        }
+
+        let changed = original_pinned != *pinned || original_deprioritized != *deprioritized;
+        if changed {
+            self.record_tool_preferences_rollback(
+                original_pinned.clone(),
+                original_deprioritized.clone(),
+                format!("deprioritize_tool:{tool}"),
+            );
+        }
+        json!({
+            "status": "ok",
+            "deprioritized_tool": tool,
+            "previous_pinned_tools": original_pinned,
+            "previous_deprioritized_tools": original_deprioritized,
+            "pinned_tools": pinned.clone(),
+            "deprioritized_tools": deprioritized.clone(),
+        })
+        .to_string()
+    }
+
+    fn set_goal(&self, args: &Value) -> String {
+        let goal = match args.get("goal").and_then(Value::as_str) {
+            Some(goal) if !goal.trim().is_empty() => goal.trim(),
+            _ => return json!({"error": "Missing required parameter: goal"}).to_string(),
+        };
+        let Some(observability_session) = self.observability_session.as_ref() else {
+            return json!({"error": "No observability session available"}).to_string();
+        };
+        let mut session = match observability_session.write() {
+            Ok(guard) => guard,
+            Err(_) => {
+                return json!({"error": "Failed to acquire observability session"}).to_string();
+            }
+        };
+        let session_snapshot = session.rollback_snapshot();
+        let previous_goal = session
+            .goal_tracker
+            .as_ref()
+            .map(|tracker| tracker.goal().to_string())
+            .or_else(|| session.original_query.clone());
+
+        if let Err(error) =
+            persist_goal_override(&self.session_id, goal, "server_tool_executor:set_goal")
+        {
+            return json!({
+                "error": "failed_to_persist_goal",
+                "detail": error,
+                "goal": goal,
+            })
+            .to_string();
+        }
+
+        let goal_changed = session.steer_goal(goal);
+        if goal_changed {
+            self.record_goal_rollback(previous_goal.clone(), session_snapshot);
+        }
+
+        json!({
+            "status": "ok",
+            "previous_goal": previous_goal,
+            "goal": goal,
+            "goal_changed": goal_changed,
+            "turn": session.turn_number,
+        })
+        .to_string()
+    }
+
+    fn compress_context(&self, args: &Value) -> String {
+        let reason = args
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or("manual_request");
+        let Some(observability_session) = self.observability_session.as_ref() else {
+            return json!({"error": "No observability session available"}).to_string();
+        };
+        let mut session = match observability_session.write() {
+            Ok(guard) => guard,
+            Err(_) => {
+                return json!({"error": "Failed to acquire observability session"}).to_string();
+            }
+        };
+        let session_snapshot = session.rollback_snapshot();
+
+        let turn = if session.turn_number == 0 {
+            1
+        } else {
+            session.turn_number
+        };
+        let previous_compression_count = session.compressed_turns.len();
+        let already_compressed_this_turn = session.compressed_turns.contains(&turn);
+
+        if let Err(error) = persist_manual_compression(
+            &self.session_id,
+            turn,
+            reason,
+            "server_tool_executor:compress_context",
+        ) {
+            return json!({
+                "error": "failed_to_persist_manual_compression",
+                "detail": error,
+                "turn": turn,
+                "reason": reason,
+            })
+            .to_string();
+        }
+
+        session.record_compression(turn);
+        self.record_compression_rollback(turn, session_snapshot);
+
+        json!({
+            "status": "ok",
+            "turn": turn,
+            "reason": reason,
+            "previous_compression_count": previous_compression_count,
+            "already_compressed_this_turn": already_compressed_this_turn,
+            "compression_count": session.compressed_turns.len(),
+        })
+        .to_string()
+    }
+
+    pub(crate) fn rollback_session_state(&self, args: &Value) -> String {
+        let scope = args
+            .get("scope")
+            .and_then(Value::as_str)
+            .unwrap_or("current_turn");
+        let explicit_turn_index = if scope == "turn" {
+            match args.get("turn_index").and_then(Value::as_u64) {
+                Some(turn_index) => Some(turn_index),
+                None => {
+                    return json!({
+                        "success": false,
+                        "error": "missing 'turn_index' for scope=turn",
+                    })
+                    .to_string();
+                }
+            }
+        } else {
+            None
+        };
+        let checkpoint = args
+            .get("session_state_after_sequence")
+            .or_else(|| args.get("after_sequence"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+
+        match scope {
+            "list" => {
+                let entries = self
+                    .session_state_entries()
+                    .into_iter()
+                    .map(|entry| Self::rollback_session_state_entry_json(&entry))
+                    .collect::<Vec<_>>();
+                json!({
+                    "success": true,
+                    "scope": "list",
+                    "total_entries": entries.len(),
+                    "entries": entries,
+                    "summary": format!(
+                        "Listed {} recorded session-state rollback entr{}",
+                        entries.len(),
+                        if entries.len() == 1 { "y" } else { "ies" },
+                    ),
+                })
+                .to_string()
+            }
+            "turn" | "current_turn" => {
+                let turn_index = explicit_turn_index
+                    .unwrap_or_else(|| self.journal_turn_index.load(Ordering::Relaxed) as u64)
+                    as u32;
+                let plan = if checkpoint > 0 {
+                    self.session_state_restore_plan_for_turn_since(turn_index, checkpoint)
+                } else {
+                    self.session_state_restore_plan_for_turn(turn_index)
+                };
+                let mut restored = Vec::new();
+                let mut failed = Vec::new();
+                for entry in &plan {
+                    match self.rollback_session_state_entry(entry) {
+                        Ok(()) => {
+                            self.remove_session_state_rollback(entry.sequence);
+                            restored.push(Self::rollback_session_state_entry_json(entry));
+                        }
+                        Err(error) => {
+                            let mut failed_entry = Self::rollback_session_state_entry_json(entry)
+                                .as_object()
+                                .cloned()
+                                .unwrap_or_default();
+                            failed_entry.insert("error".to_string(), Value::String(error));
+                            failed.push(Value::Object(failed_entry));
+                        }
+                    }
+                }
+                let success = !restored.is_empty() && failed.is_empty();
+                let summary = if plan.is_empty() {
+                    format!(
+                        "No recorded session-state rollback handles found for turn {turn_index}"
+                    )
+                } else if failed.is_empty() {
+                    format!(
+                        "Restored {} recorded session-state mutation{} for turn {turn_index}",
+                        restored.len(),
+                        if restored.len() == 1 { "" } else { "s" },
+                    )
+                } else {
+                    format!(
+                        "Restored {} recorded session-state mutation{} for turn {turn_index} with {} failure{}",
+                        restored.len(),
+                        if restored.len() == 1 { "" } else { "s" },
+                        failed.len(),
+                        if failed.len() == 1 { "" } else { "s" },
+                    )
+                };
+                json!({
+                    "success": success,
+                    "scope": scope,
+                    "turn_index": turn_index,
+                    "restored": restored,
+                    "failed": failed,
+                    "summary": summary,
+                })
+                .to_string()
+            }
+            other => json!({
+                "success": false,
+                "error": format!(
+                    "unknown scope `{other}`. Supported: current_turn, turn, list"
+                ),
+            })
+            .to_string(),
+        }
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -450,7 +2670,7 @@ impl ServerToolExecutor {
         // Record journal entry
         if let Ok(mut journal) = self.file_journal.lock() {
             let turn_idx = self.journal_turn_index.load(Ordering::Relaxed);
-            journal.record_before(&path, "server-str-replace", turn_idx);
+            journal.record_before_patch(&path, "server-str-replace", turn_idx);
         }
 
         let new_content = content.replacen(old_str, new_str, 1);
@@ -479,14 +2699,190 @@ impl ServerToolExecutor {
             return format!("Error: File not found: {path_str}");
         }
 
-        if let Ok(mut journal) = self.file_journal.lock() {
-            let turn_idx = self.journal_turn_index.load(Ordering::Relaxed);
-            journal.record_before(&path, "server-delete", turn_idx);
-        }
+        let before_content = match std::fs::read(&path) {
+            Ok(content) => content,
+            Err(e) => return format!("Error: Cannot read file before delete: {e}"),
+        };
+        let turn_idx = self.journal_turn_index.load(Ordering::Relaxed);
 
         match std::fs::remove_file(&path) {
-            Ok(()) => format!("Successfully deleted {path_str}"),
+            Ok(()) => {
+                if let Ok(mut journal) = self.file_journal.lock() {
+                    journal.record_delete(&path, "server-delete", turn_idx, before_content);
+                }
+                format!("Successfully deleted {path_str}")
+            }
             Err(e) => format!("Error: Cannot delete file: {e}"),
+        }
+    }
+
+    fn rollback_display_path(&self, path: &Path) -> String {
+        path.strip_prefix(&self.workspace_root)
+            .unwrap_or(path)
+            .display()
+            .to_string()
+    }
+
+    pub(crate) fn rollback_file_edits(&self, args: &Value) -> String {
+        let scope = args
+            .get("scope")
+            .and_then(Value::as_str)
+            .or_else(|| {
+                if args.get("path").is_some() {
+                    Some("file")
+                } else {
+                    None
+                }
+            })
+            .unwrap_or("current_turn");
+
+        match scope {
+            "list" => {
+                let summary = match self.file_journal.lock() {
+                    Ok(journal) => journal.summary(),
+                    Err(poisoned) => poisoned.into_inner().summary(),
+                };
+                let entries: Vec<Value> = summary
+                    .into_iter()
+                    .map(|(path, turn_index, edit_type)| {
+                        json!({
+                            "path": self.rollback_display_path(&path),
+                            "turn_index": turn_index,
+                            "edit_type": edit_type_label(edit_type),
+                        })
+                    })
+                    .collect();
+                json!({
+                    "success": true,
+                    "scope": "list",
+                    "total_entries": entries.len(),
+                    "entries": entries,
+                })
+                .to_string()
+            }
+            "file" => {
+                let raw_path = match args.get("path").and_then(Value::as_str) {
+                    Some(path) => path,
+                    None => {
+                        return json!({
+                            "success": false,
+                            "error": "missing 'path' for scope=file",
+                        })
+                        .to_string();
+                    }
+                };
+                let path = match self.resolve_path(raw_path) {
+                    Ok(path) => path,
+                    Err(error) => return error,
+                };
+                let undo_result = match self.file_journal.lock() {
+                    Ok(journal) => journal.undo_file(&path),
+                    Err(poisoned) => poisoned.into_inner().undo_file(&path),
+                };
+                match undo_result {
+                    Ok(Some(edit_type)) => json!({
+                        "success": true,
+                        "scope": "file",
+                        "path": self.rollback_display_path(&path),
+                        "edit_type": edit_type_label(edit_type),
+                        "summary": format!(
+                            "Rolled back the latest recorded edit for {}",
+                            self.rollback_display_path(&path)
+                        ),
+                    })
+                    .to_string(),
+                    Ok(None) => json!({
+                        "success": false,
+                        "scope": "file",
+                        "path": self.rollback_display_path(&path),
+                        "error": "no recorded file edit found for that path",
+                    })
+                    .to_string(),
+                    Err(error) => json!({
+                        "success": false,
+                        "scope": "file",
+                        "path": self.rollback_display_path(&path),
+                        "error": error.to_string(),
+                    })
+                    .to_string(),
+                }
+            }
+            "turn" | "current_turn" => {
+                let turn_index = if scope == "turn" {
+                    match args.get("turn_index").and_then(Value::as_u64) {
+                        Some(turn_index) => turn_index as u32,
+                        None => {
+                            return json!({
+                                "success": false,
+                                "error": "missing 'turn_index' for scope=turn",
+                            })
+                            .to_string();
+                        }
+                    }
+                } else {
+                    self.journal_turn_index.load(Ordering::Relaxed)
+                };
+                let checkpoint = args
+                    .get("file_after_sequence")
+                    .or_else(|| args.get("after_sequence"))
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+                let result = match self.file_journal.lock() {
+                    Ok(journal) => journal.undo_turn_since(turn_index, checkpoint),
+                    Err(poisoned) => poisoned
+                        .into_inner()
+                        .undo_turn_since(turn_index, checkpoint),
+                };
+                let reverted: Vec<String> = result
+                    .reverted
+                    .iter()
+                    .map(|path| self.rollback_display_path(path))
+                    .collect();
+                let failed: Vec<Value> = result
+                    .failed
+                    .iter()
+                    .map(|(path, error)| {
+                        json!({
+                            "path": self.rollback_display_path(path),
+                            "error": error,
+                        })
+                    })
+                    .collect();
+                let success = !reverted.is_empty() && failed.is_empty();
+                let summary = if reverted.is_empty() {
+                    format!("No recorded file edits found for turn {turn_index}")
+                } else if failed.is_empty() {
+                    format!(
+                        "Rolled back {} file edit{} from turn {turn_index}",
+                        reverted.len(),
+                        if reverted.len() == 1 { "" } else { "s" }
+                    )
+                } else {
+                    format!(
+                        "Rolled back {} file edit{} from turn {turn_index} with {} failure{}",
+                        reverted.len(),
+                        if reverted.len() == 1 { "" } else { "s" },
+                        failed.len(),
+                        if failed.len() == 1 { "" } else { "s" }
+                    )
+                };
+                json!({
+                    "success": success,
+                    "scope": scope,
+                    "turn_index": turn_index,
+                    "reverted": reverted,
+                    "failed": failed,
+                    "summary": summary,
+                })
+                .to_string()
+            }
+            other => json!({
+                "success": false,
+                "error": format!(
+                    "invalid 'scope': {other} (expected one of current_turn, turn, file, list)"
+                ),
+            })
+            .to_string(),
         }
     }
 
@@ -575,11 +2971,109 @@ fn uuid_v4_short() -> String {
     format!("{:08x}", (ts & 0xFFFF_FFFF) as u32)
 }
 
+fn edit_type_label(edit_type: EditType) -> &'static str {
+    match edit_type {
+        EditType::Create => "create",
+        EditType::Overwrite => "overwrite",
+        EditType::Patch => "patch",
+        EditType::Delete => "delete",
+    }
+}
+
+fn tool_result_from_output(output: String) -> astra_tools::ToolResult {
+    let parsed = serde_json::from_str::<Value>(&output).ok();
+    let json_error = parsed
+        .as_ref()
+        .and_then(|value| value.get("success").and_then(Value::as_bool))
+        .is_some_and(|success| !success)
+        || parsed
+            .as_ref()
+            .and_then(|value| value.get("error"))
+            .is_some();
+    if output.starts_with("Error:") || output.starts_with("SANDBOX_DENIED:") || json_error {
+        astra_tools::ToolResult::error(output)
+    } else {
+        astra_tools::ToolResult::text(output)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
+    use std::path::Path;
+    use std::sync::{Mutex as StdMutex, MutexGuard, OnceLock};
+
     use super::*;
     use serde_json::json;
     use tempfile::TempDir;
+
+    fn env_guard() -> MutexGuard<'static, ()> {
+        static ENV_LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+        ENV_LOCK
+            .get_or_init(|| StdMutex::new(()))
+            .lock()
+            .expect("env lock poisoned")
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    fn set_env_var(key: &'static str, value: impl Into<OsString>) -> EnvVarGuard {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, value.into());
+        }
+        EnvVarGuard { key, previous }
+    }
+
+    #[cfg(unix)]
+    fn write_fake_mysql(dir: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = dir.join("mysql");
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+case "$*" in
+  *"SELECT current_account_name() AS name"*)
+    printf '+------+\n| name |\n+------+\n| sys  |\n+------+\n'
+    ;;
+  *"CREATE SNAPSHOT"*)
+    printf 'Query OK, 1 row affected\n'
+    ;;
+  *"RESTORE ACCOUNT"*)
+    printf 'Query OK, 1 row affected\n'
+    ;;
+  *"UPDATE metrics SET value = 1"*)
+    printf 'Query OK, 1 row affected\n'
+    ;;
+  *"SELECT 1"*)
+    printf '+---+\n| 1 |\n+---+\n| 1 |\n+---+\n'
+    ;;
+  *)
+    printf 'Query OK, 1 row affected\n'
+    ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+    }
 
     fn test_executor() -> (ServerToolExecutor, TempDir) {
         let dir = TempDir::new().unwrap();
@@ -591,6 +3085,44 @@ mod tests {
             None,
         );
         (exec, dir)
+    }
+
+    fn cleanup_session_artifacts(session_id: &str) {
+        std::fs::remove_dir_all(
+            astra_services::session_journal::local_sessions_dir().join(session_id),
+        )
+        .ok();
+    }
+
+    fn session_state_test_executor(
+        turn_index: u32,
+    ) -> (
+        ServerToolExecutor,
+        TempDir,
+        String,
+        std::sync::Arc<std::sync::RwLock<crate::observability_integration::ObservabilitySession>>,
+    ) {
+        let dir = TempDir::new().unwrap();
+        let session_id = format!("test-session-{}", uuid::Uuid::new_v4());
+        let mut workspace =
+            astra_services::session_workspace::WorkspaceMetadata::new(&session_id, "test-model");
+        workspace.cwd = dir.path().display().to_string();
+        astra_services::session_workspace::write_workspace(&workspace).unwrap();
+
+        let mut exec = ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            session_id.clone(),
+            None,
+            None,
+        );
+        let session = std::sync::Arc::new(std::sync::RwLock::new(
+            crate::observability_integration::ObservabilitySession::new_simple(&session_id),
+        ));
+        session.write().unwrap().turn_number = turn_index;
+        exec.set_observability_session(session.clone());
+        exec.set_turn_index(turn_index);
+        (exec, dir, session_id, session)
     }
 
     // ── Path traversal security ────────────────────────────────────────
@@ -824,6 +3356,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rollback_file_edits_current_turn_reverts_server_writes() {
+        let (exec, dir) = test_executor();
+        exec.set_turn_index(7);
+
+        let first = exec
+            .execute("write_file", &json!({"path": "a.txt", "content": "A"}))
+            .await;
+        let second = exec
+            .execute("write_file", &json!({"path": "b.txt", "content": "B"}))
+            .await;
+        assert!(first.contains("Successfully wrote"));
+        assert!(second.contains("Successfully wrote"));
+
+        let rollback = exec
+            .execute("rollback_file_edits", &json!({"scope": "current_turn"}))
+            .await;
+        let rollback_json: Value = serde_json::from_str(&rollback).unwrap();
+        assert_eq!(
+            rollback_json["success"].as_bool(),
+            Some(true),
+            "got: {rollback}"
+        );
+        assert_eq!(rollback_json["turn_index"].as_u64(), Some(7));
+        assert_eq!(rollback_json["reverted"].as_array().map(Vec::len), Some(2));
+
+        assert!(!dir.path().join("a.txt").exists());
+        assert!(!dir.path().join("b.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn rollback_file_edits_file_scope_restores_deleted_file() {
+        let (exec, dir) = test_executor();
+        let target = dir.path().join("gone.txt");
+        std::fs::write(&target, "restore me").unwrap();
+
+        let deleted = exec
+            .execute("delete_file", &json!({"path": "gone.txt"}))
+            .await;
+        assert!(deleted.contains("Successfully deleted"));
+        assert!(!target.exists());
+
+        let rollback = exec
+            .execute(
+                "rollback_file_edits",
+                &json!({"scope": "file", "path": "gone.txt"}),
+            )
+            .await;
+        let rollback_json: Value = serde_json::from_str(&rollback).unwrap();
+        assert_eq!(
+            rollback_json["success"].as_bool(),
+            Some(true),
+            "got: {rollback}"
+        );
+        assert_eq!(rollback_json["scope"].as_str(), Some("file"));
+        assert_eq!(rollback_json["path"].as_str(), Some("gone.txt"));
+        assert_eq!(rollback_json["edit_type"].as_str(), Some("delete"));
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "restore me");
+    }
+
+    #[tokio::test]
     async fn list_dir_shows_files_and_dirs() {
         let (exec, dir) = test_executor();
         std::fs::write(dir.path().join("a.txt"), "").unwrap();
@@ -962,6 +3554,169 @@ mod tests {
         // Request 999 — should be capped at 100
         let result = exec.execute("git_log", &json!({"n": 999})).await;
         assert!(result.contains("initial"));
+    }
+
+    #[tokio::test]
+    async fn rollback_database_snapshots_snapshot_scope_requires_snapshot_id() {
+        let (exec, _dir) = test_executor();
+        let value: Value =
+            serde_json::from_str(&exec.rollback_database_snapshots(&json!({"scope": "snapshot"})))
+                .expect("rollback_database_snapshots json");
+        assert_eq!(value["success"].as_bool(), Some(false));
+        assert_eq!(value["scope"].as_str(), Some("snapshot"));
+        assert!(
+            value["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("missing 'snapshot_id'")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mo_query_records_snapshot_and_rollback_restores_current_turn() {
+        let _guard = env_guard();
+        let fake_bin = TempDir::new().unwrap();
+        write_fake_mysql(fake_bin.path());
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        let joined = std::env::join_paths(
+            std::iter::once(fake_bin.path().to_path_buf()).chain(std::env::split_paths(&path)),
+        )
+        .unwrap();
+        let _path_guard = set_env_var("PATH", joined);
+
+        let (exec, _dir) = test_executor();
+        exec.set_turn_index(11);
+
+        let result = exec
+            .execute_with_metadata("mo_query", &json!({"sql": "UPDATE metrics SET value = 1"}))
+            .await;
+        assert!(!result.is_error, "got: {}", result.output);
+        let fields = result.metadata.as_ref().expect("mo_query metadata");
+        assert!(
+            fields["pre_state_snapshot_id"]
+                .as_str()
+                .is_some_and(|snapshot_id| snapshot_id.starts_with("moq_"))
+        );
+        let expected_database =
+            astra_core::resolve_matrixone_database_name(&|key| std::env::var(key).ok());
+        assert_eq!(
+            fields["pre_state_snapshot_database"].as_str(),
+            Some(expected_database.as_str())
+        );
+
+        let rollback = exec
+            .execute(
+                "rollback_database_snapshots",
+                &json!({"scope": "current_turn"}),
+            )
+            .await;
+        let rollback_json: Value = serde_json::from_str(&rollback).unwrap();
+        assert_eq!(
+            rollback_json["success"].as_bool(),
+            Some(true),
+            "got: {rollback}"
+        );
+        assert_eq!(rollback_json["turn_index"].as_u64(), Some(11));
+        assert_eq!(rollback_json["restored"].as_array().map(Vec::len), Some(1));
+    }
+
+    #[tokio::test]
+    async fn rollback_session_state_current_turn_restores_server_self_mod_and_tasks() {
+        let (exec, _dir, session_id, session) = session_state_test_executor(13);
+        let original_top_k = session.read().unwrap().config.memory.retrieval_top_k;
+        let new_top_k = if original_top_k < 20 {
+            original_top_k + 1
+        } else {
+            original_top_k.saturating_sub(1)
+        };
+
+        let adjust: Value = serde_json::from_str(
+            &exec
+                .execute(
+                    "adjust_config",
+                    &json!({"path": "memory.retrieval_top_k", "value": new_top_k}),
+                )
+                .await,
+        )
+        .unwrap();
+        assert_eq!(adjust["status"].as_str(), Some("ok"));
+
+        let prioritize: Value = serde_json::from_str(
+            &exec
+                .execute("prioritize_tool", &json!({"tool": "bash"}))
+                .await,
+        )
+        .unwrap();
+        assert_eq!(prioritize["status"].as_str(), Some("ok"));
+
+        let goal: Value = serde_json::from_str(
+            &exec
+                .execute("set_goal", &json!({"goal": "ship parity"}))
+                .await,
+        )
+        .unwrap();
+        assert_eq!(goal["status"].as_str(), Some("ok"));
+
+        let compress: Value = serde_json::from_str(
+            &exec
+                .execute("compress_context", &json!({"reason": "manual"}))
+                .await,
+        )
+        .unwrap();
+        assert_eq!(compress["status"].as_str(), Some("ok"));
+
+        let created: Value =
+            serde_json::from_str(&exec.execute("task_create", &json!({"title": "demo"})).await)
+                .unwrap();
+        let task_id = created["task_id"].as_str().unwrap().to_string();
+
+        let updated: Value = serde_json::from_str(
+            &exec
+                .execute(
+                    "task_update",
+                    &json!({"task_id": task_id.as_str(), "status": "in_progress"}),
+                )
+                .await,
+        )
+        .unwrap();
+        assert_eq!(updated["success"].as_bool(), Some(true));
+
+        let stopped: Value = serde_json::from_str(
+            &exec
+                .execute(
+                    "task_stop",
+                    &json!({"task_id": task_id.as_str(), "reason": "rollback test"}),
+                )
+                .await,
+        )
+        .unwrap();
+        assert_eq!(stopped["success"].as_bool(), Some(true));
+
+        let rollback: Value =
+            serde_json::from_str(&exec.execute("rollback_session_state", &json!({})).await)
+                .unwrap();
+        assert_eq!(rollback["success"].as_bool(), Some(true), "got: {rollback}");
+        assert_eq!(rollback["turn_index"].as_u64(), Some(13));
+        assert_eq!(rollback["restored"].as_array().map(Vec::len), Some(7));
+
+        let session = session.read().unwrap();
+        assert_eq!(session.config.memory.retrieval_top_k, original_top_k);
+        assert!(session.original_query.is_none());
+        assert!(session.goal_tracker.is_none());
+        assert!(session.compressed_turns.is_empty());
+        drop(session);
+
+        let task_list = exec.execute("task_list", &json!({})).await;
+        assert!(task_list.contains("No tasks found"));
+
+        let workspace = astra_services::session_workspace::read_workspace(&session_id).unwrap();
+        assert!(workspace.session_goal.is_none());
+        assert!(workspace.pinned_tools.is_empty());
+        assert!(workspace.deprioritized_tools.is_empty());
+        assert!(workspace.tuned_config_json.is_none());
+
+        cleanup_session_artifacts(&session_id);
     }
 
     // ── Memory tool user isolation ─────────────────────────────────────

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -98,6 +98,10 @@ impl DatabaseSnapshotRollbackJournal {
         plan
     }
 
+    fn checkpoint(&self) -> u64 {
+        self.next_sequence
+    }
+
     fn remove_snapshot(&mut self, snapshot_id: &str) -> bool {
         if let Some(index) = self
             .entries
@@ -827,6 +831,10 @@ fn mo_restore_snapshot_sql(name: &str, database: Option<&str>) -> String {
     )
 }
 
+fn mo_drop_snapshot_sql(name: &str) -> String {
+    format!("DROP SNAPSHOT IF EXISTS `{name}`")
+}
+
 fn mo_query_requires_pre_state_snapshot(sql: &str, allow_destructive: bool) -> bool {
     match sql
         .split_whitespace()
@@ -1285,6 +1293,13 @@ impl ServerToolExecutor {
         }
     }
 
+    pub(crate) fn database_snapshot_journal_checkpoint(&self) -> u64 {
+        match self.database_snapshot_journal.lock() {
+            Ok(journal) => journal.checkpoint(),
+            Err(poisoned) => poisoned.into_inner().checkpoint(),
+        }
+    }
+
     fn record_database_snapshot_rollback(
         &self,
         snapshot_id: impl Into<String>,
@@ -1361,12 +1376,20 @@ impl ServerToolExecutor {
         &self,
         entry: &DatabaseSnapshotRollbackEntry,
     ) -> Result<(), String> {
-        let output = mo_execute_sql(
+        let restore_output = mo_execute_sql(
             &mo_restore_snapshot_sql(&entry.snapshot_id, entry.database.as_deref()),
             None,
         );
-        if is_mo_error(&output) {
-            Err(output)
+        if is_mo_error(&restore_output) {
+            return Err(restore_output);
+        }
+
+        let drop_output = mo_execute_sql(&mo_drop_snapshot_sql(&entry.snapshot_id), None);
+        if is_mo_error(&drop_output) {
+            Err(format!(
+                "restored MatrixOne snapshot `{}` but failed to drop it afterwards.\n{}",
+                entry.snapshot_id, drop_output
+            ))
         } else {
             Ok(())
         }
@@ -3055,6 +3078,9 @@ case "$*" in
     printf 'Query OK, 1 row affected\n'
     ;;
   *"RESTORE ACCOUNT"*)
+    printf 'Query OK, 1 row affected\n'
+    ;;
+  *"DROP SNAPSHOT"*)
     printf 'Query OK, 1 row affected\n'
     ;;
   *"UPDATE metrics SET value = 1"*)

--- a/rust/crates/runtime/src/turn/action_compensation.rs
+++ b/rust/crates/runtime/src/turn/action_compensation.rs
@@ -396,7 +396,7 @@ fn rollback_file_tool_scope_hint(path: Option<&str>) -> String {
 }
 
 fn rollback_turn_tool_scope_hint() -> &'static str {
-    "use `rollback_turn_actions` with scope=`current_turn` to revert mixed file/database changes from the same turn"
+    "when available, use `rollback_turn_actions` with scope=`current_turn` to revert mixed file/database changes from the same turn"
 }
 
 fn restore_file_compensation_summary(path: Option<&str>, delete_if_created: bool) -> String {
@@ -460,23 +460,23 @@ fn tool_priority_compensation_summary(tool: Option<&str>) -> String {
 }
 
 fn set_goal_compensation_summary() -> &'static str {
-    "prefer `rollback_session_state` with scope=`current_turn` (or `rollback_turn_actions`) to restore the previous_goal and goal-tracking snapshot; rerun `set_goal` with the `previous_goal` from the tool result only as the manual fallback"
+    "prefer `rollback_session_state` with scope=`current_turn` (or, when available, `rollback_turn_actions`) to restore the previous_goal and goal-tracking snapshot; rerun `set_goal` with the `previous_goal` from the tool result only as the manual fallback"
 }
 
 fn compress_context_compensation_summary() -> &'static str {
-    "prefer `rollback_session_state` with scope=`current_turn` (or `rollback_turn_actions`) to restore session-local compression state; manual compression journal markers remain append-only if you inspect the persisted journal later"
+    "prefer `rollback_session_state` with scope=`current_turn` (or, when available, `rollback_turn_actions`) to restore session-local compression state; manual compression journal markers remain append-only if you inspect the persisted journal later"
 }
 
 fn task_create_compensation_summary() -> &'static str {
-    "prefer `rollback_session_state` with scope=`current_turn` (or `rollback_turn_actions`) to restore the pre-task snapshot; `task_stop` with the returned `task_id` remains the manual fallback if you only want to cancel the created task"
+    "prefer `rollback_session_state` with scope=`current_turn` (or, when available, `rollback_turn_actions`) to restore the pre-task snapshot; `task_stop` with the returned `task_id` remains the manual fallback if you only want to cancel the created task"
 }
 
 fn task_update_compensation_summary() -> &'static str {
-    "prefer `rollback_session_state` with scope=`current_turn` (or `rollback_turn_actions`) to restore the pre-update task snapshot; otherwise use `task_get` plus the `previous_status` from the tool result and rerun `task_update` manually"
+    "prefer `rollback_session_state` with scope=`current_turn` (or, when available, `rollback_turn_actions`) to restore the pre-update task snapshot; otherwise use `task_get` plus the `previous_status` from the tool result and rerun `task_update` manually"
 }
 
 fn task_stop_compensation_summary() -> &'static str {
-    "prefer `rollback_session_state` with scope=`current_turn` (or `rollback_turn_actions`) to restore the pre-stop task snapshot; otherwise use `task_update` with the `previous_status` from the tool result to reopen the task manually"
+    "prefer `rollback_session_state` with scope=`current_turn` (or, when available, `rollback_turn_actions`) to restore the pre-stop task snapshot; otherwise use `task_update` with the `previous_status` from the tool result to reopen the task manually"
 }
 
 fn session_state_action_profile(

--- a/rust/crates/runtime/src/turn/action_compensation.rs
+++ b/rust/crates/runtime/src/turn/action_compensation.rs
@@ -29,6 +29,7 @@ pub enum CompensationKind {
     GitRestoreWorktree,
     GitRevertCommit,
     RestoreDatabaseSnapshot,
+    RestoreSessionState,
     Manual,
 }
 
@@ -353,6 +354,7 @@ fn compensation_kind_label(kind: CompensationKind) -> String {
         CompensationKind::GitRestoreWorktree => "git_restore_worktree",
         CompensationKind::GitRevertCommit => "git_revert_commit",
         CompensationKind::RestoreDatabaseSnapshot => "restore_database_snapshot",
+        CompensationKind::RestoreSessionState => "restore_session_state",
         CompensationKind::Manual => "manual",
     }
     .to_string()
@@ -475,6 +477,19 @@ fn task_update_compensation_summary() -> &'static str {
 
 fn task_stop_compensation_summary() -> &'static str {
     "prefer `rollback_session_state` with scope=`current_turn` (or `rollback_turn_actions`) to restore the pre-stop task snapshot; otherwise use `task_update` with the `previous_status` from the tool result to reopen the task manually"
+}
+
+fn session_state_action_profile(
+    category: ActionCategory,
+    compensation_summary: impl Into<String>,
+) -> ActionCompensationProfile {
+    ActionCompensationProfile::compensated(
+        true,
+        category,
+        false,
+        CompensationKind::RestoreSessionState,
+        compensation_summary.into(),
+    )
 }
 
 fn shell_action_profile(command: Option<&str>) -> ActionCompensationProfile {
@@ -619,38 +634,31 @@ pub fn tool_action_profile(tool_name: &str, args: &Value) -> ActionCompensationP
             CompensationKind::RestoreOrDeleteFile,
             restore_file_compensation_summary(string_arg(&normalized_args, "path"), true),
         ),
-        "adjust_config" => ActionCompensationProfile::manual(
-            true,
+        "adjust_config" => session_state_action_profile(
             ActionCategory::Write,
-            &adjust_config_compensation_summary(string_arg(&normalized_args, "path")),
+            adjust_config_compensation_summary(string_arg(&normalized_args, "path")),
         ),
-        "prioritize_tool" | "deprioritize_tool" => ActionCompensationProfile::manual(
-            true,
+        "prioritize_tool" | "deprioritize_tool" => session_state_action_profile(
             ActionCategory::Write,
-            &tool_priority_compensation_summary(string_arg(&normalized_args, "tool")),
+            tool_priority_compensation_summary(string_arg(&normalized_args, "tool")),
         ),
-        "set_goal" => ActionCompensationProfile::manual(
-            true,
+        "set_goal" => session_state_action_profile(
             ActionCategory::Destructive,
             set_goal_compensation_summary(),
         ),
-        "compress_context" => ActionCompensationProfile::manual(
-            true,
+        "compress_context" => session_state_action_profile(
             ActionCategory::Write,
             compress_context_compensation_summary(),
         ),
-        "task_create" => ActionCompensationProfile::manual(
-            true,
+        "task_create" => session_state_action_profile(
             ActionCategory::Write,
             task_create_compensation_summary(),
         ),
-        "task_update" => ActionCompensationProfile::manual(
-            true,
+        "task_update" => session_state_action_profile(
             ActionCategory::Write,
             task_update_compensation_summary(),
         ),
-        "task_stop" => ActionCompensationProfile::manual(
-            true,
+        "task_stop" => session_state_action_profile(
             ActionCategory::Destructive,
             task_stop_compensation_summary(),
         ),
@@ -965,28 +973,50 @@ mod tests {
     }
 
     #[test]
-    fn session_state_tools_are_not_treated_as_reads() {
+    fn session_state_tools_use_session_rollback_compensation() {
         let adjust = tool_action_profile(
             "adjust_config",
             &json!({"path": "memory.retrieval_top_k", "value": 6}),
         );
         assert!(adjust.bounded);
         assert_eq!(adjust.category, ActionCategory::Write);
-        assert!(!adjust.reversible);
-        assert_eq!(adjust.compensation_kind, Some(CompensationKind::Manual));
+        assert!(adjust.reversible);
+        assert_eq!(
+            adjust.compensation_kind,
+            Some(CompensationKind::RestoreSessionState)
+        );
         assert!(
             adjust
                 .compensation_summary
                 .as_deref()
                 .unwrap_or_default()
-                .contains("adjust_config")
+                .contains("rollback_session_state")
+        );
+
+        let prioritize = tool_action_profile("prioritize_tool", &json!({"tool": "bash"}));
+        assert!(prioritize.bounded);
+        assert_eq!(prioritize.category, ActionCategory::Write);
+        assert!(prioritize.reversible);
+        assert_eq!(
+            prioritize.compensation_kind,
+            Some(CompensationKind::RestoreSessionState)
+        );
+        assert!(
+            prioritize
+                .compensation_summary
+                .as_deref()
+                .unwrap_or_default()
+                .contains("prior preference state")
         );
 
         let set_goal = tool_action_profile("set_goal", &json!({"goal": "ship rollback shell"}));
         assert!(set_goal.bounded);
         assert_eq!(set_goal.category, ActionCategory::Destructive);
-        assert!(!set_goal.reversible);
-        assert_eq!(set_goal.compensation_kind, Some(CompensationKind::Manual));
+        assert!(set_goal.reversible);
+        assert_eq!(
+            set_goal.compensation_kind,
+            Some(CompensationKind::RestoreSessionState)
+        );
         assert!(
             set_goal
                 .compensation_summary
@@ -994,28 +1024,69 @@ mod tests {
                 .unwrap_or_default()
                 .contains("previous_goal")
         );
+
+        let compress = tool_action_profile("compress_context", &json!({"turns": 4}));
+        assert!(compress.bounded);
+        assert_eq!(compress.category, ActionCategory::Write);
+        assert!(compress.reversible);
+        assert_eq!(
+            compress.compensation_kind,
+            Some(CompensationKind::RestoreSessionState)
+        );
+        assert!(
+            compress
+                .compensation_summary
+                .as_deref()
+                .unwrap_or_default()
+                .contains("session-local compression state")
+        );
     }
 
     #[test]
-    fn task_mutators_are_bounded_manual_actions() {
+    fn task_mutators_use_session_rollback_compensation() {
         let create = tool_action_profile("task_create", &json!({"title": "demo"}));
         assert!(create.bounded);
         assert_eq!(create.category, ActionCategory::Write);
-        assert!(!create.reversible);
-        assert_eq!(create.compensation_kind, Some(CompensationKind::Manual));
+        assert!(create.reversible);
+        assert_eq!(
+            create.compensation_kind,
+            Some(CompensationKind::RestoreSessionState)
+        );
         assert!(
             create
                 .compensation_summary
                 .as_deref()
                 .unwrap_or_default()
-                .contains("task_stop")
+                .contains("rollback_session_state")
+        );
+
+        let update = tool_action_profile(
+            "task_update",
+            &json!({"task_id": "task-1", "status": "done"}),
+        );
+        assert!(update.bounded);
+        assert_eq!(update.category, ActionCategory::Write);
+        assert!(update.reversible);
+        assert_eq!(
+            update.compensation_kind,
+            Some(CompensationKind::RestoreSessionState)
+        );
+        assert!(
+            update
+                .compensation_summary
+                .as_deref()
+                .unwrap_or_default()
+                .contains("pre-update task snapshot")
         );
 
         let stop = tool_action_profile("task_stop", &json!({"task_id": "task-1"}));
         assert!(stop.bounded);
         assert_eq!(stop.category, ActionCategory::Destructive);
-        assert!(!stop.reversible);
-        assert_eq!(stop.compensation_kind, Some(CompensationKind::Manual));
+        assert!(stop.reversible);
+        assert_eq!(
+            stop.compensation_kind,
+            Some(CompensationKind::RestoreSessionState)
+        );
         assert!(
             stop.compensation_summary
                 .as_deref()
@@ -1225,6 +1296,30 @@ mod tests {
         assert_eq!(
             policy.compensation_kind.as_deref(),
             Some("restore_or_delete_file")
+        );
+    }
+
+    #[test]
+    fn session_state_profile_bridges_to_restore_session_state_policy() {
+        let policy = tool_action_profile(
+            "adjust_config",
+            &json!({"path": "memory.retrieval_top_k", "value": 6}),
+        )
+        .mutation_compensation_policy();
+        assert!(policy.bounded);
+        assert!(policy.reversible);
+        assert!(!policy.requires_pre_state);
+        assert_eq!(policy.action_category, MutationActionCategory::Write);
+        assert_eq!(
+            policy.compensation_kind.as_deref(),
+            Some("restore_session_state")
+        );
+        assert!(
+            policy
+                .compensation_summary
+                .as_deref()
+                .unwrap_or_default()
+                .contains("rollback_session_state")
         );
     }
 

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
@@ -54,6 +54,8 @@ const EXECUTION_BOUNDARY_KIND_TURN_ROLLBACK: &str = "turn_rollback";
 struct ServerRollbackBoundary {
     turn_index: u32,
     file_checkpoint: Option<u64>,
+    database_checkpoint: Option<u64>,
+    git_mutations: bool,
     session_state_checkpoint: Option<u64>,
 }
 
@@ -62,6 +64,21 @@ fn server_file_mutator_in_round(tool_calls: &[Value]) -> bool {
         matches!(
             tool_call_name(tool_call),
             Some("write_file" | "str_replace" | "delete_file")
+        )
+    })
+}
+
+fn server_database_mutator_in_round(tool_calls: &[Value]) -> bool {
+    tool_calls
+        .iter()
+        .any(|tool_call| matches!(tool_call_name(tool_call), Some("mo_query")))
+}
+
+fn server_git_mutator_in_round(tool_calls: &[Value]) -> bool {
+    tool_calls.iter().any(|tool_call| {
+        matches!(
+            tool_call_name(tool_call),
+            Some("git_commit" | "git_revert_commit")
         )
     })
 }
@@ -103,6 +120,12 @@ fn server_boundary_surfaces(boundary: &ServerRollbackBoundary) -> Vec<&'static s
     if boundary.file_checkpoint.is_some() {
         surfaces.push("file_edits");
     }
+    if boundary.database_checkpoint.is_some() {
+        surfaces.push("database_snapshots");
+    }
+    if boundary.git_mutations {
+        surfaces.push("git_mutations");
+    }
     if boundary.session_state_checkpoint.is_some() {
         surfaces.push("session_state");
     }
@@ -140,6 +163,12 @@ fn server_boundary_checkpoints(boundary: &ServerRollbackBoundary) -> Value {
             Value::Number(serde_json::Number::from(file_checkpoint)),
         );
     }
+    if let Some(database_checkpoint) = boundary.database_checkpoint {
+        checkpoints.insert(
+            "database_after_sequence".to_string(),
+            Value::Number(serde_json::Number::from(database_checkpoint)),
+        );
+    }
     if let Some(session_state_checkpoint) = boundary.session_state_checkpoint {
         checkpoints.insert(
             "session_state_after_sequence".to_string(),
@@ -153,6 +182,8 @@ fn server_boundary_commit_detail(
     boundary: &ServerRollbackBoundary,
     executed_requests: usize,
     file_entries_added: u64,
+    database_entries_added: u64,
+    git_mutations_recorded: u64,
     session_state_entries_added: u64,
 ) -> Value {
     let surfaces = server_boundary_surfaces(boundary);
@@ -189,6 +220,18 @@ fn server_boundary_commit_detail(
             Value::Number(serde_json::Number::from(file_entries_added)),
         );
     }
+    if boundary.database_checkpoint.is_some() {
+        detail.insert(
+            "database_entries_recorded".to_string(),
+            Value::Number(serde_json::Number::from(database_entries_added)),
+        );
+    }
+    if boundary.git_mutations {
+        detail.insert(
+            "git_mutations_recorded".to_string(),
+            Value::Number(serde_json::Number::from(git_mutations_recorded)),
+        );
+    }
     if boundary.session_state_checkpoint.is_some() {
         detail.insert(
             "session_state_entries_recorded".to_string(),
@@ -211,9 +254,15 @@ fn parse_server_rollback_output(tool_name: &str, output: String) -> Value {
 fn combine_server_rollback_outputs(
     turn_index: u32,
     file_edits: Option<Value>,
+    database_snapshots: Option<Value>,
+    git_mutations: Option<Value>,
     session_state: Option<Value>,
 ) -> Option<Value> {
-    if file_edits.is_none() && session_state.is_none() {
+    if file_edits.is_none()
+        && database_snapshots.is_none()
+        && git_mutations.is_none()
+        && session_state.is_none()
+    {
         return None;
     }
 
@@ -229,6 +278,26 @@ fn combine_server_rollback_outputs(
             summaries.push(summary.to_string());
         }
         rollback.insert("file_edits".to_string(), file_edits);
+    }
+    if let Some(database_snapshots) = database_snapshots {
+        success &= database_snapshots
+            .get("success")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if let Some(summary) = database_snapshots.get("summary").and_then(Value::as_str) {
+            summaries.push(summary.to_string());
+        }
+        rollback.insert("database_snapshots".to_string(), database_snapshots);
+    }
+    if let Some(git_mutations) = git_mutations {
+        success &= git_mutations
+            .get("success")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if let Some(summary) = git_mutations.get("summary").and_then(Value::as_str) {
+            summaries.push(summary.to_string());
+        }
+        rollback.insert("git_mutations".to_string(), git_mutations);
     }
     if let Some(session_state) = session_state {
         success &= session_state
@@ -252,6 +321,79 @@ fn combine_server_rollback_outputs(
     Some(Value::Object(rollback))
 }
 
+fn server_git_mutation_targets(tool_results: &[Value]) -> Vec<String> {
+    tool_results
+        .iter()
+        .filter_map(|tool_result| {
+            let tool_name = tool_result.get("name").and_then(Value::as_str)?;
+            match tool_name {
+                "git_commit" => tool_result.get("commit_sha").and_then(Value::as_str),
+                "git_revert_commit" => tool_result.get("revert_commit_sha").and_then(Value::as_str),
+                _ => None,
+            }
+            .map(ToString::to_string)
+        })
+        .collect()
+}
+
+async fn rollback_server_git_mutations(
+    executor: &crate::server::server_tool_executor::ServerToolExecutor,
+    targets: &[String],
+) -> Option<Value> {
+    if targets.is_empty() {
+        return None;
+    }
+
+    let mut reverted = Vec::new();
+    let mut failed = Vec::new();
+    for commit_sha in targets.iter().rev() {
+        let result = executor
+            .execute_with_metadata(
+                "git_revert_commit",
+                &serde_json::json!({ "commit_sha": commit_sha }),
+            )
+            .await;
+        let mut entry = serde_json::Map::from_iter([(
+            "commit_sha".to_string(),
+            Value::String(commit_sha.clone()),
+        )]);
+        if let Some(metadata) = result.metadata {
+            entry.extend(metadata);
+        }
+        if result.is_error {
+            entry.insert("error".to_string(), Value::String(result.output));
+            failed.push(Value::Object(entry));
+        } else {
+            entry.insert("result".to_string(), Value::String(result.output));
+            reverted.push(Value::Object(entry));
+        }
+    }
+
+    let success = !reverted.is_empty() && failed.is_empty();
+    let summary = if failed.is_empty() {
+        format!(
+            "Created {} compensating git revert commit{} during turn rollback",
+            reverted.len(),
+            if reverted.len() == 1 { "" } else { "s" }
+        )
+    } else {
+        format!(
+            "Created {} compensating git revert commit{} during turn rollback with {} failure{}",
+            reverted.len(),
+            if reverted.len() == 1 { "" } else { "s" },
+            failed.len(),
+            if failed.len() == 1 { "" } else { "s" }
+        )
+    };
+
+    Some(serde_json::json!({
+        "success": success,
+        "reverted": reverted,
+        "failed": failed,
+        "summary": summary,
+    }))
+}
+
 fn open_server_rollback_boundary(
     session_id: Option<&str>,
     executor: &crate::server::server_tool_executor::ServerToolExecutor,
@@ -259,14 +401,20 @@ fn open_server_rollback_boundary(
     tool_calls: &[Value],
 ) -> Option<ServerRollbackBoundary> {
     let has_file_mutator = server_file_mutator_in_round(tool_calls);
+    let has_database_mutator = server_database_mutator_in_round(tool_calls);
+    let has_git_mutator = server_git_mutator_in_round(tool_calls);
     let has_session_state_mutator = server_session_state_mutator_in_round(tool_calls);
-    if !has_file_mutator && !has_session_state_mutator {
+    if !has_file_mutator && !has_database_mutator && !has_git_mutator && !has_session_state_mutator
+    {
         return None;
     }
 
     let active = ServerRollbackBoundary {
         turn_index,
         file_checkpoint: has_file_mutator.then(|| executor.file_journal_checkpoint()),
+        database_checkpoint: has_database_mutator
+            .then(|| executor.database_snapshot_journal_checkpoint()),
+        git_mutations: has_git_mutator,
         session_state_checkpoint: has_session_state_mutator
             .then(|| executor.session_state_journal_checkpoint()),
     };
@@ -285,15 +433,21 @@ fn open_server_rollback_boundary(
     Some(active)
 }
 
-fn finalize_server_rollback_boundary(
+async fn finalize_server_rollback_boundary(
     session_id: Option<&str>,
     executor: &crate::server::server_tool_executor::ServerToolExecutor,
     active: &ServerRollbackBoundary,
     new_records: &[astra_services::session_journal::ToolCallRecord],
+    new_tool_results: &[Value],
 ) {
     let file_entries_added = active.file_checkpoint.map_or(0, |checkpoint| {
         executor
             .file_journal_checkpoint()
+            .saturating_sub(checkpoint)
+    });
+    let database_entries_added = active.database_checkpoint.map_or(0, |checkpoint| {
+        executor
+            .database_snapshot_journal_checkpoint()
             .saturating_sub(checkpoint)
     });
     let session_state_entries_added = active.session_state_checkpoint.map_or(0, |checkpoint| {
@@ -301,6 +455,12 @@ fn finalize_server_rollback_boundary(
             .session_state_journal_checkpoint()
             .saturating_sub(checkpoint)
     });
+    let git_mutation_targets = if active.git_mutations {
+        server_git_mutation_targets(new_tool_results)
+    } else {
+        Vec::new()
+    };
+    let git_mutations_recorded = git_mutation_targets.len() as u64;
     if let Some(failed_record) = new_records.iter().find(|record| !record.ok) {
         let file_rollback = if let Some(file_checkpoint) = active.file_checkpoint {
             (file_entries_added > 0).then(|| {
@@ -315,6 +475,22 @@ fn finalize_server_rollback_boundary(
         } else {
             None
         };
+        let database_snapshot_rollback =
+            if let Some(database_checkpoint) = active.database_checkpoint {
+                (database_entries_added > 0).then(|| {
+                    parse_server_rollback_output(
+                        "rollback_database_snapshots",
+                        executor.rollback_database_snapshots(&serde_json::json!({
+                            "scope": "current_turn",
+                            "database_after_sequence": database_checkpoint,
+                        })),
+                    )
+                })
+            } else {
+                None
+            };
+        let git_mutation_rollback =
+            rollback_server_git_mutations(executor, &git_mutation_targets).await;
         let session_state_rollback =
             if let Some(session_state_checkpoint) = active.session_state_checkpoint {
                 (session_state_entries_added > 0).then(|| {
@@ -332,6 +508,8 @@ fn finalize_server_rollback_boundary(
         let rollback = combine_server_rollback_outputs(
             active.turn_index,
             file_rollback,
+            database_snapshot_rollback,
+            git_mutation_rollback,
             session_state_rollback,
         );
         if let Some(session_id) = session_id {
@@ -361,6 +539,8 @@ fn finalize_server_rollback_boundary(
                     active,
                     new_records.len(),
                     file_entries_added,
+                    database_entries_added,
+                    git_mutations_recorded,
                     session_state_entries_added,
                 )),
             ),
@@ -435,6 +615,7 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
         .collect();
 
     let evo_records_before = state.stall.tool_call_records.len();
+    let tool_results_before = state.tool_results.len();
     {
         let valid_tool_names = host.valid_tool_names().clone();
         let mut term_adapter = HostTerminalAdapter(host);
@@ -476,12 +657,15 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
         state.server_tool_executor.as_deref(),
     ) {
         let new_records = &state.stall.tool_call_records[evo_records_before..];
+        let new_tool_results = &state.tool_results[tool_results_before..];
         finalize_server_rollback_boundary(
             state.current_session_id.as_deref(),
             executor,
             active,
             new_records,
-        );
+            new_tool_results,
+        )
+        .await;
     }
 
     if let Some(ref evo) = state.evolution_service {
@@ -934,6 +1118,21 @@ mod tests {
         }
     }
 
+    fn tool_result_row(name: &str, result: astra_tools::ToolResult) -> Value {
+        let mut row = serde_json::Map::from_iter([
+            (
+                "tool_call_id".to_string(),
+                Value::String(format!("{name}-call")),
+            ),
+            ("name".to_string(), Value::String(name.to_string())),
+            ("result".to_string(), Value::String(result.output.clone())),
+        ]);
+        if let Some(fields) = result.metadata {
+            row.extend(fields);
+        }
+        Value::Object(row)
+    }
+
     fn read_journal_events(session_id: &str) -> Vec<JournalEvent> {
         let writer = JournalWriter::new(session_id).unwrap();
         let content = std::fs::read_to_string(writer.path()).unwrap_or_default();
@@ -954,6 +1153,72 @@ mod tests {
             astra_services::session_journal::local_sessions_dir().join(session_id),
         )
         .ok();
+    }
+
+    #[cfg(unix)]
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    #[cfg(unix)]
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn set_env_var(key: &'static str, value: impl Into<std::ffi::OsString>) -> EnvVarGuard {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, value.into());
+        }
+        EnvVarGuard { key, previous }
+    }
+
+    #[cfg(unix)]
+    fn write_fake_mysql(dir: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = dir.join("mysql");
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+case "$*" in
+  *"SELECT current_account_name() AS name"*)
+    printf '+------+\n| name |\n+------+\n| sys  |\n+------+\n'
+    ;;
+  *"CREATE SNAPSHOT"*)
+    printf 'Query OK, 1 row affected\n'
+    ;;
+  *"RESTORE ACCOUNT"*)
+    printf 'Query OK, 1 row affected\n'
+    ;;
+  *"DROP SNAPSHOT"*)
+    printf 'Query OK, 1 row affected\n'
+    ;;
+  *"UPDATE metrics SET value = 1"*)
+    printf 'Query OK, 1 row affected\n'
+    ;;
+  *"SELECT 1"*)
+    printf '+---+\n| 1 |\n+---+\n| 1 |\n+---+\n'
+    ;;
+  *)
+    printf 'Query OK, 1 row affected\n'
+    ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
     }
 
     fn session_state_executor(
@@ -1016,7 +1281,9 @@ mod tests {
             &executor,
             &active,
             &[tool_record("write_file", true)],
-        );
+            &[],
+        )
+        .await;
 
         let events = read_journal_events(&session_id);
         assert_eq!(events.len(), 2);
@@ -1071,7 +1338,9 @@ mod tests {
             &executor,
             &active,
             &[tool_record("write_file", true), tool_record("grep", false)],
-        );
+            &[],
+        )
+        .await;
 
         let events = read_journal_events(&session_id);
         assert_eq!(events.len(), 2);
@@ -1094,6 +1363,170 @@ mod tests {
             Some(1)
         );
         assert!(!dir.path().join("turn.txt").exists());
+
+        cleanup_session_artifacts(&session_id);
+    }
+
+    #[tokio::test]
+    async fn server_git_boundary_aborts_and_reverts_failed_turn() {
+        let session_id = format!("server-git-boundary-{}", uuid::Uuid::new_v4());
+        let dir = tempfile::TempDir::new().unwrap();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::fs::write(dir.path().join("tracked.txt"), "before").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::fs::write(dir.path().join("tracked.txt"), "after").unwrap();
+
+        let executor = crate::server::server_tool_executor::ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            session_id.clone(),
+            None,
+            None,
+        );
+        executor.set_turn_index(8);
+
+        let active = open_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            8,
+            &[json!({"function": {"name": "git_commit", "arguments": "{}"}})],
+        )
+        .expect("boundary should open for git_commit");
+
+        let commit_result = executor
+            .execute_with_metadata("git_commit", &json!({"message": "turn commit"}))
+            .await;
+        assert!(!commit_result.is_error, "got: {}", commit_result.output);
+
+        finalize_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            &active,
+            &[tool_record("git_commit", true), tool_record("grep", false)],
+            &[tool_result_row("git_commit", commit_result)],
+        )
+        .await;
+
+        let events = read_journal_events(&session_id);
+        let boundary_events: Vec<_> = events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event.event_type,
+                    JournalEventType::ExecutionBoundaryOpened
+                        | JournalEventType::ExecutionBoundaryAborted
+                )
+            })
+            .collect();
+        assert_eq!(boundary_events.len(), 2);
+        let boundary = &boundary_events[1].metadata.as_ref().unwrap()["execution_boundary"];
+        assert_eq!(boundary["kind"].as_str(), Some("turn_rollback"));
+        assert_eq!(boundary["reason"].as_str(), Some("tool_error"));
+        assert_eq!(boundary["trigger_tool_name"].as_str(), Some("grep"));
+        assert_eq!(
+            boundary["rollback"]["git_mutations"]["reverted"]
+                .as_array()
+                .map(Vec::len),
+            Some(1)
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("tracked.txt")).unwrap(),
+            "before"
+        );
+
+        cleanup_session_artifacts(&session_id);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn server_database_boundary_aborts_and_rolls_back_failed_turn() {
+        let fake_bin = tempfile::TempDir::new().unwrap();
+        write_fake_mysql(fake_bin.path());
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        let joined = std::env::join_paths(
+            std::iter::once(fake_bin.path().to_path_buf()).chain(std::env::split_paths(&path)),
+        )
+        .unwrap();
+        let _path_guard = set_env_var("PATH", joined);
+
+        let session_id = format!("server-db-boundary-{}", uuid::Uuid::new_v4());
+        let dir = tempfile::TempDir::new().unwrap();
+        let executor = crate::server::server_tool_executor::ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            session_id.clone(),
+            None,
+            None,
+        );
+        executor.set_turn_index(11);
+
+        let active = open_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            11,
+            &[json!({"function": {"name": "mo_query", "arguments": "{}"}})],
+        )
+        .expect("boundary should open for mo_query");
+
+        let query_out = executor
+            .execute("mo_query", &json!({"sql": "UPDATE metrics SET value = 1"}))
+            .await;
+        assert!(query_out.contains("Query OK"), "got: {query_out}");
+
+        finalize_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            &active,
+            &[tool_record("mo_query", true), tool_record("grep", false)],
+            &[],
+        )
+        .await;
+
+        let events = read_journal_events(&session_id);
+        let boundary_events: Vec<_> = events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event.event_type,
+                    JournalEventType::ExecutionBoundaryOpened
+                        | JournalEventType::ExecutionBoundaryAborted
+                )
+            })
+            .collect();
+        assert_eq!(boundary_events.len(), 2);
+        let boundary = &boundary_events[1].metadata.as_ref().unwrap()["execution_boundary"];
+        assert_eq!(boundary["kind"].as_str(), Some("turn_rollback"));
+        assert_eq!(boundary["reason"].as_str(), Some("tool_error"));
+        assert_eq!(boundary["trigger_tool_name"].as_str(), Some("grep"));
+        assert_eq!(
+            boundary["rollback"]["database_snapshots"]["restored"]
+                .as_array()
+                .map(Vec::len),
+            Some(1)
+        );
 
         cleanup_session_artifacts(&session_id);
     }
@@ -1139,7 +1572,9 @@ mod tests {
                 tool_record("adjust_config", true),
                 tool_record("grep", false),
             ],
-        );
+            &[],
+        )
+        .await;
 
         let events = read_journal_events(&session_id);
         let boundary_events: Vec<_> = events

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
@@ -1,10 +1,14 @@
 use std::collections::HashMap;
 
+use serde_json::Value;
+
 use super::agentic_adaptive_tuning::{
     apply_per_turn_adaptation, apply_tactical_actions, maybe_run_tuning_cycle,
 };
 use super::agentic_auto_reflection::maybe_trigger_auto_reflection;
-use super::agentic_delegate_interception::{DelegationInterceptionResult, intercept_delegations};
+use super::agentic_delegate_interception::{
+    DelegationInterceptionResult, intercept_delegations, tool_call_name,
+};
 use super::agentic_headless_round::{
     HeadlessRoundTerminal, HeadlessStderrStyle, HeadlessToolRoundCtx,
     run_agentic_headless_tool_round,
@@ -43,6 +47,325 @@ fn tool_record_was_rejected(rec: &astra_services::session_journal::ToolCallRecor
         .as_deref()
         .map(|error| error.starts_with("blocked_tool:"))
         .unwrap_or(false)
+}
+
+const EXECUTION_BOUNDARY_KIND_TURN_ROLLBACK: &str = "turn_rollback";
+
+struct ServerRollbackBoundary {
+    turn_index: u32,
+    file_checkpoint: Option<u64>,
+    session_state_checkpoint: Option<u64>,
+}
+
+fn server_file_mutator_in_round(tool_calls: &[Value]) -> bool {
+    tool_calls.iter().any(|tool_call| {
+        matches!(
+            tool_call_name(tool_call),
+            Some("write_file" | "str_replace" | "delete_file")
+        )
+    })
+}
+
+fn server_session_state_mutator_in_round(tool_calls: &[Value]) -> bool {
+    tool_calls.iter().any(|tool_call| {
+        matches!(
+            tool_call_name(tool_call),
+            Some(
+                "adjust_config"
+                    | "prioritize_tool"
+                    | "deprioritize_tool"
+                    | "set_goal"
+                    | "compress_context"
+                    | "task_create"
+                    | "task_update"
+                    | "task_stop"
+            )
+        )
+    })
+}
+
+fn append_session_journal_event(
+    session_id: &str,
+    event: astra_services::session_journal::JournalEvent,
+) {
+    match astra_services::session_journal::JournalWriter::new(session_id) {
+        Ok(journal) => {
+            if let Err(err) = journal.append(&event) {
+                eprintln!("  ⚠ execution boundary journal append failed: {err}");
+            }
+        }
+        Err(err) => eprintln!("  ⚠ execution boundary journal init failed: {err}"),
+    }
+}
+
+fn server_boundary_surfaces(boundary: &ServerRollbackBoundary) -> Vec<&'static str> {
+    let mut surfaces = Vec::new();
+    if boundary.file_checkpoint.is_some() {
+        surfaces.push("file_edits");
+    }
+    if boundary.session_state_checkpoint.is_some() {
+        surfaces.push("session_state");
+    }
+    surfaces
+}
+
+fn server_boundary_checkpoints(boundary: &ServerRollbackBoundary) -> Value {
+    let surfaces = server_boundary_surfaces(boundary);
+    let mut checkpoints = serde_json::Map::from_iter([
+        (
+            "execution_mode".to_string(),
+            Value::String("server".to_string()),
+        ),
+        (
+            "rollback_surfaces".to_string(),
+            Value::Array(
+                surfaces
+                    .iter()
+                    .map(|surface| Value::String((*surface).to_string()))
+                    .collect(),
+            ),
+        ),
+    ]);
+    if let Some(surface) = surfaces.first()
+        && surfaces.len() == 1
+    {
+        checkpoints.insert(
+            "rollback_surface".to_string(),
+            Value::String((*surface).to_string()),
+        );
+    }
+    if let Some(file_checkpoint) = boundary.file_checkpoint {
+        checkpoints.insert(
+            "file_after_sequence".to_string(),
+            Value::Number(serde_json::Number::from(file_checkpoint)),
+        );
+    }
+    if let Some(session_state_checkpoint) = boundary.session_state_checkpoint {
+        checkpoints.insert(
+            "session_state_after_sequence".to_string(),
+            Value::Number(serde_json::Number::from(session_state_checkpoint)),
+        );
+    }
+    Value::Object(checkpoints)
+}
+
+fn server_boundary_commit_detail(
+    boundary: &ServerRollbackBoundary,
+    executed_requests: usize,
+    file_entries_added: u64,
+    session_state_entries_added: u64,
+) -> Value {
+    let surfaces = server_boundary_surfaces(boundary);
+    let mut detail = serde_json::Map::from_iter([
+        (
+            "executed_requests".to_string(),
+            Value::Number(serde_json::Number::from(executed_requests as u64)),
+        ),
+        (
+            "execution_mode".to_string(),
+            Value::String("server".to_string()),
+        ),
+        (
+            "rollback_surfaces".to_string(),
+            Value::Array(
+                surfaces
+                    .iter()
+                    .map(|surface| Value::String((*surface).to_string()))
+                    .collect(),
+            ),
+        ),
+    ]);
+    if let Some(surface) = surfaces.first()
+        && surfaces.len() == 1
+    {
+        detail.insert(
+            "rollback_surface".to_string(),
+            Value::String((*surface).to_string()),
+        );
+    }
+    if boundary.file_checkpoint.is_some() {
+        detail.insert(
+            "file_entries_recorded".to_string(),
+            Value::Number(serde_json::Number::from(file_entries_added)),
+        );
+    }
+    if boundary.session_state_checkpoint.is_some() {
+        detail.insert(
+            "session_state_entries_recorded".to_string(),
+            Value::Number(serde_json::Number::from(session_state_entries_added)),
+        );
+    }
+    Value::Object(detail)
+}
+
+fn parse_server_rollback_output(tool_name: &str, output: String) -> Value {
+    serde_json::from_str(&output).unwrap_or_else(|error| {
+        serde_json::json!({
+            "success": false,
+            "error": format!("invalid {tool_name} output: {error}"),
+            "raw_output": output,
+        })
+    })
+}
+
+fn combine_server_rollback_outputs(
+    turn_index: u32,
+    file_edits: Option<Value>,
+    session_state: Option<Value>,
+) -> Option<Value> {
+    if file_edits.is_none() && session_state.is_none() {
+        return None;
+    }
+
+    let mut success = true;
+    let mut summaries = Vec::new();
+    let mut rollback = serde_json::Map::new();
+    if let Some(file_edits) = file_edits {
+        success &= file_edits
+            .get("success")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if let Some(summary) = file_edits.get("summary").and_then(Value::as_str) {
+            summaries.push(summary.to_string());
+        }
+        rollback.insert("file_edits".to_string(), file_edits);
+    }
+    if let Some(session_state) = session_state {
+        success &= session_state
+            .get("success")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if let Some(summary) = session_state.get("summary").and_then(Value::as_str) {
+            summaries.push(summary.to_string());
+        }
+        rollback.insert("session_state".to_string(), session_state);
+    }
+    rollback.insert("success".to_string(), Value::Bool(success));
+    rollback.insert(
+        "summary".to_string(),
+        Value::String(if summaries.is_empty() {
+            format!("Attempted bounded rollback for turn {turn_index}")
+        } else {
+            summaries.join(" ")
+        }),
+    );
+    Some(Value::Object(rollback))
+}
+
+fn open_server_rollback_boundary(
+    session_id: Option<&str>,
+    executor: &crate::server::server_tool_executor::ServerToolExecutor,
+    turn_index: u32,
+    tool_calls: &[Value],
+) -> Option<ServerRollbackBoundary> {
+    let has_file_mutator = server_file_mutator_in_round(tool_calls);
+    let has_session_state_mutator = server_session_state_mutator_in_round(tool_calls);
+    if !has_file_mutator && !has_session_state_mutator {
+        return None;
+    }
+
+    let active = ServerRollbackBoundary {
+        turn_index,
+        file_checkpoint: has_file_mutator.then(|| executor.file_journal_checkpoint()),
+        session_state_checkpoint: has_session_state_mutator
+            .then(|| executor.session_state_journal_checkpoint()),
+    };
+    if let Some(session_id) = session_id {
+        append_session_journal_event(
+            session_id,
+            astra_services::session_journal::JournalEvent::execution_boundary_opened(
+                Some(session_id),
+                turn_index,
+                EXECUTION_BOUNDARY_KIND_TURN_ROLLBACK,
+                None,
+                server_boundary_checkpoints(&active),
+            ),
+        );
+    }
+    Some(active)
+}
+
+fn finalize_server_rollback_boundary(
+    session_id: Option<&str>,
+    executor: &crate::server::server_tool_executor::ServerToolExecutor,
+    active: &ServerRollbackBoundary,
+    new_records: &[astra_services::session_journal::ToolCallRecord],
+) {
+    let file_entries_added = active.file_checkpoint.map_or(0, |checkpoint| {
+        executor
+            .file_journal_checkpoint()
+            .saturating_sub(checkpoint)
+    });
+    let session_state_entries_added = active.session_state_checkpoint.map_or(0, |checkpoint| {
+        executor
+            .session_state_journal_checkpoint()
+            .saturating_sub(checkpoint)
+    });
+    if let Some(failed_record) = new_records.iter().find(|record| !record.ok) {
+        let file_rollback = if let Some(file_checkpoint) = active.file_checkpoint {
+            (file_entries_added > 0).then(|| {
+                parse_server_rollback_output(
+                    "rollback_file_edits",
+                    executor.rollback_file_edits(&serde_json::json!({
+                        "scope": "current_turn",
+                        "after_sequence": file_checkpoint,
+                    })),
+                )
+            })
+        } else {
+            None
+        };
+        let session_state_rollback =
+            if let Some(session_state_checkpoint) = active.session_state_checkpoint {
+                (session_state_entries_added > 0).then(|| {
+                    parse_server_rollback_output(
+                        "rollback_session_state",
+                        executor.rollback_session_state(&serde_json::json!({
+                            "scope": "current_turn",
+                            "session_state_after_sequence": session_state_checkpoint,
+                        })),
+                    )
+                })
+            } else {
+                None
+            };
+        let rollback = combine_server_rollback_outputs(
+            active.turn_index,
+            file_rollback,
+            session_state_rollback,
+        );
+        if let Some(session_id) = session_id {
+            append_session_journal_event(
+                session_id,
+                astra_services::session_journal::JournalEvent::execution_boundary_aborted(
+                    Some(session_id),
+                    active.turn_index,
+                    EXECUTION_BOUNDARY_KIND_TURN_ROLLBACK,
+                    None,
+                    "tool_error",
+                    Some(failed_record.name.as_str()),
+                    None,
+                    rollback,
+                ),
+            );
+        }
+    } else if let Some(session_id) = session_id {
+        append_session_journal_event(
+            session_id,
+            astra_services::session_journal::JournalEvent::execution_boundary_committed(
+                Some(session_id),
+                active.turn_index,
+                EXECUTION_BOUNDARY_KIND_TURN_ROLLBACK,
+                None,
+                Some(server_boundary_commit_detail(
+                    active,
+                    new_records.len(),
+                    file_entries_added,
+                    session_state_entries_added,
+                )),
+            ),
+        );
+    }
 }
 
 pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
@@ -85,6 +408,15 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
     .await;
     let all_tool_calls = tool_calls.as_slice();
     let edge_round_for_headless = edge_tool_round.as_slice();
+    let active_server_rollback_boundary =
+        state.server_tool_executor.as_deref().and_then(|executor| {
+            open_server_rollback_boundary(
+                state.current_session_id.as_deref(),
+                executor,
+                turn_index as u32,
+                all_tool_calls,
+            )
+        });
 
     let errors_before_round = state.turn_guard.errors.total_errors;
     let errors_by_cat_before = state.turn_guard.errors.errors_by_category.clone();
@@ -138,6 +470,18 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
             server_tool_executor: state.server_tool_executor.as_deref(),
         })
         .await;
+    }
+    if let (Some(active), Some(executor)) = (
+        active_server_rollback_boundary.as_ref(),
+        state.server_tool_executor.as_deref(),
+    ) {
+        let new_records = &state.stall.tool_call_records[evo_records_before..];
+        finalize_server_rollback_boundary(
+            state.current_session_id.as_deref(),
+            executor,
+            active,
+            new_records,
+        );
     }
 
     if let Some(ref evo) = state.evolution_service {
@@ -533,10 +877,17 @@ fn observe_gate_cancelled(
 
 #[cfg(test)]
 mod tests {
-    use super::{tool_record_result_text, tool_record_was_rejected};
-    use astra_services::session_journal::ToolCallRecord;
+    use super::*;
+    use astra_services::session_journal::{
+        JournalEvent, JournalEventType, JournalWriter, ToolCallRecord,
+    };
+    use serde_json::json;
 
-    fn tool_record(ok: bool, error: Option<&str>, result_preview: Option<&str>) -> ToolCallRecord {
+    fn summary_tool_record(
+        ok: bool,
+        error: Option<&str>,
+        result_preview: Option<&str>,
+    ) -> ToolCallRecord {
         ToolCallRecord {
             name: "bash".into(),
             ok,
@@ -551,7 +902,7 @@ mod tests {
 
     #[test]
     fn blocked_tool_records_fall_back_to_error_text_and_mark_rejected() {
-        let rec = tool_record(
+        let rec = summary_tool_record(
             false,
             Some("blocked_tool: Explicit approval required: action scope is unbounded."),
             None,
@@ -565,8 +916,258 @@ mod tests {
 
     #[test]
     fn executed_tool_records_prefer_result_preview() {
-        let rec = tool_record(false, Some("Error: command failed"), Some("stderr preview"));
+        let rec = summary_tool_record(false, Some("Error: command failed"), Some("stderr preview"));
         assert_eq!(tool_record_result_text(&rec), "stderr preview");
         assert!(!tool_record_was_rejected(&rec));
+    }
+
+    fn tool_record(name: &str, ok: bool) -> ToolCallRecord {
+        ToolCallRecord {
+            name: name.to_string(),
+            ok,
+            ms: 1,
+            error: (!ok).then(|| "simulated error".to_string()),
+            input_bytes: None,
+            output_bytes: None,
+            args_preview: None,
+            result_preview: None,
+        }
+    }
+
+    fn read_journal_events(session_id: &str) -> Vec<JournalEvent> {
+        let writer = JournalWriter::new(session_id).unwrap();
+        let content = std::fs::read_to_string(writer.path()).unwrap_or_default();
+        content
+            .lines()
+            .filter_map(|line| serde_json::from_str(line).ok())
+            .collect()
+    }
+
+    fn cleanup_journal(session_id: &str) {
+        let writer = JournalWriter::new(session_id).unwrap();
+        std::fs::remove_file(writer.path()).ok();
+    }
+
+    fn cleanup_session_artifacts(session_id: &str) {
+        cleanup_journal(session_id);
+        std::fs::remove_dir_all(
+            astra_services::session_journal::local_sessions_dir().join(session_id),
+        )
+        .ok();
+    }
+
+    fn session_state_executor(
+        session_id: &str,
+        dir: &tempfile::TempDir,
+        turn_index: u32,
+    ) -> (
+        crate::server::server_tool_executor::ServerToolExecutor,
+        std::sync::Arc<std::sync::RwLock<crate::observability_integration::ObservabilitySession>>,
+    ) {
+        let mut workspace =
+            astra_services::session_workspace::WorkspaceMetadata::new(session_id, "test-model");
+        workspace.cwd = dir.path().display().to_string();
+        astra_services::session_workspace::write_workspace(&workspace).unwrap();
+
+        let mut executor = crate::server::server_tool_executor::ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            session_id.to_string(),
+            None,
+            None,
+        );
+        let session = std::sync::Arc::new(std::sync::RwLock::new(
+            crate::observability_integration::ObservabilitySession::new_simple(session_id),
+        ));
+        session.write().unwrap().turn_number = turn_index;
+        executor.set_observability_session(session.clone());
+        executor.set_turn_index(turn_index);
+        (executor, session)
+    }
+
+    #[tokio::test]
+    async fn server_file_boundary_commits_successful_turn() {
+        let session_id = format!("server-file-boundary-{}", uuid::Uuid::new_v4());
+        let dir = tempfile::TempDir::new().unwrap();
+        let executor = crate::server::server_tool_executor::ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            session_id.clone(),
+            None,
+            None,
+        );
+        executor.set_turn_index(5);
+
+        let active = open_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            5,
+            &[json!({"function": {"name": "write_file", "arguments": "{}"}})],
+        )
+        .expect("boundary should open for write_file");
+
+        let write_out = executor
+            .execute("write_file", &json!({"path": "ok.txt", "content": "hello"}))
+            .await;
+        assert!(write_out.contains("Successfully wrote"));
+
+        finalize_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            &active,
+            &[tool_record("write_file", true)],
+        );
+
+        let events = read_journal_events(&session_id);
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].event_type,
+            JournalEventType::ExecutionBoundaryOpened
+        );
+        assert_eq!(
+            events[1].event_type,
+            JournalEventType::ExecutionBoundaryCommitted
+        );
+        let detail = events[1].metadata.as_ref().unwrap()["execution_boundary"]["detail"].clone();
+        assert_eq!(detail["executed_requests"].as_u64(), Some(1));
+        assert_eq!(detail["file_entries_recorded"].as_u64(), Some(1));
+        assert!(dir.path().join("ok.txt").exists());
+
+        cleanup_session_artifacts(&session_id);
+    }
+
+    #[tokio::test]
+    async fn server_file_boundary_aborts_and_rolls_back_failed_turn() {
+        let session_id = format!("server-file-boundary-{}", uuid::Uuid::new_v4());
+        let dir = tempfile::TempDir::new().unwrap();
+        let executor = crate::server::server_tool_executor::ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            session_id.clone(),
+            None,
+            None,
+        );
+        executor.set_turn_index(7);
+
+        let active = open_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            7,
+            &[json!({"function": {"name": "write_file", "arguments": "{}"}})],
+        )
+        .expect("boundary should open for write_file");
+
+        let write_out = executor
+            .execute(
+                "write_file",
+                &json!({"path": "turn.txt", "content": "hello"}),
+            )
+            .await;
+        assert!(write_out.contains("Successfully wrote"));
+        assert!(dir.path().join("turn.txt").exists());
+
+        finalize_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            &active,
+            &[tool_record("write_file", true), tool_record("grep", false)],
+        );
+
+        let events = read_journal_events(&session_id);
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].event_type,
+            JournalEventType::ExecutionBoundaryOpened
+        );
+        assert_eq!(
+            events[1].event_type,
+            JournalEventType::ExecutionBoundaryAborted
+        );
+        let boundary = &events[1].metadata.as_ref().unwrap()["execution_boundary"];
+        assert_eq!(boundary["kind"].as_str(), Some("turn_rollback"));
+        assert_eq!(boundary["reason"].as_str(), Some("tool_error"));
+        assert_eq!(boundary["trigger_tool_name"].as_str(), Some("grep"));
+        assert_eq!(
+            boundary["rollback"]["file_edits"]["reverted"]
+                .as_array()
+                .map(Vec::len),
+            Some(1)
+        );
+        assert!(!dir.path().join("turn.txt").exists());
+
+        cleanup_session_artifacts(&session_id);
+    }
+
+    #[tokio::test]
+    async fn server_session_state_boundary_aborts_and_rolls_back_failed_turn() {
+        let session_id = format!("server-session-boundary-{}", uuid::Uuid::new_v4());
+        let dir = tempfile::TempDir::new().unwrap();
+        let (executor, session) = session_state_executor(&session_id, &dir, 9);
+        let original_top_k = session.read().unwrap().config.memory.retrieval_top_k;
+        let new_top_k = if original_top_k < 20 {
+            original_top_k + 1
+        } else {
+            original_top_k.saturating_sub(1)
+        };
+
+        let active = open_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            9,
+            &[json!({"function": {"name": "adjust_config", "arguments": "{}"}})],
+        )
+        .expect("boundary should open for adjust_config");
+
+        let adjust_out = executor
+            .execute(
+                "adjust_config",
+                &json!({"path": "memory.retrieval_top_k", "value": new_top_k}),
+            )
+            .await;
+        let adjust_json: Value = serde_json::from_str(&adjust_out).unwrap();
+        assert_eq!(adjust_json["status"].as_str(), Some("ok"));
+        assert_eq!(
+            session.read().unwrap().config.memory.retrieval_top_k,
+            new_top_k
+        );
+
+        finalize_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            &active,
+            &[
+                tool_record("adjust_config", true),
+                tool_record("grep", false),
+            ],
+        );
+
+        let events = read_journal_events(&session_id);
+        let boundary_events: Vec<_> = events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event.event_type,
+                    JournalEventType::ExecutionBoundaryOpened
+                        | JournalEventType::ExecutionBoundaryAborted
+                )
+            })
+            .collect();
+        assert_eq!(boundary_events.len(), 2);
+        let boundary = &boundary_events[1].metadata.as_ref().unwrap()["execution_boundary"];
+        assert_eq!(boundary["kind"].as_str(), Some("turn_rollback"));
+        assert_eq!(boundary["reason"].as_str(), Some("tool_error"));
+        assert_eq!(boundary["trigger_tool_name"].as_str(), Some("grep"));
+        assert_eq!(
+            boundary["rollback"]["session_state"]["restored"]
+                .as_array()
+                .map(Vec::len),
+            Some(1)
+        );
+        assert_eq!(
+            session.read().unwrap().config.memory.retrieval_top_k,
+            original_top_k
+        );
+
+        cleanup_session_artifacts(&session_id);
     }
 }

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
@@ -225,12 +225,32 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
     use serde_json::json;
 
     use crate::skills::hooks::{HookAction, ToolEventHook, ToolEventHookRegistry, ToolEventKind};
     use crate::turn::agentic_headless_round::NoopHeadlessTerminal;
     use crate::turn::sse_stream_host::EdgeToolExecResult;
+
+    fn init_git_repo(dir: &Path) {
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+    }
 
     struct PipelineHarness {
         api: ThinClient,
@@ -284,9 +304,19 @@ mod tests {
         }
 
         fn pipeline(&mut self) -> HeadlessToolExecutionPipeline<'_, EdgeToolExecResult> {
+            self.pipeline_with_server_executor(0, None)
+        }
+
+        fn pipeline_with_server_executor<'a>(
+            &'a mut self,
+            turn_index: usize,
+            server_tool_executor: Option<
+                &'a crate::server::server_tool_executor::ServerToolExecutor,
+            >,
+        ) -> HeadlessToolExecutionPipeline<'a, EdgeToolExecResult> {
             HeadlessToolExecutionPipeline::new(
                 HeadlessToolExecutionCtx {
-                    turn_index: 0,
+                    turn_index,
                     quiet: true,
                     api: &self.api,
                     token: "",
@@ -313,7 +343,7 @@ mod tests {
                     permission_context: None,
                     progress_emitter: None,
                     effective_permission_timeout: Duration::from_secs(30),
-                    server_tool_executor: None,
+                    server_tool_executor,
                 },
                 vec![false; self.edge_tool_round.len()],
             )
@@ -445,6 +475,103 @@ mod tests {
             pipeline.ctx.tool_results[0]
                 .to_string()
                 .contains("hooked result")
+        );
+    }
+
+    #[tokio::test]
+    async fn server_fallback_sets_turn_index_for_current_turn_rollback() {
+        let mut harness = PipelineHarness::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let server_exec = crate::server::server_tool_executor::ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            "test-session".into(),
+            None,
+            None,
+        );
+        let mut pipeline = harness.pipeline_with_server_executor(7, Some(&server_exec));
+        let args = json!({"path": "turn.txt", "content": "hello"});
+        let permitted = PermittedExecution {
+            execution: HeadlessResolvedExecution {
+                id: "call-1".into(),
+                name: "write_file".into(),
+                args: args.clone(),
+                result_str: "Error: headless edge protocol: no matching edge result".into(),
+                tool_result_fields: None,
+                edge_duration_ms: 0,
+                is_edge_tool: false,
+                early_exit_ms: 0,
+            },
+            idem_key: IdempotencyKey::semantic("write_file", &args),
+        };
+
+        let executed = pipeline.execute_execution(permitted).await;
+        assert!(!executed.is_err);
+        assert!(dir.path().join("turn.txt").exists());
+
+        let rollback = server_exec
+            .execute("rollback_file_edits", &json!({"scope": "current_turn"}))
+            .await;
+        let rollback_json: Value = serde_json::from_str(&rollback).unwrap();
+        assert_eq!(
+            rollback_json["success"].as_bool(),
+            Some(true),
+            "got: {rollback}"
+        );
+        assert_eq!(rollback_json["turn_index"].as_u64(), Some(7));
+        assert_eq!(rollback_json["reverted"].as_array().map(Vec::len), Some(1));
+        assert!(!dir.path().join("turn.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn server_fallback_preserves_tool_result_fields() {
+        let mut harness = PipelineHarness::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        init_git_repo(dir.path());
+        std::fs::write(dir.path().join("tracked.txt"), "hello\n").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        let server_exec = crate::server::server_tool_executor::ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            "test-session".into(),
+            None,
+            None,
+        );
+        let mut pipeline = harness.pipeline_with_server_executor(3, Some(&server_exec));
+        let args = json!({"message": "initial"});
+        let permitted = PermittedExecution {
+            execution: HeadlessResolvedExecution {
+                id: "call-git-commit".into(),
+                name: "git_commit".into(),
+                args: args.clone(),
+                result_str: "Error: headless edge protocol: no matching edge result".into(),
+                tool_result_fields: None,
+                edge_duration_ms: 0,
+                is_edge_tool: false,
+                early_exit_ms: 0,
+            },
+            idem_key: IdempotencyKey::semantic("git_commit", &args),
+        };
+
+        let executed = pipeline.execute_execution(permitted).await;
+        assert!(!executed.is_err, "got: {}", executed.execution.result_str);
+        let result_fields = executed
+            .execution
+            .tool_result_fields
+            .as_ref()
+            .expect("server fallback metadata");
+        assert!(result_fields["commit_sha"].as_str().is_some());
+        pipeline.record_execution(executed).await;
+        assert!(
+            pipeline.ctx.tool_results[0]
+                .to_string()
+                .contains("\"commit_sha\""),
+            "got: {}",
+            pipeline.ctx.tool_results[0]
         );
     }
 }

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline/execute.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline/execute.rs
@@ -34,7 +34,12 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
         // execute the tool directly on the server instead.
         if !execution.is_edge_tool && execution.result_str.starts_with(EDGE_PROTOCOL_ERROR_PREFIX) {
             if let Some(executor) = self.ctx.server_tool_executor {
-                execution.result_str = executor.execute(&execution.name, &execution.args).await;
+                executor.set_turn_index(self.ctx.turn_index.min(u32::MAX as usize) as u32);
+                let result = executor
+                    .execute_with_metadata(&execution.name, &execution.args)
+                    .await;
+                execution.tool_result_fields = result.metadata;
+                execution.result_str = result.output;
             }
         }
 

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/harness.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/harness.rs
@@ -8,18 +8,21 @@
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+use astra_core::SharedPool;
 use astra_core::config::AppSettings;
-use astra_runtime::{MemoriaForwarder, build_app, build_server_state};
+use astra_runtime::{DatabaseEvaluationService, MemoriaForwarder, build_app, build_server_state};
 use async_trait::async_trait;
 use axum::{
-    Router,
+    Json, Router,
     body::{self, Body},
     http::{Request, StatusCode},
+    routing::get,
 };
 use futures_util::StreamExt;
 use serde_json::{Value, json};
 use sqlx::Row;
 use sqlx::mysql::MySqlRow;
+use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tower::util::ServiceExt;
 use uuid::Uuid;
@@ -56,6 +59,58 @@ impl MemoriaForwarder for E2eMemoriaStub {
         }
         Ok(json!({ "memory_id": "e2e-stub-memory" }))
     }
+}
+
+async fn start_mock_memoria_health() -> String {
+    let app = Router::new()
+        .route(
+            "/v1/health/storage",
+            get(|| async move {
+                Json(json!({
+                    "total": 12,
+                    "active": 9,
+                    "inactive": 3
+                }))
+            }),
+        )
+        .route(
+            "/v1/health/analyze",
+            get(|| async move {
+                Json(json!({
+                    "semantic": {
+                        "total": 4,
+                        "avg_confidence": 0.8
+                    },
+                    "profile": {
+                        "total": 8,
+                        "avg_confidence": 0.6
+                    }
+                }))
+            }),
+        )
+        .route(
+            "/v1/health/hygiene",
+            get(|| async move {
+                Json(json!({
+                    "inactive_memories": 0,
+                    "stale_working_memories": 2,
+                    "orphan_memory_entity_links": 0,
+                    "orphan_entity_links": 0,
+                    "orphan_graph_nodes": 0
+                }))
+            }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock memoria health");
+    let addr = listener.local_addr().expect("mock memoria local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve mock memoria health");
+    });
+    tokio::task::yield_now().await;
+    format!("http://{addr}")
 }
 
 pub async fn get_json(
@@ -383,6 +438,7 @@ pub async fn bootstrap() -> BootstrapResult {
     dotenvy::dotenv().ok();
 
     let settings = AppSettings::from_env().expect("AppSettings::from_env (see astra-server env)");
+    let matrixone_settings = settings.matrixone.clone();
     let matrixone_database = settings.matrixone.database.clone();
     let url = settings.matrixone.database_url();
 
@@ -399,6 +455,19 @@ pub async fn bootstrap() -> BootstrapResult {
         .connect(&url)
         .await
         .expect("connect MatrixOne for assertions");
+
+    let evaluation_pool = SharedPool::new(&matrixone_settings)
+        .await
+        .expect("connect MatrixOne shared pool for evaluation");
+    let memoria_health_base_url = start_mock_memoria_health().await;
+    let state = state.with_evaluation_service(Arc::new(
+        DatabaseEvaluationService::new(matrixone_settings)
+            .with_pool(evaluation_pool)
+            .with_memoria_config(
+                memoria_health_base_url,
+                Some("system-e2e-mock-master-key".to_string()),
+            ),
+    ));
 
     let app = build_app(state);
 

--- a/rust/crates/services/src/mutation_scoreboard.rs
+++ b/rust/crates/services/src/mutation_scoreboard.rs
@@ -1108,6 +1108,60 @@ mod tests {
     }
 
     #[test]
+    fn session_state_compensation_stays_staged_apply_ready_without_snapshot() {
+        let mutation = StagedMutation::new(
+            "mut-session",
+            "session-1",
+            7,
+            "adjust_config",
+            serde_json::json!({"path": "memory.retrieval_top_k", "value": 6}),
+            None,
+            MutationObjectiveScore::from_learning_signal(0.91, Some(86), 0.04, 0.83, false),
+            Some(MutationVerifierSummary::from_report(&verification_report(
+                true,
+            ))),
+            MutationCompensationPolicy {
+                bounded: true,
+                reversible: true,
+                requires_pre_state: false,
+                action_category: MutationActionCategory::Write,
+                compensation_kind: Some("restore_session_state".into()),
+                compensation_summary: Some(
+                    "call `rollback_session_state` with scope=`current_turn` to restore the previous session state"
+                        .into(),
+                ),
+            },
+        );
+
+        assert_eq!(
+            mutation.judgment.safety_verdict,
+            MutationSafetyVerdict::Safe
+        );
+        assert!(
+            mutation
+                .judgment
+                .promotion_verdict
+                .evidence
+                .iter()
+                .any(|evidence| evidence == "bounded_reversible_compensation")
+        );
+        assert!(
+            mutation
+                .judgment
+                .promotion_verdict
+                .evidence
+                .iter()
+                .all(|evidence| evidence != "missing_pre_state_snapshot")
+        );
+        assert_eq!(
+            mutation.judgment.promotion_verdict.rollback_hint.as_deref(),
+            Some(
+                "call `rollback_session_state` with scope=`current_turn` to restore the previous session state"
+            )
+        );
+    }
+
+    #[test]
     fn uncertain_retention_score_stays_review_instead_of_reject() {
         let mutation = StagedMutation::new(
             "mut-uncertain",


### PR DESCRIPTION
## Summary
- close the remaining no-edge server rollback shell gaps by bringing rollback-backed session-state, database, and git mutation flows into the live server boundary
- auto-rollback recorded file edits, MatrixOne snapshots, git history mutations, and session-state mutations when a server-side round aborts after partial execution
- align server-visible rollback guidance with the actual tool surface and clean up restored MatrixOne snapshots after rollback
- make `system_matrix_http_e2e` self-contained for evaluation memory-health calls by routing them through a local mock Memoria health service instead of placeholder env credentials

## Testing
- `make format`
- `make check`
- `make test-offline`
- `make test-online`
