### PR TITLE
feat(runtime): bridge DB evaluation signals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ dev-deps-logs-once:
 dev-deps-wait:
 	@echo "Waiting for MatrixOne..."
 	@for i in $$(seq 1 90); do \
-		if curl -sf "http://127.0.0.1:$${MATRIXONE_DEBUG_HTTP_PORT:-6060}/debug/vars" >/dev/null 2>&1; then \
+		if curl --noproxy '*' -sf "http://127.0.0.1:$${MATRIXONE_DEBUG_HTTP_PORT:-6060}/debug/vars" >/dev/null 2>&1; then \
 			echo "✅ MatrixOne is healthy"; \
 			break; \
 		fi; \
@@ -199,7 +199,7 @@ dev-deps-wait:
 	done
 	@echo "Waiting for Memoria..."
 	@for i in $$(seq 1 60); do \
-		if curl -sf "http://127.0.0.1:$${MEMORIA_PORT:-8100}/health" >/dev/null 2>&1; then \
+		if curl --noproxy '*' -sf "http://127.0.0.1:$${MEMORIA_PORT:-8100}/health" >/dev/null 2>&1; then \
 			echo "✅ Memoria is healthy"; \
 			echo "✅ Dependency services ready"; \
 			exit 0; \

--- a/deployment/all-in-one/docker-compose.deps.yml
+++ b/deployment/all-in-one/docker-compose.deps.yml
@@ -75,7 +75,7 @@ services:
     networks:
       - mo-net
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8100/health"]
+      test: ["CMD-SHELL", "grep -aq 'memoria' /proc/1/cmdline"]
       interval: 15s
       timeout: 5s
       retries: 6

--- a/deployment/all-in-one/docker-compose.memoria.yml
+++ b/deployment/all-in-one/docker-compose.memoria.yml
@@ -72,7 +72,7 @@ services:
     networks:
       - mo-net
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD-SHELL", "grep -aq 'memoria' /proc/1/cmdline"]
       interval: 30s
       timeout: 3s
       retries: 3

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -283,6 +283,7 @@ dependencies = [
  "fernet",
  "filetime",
  "flate2",
+ "fs2",
  "jsonwebtoken",
  "regex",
  "reqwest 0.12.28",
@@ -1236,6 +1237,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -495,6 +495,7 @@ pub(crate) async fn stream_chat_sse(
             turn_trace_collector: None,
             completed_turns_for_tuning: 0,
             runtime_promotion_signals: None,
+            evaluation_persistence: None,
             promotion_events: Vec::new(),
         },
         skills: SkillState {

--- a/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
@@ -23,7 +23,8 @@ fn executor_tool_names_match_schemas() {
 async fn execute_unknown_tool_returns_error() {
     let executor = test_executor();
     let result = executor.execute("nonexistent_tool", &json!({})).await;
-    assert!(result.contains("Unknown tool"), "got: {result}");
+    assert!(result.contains("nonexistent_tool"), "got: {result}");
+    assert!(result.contains("not available"), "got: {result}");
 }
 
 #[tokio::test]

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -37,8 +37,8 @@ use crate::observability_integration::ObservabilityHub;
 use crate::pipeline::step_recorder::StepRecorder;
 use crate::runtime_promotion_signals::{RuntimePromotionGateSignal, RuntimePromotionSignals};
 use crate::turn::agentic_loop_host::{
-    AgenticLoopOutcome, AgenticLoopState, CancellationState, MessagingState, SkillState,
-    StopHookState, run_agentic_loop_with_host,
+    AgenticLoopOutcome, AgenticLoopState, CancellationState, EvaluationPersistenceContext,
+    MessagingState, SkillState, StopHookState, run_agentic_loop_with_host,
 };
 use crate::{
     DatabaseEvaluationService, DatabaseEventService, EvaluationService, EventCreateRequestData,
@@ -113,7 +113,7 @@ fn build_server_skill_executor(
     Some(Arc::new(router))
 }
 
-fn has_turn_verdict_warning(
+pub(crate) fn has_turn_verdict_warning(
     verdict_events: &[crate::turn::agentic_verdict_audit::AgenticVerdictAuditEvent],
 ) -> bool {
     verdict_events.iter().any(|event| {
@@ -187,12 +187,10 @@ fn build_runtime_evaluation_service(
     }
 }
 
-async fn load_runtime_promotion_signals(
-    matrixone: &MatrixOneSettings,
-    shared_pool: Option<&SharedPool>,
+pub(crate) async fn load_runtime_promotion_signals_with_service(
+    service: &impl EvaluationService,
     user_id: &str,
 ) -> Result<RuntimePromotionSignals, (StatusCode, Json<ErrorResponse>)> {
-    let service = build_runtime_evaluation_service(matrixone, shared_pool);
     let quality = service.get_quality_trend(user_id, 30, None).await?;
     let gate_history = service.get_gate_history(user_id, 1).await?;
     let calibration = service.get_calibration(user_id, None, 30).await?;
@@ -228,6 +226,7 @@ async fn initialize_runtime_controllers(
     user_id: &str,
     session_id: &str,
     promotion_signals: Option<RuntimePromotionSignals>,
+    evaluation_persistence: Option<EvaluationPersistenceContext>,
 ) -> super::state_builder::PipelineLearningStack {
     let learning_stack = super::state_builder::build_pipeline_learning_stack(Some("default"));
     let hub = Arc::new(ObservabilityHub::new());
@@ -259,6 +258,7 @@ async fn initialize_runtime_controllers(
     loop_state.telemetry.observability_hub = Some(hub);
     loop_state.telemetry.observability_session = Some(session);
     loop_state.telemetry.runtime_promotion_signals = promotion_signals;
+    loop_state.telemetry.evaluation_persistence = evaluation_persistence;
     loop_state.evolution_service = Some(evolution_service);
     learning_stack
 }
@@ -273,8 +273,14 @@ async fn configure_runtime_controllers(
     // Promotion signals require a live database connection. When no shared pool
     // is available (e.g. edge-only mode) skip the preload rather than creating a
     // throwaway connection that may hang on unreachable hosts.
-    let promotion_signals = if shared_pool.is_some() {
-        match load_runtime_promotion_signals(matrixone, shared_pool, user_id).await {
+    let evaluation_persistence = shared_pool.map(|pool| EvaluationPersistenceContext {
+        user_id: user_id.to_string(),
+        evaluation_service: build_runtime_evaluation_service(matrixone, Some(pool)),
+    });
+    let promotion_signals = if let Some(context) = evaluation_persistence.as_ref() {
+        match load_runtime_promotion_signals_with_service(&context.evaluation_service, user_id)
+            .await
+        {
             Ok(context) => Some(context),
             Err((status, response)) => {
                 eprintln!(
@@ -288,7 +294,14 @@ async fn configure_runtime_controllers(
         tracing::debug!("skipping promotion-signals preload: no shared database pool");
         None
     };
-    initialize_runtime_controllers(loop_state, user_id, session_id, promotion_signals).await
+    initialize_runtime_controllers(
+        loop_state,
+        user_id,
+        session_id,
+        promotion_signals,
+        evaluation_persistence,
+    )
+    .await
 }
 
 fn build_runtime_event_service(

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -52,6 +52,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
+use astra_services::DatabaseEvaluationService;
 use astra_services::session_audit::RuntimePromotionEventData;
 use astra_services::session_journal::ToolCallRecord;
 use async_trait::async_trait;
@@ -417,6 +418,8 @@ pub struct TelemetryState {
     /// Optional preloaded evaluation summaries used to damp runtime promotions.
     pub runtime_promotion_signals:
         Option<crate::runtime_promotion_signals::RuntimePromotionSignals>,
+    /// Optional evaluation persistence context for refreshing DB-backed runtime signals.
+    pub evaluation_persistence: Option<EvaluationPersistenceContext>,
     /// Runtime promotion verdicts captured for later audit/report persistence.
     pub promotion_events: Vec<RuntimePromotionEventData>,
     /// Optional turn trace collector for detailed context assembly observability.
@@ -425,6 +428,12 @@ pub struct TelemetryState {
     pub turn_trace_collector: Option<crate::turn::turn_trace_collector::TurnTraceCollector>,
     /// Number of turns completed in this loop invocation (for tuning cycle trigger).
     pub completed_turns_for_tuning: u32,
+}
+
+#[derive(Clone, Debug)]
+pub struct EvaluationPersistenceContext {
+    pub user_id: String,
+    pub evaluation_service: DatabaseEvaluationService,
 }
 
 /// Stall and verdict tracking state for the agentic loop.

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
@@ -2,6 +2,9 @@ use std::collections::HashMap;
 
 use serde_json::Value;
 
+use astra_services::EvaluationService;
+use astra_services::evaluation::SessionQualityAssessmentRequest;
+
 use super::agentic_adaptive_tuning::{
     apply_per_turn_adaptation, apply_tactical_actions, maybe_run_tuning_cycle,
 };
@@ -34,6 +37,81 @@ use crate::runtime_promotion_signals::{RuntimePromotionSignals, RuntimeTurnEvalu
 pub(crate) enum TurnToolPhaseControl {
     ContinueLoop,
     Return(AgenticLoopOutcome),
+}
+
+fn build_runtime_session_quality_assessment(
+    session_id: &str,
+    quality: f64,
+    total_tools: usize,
+) -> SessionQualityAssessmentRequest {
+    SessionQualityAssessmentRequest {
+        session_id: session_id.to_string(),
+        score: quality,
+        step_count: i32::try_from(total_tools).unwrap_or(i32::MAX),
+    }
+}
+
+async fn refresh_runtime_promotion_signals_from_db(state: &mut AgenticLoopState) {
+    let (session_id, persistence) = match (
+        state.current_session_id.as_deref(),
+        state.telemetry.evaluation_persistence.clone(),
+    ) {
+        (Some(session_id), Some(persistence)) if !session_id.is_empty() => {
+            (session_id.to_string(), persistence)
+        }
+        _ => return,
+    };
+    let verdict_warning =
+        crate::server::run_lifecycle::has_turn_verdict_warning(&state.stall.verdict_events);
+    let evaluation = crate::pipeline::evaluation::evaluate_tool_call_records(
+        &state.message,
+        &state.recent_tools,
+        &state.stall.tool_call_records,
+        state.stall.events.len(),
+        verdict_warning,
+        state.telemetry.first_budget_pressure,
+    );
+    let assessment = build_runtime_session_quality_assessment(
+        &session_id,
+        evaluation.quality,
+        state.step_recorder.summary().total_tools,
+    );
+
+    if let Err((status, response)) = persistence
+        .evaluation_service
+        .record_session_quality_assessment(&persistence.user_id, assessment)
+        .await
+    {
+        astra_core::agent_warn!(
+            "promotion-signals",
+            "Failed to persist session quality assessment for {}: {} {}",
+            session_id,
+            status,
+            response.0.detail
+        );
+        return;
+    }
+
+    match crate::server::run_lifecycle::load_runtime_promotion_signals_with_service(
+        &persistence.evaluation_service,
+        &persistence.user_id,
+    )
+    .await
+    {
+        Ok(signals) => {
+            state.telemetry.runtime_promotion_signals = Some(signals.clone());
+            if let Some(evolution_service) = state.evolution_service.as_ref() {
+                evolution_service.set_runtime_promotion_signals(Some(signals));
+            }
+        }
+        Err((status, response)) => astra_core::agent_warn!(
+            "promotion-signals",
+            "Failed to refresh runtime promotion signals for {}: {} {}",
+            session_id,
+            status,
+            response.0.detail
+        ),
+    }
 }
 
 fn tool_record_result_text(rec: &astra_services::session_journal::ToolCallRecord) -> &str {
@@ -983,6 +1061,7 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
                     state.telemetry.runtime_promotion_signals = updated_promotion_signals;
                     observe_gate_cancelled(state, turn_index, prep.turn_start_time, &turn_result);
                     state.step_recorder.end_turn(true);
+                    refresh_runtime_promotion_signals_from_db(state).await;
                     finalize_turn_trace(state);
                     return Ok(TurnToolPhaseControl::Return(AgenticLoopOutcome::Cancelled));
                 }
@@ -1025,6 +1104,8 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
                 state.telemetry.first_budget_pressure,
             );
             state.telemetry.runtime_promotion_signals = updated_promotion_signals;
+            state.step_recorder.end_turn(true);
+            refresh_runtime_promotion_signals_from_db(state).await;
             finalize_turn_trace(state);
             return Err(e);
         }
@@ -1108,6 +1189,7 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
             state.telemetry.runtime_promotion_signals = updated_promotion_signals;
             finalize_turn_trace(state);
             state.step_recorder.end_turn(false);
+            refresh_runtime_promotion_signals_from_db(state).await;
             state.telemetry.completed_turns_for_tuning += 1;
             maybe_run_tuning_cycle(state);
             maybe_trigger_auto_reflection(host, state).await;
@@ -1188,6 +1270,26 @@ mod tests {
         let rec = summary_tool_record(false, Some("Error: command failed"), Some("stderr preview"));
         assert_eq!(tool_record_result_text(&rec), "stderr preview");
         assert!(!tool_record_was_rejected(&rec));
+    }
+
+    #[test]
+    fn runtime_session_quality_assessment_uses_session_score_and_tools() {
+        assert_eq!(
+            build_runtime_session_quality_assessment("sess-9", 0.63, 7),
+            SessionQualityAssessmentRequest {
+                session_id: "sess-9".to_string(),
+                score: 0.63,
+                step_count: 7,
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_session_quality_assessment_saturates_large_tool_counts() {
+        assert_eq!(
+            build_runtime_session_quality_assessment("sess-9", 0.63, usize::MAX).step_count,
+            i32::MAX
+        );
     }
 
     fn tool_record(name: &str, ok: bool) -> ToolCallRecord {

--- a/rust/crates/services/Cargo.toml
+++ b/rust/crates/services/Cargo.toml
@@ -24,6 +24,7 @@ thiserror.workspace = true
 tokio.workspace = true
 uuid.workspace = true
 dirs = "6.0.0"
+fs2 = "0.4.3"
 
 [dev-dependencies]
 dotenvy.workspace = true

--- a/rust/crates/services/src/evaluation/database.rs
+++ b/rust/crates/services/src/evaluation/database.rs
@@ -23,6 +23,17 @@ const LOOP_QUALITY_THRESHOLD: f64 = 0.70;
 const LOOP_DRIFT_DELTA_THRESHOLD: f64 = 0.10;
 const TRUST_SLO_TARGET: f64 = 0.95;
 const ZERO_IQR_NOISE_BAND: f64 = 0.05;
+const SESSION_QUALITY_LEVEL: &str = "session";
+const UPSERT_SESSION_QUALITY_ASSESSMENT_SQL: &str = "INSERT INTO eval_quality_assessments \
+     (assessment_id, user_id, target_id, score, step_count, level) \
+     VALUES (?, ?, ?, ?, ?, ?) \
+     ON DUPLICATE KEY UPDATE \
+       user_id = VALUES(user_id), \
+       target_id = VALUES(target_id), \
+       score = VALUES(score), \
+       step_count = VALUES(step_count), \
+       level = VALUES(level), \
+       updated_at = CURRENT_TIMESTAMP(6)";
 
 fn clamp_eval_limit(limit: i32) -> i32 {
     limit.clamp(1, MAX_EVALUATION_ROWS)
@@ -34,6 +45,10 @@ fn clamp_eval_days(days: i32) -> i32 {
 
 fn clamp_extract_limit(limit: i32) -> i32 {
     limit.clamp(1, MAX_EXTRACT_SAMPLES)
+}
+
+fn session_quality_assessment_id(session_id: &str) -> String {
+    format!("session:{session_id}")
 }
 
 fn classify_drift_severity(delta: f64) -> Option<DriftSeverity> {
@@ -1287,6 +1302,30 @@ impl EvaluationService for DatabaseEvaluationService {
         Ok(SessionScoresListResponse { sessions, total })
     }
 
+    async fn record_session_quality_assessment(
+        &self,
+        user_id: &str,
+        request: SessionQualityAssessmentRequest,
+    ) -> ServiceResult<()> {
+        let pool = self.get_pool().await.map_err(internal_error)?;
+        let assessment_id = session_quality_assessment_id(&request.session_id);
+        let score = request.score.clamp(0.0, 1.0);
+        let step_count = request.step_count.max(0);
+
+        query(UPSERT_SESSION_QUALITY_ASSESSMENT_SQL)
+            .bind(&assessment_id)
+            .bind(user_id)
+            .bind(&request.session_id)
+            .bind(score)
+            .bind(step_count)
+            .bind(SESSION_QUALITY_LEVEL)
+            .execute(&pool)
+            .await
+            .map_err(internal_error)?;
+
+        Ok(())
+    }
+
     async fn validate_gate(
         &self,
         user_id: &str,
@@ -2398,6 +2437,22 @@ mod tests {
         assert!(sql.contains("EXISTS ("));
         assert!(sql.contains("e.session_id = qa.target_id"));
         assert!(sql.contains("e.llm_model_used = ?"));
+    }
+
+    #[test]
+    fn session_quality_assessment_id_is_stable() {
+        assert_eq!(
+            session_quality_assessment_id("sess-123"),
+            "session:sess-123".to_string()
+        );
+    }
+
+    #[test]
+    fn session_quality_assessment_upsert_query_updates_existing_rows() {
+        assert!(UPSERT_SESSION_QUALITY_ASSESSMENT_SQL.contains("ON DUPLICATE KEY UPDATE"));
+        assert!(
+            UPSERT_SESSION_QUALITY_ASSESSMENT_SQL.contains("updated_at = CURRENT_TIMESTAMP(6)")
+        );
     }
 
     #[test]

--- a/rust/crates/services/src/evaluation/noop.rs
+++ b/rust/crates/services/src/evaluation/noop.rs
@@ -39,6 +39,13 @@ impl EvaluationService for UnconfiguredEvaluationService {
     ) -> ServiceResult<SessionScoresListResponse> {
         Err(internal_error("evaluation service not configured"))
     }
+    async fn record_session_quality_assessment(
+        &self,
+        _: &str,
+        _: SessionQualityAssessmentRequest,
+    ) -> ServiceResult<()> {
+        Err(internal_error("evaluation service not configured"))
+    }
     async fn validate_gate(
         &self,
         _: &str,

--- a/rust/crates/services/src/evaluation/service.rs
+++ b/rust/crates/services/src/evaluation/service.rs
@@ -29,6 +29,11 @@ pub trait EvaluationService: Send + Sync {
         limit: i32,
         min_score: f64,
     ) -> ServiceResult<SessionScoresListResponse>;
+    async fn record_session_quality_assessment(
+        &self,
+        user_id: &str,
+        request: SessionQualityAssessmentRequest,
+    ) -> ServiceResult<()>;
     async fn validate_gate(
         &self,
         user_id: &str,

--- a/rust/crates/services/src/evaluation/types.rs
+++ b/rust/crates/services/src/evaluation/types.rs
@@ -81,6 +81,14 @@ pub struct GateValidateRequest {
     pub score_regression_threshold: f64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SessionQualityAssessmentRequest {
+    pub session_id: String,
+    pub score: f64,
+    #[serde(default)]
+    pub step_count: i32,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct ClosedLoopQuery {
     #[serde(default = "default_days")]
@@ -248,6 +256,20 @@ mod tests {
         assert_eq!(req.golden_session_count, 50);
         assert!((req.error_rate_threshold - 0.05).abs() < 1e-9);
         assert!((req.score_regression_threshold - (-0.1)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn session_quality_assessment_request_defaults_step_count() {
+        let req: SessionQualityAssessmentRequest =
+            serde_json::from_str(r#"{"session_id":"sess-1","score":0.72}"#).unwrap();
+        assert_eq!(
+            req,
+            SessionQualityAssessmentRequest {
+                session_id: "sess-1".to_string(),
+                score: 0.72,
+                step_count: 0,
+            }
+        );
     }
 
     #[test]

--- a/rust/crates/services/src/storage.rs
+++ b/rust/crates/services/src/storage.rs
@@ -2,12 +2,54 @@ use crate::auth::DatabaseUserRecord;
 use crate::auth::session::SessionRecord;
 use astra_core::{ErrorResponse, MatrixOneSettings, connect_matrixone, internal_error};
 use axum::{Json, http::StatusCode};
+use fs2::FileExt;
 use sqlx::{MySql, QueryBuilder, Row, query};
 use std::collections::HashSet;
 use std::collections::{BTreeSet, HashMap};
+use std::fs::OpenOptions;
+use std::sync::OnceLock;
 use uuid::Uuid;
 
 const CAUSAL_EDGE_KIND: &str = "causal";
+static CORE_SCHEMA_INIT_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+
+struct CoreSchemaFileLock {
+    file: std::fs::File,
+}
+
+impl Drop for CoreSchemaFileLock {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+fn schema_lock_component(raw: &str) -> String {
+    raw.chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect()
+}
+
+fn acquire_core_schema_file_lock(
+    settings: &MatrixOneSettings,
+) -> Result<CoreSchemaFileLock, sqlx::Error> {
+    let lock_dir = std::env::temp_dir().join("astra-engine-locks");
+    std::fs::create_dir_all(&lock_dir).map_err(sqlx::Error::Io)?;
+    let lock_path = lock_dir.join(format!(
+        "core-schema-{}-{}-{}.lock",
+        schema_lock_component(&settings.host),
+        settings.port,
+        schema_lock_component(&settings.database),
+    ));
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_path)
+        .map_err(sqlx::Error::Io)?;
+    file.lock_exclusive().map_err(sqlx::Error::Io)?;
+    Ok(CoreSchemaFileLock { file })
+}
 
 fn unique_event_ids(event_ids: &[String]) -> Vec<&str> {
     let mut seen = HashSet::new();
@@ -182,6 +224,14 @@ async fn ensure_matrixone_database_exists(settings: &MatrixOneSettings) -> Resul
 }
 
 pub async fn ensure_core_schema(settings: &MatrixOneSettings) -> Result<(), sqlx::Error> {
+    // Tests and startup paths can race on schema bootstrap inside the same process.
+    // Serialize schema setup so migration markers and DDL stay idempotent.
+    let _init_guard = CORE_SCHEMA_INIT_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
+    let _file_lock = acquire_core_schema_file_lock(settings)?;
+
     if std::env::var("MATRIXONE_AUTO_CREATE_DATABASE")
         .map(|v| v == "1")
         .unwrap_or(false)
@@ -1237,7 +1287,7 @@ async fn run_migration(
 
     query(sql).execute(pool).await?;
 
-    query("INSERT INTO schema_migrations (version, description) VALUES (?, ?)")
+    query("INSERT IGNORE INTO schema_migrations (version, description) VALUES (?, ?)")
         .bind(version)
         .bind(description)
         .execute(pool)


### PR DESCRIPTION
## Summary
- persist session-quality assessments into `eval_quality_assessments` and reload runtime promotion signals at turn boundaries
- harden local online validation by fixing Memoria dev healthchecks and bypassing ambient proxies in `make dev-deps-wait`
- serialize core schema bootstrap across local parallel processes and align the CLI unknown-tool test with the current executor contract

## Validation
- make check
- make test-offline
- make test-online