### PR TITLE
fix(cli): normalize symlinked workspace paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,13 +34,31 @@ jobs:
       # Partition by Rust test path: `edge_tools::` marks tests under src/edge_tools/.
       # `source()` is invalid filterset DSL; `/edge_tools/` alone parses as a broken regex.
       - name: "Test astra-cli (bins: non-edge_tools modules)"
-        run: >-
-          cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
-          -E 'not test(/edge_tools::/)' --no-fail-fast
-      - name: "Test astra-cli (bins: edge_tools)"
-        run: >-
-          cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
-          -E 'test(/edge_tools::/)' --no-fail-fast
+        run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'not test(/edge_tools::/)' --no-fail-fast
+      - name: "Test astra-cli (bins: edge_tools shell)"
+        timeout-minutes: 15
+        run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'test(/edge_tools::shell::/)' --no-fail-fast
+      - name: "Dump processes after edge_tools shell failure"
+        if: failure()
+        run: |
+          ps -ef
+          pgrep -a -f 'cargo|nextest|astra|bash|sleep|git|rust-analyzer|fake-rust-analyzer' || true
+      - name: "Test astra-cli (bins: edge_tools lsp/worktree)"
+        timeout-minutes: 15
+        run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'test(/edge_tools::tests::lsp_tests::/) or test(/edge_tools::tests::worktree_tests::/)' --no-fail-fast
+      - name: "Dump processes after edge_tools lsp/worktree failure"
+        if: failure()
+        run: |
+          ps -ef
+          pgrep -a -f 'cargo|nextest|astra|bash|sleep|git|rust-analyzer|fake-rust-analyzer' || true
+      - name: "Test astra-cli (bins: edge_tools remaining)"
+        timeout-minutes: 15
+        run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'test(/edge_tools::/) and not test(/edge_tools::shell::/) and not test(/edge_tools::tests::lsp_tests::/) and not test(/edge_tools::tests::worktree_tests::/)' --no-fail-fast
+      - name: "Dump processes after edge_tools remaining failure"
+        if: failure()
+        run: |
+          ps -ef
+          pgrep -a -f 'cargo|nextest|astra|bash|sleep|git|rust-analyzer|fake-rust-analyzer' || true
 
   test-offline-runtime:
     name: "Offline: astra-runtime"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,17 +35,49 @@ jobs:
       # `source()` is invalid filterset DSL; `/edge_tools/` alone parses as a broken regex.
       - name: "Test astra-cli (bins: non-edge_tools modules)"
         run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'not test(/edge_tools::/)' --no-fail-fast
-      - name: "Test astra-cli (bins: edge_tools shell)"
+      - name: "Test astra-cli (bins: edge_tools shell proc/cleanup)"
         timeout-minutes: 15
-        run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'test(/edge_tools::shell::/)' --no-fail-fast
-      - name: "Dump processes after edge_tools shell failure"
+        run: >-
+          timeout --signal=TERM --kill-after=30s 15m
+          cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
+          -E 'test(/edge_tools::shell::tests::(bash_timeout_.*|bash_background_command_does_not_block|run_command_with_cleanup_.*|grep_uses_process_group_cleanup|glob_uses_process_group_cleanup)/)'
+          --no-fail-fast
+      - name: "Dump processes after edge_tools shell proc/cleanup failure"
+        if: failure()
+        run: |
+          ps -ef
+          pgrep -a -f 'cargo|nextest|astra|bash|sleep|git|rust-analyzer|fake-rust-analyzer' || true
+      - name: "Test astra-cli (bins: edge_tools shell grep timeout)"
+        timeout-minutes: 15
+        run: >-
+          timeout --signal=TERM --kill-after=30s 15m
+          cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
+          -E 'test(/edge_tools::shell::tests::(grep_streaming_preserves_partial_on_timeout|grep_timeout_.*)/)'
+          --no-fail-fast
+      - name: "Dump processes after edge_tools shell grep timeout failure"
+        if: failure()
+        run: |
+          ps -ef
+          pgrep -a -f 'cargo|nextest|astra|bash|sleep|git|rust-analyzer|fake-rust-analyzer' || true
+      - name: "Test astra-cli (bins: edge_tools shell remaining)"
+        timeout-minutes: 15
+        run: >-
+          timeout --signal=TERM --kill-after=30s 15m
+          cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
+          -E 'test(/edge_tools::shell::/) and not test(/edge_tools::shell::tests::(bash_timeout_.*|bash_background_command_does_not_block|run_command_with_cleanup_.*|grep_uses_process_group_cleanup|glob_uses_process_group_cleanup)/) and not test(/edge_tools::shell::tests::(grep_streaming_preserves_partial_on_timeout|grep_timeout_.*)/)'
+          --no-fail-fast
+      - name: "Dump processes after edge_tools shell remaining failure"
         if: failure()
         run: |
           ps -ef
           pgrep -a -f 'cargo|nextest|astra|bash|sleep|git|rust-analyzer|fake-rust-analyzer' || true
       - name: "Test astra-cli (bins: edge_tools lsp/worktree)"
         timeout-minutes: 15
-        run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'test(/edge_tools::tests::lsp_tests::/) or test(/edge_tools::tests::worktree_tests::/)' --no-fail-fast
+        run: >-
+          timeout --signal=TERM --kill-after=30s 15m
+          cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
+          -E 'test(/edge_tools::tests::lsp_tests::/) or test(/edge_tools::tests::worktree_tests::/)'
+          --no-fail-fast
       - name: "Dump processes after edge_tools lsp/worktree failure"
         if: failure()
         run: |
@@ -53,7 +85,11 @@ jobs:
           pgrep -a -f 'cargo|nextest|astra|bash|sleep|git|rust-analyzer|fake-rust-analyzer' || true
       - name: "Test astra-cli (bins: edge_tools remaining)"
         timeout-minutes: 15
-        run: cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'test(/edge_tools::/) and not test(/edge_tools::shell::/) and not test(/edge_tools::tests::lsp_tests::/) and not test(/edge_tools::tests::worktree_tests::/)' --no-fail-fast
+        run: >-
+          timeout --signal=TERM --kill-after=30s 15m
+          cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins
+          -E 'test(/edge_tools::/) and not test(/edge_tools::shell::/) and not test(/edge_tools::tests::lsp_tests::/) and not test(/edge_tools::tests::worktree_tests::/)'
+          --no-fail-fast
       - name: "Dump processes after edge_tools remaining failure"
         if: failure()
         run: |

--- a/rust/crates/astra-cli/src/edge_tools/file_state.rs
+++ b/rust/crates/astra-cli/src/edge_tools/file_state.rs
@@ -92,6 +92,34 @@ fn ranges_cover(ranges: &[(u64, u64)], start: u64, end: u64) -> bool {
 impl ToolExecutor {
     // ─── File state helpers ──────────────────────────────────────────────────
 
+    pub(super) fn file_state_key(path: &Path) -> PathBuf {
+        if let Ok(canonical) = path.canonicalize() {
+            return canonical;
+        }
+
+        if let (Some(parent), Some(name)) = (path.parent(), path.file_name())
+            && let Ok(canonical_parent) = parent.canonicalize()
+        {
+            return canonical_parent.join(name);
+        }
+
+        path.to_path_buf()
+    }
+
+    pub(super) fn project_relative_path(&self, path: &Path) -> PathBuf {
+        if let Ok(rel) = path.strip_prefix(&self.project_root) {
+            return rel.to_path_buf();
+        }
+
+        if let Ok(canonical_root) = self.project_root.canonicalize()
+            && let Ok(rel) = path.strip_prefix(&canonical_root)
+        {
+            return rel.to_path_buf();
+        }
+
+        path.to_path_buf()
+    }
+
     /// Get the mtime of a file in milliseconds. Returns 0 on error.
     pub(super) fn file_mtime_ms(path: &Path) -> u128 {
         fs::metadata(path)
@@ -129,8 +157,9 @@ impl ToolExecutor {
     ) {
         let ts = Self::file_mtime_ms(path);
         let cached_content = content.filter(|c| c.len() <= MAX_CACHED_FILE_BYTES);
+        let key = Self::file_state_key(path);
         if let Ok(mut state) = self.file_state.lock() {
-            let prev = state.get(path);
+            let prev = state.get(&key);
             let prev_count = prev.map(|fs| fs.read_count).unwrap_or(0);
             let prev_ranged = prev.map(|fs| fs.ranged_read_count).unwrap_or(0);
             // Carry forward read_ranges if mtime unchanged, else reset.
@@ -162,7 +191,7 @@ impl ToolExecutor {
                 prev_ranged
             };
             state.insert(
-                path.to_path_buf(),
+                key,
                 FileState {
                     timestamp_ms: ts,
                     from_read: true,
@@ -196,9 +225,10 @@ impl ToolExecutor {
         let cached_content = content
             .filter(|c| c.len() <= MAX_CACHED_FILE_BYTES)
             .map(String::from);
+        let key = Self::file_state_key(path);
         if let Ok(mut state) = self.file_state.lock() {
             state.insert(
-                path.to_path_buf(),
+                key,
                 FileState {
                     timestamp_ms: ts,
                     from_read: false,
@@ -235,17 +265,16 @@ impl ToolExecutor {
         if current_ts == 0 {
             return Ok(()); // file doesn't exist yet — ok for write_file
         }
-        let rel = path
-            .strip_prefix(&self.project_root)
-            .unwrap_or(path)
-            .to_string_lossy();
+        let rel = self.project_relative_path(path);
+        let rel_display = rel.display();
+        let key = Self::file_state_key(path);
         if let Ok(state) = self.file_state.lock() {
-            if let Some(fs) = state.get(path) {
+            if let Some(fs) = state.get(&key) {
                 if current_ts > fs.timestamp_ms {
                     return Err(format!(
                         "File has been modified since last read (by user or linter). \
                          Read it again before editing.\n\
-                         → Action required: call read_file(\"{rel}\") first, then retry."
+                         → Action required: call read_file(\"{rel_display}\") first, then retry."
                     ));
                 }
             } else {
@@ -253,7 +282,7 @@ impl ToolExecutor {
                 return Err(format!(
                     "File exists but has not been read yet. \
                      Read it first before writing/editing.\n\
-                     → Action required: call read_file(\"{rel}\") first, then retry."
+                     → Action required: call read_file(\"{rel_display}\") first, then retry."
                 ));
             }
         }
@@ -274,10 +303,11 @@ impl ToolExecutor {
 
     /// Check if a file was read as a full view (not partial/outline).
     pub(super) fn was_fully_read(&self, path: &Path) -> bool {
+        let key = Self::file_state_key(path);
         self.file_state
             .lock()
             .ok()
-            .and_then(|s| s.get(path).map(|fs| !fs.is_partial))
+            .and_then(|s| s.get(&key).map(|fs| !fs.is_partial))
             .unwrap_or(false)
     }
 
@@ -299,11 +329,12 @@ impl ToolExecutor {
         if current_ts == 0 {
             return false;
         }
+        let key = Self::file_state_key(path);
         self.file_state
             .lock()
             .ok()
             .and_then(|s| {
-                s.get(path).and_then(|fs| {
+                s.get(&key).and_then(|fs| {
                     (fs.from_read
                         && fs.timestamp_ms == current_ts
                         && fs.last_dedup_key == *requested)
@@ -324,11 +355,12 @@ impl ToolExecutor {
         if current_ts == 0 {
             return false;
         }
+        let key = Self::file_state_key(path);
         self.file_state
             .lock()
             .ok()
             .and_then(|s| {
-                s.get(path)
+                s.get(&key)
                     .map(|fs| fs.from_read && !fs.is_partial && fs.timestamp_ms == current_ts)
             })
             .unwrap_or(false)
@@ -346,11 +378,12 @@ impl ToolExecutor {
         if current_ts == 0 {
             return false;
         }
+        let key = Self::file_state_key(path);
         self.file_state
             .lock()
             .ok()
             .and_then(|s| {
-                s.get(path).and_then(|fs| {
+                s.get(&key).and_then(|fs| {
                     (fs.from_read
                         && fs.timestamp_ms == current_ts
                         && ranges_cover(&fs.read_ranges, start, end))
@@ -362,19 +395,21 @@ impl ToolExecutor {
 
     /// How many times this file has been read in the current session.
     pub(super) fn file_read_count(&self, path: &Path) -> u32 {
+        let key = Self::file_state_key(path);
         self.file_state
             .lock()
             .ok()
-            .and_then(|s| s.get(path).map(|fs| fs.read_count))
+            .and_then(|s| s.get(&key).map(|fs| fs.read_count))
             .unwrap_or(0)
     }
 
     /// How many times this file has been read with different ranges.
     pub(super) fn file_ranged_read_count(&self, path: &Path) -> u32 {
+        let key = Self::file_state_key(path);
         self.file_state
             .lock()
             .ok()
-            .and_then(|s| s.get(path).map(|fs| fs.ranged_read_count))
+            .and_then(|s| s.get(&key).map(|fs| fs.ranged_read_count))
             .unwrap_or(0)
     }
 
@@ -386,11 +421,12 @@ impl ToolExecutor {
         if current_ts == 0 {
             return false;
         }
+        let key = Self::file_state_key(path);
         self.file_state
             .lock()
             .ok()
             .and_then(|s| {
-                s.get(path)
+                s.get(&key)
                     .map(|fs| fs.from_read && fs.is_partial && fs.timestamp_ms == current_ts)
             })
             .unwrap_or(false)
@@ -408,8 +444,9 @@ impl ToolExecutor {
         if current_ts == 0 {
             return None;
         }
+        let key = Self::file_state_key(path);
         self.file_state.lock().ok().and_then(|s| {
-            s.get(path).and_then(|fs| {
+            s.get(&key).and_then(|fs| {
                 if fs.timestamp_ms == current_ts {
                     fs.cached_content.clone()
                 } else {
@@ -429,8 +466,9 @@ impl ToolExecutor {
 
     /// Remove a single file from state tracking (call after delete).
     pub(super) fn remove_file_state(&self, path: &Path) {
+        let key = Self::file_state_key(path);
         if let Ok(mut state) = self.file_state.lock() {
-            state.remove(path);
+            state.remove(&key);
         }
     }
 

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -618,7 +618,7 @@ impl ToolExecutor {
         }
 
         // Dangerous file guard
-        let rel = path.strip_prefix(&self.project_root).unwrap_or(&path);
+        let rel = self.project_relative_path(&path);
         let rel_str = rel.to_string_lossy();
         if let Some(warning) = is_dangerous_write_target(&rel_str) {
             return json!({
@@ -634,7 +634,7 @@ impl ToolExecutor {
             }
             // Require full read (not outline/partial) before overwriting
             if !self.was_fully_read(&path) {
-                let rel = path.strip_prefix(&self.project_root).unwrap_or(&path);
+                let rel = self.project_relative_path(&path);
                 return json!({
                     "success": false,
                     "error": format!(
@@ -674,7 +674,12 @@ impl ToolExecutor {
         // symlink swaps (TOCTOU) between the initial resolve_checked and now.
         if path.exists() {
             if let Ok(canonical) = path.canonicalize() {
-                if !canonical.starts_with(&self.project_root) {
+                let allowed = self
+                    .sandbox_policy
+                    .as_ref()
+                    .map(|policy| policy.is_path_allowed(&canonical))
+                    .unwrap_or_else(|| canonical.starts_with(&self.project_root));
+                if !allowed {
                     return json!({
                         "success": false,
                         "error": format!(
@@ -691,8 +696,9 @@ impl ToolExecutor {
             .journal_turn_index
             .load(std::sync::atomic::Ordering::Relaxed);
         let journal_call_id = format!("write_file:{}", path.display());
+        let journal_path = Self::file_state_key(&path);
         if let Ok(mut journal) = self.file_journal.lock() {
-            journal.record_before(&path, &journal_call_id, turn_idx);
+            journal.record_before(&journal_path, &journal_call_id, turn_idx);
         }
 
         match fs::write(&path, content) {
@@ -701,7 +707,7 @@ impl ToolExecutor {
                 self.record_write_with_content(&path, content);
                 // Journal: record after-state
                 if let Ok(mut journal) = self.file_journal.lock() {
-                    journal.record_after(&path, &journal_call_id, content.as_bytes());
+                    journal.record_after(&journal_path, &journal_call_id, content.as_bytes());
                 }
                 let old_slice = prior_for_diff.as_deref().unwrap_or("");
                 let cli_diff = cap_cli_unified_diff(unified_diff_raw(old_slice, content, &path));
@@ -750,7 +756,7 @@ impl ToolExecutor {
             .unwrap_or(false);
 
         // Dangerous file guard
-        let rel = path.strip_prefix(&self.project_root).unwrap_or(&path);
+        let rel = self.project_relative_path(&path);
         let rel_str = rel.to_string_lossy();
         if let Some(warning) = is_dangerous_write_target(&rel_str) {
             return format!(
@@ -813,15 +819,20 @@ impl ToolExecutor {
                 } else {
                     format!("str_replace_fuzzy:{}", path.display())
                 };
+                let journal_path = Self::file_state_key(&path);
                 if let Ok(mut journal) = self.file_journal.lock() {
-                    journal.record_before_patch(&path, &journal_call_id, turn_idx);
+                    journal.record_before_patch(&journal_path, &journal_call_id, turn_idx);
                 }
                 match fs::write(&path, &new_content) {
                     Ok(_) => {
                         self.record_write_with_content(&path, &new_content);
                         // Journal: record after-state
                         if let Ok(mut journal) = self.file_journal.lock() {
-                            journal.record_after(&path, &journal_call_id, new_content.as_bytes());
+                            journal.record_after(
+                                &journal_path,
+                                &journal_call_id,
+                                new_content.as_bytes(),
+                            );
                         }
                         let format_result = auto_format_file(&path, &self.project_root);
                         if format_result.is_some() {
@@ -911,8 +922,9 @@ impl ToolExecutor {
             .journal_turn_index
             .load(std::sync::atomic::Ordering::Relaxed);
         let journal_call_id = format!("str_replace:{}", path.display());
+        let journal_path = Self::file_state_key(&path);
         if let Ok(mut journal) = self.file_journal.lock() {
-            journal.record_before_patch(&path, &journal_call_id, turn_idx);
+            journal.record_before_patch(&journal_path, &journal_call_id, turn_idx);
         }
 
         match fs::write(&path, &new_content) {
@@ -921,7 +933,7 @@ impl ToolExecutor {
                 self.record_write_with_content(&path, &new_content);
                 // Journal: record after-state
                 if let Ok(mut journal) = self.file_journal.lock() {
-                    journal.record_after(&path, &journal_call_id, new_content.as_bytes());
+                    journal.record_after(&journal_path, &journal_call_id, new_content.as_bytes());
                 }
 
                 // Auto-format if formatter is available
@@ -995,7 +1007,7 @@ impl ToolExecutor {
         };
 
         // Safety: refuse .git/ contents
-        let rel = path.strip_prefix(&self.project_root).unwrap_or(&path);
+        let rel = self.project_relative_path(&path);
         let rel_str = rel.to_string_lossy();
         if rel_str.starts_with(".git/") || rel_str.starts_with(".git\\") || rel_str == ".git" {
             return "Error: refusing to delete .git contents".to_string();
@@ -1022,12 +1034,16 @@ impl ToolExecutor {
         match fs::remove_file(&path) {
             Ok(_) => {
                 self.remove_file_state(&path);
+                let journal_path = Self::file_state_key(&path);
                 match self.file_journal.lock() {
-                    Ok(mut journal) => {
-                        journal.record_delete(&path, &journal_call_id, turn_idx, before_content)
-                    }
+                    Ok(mut journal) => journal.record_delete(
+                        &journal_path,
+                        &journal_call_id,
+                        turn_idx,
+                        before_content,
+                    ),
                     Err(poisoned) => poisoned.into_inner().record_delete(
-                        &path,
+                        &journal_path,
                         &journal_call_id,
                         turn_idx,
                         before_content,
@@ -1040,10 +1056,7 @@ impl ToolExecutor {
     }
 
     fn rollback_display_path(&self, path: &Path) -> String {
-        path.strip_prefix(&self.project_root)
-            .unwrap_or(path)
-            .display()
-            .to_string()
+        self.project_relative_path(path).display().to_string()
     }
 
     fn parse_rollback_tool_output(tool_name: &str, output: String) -> Value {
@@ -1540,9 +1553,10 @@ impl ToolExecutor {
                     Ok(path) => path,
                     Err(error) => return error,
                 };
+                let journal_path = Self::file_state_key(&path);
                 let undo_result = match self.file_journal.lock() {
-                    Ok(journal) => journal.undo_file(&path),
-                    Err(poisoned) => poisoned.into_inner().undo_file(&path),
+                    Ok(journal) => journal.undo_file(&journal_path),
+                    Err(poisoned) => poisoned.into_inner().undo_file(&journal_path),
                 };
                 match undo_result {
                     Ok(Some(edit_type)) => {
@@ -1735,8 +1749,9 @@ impl ToolExecutor {
             .journal_turn_index
             .load(std::sync::atomic::Ordering::Relaxed);
         let journal_call_id = format!("batch_edit:{}", path.display());
+        let journal_path = Self::file_state_key(&path);
         if let Ok(mut journal) = self.file_journal.lock() {
-            journal.record_before_patch(&path, &journal_call_id, turn_idx);
+            journal.record_before_patch(&journal_path, &journal_call_id, turn_idx);
         }
 
         // Apply
@@ -1745,7 +1760,7 @@ impl ToolExecutor {
                 self.record_write_with_content(&path, &working);
                 // Journal: record after-state
                 if let Ok(mut journal) = self.file_journal.lock() {
-                    journal.record_after(&path, &journal_call_id, working.as_bytes());
+                    journal.record_after(&journal_path, &journal_call_id, working.as_bytes());
                 }
                 let format_result = auto_format_file(&path, &self.project_root);
                 if format_result.is_some() {

--- a/rust/crates/astra-sandbox/src/path.rs
+++ b/rust/crates/astra-sandbox/src/path.rs
@@ -286,6 +286,39 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn validates_existing_path_when_project_root_is_symlink_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_root = dir.path().join("real-root");
+        let aliased_root = dir.path().join("aliased-root");
+        std::fs::create_dir(&real_root).unwrap();
+        std::os::unix::fs::symlink(&real_root, &aliased_root).unwrap();
+
+        let file = real_root.join("test.txt");
+        std::fs::write(&file, "hello").unwrap();
+
+        let p = standard_policy(aliased_root.to_str().unwrap());
+        let result = validate_path(&p, "test.txt");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), file.canonicalize().unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validates_new_path_when_project_root_is_symlink_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_root = dir.path().join("real-root");
+        let aliased_root = dir.path().join("aliased-root");
+        std::fs::create_dir(&real_root).unwrap();
+        std::os::unix::fs::symlink(&real_root, &aliased_root).unwrap();
+
+        let p = standard_policy(aliased_root.to_str().unwrap());
+        let result = validate_path(&p, "newfile.txt");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), aliased_root.join("newfile.txt"));
+    }
+
     #[test]
     fn blocks_symlink_escape() {
         let dir = tempfile::tempdir().unwrap();

--- a/rust/crates/astra-sandbox/src/policy.rs
+++ b/rust/crates/astra-sandbox/src/policy.rs
@@ -1,6 +1,6 @@
 //! Sandbox policy configuration.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Security enforcement level (ordered from least to most restrictive).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -161,10 +161,12 @@ impl SandboxPolicy {
         if self.mode == SandboxMode::Permissive {
             return true;
         }
-        if path.starts_with(&self.project_root) {
+        if path_matches_allowed_prefix(path, &self.project_root) {
             return true;
         }
-        self.allowed_paths.iter().any(|ap| path.starts_with(ap))
+        self.allowed_paths
+            .iter()
+            .any(|ap| path_matches_allowed_prefix(path, ap))
     }
 
     /// Check if an environment variable should be passed to child process.
@@ -181,6 +183,19 @@ impl SandboxPolicy {
         // No explicit allowlist in Standard mode → allow all
         true
     }
+}
+
+fn path_matches_allowed_prefix(path: &Path, allowed_prefix: &Path) -> bool {
+    if path.starts_with(allowed_prefix) {
+        return true;
+    }
+
+    allowed_prefix
+        .canonicalize()
+        .ok()
+        .is_some_and(|canonical_prefix| {
+            canonical_prefix != allowed_prefix && path.starts_with(&canonical_prefix)
+        })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- normalize sandbox and edge tool path handling for symlinked workspace roots
- add regression coverage for raw and canonical project-root aliases
- split astra-cli edge_tools CI into diagnostic shards to isolate the hanging Linux runner step

## Why
Local reproduction showed macOS path alias mismatches under /var and /private/var, and GitHub Actions runs showed the Offline astra-cli job hanging specifically in the edge_tools portion. This PR fixes the path normalization issue and adds temporary CI isolation to pinpoint which edge_tools group is hanging on Ubuntu runners.

## Testing
- cargo test --manifest-path rust/Cargo.toml -p astra-runtime tool_sandbox::path
- cargo nextest run --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'test(/edge_tools::/)' --no-fail-fast
- cargo nextest list --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'not test(/edge_tools::/)'
- cargo nextest list --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'test(/edge_tools::shell::/)'
- cargo nextest list --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'test(/edge_tools::tests::lsp_tests::/) or test(/edge_tools::tests::worktree_tests::/)'
- cargo nextest list --manifest-path rust/Cargo.toml -p astra-cli --bins -E 'test(/edge_tools::/) and not test(/edge_tools::shell::/) and not test(/edge_tools::tests::lsp_tests::/) and not test(/edge_tools::tests::worktree_tests::/)'
