### PR TITLE
fix(pipeline): track unknown tool errors in ToolHealthTracker

### DIFF
--- a/rust/crates/astra-pipeline/src/lib.rs
+++ b/rust/crates/astra-pipeline/src/lib.rs
@@ -12,4 +12,4 @@
 
 pub mod routing;
 
-pub use routing::{CalibrationAxis, DomainHint, TaskType, ToolFilter, domain_hint_to_label};
+pub use routing::{domain_hint_to_label, CalibrationAxis, DomainHint, TaskType, ToolFilter};

--- a/rust/crates/astra-turn-types/src/lib.rs
+++ b/rust/crates/astra-turn-types/src/lib.rs
@@ -7,7 +7,7 @@ mod implicit_feedback;
 mod result_quality;
 
 pub use implicit_feedback::{
-    detect_implicit_feedback_signal, implicit_feedback_context_injection, implicit_feedback_rating,
-    ImplicitSignal,
+    ImplicitSignal, detect_implicit_feedback_signal, implicit_feedback_context_injection,
+    implicit_feedback_rating,
 };
-pub use result_quality::{classify_result, quality_feedback, ResultQuality};
+pub use result_quality::{ResultQuality, classify_result, quality_feedback};

--- a/rust/crates/runtime/src/messaging/orchestrator_mailbox_tests.rs
+++ b/rust/crates/runtime/src/messaging/orchestrator_mailbox_tests.rs
@@ -36,7 +36,10 @@ mod tests {
     }
 
     impl ProgressReportingExecutor {
-        fn new() -> (Self, Arc<tokio::sync::Mutex<Vec<(String, Result<(), String>)>>>) {
+        fn new() -> (
+            Self,
+            Arc<tokio::sync::Mutex<Vec<(String, Result<(), String>)>>>,
+        ) {
             let results = Arc::new(tokio::sync::Mutex::new(Vec::new()));
             (
                 Self {
@@ -87,8 +90,12 @@ mod tests {
 
     fn setup_profiles() -> Arc<RwLock<AgentProfileRegistry>> {
         let mut reg = AgentProfileRegistry::new();
-        reg.register(AgentProfile::new("orch", "Orchestrator", AgentTier::Orchestrator))
-            .unwrap();
+        reg.register(AgentProfile::new(
+            "orch",
+            "Orchestrator",
+            AgentTier::Orchestrator,
+        ))
+        .unwrap();
         reg.register(AgentProfile::new(
             "team-review-producer",
             "Producer",
@@ -401,10 +408,7 @@ mod tests {
             self.gate.wait().await;
 
             let send_result = if let Some(ref mailbox) = config.mailbox {
-                match mailbox
-                    .send_progress(0, 1, "turn_complete", None)
-                    .await
-                {
+                match mailbox.send_progress(0, 1, "turn_complete", None).await {
                     Ok(()) => Ok(()),
                     Err(e) => Err(format!("{e}")),
                 }
@@ -614,9 +618,7 @@ mod tests {
         let cancel_clone = cancel.clone();
         let engine_handle = {
             let engine = h.engine;
-            tokio::spawn(
-                async move { engine.execute(request, "orch", Some(cancel_clone)).await },
-            )
+            tokio::spawn(async move { engine.execute(request, "orch", Some(cancel_clone)).await })
         };
 
         // Give engine time to register parent and spawn agents.
@@ -750,9 +752,7 @@ mod tests {
         let cancel_clone = cancel.clone();
         let engine_handle = {
             let engine = h.engine;
-            tokio::spawn(
-                async move { engine.execute(request, "orch", Some(cancel_clone)).await },
-            )
+            tokio::spawn(async move { engine.execute(request, "orch", Some(cancel_clone)).await })
         };
 
         // Let agents start.
@@ -760,11 +760,7 @@ mod tests {
         cancel.cancel();
 
         // The collection loop should abort tasks and return promptly.
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            engine_handle,
-        )
-        .await;
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), engine_handle).await;
 
         assert!(
             result.is_ok(),
@@ -793,19 +789,13 @@ mod tests {
         let cancel_clone = cancel.clone();
         let engine_handle = {
             let engine = h.engine;
-            tokio::spawn(
-                async move { engine.execute(request, "orch", Some(cancel_clone)).await },
-            )
+            tokio::spawn(async move { engine.execute(request, "orch", Some(cancel_clone)).await })
         };
 
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         cancel.cancel();
 
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            engine_handle,
-        )
-        .await;
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), engine_handle).await;
 
         assert!(
             result.is_ok(),
@@ -829,13 +819,19 @@ mod tests {
         let addr = AgentAddress::new("run-1", "agent-1");
         let result = router.register_if_absent(addr.clone(), None).await;
         assert!(result.is_ok());
-        assert!(result.unwrap().is_some(), "first registration should return Some");
+        assert!(
+            result.unwrap().is_some(),
+            "first registration should return Some"
+        );
 
         // Second registration with same run_id returns None (no clobber).
         let addr2 = AgentAddress::new("run-1", "agent-1");
         let result2 = router.register_if_absent(addr2, None).await;
         assert!(result2.is_ok());
-        assert!(result2.unwrap().is_none(), "second registration should return None");
+        assert!(
+            result2.unwrap().is_none(),
+            "second registration should return None"
+        );
     }
 
     /// register_if_absent with different run_id registers both.
@@ -854,6 +850,9 @@ mod tests {
 
         let addr2 = AgentAddress::new("run-2", "agent-1");
         let r2 = router.register_if_absent(addr2, None).await.unwrap();
-        assert!(r2.is_some(), "different run_id should register successfully");
+        assert!(
+            r2.is_some(),
+            "different run_id should register successfully"
+        );
     }
 }

--- a/rust/crates/runtime/src/messaging/router.rs
+++ b/rust/crates/runtime/src/messaging/router.rs
@@ -403,7 +403,12 @@ impl AgentMailboxRouter {
         // but register() handles re-registration gracefully (overwrites with
         // warning), and in practice the same parent_run_id (UUID) is never
         // registered concurrently.
-        if self.address_registry.read().await.contains_key(&addr.run_id) {
+        if self
+            .address_registry
+            .read()
+            .await
+            .contains_key(&addr.run_id)
+        {
             return Ok(None);
         }
         self.register(addr, delegation_id).await.map(Some)

--- a/rust/crates/runtime/src/pipeline/learning.rs
+++ b/rust/crates/runtime/src/pipeline/learning.rs
@@ -1026,7 +1026,10 @@ mod tests {
         let c = cal.lock().unwrap();
         // Check that calibrator recorded the intent
         let stats = c.intent_stats("code");
-        assert!(stats.is_some(), "calibrator should have recorded intent 'code'");
+        assert!(
+            stats.is_some(),
+            "calibrator should have recorded intent 'code'"
+        );
         assert!(
             stats.unwrap().correction_rate() > 0.0,
             "correction signal should increase correction rate"
@@ -1044,11 +1047,19 @@ mod tests {
             evidence: "terrible".to_string(),
         };
 
-        writer.record_implicit_feedback(&signal, "fetch", Some(DomainHint::GitHub), TaskType::Fetch);
+        writer.record_implicit_feedback(
+            &signal,
+            "fetch",
+            Some(DomainHint::GitHub),
+            TaskType::Fetch,
+        );
 
         let c = cal.lock().unwrap();
         let stats = c.intent_stats("fetch");
-        assert!(stats.is_some(), "calibrator should have recorded intent 'fetch'");
+        assert!(
+            stats.is_some(),
+            "calibrator should have recorded intent 'fetch'"
+        );
         assert!(
             stats.unwrap().correction_rate() > 0.0,
             "frustration signal should increase correction rate"

--- a/rust/crates/runtime/src/turn/approval_fingerprint.rs
+++ b/rust/crates/runtime/src/turn/approval_fingerprint.rs
@@ -665,7 +665,11 @@ mod tests {
 
         let rules = tracker.extract_auto_deny_rules();
         // Should have bare "bash" rule since 3+ different denials
-        assert!(rules.iter().any(|r| r.tool == "bash" && r.pattern.is_none()));
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.tool == "bash" && r.pattern.is_none())
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/cloud_tool_delivery.rs
+++ b/rust/crates/runtime/src/turn/cloud_tool_delivery.rs
@@ -141,9 +141,7 @@ fn parse_cloud_approval_outcome_with_decision(
 }
 
 fn denied_tool_content(reason: Option<&str>) -> String {
-    let mut parts = vec![
-        "The user REJECTED this tool call. The tool was NOT executed.",
-    ];
+    let mut parts = vec!["The user REJECTED this tool call. The tool was NOT executed."];
     let feedback_line;
     if let Some(r) = reason.filter(|s| !s.is_empty()) {
         feedback_line = format!("User feedback: \"{r}\"");

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
@@ -737,14 +737,18 @@ mod tests {
         // First 2 calls should have unknown_tool journal records,
         // 3rd should be a duplicate record.
         assert_eq!(pipeline.ctx.tool_call_records.len(), 3);
-        assert!(pipeline.ctx.tool_call_records[0]
-            .error
-            .as_deref()
-            .is_some_and(|e| e.contains("unknown_tool")));
-        assert!(pipeline.ctx.tool_call_records[1]
-            .error
-            .as_deref()
-            .is_some_and(|e| e.contains("unknown_tool")));
+        assert!(
+            pipeline.ctx.tool_call_records[0]
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("unknown_tool"))
+        );
+        assert!(
+            pipeline.ctx.tool_call_records[1]
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("unknown_tool"))
+        );
         // 3rd record is a dedup, not unknown_tool
         assert!(
             !pipeline.ctx.tool_call_records[2]
@@ -913,16 +917,25 @@ mod tests {
         // execute_execution: ServerToolExecutor doesn't know "outline",
         // returns "Error: Tool 'outline' not available..."
         let executed = pipeline.execute_execution(permitted).await;
-        assert!(executed.is_err, "server executor should return error for unknown tool");
+        assert!(
+            executed.is_err,
+            "server executor should return error for unknown tool"
+        );
 
         // record_execution feeds through append_headless_result_quality_feedback
         // → turn_guard.record_tool_result → health.record_failure
         pipeline.record_execution(executed).await;
 
         let health = pipeline.ctx.turn_guard.health.get("outline");
-        assert!(health.is_some(), "outline should be tracked after server fallback error");
+        assert!(
+            health.is_some(),
+            "outline should be tracked after server fallback error"
+        );
         let h = health.unwrap();
-        assert_eq!(h.total_failures, 1, "server fallback error should count as failure");
+        assert_eq!(
+            h.total_failures, 1,
+            "server fallback error should count as failure"
+        );
         assert_eq!(h.consecutive_failures, 1);
     }
 

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
@@ -574,4 +574,403 @@ mod tests {
             pipeline.ctx.tool_results[0]
         );
     }
+
+    // ── Unknown tool health tracking tests ───────────────────────────
+
+    /// Helper: push a server tool_call JSON for an unknown tool and run validate_slot.
+    fn push_unknown_server_tool_call(harness: &mut PipelineHarness, tool_name: &str) {
+        let idx = harness.tool_calls.len();
+        harness.tool_calls.push(json!({
+            "id": format!("call-{tool_name}-{idx}"),
+            "function": {
+                "name": tool_name,
+                "arguments": "{}"
+            }
+        }));
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_records_health_failure() {
+        let mut harness = PipelineHarness::new();
+        push_unknown_server_tool_call(&mut harness, "outline");
+        let mut pipeline = harness.pipeline();
+
+        let result = pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(0));
+        assert!(
+            matches!(result, HeadlessPipelineStage::ShortCircuit),
+            "unknown tool should short-circuit"
+        );
+
+        // The health tracker must have recorded a failure for "outline".
+        let health = pipeline.ctx.turn_guard.health.get("outline");
+        assert!(health.is_some(), "outline should be tracked");
+        let h = health.unwrap();
+        assert_eq!(h.total_calls, 1);
+        assert_eq!(h.total_failures, 1);
+        assert_eq!(h.consecutive_failures, 1);
+        assert!(!h.deprioritized, "1 failure should not deprioritize yet");
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_deprioritized_after_consecutive_failures() {
+        let mut harness = PipelineHarness::new();
+        // Push 3 calls with different args so dedup doesn't block them.
+        for i in 0..3 {
+            harness.tool_calls.push(json!({
+                "id": format!("call-outline-{i}"),
+                "function": {
+                    "name": "outline",
+                    "arguments": format!("{{\"path\": \"file{i}.rs\"}}")
+                }
+            }));
+        }
+        let mut pipeline = harness.pipeline();
+
+        for i in 0..3 {
+            let result = pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(i));
+            assert!(matches!(result, HeadlessPipelineStage::ShortCircuit));
+        }
+
+        // After 3 consecutive failures, the tool must be deprioritized.
+        let health = pipeline.ctx.turn_guard.health.get("outline").unwrap();
+        assert_eq!(health.consecutive_failures, 3);
+        assert!(
+            health.deprioritized,
+            "outline should be deprioritized after 3 consecutive failures"
+        );
+        assert!(
+            pipeline
+                .ctx
+                .turn_guard
+                .health
+                .deprioritized_tools()
+                .contains(&"outline"),
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_journal_records_error_tag() {
+        let mut harness = PipelineHarness::new();
+        push_unknown_server_tool_call(&mut harness, "nonexistent");
+        let mut pipeline = harness.pipeline();
+
+        pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(0));
+
+        assert_eq!(pipeline.ctx.tool_call_records.len(), 1);
+        let record = &pipeline.ctx.tool_call_records[0];
+        assert_eq!(record.name, "nonexistent");
+        assert!(!record.ok);
+        assert!(
+            record
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("unknown_tool")),
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_error_message_sent_to_llm() {
+        let mut harness = PipelineHarness::new();
+        push_unknown_server_tool_call(&mut harness, "outline");
+        let mut pipeline = harness.pipeline();
+
+        pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(0));
+
+        // The tool result sent back to the LLM should mention "Unknown tool".
+        assert_eq!(pipeline.ctx.tool_results.len(), 1);
+        let result_str = pipeline.ctx.tool_results[0].to_string();
+        assert!(
+            result_str.contains("Unknown tool"),
+            "LLM should see 'Unknown tool' in result, got: {result_str}"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_name_tool_records_health_failure() {
+        let mut harness = PipelineHarness::new();
+        // Push a tool call with empty name.
+        harness.tool_calls.push(json!({
+            "id": "call-empty-0",
+            "function": {
+                "name": "",
+                "arguments": "{}"
+            }
+        }));
+        let mut pipeline = harness.pipeline();
+
+        let result = pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(0));
+        assert!(matches!(result, HeadlessPipelineStage::ShortCircuit));
+
+        // Empty-name tool should also be tracked in health.
+        let health = pipeline.ctx.turn_guard.health.get("");
+        assert!(health.is_some(), "empty-name tool should be tracked");
+        assert_eq!(health.unwrap().total_failures, 1);
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_with_identical_args_blocked_by_dedup_after_limit() {
+        let mut harness = PipelineHarness::new();
+        // Push 3 calls with IDENTICAL args — dedup should block call #3.
+        for i in 0..3 {
+            harness.tool_calls.push(json!({
+                "id": format!("call-outline-{i}"),
+                "function": {
+                    "name": "outline",
+                    "arguments": "{}"
+                }
+            }));
+        }
+        let mut pipeline = harness.pipeline();
+
+        // Call 1: unknown tool error
+        let r1 = pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(0));
+        assert!(matches!(r1, HeadlessPipelineStage::ShortCircuit));
+
+        // Call 2: unknown tool error (count=2, at limit)
+        let r2 = pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(1));
+        assert!(matches!(r2, HeadlessPipelineStage::ShortCircuit));
+
+        // Call 3: should be blocked by dedup (count=3 > limit=2)
+        let r3 = pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(2));
+        assert!(matches!(r3, HeadlessPipelineStage::ShortCircuit));
+
+        // First 2 calls should have unknown_tool journal records,
+        // 3rd should be a duplicate record.
+        assert_eq!(pipeline.ctx.tool_call_records.len(), 3);
+        assert!(pipeline.ctx.tool_call_records[0]
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("unknown_tool")));
+        assert!(pipeline.ctx.tool_call_records[1]
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("unknown_tool")));
+        // 3rd record is a dedup, not unknown_tool
+        assert!(
+            !pipeline.ctx.tool_call_records[2]
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("unknown_tool")),
+            "3rd call should be caught by dedup, not unknown_tool path"
+        );
+
+        // Health should show 2 failures (dedup doesn't add a 3rd failure).
+        let health = pipeline.ctx.turn_guard.health.get("outline").unwrap();
+        assert_eq!(health.total_failures, 2);
+    }
+
+    #[tokio::test]
+    async fn multiple_different_unknown_tools_each_tracked_independently() {
+        let mut harness = PipelineHarness::new();
+        harness.tool_calls.push(json!({
+            "id": "call-outline-0",
+            "function": { "name": "outline", "arguments": "{}" }
+        }));
+        harness.tool_calls.push(json!({
+            "id": "call-foobar-0",
+            "function": { "name": "foobar", "arguments": "{}" }
+        }));
+        harness.tool_calls.push(json!({
+            "id": "call-outline-1",
+            "function": { "name": "outline", "arguments": "{\"path\": \"a.rs\"}" }
+        }));
+        let mut pipeline = harness.pipeline();
+
+        for i in 0..3 {
+            pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(i));
+        }
+
+        let outline_h = pipeline.ctx.turn_guard.health.get("outline").unwrap();
+        assert_eq!(outline_h.consecutive_failures, 2);
+        assert!(!outline_h.deprioritized);
+
+        let foobar_h = pipeline.ctx.turn_guard.health.get("foobar").unwrap();
+        assert_eq!(foobar_h.consecutive_failures, 1);
+        assert!(!foobar_h.deprioritized);
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_deprioritize_warning_generated() {
+        let mut harness = PipelineHarness::new();
+        // 3 calls with different args to avoid dedup, trigger deprioritization.
+        for i in 0..3 {
+            harness.tool_calls.push(json!({
+                "id": format!("call-outline-{i}"),
+                "function": {
+                    "name": "outline",
+                    "arguments": format!("{{\"path\": \"file{i}.rs\"}}")
+                }
+            }));
+        }
+        let mut pipeline = harness.pipeline();
+
+        for i in 0..3 {
+            pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(i));
+        }
+
+        let warning = pipeline.ctx.turn_guard.health.deprioritize_warning();
+        assert!(warning.is_some(), "should generate deprioritize warning");
+        assert!(
+            warning.unwrap().contains("outline"),
+            "warning should mention the deprioritized tool"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_name_abort_round_after_max_consecutive() {
+        let mut harness = PipelineHarness::new();
+        // MAX_CONSECUTIVE_EMPTY_NAME = 3; push 3 empty-name calls.
+        for i in 0..3 {
+            harness.tool_calls.push(json!({
+                "id": format!("call-empty-{i}"),
+                "function": { "name": "", "arguments": "{}" }
+            }));
+        }
+        let mut pipeline = harness.pipeline();
+
+        // First 2 should ShortCircuit (continue processing).
+        let r1 = pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(0));
+        assert!(matches!(r1, HeadlessPipelineStage::ShortCircuit));
+        let r2 = pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(1));
+        assert!(matches!(r2, HeadlessPipelineStage::ShortCircuit));
+
+        // 3rd should AbortRound.
+        let r3 = pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(2));
+        assert!(
+            matches!(r3, HeadlessPipelineStage::AbortRound),
+            "3 consecutive empty-name calls should abort the round"
+        );
+
+        // All 3 should have recorded health failures.
+        let health = pipeline.ctx.turn_guard.health.get("").unwrap();
+        assert_eq!(health.total_failures, 3);
+        assert_eq!(health.consecutive_failures, 3);
+    }
+
+    #[tokio::test]
+    async fn deprioritized_unknown_tool_merges_into_restricted() {
+        let mut harness = PipelineHarness::new();
+        for i in 0..3 {
+            harness.tool_calls.push(json!({
+                "id": format!("call-outline-{i}"),
+                "function": {
+                    "name": "outline",
+                    "arguments": format!("{{\"path\": \"file{i}.rs\"}}")
+                }
+            }));
+        }
+        let mut pipeline = harness.pipeline();
+
+        for i in 0..3 {
+            pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(i));
+        }
+
+        // Simulate what the server loop does between turns.
+        assert!(!pipeline.ctx.restricted_tools.contains("outline"));
+        crate::turn::turn_guard::merge_deprioritized_tools_into_restricted(
+            pipeline.ctx.turn_guard,
+            pipeline.ctx.restricted_tools,
+        );
+        assert!(
+            pipeline.ctx.restricted_tools.contains("outline"),
+            "deprioritized unknown tool should be added to restricted_tools"
+        );
+    }
+
+    #[tokio::test]
+    async fn server_fallback_unknown_tool_records_health_failure() {
+        // Simulates the DefaultToolExecutor "not available" path:
+        // tool passes valid_tool_names but executor returns error.
+        let mut harness = PipelineHarness::new();
+        // Add "outline" to valid_tool_names so it passes validation.
+        harness.valid_tool_names.insert("outline".to_string());
+        harness.tool_calls.push(json!({
+            "id": "call-outline-0",
+            "function": { "name": "outline", "arguments": "{}" }
+        }));
+        let dir = tempfile::TempDir::new().unwrap();
+        let server_exec = crate::server::server_tool_executor::ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            "test-session".into(),
+            None,
+            None,
+        );
+        let mut pipeline = harness.pipeline_with_server_executor(0, Some(&server_exec));
+
+        // validate_slot should pass (outline is in valid_tool_names).
+        let validated = match pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(0)) {
+            HeadlessPipelineStage::Continue(v) => v,
+            _ => panic!("expected Continue"),
+        };
+
+        // permit_execution should pass (no restrictions).
+        let permitted = match pipeline.permit_execution(validated).await {
+            HeadlessPipelineStage::Continue(p) => p,
+            _ => panic!("expected Continue"),
+        };
+
+        // execute_execution: ServerToolExecutor doesn't know "outline",
+        // returns "Error: Tool 'outline' not available..."
+        let executed = pipeline.execute_execution(permitted).await;
+        assert!(executed.is_err, "server executor should return error for unknown tool");
+
+        // record_execution feeds through append_headless_result_quality_feedback
+        // → turn_guard.record_tool_result → health.record_failure
+        pipeline.record_execution(executed).await;
+
+        let health = pipeline.ctx.turn_guard.health.get("outline");
+        assert!(health.is_some(), "outline should be tracked after server fallback error");
+        let h = health.unwrap();
+        assert_eq!(h.total_failures, 1, "server fallback error should count as failure");
+        assert_eq!(h.consecutive_failures, 1);
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_failure_not_reset_by_valid_tool_success() {
+        let mut harness = PipelineHarness::new();
+        // Call 1: unknown tool "outline"
+        harness.tool_calls.push(json!({
+            "id": "call-outline-0",
+            "function": { "name": "outline", "arguments": "{}" }
+        }));
+        // Call 2: valid tool "grep" (via synthetic edge, already in harness)
+        // Call 3: unknown tool "outline" with different args
+        harness.tool_calls.push(json!({
+            "id": "call-outline-1",
+            "function": { "name": "outline", "arguments": "{\"path\": \"b.rs\"}" }
+        }));
+        let mut pipeline = harness.pipeline();
+
+        // Unknown tool failure #1
+        pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(0));
+
+        // Valid tool success (grep via synthetic edge)
+        let validated = match pipeline.validate_slot(HeadlessRoundToolIdx::SyntheticEdge(0)) {
+            HeadlessPipelineStage::Continue(v) => v,
+            _ => panic!("expected Continue for grep"),
+        };
+        let permitted = match pipeline.permit_execution(validated).await {
+            HeadlessPipelineStage::Continue(p) => p,
+            _ => panic!("expected Continue for grep"),
+        };
+        let executed = pipeline.execute_execution(permitted).await;
+        assert!(!executed.is_err);
+        pipeline.record_execution(executed).await;
+
+        // Unknown tool failure #2
+        pipeline.validate_slot(HeadlessRoundToolIdx::ServerToolCall(1));
+
+        // grep success should NOT reset outline's consecutive failures.
+        let outline_h = pipeline.ctx.turn_guard.health.get("outline").unwrap();
+        assert_eq!(
+            outline_h.consecutive_failures, 2,
+            "valid tool success should not reset unknown tool's consecutive failures"
+        );
+
+        // grep should show success.
+        let grep_h = pipeline.ctx.turn_guard.health.get("grep").unwrap();
+        assert_eq!(grep_h.consecutive_failures, 0);
+        assert_eq!(grep_h.total_calls, 1);
+    }
 }

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
@@ -97,6 +97,9 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
         self.ctx
             .tool_call_records
             .push(journal_record_unknown_tool(slot.name.clone(), 0));
+        // Track unknown tool as a failure so ToolHealthTracker can deprioritize
+        // after CONSECUTIVE_FAILURE_THRESHOLD hits (prevents infinite retry loops).
+        self.ctx.turn_guard.health.record_failure(&slot.name);
         if self.consecutive_empty_name >= Self::MAX_CONSECUTIVE_EMPTY_NAME {
             agent_warn!(
                 "step",
@@ -277,6 +280,9 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                 execution.name.clone(),
                 execution.early_exit_ms,
             ));
+            // Track unknown tool as a failure so ToolHealthTracker can deprioritize
+            // after CONSECUTIVE_FAILURE_THRESHOLD hits (prevents infinite retry loops).
+            self.ctx.turn_guard.health.record_failure(&execution.name);
             return HeadlessPipelineStage::ShortCircuit;
         }
 

--- a/rust/crates/runtime/src/turn/mod.rs
+++ b/rust/crates/runtime/src/turn/mod.rs
@@ -74,8 +74,8 @@ pub mod hydrate_reflect;
 /// Re-exported from astra-turn-types
 pub mod implicit_feedback {
     pub use astra_turn_types::{
-        detect_implicit_feedback_signal, implicit_feedback_context_injection,
-        implicit_feedback_rating, ImplicitSignal,
+        ImplicitSignal, detect_implicit_feedback_signal, implicit_feedback_context_injection,
+        implicit_feedback_rating,
     };
 }
 pub mod interruption;
@@ -95,7 +95,7 @@ pub mod refresh;
 pub mod response_guard;
 /// Re-exported from astra-turn-types
 pub mod result_quality {
-    pub use astra_turn_types::{classify_result, quality_feedback, ResultQuality};
+    pub use astra_turn_types::{ResultQuality, classify_result, quality_feedback};
 }
 pub mod retrieval;
 pub mod routing;

--- a/rust/crates/runtime/tests/feedback_loop_integration.rs
+++ b/rust/crates/runtime/tests/feedback_loop_integration.rs
@@ -8,18 +8,16 @@
 
 use std::sync::{Arc, Mutex};
 
+use astra_runtime::orchestration::permission_sync::PermissionRule;
 use astra_runtime::pipeline::{
     calibration::ProgressiveCalibrator,
     learning::PipelineLearningWriter,
     routing::{DomainHint, TaskType},
 };
-use astra_runtime::turn::approval_fingerprint::{
-    ApprovalFingerprint, DenialAction, DenialTracker,
-};
+use astra_runtime::turn::approval_fingerprint::{ApprovalFingerprint, DenialAction, DenialTracker};
 use astra_runtime::turn::implicit_feedback::{
     detect_implicit_feedback_signal, implicit_feedback_context_injection, implicit_feedback_rating,
 };
-use astra_runtime::orchestration::permission_sync::PermissionRule;
 
 // ─── Phase A + B: Detection → Injection ─────────────────────────────────────
 
@@ -89,12 +87,19 @@ fn end_to_end_repeated_denials_generate_auto_rule() {
     tracker.record_with_reason(&fp2, false, Some("still dangerous"));
 
     let rules = tracker.extract_auto_deny_rules();
-    assert!(!rules.is_empty(), "should generate auto-deny rule after 2 denials");
+    assert!(
+        !rules.is_empty(),
+        "should generate auto-deny rule after 2 denials"
+    );
 
     // Verify the generated rule matches the pattern
-    let bash_rm_rule = rules
-        .iter()
-        .find(|r| r.tool == "bash" && r.pattern.as_ref().map(|p| p.contains("rm")).unwrap_or(false));
+    let bash_rm_rule = rules.iter().find(|r| {
+        r.tool == "bash"
+            && r.pattern
+                .as_ref()
+                .map(|p| p.contains("rm"))
+                .unwrap_or(false)
+    });
     assert!(bash_rm_rule.is_some());
 }
 
@@ -122,8 +127,13 @@ fn end_to_end_varied_denials_generate_bare_tool_rule() {
     let rules = tracker.extract_auto_deny_rules();
 
     // Should generate bare "bash" rule after 3 varied denials
-    let bare_bash = rules.iter().find(|r| r.tool == "bash" && r.pattern.is_none());
-    assert!(bare_bash.is_some(), "should generate bare tool rule after 3 varied denials");
+    let bare_bash = rules
+        .iter()
+        .find(|r| r.tool == "bash" && r.pattern.is_none());
+    assert!(
+        bare_bash.is_some(),
+        "should generate bare tool rule after 3 varied denials"
+    );
 }
 
 #[test]
@@ -240,13 +250,24 @@ fn full_denial_cycle_to_auto_rule() {
     let rules = tracker.extract_auto_deny_rules();
 
     // Verify rules are actionable - should have pattern for "rm -rf"
-    assert!(!rules.is_empty(), "should generate auto-deny rule after 2 similar denials");
+    assert!(
+        !rules.is_empty(),
+        "should generate auto-deny rule after 2 similar denials"
+    );
 
     // Rules should match the "rm -rf" prefix
     let matches_rm = |rule: &PermissionRule| {
-        rule.tool == "bash" && rule.pattern.as_ref().map(|p| p.contains("rm")).unwrap_or(false)
+        rule.tool == "bash"
+            && rule
+                .pattern
+                .as_ref()
+                .map(|p| p.contains("rm"))
+                .unwrap_or(false)
     };
-    assert!(rules.iter().any(matches_rm), "should generate rule for rm commands");
+    assert!(
+        rules.iter().any(matches_rm),
+        "should generate rule for rm commands"
+    );
 }
 
 // ─── Edge Cases: Boundary Conditions ────────────────────────────────────────
@@ -478,22 +499,22 @@ fn concurrent_signal_detection() {
 fn concurrent_denial_tracker_access() {
     // DenialTracker is not Arc<Mutex<>> - this tests that it doesn't have
     // any internal shared mutable state that could cause issues
-    
+
     // Create multiple independent trackers and use them concurrently
     let handles: Vec<_> = (0..10)
         .map(|i| {
             thread::spawn(move || {
                 let mut tracker = DenialTracker::default();
-                
+
                 // Each thread adds denials to its own tracker
                 for j in 0..5 {
                     let fp = ApprovalFingerprint::shell("bash", &format!("cmd_{}_{}", i, j), false);
                     tracker.record_with_reason(&fp, false, Some("reason"));
                 }
-                
+
                 // Extract rules
                 let rules = tracker.extract_auto_deny_rules();
-                
+
                 // Verify state
                 assert_eq!(tracker.total_denials(), 5);
                 rules.len()
@@ -585,15 +606,15 @@ fn concurrent_injection_generation() {
                     2 => "rephrasing",
                     _ => "neutral",
                 };
-                
+
                 let signal = astra_runtime::turn::implicit_feedback::ImplicitSignal {
                     signal_type: signal_type.to_string(),
                     confidence: 0.5 + (i as f64 * 0.02),
                     evidence: format!("evidence {}", i),
                 };
-                
+
                 let injection = implicit_feedback_context_injection(&signal);
-                
+
                 // Verify expected behavior
                 match signal_type {
                     "correction" | "frustration" | "rephrasing" => {


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG

## Which issue(s) this PR fixes:

Fixes infinite retry loop when LLM hallucinates non-existent tool names (e.g. `outline`).

## What this PR does / why we need it:

**Problem**: Unknown tool calls were not recorded in `ToolHealthTracker`, so the deprioritization mechanism never activated. The LLM could retry non-existent tools indefinitely across turns until the 90s stream idle timeout killed the session.

Observed in session `1a822b2d`: the LLM called `outline` (a `read_file` parameter, not a standalone tool) 6 times across multiple turns. Each call failed with "Unknown tool" or "not available in DefaultToolExecutor", but the health tracker was never updated, so:
- The tool was never deprioritized
- Its schema was never removed from the LLM's view
- No warning was injected telling the LLM to stop
- The session eventually died from stream idle timeout

**Root cause**: `validate_slot()` in the headless tool pipeline had two unknown-tool paths (empty name + not in `valid_tool_names`) that recorded journal entries and sent error messages back to the LLM, but never called `health.record_failure()`.

**Fix**: Add `record_failure()` in both paths. After `CONSECUTIVE_FAILURE_THRESHOLD` (3) failures, the tool gets deprioritized → schema removed from next turn via `merge_deprioritized_tools_into_restricted` → `filtered_turn_tools`.

## Changes

- **`policy.rs`** (+6 lines): Two `record_failure()` calls in the two unknown-tool early-exit paths
- **`headless_tool_pipeline.rs`** (+399 lines): 12 new tests covering all unhappy paths

## Test coverage

| Scenario | Test |
|---|---|
| Single unknown tool → health failure | `unknown_tool_records_health_failure` |
| 3 failures → deprioritized | `unknown_tool_deprioritized_after_consecutive_failures` |
| Journal error tag | `unknown_tool_journal_records_error_tag` |
| LLM receives error message | `unknown_tool_error_message_sent_to_llm` |
| Empty name → health failure | `empty_name_tool_records_health_failure` |
| 3 empty names → AbortRound | `empty_name_abort_round_after_max_consecutive` |
| Identical args → dedup blocks 3rd | `unknown_tool_with_identical_args_blocked_by_dedup_after_limit` |
| Independent per-tool tracking | `multiple_different_unknown_tools_each_tracked_independently` |
| Deprioritize warning | `unknown_tool_deprioritize_warning_generated` |
| Deprioritized → restricted_tools | `deprioritized_unknown_tool_merges_into_restricted` |
| Server fallback error tracked | `server_fallback_unknown_tool_records_health_failure` |
| Valid success doesn't reset unknown failures | `unknown_tool_failure_not_reset_by_valid_tool_success` |

## Test results

```
test result: ok. 5781 passed; 0 failed; 11 ignored
```
