### PR TITLE
refactor: extract astra-pipeline crate (Phase 1)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -223,10 +223,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "astra-pipeline"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "astra-runtime"
 version = "0.1.0"
 dependencies = [
  "astra-core",
+ "astra-pipeline",
  "astra-services",
  "astra-thin-client",
  "astra-tools",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/astra-admin",
     "crates/astra-thin-client",
     "crates/astra-edge",
+    "crates/astra-pipeline",
 ]
 resolver = "2"
 
@@ -17,6 +18,7 @@ edition = "2024"
 
 [workspace.dependencies]
 astra-core = { path = "crates/core" }
+astra-pipeline = { path = "crates/astra-pipeline" }
 astra-tools = { path = "crates/astra-tools" }
 astra-services = { path = "crates/services" }
 astra-runtime = { path = "crates/runtime" }

--- a/rust/crates/astra-pipeline/Cargo.toml
+++ b/rust/crates/astra-pipeline/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-pipeline"
+version.workspace = true
+edition = "2021"
+description = "Astra agent learning pipeline — calibration, routing, patterns"
+license = "MIT"
+
+[features]
+default = []
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]

--- a/rust/crates/astra-pipeline/src/lib.rs
+++ b/rust/crates/astra-pipeline/src/lib.rs
@@ -1,0 +1,15 @@
+//! Astra Agent Learning Pipeline — Core Types
+//!
+//! This crate provides the foundational types for the agent's learning subsystem:
+//! - `TaskType` — 8-way task classification
+//! - `DomainHint` — 7 domain categories
+//! - `ToolFilter` — tool selection strategy
+//! - `CalibrationAxis` — calibration targeting
+//!
+//! The full calibration implementation lives in `astra-runtime::pipeline::calibration`.
+
+#![allow(clippy::too_many_arguments)]
+
+pub mod routing;
+
+pub use routing::{CalibrationAxis, DomainHint, TaskType, ToolFilter, domain_hint_to_label};

--- a/rust/crates/astra-pipeline/src/routing.rs
+++ b/rust/crates/astra-pipeline/src/routing.rs
@@ -1,0 +1,88 @@
+//! Unified Routing Decision — task types and domain hints.
+//!
+//! Core types for routing analysis:
+//! - `TaskType` — 8 task classifications
+//! - `DomainHint` — 7 domain categories
+//! - `ToolFilter` — tool selection strategy
+
+use serde::{Deserialize, Serialize};
+
+// ─── Task Type ───────────────────────────────────────────────────────────────
+
+/// Enriched task classification — 8 types for precise routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TaskType {
+    /// Code editing, generation, or file manipulation.
+    Code,
+    /// Analysis, explanation, comparison.
+    Reasoning,
+    /// Read-only data retrieval (list PRs, show status, etc.)
+    Fetch,
+    /// Create/update/delete operations.
+    Mutate,
+    /// Store or retrieve user preferences (关注/跟踪/bookmark).
+    Memory,
+    /// Greeting, chit-chat, simple questions.
+    Conversational,
+    /// Multiple task types combined (e.g., "show me PRs and fix the failing one").
+    Compound,
+    /// Cannot determine task type.
+    Unknown,
+}
+
+impl Default for TaskType {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+// ─── Domain Hint ─────────────────────────────────────────────────────────────
+
+/// Domain extracted from signals + memory hints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum DomainHint {
+    GitHub,
+    Git,
+    Code,
+    Memory,
+    Web,
+    System,
+    Database,
+}
+
+/// JSON / journal label for [`DomainHint`].
+#[must_use]
+pub fn domain_hint_to_label(d: DomainHint) -> &'static str {
+    match d {
+        DomainHint::GitHub => "github",
+        DomainHint::Git => "git",
+        DomainHint::Code => "code",
+        DomainHint::Memory => "memory",
+        DomainHint::Web => "web",
+        DomainHint::System => "system",
+        DomainHint::Database => "database",
+    }
+}
+
+// ─── Tool Filter ─────────────────────────────────────────────────────────────
+
+/// Recommended tool selection strategy based on routing analysis.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ToolFilter {
+    /// Low confidence → include all tools, let LLM decide.
+    Wide,
+    /// Domain-focused → filter to specific tool categories.
+    Domain(Vec<String>),
+    /// Conversational → minimal tools (only pinned).
+    Minimal,
+}
+
+// ─── Calibration Axis ────────────────────────────────────────────────────────
+
+/// Which axis a calibration adjustment targets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CalibrationAxis {
+    Intent(String),
+    Domain(DomainHint),
+    Task(TaskType),
+}

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -31,6 +31,7 @@ path = "src/main.rs"
 dirs = "6.0.0"
 fastrand = "2"
 astra-core.workspace = true
+astra-pipeline.workspace = true
 astra-services.workspace = true
 astra-tools.workspace = true
 astra-thin-client.workspace = true

--- a/rust/crates/runtime/src/evolution/types.rs
+++ b/rust/crates/runtime/src/evolution/types.rs
@@ -3,6 +3,9 @@
 use crate::pipeline::routing::{DomainHint, TaskType};
 use crate::turn::action_compensation::FailureCategory;
 
+// Re-export CalibrationAxis from pipeline::routing (defined in astra-pipeline)
+pub use crate::pipeline::routing::CalibrationAxis;
+
 // ── Signals ──
 
 /// A typed evolution signal detected from runtime events.
@@ -147,13 +150,6 @@ pub enum PatternAction {
     Demote,
     Boost,
     Block,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub enum CalibrationAxis {
-    Intent(String),
-    Domain(DomainHint),
-    Task(TaskType),
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/rust/crates/runtime/src/pipeline/calibration.rs
+++ b/rust/crates/runtime/src/pipeline/calibration.rs
@@ -37,8 +37,7 @@
 //! );
 //! ```
 
-use super::routing::{DomainHint, TaskType};
-use crate::evolution::types::CalibrationAxis;
+use super::routing::{CalibrationAxis, DomainHint, TaskType};
 use std::collections::HashMap;
 
 /// Get current Unix timestamp in seconds.

--- a/rust/crates/runtime/src/pipeline/routing.rs
+++ b/rust/crates/runtime/src/pipeline/routing.rs
@@ -28,69 +28,10 @@
 use crate::tool_registry::state::ConversationState;
 use crate::turn::routing_metrics::{DisambiguationAction, IntentDisambiguation};
 
-// ─── Task Type ───────────────────────────────────────────────────────────────
-
-/// Enriched task classification — 7 types vs. the old 3 (code/reasoning/None).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub enum TaskType {
-    /// Code editing, generation, or file manipulation.
-    Code,
-    /// Analysis, explanation, comparison.
-    Reasoning,
-    /// Read-only data retrieval (list PRs, show status, etc.)
-    Fetch,
-    /// Create/update/delete operations.
-    Mutate,
-    /// Store or retrieve user preferences (关注/跟踪/bookmark).
-    Memory,
-    /// Greeting, chit-chat, simple questions.
-    Conversational,
-    /// Multiple task types combined (e.g., "show me PRs and fix the failing one").
-    Compound,
-    /// Cannot determine task type.
-    Unknown,
-}
-
-// ─── Domain Hint ─────────────────────────────────────────────────────────────
-
-/// Domain extracted from signals + memory hints.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub enum DomainHint {
-    GitHub,
-    Git,
-    Code,
-    Memory,
-    Web,
-    System,
-    Database,
-}
-
-/// JSON / journal label for [`DomainHint`] (aligned with `pipeline::learning` payloads).
-#[must_use]
-pub fn domain_hint_to_label(d: DomainHint) -> &'static str {
-    match d {
-        DomainHint::GitHub => "github",
-        DomainHint::Git => "git",
-        DomainHint::Code => "code",
-        DomainHint::Memory => "memory",
-        DomainHint::Web => "web",
-        DomainHint::System => "system",
-        DomainHint::Database => "database",
-    }
-}
-
-// ─── Tool Filter ─────────────────────────────────────────────────────────────
-
-/// Recommended tool selection strategy based on routing analysis.
-#[derive(Debug, Clone, PartialEq)]
-pub enum ToolFilter {
-    /// Low confidence → include all tools, let LLM decide.
-    Wide,
-    /// Domain-focused → filter to specific tool categories.
-    Domain(Vec<String>),
-    /// Conversational → minimal tools (only pinned).
-    Minimal,
-}
+// Re-export core types from astra-pipeline
+pub use astra_pipeline::routing::{
+    CalibrationAxis, DomainHint, TaskType, ToolFilter, domain_hint_to_label,
+};
 
 // ─── RoutingDecision ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Phase 1 of the runtime crate refactoring: extract core routing types into `astra-pipeline`.

## Changes

### New crate: `astra-pipeline`

Core routing types that other crates can depend on without pulling in the full 266K LOC runtime:

- `TaskType`: 8-way task classification (Code, Reasoning, Fetch, Mutate, Memory, Conversational, Compound, Unknown)
- `DomainHint`: 7 domain categories (GitHub, Git, Code, Memory, Web, System, Database)
- `ToolFilter`: Tool selection strategy (Wide, Domain, Minimal)
- `CalibrationAxis`: Calibration targeting (Intent, Domain, Task)
- `domain_hint_to_label`: Helper function

### Runtime updates

- Re-exports types from `astra-pipeline` instead of defining them
- Removes duplicate `CalibrationAxis` from `evolution/types.rs`

## Motivation

The runtime crate is 266K LOC with tight coupling. This extraction:
1. Enables other crates (e.g., services) to use routing types without full runtime dependency
2. Sets foundation for further crate splitting (Phase 2: turn-types, Phase 3: skills)
3. Improves incremental compile times

## Testing

- `cargo test --workspace` passes (1961+ tests)
- `cargo build` passes for all workspace members

## LOC Impact

~80 lines moved to new crate, no net increase.