### PR TITLE
feat(runtime): refresh live promotion signals

### DIFF
--- a/rust/crates/runtime/src/adaptive_baselines.rs
+++ b/rust/crates/runtime/src/adaptive_baselines.rs
@@ -793,6 +793,7 @@ mod tests {
                 score_delta: Some(ValueInterval::exact(-0.11)),
             }),
             calibration_error: Some(ValueInterval::exact(0.24)),
+            ..RuntimePromotionSignals::default()
         };
 
         let verdict =

--- a/rust/crates/runtime/src/evolution/promotion_gate.rs
+++ b/rust/crates/runtime/src/evolution/promotion_gate.rs
@@ -344,9 +344,12 @@ fn recommendation_for(
 mod tests {
     use super::*;
     use crate::pipeline::calibration::ProgressiveCalibrator;
+    use crate::pipeline::evaluation::TurnEvaluation;
     use crate::pipeline::pattern::PatternLibrary;
     use crate::pipeline::routing::{DomainHint, TaskType};
-    use crate::runtime_promotion_signals::{RuntimePromotionGateSignal, RuntimePromotionSignals};
+    use crate::runtime_promotion_signals::{
+        RuntimePromotionGateSignal, RuntimePromotionSignals, RuntimeTurnEvaluationSignal,
+    };
     use astra_core::confidence::ConfidenceInterval;
     use astra_services::evaluation::types::ValueInterval;
 
@@ -579,6 +582,7 @@ mod tests {
                 score_delta: Some(ValueInterval::exact(-0.10)),
             }),
             calibration_error: Some(ValueInterval::exact(0.22)),
+            ..RuntimePromotionSignals::default()
         };
 
         let verdict = evaluate_proposal_promotion(
@@ -600,6 +604,61 @@ mod tests {
                 .blockers
                 .iter()
                 .any(|blocker| blocker.contains("significant score regression"))
+        );
+    }
+
+    #[test]
+    fn recent_runtime_turn_failure_blocks_bounded_calibration_promotion() {
+        let proposal = EvolutionProposal {
+            id: "ev_recent_turn_failure".into(),
+            signal: EvolutionSignal::LlmReflection {
+                context_id: "ctx".into(),
+            },
+            axis: EvolutionAxis::Calibration {
+                axis: CalibrationAxis::Intent("fetch".into()),
+                adjustment: 0.10,
+            },
+            confidence: 0.91,
+            reasoning: "bounded calibration".into(),
+            created_at: 0,
+            status: super::super::types::ApprovalStatus::Pending,
+            promotion_verdict: None,
+        };
+        let signals = RuntimePromotionSignals::with_recent_turn_feedback(
+            None,
+            Some(RuntimeTurnEvaluationSignal::from_turn_evaluation(
+                &TurnEvaluation {
+                    success: false,
+                    quality: 0.20,
+                    confidence: 0.72,
+                    signals: Vec::new(),
+                },
+                2,
+                1,
+                true,
+            )),
+        )
+        .expect("recent turn feedback");
+
+        let verdict = evaluate_proposal_promotion(
+            &proposal,
+            ProposalPromotionContext {
+                pattern_library: None,
+                calibrator: Some(&ProgressiveCalibrator::default()),
+                promotion_signals: Some(&signals),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            verdict.recommendation,
+            ProposalPromotionRecommendation::Hold
+        );
+        assert!(
+            verdict
+                .blockers
+                .iter()
+                .any(|blocker| blocker.contains("recent runtime turn quality"))
         );
     }
 }

--- a/rust/crates/runtime/src/evolution/service.rs
+++ b/rust/crates/runtime/src/evolution/service.rs
@@ -1060,6 +1060,7 @@ mod tests {
                 },
             ),
             calibration_error: Some(ValueInterval::new(0.05, 0.03, 0.07)),
+            ..RuntimePromotionSignals::default()
         }
     }
 
@@ -1073,6 +1074,7 @@ mod tests {
                 },
             ),
             calibration_error: Some(ValueInterval::new(0.27, 0.23, 0.31)),
+            ..RuntimePromotionSignals::default()
         }
     }
 

--- a/rust/crates/runtime/src/runtime_promotion_signals.rs
+++ b/rust/crates/runtime/src/runtime_promotion_signals.rs
@@ -1,10 +1,44 @@
 use astra_core::confidence::ConfidenceInterval;
 use astra_services::evaluation::types::ValueInterval;
 
+use crate::pipeline::evaluation::TurnEvaluation;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RuntimePromotionGateSignal {
     pub passed: bool,
     pub score_delta: Option<ValueInterval>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeTurnEvaluationSignal {
+    pub success: bool,
+    pub quality: ConfidenceInterval,
+    pub confidence: ConfidenceInterval,
+    pub calibration_error: ValueInterval,
+    pub stall_count: usize,
+    pub verdict_warning: bool,
+    pub tool_call_count: usize,
+}
+
+impl RuntimeTurnEvaluationSignal {
+    pub fn from_turn_evaluation(
+        evaluation: &TurnEvaluation,
+        tool_call_count: usize,
+        stall_count: usize,
+        verdict_warning: bool,
+    ) -> Self {
+        Self {
+            success: evaluation.success,
+            quality: ConfidenceInterval::exact(evaluation.quality),
+            confidence: ConfidenceInterval::exact(evaluation.confidence),
+            calibration_error: ValueInterval::exact(
+                (evaluation.confidence - evaluation.quality).abs(),
+            ),
+            stall_count,
+            verdict_warning,
+            tool_call_count,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -12,6 +46,25 @@ pub struct RuntimePromotionSignals {
     pub noise_filtered_quality: Option<ConfidenceInterval>,
     pub latest_gate: Option<RuntimePromotionGateSignal>,
     pub calibration_error: Option<ValueInterval>,
+    pub recent_turn: Option<RuntimeTurnEvaluationSignal>,
+}
+
+impl RuntimePromotionSignals {
+    pub fn with_recent_turn_feedback(
+        existing: Option<&Self>,
+        recent_turn: Option<RuntimeTurnEvaluationSignal>,
+    ) -> Option<Self> {
+        let mut updated = existing.cloned().unwrap_or_default();
+        updated.recent_turn = recent_turn;
+        (!updated.is_empty()).then_some(updated)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.noise_filtered_quality.is_none()
+            && self.latest_gate.is_none()
+            && self.calibration_error.is_none()
+            && self.recent_turn.is_none()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -150,6 +203,62 @@ impl RuntimePromotionScorecard {
                 self.safety_score = (self.safety_score + 0.03).min(1.0);
             }
         }
+
+        if let Some(recent_turn) = signals.recent_turn.as_ref() {
+            self.evidence.push(format!(
+                "recent runtime turn quality {:.2} [{:.2}, {:.2}] after {} tool call(s)",
+                recent_turn.quality.point,
+                recent_turn.quality.lower,
+                recent_turn.quality.upper,
+                recent_turn.tool_call_count,
+            ));
+            self.evidence.push(format!(
+                "recent runtime turn evaluation confidence {:.2} [{:.2}, {:.2}]",
+                recent_turn.confidence.point,
+                recent_turn.confidence.lower,
+                recent_turn.confidence.upper,
+            ));
+            self.evidence.push(format_value_signal(
+                "recent runtime selector calibration error",
+                recent_turn.calibration_error,
+            ));
+
+            if !recent_turn.success {
+                self.confidence_score = (self.confidence_score - 0.08).max(0.0);
+                self.support_score = (self.support_score - 0.10).max(0.0);
+                if recent_turn.quality.lower < thresholds.poor_quality_floor {
+                    self.blockers
+                        .push("recent runtime turn quality is below promotion threshold".into());
+                }
+            } else if recent_turn.quality.lower >= thresholds.strong_quality_floor {
+                self.support_score = (self.support_score + 0.04).min(1.0);
+            }
+
+            if recent_turn.stall_count > 0 {
+                self.evidence.push(format!(
+                    "recent runtime turn recorded {} stall event(s)",
+                    recent_turn.stall_count
+                ));
+                self.confidence_score = (self.confidence_score - 0.04).max(0.0);
+                self.support_score = (self.support_score - 0.04).max(0.0);
+            }
+
+            if recent_turn.verdict_warning {
+                self.evidence
+                    .push("recent runtime turn ended with a warning verdict".into());
+                self.confidence_score = (self.confidence_score - 0.05).max(0.0);
+                self.safety_score = (self.safety_score - 0.04).max(0.0);
+            }
+
+            if recent_turn.calibration_error.upper > thresholds.moderate_calibration_error_ceiling {
+                self.confidence_score = (self.confidence_score - 0.03).max(0.0);
+                self.safety_score = (self.safety_score - 0.02).max(0.0);
+            } else if recent_turn.calibration_error.upper
+                < thresholds.strong_calibration_error_floor
+            {
+                self.safety_score = (self.safety_score + 0.02).min(1.0);
+            }
+        }
     }
 }
 
@@ -173,6 +282,7 @@ mod tests {
                 score_delta: Some(ValueInterval::new(-0.12, -0.16, -0.08)),
             }),
             calibration_error: Some(ValueInterval::new(0.27, 0.23, 0.31)),
+            ..RuntimePromotionSignals::default()
         };
         let mut scorecard =
             RuntimePromotionScorecard::new(0.92, 0.88, 0.84, Vec::new(), Vec::new());
@@ -200,6 +310,7 @@ mod tests {
                 score_delta: Some(ValueInterval::new(-0.04, -0.09, 0.01)),
             }),
             calibration_error: Some(ValueInterval::new(0.14, 0.10, 0.27)),
+            ..RuntimePromotionSignals::default()
         };
         let mut scorecard =
             RuntimePromotionScorecard::new(0.90, 0.82, 0.81, Vec::new(), Vec::new());
@@ -247,5 +358,89 @@ mod tests {
                 .iter()
                 .any(|blocker| blocker.contains("significant score regression"))
         );
+    }
+
+    #[test]
+    fn recent_turn_failure_dampens_scores_and_blocks_bad_turns() {
+        let recent_turn = RuntimeTurnEvaluationSignal::from_turn_evaluation(
+            &TurnEvaluation {
+                success: false,
+                quality: 0.22,
+                confidence: 0.72,
+                signals: Vec::new(),
+            },
+            2,
+            1,
+            true,
+        );
+        let signals =
+            RuntimePromotionSignals::with_recent_turn_feedback(None, Some(recent_turn)).unwrap();
+        let mut scorecard =
+            RuntimePromotionScorecard::new(0.90, 0.82, 0.81, Vec::new(), Vec::new());
+
+        scorecard.apply_signals(Some(&signals));
+
+        assert!(scorecard.confidence_score < 0.75);
+        assert!(scorecard.support_score < 0.68);
+        assert!(scorecard.safety_score < 0.81);
+        assert!(
+            scorecard
+                .blockers
+                .iter()
+                .any(|blocker| blocker.contains("recent runtime turn quality"))
+        );
+        assert!(
+            scorecard
+                .evidence
+                .iter()
+                .any(|line| line.contains("recent runtime turn recorded 1 stall"))
+        );
+    }
+
+    #[test]
+    fn recent_turn_feedback_preserves_globals_and_collapses_empty_state() {
+        let global = RuntimePromotionSignals {
+            noise_filtered_quality: Some(ConfidenceInterval::exact(0.78)),
+            ..RuntimePromotionSignals::default()
+        };
+        let recent_turn = RuntimeTurnEvaluationSignal::from_turn_evaluation(
+            &TurnEvaluation {
+                success: true,
+                quality: 0.88,
+                confidence: 0.81,
+                signals: Vec::new(),
+            },
+            1,
+            0,
+            false,
+        );
+
+        let updated =
+            RuntimePromotionSignals::with_recent_turn_feedback(Some(&global), Some(recent_turn))
+                .unwrap();
+        assert_eq!(
+            updated.noise_filtered_quality,
+            global.noise_filtered_quality
+        );
+        assert!(updated.recent_turn.is_some());
+
+        let cleared =
+            RuntimePromotionSignals::with_recent_turn_feedback(Some(&updated), None).unwrap();
+        assert_eq!(
+            cleared.noise_filtered_quality,
+            global.noise_filtered_quality
+        );
+        assert!(cleared.recent_turn.is_none());
+
+        let collapsed = RuntimePromotionSignals::with_recent_turn_feedback(Some(&cleared), None);
+        assert_eq!(collapsed, Some(cleared));
+        let empty = RuntimePromotionSignals::with_recent_turn_feedback(
+            Some(&RuntimePromotionSignals {
+                recent_turn: updated.recent_turn.clone(),
+                ..RuntimePromotionSignals::default()
+            }),
+            None,
+        );
+        assert!(empty.is_none());
     }
 }

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -210,6 +210,7 @@ async fn load_runtime_promotion_signals(
             score_delta: Some(gate.score_delta_interval),
         }),
         calibration_error: Some(calibration_error),
+        recent_turn: None,
     })
 }
 

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -1140,6 +1140,7 @@ pub(crate) mod tests {
                 },
             ),
             calibration_error: Some(ValueInterval::new(0.05, 0.03, 0.07)),
+            ..crate::runtime_promotion_signals::RuntimePromotionSignals::default()
         }
     }
 
@@ -1154,6 +1155,7 @@ pub(crate) mod tests {
                 },
             ),
             calibration_error: Some(ValueInterval::new(0.27, 0.23, 0.31)),
+            ..crate::runtime_promotion_signals::RuntimePromotionSignals::default()
         }
     }
 

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
@@ -29,6 +29,7 @@ use super::agentic_turn_flow::{
     agentic_round_stall_preflight_with_tool_calls, append_explain_turn_batch,
 };
 use super::tool_result_semantics::tool_dedup_signature;
+use crate::runtime_promotion_signals::{RuntimePromotionSignals, RuntimeTurnEvaluationSignal};
 
 pub(crate) enum TurnToolPhaseControl {
     ContinueLoop,
@@ -47,6 +48,56 @@ fn tool_record_was_rejected(rec: &astra_services::session_journal::ToolCallRecor
         .as_deref()
         .map(|error| error.starts_with("blocked_tool:"))
         .unwrap_or(false)
+}
+
+fn turn_has_warning_verdict(
+    turn_index: usize,
+    verdict_events: &[super::agentic_verdict_audit::AgenticVerdictAuditEvent],
+) -> bool {
+    verdict_events.iter().any(|event| {
+        event.turn == turn_index as u32
+            && (event.severity.eq_ignore_ascii_case("warning")
+                || event.severity.eq_ignore_ascii_case("critical"))
+    })
+}
+
+fn refresh_runtime_promotion_signals_from_turn(
+    existing: Option<&RuntimePromotionSignals>,
+    input: &str,
+    recent_tools: &[String],
+    turn_index: usize,
+    tool_call_records: &[astra_services::session_journal::ToolCallRecord],
+    stall_events: &[(String, u32)],
+    verdict_events: &[super::agentic_verdict_audit::AgenticVerdictAuditEvent],
+    budget_pressure: f64,
+) -> Option<RuntimePromotionSignals> {
+    let stall_count = stall_events
+        .iter()
+        .filter(|(_, recorded_turn)| *recorded_turn == turn_index as u32)
+        .count();
+    let verdict_warning = turn_has_warning_verdict(turn_index, verdict_events);
+    let evaluation = crate::pipeline::evaluation::evaluate_tool_call_records(
+        input,
+        recent_tools,
+        tool_call_records,
+        stall_count,
+        verdict_warning,
+        budget_pressure,
+    );
+    let recent_turn = (!tool_call_records.is_empty()
+        || stall_count > 0
+        || verdict_warning
+        || evaluation.confidence >= 0.6)
+        .then(|| {
+            RuntimeTurnEvaluationSignal::from_turn_evaluation(
+                &evaluation,
+                tool_call_records.len(),
+                stall_count,
+                verdict_warning,
+            )
+        });
+
+    RuntimePromotionSignals::with_recent_turn_feedback(existing, recent_turn)
 }
 
 const EXECUTION_BOUNDARY_KIND_TURN_ROLLBACK: &str = "turn_rollback";
@@ -919,6 +970,17 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
             {
                 Ok(true) => {}
                 Ok(false) => {
+                    let updated_promotion_signals = refresh_runtime_promotion_signals_from_turn(
+                        state.telemetry.runtime_promotion_signals.as_ref(),
+                        &state.message,
+                        &state.recent_tools,
+                        turn_index,
+                        &state.stall.tool_call_records[evo_records_before..],
+                        &state.stall.events,
+                        &state.stall.verdict_events,
+                        state.telemetry.first_budget_pressure,
+                    );
+                    state.telemetry.runtime_promotion_signals = updated_promotion_signals;
                     observe_gate_cancelled(state, turn_index, prep.turn_start_time, &turn_result);
                     state.step_recorder.end_turn(true);
                     finalize_turn_trace(state);
@@ -952,6 +1014,17 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
         },
     )) {
         AgenticPostToolIterationControl::Abort(e) => {
+            let updated_promotion_signals = refresh_runtime_promotion_signals_from_turn(
+                state.telemetry.runtime_promotion_signals.as_ref(),
+                &state.message,
+                &state.recent_tools,
+                turn_index,
+                &state.stall.tool_call_records[evo_records_before..],
+                &state.stall.events,
+                &state.stall.verdict_events,
+                state.telemetry.first_budget_pressure,
+            );
+            state.telemetry.runtime_promotion_signals = updated_promotion_signals;
             finalize_turn_trace(state);
             return Err(e);
         }
@@ -1022,6 +1095,17 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
                 crate::observability_integration::on_turn_end(hub, &mut session_guard, timing);
             }
 
+            let updated_promotion_signals = refresh_runtime_promotion_signals_from_turn(
+                state.telemetry.runtime_promotion_signals.as_ref(),
+                &state.message,
+                &state.recent_tools,
+                turn_index,
+                &state.stall.tool_call_records[evo_records_before..],
+                &state.stall.events,
+                &state.stall.verdict_events,
+                state.telemetry.first_budget_pressure,
+            );
+            state.telemetry.runtime_promotion_signals = updated_promotion_signals;
             finalize_turn_trace(state);
             state.step_recorder.end_turn(false);
             state.telemetry.completed_turns_for_tuning += 1;
@@ -1062,6 +1146,7 @@ fn observe_gate_cancelled(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use astra_core::confidence::ConfidenceInterval;
     use astra_services::session_journal::{
         JournalEvent, JournalEventType, JournalWriter, ToolCallRecord,
     };
@@ -1131,6 +1216,67 @@ mod tests {
             row.extend(fields);
         }
         Value::Object(row)
+    }
+
+    #[test]
+    fn refresh_runtime_promotion_signals_captures_live_query_failures_without_tools() {
+        let existing = RuntimePromotionSignals {
+            noise_filtered_quality: Some(ConfidenceInterval::exact(0.78)),
+            ..RuntimePromotionSignals::default()
+        };
+
+        let updated = refresh_runtime_promotion_signals_from_turn(
+            Some(&existing),
+            "Check the latest git status",
+            &["git_status".to_string()],
+            2,
+            &[],
+            &[],
+            &[],
+            0.2,
+        )
+        .expect("recent turn signal should be captured");
+
+        assert_eq!(
+            updated.noise_filtered_quality,
+            existing.noise_filtered_quality
+        );
+        let recent = updated.recent_turn.expect("recent turn");
+        assert!(!recent.success);
+        assert_eq!(recent.tool_call_count, 0);
+        assert_eq!(recent.quality, ConfidenceInterval::exact(0.2));
+    }
+
+    #[test]
+    fn refresh_runtime_promotion_signals_clears_stale_recent_turn_for_neutral_turns() {
+        let existing = RuntimePromotionSignals::with_recent_turn_feedback(
+            None,
+            Some(RuntimeTurnEvaluationSignal::from_turn_evaluation(
+                &crate::pipeline::evaluation::TurnEvaluation {
+                    success: false,
+                    quality: 0.22,
+                    confidence: 0.72,
+                    signals: Vec::new(),
+                },
+                2,
+                1,
+                true,
+            )),
+        )
+        .expect("seed recent turn");
+
+        let updated = refresh_runtime_promotion_signals_from_turn(
+            Some(&existing),
+            "Thanks!",
+            &[],
+            3,
+            &[],
+            &[],
+            &[],
+            0.0,
+        );
+
+        assert!(updated.is_none());
     }
 
     fn read_journal_events(session_id: &str) -> Vec<JournalEvent> {


### PR DESCRIPTION
## Summary
- add a recent-turn runtime promotion signal alongside the existing global quality/gate/calibration signals
- refresh that live signal on normal turn completion and abort/cancel exits before tuning and auto-reflection consumers run
- let promotion scorecards consume fresh turn evidence so canary and promotion decisions react within the same run

## Testing
- cargo test -p astra-runtime recent_turn_failure_dampens_scores_and_blocks_bad_turns -- --nocapture
- cargo test -p astra-runtime recent_runtime_turn_failure_blocks_bounded_calibration_promotion -- --nocapture
- cargo test -p astra-runtime refresh_runtime_promotion_signals_captures_live_query_failures_without_tools -- --nocapture
- cargo test -p astra-runtime refresh_runtime_promotion_signals_clears_stale_recent_turn_for_neutral_turns -- --nocapture
- cargo test -p astra-runtime promotion_gate -- --nocapture
- cargo test -p astra-runtime maybe_trigger_auto_reflection_records_auto_canary_promotions -- --nocapture
- cargo test -p astra-runtime maybe_trigger_auto_reflection_records_auto_canary_rollbacks -- --nocapture
- make format
- make check
- make test-offline