### PR TITLE
feat(auth): add trusted_moi mode and mode-aware e2e coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,19 @@ JWT_ALGORITHM=HS256
 JWT_ACCESS_TOKEN_EXPIRE_MINUTES=60
 JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
 
+# Auth mode
+# - local_jwt (default): astra built-in register/login/refresh/logout
+# - trusted_moi: trust external Moi JWT only; local auth endpoints are disabled
+ASTRA_AUTH_MODE=local_jwt
+
+# trusted_moi mode settings (used when ASTRA_AUTH_MODE=trusted_moi)
+# TRUSTED_MOI_JWT_SECRET_KEY has priority; falls back to JWT_SECRET_KEY if unset.
+#TRUSTED_MOI_JWT_SECRET_KEY=your-shared-secret
+#TRUSTED_MOI_JWT_ALGORITHM=HS256
+#TRUSTED_MOI_JWT_ISSUER=
+#TRUSTED_MOI_JWT_AUDIENCE=
+#TRUSTED_MOI_JWT_LEEWAY_SECS=30
+
 # Token Encryption (REQUIRED)
 # Generate automatically with: bash scripts/dev/init.sh
 TOKEN_ENCRYPTION_KEY=CHANGE_ME_IN_PRODUCTION

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,8 @@ jobs:
           shared-key: ci-offline
           save-if: false
       - run: cargo test --manifest-path rust/Cargo.toml -p astra-runtime
+      - name: Run trusted_moi auth integration tests
+        run: cargo test --manifest-path rust/Cargo.toml -p astra-runtime --test trusted_moi_auth_integration -- --nocapture
       - name: Run bridge-e2e-hooks tests
         run: cargo test --manifest-path rust/Cargo.toml -p astra-runtime --features bridge-e2e-hooks
 

--- a/docs/implementation/authentication.md
+++ b/docs/implementation/authentication.md
@@ -9,6 +9,11 @@ Two-layer separation:
 
 The platform does NOT implement RBAC. It does NOT query `mo_catalog.mo_user_grant`. Authorization is ownership-based: you can only operate on resources you created.
 
+## Runtime Modes
+
+- `ASTRA_AUTH_MODE=local_jwt` (default): astra issues and validates local JWTs via `/auth/login` and `/auth/refresh`.
+- `ASTRA_AUTH_MODE=trusted_moi`: astra trusts externally issued Moi JWTs (`Authorization: Bearer ...`) and disables local auth endpoints (`/auth/register`, `/auth/login`, `/auth/refresh`, `/auth/logout` return 403).
+
 ## Authentication: JWT
 
 ```

--- a/docs/testing/system-e2e-matrix.md
+++ b/docs/testing/system-e2e-matrix.md
@@ -39,7 +39,7 @@ Evaluation **read** routes in the full journey use `x-user-id` without bearer (s
 
 ## Test binaries (ignored by default)
 
-Nine tests in `system_matrix_http_e2e` — overlap with the full journey is avoided (e.g. no separate “basic session” test that repeats the same list/get/close/resume steps).
+Ten tests in `system_matrix_http_e2e` — overlap with the full journey is avoided (e.g. no separate “basic session” test that repeats the same list/get/close/resume steps).
 
 **Related (separate crate / gate):** `ASTRA_SERVICES_DB_IT=1` runs `cargo test -p astra-services --test services_db_integration -- --ignored` (MatrixOne): pagination clamps, `skills_registry` list/index, cross-session audit service paths, and `MatrixOneDurableTaskLifecycle::resume_task` verification history (see that test file’s module doc).
 
@@ -50,17 +50,18 @@ Nine tests in `system_matrix_http_e2e` — overlap with the full journey is avoi
 | `e2e_matrix_chat_run_pause_resume_http` | `journey_tasks_runs.rs` | `POST /chat` (background run), `POST .../pause`, `GET /chat/runs/{id}`, `POST .../resume` |
 | `e2e_matrix_session_cancel_delete` | `journey_extended.rs` | `POST /sessions/{id}/cancel` + `agent_sessions.status`, `DELETE /sessions/{id}` |
 | `e2e_matrix_chat_stream_session_info` | `journey_extended.rs` | `POST /chat/stream` SSE → `session_info` + `run_id` |
-| `e2e_matrix_auth_session_negative_paths` | `journey_extended.rs` | `GET /sessions` without auth (401); duplicate `POST /auth/register`; bad `POST /auth/login`; successful login |
+| `e2e_matrix_auth_session_negative_paths` | `journey_extended.rs` | `GET /sessions` without auth (401); mode-aware auth negatives: `local_jwt` checks duplicate register + bad login + successful login, `trusted_moi` checks local auth endpoints disabled |
 | `e2e_matrix_memory_proxy_user_isolation` | `journey_extended.rs` | Unauthenticated `POST /memory/store` (401); spoofed `user_id`/`session_id` in body → forwarder receives JWT `user_id` for both fields |
-| `e2e_matrix_models_admin_crud` | `journey_extended.rs` | SQL `astra_admin` role grant; `POST/PUT/DELETE /models` with `provider: mock` + `infra_llm_models` row checks |
+| `e2e_matrix_models_admin_crud` | `journey_extended.rs` | Mode-aware: `local_jwt` runs SQL `astra_admin` role grant + `POST/PUT/DELETE /models` with DB checks; `trusted_moi` asserts current admin path rejects the call (admin auth still local-JWT based) |
 | `e2e_matrix_audit_cross_session_analytics_http` | `journey_audit_cross_session.rs` | Seed `agent_sessions` / `agent_events` / `ctx_decision_audits`; `GET /audit/stats`, `GET /audit/mutations`, `GET /audit/promotions` JSON assertions |
+| `e2e_matrix_trusted_moi_user_system_integration` | `journey_trusted_moi.rs` | Startup in `trusted_moi`; external JWT `/auth/me`; local auth endpoints disabled (`/auth/register|login|refresh`=403); `POST /sessions` + DB owner and memory proxy identity isolation bound to upstream user ID |
 
-Shared helpers: `tests/system_matrix_http_e2e/harness.rs` (`bootstrap`, `grant_astra_admin_role`, HTTP helpers, `cleanup_*`, row getters, SSE helpers, `wait_for_agent_event_types` — polls `agent_events` after `chat/turn` instead of a fixed sleep).
+Shared helpers: `tests/system_matrix_http_e2e/harness.rs` (`bootstrap`, `bootstrap_trusted_moi`, `grant_astra_admin_role`, HTTP helpers, `cleanup_*`, row getters, SSE helpers, `wait_for_agent_event_types` — polls `agent_events` after `chat/turn` instead of a fixed sleep).
 
 ## Database isolation
 
 - **Shared database**: All tests use the same MatrixOne database from `AppSettings` (typically `astra_runtime`). There is **no separate schema per test**.
-- **Row isolation**: Each `bootstrap()` registers a **new user** (`prod_matrix_{uuid}`), obtains a new `user_id`, creates a **new** `session_id`, and uses an `edge_agent_id` / `suffix` unique to that run. API state and SQL assertions are scoped by those IDs.
+- **Row isolation**: Each `bootstrap()` registers a **new user** (`prod_matrix_{uuid}`), and `bootstrap_trusted_moi()` creates a **new external user principal** (`moi-user-{uuid}`); both create a **new** `session_id` and use an `edge_agent_id` / `suffix` unique to that run. API state and SQL assertions are scoped by those IDs.
 - **Parallel runs**: Tests are safe to run in parallel by default (`cargo` / `make test-online` without `ASTRA_SYSTEM_MATRIX_E2E_TEST_THREADS=1`). The full journey uses a **suffix-scoped marketplace skill name** (`e2e_matrix_mkt_{suffix}`) so concurrent runs do not fight over the same global marketplace stats key.
 - **Opt-in serial**: If you hit flakiness (shared Redis keys, connection limits, etc.), run with `ASTRA_SYSTEM_MATRIX_E2E_TEST_THREADS=1` (see `Makefile` `test-ignored-integration`) to force `--test-threads=1` for `system_matrix_http_e2e` only.
 

--- a/rust/crates/runtime/src/server/state_builder.rs
+++ b/rust/crates/runtime/src/server/state_builder.rs
@@ -10,6 +10,26 @@ pub async fn build_server_state(
     ensure_core_schema(&settings.matrixone).await?;
     let shared_pool = SharedPool::new(&settings.matrixone).await?;
     let lease_hold_cache = Arc::new(TaskLeaseHoldCache::default());
+    let auth_mode = std::env::var("ASTRA_AUTH_MODE")
+        .unwrap_or_else(|_| "local_jwt".to_string())
+        .trim()
+        .to_ascii_lowercase();
+    let auth_service: Arc<dyn AuthService> = match auth_mode.as_str() {
+        "" | "local_jwt" | "local" | "database" => Arc::new(
+            DatabaseAuthService::new(settings.matrixone.clone(), settings.jwt.clone())
+                .with_pool(shared_pool.clone()),
+        ),
+        "trusted_moi" => Arc::new(
+            astra_services::auth::TrustedMoiAuthService::from_env()
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?,
+        ),
+        other => {
+            return Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("unsupported ASTRA_AUTH_MODE={other}; expected local_jwt or trusted_moi"),
+            )));
+        }
+    };
 
     // Build shared pipeline learning modules (server-wide singleton).
     let learning_stack = build_pipeline_learning_stack(None);
@@ -19,10 +39,7 @@ pub async fn build_server_state(
         Arc::new(MatrixOneHealthChecker::new(settings.matrixone.clone())),
     )
     .with_shared_pool(shared_pool.clone())
-    .with_auth_service(Arc::new(
-        DatabaseAuthService::new(settings.matrixone.clone(), settings.jwt.clone())
-            .with_pool(shared_pool.clone()),
-    ))
+    .with_auth_service(auth_service)
     .with_session_service(Arc::new(
         DatabaseSessionService::new(settings.matrixone.clone()).with_pool(shared_pool.clone()),
     ))

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/harness.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/harness.rs
@@ -18,8 +18,10 @@ use axum::{
     http::{Request, StatusCode},
     routing::get,
 };
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use futures_util::StreamExt;
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use sqlx::Row;
 use sqlx::mysql::MySqlRow;
 use tokio::net::TcpListener;
@@ -28,6 +30,14 @@ use tower::util::ServiceExt;
 use uuid::Uuid;
 
 static E2E_ENV_INIT: OnceLock<()> = OnceLock::new();
+static SERVER_STATE_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+const TRUSTED_MOI_E2E_SECRET: &str = "trusted_moi_system_e2e_secret_key_123456";
+const TRUSTED_MOI_E2E_EXP: u64 = 4_102_444_800; // 2100-01-01T00:00:00Z
+
+fn server_state_env_lock() -> &'static Mutex<()> {
+    SERVER_STATE_ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
 
 pub fn require_system_e2e_env() {
     assert_eq!(
@@ -43,6 +53,117 @@ pub fn require_system_e2e_env() {
             std::env::set_var("ASTRA_BRIDGE_TEST_SECRET", &secret);
         }
     });
+}
+
+fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
+    const BLOCK_SIZE: usize = 64;
+    let mut normalized_key = [0u8; BLOCK_SIZE];
+    if key.len() > BLOCK_SIZE {
+        let digest = Sha256::digest(key);
+        normalized_key[..32].copy_from_slice(&digest);
+    } else {
+        normalized_key[..key.len()].copy_from_slice(key);
+    }
+
+    let mut inner_pad = [0x36u8; BLOCK_SIZE];
+    let mut outer_pad = [0x5cu8; BLOCK_SIZE];
+    for i in 0..BLOCK_SIZE {
+        inner_pad[i] ^= normalized_key[i];
+        outer_pad[i] ^= normalized_key[i];
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(inner_pad);
+    inner.update(message);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(outer_pad);
+    outer.update(inner_digest);
+    let digest = outer.finalize();
+
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    out
+}
+
+fn build_hs256_jwt(secret: &str, claims: Value) -> String {
+    let header = json!({
+        "alg": "HS256",
+        "typ": "JWT"
+    });
+    let header_b64 = URL_SAFE_NO_PAD.encode(header.to_string().as_bytes());
+    let claims_b64 = URL_SAFE_NO_PAD.encode(claims.to_string().as_bytes());
+    let signing_input = format!("{header_b64}.{claims_b64}");
+    let signature = hmac_sha256(secret.as_bytes(), signing_input.as_bytes());
+    let signature_b64 = URL_SAFE_NO_PAD.encode(signature);
+    format!("{signing_input}.{signature_b64}")
+}
+
+fn set_env_var_for_e2e(name: &str, value: &str) {
+    // SAFETY: this is guarded by `SERVER_STATE_ENV_LOCK`, so no concurrent env mutation/read among
+    // system E2E bootstrap paths.
+    unsafe {
+        std::env::set_var(name, value);
+    }
+}
+
+fn restore_env_var_for_e2e(name: &str, old_value: Option<String>) {
+    // SAFETY: this is guarded by `SERVER_STATE_ENV_LOCK`, so no concurrent env mutation/read among
+    // system E2E bootstrap paths.
+    unsafe {
+        if let Some(v) = old_value {
+            std::env::set_var(name, v);
+        } else {
+            std::env::remove_var(name);
+        }
+    }
+}
+
+async fn build_state_with_mode(
+    memoria: Arc<E2eMemoriaStub>,
+    trusted_moi_mode: bool,
+) -> (astra_runtime::AppState, String, String) {
+    let _env_guard = server_state_env_lock().lock().await;
+    dotenvy::dotenv().ok();
+
+    let prev_auth_mode = std::env::var("ASTRA_AUTH_MODE").ok();
+    let prev_trusted_secret = std::env::var("TRUSTED_MOI_JWT_SECRET_KEY").ok();
+    let prev_trusted_algorithm = std::env::var("TRUSTED_MOI_JWT_ALGORITHM").ok();
+    let prev_trusted_issuer = std::env::var("TRUSTED_MOI_JWT_ISSUER").ok();
+    let prev_trusted_audience = std::env::var("TRUSTED_MOI_JWT_AUDIENCE").ok();
+    let prev_trusted_leeway = std::env::var("TRUSTED_MOI_JWT_LEEWAY_SECS").ok();
+
+    if trusted_moi_mode {
+        set_env_var_for_e2e("ASTRA_AUTH_MODE", "trusted_moi");
+        set_env_var_for_e2e("TRUSTED_MOI_JWT_SECRET_KEY", TRUSTED_MOI_E2E_SECRET);
+        set_env_var_for_e2e("TRUSTED_MOI_JWT_ALGORITHM", "HS256");
+        restore_env_var_for_e2e("TRUSTED_MOI_JWT_ISSUER", None);
+        restore_env_var_for_e2e("TRUSTED_MOI_JWT_AUDIENCE", None);
+        set_env_var_for_e2e("TRUSTED_MOI_JWT_LEEWAY_SECS", "30");
+    }
+
+    let settings = AppSettings::from_env().expect("AppSettings::from_env (see astra-server env)");
+    let matrixone_database = settings.matrixone.database.clone();
+    let url = settings.matrixone.database_url();
+    let state = build_server_state(settings).await;
+
+    if trusted_moi_mode {
+        restore_env_var_for_e2e("ASTRA_AUTH_MODE", prev_auth_mode);
+        restore_env_var_for_e2e("TRUSTED_MOI_JWT_SECRET_KEY", prev_trusted_secret);
+        restore_env_var_for_e2e("TRUSTED_MOI_JWT_ALGORITHM", prev_trusted_algorithm);
+        restore_env_var_for_e2e("TRUSTED_MOI_JWT_ISSUER", prev_trusted_issuer);
+        restore_env_var_for_e2e("TRUSTED_MOI_JWT_AUDIENCE", prev_trusted_audience);
+        restore_env_var_for_e2e("TRUSTED_MOI_JWT_LEEWAY_SECS", prev_trusted_leeway);
+    }
+
+    (
+        state
+            .expect("build_server_state")
+            .with_memoria_forwarder(memoria),
+        matrixone_database,
+        url,
+    )
 }
 
 #[derive(Clone, Default)]
@@ -399,10 +520,34 @@ pub struct MatrixE2eCtx {
     pub suffix: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum E2eAuthMode {
+    LocalJwt,
+    TrustedMoi,
+}
+
+pub fn current_auth_mode() -> E2eAuthMode {
+    let mode = std::env::var("ASTRA_AUTH_MODE")
+        .unwrap_or_else(|_| "local_jwt".to_string())
+        .trim()
+        .to_ascii_lowercase();
+    match mode.as_str() {
+        "" | "local_jwt" | "local" | "database" => E2eAuthMode::LocalJwt,
+        "trusted_moi" => E2eAuthMode::TrustedMoi,
+        other => panic!("unsupported ASTRA_AUTH_MODE in e2e: {other}"),
+    }
+}
+
 pub struct BootstrapResult {
     pub ctx: MatrixE2eCtx,
     pub auth_header: String,
     pub refresh_token: String,
+    pub auth_mode: E2eAuthMode,
+}
+
+pub struct TrustedMoiBootstrapResult {
+    pub ctx: MatrixE2eCtx,
+    pub auth_header: String,
 }
 
 pub const E2E_PASSWORD: &str = "E2e-matrix-pass-9";
@@ -435,20 +580,23 @@ pub async fn grant_astra_admin_role(pool: &sqlx::MySqlPool, user_id: &str) {
 
 /// Build app, connect pool, register user, refresh token, create session (with cleanup of stale rows).
 pub async fn bootstrap() -> BootstrapResult {
-    dotenvy::dotenv().ok();
+    match current_auth_mode() {
+        E2eAuthMode::LocalJwt => bootstrap_local_jwt().await,
+        E2eAuthMode::TrustedMoi => {
+            let trusted = bootstrap_trusted_moi().await;
+            BootstrapResult {
+                ctx: trusted.ctx,
+                auth_header: trusted.auth_header,
+                refresh_token: String::new(),
+                auth_mode: E2eAuthMode::TrustedMoi,
+            }
+        }
+    }
+}
 
-    let settings = AppSettings::from_env().expect("AppSettings::from_env (see astra-server env)");
-    let matrixone_settings = settings.matrixone.clone();
-    let matrixone_database = settings.matrixone.database.clone();
-    let url = settings.matrixone.database_url();
-
+async fn bootstrap_local_jwt() -> BootstrapResult {
     let memoria = Arc::new(E2eMemoriaStub::default());
-    // build_server_state runs ensure_core_schema which creates the database when
-    // MATRIXONE_AUTO_CREATE_DATABASE=1, so it must run before the assertion pool connects.
-    let state = build_server_state(settings)
-        .await
-        .expect("build_server_state")
-        .with_memoria_forwarder(memoria.clone());
+    let (state, matrixone_database, url) = build_state_with_mode(memoria.clone(), false).await;
 
     let pool = sqlx::mysql::MySqlPoolOptions::new()
         .max_connections(4)
@@ -456,6 +604,9 @@ pub async fn bootstrap() -> BootstrapResult {
         .await
         .expect("connect MatrixOne for assertions");
 
+    let matrixone_settings = AppSettings::from_env()
+        .expect("AppSettings::from_env (see astra-server env)")
+        .matrixone;
     let evaluation_pool = SharedPool::new(&matrixone_settings)
         .await
         .expect("connect MatrixOne shared pool for evaluation");
@@ -590,5 +741,111 @@ pub async fn bootstrap() -> BootstrapResult {
         },
         auth_header,
         refresh_token,
+        auth_mode: E2eAuthMode::LocalJwt,
+    }
+}
+
+/// Build app in `trusted_moi` mode and bootstrap an external user token/session.
+pub async fn bootstrap_trusted_moi() -> TrustedMoiBootstrapResult {
+    let memoria = Arc::new(E2eMemoriaStub::default());
+    let (state, matrixone_database, url) = build_state_with_mode(memoria.clone(), true).await;
+
+    let pool = sqlx::mysql::MySqlPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("connect MatrixOne for assertions");
+    let app = build_app(state);
+
+    let suffix = Uuid::new_v4().simple().to_string();
+    let username = format!("moi_matrix_{suffix}");
+    let email = format!("moi_matrix_{suffix}@e2e.test");
+    let user_id = format!("moi-user-{suffix}");
+    let edge_agent_id = format!("edge-{suffix}");
+
+    let token = build_hs256_jwt(
+        TRUSTED_MOI_E2E_SECRET,
+        json!({
+            "sub": user_id,
+            "username": username,
+            "email": email,
+            "name": "Trusted Moi E2E",
+            "exp": TRUSTED_MOI_E2E_EXP
+        }),
+    );
+    let auth_header = format!("Bearer {token}");
+
+    let (st_me, me) = get_json(&app, "/auth/me", Some(auth_header.as_str()), &[]).await;
+    assert_eq!(st_me, StatusCode::OK, "trusted_moi me: {me}");
+    let user_id = me["user_id"]
+        .as_str()
+        .expect("trusted_moi /auth/me user_id")
+        .to_string();
+    let username = me["username"]
+        .as_str()
+        .expect("trusted_moi /auth/me username")
+        .to_string();
+
+    let (st_sess, sess) = post_json(
+        &app,
+        "/sessions",
+        Some(auth_header.as_str()),
+        json!({ "title": "trusted moi matrix session", "metadata": { "suite": "trusted_moi" } }),
+    )
+    .await;
+    assert_eq!(
+        st_sess,
+        StatusCode::CREATED,
+        "trusted_moi create session: {sess}"
+    );
+    let session_id = sess["session_id"].as_str().expect("session_id").to_string();
+
+    let row = sqlx::query("SELECT user_id FROM agent_sessions WHERE session_id = ?")
+        .bind(&session_id)
+        .fetch_optional(&pool)
+        .await
+        .expect("trusted_moi session owner select");
+    let row = row.expect("trusted_moi session row");
+    assert_eq!(
+        row.try_get::<String, _>("user_id").ok().as_deref(),
+        Some(user_id.as_str()),
+        "trusted_moi session should be owned by external user id"
+    );
+
+    cleanup_edge_registry(&pool, &user_id, &edge_agent_id).await;
+
+    let (st_learn_h, learn_h) = get_json(&app, "/api/v1/learning/health", None, &[]).await;
+    assert_eq!(
+        st_learn_h,
+        StatusCode::OK,
+        "trusted_moi learning health: {learn_h}"
+    );
+
+    // Seed a mock model directly in DB so run-lifecycle tests don't depend on admin auth mode.
+    let mock_model = format!("mock-{suffix}");
+    let model_id = Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO infra_llm_models (model_id, model_name, provider, base_url, is_active) \
+         VALUES (?, ?, 'mock', 'http://127.0.0.1:1', 1)",
+    )
+    .bind(&model_id)
+    .bind(&mock_model)
+    .execute(&pool)
+    .await
+    .expect("trusted_moi seed mock model");
+
+    TrustedMoiBootstrapResult {
+        ctx: MatrixE2eCtx {
+            app,
+            pool,
+            matrixone_database,
+            memoria,
+            user_id,
+            username,
+            session_id,
+            edge_agent_id,
+            suffix,
+        },
+        auth_header,
     }
 }

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_extended.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_extended.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use sqlx::Row;
 
 use super::harness::{
-    E2E_PASSWORD, bootstrap, collect_sse_body_text, delete_no_content, get_json,
+    E2E_PASSWORD, E2eAuthMode, bootstrap, collect_sse_body_text, delete_no_content, get_json,
     grant_astra_admin_role, post_empty, post_json, put_json,
 };
 use axum::{body::Body, http::Request};
@@ -129,57 +129,87 @@ pub async fn run_auth_and_session_negative_paths() {
         "GET /sessions without auth: {j_sess}"
     );
 
-    let dup_email = format!("dup_{}@e2e.test", ctx.suffix);
-    let (st_dup, j_dup) = post_json(
-        app,
-        "/auth/register",
-        None,
-        json!({
-            "username": ctx.username,
-            "email": dup_email,
-            "password": "DifferentPass-1",
-            "display_name": "duplicate probe"
-        }),
-    )
-    .await;
-    assert_eq!(
-        st_dup,
-        StatusCode::BAD_REQUEST,
-        "duplicate username register: {j_dup}"
-    );
-    assert_eq!(
-        j_dup["detail"].as_str(),
-        Some("Username already exists"),
-        "duplicate username detail: {j_dup}"
-    );
+    match b.auth_mode {
+        E2eAuthMode::LocalJwt => {
+            let dup_email = format!("dup_{}@e2e.test", ctx.suffix);
+            let (st_dup, j_dup) = post_json(
+                app,
+                "/auth/register",
+                None,
+                json!({
+                    "username": ctx.username,
+                    "email": dup_email,
+                    "password": "DifferentPass-1",
+                    "display_name": "duplicate probe"
+                }),
+            )
+            .await;
+            assert_eq!(
+                st_dup,
+                StatusCode::BAD_REQUEST,
+                "duplicate username register: {j_dup}"
+            );
+            assert_eq!(
+                j_dup["detail"].as_str(),
+                Some("Username already exists"),
+                "duplicate username detail: {j_dup}"
+            );
 
-    let (st_bad_login, j_bad) = post_json(
-        app,
-        "/auth/login",
-        None,
-        json!({ "username": ctx.username, "password": "wrong-password-not-real" }),
-    )
-    .await;
-    assert_eq!(
-        st_bad_login,
-        StatusCode::UNAUTHORIZED,
-        "bad password login: {j_bad}"
-    );
-    assert_eq!(
-        j_bad["detail"].as_str(),
-        Some("Invalid username or password"),
-        "bad login detail: {j_bad}"
-    );
+            let (st_bad_login, j_bad) = post_json(
+                app,
+                "/auth/login",
+                None,
+                json!({ "username": ctx.username, "password": "wrong-password-not-real" }),
+            )
+            .await;
+            assert_eq!(
+                st_bad_login,
+                StatusCode::UNAUTHORIZED,
+                "bad password login: {j_bad}"
+            );
+            assert_eq!(
+                j_bad["detail"].as_str(),
+                Some("Invalid username or password"),
+                "bad login detail: {j_bad}"
+            );
 
-    // Sanity: bearer still works after negative calls
-    let (st_ok, j_ok) = post_json(
-        app,
-        "/auth/login",
-        None,
-        json!({ "username": ctx.username, "password": E2E_PASSWORD }),
-    )
-    .await;
-    assert_eq!(st_ok, StatusCode::OK, "login still ok: {j_ok}");
+            // Sanity: login still works after negative calls.
+            let (st_ok, j_ok) = post_json(
+                app,
+                "/auth/login",
+                None,
+                json!({ "username": ctx.username, "password": E2E_PASSWORD }),
+            )
+            .await;
+            assert_eq!(st_ok, StatusCode::OK, "login still ok: {j_ok}");
+        }
+        E2eAuthMode::TrustedMoi => {
+            for (path, payload) in [
+                (
+                    "/auth/register",
+                    json!({
+                        "username": "should-not-work",
+                        "email": "should-not-work@e2e.test",
+                        "password": "ignored"
+                    }),
+                ),
+                ("/auth/login", json!({ "username": "x", "password": "y" })),
+                ("/auth/refresh", json!({ "refresh_token": "not-used" })),
+            ] {
+                let (status, body) = post_json(app, path, None, payload).await;
+                assert_eq!(
+                    status,
+                    StatusCode::FORBIDDEN,
+                    "trusted_moi local auth endpoint should be disabled: {path} {body}"
+                );
+                assert_eq!(
+                    body["detail"].as_str(),
+                    Some("Local auth endpoints are disabled in trusted_moi mode"),
+                    "trusted_moi local auth detail: {path} {body}"
+                );
+            }
+        }
+    }
 
     ctx.pool.close().await;
 }
@@ -232,12 +262,32 @@ pub async fn run_chat_stream_session_info_smoke() {
 pub async fn run_models_admin_crud_with_db() {
     let b = bootstrap().await;
     let ctx = &b.ctx;
-    grant_astra_admin_role(&ctx.pool, &ctx.user_id).await;
-
     let app = &ctx.app;
     let auth = b.auth_header.as_str();
     let pool = &ctx.pool;
     let model_name = format!("e2e_mtx_mdl_{}", ctx.suffix);
+
+    if b.auth_mode == E2eAuthMode::TrustedMoi {
+        let (st_forbidden, body) = post_json(
+            app,
+            "/models",
+            Some(auth),
+            json!({
+                "name": model_name,
+                "provider": "mock",
+                "api_key": "e2e-key-not-used"
+            }),
+        )
+        .await;
+        assert!(
+            st_forbidden == StatusCode::UNAUTHORIZED || st_forbidden == StatusCode::FORBIDDEN,
+            "trusted_moi admin model CRUD should be blocked by current admin auth path: {body}"
+        );
+        ctx.pool.close().await;
+        return;
+    }
+
+    grant_astra_admin_role(&ctx.pool, &ctx.user_id).await;
 
     let (st_c, j_c) = post_json(
         app,

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_full.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_full.rs
@@ -9,15 +9,16 @@ use sqlx::Row;
 use tower::util::ServiceExt;
 
 use super::harness::{
-    MatrixE2eCtx, cleanup_edge_registry, cleanup_session_data, delete_json, delete_no_content,
-    get_json, post_empty, post_json, post_json_with_headers, put_json, row_get_opt_i64,
-    row_get_opt_str, row_get_str, wait_for_agent_event_types,
+    E2eAuthMode, MatrixE2eCtx, cleanup_edge_registry, cleanup_session_data, delete_json,
+    delete_no_content, get_json, post_empty, post_json, post_json_with_headers, put_json,
+    row_get_opt_i64, row_get_opt_str, row_get_str, wait_for_agent_event_types,
 };
 
 pub async fn run_product_matrix_full_journey(
     ctx: &MatrixE2eCtx,
     auth_header: &mut String,
     refresh_token: &mut String,
+    auth_mode: E2eAuthMode,
 ) {
     let session_id = ctx.session_id.clone();
     let user_id = ctx.user_id.clone();
@@ -1188,5 +1189,17 @@ pub async fn run_product_matrix_full_journey(
         json!({ "refresh_token": refresh_token.as_str() }),
     )
     .await;
-    assert_eq!(st_out, StatusCode::OK, "logout: {out_j}");
+    match auth_mode {
+        E2eAuthMode::LocalJwt => {
+            assert_eq!(st_out, StatusCode::OK, "logout: {out_j}");
+        }
+        E2eAuthMode::TrustedMoi => {
+            assert_eq!(st_out, StatusCode::FORBIDDEN, "trusted_moi logout: {out_j}");
+            assert_eq!(
+                out_j["detail"].as_str(),
+                Some("Local auth endpoints are disabled in trusted_moi mode"),
+                "trusted_moi logout detail: {out_j}"
+            );
+        }
+    }
 }

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_trusted_moi.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_trusted_moi.rs
@@ -1,0 +1,130 @@
+//! Trusted MOI E2E: external user JWT is accepted and propagated to Astra-owned data surfaces.
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::Row;
+
+use super::harness::{bootstrap_trusted_moi, cleanup_session_data, get_json, post_json};
+
+pub async fn run_trusted_moi_user_system_integration() {
+    let b = bootstrap_trusted_moi().await;
+    let ctx = &b.ctx;
+    let app = &ctx.app;
+    let auth = b.auth_header.as_str();
+    let pool = &ctx.pool;
+
+    let (st_me, me) = get_json(app, "/auth/me", Some(auth), &[]).await;
+    assert_eq!(st_me, StatusCode::OK, "trusted_moi /auth/me: {me}");
+    assert_eq!(me["user_id"].as_str(), Some(ctx.user_id.as_str()));
+    assert_eq!(me["username"].as_str(), Some(ctx.username.as_str()));
+
+    let (st_register, j_register) = post_json(
+        app,
+        "/auth/register",
+        None,
+        json!({
+            "username": "should-not-work",
+            "email": "should-not-work@e2e.test",
+            "password": "ignored"
+        }),
+    )
+    .await;
+    assert_eq!(
+        st_register,
+        StatusCode::FORBIDDEN,
+        "trusted_moi register should be disabled: {j_register}"
+    );
+    assert_eq!(
+        j_register["detail"].as_str(),
+        Some("Local auth endpoints are disabled in trusted_moi mode")
+    );
+
+    let (st_login, j_login) = post_json(
+        app,
+        "/auth/login",
+        None,
+        json!({ "username": "x", "password": "y" }),
+    )
+    .await;
+    assert_eq!(
+        st_login,
+        StatusCode::FORBIDDEN,
+        "trusted_moi login should be disabled: {j_login}"
+    );
+
+    let (st_refresh, j_refresh) = post_json(
+        app,
+        "/auth/refresh",
+        None,
+        json!({ "refresh_token": "not-used" }),
+    )
+    .await;
+    assert_eq!(
+        st_refresh,
+        StatusCode::FORBIDDEN,
+        "trusted_moi refresh should be disabled: {j_refresh}"
+    );
+
+    let (st_sess, sess) = post_json(
+        app,
+        "/sessions",
+        Some(auth),
+        json!({ "title": "trusted moi user-system e2e", "metadata": { "suite": "trusted_moi" } }),
+    )
+    .await;
+    assert_eq!(
+        st_sess,
+        StatusCode::CREATED,
+        "trusted_moi create session: {sess}"
+    );
+    let extra_session_id = sess["session_id"]
+        .as_str()
+        .expect("trusted_moi session_id")
+        .to_string();
+
+    let row = sqlx::query("SELECT user_id FROM agent_sessions WHERE session_id = ?")
+        .bind(&extra_session_id)
+        .fetch_optional(pool)
+        .await
+        .expect("select trusted_moi session owner");
+    let row = row.expect("trusted_moi created session row");
+    assert_eq!(
+        row.try_get::<String, _>("user_id").ok().as_deref(),
+        Some(ctx.user_id.as_str()),
+        "session owner should be external user id from trusted_moi token"
+    );
+
+    let prior_calls = ctx.memoria.calls.lock().await.len();
+    let (st_mem, j_mem) = post_json(
+        app,
+        "/memory/store",
+        Some(auth),
+        json!({
+            "content": "trusted moi isolation probe",
+            "memory_type": "semantic",
+            "user_id": "spoofed-victim",
+            "session_id": "spoofed-session"
+        }),
+    )
+    .await;
+    assert_eq!(st_mem, StatusCode::OK, "trusted_moi memory store: {j_mem}");
+    let calls = ctx.memoria.calls.lock().await;
+    assert!(
+        calls.len() > prior_calls,
+        "trusted_moi memory proxy should forward at least one call"
+    );
+    let (_, body) = calls.last().expect("trusted_moi last memoria call");
+    assert_eq!(
+        body["user_id"].as_str(),
+        Some(ctx.user_id.as_str()),
+        "spoofed user_id must be replaced by trusted_moi principal"
+    );
+    assert_eq!(
+        body["session_id"].as_str(),
+        Some(ctx.user_id.as_str()),
+        "spoofed session_id must be replaced by trusted_moi principal"
+    );
+
+    cleanup_session_data(pool, &ctx.session_id).await;
+    cleanup_session_data(pool, &extra_session_id).await;
+    ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/main.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/main.rs
@@ -1,6 +1,6 @@
 //! System HTTP end-to-end: real Axum app + MatrixOne + full `build_server_state` wiring.
 //!
-//! ## Tests in this binary (nine ignored tests)
+//! ## Tests in this binary (ten ignored tests)
 //! - **`product_matrix_api_journey_hits_multiple_tables`** — full product journey (sessions → agents →
 //!   events → jobs → `chat/turn` SSE + `agent_events` assertions → logout), including
 //!   `GET /platform/snapshot` after session activity.
@@ -13,9 +13,10 @@
 //! - **`e2e_matrix_session_cancel_delete`** — `POST .../cancel` + DB `cancelled`, then `DELETE` + 404.
 //! - **`e2e_matrix_chat_stream_session_info`** — `POST /chat/stream` buffered SSE; first `session_info`
 //!   event contains `run_id`.
-//! - **`e2e_matrix_auth_session_negative_paths`** — `GET /sessions` without auth (401), duplicate
-//!   `POST /auth/register` (400), bad `POST /auth/login` (401), then successful login (replaces stub
-//!   `auth_contract` / `session_contract` negative coverage).
+//! - **`e2e_matrix_auth_session_negative_paths`** — `GET /sessions` without auth (401), plus
+//!   mode-aware auth negatives: in `local_jwt` validates duplicate register/bad login; in
+//!   `trusted_moi` validates local auth endpoints are disabled (replaces stub `auth_contract` /
+//!   `session_contract` negative coverage).
 //! - **`e2e_matrix_memory_proxy_user_isolation`** — unauthenticated memory returns 401; spoofed
 //!   `user_id` / `session_id` in body are overwritten to JWT user on forward (replaces `memory_contract`
 //!   isolation tests).
@@ -23,6 +24,9 @@
 //!   `provider: mock` + `infra_llm_models` SQL checks (replaces `model_crud_contract`).
 //! - **`e2e_matrix_audit_cross_session_analytics_http`** — SQL-seeded `agent_events` / `ctx_decision_audits`,
 //!   then `GET /audit/stats`, `/audit/mutations`, `/audit/promotions` with JWT auth (cross-session audit).
+//! - **`e2e_matrix_trusted_moi_user_system_integration`** — run server in `trusted_moi` mode,
+//!   authenticate via external JWT claims, verify local auth endpoints are disabled, and assert
+//!   session/memory ownership maps to upstream user id.
 //!
 //! Session list/get/put, close/resume, activity, and DB checks for close/resume live only in the full
 //! journey (not duplicated in a separate test).
@@ -50,6 +54,7 @@ mod journey_audit_cross_session;
 mod journey_extended;
 mod journey_full;
 mod journey_tasks_runs;
+mod journey_trusted_moi;
 
 use harness::require_system_e2e_env;
 
@@ -58,8 +63,13 @@ use harness::require_system_e2e_env;
 async fn product_matrix_api_journey_hits_multiple_tables() {
     require_system_e2e_env();
     let mut b = harness::bootstrap().await;
-    journey_full::run_product_matrix_full_journey(&b.ctx, &mut b.auth_header, &mut b.refresh_token)
-        .await;
+    journey_full::run_product_matrix_full_journey(
+        &b.ctx,
+        &mut b.auth_header,
+        &mut b.refresh_token,
+        b.auth_mode,
+    )
+    .await;
     b.ctx.pool.close().await;
 }
 
@@ -117,4 +127,11 @@ async fn e2e_matrix_models_admin_crud() {
 async fn e2e_matrix_audit_cross_session_analytics_http() {
     require_system_e2e_env();
     journey_audit_cross_session::run_audit_cross_session_analytics_http().await;
+}
+
+#[tokio::test]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_trusted_moi_user_system_integration() {
+    require_system_e2e_env();
+    journey_trusted_moi::run_trusted_moi_user_system_integration().await;
 }

--- a/rust/crates/runtime/tests/trusted_moi_auth_integration.rs
+++ b/rust/crates/runtime/tests/trusted_moi_auth_integration.rs
@@ -1,0 +1,201 @@
+use std::sync::Arc;
+
+use astra_runtime::{AppState, HealthChecker, ServiceInfo, build_app};
+use astra_services::auth::TrustedMoiAuthService;
+use async_trait::async_trait;
+use axum::{
+    Router,
+    body::{self, Body},
+    http::{Request, StatusCode},
+};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use tower::util::ServiceExt;
+
+const TEST_SECRET: &str = "trusted_moi_test_secret_key_123456";
+const FAR_FUTURE_EXP: u64 = 4_102_444_800; // 2100-01-01T00:00:00Z
+
+#[derive(Clone)]
+struct StubHealthChecker;
+
+#[async_trait]
+impl HealthChecker for StubHealthChecker {
+    async fn database_healthy(&self) -> bool {
+        true
+    }
+}
+
+fn build_test_app() -> Router {
+    let auth = TrustedMoiAuthService::new(TEST_SECRET, "HS256", None, None, 30)
+        .expect("trusted_moi service should be constructible");
+    let state = AppState::new(ServiceInfo::default(), Arc::new(StubHealthChecker))
+        .with_auth_service(Arc::new(auth));
+    build_app(state)
+}
+
+fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
+    const BLOCK_SIZE: usize = 64;
+    let mut normalized_key = [0u8; BLOCK_SIZE];
+    if key.len() > BLOCK_SIZE {
+        let digest = Sha256::digest(key);
+        normalized_key[..32].copy_from_slice(&digest);
+    } else {
+        normalized_key[..key.len()].copy_from_slice(key);
+    }
+
+    let mut inner_pad = [0x36u8; BLOCK_SIZE];
+    let mut outer_pad = [0x5cu8; BLOCK_SIZE];
+    for i in 0..BLOCK_SIZE {
+        inner_pad[i] ^= normalized_key[i];
+        outer_pad[i] ^= normalized_key[i];
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(inner_pad);
+    inner.update(message);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(outer_pad);
+    outer.update(inner_digest);
+    let outer_digest = outer.finalize();
+
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&outer_digest);
+    out
+}
+
+fn build_hs256_jwt(secret: &str, claims: Value) -> String {
+    let header = json!({
+        "alg": "HS256",
+        "typ": "JWT"
+    });
+    let header_b64 = URL_SAFE_NO_PAD.encode(header.to_string().as_bytes());
+    let claims_b64 = URL_SAFE_NO_PAD.encode(claims.to_string().as_bytes());
+    let signing_input = format!("{header_b64}.{claims_b64}");
+    let signature = hmac_sha256(secret.as_bytes(), signing_input.as_bytes());
+    let signature_b64 = URL_SAFE_NO_PAD.encode(signature);
+    format!("{signing_input}.{signature_b64}")
+}
+
+async fn post_json(app: Router, path: &str, payload: Value) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header("content-type", "application/json")
+                .body(Body::from(payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    (status, json)
+}
+
+async fn get_json_with_token(app: Router, path: &str, token: &str) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(path)
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    (status, json)
+}
+
+#[tokio::test]
+async fn trusted_moi_login_endpoint_returns_forbidden() {
+    let app = build_test_app();
+    let (status, json) = post_json(
+        app,
+        "/auth/login",
+        json!({
+            "username": "moi-user",
+            "password": "ignored"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        json["detail"],
+        json!("Local auth endpoints are disabled in trusted_moi mode")
+    );
+}
+
+#[tokio::test]
+async fn trusted_moi_auth_me_accepts_valid_external_token() {
+    let app = build_test_app();
+    let token = build_hs256_jwt(
+        TEST_SECRET,
+        json!({
+            "sub": "moi-user-123",
+            "username": "moi_user",
+            "email": "moi_user@example.com",
+            "name": "Moi User",
+            "exp": FAR_FUTURE_EXP
+        }),
+    );
+
+    let (status, json) = get_json_with_token(app, "/auth/me", &token).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["user_id"], json!("moi-user-123"));
+    assert_eq!(json["username"], json!("moi_user"));
+    assert_eq!(json["email"], json!("moi_user@example.com"));
+    assert_eq!(json["display_name"], json!("Moi User"));
+}
+
+#[tokio::test]
+async fn trusted_moi_auth_me_falls_back_to_uid_and_name() {
+    let app = build_test_app();
+    let token = build_hs256_jwt(
+        TEST_SECRET,
+        json!({
+            "uid": "moi-uid-456",
+            "name": "Fallback Name",
+            "exp": FAR_FUTURE_EXP
+        }),
+    );
+
+    let (status, json) = get_json_with_token(app, "/auth/me", &token).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["user_id"], json!("moi-uid-456"));
+    assert_eq!(json["username"], json!("Fallback Name"));
+    assert_eq!(json["email"], json!(""));
+    assert_eq!(json["display_name"], json!("Fallback Name"));
+}
+
+#[tokio::test]
+async fn trusted_moi_auth_me_rejects_bad_signature() {
+    let app = build_test_app();
+    let token = build_hs256_jwt(
+        "different-secret",
+        json!({
+            "sub": "moi-user-123",
+            "exp": FAR_FUTURE_EXP
+        }),
+    );
+
+    let (status, json) = get_json_with_token(app, "/auth/me", &token).await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(json["detail"], json!("Invalid trusted_moi token"));
+}

--- a/rust/crates/services/src/auth/mod.rs
+++ b/rust/crates/services/src/auth/mod.rs
@@ -10,6 +10,8 @@ use axum::{
 };
 use bcrypt::{hash as bcrypt_hash, verify as bcrypt_verify};
 use chrono::{Duration as ChronoDuration, Utc};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+use serde::Deserialize;
 use sqlx::{MySql, Row, query};
 use uuid::Uuid;
 
@@ -117,6 +119,32 @@ pub struct DatabaseUserRecord {
     pub password_hash: String,
     pub display_name: Option<String>,
     pub is_active: bool,
+}
+
+#[derive(Clone, Debug)]
+struct TrustedMoiJwtSettings {
+    secret_key: String,
+    algorithm: Algorithm,
+    expected_issuer: Option<String>,
+    expected_audience: Option<String>,
+    leeway_seconds: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct TrustedMoiAuthService {
+    settings: TrustedMoiJwtSettings,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct TrustedMoiClaims {
+    sub: Option<String>,
+    uid: Option<String>,
+    user_id: Option<String>,
+    username: Option<String>,
+    email: Option<String>,
+    display_name: Option<String>,
+    nickname: Option<String>,
+    name: Option<String>,
 }
 
 impl DatabaseAuthService {
@@ -272,6 +300,108 @@ impl DatabaseAuthService {
             return Ok(p.get().clone());
         }
         connect_matrixone(&self.matrixone).await
+    }
+}
+
+impl TrustedMoiAuthService {
+    pub fn new(
+        secret_key: &str,
+        algorithm: &str,
+        expected_issuer: Option<String>,
+        expected_audience: Option<String>,
+        leeway_seconds: u64,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            settings: TrustedMoiJwtSettings {
+                secret_key: normalize_jwt_secret_for_trusted_mode(secret_key),
+                algorithm: parse_trusted_moi_algorithm(algorithm)?,
+                expected_issuer,
+                expected_audience,
+                leeway_seconds,
+            },
+        })
+    }
+
+    pub fn from_env() -> Result<Self, String> {
+        let raw_secret = std::env::var("TRUSTED_MOI_JWT_SECRET_KEY")
+            .or_else(|_| std::env::var("JWT_SECRET_KEY"))
+            .map_err(|_| {
+                "TRUSTED_MOI_JWT_SECRET_KEY (or JWT_SECRET_KEY fallback) must be set".to_string()
+            })?;
+
+        let algorithm = std::env::var("TRUSTED_MOI_JWT_ALGORITHM")
+            .or_else(|_| std::env::var("JWT_ALGORITHM"))
+            .unwrap_or_else(|_| "HS256".to_string());
+
+        let expected_issuer = std::env::var("TRUSTED_MOI_JWT_ISSUER")
+            .ok()
+            .filter(|v| !v.is_empty());
+        let expected_audience = std::env::var("TRUSTED_MOI_JWT_AUDIENCE")
+            .ok()
+            .filter(|v| !v.is_empty());
+        let leeway_seconds = std::env::var("TRUSTED_MOI_JWT_LEEWAY_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(30);
+
+        Self::new(
+            &raw_secret,
+            &algorithm,
+            expected_issuer,
+            expected_audience,
+            leeway_seconds,
+        )
+    }
+
+    fn auth_disabled_error() -> (StatusCode, Json<ErrorResponse>) {
+        error_response(
+            StatusCode::FORBIDDEN,
+            "Local auth endpoints are disabled in trusted_moi mode",
+        )
+    }
+
+    fn decode_trusted_claims(
+        &self,
+        token: &str,
+    ) -> Result<TrustedMoiClaims, (StatusCode, Json<ErrorResponse>)> {
+        let mut validation = Validation::new(self.settings.algorithm);
+        validation.leeway = self.settings.leeway_seconds;
+        validation.validate_exp = true;
+        if let Some(expected_issuer) = &self.settings.expected_issuer {
+            validation.set_issuer(&[expected_issuer]);
+        }
+        if let Some(expected_audience) = &self.settings.expected_audience {
+            validation.set_audience(&[expected_audience]);
+        }
+
+        decode::<TrustedMoiClaims>(
+            token,
+            &DecodingKey::from_secret(self.settings.secret_key.as_bytes()),
+            &validation,
+        )
+        .map(|data| data.claims)
+        .map_err(|_| error_response(StatusCode::UNAUTHORIZED, "Invalid trusted_moi token"))
+    }
+}
+
+fn parse_trusted_moi_algorithm(algorithm: &str) -> Result<Algorithm, String> {
+    match algorithm {
+        "HS256" => Ok(Algorithm::HS256),
+        "HS384" => Ok(Algorithm::HS384),
+        "HS512" => Ok(Algorithm::HS512),
+        _ => Err(format!(
+            "unsupported TRUSTED_MOI_JWT_ALGORITHM: {algorithm}"
+        )),
+    }
+}
+
+fn normalize_jwt_secret_for_trusted_mode(secret: &str) -> String {
+    if secret.len() >= 32 {
+        secret.to_string()
+    } else {
+        let mut padded = secret.to_string();
+        padded.extend(std::iter::repeat_n('0', 32 - secret.len()));
+        padded
     }
 }
 
@@ -590,6 +720,65 @@ impl AuthService for DatabaseAuthService {
     }
 }
 
+#[async_trait]
+impl AuthService for TrustedMoiAuthService {
+    async fn register(
+        &self,
+        _request: AuthRegisterRequestData,
+    ) -> Result<AuthUserRecord, (StatusCode, Json<ErrorResponse>)> {
+        Err(Self::auth_disabled_error())
+    }
+
+    async fn login(
+        &self,
+        _request: AuthLoginRequestData,
+    ) -> Result<AuthTokenRecord, (StatusCode, Json<ErrorResponse>)> {
+        Err(Self::auth_disabled_error())
+    }
+
+    async fn refresh(
+        &self,
+        _request: AuthRefreshRequestData,
+    ) -> Result<AuthTokenRecord, (StatusCode, Json<ErrorResponse>)> {
+        Err(Self::auth_disabled_error())
+    }
+
+    async fn logout(
+        &self,
+        _request: AuthRefreshRequestData,
+    ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+        Err(Self::auth_disabled_error())
+    }
+
+    async fn current_user(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthUserRecord, (StatusCode, Json<ErrorResponse>)> {
+        let token = bearer_token(headers)?;
+        let claims = self.decode_trusted_claims(token)?;
+
+        let user_id = claims
+            .sub
+            .or(claims.uid)
+            .or(claims.user_id)
+            .ok_or_else(|| error_response(StatusCode::UNAUTHORIZED, "Missing user id claim"))?;
+
+        let preferred_name = claims.name.or(claims.nickname).or(claims.display_name);
+        let username = claims
+            .username
+            .or_else(|| preferred_name.clone())
+            .unwrap_or_else(|| user_id.clone());
+        let display_name = preferred_name;
+
+        Ok(AuthUserRecord {
+            user_id,
+            username,
+            email: claims.email.unwrap_or_default(),
+            display_name,
+        })
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct UnconfiguredAuthService;
 
@@ -643,5 +832,224 @@ impl AuthService for UnconfiguredAuthService {
             StatusCode::NOT_IMPLEMENTED,
             "Auth service not configured",
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use jsonwebtoken::{EncodingKey, Header, encode};
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct TrustedMoiTestClaims<'a> {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sub: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        uid: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        user_id: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        username: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        email: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        display_name: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        iss: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        aud: Option<&'a str>,
+        iat: usize,
+        exp: usize,
+    }
+
+    fn make_token(secret: &str, claims: TrustedMoiTestClaims<'_>) -> String {
+        encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(normalize_jwt_secret_for_trusted_mode(secret).as_bytes()),
+        )
+        .expect("encode token")
+    }
+
+    fn auth_headers(token: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            format!("Bearer {token}").parse().expect("valid header"),
+        );
+        headers
+    }
+
+    fn now_exp_pair() -> (usize, usize) {
+        let now = Utc::now().timestamp() as usize;
+        (now, now + 3600)
+    }
+
+    #[tokio::test]
+    async fn trusted_moi_current_user_from_sub_username_email() {
+        let service = TrustedMoiAuthService::new("secret", "HS256", None, None, 30).unwrap();
+        let (iat, exp) = now_exp_pair();
+        let token = make_token(
+            "secret",
+            TrustedMoiTestClaims {
+                sub: Some("moi-user-1"),
+                uid: None,
+                user_id: None,
+                username: Some("alice"),
+                email: Some("alice@example.com"),
+                display_name: Some("Alice"),
+                name: None,
+                iss: None,
+                aud: None,
+                iat,
+                exp,
+            },
+        );
+        let user = service
+            .current_user(&auth_headers(&token))
+            .await
+            .expect("current_user");
+        assert_eq!(user.user_id, "moi-user-1");
+        assert_eq!(user.username, "alice");
+        assert_eq!(user.email, "alice@example.com");
+        assert_eq!(user.display_name.as_deref(), Some("Alice"));
+    }
+
+    #[tokio::test]
+    async fn trusted_moi_current_user_fallback_to_uid_and_name() {
+        let service = TrustedMoiAuthService::new("secret", "HS256", None, None, 30).unwrap();
+        let (iat, exp) = now_exp_pair();
+        let token = make_token(
+            "secret",
+            TrustedMoiTestClaims {
+                sub: None,
+                uid: Some("moi-user-2"),
+                user_id: None,
+                username: None,
+                email: None,
+                display_name: None,
+                name: Some("Bob"),
+                iss: None,
+                aud: None,
+                iat,
+                exp,
+            },
+        );
+        let user = service
+            .current_user(&auth_headers(&token))
+            .await
+            .expect("current_user");
+        assert_eq!(user.user_id, "moi-user-2");
+        assert_eq!(user.username, "Bob");
+        assert_eq!(user.email, "");
+        assert_eq!(user.display_name.as_deref(), Some("Bob"));
+    }
+
+    #[tokio::test]
+    async fn trusted_moi_rejects_missing_identity_claim() {
+        let service = TrustedMoiAuthService::new("secret", "HS256", None, None, 30).unwrap();
+        let (iat, exp) = now_exp_pair();
+        let token = make_token(
+            "secret",
+            TrustedMoiTestClaims {
+                sub: None,
+                uid: None,
+                user_id: None,
+                username: Some("nobody"),
+                email: None,
+                display_name: None,
+                name: None,
+                iss: None,
+                aud: None,
+                iat,
+                exp,
+            },
+        );
+        let err = service
+            .current_user(&auth_headers(&token))
+            .await
+            .expect_err("should reject");
+        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+        assert_eq!(err.1.detail, "Missing user id claim");
+    }
+
+    #[tokio::test]
+    async fn trusted_moi_rejects_wrong_issuer_or_audience() {
+        let service = TrustedMoiAuthService::new(
+            "secret",
+            "HS256",
+            Some("issuer-good".to_string()),
+            Some("astra".to_string()),
+            30,
+        )
+        .unwrap();
+        let (iat, exp) = now_exp_pair();
+        let token = make_token(
+            "secret",
+            TrustedMoiTestClaims {
+                sub: Some("moi-user-3"),
+                uid: None,
+                user_id: None,
+                username: Some("charlie"),
+                email: None,
+                display_name: None,
+                name: None,
+                iss: Some("issuer-bad"),
+                aud: Some("not-astra"),
+                iat,
+                exp,
+            },
+        );
+        let err = service
+            .current_user(&auth_headers(&token))
+            .await
+            .expect_err("should reject");
+        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+        assert_eq!(err.1.detail, "Invalid trusted_moi token");
+    }
+
+    #[tokio::test]
+    async fn trusted_moi_disables_local_auth_endpoints() {
+        let service = TrustedMoiAuthService::new("secret", "HS256", None, None, 30).unwrap();
+
+        let login = service
+            .login(AuthLoginRequestData {
+                username: "alice".to_string(),
+                password: "pw".to_string(),
+            })
+            .await
+            .expect_err("login should be disabled");
+        assert_eq!(login.0, StatusCode::FORBIDDEN);
+
+        let register = service
+            .register(AuthRegisterRequestData {
+                username: "alice".to_string(),
+                email: "alice@example.com".to_string(),
+                password: "pw".to_string(),
+                display_name: Some("Alice".to_string()),
+            })
+            .await
+            .expect_err("register should be disabled");
+        assert_eq!(register.0, StatusCode::FORBIDDEN);
+
+        let refresh = service
+            .refresh(AuthRefreshRequestData {
+                refresh_token: "refresh".to_string(),
+            })
+            .await
+            .expect_err("refresh should be disabled");
+        assert_eq!(refresh.0, StatusCode::FORBIDDEN);
+
+        let logout = service
+            .logout(AuthRefreshRequestData {
+                refresh_token: "refresh".to_string(),
+            })
+            .await
+            .expect_err("logout should be disabled");
+        assert_eq!(logout.0, StatusCode::FORBIDDEN);
     }
 }


### PR DESCRIPTION
## Summary
- add trusted_moi auth mode in runtime auth service and state builder wiring
- add runtime integration test for trusted_moi auth validation
- make system_matrix_http_e2e auth-aware so tests auto-adapt to local_jwt and trusted_moi
- add trusted_moi user-system integration journey and update test docs
- wire trusted_moi runtime integration test into CI workflow

## Notes
- matrix e2e now gates local auth endpoints in trusted_moi mode and adjusts assertions accordingly
- admin model CRUD in trusted_moi mode is expected to be blocked by auth guard

## Validation
- cargo fmt --all
- cargo check -p astra-runtime
- cargo test -p astra-runtime --test system_matrix_http_e2e --features bridge-e2e-hooks --no-run
- mode-specific runs for auth/admin/task/trusted_moi journeys
