### PR TITLE
feat(executor): Phase D - ToolResult refactor + CLI delegation

### DIFF
--- a/rust/crates/astra-cli/src/edge_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools.rs
@@ -422,6 +422,8 @@ pub struct ToolExecutor {
     /// Per-turn mutation accounting for adjust_config governor.
     /// (turn_number, mutations_applied_on_turn)
     self_mod_mutation_counter: std::sync::Mutex<(u32, u32)>,
+    /// Shared tool executor for delegating unknown tools to astra-tools.
+    default_executor: astra_tools::executor::DefaultToolExecutor,
 }
 
 impl ToolExecutor {
@@ -430,7 +432,7 @@ impl ToolExecutor {
         let preferred_repos = detect_git_remote_repos(&root);
         let sandbox = astra_runtime::tool_sandbox::SandboxPolicy::for_project(&root);
         Self {
-            project_root: root,
+            project_root: root.clone(),
             cloud_base: None,
             cloud_token: None,
             // TODO: Consider using a zeroize-capable wrapper for tokens to prevent
@@ -486,6 +488,17 @@ impl ToolExecutor {
             self_mod_pinned_tools: std::sync::Mutex::new(Vec::new()),
             self_mod_deprioritized_tools: std::sync::Mutex::new(Vec::new()),
             self_mod_mutation_counter: std::sync::Mutex::new((0, 0)),
+            default_executor: astra_tools::executor::DefaultToolExecutor::new(
+                astra_tools::ToolContext {
+                    project_root: root.clone(),
+                    workspace_root: root.clone(),
+                    user_id: String::new(),
+                    session_id: String::new(),
+                    sandbox: astra_tools::SandboxConfig::standard(&root),
+                    http_client: None,
+                    logger: std::sync::Arc::new(astra_tools::TracingLogger),
+                },
+            ),
         }
     }
 
@@ -1096,16 +1109,11 @@ impl ToolExecutor {
                 "brief" => self.brief(args),
                 "context_analysis" => self.context_analysis(args),
                 _ if name.starts_with("mcp_") => self.execute_mcp_tool(name, args).await,
-                _ => format!(
-                    "Unknown tool: {name}. Available tools: bash, read_file, write_file, str_replace, \
-                 list_dir, grep, glob, symbols, find_definition, find_references, git_status, \
-                 git_diff, git_log, git_show, git_blame, call_graph, run_build_test, web_fetch, \
-                 mo_query, memory_search, memory_profile, adjust_config, prioritize_tool, \
-                 deprioritize_tool, set_goal, compress_context, ask_user, task_create, task_list, \
-                 task_get, task_update, task_stop, sleep, tool_search, web_search, send_message, \
-                 spawn_agent, share_context, query_context, context_analysis, \
-                 diagnose, lsp, env, notebook_edit, config, powershell, brief"
-                ),
+                _ => {
+                    // Delegate unknown tools to the shared DefaultToolExecutor.
+                    use astra_tools::ToolExecutor as _;
+                    self.default_executor.execute(name, args).await.output
+                }
             }
         };
         // Normalize empty output, then apply global safety net

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -64,6 +64,17 @@ impl ToolResult {
             is_error: true,
         }
     }
+
+    /// Convert a legacy `String` output into a `ToolResult`.
+    ///
+    /// Heuristic: strings starting with `"Error"` are treated as errors.
+    pub fn from_string(output: String) -> Self {
+        if output.starts_with("Error") {
+            Self::error(output)
+        } else {
+            Self::text(output)
+        }
+    }
 }
 
 /// Trait for executing tools. Implementations provide the actual tool logic

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -24,6 +24,7 @@ use serde_json::{Value, json};
 
 use astra_tools::executor::DefaultToolExecutor;
 use astra_tools::{ToolContext, ToolExecutor};
+use async_trait::async_trait;
 
 use crate::tool_sandbox::{
     IsolationConfig, SandboxMode, SandboxPolicy, ToolTier, effective_tier, execute_isolated,
@@ -3017,6 +3018,34 @@ fn tool_result_from_output(output: String) -> astra_tools::ToolResult {
         astra_tools::ToolResult::error(output)
     } else {
         astra_tools::ToolResult::text(output)
+    }
+}
+
+// ─── ToolExecutor trait implementation ────────────────────────────────────────
+//
+// This allows ServerToolExecutor to be used polymorphically wherever
+// `dyn ToolExecutor` (or `impl ToolExecutor`) is required, e.g. in
+// shared pipeline code that doesn't know whether it runs on the server
+// or on an edge/CLI client.
+
+#[async_trait]
+impl ToolExecutor for ServerToolExecutor {
+    async fn execute(&self, name: &str, args: &Value) -> astra_tools::ToolResult {
+        // Delegate to the concrete method that already returns ToolResult.
+        ServerToolExecutor::execute_with_metadata(self, name, args).await
+    }
+
+    fn tool_schemas(&self) -> Vec<Value> {
+        self.default_executor.tool_schemas()
+    }
+
+    fn project_root(&self) -> &Path {
+        &self.workspace_root
+    }
+
+    async fn execute_with_metadata(&self, name: &str, args: &Value) -> astra_tools::ToolResult {
+        // Explicitly delegate to the inherent method (not the default trait impl).
+        ServerToolExecutor::execute_with_metadata(self, name, args).await
     }
 }
 


### PR DESCRIPTION
## Summary

Phase D of the web agent tool extraction plan.

### D.1: ServerToolExecutor returns ToolResult
- `execute()` and `execute_local()` now return `astra_tools::ToolResult` instead of `String`
- Added `ToolResult::from_string()` for legacy String→ToolResult conversion
- `impl ToolExecutor for ServerToolExecutor` enables polymorphic trait-based dispatch
- 34 test assertions updated

### D.3: CLI delegates to DefaultToolExecutor
- CLI `ToolExecutor` now embeds a `DefaultToolExecutor` as fallback
- Unknown tools delegate to shared executor instead of returning 'Unknown tool'
- Any tool added to `astra-tools` is automatically available in CLI
- CLI-specific tools retain their specialized implementations

### Impact
- Server executor now trait-compatible with `ToolExecutor`
- CLI gains automatic tool availability from shared library
- Foundation for consistent tool behavior across all three consumers