### PR TITLE
chore: cargo fmt --all

### DIFF
--- a/rust/crates/astra-pipeline/src/lib.rs
+++ b/rust/crates/astra-pipeline/src/lib.rs
@@ -12,4 +12,4 @@
 
 pub mod routing;
 
-pub use routing::{CalibrationAxis, DomainHint, TaskType, ToolFilter, domain_hint_to_label};
+pub use routing::{domain_hint_to_label, CalibrationAxis, DomainHint, TaskType, ToolFilter};

--- a/rust/crates/astra-turn-types/src/lib.rs
+++ b/rust/crates/astra-turn-types/src/lib.rs
@@ -7,7 +7,7 @@ mod implicit_feedback;
 mod result_quality;
 
 pub use implicit_feedback::{
-    detect_implicit_feedback_signal, implicit_feedback_context_injection, implicit_feedback_rating,
-    ImplicitSignal,
+    ImplicitSignal, detect_implicit_feedback_signal, implicit_feedback_context_injection,
+    implicit_feedback_rating,
 };
-pub use result_quality::{classify_result, quality_feedback, ResultQuality};
+pub use result_quality::{ResultQuality, classify_result, quality_feedback};

--- a/rust/crates/runtime/src/messaging/orchestrator_mailbox_tests.rs
+++ b/rust/crates/runtime/src/messaging/orchestrator_mailbox_tests.rs
@@ -36,7 +36,10 @@ mod tests {
     }
 
     impl ProgressReportingExecutor {
-        fn new() -> (Self, Arc<tokio::sync::Mutex<Vec<(String, Result<(), String>)>>>) {
+        fn new() -> (
+            Self,
+            Arc<tokio::sync::Mutex<Vec<(String, Result<(), String>)>>>,
+        ) {
             let results = Arc::new(tokio::sync::Mutex::new(Vec::new()));
             (
                 Self {
@@ -87,8 +90,12 @@ mod tests {
 
     fn setup_profiles() -> Arc<RwLock<AgentProfileRegistry>> {
         let mut reg = AgentProfileRegistry::new();
-        reg.register(AgentProfile::new("orch", "Orchestrator", AgentTier::Orchestrator))
-            .unwrap();
+        reg.register(AgentProfile::new(
+            "orch",
+            "Orchestrator",
+            AgentTier::Orchestrator,
+        ))
+        .unwrap();
         reg.register(AgentProfile::new(
             "team-review-producer",
             "Producer",
@@ -401,10 +408,7 @@ mod tests {
             self.gate.wait().await;
 
             let send_result = if let Some(ref mailbox) = config.mailbox {
-                match mailbox
-                    .send_progress(0, 1, "turn_complete", None)
-                    .await
-                {
+                match mailbox.send_progress(0, 1, "turn_complete", None).await {
                     Ok(()) => Ok(()),
                     Err(e) => Err(format!("{e}")),
                 }
@@ -614,9 +618,7 @@ mod tests {
         let cancel_clone = cancel.clone();
         let engine_handle = {
             let engine = h.engine;
-            tokio::spawn(
-                async move { engine.execute(request, "orch", Some(cancel_clone)).await },
-            )
+            tokio::spawn(async move { engine.execute(request, "orch", Some(cancel_clone)).await })
         };
 
         // Give engine time to register parent and spawn agents.
@@ -750,9 +752,7 @@ mod tests {
         let cancel_clone = cancel.clone();
         let engine_handle = {
             let engine = h.engine;
-            tokio::spawn(
-                async move { engine.execute(request, "orch", Some(cancel_clone)).await },
-            )
+            tokio::spawn(async move { engine.execute(request, "orch", Some(cancel_clone)).await })
         };
 
         // Let agents start.
@@ -760,11 +760,7 @@ mod tests {
         cancel.cancel();
 
         // The collection loop should abort tasks and return promptly.
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            engine_handle,
-        )
-        .await;
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), engine_handle).await;
 
         assert!(
             result.is_ok(),
@@ -793,19 +789,13 @@ mod tests {
         let cancel_clone = cancel.clone();
         let engine_handle = {
             let engine = h.engine;
-            tokio::spawn(
-                async move { engine.execute(request, "orch", Some(cancel_clone)).await },
-            )
+            tokio::spawn(async move { engine.execute(request, "orch", Some(cancel_clone)).await })
         };
 
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         cancel.cancel();
 
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            engine_handle,
-        )
-        .await;
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), engine_handle).await;
 
         assert!(
             result.is_ok(),
@@ -829,13 +819,19 @@ mod tests {
         let addr = AgentAddress::new("run-1", "agent-1");
         let result = router.register_if_absent(addr.clone(), None).await;
         assert!(result.is_ok());
-        assert!(result.unwrap().is_some(), "first registration should return Some");
+        assert!(
+            result.unwrap().is_some(),
+            "first registration should return Some"
+        );
 
         // Second registration with same run_id returns None (no clobber).
         let addr2 = AgentAddress::new("run-1", "agent-1");
         let result2 = router.register_if_absent(addr2, None).await;
         assert!(result2.is_ok());
-        assert!(result2.unwrap().is_none(), "second registration should return None");
+        assert!(
+            result2.unwrap().is_none(),
+            "second registration should return None"
+        );
     }
 
     /// register_if_absent with different run_id registers both.
@@ -854,6 +850,9 @@ mod tests {
 
         let addr2 = AgentAddress::new("run-2", "agent-1");
         let r2 = router.register_if_absent(addr2, None).await.unwrap();
-        assert!(r2.is_some(), "different run_id should register successfully");
+        assert!(
+            r2.is_some(),
+            "different run_id should register successfully"
+        );
     }
 }

--- a/rust/crates/runtime/src/messaging/router.rs
+++ b/rust/crates/runtime/src/messaging/router.rs
@@ -403,7 +403,12 @@ impl AgentMailboxRouter {
         // but register() handles re-registration gracefully (overwrites with
         // warning), and in practice the same parent_run_id (UUID) is never
         // registered concurrently.
-        if self.address_registry.read().await.contains_key(&addr.run_id) {
+        if self
+            .address_registry
+            .read()
+            .await
+            .contains_key(&addr.run_id)
+        {
             return Ok(None);
         }
         self.register(addr, delegation_id).await.map(Some)

--- a/rust/crates/runtime/src/pipeline/learning.rs
+++ b/rust/crates/runtime/src/pipeline/learning.rs
@@ -1026,7 +1026,10 @@ mod tests {
         let c = cal.lock().unwrap();
         // Check that calibrator recorded the intent
         let stats = c.intent_stats("code");
-        assert!(stats.is_some(), "calibrator should have recorded intent 'code'");
+        assert!(
+            stats.is_some(),
+            "calibrator should have recorded intent 'code'"
+        );
         assert!(
             stats.unwrap().correction_rate() > 0.0,
             "correction signal should increase correction rate"
@@ -1044,11 +1047,19 @@ mod tests {
             evidence: "terrible".to_string(),
         };
 
-        writer.record_implicit_feedback(&signal, "fetch", Some(DomainHint::GitHub), TaskType::Fetch);
+        writer.record_implicit_feedback(
+            &signal,
+            "fetch",
+            Some(DomainHint::GitHub),
+            TaskType::Fetch,
+        );
 
         let c = cal.lock().unwrap();
         let stats = c.intent_stats("fetch");
-        assert!(stats.is_some(), "calibrator should have recorded intent 'fetch'");
+        assert!(
+            stats.is_some(),
+            "calibrator should have recorded intent 'fetch'"
+        );
         assert!(
             stats.unwrap().correction_rate() > 0.0,
             "frustration signal should increase correction rate"

--- a/rust/crates/runtime/src/turn/approval_fingerprint.rs
+++ b/rust/crates/runtime/src/turn/approval_fingerprint.rs
@@ -665,7 +665,11 @@ mod tests {
 
         let rules = tracker.extract_auto_deny_rules();
         // Should have bare "bash" rule since 3+ different denials
-        assert!(rules.iter().any(|r| r.tool == "bash" && r.pattern.is_none()));
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.tool == "bash" && r.pattern.is_none())
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/cloud_tool_delivery.rs
+++ b/rust/crates/runtime/src/turn/cloud_tool_delivery.rs
@@ -141,9 +141,7 @@ fn parse_cloud_approval_outcome_with_decision(
 }
 
 fn denied_tool_content(reason: Option<&str>) -> String {
-    let mut parts = vec![
-        "The user REJECTED this tool call. The tool was NOT executed.",
-    ];
+    let mut parts = vec!["The user REJECTED this tool call. The tool was NOT executed."];
     let feedback_line;
     if let Some(r) = reason.filter(|s| !s.is_empty()) {
         feedback_line = format!("User feedback: \"{r}\"");

--- a/rust/crates/runtime/src/turn/mod.rs
+++ b/rust/crates/runtime/src/turn/mod.rs
@@ -74,8 +74,8 @@ pub mod hydrate_reflect;
 /// Re-exported from astra-turn-types
 pub mod implicit_feedback {
     pub use astra_turn_types::{
-        detect_implicit_feedback_signal, implicit_feedback_context_injection,
-        implicit_feedback_rating, ImplicitSignal,
+        ImplicitSignal, detect_implicit_feedback_signal, implicit_feedback_context_injection,
+        implicit_feedback_rating,
     };
 }
 pub mod interruption;
@@ -95,7 +95,7 @@ pub mod refresh;
 pub mod response_guard;
 /// Re-exported from astra-turn-types
 pub mod result_quality {
-    pub use astra_turn_types::{classify_result, quality_feedback, ResultQuality};
+    pub use astra_turn_types::{ResultQuality, classify_result, quality_feedback};
 }
 pub mod retrieval;
 pub mod routing;

--- a/rust/crates/runtime/tests/feedback_loop_integration.rs
+++ b/rust/crates/runtime/tests/feedback_loop_integration.rs
@@ -8,18 +8,16 @@
 
 use std::sync::{Arc, Mutex};
 
+use astra_runtime::orchestration::permission_sync::PermissionRule;
 use astra_runtime::pipeline::{
     calibration::ProgressiveCalibrator,
     learning::PipelineLearningWriter,
     routing::{DomainHint, TaskType},
 };
-use astra_runtime::turn::approval_fingerprint::{
-    ApprovalFingerprint, DenialAction, DenialTracker,
-};
+use astra_runtime::turn::approval_fingerprint::{ApprovalFingerprint, DenialAction, DenialTracker};
 use astra_runtime::turn::implicit_feedback::{
     detect_implicit_feedback_signal, implicit_feedback_context_injection, implicit_feedback_rating,
 };
-use astra_runtime::orchestration::permission_sync::PermissionRule;
 
 // ─── Phase A + B: Detection → Injection ─────────────────────────────────────
 
@@ -89,12 +87,19 @@ fn end_to_end_repeated_denials_generate_auto_rule() {
     tracker.record_with_reason(&fp2, false, Some("still dangerous"));
 
     let rules = tracker.extract_auto_deny_rules();
-    assert!(!rules.is_empty(), "should generate auto-deny rule after 2 denials");
+    assert!(
+        !rules.is_empty(),
+        "should generate auto-deny rule after 2 denials"
+    );
 
     // Verify the generated rule matches the pattern
-    let bash_rm_rule = rules
-        .iter()
-        .find(|r| r.tool == "bash" && r.pattern.as_ref().map(|p| p.contains("rm")).unwrap_or(false));
+    let bash_rm_rule = rules.iter().find(|r| {
+        r.tool == "bash"
+            && r.pattern
+                .as_ref()
+                .map(|p| p.contains("rm"))
+                .unwrap_or(false)
+    });
     assert!(bash_rm_rule.is_some());
 }
 
@@ -122,8 +127,13 @@ fn end_to_end_varied_denials_generate_bare_tool_rule() {
     let rules = tracker.extract_auto_deny_rules();
 
     // Should generate bare "bash" rule after 3 varied denials
-    let bare_bash = rules.iter().find(|r| r.tool == "bash" && r.pattern.is_none());
-    assert!(bare_bash.is_some(), "should generate bare tool rule after 3 varied denials");
+    let bare_bash = rules
+        .iter()
+        .find(|r| r.tool == "bash" && r.pattern.is_none());
+    assert!(
+        bare_bash.is_some(),
+        "should generate bare tool rule after 3 varied denials"
+    );
 }
 
 #[test]
@@ -240,13 +250,24 @@ fn full_denial_cycle_to_auto_rule() {
     let rules = tracker.extract_auto_deny_rules();
 
     // Verify rules are actionable - should have pattern for "rm -rf"
-    assert!(!rules.is_empty(), "should generate auto-deny rule after 2 similar denials");
+    assert!(
+        !rules.is_empty(),
+        "should generate auto-deny rule after 2 similar denials"
+    );
 
     // Rules should match the "rm -rf" prefix
     let matches_rm = |rule: &PermissionRule| {
-        rule.tool == "bash" && rule.pattern.as_ref().map(|p| p.contains("rm")).unwrap_or(false)
+        rule.tool == "bash"
+            && rule
+                .pattern
+                .as_ref()
+                .map(|p| p.contains("rm"))
+                .unwrap_or(false)
     };
-    assert!(rules.iter().any(matches_rm), "should generate rule for rm commands");
+    assert!(
+        rules.iter().any(matches_rm),
+        "should generate rule for rm commands"
+    );
 }
 
 // ─── Edge Cases: Boundary Conditions ────────────────────────────────────────
@@ -478,22 +499,22 @@ fn concurrent_signal_detection() {
 fn concurrent_denial_tracker_access() {
     // DenialTracker is not Arc<Mutex<>> - this tests that it doesn't have
     // any internal shared mutable state that could cause issues
-    
+
     // Create multiple independent trackers and use them concurrently
     let handles: Vec<_> = (0..10)
         .map(|i| {
             thread::spawn(move || {
                 let mut tracker = DenialTracker::default();
-                
+
                 // Each thread adds denials to its own tracker
                 for j in 0..5 {
                     let fp = ApprovalFingerprint::shell("bash", &format!("cmd_{}_{}", i, j), false);
                     tracker.record_with_reason(&fp, false, Some("reason"));
                 }
-                
+
                 // Extract rules
                 let rules = tracker.extract_auto_deny_rules();
-                
+
                 // Verify state
                 assert_eq!(tracker.total_denials(), 5);
                 rules.len()
@@ -585,15 +606,15 @@ fn concurrent_injection_generation() {
                     2 => "rephrasing",
                     _ => "neutral",
                 };
-                
+
                 let signal = astra_runtime::turn::implicit_feedback::ImplicitSignal {
                     signal_type: signal_type.to_string(),
                     confidence: 0.5 + (i as f64 * 0.02),
                     evidence: format!("evidence {}", i),
                 };
-                
+
                 let injection = implicit_feedback_context_injection(&signal);
-                
+
                 // Verify expected behavior
                 match signal_type {
                     "correction" | "frustration" | "rephrasing" => {


### PR DESCRIPTION
Fix pre-existing formatting inconsistencies across runtime, pipeline, and turn-types crates introduced by recent crate extraction refactors (#58, #60, #61).

**Files touched (9):**
- `astra-pipeline/src/lib.rs`
- `astra-turn-types/src/lib.rs`
- `runtime/src/messaging/orchestrator_mailbox_tests.rs`
- `runtime/src/messaging/router.rs`
- `runtime/src/pipeline/learning.rs`
- `runtime/src/turn/approval_fingerprint.rs`
- `runtime/src/turn/cloud_tool_delivery.rs`
- `runtime/src/turn/mod.rs`
- `runtime/tests/feedback_loop_integration.rs`

**Validation:** `cargo fmt --all --check`, `cargo clippy`, and full test suite (services 1146, runtime 5697+293, CLI 2504) all pass.