### PR TITLE
feat(sdk): complete test suite + docs for @astra/sdk

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -46,7 +46,7 @@ const stream = client.streamChat(
   {
     onEvent(event) {
       if (event.type === 'text_delta') {
-        process.stdout.write(event.delta);
+        process.stdout.write(event.content);
       }
     },
   },
@@ -68,7 +68,7 @@ const ws = new AstraWebSocket({
 await ws.connect();
 
 // Listen for specific event types
-ws.on('text_delta', (event) => console.log(event.delta));
+ws.on('text_delta', (event) => console.log(event.content));
 ws.on('tool_approval_request', (event) => {
   ws.approveToolCall({ callId: event.request_id, approved: true });
 });
@@ -84,11 +84,16 @@ ws.resumeRun('run-id');
 
 ```tsx
 import { useAstraChat } from '@astra/sdk/react';
+import { AstraClient } from '@astra/sdk';
+
+const client = new AstraClient({
+  baseUrl: 'http://localhost:8000',
+  accessToken: token,
+});
 
 function Chat() {
   const { messages, sendMessage, isStreaming, plan, usage } = useAstraChat({
-    baseUrl: 'http://localhost:8000',
-    accessToken: token,
+    client,
   });
 
   return (
@@ -168,6 +173,25 @@ import type {
   // ... and more
 } from '@astra/sdk';
 ```
+
+## Testing
+
+```bash
+cd packages/sdk
+npm test        # 67 tests across 4 suites
+```
+
+Test coverage:
+- `client.test.ts` — AstraClient REST methods, auth, auto-refresh (24 tests)
+- `websocket.test.ts` — AstraWebSocket connection, events, methods (12 tests)
+- `sse-client.test.ts` — SSEClient connection, parsing, state, abort (16 tests)
+- `hooks.test.ts` — useAstraChat & useAstraRun React hooks (15 tests)
+
+## Migration from web/ Internal APIs
+
+Types (`StreamEvent`, `ChatMessage`, `ToolCall`, etc.) are already re-exported from `@astra/sdk` by `web/lib/streaming/types.ts` and `web/lib/workspace/types.ts`.
+
+The web app's `useChatStream` hook uses cookie-based auth via Next.js proxy (`/api/backend/chat/stream`), while the SDK uses JWT auth directly. Full hook migration requires an auth adapter layer.
 
 ## License
 

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -8,10 +8,15 @@
       "name": "@astra/sdk",
       "version": "0.1.0",
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/jest": "^29.5.0",
         "@types/react": "^19.0.12",
+        "@types/react-dom": "^19.2.3",
         "jest": "^30.3.0",
+        "jest-environment-jsdom": "^30.3.0",
         "react": "^19.0.0",
+        "react-dom": "^19.2.5",
         "ts-jest": "^29.4.6",
         "tsup": "^8.4.0",
         "typescript": "^5.8.3"
@@ -24,6 +29,27 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -56,7 +82,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -467,6 +492,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -521,6 +556,121 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
@@ -1263,6 +1413,52 @@
         "@jest/types": "30.3.0",
         "@types/node": "*",
         "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+      "integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -2263,6 +2459,99 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2273,6 +2562,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2364,6 +2660,18 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -2384,10 +2692,27 @@
         "csstype": "^3.2.2"
       }
     },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2697,6 +3022,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2784,6 +3119,16 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/babel-jest": {
@@ -2948,7 +3293,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3298,12 +3642,40 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3322,6 +3694,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -3348,6 +3727,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3367,6 +3756,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -3402,6 +3798,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -3419,7 +3828,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3764,12 +4172,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3779,6 +4228,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/import-local": {
@@ -3866,6 +4328,13 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -3993,7 +4462,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -4417,6 +4885,29 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+      "integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/environment-jsdom-abstract": "30.3.0",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-environment-node": {
@@ -5381,6 +5872,46 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -5482,6 +6013,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -5719,6 +6260,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5834,6 +6382,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -6043,6 +6604,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -6068,6 +6639,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-is": {
@@ -6168,6 +6752,40 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -6476,6 +7094,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -6600,6 +7225,26 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6618,6 +7263,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tree-kill": {
@@ -6816,7 +7487,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6934,6 +7604,19 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -6942,6 +7625,54 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -7082,6 +7813,45 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -36,10 +36,15 @@
     }
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/jest": "^29.5.0",
     "@types/react": "^19.0.12",
+    "@types/react-dom": "^19.2.3",
     "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.3.0",
     "react": "^19.0.0",
+    "react-dom": "^19.2.5",
     "ts-jest": "^29.4.6",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3"

--- a/packages/sdk/src/__tests__/hooks.test.ts
+++ b/packages/sdk/src/__tests__/hooks.test.ts
@@ -1,0 +1,414 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { useAstraChat, useAstraRun } from '../hooks';
+import { AstraClient } from '../client';
+import type { SSEClient } from '../sse-client';
+import type { StreamEvent, ConnectionState } from '../types';
+
+// ─── Mock AstraClient ──────────────────────────────────────────────
+
+function createMockClient() {
+  const client = new AstraClient({ baseUrl: 'http://localhost' });
+
+  // Mock streamChat to call onEvent callbacks synchronously
+  const streamChatMock = jest.fn();
+  client.streamChat = streamChatMock;
+
+  // Mock run polling
+  const getRunStatusMock = jest.fn();
+  const getRunEventsMock = jest.fn();
+  client.getRunStatus = getRunStatusMock;
+  client.getRunEvents = getRunEventsMock;
+
+  return { client, streamChatMock, getRunStatusMock, getRunEventsMock };
+}
+
+/**
+ * Helper: set up streamChat mock to fire a sequence of events.
+ * Returns a fake SSEClient with a close() spy.
+ */
+function mockStreamEvents(
+  streamChatMock: jest.Mock,
+  events: StreamEvent[],
+) {
+  const closeSpy = jest.fn();
+
+  streamChatMock.mockImplementation(
+    (_params: unknown, opts: { onEvent: (e: StreamEvent) => void; onStateChange?: (s: ConnectionState) => void }) => {
+      // Fire state changes and events synchronously
+      opts.onStateChange?.('connecting');
+      opts.onStateChange?.('connected');
+      for (const event of events) {
+        opts.onEvent(event);
+      }
+      opts.onStateChange?.('disconnected');
+      return { close: closeSpy } as unknown as SSEClient;
+    },
+  );
+
+  return closeSpy;
+}
+
+// ─── useAstraChat ──────────────────────────────────────────────────
+
+describe('useAstraChat', () => {
+  test('initial state is idle with empty arrays', () => {
+    const { client } = createMockClient();
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    expect(result.current.sessionId).toBeNull();
+    expect(result.current.runId).toBeNull();
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.toolCalls).toEqual([]);
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.plan).toBeNull();
+    expect(result.current.connectionState).toBe('idle');
+    expect(result.current.agentEvents).toEqual([]);
+  });
+
+  test('sendMessage adds user + assistant placeholder', () => {
+    const { client, streamChatMock } = createMockClient();
+    mockStreamEvents(streamChatMock, []);
+
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    act(() => {
+      result.current.sendMessage('Hello');
+    });
+
+    // Should have user message + empty assistant placeholder
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[0].role).toBe('user');
+    expect(result.current.messages[0].content).toBe('Hello');
+    expect(result.current.messages[1].role).toBe('assistant');
+    expect(result.current.messages[1].streaming).toBe(true);
+  });
+
+  test('processes session_info event', () => {
+    const { client, streamChatMock } = createMockClient();
+    mockStreamEvents(streamChatMock, [
+      { type: 'session_info', session_id: 'sess-1', run_id: 'run-1' } as StreamEvent,
+    ]);
+
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    act(() => {
+      result.current.sendMessage('Hi');
+    });
+
+    expect(result.current.sessionId).toBe('sess-1');
+    expect(result.current.runId).toBe('run-1');
+  });
+
+  test('processes text_delta events to build assistant content', () => {
+    const { client, streamChatMock } = createMockClient();
+    mockStreamEvents(streamChatMock, [
+      { type: 'text_delta', content: 'Hello ' } as StreamEvent,
+      { type: 'text_delta', content: 'World' } as StreamEvent,
+    ]);
+
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    act(() => {
+      result.current.sendMessage('Hi');
+    });
+
+    const assistantMsg = result.current.messages.find((m) => m.role === 'assistant');
+    expect(assistantMsg?.content).toBe('Hello World');
+  });
+
+  test('processes tool_call_start and tool_call_end', () => {
+    const { client, streamChatMock } = createMockClient();
+    mockStreamEvents(streamChatMock, [
+      {
+        type: 'tool_call_start',
+        call_id: 'tc-1',
+        tool: 'bash',
+        arguments: '{"command":"ls"}',
+      } as StreamEvent,
+      {
+        type: 'tool_call_end',
+        call_id: 'tc-1',
+        result: 'file1\nfile2',
+      } as StreamEvent,
+    ]);
+
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    act(() => {
+      result.current.sendMessage('list files');
+    });
+
+    expect(result.current.toolCalls).toHaveLength(1);
+    expect(result.current.toolCalls[0].tool).toBe('bash');
+    expect(result.current.toolCalls[0].status).toBe('done');
+    expect(result.current.toolCalls[0].result).toBe('file1\nfile2');
+  });
+
+  test('processes usage event', () => {
+    const { client, streamChatMock } = createMockClient();
+    mockStreamEvents(streamChatMock, [
+      {
+        type: 'usage',
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        cache_creation_tokens: 10,
+        cache_read_tokens: 5,
+      } as StreamEvent,
+    ]);
+
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    act(() => {
+      result.current.sendMessage('Hi');
+    });
+
+    expect(result.current.usage.promptTokens).toBe(100);
+    expect(result.current.usage.completionTokens).toBe(50);
+    expect(result.current.usage.totalTokens).toBe(150);
+    expect(result.current.usage.cacheCreationTokens).toBe(10);
+    expect(result.current.usage.cacheReadTokens).toBe(5);
+  });
+
+  test('processes error event', () => {
+    const { client, streamChatMock } = createMockClient();
+    mockStreamEvents(streamChatMock, [
+      { type: 'error', message: 'Server error' } as StreamEvent,
+    ]);
+
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    act(() => {
+      result.current.sendMessage('Hi');
+    });
+
+    expect(result.current.error).toBe('Server error');
+  });
+
+  test('run_finished finalizes assistant message', () => {
+    const { client, streamChatMock } = createMockClient();
+    mockStreamEvents(streamChatMock, [
+      { type: 'text_delta', content: 'done' } as StreamEvent,
+      { type: 'run_finished', run_id: 'r1' } as StreamEvent,
+    ]);
+
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    act(() => {
+      result.current.sendMessage('Hi');
+    });
+
+    const lastMsg = result.current.messages[result.current.messages.length - 1];
+    expect(lastMsg.streaming).toBe(false);
+    expect(lastMsg.content).toBe('done');
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  test('stop() aborts stream and finalizes', () => {
+    const { client, streamChatMock } = createMockClient();
+    // Don't fire run_finished so we stay in streaming state
+    mockStreamEvents(streamChatMock, [
+      { type: 'text_delta', content: 'partial' } as StreamEvent,
+    ]);
+
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    act(() => {
+      result.current.sendMessage('Hi');
+    });
+
+    // Still streaming (no run_finished)
+    expect(result.current.isStreaming).toBe(true);
+
+    act(() => {
+      result.current.stop();
+    });
+
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.connectionState).toBe('idle');
+  });
+
+  test('reset() clears all state', () => {
+    const { client, streamChatMock } = createMockClient();
+    mockStreamEvents(streamChatMock, [
+      { type: 'session_info', session_id: 'sess-1' } as StreamEvent,
+      { type: 'text_delta', content: 'text' } as StreamEvent,
+    ]);
+
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    act(() => {
+      result.current.sendMessage('Hi');
+    });
+
+    expect(result.current.messages.length).toBeGreaterThan(0);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.sessionId).toBeNull();
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.connectionState).toBe('idle');
+  });
+
+  test('agent events are tracked', () => {
+    const { client, streamChatMock } = createMockClient();
+    mockStreamEvents(streamChatMock, [
+      { type: 'agent_delegated', agent_id: 'a1', role: 'coder', task: 'implement feature' } as StreamEvent,
+      { type: 'agent_completed', agent_id: 'a1', status: 'completed', result: 'ok' } as StreamEvent,
+    ]);
+
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    act(() => {
+      result.current.sendMessage('Hi');
+    });
+
+    expect(result.current.agentEvents).toHaveLength(2);
+    expect(result.current.agentEvents[0].type).toBe('agent_delegated');
+    expect(result.current.agentEvents[1].type).toBe('agent_completed');
+  });
+
+  test('plan events create and update plan state', () => {
+    const { client, streamChatMock } = createMockClient();
+    mockStreamEvents(streamChatMock, [
+      {
+        type: 'plan_created',
+        plan: {
+          plan_id: 'p1',
+          title: 'Test Plan',
+          subtasks: [
+            { id: 's1', title: 'Step 1' },
+            { id: 's2', title: 'Step 2' },
+          ],
+        },
+      } as unknown as StreamEvent,
+      {
+        type: 'plan_step_start',
+        subtask_id: 's1',
+        step: 's1',
+      } as StreamEvent,
+      {
+        type: 'plan_step_done',
+        subtask_id: 's1',
+        step: 's1',
+        result: 'success',
+      } as StreamEvent,
+    ]);
+
+    const { result } = renderHook(() =>
+      useAstraChat({ client }),
+    );
+
+    act(() => {
+      result.current.sendMessage('Hi');
+    });
+
+    expect(result.current.plan).not.toBeNull();
+    expect(result.current.plan?.title).toBe('Test Plan');
+    expect(result.current.plan?.subtasks).toHaveLength(2);
+    expect(result.current.plan?.subtasks[0].status).toBe('done');
+    expect(result.current.plan?.subtasks[1].status).toBe('pending');
+  });
+});
+
+// ─── useAstraRun ───────────────────────────────────────────────────
+
+describe('useAstraRun', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('polls run status on mount', async () => {
+    const { client, getRunStatusMock, getRunEventsMock } = createMockClient();
+    getRunStatusMock.mockResolvedValue({ status: 'running' });
+    getRunEventsMock.mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useAstraRun({ client, runId: 'run-1' }),
+    );
+
+    // Flush the initial refresh
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(getRunStatusMock).toHaveBeenCalledWith('run-1');
+    expect(result.current.status).toBe('running');
+  });
+
+  test('accumulates events from polling', async () => {
+    const { client, getRunStatusMock, getRunEventsMock } = createMockClient();
+    getRunStatusMock.mockResolvedValue({ status: 'running' });
+    getRunEventsMock
+      .mockResolvedValueOnce([
+        { type: 'text_delta', content: 'a' },
+      ])
+      .mockResolvedValueOnce([
+        { type: 'text_delta', content: 'b' },
+      ])
+      .mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useAstraRun({ client, runId: 'run-1', pollIntervalMs: 1000 }),
+    );
+
+    // First poll
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.events).toHaveLength(1);
+
+    // Second poll
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(1000);
+    });
+    expect(result.current.events).toHaveLength(2);
+  });
+
+  test('sets error on polling failure', async () => {
+    const { client, getRunStatusMock, getRunEventsMock } = createMockClient();
+    getRunStatusMock.mockRejectedValue(new Error('Network error'));
+    getRunEventsMock.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() =>
+      useAstraRun({ client, runId: 'run-1' }),
+    );
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.error).toBe('Network error');
+  });
+});

--- a/packages/sdk/src/__tests__/sse-client.test.ts
+++ b/packages/sdk/src/__tests__/sse-client.test.ts
@@ -1,0 +1,335 @@
+import { SSEClient } from '../sse-client';
+import type { StreamEvent, ConnectionState } from '../types';
+
+// ─── Mock Fetch + ReadableStream ────────────────────────────────────
+
+function createMockStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let idx = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (idx < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[idx]));
+        idx++;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function mockFetchStream(chunks: string[], status = 200) {
+  return jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    body: createMockStream(chunks),
+    headers: new Headers(),
+  } as unknown as Response);
+}
+
+function mockFetchNoBody(status = 200) {
+  return jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    body: null,
+    headers: new Headers(),
+  } as unknown as Response);
+}
+
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ─── Basic Connection ──────────────────────────────────────────────
+
+describe('SSEClient — Connection', () => {
+  test('connect sends Accept header and token', async () => {
+    const chunks = ['data: {"type":"text_delta","content":"hi"}\n\n'];
+    globalThis.fetch = mockFetchStream(chunks);
+
+    const events: StreamEvent[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      token: 'my-token',
+      onEvent: (e) => events.push(e),
+    });
+    await client.connect();
+
+    const call = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe('http://localhost/stream');
+    expect(call[1].headers['Accept']).toBe('text/event-stream');
+    expect(call[1].headers['Authorization']).toBe('Bearer my-token');
+    expect(call[1].headers['Cache-Control']).toBe('no-cache');
+  });
+
+  test('connect without token omits Authorization', async () => {
+    const chunks = ['data: {"type":"text_delta","content":"hi"}\n\n'];
+    globalThis.fetch = mockFetchStream(chunks);
+
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: () => {},
+    });
+    await client.connect();
+
+    const call = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(call[1].headers['Authorization']).toBeUndefined();
+  });
+
+  test('custom headers are sent', async () => {
+    const chunks = ['data: {"type":"text_delta","content":"x"}\n\n'];
+    globalThis.fetch = mockFetchStream(chunks);
+
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      headers: { 'X-Custom': 'value' },
+      onEvent: () => {},
+    });
+    await client.connect();
+
+    const call = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(call[1].headers['X-Custom']).toBe('value');
+  });
+});
+
+// ─── Event Parsing ─────────────────────────────────────────────────
+
+describe('SSEClient — Event Parsing', () => {
+  test('parses single SSE event', async () => {
+    const chunks = ['data: {"type":"text_delta","content":"hello"}\n\n'];
+    globalThis.fetch = mockFetchStream(chunks);
+
+    const events: StreamEvent[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: (e) => events.push(e),
+    });
+    await client.connect();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('text_delta');
+  });
+
+  test('parses multiple events in one chunk', async () => {
+    const chunks = [
+      'data: {"type":"run_started","run_id":"r1"}\n\n' +
+        'data: {"type":"text_delta","content":"a"}\n\n' +
+        'data: {"type":"text_delta","content":"b"}\n\n',
+    ];
+    globalThis.fetch = mockFetchStream(chunks);
+
+    const events: StreamEvent[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: (e) => events.push(e),
+    });
+    await client.connect();
+
+    expect(events).toHaveLength(3);
+    expect(events[0].type).toBe('run_started');
+    expect(events[1].type).toBe('text_delta');
+    expect(events[2].type).toBe('text_delta');
+  });
+
+  test('parses events split across chunks', async () => {
+    // Event split in the middle
+    const chunks = [
+      'data: {"type":"text_del',
+      'ta","content":"x"}\n\n',
+    ];
+    globalThis.fetch = mockFetchStream(chunks);
+
+    const events: StreamEvent[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: (e) => events.push(e),
+    });
+    await client.connect();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('text_delta');
+  });
+
+  test('ignores malformed JSON lines', async () => {
+    const chunks = [
+      'data: not-json\n\n' +
+        'data: {"type":"text_delta","content":"ok"}\n\n',
+    ];
+    globalThis.fetch = mockFetchStream(chunks);
+
+    const events: StreamEvent[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: (e) => events.push(e),
+    });
+    await client.connect();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('text_delta');
+  });
+
+  test('handles data: with and without space prefix', async () => {
+    const chunks = [
+      'data:{"type":"text_delta","content":"no-space"}\n\n' +
+        'data: {"type":"text_delta","content":"with-space"}\n\n',
+    ];
+    globalThis.fetch = mockFetchStream(chunks);
+
+    const events: StreamEvent[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: (e) => events.push(e),
+    });
+    await client.connect();
+
+    expect(events).toHaveLength(2);
+  });
+
+  test('calls onRawLine for each line', async () => {
+    const chunks = ['data: {"type":"text_delta","content":"x"}\n\n'];
+    globalThis.fetch = mockFetchStream(chunks);
+
+    const lines: string[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: () => {},
+      onRawLine: (l) => lines.push(l),
+    });
+    await client.connect();
+
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    expect(lines[0]).toContain('data:');
+  });
+});
+
+// ─── State Changes ─────────────────────────────────────────────────
+
+describe('SSEClient — State Changes', () => {
+  test('fires connecting → connected → disconnected', async () => {
+    const chunks = ['data: {"type":"text_delta","content":"x"}\n\n'];
+    globalThis.fetch = mockFetchStream(chunks);
+
+    const states: ConnectionState[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: () => {},
+      onStateChange: (s) => states.push(s),
+    });
+    await client.connect();
+
+    expect(states[0]).toBe('connecting');
+    expect(states[1]).toBe('connected');
+    expect(states[2]).toBe('disconnected');
+  });
+
+  test('fires error state on non-OK response', async () => {
+    globalThis.fetch = mockFetchStream([], 500);
+
+    const states: ConnectionState[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: () => {},
+      onStateChange: (s) => states.push(s),
+      maxRetries: 0,
+    });
+    await client.connect();
+
+    expect(states).toContain('error');
+  });
+
+  test('fires error state when body is null', async () => {
+    globalThis.fetch = mockFetchNoBody(200);
+
+    const states: ConnectionState[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: () => {},
+      onStateChange: (s) => states.push(s),
+      maxRetries: 0,
+    });
+    await client.connect();
+
+    expect(states).toContain('error');
+  });
+});
+
+// ─── Close / Abort ─────────────────────────────────────────────────
+
+describe('SSEClient — Close', () => {
+  test('close() fires disconnected state', () => {
+    const states: ConnectionState[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: () => {},
+      onStateChange: (s) => states.push(s),
+    });
+    client.close();
+    expect(states).toContain('disconnected');
+  });
+
+  test('close() before connect is safe', () => {
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: () => {},
+    });
+    // Should not throw
+    client.close();
+  });
+
+  test('close() during connect aborts fetch', async () => {
+    let fetchAborted = false;
+    globalThis.fetch = jest.fn().mockImplementation((_url: string, opts: { signal: AbortSignal }) => {
+      opts.signal.addEventListener('abort', () => {
+        fetchAborted = true;
+      });
+      // Return a promise that never resolves until aborted
+      return new Promise((_resolve, reject) => {
+        opts.signal.addEventListener('abort', () => {
+          reject(new DOMException('aborted', 'AbortError'));
+        });
+      });
+    });
+
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: () => {},
+      maxRetries: 0,
+    });
+
+    const connectPromise = client.connect();
+    // Give connect time to call fetch
+    await new Promise((r) => setTimeout(r, 10));
+    client.close();
+    await connectPromise;
+
+    expect(fetchAborted).toBe(true);
+  });
+});
+
+// ─── AbortSignal ───────────────────────────────────────────────────
+
+describe('SSEClient — AbortSignal', () => {
+  test('respects external AbortSignal', async () => {
+    const controller = new AbortController();
+    // Abort immediately
+    controller.abort();
+
+    globalThis.fetch = jest.fn().mockRejectedValue(new DOMException('aborted', 'AbortError'));
+
+    const events: StreamEvent[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: (e) => events.push(e),
+      signal: controller.signal,
+    });
+
+    await client.connect();
+    expect(events).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Completes Phase 3.3 (tests) and Phase 3.5 (documentation) of the TypeScript SDK.

### Phase 3.3 — Test Suite (31 new tests)

**SSEClient tests** (`sse-client.test.ts`, 16 tests):
- Connection: headers, Authorization token, custom headers
- Event parsing: single event, multi-event chunks, cross-chunk splits, malformed JSON
- State transitions: connecting → connected → disconnected, error states
- Close/abort: close fires disconnected, abort during fetch, external AbortSignal

**React Hooks tests** (`hooks.test.ts`, 15 tests):
- `useAstraChat`: initial state, sendMessage lifecycle, session_info/text_delta/tool_call/usage/error/plan event processing, run_finished finalization, stop(), reset(), agent event tracking
- `useAstraRun`: mount polling, event accumulation, error handling

**Total: 67 tests passing across 4 suites** (was 36 before).

### Phase 3.5 — Documentation
- Fixed README examples (correct field names, complete React hook setup)
- Added test coverage section
- Added web/ migration note documenting auth adapter pattern

### Phase 3.4 — Web Migration (assessed, partially deferred)
Types are already re-exported from `@astra/sdk`. Full hook migration requires auth adapter layer (web uses cookie-based auth via Next.js proxy, SDK uses JWT) — documented as future work.