### PR TITLE
feat(sdk): Phase 3 — complete @astra/sdk

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,174 @@
+# @astra/sdk
+
+TypeScript SDK for the Astra AI Agent Runtime — provides type-safe REST, WebSocket, and SSE clients for building AI-powered applications.
+
+## Installation
+
+```bash
+npm install @astra/sdk
+```
+
+## Quick Start
+
+### REST Client
+
+```typescript
+import { AstraClient } from '@astra/sdk';
+
+const client = new AstraClient({ baseUrl: 'http://localhost:8000' });
+
+// Authenticate
+const { access_token } = await client.login('alice', 'password');
+
+// Create a session and start a run
+const session = await client.createSession();
+const run = await client.createRun({
+  message: 'Hello, world!',
+  sessionId: session.sessionId,
+});
+
+// Check run status
+const status = await client.getRunStatus(run.runId);
+```
+
+### Streaming (SSE)
+
+```typescript
+import { AstraClient } from '@astra/sdk';
+
+const client = new AstraClient({
+  baseUrl: 'http://localhost:8000',
+  accessToken: 'your-token',
+});
+
+const stream = client.streamChat(
+  { message: 'Explain quantum computing', sessionId: 'sess-1' },
+  {
+    onEvent(event) {
+      if (event.type === 'text_delta') {
+        process.stdout.write(event.delta);
+      }
+    },
+  },
+);
+
+// To cancel: stream.close()
+```
+
+### WebSocket
+
+```typescript
+import { AstraWebSocket } from '@astra/sdk';
+
+const ws = new AstraWebSocket({
+  url: 'ws://localhost:8000/api/chat/ws',
+  token: 'your-token',
+});
+
+await ws.connect();
+
+// Listen for specific event types
+ws.on('text_delta', (event) => console.log(event.delta));
+ws.on('tool_approval_request', (event) => {
+  ws.approveToolCall({ callId: event.request_id, approved: true });
+});
+
+ws.sendMessage('Build a REST API', { sessionId: 'sess-1' });
+
+// Pause / resume
+ws.pauseRun('run-id');
+ws.resumeRun('run-id');
+```
+
+### React Hooks
+
+```tsx
+import { useAstraChat } from '@astra/sdk/react';
+
+function Chat() {
+  const { messages, sendMessage, isStreaming, plan, usage } = useAstraChat({
+    baseUrl: 'http://localhost:8000',
+    accessToken: token,
+  });
+
+  return (
+    <div>
+      {messages.map((m) => (
+        <div key={m.id}>{m.content}</div>
+      ))}
+      <button onClick={() => sendMessage('Hello!')}>Send</button>
+    </div>
+  );
+}
+```
+
+## API Reference
+
+### `AstraClient`
+
+| Method | Description |
+|--------|-------------|
+| `login(username, password)` | Authenticate and store tokens |
+| `register(username, password)` | Create account and store tokens |
+| `logout()` | Clear session |
+| `getMe()` | Get current user info |
+| `createSession()` | Create a new chat session |
+| `getSession(id)` | Get session details |
+| `listSessions()` | List all sessions |
+| `deleteSession(id)` | Delete a session |
+| `getSessionAudit(id)` | Get session activity audit |
+| `createRun(request)` | Start a new agent run |
+| `getRunStatus(id)` | Check run status |
+| `cancelRun(id)` | Cancel a running agent |
+| `pauseRun(id)` | Pause a running agent |
+| `resumeRun(id)` | Resume a paused agent |
+| `getRunEvents(id, start?)` | Fetch run events |
+| `streamChat(request, callbacks)` | Stream via SSE |
+| `memoryStore(entry)` | Store a memory entry |
+| `memorySearch(query, topK?)` | Search memories |
+| `memoryRetrieve(query, topK?)` | Retrieve memories |
+| `memoryPurge(topic)` | Purge memories by topic |
+| `listSkills()` | List available skills |
+
+### `AstraWebSocket`
+
+| Method | Description |
+|--------|-------------|
+| `connect()` | Connect (returns Promise) |
+| `close()` | Disconnect |
+| `on(event, handler)` | Subscribe to events |
+| `off(event, handler)` | Unsubscribe |
+| `sendMessage(content, options?)` | Send a chat message |
+| `cancelRun(runId?)` | Cancel current run |
+| `pauseRun(runId?)` | Pause current run |
+| `resumeRun(runId?)` | Resume paused run |
+| `approveToolCall(approval)` | Respond to tool approval |
+
+### React Hooks
+
+| Hook | Description |
+|------|-------------|
+| `useAstraChat(config)` | Full chat state management with streaming |
+| `useAstraRun(config)` | Lower-level run monitoring |
+
+## Types
+
+All 31 stream event types are exported:
+
+```typescript
+import type {
+  StreamEvent,
+  TextDeltaEvent,
+  ToolApprovalRequestEvent,
+  RunStatus,
+  SessionInfo,
+  AuthResult,
+  MemoryEntry,
+  MemorySearchResult,
+  // ... and more
+} from '@astra/sdk';
+```
+
+## License
+
+MIT

--- a/packages/sdk/jest.config.ts
+++ b/packages/sdk/jest.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+};
+
+export default config;

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -1,0 +1,294 @@
+import { AstraClient, AstraApiError } from '../client';
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function mockFetch(status: number, body: unknown = {}, headers?: Record<string, string>) {
+  return jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+    headers: new Headers(headers),
+  } as unknown as Response);
+}
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function createClient(token = 'test-access-token') {
+  return new AstraClient({
+    baseUrl: 'http://localhost:8000',
+    accessToken: token,
+  });
+}
+
+// ─── Auth ─────────────────────────────────────────────────────────
+
+describe('AstraClient — Auth', () => {
+  test('login stores tokens and returns result', async () => {
+    const authResult = {
+      access_token: 'new-at',
+      refresh_token: 'new-rt',
+      user_id: 'u1',
+    };
+    globalThis.fetch = mockFetch(200, authResult);
+
+    const client = createClient();
+    const result = await client.login('alice', 'pass');
+
+    expect(result).toEqual(authResult);
+    const call = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe('http://localhost:8000/api/auth/login');
+    expect(JSON.parse(call[1].body)).toEqual({ username: 'alice', password: 'pass' });
+  });
+
+  test('register stores tokens', async () => {
+    const authResult = {
+      access_token: 'reg-at',
+      refresh_token: 'reg-rt',
+      user_id: 'u2',
+    };
+    globalThis.fetch = mockFetch(200, authResult);
+
+    const client = createClient();
+    const result = await client.register('bob', 'pass');
+
+    expect(result).toEqual(authResult);
+  });
+
+  test('logout clears tokens', async () => {
+    globalThis.fetch = mockFetch(200);
+
+    const client = createClient('tok');
+    await client.logout();
+
+    // Next call should have no Authorization header
+    globalThis.fetch = mockFetch(200, { user_id: 'u1', username: 'a', created_at: '' });
+    await client.getMe().catch(() => {});
+    const headers = (globalThis.fetch as jest.Mock).mock.calls[0][1].headers;
+    expect(headers['Authorization']).toBeUndefined();
+  });
+
+  test('getMe returns user info', async () => {
+    const user = { user_id: 'u1', username: 'alice', created_at: '2025-01-01' };
+    globalThis.fetch = mockFetch(200, user);
+
+    const client = createClient();
+    const result = await client.getMe();
+    expect(result).toEqual(user);
+  });
+});
+
+// ─── Sessions ─────────────────────────────────────────────────────
+
+describe('AstraClient — Sessions', () => {
+  test('createSession', async () => {
+    const session = { sessionId: 's1', createdAt: '', lastActive: '' };
+    globalThis.fetch = mockFetch(200, session);
+
+    const result = await createClient().createSession();
+    expect(result.sessionId).toBe('s1');
+  });
+
+  test('getSession', async () => {
+    const session = { sessionId: 's2', createdAt: '', lastActive: '' };
+    globalThis.fetch = mockFetch(200, session);
+
+    const result = await createClient().getSession('s2');
+    expect(result.sessionId).toBe('s2');
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/sessions/s2');
+  });
+
+  test('listSessions', async () => {
+    globalThis.fetch = mockFetch(200, []);
+    const result = await createClient().listSessions();
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  test('deleteSession', async () => {
+    globalThis.fetch = mockFetch(204);
+    await createClient().deleteSession('s3');
+    const call = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toContain('/api/sessions/s3');
+    expect(call[1].method).toBe('DELETE');
+  });
+
+  test('getSessionAudit', async () => {
+    const audit = { session_id: 's4', events: [], tool_calls: 3, turns: 2 };
+    globalThis.fetch = mockFetch(200, audit);
+    const result = await createClient().getSessionAudit('s4');
+    expect(result.session_id).toBe('s4');
+  });
+});
+
+// ─── Runs ─────────────────────────────────────────────────────────
+
+describe('AstraClient — Runs', () => {
+  test('createRun', async () => {
+    const run = { runId: 'r1', sessionId: 's1', status: 'running', eventsCount: 0 };
+    globalThis.fetch = mockFetch(200, run);
+
+    const result = await createClient().createRun({ message: 'hello' });
+    expect(result.runId).toBe('r1');
+  });
+
+  test('getRunStatus', async () => {
+    const run = { runId: 'r1', sessionId: 's1', status: 'completed', eventsCount: 5 };
+    globalThis.fetch = mockFetch(200, run);
+
+    const result = await createClient().getRunStatus('r1');
+    expect(result.status).toBe('completed');
+  });
+
+  test('cancelRun', async () => {
+    globalThis.fetch = mockFetch(200);
+    await createClient().cancelRun('r1');
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/runs/r1/cancel');
+  });
+
+  test('pauseRun', async () => {
+    globalThis.fetch = mockFetch(200);
+    await createClient().pauseRun('r1');
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/runs/r1/pause');
+  });
+
+  test('resumeRun', async () => {
+    globalThis.fetch = mockFetch(200);
+    await createClient().resumeRun('r1');
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/runs/r1/resume');
+  });
+
+  test('getRunEvents', async () => {
+    globalThis.fetch = mockFetch(200, []);
+    const result = await createClient().getRunEvents('r1');
+    expect(Array.isArray(result)).toBe(true);
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][0]).toContain('start=0');
+  });
+
+  test('getRunEvents with startIndex', async () => {
+    globalThis.fetch = mockFetch(200, []);
+    await createClient().getRunEvents('r1', 5);
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][0]).toContain('start=5');
+  });
+});
+
+// ─── Memory ─────────────────────────────────────────────────────────
+
+describe('AstraClient — Memory', () => {
+  test('memoryStore', async () => {
+    globalThis.fetch = mockFetch(200, { id: 'm1' });
+    const result = await createClient().memoryStore({ content: 'hello' });
+    expect(result.id).toBe('m1');
+    const body = JSON.parse((globalThis.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.content).toBe('hello');
+  });
+
+  test('memorySearch', async () => {
+    globalThis.fetch = mockFetch(200, [{ id: 'm1', content: 'hello', score: 0.9 }]);
+    const result = await createClient().memorySearch('hello');
+    expect(result).toHaveLength(1);
+    const body = JSON.parse((globalThis.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.query).toBe('hello');
+    expect(body.top_k).toBe(10);
+  });
+
+  test('memoryRetrieve', async () => {
+    globalThis.fetch = mockFetch(200, []);
+    await createClient().memoryRetrieve('query', 3);
+    const body = JSON.parse((globalThis.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.top_k).toBe(3);
+  });
+
+  test('memoryPurge', async () => {
+    globalThis.fetch = mockFetch(200);
+    await createClient().memoryPurge('old-topic');
+    const body = JSON.parse((globalThis.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.topic).toBe('old-topic');
+  });
+});
+
+// ─── Skills ─────────────────────────────────────────────────────────
+
+describe('AstraClient — Skills', () => {
+  test('listSkills', async () => {
+    globalThis.fetch = mockFetch(200, []);
+    const result = await createClient().listSkills();
+    expect(Array.isArray(result)).toBe(true);
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/skills');
+  });
+});
+
+// ─── Error handling ────────────────────────────────────────────────
+
+describe('AstraClient — Errors', () => {
+  test('throws AstraApiError on non-OK response', async () => {
+    globalThis.fetch = mockFetch(404, 'Not Found');
+
+    try {
+      await createClient().getSession('nonexistent');
+      fail('Expected error');
+    } catch (e) {
+      expect(e).toBeInstanceOf(AstraApiError);
+      expect((e as AstraApiError).status).toBe(404);
+    }
+  });
+
+  test('auto-refresh on 401', async () => {
+    const refreshResult = { access_token: 'refreshed', refresh_token: 'new-rt' };
+    let callCount = 0;
+
+    globalThis.fetch = jest.fn().mockImplementation((url: string) => {
+      callCount++;
+      if (callCount === 1) {
+        // First call: 401
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve('Unauthorized'),
+          headers: new Headers(),
+        });
+      }
+      if (callCount === 2 && url.includes('/auth/refresh')) {
+        // Refresh call
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(refreshResult),
+          text: () => Promise.resolve(JSON.stringify(refreshResult)),
+          headers: new Headers(),
+        });
+      }
+      // Retry call
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ sessionId: 's1', createdAt: '', lastActive: '' }),
+        text: () => Promise.resolve(''),
+        headers: new Headers(),
+      });
+    });
+
+    const onRefresh = jest.fn();
+    const client = new AstraClient({
+      baseUrl: 'http://localhost:8000',
+      accessToken: 'expired',
+      refreshToken: 'valid-rt',
+      onTokenRefresh: onRefresh,
+    });
+
+    const session = await client.getSession('s1');
+    expect(session.sessionId).toBe('s1');
+    expect(onRefresh).toHaveBeenCalledWith({
+      accessToken: 'refreshed',
+      refreshToken: 'new-rt',
+    });
+  });
+});

--- a/packages/sdk/src/__tests__/websocket.test.ts
+++ b/packages/sdk/src/__tests__/websocket.test.ts
@@ -1,0 +1,218 @@
+import { AstraWebSocket } from '../websocket';
+
+// ─── Mock WebSocket ────────────────────────────────────────────────
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  sent: string[] = [];
+  url: string;
+  protocols?: string | string[];
+
+  constructor(url: string, protocols?: string | string[]) {
+    this.url = url;
+    this.protocols = protocols;
+    // Auto-open after microtask to simulate real WS
+    setTimeout(() => {
+      this.readyState = MockWebSocket.OPEN;
+      this.onopen?.();
+    }, 0);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  // Test helper: simulate server message
+  _receive(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+}
+
+// Patch global
+const origWS = globalThis.WebSocket;
+beforeAll(() => {
+  (globalThis as any).WebSocket = MockWebSocket;
+});
+afterAll(() => {
+  (globalThis as any).WebSocket = origWS;
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe('AstraWebSocket', () => {
+  test('connect() resolves when WebSocket opens', async () => {
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    await ws.connect();
+    expect(ws.connectionState).toBe('connected');
+  });
+
+  test('emits events via .on()', async () => {
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    await ws.connect();
+
+    const events: any[] = [];
+    ws.on('event', (e) => events.push(e));
+
+    // Simulate server event
+    const raw = (ws as any).ws as MockWebSocket;
+    raw._receive({ type: 'text_delta', delta: 'hello' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('text_delta');
+  });
+
+  test('emits type-specific events', async () => {
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    await ws.connect();
+
+    const deltas: any[] = [];
+    ws.on('text_delta', (e) => deltas.push(e));
+
+    const raw = (ws as any).ws as MockWebSocket;
+    raw._receive({ type: 'text_delta', delta: 'a' });
+    raw._receive({ type: 'run_started', runId: 'r1' });
+    raw._receive({ type: 'text_delta', delta: 'b' });
+
+    expect(deltas).toHaveLength(2);
+  });
+
+  test('off() removes listener', async () => {
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    await ws.connect();
+
+    const events: any[] = [];
+    const handler = (e: any) => events.push(e);
+    ws.on('event', handler);
+
+    const raw = (ws as any).ws as MockWebSocket;
+    raw._receive({ type: 'text_delta', delta: 'a' });
+    ws.off('event', handler);
+    raw._receive({ type: 'text_delta', delta: 'b' });
+
+    expect(events).toHaveLength(1);
+  });
+
+  test('sendMessage sends correct JSON', async () => {
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    await ws.connect();
+
+    ws.sendMessage('hello', { sessionId: 's1', model: 'gpt-4' });
+
+    const raw = (ws as any).ws as MockWebSocket;
+    const sent = JSON.parse(raw.sent[0]);
+    expect(sent).toEqual({
+      type: 'message',
+      content: 'hello',
+      session_id: 's1',
+      model: 'gpt-4',
+    });
+  });
+
+  test('cancelRun sends cancel message', async () => {
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    await ws.connect();
+
+    ws.cancelRun('r1');
+
+    const raw = (ws as any).ws as MockWebSocket;
+    const sent = JSON.parse(raw.sent[0]);
+    expect(sent).toEqual({ type: 'cancel_run', run_id: 'r1' });
+  });
+
+  test('pauseRun and resumeRun', async () => {
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    await ws.connect();
+
+    ws.pauseRun('r1');
+    ws.resumeRun('r1');
+
+    const raw = (ws as any).ws as MockWebSocket;
+    expect(JSON.parse(raw.sent[0])).toEqual({ type: 'pause_run', run_id: 'r1' });
+    expect(JSON.parse(raw.sent[1])).toEqual({ type: 'resume_run', run_id: 'r1' });
+  });
+
+  test('approveToolCall sends approval', async () => {
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    await ws.connect();
+
+    ws.approveToolCall({ callId: 'req1', approved: true });
+
+    const raw = (ws as any).ws as MockWebSocket;
+    const sent = JSON.parse(raw.sent[0]);
+    expect(sent).toEqual({
+      type: 'tool_approval',
+      request_id: 'req1',
+      approved: true,
+    });
+  });
+
+  test('tracks sessionId from session_info event', async () => {
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    await ws.connect();
+
+    const raw = (ws as any).ws as MockWebSocket;
+    raw._receive({ type: 'session_info', session_id: 'abc' });
+
+    expect(ws.sessionId).toBe('abc');
+  });
+
+  test('tracks runId from run_started/run_finished', async () => {
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    await ws.connect();
+
+    const raw = (ws as any).ws as MockWebSocket;
+    raw._receive({ type: 'run_started', run_id: 'r1' });
+    expect(ws.runId).toBe('r1');
+
+    raw._receive({ type: 'run_finished', run_id: 'r1' });
+    expect(ws.runId).toBeNull();
+  });
+
+  test('close closes WebSocket', async () => {
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    await ws.connect();
+
+    ws.close();
+    expect(ws.connectionState).toBe('disconnected');
+  });
+
+  test('legacy onEvent callback fires', async () => {
+    const events: any[] = [];
+    const ws = new AstraWebSocket({
+      url: 'ws://localhost/ws',
+      onEvent: (e) => events.push(e),
+    });
+    await ws.connect();
+
+    const raw = (ws as any).ws as MockWebSocket;
+    raw._receive({ type: 'text_delta', delta: 'x' });
+
+    expect(events).toHaveLength(1);
+  });
+
+  test('stateChange events fire', async () => {
+    const states: string[] = [];
+    const ws = new AstraWebSocket({ url: 'ws://localhost/ws' });
+    ws.on('stateChange', (s) => states.push(s));
+
+    await ws.connect();
+    expect(states).toContain('connected');
+
+    ws.close();
+    expect(states).toContain('disconnected');
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,10 +1,16 @@
 import type {
   AstraClientConfig,
+  AuthResult,
   ChatRequest,
+  MemoryEntry,
+  MemorySearchResult,
   RunStatus,
+  SessionAudit,
   SessionInfo,
+  SkillInfo,
   StreamEvent,
   ConnectionState,
+  UserInfo,
 } from './types';
 import { SSEClient } from './sse-client';
 
@@ -26,6 +32,37 @@ export class AstraClient {
   }
 
   // ─── Auth ──────────────────────────────────────────────────────────
+
+  /** Register a new user account. */
+  async register(username: string, password: string): Promise<AuthResult> {
+    const result = await this.post<AuthResult>('/api/auth/register', { username, password });
+    this.accessToken = result.access_token;
+    this.refreshTokenValue = result.refresh_token;
+    return result;
+  }
+
+  /** Log in with username/password. Stores tokens automatically. */
+  async login(username: string, password: string): Promise<AuthResult> {
+    const result = await this.post<AuthResult>('/api/auth/login', { username, password });
+    this.accessToken = result.access_token;
+    this.refreshTokenValue = result.refresh_token;
+    return result;
+  }
+
+  /** Log out and clear stored tokens. */
+  async logout(): Promise<void> {
+    try {
+      await this.post('/api/auth/logout');
+    } finally {
+      this.accessToken = null;
+      this.refreshTokenValue = null;
+    }
+  }
+
+  /** Get the current authenticated user's info. */
+  async getMe(): Promise<UserInfo> {
+    return this.fetch<UserInfo>('/api/auth/me');
+  }
 
   setTokens(accessToken: string, refreshToken?: string): void {
     this.accessToken = accessToken;
@@ -112,6 +149,14 @@ export class AstraClient {
     return this.fetch<SessionInfo[]>('/api/sessions');
   }
 
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.fetch(`/api/sessions/${sessionId}`, { method: 'DELETE' });
+  }
+
+  async getSessionAudit(sessionId: string): Promise<SessionAudit> {
+    return this.fetch<SessionAudit>(`/api/sessions/${sessionId}/audit`);
+  }
+
   // ─── Runs ──────────────────────────────────────────────────────────
 
   async createRun(request: ChatRequest): Promise<RunStatus> {
@@ -126,8 +171,40 @@ export class AstraClient {
     await this.post(`/api/runs/${runId}/cancel`);
   }
 
+  async pauseRun(runId: string): Promise<void> {
+    await this.post(`/api/runs/${runId}/pause`);
+  }
+
+  async resumeRun(runId: string): Promise<void> {
+    await this.post(`/api/runs/${runId}/resume`);
+  }
+
   async getRunEvents(runId: string, startIndex = 0): Promise<StreamEvent[]> {
     return this.fetch<StreamEvent[]>(`/api/runs/${runId}/events?start=${startIndex}`);
+  }
+
+  // ─── Memory ─────────────────────────────────────────────────────────
+
+  async memoryStore(entry: MemoryEntry): Promise<{ id: string }> {
+    return this.post<{ id: string }>('/api/memory/store', entry);
+  }
+
+  async memorySearch(query: string, topK = 10): Promise<MemorySearchResult[]> {
+    return this.post<MemorySearchResult[]>('/api/memory/search', { query, top_k: topK });
+  }
+
+  async memoryRetrieve(query: string, topK = 5): Promise<MemorySearchResult[]> {
+    return this.post<MemorySearchResult[]>('/api/memory/retrieve', { query, top_k: topK });
+  }
+
+  async memoryPurge(topic: string): Promise<void> {
+    await this.post('/api/memory/purge', { topic });
+  }
+
+  // ─── Skills ─────────────────────────────────────────────────────────
+
+  async listSkills(): Promise<SkillInfo[]> {
+    return this.fetch<SkillInfo[]>('/api/skills');
   }
 
   // ─── Streaming ─────────────────────────────────────────────────────

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -49,6 +49,17 @@ export type {
   ChatRequest,
   RunStatus,
   SessionInfo,
+  // Auth types
+  AuthResult,
+  UserInfo,
+  // Memory types
+  MemoryEntry,
+  MemorySearchResult,
+  // Skill types
+  SkillInfo,
+  // Audit types
+  SessionActivity,
+  SessionAudit,
 } from './types';
 
 export { AstraClient, AstraApiError } from './client';

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -372,3 +372,58 @@ export type SessionInfo = {
   createdAt: string;
   lastActive: string;
 };
+
+// ─── Auth Types ────────────────────────────────────────────────────
+
+export type AuthResult = {
+  access_token: string;
+  refresh_token: string;
+  user_id: string;
+};
+
+export type UserInfo = {
+  user_id: string;
+  username: string;
+  created_at: string;
+};
+
+// ─── Memory Types ──────────────────────────────────────────────────
+
+export type MemoryEntry = {
+  content: string;
+  memory_type?: 'semantic' | 'episodic' | 'procedural';
+  session_id?: string;
+  trust_tier?: string;
+};
+
+export type MemorySearchResult = {
+  id: string;
+  content: string;
+  score: number;
+  memory_type?: string;
+  created_at?: string;
+};
+
+// ─── Skill Types ───────────────────────────────────────────────────
+
+export type SkillInfo = {
+  id: string;
+  name: string;
+  description: string;
+  status: string;
+};
+
+// ─── Audit Types ───────────────────────────────────────────────────
+
+export type SessionActivity = {
+  timestamp: string;
+  event_type: string;
+  details: Record<string, unknown>;
+};
+
+export type SessionAudit = {
+  session_id: string;
+  events: SessionActivity[];
+  tool_calls: number;
+  turns: number;
+};

--- a/packages/sdk/src/websocket.ts
+++ b/packages/sdk/src/websocket.ts
@@ -1,11 +1,34 @@
-import type { StreamEvent, ConnectionState } from './types';
+import type { StreamEvent, StreamEventType, ConnectionState } from './types';
+
+// ─── Event Emitter Types ────────────────────────────────────────────
+
+export type AstraWSEventMap = {
+  /** Fired for every stream event from the server. */
+  event: StreamEvent;
+  /** Fired when connection state changes. */
+  stateChange: ConnectionState;
+} & {
+  /** Fired for a specific stream event type (e.g. 'text_delta'). */
+  [K in StreamEventType]: StreamEvent;
+};
+
+type Listener<T> = (data: T) => void;
+
+// ─── Options ────────────────────────────────────────────────────────
 
 export type AstraWebSocketOptions = {
+  /** WebSocket URL (e.g. `ws://localhost:8000/api/chat/ws`). */
   url: string;
+  /** JWT access token for authentication. */
   token?: string;
+  /** WebSocket sub-protocols. */
   protocols?: string[];
-  onEvent: (event: StreamEvent) => void;
+
+  // ── Legacy callback (backward compat) ──
+  onEvent?: (event: StreamEvent) => void;
   onStateChange?: (state: ConnectionState) => void;
+
+  // ── Reconnection ──
   reconnect?: boolean;
   maxReconnectAttempts?: number;
   reconnectDelayMs?: number;
@@ -17,21 +40,43 @@ export type ToolApproval = {
   reason?: string;
 };
 
+// ─── AstraWebSocket ─────────────────────────────────────────────────
+
 /**
  * WebSocket client for interactive Astra sessions.
  *
  * Supports bidirectional communication: receiving streaming events and
  * sending tool approvals, messages, and control signals.
+ *
+ * @example Event emitter pattern
+ * ```ts
+ * const ws = new AstraWebSocket({ url: 'ws://localhost:8000/api/chat/ws', token });
+ * ws.on('tool_approval_request', (event) => {
+ *   ws.approveToolCall({ callId: event.request_id, approved: true });
+ * });
+ * ws.on('text_delta', (event) => console.log(event.content));
+ * await ws.connect();
+ * ws.sendMessage('Hello!');
+ * ```
  */
 export class AstraWebSocket {
   private ws: WebSocket | null = null;
-  private options: Required<Pick<AstraWebSocketOptions, 'reconnect' | 'maxReconnectAttempts' | 'reconnectDelayMs'>> &
+  private opts: Required<
+    Pick<AstraWebSocketOptions, 'reconnect' | 'maxReconnectAttempts' | 'reconnectDelayMs'>
+  > &
     AstraWebSocketOptions;
   private reconnectAttempts = 0;
   private closed = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private listeners = new Map<string, Set<Listener<any>>>();
+
+  // ── Public state ──
+  sessionId: string | null = null;
+  runId: string | null = null;
+  connectionState: ConnectionState = 'disconnected';
 
   constructor(options: AstraWebSocketOptions) {
-    this.options = {
+    this.opts = {
       reconnect: true,
       maxReconnectAttempts: 5,
       reconnectDelayMs: 2000,
@@ -39,83 +84,137 @@ export class AstraWebSocket {
     };
   }
 
-  connect(): void {
-    this.closed = false;
-    this.options.onStateChange?.('connecting');
+  // ─── Event emitter ────────────────────────────────────────────────
 
-    const url = new URL(this.options.url);
-    if (this.options.token) {
-      url.searchParams.set('token', this.options.token);
+  /**
+   * Subscribe to events.
+   *
+   * - `'event'` — all stream events
+   * - `'stateChange'` — connection state changes
+   * - Any `StreamEventType` (e.g. `'text_delta'`, `'tool_approval_request'`)
+   */
+  on<K extends keyof AstraWSEventMap>(type: K, listener: Listener<AstraWSEventMap[K]>): this {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set());
     }
-
-    this.ws = new WebSocket(url.toString(), this.options.protocols);
-
-    this.ws.onopen = () => {
-      this.reconnectAttempts = 0;
-      this.options.onStateChange?.('connected');
-    };
-
-    this.ws.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data as string) as StreamEvent;
-        this.options.onEvent(data);
-      } catch {
-        // Ignore malformed messages
-      }
-    };
-
-    this.ws.onclose = () => {
-      if (this.closed) {
-        this.options.onStateChange?.('disconnected');
-        return;
-      }
-      this.options.onStateChange?.('disconnected');
-      this.maybeReconnect();
-    };
-
-    this.ws.onerror = () => {
-      this.options.onStateChange?.('error');
-    };
+    this.listeners.get(type)!.add(listener);
+    return this;
   }
 
+  /** Unsubscribe from events. */
+  off<K extends keyof AstraWSEventMap>(type: K, listener: Listener<AstraWSEventMap[K]>): this {
+    this.listeners.get(type)?.delete(listener);
+    return this;
+  }
+
+  private emit<K extends keyof AstraWSEventMap>(type: K, data: AstraWSEventMap[K]): void {
+    this.listeners.get(type)?.forEach((fn) => {
+      try {
+        fn(data);
+      } catch {
+        // Don't let listener errors break the stream
+      }
+    });
+  }
+
+  // ─── Connection ───────────────────────────────────────────────────
+
+  /**
+   * Connect to the WebSocket server. Resolves when the connection is open
+   * (or rejects on immediate failure).
+   */
+  connect(): Promise<void> {
+    this.closed = false;
+    this.setConnectionState('connecting');
+
+    return new Promise<void>((resolve, reject) => {
+      const url = new URL(this.opts.url);
+      if (this.opts.token) {
+        url.searchParams.set('token', this.opts.token);
+      }
+
+      this.ws = new WebSocket(url.toString(), this.opts.protocols);
+
+      this.ws.onopen = () => {
+        this.reconnectAttempts = 0;
+        this.setConnectionState('connected');
+        resolve();
+      };
+
+      this.ws.onmessage = (msg) => {
+        try {
+          const data = JSON.parse(msg.data as string) as StreamEvent;
+          this.processEvent(data);
+        } catch {
+          // Ignore malformed messages
+        }
+      };
+
+      this.ws.onclose = () => {
+        if (this.closed) {
+          this.setConnectionState('disconnected');
+          return;
+        }
+        this.setConnectionState('disconnected');
+        this.maybeReconnect();
+      };
+
+      this.ws.onerror = () => {
+        this.setConnectionState('error');
+        // Only reject on initial connect; reconnects don't have a promise
+        if (this.reconnectAttempts === 0) {
+          reject(new Error('WebSocket connection failed'));
+        }
+      };
+    });
+  }
+
+  /** Disconnect and stop reconnection. */
   close(): void {
     this.closed = true;
     this.ws?.close();
     this.ws = null;
-    this.options.onStateChange?.('disconnected');
+    this.setConnectionState('disconnected');
   }
 
-  sendMessage(content: string): void {
-    this.send({ type: 'message', content });
+  // ─── Outgoing messages ────────────────────────────────────────────
+
+  /** Send a chat message to the agent. */
+  sendMessage(content: string, options?: { sessionId?: string; model?: string }): void {
+    this.send({
+      type: 'message',
+      content,
+      ...(options?.sessionId && { session_id: options.sessionId }),
+      ...(options?.model && { model: options.model }),
+    });
   }
 
+  /** Respond to a tool approval request. */
   approveToolCall(approval: ToolApproval): void {
-    this.send({ type: 'tool_approval', ...approval });
+    this.send({
+      type: 'tool_approval',
+      request_id: approval.callId,
+      approved: approval.approved,
+      ...(approval.reason && { reason: approval.reason }),
+    });
   }
 
-  cancelRun(): void {
-    this.send({ type: 'cancel' });
+  /** Cancel the currently running agent run. */
+  cancelRun(runId?: string): void {
+    this.send({ type: 'cancel_run', ...(runId && { run_id: runId }) });
   }
 
-  private send(payload: unknown): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify(payload));
-    }
+  /** Pause the currently running agent run. */
+  pauseRun(runId?: string): void {
+    this.send({ type: 'pause_run', ...(runId && { run_id: runId }) });
   }
 
-  private maybeReconnect(): void {
-    if (!this.options.reconnect || this.closed) return;
-    if (this.reconnectAttempts >= this.options.maxReconnectAttempts) return;
-
-    this.reconnectAttempts++;
-    const delay = this.options.reconnectDelayMs * Math.pow(1.5, this.reconnectAttempts - 1);
-
-    setTimeout(() => {
-      if (!this.closed) {
-        this.connect();
-      }
-    }, delay);
+  /** Resume a paused agent run. */
+  resumeRun(runId?: string): void {
+    this.send({ type: 'resume_run', ...(runId && { run_id: runId }) });
   }
+
+  // ─── Getters ──────────────────────────────────────────────────────
 
   get readyState(): number {
     return this.ws?.readyState ?? WebSocket.CLOSED;
@@ -123,5 +222,57 @@ export class AstraWebSocket {
 
   get isConnected(): boolean {
     return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  // ─── Internals ────────────────────────────────────────────────────
+
+  private send(payload: unknown): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(payload));
+    }
+  }
+
+  private setConnectionState(state: ConnectionState): void {
+    this.connectionState = state;
+    // Legacy callback
+    this.opts.onStateChange?.(state);
+    // Event emitter
+    this.emit('stateChange', state);
+  }
+
+  private processEvent(event: StreamEvent): void {
+    // Track session/run state from events
+    if (event.type === 'session_info' && 'session_id' in event) {
+      this.sessionId = (event as { session_id: string }).session_id;
+    }
+    if (event.type === 'run_started' && 'run_id' in event) {
+      this.runId = (event as { run_id: string }).run_id;
+    }
+    if (event.type === 'run_finished' || event.type === 'run_cancelled') {
+      this.runId = null;
+    }
+
+    // Legacy callback
+    this.opts.onEvent?.(event);
+    // Emit to generic 'event' listeners
+    this.emit('event', event);
+    // Emit to type-specific listeners (e.g. 'text_delta')
+    this.emit(event.type as keyof AstraWSEventMap, event);
+  }
+
+  private maybeReconnect(): void {
+    if (!this.opts.reconnect || this.closed) return;
+    if (this.reconnectAttempts >= this.opts.maxReconnectAttempts) return;
+
+    this.reconnectAttempts++;
+    const delay = this.opts.reconnectDelayMs * Math.pow(1.5, this.reconnectAttempts - 1);
+
+    setTimeout(() => {
+      if (!this.closed) {
+        this.connect().catch(() => {
+          // Reconnect failures handled by onclose → maybeReconnect cycle
+        });
+      }
+    }, delay);
   }
 }


### PR DESCRIPTION
## Summary

Completes the `@astra/sdk` TypeScript package with full API coverage, event-driven WebSocket, tests, and documentation.

### Changes

**WebSocket (`websocket.ts`)**
- Event emitter pattern: `.on(event, handler)` / `.off(event, handler)`
- Type-specific event listeners (e.g. `ws.on('text_delta', ...)`)
- `pauseRun()`, `resumeRun()` methods
- Promise-based `connect()`
- Session/run state tracking (`sessionId`, `runId`, `connectionState`)
- Backward compatible: constructor `onEvent` callback still works

**Client APIs (`client.ts`)**
- Auth: `login()`, `register()`, `logout()`, `getMe()`
- Sessions: `deleteSession()`, `getSessionAudit()`
- Runs: `pauseRun()`, `resumeRun()`
- Memory: `memoryStore()`, `memorySearch()`, `memoryRetrieve()`, `memoryPurge()`
- Skills: `listSkills()`

**Types (`types.ts`)**
- `AuthResult`, `UserInfo`, `MemoryEntry`, `MemorySearchResult`, `SkillInfo`, `SessionActivity`, `SessionAudit`

**Tests**
- 36 tests across 2 suites (client + websocket)
- Mock fetch for all REST endpoints
- Mock WebSocket for event emitter, message sending, state tracking

**Documentation**
- README with quick-start (REST, SSE, WebSocket, React hooks)
- API reference tables

### Stats
```
8 files changed, 1040 insertions(+), 49 deletions(-)
```