### PR TITLE
feat(runtime): approval checkpoint persistence + compaction telemetry

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -254,6 +254,9 @@ impl AgenticLoopHost for CliAgenticLoopHost<'_> {
         // Restore previous sandbox policy after the turn.
         self.executor.sandbox_policy = prev_sandbox;
 
+        // Sync latest approval overrides into state for checkpoint persistence.
+        state.approval_overrides = self.perm_manager.export_session_overrides();
+
         let turn_result = turn_result?;
 
         Ok(HostTurnResult {

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -311,6 +311,9 @@ pub(crate) async fn stream_chat_sse(
     let parent_perm_mode = p.perm_manager.mode();
     let parent_cancel_token = p.cancel_token.clone();
 
+    // Snapshot approval overrides for checkpoint persistence.
+    let initial_approval_overrides = p.perm_manager.export_session_overrides();
+
     // ─── Build host + state ──────────────────────────────────────────────
     let mut host = CliAgenticLoopHost {
         api: p.api,
@@ -576,7 +579,7 @@ pub(crate) async fn stream_chat_sse(
         recent_tactical_actions: Vec::new(),
         server_tool_executor: None,
         interruption: None,
-        approval_overrides: None,
+        approval_overrides: initial_approval_overrides,
         confidence_trend: Default::default(),
         last_confidence_diagnosis: None,
     };

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -576,6 +576,7 @@ pub(crate) async fn stream_chat_sse(
         recent_tactical_actions: Vec::new(),
         server_tool_executor: None,
         interruption: None,
+        approval_overrides: None,
         confidence_trend: Default::default(),
         last_confidence_diagnosis: None,
     };

--- a/rust/crates/astra-cli/src/cli/delegate_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/delegate_subrun.rs
@@ -385,6 +385,7 @@ impl SubRunExecutor for CliDelegateSubRunExecutor {
             recent_tactical_actions: Vec::new(),
             server_tool_executor: None,
             interruption: None,
+            approval_overrides: None,
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         };

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -1412,6 +1412,23 @@ impl PermissionManager {
         }
         out
     }
+
+    /// Merge restored approval overrides from a checkpoint into this session.
+    /// Existing live overrides take priority (session-priority merge).
+    pub(super) fn merge_restored_overrides(&mut self, json: &serde_json::Value) {
+        self.session_overrides.merge_from_json(json);
+    }
+
+    /// Export session overrides as a `FingerprintedOverrides` clone for checkpoint persistence.
+    pub(super) fn export_session_overrides(
+        &self,
+    ) -> Option<astra_runtime::turn::approval_fingerprint::FingerprintedOverrides> {
+        if self.session_overrides.is_empty() {
+            None
+        } else {
+            Some(self.session_overrides.clone())
+        }
+    }
 }
 
 /// Result of a non-blocking permission check.

--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -1901,6 +1901,8 @@ fn build_manual_heavy_step_checkpoint(
         delegation_pattern: None,
         delegation_sub_run_summaries: Vec::new(),
         interruption: None,
+        approval_overrides: None,
+        consecutive_context_window_errors: 0,
     };
     StepCheckpoint::Heavy(Box::new(heavy))
 }

--- a/rust/crates/astra-cli/src/cli/self_command.rs
+++ b/rust/crates/astra-cli/src/cli/self_command.rs
@@ -2309,6 +2309,7 @@ fn event_type_name(event_type: &JournalEventType) -> String {
         JournalEventType::AdaptiveTuningRuleTriggered => "adaptive_tuning_rule_triggered",
         JournalEventType::InterruptionRecorded => "interruption_recorded",
         JournalEventType::ConfidenceDiagnosisRecorded => "confidence_diagnosis_recorded",
+        JournalEventType::CompactionRetry => "compaction_retry",
     }
     .to_string()
 }

--- a/rust/crates/astra-cli/src/cli/skill_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/skill_subrun.rs
@@ -554,6 +554,7 @@ impl SkillSubRunExecutor for CliSkillSubRunExecutor {
             recent_tactical_actions: Vec::new(),
             server_tool_executor: None,
             interruption: None,
+            approval_overrides: None,
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         };

--- a/rust/crates/astra-cli/src/cli/slash_session.rs
+++ b/rust/crates/astra-cli/src/cli/slash_session.rs
@@ -1787,6 +1787,30 @@ pub(super) fn handle_session_command(arg: &str, state: &mut ReplState) {
                                     tier,
                                 );
                             }
+                            session_journal::JournalEventType::CompactionRetry => {
+                                let retry_count = evt
+                                    .metadata
+                                    .as_ref()
+                                    .and_then(|m| m.get("compaction"))
+                                    .and_then(|v| v.get("retry_count"))
+                                    .and_then(|v| v.as_u64())
+                                    .unwrap_or(0);
+                                let tokens_freed = evt
+                                    .metadata
+                                    .as_ref()
+                                    .and_then(|m| m.get("compaction"))
+                                    .and_then(|v| v.get("tokens_freed"))
+                                    .and_then(|v| v.as_u64())
+                                    .unwrap_or(0);
+                                eprintln!(
+                                    "  {} {} T{} compaction retry #{} (freed {} tokens)",
+                                    ts_short.dim(),
+                                    "🗜️",
+                                    evt.turn.unwrap_or(0),
+                                    retry_count,
+                                    tokens_freed,
+                                );
+                            }
                         }
                     }
                     // Summary stats

--- a/rust/crates/astra-cli/src/cli/slash_session.rs
+++ b/rust/crates/astra-cli/src/cli/slash_session.rs
@@ -1803,9 +1803,8 @@ pub(super) fn handle_session_command(arg: &str, state: &mut ReplState) {
                                     .and_then(|v| v.as_u64())
                                     .unwrap_or(0);
                                 eprintln!(
-                                    "  {} {} T{} compaction retry #{} (freed {} tokens)",
+                                    "  {} 🗜️ T{} compaction retry #{} (freed {} tokens)",
                                     ts_short.dim(),
-                                    "🗜️",
                                     evt.turn.unwrap_or(0),
                                     retry_count,
                                     tokens_freed,

--- a/rust/crates/astra-cli/src/cli/slash_session.rs
+++ b/rust/crates/astra-cli/src/cli/slash_session.rs
@@ -4732,6 +4732,10 @@ pub(super) async fn handle_resume_command(arg: &str, profile: Option<&str>, stat
                         state.resume_guidance = Some(guidance);
                     }
                 }
+                // Restore approval overrides so previously-approved tools stay approved.
+                if let Some(ref ao_json) = step_restored.approval_overrides {
+                    state.perm_manager.merge_restored_overrides(ao_json);
+                }
                 eprintln!("  {} {}", "↻".cyan(), summary.dim());
             } else if let Ok(Some(heavy)) =
                 astra_runtime::pipeline::step_checkpoint::read_latest_heavy_checkpoint(

--- a/rust/crates/astra-cli/src/cli/spawn_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/spawn_subrun.rs
@@ -281,6 +281,7 @@ impl SpawnAgentExecutor for CliSpawnAgentExecutor {
             recent_tactical_actions: Vec::new(),
             server_tool_executor: None,
             interruption: None,
+            approval_overrides: None,
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         };

--- a/rust/crates/runtime/src/messaging/e2e_loop_tests.rs
+++ b/rust/crates/runtime/src/messaging/e2e_loop_tests.rs
@@ -200,6 +200,7 @@ mod tests {
             recent_tactical_actions: Vec::new(),
             server_tool_executor: None,
             interruption: None,
+            approval_overrides: None,
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         }

--- a/rust/crates/runtime/src/pipeline/mo_persistence.rs
+++ b/rust/crates/runtime/src/pipeline/mo_persistence.rs
@@ -108,6 +108,8 @@ impl MatrixOneCheckpointWriter {
                     delegation_pattern: None,
                     delegation_sub_run_summaries: Vec::new(),
                     interruption: None,
+                    approval_overrides: None,
+                    consecutive_context_window_errors: 0,
                 };
                 StepCheckpoint::Heavy(Box::new(heavy))
             }
@@ -596,6 +598,8 @@ mod tests {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         };
         let cp = StepCheckpoint::Heavy(Box::new(heavy));
         let json = serde_json::to_string(&cp).unwrap();

--- a/rust/crates/runtime/src/pipeline/step_checkpoint.rs
+++ b/rust/crates/runtime/src/pipeline/step_checkpoint.rs
@@ -476,6 +476,8 @@ mod tests {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         }
     }
 

--- a/rust/crates/runtime/src/pipeline/step_protocol.rs
+++ b/rust/crates/runtime/src/pipeline/step_protocol.rs
@@ -838,6 +838,15 @@ pub struct HeavyCheckpoint {
     /// context overflow, cancellation, etc.).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interruption: Option<serde_json::Value>,
+    /// Serialized approval overrides (FingerprintedOverrides) for session continuity.
+    /// When restored, merged into the live PermissionManager so approval decisions
+    /// survive session restarts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_overrides: Option<serde_json::Value>,
+    /// Consecutive context-window errors counter for compaction tier escalation.
+    /// Persisted so aggressive-tier compaction survives session resume.
+    #[serde(default)]
+    pub consecutive_context_window_errors: u32,
 }
 
 /// Unified checkpoint type (stored in Step)
@@ -955,6 +964,8 @@ impl StepCheckpoint {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         }))
     }
 
@@ -2926,6 +2937,8 @@ mod tests {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         }));
         let err = cp.validate().unwrap_err();
         assert!(matches!(err, ProtocolError::CheckpointCorrupt(_)));
@@ -2957,6 +2970,8 @@ mod tests {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         }));
         assert!(cp.validate().is_ok());
     }

--- a/rust/crates/runtime/src/pipeline/step_recorder.rs
+++ b/rust/crates/runtime/src/pipeline/step_recorder.rs
@@ -557,10 +557,13 @@ impl StepRecorder {
             blocked_tools,
             recent_tools,
             None,
+            None,
+            0,
         )
     }
 
-    /// Build a heavy checkpoint, optionally including a structured interruption record.
+    /// Build a heavy checkpoint, optionally including a structured interruption record
+    /// and approval overrides for session continuity.
     pub fn build_heavy_checkpoint_with_interruption(
         &self,
         messages: &[serde_json::Value],
@@ -569,6 +572,8 @@ impl StepRecorder {
         blocked_tools: &[String],
         recent_tools: &[String],
         interruption: Option<serde_json::Value>,
+        approval_overrides: Option<serde_json::Value>,
+        consecutive_context_window_errors: u32,
     ) -> Option<HeavyCheckpoint> {
         let light = self.build_light_checkpoint()?;
         Some(HeavyCheckpoint {
@@ -587,6 +592,8 @@ impl StepRecorder {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption,
+            approval_overrides,
+            consecutive_context_window_errors,
         })
     }
 

--- a/rust/crates/runtime/src/pipeline/step_restore.rs
+++ b/rust/crates/runtime/src/pipeline/step_restore.rs
@@ -54,6 +54,11 @@ pub struct RestoredSession {
     /// point. When present, describes why the previous run was interrupted and
     /// what the caller should do to resume (e.g., wait, compact, intervene).
     pub interruption: Option<serde_json::Value>,
+    /// Serialized approval overrides restored from checkpoint.
+    /// The caller should merge these into PermissionManager on resume.
+    pub approval_overrides: Option<serde_json::Value>,
+    /// Consecutive context-window errors counter restored from checkpoint.
+    pub consecutive_context_window_errors: u32,
 }
 
 /// Error types for session restore.
@@ -137,6 +142,8 @@ fn build_restored_session(
         completed_tool_results: completed_results,
         learning_snapshot_id: heavy.learning_snapshot_id,
         interruption: heavy.interruption,
+        approval_overrides: heavy.approval_overrides,
+        consecutive_context_window_errors: heavy.consecutive_context_window_errors,
     }))
 }
 
@@ -375,6 +382,8 @@ mod tests {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         }
     }
 
@@ -472,6 +481,8 @@ mod tests {
             completed_tool_results: HashMap::new(),
             learning_snapshot_id: None,
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         };
 
         let summary = restore_summary(&restored);

--- a/rust/crates/runtime/src/pipeline/step_restore.rs
+++ b/rust/crates/runtime/src/pipeline/step_restore.rs
@@ -268,7 +268,7 @@ pub fn restore_summary(restored: &RestoredSession) -> String {
         .values()
         .map(|v| v.len())
         .sum();
-    format!(
+    let mut s = format!(
         "Restored session: turn={}, messages={}, cache={} entries, \
          completed_tools={}, blocked={}, budget_tokens={}, budget_rounds={}",
         restored.resume_turn,
@@ -278,7 +278,17 @@ pub fn restore_summary(restored: &RestoredSession) -> String {
         restored.blocked_tools.len(),
         restored.budget_remaining_tokens,
         restored.budget_remaining_rounds,
-    )
+    );
+    if restored.consecutive_context_window_errors > 0 {
+        s.push_str(&format!(
+            ", ctx_window_errors={}",
+            restored.consecutive_context_window_errors
+        ));
+    }
+    if restored.approval_overrides.is_some() {
+        s.push_str(", approval_overrides=yes");
+    }
+    s
 }
 
 /// Validate and convert raw event payloads into structured tool completion records.

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -916,6 +916,7 @@ impl AgenticRunLifecycleService {
             recent_tactical_actions: Vec::new(),
             server_tool_executor: None,
             interruption: None,
+            approval_overrides: None,
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         }
@@ -1969,6 +1970,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
             recent_tactical_actions: Vec::new(),
             server_tool_executor: None,
             interruption: None,
+            approval_overrides: None,
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         };

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -1607,6 +1607,7 @@ mod tests {
             recent_tactical_actions: Vec::new(),
             server_tool_executor: None,
             interruption: None,
+            approval_overrides: None,
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         }

--- a/rust/crates/runtime/src/server/server_skill_subrun.rs
+++ b/rust/crates/runtime/src/server/server_skill_subrun.rs
@@ -338,6 +338,7 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
             recent_tactical_actions: Vec::new(),
             server_tool_executor: None,
             interruption: None,
+            approval_overrides: None,
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         };

--- a/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
@@ -171,6 +171,33 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                             ),
                         );
                     }
+
+                    // Emit structured compaction telemetry for observability.
+                    if let Some(sid) = state.current_session_id.as_deref() {
+                        let turn = (state.max_turns - state.remaining_turns) as u32;
+                        let tokens_freed = result.pipeline_outcome.total_tokens_freed;
+                        let budget_likely_satisfied = result.budget_likely_satisfied;
+                        let layers: Vec<(String, u64)> = result
+                            .pipeline_outcome
+                            .layer_results
+                            .iter()
+                            .map(|(name, cr)| (name.clone(), cr.estimated_tokens_freed))
+                            .collect();
+                        let evt = astra_services::session_journal::JournalEvent::compaction_retry(
+                            Some(sid),
+                            turn,
+                            tier_label,
+                            tokens_freed,
+                            budget_likely_satisfied,
+                            state.consecutive_context_window_errors,
+                            layers,
+                        );
+                        if let Ok(writer) = astra_services::session_journal::JournalWriter::new(sid)
+                        {
+                            let _ = writer.append(&evt);
+                        }
+                    }
+
                     try_write_heavy_checkpoint(state);
                     return Ok(TurnExecutionControl::ContinueLoop);
                 }

--- a/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
@@ -191,6 +191,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                             budget_likely_satisfied,
                             state.consecutive_context_window_errors,
                             layers,
+                            state.consecutive_context_window_errors,
                         );
                         if let Ok(writer) = astra_services::session_journal::JournalWriter::new(sid)
                         {

--- a/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
@@ -216,6 +216,12 @@ pub(crate) fn try_write_heavy_checkpoint(state: &mut AgenticLoopState) {
         .as_ref()
         .and_then(|ir| serde_json::to_value(ir).ok());
 
+    // Serialize approval overrides (if any) for session continuity.
+    let approval_overrides_json = state
+        .approval_overrides
+        .as_ref()
+        .and_then(|ao| ao.to_json());
+
     let Some(heavy) = state
         .step_recorder
         .build_heavy_checkpoint_with_interruption(
@@ -231,6 +237,8 @@ pub(crate) fn try_write_heavy_checkpoint(state: &mut AgenticLoopState) {
                 .collect::<Vec<_>>(),
             &state.recent_tools,
             interruption_json,
+            approval_overrides_json,
+            state.consecutive_context_window_errors,
         )
     else {
         return;

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -708,6 +708,11 @@ pub struct AgenticLoopState {
     /// interruption context for structured resumption.
     pub interruption: Option<super::interruption::InterruptionRecord>,
 
+    // ── Approval checkpoint persistence ──
+    /// Approval overrides synchronized from CLI's PermissionManager before each turn.
+    /// Written to HeavyCheckpoint so approval decisions survive session restarts.
+    pub approval_overrides: Option<super::approval_fingerprint::FingerprintedOverrides>,
+
     // ── Confidence tracking ──
     /// Tracks selector confidence trends across turns to detect floor loops.
     pub confidence_trend: super::confidence_contract::ConfidenceTrendTracker,
@@ -1145,6 +1150,7 @@ pub(crate) mod tests {
             recent_tactical_actions: Vec::new(),
             server_tool_executor: None,
             interruption: None,
+            approval_overrides: None,
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         }

--- a/rust/crates/runtime/src/turn/approval_fingerprint.rs
+++ b/rust/crates/runtime/src/turn/approval_fingerprint.rs
@@ -212,7 +212,7 @@ fn path_pattern_matches(pattern: &str, candidate: &str) -> bool {
 // ─── Denial Tracking ─────────────────────────────────────────────────────────
 
 /// Limits for denial tracking (inspired by Claude Code's `denialTracking.ts`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DenialLimits {
     /// Max consecutive denials for the same fingerprint before fallback.
     pub max_consecutive: u32,
@@ -238,7 +238,7 @@ impl Default for DenialLimits {
 ///
 /// Phase C: Also records denial reasons and fingerprint details to
 /// auto-generate session deny rules when patterns repeat.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct DenialTracker {
     /// Per-fingerprint consecutive denial count.
     consecutive: HashMap<u64, u32>,
@@ -401,7 +401,7 @@ impl DenialTracker {
 /// Replaces the previous `HashMap<String, bool>` (tool-name-only) with
 /// fingerprint-aware matching that distinguishes between different commands
 /// and paths for the same tool.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct FingerprintedOverrides {
     /// Ordered list of (fingerprint, allowed) rules, checked in insertion order.
     rules: Vec<(ApprovalFingerprint, bool)>,
@@ -459,6 +459,31 @@ impl FingerprintedOverrides {
     /// Iterate over all stored overrides.
     pub fn iter(&self) -> impl Iterator<Item = &(ApprovalFingerprint, bool)> {
         self.rules.iter()
+    }
+
+    /// Serialize to JSON for checkpoint persistence.
+    /// Returns `None` if there are no overrides to persist.
+    #[must_use]
+    pub fn to_json(&self) -> Option<serde_json::Value> {
+        if self.rules.is_empty() {
+            return None;
+        }
+        serde_json::to_value(self).ok()
+    }
+
+    /// Merge overrides restored from a checkpoint.
+    /// Session-priority merge: existing (live) overrides take precedence over
+    /// restored ones, so a user who changed their mind mid-session wins.
+    pub fn merge_from_json(&mut self, json: &serde_json::Value) {
+        let Ok(restored) = serde_json::from_value::<FingerprintedOverrides>(json.clone()) else {
+            return;
+        };
+        for (fp, allowed) in restored.rules {
+            // Only insert if no live override already covers this fingerprint.
+            if self.check(&fp).is_none() {
+                self.rules.push((fp, allowed));
+            }
+        }
     }
 }
 
@@ -679,5 +704,62 @@ mod tests {
 
         tracker.reset();
         assert!(tracker.extract_auto_deny_rules().is_empty());
+    }
+
+    #[test]
+    fn fingerprinted_overrides_roundtrip_json() {
+        let mut overrides = FingerprintedOverrides::default();
+        overrides.insert(
+            ApprovalFingerprint::shell("bash", "git commit -m 'wip'", false),
+            true,
+        );
+        overrides.insert(
+            ApprovalFingerprint::file_op("write_file", Some("src/main.rs")),
+            false,
+        );
+
+        let json = overrides.to_json().expect("non-empty should serialize");
+        let mut restored = FingerprintedOverrides::default();
+        restored.merge_from_json(&json);
+
+        assert_eq!(restored.len(), 2);
+        let git_fp = ApprovalFingerprint::shell("bash", "git commit -m 'test'", false);
+        assert_eq!(restored.check(&git_fp), Some(true));
+    }
+
+    #[test]
+    fn fingerprinted_overrides_empty_returns_none() {
+        let overrides = FingerprintedOverrides::default();
+        assert!(overrides.to_json().is_none());
+    }
+
+    #[test]
+    fn merge_from_json_does_not_overwrite_existing() {
+        let mut live = FingerprintedOverrides::default();
+        live.insert(ApprovalFingerprint::bare("bash"), false); // denied in live session
+
+        let mut checkpoint = FingerprintedOverrides::default();
+        checkpoint.insert(ApprovalFingerprint::bare("bash"), true); // allowed in checkpoint
+        let json = checkpoint.to_json().unwrap();
+
+        live.merge_from_json(&json);
+        // Live (deny) wins over checkpoint (allow).
+        let fp = ApprovalFingerprint::shell("bash", "ls", true);
+        assert_eq!(live.check(&fp), Some(false));
+    }
+
+    #[test]
+    fn denial_tracker_roundtrip_json() {
+        let mut tracker = DenialTracker::with_limits(DenialLimits {
+            max_consecutive: 3,
+            max_total: 10,
+        });
+        let fp = ApprovalFingerprint::bare("bash");
+        tracker.record(&fp, false);
+        tracker.record(&fp, false);
+
+        let json = serde_json::to_value(&tracker).unwrap();
+        let restored: DenialTracker = serde_json::from_value(json).unwrap();
+        assert_eq!(restored.total_denials(), 2);
     }
 }

--- a/rust/crates/runtime/src/turn/loop_dispatcher.rs
+++ b/rust/crates/runtime/src/turn/loop_dispatcher.rs
@@ -321,6 +321,7 @@ mod tests {
             recent_tactical_actions: Vec::new(),
             server_tool_executor: None,
             interruption: None,
+            approval_overrides: None,
             confidence_trend: Default::default(),
             last_confidence_diagnosis: None,
         }

--- a/rust/crates/runtime/tests/improvement_proofs.rs
+++ b/rust/crates/runtime/tests/improvement_proofs.rs
@@ -4993,6 +4993,8 @@ mod file_event_store_proofs {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         };
         let ckpt = StepCheckpoint::Heavy(Box::new(heavy));
         write_step_checkpoint(&sid, 1, &ckpt).unwrap();
@@ -6141,6 +6143,8 @@ mod crash_recovery_proofs {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         };
 
         // Serialize → deserialize roundtrip
@@ -6187,6 +6191,8 @@ mod crash_recovery_proofs {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         };
 
         // Simulate: slots 0,1 completed; slot 2 failed; slot 3 running; slot 4 pending
@@ -6302,6 +6308,8 @@ mod crash_recovery_proofs {
             completed_tool_results: completed,
             learning_snapshot_id: Some("snap-xyz".to_string()),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         };
 
         let summary = restore_summary(&restored);
@@ -6339,6 +6347,8 @@ mod crash_recovery_proofs {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         };
 
         // Strict should reject
@@ -7020,6 +7030,8 @@ mod checkpoint_cloud_persistence_proofs {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         }
     }
 
@@ -7142,6 +7154,8 @@ mod checkpoint_cloud_persistence_proofs {
             delegation_pattern: None,
             delegation_sub_run_summaries: Vec::new(),
             interruption: None,
+            approval_overrides: None,
+            consecutive_context_window_errors: 0,
         }));
         let json = serde_json::to_string(&cp).unwrap();
         let restored: StepCheckpoint = serde_json::from_str(&json).unwrap();

--- a/rust/crates/services/src/self_surface.rs
+++ b/rust/crates/services/src/self_surface.rs
@@ -2137,6 +2137,7 @@ fn event_type_name(event_type: &JournalEventType) -> String {
         JournalEventType::AdaptiveTuningRuleTriggered => "adaptive_tuning_rule_triggered",
         JournalEventType::InterruptionRecorded => "interruption_recorded",
         JournalEventType::ConfidenceDiagnosisRecorded => "confidence_diagnosis_recorded",
+        JournalEventType::CompactionRetry => "compaction_retry",
     }
     .to_string()
 }

--- a/rust/crates/services/src/session_journal.rs
+++ b/rust/crates/services/src/session_journal.rs
@@ -2606,6 +2606,7 @@ impl JournalEvent {
         budget_likely_satisfied: bool,
         retry_count: u32,
         layers: Vec<(String, u64)>,
+        consecutive_context_window_errors: u32,
     ) -> Self {
         let mut evt = Self::base(JournalEventType::CompactionRetry, session_id);
         evt.turn = Some(turn);
@@ -2615,6 +2616,7 @@ impl JournalEvent {
                 "tokens_freed": tokens_freed,
                 "budget_likely_satisfied": budget_likely_satisfied,
                 "retry_count": retry_count,
+                "consecutive_context_window_errors": consecutive_context_window_errors,
                 "layers": layers.iter().map(|(name, freed)| {
                     serde_json::json!({ "name": name, "tokens_freed": freed })
                 }).collect::<Vec<_>>(),

--- a/rust/crates/services/src/session_journal.rs
+++ b/rust/crates/services/src/session_journal.rs
@@ -741,6 +741,8 @@ pub enum JournalEventType {
     InterruptionRecorded,
     /// Low or very-low selector confidence diagnosed (tier, reasons, fallback action).
     ConfidenceDiagnosisRecorded,
+    /// Compaction retry completed — records tier, tokens freed, and per-layer breakdown.
+    CompactionRetry,
 }
 
 /// Writer that appends events to a session journal file.
@@ -2587,6 +2589,36 @@ impl JournalEvent {
         evt.selector_confidence = Some(confidence);
         evt.metadata = Some(serde_json::json!({
             "confidence_diagnosis": diagnosis_json,
+        }));
+        evt
+    }
+
+    /// Build a compaction retry telemetry event.
+    ///
+    /// Emitted after a successful compaction retry to capture operational metrics:
+    /// tier escalation, tokens freed, budget satisfaction, and per-layer breakdown.
+    #[allow(clippy::too_many_arguments)]
+    pub fn compaction_retry(
+        session_id: Option<&str>,
+        turn: u32,
+        tier: &str,
+        tokens_freed: u64,
+        budget_likely_satisfied: bool,
+        retry_count: u32,
+        layers: Vec<(String, u64)>,
+    ) -> Self {
+        let mut evt = Self::base(JournalEventType::CompactionRetry, session_id);
+        evt.turn = Some(turn);
+        evt.metadata = Some(serde_json::json!({
+            "compaction": {
+                "tier": tier,
+                "tokens_freed": tokens_freed,
+                "budget_likely_satisfied": budget_likely_satisfied,
+                "retry_count": retry_count,
+                "layers": layers.iter().map(|(name, freed)| {
+                    serde_json::json!({ "name": name, "tokens_freed": freed })
+                }).collect::<Vec<_>>(),
+            }
         }));
         evt
     }


### PR DESCRIPTION
## Summary

Resilience phase 2: adds approval override persistence through checkpoints and compaction telemetry journal events.

### Changes

**Approval checkpoint persistence:**
- Add `Serialize`/`Deserialize` to `FingerprintedOverrides`, `DenialTracker`, `DenialLimits`
- Add `to_json()`/`merge_from_json()` to `FingerprintedOverrides` for session-priority merge (live overrides win over restored)
- Persist `approval_overrides` (`Option<serde_json::Value>`) and `consecutive_context_window_errors` (`u32`) through `HeavyCheckpoint` → `RestoredSession` → `AgenticLoopState`
- Wire serialization in `try_write_heavy_checkpoint()` and restoration in `build_restored_session()`
- Updated all 24 construction sites across runtime, CLI, and test files

**Compaction telemetry:**
- Add `CompactionRetry` journal event type with tier, tokens_freed, budget_likely_satisfied, retry_count, layers
- Wire compaction telemetry emission in execution phase after successful compaction retry
- Add `CompactionRetry` display in `slash_session` timeline (retry count + tokens freed)

### Motivation

When sessions resume from checkpoints, approval overrides were previously lost, forcing users to re-approve previously-approved tools. This change persists approval state through the checkpoint lifecycle.

Compaction retry events were previously silent — operators had no visibility into whether compaction was effective. The new journal event enables correlation of compaction attempts with downstream budget satisfaction.

### Testing

All existing tests pass:
- `astra-services`: ✅
- `astra-runtime`: 293 tests ✅ (including 4 new approval fingerprint roundtrip tests)
- `astra-cli`: 2504 tests ✅

Follows up on PR #50 (proactive resilience hardening).