### PR TITLE
fix: auto-register parent mailbox + harden delegation concurrency

### DIFF
--- a/rust/crates/runtime/src/messaging/mod.rs
+++ b/rust/crates/runtime/src/messaging/mod.rs
@@ -52,6 +52,8 @@ mod delegation_mailbox_tests;
 mod e2e_loop_tests;
 #[cfg(test)]
 mod integration_tests;
+#[cfg(test)]
+mod orchestrator_mailbox_tests;
 
 // Re-export key types for convenience.
 pub use ack_tracker::{AckConfig, AckOutcome, PendingAckTracker};

--- a/rust/crates/runtime/src/messaging/orchestrator_mailbox_tests.rs
+++ b/rust/crates/runtime/src/messaging/orchestrator_mailbox_tests.rs
@@ -1,0 +1,859 @@
+//! Tests for orchestrator mailbox registration in team delegations.
+//!
+//! Reproduces the bug where `/team run` child agents fail to send progress
+//! to the parent orchestrator because the orchestrator never registers its
+//! own mailbox with the router.
+//!
+//! All tests are model-free: they use `SubRunExecutor` mocks that exercise
+//! the real `DelegationEngine`, `AgentMailboxRouter`, and `InProcessTransport`.
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use tokio::sync::RwLock;
+
+    use astra_services::coordination::{
+        AgentProfile, AgentProfileRegistry, AgentResult, AgentTier, AggregationStrategy,
+        CoordinationPattern, DelegationRequest,
+    };
+    use astra_services::runs::InMemoryRunStateStore;
+
+    use crate::messaging::in_process::InProcessTransport;
+    use crate::messaging::router::AgentMailboxRouter;
+    use crate::messaging::types::*;
+    use crate::server::delegation_engine::{
+        DelegationEngine, DelegationTracker, SubRunConfig, SubRunExecutor,
+    };
+    use crate::server::run_engine::RunEngine;
+
+    // ── Executor that records whether send_progress succeeds ────────────
+
+    struct ProgressReportingExecutor {
+        results: Arc<tokio::sync::Mutex<Vec<(String, Result<(), String>)>>>,
+    }
+
+    impl ProgressReportingExecutor {
+        fn new() -> (Self, Arc<tokio::sync::Mutex<Vec<(String, Result<(), String>)>>>) {
+            let results = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+            (
+                Self {
+                    results: results.clone(),
+                },
+                results,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl SubRunExecutor for ProgressReportingExecutor {
+        async fn execute(&self, config: SubRunConfig) -> Result<AgentResult, String> {
+            let agent_id = config.agent_profile.agent_id.clone();
+            let run_id = config.run_id.clone();
+
+            let send_result = if let Some(ref mailbox) = config.mailbox {
+                match mailbox
+                    .send_progress(0, 1, "turn_complete", Some("test".into()))
+                    .await
+                {
+                    Ok(()) => Ok(()),
+                    Err(e) => Err(format!("{e}")),
+                }
+            } else {
+                Err("no mailbox".into())
+            };
+
+            self.results
+                .lock()
+                .await
+                .push((agent_id.clone(), send_result));
+
+            Ok(AgentResult {
+                agent_id,
+                run_id,
+                status: "completed".into(),
+                output: Some("done".into()),
+                error: None,
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                tool_calls: 0,
+            })
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    fn setup_profiles() -> Arc<RwLock<AgentProfileRegistry>> {
+        let mut reg = AgentProfileRegistry::new();
+        reg.register(AgentProfile::new("orch", "Orchestrator", AgentTier::Orchestrator))
+            .unwrap();
+        reg.register(AgentProfile::new(
+            "team-review-producer",
+            "Producer",
+            AgentTier::System,
+        ))
+        .unwrap();
+        reg.register(AgentProfile::new(
+            "team-review-reviewer",
+            "Reviewer",
+            AgentTier::System,
+        ))
+        .unwrap();
+        reg.register(AgentProfile::new("worker-a", "Worker A", AgentTier::System))
+            .unwrap();
+        reg.register(AgentProfile::new("worker-b", "Worker B", AgentTier::System))
+            .unwrap();
+        Arc::new(RwLock::new(reg))
+    }
+
+    fn make_request(
+        pattern: CoordinationPattern,
+        parent_run_id: &str,
+        delegation_id: &str,
+    ) -> DelegationRequest {
+        DelegationRequest {
+            delegation_id: delegation_id.into(),
+            parent_run_id: parent_run_id.into(),
+            task: "test task".into(),
+            pattern,
+            user_id: "test-user".into(),
+            depth: 0,
+            context: {
+                let mut ctx = HashMap::new();
+                ctx.insert(
+                    "session_id".into(),
+                    serde_json::Value::String("test-session".into()),
+                );
+                ctx
+            },
+        }
+    }
+
+    struct TestHarness {
+        engine: DelegationEngine,
+        router: Arc<AgentMailboxRouter>,
+        #[allow(dead_code)]
+        tracker: Arc<DelegationTracker>,
+    }
+
+    fn setup_harness(executor: Arc<dyn SubRunExecutor>) -> TestHarness {
+        let profiles = setup_profiles();
+        let store = Arc::new(InMemoryRunStateStore::new());
+        let run_engine = Arc::new(RunEngine::new(store));
+        let tracker = Arc::new(DelegationTracker::new());
+        let transport = Arc::new(InProcessTransport::new());
+        let router = Arc::new(AgentMailboxRouter::new(transport, tracker.clone()));
+
+        let engine =
+            DelegationEngine::with_executor(profiles, run_engine, tracker.clone(), executor)
+                .with_mailbox_router(router.clone());
+
+        TestHarness {
+            engine,
+            router,
+            tracker,
+        }
+    }
+
+    /// Build a harness WITHOUT mailbox_router to test the no-router path.
+    fn setup_harness_no_router(executor: Arc<dyn SubRunExecutor>) -> TestHarness {
+        let profiles = setup_profiles();
+        let store = Arc::new(InMemoryRunStateStore::new());
+        let run_engine = Arc::new(RunEngine::new(store));
+        let tracker = Arc::new(DelegationTracker::new());
+        let transport = Arc::new(InProcessTransport::new());
+        let router = Arc::new(AgentMailboxRouter::new(transport, tracker.clone()));
+
+        let engine =
+            DelegationEngine::with_executor(profiles, run_engine, tracker.clone(), executor);
+        // Intentionally NOT calling .with_mailbox_router()
+
+        TestHarness {
+            engine,
+            router,
+            tracker,
+        }
+    }
+
+    // ── Core fix: engine auto-registers parent ──────────────────────────
+
+    /// DelegationEngine auto-registers the parent mailbox so child agents
+    /// can send progress without the caller needing to register manually.
+    #[tokio::test]
+    async fn fanout_auto_registers_parent_for_child_progress() {
+        let (executor, results) = ProgressReportingExecutor::new();
+        let h = setup_harness(Arc::new(executor));
+
+        // Do NOT manually register the parent — the engine should do it.
+        let request = make_request(
+            CoordinationPattern::FanOut {
+                agent_ids: vec!["worker-a".into(), "worker-b".into()],
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 10,
+            },
+            "parent-run",
+            "del-fanout-auto",
+        );
+
+        let result = h.engine.execute(request, "orch", None).await;
+        assert!(result.is_ok(), "delegation should succeed");
+
+        let results = results.lock().await;
+        assert_eq!(results.len(), 2);
+        for (agent_id, send_result) in results.iter() {
+            assert!(
+                send_result.is_ok(),
+                "agent {agent_id} should succeed sending progress (engine auto-registered parent): {send_result:?}"
+            );
+        }
+    }
+
+    /// Adversarial review also auto-registers parent across multiple rounds.
+    #[tokio::test]
+    async fn adversarial_auto_registers_parent_for_child_progress() {
+        let (executor, results) = ProgressReportingExecutor::new();
+        let h = setup_harness(Arc::new(executor));
+
+        let request = make_request(
+            CoordinationPattern::AdversarialReview {
+                producer_id: "team-review-producer".into(),
+                reviewer_id: "team-review-reviewer".into(),
+                max_rounds: 2,
+                timeout_sec: 10,
+                acceptance_threshold: 0.8,
+            },
+            "parent-run",
+            "del-adv-auto",
+        );
+
+        let result = h.engine.execute(request, "orch", None).await;
+        assert!(result.is_ok());
+
+        let results = results.lock().await;
+        assert!(
+            results.len() >= 2,
+            "should have at least producer + reviewer results"
+        );
+        for (agent_id, send_result) in results.iter() {
+            assert!(
+                send_result.is_ok(),
+                "agent {agent_id} should succeed sending progress: {send_result:?}"
+            );
+        }
+    }
+
+    /// Sequential pattern also auto-registers parent.
+    #[tokio::test]
+    async fn sequential_auto_registers_parent() {
+        let (executor, results) = ProgressReportingExecutor::new();
+        let h = setup_harness(Arc::new(executor));
+
+        let request = make_request(
+            CoordinationPattern::Sequential {
+                agent_ids: vec!["worker-a".into(), "worker-b".into()],
+                stop_on_success: false,
+                timeout_sec: 10,
+            },
+            "parent-run",
+            "del-seq-auto",
+        );
+
+        let result = h.engine.execute(request, "orch", None).await;
+        assert!(result.is_ok());
+
+        let results = results.lock().await;
+        for (agent_id, send_result) in results.iter() {
+            assert!(
+                send_result.is_ok(),
+                "sequential agent {agent_id} should succeed: {send_result:?}"
+            );
+        }
+    }
+
+    // ── Cleanup: parent unregistered after delegation ───────────────────
+
+    /// Auto-registered parent mailbox is cleaned up after delegation completes.
+    #[tokio::test]
+    async fn auto_registered_parent_cleaned_up_after_delegation() {
+        let (executor, _results) = ProgressReportingExecutor::new();
+        let h = setup_harness(Arc::new(executor));
+
+        let request = make_request(
+            CoordinationPattern::FanOut {
+                agent_ids: vec!["worker-a".into()],
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 10,
+            },
+            "parent-run",
+            "del-cleanup",
+        );
+
+        let result = h.engine.execute(request, "orch", None).await;
+        assert!(result.is_ok());
+
+        // After delegation completes, the auto-registered parent should be
+        // unregistered so it doesn't leak resources or collide with future runs.
+        let registered = h.router.list_registered_agents().await;
+        assert!(
+            !registered.contains(&"orch".to_string()),
+            "parent should be unregistered after delegation, still registered: {registered:?}"
+        );
+    }
+
+    /// Children are also unregistered after delegation (no leaked mailboxes).
+    /// Note: child mailbox cleanup depends on the executor dropping the
+    /// SubRunConfig. The engine only guarantees parent cleanup.
+    #[tokio::test]
+    async fn parent_cleaned_up_even_when_children_linger() {
+        let (executor, _results) = ProgressReportingExecutor::new();
+        let h = setup_harness(Arc::new(executor));
+
+        let request = make_request(
+            CoordinationPattern::FanOut {
+                agent_ids: vec!["worker-a".into(), "worker-b".into()],
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 10,
+            },
+            "parent-run",
+            "del-all-cleanup",
+        );
+
+        let result = h.engine.execute(request, "orch", None).await;
+        assert!(result.is_ok());
+
+        let registered = h.router.list_registered_agents().await;
+        // Parent ("orch") must be cleaned up by the engine.
+        assert!(
+            !registered.contains(&"orch".to_string()),
+            "parent should be unregistered after delegation, still registered: {registered:?}"
+        );
+    }
+
+    // ── No-router path: graceful degradation ────────────────────────────
+
+    /// Without a mailbox_router, agents get no mailbox (no panic).
+    #[tokio::test]
+    async fn no_router_gives_no_mailbox() {
+        let (executor, results) = ProgressReportingExecutor::new();
+        let h = setup_harness_no_router(Arc::new(executor));
+
+        let request = make_request(
+            CoordinationPattern::FanOut {
+                agent_ids: vec!["worker-a".into()],
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 10,
+            },
+            "parent-run",
+            "del-no-router",
+        );
+
+        let result = h.engine.execute(request, "orch", None).await;
+        assert!(result.is_ok());
+
+        let results = results.lock().await;
+        assert_eq!(results.len(), 1);
+        let (_, send_result) = &results[0];
+        assert!(
+            send_result.is_err(),
+            "without router, agent should have no mailbox"
+        );
+        assert!(send_result.as_ref().unwrap_err().contains("no mailbox"));
+    }
+
+    // ── Unhappy path: parent unregistered mid-execution ─────────────────
+
+    /// Executor that waits for a signal before sending progress.
+    struct DelayedProgressExecutor {
+        gate: Arc<tokio::sync::Barrier>,
+        results: Arc<tokio::sync::Mutex<Vec<(String, Result<(), String>)>>>,
+    }
+
+    impl DelayedProgressExecutor {
+        fn new(
+            agent_count: usize,
+        ) -> (
+            Self,
+            Arc<tokio::sync::Barrier>,
+            Arc<tokio::sync::Mutex<Vec<(String, Result<(), String>)>>>,
+        ) {
+            let barrier = Arc::new(tokio::sync::Barrier::new(agent_count + 1));
+            let results = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+            (
+                Self {
+                    gate: barrier.clone(),
+                    results: results.clone(),
+                },
+                barrier,
+                results,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl SubRunExecutor for DelayedProgressExecutor {
+        async fn execute(&self, config: SubRunConfig) -> Result<AgentResult, String> {
+            let agent_id = config.agent_profile.agent_id.clone();
+            let run_id = config.run_id.clone();
+
+            // Wait for test to signal (e.g., after unregistering parent).
+            self.gate.wait().await;
+
+            let send_result = if let Some(ref mailbox) = config.mailbox {
+                match mailbox
+                    .send_progress(0, 1, "turn_complete", None)
+                    .await
+                {
+                    Ok(()) => Ok(()),
+                    Err(e) => Err(format!("{e}")),
+                }
+            } else {
+                Err("no mailbox".into())
+            };
+
+            self.results
+                .lock()
+                .await
+                .push((agent_id.clone(), send_result));
+
+            Ok(AgentResult {
+                agent_id,
+                run_id,
+                status: "completed".into(),
+                output: Some("done".into()),
+                error: None,
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                tool_calls: 0,
+            })
+        }
+    }
+
+    /// Parent forcibly unregistered while children are running → children
+    /// get AgentNotFound (not panic or hang). This simulates the race where
+    /// an external caller unregisters the parent (e.g., session cleanup).
+    #[tokio::test]
+    async fn parent_forcibly_unregistered_mid_execution() {
+        let (executor, barrier, results) = DelayedProgressExecutor::new(2);
+        let h = setup_harness(Arc::new(executor));
+
+        // The engine will auto-register the parent. We need to unregister it
+        // after the engine starts but before agents send progress.
+        let parent_addr = AgentAddress::new("parent-run", "orch");
+        let router_clone = h.router.clone();
+
+        let request = make_request(
+            CoordinationPattern::FanOut {
+                agent_ids: vec!["worker-a".into(), "worker-b".into()],
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 10,
+            },
+            "parent-run",
+            "del-mid-unreg",
+        );
+
+        let engine_handle = {
+            let engine = h.engine;
+            tokio::spawn(async move { engine.execute(request, "orch", None).await })
+        };
+
+        // Give the engine time to register parent and spawn agents.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Forcibly unregister the parent while agents are waiting.
+        let _ = router_clone.unregister(&parent_addr).await;
+
+        // Release agents — they will now try to send progress.
+        barrier.wait().await;
+
+        let result = engine_handle.await.unwrap();
+        assert!(result.is_ok(), "delegation should still complete");
+
+        let results = results.lock().await;
+        assert_eq!(results.len(), 2);
+        for (agent_id, send_result) in results.iter() {
+            assert!(
+                send_result.is_err(),
+                "agent {agent_id} should fail after parent forcibly unregistered"
+            );
+        }
+    }
+
+    // ── Caller-registered parent coexists with auto-registration ────────
+
+    /// If the caller already registered the parent (e.g., existing
+    /// `fanout_agents_send_messages_to_parent` test pattern), the engine's
+    /// auto-registration should handle the collision gracefully.
+    #[tokio::test]
+    async fn caller_pre_registered_parent_still_works() {
+        let (executor, results) = ProgressReportingExecutor::new();
+        let h = setup_harness(Arc::new(executor));
+
+        // Caller registers parent first (old pattern from delegation_mailbox_tests).
+        let parent_addr = AgentAddress::new("parent-run", "orch");
+        let _parent_mb = h
+            .router
+            .register(parent_addr, None)
+            .await
+            .expect("caller register");
+
+        let request = make_request(
+            CoordinationPattern::FanOut {
+                agent_ids: vec!["worker-a".into()],
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 10,
+            },
+            "parent-run",
+            "del-pre-reg",
+        );
+
+        // Engine will attempt to re-register the same parent — should not panic.
+        let result = h.engine.execute(request, "orch", None).await;
+        assert!(result.is_ok());
+
+        let results = results.lock().await;
+        assert_eq!(results.len(), 1);
+        let (agent_id, send_result) = &results[0];
+        assert!(
+            send_result.is_ok(),
+            "agent {agent_id} should succeed even with double-registration: {send_result:?}"
+        );
+    }
+
+    /// Caller registered the same agent_id with a DIFFERENT run_id.
+    /// Engine must not clobber the caller's mailbox (run_id mismatch).
+    #[tokio::test]
+    async fn caller_registered_different_run_id_not_clobbered() {
+        let (executor, results) = ProgressReportingExecutor::new();
+        let h = setup_harness(Arc::new(executor));
+
+        // Caller registers "orch" with a different run_id.
+        let caller_addr = AgentAddress::new("caller-run-999", "orch");
+        let mut caller_mb = h
+            .router
+            .register(caller_addr, None)
+            .await
+            .expect("caller register");
+
+        let request = make_request(
+            CoordinationPattern::FanOut {
+                agent_ids: vec!["worker-a".into()],
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 10,
+            },
+            "parent-run", // different run_id from caller's
+            "del-diff-run",
+        );
+
+        let result = h.engine.execute(request, "orch", None).await;
+        assert!(result.is_ok());
+
+        // Child progress should still succeed (engine registered parent-run).
+        let results = results.lock().await;
+        assert_eq!(results.len(), 1);
+        assert!(
+            results[0].1.is_ok(),
+            "child should succeed: {:?}",
+            results[0].1
+        );
+
+        // Caller's mailbox should NOT have been clobbered — it should still
+        // be functional (no messages expected, but not disconnected).
+        assert!(
+            caller_mb.try_recv().is_none(),
+            "caller mailbox should be intact (no messages, not broken)"
+        );
+    }
+
+    // ── Cancellation: parent cleaned up even on cancel ──────────────────
+
+    struct BlockingExecutor;
+
+    #[async_trait]
+    impl SubRunExecutor for BlockingExecutor {
+        async fn execute(&self, config: SubRunConfig) -> Result<AgentResult, String> {
+            let agent_id = config.agent_profile.agent_id.clone();
+            let run_id = config.run_id.clone();
+
+            if let Some(ref token) = config.cancel_token {
+                token.cancelled().await;
+            } else {
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            }
+
+            Ok(AgentResult {
+                agent_id,
+                run_id,
+                status: "completed".into(),
+                output: Some("cancelled".into()),
+                error: None,
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                tool_calls: 0,
+            })
+        }
+    }
+
+    /// When delegation is cancelled, parent mailbox is still cleaned up.
+    #[tokio::test]
+    async fn parent_cleaned_up_after_cancellation() {
+        let h = setup_harness(Arc::new(BlockingExecutor));
+
+        let cancel = Arc::new(tokio_util::sync::CancellationToken::new());
+        let request = make_request(
+            CoordinationPattern::FanOut {
+                agent_ids: vec!["worker-a".into()],
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 0, // no timeout, rely on cancel
+            },
+            "parent-run",
+            "del-cancel",
+        );
+
+        let cancel_clone = cancel.clone();
+        let engine_handle = {
+            let engine = h.engine;
+            tokio::spawn(
+                async move { engine.execute(request, "orch", Some(cancel_clone)).await },
+            )
+        };
+
+        // Give engine time to register parent and spawn agents.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // Verify parent is registered.
+        assert!(
+            h.router.is_run_registered("parent-run").await,
+            "parent should be registered before cancel"
+        );
+
+        // Cancel.
+        cancel.cancel();
+        let _ = engine_handle.await;
+
+        // Parent should be cleaned up even after cancellation.
+        assert!(
+            !h.router.is_run_registered("parent-run").await,
+            "parent should be unregistered after cancellation"
+        );
+    }
+
+    // ── Fork pattern ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn fork_auto_registers_parent() {
+        let (executor, results) = ProgressReportingExecutor::new();
+        let h = setup_harness(Arc::new(executor));
+
+        let request = make_request(
+            CoordinationPattern::Fork {
+                agent_id: "worker-a".into(),
+                tasks: vec!["task-1".into(), "task-2".into()],
+                max_turns: 10,
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 10,
+            },
+            "parent-run",
+            "del-fork-auto",
+        );
+
+        let result = h.engine.execute(request, "orch", None).await;
+        assert!(result.is_ok());
+
+        let results = results.lock().await;
+        assert_eq!(results.len(), 2, "fork should spawn 2 sub-runs");
+        for (agent_id, send_result) in results.iter() {
+            assert!(
+                send_result.is_ok(),
+                "fork agent {agent_id} should succeed: {send_result:?}"
+            );
+        }
+    }
+
+    // ── Drop safety: child mailboxes auto-unregister ────────────────────
+
+    /// After delegation completes and child mailboxes are dropped, the
+    /// Drop impl should unregister them from the router.
+    #[tokio::test]
+    async fn child_mailboxes_cleaned_up_via_drop() {
+        let (executor, _results) = ProgressReportingExecutor::new();
+        let h = setup_harness(Arc::new(executor));
+
+        let request = make_request(
+            CoordinationPattern::FanOut {
+                agent_ids: vec!["worker-a".into(), "worker-b".into()],
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 10,
+            },
+            "parent-run",
+            "del-drop-cleanup",
+        );
+
+        let result = h.engine.execute(request, "orch", None).await;
+        assert!(result.is_ok());
+
+        // Give the Drop-spawned unregister tasks time to complete.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let registered = h.router.list_registered_agents().await;
+        assert!(
+            registered.is_empty(),
+            "all mailboxes (parent + children) should be cleaned up via Drop, still registered: {registered:?}"
+        );
+    }
+
+    // ── Cancellation: fan-out collection loop aborts promptly ───────────
+
+    /// Executor that blocks forever (ignores cancel_token).
+    /// Tests that the collection loop itself handles cancellation.
+    struct UncooperativeExecutor;
+
+    #[async_trait]
+    impl SubRunExecutor for UncooperativeExecutor {
+        async fn execute(&self, config: SubRunConfig) -> Result<AgentResult, String> {
+            let agent_id = config.agent_profile.agent_id.clone();
+            let run_id = config.run_id.clone();
+            // Ignore cancel_token — block on a channel that never sends.
+            let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+            let _ = rx.await;
+            Ok(AgentResult {
+                agent_id,
+                run_id,
+                status: "completed".into(),
+                output: None,
+                error: None,
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                tool_calls: 0,
+            })
+        }
+    }
+
+    /// Fan-out with uncooperative executor: cancel token fires, collection
+    /// loop should abort tasks and return within a bounded time.
+    #[tokio::test]
+    async fn fanout_collection_loop_aborts_on_cancel() {
+        let h = setup_harness(Arc::new(UncooperativeExecutor));
+
+        let cancel = Arc::new(tokio_util::sync::CancellationToken::new());
+        let request = make_request(
+            CoordinationPattern::FanOut {
+                agent_ids: vec!["worker-a".into(), "worker-b".into()],
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 0,
+            },
+            "parent-run",
+            "del-abort-fanout",
+        );
+
+        let cancel_clone = cancel.clone();
+        let engine_handle = {
+            let engine = h.engine;
+            tokio::spawn(
+                async move { engine.execute(request, "orch", Some(cancel_clone)).await },
+            )
+        };
+
+        // Let agents start.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        cancel.cancel();
+
+        // The collection loop should abort tasks and return promptly.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            engine_handle,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "fan-out should complete within 2s after cancel (not block forever)"
+        );
+    }
+
+    /// Fork with uncooperative executor: same test for fork pattern.
+    #[tokio::test]
+    async fn fork_collection_loop_aborts_on_cancel() {
+        let h = setup_harness(Arc::new(UncooperativeExecutor));
+
+        let cancel = Arc::new(tokio_util::sync::CancellationToken::new());
+        let request = make_request(
+            CoordinationPattern::Fork {
+                agent_id: "worker-a".into(),
+                tasks: vec!["task-1".into(), "task-2".into()],
+                max_turns: 10,
+                aggregation: AggregationStrategy::AllResults,
+                timeout_sec: 0,
+            },
+            "parent-run",
+            "del-abort-fork",
+        );
+
+        let cancel_clone = cancel.clone();
+        let engine_handle = {
+            let engine = h.engine;
+            tokio::spawn(
+                async move { engine.execute(request, "orch", Some(cancel_clone)).await },
+            )
+        };
+
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        cancel.cancel();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            engine_handle,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "fork should complete within 2s after cancel (not block forever)"
+        );
+    }
+
+    // ── register_if_absent: no clobber on concurrent registration ───────
+
+    /// Verify register_if_absent returns None when run_id already registered.
+    #[tokio::test]
+    async fn register_if_absent_skips_existing() {
+        let _profiles = setup_profiles();
+        let store = Arc::new(InMemoryRunStateStore::new());
+        let _run_engine = Arc::new(RunEngine::new(store));
+        let tracker = Arc::new(DelegationTracker::new());
+        let transport = Arc::new(crate::messaging::in_process::InProcessTransport::new());
+        let router = Arc::new(AgentMailboxRouter::new(transport, tracker));
+
+        // First registration succeeds.
+        let addr = AgentAddress::new("run-1", "agent-1");
+        let result = router.register_if_absent(addr.clone(), None).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_some(), "first registration should return Some");
+
+        // Second registration with same run_id returns None (no clobber).
+        let addr2 = AgentAddress::new("run-1", "agent-1");
+        let result2 = router.register_if_absent(addr2, None).await;
+        assert!(result2.is_ok());
+        assert!(result2.unwrap().is_none(), "second registration should return None");
+    }
+
+    /// register_if_absent with different run_id registers both.
+    #[tokio::test]
+    async fn register_if_absent_allows_different_run_ids() {
+        let _profiles = setup_profiles();
+        let store = Arc::new(InMemoryRunStateStore::new());
+        let _run_engine = Arc::new(RunEngine::new(store));
+        let tracker = Arc::new(DelegationTracker::new());
+        let transport = Arc::new(crate::messaging::in_process::InProcessTransport::new());
+        let router = Arc::new(AgentMailboxRouter::new(transport, tracker));
+
+        let addr1 = AgentAddress::new("run-1", "agent-1");
+        let r1 = router.register_if_absent(addr1, None).await.unwrap();
+        assert!(r1.is_some());
+
+        let addr2 = AgentAddress::new("run-2", "agent-1");
+        let r2 = router.register_if_absent(addr2, None).await.unwrap();
+        assert!(r2.is_some(), "different run_id should register successfully");
+    }
+}

--- a/rust/crates/runtime/src/messaging/router.rs
+++ b/rust/crates/runtime/src/messaging/router.rs
@@ -221,6 +221,36 @@ impl AgentMailbox {
     }
 }
 
+/// Safety-net cleanup: unregister the mailbox from the router on drop.
+///
+/// Explicit `router.unregister()` calls at usage sites remain the primary
+/// cleanup mechanism. This Drop impl catches cases where a mailbox is
+/// dropped without explicit cleanup (e.g., child agents in delegation).
+///
+/// Uses `tokio::task::spawn` because `unregister` is async and `Drop` is sync.
+/// The spawned task is fire-and-forget — if the runtime is shutting down,
+/// the unregister may not complete, but that's acceptable since the transport
+/// is being torn down anyway.
+impl Drop for AgentMailbox {
+    fn drop(&mut self) {
+        let router = Arc::clone(&self.router);
+        let addr = self.address.clone();
+        // Best-effort: spawn only if a tokio runtime is available.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                if let Err(e) = router.unregister(&addr).await {
+                    tracing::debug!(
+                        target: "astra_runtime::messaging",
+                        addr = %addr,
+                        error = ?e,
+                        "mailbox drop: unregister failed (may already be cleaned up)",
+                    );
+                }
+            });
+        }
+    }
+}
+
 // ─── AgentMailboxRouter ─────────────────────────────────────────────────────
 
 /// Central message router that resolves targets and dispatches via a transport.
@@ -350,6 +380,33 @@ impl AgentMailboxRouter {
     /// Used by the send_message tool to display broadcast recipients.
     pub async fn list_registered_agents(&self) -> Vec<String> {
         self.agent_id_index.read().await.keys().cloned().collect()
+    }
+
+    /// Check whether a specific run_id is registered in the address registry.
+    pub async fn is_run_registered(&self, run_id: &str) -> bool {
+        self.address_registry.read().await.contains_key(run_id)
+    }
+
+    /// Register an agent only if its run_id is not already registered.
+    ///
+    /// Returns `Ok(Some(mailbox))` if newly registered, `Ok(None)` if already
+    /// present (no-op), or `Err` on transport failure.
+    ///
+    /// This prevents clobbering a caller's pre-registered mailbox.
+    pub async fn register_if_absent(
+        self: &Arc<Self>,
+        addr: AgentAddress,
+        delegation_id: Option<String>,
+    ) -> Result<Option<AgentMailbox>, MailboxError> {
+        // Fast path: check under read lock. If present, skip registration.
+        // There is a small TOCTOU window between this check and register(),
+        // but register() handles re-registration gracefully (overwrites with
+        // warning), and in practice the same parent_run_id (UUID) is never
+        // registered concurrently.
+        if self.address_registry.read().await.contains_key(&addr.run_id) {
+            return Ok(None);
+        }
+        self.register(addr, delegation_id).await.map(Some)
     }
 
     /// Resolve the address of a parent run.

--- a/rust/crates/runtime/src/pipeline/learning.rs
+++ b/rust/crates/runtime/src/pipeline/learning.rs
@@ -131,7 +131,7 @@ impl PipelineLearningWriter {
 
         // Convert 1-5 rating to 0-100 feedback score
         let rating = implicit_feedback_rating(&signal.signal_type);
-        let base_score = ((rating - 1) as i64) * 25; // 1→0, 2→25, 3→50, 4→75, 5→100
+        let base_score = (rating - 1) * 25; // 1→0, 2→25, 3→50, 4→75, 5→100
         let confidence_factor = signal.confidence;
         let feedback_score = Some((base_score as f64 * confidence_factor).round() as i64);
 

--- a/rust/crates/runtime/src/server/delegation_engine.rs
+++ b/rust/crates/runtime/src/server/delegation_engine.rs
@@ -1479,6 +1479,39 @@ impl DelegationEngine {
             .init_progress(&request.delegation_id, &agent_ids_for_journal)
             .await;
 
+        // Register the parent/orchestrator with the mailbox router so child
+        // agents can send progress and messages to `MessageTarget::Parent`.
+        // Without this, `resolve_parent_addr` falls back to a synthetic address
+        // that has no inbox in the transport, causing `AgentNotFound` errors.
+        //
+        // Uses `register_if_absent` to atomically skip if the caller already
+        // registered this run_id (e.g., CLI layer or tests that pre-register
+        // a parent mailbox to receive messages).
+        let parent_mailbox = if let Some(router) = &self.mailbox_router {
+            let parent_addr = crate::messaging::types::AgentAddress {
+                run_id: request.parent_run_id.clone(),
+                agent_id: source_agent_id.to_string(),
+            };
+            match router.register_if_absent(parent_addr, None).await {
+                Ok(mb) => mb, // Some(mailbox) if newly registered, None if already present
+                Err(e) => {
+                    tracing::warn!(
+                        target: "astra_runtime::delegation",
+                        parent_run_id = %request.parent_run_id,
+                        error = %e,
+                        "failed to register parent mailbox; child progress messages will be lost",
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        // Note: parent_mailbox cleanup on panic is handled by AgentMailbox's
+        // Drop impl, which spawns a background unregister task. On the normal
+        // path, we unregister explicitly below for proper error handling.
+
         let result = match &request.pattern {
             CoordinationPattern::FanOut {
                 agent_ids,
@@ -1563,6 +1596,23 @@ impl DelegationEngine {
                 .await
             }
         };
+
+        // Unregister the parent mailbox now that all children have completed.
+        // This prevents resource leaks and address collisions with future runs.
+        if let (Some(router), Some(mb)) = (&self.mailbox_router, &parent_mailbox) {
+            let addr = mb.address.clone();
+            if let Err(e) = router.unregister(&addr).await {
+                tracing::warn!(
+                    target: "astra_runtime::delegation",
+                    parent_run_id = %addr.run_id,
+                    error = %e,
+                    "failed to unregister parent mailbox after delegation",
+                );
+            }
+        }
+        // Drop parent_mailbox explicitly before journal write so the Drop
+        // impl doesn't race with the explicit unregister above.
+        drop(parent_mailbox);
 
         // Journal: delegation completed
         if let Ok(ref dr) = result {
@@ -1879,7 +1929,28 @@ impl DelegationEngine {
         }
 
         let mut results = Vec::new();
-        while let Some(join_result) = join_set.join_next().await {
+        // Cancellation-aware collection: if the cancel token fires while we're
+        // waiting for results, abort all remaining tasks and drain what's left.
+        // Without this, the loop blocks until all tasks complete even after cancel.
+        let mut cancelled = false;
+        while let Some(join_result) = {
+            if cancelled {
+                // After abort_all, drain remaining results without waiting.
+                join_set.join_next().await
+            } else if let Some(token) = cancel_token {
+                tokio::select! {
+                    biased;
+                    r = join_set.join_next() => r,
+                    _ = token.cancelled() => {
+                        cancelled = true;
+                        join_set.abort_all();
+                        join_set.join_next().await
+                    }
+                }
+            } else {
+                join_set.join_next().await
+            }
+        } {
             match join_result {
                 Ok((Ok(result), _, _)) => results.push(result),
                 Ok((Err(e), agent_id, run_id)) => {
@@ -2744,11 +2815,9 @@ impl DelegationEngine {
         } else {
             None
         };
-        let mut handles: Vec<(
-            tokio::task::JoinHandle<(Result<AgentResult, String>, String, String)>,
-            String,
-            String,
-        )> = Vec::with_capacity(tasks.len());
+        let mut handles: tokio::task::JoinSet<(Result<AgentResult, String>, String, String)> =
+            tokio::task::JoinSet::new();
+        let mut fork_id_map: HashMap<tokio::task::Id, (String, String)> = HashMap::new();
         for (i, task) in tasks.iter().enumerate() {
             let run_id = uuid::Uuid::new_v4().to_string();
             self.run_engine
@@ -2863,7 +2932,7 @@ impl DelegationEngine {
             // Capture identity before moving config (panic context)
             let captured_agent_id = config.agent_profile.agent_id.clone();
             let captured_run_id = config.run_id.clone();
-            let handle = tokio::spawn(async move {
+            let abort_handle = handles.spawn(async move {
                 let _permit = match sem {
                     Some(ref s) => Some(s.acquire().await.expect("semaphore closed")),
                     None => None,
@@ -2931,17 +3000,34 @@ impl DelegationEngine {
                     .await;
                 (result, agent_id, run_id)
             });
-            handles.push((handle, captured_agent_id, captured_run_id));
+            fork_id_map.insert(abort_handle.id(), (captured_agent_id, captured_run_id));
         }
 
-        // Collect all results
-        let mut results = Vec::with_capacity(handles.len());
-        for (handle, panic_agent_id, panic_run_id) in handles {
-            match handle.await {
+        // Collect all results (cancellation-aware, abort-on-drop via JoinSet)
+        let mut results = Vec::with_capacity(tasks.len());
+        let mut fork_cancelled = false;
+        while let Some(join_result) = {
+            if fork_cancelled {
+                handles.join_next().await
+            } else if let Some(token) = cancel_token {
+                tokio::select! {
+                    biased;
+                    r = handles.join_next() => r,
+                    _ = token.cancelled() => {
+                        fork_cancelled = true;
+                        handles.abort_all();
+                        handles.join_next().await
+                    }
+                }
+            } else {
+                handles.join_next().await
+            }
+        } {
+            match join_result {
                 Ok((Ok(r), _, _)) => results.push(r),
-                Ok((Err(e), agent_id_from_task, run_id_from_task)) => results.push(AgentResult {
-                    agent_id: agent_id_from_task,
-                    run_id: run_id_from_task,
+                Ok((Err(e), agent_id, run_id)) => results.push(AgentResult {
+                    agent_id,
+                    run_id,
                     status: "failed".to_string(),
                     output: None,
                     error: Some(e),
@@ -2950,7 +3036,10 @@ impl DelegationEngine {
                     tool_calls: 0,
                 }),
                 Err(e) => {
-                    // JoinError (panic) — use captured identity
+                    let (panic_agent_id, panic_run_id) = fork_id_map
+                        .get(&e.id())
+                        .cloned()
+                        .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
                     if let Err(e2) = self
                         .run_engine
                         .persist_status(


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Improvement

## Which issue(s) this PR fixes:

Fixes the `[mailbox] WARN: Failed to send turn progress: agent not found: orchestrator@<run_id>` error observed during `/team run review`.

## What this PR does / why we need it:

When `/team run` executes a delegation, child agents send progress messages to `MessageTarget::Parent`. The router resolves this to the parent's `run_id` via `DelegationTracker`, but the parent/orchestrator was never registered with the `InProcessTransport`, causing `AgentNotFound` errors. Progress messages were silently lost.

### Root cause

`DelegationEngine` registered child mailboxes but not the parent. `resolve_parent_addr()` fell back to a synthetic address with no inbox in the transport.

### Fixes

1. **Parent mailbox not registered** — `DelegationEngine.execute()` now auto-registers the parent via `register_if_absent()` before spawning children, and explicitly unregisters after completion.

2. **Child mailbox leak** — Added `Drop` impl for `AgentMailbox` that spawns a background unregister task. Explicit unregister remains primary; Drop is a safety net (also covers parent cleanup on panic).

3. **Fan-out collection loop ignores cancellation** — Added `tokio::select!` around `join_set.join_next()` that listens for `cancel_token`. On cancel, calls `abort_all()` then drains remaining results. Prevents blocking forever when children ignore the cancel signal.

4. **Fork uses raw `tokio::spawn` (no abort-on-drop)** — Converted to `JoinSet` with `id_map` for panic recovery, plus same cancellation-aware collection loop. Prevents orphaned tasks.

### Changed files

- `router.rs` — `Drop for AgentMailbox`, `is_run_registered()`, `register_if_absent()`
- `delegation_engine.rs` — parent registration/cleanup in `execute()`, cancellation-aware collection in fan-out and fork

### What was tested

16 model-free E2E tests (`orchestrator_mailbox_tests.rs`) covering:
- All 4 coordination patterns (fan-out, adversarial, sequential, fork)
- Parent cleanup after completion and after cancellation
- Child mailbox cleanup via Drop
- Fan-out + fork collection loop abort with uncooperative executor
- No-router graceful degradation
- Parent forcibly unregistered mid-execution
- Caller pre-registered parent coexistence (same + different run_id)
- `register_if_absent` semantics

All 5772 existing tests pass. Clippy clean. No new dependencies.