### PR TITLE
fix(cli): UTF-8 safe string slicing + session continuity & memory protocol design

### DIFF
--- a/docs/design/session-continuity-crash-recovery.md
+++ b/docs/design/session-continuity-crash-recovery.md
@@ -1,0 +1,390 @@
+# Session Continuity & Crash Recovery — Design Document
+
+**Status**: Draft v2 (architecture-grounded revision)
+**Author**: astra-engine team
+**Date**: 2026-04-16
+**Problem**: 中断/崩溃的session零留存，无法追溯、无法续接、无法吸取教训
+
+## 1. 设计原则
+
+| # | 原则 | 含义 | 约束 |
+|---|------|------|------|
+| P1 | 极好用户体验 | 用户无需显式操作，系统自动感知和恢复 | 不强制交互，智能推荐 |
+| P2 | 状态可追溯 | 任何中断点可精确定位：哪一步、什么错误、为什么 | journal已有，需打通读取链路 |
+| P3 | 持续对话能力 | 上下文不丢失，说"继续"就能继续 | token必须可控 |
+| P4 | Token不爆炸 | 恢复注入≤500t，全量数据按需加载 | 分层恢复，不一次性注入全部 |
+
+## 2. 现状盘点（代码实查）
+
+### 2.1 已有基础设施
+
+| 组件 | 位置 | 实际能力 |
+|------|------|---------|
+| **Journal事件流** | `services/session_journal.rs` | append-only JSONL，`JournalEventType` 含 `InterruptionRecorded`/`Turn`/`TurnError`/`StallDetected`/`SessionEnd` 等 30+ 事件类型 |
+| **InterruptionRecord** | `runtime/turn/interruption.rs` | 11种 `InterruptionKind`，含 `is_resumable()` 判断 + `ResumeAction` 枚举 + `build_resume_guidance_with_context()` 已生成结构化恢复指导 |
+| **HeavyCheckpoint** | `runtime/pipeline/step_protocol.rs` | 含 `messages`/`blocked_tools`/`interruption`/`compaction_state`/`approval_overrides`/`delegation_*` |
+| **RestoredSession** | `services/session_restore.rs` | 含 `conversation_messages`/`blocked_tools`/`executing_plan_json`/`plan_goal`/`plan_corrections`/`contract_json`/`last_context_trace` |
+| **RestoredBreakpoint** | `services/session_restore.rs` | 含 `tool_health_entries`/`correction_history_json`/`composite_snapshot` |
+| **CompositeSnapshot** | `core/composite_snapshot.rs` | session/data/memory/git/workspace 五维快照 |
+| **L0 Anchor** | `runtime/turn/cloud/session_memory_protocol.rs` | `extract_anchor()` 生成 ~50t 锚点，`SESSION_MEMORY_PREFIX = "[session-memory:v1]"` |
+| **L1 Session Memory** | `runtime/turn/cloud/session_memory_protocol.rs` | 10个section，stored ≤4000t，injection ≤2000t，`compress_to_injection()` 零LLM压缩 |
+| **Session Memory Extract** | `runtime/turn/cloud/session_memory_extract.rs` | 双阈值触发（token增长 AND tool call次数），模板含 `## Errors & Corrections` + `## Learnings` 两个独立section |
+| **`extract_learnings_for_backflow()`** | `session_memory_extract.rs:205` | 提取 `Learnings` + `Errors & Corrections` 两个section做跨session复用 |
+| **`list_sessions_by_time()`** | `session_journal.rs:921` | 按mtime排序取最近N个session ID |
+| **`peek_session_meta()`** | `session_journal.rs:978` | 读journal头20行提取 `first_prompt`/`model`/`created_at` |
+| **`/resume` 命令** | `slash_session.rs` | CLI交互式选择 + `build_resume_guidance_with_context()` 生成guidance |
+| **resume_guidance注入** | `repl_turn.rs:275` | `state.resume_guidance.take()` → prepend到 `effective_line` |
+
+### 2.2 关键发现（与原设计文档的偏差）
+
+1. **Session Memory模板已有 `## Learnings` section** — 原设计说"不新增 `## Lessons` section，复用 `## Errors & Corrections`"，但实际模板（`SESSION_MEMORY_TEMPLATE`）已有独立的 `## Learnings` section，且 `extract_learnings_for_backflow()` 已分别提取两个section。**不应合并，应保持分离。**
+
+2. **`compress_to_injection()` 已有过滤逻辑** — Errors & Corrections 只保留 `unresolved`/`USER CORRECTION`/`❌`/`🔧` 标记的条目。Learnings section 在 injection 中被完全省略。**恢复时需要显式包含 Learnings。**
+
+3. **`SessionPeek` 确实没有 `status` 字段** — 但 `peek_session_meta()` 只读头20行。判断中断需要读 tail，这是正确的。
+
+4. **`RestoredSession` 已经非常丰富** — 含 plan state、contract、blocked tools、conversation messages。原设计提议新增 `error_lessons`/`interruption_summary` 字段，但这些信息已可从 `HeavyCheckpoint.interruption` 和 session memory 中获取，**不需要新增字段**。
+
+5. **`build_resume_guidance_with_context()` 已经很完善** — 按 interruption kind 生成针对性建议，含 compaction context。恢复时只需调用此函数 + 补充 session memory 摘要即可。
+
+## 3. 修正后的设计：两层恢复协议
+
+原设计的三层（L0/L1/L2）过度设计。实际只需要两层：
+
+### 3.1 Layer 0 — 启动探测 + 提示（≤100t）
+
+**时机**：新session的第一个turn之前
+
+**动作**：扫描本地session列表，读 journal tail 判断是否中断
+
+```rust
+/// 读journal文件最后N行（从文件末尾反向读取，不加载全文件）。
+/// 返回解析成功的事件列表。
+pub fn scan_journal_tail(session_id: &str, n_lines: usize) -> Option<Vec<JournalTailEntry>> {
+    let path = journal_dir().join(format!("{session_id}.jsonl"));
+    let content = std::fs::read_to_string(&path).ok()?;
+    // 从末尾取最后n_lines行
+    let lines: Vec<&str> = content.lines().rev().take(n_lines).collect();
+    let mut entries = Vec::new();
+    for line in lines.into_iter().rev() {
+        if let Some(entry) = parse_tail_entry(line) {
+            entries.push(entry);
+        }
+    }
+    Some(entries)
+}
+
+/// 轻量级tail entry — 只提取判断所需的字段，不反序列化完整JournalEvent。
+pub struct JournalTailEntry {
+    pub event_type: String,     // "turn", "session_end", "interruption_recorded" 等
+    pub ts: Option<String>,
+    pub interruption_kind: Option<String>,  // 仅 interruption_recorded 时有值
+    pub resumable: Option<bool>,
+}
+```
+
+**中断判断逻辑**：
+
+```rust
+enum SessionEndState {
+    Completed,                          // 最后事件 == SessionEnd
+    Interrupted { kind: String },       // 最后事件 == InterruptionRecorded
+    Zombie,                             // 有活动事件但无SessionEnd
+}
+
+fn classify_session_end_state(session_id: &str) -> SessionEndState {
+    let tail = scan_journal_tail(session_id, 20)?;
+    // 从后往前找第一个有意义的事件（跳过 Checkpoint 等辅助事件）
+    for entry in tail.iter().rev() {
+        match entry.event_type.as_str() {
+            "session_end" => return SessionEndState::Completed,
+            "interruption_recorded" => {
+                return SessionEndState::Interrupted {
+                    kind: entry.interruption_kind.clone().unwrap_or_default(),
+                };
+            }
+            "turn" | "turn_error" | "stall_detected" | "plan_progress"
+            | "delegation_completed" => {
+                return SessionEndState::Zombie;
+            }
+            _ => continue, // 跳过 checkpoint, config_change 等
+        }
+    }
+    SessionEndState::Completed // 空journal或只有辅助事件
+}
+```
+
+**防误判当前运行中的session**：检查 journal 文件的 mtime，如果距今 < 60秒，跳过（可能是当前正在运行的session）。
+
+```rust
+fn build_recovery_anchor() -> Option<String> {
+    let recent = list_sessions_by_time(5).ok()?;
+    let current_sid = current_session_id(); // 当前session的ID，排除自己
+    for sid in &recent {
+        if Some(sid.as_str()) == current_sid.as_deref() { continue; }
+        // 防误判：mtime < 60s 的跳过
+        if journal_mtime_age_secs(sid) < 60 { continue; }
+        match classify_session_end_state(sid) {
+            SessionEndState::Interrupted { kind } => {
+                let peek = peek_session_meta(sid)?;
+                let prompt = peek.first_prompt.as_deref().unwrap_or("(unknown task)");
+                return Some(format!(
+                    "[session-recovery] 上次session {short} 在做\"{prompt}\"时中断({kind})。\n\
+                     说\"继续\"恢复，或开始新任务。",
+                    short = &sid[..8],
+                ));
+            }
+            SessionEndState::Zombie => {
+                let peek = peek_session_meta(sid)?;
+                let prompt = peek.first_prompt.as_deref().unwrap_or("(unknown task)");
+                return Some(format!(
+                    "[session-recovery] 上次session {short} 在做\"{prompt}\"时异常退出。\n\
+                     说\"继续\"恢复，或开始新任务。",
+                    short = &sid[..8],
+                ));
+            }
+            SessionEndState::Completed => continue,
+        }
+    }
+    None
+}
+```
+
+**注入位置**：system prompt 末尾（和 L0 session anchor 一起），享受 prompt cache。
+
+**衰减**：prompt assembly 时检查 `current_turn > 3`，超过后不再包含。
+
+**token成本**：~100t，仅在有可恢复session时注入。
+
+### 3.2 Layer 1 — 精准恢复（≤500t）
+
+**时机**：用户说"继续" / `/resume`
+
+**动作**：复用已有的 `restore_to_checkpoint` + `build_resume_guidance_with_context`，补充 session memory 摘要。
+
+**关键改动**：不新增 `RestoredSession` 字段，而是在恢复流程中组装 Recovery Context。
+
+```rust
+fn build_recovery_context(session_id: &str) -> Option<String> {
+    let restored = restore_session(session_id)?;
+    let mut ctx = String::new();
+
+    // 1. 已有的 resume guidance（来自 HeavyCheckpoint.interruption）
+    //    build_resume_guidance_with_context() 已按 kind 生成针对性建议
+    if let Some(guidance) = load_interruption_guidance(session_id) {
+        ctx.push_str(&guidance);
+    }
+
+    // 2. Session Memory 摘要（如果有）
+    //    读取 session memory markdown，提取 Errors & Corrections + Learnings
+    if let Some(memory_md) = read_session_memory_file(session_id) {
+        let learnings = extract_learnings_for_backflow(&memory_md);
+        for (section, content) in &learnings {
+            if !content.trim().is_empty() {
+                ctx.push_str(&format!("\n[{section}]\n{content}\n"));
+            }
+        }
+    }
+
+    // 3. Plan 进度（如果有活跃 plan）
+    if let Some(plan_json) = &restored.executing_plan_json {
+        if let Some(summary) = summarize_plan_progress(plan_json) {
+            ctx.push_str(&format!("\n[plan-progress] {summary}\n"));
+        }
+    }
+
+    // 4. Blocked tools
+    if !restored.blocked_tools.is_empty() {
+        ctx.push_str(&format!(
+            "\n[blocked-tools] {}\n",
+            restored.blocked_tools.join(", ")
+        ));
+    }
+
+    if ctx.is_empty() { None } else { Some(ctx) }
+}
+```
+
+**注入位置**：`repl_turn.rs:275`，和现有 `resume_guidance` 相同路径。
+
+**token成本**：≤500t。
+
+### 3.3 深度回溯（不作为独立层）
+
+原设计的 L2 "深度回溯"不需要作为恢复协议的一部分。用户追问"之前做了什么"时，已有的 `/debug <session_id>` 和 `astra audit turns` 完全覆盖此需求。不需要新增任何代码。
+
+## 4. 用户体验流程
+
+### 场景A：正常启动，有可恢复session
+
+```
+用户: hi
+系统: [L0探测] 发现上次session abc12345 在做"修复auth模块的登录bug"时中断(budget_exhausted)。
+       说"继续"恢复，或开始新任务。
+
+用户: 继续
+系统: [L1恢复] 调用 /resume abc12345
+       注入 resume_guidance + session memory learnings
+       "好的，上次修auth.rs时build失败了。我从checkpoint继续。"
+```
+
+### 场景B：Ctrl-C中断后重启
+
+```
+[用户Ctrl-C → InterruptionRecorded {kind: UserCancelled}]
+[重启astra]
+系统: [L0探测] 上次session xyz789 在做"实现分布式缓存"时被取消。
+       说"继续"恢复，或开始新任务。
+
+用户: 那次走错了，换方向
+系统: [L1恢复 + Learnings注入]
+       "明白。上次的Learnings: HashMap方案在并发场景会死锁。
+        建议这次用分段锁。需要规划新方案吗？"
+```
+
+### 场景C：Plan中断后恢复
+
+```
+[Plan在subtask 3/7时Ctrl-C]
+[重启astra]
+系统: [L0探测] 上次session有活跃Plan "重构缓存模块"。
+       说"继续"恢复计划，或开始新任务。
+
+用户: 继续
+系统: [L1恢复] 从 RestoredSession.executing_plan_json 解析进度
+       "Plan进度: 3/7完成。从子任务4继续。"
+```
+
+## 5. Token效率策略
+
+### 5.1 分层注入
+
+| 层 | 触发 | Token | 内容 |
+|----|------|-------|------|
+| L0 Recovery Anchor | 启动时有zombie/中断 | ~100t | "有中断 + 任务名 + 中断类型" |
+| L1 Recovery Context | 用户说"继续" | ≤500t | resume_guidance + learnings + plan进度 + blocked tools |
+
+### 5.2 Cache-friendly
+
+- L0 Anchor 在 system prompt 末尾，享受 prompt cache
+- L1 Recovery Context 在 first user message 前（`repl_turn.rs:275` 现有路径）
+
+### 5.3 渐进衰减
+
+- L0 Anchor：3轮后不再包含（prompt assembly 时判断 `current_turn > 3`）
+- L1 Recovery Context：恢复后被 compaction 自然吸收为 session memory
+
+## 6. 实现路径
+
+### Phase 1 — 启动探测（最小改动）
+
+**新增 1 个函数 + 1 个调用点**：
+
+| 改动 | 位置 | 说明 |
+|------|------|------|
+| `scan_journal_tail()` | `services/session_journal.rs` | 读journal最后N行，返回轻量级 `JournalTailEntry` |
+| `classify_session_end_state()` | 同上 | 基于tail判断 Completed/Interrupted/Zombie |
+| `build_recovery_anchor()` | 同上或新文件 | 组装L0 anchor字符串 |
+| 调用点 | agentic loop bootstrap 或 `repl_runtime.rs` 初始化 | 在第一个turn前调用，结果存入 `ReplState` |
+| prompt assembly | 现有 system prompt 构建逻辑 | 检查 `state.recovery_anchor`，turn ≤ 3 时追加 |
+
+**不改动**：`RestoredSession`、`/resume`、`build_resume_guidance_with_context` — 全部复用。
+
+### Phase 2 — 恢复时补充 Session Memory Learnings
+
+**改动 1 个函数**：
+
+| 改动 | 位置 | 说明 |
+|------|------|------|
+| 增强 `/resume` 恢复流程 | `slash_session.rs` | 恢复时额外读取 session memory file，提取 Learnings + Errors & Corrections，追加到 `resume_guidance` |
+
+**具体**：在 `slash_session.rs` 的 `/resume` handler 中，`build_resume_guidance_with_context()` 之后，追加 session memory learnings：
+
+```rust
+// 现有代码
+let guidance = build_resume_guidance_with_context(&interruption_json, compaction_ctx.as_ref());
+
+// 新增：追加 session memory learnings
+if let Some(memory_md) = read_session_memory_file(&session_id) {
+    let learnings = extract_learnings_for_backflow(&memory_md);
+    for (section, content) in &learnings {
+        let trimmed = content.trim();
+        if !trimmed.is_empty() {
+            guidance.push_str(&format!("\n[{section}] {}\n",
+                truncate_to_token_budget(trimmed, 150)));
+        }
+    }
+}
+```
+
+### Phase 3 — 错误学习持久化改进
+
+**不新增 section**。现有模板已有 `## Errors & Corrections` 和 `## Learnings`。
+
+改进 session memory extraction prompt，确保：
+- 每次 TurnError 后触发一次 extraction（降低 `min_tool_calls_between_updates` 阈值）
+- Learnings section 按 `[pattern]`/`[correction]`/`[avoidance]` 标签分类
+- 每个session限5条 learnings（extraction prompt 中约束）
+
+## 7. 关键决策
+
+| 决策 | 选择 | 理由 |
+|------|------|------|
+| 恢复层数 | 2层（不是3层） | L2"深度回溯"已被 `/debug` 和 `astra audit` 覆盖 |
+| `RestoredSession` 新字段 | 不新增 | `HeavyCheckpoint.interruption` + session memory 已包含所需信息 |
+| Learnings 存储位置 | 保持 `## Learnings` 独立section | 代码实际已有此section + `extract_learnings_for_backflow()` 已分别提取 |
+| 中断判断 | journal tail 扫描 | `SessionPeek` 无 status 字段；journal tail 更准确 |
+| 防误判运行中session | mtime < 60s 跳过 + 排除当前 session_id | 避免把正在运行的session误判为zombie |
+| 恢复触发 | 用户确认（不强制） | P1原则：不打断新任务意图 |
+| 多session | 只推荐最近1个 | `/resume` 查看全部 |
+| L0衰减 | turn > 3 不包含 | prompt assembly 时判断 |
+| Fork验证 | 不做 | 过度设计，恢复后直接继续即可，错误由 TurnGuard 兜底 |
+| Cloud恢复 | 不在此设计中 | `cloud_sync.rs` 已有 delta push/pull，恢复是其自然延伸，不需要额外协议 |
+| Web Agent恢复 | 不在此设计中 | server-side SSE loop + zombie检测已有，断线重连是网络层问题 |
+| Plan恢复 | 复用 `RestoredSession.executing_plan_json` | 已有字段，只需在L1中展示进度 |
+
+## 8. 不做什么
+
+- ❌ 不新增 `RestoredSession` 字段（已有信息足够）
+- ❌ 不新增 L2 深度回溯层（`/debug` + `astra audit` 已覆盖）
+- ❌ 不做 Fork 验证恢复（TurnGuard 已兜底错误检测）
+- ❌ 不在此设计中处理 Cloud/Web Agent 恢复（已有基础设施的自然延伸）
+- ❌ 不合并 `## Learnings` 和 `## Errors & Corrections`（代码已分离）
+- ❌ 不在每次turn扫描旧session
+- ❌ 不自动恢复（不问用户就强制恢复会打断新任务）
+- ❌ 不注入全量 conversation_messages
+- ❌ 不给 `SessionPeek` 加 status 字段
+
+## 9. 新增API清单
+
+| API | 位置 | Phase |
+|-----|------|-------|
+| `scan_journal_tail(session_id, n_lines) -> Option<Vec<JournalTailEntry>>` | `session_journal.rs` | 1 |
+| `classify_session_end_state(session_id) -> SessionEndState` | `session_journal.rs` | 1 |
+| `build_recovery_anchor() -> Option<String>` | `session_journal.rs` 或新文件 | 1 |
+| `read_session_memory_file(session_id) -> Option<String>` | `session_memory_extract.rs` 或 `session_restore.rs` | 2 |
+
+**总计 4 个新函数**，0 个新 struct 字段。
+
+## 10. 验收标准
+
+| # | 标准 | 验证方式 |
+|---|------|---------|
+| A1 | Ctrl-C中断后重启，系统自动提示可恢复 | 手动测试 |
+| A2 | 说"继续"后，agent知道之前在做什么、遇到什么问题 | 检查注入的 recovery context |
+| A3 | Recovery Anchor ≤100t | token计数 |
+| A4 | Recovery Context ≤500t | token计数 |
+| A5 | 正常启动（无中断session）零额外token | 验证无 anchor |
+| A6 | 错误教训跨session可见 | session A 的 Learnings 在 session B 恢复时注入 |
+| A7 | L0 Anchor 在3轮后消失 | 第4轮 system prompt 不含 anchor |
+| A8 | 运行中的session不被误判为zombie | mtime < 60s 跳过 |
+| A9 | Plan中断后恢复显示进度 | 恢复时展示 subtask 完成状态 |
+
+## 11. 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| journal文件损坏 → L0探测失败 | `scan_journal_tail` 返回 `Option`，失败时静默跳过 |
+| 多个zombie session | 只取最近1个，`/resume` 查看全部 |
+| session memory file 不存在（短session未触发extraction） | 降级：只用 `build_resume_guidance_with_context()`，不注入 learnings |
+| `read_to_string` 对大journal文件慢 | Phase 1 可接受；后续优化为 seek-to-end 反向读取 |

--- a/docs/design/session-memory-protocol.md
+++ b/docs/design/session-memory-protocol.md
@@ -1,103 +1,122 @@
 # Session Memory Protocol — Design Document
 
-**Status**: Draft
+**Status**: Draft (revised — hybrid state model)
 **Author**: astra-engine team
 **Date**: 2026-04-16
 **References**: Claude Code compaction system analysis, Memoria API
 
 ## 1. Problem Statement
 
-Context compaction drops the user's original task, causing the agent to lose track of what it was doing. Observed in session `f3ef23fe`: after proactive compression at 83% pressure, the agent said "The original user request was lost during context compaction (35 earlier messages removed)."
+Two problems:
 
-Root cause: `TieredCompaction` (Layer 3) preserves system messages + tail N turns, but the first user message (the original task) falls in the "middle" and gets deleted.
+**P1 — Goal loss**: Context compaction drops the user's original task. Observed in session `f3ef23fe`: after proactive compression at 83% pressure, the agent said "The original user request was lost during context compaction (35 earlier messages removed)." Root cause: `TieredCompaction` preserves system messages + tail N turns, but the first user message falls in the "middle" and gets deleted.
+
+**P2 — L1 is narrative, not truth**: The entire L1 session memory is LLM-generated. `Current State`, `Progress`, `Key Files` are all "summaries" that can hallucinate. When injected at compaction, the model resumes from a potentially wrong state. We're using "summaries" where we need a "state machine."
 
 ### Goals
 
 1. **Goal preservation**: The user's original task must never be lost, under any compaction pressure
-2. **Token efficiency**: Memory injection must be cache-friendly and pressure-adaptive, not a fixed tax
-3. **Continuous high-quality memory**: Structured, governed session state that survives multiple compactions
-4. **Deployment flexibility**: Works in CLI (edge), web agent (server), and Claude Code compatibility modes
-5. **Prompt cache preservation**: Memory operations must not break the cached prefix
+2. **Ground truth first**: System-tracked facts (files, tools, errors, plan) take priority over LLM narrative
+3. **Token efficiency**: Memory injection must be cache-friendly and pressure-adaptive, not a fixed tax
+4. **Continuous high-quality memory**: Structured, governed session state that survives multiple compactions
+5. **Deployment flexibility**: Works in CLI (edge), web agent (server), and Claude Code compatibility modes
+6. **Prompt cache preservation**: Memory operations must not break the cached prefix
 
 ## 2. Architecture Overview
 
-### 2.1 Four-Layer Memory Pyramid
+### 2.1 Hybrid Memory Pyramid
 
 ```
-         ┌─────────────────┐
-    L0   │  Anchor + MC     │  Cost: zero LLM, every turn
-         │  ~50t + savings  │  Anchor in system prompt, microcompact clears old tool results
-         ├─────────────────┤
-    L1   │  Session Memory  │  Cost: cheap model, periodic (every 5K tokens + 3 tool calls)
-         │  ≤2000t inject   │  10-section structured notes, replaces LLM summary at compaction
-         │  ≤4000t stored   │
-         ├─────────────────┤
-    L2   │  Compact Summary │  Cost: cheap model, only when L1 unavailable
-         │  ≤3000t          │  9-section LLM summary with anti-drift safeguards
-         ├─────────────────┤
-    L3   │  Durable Memory  │  Cost: zero/low, session end
-         │  not injected    │  Episodic, procedural, semantic — retrieved on demand via Memoria
-         └─────────────────┘
+         ┌──────────────────────┐
+    L0   │  Anchor + MC          │  Cost: zero LLM, every turn
+         │  ~60t + savings       │  Anchor from system facts, microcompact clears old tool results
+         ├──────────────────────┤
+   L1a   │  Session Facts        │  Cost: zero LLM, every turn
+         │  ~150t inject         │  System-tracked: files, tools, errors, plan (ground truth)
+         ├──────────────────────┤
+   L1b   │  Session Narrative    │  Cost: cheap model, periodic
+         │  ≤500t inject         │  LLM-generated: task spec, decisions, user corrections, learnings
+         │  ≤2000t stored        │
+         ├──────────────────────┤
+    L2   │  Compact Summary      │  Cost: cheap model, only when L1a also unavailable (extreme fallback)
+         │  ≤3000t               │  9-section LLM summary with anti-drift safeguards
+         ├──────────────────────┤
+    L3   │  Durable Memory       │  Cost: zero/low, session end
+         │  not injected         │  Episodic, procedural, semantic — retrieved on demand via Memoria
+         └──────────────────────┘
 ```
+
+Key change from v1: L1 is split into **L1a (system facts, ground truth)** and **L1b (LLM narrative, supplement)**. L1a is always available (updated every turn, zero LLM). L1b is periodic and optional. Compaction no longer needs to wait for L1b — L1a alone is sufficient for zero-LLM compaction.
 
 ### 2.2 Design Principles
 
-Borrowed from Claude Code's production-proven patterns:
-
-| Principle | Claude Code Practice | Our Adaptation |
-|-----------|---------------------|----------------|
-| Anti-drift | All user messages verbatim in summary + direct quotes for next step | L1 "User Messages" section + L0 anchor |
-| Cache-aware | Forked agent shares cached prefix; never inject into stable prefix | Memory in CacheScope::None; injection after cache breakpoint |
-| Layered compaction | Microcompact → session memory → LLM summary → context collapse | L0 MC → L1 session memory → L2 LLM summary |
-| Size governance | Per-section 2K token cap + total 12K cap + auto-condensation warnings | Per-section budgets + total 2K inject / 4K stored |
-| Structured template | 10 immutable section headers, only content below is editable | 10-section markdown with `[session-memory:v1]` prefix |
-| Zero-LLM compaction | Session memory replaces LLM summary when available | L1 replaces L2 at compaction time |
+| Principle | Practice | Implementation |
+|-----------|----------|----------------|
+| Facts over narrative | System-tracked state takes priority over LLM summaries | L1a (facts) injected before L1b (narrative); cross-validation warnings |
+| Anti-drift | User messages preserved + user corrections never deleted | L1b "User Messages" sliding window + "User Corrections" section |
+| Cache-aware | Never inject into stable prefix | Memory in CacheScope::None; injection after cache breakpoint |
+| Layered compaction | Microcompact → session facts → narrative → LLM summary | L0 MC → L1a facts → L1b narrative → L2 LLM summary |
+| Size governance | Per-section budgets, total injection ≤700t | L1a ~150t + L1b ~500t; v1 was 2000t |
+| Zero-LLM compaction | Session facts always available, no waiting | L1a replaces L2 at compaction; L1b enriches if available |
+| LLM does LLM things | Don't ask LLM to track files/errors/progress | L1b only: task spec, decisions, corrections, learnings |
 | Post-compact restoration | Re-inject top 5 files, plans, skills, tool schemas | Same, with file dedup against preserved messages |
-| Continuation prompt | "Pick up the last task as if the break never happened" | Same, injected after compaction |
 
 ## 3. L0: Anchor + Microcompact
 
 ### 3.1 Session Anchor
 
-A single-line task summary embedded in the system prompt's dynamic section (`CacheScope::None`). Never deleted by any compaction layer.
+A compact task summary embedded in the system prompt's dynamic section (`CacheScope::None`). Never deleted by any compaction layer. **Generated from system facts, not LLM narrative.**
 
 **Format**:
 ```
-[session-anchor] {task, ≤30 words}. Currently: {current_work, ≤15 words}. {done}/{total} steps.
+[session-anchor] Goal: {task}. State: {system_state}. {constraints}.
 ```
 
-**Example**:
+**Examples**:
 ```
-[session-anchor] Add OAuth support to API with JWT tokens. Currently: token refresh in src/auth/refresh.rs. 3/5 steps.
+[session-anchor] Goal: Add OAuth support to API with JWT tokens. State: 3/5 subtasks, current: token refresh. Last error: sqlx migration column exists.
+[session-anchor] Goal: Fix auth module login bug. State: write src/auth.rs (t7). Avoid: rm, git push --force.
+```
+
+**Generation** (zero LLM):
+```rust
+fn extract_anchor(first_user_msg: &str, facts: &SessionFacts, narrative: Option<&SessionMemory>) -> String {
+    // Task: from narrative if available (LLM good at summarizing), fallback to first user msg
+    let task = narrative
+        .and_then(|n| n.section("Task Specification"))
+        .map(|s| first_sentence(s))
+        .unwrap_or_else(|| truncate_words(first_user_msg, 20));
+
+    // State: from system facts (ground truth, not LLM narrative)
+    let state = if let Some(plan) = &facts.plan_state {
+        format!("{}/{} subtasks, current: {}",
+            plan.completed, plan.total,
+            plan.current_subtask.as_deref().unwrap_or("unknown"))
+    } else if let Some(f) = facts.active_files.last() {
+        format!("{} {} (t{})", f.last_action, f.path, f.turn)
+    } else {
+        "starting".to_string()
+    };
+
+    let mut anchor = format!("[session-anchor] Goal: {task}. State: {state}.");
+
+    // Constraints: from system facts
+    if let Some(err) = &facts.error_state.last_error {
+        anchor.push_str(&format!(" Last error: {}.", truncate_words(err, 10)));
+    }
+    if !facts.blocked_tools.is_empty() {
+        anchor.push_str(&format!(" Avoid: {}.", facts.blocked_tools.join(", ")));
+    }
+    anchor
+}
 ```
 
 **Lifecycle**:
-- **Created**: Turn 1, rule-extracted from first user message (zero LLM)
-- **Updated**: Every time L1 updates, L0 is re-derived from L1's Task + Current State sections (zero LLM)
-- **Injected**: Appended to the dynamic system prompt section (after profile_desc), inside `CacheScope::None`
-- **Compaction**: Treated as part of system prompt — never removed by TieredCompaction or ReactiveCompact
-- **Cost**: ~50 tokens, constant
-
-**Cache impact**: None. Placed in `CacheScope::None` (already non-cached dynamic section). Does not affect the Global/Session cached prefix.
-
-**Rule extraction** (zero LLM):
-```rust
-/// Sections are parsed by matching `# {Section Name}` headers in the markdown.
-/// Content is everything between the header and the next `# ` header (or EOF).
-fn extract_anchor(first_user_msg: &str, l1: Option<&SessionMemory>) -> String {
-    if let Some(l1) = l1 {
-        // Derive from L1's parsed sections
-        let task = first_sentence(l1.section("Task Specification"));
-        let current = first_sentence(l1.section("Current State"));
-        let (done, total) = count_progress_markers(l1.section("Progress"));
-        format!("[session-anchor] {task}. Currently: {current}. {done}/{total} steps.")
-    } else {
-        // First turn: extract from user message
-        let task = truncate_words(first_user_msg, 30);
-        format!("[session-anchor] {task}. Currently: starting. 0/0 steps.")
-    }
-}
-```
+- **Created**: Turn 1, from first user message + empty facts
+- **Updated**: Every turn, re-derived from `SessionFacts` + narrative Task Specification
+- **Injected**: In `CacheScope::None` dynamic section
+- **Compaction**: Never removed
+- **Cost**: ~60 tokens (up from v1's ~50t, but much higher information density)
 
 ### 3.2 First User Message Preservation
 
@@ -125,11 +144,89 @@ Clears old tool result content for compactable tools, with pressure-adaptive ret
 
 **Cache impact**: Microcompact modifies message content in the volatile region (after the cache breakpoint). It does NOT affect the cached prefix. After microcompact, the cache breakpoint is re-placed on the last message.
 
-## 4. L1: Session Memory
+## 4. L1: Session State (Hybrid)
 
-The core innovation layer. A structured, incrementally-updated session state stored in Memoria, used to replace LLM summarization during compaction.
+L1 is split into two sub-layers: **L1a (system facts)** and **L1b (LLM narrative)**.
 
-### 4.1 Template (10 Sections)
+### 4.0 L1a: Session Facts (Ground Truth)
+
+System-tracked state, updated every turn from journal events and tool call records. Zero LLM cost. Always available.
+
+```rust
+/// Ground truth session state. Never hallucinated.
+pub struct SessionFacts {
+    /// Files touched (from tool_call records: read_file, write_file, str_replace)
+    pub active_files: Vec<FileEntry>,       // path + last_action + turn, last 20
+    /// Last N tool calls with outcomes (from JournalEvent.tool_calls)
+    pub recent_tool_calls: Vec<ToolFact>,   // name + ok/fail + turn, last 10
+    /// Plan progress (from RestoredSession.executing_plan_json / PlanProgress events)
+    pub plan_state: Option<PlanFact>,       // goal + completed/total + current_subtask
+    /// Blocked/unhealthy tools (from checkpoint.blocked_tools)
+    pub blocked_tools: Vec<String>,
+    /// Error state (from TurnError journal events)
+    pub error_state: ErrorFact,             // count + last_error_msg + turn
+    /// Session metadata
+    pub turn: u32,
+    pub estimated_tokens: u64,
+}
+```
+
+**Update mechanism**: At each turn end, after `JournalEvent` is written:
+```rust
+impl SessionFacts {
+    /// Incremental update from a single turn's journal event.
+    pub fn update_from_turn(&mut self, event: &JournalEvent) {
+        self.turn = event.turn.unwrap_or(self.turn);
+        if let Some(tokens) = event.tokens_in {
+            self.estimated_tokens += tokens;
+        }
+        // Extract file paths from tool_call records
+        for tc in event.tool_calls.iter().flatten() {
+            if let Some(path) = extract_file_path_from_tool_call(tc) {
+                self.upsert_file(path, action_for_tool(&tc.tool_name), self.turn);
+            }
+        }
+        // Track tool outcomes
+        for tc in event.tool_calls.iter().flatten() {
+            if !tc.is_synthetic_placeholder() {
+                self.recent_tool_calls.push(ToolFact {
+                    name: tc.tool_name.clone(), ok: tc.ok, turn: self.turn,
+                });
+                if self.recent_tool_calls.len() > 10 {
+                    self.recent_tool_calls.remove(0);
+                }
+            }
+        }
+        // Track errors
+        if event.event_type == JournalEventType::TurnError {
+            self.error_state.total_errors += 1;
+            self.error_state.last_error = event.error_message.clone();
+            self.error_state.last_error_turn = Some(self.turn);
+        }
+    }
+}
+```
+
+**Injection format** (~150 tokens):
+```
+# System State
+Turn 12, ~45K tokens
+Plan: Implement OAuth (3/5 subtasks), current: token refresh
+Active files:
+  write src/auth/refresh.rs (t11)
+  read src/auth/mod.rs (t10)
+  write src/routes/oauth.rs (t8)
+Errors: 2 total, last: sqlx migration column exists (t9)
+Blocked tools: web_fetch
+```
+
+**Cost**: ~150 tokens, updated every turn, zero LLM.
+
+### 4.1 L1b: Session Narrative (LLM-Generated)
+
+LLM-generated structured notes. Only covers what LLM is good at: task understanding, decisions, user corrections, learnings. Does NOT duplicate system-tracked state.
+
+**Template (6 sections, stored ≤2000t)**:
 
 ```markdown
 [session-memory:v1]
@@ -137,164 +234,161 @@ The core innovation layer. A structured, incrementally-updated session state sto
 {5-10 word descriptive title}
 
 # Task Specification
-{What the user originally asked. Verbatim if short, paraphrased if long. IMMUTABLE unless user explicitly changes direction.}
+{What the user originally asked. IMMUTABLE unless user explicitly changes direction.}
 
-# Current State
-{What is actively being worked on RIGHT NOW. ALWAYS updated on every extraction. Include file names and specific details.}
+# User Corrections
+{User corrections and explicit preferences. NEVER remove. Highest priority.}
 
-# Key Files
-{Files read/modified/created, one per line: path — brief purpose}
-
-# Progress
-{Checklist: ✅ done / 🔄 in progress / ⏳ pending}
-
-# Errors & Corrections
-{Errors encountered and fixes. User corrections have HIGHEST priority — never remove them.}
+# Learnings
+{Patterns, gotchas, conventions discovered. Reusable across sessions.}
 
 # Decisions
-{Key technical decisions and rationale}
+{Key technical decisions and rationale. Last 5.}
 
 # User Messages
-{ALL user messages verbatim (excluding tool results). Critical for anti-drift.}
-
-# Worklog
-{Terse step-by-step: turn N — what was attempted, what happened}
-
-# Context
-{Turn count, tokens used, pressure, last update timestamp}
+{Last 5 user messages verbatim. Older → 1-line summary: "Turn N: {what}"}
 ```
 
-### 4.2 Size Governance
+**Removed from v1**: Current State, Key Files, Progress, Worklog, Context — all replaced by L1a system facts.
 
-Two versions of L1 exist: the **stored version** (full detail in Memoria) and the **injection version** (compressed for context injection).
+**Size governance (stored version, ≤2000t)**:
 
-**Stored version** (in Memoria, ≤4000 tokens):
-
-| Section | Max Tokens | Condensation Priority |
-|---------|-----------|----------------------|
+| Section | Max Tokens | Condensation Rule |
+|---------|-----------|-------------------|
 | Session Title | 20 | Never condense |
-| Task Specification | 200 | 🔴 Never condense |
-| Current State | 400 | 🔴 Never condense |
-| Key Files | 500 | 🟡 Drop oldest entries |
-| Progress | 400 | 🟡 Drop completed items |
-| Errors & Corrections | 500 | 🟡 Drop resolved errors (keep user corrections) |
-| Decisions | 400 | 🟡 Drop oldest decisions |
-| User Messages | 800 | 🔴 Never condense (truncate oldest if over budget) |
-| Worklog | 700 | 🟢 First to condense |
-| Context | 50 | Auto-generated |
-| **Total** | **≤4000** (hard cap, enforced by update prompt) | |
+| Task Specification | 200 | 🔴 IMMUTABLE unless user changes direction |
+| User Corrections | 300 | 🔴 NEVER remove |
+| Learnings | 300 | 🟡 Drop oldest if over budget |
+| Decisions | 400 | 🟡 Keep last 5, drop oldest |
+| User Messages | 800 | Last 5 verbatim; older → 1-line summary; drop oldest summaries first |
+| **Total** | **≤2000** | Half of v1's 4000t budget |
 
-When a section exceeds its budget, the update prompt includes: "CRITICAL: Section '{name}' exceeds {max} tokens. Condense oldest entries first. Prioritize keeping 'Current State', 'Task Specification', and 'User Messages' accurate."
-
-**Injection version** (for context, ≤2000 tokens) — rule-compressed from stored version, zero LLM:
+**Injection version** (≤500t, rule-compressed, zero LLM):
 
 | Section | Injection Rule |
 |---------|---------------|
 | Task Specification | Full text |
-| Current State | Full text |
-| Key Files | File names only, no descriptions |
-| Progress | Only 🔄 and ⏳ items |
-| Errors & Corrections | Only unresolved errors + all user corrections |
-| Decisions | Most recent 2 entries, ≤15 words each |
-| User Messages | Last 3 user messages |
-| Worklog | Omitted |
-| Context | Omitted |
+| User Corrections | Full text (never drop) |
+| Learnings | Last 3 entries |
+| Decisions | Last 2 entries, ≤15 words each |
+| User Messages | Last 3 verbatim only |
+| Session Title, Worklog | Omitted |
+
+### 4.2 Combined Injection: Facts-First Assembly
+
+```rust
+pub fn build_injection(facts: &SessionFacts, narrative: Option<&SessionMemory>) -> String {
+    let mut out = String::from("[session-memory]\n");
+
+    // ── Layer 1: System Facts (ground truth, ~150t) ──
+    out.push_str(&facts.to_injection());
+
+    // ── Layer 2: LLM Narrative (supplement, ≤500t) ──
+    if let Some(n) = narrative {
+        if let Some(task) = n.section("Task Specification") {
+            out.push_str(&format!("# Task\n{}\n", truncate_to_token_budget(task, 200)));
+        }
+        if let Some(corrections) = n.section("User Corrections") {
+            if !corrections.trim().is_empty() {
+                out.push_str(&format!("# User Corrections\n{}\n",
+                    truncate_to_token_budget(corrections, 150)));
+            }
+        }
+        if let Some(learnings) = n.section("Learnings") {
+            let entries: Vec<&str> = learnings.lines()
+                .filter(|l| l.trim().starts_with("- ")).collect();
+            let last_three: Vec<&str> = entries.iter().rev().take(3).rev().copied().collect();
+            if !last_three.is_empty() {
+                out.push_str("# Learnings\n");
+                for line in last_three { out.push_str(line.trim()); out.push('\n'); }
+            }
+        }
+        if let Some(decisions) = n.section("Decisions") {
+            let entries: Vec<&str> = decisions.lines()
+                .filter(|l| l.trim().starts_with("- ")).collect();
+            if let Some(recent) = entries.last() {
+                out.push_str(&format!("# Last Decision\n{}\n", recent.trim()));
+            }
+        }
+    }
+
+    // ── Layer 3: Cross-validation ──
+    if let Some(n) = narrative {
+        if let Some(task) = n.section("Task Specification") {
+            if (task.contains("completed") || task.contains("done"))
+                && facts.error_state.total_errors > 0
+                && facts.error_state.last_error.is_some()
+            {
+                out.push_str("⚠️ Narrative says completed but system has unresolved errors\n");
+            }
+        }
+    }
+
+    out
+}
+```
 
 ### 4.3 Update Trigger
 
-Same dual-threshold as Claude Code's session memory:
+L1a (facts): **Every turn**, zero cost.
+
+L1b (narrative): Dual-threshold + error-triggered:
 
 ```
-Initial gate: context tokens ≥ 10,000 (skip for trivial sessions)
+Initial gate: context tokens ≥ 10,000
 
 Subsequent updates require BOTH:
   - Token growth ≥ 5,000 since last extraction
   - Tool calls ≥ 3 since last extraction
-  
-OR:
-  - Token growth ≥ 5,000 AND last assistant turn has no tool calls (natural break)
+
+OR: Token growth ≥ 5,000 AND last assistant turn has no tool calls (natural break)
+
+NEW — Error trigger:
+  - TurnError occurred this turn AND context tokens ≥ 10,000
+  (captures user corrections immediately, before compaction can drop them)
 ```
 
-### 4.4 Update Mechanism
+### 4.4 Update Mechanism (L1b only)
 
-Uses a **cheap text model** (e.g., `glm-4-flash-250414`, `deepseek-chat`, or the cheapest available model in the model registry).
+Uses a **cheap text model**. Async fire-and-forget — main turn does NOT block.
 
-**Execution model**: Async fire-and-forget. The main turn does NOT block on L1 extraction. The result is available on the next turn. If compaction triggers while an L1 update is in-flight, wait up to 15 seconds for it to complete (borrowed from Claude Code's `waitForSessionMemoryExtraction()`). If timeout, fallback to L2.
-
-**Update prompt**:
+**Update prompt** (revised — LLM only updates what LLM is good at):
 
 ```
-You are updating a structured session memory file based on new conversation messages.
+You are updating session notes based on new conversation messages.
 
-Rules:
-- ALWAYS update 'Current State' to reflect the most recent work
-- Add ALL new user messages to 'User Messages' section verbatim
-- 'Task Specification' can ONLY change if the user explicitly changed direction
-- User corrections in 'Errors & Corrections' have highest priority — NEVER remove them
-- Do NOT remove information unless a section exceeds its budget
-- If a section is over budget, condense OLDEST entries first
-- Keep the exact section header format (# Section Name)
+You ONLY update these sections:
+- Task Specification: ONLY change if user explicitly changed direction
+- User Corrections: Add any new user corrections or preferences. NEVER remove existing ones.
+- Learnings: Add patterns, gotchas, conventions discovered
+- Decisions: Add key technical decisions with rationale (keep last 5)
+- User Messages: Last 5 verbatim, older → 1-line summary "Turn N: {what}"
 
-{section_budget_warnings}
+Do NOT write Current State, Progress, Key Files, Errors — the system tracks those separately.
 
-Current session memory:
-{existing_session_memory OR empty template}
+Current session notes:
+{existing_narrative OR empty template}
 
 New messages since last update (turn {from_turn} to {to_turn}):
 {recent_messages, truncated to ~3000 tokens}
 
-Output the complete updated session memory in the same [session-memory:v1] format.
+Output the complete updated notes in [session-memory:v1] format.
 ```
-
-**Input budget**: ~3000 tokens for recent messages + ~2000 tokens for existing memory = ~5000 tokens input
-**Output budget**: ~2000 tokens
-**Cost per update**: ~$0.001 with cheap models
 
 ### 4.5 Format Validation
 
-Every L1 update result is validated before storage:
+Same as v1: must start with `[session-memory:v1]`, must contain `# Task Specification` with non-empty content. After 2 consecutive validation failures, L1b updates are paused — L1a (facts) alone is sufficient.
 
-1. Must start with `[session-memory:v1]`
-2. Must contain `# Task Specification` section with non-empty content
-3. Must contain `# Current State` section with non-empty content
-4. Must contain `# User Messages` section
-
-If validation fails:
-- The malformed output is discarded (not stored in Memoria)
-- The previous valid L1 remains in use
-- A warning is logged: `session_memory.validation_failed`
-- After 2 consecutive validation failures, the cheap model is considered unreliable for this session; L1 updates are paused and L2 becomes the primary compaction source
-
-### 4.6 Cache-Aware Injection
-
-**Critical design decision**: L1 is injected as a **system message at position 1** (after the main system prompt), NOT into the conversation messages.
-
-```
-Message array structure:
-  [0] System prompt (Global + Session + Dynamic sections)  ← CACHED PREFIX
-      └─ Dynamic section includes L0 anchor
-  [1] [Session Memory] system message (L1 injection)       ← NOT in cached prefix
-  [2..N-1] Conversation messages                           ← Volatile
-  [N] Last message with cache_control breakpoint           ← Cache boundary
-```
-
-**Why position 1 as system message**:
-- Does NOT break the system prompt's cached prefix (Global + Session sections are in message [0])
-- System messages at position 1 are outside the Anthropic cache breakpoint (which is on the last message)
-- For OpenAI automatic prefix caching: the primary system message [0] stays identical, so the prefix cache hits
-- L1 content changes periodically (~every 5K tokens), which is acceptable for a non-cached position
-
-**Provider-specific position**: The layout above shows the Anthropic path. For OpenAI (automatic prefix caching), message [0] is split into stable (Global+Session) and dynamic (None+L0) system messages, so L1 is at position 2. The principle is the same: L1 is always placed AFTER the stable cached prefix, never inside it.
-
-**Pressure-adaptive injection**:
+### 4.6 Pressure-Adaptive Injection
 
 | Context Pressure | What's Injected | Token Cost |
 |-----------------|-----------------|------------|
-| < 75% | L1 injection version (compressed) | ~2000 |
-| 75–85% | L1 minimal (Task + Current State + Progress only) | ~800 |
-| 85–95% | L0 anchor only (in system prompt) | ~50 |
-| > 95% | L0 anchor only | ~50 |
-| Post-compaction first turn | L1 injection version (full) + continuation prompt | ~2200 |
+| < 75% | L1a facts + L1b narrative | ~650 |
+| 75–85% | L1a facts only | ~150 |
+| ≥ 85% | L0 anchor only | ~60 |
+| Post-compaction | L1a facts + L1b narrative + continuation prompt | ~850 |
+
+v1 injected 2000t at < 75% pressure. This design injects ~650t. **Saves ~1350t/turn.**
 
 ### 4.7 Memoria Storage Protocol
 
@@ -459,7 +553,7 @@ At session start, the per-turn prefetch retrieves relevant memories from all typ
 | Operation | Cache Impact | Mitigation |
 |-----------|-------------|------------|
 | L0 anchor update | None — in CacheScope::None | Already non-cached |
-| L1 injection update | **Moderate** — message [1] changes invalidate conversation KV cache from [1] onward | Acceptable: L1 updates ~every 3-5 turns; conversation messages change every turn anyway, so the incremental cache loss is small relative to the new content being added. Net effect: one turn of extra cache-creation cost per L1 update. |
+| L1 injection update | **Low** — message [1] changes; L1a+L1b combined ~650t (was 2000t in v1) | L1a updates every turn but is small (~150t); L1b updates ~every 3-5 turns |
 | L1 periodic extraction | None — runs as separate cheap-model API call | Does not touch main conversation |
 | Microcompact | None — modifies volatile messages after cache breakpoint | Content changes are in non-cached region |
 | Compaction | Full cache reset (expected) | Notify CacheBreakDetector to suppress false-positive alerts |
@@ -493,28 +587,25 @@ At session start, the per-turn prefetch retrieves relevant memories from all typ
 ### 8.1 CLI Edge Mode
 
 ```
-L0: In-memory (process lifetime)
-L1: Local file + async sync to Memoria
-    - Path: {cwd}/.astra/sessions/{sid}/session-memory.md
-      (consistent with existing session_memory_extract.rs write_session_memory_file)
-    - Write locally first (low latency, atomic write via .tmp + rename)
-    - Background task syncs to Memoria every update
-    - Compaction reads local file first, falls back to Memoria
-    - Claude Code compatibility: also reads ~/.claude/projects/{cwd}/{sid}/session-memory/summary.md
-      via existing SessionMemoryFileCombine::Merge mode
-L2: Generated on-demand, stored in Memoria
-L3: Memoria (server-side)
+L0:  In-memory (process lifetime), derived from L1a facts
+L1a: In-memory (process lifetime), persisted in journal events + checkpoint
+     Rebuilt on session resume from journal + HeavyCheckpoint
+L1b: Local file + async sync to Memoria
+     Path: {cwd}/.astra/sessions/{sid}/session-memory.md
+     Claude Code compat: reads ~/.claude/projects/{cwd}/{sid}/session-memory/summary.md
+L2:  Generated on-demand (extreme fallback only)
+L3:  Memoria (server-side)
 ```
 
 ### 8.2 Web Agent Mode
 
 ```
-L0: In-memory (request-scoped, reconstructed from L1 on session resume)
-L1: Directly in Memoria (no local file)
-    - Store/correct via HTTP API
-    - Retrieve via HTTP API at compaction time
-L2: Generated on-demand, stored in Memoria
-L3: Memoria (server-side)
+L0:  In-memory, derived from L1a facts
+L1a: In-memory, persisted via cloud checkpoint
+     Rebuilt on session resume from cloud events + checkpoint
+L1b: Directly in Memoria (no local file)
+L2:  Generated on-demand (extreme fallback only)
+L3:  Memoria (server-side)
 ```
 
 ### 8.3 Claude Code Compatibility
@@ -542,40 +633,36 @@ Compaction triggered (pressure ≥ 75%):
     - Keep all system messages (including L0 anchor in system prompt)
     - Keep first user message (original task) — NEVER remove
     - Keep tail N turn pairs
-    - Identify and skip old compaction boundary messages (compact_metadata markers
-      from previous compactions) — prevents summary-of-summary nesting
+    - Skip old compaction boundary messages (compact_metadata markers)
 
-  Step 2: Wait for in-flight L1 update (max 15 seconds)
-    - If L1 extraction is in progress, wait for completion
-    - If timeout, proceed without L1
+  Step 2: Build SessionFacts from journal (zero LLM, instant)
+    - Always available — no waiting, no fallback needed
+    - This alone is sufficient for zero-LLM compaction
 
-  Step 3: Retrieve L1 from Memoria (or local file in CLI mode)
-    POST /v1/memories/search { query: "[session-memory:v1]", memory_types: ["working"] }
-    Filter by session_id + prefix match
+  Step 3: Retrieve L1b narrative from Memoria (or local file in CLI mode)
+    - Best-effort: if available, enriches the summary
+    - If unavailable (Memoria down, extraction not yet triggered): proceed without it
 
   Step 4: Choose summary source
-    ├─ L1 available, valid, and non-empty → Use L1 as summary (ZERO LLM compaction)
-    └─ L1 unavailable or malformed → Generate L2 with cheap model (9-section prompt)
+    ├─ L1a facts available (always) → Use facts as summary base (ZERO LLM)
+    │   ├─ L1b narrative available → Merge: facts + task spec + corrections + learnings
+    │   └─ L1b narrative unavailable → Facts alone (still zero LLM, still good)
+    └─ L1a facts somehow unavailable (journal corrupted) → Generate L2 with cheap model
 
-  Step 5: Build post-compact message array (with explicit roles)
-    [0] role:system  — System prompt (with L0 anchor in dynamic section)
-    [1] role:system  — Summary (L1 injection version or L2), with compact_metadata marker
-    [2] role:user    — Continuation prompt ("pick up where you left off")
-    [3..K] role:user + role:assistant — File restorations (synthetic read_file tool
-           call/result pairs for deduped recently-read files)
-    [K+1..] — Preserved tail messages (original roles)
+  Step 5: Build post-compact message array
+    [0] role:system  — System prompt (with L0 anchor)
+    [1] role:system  — Summary (L1a facts + L1b narrative), with compact_metadata marker
+    [2] role:user    — Continuation prompt
+    [3..K] — File restorations (deduped)
+    [K+1..] — Preserved tail messages
 
   Step 6: Post-compact actions
     - Store compaction summary as semantic memory in Memoria
-      with [compaction:{sid}] tag and compact_metadata in content
-    - Notify CacheBreakDetector (suppress false-positive alerts)
+    - Notify CacheBreakDetector
     - Reset microcompact state
-    - Clear section caches (system prompt, tool schemas)
-
-  Step 7: Store updated working memory
-    - If L1 was used as summary, no additional store needed
-    - If L2 was generated, store it as semantic memory with [compaction:{sid}] tag
 ```
+
+Key improvement over v1: **No 15-second wait for L1b extraction.** L1a (facts) is always available, so compaction is always instant and zero-LLM. L1b enriches if available but is never blocking.
 
 ### 9.1 Multi-Compaction Handling
 
@@ -593,35 +680,39 @@ A long session may compact multiple times. Key invariants:
 
 | Phase | Scope | Key Changes | Files |
 |-------|-------|-------------|-------|
-| **P0** | Goal preservation | TieredCompaction/ReactiveCompact preserve first user message; L0 anchor extraction + injection in system prompt; continuation prompt after compaction | `context_compression.rs`, `prompts/system.rs`, `memoria_compact.rs` |
-| **P1** | Microcompact improvements | Adaptive retention by pressure; duplicate read elimination; cache-aware clearing | `microcompact.rs` |
-| **P2** | L1 Session Memory | Template definition; cheap model extraction; per-section budget governance; Memoria store/correct; injection version compression | New: `session_memory.rs`; Modified: `bridge_inprocess.rs`, `server_loop_host.rs` |
-| **P3** | Zero-LLM compaction | L1 replaces L2 at compaction time; post-compact file restoration with dedup | `memoria_compact.rs`, `compact_prompt.rs` |
-| **P4** | L2 improvements | 9-section prompt with analysis scratchpad; anti-drift safeguards; format validation | `compact_prompt.rs` |
-| **P5** | L3 governance | Session end: knowledge backflow, episodic summary, working memory purge, goal update | `agentic_loop_lifecycle.rs`, `memoria_compact.rs` |
-| **P6** | Cloud-edge sync | CLI local file + async Memoria sync; web agent direct Memoria; CC compatibility | `session_memory.rs`, `memoria_compact.rs` |
+| **P0** | Goal preservation | TieredCompaction/ReactiveCompact preserve first user message; continuation prompt after compaction | `context_compression.rs`, `memoria_compact.rs` |
+| **P1** | L1a Session Facts | `SessionFacts` struct; update from journal events every turn; `to_injection()` serialization | New: `session_facts.rs` in runtime |
+| **P2** | L0 anchor from facts | `extract_anchor()` uses `SessionFacts` for State/Constraints instead of LLM narrative | `session_memory_protocol.rs` |
+| **P3** | L1b narrative slimdown | Template from 10→6 sections; extraction prompt only updates LLM-appropriate sections; error-triggered extraction | `session_memory_extract.rs`, `session_memory_protocol.rs` |
+| **P4** | Facts-first injection | `build_injection()` assembles L1a + L1b with cross-validation; pressure-adaptive levels | `session_memory_protocol.rs` |
+| **P5** | Facts-first compaction | Compaction uses L1a (always available) as base; L1b enriches; remove 15s wait | `memoria_compact.rs` |
+| **P6** | Microcompact improvements | Adaptive retention by pressure; duplicate read elimination; `SessionFacts.active_files` as pin list | `microcompact.rs` |
+| **P7** | L3 governance | Session end: knowledge backflow from L1b Learnings + User Corrections; working memory purge | `agentic_loop_lifecycle.rs` |
 
 ## 11. Metrics & Observability
 
 | Metric | Source | Purpose |
 |--------|--------|---------|
-| `session_memory.update_count` | L1 update trigger | Track extraction frequency |
-| `session_memory.update_latency_ms` | Cheap model API call | Monitor extraction cost |
-| `session_memory.injection_tokens` | Token count of injected L1 | Track token overhead |
-| `compaction.summary_source` | `l1_session_memory` / `l2_llm_summary` / `l2_fallback` | Track zero-LLM compaction rate |
-| `compaction.goal_preserved` | Boolean: was first user message + L0 anchor present post-compact | Verify goal preservation |
-| `cache.hit_rate` | Existing cache diagnostics | Verify memory injection doesn't degrade cache |
-| `cache.break_reason` | Existing cache break detector | Detect if L1 injection causes unexpected breaks |
+| `session_facts.update_count` | L1a turn-end update | Track facts freshness |
+| `session_facts.active_files_count` | L1a | Monitor file tracking coverage |
+| `session_narrative.update_count` | L1b extraction trigger | Track narrative extraction frequency |
+| `session_narrative.update_latency_ms` | Cheap model API call | Monitor extraction cost |
+| `session_memory.injection_tokens` | Token count of L1a+L1b injection | Track token overhead (target: ≤700t) |
+| `session_memory.cross_validation_warnings` | `build_injection()` | Track facts/narrative inconsistencies |
+| `compaction.summary_source` | `l1a_facts` / `l1a_facts_plus_narrative` / `l2_llm_summary` | Track zero-LLM compaction rate |
+| `compaction.goal_preserved` | Boolean: first user message + L0 anchor present post-compact | Verify goal preservation |
+| `cache.hit_rate` | Existing cache diagnostics | Verify injection doesn't degrade cache |
 
 ## 12. Risks & Mitigations
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| Cheap model produces low-quality L1 | Goal drift, incorrect state | Format validation (4.5): must contain required sections; 2 consecutive failures → pause L1, use L2 |
-| L1 update latency blocks main turn | User-visible delay | Async fire-and-forget (4.4); result available next turn; compaction waits max 15s then falls back to L2 |
-| Memoria unavailable during compaction | No L1 available | Fallback chain: local file (CLI) → L2 (LLM summary) → pure truncation with first-user-message preserved |
-| L1 injection invalidates conversation KV cache | Higher cache-creation costs | L1 updates ~every 3-5 turns; conversation changes every turn anyway; net cost is one turn of extra cache-creation per update (7.2) |
-| Per-section budgets too restrictive | Important info truncated | Stored version has generous budgets (4K total); injection version is separately compressed (2K); condensation prompt prioritizes Task/CurrentState/UserMessages |
-| Claude Code compatibility conflicts | Duplicate/conflicting memories | Merge mode with budget split (28% CC / 72% Memoria); CC file is read-only, never modified by astra-engine |
-| Multiple compactions nest summaries | Summary-of-summary quality degradation | Old compaction boundaries identified by compact_metadata and skipped (9.1); L1 is always latest version, not derived from previous summary |
-| Session resume without cached memory_id | Cannot update L1 via correct endpoint | Search fallback: `POST /v1/memories/search` with prefix filter recovers the memory_id (4.7) |
+| Cheap model produces low-quality L1b narrative | Incorrect task spec or decisions | Format validation (4.5); 2 consecutive failures → pause L1b; L1a facts alone is sufficient |
+| L1b update latency blocks main turn | User-visible delay | Async fire-and-forget; result available next turn; compaction does NOT wait (uses L1a facts) |
+| Memoria unavailable during compaction | No L1b narrative | L1a facts always available locally; L2 only needed if journal also corrupted |
+| L1a facts miss some state | Incomplete file/tool tracking | Facts are best-effort; narrative supplements; cross-validation catches inconsistencies |
+| L1b narrative contradicts L1a facts | Confusing injection | Cross-validation warning in `build_injection()`: "⚠️ Narrative says X but system shows Y" |
+| Per-section budgets too restrictive | Important info truncated | Stored version has 2000t total (generous for 6 sections); injection separately compressed |
+| User corrections lost before extraction | Correction dropped by compaction | Error-triggered extraction (4.3): TurnError → immediate L1b update captures correction |
+| Multiple compactions nest summaries | Summary-of-summary degradation | L1a facts are always fresh (not derived from previous summary); old boundaries identified by compact_metadata |
+| Session resume without cached facts | Cannot restore L1a | `SessionFacts::from_journal_and_checkpoint()` rebuilds from persisted journal + checkpoint |

--- a/docs/design/shell-permission-security-improvements.md
+++ b/docs/design/shell-permission-security-improvements.md
@@ -1,6 +1,6 @@
 # Shell & Permission Security Improvements
 
-Inspired by Claude Code's architecture, adapted to the existing Rust codebase.
+Layered security model adapted to the existing Rust codebase.
 
 ## Changes Summary
 
@@ -10,7 +10,7 @@ Inspired by Claude Code's architecture, adapted to the existing Rust codebase.
 
 - **Rule-based permissions**: Added `PermissionRule` with glob-style matching (`Bash(git commit:*)`)
 - **Settings persistence**: `PermissionSettings` loads/saves from `.kiro/permissions.json`
-- **Layered evaluation order** (matching Claude Code's architecture):
+- **Layered evaluation order**:
   1. Deny rules (bypass-immune — checked even with auto_approve)
   2. Session overrides
   3. Git safety checks (bypass-immune)
@@ -88,19 +88,15 @@ Validates git commands before execution:
 | Full runtime suite | 2312 tests | ✅ All pass |
 | Full CLI suite | 852 tests | ✅ All pass |
 
-## Architecture Alignment
+## Architecture
 
-The implementation follows Claude Code's layered security model while fitting into the existing Rust architecture:
+The implementation follows a layered security model:
 
 ```
-Claude Code (TypeScript)          →  astra-runtime (Rust)
+Module Mapping
 ─────────────────────────────────────────────────────────────
-permissions.ts (rule engine)      →  permission_manager.rs (PermissionRule + PermissionSettings)
-bashSecurity.ts (git validation)  →  git_safety.rs (validate_git_command)
-readOnlyValidation.ts (bare repo) →  git_safety.rs (is_bare_git_repo)
-bashProvider.ts (extglob/IFS)     →  shell_hardening.rs (build_hardened_command)
-subprocessEnv.ts (secret scrub)   →  shell_hardening.rs (scrub_secrets_from_env)
-ShellCommand.ts (streaming)       →  shell.rs (run_command_streaming)
-ShellCommand.ts (backgrounding)   →  shell.rs (size_watchdog)
-filesystem.ts (dangerous paths)   →  shell_hardening.rs (DANGEROUS_FILE_PATHS)
+permission_manager.rs   — PermissionRule + PermissionSettings
+git_safety.rs           — validate_git_command, is_bare_git_repo
+shell_hardening.rs      — build_hardened_command, scrub_secrets_from_env, DANGEROUS_FILE_PATHS
+shell.rs                — run_command_streaming, size_watchdog
 ```

--- a/rust/crates/astra-cli/src/cli/agent_loader.rs
+++ b/rust/crates/astra-cli/src/cli/agent_loader.rs
@@ -1,6 +1,6 @@
 //! Load custom agent profiles from Markdown files with YAML frontmatter.
 //!
-//! Inspired by Claude Code's `.claude/agents/*.md` pattern, this module
+//! This module
 //! scans well-known directories for agent definition files and builds
 //! [`AgentProfile`] structs that the delegation engine can use.
 //!

--- a/rust/crates/astra-cli/src/cli/cli_formatting.rs
+++ b/rust/crates/astra-cli/src/cli/cli_formatting.rs
@@ -302,9 +302,9 @@ fn find_comment_start(code: &str) -> Option<usize> {
     let mut in_string = false;
     let mut string_char = '\0';
     let mut escape_next = false;
-    let chars: Vec<char> = code.chars().collect();
 
-    for (i, &c) in chars.iter().enumerate() {
+    let mut chars = code.char_indices().peekable();
+    while let Some((byte_pos, c)) = chars.next() {
         if escape_next {
             escape_next = false;
             continue;
@@ -319,11 +319,11 @@ fn find_comment_start(code: &str) -> Option<usize> {
             if c == '"' || c == '\'' {
                 in_string = true;
                 string_char = c;
-            } else if c == '/' && chars.get(i + 1) == Some(&'/') {
-                return Some(i);
+            } else if c == '/' && chars.peek().map(|&(_, nc)| nc) == Some('/') {
+                return Some(byte_pos);
             } else if c == '#' {
                 // Python/shell comment
-                return Some(i);
+                return Some(byte_pos);
             }
         } else if c == string_char {
             in_string = false;
@@ -452,6 +452,37 @@ mod tests {
         let output3 = highlight_code_line(input3);
         let stripped3 = strip_ansi(&output3);
         assert!(stripped3.starts_with("10000│"));
+    }
+
+    #[test]
+    fn test_find_comment_start_multibyte() {
+        // '#' after CJK chars — byte offset must be returned, not char index
+        let s = "| 错误学习 | # comment";
+        let pos = find_comment_start(s).unwrap();
+        assert_eq!(&s[pos..pos + 1], "#");
+    }
+
+    #[test]
+    fn test_highlight_code_line_multibyte() {
+        // Must not panic on CJK content with comment-like characters
+        let input = "| 错误学习 | 写入 `## Errors`（`[lesson]` 标签） |";
+        let _output = highlight_code_line(input);
+    }
+
+    #[test]
+    fn test_floor_char_boundary_truncation_safety() {
+        // Regression: raw truncate at byte offset inside multi-byte char panics.
+        // All truncation sites must use floor_char_boundary.
+        let s = "abc你好def".to_string(); // 你 = bytes 3..6, 好 = bytes 6..9
+        for n in 0..=s.len() {
+            let boundary = s.floor_char_boundary(n);
+            // Must not panic
+            let _ = &s[..boundary];
+        }
+        // Verify it rounds down correctly
+        assert_eq!(s.floor_char_boundary(4), 3); // inside '你', rounds to 3
+        assert_eq!(s.floor_char_boundary(5), 3);
+        assert_eq!(s.floor_char_boundary(6), 6); // exact boundary of '好'
     }
 
     /// Helper to strip ANSI escape codes for testing

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -1471,7 +1471,7 @@ fn is_read_only_allowlisted(lower_cmd: &str) -> bool {
         return false;
     }
 
-    // Minimal allowlist, modeled after Claude Code's "read-only command subsets" idea.
+    // Minimal allowlist of read-only commands.
     // Kept deliberately small to avoid silently allowing write-capable commands.
     let prefixes = [
         "git status",

--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -26,7 +26,7 @@ pub(super) fn enqueue_ingestion_pub(state: &ReplState, event: &session_journal::
 }
 
 /// Pull a few Memoria hits after compact so the shortened context keeps **session-relevant**
-/// recall (similar in spirit to Claude Code keeping session memory as an anchor).
+/// recall (keeps session-relevant context as an anchor after compaction).
 const COMPACT_ANCHOR_QUERY_MAX: usize = 220;
 const COMPACT_ANCHOR_TOP_K: u32 = 3;
 const COMPACT_ANCHOR_MAX_LINES: usize = 3;

--- a/rust/crates/astra-cli/src/cli/slash_info.rs
+++ b/rust/crates/astra-cli/src/cli/slash_info.rs
@@ -349,7 +349,7 @@ fn prefetch_review_git_stat(project_root: &std::path::Path, target: ReviewGitTar
     }
     let mut s = trimmed.to_string();
     if s.len() > REVIEW_PREFETCH_MAX {
-        s.truncate(REVIEW_PREFETCH_MAX);
+        s.truncate(s.floor_char_boundary(REVIEW_PREFETCH_MAX));
         s.push_str("\n[truncated]");
     }
     s
@@ -419,7 +419,7 @@ fn format_review_search_result(files: &[String], raw: &str) -> String {
     }
 
     if out.len() > 20_000 {
-        out.truncate(20_000);
+        out.truncate(out.floor_char_boundary(20_000));
         out.push_str("\n[truncated]");
     }
     out

--- a/rust/crates/astra-cli/src/edge_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools.rs
@@ -147,8 +147,7 @@ fn tool_output_limit() -> usize {
 /// Glob results are filename-only, so 100KB is fine. Bash has its own
 /// streaming cap at 30KB. Everything else uses the global default.
 ///
-/// Inspired by Claude Code's per-tool `maxResultSizeChars` overrides
-/// (grep: 20K, glob: 100K, default: 50K).
+/// Per-tool output size overrides (grep: 10K, glob: 100K, default: 50K).
 pub(crate) fn per_tool_output_limit(tool_name: &str) -> usize {
     let base = tool_output_limit();
     match tool_name {
@@ -173,7 +172,7 @@ const AGGREGATE_SOFT_LIMIT: usize = 120_000;
 /// this AND aggregate output is above the soft limit, the result is persisted
 /// to disk and replaced with a preview + file path. The model can use
 /// `read_file` with `start_line/end_line` to access specific parts.
-/// Inspired by Claude Code's `DEFAULT_MAX_RESULT_SIZE_CHARS` (50K).
+/// Global default for large-output persistence threshold (50K).
 const PERSIST_THRESHOLD: usize = 50_000;
 
 /// Preview size (bytes) included in the persisted-output reference message.
@@ -226,7 +225,7 @@ fn truncate_output(mut output: String, max_bytes: usize) -> String {
 
 /// Normalize empty/whitespace-only tool output to a short marker.
 /// Prevents model confusion from truly empty tool results.
-/// Inspired by Claude Code's `isToolResultContentEmpty` guard.
+/// Prevents model confusion from truly empty tool results.
 fn normalize_empty_output(output: String, tool_name: &str) -> String {
     if output.trim().is_empty() {
         format!("({tool_name} completed with no output)")
@@ -348,8 +347,8 @@ pub struct ToolExecutor {
     file_state: std::sync::Mutex<HashMap<PathBuf, FileState>>,
     /// Per-turn aggregate tool output size (bytes). When this exceeds
     /// `AGGREGATE_OUTPUT_BUDGET`, subsequent tool outputs are truncated
-    /// more aggressively. Inspired by Claude Code's
-    /// `MAX_TOOL_RESULTS_PER_MESSAGE_CHARS` (200K).
+    /// more aggressively.
+    /// Per-turn aggregate budget is 200K.
     aggregate_output_bytes: std::sync::atomic::AtomicUsize,
     /// URL fetch cache: LRU-style cache mapping URL → (response, timestamp).
     /// Returns cached response for repeated fetches within TTL (15 minutes).
@@ -1131,8 +1130,8 @@ impl ToolExecutor {
     /// ~2KB preview + file path. The model can use `read_file` with
     /// `start_line/end_line` to access specific parts of the persisted file.
     ///
-    /// Inspired by Claude Code's `toolResultStorage.ts` which persists large
-    /// results to `~/.claude/projects/<hash>/<session>/tool-results/`.
+    /// Large results are persisted to a temp file and replaced with a
+    /// ~2KB preview + file path.
     fn maybe_persist_large_output(&self, output: String, _tool_name: &str) -> String {
         // Skip small outputs
         if output.len() < PERSIST_THRESHOLD {

--- a/rust/crates/astra-cli/src/edge_tools/agent_messaging.rs
+++ b/rust/crates/astra-cli/src/edge_tools/agent_messaging.rs
@@ -3,7 +3,7 @@
 //! Provides `send_message` tool for point-to-point and broadcast communication
 //! between agents during delegation or team collaboration.
 //!
-//! Features (vs Claude Code's file-based mailbox):
+//! Features:
 //! - Database-backed transport (optional) with ack/nack
 //! - Dead letter queue for failed deliveries
 //! - Structured message types with priorities

--- a/rust/crates/astra-cli/src/edge_tools/ask_user.rs
+++ b/rust/crates/astra-cli/src/edge_tools/ask_user.rs
@@ -62,7 +62,7 @@ impl ToolExecutor {
             }
             // Truncate if too long
             if response.len() > MAX_INPUT_LEN {
-                response.truncate(MAX_INPUT_LEN);
+                response.truncate(response.floor_char_boundary(MAX_INPUT_LEN));
             }
             let response = response.trim();
             let answer = if response.is_empty() {
@@ -190,7 +190,7 @@ impl ToolExecutor {
                     return "Error: failed to read user input".to_string();
                 }
                 if response.len() > MAX_INPUT_LEN {
-                    response.truncate(MAX_INPUT_LEN);
+                    response.truncate(response.floor_char_boundary(MAX_INPUT_LEN));
                 }
                 let trimmed = response.trim();
                 if trimmed.is_empty() {

--- a/rust/crates/astra-cli/src/edge_tools/file_state.rs
+++ b/rust/crates/astra-cli/src/edge_tools/file_state.rs
@@ -1,7 +1,7 @@
 //! File state tracking for staleness detection and read deduplication.
 //!
 //! Tracks mtime after each read/write/edit to prevent overwriting user edits
-//! and skip re-reading unchanged files. Inspired by Claude Code's readFileState.
+//! and skip re-reading unchanged files.
 
 use std::collections::HashMap;
 use std::fs;
@@ -23,8 +23,8 @@ const MAX_CACHED_FILE_BYTES: usize = 256 * 1024;
 /// keeping metadata intact for dedup/staleness tracking.
 const MAX_TOTAL_CACHED_BYTES: usize = 8 * 1024 * 1024;
 
-/// Shape of the last `read_file` call, for consecutive-request dedup (same idea as
-/// Claude Code `FileReadTool`: same offset+limit + unchanged mtime → stub before I/O).
+/// Shape of the last `read_file` call, for consecutive-request dedup (same
+/// offset+limit + unchanged mtime → stub before I/O).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ReadDedupKey {
     Full,
@@ -37,7 +37,6 @@ pub(crate) enum ReadDedupKey {
 }
 
 /// Tracks the last-read state of a file for staleness detection and dedup.
-/// Inspired by Claude Code's readFileState mechanism.
 pub(super) struct FileState {
     /// mtime (milliseconds) at the time of last read/write.
     pub(super) timestamp_ms: u128,
@@ -56,8 +55,7 @@ pub(super) struct FileState {
     pub(super) last_dedup_key: ReadDedupKey,
     /// Cached full file content. Stored on reads/writes when the full content
     /// is available and fits within `MAX_CACHED_FILE_BYTES`. Serves subsequent
-    /// reads without disk I/O when mtime is unchanged. Inspired by Claude Code's
-    /// FileStateCache content caching.
+    /// reads without disk I/O when mtime is unchanged.
     pub(super) cached_content: Option<String>,
     /// Merged line ranges already read (sorted, non-overlapping).
     /// Used to detect when a new ranged read is fully covered by prior reads.
@@ -282,7 +280,7 @@ impl ToolExecutor {
     }
 
     /// Consecutive identical partial read (outline or same raw line range) with unchanged
-    /// mtime — stub **before** disk read, like Claude Code `tengu_file_read_dedup` for
+    /// mtime — stub **before** disk read for
     /// the same offset/limit as the immediately previous read.
     pub(super) fn can_dedup_identical_partial_read(
         &self,
@@ -314,8 +312,7 @@ impl ToolExecutor {
     }
 
     /// Check if we can dedup a read (previous op was a full read, unchanged mtime).
-    /// Respects `MO_DEDUP_DISABLED=1` env var killswitch (inspired by Claude Code's
-    /// `tengu_read_dedup_killswitch` feature flag).
+    /// Respects `MO_DEDUP_DISABLED=1` env var killswitch.
     pub(super) fn can_dedup_read(&self, path: &Path) -> bool {
         if std::env::var("MO_DEDUP_DISABLED").is_ok_and(|v| v == "1" || v == "true") {
             return false;

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -247,7 +247,7 @@ impl ToolExecutor {
             }
         }
 
-        // Raw range keys (match Claude Code offset/limit identity for consecutive dedup).
+        // Raw range keys for consecutive dedup.
         let start_raw = args.get("start_line").and_then(Value::as_u64);
         let end_raw = args.get("end_line").and_then(Value::as_u64);
         let has_range = start_raw.is_some() || end_raw.is_some();
@@ -266,8 +266,7 @@ impl ToolExecutor {
             ReadDedupKey::Full
         };
 
-        // Consecutive identical outline/range request + unchanged file → stub before I/O
-        // (Claude Code FileReadTool dedup for the same offset/limit as last read).
+        // Consecutive identical outline/range request + unchanged file → stub before I/O.
         if self.can_dedup_identical_partial_read(&path, &dedup_key) {
             return format!(
                 "[Same read_file request as immediately before — file unchanged. \
@@ -293,7 +292,6 @@ impl ToolExecutor {
 
         // Pre-read size gate: check file size before reading.
         // Large files without a line range should use outline or start_line/end_line.
-        // Inspired by Claude Code's maxSizeBytes (256KB) pre-read check.
         if !has_range
             && !has_outline
             && let Ok(meta) = fs::metadata(&path)
@@ -314,8 +312,7 @@ impl ToolExecutor {
         // Aggregate output gate: when cumulative tool output this turn is
         // already high and a full-file read would be too large, auto-downgrade
         // to outline mode instead of blocking. Ranged reads are always allowed
-        // (they're already targeted). Inspired by Claude Code's approach of
-        // never blocking tool calls but degrading gracefully.
+        // (they're already targeted). Degrades gracefully instead of blocking.
         if !has_range && !has_outline {
             let agg = self
                 .aggregate_output_bytes
@@ -521,8 +518,7 @@ impl ToolExecutor {
         self.record_read_cached(&path, is_ranged, record_key, content.clone());
 
         // Escalating warning when the same file is read too many times.
-        // Inspired by Claude Code's dedup stub behavior: train the model
-        // to stop re-reading by making the cost of repetition visible.
+        // Trains the model to stop re-reading by making the cost of repetition visible.
         let read_count = self.file_read_count(&path);
         let ranged_count = self.file_ranged_read_count(&path);
         let read_warning = if read_count >= 4 {
@@ -3457,7 +3453,7 @@ type Handler interface {
         );
     }
 
-    // ── Claude Code–style consecutive identical partial read dedup ───────────
+    // ── Consecutive identical partial read dedup ───────────
 
     #[test]
     fn read_file_consecutive_identical_range_dedups() {

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -102,7 +102,6 @@ fn last_pipeline_command(command: &str) -> &str {
 
 // ---------------------------------------------------------------------------
 // Destructive command detection — warn before dangerous operations.
-// Inspired by Claude Code's destructiveCommandWarning.ts.
 // ---------------------------------------------------------------------------
 
 /// Check if a bash command references file paths outside the sandbox boundary.
@@ -2388,10 +2387,10 @@ fn run_command_with_cleanup(
 }
 
 // ---------------------------------------------------------------------------
-// Streaming output support — inspired by Claude Code's ShellCommand.ts
+// Streaming output support
 // ---------------------------------------------------------------------------
 
-/// Maximum output size before truncation (30K chars, matching Claude Code's default).
+/// Maximum output size before truncation (30K chars).
 const MAX_OUTPUT_CHARS: usize = 30_000;
 
 /// Size watchdog poll interval for backgrounded tasks.
@@ -2399,7 +2398,6 @@ const SIZE_WATCHDOG_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Execute a command with streaming output and optional auto-backgrounding on timeout.
 ///
-/// Inspired by Claude Code's `ShellCommandImpl`:
 /// - Streams stdout/stderr incrementally via `on_output` callback
 /// - On timeout: backgrounds the process instead of killing it (if `allow_background` is true)
 /// - Watchdog kills backgrounded processes after 30 minutes
@@ -2577,7 +2575,6 @@ enum OutputChunk {
 
 /// Time-limit watchdog for backgrounded processes.
 /// Kills the process after 30 minutes to prevent indefinite resource consumption.
-/// Inspired by Claude Code's background task management.
 fn size_watchdog(
     mut child: std::process::Child,
     stdout_thread: std::thread::JoinHandle<()>,
@@ -2724,7 +2721,7 @@ fn run_readonly_command_with_partial(
                             output.push_str(&chunk);
                         }
                     }
-                    // Drop the last line — it may be incomplete (like Claude Code)
+                    // Drop the last line — it may be incomplete
                     if let Some(last_nl) = output.rfind('\n') {
                         output.truncate(last_nl);
                     }
@@ -3681,7 +3678,7 @@ impl ToolExecutor {
                 }
 
                 if result.len() > max_bytes {
-                    result.truncate(max_bytes);
+                    result.truncate(result.floor_char_boundary(max_bytes));
                     result.push_str("\n[truncated]");
                 }
 
@@ -6708,5 +6705,16 @@ mod tests {
             result.contains("⚠️"),
             "command containing destructive pattern should have warning: {result}"
         );
+    }
+
+    #[test]
+    fn truncate_multibyte_does_not_panic() {
+        // Regression: raw truncate at byte offset inside multi-byte char panics.
+        let mut s = "café ☕ 你好世界".to_string();
+        let limit = 10; // lands inside '☕' (bytes 6..9)
+        let boundary = s.floor_char_boundary(limit);
+        s.truncate(boundary);
+        s.push_str("\n[truncated]");
+        assert!(s.starts_with("café "));
     }
 }

--- a/rust/crates/astra-cli/src/manifest_loader.rs
+++ b/rust/crates/astra-cli/src/manifest_loader.rs
@@ -8,7 +8,7 @@
 
 #![allow(deprecated)]
 //!
-//! Also supports SKILL.md files for detailed instructions (Claude Code style).
+//! Also supports SKILL.md files for detailed instructions.
 //!
 #![allow(dead_code)] // Module provides future extensibility APIs
 //! Example manifest with tools:

--- a/rust/crates/astra-cli/src/mcp_client.rs
+++ b/rust/crates/astra-cli/src/mcp_client.rs
@@ -1929,7 +1929,6 @@ pub enum McpError {
 }
 
 /// Maximum length for tool descriptions sent to the model.
-/// Matches Claude Code's MAX_MCP_DESCRIPTION_LENGTH.
 pub const MAX_DESCRIPTION_LENGTH: usize = 2048;
 
 /// Maximum character length for tool call result content.

--- a/rust/crates/astra-cli/src/skill_instructions.rs
+++ b/rust/crates/astra-cli/src/skill_instructions.rs
@@ -1,6 +1,6 @@
 //! SKILL.md parser: parse skill instruction files with YAML frontmatter + Markdown body.
 //!
-//! This module implements Claude Code-style skill instructions, allowing skills to include
+//! This module parses skill instruction files, allowing skills to include
 //! detailed, step-by-step guidance that gets injected into the agent's context when the
 //! skill is invoked.
 //!
@@ -33,7 +33,7 @@
 //! # Discovery Paths
 //!
 //! Skills are discovered from (highest priority first):
-//! 1. `{cwd}/.astra/skills/` — project-level (Claude Code–style `.claude/skills`)
+//! 1. `{cwd}/.astra/skills/` — project-level
 //! 2. `{cwd}/skills/` — project-level (explicit)
 //! 3. `~/.astra/skills/` — user-level global skills
 //!
@@ -54,7 +54,7 @@ use std::path::{Path, PathBuf};
 
 /// Standard skill directory search order (high → low priority):
 ///
-/// 1. `{cwd}/.astra/skills/`  — project-level (Claude Code–style .claude/skills)
+/// 1. `{cwd}/.astra/skills/`  — project-level
 /// 2. `{cwd}/skills/`         — project-level (legacy / explicit)
 /// 3. `~/.astra/skills/`      — user-level global skills
 pub fn skill_search_paths() -> Vec<PathBuf> {
@@ -93,7 +93,7 @@ pub struct SkillInstruction {
     #[serde(default)]
     pub allowed_tools: Vec<String>,
 
-    // ── Claude Code–aligned extended fields ──
+    // ── Extended fields ──
     /// When this skill should be activated (natural-language hint for the model).
     /// Analogous to CC's `whenToUse` frontmatter field.
     #[serde(default)]

--- a/rust/crates/astra-sandbox/src/command.rs
+++ b/rust/crates/astra-sandbox/src/command.rs
@@ -63,8 +63,8 @@ pub fn sandbox_command(
 /// Applies shell hardening (extglob disable, IFS reset, stdin redirect)
 /// for Standard+ modes.
 ///
-/// Note: ulimit-based resource limits were removed to match Claude Code's
-/// approach (relies on timeouts and concurrent tool limits instead).
+/// Note: ulimit-based resource limits were removed (relies on timeouts
+/// and concurrent tool limits instead).
 /// ulimit -u is UID-wide and caused false-positive fork failures.
 pub fn wrap_command_with_limits(policy: &SandboxPolicy, user_command: &str) -> String {
     if policy.mode == SandboxMode::Permissive {
@@ -316,7 +316,7 @@ mod tests {
     fn standard_applies_shell_hardening() {
         let p = SandboxPolicy::for_project("/tmp");
         let wrapped = wrap_command_with_limits(&p, "echo hello");
-        // No ulimit restrictions (removed to match Claude Code approach)
+        // No ulimit restrictions (removed for reliability)
         assert!(
             !wrapped.contains("ulimit"),
             "should NOT contain ulimit (removed)"

--- a/rust/crates/astra-sandbox/src/git_safety.rs
+++ b/rust/crates/astra-sandbox/src/git_safety.rs
@@ -1,6 +1,5 @@
 //! Git safety validation for shell commands.
 //!
-//! Inspired by Claude Code's `bashSecurity.ts`, `readOnlyValidation.ts`, and `gitSafety.ts`.
 //! Provides defense-in-depth checks that run *before* a git command is executed.
 
 use std::path::Path;

--- a/rust/crates/astra-sandbox/src/policy.rs
+++ b/rust/crates/astra-sandbox/src/policy.rs
@@ -16,7 +16,7 @@ pub enum SandboxMode {
 /// Configurable security policy for tool execution.
 ///
 /// Note: ulimit-based resource limits (max_processes, max_memory_bytes) were
-/// removed to match Claude Code's approach. Resource control now relies on:
+/// removed. Resource control now relies on:
 /// - Concurrent tool execution limit (MAX_CONCURRENT_READ_ONLY_TOOLS = 10)
 /// - Per-command timeouts (max_execution_secs)
 ///

--- a/rust/crates/astra-sandbox/src/shell_hardening.rs
+++ b/rust/crates/astra-sandbox/src/shell_hardening.rs
@@ -1,6 +1,5 @@
 //! Shell security hardening for command execution.
 //!
-//! Inspired by Claude Code's `bashProvider.ts`, `subprocessEnv.ts`, and `shellQuote.ts`.
 //! Provides:
 //! - Extglob/extended-glob disabling (prevents malicious filename expansion after validation)
 //! - IFS reset (prevents word-splitting attacks)
@@ -37,11 +36,9 @@ pub const DANGEROUS_FILE_PATHS: &[&str] = &[
 ];
 
 /// Environment variables that contain secrets and must be scrubbed from subprocesses.
-/// Inspired by Claude Code's `subprocessEnv.ts` scrub list.
 pub const SENSITIVE_ENV_VARS: &[&str] = &[
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
-    "CLAUDE_CODE_OAUTH_TOKEN",
     "AWS_SECRET_ACCESS_KEY",
     "AWS_SESSION_TOKEN",
     "ACTIONS_ID_TOKEN_REQUEST_TOKEN",

--- a/rust/crates/astra-skills/src/activation.rs
+++ b/rust/crates/astra-skills/src/activation.rs
@@ -1,7 +1,7 @@
 //! Conditional skill activation — path-glob matching and trigger detection.
 //!
 //! Skills with `paths` frontmatter are only visible after the model touches
-//! matching files (inspired by Claude Code's conditional skills).
+//! matching files (conditional activation based on path globs).
 
 use super::manifest::SkillManifest;
 

--- a/rust/crates/astra-skills/src/hooks.rs
+++ b/rust/crates/astra-skills/src/hooks.rs
@@ -3,11 +3,9 @@
 //! Three hook systems coexist:
 //!
 //! 1. **Skill lifecycle hooks** (`SkillHooks`) — pre/post invocation of a skill itself.
-//! 2. **Tool event hooks** (`ToolEventHook`) — fire on any tool call matching a pattern,
-//!    inspired by Claude Code's PreToolUse / PostToolUse system.
+//! 2. **Tool event hooks** (`ToolEventHook`) — fire on any tool call matching a pattern.
 //! 3. **Session event hooks** (`SessionEventHook`) — fire on session lifecycle events
-//!    (SessionStart, SessionEnd, UserPromptSubmit, SubagentStart), compatible with
-//!    Claude Code's hook event model.
+//!    (SessionStart, SessionEnd, UserPromptSubmit, SubagentStart).
 
 use serde::{Deserialize, Serialize};
 
@@ -941,8 +939,6 @@ pub enum SkillLifecycleEvent {
 // ── Session event hooks (CC-compatible) ─────────────────────────────────
 
 /// Session lifecycle events that can trigger hooks.
-///
-/// Compatible with Claude Code's hook event model.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionEvent {

--- a/rust/crates/astra-turn-types/src/implicit_feedback.rs
+++ b/rust/crates/astra-turn-types/src/implicit_feedback.rs
@@ -11,9 +11,8 @@ pub struct ImplicitSignal {
 
 /// Structured feedback extracted from a correction signal.
 ///
-/// Inspired by Claude Code's feedback memory format: captures *why* the user
-/// corrected and *when* the rule applies, so the system can judge edge cases
-/// rather than blindly following statistical patterns.
+/// Captures *why* the user corrected and *when* the rule applies, so the system
+/// can judge edge cases rather than blindly following statistical patterns.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct StructuredFeedback {
     /// The rule itself — what the user wants changed.

--- a/rust/crates/runtime/src/pipeline/feedback_extraction.rs
+++ b/rust/crates/runtime/src/pipeline/feedback_extraction.rs
@@ -5,7 +5,7 @@
 //! the rule, the reason (why), and when it applies.
 //!
 //! This bridges the gap between Astra's regex-based signal detection and
-//! Claude Code's LLM-driven semantic understanding of user corrections.
+//! LLM-driven semantic understanding of user corrections.
 
 use astra_turn_types::StructuredFeedback;
 

--- a/rust/crates/runtime/src/pipeline/learning_quality_gate.rs
+++ b/rust/crates/runtime/src/pipeline/learning_quality_gate.rs
@@ -1,7 +1,7 @@
 //! Learning Quality Gate — filters out low-value or derivable signals before
 //! they enter the learning pipeline.
 //!
-//! Inspired by Claude Code's "what not to save" rules: code patterns,
+//! Filters out low-value or derivable signals: code patterns,
 //! architecture, git history, and file structure are derivable from the
 //! codebase and should not pollute the learning system.
 

--- a/rust/crates/runtime/src/server/agent_mailbox.rs
+++ b/rust/crates/runtime/src/server/agent_mailbox.rs
@@ -1,7 +1,6 @@
 //! Bidirectional Agent Communication (D-8)
 //!
-//! An in-memory mailbox system for agent-to-agent messaging, inspired by
-//! Claude Code's SendMessageTool + file-system mailbox architecture.
+//! An in-memory mailbox system for agent-to-agent messaging.
 //!
 //! Key features:
 //! - Unicast (agent-to-agent) and broadcast messaging

--- a/rust/crates/runtime/src/tool_registry/tool_pool.rs
+++ b/rust/crates/runtime/src/tool_registry/tool_pool.rs
@@ -1,7 +1,6 @@
 //! ToolPool: two-phase tool selection for large dynamic tool sets.
 //!
-//! This module is the runtime-native analogue of Claude Code's ToolSearch:
-//! instead of relying on `tool_reference` blocks, we keep a large searchable
+//! Instead of relying on `tool_reference` blocks, we keep a large searchable
 //! metadata index and only materialize full tool schemas for the small set of
 //! selected tools.
 
@@ -108,8 +107,6 @@ impl Default for ToolSearchConfig {
 }
 
 /// Persisted tool-search state across turns/compaction boundaries.
-///
-/// This is the runtime-native equivalent of Claude Code's "discovered tools set".
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ToolSearchState {
     /// Tools that have been materialized/selected previously in this conversation.

--- a/rust/crates/runtime/src/turn/agent_progress_ui.rs
+++ b/rust/crates/runtime/src/turn/agent_progress_ui.rs
@@ -1,8 +1,7 @@
 //! Terminal Progress Visualization for Sub-Agent Execution (D-11)
 //!
 //! Provides a structured progress display for multi-agent runs in CLI mode.
-//! Inspired by Claude Code's Tmux/iTerm2 split-pane visualization where
-//! each agent has a visible progress indicator.
+//! Each agent has a visible progress indicator.
 //!
 //! This module provides the data model and text-rendering layer. It does NOT
 //! depend on ratatui or ncurses — it uses simple ANSI escape sequences for

--- a/rust/crates/runtime/src/turn/approval_fingerprint.rs
+++ b/rust/crates/runtime/src/turn/approval_fingerprint.rs
@@ -3,8 +3,7 @@
 //! Instead of keying session overrides by bare tool name (`"bash" → allow`),
 //! this module produces content-aware fingerprints that distinguish between
 //! e.g. `bash("git status")` and `bash("rm -rf /")`. Denial tracking implements
-//! consecutive/total limits inspired by Claude Code's `denialTracking.ts`,
-//! preventing infinite approval loops from stalling sessions.
+//! consecutive/total limits prevent infinite approval loops from stalling sessions.
 //!
 //! Phase C enhancement: When 2+ denials share a similar pattern (same tool +
 //! command prefix, or same denial reason keyword), auto-generates session deny
@@ -211,7 +210,7 @@ fn path_pattern_matches(pattern: &str, candidate: &str) -> bool {
 
 // ─── Denial Tracking ─────────────────────────────────────────────────────────
 
-/// Limits for denial tracking (inspired by Claude Code's `denialTracking.ts`).
+/// Limits for denial tracking.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DenialLimits {
     /// Max consecutive denials for the same fingerprint before fallback.

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -1,14 +1,14 @@
 /// In-process ChatTurnBridge — calls LLM directly without an external bridge service.
 ///
-/// # Claude Code–style behaviors mapped onto this stack
+/// # Key behaviors
 ///
-/// | Claude Code (desktop) | Here |
+/// | Behavior | Implementation |
 /// |------------------------|------|
 /// | Long-lived stream “stall” / no chunks | [`super::llm_client::stream_idle_timeout`] on SSE `next()` (90s default, `MO_STREAM_IDLE_TIMEOUT_MS`) |
 /// | Recover via one-shot completion | [`super::llm_client::call_llm_nonstream_fallback`] after idle in both `call_llm_and_collect` and [`call_llm_stream`] below |
 /// | User cancel clears in-flight work | HTTP `/chat/turn` passes `CancellationToken`; dropping the SSE body (client disconnect) cancels in-flight LLM byte/SSE consumption in-process |
 /// | Cooldown / 429 wait cannot ignore disconnect | [`super::llm_client::sleep_ms_or_llm_cancel`] on retry backoff + rate-limit waits in [`call_llm_stream`]; initial cooldown wait `select!`s [`wait_until_cancelled_or_pending`](super::llm_client::wait_until_cancelled_or_pending) in the bridge stream |
-/// | Tool permission queue + single resolve | CLI: `astra-cli` `permission_manager`; cloud: edge approval ledger / `POST /tools/result`. Claude’s `PermissionContext` “resolve once” matches ledger single-shot semantics |
+/// | Tool permission queue + single resolve | CLI: `astra-cli` `permission_manager`; cloud: edge approval ledger / `POST /tools/result`. "resolve once" matches ledger single-shot semantics |
 ///
 /// # Legacy Status
 ///
@@ -54,7 +54,6 @@ use futures_util::{StreamExt, stream};
 
 /// Maximum number of read-only tools to execute concurrently.
 /// Prevents resource exhaustion from parallel tool execution.
-/// Matches Claude Code's default `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY`.
 const MAX_CONCURRENT_READ_ONLY_TOOLS: usize = 10;
 use serde_json::{Map, Value, json};
 use tokio_util::sync::CancellationToken;
@@ -697,7 +696,6 @@ fn rate_limit_cooldown() -> &'static PerModelCooldown {
 
 // ── Cache Configuration (session-latched) ────────────────────────────────────
 // Latched at session start to prevent mid-session flips from busting the cache.
-// Claude Code calls these "session-stable latches."
 
 /// Prompt cache configuration, latched once per session.
 ///
@@ -932,8 +930,8 @@ pub(crate) fn build_system_message(
 /// - Tools: 1 breakpoint (last tool only)
 /// - Messages: 1 breakpoint (last message)
 ///
-/// This matches Claude Code's strategy of prioritizing message history caching
-/// for multi-turn conversations while still caching the stable tool prefix.
+/// Prioritizes message history caching for multi-turn conversations
+/// while still caching the stable tool prefix.
 pub(crate) fn annotate_tool_schemas_for_caching(
     tools: &mut [Value],
     cache_cfg: &PromptCacheConfig,
@@ -987,7 +985,7 @@ fn bridge_llm_cancel(cc: &Option<Arc<CancellationToken>>) -> LlmCancel<'_> {
 /// Emits: text_delta, reasoning_delta, reasoning_done, tool_call_start, usage SSE events,
 /// then a final `_inprocess_summary` event with full_text/tool_calls/usage/model_used.
 ///
-/// **Stream resilience (Claude Code–style, same as [`super::llm_client::call_llm_and_collect`])**:
+/// **Stream resilience (same as [`super::llm_client::call_llm_and_collect`])**:
 /// per-chunk idle watchdog on parsed SSE; if the provider stops sending, partial state is
 /// discarded and a **single non-stream** `/chat/completions` request attempts recovery.
 ///

--- a/rust/crates/runtime/src/turn/cache_diagnostics.rs
+++ b/rust/crates/runtime/src/turn/cache_diagnostics.rs
@@ -4,8 +4,7 @@
 //! the KV cache prefix is broken. Classifies breaks by cause and logs
 //! diagnostics with token impact estimates.
 //!
-//! Inspired by Claude Code's `promptCacheBreakDetection.ts`, but with
-//! auto-remediation suggestions and richer classification.
+//! diagnostics with token impact estimates and auto-remediation suggestions.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/rust/crates/runtime/src/turn/cloud/analytics.rs
+++ b/rust/crates/runtime/src/turn/cloud/analytics.rs
@@ -290,8 +290,7 @@ fn find_last_assistant_timestamp(messages: &[Value]) -> Option<u64> {
 }
 
 /// Tool names whose results are eligible for microcompaction clearing.
-/// Mirrors Claude Code's compactable tools list — only tools producing
-/// large, reproducible output that the LLM can re-run if needed.
+/// Only tools producing large, reproducible output that the LLM can re-run if needed.
 fn is_clearable_tool(name: &str) -> bool {
     let n = name.to_lowercase();
     // File read operations

--- a/rust/crates/runtime/src/turn/cloud/cache_diagnostics.rs
+++ b/rust/crates/runtime/src/turn/cloud/cache_diagnostics.rs
@@ -2,8 +2,6 @@
 //!
 //! Tracks what causes prompt cache invalidation (system prompt changes,
 //! tool schema changes, model switches) and logs actionable diagnostics.
-//!
-//! Inspired by Claude Code's `promptCacheBreakDetection.ts`.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/rust/crates/runtime/src/turn/cloud/compaction.rs
+++ b/rust/crates/runtime/src/turn/cloud/compaction.rs
@@ -154,7 +154,6 @@ pub struct CompactBoundary {
     pub recent_files: Vec<String>,
     /// Discovered tools carried across compaction/replay boundaries.
     ///
-    /// This is the runtime-native equivalent of Claude Code's discovered-tool set.
     /// These names can be used by the tool selection layer to re-materialize
     /// schemas even if the current tool index no longer lists them.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -416,7 +415,6 @@ pub fn compact_tiered_with_result(
         }
         // For CompactHistory+, replace large non-error tool results with a
         // compact preview stub — the file can be re-read if needed.
-        // Inspired by Claude Code's microcompact pattern.
         let line_count = content.lines().count();
         if matches!(
             tier,

--- a/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
+++ b/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
@@ -11,11 +11,11 @@
 //! 4. Optionally store new working memory with updated context
 //! ```
 //!
-//! ## On-disk session memory (Claude Code–compatible)
+//! ## On-disk session memory
 //!
 //! When `ASTRA_SESSION_MEMORY_COMBINE` is set, the compactor can read
 //! `CLAUDE_CONFIG_DIR/projects/<sanitized-cwd>/<session_id>/session-memory/summary.md`
-//! (same layout as Claude Code) or a path from `ASTRA_SESSION_MEMORY_FILE`.
+//! or a path from `ASTRA_SESSION_MEMORY_FILE`.
 //! - `fallback`: use the file only if Memoria returns no memories.
 //! - `merge` / `true` / `1` / `both`: keep Memoria hits and add a capped file excerpt.
 
@@ -59,7 +59,7 @@ impl Default for MemoriaCompactConfig {
     }
 }
 
-/// How to mix Claude Code–style on-disk `summary.md` with Memoria HTTP retrieval.
+/// How to mix on-disk `summary.md` with Memoria HTTP retrieval.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum SessionMemoryFileCombine {
     /// Ignore on-disk session memory for compaction injection.
@@ -98,14 +98,14 @@ pub struct MemoriaCompactParams {
     pub keep_recent_turns: usize,
     /// Current token count before compaction.
     pub current_tokens: usize,
-    /// Optional path to on-disk session memory (e.g. Claude Code `session-memory/summary.md`).
+    /// Optional path to on-disk session memory.
     pub session_memory_file: Option<PathBuf>,
     /// How to combine that file with Memoria retrieval.
     pub session_memory_combine: SessionMemoryFileCombine,
 }
 
 // ---------------------------------------------------------------------------
-// Claude Code–compatible session memory paths
+// Compatible session memory paths
 // ---------------------------------------------------------------------------
 
 const CLAUDE_PROJECTS_SANITIZE_MAX_CHARS: usize = 200;
@@ -138,7 +138,7 @@ fn abs_hash_to_string_36(h: i32) -> String {
 }
 
 /// Sanitize a working-directory path for use under `CLAUDE_CONFIG_DIR/projects/`,
-/// matching Claude Code’s `sanitizePath` (alphanumeric → keep, else `-`, length cap + djb2).
+/// (alphanumeric → keep, else `-`, length cap + djb2).
 pub fn sanitize_path_for_claude_projects(name: &str) -> String {
     let sanitized: String = name
         .chars()

--- a/rust/crates/runtime/src/turn/context_compression.rs
+++ b/rust/crates/runtime/src/turn/context_compression.rs
@@ -1,6 +1,6 @@
 //! Context Compression Pipeline (D-4)
 //!
-//! Layered, progressive compression inspired by Claude Code's 5-layer approach.
+//! Layered, progressive compression pipeline.
 //! Each layer estimates savings, decides whether to trigger, and compresses
 //! the conversation state. The pipeline runs layers in order, stopping as soon
 //! as the token budget is satisfied.
@@ -291,8 +291,8 @@ impl CompressionPipeline {
 
 /// Clears or shortens tool-result content bodies older than `age_threshold`.
 ///
-/// Inspired by Claude Code's time-based microcompact: tool results older than
-/// 60 minutes get their content cleared (keeping the role/tool_use_id structure).
+/// Tool results older than the threshold get their content cleared
+/// (keeping the role/tool_use_id structure).
 pub struct ToolResultTruncation {
     /// Results older than this are eligible for truncation.
     age_threshold: Duration,

--- a/rust/crates/runtime/src/turn/file_edit_journal.rs
+++ b/rust/crates/runtime/src/turn/file_edit_journal.rs
@@ -1,8 +1,7 @@
 //! File edit journal — tracks file mutations for undo support.
 //!
-//! Inspired by Claude Code's built-in file history system, this module records
-//! the before-state of every file write so that changes can be reverted at the
-//! file level or turn level.
+//! Records the before-state of every file write so that changes can be reverted
+//! at the file level or turn level.
 //!
 //! # Usage
 //!

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -217,7 +217,7 @@ pub(crate) async fn sleep_ms_or_llm_cancel(
     }
 }
 
-/// Per-chunk idle watchdog (Claude Code–style): no SSE JSON for this long → treat as stalled.
+/// Per-chunk idle watchdog: no SSE JSON for this long → treat as stalled.
 pub(crate) fn stream_idle_timeout() -> std::time::Duration {
     // Delegate to the canonical public function in sse_stream_host.
     crate::turn::sse_stream_host::stream_idle_timeout()

--- a/rust/crates/runtime/src/turn/microcompact.rs
+++ b/rust/crates/runtime/src/turn/microcompact.rs
@@ -1,7 +1,6 @@
 //! Microcompact: clear old tool result content before each LLM call.
 //!
-//! Inspired by Claude Code's microcompact strategy. Tool results (file reads,
-//! grep output, git diffs) dominate history token cost. Once the LLM has acted
+//! Tool results (file reads, grep output, git diffs) dominate history token cost. Once the LLM has acted
 //! on a tool result, the full content is rarely needed again. This module
 //! replaces old tool result content with a short placeholder, keeping only the
 //! most recent N results intact.

--- a/rust/crates/runtime/src/turn/parallel_tool_exec.rs
+++ b/rust/crates/runtime/src/turn/parallel_tool_exec.rs
@@ -1,7 +1,7 @@
 //! Parallel Tool Execution (D-1)
 //!
 //! Classifies tool calls as read-only (safe for parallel execution) vs mutating
-//! (must run sequentially), inspired by Claude Code's `StreamingToolExecutor`.
+//! (must run sequentially).
 //!
 //! Read-only tools can be dispatched concurrently via `tokio::JoinSet` with
 //! a semaphore limiting concurrency. Mutating tools run one at a time after

--- a/rust/crates/runtime/src/turn/safety_middleware.rs
+++ b/rust/crates/runtime/src/turn/safety_middleware.rs
@@ -11,7 +11,6 @@ const SHELL_EXECUTION_TOOLS: &[&str] = &["bash", "exec", "run_command", "shell"]
 /// Zsh-specific dangerous commands that can bypass security checks.
 /// These commands allow arbitrary file I/O, network access, or code execution
 /// without going through standard binaries that we can validate.
-/// Ref: Claude Code `bashSecurity.ts` ZSH_DANGEROUS_COMMANDS
 const ZSH_DANGEROUS_COMMANDS: &[&str] = &[
     // zmodload is the gateway to many dangerous module-based attacks
     "zmodload", // emulate with -c flag is an eval-equivalent

--- a/rust/crates/runtime/src/turn/skill_tool.rs
+++ b/rust/crates/runtime/src/turn/skill_tool.rs
@@ -192,7 +192,7 @@ pub trait SkillResolver: Send + Sync {
 
 pub const SKILL_TOOL_NAME: &str = "skill";
 
-/// Second-stage discovery tool (Claude Code skill-search parity).
+/// Second-stage discovery tool for skill search.
 pub const DISCOVER_SKILLS_TOOL_NAME: &str = "discover_skills";
 
 /// Max skills returned from a single `discover_skills` call.
@@ -708,8 +708,7 @@ pub fn skill_tool_schema(
 /// Build a system-reminder message listing available skills.
 ///
 /// Injected into the conversation so the LLM is aware skills exist even
-/// before inspecting tool schemas (mirrors Claude Code's `skill_listing`
-/// attachment pattern). Uses the same budget as the tool schema.
+/// before inspecting tool schemas. Uses the same budget as the tool schema.
 pub fn skill_listing_system_message(
     skills: &[SkillToolInfo],
     quality_tracker: Option<&crate::skills::quality::SkillQualityTracker>,

--- a/rust/crates/runtime/src/turn/streaming_tool_exec.rs
+++ b/rust/crates/runtime/src/turn/streaming_tool_exec.rs
@@ -1,6 +1,6 @@
 //! Streaming / Speculative Tool Execution (D-9)
 //!
-//! Inspired by Claude Code's `StreamingToolExecutor`, this module allows
+//! This module allows
 //! read-only tools to begin executing **while the LLM response is still
 //! streaming**. When the SSE stream emits a complete `tool_use` block for
 //! a tool classified as read-only (see `parallel_tool_exec::is_read_only_tool`),

--- a/rust/crates/runtime/src/turn/tool_result_storage.rs
+++ b/rust/crates/runtime/src/turn/tool_result_storage.rs
@@ -5,8 +5,6 @@
 //! and the in-memory content is replaced with a compact preview + file
 //! reference.  This prevents oversized tool outputs from bloating the LLM
 //! context window while still preserving the full output for later retrieval.
-//!
-//! Inspired by Claude Code's `toolResultStorage.ts`.
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Documentation

## What this PR does / why we need it:

### Bug fix: UTF-8 safe string slicing

`find_comment_start()` in `cli_formatting.rs` returned a **char index** but callers used it as a **byte offset** to slice strings. This panics on multi-byte UTF-8 content (CJK characters, emoji).

**Root cause**: `chars().enumerate()` yields char indices (0,1,2...) which diverge from byte offsets for multi-byte characters. Fixed by switching to `char_indices()`.

Also fixed 4 additional `String::truncate(N)` sites that could panic on multi-byte boundaries — replaced with `truncate(floor_char_boundary(N))`:
- `slash_info.rs` (2 sites)
- `ask_user.rs` (2 sites)  
- `shell.rs` (1 site — HTTP fetch truncation)

All fixes have regression tests.

### Design docs

**session-continuity-crash-recovery.md** — 2-layer recovery protocol:
- L0: startup probe via `scan_journal_tail()` — detect interrupted/zombie sessions
- L1: precise recovery via existing `restore_to_checkpoint` + `build_resume_guidance_with_context` + session memory learnings
- Grounded in actual codebase: 4 new functions, 0 new struct fields

**session-memory-protocol.md** — revised with hybrid state model:
- Split L1 into L1a (system-tracked facts, ground truth, zero LLM) + L1b (LLM narrative, supplement)
- L1b template reduced from 10 to 6 sections (removed Current State/Key Files/Progress/Worklog/Context — replaced by system facts)
- Facts-first injection with cross-validation warnings
- Injection budget: ~650t (down from 2000t)
- Compaction no longer waits 15s for L1b — L1a facts always available
- Error-triggered extraction to capture user corrections before compaction
- User Messages sliding window (last 5 verbatim, older summarized)

## How was this tested?

- `cargo test -p astra-cli cli_formatting` — 14 tests pass (3 new)
- `cargo test -p astra-cli truncate_multibyte` — 2 tests pass (1 new)
- `cargo build -p astra-cli` — clean build
