### PR TITLE
fix: wire ServerToolExecutor for delegation sub-runs + graceful parent routing

### DIFF
--- a/rust/crates/runtime/src/messaging/router.rs
+++ b/rust/crates/runtime/src/messaging/router.rs
@@ -370,15 +370,24 @@ impl AgentMailboxRouter {
             .delegation_tracker
             .get_agent_id(&parent_run_id)
             .await
-            .filter(|id| !id.is_empty())
-            .ok_or_else(|| {
-                MailboxError::Transport(format!(
-                    "parent run_id '{}' has no agent_id in delegation tracker",
-                    parent_run_id
-                ))
-            })?;
+            .filter(|id| !id.is_empty());
 
-        Ok(AgentAddress::new(&parent_run_id, &agent_id))
+        match agent_id {
+            Some(id) => Ok(AgentAddress::new(&parent_run_id, &id)),
+            None => {
+                // Parent is the orchestrator/root run — not itself a sub-run,
+                // so it has no agent_id in the tracker. Use a synthetic address
+                // so progress messages can still be routed (best-effort).
+                tracing::debug!(
+                    target: "astra_runtime::messaging",
+                    parent_run_id = %parent_run_id,
+                    child_run_id = %child_run_id,
+                    "parent run_id not found in address registry or tracker; \
+                     using synthetic 'orchestrator' agent_id",
+                );
+                Ok(AgentAddress::new(&parent_run_id, "orchestrator"))
+            }
+        }
     }
 
     /// Resolve a Direct target that may have an empty run_id (from send_tool).

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -93,11 +93,12 @@ fn build_server_skill_executor(
     edge_profile: &Map<String, Value>,
     skill_resolver: Option<Arc<dyn crate::turn::skill_tool::SkillResolver>>,
     session_id: &str,
+    edge_connection_pool: Option<&super::edge_connection_pool::EdgeConnectionPool>,
 ) -> Option<Arc<dyn crate::skills::traits::SkillExecutor>> {
     use super::server_skill_subrun::ServerSkillSubRunExecutor;
     use crate::skills::executor::isolated::{IsolatedSkillExecutor, SkillExecutionRouter};
 
-    let subrun_executor = ServerSkillSubRunExecutor::new(
+    let mut subrun_executor = ServerSkillSubRunExecutor::new(
         matrixone.clone(),
         Arc::clone(encryptor),
         session_id.to_string(),
@@ -107,6 +108,9 @@ fn build_server_skill_executor(
     .with_edge_tools(edge_tools.to_vec())
     .with_edge_profile(edge_profile.clone())
     .with_skill_resolver(skill_resolver);
+    if let Some(pool) = edge_connection_pool {
+        subrun_executor = subrun_executor.with_edge_connection_pool(pool.clone());
+    }
 
     let isolated = Arc::new(IsolatedSkillExecutor::new(Arc::new(subrun_executor)));
     let router = SkillExecutionRouter::new(Some(isolated));
@@ -817,6 +821,7 @@ impl AgenticRunLifecycleService {
             &edge_profile,
             skill_resolver.clone(),
             session_id,
+            self.edge_connection_pool.as_ref(),
         );
 
         AgenticLoopState {
@@ -1730,6 +1735,7 @@ pub struct ServerSubRunExecutor {
     encryptor: Arc<FernetTokenEncryptor>,
     shared_pool: Option<SharedPool>,
     edge_callback_ledger: Arc<TokioMutex<HashMap<String, Value>>>,
+    edge_connection_pool: Option<super::edge_connection_pool::EdgeConnectionPool>,
 }
 
 impl ServerSubRunExecutor {
@@ -1743,12 +1749,46 @@ impl ServerSubRunExecutor {
             encryptor,
             shared_pool: None,
             edge_callback_ledger,
+            edge_connection_pool: None,
         }
     }
 
     pub fn with_pool(mut self, pool: SharedPool) -> Self {
         self.shared_pool = Some(pool);
         self
+    }
+
+    pub fn with_edge_connection_pool(
+        mut self,
+        pool: super::edge_connection_pool::EdgeConnectionPool,
+    ) -> Self {
+        self.edge_connection_pool = Some(pool);
+        self
+    }
+}
+
+impl ServerSubRunExecutor {
+    /// Provision a workspace directory for a delegation sub-run.
+    ///
+    /// Sub-runs get a subdirectory under the parent session workspace to
+    /// keep file operations isolated while sharing the same base.
+    fn provision_subrun_workspace(&self, session_id: &str, run_id: &str) -> std::path::PathBuf {
+        let sanitize = |s: &str| -> String {
+            s.chars()
+                .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
+                .collect()
+        };
+        let safe_session = sanitize(session_id);
+        let safe_run = sanitize(run_id);
+        assert!(!safe_session.is_empty(), "session_id must be non-empty");
+        assert!(!safe_run.is_empty(), "run_id must be non-empty");
+
+        let base = std::env::var("ASTRA_SERVER_WORKSPACES")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| std::env::temp_dir().join("astra-workspaces"));
+        let workspace = base.join(&safe_session).join(&safe_run);
+        let _ = std::fs::create_dir_all(&workspace);
+        workspace
     }
 }
 
@@ -1921,6 +1961,29 @@ impl SubRunExecutor for ServerSubRunExecutor {
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         };
+
+        // ── Wire ServerToolExecutor for sub-run tool execution ──────────
+        // Without this, the headless pipeline fallback cannot execute tools
+        // server-side and sub-agents would get edge-protocol errors.
+        {
+            let workspace = self.provision_subrun_workspace(&config.session_id, &config.run_id);
+            let memoria_base = std::env::var("MEMORIA_BASE_URL").ok();
+            let mut executor = super::server_tool_executor::ServerToolExecutor::new(
+                workspace,
+                config.user_id.clone(),
+                config.session_id.clone(),
+                memoria_base,
+                None,
+            );
+            if let Some(pool) = &self.edge_connection_pool {
+                executor.set_edge_connection_pool(pool.clone());
+            }
+            if let Some(obs) = loop_state.telemetry.observability_session.clone() {
+                executor.set_observability_session(obs);
+            }
+            loop_state.server_tool_executor = Some(std::sync::Arc::new(executor));
+        }
+
         let learning_stack = configure_runtime_controllers(
             &self.matrixone,
             self.shared_pool.as_ref(),

--- a/rust/crates/runtime/src/server/server_skill_subrun.rs
+++ b/rust/crates/runtime/src/server/server_skill_subrun.rs
@@ -58,6 +58,8 @@ pub struct ServerSkillSubRunExecutor {
     cancel_token: Option<Arc<tokio_util::sync::CancellationToken>>,
     /// Session ID for the parent run.
     session_id: String,
+    /// Edge connection pool for routing tool calls to connected edges.
+    edge_connection_pool: Option<super::edge_connection_pool::EdgeConnectionPool>,
 }
 
 impl ServerSkillSubRunExecutor {
@@ -76,6 +78,7 @@ impl ServerSkillSubRunExecutor {
             skill_resolver: None,
             cancel_token: None,
             session_id,
+            edge_connection_pool: None,
         }
     }
 
@@ -113,6 +116,40 @@ impl ServerSkillSubRunExecutor {
     ) -> Self {
         self.cancel_token = token;
         self
+    }
+
+    pub fn with_edge_connection_pool(
+        mut self,
+        pool: super::edge_connection_pool::EdgeConnectionPool,
+    ) -> Self {
+        self.edge_connection_pool = Some(pool);
+        self
+    }
+}
+
+impl ServerSkillSubRunExecutor {
+    /// Provision a workspace directory for a skill sub-run.
+    fn provision_skill_workspace(&self, skill_name: &str, session_id: &str) -> std::path::PathBuf {
+        let sanitize = |s: &str| -> String {
+            s.chars()
+                .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
+                .collect()
+        };
+        let safe_session = sanitize(session_id);
+        let safe_skill = sanitize(skill_name);
+        assert!(!safe_session.is_empty(), "session_id must be non-empty");
+
+        let base = std::env::var("ASTRA_SERVER_WORKSPACES")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| std::env::temp_dir().join("astra-workspaces"));
+        let dir_name = if safe_skill.is_empty() {
+            safe_session.clone()
+        } else {
+            format!("{}-skill-{}", safe_session, safe_skill)
+        };
+        let workspace = base.join(&dir_name);
+        let _ = std::fs::create_dir_all(&workspace);
+        workspace
     }
 }
 
@@ -304,6 +341,23 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         };
+
+        // ── Wire ServerToolExecutor for skill sub-run tool execution ────
+        {
+            let workspace = self.provision_skill_workspace(skill_name, &subrun_session_id);
+            let memoria_base = std::env::var("MEMORIA_BASE_URL").ok();
+            let mut executor = super::server_tool_executor::ServerToolExecutor::new(
+                workspace,
+                String::new(), // skill sub-runs don't track user_id
+                subrun_session_id.clone(),
+                memoria_base,
+                None,
+            );
+            if let Some(pool) = &self.edge_connection_pool {
+                executor.set_edge_connection_pool(pool.clone());
+            }
+            state.server_tool_executor = Some(std::sync::Arc::new(executor));
+        }
 
         if let Err(err) = run_agentic_loop_with_host(&mut host, &mut state).await {
             return Err(format!(

--- a/rust/crates/runtime/src/server/state_builder.rs
+++ b/rust/crates/runtime/src/server/state_builder.rs
@@ -246,7 +246,8 @@ pub async fn build_server_state(
             run_encryptor.clone(),
             state.edge_callback_ledger.clone(),
         )
-        .with_pool(shared_pool.clone()),
+        .with_pool(shared_pool.clone())
+        .with_edge_connection_pool(state.edge_connection_pool.clone()),
     );
     let delegation_engine = Arc::new(
         crate::server::delegation_engine::DelegationEngine::with_executor(


### PR DESCRIPTION
## Problem

Two critical bugs discovered from analyzing a team delegation session log:

### Issue 1: Sub-agent tool execution broken
When sub-agents are spawned (team delegation or skill fork), their `AgenticLoopState.server_tool_executor` is set to `None`. The headless pipeline has a fallback mechanism that executes tools server-side when `server_tool_executor` is `Some`, but since sub-runs have `None`, the fallback doesn't fire — resulting in edge-protocol errors.

**Fix:** Provision a workspace and create a `ServerToolExecutor` for each sub-run in both `ServerSubRunExecutor` (delegation) and `ServerSkillSubRunExecutor` (skill fork). Wire `edge_connection_pool` through from AppState.

### Issue 2: Delegation progress routing broken
When a sub-agent sends turn progress to its parent, the mailbox router calls `delegation_tracker.get_agent_id(parent_run_id)`. But the parent (orchestrator) run_id is never recorded as a sub-run — only actual sub-runs have `SubRunRecord` entries.

**Fix:** Instead of returning an error when the parent's agent_id is not found, construct a synthetic `orchestrator` address so progress messages can still be routed.

## Changes

- **`run_lifecycle.rs`**: Add `edge_connection_pool` field to `ServerSubRunExecutor`, add `provision_subrun_workspace()` helper, wire `ServerToolExecutor` into sub-run loop state. Pass `edge_connection_pool` to skill executor builder.
- **`server_skill_subrun.rs`**: Add `edge_connection_pool` field, add `provision_skill_workspace()` helper, wire `ServerToolExecutor` into skill sub-run state.
- **`state_builder.rs`**: Wire `edge_connection_pool` into `ServerSubRunExecutor`.
- **`router.rs`**: Replace hard error with graceful fallback using synthetic `orchestrator` agent_id.

## Testing

- `cargo check -p astra-runtime` ✅
- All 545 runtime tests pass ✅  
- All 120 delegation tests pass ✅