### PR TITLE
fix(cli): fix two fragile test assertions after Phase D executor delegation

### DIFF
--- a/rust/crates/astra-cli/src/edge_tools/git_gix.rs
+++ b/rust/crates/astra-cli/src/edge_tools/git_gix.rs
@@ -2225,7 +2225,7 @@ mod tests {
         let root = repo_root();
         let result = git_worktree(&root, &json!({"action": "ls"}));
         assert!(
-            !result.contains("unknown"),
+            !(result.contains("Error") && result.contains("unknown action")),
             "ls should be accepted as alias for list: {result}"
         );
     }

--- a/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
@@ -23,7 +23,7 @@ fn executor_tool_names_match_schemas() {
 async fn execute_unknown_tool_returns_error() {
     let executor = test_executor();
     let result = executor.execute("nonexistent_tool", &json!({})).await;
-    assert!(result.contains("Unknown tool"), "got: {result}");
+    assert!(result.contains("not available"), "got: {result}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

Two CLI tests broke after PR #40 (Phase D executor refactor):

1. **`execute_unknown_tool_returns_error`** — CLI now delegates unknown tools to `DefaultToolExecutor`, which returns `"Error: Tool '...' not available in DefaultToolExecutor"` instead of the old `"Unknown tool"` message.


## Fix

- Match `"not available"` instead of `"Unknown tool"` for the executor test
- Check for `"Error" + "unknown action"` pattern instead of bare `"unknown"` substring for the worktree test

## Testing

- `cargo test -p astra-cli`: 2504 passed, 0 failed
- `cargo test -p astra-runtime`: all passed
- `cargo test -p astra-services`: all passed