### PR TITLE
ci: offline nextest everywhere + astra-cli bin split

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,15 +31,16 @@ jobs:
           shared-key: ci-offline
           save-if: ${{ github.ref == 'refs/heads/main' }}
       # astra-cli is binary-only (no lib target, no crate-root integration tests/).
-      # Split by nextest source filter instead of --lib / --tests.
-      - name: "Test astra-cli (bins: cli, main, src/tests, …)"
+      # Partition by Rust test path: `edge_tools::` marks tests under src/edge_tools/.
+      # `source()` is invalid filterset DSL; `/edge_tools/` alone parses as a broken regex.
+      - name: "Test astra-cli (bins: non-edge_tools modules)"
         run: >-
           cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
-          -E 'not source(/edge_tools/)' --no-fail-fast
+          -E 'not test(/edge_tools::/)' --no-fail-fast
       - name: "Test astra-cli (bins: edge_tools)"
         run: >-
           cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
-          -E 'source(/edge_tools/)' --no-fail-fast
+          -E 'test(/edge_tools::/)' --no-fail-fast
 
   test-offline-runtime:
     name: "Offline: astra-runtime"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,16 @@ jobs:
           workspaces: rust
           shared-key: ci-offline
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli
+      # astra-cli is binary-only (no lib target, no crate-root integration tests/).
+      # Split by nextest source filter instead of --lib / --tests.
+      - name: "Test astra-cli (bins: cli, main, src/tests, …)"
+        run: >-
+          cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
+          -E 'not source(/edge_tools/)' --no-fail-fast
+      - name: "Test astra-cli (bins: edge_tools)"
+        run: >-
+          cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
+          -E 'source(/edge_tools/)' --no-fail-fast
 
   test-offline-runtime:
     name: "Offline: astra-runtime"
@@ -40,14 +49,16 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
           shared-key: ci-offline
           save-if: false
-      - run: cargo test --manifest-path rust/Cargo.toml -p astra-runtime
-      - name: Run trusted_moi auth integration tests
-        run: cargo test --manifest-path rust/Cargo.toml -p astra-runtime --test trusted_moi_auth_integration -- --nocapture
+      - name: Test astra-runtime (default features)
+        run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-runtime --no-fail-fast
+      - name: Test trusted_moi auth integration
+        run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-runtime --test trusted_moi_auth_integration --no-capture
 
   test-offline-runtime-e2e:
     name: "Offline: bridge-e2e-hooks"
@@ -57,13 +68,14 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
           shared-key: ci-offline
           save-if: false
-      - name: Run bridge-e2e-hooks tests
-        run: cargo test --manifest-path rust/Cargo.toml -p astra-runtime --features bridge-e2e-hooks
+      - name: Test bridge-e2e-hooks
+        run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-runtime --features bridge-e2e-hooks --no-fail-fast
 
   test-offline-services:
     name: "Offline: astra-services"
@@ -73,12 +85,14 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
           shared-key: ci-offline
           save-if: false
-      - run: cargo test --manifest-path rust/Cargo.toml -p astra-services
+      - name: Test astra-services
+        run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-services --no-fail-fast
 
   test-offline-core:
     name: "Offline: core crates"
@@ -88,15 +102,19 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
           shared-key: ci-offline
           save-if: false
-      - name: Test foundational crates
-        run: cargo test --manifest-path rust/Cargo.toml -p astra-core -p astra-thin-client -p astra-admin-cli
-      - name: Test extracted crates
-        run: cargo test --manifest-path rust/Cargo.toml -p astra-tools -p astra-pipeline -p astra-turn-types -p astra-skills -p astra-sandbox
+      - name: Test all core crates
+        run: >-
+          cargo nextest run --manifest-path rust/Cargo.toml
+          -p astra-core -p astra-thin-client -p astra-admin-cli
+          -p astra-tools -p astra-pipeline -p astra-turn-types
+          -p astra-skills -p astra-sandbox
+          --no-fail-fast
 
   # ── Online: needs MatrixOne + Memoria ─────────────────────────────────
   test-online:


### PR DESCRIPTION
## Summary

- Use **`cargo nextest run`** for all **offline** jobs (not only `astra-cli`), with **`taiki-e/install-action@nextest`** where missing.
- Add **`--no-fail-fast`** on broad crate runs; **`trusted_moi`** uses nextest **`--no-capture`** instead of `cargo test -- --nocapture`.
- Merge the two **core crates** `cargo test` steps into **one** `nextest` invocation listing all packages.
- **`astra-cli`**: two **`--bins`** runs with complementary **`source(/edge_tools/)`** filters (binary-only crate; documents why not `--lib` / `--tests`).

## Related

- Complements / supersedes piecemeal nextest usage: keeps the **edge_tools vs rest** split from the earlier focused PR while extending nextest to **runtime / services / core / e2e** offline paths.

## Test plan

- [ ] GitHub Actions: all offline jobs green on `ubuntu-latest`.

Made with [Cursor](https://cursor.com)