### PR TITLE
feat(runtime): content-aware approval fingerprints + confidence telemetry

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
@@ -213,6 +213,8 @@ struct PrepareChatTurnRequest<'a> {
     tool_budget_override: Option<u32>,
     interaction_mode: TurnInteractionMode,
     turn_policy: &'a mut TurnInteractionPolicy,
+    previous_confidence_fallback:
+        Option<astra_runtime::turn::confidence_contract::ConfidenceFallback>,
 }
 
 pub(crate) fn turn_policy_from_payload_edge_tools(
@@ -375,6 +377,7 @@ async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
             ctx.file_context.to_vec(),
             false,
             ctx.tool_budget_override,
+            ctx.previous_confidence_fallback.clone(),
         );
         touch_prep_ui_phase(&ctx.prep_ui_phase, "Thinking…");
         let sel_result = ctx
@@ -430,6 +433,7 @@ async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
             ctx.file_context.to_vec(),
             true,
             ctx.tool_budget_override,
+            ctx.previous_confidence_fallback.clone(),
         );
         touch_prep_ui_phase(&ctx.prep_ui_phase, "Thinking…");
         let sel_start = Instant::now();
@@ -711,6 +715,9 @@ pub(crate) struct ChatTurnSseFetchRequest<'a> {
     pub skill_continuation: bool,
     /// Cross-turn tool output cache (persists across turns via `CliAgenticLoopHost`).
     pub tool_cache: &'a mut crate::stream_render::EdgeToolCache,
+    /// Fallback from previous turn's confidence diagnosis for broadening.
+    pub previous_confidence_fallback:
+        Option<astra_runtime::turn::confidence_contract::ConfidenceFallback>,
 }
 
 /// stderr prep line + timing toggles for [`fetch_chat_turn_sse`].
@@ -832,6 +839,7 @@ pub(crate) async fn fetch_chat_turn_sse(
         turn_policy,
         skill_continuation,
         tool_cache,
+        previous_confidence_fallback,
     } = ctx;
 
     let ui = chat_turn_sse_fetch_ui(render_policy, plan_assemble_line_release.as_ref());
@@ -876,6 +884,7 @@ pub(crate) async fn fetch_chat_turn_sse(
             tool_budget_override,
             interaction_mode,
             turn_policy,
+            previous_confidence_fallback,
         },
     )
     .await?;

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -235,6 +235,10 @@ impl AgenticLoopHost for CliAgenticLoopHost<'_> {
             turn_policy: &mut state.last_turn_policy,
             skill_continuation: state.skill_produced_output,
             tool_cache: &mut self.tool_cache,
+            previous_confidence_fallback: state
+                .last_confidence_diagnosis
+                .as_ref()
+                .map(|d| d.fallback.clone()),
         })
         .await;
 

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -574,6 +574,7 @@ pub(crate) async fn stream_chat_sse(
         server_tool_executor: None,
         interruption: None,
         confidence_trend: Default::default(),
+        last_confidence_diagnosis: None,
     };
 
     // ─── Run the runtime loop ────────────────────────────────────────────

--- a/rust/crates/astra-cli/src/cli/delegate_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/delegate_subrun.rs
@@ -386,6 +386,7 @@ impl SubRunExecutor for CliDelegateSubRunExecutor {
             server_tool_executor: None,
             interruption: None,
             confidence_trend: Default::default(),
+            last_confidence_diagnosis: None,
         };
 
         let loop_result = run_agentic_loop_with_host(&mut host, &mut state).await;

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -11,6 +11,35 @@ use astra_runtime::turn::tool_argument_hints::{
 use astra_runtime::{compensation_prompt_note, explicit_approval_reason};
 use astra_thin_client::ApprovalKind;
 
+/// Build a content-aware fingerprint from tool name and arguments.
+///
+/// For shell/execute tools, extracts the command prefix (e.g. `git commit`).
+/// For file/write tools, extracts the path pattern (e.g. `src/turn/**`).
+/// Falls back to [`ApprovalFingerprint::bare`] when no content is available.
+fn content_aware_fingerprint(
+    name: &str,
+    args: &serde_json::Value,
+) -> astra_runtime::turn::approval_fingerprint::ApprovalFingerprint {
+    use astra_runtime::turn::approval_fingerprint::ApprovalFingerprint;
+
+    match cloud_gated_tool_kind(name) {
+        Some(CloudGatedToolKind::Execute) => {
+            if let Some(cmd) = command_hint_from_args(args) {
+                let lower = cmd.to_ascii_lowercase();
+                let is_ro = is_read_only_allowlisted(&lower);
+                ApprovalFingerprint::shell(name, cmd, is_ro)
+            } else {
+                ApprovalFingerprint::bare(name)
+            }
+        }
+        Some(CloudGatedToolKind::Write) => {
+            let path = path_hint_from_args(args);
+            ApprovalFingerprint::file_op(name, path.as_deref())
+        }
+        None => ApprovalFingerprint::bare(name),
+    }
+}
+
 /// Permission mode controls how tool approval decisions are handled.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(super) enum PermissionMode {
@@ -461,7 +490,17 @@ impl PermissionManager {
             PermissionMode::Deny => return ApprovalDecision::Deny,
             PermissionMode::Prompt => {}
         }
-        let fp = astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(tool);
+        let fp = match (cloud_gated_tool_kind(tool), detail) {
+            (Some(CloudGatedToolKind::Execute), Some(cmd)) => {
+                astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::shell(
+                    tool, cmd, false,
+                )
+            }
+            (Some(CloudGatedToolKind::Write), d) => {
+                astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::file_op(tool, d)
+            }
+            _ => astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(tool),
+        };
         if let Some(allowed) = self.session_overrides.check(&fp) {
             return if allowed {
                 ApprovalDecision::Allow
@@ -486,6 +525,7 @@ impl PermissionManager {
         }
         self.apply_cloud_approval_choice(
             tool,
+            detail,
             Self::prompt_approval(ApprovalPromptKind::CloudStandard),
         )
     }
@@ -539,7 +579,17 @@ impl PermissionManager {
             PermissionMode::Deny => return ApprovalDecision::Deny,
             PermissionMode::Prompt => {}
         }
-        let fp = astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(tool);
+        let fp = match (cloud_gated_tool_kind(tool), detail) {
+            (Some(CloudGatedToolKind::Execute), Some(cmd)) => {
+                astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::shell(
+                    tool, cmd, false,
+                )
+            }
+            (Some(CloudGatedToolKind::Write), d) => {
+                astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::file_op(tool, d)
+            }
+            _ => astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(tool),
+        };
         if let Some(allowed) = self.session_overrides.check(&fp) {
             return if allowed {
                 ApprovalDecision::Allow
@@ -567,7 +617,7 @@ impl PermissionManager {
         })
         .await
         .unwrap_or('n');
-        self.apply_cloud_approval_choice(tool, ch)
+        self.apply_cloud_approval_choice(tool, detail, ch)
     }
 
     fn classify(name: &str) -> SideEffect {
@@ -842,6 +892,7 @@ impl PermissionManager {
     fn apply_cloud_approval_choice(
         &mut self,
         tool: &str,
+        detail: Option<&str>,
         choice: char,
     ) -> astra_thin_client::ApprovalDecision {
         use astra_thin_client::ApprovalDecision;
@@ -849,7 +900,19 @@ impl PermissionManager {
         match choice {
             'y' => ApprovalDecision::Allow,
             'a' => {
-                let fp = astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(tool);
+                let fp = match (cloud_gated_tool_kind(tool), detail) {
+                    (Some(CloudGatedToolKind::Execute), Some(cmd)) => {
+                        astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::shell(
+                            tool, cmd, false,
+                        )
+                    }
+                    (Some(CloudGatedToolKind::Write), d) => {
+                        astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::file_op(
+                            tool, d,
+                        )
+                    }
+                    _ => astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(tool),
+                };
                 self.session_overrides.insert(fp, true);
                 eprintln!("{}", format!("  ✓ {tool}: allowed for this session").dim());
                 ApprovalDecision::AllowSession
@@ -864,7 +927,19 @@ impl PermissionManager {
                 ApprovalDecision::Allow
             }
             's' => {
-                let fp = astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(tool);
+                let fp = match (cloud_gated_tool_kind(tool), detail) {
+                    (Some(CloudGatedToolKind::Execute), Some(cmd)) => {
+                        astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::shell(
+                            tool, cmd, false,
+                        )
+                    }
+                    (Some(CloudGatedToolKind::Write), d) => {
+                        astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::file_op(
+                            tool, d,
+                        )
+                    }
+                    _ => astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(tool),
+                };
                 self.session_overrides.insert(fp.clone(), false);
                 self.denial_tracker.record(&fp, false);
                 eprintln!("  {}", format!("  ✗ {tool}: skipped for session").dim());
@@ -943,9 +1018,10 @@ impl PermissionManager {
                     if self.mode == PermissionMode::Auto {
                         return true;
                     }
-                    if let Some(allowed) = self.session_overrides.check(
-                        &astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(name),
-                    ) {
+                    if let Some(allowed) = self
+                        .session_overrides
+                        .check(&content_aware_fingerprint(name, args))
+                    {
                         return allowed;
                     }
                 }
@@ -1024,7 +1100,7 @@ impl PermissionManager {
         // Step 5: Session overrides (AFTER bypass-immune safety checks).
         if let Some(allowed) = self
             .session_overrides
-            .check(&astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(name))
+            .check(&content_aware_fingerprint(name, args))
         {
             return allowed;
         }
@@ -1051,7 +1127,7 @@ impl PermissionManager {
             eprintln!("{}", detail.dim());
         }
         // Check denial limits before prompting.
-        let fp = astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(name);
+        let fp = content_aware_fingerprint(name, args);
         match self.denial_tracker.should_prompt(&fp) {
             astra_runtime::turn::approval_fingerprint::DenialAction::SkipTool => {
                 eprintln!(
@@ -1116,7 +1192,7 @@ impl PermissionManager {
             // Check session overrides first
             if let Some(allowed) = self
                 .session_overrides
-                .check(&astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(name))
+                .check(&content_aware_fingerprint(name, args))
             {
                 return if allowed {
                     PermissionDecision::Allow
@@ -1167,9 +1243,10 @@ impl PermissionManager {
                     if self.mode == PermissionMode::Auto {
                         return PermissionDecision::Allow;
                     }
-                    if let Some(allowed) = self.session_overrides.check(
-                        &astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(name),
-                    ) {
+                    if let Some(allowed) = self
+                        .session_overrides
+                        .check(&content_aware_fingerprint(name, args))
+                    {
                         return if allowed {
                             PermissionDecision::Allow
                         } else {
@@ -1242,7 +1319,7 @@ impl PermissionManager {
         // Step 5: Session overrides (AFTER bypass-immune safety checks).
         if let Some(allowed) = self
             .session_overrides
-            .check(&astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(name))
+            .check(&content_aware_fingerprint(name, args))
         {
             return if allowed {
                 PermissionDecision::Allow
@@ -1262,7 +1339,7 @@ impl PermissionManager {
             PermissionMode::Deny => PermissionDecision::Deny("Denied by mode".into()),
             PermissionMode::Prompt => {
                 // Check denial limits before prompting.
-                let fp = astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(name);
+                let fp = content_aware_fingerprint(name, args);
                 match self.denial_tracker.should_prompt(&fp) {
                     astra_runtime::turn::approval_fingerprint::DenialAction::SkipTool => {
                         return PermissionDecision::Deny(format!(
@@ -1879,7 +1956,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
-        let decision = pm.apply_cloud_approval_choice("bash", '!');
+        let decision = pm.apply_cloud_approval_choice("bash", None, '!');
 
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
         assert_eq!(pm.mode, PermissionMode::Auto);
@@ -1890,7 +1967,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
-        let decision = pm.apply_cloud_approval_choice("bash", 'a');
+        let decision = pm.apply_cloud_approval_choice("bash", None, 'a');
 
         assert_eq!(decision, astra_thin_client::ApprovalDecision::AllowSession);
         assert_eq!(pm.session_overrides.check(&bare_fp("bash")), Some(true));
@@ -1901,7 +1978,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
-        let decision = pm.apply_cloud_approval_choice("bash", 's');
+        let decision = pm.apply_cloud_approval_choice("bash", None, 's');
 
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Deny);
         assert_eq!(pm.session_overrides.check(&bare_fp("bash")), Some(false));
@@ -2464,7 +2541,7 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
         // Simulate user selecting "always allow this tool" in cloud approval
-        let decision = pm.apply_cloud_approval_choice("write_file", 'a');
+        let decision = pm.apply_cloud_approval_choice("write_file", None, 'a');
         assert_eq!(decision, astra_thin_client::ApprovalDecision::AllowSession);
 
         // Now the local check_nonblocking must auto-allow (no prompt)
@@ -2484,7 +2561,7 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
         // Simulate user selecting "auto-run session" in cloud approval
-        let decision = pm.apply_cloud_approval_choice("bash", '!');
+        let decision = pm.apply_cloud_approval_choice("bash", None, '!');
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
         assert_eq!(pm.mode, PermissionMode::Auto);
 
@@ -2506,7 +2583,7 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
         // 1st call: user selects 'a' in cloud approval
-        pm.apply_cloud_approval_choice("write_file", 'a');
+        pm.apply_cloud_approval_choice("write_file", None, 'a');
 
         // 1st call: local check
         let args1 = serde_json::json!({"path": "src/lib.rs", "content": "pub fn one() {}\n"});

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -469,6 +469,13 @@ impl PermissionManager {
                 ApprovalDecision::Deny
             };
         }
+        match self.denial_tracker.should_prompt(&fp) {
+            astra_runtime::turn::approval_fingerprint::DenialAction::SkipTool => {
+                return ApprovalDecision::Deny;
+            }
+            astra_runtime::turn::approval_fingerprint::DenialAction::FallbackToUser => {}
+            astra_runtime::turn::approval_fingerprint::DenialAction::Continue => {}
+        }
 
         eprintln!(
             "{}",
@@ -539,6 +546,13 @@ impl PermissionManager {
             } else {
                 ApprovalDecision::Deny
             };
+        }
+        match self.denial_tracker.should_prompt(&fp) {
+            astra_runtime::turn::approval_fingerprint::DenialAction::SkipTool => {
+                return ApprovalDecision::Deny;
+            }
+            astra_runtime::turn::approval_fingerprint::DenialAction::FallbackToUser => {}
+            astra_runtime::turn::approval_fingerprint::DenialAction::Continue => {}
         }
 
         eprintln!(
@@ -1036,10 +1050,24 @@ impl PermissionManager {
         if let Some(detail) = detail {
             eprintln!("{}", detail.dim());
         }
+        // Check denial limits before prompting.
+        let fp = astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(name);
+        match self.denial_tracker.should_prompt(&fp) {
+            astra_runtime::turn::approval_fingerprint::DenialAction::SkipTool => {
+                eprintln!(
+                    "  {}",
+                    format!("  ✗ {name}: auto-denied (repeated denials)").dim()
+                );
+                return false;
+            }
+            astra_runtime::turn::approval_fingerprint::DenialAction::FallbackToUser => {
+                // Still show the prompt but could add escalation context
+            }
+            astra_runtime::turn::approval_fingerprint::DenialAction::Continue => {}
+        }
         match Self::prompt_approval(ApprovalPromptKind::LocalStandard) {
             'y' => true,
             'a' => {
-                let fp = astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(name);
                 self.session_overrides.insert(fp, true);
                 // Persist as a project-level allow rule with command pattern
                 let rule = Self::make_allow_rule(name, args);
@@ -1056,13 +1084,15 @@ impl PermissionManager {
                 true
             }
             's' => {
-                let fp = astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(name);
                 self.session_overrides.insert(fp.clone(), false);
                 self.denial_tracker.record(&fp, false);
                 eprintln!("  {}", format!("  ✗ {name}: skipped for session").dim());
                 false
             }
-            _ => false,
+            _ => {
+                self.denial_tracker.record(&fp, false);
+                false
+            }
         }
     }
 
@@ -1231,6 +1261,19 @@ impl PermissionManager {
             PermissionMode::Auto => PermissionDecision::Allow,
             PermissionMode::Deny => PermissionDecision::Deny("Denied by mode".into()),
             PermissionMode::Prompt => {
+                // Check denial limits before prompting.
+                let fp = astra_runtime::turn::approval_fingerprint::ApprovalFingerprint::bare(name);
+                match self.denial_tracker.should_prompt(&fp) {
+                    astra_runtime::turn::approval_fingerprint::DenialAction::SkipTool => {
+                        return PermissionDecision::Deny(format!(
+                            "{name}: auto-denied (repeated denials)"
+                        ));
+                    }
+                    astra_runtime::turn::approval_fingerprint::DenialAction::FallbackToUser => {
+                        // Still show the prompt but add escalation context
+                    }
+                    astra_runtime::turn::approval_fingerprint::DenialAction::Continue => {}
+                }
                 let (header, detail) = Self::format_tool_display(name, args);
                 PermissionDecision::NeedApproval {
                     tool: name.to_string(),

--- a/rust/crates/astra-cli/src/cli/plan_executor.rs
+++ b/rust/crates/astra-cli/src/cli/plan_executor.rs
@@ -1580,6 +1580,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let res = selector.select(&sel_ctx).await;
         assert!(!res.tool_names.is_empty());
@@ -1600,6 +1601,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let res = selector.select(&sel_ctx).await;
         assert!(!res.tool_names.is_empty());

--- a/rust/crates/astra-cli/src/cli/self_command.rs
+++ b/rust/crates/astra-cli/src/cli/self_command.rs
@@ -2308,6 +2308,7 @@ fn event_type_name(event_type: &JournalEventType) -> String {
         JournalEventType::AdaptiveExperimentEnrolled => "adaptive_experiment_enrolled",
         JournalEventType::AdaptiveTuningRuleTriggered => "adaptive_tuning_rule_triggered",
         JournalEventType::InterruptionRecorded => "interruption_recorded",
+        JournalEventType::ConfidenceDiagnosisRecorded => "confidence_diagnosis_recorded",
     }
     .to_string()
 }

--- a/rust/crates/astra-cli/src/cli/skill_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/skill_subrun.rs
@@ -555,6 +555,7 @@ impl SkillSubRunExecutor for CliSkillSubRunExecutor {
             server_tool_executor: None,
             interruption: None,
             confidence_trend: Default::default(),
+            last_confidence_diagnosis: None,
         };
 
         if let Err(err) = run_agentic_loop_with_host(&mut host, &mut state).await {

--- a/rust/crates/astra-cli/src/cli/slash_session.rs
+++ b/rust/crates/astra-cli/src/cli/slash_session.rs
@@ -1769,6 +1769,24 @@ pub(super) fn handle_session_command(arg: &str, state: &mut ReplState) {
                                     resumable,
                                 );
                             }
+                            session_journal::JournalEventType::ConfidenceDiagnosisRecorded => {
+                                let conf = evt.selector_confidence.unwrap_or(0.0);
+                                let tier = evt
+                                    .metadata
+                                    .as_ref()
+                                    .and_then(|m| m.get("confidence_diagnosis"))
+                                    .and_then(|v| v.get("tier"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("unknown");
+                                eprintln!(
+                                    "  {} {} T{} confidence: {:.2} ({})",
+                                    ts_short.dim(),
+                                    "🔍".yellow(),
+                                    evt.turn.unwrap_or(0),
+                                    conf,
+                                    tier,
+                                );
+                            }
                         }
                     }
                     // Summary stats

--- a/rust/crates/astra-cli/src/cli/spawn_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/spawn_subrun.rs
@@ -282,6 +282,7 @@ impl SpawnAgentExecutor for CliSpawnAgentExecutor {
             server_tool_executor: None,
             interruption: None,
             confidence_trend: Default::default(),
+            last_confidence_diagnosis: None,
         };
 
         // Inherit skills from parent: pre-populate discovered skills

--- a/rust/crates/runtime/src/messaging/e2e_loop_tests.rs
+++ b/rust/crates/runtime/src/messaging/e2e_loop_tests.rs
@@ -201,6 +201,7 @@ mod tests {
             server_tool_executor: None,
             interruption: None,
             confidence_trend: Default::default(),
+            last_confidence_diagnosis: None,
         }
     }
 

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -887,6 +887,7 @@ impl AgenticRunLifecycleService {
             server_tool_executor: None,
             interruption: None,
             confidence_trend: Default::default(),
+            last_confidence_diagnosis: None,
         }
     }
 
@@ -1900,6 +1901,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
             server_tool_executor: None,
             interruption: None,
             confidence_trend: Default::default(),
+            last_confidence_diagnosis: None,
         };
         let learning_stack = configure_runtime_controllers(
             &self.matrixone,

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -1588,6 +1588,7 @@ mod tests {
             server_tool_executor: None,
             interruption: None,
             confidence_trend: Default::default(),
+            last_confidence_diagnosis: None,
         }
     }
 

--- a/rust/crates/runtime/src/server/server_skill_subrun.rs
+++ b/rust/crates/runtime/src/server/server_skill_subrun.rs
@@ -302,6 +302,7 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
             server_tool_executor: None,
             interruption: None,
             confidence_trend: Default::default(),
+            last_confidence_diagnosis: None,
         };
 
         if let Err(err) = run_agentic_loop_with_host(&mut host, &mut state).await {

--- a/rust/crates/runtime/src/tool_selector.rs
+++ b/rust/crates/runtime/src/tool_selector.rs
@@ -79,6 +79,10 @@ pub struct SelectionContext<'a> {
     /// e.g., ["rust"] from Cargo.toml, ["typescript"] from tsconfig.json.
     /// Boosts tools relevant to the detected project type.
     pub file_context: Vec<String>,
+    /// Fallback action from the previous turn's confidence diagnosis.
+    /// When `Some(Broaden)`, the selector should relax budget constraints
+    /// and include more candidate tools.
+    pub previous_confidence_fallback: Option<crate::turn::confidence_contract::ConfidenceFallback>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -670,8 +674,21 @@ impl ToolSelector for TfIdfSelector {
         // pressure=0.0 → full budget, pressure=1.0 → 30% budget.
         // Enforce a minimum floor so pressure can never starve tool selection.
         const MINIMUM_TOOL_BUDGET: u32 = 300;
-        let effective_budget = if ctx.budget_pressure > 0.0 {
-            let scale = 1.0 - ctx.budget_pressure.clamp(0.0, 1.0) * 0.7;
+
+        // If the previous turn diagnosed low confidence, reduce budget pressure
+        // to broaden the tool set for this turn.
+        let effective_pressure = match ctx.previous_confidence_fallback {
+            Some(crate::turn::confidence_contract::ConfidenceFallback::Broaden) => {
+                (ctx.budget_pressure * 0.3).min(0.3) // cap pressure at 0.3
+            }
+            Some(crate::turn::confidence_contract::ConfidenceFallback::EscalateToLlm) => {
+                0.0 // remove all pressure to maximize tool availability
+            }
+            _ => ctx.budget_pressure,
+        };
+
+        let effective_budget = if effective_pressure > 0.0 {
+            let scale = 1.0 - effective_pressure.clamp(0.0, 1.0) * 0.7;
             ((ctx.budget_tokens as f64 * scale) as u32).max(MINIMUM_TOOL_BUDGET)
         } else {
             ctx.budget_tokens.max(MINIMUM_TOOL_BUDGET)
@@ -1668,6 +1685,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         assert!(
@@ -1691,6 +1709,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         let dynamic_count = result
@@ -1852,6 +1871,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         }
     }
 
@@ -1996,6 +2016,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         // Primary should be called because fallback had dynamic tools with low confidence
@@ -2053,6 +2074,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         assert_eq!(result.strategy, "tfidf_routed_after_llm");
@@ -2156,6 +2178,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
 
         let provided = LearnedContext {
@@ -2243,6 +2266,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
 
         let baseline = LearnedAwarePrimary.select(&ctx).await;
@@ -2317,6 +2341,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         assert!(!result.tool_names.is_empty());
@@ -2351,6 +2376,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         assert!(!result.tool_names.is_empty());
@@ -2374,6 +2400,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_no_boost = selector.select(&ctx_no_boost).await;
 
@@ -2388,6 +2415,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_boosted = selector.select(&ctx_boosted).await;
 
@@ -2424,6 +2452,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         // Should still work (conversational may or may not include github depending
@@ -2444,6 +2473,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let ctx_empty = SelectionContext {
             query: "check the status",
@@ -2455,6 +2485,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let r1 = selector.select(&ctx_none).await;
         let r2 = selector.select(&ctx_empty).await;
@@ -2478,6 +2509,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let ctx_irrelevant = SelectionContext {
             query: "show git status",
@@ -2489,6 +2521,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let r1 = selector.select(&ctx_no_boost).await;
         let r2 = selector.select(&ctx_irrelevant).await;
@@ -2517,6 +2550,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         let has_git = result.tool_names.iter().any(|n| n.contains("git"));
@@ -2540,6 +2574,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         let has_memory = result.tool_names.iter().any(|n| n.contains("memory"));
@@ -2564,6 +2599,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         assert!(!result.failed, "100 boost terms should not crash");
@@ -2583,6 +2619,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         let has_github = result.tool_names.iter().any(|n| n.contains("github"));
@@ -2606,6 +2643,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         assert!(!result.failed, "CJK boost terms should not cause errors");
@@ -2625,6 +2663,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let r1 = selector.select(&ctx_no_boost).await;
         // With boost → might trigger github signal → higher confidence
@@ -2643,6 +2682,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let r2 = selector.select(&ctx_boosted).await;
         assert!(
@@ -2666,6 +2706,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let ctx_with_hint = SelectionContext {
             query: "matrixorigin",
@@ -2677,6 +2718,7 @@ mod tests {
             memory_domain_hints: vec![DomainHint::GitHub],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let r1 = selector.select(&ctx_no_hint).await;
         let r2 = selector.select(&ctx_with_hint).await;
@@ -2701,6 +2743,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let ctx_code = SelectionContext {
             query: "improve webhook capability",
@@ -2712,6 +2755,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec!["rust".into()],
+            previous_confidence_fallback: None,
         };
         let r1 = selector.select(&ctx_plain).await;
         let r2 = selector.select(&ctx_code).await;
@@ -2761,6 +2805,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
 
         let r_baseline = baseline.select(&ctx).await;
@@ -2808,6 +2853,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
 
         let result = selector.select(&ctx).await;
@@ -2997,6 +3043,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
 
         let result = selector.select(&ctx).await;
@@ -3025,6 +3072,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
 
         // First selection: no learned knowledge
@@ -3103,6 +3151,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
 
         let result = selector.select(&ctx).await;
@@ -3162,6 +3211,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
 
         let result = selector.select(&ctx).await;
@@ -3267,6 +3317,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_normal = selector.select(&ctx_normal).await;
 
@@ -3281,6 +3332,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_pressure = selector.select(&ctx_pressure).await;
 
@@ -3305,6 +3357,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         // budget_pressure=0.0 should not change behavior at all
@@ -3326,6 +3379,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_neg = selector.select(&ctx_neg).await;
 
@@ -3340,6 +3394,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_over = selector.select(&ctx_over).await;
 
@@ -3364,6 +3419,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_no_hint = selector.select(&ctx_no_hint).await;
 
@@ -3378,6 +3434,7 @@ mod tests {
             memory_domain_hints: vec![DomainHint::GitHub],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_hint = selector.select(&ctx_hint).await;
 
@@ -3416,6 +3473,7 @@ mod tests {
             memory_domain_hints: vec![DomainHint::Git],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         // With Git hint, should include git tools despite vague query
@@ -3440,6 +3498,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_none = selector.select(&ctx_none).await;
 
@@ -3462,6 +3521,7 @@ mod tests {
             memory_domain_hints: vec![DomainHint::GitHub],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         // Should still select some tools (domain hint helps ranking despite pressure)
@@ -3490,6 +3550,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_open = selector.select(&ctx_open).await;
         assert!(
@@ -3511,6 +3572,7 @@ mod tests {
             memory_domain_hints: vec![],
             restricted_tools: vec!["github_list_prs".to_string()],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_restricted = selector.select(&ctx_restricted).await;
         assert!(

--- a/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
@@ -394,7 +394,36 @@ fn record_tool_selection(
 ) {
     // Feed confidence trend tracker with latest selector confidence.
     if let Some(conf) = state.telemetry.first_selector_confidence {
-        state.confidence_trend.record(conf);
+        let floor_loop = state.confidence_trend.record(conf);
+
+        // Compute diagnosis from available signals.
+        let query_tokens = state.message.split_whitespace().count();
+        let dynamic_tools = turn_result.edge_tool_round.len();
+        let diagnosis = crate::turn::confidence_contract::ConfidenceDiagnosis::diagnose(
+            conf,
+            dynamic_tools,     // signal_count proxy
+            dynamic_tools > 0, // task_type_known proxy
+            0,                 // memory_hint_count: not available here
+            0,                 // file_context_count: not available here
+            false,             // disambiguation: not available here
+            query_tokens,
+        );
+
+        if floor_loop {
+            tracing::warn!(
+                streak = state.confidence_trend.floor_streak(),
+                avg = %format!("{:.2}", state.confidence_trend.average_confidence()),
+                "confidence-floor loop detected"
+            );
+        } else if diagnosis.is_actionable() {
+            tracing::info!(
+                tier = diagnosis.tier.label(),
+                confidence = %format!("{:.2}", conf),
+                "low-confidence tool selection"
+            );
+        }
+
+        state.last_confidence_diagnosis = Some(diagnosis);
     }
 
     if let Some(session) = &state.telemetry.observability_session {

--- a/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
@@ -424,6 +424,23 @@ fn record_tool_selection(
         }
 
         state.last_confidence_diagnosis = Some(diagnosis);
+
+        // Emit journal event for actionable (low/very-low) confidence diagnoses.
+        if let Some(ref diag) = state.last_confidence_diagnosis {
+            if diag.is_actionable() {
+                if let Some(ref sid) = state.current_session_id {
+                    if let Ok(writer) = astra_services::session_journal::JournalWriter::new(sid) {
+                        let evt = astra_services::session_journal::JournalEvent::confidence_diagnosis_recorded(
+                            Some(sid),
+                            turn_index as u32,
+                            conf,
+                            diag.to_json(),
+                        );
+                        let _ = writer.append(&evt);
+                    }
+                }
+            }
+        }
     }
 
     if let Some(session) = &state.telemetry.observability_session {

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -690,6 +690,8 @@ pub struct AgenticLoopState {
     // ── Confidence tracking ──
     /// Tracks selector confidence trends across turns to detect floor loops.
     pub confidence_trend: super::confidence_contract::ConfidenceTrendTracker,
+    /// Last diagnosis computed after tool selection (for telemetry and fallback).
+    pub last_confidence_diagnosis: Option<super::confidence_contract::ConfidenceDiagnosis>,
 }
 
 /// Consecutive same-category error turns before forcing a strategy change.
@@ -1123,6 +1125,7 @@ pub(crate) mod tests {
             server_tool_executor: None,
             interruption: None,
             confidence_trend: Default::default(),
+            last_confidence_diagnosis: None,
         }
     }
 

--- a/rust/crates/runtime/src/turn/chat_turn_selection_context.rs
+++ b/rust/crates/runtime/src/turn/chat_turn_selection_context.rs
@@ -19,6 +19,7 @@ pub fn build_agentic_tool_selection_context<'a>(
     file_context: Vec<String>,
     follow_up_tool_round: bool,
     tool_budget_override: Option<u32>,
+    previous_confidence_fallback: Option<crate::turn::confidence_contract::ConfidenceFallback>,
 ) -> SelectionContext<'a> {
     let turn_count = history_pair_count as u32 + 1;
     let base = tool_budget_override
@@ -35,6 +36,7 @@ pub fn build_agentic_tool_selection_context<'a>(
         memory_domain_hints,
         restricted_tools,
         file_context,
+        previous_confidence_fallback,
     }
 }
 
@@ -58,6 +60,7 @@ mod tests {
             vec![],
             false,
             None,
+            None,
         );
         let ctx_b = build_agentic_tool_selection_context(
             "hi",
@@ -70,6 +73,7 @@ mod tests {
             vec![],
             vec![],
             true,
+            None,
             None,
         );
         assert_eq!(ctx_b.budget_tokens, ctx_a.budget_tokens * 2);
@@ -94,6 +98,7 @@ mod tests {
             vec![],
             false,
             None,
+            None,
         );
         assert_eq!(ctx_none.budget_tokens, default_budget);
 
@@ -110,6 +115,7 @@ mod tests {
             vec![],
             false,
             Some(1200),
+            None,
         );
         assert_eq!(ctx_override.budget_tokens, 1200);
 
@@ -126,6 +132,7 @@ mod tests {
             vec![],
             false,
             Some(0),
+            None,
         );
         assert_eq!(ctx_zero.budget_tokens, default_budget);
 
@@ -142,6 +149,7 @@ mod tests {
             vec![],
             true,
             Some(1200),
+            None,
         );
         assert_eq!(ctx_followup.budget_tokens, 2400);
     }

--- a/rust/crates/runtime/src/turn/loop_dispatcher.rs
+++ b/rust/crates/runtime/src/turn/loop_dispatcher.rs
@@ -322,6 +322,7 @@ mod tests {
             server_tool_executor: None,
             interruption: None,
             confidence_trend: Default::default(),
+            last_confidence_diagnosis: None,
         }
     }
 

--- a/rust/crates/runtime/tests/improvement_proofs.rs
+++ b/rust/crates/runtime/tests/improvement_proofs.rs
@@ -3548,6 +3548,7 @@ mod learning_improves_selection {
                 memory_domain_hints: hints,
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
 
@@ -3562,6 +3563,7 @@ mod learning_improves_selection {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
 
@@ -8836,6 +8838,7 @@ mod co_occurrence_scoring_proofs {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_with = selector.select(&ctx_with_recent).await;
 
@@ -8850,6 +8853,7 @@ mod co_occurrence_scoring_proofs {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result_without = selector.select(&ctx_without_recent).await;
 
@@ -8995,6 +8999,7 @@ mod file_context_scoring_proofs {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec!["typescript".to_string()],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         assert!(!result.failed, "selection with file_context should succeed");

--- a/rust/crates/runtime/tests/memory_boost_integration.rs
+++ b/rust/crates/runtime/tests/memory_boost_integration.rs
@@ -217,6 +217,7 @@ fn full_pipeline_boost_improves_github_selection() {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let r_no = selector.select(&ctx_no).await;
 
@@ -230,6 +231,7 @@ fn full_pipeline_boost_improves_github_selection() {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let r_boost = selector.select(&ctx_boost).await;
 
@@ -280,6 +282,7 @@ fn full_pipeline_no_history_safe() {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         selector.select(&ctx).await
     });
@@ -348,6 +351,7 @@ fn full_pipeline_confidence_improves_with_history() {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let r_no = selector.select(&ctx_no).await;
 
@@ -361,6 +365,7 @@ fn full_pipeline_confidence_improves_with_history() {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let r_boost = selector.select(&ctx_boost).await;
 
@@ -544,6 +549,7 @@ fn cold_start_boost_improves_tool_selection() {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let r_no = selector.select(&ctx_no).await;
 
@@ -564,6 +570,7 @@ fn cold_start_boost_improves_tool_selection() {
             memory_domain_hints: vec![],
             restricted_tools: vec![],
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let r_boost = selector.select(&ctx_boost).await;
         (r_no, r_boost)

--- a/rust/crates/runtime/tests/nonhappy_path.rs
+++ b/rust/crates/runtime/tests/nonhappy_path.rs
@@ -1274,6 +1274,7 @@ mod chat_stream_turnguard_e2e {
             memory_domain_hints: vec![],
             restricted_tools: restricted,
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         assert!(
@@ -1444,6 +1445,7 @@ mod chat_stream_turnguard_e2e {
             memory_domain_hints: vec![],
             restricted_tools: restricted,
             file_context: vec![],
+            previous_confidence_fallback: None,
         };
         let result = selector.select(&ctx).await;
         assert!(

--- a/rust/crates/runtime/tests/utterance_regression.rs
+++ b/rust/crates/runtime/tests/utterance_regression.rs
@@ -2861,6 +2861,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
 
@@ -2875,6 +2876,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
 
@@ -2900,6 +2902,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         assert!(
@@ -2925,6 +2928,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec!["github_ci_status".to_string()],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         assert!(
@@ -2951,6 +2955,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec!["git_log".to_string(), "git_diff".to_string()],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         assert!(
@@ -2977,6 +2982,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
 
@@ -2992,6 +2998,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![DomainHint::GitHub],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
 
@@ -3021,6 +3028,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![DomainHint::Database],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         let has_db = result
@@ -3050,6 +3058,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         // Recent github_list_prs should boost github tools in followup
@@ -3075,6 +3084,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         let has_git = result.tool_names.iter().any(|n| n.starts_with("git_"));
@@ -3101,6 +3111,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         assert!(
@@ -3124,6 +3135,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         let has_memory = result.tool_names.iter().any(|n| n.contains("memory"));
@@ -3148,6 +3160,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         let has_git = result.tool_names.iter().any(|n| n.starts_with("git_"));
@@ -3174,6 +3187,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec!["github_ci_status".to_string()],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         assert!(
@@ -3202,6 +3216,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![DomainHint::GitHub],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         let has_github = result.tool_names.iter().any(|n| n.starts_with("github_"));
@@ -3228,6 +3243,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         let vague = selector
@@ -3241,6 +3257,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         assert!(
@@ -3265,6 +3282,7 @@ mod pipeline_integration {
                 memory_domain_hints: vec![],
                 restricted_tools: vec![],
                 file_context: vec![],
+                previous_confidence_fallback: None,
             })
             .await;
         // Conversational should rely mostly on pinned tools

--- a/rust/crates/services/src/self_surface.rs
+++ b/rust/crates/services/src/self_surface.rs
@@ -2136,6 +2136,7 @@ fn event_type_name(event_type: &JournalEventType) -> String {
         JournalEventType::AdaptiveExperimentEnrolled => "adaptive_experiment_enrolled",
         JournalEventType::AdaptiveTuningRuleTriggered => "adaptive_tuning_rule_triggered",
         JournalEventType::InterruptionRecorded => "interruption_recorded",
+        JournalEventType::ConfidenceDiagnosisRecorded => "confidence_diagnosis_recorded",
     }
     .to_string()
 }

--- a/rust/crates/services/src/session_journal.rs
+++ b/rust/crates/services/src/session_journal.rs
@@ -739,6 +739,8 @@ pub enum JournalEventType {
     AdaptiveTuningRuleTriggered,
     /// A structured interruption was recorded (budget exhaustion, rate limit, cancel, etc.).
     InterruptionRecorded,
+    /// Low or very-low selector confidence diagnosed (tier, reasons, fallback action).
+    ConfidenceDiagnosisRecorded,
 }
 
 /// Writer that appends events to a session journal file.
@@ -2569,6 +2571,22 @@ impl JournalEvent {
         ));
         evt.metadata = Some(serde_json::json!({
             "interruption": interruption_json,
+        }));
+        evt
+    }
+
+    /// Record a selector confidence diagnosis (emitted only for actionable tiers).
+    pub fn confidence_diagnosis_recorded(
+        session_id: Option<&str>,
+        turn: u32,
+        confidence: f64,
+        diagnosis_json: serde_json::Value,
+    ) -> Self {
+        let mut evt = Self::base(JournalEventType::ConfidenceDiagnosisRecorded, session_id);
+        evt.turn = Some(turn);
+        evt.selector_confidence = Some(confidence);
+        evt.metadata = Some(serde_json::json!({
+            "confidence_diagnosis": diagnosis_json,
         }));
         evt
     }


### PR DESCRIPTION
## Summary

Two reliability hardening features that upgrade the approval fingerprint system and add observability for low-confidence tool selection:

### 1. Content-aware approval fingerprints

Replace bare tool-name-only fingerprints with content-aware variants:
- **Shell tools** → `shell(name, cmd_prefix, is_read_only)` — captures command hint + read-only classification
- **File tools** → `file_op(name, path)` — captures target path pattern
- **Other tools** → `bare(name)` fallback

Updated in `check()`, `check_nonblocking()`, cloud approval flows, and `apply_cloud_approval_choice()`. The `record_approval()` path intentionally keeps `bare()` for broadest subsumption semantics when args aren't available.

### 2. ConfidenceDiagnosis journal telemetry

- New `ConfidenceDiagnosisRecorded` journal event type with builder method
- Emits in `record_tool_selection()` when diagnosis is actionable (low/very-low tier)
- Captures confidence score + full diagnosis JSON for post-session analysis
- Wired into `/session show` display and `event_type_name` helpers

### Also includes

Cherry-picked wiring commit (DenialTracker + ConfidenceDiagnosis into live runtime paths) that was missed in the PR #36 squash merge.

## Testing

- `cargo test -p astra-cli`: 2504 passed
- `cargo test -p astra-runtime`: 293 passed  
- `cargo test -p astra-services`: all passed
- `cargo fmt --all` clean