### PR TITLE
feat(runtime): bridge context trace calibration

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -496,6 +496,7 @@ pub(crate) async fn stream_chat_sse(
             completed_turns_for_tuning: 0,
             runtime_promotion_signals: None,
             evaluation_persistence: None,
+            context_trace_persistence: None,
             promotion_events: Vec::new(),
         },
         skills: SkillState {

--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -1,9 +1,8 @@
 use std::time::Instant;
 
-use astra_services::session_workspace::{
-    ContextTraceBudgetSignal, ContextTraceHistorySignal, ContextTraceMemorySignal,
-    ContextTraceSignal, ContextTraceTimingSignal, ContextTraceToolSelection,
-};
+use astra_services::session_workspace::ContextTraceSignal;
+#[cfg(test)]
+use astra_services::session_workspace::{ContextTraceBudgetSignal, ContextTraceToolSelection};
 
 use super::*;
 
@@ -1822,88 +1821,7 @@ pub(super) fn apply_pending_goal_progress_state(state: &mut ReplState) {
 fn latest_context_trace_signal(state: &ReplState) -> Option<ContextTraceSignal> {
     let obs = state.observability_session.as_ref()?;
     let guard = obs.read().ok()?;
-    let trace = guard.context_traces.last()?;
-    let timing = guard.turn_timings.last().cloned();
-
-    let tool_selection = (!trace.tools.selection_strategy.is_empty()
-        || !trace.tools.tools_selected.is_empty()
-        || trace.tools.tools_available > 0)
-        .then(|| ContextTraceToolSelection {
-            tools_available: trace.tools.tools_available,
-            selected_tools: trace
-                .tools
-                .tools_selected
-                .iter()
-                .map(|tool| tool.tool_name.clone())
-                .collect(),
-            rejected_tools: trace.tools.tools_rejected.len(),
-            strategy: trace.tools.selection_strategy.clone(),
-            confidence: trace.tools.selection_confidence,
-            latency_ms: trace.tools.selection_latency_ms,
-        });
-    let memory = (!trace.memory.query.trim().is_empty()
-        || !trace.memory.memories_selected.is_empty()
-        || trace.memory.candidates_considered > 0)
-        .then(|| ContextTraceMemorySignal {
-            query: trace.memory.query.trim().chars().take(160).collect(),
-            candidates_considered: trace.memory.candidates_considered,
-            selected_memory_ids: trace
-                .memory
-                .memories_selected
-                .iter()
-                .map(|memory| memory.memory_id.clone())
-                .collect(),
-            total_tokens: trace.memory.total_tokens,
-            latency_ms: trace.memory.retrieval_latency_ms,
-        });
-    let history = (trace.history.total_turns_available > 0
-        || !trace.history.turns_retained.is_empty()
-        || !trace.history.turns_compressed.is_empty()
-        || !trace.history.turns_dropped.is_empty())
-    .then_some(ContextTraceHistorySignal {
-        total_turns_available: trace.history.total_turns_available,
-        retained_turns: trace.history.turns_retained.len(),
-        compressed_turns: trace.history.turns_compressed.len(),
-        dropped_turns: trace.history.turns_dropped.len(),
-        compression_ratio: trace.history.compression_ratio,
-        tokens_before: trace.history.tokens_before,
-        tokens_after: trace.history.tokens_after,
-    });
-    let budget = (trace.token_budget.max_tokens > 0 || trace.token_budget.total_used > 0)
-        .then_some({
-            ContextTraceBudgetSignal {
-                max_tokens: trace.token_budget.max_tokens,
-                total_used: trace.token_budget.total_used,
-                budget_pressure: trace.token_budget.budget_pressure,
-                compression_triggered: trace.token_budget.compression_triggered,
-            }
-        });
-    let timing = timing.map(|timing| ContextTraceTimingSignal {
-        turn: timing.turn,
-        context_assembly_ms: timing.context_assembly_ms,
-        ttft_ms: timing.ttft_ms,
-        llm_total_ms: timing.llm_total_ms,
-        tool_execution_ms: timing.tool_execution_ms,
-        total_ms: timing.total_ms,
-    });
-
-    Some(ContextTraceSignal {
-        turn_id: trace.turn_id.clone(),
-        captured_at: Some(chrono::DateTime::<chrono::Utc>::from(trace.timestamp).to_rfc3339()),
-        tool_selection,
-        memory,
-        history,
-        budget,
-        timing,
-        explanations: trace
-            .explanations
-            .iter()
-            .filter_map(|explanation| {
-                let trimmed = explanation.reasoning.trim();
-                (!trimmed.is_empty()).then(|| trimmed.chars().take(200).collect::<String>())
-            })
-            .collect(),
-    })
+    astra_runtime::observability_integration::latest_context_trace_signal(&guard)
 }
 
 fn sync_context_trace_to_workspace(

--- a/rust/crates/runtime/src/observability_integration.rs
+++ b/rust/crates/runtime/src/observability_integration.rs
@@ -17,7 +17,10 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use astra_services::session_journal::{JournalEvent, JournalWriter};
-use astra_services::session_workspace::GoalProgressSnapshot;
+use astra_services::session_workspace::{
+    ContextTraceBudgetSignal, ContextTraceHistorySignal, ContextTraceMemorySignal,
+    ContextTraceSignal, ContextTraceTimingSignal, ContextTraceToolSelection, GoalProgressSnapshot,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::ab_testing::{ExperimentAnalyzer, ExperimentOutcome, ExperimentStatus, ExperimentStore};
@@ -1102,6 +1105,89 @@ pub fn on_turn_start(hub: &ObservabilityHub, session_id: &str, user_id: &str, qu
 /// Hook called after context assembly.
 pub fn on_context_assembled(session: &mut ObservabilitySession, trace: ContextAssemblyTrace) {
     session.record_context_trace(trace);
+}
+
+pub fn latest_context_trace_signal(session: &ObservabilitySession) -> Option<ContextTraceSignal> {
+    let trace = session.context_traces.last()?;
+    let timing = session.turn_timings.last().cloned();
+
+    let tool_selection = (!trace.tools.selection_strategy.is_empty()
+        || !trace.tools.tools_selected.is_empty()
+        || trace.tools.tools_available > 0)
+        .then(|| ContextTraceToolSelection {
+            tools_available: trace.tools.tools_available,
+            selected_tools: trace
+                .tools
+                .tools_selected
+                .iter()
+                .map(|tool| tool.tool_name.clone())
+                .collect(),
+            rejected_tools: trace.tools.tools_rejected.len(),
+            strategy: trace.tools.selection_strategy.clone(),
+            confidence: trace.tools.selection_confidence,
+            latency_ms: trace.tools.selection_latency_ms,
+        });
+    let memory = (!trace.memory.query.trim().is_empty()
+        || !trace.memory.memories_selected.is_empty()
+        || trace.memory.candidates_considered > 0)
+        .then(|| ContextTraceMemorySignal {
+            query: trace.memory.query.trim().chars().take(160).collect(),
+            candidates_considered: trace.memory.candidates_considered,
+            selected_memory_ids: trace
+                .memory
+                .memories_selected
+                .iter()
+                .map(|memory| memory.memory_id.clone())
+                .collect(),
+            total_tokens: trace.memory.total_tokens,
+            latency_ms: trace.memory.retrieval_latency_ms,
+        });
+    let history = (trace.history.total_turns_available > 0
+        || !trace.history.turns_retained.is_empty()
+        || !trace.history.turns_compressed.is_empty()
+        || !trace.history.turns_dropped.is_empty())
+    .then_some(ContextTraceHistorySignal {
+        total_turns_available: trace.history.total_turns_available,
+        retained_turns: trace.history.turns_retained.len(),
+        compressed_turns: trace.history.turns_compressed.len(),
+        dropped_turns: trace.history.turns_dropped.len(),
+        compression_ratio: trace.history.compression_ratio,
+        tokens_before: trace.history.tokens_before,
+        tokens_after: trace.history.tokens_after,
+    });
+    let budget = (trace.token_budget.max_tokens > 0 || trace.token_budget.total_used > 0)
+        .then_some(ContextTraceBudgetSignal {
+            max_tokens: trace.token_budget.max_tokens,
+            total_used: trace.token_budget.total_used,
+            budget_pressure: trace.token_budget.budget_pressure,
+            compression_triggered: trace.token_budget.compression_triggered,
+        });
+    let timing = timing.map(|timing| ContextTraceTimingSignal {
+        turn: timing.turn,
+        context_assembly_ms: timing.context_assembly_ms,
+        ttft_ms: timing.ttft_ms,
+        llm_total_ms: timing.llm_total_ms,
+        tool_execution_ms: timing.tool_execution_ms,
+        total_ms: timing.total_ms,
+    });
+
+    Some(ContextTraceSignal {
+        turn_id: trace.turn_id.clone(),
+        captured_at: Some(chrono::DateTime::<chrono::Utc>::from(trace.timestamp).to_rfc3339()),
+        tool_selection,
+        memory,
+        history,
+        budget,
+        timing,
+        explanations: trace
+            .explanations
+            .iter()
+            .filter_map(|explanation| {
+                let trimmed = explanation.reasoning.trim();
+                (!trimmed.is_empty()).then(|| trimmed.chars().take(200).collect::<String>())
+            })
+            .collect(),
+    })
 }
 
 /// Hook called after tool selection decision.

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -37,8 +37,9 @@ use crate::observability_integration::ObservabilityHub;
 use crate::pipeline::step_recorder::StepRecorder;
 use crate::runtime_promotion_signals::{RuntimePromotionGateSignal, RuntimePromotionSignals};
 use crate::turn::agentic_loop_host::{
-    AgenticLoopOutcome, AgenticLoopState, CancellationState, EvaluationPersistenceContext,
-    MessagingState, SkillState, StopHookState, run_agentic_loop_with_host,
+    AgenticLoopOutcome, AgenticLoopState, CancellationState, ContextTracePersistenceContext,
+    EvaluationPersistenceContext, MessagingState, SkillState, StopHookState,
+    run_agentic_loop_with_host,
 };
 use crate::{
     DatabaseEvaluationService, DatabaseEventService, EvaluationService, EventCreateRequestData,
@@ -52,6 +53,8 @@ use astra_core::{
 
 use super::run_engine::RunEngine;
 use super::server_loop_host::ServerAgenticLoopHostBuilder;
+
+const RUNTIME_CONTEXT_TRACE_AGENT_ID: &str = "astra-server";
 
 // ─── Skill wiring for server paths ──────────────────────────────────────────
 
@@ -227,6 +230,7 @@ async fn initialize_runtime_controllers(
     session_id: &str,
     promotion_signals: Option<RuntimePromotionSignals>,
     evaluation_persistence: Option<EvaluationPersistenceContext>,
+    context_trace_persistence: Option<ContextTracePersistenceContext>,
 ) -> super::state_builder::PipelineLearningStack {
     let learning_stack = super::state_builder::build_pipeline_learning_stack(Some("default"));
     let hub = Arc::new(ObservabilityHub::new());
@@ -259,6 +263,7 @@ async fn initialize_runtime_controllers(
     loop_state.telemetry.observability_session = Some(session);
     loop_state.telemetry.runtime_promotion_signals = promotion_signals;
     loop_state.telemetry.evaluation_persistence = evaluation_persistence;
+    loop_state.telemetry.context_trace_persistence = context_trace_persistence;
     loop_state.evolution_service = Some(evolution_service);
     learning_stack
 }
@@ -276,6 +281,11 @@ async fn configure_runtime_controllers(
     let evaluation_persistence = shared_pool.map(|pool| EvaluationPersistenceContext {
         user_id: user_id.to_string(),
         evaluation_service: build_runtime_evaluation_service(matrixone, Some(pool)),
+    });
+    let context_trace_persistence = shared_pool.map(|pool| ContextTracePersistenceContext {
+        user_id: user_id.to_string(),
+        event_service: build_runtime_event_service(matrixone, Some(pool)),
+        agent_id: RUNTIME_CONTEXT_TRACE_AGENT_ID.to_string(),
     });
     let promotion_signals = if let Some(context) = evaluation_persistence.as_ref() {
         match load_runtime_promotion_signals_with_service(&context.evaluation_service, user_id)
@@ -300,6 +310,7 @@ async fn configure_runtime_controllers(
         session_id,
         promotion_signals,
         evaluation_persistence,
+        context_trace_persistence,
     )
     .await
 }

--- a/rust/crates/runtime/src/server/state_builder.rs
+++ b/rust/crates/runtime/src/server/state_builder.rs
@@ -181,6 +181,7 @@ pub async fn build_server_state(
                     settings.matrixone.clone(),
                     encryptor,
                 )
+                .with_pool(shared_pool.clone())
                 .with_learning_writer(learning_stack.writer.clone())
                 .with_edge_callback_ledger(edge_ledger),
             ))

--- a/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
@@ -127,7 +127,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                     prep.turn_start_time,
                     turn_result.ttft_ms,
                 );
-                finalize_and_render(host, state);
+                finalize_and_render(host, state).await;
                 return Ok(TurnExecutionControl::Return(AgenticLoopOutcome::Completed));
             }
 
@@ -180,7 +180,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                 ));
             }
 
-            finalize_turn_trace(state);
+            finalize_turn_trace(state).await;
             try_write_heavy_checkpoint(state);
             return Err(e);
         }
@@ -207,7 +207,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                 prep.turn_start_time,
                 turn_result.ttft_ms,
             );
-            finalize_and_render(host, state);
+            finalize_and_render(host, state).await;
             return Ok(TurnExecutionControl::Return(AgenticLoopOutcome::Completed));
         }
         AgenticIngestIterationControl::ContinueIterating => {
@@ -218,7 +218,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
     }
 
     emit_subrun_text_preview(host, state, prep.quiet);
-    if let Some(control) = handle_token_budget(host, state, turn_index, prep, &turn_result) {
+    if let Some(control) = handle_token_budget(host, state, turn_index, prep, &turn_result).await {
         return Ok(control);
     }
     if should_wrap_up_for_cumulative_budget(host, state, prep.quiet) {
@@ -290,7 +290,7 @@ fn emit_subrun_text_preview<H: AgenticLoopHost>(
     }
 }
 
-fn handle_token_budget<H: AgenticLoopHost>(
+async fn handle_token_budget<H: AgenticLoopHost>(
     host: &mut H,
     state: &mut AgenticLoopState,
     turn_index: usize,
@@ -329,7 +329,7 @@ fn handle_token_budget<H: AgenticLoopHost>(
             prep.turn_start_time,
             turn_result.ttft_ms,
         );
-        finalize_and_render(host, state);
+        finalize_and_render(host, state).await;
         return Some(TurnExecutionControl::Return(AgenticLoopOutcome::Completed));
     }
 

--- a/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
@@ -1,5 +1,6 @@
 use crate::pipeline::step_checkpoint;
 use crate::pipeline::step_protocol::StepCheckpoint;
+use crate::{EventCreateRequestData, EventService};
 
 use super::agentic_adaptive_tuning::{
     record_loop_completion_feedback, record_new_evolution_promotion_events,
@@ -12,7 +13,7 @@ use super::agentic_loop_host::{
 /// Finalize the turn trace collector: record measured token budget, feed to
 /// observability session, and persist to journal. Called from every exit path
 /// in the agentic loop so `/context breakdown` always reflects the latest turn.
-pub(crate) fn finalize_turn_trace(state: &mut AgenticLoopState) {
+pub(crate) async fn finalize_turn_trace(state: &mut AgenticLoopState) {
     let Some(collector) = state.telemetry.turn_trace_collector.take() else {
         return;
     };
@@ -52,6 +53,7 @@ pub(crate) fn finalize_turn_trace(state: &mut AgenticLoopState) {
             let _ = writer.append(&event);
         }
     }
+    persist_latest_context_trace_signal(state).await;
 }
 
 fn context_trace_turn_number(state: &AgenticLoopState) -> u32 {
@@ -63,6 +65,137 @@ fn context_trace_turn_number(state: &AgenticLoopState) -> u32 {
         .and_then(|s| s.read().ok().map(|g| g.turn_number))
         .filter(|turn| *turn > 0)
         .unwrap_or(outer_turn)
+}
+
+async fn persist_latest_context_trace_signal(state: &mut AgenticLoopState) {
+    let (session_id, persistence, session) = match (
+        state.current_session_id.as_deref(),
+        state.telemetry.context_trace_persistence.clone(),
+        state.telemetry.observability_session.clone(),
+    ) {
+        (Some(session_id), Some(persistence), Some(session)) if !session_id.is_empty() => {
+            (session_id.to_string(), persistence, session)
+        }
+        _ => return,
+    };
+    let signal = {
+        let guard = session.read().unwrap_or_else(|e| e.into_inner());
+        crate::observability_integration::latest_context_trace_signal(&guard)
+    };
+    let Some(signal) = signal else {
+        return;
+    };
+
+    persist_context_trace_to_workspace_if_present(session_id.clone(), signal.clone()).await;
+
+    let mut metadata = match serde_json::to_value(&signal) {
+        Ok(value) => value,
+        Err(err) => {
+            astra_core::agent_warn!(
+                "context-trace",
+                "Failed to serialize context trace signal for {}: {}",
+                session_id,
+                err
+            );
+            return;
+        }
+    };
+    if let Some(metadata_obj) = metadata.as_object_mut() {
+        if let Some(duration_ms) = signal.timing.as_ref().map(|timing| timing.total_ms) {
+            metadata_obj.insert(
+                "duration_ms".to_string(),
+                serde_json::json!(duration_ms.min(i32::MAX as u64)),
+            );
+        }
+        if let Some(tool_name) = signal
+            .tool_selection
+            .as_ref()
+            .and_then(|selection| selection.selected_tools.first())
+        {
+            metadata_obj.insert("tool_name".to_string(), serde_json::json!(tool_name));
+        }
+    }
+
+    let content = {
+        let preview = signal.preview();
+        if preview.is_empty() {
+            "context trace signal".to_string()
+        } else {
+            preview
+        }
+    };
+    let turn_id = if signal.turn_id.is_empty() {
+        "latest".to_string()
+    } else {
+        signal.turn_id.clone()
+    };
+    if let Err((status, response)) = persistence
+        .event_service
+        .create_event(
+            persistence.user_id.clone(),
+            EventCreateRequestData {
+                session_id: session_id.clone(),
+                event_type: "context_trace_signal".to_string(),
+                content,
+                agent_id: Some(persistence.agent_id),
+                agent_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                parent_event_id: None,
+                parent_event_ids: Some(Vec::new()),
+                causal_chain_id: Some(format!("{session_id}:context-trace:{turn_id}")),
+                metadata: Some(metadata),
+            },
+        )
+        .await
+    {
+        astra_core::agent_warn!(
+            "context-trace",
+            "Failed to persist context trace signal for {}: {} {}",
+            session_id,
+            status,
+            response.0.detail
+        );
+    }
+}
+
+async fn persist_context_trace_to_workspace_if_present(
+    session_id: String,
+    signal: astra_services::session_workspace::ContextTraceSignal,
+) {
+    let workspace_session_id = session_id.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let workspace_path =
+            astra_services::session_workspace::workspace_dir_for(&workspace_session_id)
+                .join("workspace.yaml");
+        if !workspace_path.is_file() {
+            return Ok(());
+        }
+        let mut workspace =
+            astra_services::session_workspace::read_workspace(&workspace_session_id)?;
+        workspace.last_context_trace = Some(signal);
+        workspace.updated_at = chrono::Utc::now().to_rfc3339();
+        astra_services::session_workspace::write_workspace(&workspace)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            astra_core::agent_warn!(
+                "context-trace",
+                "Failed to persist workspace trace for {}: {}",
+                session_id,
+                err
+            );
+        }
+        Err(err) => {
+            astra_core::agent_warn!(
+                "context-trace",
+                "Workspace trace persistence task failed for {}: {}",
+                session_id,
+                err
+            );
+        }
+    }
 }
 
 /// Best-effort heavy checkpoint write.
@@ -257,8 +390,11 @@ pub async fn run_agentic_loop_with_host<H: AgenticLoopHost>(
 }
 
 /// Render deferred final text if any is buffered, then write heavy checkpoint.
-pub(crate) fn finalize_and_render<H: AgenticLoopHost>(host: &mut H, state: &mut AgenticLoopState) {
-    finalize_turn_trace(state);
+pub(crate) async fn finalize_and_render<H: AgenticLoopHost>(
+    host: &mut H,
+    state: &mut AgenticLoopState,
+) {
+    finalize_turn_trace(state).await;
     try_write_heavy_checkpoint(state);
     if !state.final_text.is_empty() {
         host.render_final_text(&state.final_text);
@@ -323,8 +459,8 @@ mod tests {
         assert_eq!(host.rendered_final_text[0], "Done!");
     }
 
-    #[test]
-    fn finalize_turn_trace_feeds_observability_session() {
+    #[tokio::test]
+    async fn finalize_turn_trace_feeds_observability_session() {
         let mut state = make_state();
         let hub = crate::observability_integration::ObservabilityHub::new();
         let session = hub.start_session("u1", "s1");
@@ -339,7 +475,7 @@ mod tests {
         collector.record_token_budget_estimate(14_000, 5_000, 0, 3_000, 200, 22_200, 100_000, 0.22);
         state.telemetry.turn_trace_collector = Some(collector);
 
-        finalize_turn_trace(&mut state);
+        finalize_turn_trace(&mut state).await;
 
         assert!(state.telemetry.turn_trace_collector.is_none());
         let guard = session.read().unwrap();
@@ -353,15 +489,15 @@ mod tests {
         assert!((trace.token_budget.budget_pressure - 0.25).abs() < 0.01);
     }
 
-    #[test]
-    fn finalize_turn_trace_noop_when_no_collector() {
+    #[tokio::test]
+    async fn finalize_turn_trace_noop_when_no_collector() {
         let mut state = make_state();
         assert!(state.telemetry.turn_trace_collector.is_none());
-        finalize_turn_trace(&mut state);
+        finalize_turn_trace(&mut state).await;
     }
 
-    #[test]
-    fn finalize_turn_trace_updates_on_consecutive_turns() {
+    #[tokio::test]
+    async fn finalize_turn_trace_updates_on_consecutive_turns() {
         let mut state = make_state();
         let hub = crate::observability_integration::ObservabilityHub::new();
         let session = hub.start_session("u1", "s1");
@@ -375,7 +511,7 @@ mod tests {
                 "turn-0".to_string(),
                 "s1".to_string(),
             ));
-        finalize_turn_trace(&mut state);
+        finalize_turn_trace(&mut state).await;
 
         session.write().unwrap().turn_number = 2;
         state.last_measured_prompt_tokens = Some(30_000);
@@ -384,7 +520,7 @@ mod tests {
                 "turn-1".to_string(),
                 "s1".to_string(),
             ));
-        finalize_turn_trace(&mut state);
+        finalize_turn_trace(&mut state).await;
 
         let guard = session.read().unwrap();
         assert_eq!(guard.context_traces.len(), 2);
@@ -394,8 +530,8 @@ mod tests {
         assert_eq!(guard.context_traces[1].token_budget.total_used, 30_000);
     }
 
-    #[test]
-    fn finalize_turn_trace_aligns_trace_turn_id_with_journal_turn() {
+    #[tokio::test]
+    async fn finalize_turn_trace_aligns_trace_turn_id_with_journal_turn() {
         let temp = tempfile::tempdir().unwrap();
         let _guard = astra_services::session_journal::JournalDirGuard::new(temp.path());
 
@@ -413,7 +549,7 @@ mod tests {
         state.max_turn_input_tokens = 100_000;
         state.last_measured_prompt_tokens = Some(42_000);
 
-        finalize_turn_trace(&mut state);
+        finalize_turn_trace(&mut state).await;
 
         let session_guard = session.read().unwrap();
         assert_eq!(session_guard.context_traces.len(), 1);

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -52,9 +52,9 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use astra_services::DatabaseEvaluationService;
 use astra_services::session_audit::RuntimePromotionEventData;
 use astra_services::session_journal::ToolCallRecord;
+use astra_services::{DatabaseEvaluationService, DatabaseEventService};
 use async_trait::async_trait;
 use serde_json::Value;
 
@@ -420,6 +420,8 @@ pub struct TelemetryState {
         Option<crate::runtime_promotion_signals::RuntimePromotionSignals>,
     /// Optional evaluation persistence context for refreshing DB-backed runtime signals.
     pub evaluation_persistence: Option<EvaluationPersistenceContext>,
+    /// Optional event persistence context for mirroring context traces into cloud events.
+    pub context_trace_persistence: Option<ContextTracePersistenceContext>,
     /// Runtime promotion verdicts captured for later audit/report persistence.
     pub promotion_events: Vec<RuntimePromotionEventData>,
     /// Optional turn trace collector for detailed context assembly observability.
@@ -434,6 +436,13 @@ pub struct TelemetryState {
 pub struct EvaluationPersistenceContext {
     pub user_id: String,
     pub evaluation_service: DatabaseEvaluationService,
+}
+
+#[derive(Clone, Debug)]
+pub struct ContextTracePersistenceContext {
+    pub user_id: String,
+    pub event_service: DatabaseEventService,
+    pub agent_id: String,
 }
 
 /// Stall and verdict tracking state for the agentic loop.
@@ -788,7 +797,7 @@ pub(crate) async fn run_agentic_loop_impl<H: AgenticLoopHost>(
             PreparedTurnIteration::Finished(outcome) => {
                 if matches!(outcome, AgenticLoopOutcome::Completed) && !state.final_text.is_empty()
                 {
-                    finalize_and_render(host, state);
+                    finalize_and_render(host, state).await;
                 }
                 return Ok(outcome);
             }
@@ -833,7 +842,7 @@ pub(crate) async fn run_agentic_loop_impl<H: AgenticLoopHost>(
         }
     }
     // Loop exhausted max_turns without explicit break — write final state.
-    finalize_and_render(host, state);
+    finalize_and_render(host, state).await;
     Ok(AgenticLoopOutcome::Completed)
 }
 

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
@@ -1061,8 +1061,8 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
                     state.telemetry.runtime_promotion_signals = updated_promotion_signals;
                     observe_gate_cancelled(state, turn_index, prep.turn_start_time, &turn_result);
                     state.step_recorder.end_turn(true);
+                    finalize_turn_trace(state).await;
                     refresh_runtime_promotion_signals_from_db(state).await;
-                    finalize_turn_trace(state);
                     return Ok(TurnToolPhaseControl::Return(AgenticLoopOutcome::Cancelled));
                 }
                 Err(e) => {
@@ -1105,8 +1105,8 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
             );
             state.telemetry.runtime_promotion_signals = updated_promotion_signals;
             state.step_recorder.end_turn(true);
+            finalize_turn_trace(state).await;
             refresh_runtime_promotion_signals_from_db(state).await;
-            finalize_turn_trace(state);
             return Err(e);
         }
         AgenticPostToolIterationControl::RetryLlmClearToolResults => {
@@ -1187,8 +1187,8 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
                 state.telemetry.first_budget_pressure,
             );
             state.telemetry.runtime_promotion_signals = updated_promotion_signals;
-            finalize_turn_trace(state);
             state.step_recorder.end_turn(false);
+            finalize_turn_trace(state).await;
             refresh_runtime_promotion_signals_from_db(state).await;
             state.telemetry.completed_turns_for_tuning += 1;
             maybe_run_tuning_cycle(state);

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -248,6 +248,7 @@ fn build_bridge_tool_call_records(
 }
 
 fn build_legacy_context_trace_signal(
+    turn: u32,
     turn_id: String,
     tools_available: usize,
     selected_tools: Vec<String>,
@@ -268,7 +269,7 @@ fn build_legacy_context_trace_signal(
         },
         compression_triggered: false,
     });
-    let context_assembly_ms = total_ms.saturating_sub(tool_execution_ms);
+    let llm_total_ms = total_ms.saturating_sub(tool_execution_ms);
 
     ContextTraceSignal {
         turn_id,
@@ -277,7 +278,7 @@ fn build_legacy_context_trace_signal(
             tools_available: tools_available.min(u32::MAX as usize) as u32,
             selected_tools,
             rejected_tools: tools_available.saturating_sub(unique_selected),
-            strategy: "legacy_bridge".to_string(),
+            strategy: "inprocess_bridge".to_string(),
             confidence: selection_confidence,
             latency_ms: 0,
         }),
@@ -285,10 +286,10 @@ fn build_legacy_context_trace_signal(
         history: None,
         budget,
         timing: Some(ContextTraceTimingSignal {
-            turn: 1,
-            context_assembly_ms,
+            turn,
+            context_assembly_ms: 0,
             ttft_ms: 0,
-            llm_total_ms: total_ms.saturating_sub(context_assembly_ms),
+            llm_total_ms,
             tool_execution_ms,
             total_ms,
         }),
@@ -2816,8 +2817,10 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                         .and_then(Value::as_u64)
                 })
                 .sum();
+            let trace_turn = turn_count_from_messages(&messages).max(1) as u32;
             let trace_signal = build_legacy_context_trace_signal(
-                format!("turn-{}", turn_count_from_messages(&messages).max(1)),
+                trace_turn,
+                format!("turn-{trace_turn}"),
                 edge_tools.len(),
                 recent_tools_for_quality.clone(),
                 selection_confidence,
@@ -3271,6 +3274,32 @@ mod tests {
     fn count_inprocess_persisted_events_skips_failed_tool_events() {
         assert_eq!(count_inprocess_persisted_events(2, 3, false), 2);
         assert_eq!(count_inprocess_persisted_events(2, 3, true), 5);
+    }
+
+    #[test]
+    fn build_legacy_context_trace_signal_keeps_only_known_timing_values() {
+        let signal = build_legacy_context_trace_signal(
+            3,
+            "turn-3".to_string(),
+            5,
+            vec!["read_file".to_string(), "grep".to_string()],
+            0.82,
+            Some(1200),
+            8000,
+            450,
+            1500,
+        );
+
+        let tool_selection = signal.tool_selection.as_ref().expect("tool selection");
+        assert_eq!(tool_selection.strategy, "inprocess_bridge");
+        assert_eq!(tool_selection.confidence, 0.82);
+
+        let timing = signal.timing.as_ref().expect("timing");
+        assert_eq!(timing.turn, 3);
+        assert_eq!(timing.context_assembly_ms, 0);
+        assert_eq!(timing.llm_total_ms, 1050);
+        assert_eq!(timing.tool_execution_ms, 450);
+        assert_eq!(timing.total_ms, 1500);
     }
 
     // ── Static/dynamic prompt boundary tests ──

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -38,6 +38,13 @@ use std::{
     time::Instant,
 };
 
+use astra_core::SharedPool;
+use astra_services::evaluation::SessionQualityAssessmentRequest;
+use astra_services::session_journal::ToolCallRecord;
+use astra_services::session_workspace::{
+    ContextTraceBudgetSignal, ContextTraceSignal, ContextTraceTimingSignal,
+    ContextTraceToolSelection,
+};
 use async_stream::stream;
 use axum::body::Body;
 use axum::body::Bytes;
@@ -54,11 +61,12 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::{
-    ChatTurnBridge, FernetTokenEncryptor, MatrixOneSettings, SessionActivityUpdatePlan,
-    TurnAuxiliaryEventWriter, TurnCoreEventRecord, TurnCoreEventWriter, TurnCorePersistPlan,
-    TurnHookDbWriter, TurnObserverWorker, TurnReflectionLessonWriter, TurnReflectionStateStore,
-    TurnSessionActivityWriter, TurnToolEventPersistPlan, TurnToolEventRecord, TurnToolEventWriter,
-    build_explain_event, build_stream_error_event,
+    ChatTurnBridge, DatabaseEvaluationService, DatabaseEventService, EvaluationService,
+    EventCreateRequestData, EventService, FernetTokenEncryptor, MatrixOneSettings,
+    SessionActivityUpdatePlan, TurnAuxiliaryEventWriter, TurnCoreEventRecord, TurnCoreEventWriter,
+    TurnCorePersistPlan, TurnHookDbWriter, TurnObserverWorker, TurnReflectionLessonWriter,
+    TurnReflectionStateStore, TurnSessionActivityWriter, TurnToolEventPersistPlan,
+    TurnToolEventRecord, TurnToolEventWriter, build_explain_event, build_stream_error_event,
     pipeline::{step_protocol::StepCheckpoint, step_recorder::StepRecorder},
     prompts,
     turn::agentic_post_tool_policy::{
@@ -123,6 +131,274 @@ fn render_sse(event: &Value) -> Bytes {
 
 fn render_sse_map(event: &Map<String, Value>) -> Bytes {
     render_sse(&Value::Object(event.clone()))
+}
+
+fn preview_chars(value: &str, limit: usize) -> String {
+    value.chars().take(limit).collect()
+}
+
+fn build_bridge_tool_call_records(
+    tool_calls: &[Value],
+    tool_results: &[Value],
+) -> Vec<ToolCallRecord> {
+    let mut call_metadata: HashMap<String, (String, Option<String>, Option<u32>)> = HashMap::new();
+    for tool_call in tool_calls {
+        let Some(tool_call) = tool_call.as_object() else {
+            continue;
+        };
+        let request_id = tool_call
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let function = tool_call.get("function").and_then(Value::as_object);
+        let tool_name = function
+            .and_then(|function| function.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let arguments = function
+            .and_then(|function| function.get("arguments"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+        let input_bytes = arguments
+            .as_ref()
+            .map(|arguments| arguments.len().min(u32::MAX as usize) as u32);
+        if !request_id.is_empty() {
+            call_metadata.insert(request_id, (tool_name, arguments, input_bytes));
+        }
+    }
+
+    let mut seen_request_ids = HashSet::new();
+    let mut records = Vec::new();
+    for tool_result in tool_results {
+        let Some(tool_result) = tool_result.as_object() else {
+            continue;
+        };
+        let request_id = tool_result
+            .get("request_id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        if !request_id.is_empty() {
+            seen_request_ids.insert(request_id.clone());
+        }
+        let fallback_name = tool_result
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let (tool_name, arguments, input_bytes) = call_metadata
+            .get(&request_id)
+            .cloned()
+            .unwrap_or((fallback_name, None, None));
+        let status = tool_result
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("ok");
+        let ok = status.eq_ignore_ascii_case("ok");
+        let output = tool_result.get("output").map(|output| match output {
+            Value::String(output) => output.clone(),
+            other => other.to_string(),
+        });
+        let error = tool_result
+            .get("error")
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+            .or_else(|| (!ok).then(|| output.clone().unwrap_or_else(|| status.to_string())));
+        let output_bytes = output
+            .as_ref()
+            .map(|output| output.len().min(u32::MAX as usize) as u32);
+        records.push(ToolCallRecord {
+            name: tool_name,
+            ok,
+            ms: tool_result
+                .get("duration_ms")
+                .and_then(Value::as_u64)
+                .unwrap_or_default(),
+            error,
+            input_bytes,
+            output_bytes,
+            args_preview: arguments
+                .as_deref()
+                .map(|arguments| preview_chars(arguments, 80)),
+            result_preview: output.as_deref().map(|output| preview_chars(output, 500)),
+        });
+    }
+
+    for (request_id, (tool_name, arguments, input_bytes)) in call_metadata {
+        if seen_request_ids.contains(&request_id) {
+            continue;
+        }
+        records.push(ToolCallRecord {
+            name: tool_name,
+            ok: false,
+            ms: 0,
+            error: Some("missing tool result".to_string()),
+            input_bytes,
+            output_bytes: None,
+            args_preview: arguments
+                .as_deref()
+                .map(|arguments| preview_chars(arguments, 80)),
+            result_preview: None,
+        });
+    }
+
+    records
+}
+
+fn build_legacy_context_trace_signal(
+    turn_id: String,
+    tools_available: usize,
+    selected_tools: Vec<String>,
+    selection_confidence: f64,
+    measured_prompt_tokens: Option<u64>,
+    model_limit: usize,
+    tool_execution_ms: u64,
+    total_ms: u64,
+) -> ContextTraceSignal {
+    let unique_selected = selected_tools.iter().cloned().collect::<HashSet<_>>().len();
+    let budget = measured_prompt_tokens.map(|total_used| ContextTraceBudgetSignal {
+        max_tokens: model_limit.min(u32::MAX as usize) as u32,
+        total_used: total_used.min(u32::MAX as u64) as u32,
+        budget_pressure: if model_limit > 0 {
+            total_used as f64 / model_limit as f64
+        } else {
+            0.0
+        },
+        compression_triggered: false,
+    });
+    let context_assembly_ms = total_ms.saturating_sub(tool_execution_ms);
+
+    ContextTraceSignal {
+        turn_id,
+        captured_at: Some(chrono::Utc::now().to_rfc3339()),
+        tool_selection: Some(ContextTraceToolSelection {
+            tools_available: tools_available.min(u32::MAX as usize) as u32,
+            selected_tools,
+            rejected_tools: tools_available.saturating_sub(unique_selected),
+            strategy: "legacy_bridge".to_string(),
+            confidence: selection_confidence,
+            latency_ms: 0,
+        }),
+        memory: None,
+        history: None,
+        budget,
+        timing: Some(ContextTraceTimingSignal {
+            turn: 1,
+            context_assembly_ms,
+            ttft_ms: 0,
+            llm_total_ms: total_ms.saturating_sub(context_assembly_ms),
+            tool_execution_ms,
+            total_ms,
+        }),
+        explanations: Vec::new(),
+    }
+}
+
+async fn persist_legacy_bridge_trace_and_quality(
+    matrixone: &MatrixOneSettings,
+    shared_pool: Option<SharedPool>,
+    user_id: String,
+    session_id: String,
+    agent_id: Option<String>,
+    turn_chain_id: String,
+    signal: ContextTraceSignal,
+    evaluation: Option<crate::pipeline::evaluation::TurnEvaluation>,
+    step_count: usize,
+) {
+    let Some(shared_pool) = shared_pool else {
+        return;
+    };
+
+    if let Some(evaluation) = evaluation {
+        let evaluation_service =
+            DatabaseEvaluationService::new(matrixone.clone()).with_pool(shared_pool.clone());
+        let assessment = SessionQualityAssessmentRequest {
+            session_id: session_id.clone(),
+            score: evaluation.quality,
+            step_count: i32::try_from(step_count).unwrap_or(i32::MAX),
+        };
+        if let Err((status, response)) = evaluation_service
+            .record_session_quality_assessment(&user_id, assessment)
+            .await
+        {
+            astra_core::agent_warn!(
+                "legacy-bridge",
+                "Failed to persist session quality assessment for {}: {} {}",
+                session_id,
+                status,
+                response.0.detail
+            );
+        }
+    }
+
+    let event_service = DatabaseEventService::new(matrixone.clone()).with_pool(shared_pool);
+    let mut metadata = match serde_json::to_value(&signal) {
+        Ok(metadata) => metadata,
+        Err(err) => {
+            astra_core::agent_warn!(
+                "legacy-bridge",
+                "Failed to serialize context trace signal for {}: {}",
+                session_id,
+                err
+            );
+            return;
+        }
+    };
+    if let Some(metadata_obj) = metadata.as_object_mut() {
+        if let Some(duration_ms) = signal.timing.as_ref().map(|timing| timing.total_ms) {
+            metadata_obj.insert(
+                "duration_ms".to_string(),
+                json!(duration_ms.min(i32::MAX as u64)),
+            );
+        }
+        if let Some(tool_name) = signal
+            .tool_selection
+            .as_ref()
+            .and_then(|selection| selection.selected_tools.first())
+        {
+            metadata_obj.insert("tool_name".to_string(), json!(tool_name));
+        }
+    }
+
+    let content = {
+        let preview = signal.preview();
+        if preview.is_empty() {
+            "context trace signal".to_string()
+        } else {
+            preview
+        }
+    };
+    let turn_id = if signal.turn_id.is_empty() {
+        "latest".to_string()
+    } else {
+        signal.turn_id.clone()
+    };
+    if let Err((status, response)) = event_service
+        .create_event(
+            user_id,
+            EventCreateRequestData {
+                session_id,
+                event_type: "context_trace_signal".to_string(),
+                content,
+                agent_id,
+                agent_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                parent_event_id: None,
+                parent_event_ids: Some(Vec::new()),
+                causal_chain_id: Some(format!("{turn_chain_id}:context-trace:{turn_id}")),
+                metadata: Some(metadata),
+            },
+        )
+        .await
+    {
+        astra_core::agent_warn!(
+            "legacy-bridge",
+            "Failed to persist context trace signal: {} {}",
+            status,
+            response.0.detail
+        );
+    }
 }
 
 /// Returns `true` if `name` looks like a valid tool function name.
@@ -1131,7 +1407,7 @@ pub struct InProcessChatTurnBridge {
     pub encryptor: Arc<FernetTokenEncryptor>,
     /// Shared DB pool — avoids creating a new connection per turn.
     /// When `None`, falls back to ephemeral single-connection pool.
-    pub shared_pool: Option<Arc<sqlx::Pool<sqlx::MySql>>>,
+    pub shared_pool: Option<SharedPool>,
     /// Pipeline learning writer — auto-updates EntityGraph/PatternLibrary/Calibrator.
     pub turn_learning_writer: Option<Arc<dyn crate::TurnLearningWriter>>,
     /// Same `Arc` as [`crate::AppState::edge_callback_ledger`] — bridge takes tool callbacks here.
@@ -1149,7 +1425,7 @@ impl InProcessChatTurnBridge {
         }
     }
 
-    pub fn with_pool(mut self, pool: Arc<sqlx::Pool<sqlx::MySql>>) -> Self {
+    pub fn with_pool(mut self, pool: SharedPool) -> Self {
         self.shared_pool = Some(pool);
         self
     }
@@ -1278,7 +1554,7 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
 
             // Resolve LLM model (skipped when `test_llm_rounds` drives the turn — feature `bridge-e2e-hooks`).
             // Also capture fallback_model name for rate-limit-triggered fallback.
-            let pool_ref = shared_pool.as_deref();
+            let pool_ref = shared_pool.as_ref().map(SharedPool::get);
             let (mut model_name, mut api_key, mut base_url, mut provider, fallback_model_name) = if use_e2e_llm {
                 (
                     "bridge-e2e-mock".to_string(),
@@ -2508,6 +2784,49 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                 );
             }
 
+            let tool_call_records =
+                build_bridge_tool_call_records(&all_round_tool_calls, &merged_tool_results);
+            let verdict_warning = bridge_verdict_events.iter().any(|event| {
+                event.severity.eq_ignore_ascii_case("warning")
+                    || event.severity.eq_ignore_ascii_case("critical")
+            });
+            let recent_tools_for_quality = tool_names_from_tool_calls(&all_round_tool_calls);
+            let budget_pressure = last_measured_prompt.map_or(0.0, |measured| {
+                if budget.model_limit > 0 {
+                    measured as f64 / budget.model_limit as f64
+                } else {
+                    0.0
+                }
+            });
+            let evaluation = (!tool_call_records.is_empty()).then(|| {
+                crate::pipeline::evaluation::evaluate_tool_call_records(
+                    &user_message_for_guard,
+                    &recent_tools_for_quality,
+                    &tool_call_records,
+                    bridge_stall_events.len(),
+                    verdict_warning,
+                    budget_pressure,
+                )
+            });
+            let tool_execution_ms: u64 = merged_tool_results
+                .iter()
+                .filter_map(|tool_result| {
+                    tool_result
+                        .get("duration_ms")
+                        .and_then(Value::as_u64)
+                })
+                .sum();
+            let trace_signal = build_legacy_context_trace_signal(
+                format!("turn-{}", turn_count_from_messages(&messages).max(1)),
+                edge_tools.len(),
+                recent_tools_for_quality.clone(),
+                selection_confidence,
+                last_measured_prompt,
+                budget.model_limit,
+                tool_execution_ms,
+                turn_started.elapsed().as_millis() as u64,
+            );
+
             // Auxiliary events: routing decisions, quality assessments, snapshots
             {
                 let aux_writer = turn_auxiliary_event_writer.clone();
@@ -2516,18 +2835,23 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                 let aux_aid = agent_id.clone();
                 let aux_chain = turn_chain_id.clone();
                 let aux_parent = user_query_event_id.clone();
+                let aux_matrixone = matrixone.clone();
+                let aux_pool = shared_pool.clone();
+                let aux_trace_signal = trace_signal.clone();
+                let aux_evaluation = evaluation.clone();
+                let aux_step_count = tool_call_records.len();
                 tokio::spawn(async move {
                     // Routing decision event (inprocess uses default router)
                     let routing_event = crate::TurnAuxiliaryEventRecord {
                         event_id: Uuid::now_v7().to_string(),
                         user_id: aux_uid.clone(),
                         session_id: aux_sid.clone(),
-                        agent_id: aux_aid,
+                        agent_id: aux_aid.clone(),
                         event_type: "routing_decision".to_string(),
                         content: json!({"router": "inprocess-default", "intent": "default"}).to_string(),
                         parent_event_id: Some(aux_parent.clone()),
                         parent_event_ids: vec![aux_parent],
-                        causal_chain_id: aux_chain,
+                        causal_chain_id: aux_chain.clone(),
                         metadata: None,
                         reasoning_content: None,
                     };
@@ -2537,6 +2861,18 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                             aux_sid, e
                         );
                     }
+                    persist_legacy_bridge_trace_and_quality(
+                        &aux_matrixone,
+                        aux_pool,
+                        aux_uid,
+                        aux_sid,
+                        aux_aid,
+                        aux_chain,
+                        aux_trace_signal,
+                        aux_evaluation,
+                        aux_step_count,
+                    )
+                    .await;
                 });
             }
 

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_full.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_full.rs
@@ -14,6 +14,112 @@ use super::harness::{
     row_get_opt_str, row_get_str, wait_for_agent_event_types,
 };
 
+async fn run_tool_backed_chat_turn(
+    app: &axum::Router,
+    auth_header: &str,
+    session_id: &str,
+    agent_id: &str,
+    test_secret: &str,
+) -> String {
+    let read_file_tool = json!({
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "read a file",
+            "parameters": {
+                "type": "object",
+                "properties": { "path": { "type": "string" } },
+                "required": ["path"]
+            }
+        }
+    });
+    let payload = json!({
+        "agent_id": agent_id,
+        "session_id": session_id,
+        "messages": [{ "role": "user", "content": "read README through a tool" }],
+        "edge_tools": [read_file_tool],
+        "test_llm_rounds": [
+            {
+                "tool_calls": [{
+                    "id": "ctx-trace-tool-1",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": "{\"path\":\"README.md\"}"
+                    }
+                }]
+            },
+            {
+                "full_text": "tool-backed calibration reply",
+                "reasoning": "",
+                "usage": { "prompt": 7, "completion": 9, "total": 16 }
+            }
+        ]
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/chat/turn")
+        .header("authorization", auth_header)
+        .header("content-type", "application/json")
+        .header("x-mo-bridge-test-secret", test_secret)
+        .body(Body::from(payload.to_string()))
+        .expect("tool-backed chat request");
+    let response = app
+        .clone()
+        .oneshot(req)
+        .await
+        .expect("tool-backed chat oneshot");
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "tool-backed chat/turn should return 200"
+    );
+
+    let mut stream = response.into_body().into_data_stream();
+    let mut acc = Vec::new();
+    let mut posted_result = false;
+    let mut saw_turn_complete = false;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.expect("tool-backed sse chunk");
+        acc.extend_from_slice(&chunk);
+        let s = String::from_utf8_lossy(&acc);
+        if !posted_result
+            && s.contains("\"type\":\"tool_request\"")
+            && s.contains("ctx-trace-tool-1")
+        {
+            let (st_result, result_body) = post_json(
+                app,
+                "/tools/result",
+                Some(auth_header),
+                json!({
+                    "request_id": "ctx-trace-tool-1",
+                    "status": "ok",
+                    "output": "# README\nfrom tool-backed matrix e2e\n",
+                }),
+            )
+            .await;
+            assert_eq!(
+                st_result,
+                StatusCode::OK,
+                "POST /tools/result for ctx-trace-tool-1: {result_body}"
+            );
+            posted_result = true;
+        }
+        if s.contains("turn_complete") {
+            saw_turn_complete = true;
+            break;
+        }
+    }
+
+    assert!(posted_result, "tool-backed chat never emitted tool_request");
+    assert!(
+        saw_turn_complete,
+        "tool-backed chat never reached turn_complete"
+    );
+    String::from_utf8_lossy(&acc).into_owned()
+}
+
 pub async fn run_product_matrix_full_journey(
     ctx: &MatrixE2eCtx,
     auth_header: &mut String,
@@ -1156,6 +1262,125 @@ pub async fn run_product_matrix_full_journey(
     assert!(
         ui.contains("matrix journey ping"),
         "turn detail user_input should include user prompt: {td_j}"
+    );
+
+    let tool_turn_sse = run_tool_backed_chat_turn(
+        app,
+        auth_header.as_str(),
+        &session_id,
+        &agent_id,
+        &test_secret,
+    )
+    .await;
+    assert!(
+        tool_turn_sse.contains("\"type\":\"tool_request\""),
+        "tool-backed chat should emit tool_request: {tool_turn_sse}"
+    );
+    wait_for_agent_event_types(
+        pool,
+        &session_id,
+        &["context_trace_signal"],
+        std::time::Duration::from_secs(30),
+    )
+    .await;
+
+    let trace_row = {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            if let Some(row) = sqlx::query(
+                "SELECT \
+                     JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.turn_id')) AS turn_id, \
+                     JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.tool_selection.selected_tools[0]')) AS selected_tool, \
+                     JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.tool_selection.strategy')) AS strategy, \
+                     CAST(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.tool_selection.confidence')) AS DOUBLE) AS selection_confidence \
+                 FROM agent_events \
+                 WHERE session_id = ? \
+                   AND event_type = 'context_trace_signal' \
+                   AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.tool_selection.selected_tools[0]')) IS NOT NULL \
+                 ORDER BY created_at DESC \
+                 LIMIT 1",
+            )
+            .bind(&session_id)
+            .fetch_optional(pool)
+            .await
+            .expect("latest tool-backed context_trace_signal event")
+            {
+                break row;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!(
+                    "timeout waiting for tool-backed context_trace_signal for session_id={session_id}"
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    };
+    assert!(
+        trace_row
+            .try_get::<Option<String>, _>("turn_id")
+            .ok()
+            .flatten()
+            .is_some_and(|turn_id| turn_id.starts_with("turn-")),
+        "context trace event should carry turn_id"
+    );
+    assert_eq!(
+        trace_row
+            .try_get::<Option<String>, _>("selected_tool")
+            .ok()
+            .flatten()
+            .as_deref(),
+        Some("read_file"),
+        "context trace event should persist selected tool"
+    );
+    assert!(
+        trace_row
+            .try_get::<Option<String>, _>("strategy")
+            .ok()
+            .flatten()
+            .is_some_and(|strategy| !strategy.is_empty()),
+        "context trace event should persist tool selection strategy"
+    );
+    assert!(
+        trace_row
+            .try_get::<Option<f64>, _>("selection_confidence")
+            .ok()
+            .flatten()
+            .is_some_and(|confidence| confidence >= 0.0),
+        "context trace event should persist selection confidence"
+    );
+
+    let assessment_row = sqlx::query(
+        "SELECT score, step_count \
+         FROM eval_quality_assessments \
+         WHERE user_id = ? AND target_id = ? AND level = 'session' \
+         ORDER BY updated_at DESC \
+         LIMIT 1",
+    )
+    .bind(&user_id)
+    .bind(&session_id)
+    .fetch_optional(pool)
+    .await
+    .expect("session quality assessment row");
+    let assessment_row = assessment_row.expect("session quality assessment after tool-backed turn");
+    assert!(
+        assessment_row
+            .try_get::<Option<i32>, _>("step_count")
+            .ok()
+            .flatten()
+            .is_some_and(|step_count| step_count >= 1),
+        "session quality assessment should record tool-backed step_count"
+    );
+
+    let (st_cal_after, cal_after_j) =
+        get_json(app, "/evaluation/calibration?days=7", None, xuid).await;
+    assert_eq!(
+        st_cal_after,
+        StatusCode::OK,
+        "evaluation calibration after tool-backed turn: {cal_after_j}"
+    );
+    assert!(
+        cal_after_j["sample_count"].as_u64().unwrap_or(0) >= 1,
+        "calibration should include at least one sample after tool-backed turn: {cal_after_j}"
     );
 
     let replay_cmp_path = format!("/sessions/{session_id}/replay/compare");

--- a/rust/crates/services/src/evaluation/database.rs
+++ b/rust/crates/services/src/evaluation/database.rs
@@ -346,6 +346,7 @@ fn complement_interval(interval: ConfidenceInterval) -> ConfidenceInterval {
 fn context_trace_confidence_expr(alias: &str) -> String {
     format!(
         "COALESCE(\
+            CAST(JSON_UNQUOTE(JSON_EXTRACT({alias}.metadata, '$.tool_selection.confidence')) AS DOUBLE), \
             CAST(JSON_UNQUOTE(JSON_EXTRACT({alias}.metadata, '$.tool_selection.selection_confidence')) AS DOUBLE), \
             CAST(JSON_UNQUOTE(JSON_EXTRACT({alias}.metadata, '$.selection_confidence')) AS DOUBLE)\
         )"
@@ -2062,6 +2063,14 @@ mod tests {
         assert_eq!(clamp_extract_limit(0), 1);
         assert_eq!(clamp_extract_limit(500), 500);
         assert_eq!(clamp_extract_limit(5000), MAX_EXTRACT_SAMPLES);
+    }
+
+    #[test]
+    fn context_trace_confidence_expr_accepts_current_signal_shape() {
+        let expr = context_trace_confidence_expr("ev");
+        assert!(expr.contains("$.tool_selection.confidence"));
+        assert!(expr.contains("$.tool_selection.selection_confidence"));
+        assert!(expr.contains("$.selection_confidence"));
     }
 
     #[test]

--- a/rust/crates/services/src/evaluation/database.rs
+++ b/rust/crates/services/src/evaluation/database.rs
@@ -345,11 +345,7 @@ fn complement_interval(interval: ConfidenceInterval) -> ConfidenceInterval {
 
 fn context_trace_confidence_expr(alias: &str) -> String {
     format!(
-        "COALESCE(\
-            CAST(JSON_UNQUOTE(JSON_EXTRACT({alias}.metadata, '$.tool_selection.confidence')) AS DOUBLE), \
-            CAST(JSON_UNQUOTE(JSON_EXTRACT({alias}.metadata, '$.tool_selection.selection_confidence')) AS DOUBLE), \
-            CAST(JSON_UNQUOTE(JSON_EXTRACT({alias}.metadata, '$.selection_confidence')) AS DOUBLE)\
-        )"
+        "CAST(JSON_UNQUOTE(JSON_EXTRACT({alias}.metadata, '$.tool_selection.confidence')) AS DOUBLE)"
     )
 }
 
@@ -2066,11 +2062,11 @@ mod tests {
     }
 
     #[test]
-    fn context_trace_confidence_expr_accepts_current_signal_shape() {
+    fn context_trace_confidence_expr_uses_canonical_signal_shape() {
         let expr = context_trace_confidence_expr("ev");
         assert!(expr.contains("$.tool_selection.confidence"));
-        assert!(expr.contains("$.tool_selection.selection_confidence"));
-        assert!(expr.contains("$.selection_confidence"));
+        assert!(!expr.contains("$.tool_selection.selection_confidence"));
+        assert!(!expr.contains("$.selection_confidence"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- persist `context_trace_signal` across unified runtime/server turn finalization and the legacy in-process `/chat/turn` bridge
- reuse a shared runtime trace mapper, keep CLI/runtime signal shape aligned, and teach calibration queries to read the current `tool_selection.confidence` field
- extend the live HTTP product journey to prove a tool-backed bridge turn produces trace, assessment, and calibration samples

## Validation
- make format
- make check
- make dev-deps-up
- make dev-deps-wait
- make test-online