### PR TITLE
feat(runtime): session memory protocol — L0 anchor, L1 persistence, first-user preservation

### DIFF
--- a/docs/design/session-memory-protocol.md
+++ b/docs/design/session-memory-protocol.md
@@ -1,0 +1,627 @@
+# Session Memory Protocol — Design Document
+
+**Status**: Draft
+**Author**: astra-engine team
+**Date**: 2026-04-16
+**References**: Claude Code compaction system analysis, Memoria API
+
+## 1. Problem Statement
+
+Context compaction drops the user's original task, causing the agent to lose track of what it was doing. Observed in session `f3ef23fe`: after proactive compression at 83% pressure, the agent said "The original user request was lost during context compaction (35 earlier messages removed)."
+
+Root cause: `TieredCompaction` (Layer 3) preserves system messages + tail N turns, but the first user message (the original task) falls in the "middle" and gets deleted.
+
+### Goals
+
+1. **Goal preservation**: The user's original task must never be lost, under any compaction pressure
+2. **Token efficiency**: Memory injection must be cache-friendly and pressure-adaptive, not a fixed tax
+3. **Continuous high-quality memory**: Structured, governed session state that survives multiple compactions
+4. **Deployment flexibility**: Works in CLI (edge), web agent (server), and Claude Code compatibility modes
+5. **Prompt cache preservation**: Memory operations must not break the cached prefix
+
+## 2. Architecture Overview
+
+### 2.1 Four-Layer Memory Pyramid
+
+```
+         ┌─────────────────┐
+    L0   │  Anchor + MC     │  Cost: zero LLM, every turn
+         │  ~50t + savings  │  Anchor in system prompt, microcompact clears old tool results
+         ├─────────────────┤
+    L1   │  Session Memory  │  Cost: cheap model, periodic (every 5K tokens + 3 tool calls)
+         │  ≤2000t inject   │  10-section structured notes, replaces LLM summary at compaction
+         │  ≤4000t stored   │
+         ├─────────────────┤
+    L2   │  Compact Summary │  Cost: cheap model, only when L1 unavailable
+         │  ≤3000t          │  9-section LLM summary with anti-drift safeguards
+         ├─────────────────┤
+    L3   │  Durable Memory  │  Cost: zero/low, session end
+         │  not injected    │  Episodic, procedural, semantic — retrieved on demand via Memoria
+         └─────────────────┘
+```
+
+### 2.2 Design Principles
+
+Borrowed from Claude Code's production-proven patterns:
+
+| Principle | Claude Code Practice | Our Adaptation |
+|-----------|---------------------|----------------|
+| Anti-drift | All user messages verbatim in summary + direct quotes for next step | L1 "User Messages" section + L0 anchor |
+| Cache-aware | Forked agent shares cached prefix; never inject into stable prefix | Memory in CacheScope::None; injection after cache breakpoint |
+| Layered compaction | Microcompact → session memory → LLM summary → context collapse | L0 MC → L1 session memory → L2 LLM summary |
+| Size governance | Per-section 2K token cap + total 12K cap + auto-condensation warnings | Per-section budgets + total 2K inject / 4K stored |
+| Structured template | 10 immutable section headers, only content below is editable | 10-section markdown with `[session-memory:v1]` prefix |
+| Zero-LLM compaction | Session memory replaces LLM summary when available | L1 replaces L2 at compaction time |
+| Post-compact restoration | Re-inject top 5 files, plans, skills, tool schemas | Same, with file dedup against preserved messages |
+| Continuation prompt | "Pick up the last task as if the break never happened" | Same, injected after compaction |
+
+## 3. L0: Anchor + Microcompact
+
+### 3.1 Session Anchor
+
+A single-line task summary embedded in the system prompt's dynamic section (`CacheScope::None`). Never deleted by any compaction layer.
+
+**Format**:
+```
+[session-anchor] {task, ≤30 words}. Currently: {current_work, ≤15 words}. {done}/{total} steps.
+```
+
+**Example**:
+```
+[session-anchor] Add OAuth support to API with JWT tokens. Currently: token refresh in src/auth/refresh.rs. 3/5 steps.
+```
+
+**Lifecycle**:
+- **Created**: Turn 1, rule-extracted from first user message (zero LLM)
+- **Updated**: Every time L1 updates, L0 is re-derived from L1's Task + Current State sections (zero LLM)
+- **Injected**: Appended to the dynamic system prompt section (after profile_desc), inside `CacheScope::None`
+- **Compaction**: Treated as part of system prompt — never removed by TieredCompaction or ReactiveCompact
+- **Cost**: ~50 tokens, constant
+
+**Cache impact**: None. Placed in `CacheScope::None` (already non-cached dynamic section). Does not affect the Global/Session cached prefix.
+
+**Rule extraction** (zero LLM):
+```rust
+/// Sections are parsed by matching `# {Section Name}` headers in the markdown.
+/// Content is everything between the header and the next `# ` header (or EOF).
+fn extract_anchor(first_user_msg: &str, l1: Option<&SessionMemory>) -> String {
+    if let Some(l1) = l1 {
+        // Derive from L1's parsed sections
+        let task = first_sentence(l1.section("Task Specification"));
+        let current = first_sentence(l1.section("Current State"));
+        let (done, total) = count_progress_markers(l1.section("Progress"));
+        format!("[session-anchor] {task}. Currently: {current}. {done}/{total} steps.")
+    } else {
+        // First turn: extract from user message
+        let task = truncate_words(first_user_msg, 30);
+        format!("[session-anchor] {task}. Currently: starting. 0/0 steps.")
+    }
+}
+```
+
+### 3.2 First User Message Preservation
+
+In addition to the anchor, `TieredCompaction` and `ReactiveCompact` must preserve the first `role: "user"` message (the original task). This is a ~10-line change in each compressor's `compress()` method.
+
+**Rationale**: The anchor is a compressed summary; the original message preserves the user's exact words, which is critical for anti-drift (Claude Code's Section 6 "All User Messages" pattern).
+
+### 3.3 Adaptive Microcompact
+
+Clears old tool result content for compactable tools, with pressure-adaptive retention.
+
+**Compactable tools**: `read_file, grep, glob, git_show, git_log, web_search, web_fetch, code intel tools`
+**Non-compactable**: `bash, write_file, str_replace, skill, delegate, memory_store` (side effects / non-idempotent)
+
+**Adaptive retention** (existing logic, refined):
+
+| Context Pressure | Keep Recent N | Token Budget per Result |
+|-----------------|---------------|------------------------|
+| < 60% | 6 | 12K |
+| 60–75% | 4 | 8K |
+| 75–90% | 2 | 4K |
+| ≥ 90% | 1 | 2K |
+
+**Duplicate read elimination**: When the same file path appears in multiple `read_file` results, only the most recent is kept. Earlier reads are replaced with `"[Earlier read of {path} — see later read for current content]"`.
+
+**Cache impact**: Microcompact modifies message content in the volatile region (after the cache breakpoint). It does NOT affect the cached prefix. After microcompact, the cache breakpoint is re-placed on the last message.
+
+## 4. L1: Session Memory
+
+The core innovation layer. A structured, incrementally-updated session state stored in Memoria, used to replace LLM summarization during compaction.
+
+### 4.1 Template (10 Sections)
+
+```markdown
+[session-memory:v1]
+# Session Title
+{5-10 word descriptive title}
+
+# Task Specification
+{What the user originally asked. Verbatim if short, paraphrased if long. IMMUTABLE unless user explicitly changes direction.}
+
+# Current State
+{What is actively being worked on RIGHT NOW. ALWAYS updated on every extraction. Include file names and specific details.}
+
+# Key Files
+{Files read/modified/created, one per line: path — brief purpose}
+
+# Progress
+{Checklist: ✅ done / 🔄 in progress / ⏳ pending}
+
+# Errors & Corrections
+{Errors encountered and fixes. User corrections have HIGHEST priority — never remove them.}
+
+# Decisions
+{Key technical decisions and rationale}
+
+# User Messages
+{ALL user messages verbatim (excluding tool results). Critical for anti-drift.}
+
+# Worklog
+{Terse step-by-step: turn N — what was attempted, what happened}
+
+# Context
+{Turn count, tokens used, pressure, last update timestamp}
+```
+
+### 4.2 Size Governance
+
+Two versions of L1 exist: the **stored version** (full detail in Memoria) and the **injection version** (compressed for context injection).
+
+**Stored version** (in Memoria, ≤4000 tokens):
+
+| Section | Max Tokens | Condensation Priority |
+|---------|-----------|----------------------|
+| Session Title | 20 | Never condense |
+| Task Specification | 200 | 🔴 Never condense |
+| Current State | 400 | 🔴 Never condense |
+| Key Files | 500 | 🟡 Drop oldest entries |
+| Progress | 400 | 🟡 Drop completed items |
+| Errors & Corrections | 500 | 🟡 Drop resolved errors (keep user corrections) |
+| Decisions | 400 | 🟡 Drop oldest decisions |
+| User Messages | 800 | 🔴 Never condense (truncate oldest if over budget) |
+| Worklog | 700 | 🟢 First to condense |
+| Context | 50 | Auto-generated |
+| **Total** | **≤4000** (hard cap, enforced by update prompt) | |
+
+When a section exceeds its budget, the update prompt includes: "CRITICAL: Section '{name}' exceeds {max} tokens. Condense oldest entries first. Prioritize keeping 'Current State', 'Task Specification', and 'User Messages' accurate."
+
+**Injection version** (for context, ≤2000 tokens) — rule-compressed from stored version, zero LLM:
+
+| Section | Injection Rule |
+|---------|---------------|
+| Task Specification | Full text |
+| Current State | Full text |
+| Key Files | File names only, no descriptions |
+| Progress | Only 🔄 and ⏳ items |
+| Errors & Corrections | Only unresolved errors + all user corrections |
+| Decisions | Most recent 2 entries, ≤15 words each |
+| User Messages | Last 3 user messages |
+| Worklog | Omitted |
+| Context | Omitted |
+
+### 4.3 Update Trigger
+
+Same dual-threshold as Claude Code's session memory:
+
+```
+Initial gate: context tokens ≥ 10,000 (skip for trivial sessions)
+
+Subsequent updates require BOTH:
+  - Token growth ≥ 5,000 since last extraction
+  - Tool calls ≥ 3 since last extraction
+  
+OR:
+  - Token growth ≥ 5,000 AND last assistant turn has no tool calls (natural break)
+```
+
+### 4.4 Update Mechanism
+
+Uses a **cheap text model** (e.g., `glm-4-flash-250414`, `deepseek-chat`, or the cheapest available model in the model registry).
+
+**Execution model**: Async fire-and-forget. The main turn does NOT block on L1 extraction. The result is available on the next turn. If compaction triggers while an L1 update is in-flight, wait up to 15 seconds for it to complete (borrowed from Claude Code's `waitForSessionMemoryExtraction()`). If timeout, fallback to L2.
+
+**Update prompt**:
+
+```
+You are updating a structured session memory file based on new conversation messages.
+
+Rules:
+- ALWAYS update 'Current State' to reflect the most recent work
+- Add ALL new user messages to 'User Messages' section verbatim
+- 'Task Specification' can ONLY change if the user explicitly changed direction
+- User corrections in 'Errors & Corrections' have highest priority — NEVER remove them
+- Do NOT remove information unless a section exceeds its budget
+- If a section is over budget, condense OLDEST entries first
+- Keep the exact section header format (# Section Name)
+
+{section_budget_warnings}
+
+Current session memory:
+{existing_session_memory OR empty template}
+
+New messages since last update (turn {from_turn} to {to_turn}):
+{recent_messages, truncated to ~3000 tokens}
+
+Output the complete updated session memory in the same [session-memory:v1] format.
+```
+
+**Input budget**: ~3000 tokens for recent messages + ~2000 tokens for existing memory = ~5000 tokens input
+**Output budget**: ~2000 tokens
+**Cost per update**: ~$0.001 with cheap models
+
+### 4.5 Format Validation
+
+Every L1 update result is validated before storage:
+
+1. Must start with `[session-memory:v1]`
+2. Must contain `# Task Specification` section with non-empty content
+3. Must contain `# Current State` section with non-empty content
+4. Must contain `# User Messages` section
+
+If validation fails:
+- The malformed output is discarded (not stored in Memoria)
+- The previous valid L1 remains in use
+- A warning is logged: `session_memory.validation_failed`
+- After 2 consecutive validation failures, the cheap model is considered unreliable for this session; L1 updates are paused and L2 becomes the primary compaction source
+
+### 4.6 Cache-Aware Injection
+
+**Critical design decision**: L1 is injected as a **system message at position 1** (after the main system prompt), NOT into the conversation messages.
+
+```
+Message array structure:
+  [0] System prompt (Global + Session + Dynamic sections)  ← CACHED PREFIX
+      └─ Dynamic section includes L0 anchor
+  [1] [Session Memory] system message (L1 injection)       ← NOT in cached prefix
+  [2..N-1] Conversation messages                           ← Volatile
+  [N] Last message with cache_control breakpoint           ← Cache boundary
+```
+
+**Why position 1 as system message**:
+- Does NOT break the system prompt's cached prefix (Global + Session sections are in message [0])
+- System messages at position 1 are outside the Anthropic cache breakpoint (which is on the last message)
+- For OpenAI automatic prefix caching: the primary system message [0] stays identical, so the prefix cache hits
+- L1 content changes periodically (~every 5K tokens), which is acceptable for a non-cached position
+
+**Provider-specific position**: The layout above shows the Anthropic path. For OpenAI (automatic prefix caching), message [0] is split into stable (Global+Session) and dynamic (None+L0) system messages, so L1 is at position 2. The principle is the same: L1 is always placed AFTER the stable cached prefix, never inside it.
+
+**Pressure-adaptive injection**:
+
+| Context Pressure | What's Injected | Token Cost |
+|-----------------|-----------------|------------|
+| < 75% | L1 injection version (compressed) | ~2000 |
+| 75–85% | L1 minimal (Task + Current State + Progress only) | ~800 |
+| 85–95% | L0 anchor only (in system prompt) | ~50 |
+| > 95% | L0 anchor only | ~50 |
+| Post-compaction first turn | L1 injection version (full) + continuation prompt | ~2200 |
+
+### 4.7 Memoria Storage Protocol
+
+```
+Store/Update L1:
+  POST /v1/memories
+  {
+    "content": "[session-memory:v1]\n# Session Title\n...",
+    "memory_type": "working",
+    "session_id": "{session_id}"
+  }
+
+  On subsequent updates:
+  PUT /v1/memories/{memory_id}/correct
+  {
+    "new_content": "[session-memory:v1]\n# Session Title\n...",
+    "reason": "session memory update turn {N}"
+  }
+
+Retrieve L1 (at compaction time):
+  POST /v1/memories/search
+  {
+    "query": "[session-memory:v1] session state",
+    "top_k": 3,
+    "memory_types": ["working"]
+  }
+  Then filter results client-side:
+    - Match session_id
+    - Match content prefix "[session-memory:v1]"
+    - Take the most recent (by updated_at)
+```
+
+**Why `search` + client filter instead of `retrieve`**: The `[session-memory:v1]` prefix is a structural marker, not a semantic concept. Memoria's fulltext index (ngram parser) reliably matches this literal prefix. Using `search` with `memory_types` filter narrows the candidate set. Client-side `session_id` + prefix filtering ensures exact match. The `retrieve` endpoint's session_id filtering is post-retrieval anyway, so there's no efficiency difference.
+
+**Memory ID tracking**: The L1 writer keeps the `memory_id` of the current session memory in-memory. Subsequent updates use `PUT /v1/memories/{id}/correct` directly, avoiding the search round-trip. The search path is only needed when recovering (e.g., session resume, compaction without cached ID).
+
+## 5. L2: Compaction Summary (Fallback)
+
+Used only when L1 is unavailable (first compaction before L1 is populated, or Memoria unreachable).
+
+### 5.1 Nine-Section Prompt
+
+Borrowed from Claude Code's `compact_prompt.ts` with adaptations:
+
+```
+CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.
+
+First, write an <analysis> block analyzing the conversation chronologically.
+Then, write a <summary> block with these REQUIRED sections:
+
+1. Primary Request and Intent — ALL of the user's explicit requests
+2. Key Technical Concepts — technologies, frameworks discussed
+3. Files and Code Modified — files examined/modified with code snippets
+4. Errors and Fixes — all errors + how fixed + user feedback
+5. Problem Solving — problems solved, ongoing troubleshooting
+6. All User Messages — list ALL user messages that are not tool results
+7. Pending Tasks — tasks explicitly asked to work on
+8. Current Work — what was being worked on immediately before this summary,
+   with DIRECT QUOTES from the most recent conversation
+9. Next Step — DIRECTLY in line with user's most recent explicit requests.
+   Do not start on tangential or old completed requests.
+
+The <analysis> block will be stripped. Only <summary> enters context.
+```
+
+### 5.2 Anti-Drift Safeguards
+
+- Section 6 preserves all user messages verbatim
+- Section 8 requires "direct quotes from the most recent conversation showing exactly what task was being worked on"
+- Section 9 requires alignment with "user's most recent explicit requests"
+- `format_structured_summary()` warns if required sections (Primary Request, Pending Tasks, Current Work) are missing
+
+### 5.3 Post-Compaction Continuation Prompt
+
+Injected as a user message after the summary:
+
+```
+This session is being continued from a previous conversation that was compacted.
+The session state above preserves your task and progress.
+Continue the conversation from where it left off without asking the user any further questions.
+Resume directly — do not acknowledge the summary, do not recap what was happening,
+do not preface with "I'll continue" or similar.
+Pick up the last task as if the break never happened.
+```
+
+### 5.4 Post-Compaction Restoration
+
+Borrowed from Claude Code's `postCompactCleanup.ts`:
+
+| Restore Item | Condition | Budget |
+|-------------|-----------|--------|
+| Recently read files | Not already in preserved messages (dedup) | Top 5, ≤5K tokens each, ≤25K total |
+| Active plan | If plan exists | Full content |
+| Invoked skills | If skills were activated | ≤5K per skill, ≤15K total |
+| Tool schemas | If tools were discovered mid-session | Delta re-announcement |
+
+**File dedup** (Claude Code pattern): Scan preserved tail messages for `read_file` tool results. Extract file paths. Skip any file that's already visible in the preserved messages during restoration.
+
+## 6. L3: Durable Memory (Memoria)
+
+Not injected into context. Retrieved on demand via Memoria's semantic search.
+
+### 6.1 Memory Types
+
+| Type | memory_type | Content Convention | Lifecycle |
+|------|------------|-------------------|-----------|
+| Session Memory | `working` | `[session-memory:v1]` prefix | Purged at session end |
+| Compaction Archive | `semantic` | `[compaction:{session_id}]` prefix | Permanent |
+| Session Episodic | `episodic` | topic/action/outcome structure | Permanent |
+| Goal/Plan | `procedural` | `🎯 GOAL:` / `📋 PLAN:` prefix | Cross-session |
+| User Profile | `profile` | Free-form preferences | Permanent |
+| Knowledge | `semantic` | Reusable learnings from sessions | Permanent |
+
+### 6.2 Session End Governance
+
+```
+Session end:
+  1. Extract reusable knowledge from L1's Errors & Decisions sections
+     → Store as semantic memory (cross-session)
+  2. Generate episodic summary (cheap model)
+     → Store as episodic memory
+  3. Purge working memory for this session_id
+     → POST /v1/memories/purge { "topic": "session:{session_id}", "reason": "session ended" }
+       (Memoria purge uses topic-based keyword matching, not a session_id field)
+  4. Update active Goal status if applicable
+     → PUT /v1/memories/{goal_id}/correct
+```
+
+### 6.3 Cross-Session Bootstrap
+
+At session start, the per-turn prefetch retrieves relevant memories from all types. Active goals (`🎯 GOAL: ... Status: ACTIVE`) and recent episodic summaries provide cross-session continuity.
+
+## 7. Prompt Cache Strategy
+
+### 7.1 Cache-Friendly Message Layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Message [0]: System Prompt                                   │
+│   ├─ CacheScope::Global  ─── identity, rules, coding ──┐   │
+│   ├─ CacheScope::Session ─── tools, task strategy ──────┤   │
+│   │                                          CACHED PREFIX   │
+│   ├─ CacheScope::None ───── profile, skills, L0 anchor ─┘   │
+│   │                                          NOT CACHED      │
+├─────────────────────────────────────────────────────────────┤
+│ Message [1]: L1 Session Memory (system role)                 │
+│   Content: [session-memory:v1] injection version             │
+│   NOT CACHED (changes periodically)                          │
+├─────────────────────────────────────────────────────────────┤
+│ Messages [2..N-1]: Conversation                              │
+│   User messages, assistant responses, tool calls/results     │
+│   Microcompact clears old tool results here                  │
+│   INCREMENTALLY CACHED (turn-to-turn KV reuse)               │
+├─────────────────────────────────────────────────────────────┤
+│ Message [N]: Last message                                    │
+│   cache_control: { type: "ephemeral" }  ← CACHE BREAKPOINT  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 7.2 Cache Impact Analysis
+
+| Operation | Cache Impact | Mitigation |
+|-----------|-------------|------------|
+| L0 anchor update | None — in CacheScope::None | Already non-cached |
+| L1 injection update | **Moderate** — message [1] changes invalidate conversation KV cache from [1] onward | Acceptable: L1 updates ~every 3-5 turns; conversation messages change every turn anyway, so the incremental cache loss is small relative to the new content being added. Net effect: one turn of extra cache-creation cost per L1 update. |
+| L1 periodic extraction | None — runs as separate cheap-model API call | Does not touch main conversation |
+| Microcompact | None — modifies volatile messages after cache breakpoint | Content changes are in non-cached region |
+| Compaction | Full cache reset (expected) | Notify CacheBreakDetector to suppress false-positive alerts |
+| Post-compact restoration | New messages appended after summary | New cache prefix established on next turn |
+
+### 7.3 Cache Break Prevention Rules
+
+1. **L0 anchor goes in `CacheScope::None`** — never in Global or Session sections
+2. **L1 injection is a separate system message [1]** — does not modify message [0]'s cached content
+3. **L1 extraction uses a separate API call** (cheap model) — does not affect main conversation's cache
+4. **Microcompact only touches messages after the cache breakpoint** — preserves cached prefix
+5. **Tool schemas remain alphabetically sorted** — prevents score fluctuation from breaking cache
+6. **Session-latched cache config** — `PromptCacheConfig` captured once at session start
+7. **Compaction notifies `CacheBreakDetector`** — suppresses false-positive alerts after expected cache reset
+
+### 7.4 Anthropic vs OpenAI Cache Handling
+
+**Anthropic** (explicit `cache_control`):
+- Message [0] has `cache_control` on last Global section and last Session section
+- Message [N] has `cache_control: { type: "ephemeral" }` for turn-to-turn KV reuse
+- L1 at message [1] has no `cache_control` — it's between the system prompt cache and the conversation cache
+
+**OpenAI** (automatic prefix caching):
+- Message [0] is split into two system messages: stable (Global+Session) and dynamic (None+L0)
+- L1 is a third system message
+- The stable message stays identical across turns → automatic prefix cache hits
+- L1 changes don't affect the stable message's cache
+
+## 8. Deployment Modes
+
+### 8.1 CLI Edge Mode
+
+```
+L0: In-memory (process lifetime)
+L1: Local file + async sync to Memoria
+    - Path: {cwd}/.astra/sessions/{sid}/session-memory.md
+      (consistent with existing session_memory_extract.rs write_session_memory_file)
+    - Write locally first (low latency, atomic write via .tmp + rename)
+    - Background task syncs to Memoria every update
+    - Compaction reads local file first, falls back to Memoria
+    - Claude Code compatibility: also reads ~/.claude/projects/{cwd}/{sid}/session-memory/summary.md
+      via existing SessionMemoryFileCombine::Merge mode
+L2: Generated on-demand, stored in Memoria
+L3: Memoria (server-side)
+```
+
+### 8.2 Web Agent Mode
+
+```
+L0: In-memory (request-scoped, reconstructed from L1 on session resume)
+L1: Directly in Memoria (no local file)
+    - Store/correct via HTTP API
+    - Retrieve via HTTP API at compaction time
+L2: Generated on-demand, stored in Memoria
+L3: Memoria (server-side)
+```
+
+### 8.3 Claude Code Compatibility
+
+Existing `SessionMemoryFileCombine` modes in `memoria_compact.rs`:
+
+| Mode | Behavior |
+|------|----------|
+| `None` | Ignore Claude Code's `summary.md` files |
+| `Fallback` | Use CC's file only if Memoria returns nothing |
+| `Merge` | Combine both: CC file gets 28% of memory token budget, Memoria gets the rest |
+
+When running alongside Claude Code:
+- Claude Code maintains its own `~/.claude/projects/{cwd}/{sid}/session-memory/summary.md`
+- astra-engine reads this file during compaction (Merge mode)
+- astra-engine also maintains its own L1 in Memoria
+- Both sources are combined for maximum context preservation
+
+## 9. Compaction Flow (Revised)
+
+```
+Compaction triggered (pressure ≥ 75%):
+
+  Step 1: Preserve anchors
+    - Keep all system messages (including L0 anchor in system prompt)
+    - Keep first user message (original task) — NEVER remove
+    - Keep tail N turn pairs
+    - Identify and skip old compaction boundary messages (compact_metadata markers
+      from previous compactions) — prevents summary-of-summary nesting
+
+  Step 2: Wait for in-flight L1 update (max 15 seconds)
+    - If L1 extraction is in progress, wait for completion
+    - If timeout, proceed without L1
+
+  Step 3: Retrieve L1 from Memoria (or local file in CLI mode)
+    POST /v1/memories/search { query: "[session-memory:v1]", memory_types: ["working"] }
+    Filter by session_id + prefix match
+
+  Step 4: Choose summary source
+    ├─ L1 available, valid, and non-empty → Use L1 as summary (ZERO LLM compaction)
+    └─ L1 unavailable or malformed → Generate L2 with cheap model (9-section prompt)
+
+  Step 5: Build post-compact message array (with explicit roles)
+    [0] role:system  — System prompt (with L0 anchor in dynamic section)
+    [1] role:system  — Summary (L1 injection version or L2), with compact_metadata marker
+    [2] role:user    — Continuation prompt ("pick up where you left off")
+    [3..K] role:user + role:assistant — File restorations (synthetic read_file tool
+           call/result pairs for deduped recently-read files)
+    [K+1..] — Preserved tail messages (original roles)
+
+  Step 6: Post-compact actions
+    - Store compaction summary as semantic memory in Memoria
+      with [compaction:{sid}] tag and compact_metadata in content
+    - Notify CacheBreakDetector (suppress false-positive alerts)
+    - Reset microcompact state
+    - Clear section caches (system prompt, tool schemas)
+
+  Step 7: Store updated working memory
+    - If L1 was used as summary, no additional store needed
+    - If L2 was generated, store it as semantic memory with [compaction:{sid}] tag
+```
+
+### 9.1 Multi-Compaction Handling
+
+A long session may compact multiple times. Key invariants:
+
+1. **Old compaction boundaries are identified by `compact_metadata`** in the message. When building the preserved set, these boundary messages are recognized and treated as summaries, not as regular conversation.
+
+2. **L1 is always the latest version** — it's updated incrementally, so the second compaction's L1 already incorporates everything from the first compaction's preserved context. No summary-of-summary problem.
+
+3. **First user message is always preserved** — even across multiple compactions, the original task message is pinned. It may appear immediately after the latest summary message.
+
+4. **Compaction archives accumulate in L3** — each compaction stores a semantic memory with `[compaction:{sid}]` tag. These form a chain of historical snapshots, retrievable for debugging but never re-injected.
+
+## 10. Implementation Plan
+
+| Phase | Scope | Key Changes | Files |
+|-------|-------|-------------|-------|
+| **P0** | Goal preservation | TieredCompaction/ReactiveCompact preserve first user message; L0 anchor extraction + injection in system prompt; continuation prompt after compaction | `context_compression.rs`, `prompts/system.rs`, `memoria_compact.rs` |
+| **P1** | Microcompact improvements | Adaptive retention by pressure; duplicate read elimination; cache-aware clearing | `microcompact.rs` |
+| **P2** | L1 Session Memory | Template definition; cheap model extraction; per-section budget governance; Memoria store/correct; injection version compression | New: `session_memory.rs`; Modified: `bridge_inprocess.rs`, `server_loop_host.rs` |
+| **P3** | Zero-LLM compaction | L1 replaces L2 at compaction time; post-compact file restoration with dedup | `memoria_compact.rs`, `compact_prompt.rs` |
+| **P4** | L2 improvements | 9-section prompt with analysis scratchpad; anti-drift safeguards; format validation | `compact_prompt.rs` |
+| **P5** | L3 governance | Session end: knowledge backflow, episodic summary, working memory purge, goal update | `agentic_loop_lifecycle.rs`, `memoria_compact.rs` |
+| **P6** | Cloud-edge sync | CLI local file + async Memoria sync; web agent direct Memoria; CC compatibility | `session_memory.rs`, `memoria_compact.rs` |
+
+## 11. Metrics & Observability
+
+| Metric | Source | Purpose |
+|--------|--------|---------|
+| `session_memory.update_count` | L1 update trigger | Track extraction frequency |
+| `session_memory.update_latency_ms` | Cheap model API call | Monitor extraction cost |
+| `session_memory.injection_tokens` | Token count of injected L1 | Track token overhead |
+| `compaction.summary_source` | `l1_session_memory` / `l2_llm_summary` / `l2_fallback` | Track zero-LLM compaction rate |
+| `compaction.goal_preserved` | Boolean: was first user message + L0 anchor present post-compact | Verify goal preservation |
+| `cache.hit_rate` | Existing cache diagnostics | Verify memory injection doesn't degrade cache |
+| `cache.break_reason` | Existing cache break detector | Detect if L1 injection causes unexpected breaks |
+
+## 12. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Cheap model produces low-quality L1 | Goal drift, incorrect state | Format validation (4.5): must contain required sections; 2 consecutive failures → pause L1, use L2 |
+| L1 update latency blocks main turn | User-visible delay | Async fire-and-forget (4.4); result available next turn; compaction waits max 15s then falls back to L2 |
+| Memoria unavailable during compaction | No L1 available | Fallback chain: local file (CLI) → L2 (LLM summary) → pure truncation with first-user-message preserved |
+| L1 injection invalidates conversation KV cache | Higher cache-creation costs | L1 updates ~every 3-5 turns; conversation changes every turn anyway; net cost is one turn of extra cache-creation per update (7.2) |
+| Per-section budgets too restrictive | Important info truncated | Stored version has generous budgets (4K total); injection version is separately compressed (2K); condensation prompt prioritizes Task/CurrentState/UserMessages |
+| Claude Code compatibility conflicts | Duplicate/conflicting memories | Merge mode with budget split (28% CC / 72% Memoria); CC file is read-only, never modified by astra-engine |
+| Multiple compactions nest summaries | Summary-of-summary quality degradation | Old compaction boundaries identified by compact_metadata and skipped (9.1); L1 is always latest version, not derived from previous summary |
+| Session resume without cached memory_id | Cannot update L1 via correct endpoint | Search fallback: `POST /v1/memories/search` with prefix filter recovers the memory_id (4.7) |

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
  "futures-util",
  "http-body-util",
  "notify",
+ "percent-encoding",
  "proptest",
  "regex",
  "reqwest 0.12.28",

--- a/rust/crates/core/src/runtime_limits.rs
+++ b/rust/crates/core/src/runtime_limits.rs
@@ -6,7 +6,7 @@
 //! ```text
 //! MO_MAX_TURNS=50              # conversation turns per session
 //! MO_PLAN_SUBTASK_MAX_TURNS=0  # per-subtask turn budget (0 = use MO_MAX_TURNS)
-//! MO_MAX_TOOL_ROUNDS=15        # tool execution rounds per turn
+//! MO_MAX_TOOL_ROUNDS=30        # tool execution rounds per turn
 //! MO_TURN_TIMEOUT_S=300        # seconds before a turn is force-completed
 //! MO_GLOBAL_OUTPUT_LIMIT=80000 # combined tool output bytes
 //! MO_TOOL_OUTPUT_LIMIT=30000   # per-tool output bytes
@@ -54,7 +54,7 @@ impl Default for RuntimeLimits {
         Self {
             max_turns: 50,
             plan_subtask_max_turns: 0,
-            max_tool_rounds: 15,
+            max_tool_rounds: 30,
             turn_timeout_s: 300.0,
             global_output_limit: 200_000,
             tool_output_limit: 80_000,
@@ -139,7 +139,7 @@ mod tests {
         let d = RuntimeLimits::default();
         assert_eq!(d.max_turns, 50);
         assert_eq!(d.plan_subtask_max_turns, 0);
-        assert_eq!(d.max_tool_rounds, 15);
+        assert_eq!(d.max_tool_rounds, 30);
         assert!((d.turn_timeout_s - 300.0).abs() < f64::EPSILON);
         assert_eq!(d.global_output_limit, 200_000);
         assert_eq!(d.tool_output_limit, 80_000);

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -30,6 +30,7 @@ path = "src/main.rs"
 [dependencies]
 dirs = "6.0.0"
 fastrand = "2"
+percent-encoding = "2.3"
 astra-core.workspace = true
 astra-pipeline.workspace = true
 astra-sandbox.workspace = true

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -2009,8 +2009,7 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                         .and_then(|m| m.get("content").and_then(Value::as_str))
                         .map(|c| {
                             let lower = c.to_ascii_lowercase();
-                            let has_negation = lower.contains("not ") || lower.contains("haven't")
-                                || lower.contains("hasn't") || lower.contains("isn't")
+                            let has_negation = lower.contains("not ") || lower.contains("n't")
                                 || lower.contains("没有") || lower.contains("尚未")
                                 || lower.contains("except") || lower.contains("but ");
                             let has_completion = lower.contains("task complete") || lower.contains("all done")
@@ -3113,7 +3112,7 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                     if let Err(e) = crate::turn::cloud::session_memory_protocol::persist_l1(
                         &client, &l1_content, &l1_sid,
                     ).await {
-                        eprintln!("[session-memory] L1 persist failed for session {l1_sid}: {e}");
+                        tracing::warn!(session_id = %l1_sid, error = %e, "L1 session memory persist failed");
                     }
                 });
             }
@@ -5770,8 +5769,7 @@ mod tests {
     /// Helper matching the actual P2 completion detection logic in the turn loop.
     fn signals_done(content: &str) -> bool {
         let lower = content.to_ascii_lowercase();
-        let has_negation = lower.contains("not ") || lower.contains("haven't")
-            || lower.contains("hasn't") || lower.contains("isn't")
+        let has_negation = lower.contains("not ") || lower.contains("n't")
             || lower.contains("没有") || lower.contains("尚未")
             || lower.contains("except") || lower.contains("but ");
         let has_completion = lower.contains("task complete") || lower.contains("all done")
@@ -5808,6 +5806,21 @@ mod tests {
     #[test]
     fn p2_no_false_positive_all_done_except() {
         assert!(!signals_done("All done except the deployment step."));
+    }
+
+    #[test]
+    fn p2_no_false_positive_wont_be_finished() {
+        assert!(!signals_done("The task won't be finished until deployment is done."));
+    }
+
+    #[test]
+    fn p2_no_false_positive_cannot_be_completed() {
+        assert!(!signals_done("This cannot be completed today."));
+    }
+
+    #[test]
+    fn p2_no_false_positive_dont_think_finished() {
+        assert!(!signals_done("I don't think we're finished yet."));
     }
 
     // ── P1 latency fix: anchor from local messages, no network ──────────

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -1425,6 +1425,8 @@ pub struct InProcessChatTurnBridge {
     /// Session-scoped structured feedback store — accumulates correction rules
     /// and injects them into subsequent turn system prompts.
     pub feedback_store: Arc<crate::pipeline::feedback_store::FeedbackStore>,
+    /// Cached Memoria client — created once, reused across turns.
+    pub memoria_client: Option<crate::turn::cloud::memoria_compact::HttpMemoriaClient>,
 }
 
 impl InProcessChatTurnBridge {
@@ -1436,6 +1438,7 @@ impl InProcessChatTurnBridge {
             turn_learning_writer: None,
             edge_callback_ledger: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             feedback_store: Arc::new(crate::pipeline::feedback_store::FeedbackStore::new()),
+            memoria_client: crate::turn::cloud::memoria_compact::HttpMemoriaClient::from_env(),
         }
     }
 
@@ -1554,6 +1557,7 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
         let bridge_e2e_capture = bridge_e2e_for_stream.clone();
         let client_cancel_capture = client_cancel.clone();
         let feedback_store_capture = self.feedback_store.clone();
+        let memoria_client_owned = self.memoria_client.clone();
 
         let stream = stream! {
             let cc = client_cancel_capture.clone();
@@ -1867,8 +1871,43 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                     .unwrap_or_default()
             };
 
-            // Build per-turn dynamic content (profile + skills + memory signal + feedback + self-awareness + learned rules)
-            let dynamic_desc = format!("{profile_with_hints}{memory_signal_hint}{implicit_feedback_hint}{feedback_rules_hint}{self_awareness_hint}");
+            // ── Memoria client (shared across P1 anchor + compaction + P3 write) ──
+            let memoria_client_shared = memoria_client_owned.clone();
+
+            // ── P1: L0 session anchor — inject original task into dynamic system prompt ──
+            // Derive anchor from current conversation state. On turn 1, falls back to
+            // first user message. On subsequent turns, builds a lightweight L1 from
+            // messages to show current state + progress — zero network calls.
+            let session_anchor = {
+                use crate::turn::cloud::session_memory_protocol::{
+                    extract_anchor, extract_message_text, build_l1_from_messages, SessionMemory,
+                };
+                let first_user_text = messages
+                    .iter()
+                    .find(|m| m.get("role").and_then(Value::as_str) == Some("user"))
+                    .and_then(|m| extract_message_text(m))
+                    .unwrap_or_default();
+
+                if first_user_text.is_empty() {
+                    String::new()
+                } else {
+                    // After first turn, derive anchor from conversation state (no network)
+                    let turn_count = messages.iter()
+                        .filter(|m| m.get("role").and_then(Value::as_str) == Some("assistant"))
+                        .count();
+                    let l1 = if turn_count > 0 {
+                        let l1_text = build_l1_from_messages(&messages, turn_count, 0);
+                        SessionMemory::parse(&l1_text).filter(|l| l.validate().is_ok())
+                    } else {
+                        None
+                    };
+                    let anchor = extract_anchor(&first_user_text, l1.as_ref());
+                    format!("\n\n{anchor}")
+                }
+            };
+
+            // Build per-turn dynamic content (profile + skills + memory signal + feedback + self-awareness + learned rules + anchor)
+            let dynamic_desc = format!("{profile_with_hints}{memory_signal_hint}{implicit_feedback_hint}{feedback_rules_hint}{self_awareness_hint}{session_anchor}");
 
             // Build provider-aware system message with static/dynamic boundary.
             // Anthropic gets multi-block content with cache_control on stable sections;
@@ -1931,9 +1970,8 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                     session_memory_combine,
                 };
 
-                // Try to create Memoria client from environment
-                let memoria_client =
-                    crate::turn::cloud::memoria_compact::HttpMemoriaClient::from_env();
+                // Reuse shared Memoria client for compaction
+                let memoria_client = memoria_client_shared.clone();
 
                 // Build summary client for LLM-based compaction
                 let compact_config = crate::prompts::CompactConfig::from_env();
@@ -1958,7 +1996,49 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                 )
                 .await;
 
-                (compact_result.messages, tier) // tier only feeds memoria_compact params
+                // ── P2: Continuation prompt after compaction ──
+                // When compaction removed messages, append a user-role nudge so the
+                // LLM resumes the task instead of asking "how can I help?"
+                // Skip if the last assistant message signals task completion.
+                let mut msgs = compact_result.messages;
+                if compact_result.boundary.is_some() && msgs.len() >= 2 {
+                    let last_is_user = msgs.last()
+                        .and_then(|m| m.get("role").and_then(Value::as_str))
+                        == Some("user");
+                    let last_signals_done = msgs.last()
+                        .and_then(|m| m.get("content").and_then(Value::as_str))
+                        .map(|c| {
+                            let lower = c.to_ascii_lowercase();
+                            let has_negation = lower.contains("not ") || lower.contains("haven't")
+                                || lower.contains("hasn't") || lower.contains("isn't")
+                                || lower.contains("没有") || lower.contains("尚未")
+                                || lower.contains("except") || lower.contains("but ");
+                            let has_completion = lower.contains("task complete") || lower.contains("all done")
+                                || lower.contains("finished") || lower.contains("completed successfully")
+                                || lower.contains("任务完成") || lower.contains("已完成");
+                            has_completion && !has_negation
+                        })
+                        .unwrap_or(false);
+                    if !last_is_user && !last_signals_done {
+                        // Detect if conversation is primarily CJK (Chinese/Japanese/Korean)
+                        let is_cjk = msgs.iter().rev().take(4)
+                            .filter_map(|m| m.get("content").and_then(Value::as_str))
+                            .any(|c| c.chars().take(200).filter(|ch| ('\u{4e00}'..='\u{9fff}').contains(ch)).count() > 10);
+                        let prompt = if is_cjk {
+                            "从上次中断的地方继续。不要向用户提问，直接继续当前任务。"
+                        } else {
+                            "Continue the conversation from where it left off. \
+                             Do not ask the user any further questions — \
+                             pick up the current task and keep going."
+                        };
+                        msgs.push(serde_json::json!({
+                            "role": "user",
+                            "content": prompt
+                        }));
+                    }
+                }
+
+                (msgs, tier) // tier only feeds memoria_compact params
             };
 
             llm_messages.extend(merged_messages);
@@ -2183,7 +2263,7 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                                     max_output_tokens: compact_config.summary_token_budget,
                                 },
                             );
-                            let memoria_client = crate::turn::cloud::memoria_compact::HttpMemoriaClient::from_env();
+                            let memoria_client = memoria_client_owned.clone();
                             let memoria_config = crate::turn::cloud::memoria_compact::MemoriaCompactConfig::default();
 
                             // Get original messages (exclude leading system messages)
@@ -3016,6 +3096,26 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                     auxiliary_llm_calls,
                 );
                 yield render_sse_map(&explain_event);
+            }
+
+            // ── P3: Async L1 session memory write to Memoria ──
+            // Writes L1 at turn end. Deletes previous L1 for this session first to
+            // avoid accumulating stale working memories. Retries once on failure.
+            if cloud_loop_turns > 1 || !all_round_tool_calls.is_empty() {
+                let l1_content = crate::turn::cloud::session_memory_protocol::build_l1_from_messages(
+                    &messages, cloud_loop_turns as usize,
+                    usage.get("prompt_tokens").and_then(Value::as_i64).unwrap_or(0) as usize,
+                );
+                let l1_sid = session_id.clone();
+                let l1_client = memoria_client_shared.clone();
+                tokio::spawn(async move {
+                    let Some(client) = l1_client else { return; };
+                    if let Err(e) = crate::turn::cloud::session_memory_protocol::persist_l1(
+                        &client, &l1_content, &l1_sid,
+                    ).await {
+                        eprintln!("[session-memory] L1 persist failed for session {l1_sid}: {e}");
+                    }
+                });
             }
 
             // turn_complete
@@ -5342,5 +5442,431 @@ mod tests {
         assert_eq!(event["type"], "turn_complete");
         assert_eq!(event["has_tool_calls"], false);
         assert_eq!(event["followup_suggestion"], "继续");
+    }
+
+    // ── P1: L0 anchor appears in system prompt ──────────────────────────
+
+    #[test]
+    fn p1_anchor_injected_into_openai_dynamic_message() {
+        use crate::turn::cloud::session_memory_protocol::extract_anchor;
+
+        let anchor = extract_anchor("Build a distributed rate limiter using Redis", None);
+        let profile_desc = format!("cwd: /home/user/project\n\n{anchor}");
+
+        let cache_cfg = PromptCacheConfig {
+            is_anthropic: false,
+            cache_enabled: false,
+        };
+        let (_primary, dynamic, _sections) = build_system_message(
+            &["read_file", "grep"],
+            &profile_desc,
+            0.9,
+            None,
+            &cache_cfg,
+        );
+
+        let dyn_content = dynamic
+            .expect("OpenAI should have dynamic message")
+            .get("content")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        assert!(
+            dyn_content.contains("[session-anchor]"),
+            "Dynamic message should contain anchor: {dyn_content}"
+        );
+        assert!(dyn_content.contains("rate limiter"));
+    }
+
+    #[test]
+    fn p1_anchor_injected_into_anthropic_blocks() {
+        use crate::turn::cloud::session_memory_protocol::extract_anchor;
+
+        let anchor = extract_anchor("Refactor auth module to use JWT", None);
+        let profile_desc = format!("cwd: /project\n\n{anchor}");
+
+        let cache_cfg = PromptCacheConfig {
+            is_anthropic: true,
+            cache_enabled: true,
+        };
+        let (msg, _, _) = build_system_message(
+            &["read_file"],
+            &profile_desc,
+            0.9,
+            None,
+            &cache_cfg,
+        );
+
+        // Anthropic: single message with content blocks array
+        let blocks = msg.get("content").and_then(Value::as_array).unwrap();
+        let all_text: String = blocks
+            .iter()
+            .filter_map(|b| b.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            all_text.contains("[session-anchor]"),
+            "Anthropic blocks should contain anchor"
+        );
+        assert!(all_text.contains("JWT"));
+    }
+
+    // ── P2: Continuation prompt after compaction ────────────────────────
+
+    #[test]
+    fn p2_continuation_prompt_appended_after_compaction() {
+        use crate::turn::cloud::memoria_compact::{
+            MemoriaCompactConfig, MemoriaCompactParams, compact_with_memoria,
+        };
+
+        let mut messages: Vec<Value> = vec![json!({"role": "system", "content": "sys"})];
+        messages.push(json!({"role": "user", "content": "Build X"}));
+        for i in 0..20 {
+            messages.push(json!({"role": "assistant", "content": format!("Step {i} {}", "x".repeat(400))}));
+            messages.push(json!({"role": "user", "content": format!("Next {}", i + 1)}));
+        }
+
+        let config = MemoriaCompactConfig::default();
+        let params = MemoriaCompactParams {
+            budget_chars: 3000,
+            keep_chars: 1500,
+            tier: crate::prompts::CompactionTier::AggressivePrune,
+            keep_recent_turns: 2,
+            current_tokens: 80000,
+            session_memory_file: None,
+            session_memory_combine:
+                crate::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
+        };
+
+        let result = tokio::runtime::Runtime::new().unwrap().block_on(
+            compact_with_memoria(&messages, None, &config, &params, None, None, None),
+        );
+
+        // Compaction happened (boundary present), so we simulate what the turn loop does
+        assert!(result.boundary.is_some(), "compaction should have triggered");
+
+        let mut msgs = result.messages;
+        if result.boundary.is_some() && msgs.len() >= 2 {
+            msgs.push(json!({
+                "role": "user",
+                "content": "Continue the conversation from where it left off. \
+                            Do not ask the user any further questions — \
+                            pick up the current task and keep going."
+            }));
+        }
+
+        let last = msgs.last().unwrap();
+        assert_eq!(last["role"], "user");
+        assert!(last["content"].as_str().unwrap().contains("Continue"));
+        assert!(last["content"].as_str().unwrap().contains("keep going"));
+    }
+
+    #[test]
+    fn p2_no_continuation_when_no_compaction() {
+        use crate::turn::cloud::memoria_compact::{
+            MemoriaCompactConfig, MemoriaCompactParams, compact_with_memoria,
+        };
+
+        // Small conversation — no compaction needed
+        let messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "hi"}),
+        ];
+
+        let config = MemoriaCompactConfig::default();
+        let params = MemoriaCompactParams {
+            budget_chars: 100_000,
+            keep_chars: 50_000,
+            tier: crate::prompts::CompactionTier::CompactHistory,
+            keep_recent_turns: 2,
+            current_tokens: 500,
+            session_memory_file: None,
+            session_memory_combine:
+                crate::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
+        };
+
+        let result = tokio::runtime::Runtime::new().unwrap().block_on(
+            compact_with_memoria(&messages, None, &config, &params, None, None, None),
+        );
+
+        assert!(result.boundary.is_none(), "no compaction should happen");
+        // No continuation prompt should be added
+        assert_eq!(result.messages.len(), 3);
+        assert_eq!(result.messages.last().unwrap()["role"], "assistant");
+    }
+
+    #[test]
+    fn p2_no_continuation_when_last_message_is_user() {
+        use crate::turn::cloud::memoria_compact::{
+            MemoriaCompactConfig, MemoriaCompactParams, compact_with_memoria,
+        };
+
+        // Build conversation where last message after compaction will be user
+        let mut messages: Vec<Value> = vec![json!({"role": "system", "content": "sys"})];
+        messages.push(json!({"role": "user", "content": "Build X"}));
+        for i in 0..20 {
+            messages.push(json!({"role": "assistant", "content": format!("Step {i} {}", "x".repeat(400))}));
+            messages.push(json!({"role": "user", "content": format!("Next {}", i + 1)}));
+        }
+
+        let config = MemoriaCompactConfig::default();
+        let params = MemoriaCompactParams {
+            budget_chars: 3000,
+            keep_chars: 1500,
+            tier: crate::prompts::CompactionTier::AggressivePrune,
+            keep_recent_turns: 2,
+            current_tokens: 80000,
+            session_memory_file: None,
+            session_memory_combine:
+                crate::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
+        };
+
+        let result = tokio::runtime::Runtime::new().unwrap().block_on(
+            compact_with_memoria(&messages, None, &config, &params, None, None, None),
+        );
+
+        assert!(result.boundary.is_some(), "compaction should trigger");
+
+        // Simulate the turn loop's P2 logic
+        let mut msgs = result.messages;
+        if result.boundary.is_some() && msgs.len() >= 2 {
+            let last_is_user = msgs.last()
+                .and_then(|m| m.get("role").and_then(Value::as_str))
+                == Some("user");
+            if !last_is_user {
+                msgs.push(json!({
+                    "role": "user",
+                    "content": "Continue..."
+                }));
+            }
+        }
+
+        // Verify no consecutive user messages
+        for window in msgs.windows(2) {
+            let r0 = window[0].get("role").and_then(Value::as_str).unwrap_or("");
+            let r1 = window[1].get("role").and_then(Value::as_str).unwrap_or("");
+            assert!(
+                !(r0 == "user" && r1 == "user"),
+                "Consecutive user messages found: [{r0}] then [{r1}]"
+            );
+        }
+    }
+
+    #[test]
+    fn p1_anchor_handles_anthropic_content_blocks_in_user_message() {
+        use crate::turn::cloud::session_memory_protocol::extract_anchor;
+
+        // Simulate Anthropic-style content blocks in user message
+        let messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": [
+                {"type": "text", "text": "Build a distributed cache with LRU eviction"}
+            ]}),
+        ];
+
+        let first_user_text = messages
+            .iter()
+            .find(|m| m.get("role").and_then(Value::as_str) == Some("user"))
+            .and_then(|m| {
+                m.get("content").and_then(|c| {
+                    c.as_str().map(String::from).or_else(|| {
+                        c.as_array().and_then(|blocks| {
+                            blocks.iter().find_map(|b| {
+                                b.get("text").and_then(Value::as_str).map(String::from)
+                            })
+                        })
+                    })
+                })
+            });
+
+        assert!(first_user_text.is_some(), "Should extract text from content blocks");
+        let anchor = extract_anchor(&first_user_text.unwrap(), None);
+        assert!(anchor.contains("distributed cache"));
+    }
+
+    #[test]
+    fn p1_anchor_does_not_break_cached_prefix() {
+        use crate::turn::cloud::session_memory_protocol::extract_anchor;
+
+        let cache_cfg = PromptCacheConfig {
+            is_anthropic: false,
+            cache_enabled: true,
+        };
+        let tools = &["read_file", "grep"];
+
+        // Turn 1: no anchor
+        let (primary1, _, _) =
+            build_system_message(tools, "cwd: /project", 0.9, None, &cache_cfg);
+
+        // Turn 2: with anchor
+        let anchor = extract_anchor("Build rate limiter", None);
+        let profile_with_anchor = format!("cwd: /project\n\n{anchor}");
+        let (primary2, _, _) =
+            build_system_message(tools, &profile_with_anchor, 0.9, None, &cache_cfg);
+
+        // Stable cached primary must be identical — anchor only in dynamic
+        assert_eq!(
+            primary1.get("content").and_then(Value::as_str),
+            primary2.get("content").and_then(Value::as_str),
+            "Anchor must not change the cached primary system message"
+        );
+    }
+
+    #[test]
+    fn p3_usage_key_is_prompt_tokens_not_prompt() {
+        // Regression: the P3 code previously used usage.get("prompt") which always
+        // returned None. The correct key from LLM providers is "prompt_tokens".
+        let mut usage = serde_json::Map::new();
+        usage.insert("prompt_tokens".to_string(), json!(45000));
+        usage.insert("completion_tokens".to_string(), json!(2000));
+
+        // This is the exact expression from the P3 code path
+        let estimated_tokens = usage.get("prompt_tokens").and_then(Value::as_i64).unwrap_or(0) as usize;
+        assert_eq!(estimated_tokens, 45000);
+
+        // The old buggy key must NOT work
+        let wrong = usage.get("prompt").and_then(Value::as_i64).unwrap_or(0) as usize;
+        assert_eq!(wrong, 0, "usage.get(\"prompt\") should return None — the key is prompt_tokens");
+    }
+
+    // ── Fix #1: anchor evolves with L1 ──────────────────────────────────
+
+    #[test]
+    fn p1_anchor_evolves_when_l1_available() {
+        use crate::turn::cloud::session_memory_protocol::{
+            extract_anchor, SessionMemory, SESSION_MEMORY_PREFIX,
+        };
+
+        // Without L1 — shows "starting"
+        let anchor_no_l1 = extract_anchor("Build rate limiter", None);
+        assert!(anchor_no_l1.contains("starting"));
+        assert!(anchor_no_l1.contains("0/0"));
+
+        // With L1 — shows current state and progress
+        let l1_text = format!(
+            "{SESSION_MEMORY_PREFIX}\n\
+             # Session Title\nRate Limiter\n\
+             # Task Specification\nBuild a distributed rate limiter.\n\
+             # Current State\nRedis integration complete, testing.\n\
+             # Key Files\nsrc/main.rs\n\
+             # Progress\n✅ Setup\n✅ Redis\n🔄 Testing\n⏳ Deploy\n\
+             # Errors & Corrections\nNone\n\
+             # Decisions\n- Use Redis\n\
+             # User Messages\nBuild rate limiter\n\
+             # Worklog\nT1\n\
+             # Context\nT5"
+        );
+        let l1 = SessionMemory::parse(&l1_text).unwrap();
+        let anchor_with_l1 = extract_anchor("Build rate limiter", Some(&l1));
+
+        assert!(!anchor_with_l1.contains("starting"), "should not say 'starting' when L1 available");
+        assert!(anchor_with_l1.contains("Redis integration"), "should show current state from L1");
+        assert!(anchor_with_l1.contains("2/4"), "should show progress from L1");
+    }
+
+    // ── Fix #4: P2 skips continuation when task is done ─────────────────
+
+    /// Helper matching the actual P2 completion detection logic in the turn loop.
+    fn signals_done(content: &str) -> bool {
+        let lower = content.to_ascii_lowercase();
+        let has_negation = lower.contains("not ") || lower.contains("haven't")
+            || lower.contains("hasn't") || lower.contains("isn't")
+            || lower.contains("没有") || lower.contains("尚未")
+            || lower.contains("except") || lower.contains("but ");
+        let has_completion = lower.contains("task complete") || lower.contains("all done")
+            || lower.contains("finished") || lower.contains("completed successfully")
+            || lower.contains("任务完成") || lower.contains("已完成");
+        has_completion && !has_negation
+    }
+
+    #[test]
+    fn p2_no_continuation_when_task_complete() {
+        assert!(signals_done("All tasks completed successfully. The rate limiter is deployed."));
+    }
+
+    #[test]
+    fn p2_continuation_when_task_in_progress() {
+        assert!(!signals_done("I've implemented step 3. Working on step 4 next."));
+    }
+
+    #[test]
+    fn p2_no_continuation_chinese_completion() {
+        assert!(signals_done("所有步骤已完成，任务完成！"));
+    }
+
+    #[test]
+    fn p2_no_false_positive_negated_finished() {
+        assert!(!signals_done("I haven't finished yet, still working on it."));
+    }
+
+    #[test]
+    fn p2_no_false_positive_not_complete() {
+        assert!(!signals_done("The task is not yet complete, need more work."));
+    }
+
+    #[test]
+    fn p2_no_false_positive_all_done_except() {
+        assert!(!signals_done("All done except the deployment step."));
+    }
+
+    // ── P1 latency fix: anchor from local messages, no network ──────────
+
+    #[test]
+    fn p1_anchor_evolves_from_local_messages_no_network() {
+        use crate::turn::cloud::session_memory_protocol::{
+            extract_anchor, build_l1_from_messages, SessionMemory,
+        };
+
+        // Multi-turn conversation — anchor should show progress, not "starting"
+        let messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "Build a rate limiter using Redis"}),
+            json!({"role": "assistant", "content": "Starting implementation.", "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\": \"src/main.rs\"}"}}
+            ]}),
+            json!({"role": "tool", "content": "fn main() {}", "tool_call_id": "c1"}),
+            json!({"role": "assistant", "content": "Done with step 1."}),
+            json!({"role": "user", "content": "Now add Redis connection"}),
+            json!({"role": "assistant", "content": "Added Redis."}),
+        ];
+
+        let turn_count = messages.iter()
+            .filter(|m| m.get("role").and_then(Value::as_str) == Some("assistant"))
+            .count();
+        assert_eq!(turn_count, 3);
+
+        let l1_text = build_l1_from_messages(&messages, turn_count, 0);
+        let l1 = SessionMemory::parse(&l1_text).unwrap();
+        let anchor = extract_anchor("Build a rate limiter using Redis", Some(&l1));
+
+        assert!(!anchor.contains("starting"), "multi-turn anchor should not say 'starting'");
+        assert!(anchor.contains("Turn 3"), "should reflect current turn");
+    }
+
+    // ── Fix #11: CJK detection for bilingual continuation prompt ────────
+
+    #[test]
+    fn p2_cjk_detection_chinese_content() {
+        let msgs = vec![
+            json!({"role": "assistant", "content": "我已经完成了第一步的实现，接下来处理数据库连接。"}),
+            json!({"role": "user", "content": "继续"}),
+        ];
+        let is_cjk = msgs.iter().rev().take(4)
+            .filter_map(|m| m.get("content").and_then(Value::as_str))
+            .any(|c| c.chars().take(200).filter(|ch| ('\u{4e00}'..='\u{9fff}').contains(ch)).count() > 10);
+        assert!(is_cjk, "should detect Chinese content");
+    }
+
+    #[test]
+    fn p2_cjk_detection_english_content() {
+        let msgs = vec![
+            json!({"role": "assistant", "content": "I've implemented step 1. Working on the database connection next."}),
+            json!({"role": "user", "content": "continue"}),
+        ];
+        let is_cjk = msgs.iter().rev().take(4)
+            .filter_map(|m| m.get("content").and_then(Value::as_str))
+            .any(|c| c.chars().take(200).filter(|ch| ('\u{4e00}'..='\u{9fff}').contains(ch)).count() > 10);
+        assert!(!is_cjk, "should not detect CJK in English content");
     }
 }

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -5465,13 +5465,8 @@ mod tests {
             is_anthropic: false,
             cache_enabled: false,
         };
-        let (_primary, dynamic, _sections) = build_system_message(
-            &["read_file", "grep"],
-            &profile_desc,
-            0.9,
-            None,
-            &cache_cfg,
-        );
+        let (_primary, dynamic, _sections) =
+            build_system_message(&["read_file", "grep"], &profile_desc, 0.9, None, &cache_cfg);
 
         let dyn_content = dynamic
             .expect("OpenAI should have dynamic message")
@@ -5497,13 +5492,8 @@ mod tests {
             is_anthropic: true,
             cache_enabled: true,
         };
-        let (msg, _, _) = build_system_message(
-            &["read_file"],
-            &profile_desc,
-            0.9,
-            None,
-            &cache_cfg,
-        );
+        let (msg, _, _) =
+            build_system_message(&["read_file"], &profile_desc, 0.9, None, &cache_cfg);
 
         // Anthropic: single message with content blocks array
         let blocks = msg.get("content").and_then(Value::as_array).unwrap();
@@ -5530,7 +5520,9 @@ mod tests {
         let mut messages: Vec<Value> = vec![json!({"role": "system", "content": "sys"})];
         messages.push(json!({"role": "user", "content": "Build X"}));
         for i in 0..20 {
-            messages.push(json!({"role": "assistant", "content": format!("Step {i} {}", "x".repeat(400))}));
+            messages.push(
+                json!({"role": "assistant", "content": format!("Step {i} {}", "x".repeat(400))}),
+            );
             messages.push(json!({"role": "user", "content": format!("Next {}", i + 1)}));
         }
 
@@ -5546,12 +5538,17 @@ mod tests {
                 crate::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
         };
 
-        let result = tokio::runtime::Runtime::new().unwrap().block_on(
-            compact_with_memoria(&messages, None, &config, &params, None, None, None),
-        );
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(compact_with_memoria(
+                &messages, None, &config, &params, None, None, None,
+            ));
 
         // Compaction happened (boundary present), so we simulate what the turn loop does
-        assert!(result.boundary.is_some(), "compaction should have triggered");
+        assert!(
+            result.boundary.is_some(),
+            "compaction should have triggered"
+        );
 
         let mut msgs = result.messages;
         if result.boundary.is_some() && msgs.len() >= 2 {
@@ -5594,9 +5591,11 @@ mod tests {
                 crate::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
         };
 
-        let result = tokio::runtime::Runtime::new().unwrap().block_on(
-            compact_with_memoria(&messages, None, &config, &params, None, None, None),
-        );
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(compact_with_memoria(
+                &messages, None, &config, &params, None, None, None,
+            ));
 
         assert!(result.boundary.is_none(), "no compaction should happen");
         // No continuation prompt should be added
@@ -5614,7 +5613,9 @@ mod tests {
         let mut messages: Vec<Value> = vec![json!({"role": "system", "content": "sys"})];
         messages.push(json!({"role": "user", "content": "Build X"}));
         for i in 0..20 {
-            messages.push(json!({"role": "assistant", "content": format!("Step {i} {}", "x".repeat(400))}));
+            messages.push(
+                json!({"role": "assistant", "content": format!("Step {i} {}", "x".repeat(400))}),
+            );
             messages.push(json!({"role": "user", "content": format!("Next {}", i + 1)}));
         }
 
@@ -5630,16 +5631,19 @@ mod tests {
                 crate::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
         };
 
-        let result = tokio::runtime::Runtime::new().unwrap().block_on(
-            compact_with_memoria(&messages, None, &config, &params, None, None, None),
-        );
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(compact_with_memoria(
+                &messages, None, &config, &params, None, None, None,
+            ));
 
         assert!(result.boundary.is_some(), "compaction should trigger");
 
         // Simulate the turn loop's P2 logic
         let mut msgs = result.messages;
         if result.boundary.is_some() && msgs.len() >= 2 {
-            let last_is_user = msgs.last()
+            let last_is_user = msgs
+                .last()
                 .and_then(|m| m.get("role").and_then(Value::as_str))
                 == Some("user");
             if !last_is_user {
@@ -5688,7 +5692,10 @@ mod tests {
                 })
             });
 
-        assert!(first_user_text.is_some(), "Should extract text from content blocks");
+        assert!(
+            first_user_text.is_some(),
+            "Should extract text from content blocks"
+        );
         let anchor = extract_anchor(&first_user_text.unwrap(), None);
         assert!(anchor.contains("distributed cache"));
     }
@@ -5704,8 +5711,7 @@ mod tests {
         let tools = &["read_file", "grep"];
 
         // Turn 1: no anchor
-        let (primary1, _, _) =
-            build_system_message(tools, "cwd: /project", 0.9, None, &cache_cfg);
+        let (primary1, _, _) = build_system_message(tools, "cwd: /project", 0.9, None, &cache_cfg);
 
         // Turn 2: with anchor
         let anchor = extract_anchor("Build rate limiter", None);
@@ -5730,12 +5736,18 @@ mod tests {
         usage.insert("completion_tokens".to_string(), json!(2000));
 
         // This is the exact expression from the P3 code path
-        let estimated_tokens = usage.get("prompt_tokens").and_then(Value::as_i64).unwrap_or(0) as usize;
+        let estimated_tokens = usage
+            .get("prompt_tokens")
+            .and_then(Value::as_i64)
+            .unwrap_or(0) as usize;
         assert_eq!(estimated_tokens, 45000);
 
         // The old buggy key must NOT work
         let wrong = usage.get("prompt").and_then(Value::as_i64).unwrap_or(0) as usize;
-        assert_eq!(wrong, 0, "usage.get(\"prompt\") should return None — the key is prompt_tokens");
+        assert_eq!(
+            wrong, 0,
+            "usage.get(\"prompt\") should return None — the key is prompt_tokens"
+        );
     }
 
     // ── Fix #1: anchor evolves with L1 ──────────────────────────────────
@@ -5743,7 +5755,7 @@ mod tests {
     #[test]
     fn p1_anchor_evolves_when_l1_available() {
         use crate::turn::cloud::session_memory_protocol::{
-            extract_anchor, SessionMemory, SESSION_MEMORY_PREFIX,
+            SESSION_MEMORY_PREFIX, SessionMemory, extract_anchor,
         };
 
         // Without L1 — shows "starting"
@@ -5768,38 +5780,66 @@ mod tests {
         let l1 = SessionMemory::parse(&l1_text).unwrap();
         let anchor_with_l1 = extract_anchor("Build rate limiter", Some(&l1));
 
-        assert!(!anchor_with_l1.contains("starting"), "should not say 'starting' when L1 available");
-        assert!(anchor_with_l1.contains("Redis integration"), "should show current state from L1");
-        assert!(anchor_with_l1.contains("2/4"), "should show progress from L1");
+        assert!(
+            !anchor_with_l1.contains("starting"),
+            "should not say 'starting' when L1 available"
+        );
+        assert!(
+            anchor_with_l1.contains("Redis integration"),
+            "should show current state from L1"
+        );
+        assert!(
+            anchor_with_l1.contains("2/4"),
+            "should show progress from L1"
+        );
     }
 
     // ── Fix #4: P2 skips continuation when task is done ─────────────────
 
     /// Helper matching the actual P2 completion detection logic in the turn loop.
     fn signals_done(content: &str) -> bool {
-        let tail = if content.len() > 200 { &content[content.floor_char_boundary(content.len() - 200)..] } else { content };
+        let tail = if content.len() > 200 {
+            &content[content.floor_char_boundary(content.len() - 200)..]
+        } else {
+            content
+        };
         let lower = tail.to_ascii_lowercase();
-        let has_completion = lower.contains("task complete") || lower.contains("all done")
-            || lower.contains("finished") || lower.contains("completed successfully")
-            || lower.contains("任务完成") || lower.contains("已完成");
-        if !has_completion { return false; }
-        let has_negation = lower.contains("not yet") || lower.contains("not complete")
-            || lower.contains("not finished") || lower.contains("haven't finished")
-            || lower.contains("hasn't finished") || lower.contains("won't be finished")
-            || lower.contains("don't think") || lower.contains("not sure")
-            || lower.contains("没有完成") || lower.contains("尚未完成")
-            || lower.contains("except") || lower.contains("but ");
+        let has_completion = lower.contains("task complete")
+            || lower.contains("all done")
+            || lower.contains("finished")
+            || lower.contains("completed successfully")
+            || lower.contains("任务完成")
+            || lower.contains("已完成");
+        if !has_completion {
+            return false;
+        }
+        let has_negation = lower.contains("not yet")
+            || lower.contains("not complete")
+            || lower.contains("not finished")
+            || lower.contains("haven't finished")
+            || lower.contains("hasn't finished")
+            || lower.contains("won't be finished")
+            || lower.contains("don't think")
+            || lower.contains("not sure")
+            || lower.contains("没有完成")
+            || lower.contains("尚未完成")
+            || lower.contains("except")
+            || lower.contains("but ");
         has_completion && !has_negation
     }
 
     #[test]
     fn p2_no_continuation_when_task_complete() {
-        assert!(signals_done("All tasks completed successfully. The rate limiter is deployed."));
+        assert!(signals_done(
+            "All tasks completed successfully. The rate limiter is deployed."
+        ));
     }
 
     #[test]
     fn p2_continuation_when_task_in_progress() {
-        assert!(!signals_done("I've implemented step 3. Working on step 4 next."));
+        assert!(!signals_done(
+            "I've implemented step 3. Working on step 4 next."
+        ));
     }
 
     #[test]
@@ -5809,12 +5849,16 @@ mod tests {
 
     #[test]
     fn p2_no_false_positive_negated_finished() {
-        assert!(!signals_done("I haven't finished yet, still working on it."));
+        assert!(!signals_done(
+            "I haven't finished yet, still working on it."
+        ));
     }
 
     #[test]
     fn p2_no_false_positive_not_complete() {
-        assert!(!signals_done("The task is not yet complete, need more work."));
+        assert!(!signals_done(
+            "The task is not yet complete, need more work."
+        ));
     }
 
     #[test]
@@ -5824,7 +5868,9 @@ mod tests {
 
     #[test]
     fn p2_no_false_positive_wont_be_finished() {
-        assert!(!signals_done("The task won't be finished until deployment is done."));
+        assert!(!signals_done(
+            "The task won't be finished until deployment is done."
+        ));
     }
 
     #[test]
@@ -5848,7 +5894,7 @@ mod tests {
     #[test]
     fn p1_anchor_evolves_from_local_messages_no_network() {
         use crate::turn::cloud::session_memory_protocol::{
-            extract_anchor, build_l1_from_messages, SessionMemory,
+            SessionMemory, build_l1_from_messages, extract_anchor,
         };
 
         // Multi-turn conversation — anchor should show progress, not "starting"
@@ -5864,7 +5910,8 @@ mod tests {
             json!({"role": "assistant", "content": "Added Redis."}),
         ];
 
-        let turn_count = messages.iter()
+        let turn_count = messages
+            .iter()
             .filter(|m| m.get("role").and_then(Value::as_str) == Some("assistant"))
             .count();
         assert_eq!(turn_count, 3);
@@ -5873,7 +5920,10 @@ mod tests {
         let l1 = SessionMemory::parse(&l1_text).unwrap();
         let anchor = extract_anchor("Build a rate limiter using Redis", Some(&l1));
 
-        assert!(!anchor.contains("starting"), "multi-turn anchor should not say 'starting'");
+        assert!(
+            !anchor.contains("starting"),
+            "multi-turn anchor should not say 'starting'"
+        );
         assert!(anchor.contains("Turn 3"), "should reflect current turn");
     }
 
@@ -5885,9 +5935,18 @@ mod tests {
             json!({"role": "assistant", "content": "我已经完成了第一步的实现，接下来处理数据库连接。"}),
             json!({"role": "user", "content": "继续"}),
         ];
-        let is_cjk = msgs.iter().rev().take(4)
+        let is_cjk = msgs
+            .iter()
+            .rev()
+            .take(4)
             .filter_map(|m| m.get("content").and_then(Value::as_str))
-            .any(|c| c.chars().take(200).filter(|ch| ('\u{4e00}'..='\u{9fff}').contains(ch)).count() > 10);
+            .any(|c| {
+                c.chars()
+                    .take(200)
+                    .filter(|ch| ('\u{4e00}'..='\u{9fff}').contains(ch))
+                    .count()
+                    > 10
+            });
         assert!(is_cjk, "should detect Chinese content");
     }
 
@@ -5897,9 +5956,18 @@ mod tests {
             json!({"role": "assistant", "content": "I've implemented step 1. Working on the database connection next."}),
             json!({"role": "user", "content": "continue"}),
         ];
-        let is_cjk = msgs.iter().rev().take(4)
+        let is_cjk = msgs
+            .iter()
+            .rev()
+            .take(4)
             .filter_map(|m| m.get("content").and_then(Value::as_str))
-            .any(|c| c.chars().take(200).filter(|ch| ('\u{4e00}'..='\u{9fff}').contains(ch)).count() > 10);
+            .any(|c| {
+                c.chars()
+                    .take(200)
+                    .filter(|ch| ('\u{4e00}'..='\u{9fff}').contains(ch))
+                    .count()
+                    > 10
+            });
         assert!(!is_cjk, "should not detect CJK in English content");
     }
 }

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -2008,13 +2008,21 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                     let last_signals_done = msgs.last()
                         .and_then(|m| m.get("content").and_then(Value::as_str))
                         .map(|c| {
-                            let lower = c.to_ascii_lowercase();
-                            let has_negation = lower.contains("not ") || lower.contains("n't")
-                                || lower.contains("没有") || lower.contains("尚未")
-                                || lower.contains("except") || lower.contains("but ");
+                            // Check only the last ~200 chars (the conclusion) to avoid
+                            // false positives from negations in earlier context.
+                            let tail = if c.len() > 200 { &c[c.floor_char_boundary(c.len() - 200)..] } else { c };
+                            let lower = tail.to_ascii_lowercase();
                             let has_completion = lower.contains("task complete") || lower.contains("all done")
                                 || lower.contains("finished") || lower.contains("completed successfully")
                                 || lower.contains("任务完成") || lower.contains("已完成");
+                            if !has_completion { return false; }
+                            // Only check negation near the completion phrase (same tail)
+                            let has_negation = lower.contains("not yet") || lower.contains("not complete")
+                                || lower.contains("not finished") || lower.contains("haven't finished")
+                                || lower.contains("hasn't finished") || lower.contains("won't be finished")
+                                || lower.contains("don't think") || lower.contains("not sure")
+                                || lower.contains("没有完成") || lower.contains("尚未完成")
+                                || lower.contains("except") || lower.contains("but ");
                             has_completion && !has_negation
                         })
                         .unwrap_or(false);
@@ -3109,10 +3117,11 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                 let l1_client = memoria_client_shared.clone();
                 tokio::spawn(async move {
                     let Some(client) = l1_client else { return; };
-                    if let Err(e) = crate::turn::cloud::session_memory_protocol::persist_l1(
+                    match crate::turn::cloud::session_memory_protocol::persist_l1(
                         &client, &l1_content, &l1_sid,
                     ).await {
-                        tracing::warn!(session_id = %l1_sid, error = %e, "L1 session memory persist failed");
+                        Ok(id) => tracing::debug!(session_id = %l1_sid, memory_id = %id, "L1 session memory persisted"),
+                        Err(e) => tracing::warn!(session_id = %l1_sid, error = %e, "L1 session memory persist failed"),
                     }
                 });
             }
@@ -5768,13 +5777,18 @@ mod tests {
 
     /// Helper matching the actual P2 completion detection logic in the turn loop.
     fn signals_done(content: &str) -> bool {
-        let lower = content.to_ascii_lowercase();
-        let has_negation = lower.contains("not ") || lower.contains("n't")
-            || lower.contains("没有") || lower.contains("尚未")
-            || lower.contains("except") || lower.contains("but ");
+        let tail = if content.len() > 200 { &content[content.floor_char_boundary(content.len() - 200)..] } else { content };
+        let lower = tail.to_ascii_lowercase();
         let has_completion = lower.contains("task complete") || lower.contains("all done")
             || lower.contains("finished") || lower.contains("completed successfully")
             || lower.contains("任务完成") || lower.contains("已完成");
+        if !has_completion { return false; }
+        let has_negation = lower.contains("not yet") || lower.contains("not complete")
+            || lower.contains("not finished") || lower.contains("haven't finished")
+            || lower.contains("hasn't finished") || lower.contains("won't be finished")
+            || lower.contains("don't think") || lower.contains("not sure")
+            || lower.contains("没有完成") || lower.contains("尚未完成")
+            || lower.contains("except") || lower.contains("but ");
         has_completion && !has_negation
     }
 
@@ -5821,6 +5835,12 @@ mod tests {
     #[test]
     fn p2_no_false_positive_dont_think_finished() {
         assert!(!signals_done("I don't think we're finished yet."));
+    }
+
+    #[test]
+    fn p2_true_positive_cant_believe_completed() {
+        // "can't" in a non-negating context should NOT suppress completion detection
+        assert!(signals_done("I can't believe we completed successfully!"));
     }
 
     // ── P1 latency fix: anchor from local messages, no network ──────────

--- a/rust/crates/runtime/src/turn/cloud/compaction.rs
+++ b/rust/crates/runtime/src/turn/cloud/compaction.rs
@@ -469,6 +469,11 @@ pub fn compact_tiered_with_result(
 
     // AggressivePrune: also drop old conversation turns
     if tier == CompactionTier::AggressivePrune {
+        // Find the first user message index (the original task — must be preserved)
+        let first_user_idx = compacted
+            .iter()
+            .position(|m| m.get("role").and_then(Value::as_str) == Some("user"));
+
         // Count user/assistant message pairs (excluding system and tool messages)
         let conv_indices: Vec<usize> = compacted
             .iter()
@@ -484,6 +489,7 @@ pub fn compact_tiered_with_result(
             let drop_set: HashSet<usize> = conv_indices[..conv_indices.len() - keep_count]
                 .iter()
                 .copied()
+                .filter(|i| Some(*i) != first_user_idx) // never drop first user message
                 .collect();
             compacted = compacted
                 .into_iter()
@@ -671,11 +677,16 @@ mod tests {
             tool(&"x".repeat(100)),
         ];
         // keep_recent_turns=1 → keep last 2 conversation msgs (1 user + 1 assistant)
+        // + first user message is always preserved (P0 fix)
         let result = compact_tiered(&msgs, 10, 100, CompactionTier::AggressivePrune, 1);
-        // Should have: recent user, recent assistant, tool = 3 messages
-        assert_eq!(result.len(), 3, "should drop old turns, keep recent + tool");
+        // Should have: first user (preserved), recent user, recent assistant, tool = 4
+        assert_eq!(result.len(), 4, "should drop old turns, keep first user + recent + tool");
         assert_eq!(
             result[0].get("content").unwrap().as_str().unwrap(),
+            "old question 1"
+        );
+        assert_eq!(
+            result[1].get("content").unwrap().as_str().unwrap(),
             "recent question"
         );
     }

--- a/rust/crates/runtime/src/turn/cloud/compaction.rs
+++ b/rust/crates/runtime/src/turn/cloud/compaction.rs
@@ -680,7 +680,11 @@ mod tests {
         // + first user message is always preserved (P0 fix)
         let result = compact_tiered(&msgs, 10, 100, CompactionTier::AggressivePrune, 1);
         // Should have: first user (preserved), recent user, recent assistant, tool = 4
-        assert_eq!(result.len(), 4, "should drop old turns, keep first user + recent + tool");
+        assert_eq!(
+            result.len(),
+            4,
+            "should drop old turns, keep first user + recent + tool"
+        );
         assert_eq!(
             result[0].get("content").unwrap().as_str().unwrap(),
             "old question 1"

--- a/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
+++ b/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
@@ -251,7 +251,10 @@ pub trait MemoriaClient: Send + Sync {
     async fn purge_working(&self, session_id: &str) -> Result<u64, String>;
 
     /// Delete a single memory by ID.
-    async fn delete(&self, memory_id: &str) -> Result<(), String>;
+    /// Default: no-op. Override for clients that support deletion.
+    async fn delete(&self, _memory_id: &str) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 /// A memory record from Memoria.

--- a/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
+++ b/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
@@ -249,6 +249,9 @@ pub trait MemoriaClient: Send + Sync {
 
     /// Purge working memories for a session.
     async fn purge_working(&self, session_id: &str) -> Result<u64, String>;
+
+    /// Delete a single memory by ID.
+    async fn delete(&self, memory_id: &str) -> Result<(), String>;
 }
 
 /// A memory record from Memoria.
@@ -266,6 +269,7 @@ pub struct MemoriaMemory {
 // ---------------------------------------------------------------------------
 
 /// HTTP-based Memoria client.
+#[derive(Clone)]
 pub struct HttpMemoriaClient {
     base_url: String,
     api_key: String,
@@ -336,6 +340,7 @@ impl MemoriaClient for HttpMemoriaClient {
         let memories = data
             .get("memories")
             .and_then(Value::as_array)
+            .or_else(|| data.as_array())
             .map(|arr| {
                 arr.iter()
                     .filter_map(|v| serde_json::from_value(v.clone()).ok())
@@ -389,6 +394,11 @@ impl MemoriaClient for HttpMemoriaClient {
             .ok_or_else(|| "Memoria store: no memory_id in response".to_string())
     }
 
+    /// Purge working memories for a session.
+    /// NOTE: Currently uses topic-based purge which does fulltext search on content.
+    /// This does NOT reliably match UUID-style session IDs (ngram tokenizer issue).
+    /// TODO: switch to session_id-based purge once Memoria supports it
+    ///       (https://github.com/matrixorigin/Memoria/issues/182)
     async fn purge_working(&self, session_id: &str) -> Result<u64, String> {
         let url = format!("{}/v1/memories/purge", self.base_url.trim_end_matches('/'));
         let body = json!({
@@ -418,6 +428,23 @@ impl MemoriaClient for HttpMemoriaClient {
             .get("deleted_count")
             .and_then(Value::as_u64)
             .unwrap_or(0))
+    }
+
+    async fn delete(&self, memory_id: &str) -> Result<(), String> {
+        use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+        let encoded_id = utf8_percent_encode(memory_id, NON_ALPHANUMERIC).to_string();
+        let url = format!("{}/v1/memories/{}", self.base_url.trim_end_matches('/'), encoded_id);
+        let resp = self
+            .http
+            .delete(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .send()
+            .await
+            .map_err(|e| format!("Memoria delete failed: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!("Memoria delete HTTP {}", resp.status()));
+        }
+        Ok(())
     }
 }
 
@@ -790,6 +817,10 @@ pub async fn compact_with_memoria(
     };
 
     // Step 1: Retrieve session context from Memoria
+    // NOTE: session_id is currently only used for score boosting, not strict filtering.
+    // This means other sessions' memories can outrank the current session's L1.
+    // TODO: use filter_session=true once Memoria supports it
+    //       (https://github.com/matrixorigin/Memoria/issues/184)
     let query = memoria_compact_retrieve_query(messages);
     let memories = match client
         .retrieve(&query, Some(sid), config.max_memories)
@@ -1030,6 +1061,10 @@ mod tests {
 
         async fn purge_working(&self, _session_id: &str) -> Result<u64, String> {
             Ok(0)
+        }
+
+        async fn delete(&self, _memory_id: &str) -> Result<(), String> {
+            Ok(())
         }
     }
 

--- a/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
+++ b/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
@@ -436,7 +436,11 @@ impl MemoriaClient for HttpMemoriaClient {
     async fn delete(&self, memory_id: &str) -> Result<(), String> {
         use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
         let encoded_id = utf8_percent_encode(memory_id, NON_ALPHANUMERIC).to_string();
-        let url = format!("{}/v1/memories/{}", self.base_url.trim_end_matches('/'), encoded_id);
+        let url = format!(
+            "{}/v1/memories/{}",
+            self.base_url.trim_end_matches('/'),
+            encoded_id
+        );
         let resp = self
             .http
             .delete(&url)

--- a/rust/crates/runtime/src/turn/cloud/mod.rs
+++ b/rust/crates/runtime/src/turn/cloud/mod.rs
@@ -9,4 +9,5 @@ pub mod iteration;
 pub mod memoria_compact;
 pub mod prefilter;
 pub mod session_memory_extract;
+pub mod session_memory_protocol;
 pub mod summary;

--- a/rust/crates/runtime/src/turn/cloud/session_memory_protocol.rs
+++ b/rust/crates/runtime/src/turn/cloud/session_memory_protocol.rs
@@ -166,9 +166,7 @@ impl SessionMemory {
         for &name in REQUIRED_SECTIONS {
             match self.section(name) {
                 None => errors.push(format!("missing section: {name}")),
-                Some(c) if c.trim().is_empty() => {
-                    errors.push(format!("empty section: {name}"))
-                }
+                Some(c) if c.trim().is_empty() => errors.push(format!("empty section: {name}")),
                 _ => {}
             }
         }
@@ -281,10 +279,7 @@ pub fn compress_to_injection(l1: &SessionMemory) -> String {
 
     // Decisions — last 2, truncated
     if let Some(c) = l1.section("Decisions") {
-        let entries: Vec<&str> = c
-            .lines()
-            .filter(|l| l.trim().starts_with("- "))
-            .collect();
+        let entries: Vec<&str> = c.lines().filter(|l| l.trim().starts_with("- ")).collect();
         let last_two: Vec<&str> = entries.iter().rev().take(2).rev().copied().collect();
         if !last_two.is_empty() {
             out.push_str("# Decisions\n");
@@ -299,10 +294,7 @@ pub fn compress_to_injection(l1: &SessionMemory) -> String {
 
     // User Messages — last 3
     if let Some(c) = l1.section("User Messages") {
-        let msgs: Vec<&str> = c
-            .split("\n\n")
-            .filter(|s| !s.trim().is_empty())
-            .collect();
+        let msgs: Vec<&str> = c.split("\n\n").filter(|s| !s.trim().is_empty()).collect();
         let last_three: Vec<&str> = msgs.iter().rev().take(3).rev().copied().collect();
         if !last_three.is_empty() {
             out.push_str("# User Messages\n");
@@ -326,7 +318,11 @@ pub fn extract_message_text(msg: &Value) -> Option<String> {
                     .iter()
                     .filter_map(|b| b.get("text").and_then(Value::as_str))
                     .collect();
-                if texts.is_empty() { None } else { Some(texts.join("\n")) }
+                if texts.is_empty() {
+                    None
+                } else {
+                    Some(texts.join("\n"))
+                }
             })
         })
     })
@@ -411,16 +407,19 @@ pub async fn persist_l1(
     let _ = client.purge_working(session_id).await;
 
     // Store with one retry
-    match client.store(l1_content, "working", Some(session_id), Some("T2")).await {
+    match client
+        .store(l1_content, "working", Some(session_id), Some("T2"))
+        .await
+    {
         Ok(id) => Ok(id),
         Err(e) => {
-            eprintln!("[session-memory] L1 store failed (attempt 1): {e}");
+            tracing::warn!(session_id = %session_id, attempt = 1, error = %e, "L1 store failed, retrying");
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             client
                 .store(l1_content, "working", Some(session_id), Some("T2"))
                 .await
                 .map_err(|e2| {
-                    eprintln!("[session-memory] L1 store failed (attempt 2, giving up): {e2}");
+                    tracing::warn!(session_id = %session_id, attempt = 2, error = %e2, "L1 store failed, giving up");
                     e2
                 })
         }
@@ -431,15 +430,21 @@ pub async fn persist_l1(
 
 /// Build an L1 session memory string from the current conversation messages.
 /// This is called at turn end to persist session state to Memoria.
-pub fn build_l1_from_messages(messages: &[Value], turn_number: usize, estimated_tokens: usize) -> String {
-    let first_user = messages.iter()
+pub fn build_l1_from_messages(
+    messages: &[Value],
+    turn_number: usize,
+    estimated_tokens: usize,
+) -> String {
+    let first_user = messages
+        .iter()
         .find(|m| m.get("role").and_then(Value::as_str) == Some("user"))
         .and_then(|m| extract_message_text(m))
         .unwrap_or_default();
 
     // Collect user messages (deduplicated, last N)
     let mut seen_user_msgs = std::collections::HashSet::new();
-    let user_msgs: Vec<String> = messages.iter()
+    let user_msgs: Vec<String> = messages
+        .iter()
         .filter_map(|m| {
             if m.get("role").and_then(Value::as_str) == Some("user") {
                 extract_message_text(m).filter(|t| seen_user_msgs.insert(t.clone()))
@@ -455,7 +460,11 @@ pub fn build_l1_from_messages(messages: &[Value], turn_number: usize, estimated_
     for m in messages {
         if let Some(calls) = m.get("tool_calls").and_then(Value::as_array) {
             for tc in calls {
-                if let Some(name) = tc.get("function").and_then(|f| f.get("name")).and_then(Value::as_str) {
+                if let Some(name) = tc
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(Value::as_str)
+                {
                     if seen_tools.insert(name.to_string()) {
                         tool_names.push(name.to_string());
                     }
@@ -470,7 +479,11 @@ pub fn build_l1_from_messages(messages: &[Value], turn_number: usize, estimated_
     for m in messages {
         if let Some(calls) = m.get("tool_calls").and_then(Value::as_array) {
             for tc in calls {
-                if let Some(args) = tc.get("function").and_then(|f| f.get("arguments")).and_then(Value::as_str) {
+                if let Some(args) = tc
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(Value::as_str)
+                {
                     if let Ok(parsed) = serde_json::from_str::<Value>(args) {
                         if let Some(path) = parsed.get("path").and_then(Value::as_str) {
                             if seen_files.insert(path.to_string()) {
@@ -485,11 +498,17 @@ pub fn build_l1_from_messages(messages: &[Value], turn_number: usize, estimated_
 
     // Build the L1 markdown
     let task = truncate_to_token_budget(&first_user, 200); // match STORED_SECTION_BUDGETS
-    let user_section: String = user_msgs.iter().rev().take(10).rev()
+    let user_section: String = user_msgs
+        .iter()
+        .rev()
+        .take(10)
+        .rev()
         .map(|s| truncate_words(s, 30))
         .collect::<Vec<_>>()
         .join("\n");
-    let files_section = files.iter().take(20)
+    let files_section = files
+        .iter()
+        .take(20)
         .map(|f| f.as_str())
         .collect::<Vec<_>>()
         .join("\n");
@@ -508,8 +527,16 @@ pub fn build_l1_from_messages(messages: &[Value], turn_number: usize, estimated_
          # Context\nTurn {turn_number}, ~{tokens}K tokens",
         title = truncate_words(&first_user, 10),
         task = task,
-        files = if files_section.is_empty() { "None".to_string() } else { files_section },
-        tools = if tool_names.is_empty() { "none".to_string() } else { tool_names.join(", ") },
+        files = if files_section.is_empty() {
+            "None".to_string()
+        } else {
+            files_section
+        },
+        tools = if tool_names.is_empty() {
+            "none".to_string()
+        } else {
+            tool_names.join(", ")
+        },
         users = user_section,
         tokens = estimated_tokens / 1000,
     )
@@ -607,7 +634,10 @@ mod tests {
 
     #[test]
     fn anchor_truncates_long_user_message() {
-        let long_msg = (0..50).map(|i| format!("word{i}")).collect::<Vec<_>>().join(" ");
+        let long_msg = (0..50)
+            .map(|i| format!("word{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
         let anchor = extract_anchor(&long_msg, None);
         let words: Vec<&str> = anchor
             .strip_prefix("[session-anchor] ")
@@ -625,7 +655,10 @@ mod tests {
     #[test]
     fn parse_valid_l1() {
         let l1 = SessionMemory::parse(sample_l1()).unwrap();
-        assert_eq!(l1.section("Session Title"), Some("OAuth API Implementation"));
+        assert_eq!(
+            l1.section("Session Title"),
+            Some("OAuth API Implementation")
+        );
         assert!(l1.section("Task Specification").unwrap().contains("OAuth"));
         assert!(l1.section("Current State").unwrap().contains("refresh"));
         assert_eq!(l1.section_names().len(), 10);
@@ -666,7 +699,9 @@ mod tests {
     fn validate_empty_required_section() {
         let l1 = SessionMemory::parse(sample_l1_empty_required()).unwrap();
         let errors = l1.validate().unwrap_err();
-        assert!(errors.iter().any(|e| e.contains("empty section: Task Specification")));
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("empty section: Task Specification")));
     }
 
     // ── L1 Size Governance Tests ────────────────────────────────────────
@@ -709,7 +744,10 @@ mod tests {
     fn normal_l1_within_budget() {
         let l1 = SessionMemory::parse(sample_l1()).unwrap();
         let over = l1.over_budget_sections();
-        assert!(over.is_empty(), "sample L1 should be within budget: {over:?}");
+        assert!(
+            over.is_empty(),
+            "sample L1 should be within budget: {over:?}"
+        );
     }
 
     // ── L1 Injection Compression Tests ──────────────────────────────────
@@ -840,8 +878,14 @@ mod tests {
 
     #[test]
     fn injection_level_medium_pressure() {
-        assert_eq!(injection_level_for_pressure(0.75), InjectionLevel::L1Minimal);
-        assert_eq!(injection_level_for_pressure(0.84), InjectionLevel::L1Minimal);
+        assert_eq!(
+            injection_level_for_pressure(0.75),
+            InjectionLevel::L1Minimal
+        );
+        assert_eq!(
+            injection_level_for_pressure(0.84),
+            InjectionLevel::L1Minimal
+        );
     }
 
     #[test]
@@ -919,11 +963,21 @@ mod tests {
         ];
         let l1_text = build_l1_from_messages(&messages, 2, 50000);
         let l1 = SessionMemory::parse(&l1_text).expect("should parse");
-        assert!(l1.validate().is_ok(), "should be valid: {:?}", l1.validate());
-        assert!(l1.section("Task Specification").unwrap().contains("rate limiter"));
+        assert!(
+            l1.validate().is_ok(),
+            "should be valid: {:?}",
+            l1.validate()
+        );
+        assert!(l1
+            .section("Task Specification")
+            .unwrap()
+            .contains("rate limiter"));
         assert!(l1.section("Key Files").unwrap().contains("src/main.rs"));
         assert!(l1.section("Decisions").unwrap().contains("read_file"));
-        assert!(l1.section("User Messages").unwrap().contains("Redis connection"));
+        assert!(l1
+            .section("User Messages")
+            .unwrap()
+            .contains("Redis connection"));
         assert!(l1.section("Context").unwrap().contains("50K"));
     }
 
@@ -936,11 +990,15 @@ mod tests {
         ];
         for i in 0..50 {
             messages.push(json!({"role": "assistant", "content": format!("Step {i} done")}));
-            messages.push(json!({"role": "user", "content": format!("Continue with step {}", i+1)}));
+            messages
+                .push(json!({"role": "user", "content": format!("Continue with step {}", i+1)}));
         }
         let l1_text = build_l1_from_messages(&messages, 50, 100000);
         let tokens = l1_text.len() / 4;
-        assert!(tokens <= STORED_TOTAL_BUDGET, "L1 should be ≤{STORED_TOTAL_BUDGET} tokens, got {tokens}");
+        assert!(
+            tokens <= STORED_TOTAL_BUDGET,
+            "L1 should be ≤{STORED_TOTAL_BUDGET} tokens, got {tokens}"
+        );
     }
 
     #[test]
@@ -1015,11 +1073,15 @@ mod tests {
         let l1_text = build_l1_from_messages(&messages, 1, 10000);
         let l1 = SessionMemory::parse(&l1_text).unwrap();
         assert!(
-            l1.section("Task Specification").unwrap().contains("distributed cache"),
+            l1.section("Task Specification")
+                .unwrap()
+                .contains("distributed cache"),
             "Should extract text from Anthropic content blocks"
         );
         assert!(
-            l1.section("User Messages").unwrap().contains("distributed cache"),
+            l1.section("User Messages")
+                .unwrap()
+                .contains("distributed cache"),
             "User messages should include Anthropic block content"
         );
     }
@@ -1041,7 +1103,10 @@ mod tests {
         let l1 = SessionMemory::parse(&l1_text).unwrap();
         let user_section = l1.section("User Messages").unwrap();
         let count = user_section.matches("continue").count();
-        assert_eq!(count, 1, "duplicate 'continue' should appear only once, got {count}");
+        assert_eq!(
+            count, 1,
+            "duplicate 'continue' should appear only once, got {count}"
+        );
     }
 
     // ── Fix #5: shared first_user_end helper ────────────────────────────
@@ -1112,7 +1177,11 @@ mod tests {
     fn truncate_to_token_budget_long_text() {
         let long = "word ".repeat(500); // ~500 words, ~125 tokens per 100 words
         let result = truncate_to_token_budget(&long, 50); // 50 tokens = ~200 chars
-        assert!(result.len() <= 200, "should be ≤200 chars, got {}", result.len());
+        assert!(
+            result.len() <= 200,
+            "should be ≤200 chars, got {}",
+            result.len()
+        );
         assert!(!result.ends_with(' '), "should break at word boundary");
     }
 
@@ -1128,7 +1197,8 @@ mod tests {
         let l1_text = build_l1_from_messages(&messages, 1, 10000);
         let l1 = SessionMemory::parse(&l1_text).unwrap();
         let task_tokens = l1.section_tokens("Task Specification");
-        let budget = STORED_SECTION_BUDGETS.iter()
+        let budget = STORED_SECTION_BUDGETS
+            .iter()
             .find(|(n, _)| *n == "Task Specification")
             .map(|(_, b)| *b)
             .unwrap();
@@ -1203,19 +1273,30 @@ mod tests {
 
         #[async_trait::async_trait]
         impl MemoriaClient for MockMemoria {
-            async fn retrieve(&self, _q: &str, _sid: Option<&str>, _k: usize) -> Result<Vec<MemoriaMemory>, String> {
+            async fn retrieve(
+                &self,
+                _q: &str,
+                _sid: Option<&str>,
+                _k: usize,
+            ) -> Result<Vec<MemoriaMemory>, String> {
                 Ok(vec![])
             }
-            async fn store(&self, content: &str, _mt: &str, sid: Option<&str>, _tt: Option<&str>) -> Result<String, String> {
+            async fn store(
+                &self,
+                content: &str,
+                _mt: &str,
+                sid: Option<&str>,
+                _tt: Option<&str>,
+            ) -> Result<String, String> {
                 let n = self.store_calls.fetch_add(1, Ordering::SeqCst);
                 let remaining = self.fail_store_times.load(Ordering::SeqCst);
                 if n < remaining {
                     return Err(format!("mock store failure #{}", n + 1));
                 }
-                self.stored.lock().await.push((
-                    content.to_string(),
-                    sid.unwrap_or("").to_string(),
-                ));
+                self.stored
+                    .lock()
+                    .await
+                    .push((content.to_string(), sid.unwrap_or("").to_string()));
                 Ok(format!("mem-{n}"))
             }
             async fn purge_working(&self, _sid: &str) -> Result<u64, String> {
@@ -1232,8 +1313,16 @@ mod tests {
             let mock = Arc::new(MockMemoria::new(0));
             let result = persist_l1(&*mock, "L1 content", "sess-1").await;
             assert!(result.is_ok());
-            assert_eq!(mock.purge_calls.load(Ordering::SeqCst), 1, "should purge once");
-            assert_eq!(mock.store_calls.load(Ordering::SeqCst), 1, "should store once on success");
+            assert_eq!(
+                mock.purge_calls.load(Ordering::SeqCst),
+                1,
+                "should purge once"
+            );
+            assert_eq!(
+                mock.store_calls.load(Ordering::SeqCst),
+                1,
+                "should store once on success"
+            );
             let stored = mock.stored.lock().await;
             assert_eq!(stored[0].0, "L1 content");
             assert_eq!(stored[0].1, "sess-1");
@@ -1244,8 +1333,16 @@ mod tests {
             let mock = Arc::new(MockMemoria::new(1)); // fail first store, succeed second
             let result = persist_l1(&*mock, "L1 retry", "sess-2").await;
             assert!(result.is_ok(), "should succeed on retry");
-            assert_eq!(mock.store_calls.load(Ordering::SeqCst), 2, "should call store twice");
-            assert_eq!(mock.purge_calls.load(Ordering::SeqCst), 1, "purge only once");
+            assert_eq!(
+                mock.store_calls.load(Ordering::SeqCst),
+                2,
+                "should call store twice"
+            );
+            assert_eq!(
+                mock.purge_calls.load(Ordering::SeqCst),
+                1,
+                "purge only once"
+            );
         }
 
         #[tokio::test]
@@ -1253,8 +1350,15 @@ mod tests {
             let mock = Arc::new(MockMemoria::new(2)); // fail both attempts
             let result = persist_l1(&*mock, "L1 fail", "sess-3").await;
             assert!(result.is_err(), "should fail after 2 attempts");
-            assert_eq!(mock.store_calls.load(Ordering::SeqCst), 2, "should attempt exactly twice");
-            assert!(mock.stored.lock().await.is_empty(), "nothing should be stored");
+            assert_eq!(
+                mock.store_calls.load(Ordering::SeqCst),
+                2,
+                "should attempt exactly twice"
+            );
+            assert!(
+                mock.stored.lock().await.is_empty(),
+                "nothing should be stored"
+            );
         }
 
         #[tokio::test]
@@ -1263,10 +1367,29 @@ mod tests {
             struct PurgeFailMock;
             #[async_trait::async_trait]
             impl MemoriaClient for PurgeFailMock {
-                async fn retrieve(&self, _: &str, _: Option<&str>, _: usize) -> Result<Vec<MemoriaMemory>, String> { Ok(vec![]) }
-                async fn store(&self, _: &str, _: &str, _: Option<&str>, _: Option<&str>) -> Result<String, String> { Ok("ok".into()) }
-                async fn purge_working(&self, _: &str) -> Result<u64, String> { Err("purge broken".into()) }
-                async fn delete(&self, _: &str) -> Result<(), String> { Ok(()) }
+                async fn retrieve(
+                    &self,
+                    _: &str,
+                    _: Option<&str>,
+                    _: usize,
+                ) -> Result<Vec<MemoriaMemory>, String> {
+                    Ok(vec![])
+                }
+                async fn store(
+                    &self,
+                    _: &str,
+                    _: &str,
+                    _: Option<&str>,
+                    _: Option<&str>,
+                ) -> Result<String, String> {
+                    Ok("ok".into())
+                }
+                async fn purge_working(&self, _: &str) -> Result<u64, String> {
+                    Err("purge broken".into())
+                }
+                async fn delete(&self, _: &str) -> Result<(), String> {
+                    Ok(())
+                }
             }
             let result = persist_l1(&PurgeFailMock, "L1", "s").await;
             assert!(result.is_ok(), "purge failure should not prevent store");

--- a/rust/crates/runtime/src/turn/cloud/session_memory_protocol.rs
+++ b/rust/crates/runtime/src/turn/cloud/session_memory_protocol.rs
@@ -1,0 +1,1275 @@
+//! Session Memory Protocol v1 — types, parsing, validation, and compression.
+//!
+//! Implements the L0/L1 layers from `docs/design/session-memory-protocol.md`.
+
+use serde_json::Value;
+
+// ── L0: Session Anchor ──────────────────────────────────────────────────────
+
+const ANCHOR_PREFIX: &str = "[session-anchor] ";
+const MAX_TASK_WORDS: usize = 20;
+
+/// Build an L0 anchor line from the first user message or from a parsed L1.
+pub fn extract_anchor(first_user_msg: &str, l1: Option<&SessionMemory>) -> String {
+    if let Some(l1) = l1 {
+        let task = first_sentence(l1.section("Task Specification").unwrap_or(""));
+        let current = first_sentence(l1.section("Current State").unwrap_or(""));
+        let (done, total) = count_progress_markers(l1.section("Progress").unwrap_or(""));
+        format!("{ANCHOR_PREFIX}{task}. Currently: {current}. {done}/{total} steps.")
+    } else {
+        let task = truncate_words(first_user_msg, MAX_TASK_WORDS);
+        format!("{ANCHOR_PREFIX}{task}. Currently: starting. 0/0 steps.")
+    }
+}
+
+fn first_sentence(text: &str) -> &str {
+    let text = text.trim();
+    let sentence = text
+        .match_indices(['.', '。', '\n'])
+        .next()
+        .map(|(i, s)| text[..i + s.len()].trim_end_matches('\n'))
+        .unwrap_or(text);
+    // Guarantee single-line output
+    sentence.lines().next().unwrap_or("")
+}
+
+fn truncate_words(text: &str, max_words: usize) -> String {
+    text.split_whitespace()
+        .take(max_words)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Truncate text to fit within a token budget (~4 chars/token).
+fn truncate_to_token_budget(text: &str, max_tokens: usize) -> String {
+    let max_chars = max_tokens * 4;
+    if text.len() <= max_chars {
+        return text.to_string();
+    }
+    // Find a clean break point (word boundary) near the limit
+    let truncated = &text[..text.floor_char_boundary(max_chars)];
+    truncated
+        .rsplit_once(char::is_whitespace)
+        .map(|(left, _)| left)
+        .unwrap_or(truncated)
+        .to_string()
+}
+
+fn count_progress_markers(text: &str) -> (usize, usize) {
+    let mut done = 0;
+    let mut total = 0;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("✅") || trimmed.starts_with("🔄") || trimmed.starts_with("⏳") {
+            total += 1;
+            if trimmed.starts_with("✅") {
+                done += 1;
+            }
+        }
+    }
+    (done, total)
+}
+
+// ── L1: Session Memory ──────────────────────────────────────────────────────
+
+pub const SESSION_MEMORY_PREFIX: &str = "[session-memory:v1]";
+
+const REQUIRED_SECTIONS: &[&str] = &["Task Specification", "Current State", "User Messages"];
+
+#[cfg(test)]
+const SECTION_NAMES: &[&str] = &[
+    "Session Title",
+    "Task Specification",
+    "Current State",
+    "Key Files",
+    "Progress",
+    "Errors & Corrections",
+    "Decisions",
+    "User Messages",
+    "Worklog",
+    "Context",
+];
+
+/// Per-section token budgets for the stored version (≤4000 total).
+pub const STORED_SECTION_BUDGETS: &[(&str, usize)] = &[
+    ("Session Title", 20),
+    ("Task Specification", 200),
+    ("Current State", 400),
+    ("Key Files", 500),
+    ("Progress", 400),
+    ("Errors & Corrections", 500),
+    ("Decisions", 400),
+    ("User Messages", 800),
+    ("Worklog", 700),
+    ("Context", 50),
+];
+
+pub const STORED_TOTAL_BUDGET: usize = 4000;
+pub const INJECTION_TOTAL_BUDGET: usize = 2000;
+
+/// Parsed session memory with section access.
+#[derive(Debug, Clone)]
+pub struct SessionMemory {
+    pub raw: String,
+    sections: Vec<(String, String)>, // (name, content)
+}
+
+impl SessionMemory {
+    /// Parse a `[session-memory:v1]` markdown string into sections.
+    pub fn parse(raw: &str) -> Option<Self> {
+        let trimmed = raw.trim();
+        if !trimmed.starts_with(SESSION_MEMORY_PREFIX) {
+            return None;
+        }
+        let mut sections = Vec::new();
+        let mut current_name: Option<String> = None;
+        let mut current_content = String::new();
+
+        for line in trimmed.lines() {
+            if let Some(name) = line.strip_prefix("# ") {
+                if let Some(prev_name) = current_name.take() {
+                    sections.push((prev_name, current_content.trim().to_string()));
+                    current_content.clear();
+                }
+                current_name = Some(name.trim().to_string());
+            } else if current_name.is_some() {
+                current_content.push_str(line);
+                current_content.push('\n');
+            }
+        }
+        if let Some(name) = current_name {
+            sections.push((name, current_content.trim().to_string()));
+        }
+
+        Some(Self {
+            raw: raw.to_string(),
+            sections,
+        })
+    }
+
+    /// Get content of a named section.
+    pub fn section(&self, name: &str) -> Option<&str> {
+        self.sections
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, c)| c.as_str())
+    }
+
+    /// List all section names present.
+    pub fn section_names(&self) -> Vec<&str> {
+        self.sections.iter().map(|(n, _)| n.as_str()).collect()
+    }
+
+    /// Validate that required sections are present and non-empty.
+    pub fn validate(&self) -> Result<(), Vec<String>> {
+        let mut errors = Vec::new();
+        for &name in REQUIRED_SECTIONS {
+            match self.section(name) {
+                None => errors.push(format!("missing section: {name}")),
+                Some(c) if c.trim().is_empty() => {
+                    errors.push(format!("empty section: {name}"))
+                }
+                _ => {}
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
+    /// Estimate token count (~4 chars per token).
+    pub fn estimate_tokens(&self) -> usize {
+        self.raw.len() / 4
+    }
+
+    /// Estimate tokens for a single section.
+    pub fn section_tokens(&self, name: &str) -> usize {
+        self.section(name).map(|c| c.len() / 4).unwrap_or(0)
+    }
+
+    /// Check which sections exceed their stored-version budget.
+    pub fn over_budget_sections(&self) -> Vec<(&str, usize, usize)> {
+        let mut result = Vec::new();
+        for &(name, budget) in STORED_SECTION_BUDGETS {
+            let tokens = self.section_tokens(name);
+            if tokens > budget {
+                result.push((name, tokens, budget));
+            }
+        }
+        result
+    }
+}
+
+/// Compress a stored L1 into the injection version (≤2000 tokens), zero LLM.
+pub fn compress_to_injection(l1: &SessionMemory) -> String {
+    let mut out = String::from(SESSION_MEMORY_PREFIX);
+    out.push('\n');
+
+    // Task Specification — full text
+    if let Some(c) = l1.section("Task Specification") {
+        out.push_str("# Task Specification\n");
+        out.push_str(c);
+        out.push('\n');
+    }
+
+    // Current State — full text
+    if let Some(c) = l1.section("Current State") {
+        out.push_str("# Current State\n");
+        out.push_str(c);
+        out.push('\n');
+    }
+
+    // Key Files — file names only
+    if let Some(c) = l1.section("Key Files") {
+        out.push_str("# Key Files\n");
+        for line in c.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            // "path — description" → "path"
+            let name = trimmed.split(" — ").next().unwrap_or(trimmed);
+            let name = name.split(" - ").next().unwrap_or(name);
+            out.push_str(name.trim());
+            out.push('\n');
+        }
+    }
+
+    // Progress — only 🔄 and ⏳
+    if let Some(c) = l1.section("Progress") {
+        let pending: Vec<&str> = c
+            .lines()
+            .filter(|l| {
+                let t = l.trim();
+                t.starts_with("🔄") || t.starts_with("⏳")
+            })
+            .collect();
+        if !pending.is_empty() {
+            out.push_str("# Progress\n");
+            for line in pending {
+                out.push_str(line.trim());
+                out.push('\n');
+            }
+        }
+    }
+
+    // Errors & Corrections — unresolved + user corrections
+    if let Some(c) = l1.section("Errors & Corrections") {
+        let kept: Vec<&str> = c
+            .lines()
+            .filter(|l| {
+                let t = l.trim();
+                !t.is_empty()
+                    && (t.contains("unresolved")
+                        || t.contains("UNRESOLVED")
+                        || t.contains("user correction")
+                        || t.contains("USER CORRECTION")
+                        || t.starts_with("- ❌")
+                        || t.starts_with("- 🔧"))
+            })
+            .collect();
+        if !kept.is_empty() {
+            out.push_str("# Errors & Corrections\n");
+            for line in kept {
+                out.push_str(line.trim());
+                out.push('\n');
+            }
+        }
+    }
+
+    // Decisions — last 2, truncated
+    if let Some(c) = l1.section("Decisions") {
+        let entries: Vec<&str> = c
+            .lines()
+            .filter(|l| l.trim().starts_with("- "))
+            .collect();
+        let last_two: Vec<&str> = entries.iter().rev().take(2).rev().copied().collect();
+        if !last_two.is_empty() {
+            out.push_str("# Decisions\n");
+            for line in last_two {
+                let words: Vec<&str> = line.split_whitespace().collect();
+                let truncated: String = words.into_iter().take(15).collect::<Vec<_>>().join(" ");
+                out.push_str(&truncated);
+                out.push('\n');
+            }
+        }
+    }
+
+    // User Messages — last 3
+    if let Some(c) = l1.section("User Messages") {
+        let msgs: Vec<&str> = c
+            .split("\n\n")
+            .filter(|s| !s.trim().is_empty())
+            .collect();
+        let last_three: Vec<&str> = msgs.iter().rev().take(3).rev().copied().collect();
+        if !last_three.is_empty() {
+            out.push_str("# User Messages\n");
+            out.push_str(&last_three.join("\n\n"));
+            out.push('\n');
+        }
+    }
+
+    // Worklog — omitted
+    // Context — omitted
+
+    out
+}
+
+/// Extract text content from a message, handling both string and Anthropic content blocks.
+pub fn extract_message_text(msg: &Value) -> Option<String> {
+    msg.get("content").and_then(|c| {
+        c.as_str().map(String::from).or_else(|| {
+            c.as_array().and_then(|blocks| {
+                let texts: Vec<&str> = blocks
+                    .iter()
+                    .filter_map(|b| b.get("text").and_then(Value::as_str))
+                    .collect();
+                if texts.is_empty() { None } else { Some(texts.join("\n")) }
+            })
+        })
+    })
+}
+
+/// Find the end index (exclusive) of the first user message block after `start`.
+/// Returns `start` if no user message found.
+pub fn first_user_end(messages: &[Value], start: usize) -> usize {
+    messages[start..]
+        .iter()
+        .position(|m| m.get("role").and_then(|v| v.as_str()) == Some("user"))
+        .map(|i| start + i + 1)
+        .unwrap_or(start)
+}
+
+// ── First User Message Preservation ─────────────────────────────────────────
+
+/// Find the index of the first `role: "user"` message in the array.
+pub fn first_user_message_index(messages: &[Value]) -> Option<usize> {
+    messages.iter().position(|m| {
+        m.get("role")
+            .and_then(Value::as_str)
+            .map(|r| r == "user")
+            .unwrap_or(false)
+    })
+}
+
+/// Check if a message has compact_metadata (is a compaction boundary).
+pub fn is_compaction_boundary(msg: &Value) -> bool {
+    msg.get("compact_metadata").is_some()
+}
+
+// ── Pressure-Adaptive Injection ─────────────────────────────────────────────
+
+/// Determine what to inject based on context pressure.
+#[derive(Debug, Clone, PartialEq)]
+pub enum InjectionLevel {
+    /// L1 injection version (full compressed), ≤2000 tokens
+    L1Full,
+    /// L1 minimal: Task + Current State + Progress only, ~800 tokens
+    L1Minimal,
+    /// L0 anchor only, ~50 tokens
+    L0Only,
+}
+
+/// Pressure thresholds for injection level selection.
+pub const DEFAULT_L1_FULL_THRESHOLD: f64 = 0.75;
+pub const DEFAULT_L1_MINIMAL_THRESHOLD: f64 = 0.85;
+
+pub fn injection_level_for_pressure(pressure: f64) -> InjectionLevel {
+    injection_level_for_pressure_with_thresholds(
+        pressure,
+        DEFAULT_L1_FULL_THRESHOLD,
+        DEFAULT_L1_MINIMAL_THRESHOLD,
+    )
+}
+
+pub fn injection_level_for_pressure_with_thresholds(
+    pressure: f64,
+    l1_full_max: f64,
+    l1_minimal_max: f64,
+) -> InjectionLevel {
+    if pressure < l1_full_max {
+        InjectionLevel::L1Full
+    } else if pressure < l1_minimal_max {
+        InjectionLevel::L1Minimal
+    } else {
+        InjectionLevel::L0Only
+    }
+}
+
+// ── P3: Persist L1 to Memoria ────────────────────────────────────────────────
+
+/// Purge old L1 for this session, then store the new one with one retry.
+/// Extracted from the tokio::spawn body so it can be tested with a mock client.
+pub async fn persist_l1(
+    client: &dyn crate::turn::cloud::memoria_compact::MemoriaClient,
+    l1_content: &str,
+    session_id: &str,
+) -> Result<String, String> {
+    // Best-effort purge of old L1 for this session
+    let _ = client.purge_working(session_id).await;
+
+    // Store with one retry
+    match client.store(l1_content, "working", Some(session_id), Some("T2")).await {
+        Ok(id) => Ok(id),
+        Err(e) => {
+            eprintln!("[session-memory] L1 store failed (attempt 1): {e}");
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            client
+                .store(l1_content, "working", Some(session_id), Some("T2"))
+                .await
+                .map_err(|e2| {
+                    eprintln!("[session-memory] L1 store failed (attempt 2, giving up): {e2}");
+                    e2
+                })
+        }
+    }
+}
+
+// ── P3: Build L1 from conversation ──────────────────────────────────────────
+
+/// Build an L1 session memory string from the current conversation messages.
+/// This is called at turn end to persist session state to Memoria.
+pub fn build_l1_from_messages(messages: &[Value], turn_number: usize, estimated_tokens: usize) -> String {
+    let first_user = messages.iter()
+        .find(|m| m.get("role").and_then(Value::as_str) == Some("user"))
+        .and_then(|m| extract_message_text(m))
+        .unwrap_or_default();
+
+    // Collect user messages (deduplicated, last N)
+    let mut seen_user_msgs = std::collections::HashSet::new();
+    let user_msgs: Vec<String> = messages.iter()
+        .filter_map(|m| {
+            if m.get("role").and_then(Value::as_str) == Some("user") {
+                extract_message_text(m).filter(|t| seen_user_msgs.insert(t.clone()))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Collect tool names used
+    let mut tool_names: Vec<String> = Vec::new();
+    let mut seen_tools = std::collections::HashSet::new();
+    for m in messages {
+        if let Some(calls) = m.get("tool_calls").and_then(Value::as_array) {
+            for tc in calls {
+                if let Some(name) = tc.get("function").and_then(|f| f.get("name")).and_then(Value::as_str) {
+                    if seen_tools.insert(name.to_string()) {
+                        tool_names.push(name.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // Collect file paths from tool calls (read_file, fs_read, etc.)
+    let mut files: Vec<String> = Vec::new();
+    let mut seen_files = std::collections::HashSet::new();
+    for m in messages {
+        if let Some(calls) = m.get("tool_calls").and_then(Value::as_array) {
+            for tc in calls {
+                if let Some(args) = tc.get("function").and_then(|f| f.get("arguments")).and_then(Value::as_str) {
+                    if let Ok(parsed) = serde_json::from_str::<Value>(args) {
+                        if let Some(path) = parsed.get("path").and_then(Value::as_str) {
+                            if seen_files.insert(path.to_string()) {
+                                files.push(path.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Build the L1 markdown
+    let task = truncate_to_token_budget(&first_user, 200); // match STORED_SECTION_BUDGETS
+    let user_section: String = user_msgs.iter().rev().take(10).rev()
+        .map(|s| truncate_words(s, 30))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let files_section = files.iter().take(20)
+        .map(|f| f.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "{SESSION_MEMORY_PREFIX}\n\
+         # Session Title\n{title}\n\
+         # Task Specification\n{task}\n\
+         # Current State\nTurn {turn_number}, active\n\
+         # Key Files\n{files}\n\
+         # Progress\n🔄 In progress\n\
+         # Errors & Corrections\nNone\n\
+         # Decisions\nTools used: {tools}\n\
+         # User Messages\n{users}\n\
+         # Worklog\nTurn {turn_number}\n\
+         # Context\nTurn {turn_number}, ~{tokens}K tokens",
+        title = truncate_words(&first_user, 10),
+        task = task,
+        files = if files_section.is_empty() { "None".to_string() } else { files_section },
+        tools = if tool_names.is_empty() { "none".to_string() } else { tool_names.join(", ") },
+        users = user_section,
+        tokens = estimated_tokens / 1000,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    fn sample_l1() -> &'static str {
+        "[session-memory:v1]\n\
+         # Session Title\n\
+         OAuth API Implementation\n\
+         # Task Specification\n\
+         Add OAuth support to API with JWT tokens per RFC 6749.\n\
+         # Current State\n\
+         Implementing token refresh logic in src/auth/refresh.rs.\n\
+         # Key Files\n\
+         src/auth/mod.rs — added OAuthConfig struct\n\
+         src/routes/oauth.rs — authorization endpoints\n\
+         src/auth/refresh.rs — token refresh handler\n\
+         # Progress\n\
+         ✅ OAuth client registration\n\
+         ✅ Authorization code flow\n\
+         ✅ JWT signing (RS256)\n\
+         🔄 Token refresh (in progress)\n\
+         ⏳ PKCE support\n\
+         ⏳ Integration tests\n\
+         # Errors & Corrections\n\
+         - ❌ sqlx migration error: column already exists — UNRESOLVED\n\
+         - 🔧 user correction: use RS256 not HS256\n\
+         - ✅ JWT panic on empty kid — fixed by defaulting to first key\n\
+         # Decisions\n\
+         - RS256 over HS256 for key rotation support\n\
+         - Separate oauth_tokens table to avoid polluting sessions\n\
+         - 5min refresh buffer to prevent race condition\n\
+         # User Messages\n\
+         Add OAuth support to the API with JWT tokens\n\n\
+         Use RS256 instead of HS256\n\n\
+         Also add PKCE support\n\n\
+         Make sure the refresh token has a 5 minute buffer\n\
+         # Worklog\n\
+         Turn 1 — scaffolded OAuth routes\n\
+         Turn 3 — implemented JWT signing\n\
+         Turn 5 — started token refresh\n\
+         # Context\n\
+         Turn 8, ~45K tokens, pressure 65%"
+    }
+
+    fn sample_l1_missing_sections() -> &'static str {
+        "[session-memory:v1]\n\
+         # Session Title\n\
+         Test Session\n\
+         # Current State\n\
+         Working on something\n\
+         # Key Files\n\
+         foo.rs"
+    }
+
+    fn sample_l1_empty_required() -> &'static str {
+        "[session-memory:v1]\n\
+         # Session Title\n\
+         Test\n\
+         # Task Specification\n\
+         \n\
+         # Current State\n\
+         Working\n\
+         # User Messages\n\
+         hello"
+    }
+
+    // ── L0 Anchor Tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn anchor_from_first_user_message() {
+        let anchor = extract_anchor("Add OAuth support to the API with JWT tokens", None);
+        assert!(anchor.starts_with("[session-anchor] "));
+        assert!(anchor.contains("Add OAuth support"));
+        assert!(anchor.contains("Currently: starting"));
+        assert!(anchor.contains("0/0 steps"));
+    }
+
+    #[test]
+    fn anchor_from_l1() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        let anchor = extract_anchor("ignored", Some(&l1));
+        assert!(anchor.starts_with("[session-anchor] "));
+        assert!(anchor.contains("OAuth"));
+        assert!(anchor.contains("token refresh"));
+        assert!(anchor.contains("3/6 steps"));
+    }
+
+    #[test]
+    fn anchor_truncates_long_user_message() {
+        let long_msg = (0..50).map(|i| format!("word{i}")).collect::<Vec<_>>().join(" ");
+        let anchor = extract_anchor(&long_msg, None);
+        let words: Vec<&str> = anchor
+            .strip_prefix("[session-anchor] ")
+            .unwrap()
+            .split(". Currently:")
+            .next()
+            .unwrap()
+            .split_whitespace()
+            .collect();
+        assert!(words.len() <= MAX_TASK_WORDS);
+    }
+
+    // ── L1 Parsing Tests ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_valid_l1() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        assert_eq!(l1.section("Session Title"), Some("OAuth API Implementation"));
+        assert!(l1.section("Task Specification").unwrap().contains("OAuth"));
+        assert!(l1.section("Current State").unwrap().contains("refresh"));
+        assert_eq!(l1.section_names().len(), 10);
+    }
+
+    #[test]
+    fn parse_rejects_wrong_prefix() {
+        assert!(SessionMemory::parse("# Just a markdown file").is_none());
+        assert!(SessionMemory::parse("[session-memory:v2]\n# Title\nfoo").is_none());
+        assert!(SessionMemory::parse("").is_none());
+    }
+
+    #[test]
+    fn parse_handles_whitespace_prefix() {
+        let with_space = format!("  {}\n# Session Title\nTest", SESSION_MEMORY_PREFIX);
+        let l1 = SessionMemory::parse(&with_space).unwrap();
+        assert_eq!(l1.section("Session Title"), Some("Test"));
+    }
+
+    // ── L1 Validation Tests ─────────────────────────────────────────────
+
+    #[test]
+    fn validate_complete_l1() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        assert!(l1.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_missing_required_sections() {
+        let l1 = SessionMemory::parse(sample_l1_missing_sections()).unwrap();
+        let errors = l1.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("Task Specification")));
+        assert!(errors.iter().any(|e| e.contains("User Messages")));
+        assert!(!errors.iter().any(|e| e.contains("Current State"))); // present
+    }
+
+    #[test]
+    fn validate_empty_required_section() {
+        let l1 = SessionMemory::parse(sample_l1_empty_required()).unwrap();
+        let errors = l1.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("empty section: Task Specification")));
+    }
+
+    // ── L1 Size Governance Tests ────────────────────────────────────────
+
+    #[test]
+    fn budget_constants_sum_correctly() {
+        let total: usize = STORED_SECTION_BUDGETS.iter().map(|(_, b)| b).sum();
+        assert!(
+            total <= STORED_TOTAL_BUDGET,
+            "section budgets sum to {total}, exceeds stored total {STORED_TOTAL_BUDGET}"
+        );
+    }
+
+    #[test]
+    fn over_budget_detection() {
+        // Build an L1 with an oversized Worklog section
+        let big_worklog = "x ".repeat(4000); // ~1000 tokens
+        let raw = format!(
+            "{SESSION_MEMORY_PREFIX}\n\
+             # Session Title\nTest\n\
+             # Task Specification\nDo something\n\
+             # Current State\nWorking\n\
+             # Key Files\nfoo.rs\n\
+             # Progress\n✅ step1\n\
+             # Errors & Corrections\nNone\n\
+             # Decisions\n- decision1\n\
+             # User Messages\nHello\n\
+             # Worklog\n{big_worklog}\n\
+             # Context\nTurn 1"
+        );
+        let l1 = SessionMemory::parse(&raw).unwrap();
+        let over = l1.over_budget_sections();
+        assert!(
+            over.iter().any(|(name, _, _)| *name == "Worklog"),
+            "Worklog should be over budget"
+        );
+    }
+
+    #[test]
+    fn normal_l1_within_budget() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        let over = l1.over_budget_sections();
+        assert!(over.is_empty(), "sample L1 should be within budget: {over:?}");
+    }
+
+    // ── L1 Injection Compression Tests ──────────────────────────────────
+
+    #[test]
+    fn injection_contains_required_sections() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        let injected = compress_to_injection(&l1);
+        assert!(injected.starts_with(SESSION_MEMORY_PREFIX));
+        assert!(injected.contains("# Task Specification"));
+        assert!(injected.contains("# Current State"));
+    }
+
+    #[test]
+    fn injection_omits_worklog_and_context() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        let injected = compress_to_injection(&l1);
+        assert!(!injected.contains("# Worklog"));
+        assert!(!injected.contains("# Context"));
+    }
+
+    #[test]
+    fn injection_filters_completed_progress() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        let injected = compress_to_injection(&l1);
+        // Should NOT contain completed items
+        assert!(!injected.contains("✅"));
+        // Should contain in-progress and pending
+        assert!(injected.contains("🔄"));
+        assert!(injected.contains("⏳"));
+    }
+
+    #[test]
+    fn injection_strips_file_descriptions() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        let injected = compress_to_injection(&l1);
+        // Should have file names but not descriptions
+        assert!(injected.contains("src/auth/mod.rs"));
+        assert!(!injected.contains("added OAuthConfig struct"));
+    }
+
+    #[test]
+    fn injection_keeps_only_last_3_user_messages() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        let injected = compress_to_injection(&l1);
+        // Original has 4 user messages, injection should have last 3
+        assert!(!injected.contains("Add OAuth support to the API with JWT tokens"));
+        assert!(injected.contains("Use RS256 instead of HS256"));
+        assert!(injected.contains("Also add PKCE support"));
+        assert!(injected.contains("5 minute buffer"));
+    }
+
+    #[test]
+    fn injection_keeps_only_last_2_decisions() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        let injected = compress_to_injection(&l1);
+        // Original has 3 decisions, injection should have last 2
+        assert!(!injected.contains("RS256 over HS256"));
+        assert!(injected.contains("oauth_tokens table"));
+        assert!(injected.contains("refresh buffer"));
+    }
+
+    #[test]
+    fn injection_keeps_unresolved_errors_and_user_corrections() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        let injected = compress_to_injection(&l1);
+        assert!(injected.contains("UNRESOLVED"));
+        assert!(injected.contains("user correction"));
+        // Resolved error should be filtered
+        assert!(!injected.contains("fixed by defaulting"));
+    }
+
+    #[test]
+    fn injection_smaller_than_stored() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        let injected = compress_to_injection(&l1);
+        let injection_tokens = injected.len() / 4;
+        let stored_tokens = l1.estimate_tokens();
+        assert!(
+            injection_tokens < stored_tokens,
+            "injection ({injection_tokens}t) should be smaller than stored ({stored_tokens}t)"
+        );
+    }
+
+    // ── First User Message Preservation Tests ───────────────────────────
+
+    #[test]
+    fn find_first_user_message() {
+        let msgs = vec![
+            json!({"role": "system", "content": "you are helpful"}),
+            json!({"role": "user", "content": "do the thing"}),
+            json!({"role": "assistant", "content": "ok"}),
+        ];
+        assert_eq!(first_user_message_index(&msgs), Some(1));
+    }
+
+    #[test]
+    fn no_user_message() {
+        let msgs = vec![
+            json!({"role": "system", "content": "system"}),
+            json!({"role": "assistant", "content": "hello"}),
+        ];
+        assert_eq!(first_user_message_index(&msgs), None);
+    }
+
+    // ── Compaction Boundary Detection ───────────────────────────────────
+
+    #[test]
+    fn detect_compaction_boundary() {
+        let boundary_msg = json!({
+            "role": "system",
+            "content": "[Context compacted]",
+            "compact_metadata": {"tier": "compact_history"}
+        });
+        assert!(is_compaction_boundary(&boundary_msg));
+
+        let normal_msg = json!({"role": "user", "content": "hello"});
+        assert!(!is_compaction_boundary(&normal_msg));
+    }
+
+    // ── Pressure-Adaptive Injection Tests ───────────────────────────────
+
+    #[test]
+    fn injection_level_low_pressure() {
+        assert_eq!(injection_level_for_pressure(0.5), InjectionLevel::L1Full);
+        assert_eq!(injection_level_for_pressure(0.74), InjectionLevel::L1Full);
+    }
+
+    #[test]
+    fn injection_level_medium_pressure() {
+        assert_eq!(injection_level_for_pressure(0.75), InjectionLevel::L1Minimal);
+        assert_eq!(injection_level_for_pressure(0.84), InjectionLevel::L1Minimal);
+    }
+
+    #[test]
+    fn injection_level_high_pressure() {
+        assert_eq!(injection_level_for_pressure(0.85), InjectionLevel::L0Only);
+        assert_eq!(injection_level_for_pressure(0.95), InjectionLevel::L0Only);
+        assert_eq!(injection_level_for_pressure(1.0), InjectionLevel::L0Only);
+    }
+
+    #[test]
+    fn injection_level_post_compaction() {
+        // Post-compaction pressure is typically low → L1Full
+        assert_eq!(injection_level_for_pressure(0.3), InjectionLevel::L1Full);
+    }
+
+    // ── Progress Counting ───────────────────────────────────────────────
+
+    #[test]
+    fn count_progress_empty() {
+        assert_eq!(count_progress_markers(""), (0, 0));
+    }
+
+    #[test]
+    fn count_progress_mixed() {
+        let text = "✅ done1\n✅ done2\n🔄 wip\n⏳ pending\nsome other line";
+        assert_eq!(count_progress_markers(text), (2, 4));
+    }
+
+    // ── Edge Cases ──────────────────────────────────────────────────────
+
+    #[test]
+    fn anchor_from_empty_message() {
+        let anchor = extract_anchor("", None);
+        assert!(anchor.starts_with("[session-anchor] "));
+        assert!(anchor.contains("Currently: starting"));
+    }
+
+    #[test]
+    fn compress_minimal_l1() {
+        let raw = format!(
+            "{SESSION_MEMORY_PREFIX}\n\
+             # Task Specification\nDo X\n\
+             # Current State\nDoing X\n\
+             # User Messages\nDo X"
+        );
+        let l1 = SessionMemory::parse(&raw).unwrap();
+        assert!(l1.validate().is_ok());
+        let injected = compress_to_injection(&l1);
+        assert!(injected.contains("Do X"));
+        assert!(injected.contains("Doing X"));
+    }
+
+    #[test]
+    fn section_names_match_protocol() {
+        let l1 = SessionMemory::parse(sample_l1()).unwrap();
+        for &name in SECTION_NAMES {
+            assert!(
+                l1.section(name).is_some(),
+                "sample L1 missing section: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_l1_from_messages_produces_valid_l1() {
+        let messages = vec![
+            json!({"role": "system", "content": "You are helpful."}),
+            json!({"role": "user", "content": "Build a rate limiter using Redis"}),
+            json!({"role": "assistant", "content": "I'll start by reading the code.", "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\": \"src/main.rs\"}"}}
+            ]}),
+            json!({"role": "tool", "content": "fn main() {}", "tool_call_id": "c1"}),
+            json!({"role": "assistant", "content": "Done with step 1."}),
+            json!({"role": "user", "content": "Now add Redis connection"}),
+        ];
+        let l1_text = build_l1_from_messages(&messages, 2, 50000);
+        let l1 = SessionMemory::parse(&l1_text).expect("should parse");
+        assert!(l1.validate().is_ok(), "should be valid: {:?}", l1.validate());
+        assert!(l1.section("Task Specification").unwrap().contains("rate limiter"));
+        assert!(l1.section("Key Files").unwrap().contains("src/main.rs"));
+        assert!(l1.section("Decisions").unwrap().contains("read_file"));
+        assert!(l1.section("User Messages").unwrap().contains("Redis connection"));
+        assert!(l1.section("Context").unwrap().contains("50K"));
+    }
+
+    #[test]
+    fn build_l1_within_budget() {
+        // Large conversation
+        let mut messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "Implement a very complex distributed system with many requirements"}),
+        ];
+        for i in 0..50 {
+            messages.push(json!({"role": "assistant", "content": format!("Step {i} done")}));
+            messages.push(json!({"role": "user", "content": format!("Continue with step {}", i+1)}));
+        }
+        let l1_text = build_l1_from_messages(&messages, 50, 100000);
+        let tokens = l1_text.len() / 4;
+        assert!(tokens <= STORED_TOTAL_BUDGET, "L1 should be ≤{STORED_TOTAL_BUDGET} tokens, got {tokens}");
+    }
+
+    #[test]
+    fn first_sentence_handles_cjk_period() {
+        // '。' is 3 bytes in UTF-8 — must not slice into the middle of it
+        let text = "这是第一句话。这是第二句话。";
+        let result = first_sentence(text);
+        assert_eq!(result, "这是第一句话。");
+    }
+
+    #[test]
+    fn first_sentence_handles_ascii_period() {
+        assert_eq!(first_sentence("Hello world. More text."), "Hello world.");
+    }
+
+    #[test]
+    fn build_l1_context_shows_nonzero_tokens() {
+        let messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "Build something"}),
+            json!({"role": "assistant", "content": "Done."}),
+        ];
+        let l1_text = build_l1_from_messages(&messages, 5, 45000);
+        let l1 = SessionMemory::parse(&l1_text).unwrap();
+        let ctx = l1.section("Context").unwrap();
+        assert!(
+            ctx.contains("45K"),
+            "Context should show ~45K tokens, got: {ctx}"
+        );
+    }
+
+    // ── Fix #9: first_sentence strips trailing newline ──────────────────
+
+    #[test]
+    fn first_sentence_strips_trailing_newline() {
+        let text = "First line\nSecond line";
+        let result = first_sentence(text);
+        assert_eq!(result, "First line", "anchor must be single-line");
+        assert!(!result.contains('\n'));
+    }
+
+    #[test]
+    fn first_sentence_no_delimiter_still_single_line() {
+        // Text with no period/newline — unwrap_or returns full text,
+        // but .lines().next() guarantees single-line
+        let text = "Very long text with no delimiter at all";
+        let result = first_sentence(text);
+        assert!(!result.contains('\n'));
+        assert_eq!(result, text);
+    }
+
+    #[test]
+    fn first_sentence_embedded_newline_in_fallback() {
+        // Edge case: text has embedded newlines but no sentence-ending punctuation
+        // before the first newline — should still return single line
+        let text = "Line one\nLine two\nLine three";
+        let result = first_sentence(text);
+        assert_eq!(result, "Line one");
+    }
+
+    // ── Fix #2: Anthropic content blocks in build_l1 ────────────────────
+
+    #[test]
+    fn build_l1_handles_anthropic_content_blocks() {
+        let messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": [
+                {"type": "text", "text": "Build a distributed cache with LRU eviction"}
+            ]}),
+            json!({"role": "assistant", "content": "Starting."}),
+        ];
+        let l1_text = build_l1_from_messages(&messages, 1, 10000);
+        let l1 = SessionMemory::parse(&l1_text).unwrap();
+        assert!(
+            l1.section("Task Specification").unwrap().contains("distributed cache"),
+            "Should extract text from Anthropic content blocks"
+        );
+        assert!(
+            l1.section("User Messages").unwrap().contains("distributed cache"),
+            "User messages should include Anthropic block content"
+        );
+    }
+
+    // ── Fix #8: user message deduplication ──────────────────────────────
+
+    #[test]
+    fn build_l1_deduplicates_user_messages() {
+        let messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "continue"}),
+            json!({"role": "assistant", "content": "ok"}),
+            json!({"role": "user", "content": "continue"}),
+            json!({"role": "assistant", "content": "ok"}),
+            json!({"role": "user", "content": "continue"}),
+            json!({"role": "assistant", "content": "done"}),
+        ];
+        let l1_text = build_l1_from_messages(&messages, 3, 5000);
+        let l1 = SessionMemory::parse(&l1_text).unwrap();
+        let user_section = l1.section("User Messages").unwrap();
+        let count = user_section.matches("continue").count();
+        assert_eq!(count, 1, "duplicate 'continue' should appear only once, got {count}");
+    }
+
+    // ── Fix #5: shared first_user_end helper ────────────────────────────
+
+    #[test]
+    fn first_user_end_finds_user_after_system() {
+        let msgs = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "task"}),
+            json!({"role": "assistant", "content": "ok"}),
+        ];
+        assert_eq!(first_user_end(&msgs, 1), 2); // end is exclusive: index 1 is user, end = 2
+    }
+
+    #[test]
+    fn first_user_end_no_user_returns_start() {
+        let msgs = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "assistant", "content": "ok"}),
+        ];
+        assert_eq!(first_user_end(&msgs, 1), 1); // no user found, returns start
+    }
+
+    #[test]
+    fn first_user_end_skips_tool_before_user() {
+        let msgs = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "tool", "content": "stale", "tool_call_id": "x"}),
+            json!({"role": "user", "content": "THE TASK"}),
+            json!({"role": "assistant", "content": "ok"}),
+        ];
+        assert_eq!(first_user_end(&msgs, 1), 3); // tool at 1, user at 2, end = 3
+    }
+
+    // ── extract_message_text ────────────────────────────────────────────
+
+    #[test]
+    fn extract_message_text_string_content() {
+        let msg = json!({"role": "user", "content": "hello"});
+        assert_eq!(extract_message_text(&msg).unwrap(), "hello");
+    }
+
+    #[test]
+    fn extract_message_text_anthropic_blocks() {
+        let msg = json!({"role": "user", "content": [
+            {"type": "text", "text": "first"},
+            {"type": "image", "source": {}},
+            {"type": "text", "text": "second"}
+        ]});
+        assert_eq!(extract_message_text(&msg).unwrap(), "first\nsecond");
+    }
+
+    #[test]
+    fn extract_message_text_empty_blocks() {
+        let msg = json!({"role": "user", "content": [{"type": "image", "source": {}}]});
+        assert!(extract_message_text(&msg).is_none());
+    }
+
+    // ── Fix #10: token-based truncation ─────────────────────────────────
+
+    #[test]
+    fn truncate_to_token_budget_short_text() {
+        let result = truncate_to_token_budget("short text", 200);
+        assert_eq!(result, "short text");
+    }
+
+    #[test]
+    fn truncate_to_token_budget_long_text() {
+        let long = "word ".repeat(500); // ~500 words, ~125 tokens per 100 words
+        let result = truncate_to_token_budget(&long, 50); // 50 tokens = ~200 chars
+        assert!(result.len() <= 200, "should be ≤200 chars, got {}", result.len());
+        assert!(!result.ends_with(' '), "should break at word boundary");
+    }
+
+    #[test]
+    fn build_l1_task_within_stored_budget() {
+        // Very long first user message — Task Specification must stay within budget
+        let long_task = "implement ".repeat(200); // ~200 words
+        let messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": long_task}),
+            json!({"role": "assistant", "content": "ok"}),
+        ];
+        let l1_text = build_l1_from_messages(&messages, 1, 10000);
+        let l1 = SessionMemory::parse(&l1_text).unwrap();
+        let task_tokens = l1.section_tokens("Task Specification");
+        let budget = STORED_SECTION_BUDGETS.iter()
+            .find(|(n, _)| *n == "Task Specification")
+            .map(|(_, b)| *b)
+            .unwrap();
+        assert!(
+            task_tokens <= budget + 10, // small margin for overhead
+            "Task Specification should be ≤{budget} tokens, got {task_tokens}"
+        );
+    }
+
+    // ── Fix #11: configurable injection thresholds ──────────────────────
+
+    #[test]
+    fn injection_level_custom_thresholds() {
+        // Tighter thresholds
+        assert_eq!(
+            injection_level_for_pressure_with_thresholds(0.5, 0.6, 0.7),
+            InjectionLevel::L1Full
+        );
+        assert_eq!(
+            injection_level_for_pressure_with_thresholds(0.65, 0.6, 0.7),
+            InjectionLevel::L1Minimal
+        );
+        assert_eq!(
+            injection_level_for_pressure_with_thresholds(0.75, 0.6, 0.7),
+            InjectionLevel::L0Only
+        );
+    }
+
+    #[test]
+    fn injection_level_default_matches_constants() {
+        // Verify the convenience function uses the documented constants
+        assert_eq!(
+            injection_level_for_pressure(DEFAULT_L1_FULL_THRESHOLD - 0.01),
+            InjectionLevel::L1Full
+        );
+        assert_eq!(
+            injection_level_for_pressure(DEFAULT_L1_FULL_THRESHOLD),
+            InjectionLevel::L1Minimal
+        );
+        assert_eq!(
+            injection_level_for_pressure(DEFAULT_L1_MINIMAL_THRESHOLD),
+            InjectionLevel::L0Only
+        );
+    }
+
+    // ── #3/#7: persist_l1 — purge + store + retry ───────────────────────
+
+    mod persist_l1_tests {
+        use super::*;
+        use crate::turn::cloud::memoria_compact::{MemoriaClient, MemoriaMemory};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        /// Mock that tracks calls and can fail N times before succeeding.
+        struct MockMemoria {
+            store_calls: AtomicUsize,
+            purge_calls: AtomicUsize,
+            fail_store_times: AtomicUsize,
+            stored: tokio::sync::Mutex<Vec<(String, String)>>, // (content, session_id)
+        }
+
+        impl MockMemoria {
+            fn new(fail_store_times: usize) -> Self {
+                Self {
+                    store_calls: AtomicUsize::new(0),
+                    purge_calls: AtomicUsize::new(0),
+                    fail_store_times: AtomicUsize::new(fail_store_times),
+                    stored: tokio::sync::Mutex::new(Vec::new()),
+                }
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl MemoriaClient for MockMemoria {
+            async fn retrieve(&self, _q: &str, _sid: Option<&str>, _k: usize) -> Result<Vec<MemoriaMemory>, String> {
+                Ok(vec![])
+            }
+            async fn store(&self, content: &str, _mt: &str, sid: Option<&str>, _tt: Option<&str>) -> Result<String, String> {
+                let n = self.store_calls.fetch_add(1, Ordering::SeqCst);
+                let remaining = self.fail_store_times.load(Ordering::SeqCst);
+                if n < remaining {
+                    return Err(format!("mock store failure #{}", n + 1));
+                }
+                self.stored.lock().await.push((
+                    content.to_string(),
+                    sid.unwrap_or("").to_string(),
+                ));
+                Ok(format!("mem-{n}"))
+            }
+            async fn purge_working(&self, _sid: &str) -> Result<u64, String> {
+                self.purge_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(0)
+            }
+            async fn delete(&self, _id: &str) -> Result<(), String> {
+                Ok(())
+            }
+        }
+
+        #[tokio::test]
+        async fn persist_l1_purges_then_stores() {
+            let mock = Arc::new(MockMemoria::new(0));
+            let result = persist_l1(&*mock, "L1 content", "sess-1").await;
+            assert!(result.is_ok());
+            assert_eq!(mock.purge_calls.load(Ordering::SeqCst), 1, "should purge once");
+            assert_eq!(mock.store_calls.load(Ordering::SeqCst), 1, "should store once on success");
+            let stored = mock.stored.lock().await;
+            assert_eq!(stored[0].0, "L1 content");
+            assert_eq!(stored[0].1, "sess-1");
+        }
+
+        #[tokio::test]
+        async fn persist_l1_retries_on_first_failure() {
+            let mock = Arc::new(MockMemoria::new(1)); // fail first store, succeed second
+            let result = persist_l1(&*mock, "L1 retry", "sess-2").await;
+            assert!(result.is_ok(), "should succeed on retry");
+            assert_eq!(mock.store_calls.load(Ordering::SeqCst), 2, "should call store twice");
+            assert_eq!(mock.purge_calls.load(Ordering::SeqCst), 1, "purge only once");
+        }
+
+        #[tokio::test]
+        async fn persist_l1_gives_up_after_two_failures() {
+            let mock = Arc::new(MockMemoria::new(2)); // fail both attempts
+            let result = persist_l1(&*mock, "L1 fail", "sess-3").await;
+            assert!(result.is_err(), "should fail after 2 attempts");
+            assert_eq!(mock.store_calls.load(Ordering::SeqCst), 2, "should attempt exactly twice");
+            assert!(mock.stored.lock().await.is_empty(), "nothing should be stored");
+        }
+
+        #[tokio::test]
+        async fn persist_l1_purge_failure_does_not_block_store() {
+            // Mock that fails purge but succeeds store
+            struct PurgeFailMock;
+            #[async_trait::async_trait]
+            impl MemoriaClient for PurgeFailMock {
+                async fn retrieve(&self, _: &str, _: Option<&str>, _: usize) -> Result<Vec<MemoriaMemory>, String> { Ok(vec![]) }
+                async fn store(&self, _: &str, _: &str, _: Option<&str>, _: Option<&str>) -> Result<String, String> { Ok("ok".into()) }
+                async fn purge_working(&self, _: &str) -> Result<u64, String> { Err("purge broken".into()) }
+                async fn delete(&self, _: &str) -> Result<(), String> { Ok(()) }
+            }
+            let result = persist_l1(&PurgeFailMock, "L1", "s").await;
+            assert!(result.is_ok(), "purge failure should not prevent store");
+        }
+    }
+}

--- a/rust/crates/runtime/src/turn/cloud/session_memory_protocol.rs
+++ b/rust/crates/runtime/src/turn/cloud/session_memory_protocol.rs
@@ -447,7 +447,7 @@ pub fn build_l1_from_messages(
         .iter()
         .filter_map(|m| {
             if m.get("role").and_then(Value::as_str) == Some("user") {
-                extract_message_text(m).filter(|t| seen_user_msgs.insert(t.clone()))
+                extract_message_text(m).filter(|t| seen_user_msgs.insert(t.to_lowercase()))
             } else {
                 None
             }
@@ -513,13 +513,34 @@ pub fn build_l1_from_messages(
         .collect::<Vec<_>>()
         .join("\n");
 
+    // Derive current state from last assistant message
+    let current_state = messages
+        .iter()
+        .rev()
+        .find(|m| m.get("role").and_then(Value::as_str) == Some("assistant"))
+        .and_then(|m| extract_message_text(m))
+        .map(|t| truncate_words(&t, 20))
+        .unwrap_or_else(|| format!("Turn {turn_number}, active"));
+
+    // Derive progress from tool call count
+    let tool_call_count: usize = messages
+        .iter()
+        .filter_map(|m| m.get("tool_calls").and_then(Value::as_array))
+        .map(|a| a.len())
+        .sum();
+    let progress = if tool_call_count == 0 {
+        "🔄 In progress".to_string()
+    } else {
+        format!("✅ {tool_call_count} tool calls completed\n🔄 Turn {turn_number} in progress")
+    };
+
     format!(
         "{SESSION_MEMORY_PREFIX}\n\
          # Session Title\n{title}\n\
          # Task Specification\n{task}\n\
-         # Current State\nTurn {turn_number}, active\n\
+         # Current State\n{current_state}\n\
          # Key Files\n{files}\n\
-         # Progress\n🔄 In progress\n\
+         # Progress\n{progress}\n\
          # Errors & Corrections\nNone\n\
          # Decisions\nTools used: {tools}\n\
          # User Messages\n{users}\n\

--- a/rust/crates/runtime/src/turn/cloud/session_memory_protocol.rs
+++ b/rust/crates/runtime/src/turn/cloud/session_memory_protocol.rs
@@ -514,13 +514,18 @@ pub fn build_l1_from_messages(
         .join("\n");
 
     // Derive current state from last assistant message
-    let current_state = messages
+    let last_action = messages
         .iter()
         .rev()
         .find(|m| m.get("role").and_then(Value::as_str) == Some("assistant"))
         .and_then(|m| extract_message_text(m))
-        .map(|t| truncate_words(&t, 20))
-        .unwrap_or_else(|| format!("Turn {turn_number}, active"));
+        .map(|t| truncate_words(&t, 15))
+        .unwrap_or_default();
+    let current_state = if last_action.is_empty() {
+        format!("Turn {turn_number}, active")
+    } else {
+        format!("Turn {turn_number}, active. {last_action}")
+    };
 
     // Derive progress from tool call count
     let tool_call_count: usize = messages
@@ -720,9 +725,11 @@ mod tests {
     fn validate_empty_required_section() {
         let l1 = SessionMemory::parse(sample_l1_empty_required()).unwrap();
         let errors = l1.validate().unwrap_err();
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("empty section: Task Specification")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("empty section: Task Specification"))
+        );
     }
 
     // ── L1 Size Governance Tests ────────────────────────────────────────
@@ -989,16 +996,18 @@ mod tests {
             "should be valid: {:?}",
             l1.validate()
         );
-        assert!(l1
-            .section("Task Specification")
-            .unwrap()
-            .contains("rate limiter"));
+        assert!(
+            l1.section("Task Specification")
+                .unwrap()
+                .contains("rate limiter")
+        );
         assert!(l1.section("Key Files").unwrap().contains("src/main.rs"));
         assert!(l1.section("Decisions").unwrap().contains("read_file"));
-        assert!(l1
-            .section("User Messages")
-            .unwrap()
-            .contains("Redis connection"));
+        assert!(
+            l1.section("User Messages")
+                .unwrap()
+                .contains("Redis connection")
+        );
         assert!(l1.section("Context").unwrap().contains("50K"));
     }
 
@@ -1270,8 +1279,8 @@ mod tests {
     mod persist_l1_tests {
         use super::*;
         use crate::turn::cloud::memoria_compact::{MemoriaClient, MemoriaMemory};
-        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
         /// Mock that tracks calls and can fail N times before succeeding.
         struct MockMemoria {

--- a/rust/crates/runtime/src/turn/context_compression.rs
+++ b/rust/crates/runtime/src/turn/context_compression.rs
@@ -605,7 +605,8 @@ impl CompressionLayer for TieredCompaction {
         }
 
         // Preserve the first user message (the original task/goal) from compaction.
-        let first_user_end = crate::turn::cloud::session_memory_protocol::first_user_end(messages, system_end);
+        let first_user_end =
+            crate::turn::cloud::session_memory_protocol::first_user_end(messages, system_end);
 
         let keep_tail = self.keep_recent_turns * 2; // user+assistant pairs
         let tail_start = before_count.saturating_sub(keep_tail);
@@ -728,7 +729,8 @@ impl CompressionLayer for ReactiveCompact {
         }
 
         // Preserve the first user message (the original task/goal) from compaction.
-        let first_user_end = crate::turn::cloud::session_memory_protocol::first_user_end(messages, system_end);
+        let first_user_end =
+            crate::turn::cloud::session_memory_protocol::first_user_end(messages, system_end);
 
         let keep_tail = 4;
         let tail_start = messages.len().saturating_sub(keep_tail);
@@ -1057,9 +1059,15 @@ mod tests {
         let b = budget(80000, 70000);
         layer.compress(&mut msgs, &b);
 
-        let has_task = msgs.iter().any(|m|
-            m.get("content").and_then(Value::as_str).map(|s| s.contains("THE REAL TASK")).unwrap_or(false)
+        let has_task = msgs.iter().any(|m| {
+            m.get("content")
+                .and_then(Value::as_str)
+                .map(|s| s.contains("THE REAL TASK"))
+                .unwrap_or(false)
+        });
+        assert!(
+            has_task,
+            "First user message must survive even when preceded by tool msg"
         );
-        assert!(has_task, "First user message must survive even when preceded by tool msg");
     }
 }

--- a/rust/crates/runtime/src/turn/context_compression.rs
+++ b/rust/crates/runtime/src/turn/context_compression.rs
@@ -604,9 +604,12 @@ impl CompressionLayer for TieredCompaction {
             }
         }
 
+        // Preserve the first user message (the original task/goal) from compaction.
+        let first_user_end = crate::turn::cloud::session_memory_protocol::first_user_end(messages, system_end);
+
         let keep_tail = self.keep_recent_turns * 2; // user+assistant pairs
         let tail_start = before_count.saturating_sub(keep_tail);
-        let removable_start = system_end;
+        let removable_start = first_user_end;
         let removable_end = tail_start;
 
         if removable_end <= removable_start {
@@ -724,9 +727,12 @@ impl CompressionLayer for ReactiveCompact {
             }
         }
 
+        // Preserve the first user message (the original task/goal) from compaction.
+        let first_user_end = crate::turn::cloud::session_memory_protocol::first_user_end(messages, system_end);
+
         let keep_tail = 4;
         let tail_start = messages.len().saturating_sub(keep_tail);
-        let removable_start = system_end;
+        let removable_start = first_user_end;
         let removable_end = tail_start;
 
         if removable_end <= removable_start {
@@ -897,9 +903,10 @@ mod tests {
 
         let result = layer.compress(&mut msgs, &b);
         assert!(result.messages_removed > 20);
-        // Should keep: system(1) + boundary(1) + last 4
-        assert_eq!(msgs.len(), 6);
-        assert!(msgs[1]["content"].as_str().unwrap().contains("EMERGENCY"));
+        // Should keep: system(1) + first_user(1) + boundary(1) + last 4
+        assert_eq!(msgs.len(), 7);
+        assert_eq!(msgs[1]["role"], "user"); // first user message preserved
+        assert!(msgs[2]["content"].as_str().unwrap().contains("EMERGENCY"));
     }
 
     #[test]
@@ -1006,5 +1013,53 @@ mod tests {
             out_aggressive.total_tokens_freed,
             out_default.total_tokens_freed,
         );
+    }
+
+    #[test]
+    fn tiered_compaction_preserves_first_user_message() {
+        let layer = TieredCompaction::new(2, 0.75);
+        let mut msgs = make_messages(20); // system + 20 user/assistant pairs
+        let original_first_user = msgs[1]["content"].as_str().unwrap().to_string();
+        let b = budget(80000, 70000);
+
+        layer.compress(&mut msgs, &b);
+
+        // First user message must survive
+        assert_eq!(msgs[1]["role"], "user");
+        assert_eq!(msgs[1]["content"].as_str().unwrap(), original_first_user);
+    }
+
+    #[test]
+    fn reactive_compact_preserves_first_user_message() {
+        let layer = ReactiveCompact::new(0.95);
+        let mut msgs = make_messages(20);
+        let original_first_user = msgs[1]["content"].as_str().unwrap().to_string();
+        let b = budget(80000, 85000);
+
+        layer.compress(&mut msgs, &b);
+
+        assert_eq!(msgs[1]["role"], "user");
+        assert_eq!(msgs[1]["content"].as_str().unwrap(), original_first_user);
+    }
+
+    #[test]
+    fn tiered_preserves_first_user_when_preceded_by_tool() {
+        let layer = TieredCompaction::new(2, 0.75);
+        let mut msgs = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "tool", "content": "stale tool result", "tool_call_id": "x"}),
+            json!({"role": "user", "content": "THE REAL TASK"}),
+        ];
+        for i in 0..20 {
+            msgs.push(json!({"role": "assistant", "content": format!("a{i} {}", "x".repeat(200))}));
+            msgs.push(json!({"role": "user", "content": format!("q{i}")}));
+        }
+        let b = budget(80000, 70000);
+        layer.compress(&mut msgs, &b);
+
+        let has_task = msgs.iter().any(|m|
+            m.get("content").and_then(Value::as_str).map(|s| s.contains("THE REAL TASK")).unwrap_or(false)
+        );
+        assert!(has_task, "First user message must survive even when preceded by tool msg");
     }
 }

--- a/rust/crates/runtime/src/turn/stall.rs
+++ b/rust/crates/runtime/src/turn/stall.rs
@@ -706,8 +706,8 @@ mod tests {
     #[test]
     fn tool_round_abort_message_points_to_tool_round_limit() {
         assert_eq!(
-            cli_agentic_tool_round_budget_abort_msg(15),
-            "Tool-round budget exhausted. To increase, set MO_MAX_TOOL_ROUNDS to a larger value (current limit: 15, default: 15)."
+            cli_agentic_tool_round_budget_abort_msg(30),
+            "Tool-round budget exhausted. To increase, set MO_MAX_TOOL_ROUNDS to a larger value (current limit: 30, default: 30)."
         );
     }
 

--- a/rust/crates/runtime/tests/improvement_proofs.rs
+++ b/rust/crates/runtime/tests/improvement_proofs.rs
@@ -4731,7 +4731,7 @@ mod runtime_limits_proofs {
         // Now centralized with env-var override capability.
         let d = RuntimeLimits::default();
         assert_eq!(d.max_turns, 50, "was MAX_TURNS in chat_stream.rs");
-        assert_eq!(d.max_tool_rounds, 15, "was MAX_TOOL_ROUNDS in routing.rs");
+        assert_eq!(d.max_tool_rounds, 30, "was MAX_TOOL_ROUNDS in routing.rs");
         assert!(
             (d.turn_timeout_s - 300.0).abs() < f64::EPSILON,
             "was TURN_TIMEOUT_S in bridge_inprocess.rs"

--- a/rust/crates/runtime/tests/session_memory_protocol_integration.rs
+++ b/rust/crates/runtime/tests/session_memory_protocol_integration.rs
@@ -1,0 +1,1135 @@
+//! Integration tests for Session Memory Protocol against real Memoria.
+//!
+//! Requires: `MEMORIA_BASE_URL` + `MEMORIA_MASTER_KEY` (or `MEMORIA_API_KEY`).
+//! Run with: `cargo test -p astra-runtime -- session_memory_protocol_integration --ignored`
+
+use astra_runtime::turn::cloud::memoria_compact::{
+    HttpMemoriaClient, MemoriaClient, MemoriaCompactConfig, MemoriaCompactParams,
+    MemoriaMemory, compact_with_memoria,
+};
+use astra_runtime::turn::cloud::session_memory_protocol::*;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+fn memoria_client() -> Option<HttpMemoriaClient> {
+    // Load .env from project root (three levels up: crates/runtime/ → crates/ → rust/ → root)
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    // CARGO_MANIFEST_DIR = .../rust/crates/runtime
+    // workspace root with .env = .../  (3 levels up)
+    for ancestor in manifest_dir.ancestors().take(5) {
+        let env_path = ancestor.join(".env");
+        if env_path.exists() {
+            let _ = dotenvy::from_path(&env_path);
+            break;
+        }
+    }
+    HttpMemoriaClient::from_env()
+}
+
+/// Try to store a test memory. Returns None if Memoria is not fully operational
+/// (e.g., embedding service unavailable).
+async fn verified_memoria_client() -> Option<(HttpMemoriaClient, String)> {
+    let client = memoria_client()?;
+    let sid = unique_session_id();
+    // Probe: try a store to verify embedding service is working
+    match client.store("probe", "working", Some(&sid), None).await {
+        Ok(id) => {
+            let _ = client.delete(&id).await; // clean up probe
+            Some((client, unique_session_id()))
+        }
+        Err(e) => {
+            eprintln!("Memoria not fully operational (embedding?): {e}");
+            None
+        }
+    }
+}
+
+/// Helper to store and track memory IDs for cleanup.
+/// Derefs to HttpMemoriaClient so tests can call .store(), .retrieve() etc. directly.
+/// Call .cleanup() at end of test, or .track(id) to register externally-created IDs.
+struct TestMemories {
+    client: HttpMemoriaClient,
+    ids: std::sync::Mutex<Vec<String>>,
+    sid: String,
+}
+
+impl TestMemories {
+    fn new(client: HttpMemoriaClient, sid: String) -> Self {
+        Self { client, ids: std::sync::Mutex::new(Vec::new()), sid }
+    }
+
+    fn session_id(&self) -> &str { &self.sid }
+
+    /// Track a memory_id for cleanup (when store is called via client directly).
+    #[allow(dead_code)]
+    fn track(&self, id: &str) {
+        self.ids.lock().unwrap().push(id.to_string());
+    }
+
+    async fn cleanup(&self) {
+        let ids = std::mem::take(&mut *self.ids.lock().unwrap());
+        for id in &ids {
+            if let Err(e) = self.client.delete(id).await {
+                eprintln!("[test cleanup] failed to delete memory {id}: {e}");
+            }
+        }
+    }
+}
+
+impl std::ops::Deref for TestMemories {
+    type Target = HttpMemoriaClient;
+    fn deref(&self) -> &HttpMemoriaClient { &self.client }
+}
+
+macro_rules! require_memoria {
+    () => {
+        match verified_memoria_client().await {
+            Some((client, sid)) => TestMemories::new(client, sid),
+            None => {
+                eprintln!("SKIPPED: Memoria not fully operational");
+                return;
+            }
+        }
+    };
+}
+
+fn unique_session_id() -> String {
+    format!("test-smp-{}", Uuid::new_v4().simple())
+}
+
+
+/// Retrieve L1 for a specific session by content marker.
+/// Memoria's retrieve uses session_id for boosting, not strict filtering,
+/// and MemoriaMemory doesn't expose session_id. So we filter by content.
+async fn retrieve_l1_with_marker(
+    client: &HttpMemoriaClient,
+    marker: &str,
+) -> Vec<MemoriaMemory> {
+    let results = client
+        .retrieve(&format!("[session-memory:v1] {marker}"), None, 20)
+        .await
+        .unwrap_or_default();
+    results
+        .into_iter()
+        .filter(|m| {
+            m.content.starts_with(SESSION_MEMORY_PREFIX) && m.content.contains(marker)
+        })
+        .collect()
+}
+
+fn user(content: &str) -> Value {
+    json!({"role": "user", "content": content})
+}
+fn assistant(content: &str) -> Value {
+    json!({"role": "assistant", "content": content})
+}
+fn system(content: &str) -> Value {
+    json!({"role": "system", "content": content})
+}
+
+fn sample_session_memory(task: &str) -> String {
+    format!(
+        "{SESSION_MEMORY_PREFIX}\n\
+         # Session Title\n\
+         Test Session\n\
+         # Task Specification\n\
+         {task}\n\
+         # Current State\n\
+         Working on implementation\n\
+         # Key Files\n\
+         src/main.rs — entry point\n\
+         # Progress\n\
+         ✅ Setup\n\
+         🔄 Implementation\n\
+         ⏳ Testing\n\
+         # Errors & Corrections\n\
+         None\n\
+         # Decisions\n\
+         - Use Rust for performance\n\
+         # User Messages\n\
+         {task}\n\
+         # Worklog\n\
+         Turn 1 — started\n\
+         # Context\n\
+         Turn 2, ~10K tokens"
+    )
+}
+
+// ── L1 Store → Retrieve Round-Trip ──────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn l1_store_and_retrieve_via_memoria() {
+    let tm = require_memoria!();
+    let marker = format!("REST-API-{}", &tm.session_id()[..12]);
+    let content = sample_session_memory(&marker);
+
+    // Store L1 as working memory
+    let memory_id = tm
+        .store(&content, "working", Some(tm.session_id()), Some("T2"))
+        .await
+        .expect("store failed");
+    assert!(!memory_id.is_empty());
+
+    // Retrieve by content marker
+    let found = retrieve_l1_with_marker(&tm, &marker).await;
+    assert!(!found.is_empty(), "L1 not found after store+wait");
+
+    // Cleanup
+    let _ = tm.purge_working(tm.session_id()).await;
+    tm.cleanup().await;
+}
+
+// ── L1 Correct (Update) ────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn l1_correct_updates_in_place() {
+    let tm = require_memoria!();
+    let marker_v1 = format!("v1-{}", &tm.session_id()[..12]);
+    let marker_v2 = format!("v2-{}", &tm.session_id()[..12]);
+
+    let content_v1 = sample_session_memory(&marker_v1);
+    let _id = tm
+        .store(&content_v1, "working", Some(tm.session_id()), Some("T2"))
+        .await
+        .expect("store v1 failed");
+
+    let content_v2 = sample_session_memory(&marker_v2);
+    let _id2 = tm
+        .store(&content_v2, "working", Some(tm.session_id()), Some("T2"))
+        .await
+        .expect("store v2 failed");
+
+    let found = retrieve_l1_with_marker(&tm, &marker_v2).await;
+    assert!(!found.is_empty(), "v2 not found after update");
+
+    let _ = tm.purge_working(tm.session_id()).await;
+    tm.cleanup().await;
+}
+
+// ── Session End Purge ───────────────────────────────────────────────────────
+
+// TODO: blocked on https://github.com/matrixorigin/Memoria/issues/182
+// Memoria's topic-based purge uses fulltext search which doesn't match UUID session IDs.
+// Re-enable once Memoria supports session_id-based purge.
+//
+// #[tokio::test]
+// #[ignore]
+// async fn session_purge_cleans_working_memory() { ... }
+
+// ── Compaction with L1 (Zero-LLM Path) ─────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn compaction_uses_l1_when_available() {
+    let tm = require_memoria!();
+
+    // Store L1 in Memoria
+    let l1_content = sample_session_memory("Implement OAuth");
+    tm
+        .store(&l1_content, "working", Some(tm.session_id()), Some("T2"))
+        .await
+        .expect("store L1 failed");
+
+    // Build a conversation that needs compaction
+    let mut messages: Vec<Value> = vec![
+        system("You are helpful."),
+        user("Implement OAuth for the API"),
+    ];
+    // Add enough messages to trigger compaction
+    for i in 0..20 {
+        messages.push(assistant(&format!("Working on step {i}... {}", "x".repeat(200))));
+        messages.push(user(&format!("Continue with step {}", i + 1)));
+    }
+
+    let config = MemoriaCompactConfig {
+        min_tokens_for_retrieval: 0, // always retrieve
+        max_memories: 10,
+        max_memory_tokens: 4000,
+        store_on_compact: false, // don't store back to avoid side effects
+    };
+    let params = MemoriaCompactParams {
+        budget_chars: 8000,
+        keep_chars: 4000,
+        tier: astra_runtime::prompts::CompactionTier::CompactHistory,
+        keep_recent_turns: 3,
+        current_tokens: 50000,
+        session_memory_file: None,
+        session_memory_combine:
+            astra_runtime::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
+    };
+
+    let result = compact_with_memoria(
+        &messages,
+        Some(tm.session_id()),
+        &config,
+        &params,
+        Some(&*tm),
+        None,
+        None,
+    )
+    .await;
+
+    // The compacted result should contain L1 content (injected from Memoria)
+    let all_content: String = result
+        .messages
+        .iter()
+        .filter_map(|m| m.get("content").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        all_content.contains("OAuth") || all_content.contains("Session Context from Memory"),
+        "compacted messages should contain L1 content or memory context marker"
+    );
+
+    // Cleanup
+    let _ = tm.purge_working(tm.session_id()).await;
+}
+
+// ── First User Message Preserved Through Compaction ─────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn first_user_message_survives_compaction() {
+    let tm = require_memoria!();
+
+    let original_task = "UNIQUE_TASK_MARKER_12345: Build a distributed cache";
+    let mut messages: Vec<Value> = vec![
+        system("You are helpful."),
+        user(original_task),
+    ];
+    for i in 0..20 {
+        messages.push(assistant(&format!("Step {i} done. {}", "y".repeat(300))));
+        messages.push(user(&format!("Next step {}", i + 1)));
+    }
+
+    let config = MemoriaCompactConfig::default();
+    let params = MemoriaCompactParams {
+        budget_chars: 6000,
+        keep_chars: 3000,
+        tier: astra_runtime::prompts::CompactionTier::CompactHistory,
+        keep_recent_turns: 2,
+        current_tokens: 60000,
+        session_memory_file: None,
+        session_memory_combine:
+            astra_runtime::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
+    };
+
+    let result = compact_with_memoria(
+        &messages,
+        Some(tm.session_id()),
+        &config,
+        &params,
+        Some(&*tm),
+        None,
+        None,
+    )
+    .await;
+
+    // P0 fix: TieredCompaction now preserves the first user message.
+    let has_original = result
+        .messages
+        .iter()
+        .any(|m| {
+            m.get("content")
+                .and_then(Value::as_str)
+                .map(|s| s.contains("UNIQUE_TASK_MARKER_12345"))
+                .unwrap_or(false)
+        });
+    assert!(
+        has_original,
+        "First user message must survive compaction. Got {} messages: {:?}",
+        result.messages.len(),
+        result.messages.iter().map(|m| {
+            let role = m.get("role").and_then(Value::as_str).unwrap_or("?");
+            let c = m.get("content").and_then(Value::as_str).unwrap_or("");
+            format!("{role}: {}...", &c[..c.len().min(60)])
+        }).collect::<Vec<_>>()
+    );
+}
+
+// ── L1 Parsed from Memoria Matches Protocol ─────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn l1_round_trip_preserves_structure() {
+    let tm = require_memoria!();
+    let marker = format!("roundtrip-{}", &tm.session_id()[..12]);
+
+    let original = sample_session_memory(&marker);
+    let l1_before = SessionMemory::parse(&original).expect("should parse");
+    assert!(l1_before.validate().is_ok());
+
+    tm
+        .store(&original, "working", Some(tm.session_id()), Some("T2"))
+        .await
+        .expect("store failed");
+
+    let results = retrieve_l1_with_marker(&tm, &marker).await;
+    let retrieved = results.first().expect("L1 not found in results");
+
+    let l1_after = SessionMemory::parse(&retrieved.content).expect("retrieved L1 should parse");
+    assert!(l1_after.validate().is_ok(), "retrieved L1 should validate");
+
+    assert_eq!(
+        l1_before.section("Task Specification"),
+        l1_after.section("Task Specification"),
+    );
+    assert_eq!(
+        l1_before.section("Current State"),
+        l1_after.section("Current State"),
+    );
+
+    let injected = compress_to_injection(&l1_after);
+    assert!(injected.starts_with(SESSION_MEMORY_PREFIX));
+    assert!(injected.contains(&marker));
+
+    let _ = tm.purge_working(tm.session_id()).await;
+    tm.cleanup().await;
+}
+
+// ── Anchor Derived from Retrieved L1 ────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn anchor_from_retrieved_l1() {
+    let tm = require_memoria!();
+    let marker = format!("anchor-{}", &tm.session_id()[..12]);
+
+    let content = sample_session_memory(&marker);
+    tm
+        .store(&content, "working", Some(tm.session_id()), Some("T2"))
+        .await
+        .expect("store failed");
+
+    let results = retrieve_l1_with_marker(&tm, &marker).await;
+    let retrieved = results.first().expect("L1 not found");
+
+    let l1 = SessionMemory::parse(&retrieved.content).expect("should parse");
+    let anchor = extract_anchor("ignored", Some(&l1));
+
+    assert!(anchor.starts_with("[session-anchor] "));
+    assert!(anchor.contains(&marker));
+    assert!(anchor.contains("1/3 steps"));
+
+    let _ = tm.purge_working(tm.session_id()).await;
+    tm.cleanup().await;
+}
+
+// ── Session Isolation ───────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn different_sessions_are_isolated() {
+    let tm = require_memoria!();
+    let sid_a = &*unique_session_id();
+    let sid_b = unique_session_id();
+    let marker_a = format!("iso-A-{}", &sid_a[..12]);
+    let marker_b = format!("iso-B-{}", &sid_b[..12]);
+
+    tm
+        .store(
+            &sample_session_memory(&marker_a),
+            "working",
+            Some(&sid_a),
+            Some("T2"),
+        )
+        .await
+        .expect("store A failed");
+
+    tm
+        .store(
+            &sample_session_memory(&marker_b),
+            "working",
+            Some(&sid_b),
+            Some("T2"),
+        )
+        .await
+        .expect("store B failed");
+
+    // Retrieve for marker A — should find A, not B
+    let results_a = retrieve_l1_with_marker(&tm, &marker_a).await;
+    assert!(!results_a.is_empty(), "session A memory should be retrievable");
+    assert!(
+        !results_a.iter().any(|m| m.content.contains(&marker_b)),
+        "session A results should not contain B's marker"
+    );
+
+    let _ = tm.purge_working(&sid_a).await;
+    let _ = tm.purge_working(&sid_b).await;
+    tm.cleanup().await;
+}
+
+// ── Complex Multi-Compaction Scenario ───────────────────────────────────────
+
+/// Simulates a realistic long session:
+///   Phase 1: 30 turns of coding work → compaction → store L1
+///   Phase 2: 20 more turns → second compaction → update L1
+///   Verify: original task, key decisions, and file context survive both compactions.
+#[tokio::test]
+#[ignore]
+async fn multi_compaction_preserves_goal_and_decisions() {
+    let tm = require_memoria!();
+    let marker = format!("multi-{}", &tm.session_id()[..12]);
+
+    let original_task = format!(
+        "GOAL_{marker}: Implement a distributed rate limiter using Redis \
+         with sliding window algorithm, supporting 10K req/s per tenant"
+    );
+
+    // ── Phase 1: Build up a realistic 30-turn conversation ──────────────
+    let mut messages: Vec<Value> = vec![
+        system("You are a senior Rust engineer."),
+        user(&original_task),
+    ];
+
+    // Simulate tool-heavy coding turns (tool results are the biggest token consumers)
+    let decisions = [
+        "DECISION_A: Use Redis MULTI/EXEC for atomic window updates",
+        "DECISION_B: Shard by tenant_id hash to 16 Redis nodes",
+        "DECISION_C: Fallback to local token bucket when Redis is unreachable",
+    ];
+    for i in 0..30 {
+        // Assistant does tool calls, gets big results
+        messages.push(assistant(&format!(
+            "Step {i}: {}. Let me read the file...\n{}",
+            if i < 3 { decisions[i] } else { "Continuing implementation" },
+            "x".repeat(400) // simulate tool result bulk
+        )));
+        messages.push(user(&format!(
+            "{}{}",
+            if i == 15 { "Also remember: CRITICAL_NOTE_42 — must handle clock skew. " } else { "" },
+            format!("Continue with step {}", i + 1)
+        )));
+    }
+
+    // ── First compaction ────────────────────────────────────────────────
+    let config = MemoriaCompactConfig::default();
+    let params = MemoriaCompactParams {
+        budget_chars: 4000,
+        keep_chars: 2000,
+        tier: astra_runtime::prompts::CompactionTier::AggressivePrune,
+        keep_recent_turns: 3,
+        current_tokens: 80000,
+        session_memory_file: None,
+        session_memory_combine:
+            astra_runtime::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
+    };
+
+    let result1 = compact_with_memoria(
+        &messages,
+        Some(tm.session_id()),
+        &config,
+        &params,
+        Some(&*tm),
+        None,
+        None,
+    )
+    .await;
+
+    // Original task must survive first compaction
+    let has_task_1 = result1.messages.iter().any(|m| {
+        m.get("content")
+            .and_then(Value::as_str)
+            .map(|s| s.contains(&format!("GOAL_{marker}")))
+            .unwrap_or(false)
+    });
+    assert!(has_task_1, "Original task lost after first compaction");
+
+    // Store L1 to Memoria (simulating what the turn loop would do)
+    let l1_content = format!(
+        "{SESSION_MEMORY_PREFIX}\n\
+         # Session Title\n\
+         Distributed Rate Limiter\n\
+         # Task Specification\n\
+         {original_task}\n\
+         # Current State\n\
+         Phase 1 complete, 30 turns done, basic implementation working\n\
+         # Key Files\n\
+         src/rate_limiter.rs — core sliding window logic\n\
+         src/redis_backend.rs — Redis MULTI/EXEC integration\n\
+         src/fallback.rs — local token bucket fallback\n\
+         # Progress\n\
+         ✅ Redis sliding window\n\
+         ✅ Tenant sharding (16 nodes)\n\
+         ✅ Local fallback\n\
+         🔄 Clock skew handling\n\
+         ⏳ Load testing\n\
+         # Errors & Corrections\n\
+         Turn 12: Fixed off-by-one in window boundary calculation\n\
+         # Decisions\n\
+         - {}\n\
+         - {}\n\
+         - {}\n\
+         # User Messages\n\
+         {original_task}\n\
+         CRITICAL_NOTE_42 — must handle clock skew\n\
+         # Worklog\n\
+         T1-T10: Redis integration\n\
+         T11-T20: Sharding + fallback\n\
+         T21-T30: Bug fixes + clock skew start\n\
+         # Context\n\
+         Turn 30, ~80K tokens, first compaction done",
+        decisions[0], decisions[1], decisions[2]
+    );
+    tm
+        .store(&l1_content, "working", Some(tm.session_id()), Some("T2"))
+        .await
+        .expect("L1 store failed");
+
+    // ── Phase 2: Continue with compacted messages + 20 more turns ───────
+    let mut messages2 = result1.messages;
+    for i in 30..50 {
+        messages2.push(assistant(&format!(
+            "Step {i}: Working on clock skew handling. {}",
+            "z".repeat(400)
+        )));
+        messages2.push(user(&format!("Continue with step {}", i + 1)));
+    }
+
+    // ── Second compaction (should pull L1 from Memoria) ─────────────────
+    let result2 = compact_with_memoria(
+        &messages2,
+        Some(tm.session_id()),
+        &config,
+        &params,
+        Some(&*tm),
+        None,
+        None,
+    )
+    .await;
+
+    // After second compaction, verify critical information survives
+    let all_content: String = result2
+        .messages
+        .iter()
+        .filter_map(|m| m.get("content").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Original task must survive (either in first user msg or L1 injection)
+    assert!(
+        all_content.contains(&format!("GOAL_{marker}"))
+            || all_content.contains("distributed rate limiter")
+            || all_content.contains("rate limiter"),
+        "Original task lost after second compaction.\nAll content:\n{all_content}"
+    );
+
+    // First user message specifically must be preserved by P0 fix
+    // (may be at index 1 or 2 depending on whether Memoria context was injected)
+    let first_user_idx = result2.messages.iter().position(|m| {
+        m.get("role").and_then(Value::as_str) == Some("user")
+    });
+    assert!(
+        first_user_idx.is_some(),
+        "No user message found after second compaction"
+    );
+    let first_user_content = result2.messages[first_user_idx.unwrap()]
+        .get("content").and_then(Value::as_str).unwrap_or("");
+    assert!(
+        first_user_content.contains(&format!("GOAL_{marker}")),
+        "First user message should be the original task, got: {first_user_content}"
+    );
+
+    eprintln!(
+        "Multi-compaction result: {} messages after 2 compactions of 50-turn session",
+        result2.messages.len()
+    );
+    for (i, m) in result2.messages.iter().enumerate() {
+        let role = m.get("role").and_then(Value::as_str).unwrap_or("?");
+        let c = m.get("content").and_then(Value::as_str).unwrap_or("");
+        eprintln!("  [{i}] {role}: {}...", &c[..c.len().min(80)]);
+    }
+}
+
+/// Simulates a session where tool results dominate token usage (realistic agent behavior).
+/// Tool results are 80%+ of tokens. Compaction must not lose the task buried among them.
+#[tokio::test]
+#[ignore]
+async fn tool_heavy_session_preserves_task() {
+    let tm = require_memoria!();
+    let marker = format!("tools-{}", &tm.session_id()[..12]);
+
+    let original_task = format!(
+        "TASK_{marker}: Refactor the authentication module to use JWT with refresh tokens"
+    );
+
+    let mut messages: Vec<Value> = vec![
+        system("You are helpful."),
+        user(&original_task),
+    ];
+
+    // Simulate tool-heavy turns: assistant calls tools, gets huge results
+    for i in 0..15 {
+        // Assistant with tool_use
+        messages.push(json!({
+            "role": "assistant",
+            "content": format!("Let me read auth.rs to understand the current flow (step {i})"),
+            "tool_calls": [{
+                "id": format!("call_{i}"),
+                "type": "function",
+                "function": {
+                    "name": "fs_read",
+                    "arguments": format!("{{\"path\": \"src/auth_{i}.rs\"}}")
+                }
+            }]
+        }));
+        // Tool result (big — simulates file reads)
+        messages.push(json!({
+            "role": "tool",
+            "content": format!(
+                "// auth_{i}.rs\n{}\n// end of file",
+                "fn verify_token(t: &str) -> Result<Claims> { /* ... */ }\n".repeat(40)
+            ),
+            "tool_call_id": format!("call_{i}"),
+        }));
+        // User follow-up
+        if i < 14 {
+            messages.push(user(&format!("Good, now handle step {}", i + 1)));
+        }
+    }
+
+    let config = MemoriaCompactConfig::default();
+    let params = MemoriaCompactParams {
+        budget_chars: 3000,
+        keep_chars: 1500,
+        tier: astra_runtime::prompts::CompactionTier::AggressivePrune,
+        keep_recent_turns: 2,
+        current_tokens: 70000,
+        session_memory_file: None,
+        session_memory_combine:
+            astra_runtime::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
+    };
+
+    let result = compact_with_memoria(
+        &messages,
+        Some(tm.session_id()),
+        &config,
+        &params,
+        Some(&*tm),
+        None,
+        None,
+    )
+    .await;
+
+    // Task must survive even when buried under tool results
+    let has_task = result.messages.iter().any(|m| {
+        m.get("content")
+            .and_then(Value::as_str)
+            .map(|s| s.contains(&format!("TASK_{marker}")))
+            .unwrap_or(false)
+    });
+    assert!(
+        has_task,
+        "Task lost in tool-heavy session after compaction. Messages: {}",
+        result.messages.len()
+    );
+
+    // Verify significant token reduction happened
+    let original_chars: usize = messages.iter().map(|m| m.to_string().len()).sum();
+    let compacted_chars: usize = result.messages.iter().map(|m| m.to_string().len()).sum();
+    eprintln!(
+        "Tool-heavy: {original_chars} chars → {compacted_chars} chars ({:.0}% reduction), {} → {} messages",
+        (1.0 - compacted_chars as f64 / original_chars as f64) * 100.0,
+        messages.len(),
+        result.messages.len()
+    );
+    assert!(
+        compacted_chars < original_chars / 2,
+        "Compaction should reduce by at least 50%"
+    );
+}
+
+// ── P1: L0 Anchor Extraction ────────────────────────────────────────────────
+
+#[test]
+fn anchor_from_first_user_message() {
+    let anchor = extract_anchor("Build a distributed rate limiter using Redis", None);
+    assert!(anchor.contains("[session-anchor]"));
+    assert!(anchor.contains("rate limiter"));
+    assert!(anchor.contains("starting"));
+}
+
+#[test]
+fn anchor_from_l1_overrides_raw_message() {
+    let l1_text = format!(
+        "{SESSION_MEMORY_PREFIX}\n\
+         # Session Title\nRate Limiter\n\
+         # Task Specification\nImplement distributed rate limiter.\n\
+         # Current State\nRedis integration done\n\
+         # Key Files\nsrc/main.rs\n\
+         # Progress\n✅ Setup\n🔄 Redis\n⏳ Tests\n\
+         # Errors & Corrections\nNone\n\
+         # Decisions\nUse Redis\n\
+         # User Messages\nBuild rate limiter\n\
+         # Worklog\nT1\n\
+         # Context\nT2"
+    );
+    let l1 = SessionMemory::parse(&l1_text).unwrap();
+    let anchor = extract_anchor("original message ignored", Some(&l1));
+    assert!(anchor.contains("rate limiter"));
+    assert!(anchor.contains("Redis integration done"));
+    assert!(anchor.contains("1/3")); // 1 done out of 3 total
+}
+
+// ── P2: Continuation Prompt ─────────────────────────────────────────────────
+
+/// The continuation prompt constant used by the turn loop.
+const CONTINUATION_PROMPT: &str = "Continue the conversation from where it left off. \
+                                    Do not ask the user any further questions — \
+                                    pick up the current task and keep going.";
+
+#[test]
+fn continuation_prompt_is_user_role() {
+    // Verify the continuation prompt format matches what the turn loop injects
+    let msg = serde_json::json!({
+        "role": "user",
+        "content": CONTINUATION_PROMPT,
+    });
+    assert_eq!(msg["role"], "user");
+    assert!(msg["content"].as_str().unwrap().contains("Continue"));
+    assert!(msg["content"].as_str().unwrap().contains("keep going"));
+}
+
+// ── Token Efficiency Tests ──────────────────────────────────────────────────
+
+#[test]
+fn anchor_token_cost_under_budget() {
+    // L0 anchor must be ≤50 tokens (~200 chars)
+    let long_task = "Implement a distributed rate limiter using Redis with sliding \
+                     window algorithm supporting 10K requests per second per tenant \
+                     with automatic failover to local token bucket when Redis cluster \
+                     is unreachable and comprehensive metrics export to Prometheus";
+    let anchor = extract_anchor(long_task, None);
+    let estimated_tokens = anchor.len() / 4;
+    assert!(
+        estimated_tokens <= 60,
+        "Anchor should be ≤50 tokens, got ~{estimated_tokens} ({} chars): {anchor}",
+        anchor.len()
+    );
+}
+
+#[test]
+fn l1_injection_respects_budget_cap() {
+    // Build an oversized L1 and verify compress_to_injection stays within budget
+    let mut big_l1_text = format!(
+        "{SESSION_MEMORY_PREFIX}\n# Session Title\nTest\n# Task Specification\n{}\n",
+        "Implement feature X. ".repeat(100) // ~2000 chars in one section
+    );
+    big_l1_text += &format!("# Current State\n{}\n", "Working on step N. ".repeat(50));
+    big_l1_text += "# Key Files\n";
+    big_l1_text += &"src/module_N.rs — does something important\n".repeat(50);
+    big_l1_text += "# Progress\n✅ Done\n🔄 WIP\n⏳ Todo\n";
+    big_l1_text += &format!("# Errors & Corrections\n{}\n", "Fixed bug N. ".repeat(50));
+    big_l1_text += &format!("# Decisions\n{}\n", "- Decided X because Y. ".repeat(50));
+    big_l1_text += &format!("# User Messages\n{}\n", "User said something. ".repeat(80));
+    big_l1_text += &format!("# Worklog\n{}\n", "Turn N — did stuff. ".repeat(50));
+    big_l1_text += "# Context\nTurn 50, ~100K tokens";
+
+    let l1 = SessionMemory::parse(&big_l1_text).unwrap();
+    let injected = compress_to_injection(&l1);
+    let estimated_tokens = injected.len() / 4;
+    assert!(
+        estimated_tokens <= INJECTION_TOTAL_BUDGET + 100, // small margin for section headers
+        "Injection should be ≤{INJECTION_TOTAL_BUDGET} tokens, got ~{estimated_tokens} ({} chars)",
+        injected.len()
+    );
+}
+
+#[test]
+fn anchor_does_not_break_cached_prefix() {
+    // Verified in bridge_inprocess.rs unit tests (p1_anchor_injected_into_openai_dynamic_message).
+    // The anchor is passed via profile_desc (dynamic), not in the stable cached prefix.
+    // OpenAI: primary message is identical with/without anchor.
+    // Anthropic: anchor is in a non-cache-controlled block.
+    //
+    // This test just confirms the anchor doesn't accidentally end up in stable sections.
+    let anchor = extract_anchor("Build rate limiter", None);
+    assert!(anchor.contains("[session-anchor]"));
+    // Anchor should NOT contain any cache scope markers
+    assert!(!anchor.contains("cache_control"));
+}
+
+// ── Memory Overhead Measurement ─────────────────────────────────────────────
+
+/// Measures exact token overhead of enabling Memoria vs pure compaction.
+#[tokio::test]
+#[ignore]
+async fn measure_memoria_token_overhead() {
+    let tm = require_memoria!();
+
+    // Store L1 with unique marker so it ranks high in retrieve
+    let marker = format!("overhead-{}", &tm.session_id()[..12]);
+    let l1 = format!(
+        "{SESSION_MEMORY_PREFIX}\n\
+         # Session Title\n{marker} Rate Limiter\n\
+         # Task Specification\n{marker} Build a rate limiter\n\
+         # Current State\nStep 15 of 20\n\
+         # Key Files\nsrc/rate_limiter.rs\n\
+         # Progress\n✅ Setup\n🔄 Window logic\n\
+         # Errors & Corrections\nNone\n\
+         # Decisions\n- Use Redis\n\
+         # User Messages\n{marker} Build rate limiter\n\
+         # Worklog\nT1-T15\n\
+         # Context\nTurn 15"
+    );
+    tm.store(&l1, "working", Some(tm.session_id()), Some("T2")).await.unwrap();
+
+    // Messages where last user msg contains the marker for high retrieve score
+    let mut messages: Vec<Value> = vec![
+        system("You are helpful."),
+        user(&format!("{marker} Build a rate limiter with sliding window")),
+    ];
+    for i in 0..20 {
+        messages.push(assistant(&format!("Step {i}. {}", "x".repeat(300))));
+        messages.push(user(&format!("{marker} Continue rate limiter step {}", i + 1)));
+    }
+
+    let config = MemoriaCompactConfig::default();
+    let params = MemoriaCompactParams {
+        budget_chars: 4000,
+        keep_chars: 2000,
+        tier: astra_runtime::prompts::CompactionTier::AggressivePrune,
+        keep_recent_turns: 3,
+        current_tokens: 80000,
+        session_memory_file: None,
+        session_memory_combine:
+            astra_runtime::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
+    };
+
+    // Without Memoria
+    let without = compact_with_memoria(
+        &messages, Some(tm.session_id()), &config, &params,
+        None, None, None,
+    ).await;
+
+    // With Memoria
+    let with = compact_with_memoria(
+        &messages, Some(tm.session_id()), &config, &params,
+        Some(&*tm), None, None,
+    ).await;
+
+    let chars_without: usize = without.messages.iter()
+        .map(|m| m.get("content").and_then(Value::as_str).unwrap_or("").len())
+        .sum();
+    let chars_with: usize = with.messages.iter()
+        .map(|m| m.get("content").and_then(Value::as_str).unwrap_or("").len())
+        .sum();
+
+    let tokens_without = chars_without / 4;
+    let tokens_with = chars_with / 4;
+    let overhead = tokens_with.saturating_sub(tokens_without);
+
+    let has_memory_msg = with.messages.iter().any(|m| {
+        m.get("content").and_then(Value::as_str)
+            .map(|s| s.contains("[Session Context"))
+            .unwrap_or(false)
+    });
+
+    eprintln!("=== Memoria Token Overhead ===");
+    eprintln!("Without: {} msgs, ~{} tokens", without.messages.len(), tokens_without);
+    eprintln!("With:    {} msgs, ~{} tokens (injected={})", with.messages.len(), tokens_with, has_memory_msg);
+    eprintln!("Overhead: ~{} tokens", overhead);
+
+    // Budget compensation: memory injection tightens compaction budget,
+    // so total stays within budget. Overhead should be small.
+    // NOTE: injection may not trigger if retrieve doesn't return session-relevant
+    // memories — session_id is only boosting, not filtering.
+    // TODO: re-measure after https://github.com/matrixorigin/Memoria/issues/184
+    assert!(overhead < 500, "Overhead should be <500 tokens, got {overhead}");
+}
+
+// ── P3: Full Loop — L1 Write → Compaction Reads L1 → Goal Preserved ────────
+
+/// End-to-end test of the session memory protocol:
+/// 1. Build L1 from a conversation (simulating turn-end write)
+/// 2. Store L1 to Memoria
+/// 3. Run compaction on a new conversation that references the same session
+/// 4. Verify the L1 content is retrieved and injected
+#[tokio::test]
+#[ignore]
+async fn full_loop_l1_write_then_compaction_reads() {
+    let tm = require_memoria!();
+    let marker = format!("fullloop-{}", &tm.session_id()[..12]);
+
+    // Phase 1: Simulate a conversation and build L1
+    let phase1_messages: Vec<Value> = vec![
+        system("You are helpful."),
+        user(&format!("{marker}: Build a distributed cache with LRU eviction")),
+        json!({"role": "assistant", "content": "I'll start.", "tool_calls": [
+            {"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\": \"src/cache.rs\"}"}}
+        ]}),
+        json!({"role": "tool", "content": "struct Cache {}", "tool_call_id": "c1"}),
+        assistant("Cache struct found. Implementing LRU."),
+        user("Add TTL support too"),
+    ];
+
+    let l1_content = build_l1_from_messages(&phase1_messages, 3, 40000);
+
+    // Verify L1 is valid
+    let l1 = SessionMemory::parse(&l1_content).expect("L1 should parse");
+    assert!(l1.validate().is_ok());
+    assert!(l1.section("Task Specification").unwrap().contains(&marker));
+
+    // Store L1 to Memoria
+    tm.store(&l1_content, "working", Some(tm.session_id()), Some("T2")).await.expect("store failed");
+
+    // Phase 2: New conversation (after compaction dropped history)
+    // Use the marker in user messages so retrieve query matches our L1
+    let mut phase2_messages: Vec<Value> = vec![
+        system("You are helpful."),
+        user(&format!("{marker}: Build a distributed cache with LRU eviction")),
+    ];
+    for i in 0..20 {
+        phase2_messages.push(assistant(&format!("Step {i}. {}", "z".repeat(300))));
+        phase2_messages.push(user(&format!("{marker} continue cache step {}", i + 1)));
+    }
+
+    let config = MemoriaCompactConfig::default();
+    let params = MemoriaCompactParams {
+        budget_chars: 4000,
+        keep_chars: 2000,
+        tier: astra_runtime::prompts::CompactionTier::AggressivePrune,
+        keep_recent_turns: 3,
+        current_tokens: 80000,
+        session_memory_file: None,
+        session_memory_combine:
+            astra_runtime::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
+    };
+
+    let result = compact_with_memoria(
+        &phase2_messages, Some(tm.session_id()), &config, &params,
+        Some(&*tm), None, None,
+    ).await;
+
+    // Verify: original task preserved (via first user message P0 fix)
+    let all_content: String = result.messages.iter()
+        .filter_map(|m| m.get("content").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        all_content.contains(&marker),
+        "Original task marker should survive compaction"
+    );
+
+    // Check if L1 was injected as session context
+    // NOTE: may not inject if retrieve doesn't rank our L1 in top-K
+    // (blocked on https://github.com/matrixorigin/Memoria/issues/184)
+    let has_session_context = all_content.contains("[Session Context");
+    eprintln!(
+        "Full loop: {} msgs, L1 injected={}, task preserved=true",
+        result.messages.len(), has_session_context
+    );
+}
+
+// ── L2 Fallback: Memoria unavailable → LLM summary still works ─────────────
+
+#[tokio::test]
+#[ignore]
+async fn l2_fallback_when_memoria_unavailable() {
+    // No require_memoria! — we intentionally pass None as client
+    let mut messages: Vec<Value> = vec![
+        system("You are helpful."),
+        user("Build a rate limiter"),
+    ];
+    for i in 0..20 {
+        messages.push(assistant(&format!("Step {i}. {}", "x".repeat(300))));
+        messages.push(user(&format!("Next {}", i + 1)));
+    }
+
+    let config = MemoriaCompactConfig::default();
+    let params = MemoriaCompactParams {
+        budget_chars: 4000,
+        keep_chars: 2000,
+        tier: astra_runtime::prompts::CompactionTier::AggressivePrune,
+        keep_recent_turns: 3,
+        current_tokens: 80000,
+        session_memory_file: None,
+        session_memory_combine:
+            astra_runtime::turn::cloud::memoria_compact::SessionMemoryFileCombine::None,
+    };
+
+    // No Memoria client — should still compact without error
+    let result = compact_with_memoria(
+        &messages, Some("no-memoria-session"), &config, &params,
+        None, // no Memoria
+        None, None,
+    ).await;
+
+    // Compaction should still work
+    assert!(result.messages.len() < messages.len(), "should have compacted");
+    // First user message preserved
+    let has_task = result.messages.iter().any(|m| {
+        m.get("content").and_then(Value::as_str)
+            .map(|s| s.contains("rate limiter"))
+            .unwrap_or(false)
+    });
+    assert!(has_task, "Task should survive even without Memoria");
+}
+
+// ── Cross-Session Bootstrap: new session retrieves old session's memories ───
+
+#[tokio::test]
+#[ignore]
+async fn cross_session_retrieves_other_sessions_memories() {
+    let tm = require_memoria!();
+
+    // Session A stores a memory
+    let sid_a = &*unique_session_id();
+    let marker_a = format!("cross-{}", &sid_a[..12]);
+    tm
+        .store(
+            &format!("{SESSION_MEMORY_PREFIX}\n# Task Specification\n{marker_a}: old session work"),
+            "working",
+            Some(&sid_a),
+            Some("T2"),
+        )
+        .await
+        .expect("store failed");
+
+    // Session B retrieves — should find session A's memory (cross-session)
+    let sid_b = unique_session_id();
+    let results = tm
+        .retrieve(&format!("{marker_a} old session"), Some(&sid_b), 10)
+        .await
+        .expect("retrieve failed");
+
+    let found = results.iter().any(|m| m.content.contains(&marker_a));
+    assert!(
+        found,
+        "New session should retrieve old session's memories (cross-session bootstrap). Got {} results",
+        results.len()
+    );
+    tm.cleanup().await;
+}
+
+// ── Post-Compact File Restoration: recent_files carried in boundary ─────────
+
+#[test]
+fn post_compact_boundary_carries_recent_files() {
+    use astra_runtime::turn::cloud::compaction::{CompactBoundary, CompactTrigger};
+    use astra_runtime::prompts::CompactionTier;
+
+    let boundary = CompactBoundary::new(CompactTrigger::Auto, CompactionTier::CompactHistory)
+        .with_recent_files(vec!["src/main.rs".into(), "src/lib.rs".into()])
+        .with_discovered_tools(vec!["read_file".into(), "grep".into()]);
+
+    assert_eq!(boundary.recent_files, vec!["src/main.rs", "src/lib.rs"]);
+    assert_eq!(boundary.discovered_tools, vec!["read_file", "grep"]);
+}
+
+#[test]
+fn post_compact_boundary_serializes_files() {
+    use astra_runtime::turn::cloud::compaction::{CompactBoundary, CompactTrigger};
+    use astra_runtime::prompts::CompactionTier;
+
+    let boundary = CompactBoundary::new(CompactTrigger::Auto, CompactionTier::CompactHistory)
+        .with_recent_files(vec!["src/cache.rs".into()]);
+
+    let json = serde_json::to_value(&boundary).unwrap();
+    let files = json.get("recent_files").and_then(Value::as_array).unwrap();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0], "src/cache.rs");
+}

--- a/rust/crates/runtime/tests/session_memory_protocol_integration.rs
+++ b/rust/crates/runtime/tests/session_memory_protocol_integration.rs
@@ -4,11 +4,11 @@
 //! Run with: `cargo test -p astra-runtime -- session_memory_protocol_integration --ignored`
 
 use astra_runtime::turn::cloud::memoria_compact::{
-    compact_with_memoria, HttpMemoriaClient, MemoriaClient, MemoriaCompactConfig,
-    MemoriaCompactParams, MemoriaMemory,
+    HttpMemoriaClient, MemoriaClient, MemoriaCompactConfig, MemoriaCompactParams, MemoriaMemory,
+    compact_with_memoria,
 };
 use astra_runtime::turn::cloud::session_memory_protocol::*;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use uuid::Uuid;
 
 fn memoria_client() -> Option<HttpMemoriaClient> {
@@ -432,7 +432,7 @@ async fn different_sessions_are_isolated() {
     tm.store(
         &sample_session_memory(&marker_a),
         "working",
-        Some(&sid_a),
+        Some(sid_a),
         Some("T2"),
     )
     .await
@@ -458,7 +458,7 @@ async fn different_sessions_are_isolated() {
         "session A results should not contain B's marker"
     );
 
-    let _ = tm.purge_working(&sid_a).await;
+    let _ = tm.purge_working(sid_a).await;
     let _ = tm.purge_working(&sid_b).await;
     tm.cleanup().await;
 }
@@ -492,26 +492,23 @@ async fn multi_compaction_preserves_goal_and_decisions() {
         "DECISION_B: Shard by tenant_id hash to 16 Redis nodes",
         "DECISION_C: Fallback to local token bucket when Redis is unreachable",
     ];
-    for i in 0..30 {
+    for (i, decision) in decisions.iter().enumerate().take(30) {
         // Assistant does tool calls, gets big results
         messages.push(assistant(&format!(
             "Step {i}: {}. Let me read the file...\n{}",
             if i < 3 {
-                decisions[i]
+                decision
             } else {
                 "Continuing implementation"
             },
             "x".repeat(400) // simulate tool result bulk
         )));
-        messages.push(user(&format!(
-            "{}{}",
-            if i == 15 {
-                "Also remember: CRITICAL_NOTE_42 — must handle clock skew. "
-            } else {
-                ""
-            },
-            format!("Continue with step {}", i + 1)
-        )));
+        let prefix = if i == 15 {
+            "Also remember: CRITICAL_NOTE_42 — must handle clock skew. "
+        } else {
+            ""
+        };
+        messages.push(user(&format!("{prefix}Continue with step {}", i + 1)));
     }
 
     // ── First compaction ────────────────────────────────────────────────
@@ -1146,7 +1143,7 @@ async fn cross_session_retrieves_other_sessions_memories() {
     tm.store(
         &format!("{SESSION_MEMORY_PREFIX}\n# Task Specification\n{marker_a}: old session work"),
         "working",
-        Some(&sid_a),
+        Some(sid_a),
         Some("T2"),
     )
     .await

--- a/rust/crates/runtime/tests/session_memory_protocol_integration.rs
+++ b/rust/crates/runtime/tests/session_memory_protocol_integration.rs
@@ -4,11 +4,11 @@
 //! Run with: `cargo test -p astra-runtime -- session_memory_protocol_integration --ignored`
 
 use astra_runtime::turn::cloud::memoria_compact::{
-    HttpMemoriaClient, MemoriaClient, MemoriaCompactConfig, MemoriaCompactParams,
-    MemoriaMemory, compact_with_memoria,
+    compact_with_memoria, HttpMemoriaClient, MemoriaClient, MemoriaCompactConfig,
+    MemoriaCompactParams, MemoriaMemory,
 };
 use astra_runtime::turn::cloud::session_memory_protocol::*;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use uuid::Uuid;
 
 fn memoria_client() -> Option<HttpMemoriaClient> {
@@ -55,10 +55,16 @@ struct TestMemories {
 
 impl TestMemories {
     fn new(client: HttpMemoriaClient, sid: String) -> Self {
-        Self { client, ids: std::sync::Mutex::new(Vec::new()), sid }
+        Self {
+            client,
+            ids: std::sync::Mutex::new(Vec::new()),
+            sid,
+        }
     }
 
-    fn session_id(&self) -> &str { &self.sid }
+    fn session_id(&self) -> &str {
+        &self.sid
+    }
 
     /// Track a memory_id for cleanup (when store is called via client directly).
     #[allow(dead_code)]
@@ -70,7 +76,7 @@ impl TestMemories {
         let ids = std::mem::take(&mut *self.ids.lock().unwrap());
         for id in &ids {
             if let Err(e) = self.client.delete(id).await {
-                eprintln!("[test cleanup] failed to delete memory {id}: {e}");
+                tracing::warn!("[test cleanup] failed to delete memory {id}: {e}");
             }
         }
     }
@@ -78,7 +84,9 @@ impl TestMemories {
 
 impl std::ops::Deref for TestMemories {
     type Target = HttpMemoriaClient;
-    fn deref(&self) -> &HttpMemoriaClient { &self.client }
+    fn deref(&self) -> &HttpMemoriaClient {
+        &self.client
+    }
 }
 
 macro_rules! require_memoria {
@@ -97,23 +105,17 @@ fn unique_session_id() -> String {
     format!("test-smp-{}", Uuid::new_v4().simple())
 }
 
-
 /// Retrieve L1 for a specific session by content marker.
 /// Memoria's retrieve uses session_id for boosting, not strict filtering,
 /// and MemoriaMemory doesn't expose session_id. So we filter by content.
-async fn retrieve_l1_with_marker(
-    client: &HttpMemoriaClient,
-    marker: &str,
-) -> Vec<MemoriaMemory> {
+async fn retrieve_l1_with_marker(client: &HttpMemoriaClient, marker: &str) -> Vec<MemoriaMemory> {
     let results = client
         .retrieve(&format!("[session-memory:v1] {marker}"), None, 20)
         .await
         .unwrap_or_default();
     results
         .into_iter()
-        .filter(|m| {
-            m.content.starts_with(SESSION_MEMORY_PREFIX) && m.content.contains(marker)
-        })
+        .filter(|m| m.content.starts_with(SESSION_MEMORY_PREFIX) && m.content.contains(marker))
         .collect()
 }
 
@@ -227,8 +229,7 @@ async fn compaction_uses_l1_when_available() {
 
     // Store L1 in Memoria
     let l1_content = sample_session_memory("Implement OAuth");
-    tm
-        .store(&l1_content, "working", Some(tm.session_id()), Some("T2"))
+    tm.store(&l1_content, "working", Some(tm.session_id()), Some("T2"))
         .await
         .expect("store L1 failed");
 
@@ -239,7 +240,10 @@ async fn compaction_uses_l1_when_available() {
     ];
     // Add enough messages to trigger compaction
     for i in 0..20 {
-        messages.push(assistant(&format!("Working on step {i}... {}", "x".repeat(200))));
+        messages.push(assistant(&format!(
+            "Working on step {i}... {}",
+            "x".repeat(200)
+        )));
         messages.push(user(&format!("Continue with step {}", i + 1)));
     }
 
@@ -296,10 +300,7 @@ async fn first_user_message_survives_compaction() {
     let tm = require_memoria!();
 
     let original_task = "UNIQUE_TASK_MARKER_12345: Build a distributed cache";
-    let mut messages: Vec<Value> = vec![
-        system("You are helpful."),
-        user(original_task),
-    ];
+    let mut messages: Vec<Value> = vec![system("You are helpful."), user(original_task)];
     for i in 0..20 {
         messages.push(assistant(&format!("Step {i} done. {}", "y".repeat(300))));
         messages.push(user(&format!("Next step {}", i + 1)));
@@ -329,24 +330,25 @@ async fn first_user_message_survives_compaction() {
     .await;
 
     // P0 fix: TieredCompaction now preserves the first user message.
-    let has_original = result
-        .messages
-        .iter()
-        .any(|m| {
-            m.get("content")
-                .and_then(Value::as_str)
-                .map(|s| s.contains("UNIQUE_TASK_MARKER_12345"))
-                .unwrap_or(false)
-        });
+    let has_original = result.messages.iter().any(|m| {
+        m.get("content")
+            .and_then(Value::as_str)
+            .map(|s| s.contains("UNIQUE_TASK_MARKER_12345"))
+            .unwrap_or(false)
+    });
     assert!(
         has_original,
         "First user message must survive compaction. Got {} messages: {:?}",
         result.messages.len(),
-        result.messages.iter().map(|m| {
-            let role = m.get("role").and_then(Value::as_str).unwrap_or("?");
-            let c = m.get("content").and_then(Value::as_str).unwrap_or("");
-            format!("{role}: {}...", &c[..c.len().min(60)])
-        }).collect::<Vec<_>>()
+        result
+            .messages
+            .iter()
+            .map(|m| {
+                let role = m.get("role").and_then(Value::as_str).unwrap_or("?");
+                let c = m.get("content").and_then(Value::as_str).unwrap_or("");
+                format!("{role}: {}...", &c[..c.len().min(60)])
+            })
+            .collect::<Vec<_>>()
     );
 }
 
@@ -362,8 +364,7 @@ async fn l1_round_trip_preserves_structure() {
     let l1_before = SessionMemory::parse(&original).expect("should parse");
     assert!(l1_before.validate().is_ok());
 
-    tm
-        .store(&original, "working", Some(tm.session_id()), Some("T2"))
+    tm.store(&original, "working", Some(tm.session_id()), Some("T2"))
         .await
         .expect("store failed");
 
@@ -399,8 +400,7 @@ async fn anchor_from_retrieved_l1() {
     let marker = format!("anchor-{}", &tm.session_id()[..12]);
 
     let content = sample_session_memory(&marker);
-    tm
-        .store(&content, "working", Some(tm.session_id()), Some("T2"))
+    tm.store(&content, "working", Some(tm.session_id()), Some("T2"))
         .await
         .expect("store failed");
 
@@ -429,29 +429,30 @@ async fn different_sessions_are_isolated() {
     let marker_a = format!("iso-A-{}", &sid_a[..12]);
     let marker_b = format!("iso-B-{}", &sid_b[..12]);
 
-    tm
-        .store(
-            &sample_session_memory(&marker_a),
-            "working",
-            Some(&sid_a),
-            Some("T2"),
-        )
-        .await
-        .expect("store A failed");
+    tm.store(
+        &sample_session_memory(&marker_a),
+        "working",
+        Some(&sid_a),
+        Some("T2"),
+    )
+    .await
+    .expect("store A failed");
 
-    tm
-        .store(
-            &sample_session_memory(&marker_b),
-            "working",
-            Some(&sid_b),
-            Some("T2"),
-        )
-        .await
-        .expect("store B failed");
+    tm.store(
+        &sample_session_memory(&marker_b),
+        "working",
+        Some(&sid_b),
+        Some("T2"),
+    )
+    .await
+    .expect("store B failed");
 
     // Retrieve for marker A — should find A, not B
     let results_a = retrieve_l1_with_marker(&tm, &marker_a).await;
-    assert!(!results_a.is_empty(), "session A memory should be retrievable");
+    assert!(
+        !results_a.is_empty(),
+        "session A memory should be retrievable"
+    );
     assert!(
         !results_a.iter().any(|m| m.content.contains(&marker_b)),
         "session A results should not contain B's marker"
@@ -495,12 +496,20 @@ async fn multi_compaction_preserves_goal_and_decisions() {
         // Assistant does tool calls, gets big results
         messages.push(assistant(&format!(
             "Step {i}: {}. Let me read the file...\n{}",
-            if i < 3 { decisions[i] } else { "Continuing implementation" },
+            if i < 3 {
+                decisions[i]
+            } else {
+                "Continuing implementation"
+            },
             "x".repeat(400) // simulate tool result bulk
         )));
         messages.push(user(&format!(
             "{}{}",
-            if i == 15 { "Also remember: CRITICAL_NOTE_42 — must handle clock skew. " } else { "" },
+            if i == 15 {
+                "Also remember: CRITICAL_NOTE_42 — must handle clock skew. "
+            } else {
+                ""
+            },
             format!("Continue with step {}", i + 1)
         )));
     }
@@ -574,8 +583,7 @@ async fn multi_compaction_preserves_goal_and_decisions() {
          Turn 30, ~80K tokens, first compaction done",
         decisions[0], decisions[1], decisions[2]
     );
-    tm
-        .store(&l1_content, "working", Some(tm.session_id()), Some("T2"))
+    tm.store(&l1_content, "working", Some(tm.session_id()), Some("T2"))
         .await
         .expect("L1 store failed");
 
@@ -619,15 +627,18 @@ async fn multi_compaction_preserves_goal_and_decisions() {
 
     // First user message specifically must be preserved by P0 fix
     // (may be at index 1 or 2 depending on whether Memoria context was injected)
-    let first_user_idx = result2.messages.iter().position(|m| {
-        m.get("role").and_then(Value::as_str) == Some("user")
-    });
+    let first_user_idx = result2
+        .messages
+        .iter()
+        .position(|m| m.get("role").and_then(Value::as_str) == Some("user"));
     assert!(
         first_user_idx.is_some(),
         "No user message found after second compaction"
     );
     let first_user_content = result2.messages[first_user_idx.unwrap()]
-        .get("content").and_then(Value::as_str).unwrap_or("");
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or("");
     assert!(
         first_user_content.contains(&format!("GOAL_{marker}")),
         "First user message should be the original task, got: {first_user_content}"
@@ -652,14 +663,10 @@ async fn tool_heavy_session_preserves_task() {
     let tm = require_memoria!();
     let marker = format!("tools-{}", &tm.session_id()[..12]);
 
-    let original_task = format!(
-        "TASK_{marker}: Refactor the authentication module to use JWT with refresh tokens"
-    );
+    let original_task =
+        format!("TASK_{marker}: Refactor the authentication module to use JWT with refresh tokens");
 
-    let mut messages: Vec<Value> = vec![
-        system("You are helpful."),
-        user(&original_task),
-    ];
+    let mut messages: Vec<Value> = vec![system("You are helpful."), user(&original_task)];
 
     // Simulate tool-heavy turns: assistant calls tools, gets huge results
     for i in 0..15 {
@@ -875,16 +882,23 @@ async fn measure_memoria_token_overhead() {
          # Worklog\nT1-T15\n\
          # Context\nTurn 15"
     );
-    tm.store(&l1, "working", Some(tm.session_id()), Some("T2")).await.unwrap();
+    tm.store(&l1, "working", Some(tm.session_id()), Some("T2"))
+        .await
+        .unwrap();
 
     // Messages where last user msg contains the marker for high retrieve score
     let mut messages: Vec<Value> = vec![
         system("You are helpful."),
-        user(&format!("{marker} Build a rate limiter with sliding window")),
+        user(&format!(
+            "{marker} Build a rate limiter with sliding window"
+        )),
     ];
     for i in 0..20 {
         messages.push(assistant(&format!("Step {i}. {}", "x".repeat(300))));
-        messages.push(user(&format!("{marker} Continue rate limiter step {}", i + 1)));
+        messages.push(user(&format!(
+            "{marker} Continue rate limiter step {}",
+            i + 1
+        )));
     }
 
     let config = MemoriaCompactConfig::default();
@@ -901,20 +915,36 @@ async fn measure_memoria_token_overhead() {
 
     // Without Memoria
     let without = compact_with_memoria(
-        &messages, Some(tm.session_id()), &config, &params,
-        None, None, None,
-    ).await;
+        &messages,
+        Some(tm.session_id()),
+        &config,
+        &params,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     // With Memoria
     let with = compact_with_memoria(
-        &messages, Some(tm.session_id()), &config, &params,
-        Some(&*tm), None, None,
-    ).await;
+        &messages,
+        Some(tm.session_id()),
+        &config,
+        &params,
+        Some(&*tm),
+        None,
+        None,
+    )
+    .await;
 
-    let chars_without: usize = without.messages.iter()
+    let chars_without: usize = without
+        .messages
+        .iter()
         .map(|m| m.get("content").and_then(Value::as_str).unwrap_or("").len())
         .sum();
-    let chars_with: usize = with.messages.iter()
+    let chars_with: usize = with
+        .messages
+        .iter()
         .map(|m| m.get("content").and_then(Value::as_str).unwrap_or("").len())
         .sum();
 
@@ -923,14 +953,24 @@ async fn measure_memoria_token_overhead() {
     let overhead = tokens_with.saturating_sub(tokens_without);
 
     let has_memory_msg = with.messages.iter().any(|m| {
-        m.get("content").and_then(Value::as_str)
+        m.get("content")
+            .and_then(Value::as_str)
             .map(|s| s.contains("[Session Context"))
             .unwrap_or(false)
     });
 
     eprintln!("=== Memoria Token Overhead ===");
-    eprintln!("Without: {} msgs, ~{} tokens", without.messages.len(), tokens_without);
-    eprintln!("With:    {} msgs, ~{} tokens (injected={})", with.messages.len(), tokens_with, has_memory_msg);
+    eprintln!(
+        "Without: {} msgs, ~{} tokens",
+        without.messages.len(),
+        tokens_without
+    );
+    eprintln!(
+        "With:    {} msgs, ~{} tokens (injected={})",
+        with.messages.len(),
+        tokens_with,
+        has_memory_msg
+    );
     eprintln!("Overhead: ~{} tokens", overhead);
 
     // Budget compensation: memory injection tightens compaction budget,
@@ -938,7 +978,10 @@ async fn measure_memoria_token_overhead() {
     // NOTE: injection may not trigger if retrieve doesn't return session-relevant
     // memories — session_id is only boosting, not filtering.
     // TODO: re-measure after https://github.com/matrixorigin/Memoria/issues/184
-    assert!(overhead < 500, "Overhead should be <500 tokens, got {overhead}");
+    assert!(
+        overhead < 500,
+        "Overhead should be <500 tokens, got {overhead}"
+    );
 }
 
 // ── P3: Full Loop — L1 Write → Compaction Reads L1 → Goal Preserved ────────
@@ -957,7 +1000,9 @@ async fn full_loop_l1_write_then_compaction_reads() {
     // Phase 1: Simulate a conversation and build L1
     let phase1_messages: Vec<Value> = vec![
         system("You are helpful."),
-        user(&format!("{marker}: Build a distributed cache with LRU eviction")),
+        user(&format!(
+            "{marker}: Build a distributed cache with LRU eviction"
+        )),
         json!({"role": "assistant", "content": "I'll start.", "tool_calls": [
             {"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\": \"src/cache.rs\"}"}}
         ]}),
@@ -974,13 +1019,17 @@ async fn full_loop_l1_write_then_compaction_reads() {
     assert!(l1.section("Task Specification").unwrap().contains(&marker));
 
     // Store L1 to Memoria
-    tm.store(&l1_content, "working", Some(tm.session_id()), Some("T2")).await.expect("store failed");
+    tm.store(&l1_content, "working", Some(tm.session_id()), Some("T2"))
+        .await
+        .expect("store failed");
 
     // Phase 2: New conversation (after compaction dropped history)
     // Use the marker in user messages so retrieve query matches our L1
     let mut phase2_messages: Vec<Value> = vec![
         system("You are helpful."),
-        user(&format!("{marker}: Build a distributed cache with LRU eviction")),
+        user(&format!(
+            "{marker}: Build a distributed cache with LRU eviction"
+        )),
     ];
     for i in 0..20 {
         phase2_messages.push(assistant(&format!("Step {i}. {}", "z".repeat(300))));
@@ -1000,12 +1049,20 @@ async fn full_loop_l1_write_then_compaction_reads() {
     };
 
     let result = compact_with_memoria(
-        &phase2_messages, Some(tm.session_id()), &config, &params,
-        Some(&*tm), None, None,
-    ).await;
+        &phase2_messages,
+        Some(tm.session_id()),
+        &config,
+        &params,
+        Some(&*tm),
+        None,
+        None,
+    )
+    .await;
 
     // Verify: original task preserved (via first user message P0 fix)
-    let all_content: String = result.messages.iter()
+    let all_content: String = result
+        .messages
+        .iter()
         .filter_map(|m| m.get("content").and_then(Value::as_str))
         .collect::<Vec<_>>()
         .join("\n");
@@ -1020,7 +1077,8 @@ async fn full_loop_l1_write_then_compaction_reads() {
     let has_session_context = all_content.contains("[Session Context");
     eprintln!(
         "Full loop: {} msgs, L1 injected={}, task preserved=true",
-        result.messages.len(), has_session_context
+        result.messages.len(),
+        has_session_context
     );
 }
 
@@ -1030,10 +1088,7 @@ async fn full_loop_l1_write_then_compaction_reads() {
 #[ignore]
 async fn l2_fallback_when_memoria_unavailable() {
     // No require_memoria! — we intentionally pass None as client
-    let mut messages: Vec<Value> = vec![
-        system("You are helpful."),
-        user("Build a rate limiter"),
-    ];
+    let mut messages: Vec<Value> = vec![system("You are helpful."), user("Build a rate limiter")];
     for i in 0..20 {
         messages.push(assistant(&format!("Step {i}. {}", "x".repeat(300))));
         messages.push(user(&format!("Next {}", i + 1)));
@@ -1053,16 +1108,25 @@ async fn l2_fallback_when_memoria_unavailable() {
 
     // No Memoria client — should still compact without error
     let result = compact_with_memoria(
-        &messages, Some("no-memoria-session"), &config, &params,
+        &messages,
+        Some("no-memoria-session"),
+        &config,
+        &params,
         None, // no Memoria
-        None, None,
-    ).await;
+        None,
+        None,
+    )
+    .await;
 
     // Compaction should still work
-    assert!(result.messages.len() < messages.len(), "should have compacted");
+    assert!(
+        result.messages.len() < messages.len(),
+        "should have compacted"
+    );
     // First user message preserved
     let has_task = result.messages.iter().any(|m| {
-        m.get("content").and_then(Value::as_str)
+        m.get("content")
+            .and_then(Value::as_str)
             .map(|s| s.contains("rate limiter"))
             .unwrap_or(false)
     });
@@ -1079,15 +1143,14 @@ async fn cross_session_retrieves_other_sessions_memories() {
     // Session A stores a memory
     let sid_a = &*unique_session_id();
     let marker_a = format!("cross-{}", &sid_a[..12]);
-    tm
-        .store(
-            &format!("{SESSION_MEMORY_PREFIX}\n# Task Specification\n{marker_a}: old session work"),
-            "working",
-            Some(&sid_a),
-            Some("T2"),
-        )
-        .await
-        .expect("store failed");
+    tm.store(
+        &format!("{SESSION_MEMORY_PREFIX}\n# Task Specification\n{marker_a}: old session work"),
+        "working",
+        Some(&sid_a),
+        Some("T2"),
+    )
+    .await
+    .expect("store failed");
 
     // Session B retrieves — should find session A's memory (cross-session)
     let sid_b = unique_session_id();
@@ -1109,8 +1172,8 @@ async fn cross_session_retrieves_other_sessions_memories() {
 
 #[test]
 fn post_compact_boundary_carries_recent_files() {
-    use astra_runtime::turn::cloud::compaction::{CompactBoundary, CompactTrigger};
     use astra_runtime::prompts::CompactionTier;
+    use astra_runtime::turn::cloud::compaction::{CompactBoundary, CompactTrigger};
 
     let boundary = CompactBoundary::new(CompactTrigger::Auto, CompactionTier::CompactHistory)
         .with_recent_files(vec!["src/main.rs".into(), "src/lib.rs".into()])
@@ -1122,8 +1185,8 @@ fn post_compact_boundary_carries_recent_files() {
 
 #[test]
 fn post_compact_boundary_serializes_files() {
-    use astra_runtime::turn::cloud::compaction::{CompactBoundary, CompactTrigger};
     use astra_runtime::prompts::CompactionTier;
+    use astra_runtime::turn::cloud::compaction::{CompactBoundary, CompactTrigger};
 
     let boundary = CompactBoundary::new(CompactTrigger::Auto, CompactionTier::CompactHistory)
         .with_recent_files(vec!["src/cache.rs".into()]);


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [x] Improvement
- [x] Test and CI

## Which issue(s) this PR fixes:

N/A

## What this PR does / why we need it

Implements the Session Memory Protocol (L0/L1) to preserve task context across compaction boundaries and long sessions.

### New module: `session_memory_protocol.rs`

- **L0 anchor**: ~50-token single-line summary injected into the dynamic system prompt every turn. Derived from current conversation state (zero network calls) — shows real progress after turn 1.
- **L1 session memory**: Structured markdown format (`[session-memory:v1]`) with 10 sections (Task Specification, Current State, Key Files, Progress, Errors & Corrections, Decisions, User Messages, Worklog, Context). Stored to Memoria as working memory at turn end.
- **Compression**: `compress_to_injection()` reduces stored L1 (≤4000 tokens) to injection version (≤2000 tokens) — filters completed progress, strips file descriptions, keeps last 3 user messages and last 2 decisions.
- **Pressure-adaptive injection**: `injection_level_for_pressure()` selects L1Full / L1Minimal / L0Only based on context pressure, with configurable thresholds (`DEFAULT_L1_FULL_THRESHOLD=0.75`, `DEFAULT_L1_MINIMAL_THRESHOLD=0.85`).
- **`persist_l1()`**: Extracted async function (purge old L1 → store with 1 retry) — testable with mock client.

### P0: First user message preservation

- `TieredCompaction`, `ReactiveCompact`, and `AggressivePrune` all now preserve the first user message (original task/goal) from compaction.
- Shared helper `first_user_end()` eliminates the 3× duplicated logic.

### P1: L0 anchor injection

- Anchor injected into the **dynamic** (non-cached) section of the system prompt — no impact on Anthropic cache breakpoints or OpenAI prefix caching.
- Evolves each turn from current conversation state (last assistant message + tool call count).

### P2: Continuation prompt after compaction

- After compaction removes messages, a user-role nudge is appended so the LLM resumes the task.
- Skipped when last assistant message signals completion (negation-aware detection, checks last 200 chars only).
- Bilingual: detects CJK content and uses Chinese prompt variant.

### P3: Async L1 write to Memoria

- Fire-and-forget `tokio::spawn` at turn end.
- Purges old L1 for the session before writing new one (avoids stale memory accumulation).
- 1 retry with 500ms delay on failure.
- Structured `tracing::warn!` / `tracing::debug!` for observability.
- Only triggers when `cloud_loop_turns > 1` or tool calls present (avoids trivial writes).

### Other fixes

- `HttpMemoriaClient`: added `delete()` method (with default no-op on trait to avoid semver break), `Clone` derive, `or_else(|| data.as_array())` fallback in retrieve parsing.
- `MemoriaClient::delete` has a default no-op implementation — external implementors are not broken.
- `MO_MAX_TOOL_ROUNDS` default raised from 15 → 30.
- `build_l1_from_messages`: handles Anthropic content blocks, case-insensitive dedup, token-based Task Specification truncation, derives Current State from last assistant message and Progress from tool call count.
- `first_sentence`: UTF-8 safe (uses `match_indices`), guaranteed single-line output.
- `percent_encoding` crate used for correct UTF-8 percent-encoding in `delete()`.
- `InProcessChatTurnBridge`: cached Memoria client (created once, reused across turns).

## Test coverage

- **83 unit tests** in `session_memory_protocol.rs`: L0 anchor, L1 parsing/validation/compression, budget governance, pressure-adaptive injection, `persist_l1` mock tests (purge+store, retry, give-up, purge-failure isolation).
- **15 P1/P2/P3 tests** in `bridge_inprocess.rs`: anchor injection (OpenAI + Anthropic), cache prefix safety, continuation prompt (completion detection, CJK, false-positive regression), usage key regression.
- **3 compaction preservation tests** in `context_compression.rs`.
- **Integration test suite** (`session_memory_protocol_integration.rs`, `#[ignore]`): 12 tests against real Memoria covering store/retrieve round-trip, compaction with L1, first-user survival, multi-compaction, tool-heavy sessions, session isolation, cross-session bootstrap, token overhead measurement.