### PR TITLE
ci: split astra-cli offline nextest (edge_tools vs rest)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,16 @@ jobs:
           workspaces: rust
           shared-key: ci-offline
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli
+      # astra-cli is binary-only (no lib target, no crate-root integration tests/).
+      # Split by nextest source filter instead of --lib / --tests.
+      - name: "Test astra-cli (bins: cli, main, src/tests, …)"
+        run: >-
+          cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
+          -E 'not source(/edge_tools/)'
+      - name: "Test astra-cli (bins: edge_tools)"
+        run: >-
+          cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
+          -E 'source(/edge_tools/)'
 
   test-offline-runtime:
     name: "Offline: astra-runtime"


### PR DESCRIPTION
## Summary

- Split the offline `astra-cli` GitHub Actions step into two `cargo nextest run` invocations.
- `astra-cli` is **binary-only** (no `[lib]`, no crate-root `tests/`), so `--lib` / `--tests` are not applicable; both steps use `--bins` with complementary nextest filters on the source path (`edge_tools` vs everything else).
- Adds short comments in the workflow explaining why.

## Motivation

Clearer failure attribution in CI logs (CLI/main/`src/tests` failures vs `src/edge_tools` failures) without changing which tests run.

## Test plan

- [ ] Confirm Actions workflow parses and both steps run on `ubuntu-latest`.

Made with [Cursor](https://cursor.com)