### PR TITLE
refactor: align runtime file tools with shared fs ops

### DIFF
--- a/rust/crates/astra-tools/src/fs_ops.rs
+++ b/rust/crates/astra-tools/src/fs_ops.rs
@@ -283,74 +283,220 @@ fn fallback_outline(content: &str) -> Vec<(usize, String)> {
         .collect()
 }
 
-pub fn write_file(workspace_root: &Path, args: &Value) -> ToolResult {
-    let path_str = match args.get("path").and_then(|v| v.as_str()) {
-        Some(p) => p,
-        None => return ToolResult::error("Error: Missing 'path' parameter".into()),
-    };
-    let content = match args.get("content").and_then(|v| v.as_str()) {
-        Some(c) => c,
-        None => return ToolResult::error("Error: Missing 'content' parameter".into()),
-    };
-    let path = match resolve_path(workspace_root, path_str) {
-        Ok(p) => p,
-        Err(e) => return ToolResult::error(e),
-    };
+#[derive(Debug)]
+pub struct PreparedWriteFile {
+    path: PathBuf,
+    path_str: String,
+    content: String,
+}
 
-    if let Some(parent) = path.parent()
-        && let Err(e) = std::fs::create_dir_all(parent)
-    {
-        return ToolResult::error(format!("Error: Cannot create directories: {e}"));
+impl PreparedWriteFile {
+    pub fn path(&self) -> &Path {
+        &self.path
     }
 
-    match std::fs::write(&path, content) {
-        Ok(()) => ToolResult::text(format!(
-            "Successfully wrote {} bytes to {}",
-            content.len(),
-            path_str
-        )),
-        Err(e) => ToolResult::error(format!("Error: Cannot write file: {e}")),
+    pub fn content_bytes(&self) -> &[u8] {
+        self.content.as_bytes()
+    }
+
+    pub fn apply(&self) -> ToolResult {
+        if let Some(parent) = self.path.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            return ToolResult::error(format!("Error: Cannot create directories: {e}"));
+        }
+
+        match std::fs::write(&self.path, &self.content) {
+            Ok(()) => ToolResult::text(format!(
+                "Successfully wrote {} bytes to {}",
+                self.content.len(),
+                self.path_str
+            )),
+            Err(e) => ToolResult::error(format!("Error: Cannot write file: {e}")),
+        }
     }
 }
 
-pub fn str_replace(workspace_root: &Path, args: &Value) -> ToolResult {
+pub fn prepare_write_file(
+    workspace_root: &Path,
+    args: &Value,
+) -> Result<PreparedWriteFile, ToolResult> {
     let path_str = match args.get("path").and_then(|v| v.as_str()) {
         Some(p) => p,
-        None => return ToolResult::error("Error: Missing 'path' parameter".into()),
+        None => return Err(ToolResult::error("Error: Missing 'path' parameter".into())),
     };
-    let old_str = match args.get("old_str").and_then(|v| v.as_str()) {
-        Some(s) => s,
-        None => return ToolResult::error("Error: Missing 'old_str' parameter".into()),
-    };
-    let new_str = match args.get("new_str").and_then(|v| v.as_str()) {
-        Some(s) => s,
-        None => return ToolResult::error("Error: Missing 'new_str' parameter".into()),
+    let content = match args.get("content").and_then(|v| v.as_str()) {
+        Some(c) => c,
+        None => {
+            return Err(ToolResult::error(
+                "Error: Missing 'content' parameter".into(),
+            ));
+        }
     };
     let path = match resolve_path(workspace_root, path_str) {
         Ok(p) => p,
-        Err(e) => return ToolResult::error(e),
+        Err(e) => return Err(ToolResult::error(e)),
+    };
+
+    Ok(PreparedWriteFile {
+        path,
+        path_str: path_str.to_string(),
+        content: content.to_string(),
+    })
+}
+
+pub fn write_file(workspace_root: &Path, args: &Value) -> ToolResult {
+    match prepare_write_file(workspace_root, args) {
+        Ok(prepared) => prepared.apply(),
+        Err(error) => error,
+    }
+}
+
+#[derive(Debug)]
+pub struct PreparedStrReplace {
+    path: PathBuf,
+    path_str: String,
+    new_content: String,
+}
+
+impl PreparedStrReplace {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn new_content_bytes(&self) -> &[u8] {
+        self.new_content.as_bytes()
+    }
+
+    pub fn apply(&self) -> ToolResult {
+        match std::fs::write(&self.path, &self.new_content) {
+            Ok(()) => ToolResult::text(format!("Successfully replaced text in {}", self.path_str)),
+            Err(e) => ToolResult::error(format!("Error: Cannot write file: {e}")),
+        }
+    }
+}
+
+pub fn prepare_str_replace(
+    workspace_root: &Path,
+    args: &Value,
+) -> Result<PreparedStrReplace, ToolResult> {
+    let path_str = match args.get("path").and_then(|v| v.as_str()) {
+        Some(p) => p,
+        None => return Err(ToolResult::error("Error: Missing 'path' parameter".into())),
+    };
+    let old_str = match args.get("old_str").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => {
+            return Err(ToolResult::error(
+                "Error: Missing 'old_str' parameter".into(),
+            ));
+        }
+    };
+    let new_str = match args.get("new_str").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => {
+            return Err(ToolResult::error(
+                "Error: Missing 'new_str' parameter".into(),
+            ));
+        }
+    };
+    let path = match resolve_path(workspace_root, path_str) {
+        Ok(p) => p,
+        Err(e) => return Err(ToolResult::error(e)),
     };
 
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
-        Err(e) => return ToolResult::error(format!("Error: Cannot read file: {e}")),
+        Err(e) => return Err(ToolResult::error(format!("Error: Cannot read file: {e}"))),
     };
 
     let count = content.matches(old_str).count();
     if count == 0 {
-        return ToolResult::error(format!("Error: old_str not found in {path_str}"));
+        return Err(ToolResult::error(format!(
+            "Error: old_str not found in {path_str}"
+        )));
     }
     if count > 1 {
-        return ToolResult::error(format!(
+        return Err(ToolResult::error(format!(
             "Error: old_str found {count} times in {path_str}. Make old_str more specific to match exactly once."
-        ));
+        )));
     }
 
-    let new_content = content.replacen(old_str, new_str, 1);
-    match std::fs::write(&path, &new_content) {
-        Ok(()) => ToolResult::text(format!("Successfully replaced text in {path_str}")),
-        Err(e) => ToolResult::error(format!("Error: Cannot write file: {e}")),
+    Ok(PreparedStrReplace {
+        path,
+        path_str: path_str.to_string(),
+        new_content: content.replacen(old_str, new_str, 1),
+    })
+}
+
+pub fn str_replace(workspace_root: &Path, args: &Value) -> ToolResult {
+    match prepare_str_replace(workspace_root, args) {
+        Ok(prepared) => prepared.apply(),
+        Err(error) => error,
     }
+}
+
+#[derive(Debug)]
+pub struct PreparedDeleteFile {
+    path: PathBuf,
+    path_str: String,
+    before_content: Vec<u8>,
+}
+
+impl PreparedDeleteFile {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn before_content(&self) -> &[u8] {
+        &self.before_content
+    }
+
+    pub fn apply(&self) -> ToolResult {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => ToolResult::text(format!("Successfully deleted {}", self.path_str)),
+            Err(e) => ToolResult::error(format!("Error: Cannot delete file: {e}")),
+        }
+    }
+
+    pub fn into_before_content(self) -> Vec<u8> {
+        self.before_content
+    }
+}
+
+pub fn prepare_delete_file(
+    workspace_root: &Path,
+    args: &Value,
+) -> Result<PreparedDeleteFile, ToolResult> {
+    let path_str = match args.get("path").and_then(|v| v.as_str()) {
+        Some(p) => p,
+        None => return Err(ToolResult::error("Error: Missing 'path' parameter".into())),
+    };
+    let path = match resolve_path(workspace_root, path_str) {
+        Ok(p) => p,
+        Err(e) => return Err(ToolResult::error(e)),
+    };
+
+    if !path.exists() {
+        return Err(ToolResult::error(format!(
+            "Error: File not found: {path_str}"
+        )));
+    }
+
+    let before_content = match std::fs::read(&path) {
+        Ok(content) => content,
+        Err(e) => {
+            return Err(ToolResult::error(format!(
+                "Error: Cannot read file before delete: {e}"
+            )));
+        }
+    };
+
+    Ok(PreparedDeleteFile {
+        path,
+        path_str: path_str.to_string(),
+        before_content,
+    })
 }
 
 pub fn delete_file(workspace_root: &Path, args: &Value) -> ToolResult {

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -2589,164 +2589,75 @@ impl ServerToolExecutor {
     // ────────────────────────────────────────────────────────────────────────
 
     fn resolve_path(&self, relative: &str) -> Result<PathBuf, String> {
-        let path = if Path::new(relative).is_absolute() {
-            PathBuf::from(relative)
-        } else {
-            self.workspace_root.join(relative)
-        };
-
-        // Normalize the path manually to collapse ".." BEFORE the sandbox check.
-        // canonicalize() only works for existing paths; for non-existent targets
-        // the fallback was returning the raw path with ".." intact, which could
-        // pass the starts_with() prefix check yet resolve outside the sandbox
-        // when the OS normalizes it during actual I/O.
-        let normalized = path.components().fold(PathBuf::new(), |mut acc, c| {
-            match c {
-                std::path::Component::ParentDir => {
-                    acc.pop();
-                }
-                std::path::Component::CurDir => {} // skip "."
-                other => acc.push(other),
-            }
-            acc
-        });
-
-        // For existing paths, canonicalize to resolve symlinks as well.
-        let final_path = if normalized.exists() {
-            normalized
-                .canonicalize()
-                .map_err(|e| format!("Cannot resolve path: {e}"))?
-        } else {
-            normalized
-        };
-
-        if !final_path.starts_with(&self.workspace_root) {
-            return Err(format!(
-                "SANDBOX_DENIED: Path '{}' is outside workspace root '{}'",
-                relative,
-                self.workspace_root.display()
-            ));
-        }
-        Ok(final_path)
+        astra_tools::fs_ops::resolve_path(&self.workspace_root, relative)
     }
 
     fn server_write_file(&self, args: &Value) -> String {
-        let path_str = match args.get("path").and_then(|v| v.as_str()) {
-            Some(p) => p,
-            None => return "Error: Missing 'path' parameter".to_string(),
-        };
-        let content = match args.get("content").and_then(|v| v.as_str()) {
-            Some(c) => c,
-            None => return "Error: Missing 'content' parameter".to_string(),
-        };
-        let path = match self.resolve_path(path_str) {
-            Ok(p) => p,
-            Err(e) => return e,
+        let prepared = match astra_tools::fs_ops::prepare_write_file(&self.workspace_root, args) {
+            Ok(prepared) => prepared,
+            Err(error) => return error.output,
         };
 
         // Record journal entry before writing
         if let Ok(mut journal) = self.file_journal.lock() {
             let turn_idx = self.journal_turn_index.load(Ordering::Relaxed);
-            journal.record_before(&path, "server-write", turn_idx);
+            journal.record_before(prepared.path(), "server-write", turn_idx);
         }
 
-        if let Some(parent) = path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                return format!("Error: Cannot create directories: {e}");
-            }
+        let result = prepared.apply();
+        if !result.is_error
+            && let Ok(mut journal) = self.file_journal.lock()
+        {
+            journal.record_after(prepared.path(), "server-write", prepared.content_bytes());
         }
-
-        match std::fs::write(&path, content) {
-            Ok(()) => {
-                if let Ok(mut journal) = self.file_journal.lock() {
-                    journal.record_after(&path, "server-write", content.as_bytes());
-                }
-                format!("Successfully wrote {} bytes to {}", content.len(), path_str)
-            }
-            Err(e) => format!("Error: Cannot write file: {e}"),
-        }
+        result.output
     }
 
     fn server_str_replace(&self, args: &Value) -> String {
-        let path_str = match args.get("path").and_then(|v| v.as_str()) {
-            Some(p) => p,
-            None => return "Error: Missing 'path' parameter".to_string(),
+        let prepared = match astra_tools::fs_ops::prepare_str_replace(&self.workspace_root, args) {
+            Ok(prepared) => prepared,
+            Err(error) => return error.output,
         };
-        let old_str = match args.get("old_str").and_then(|v| v.as_str()) {
-            Some(s) => s,
-            None => return "Error: Missing 'old_str' parameter".to_string(),
-        };
-        let new_str = match args.get("new_str").and_then(|v| v.as_str()) {
-            Some(s) => s,
-            None => return "Error: Missing 'new_str' parameter".to_string(),
-        };
-        let path = match self.resolve_path(path_str) {
-            Ok(p) => p,
-            Err(e) => return e,
-        };
-
-        let content = match std::fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(e) => return format!("Error: Cannot read file: {e}"),
-        };
-
-        let count = content.matches(old_str).count();
-        if count == 0 {
-            return format!("Error: old_str not found in {path_str}");
-        }
-        if count > 1 {
-            return format!(
-                "Error: old_str found {count} times in {path_str}. Make old_str more specific to match exactly once."
-            );
-        }
 
         // Record journal entry
         if let Ok(mut journal) = self.file_journal.lock() {
             let turn_idx = self.journal_turn_index.load(Ordering::Relaxed);
-            journal.record_before_patch(&path, "server-str-replace", turn_idx);
+            journal.record_before_patch(prepared.path(), "server-str-replace", turn_idx);
         }
 
-        let new_content = content.replacen(old_str, new_str, 1);
-        match std::fs::write(&path, &new_content) {
-            Ok(()) => {
-                if let Ok(mut journal) = self.file_journal.lock() {
-                    journal.record_after(&path, "server-str-replace", new_content.as_bytes());
-                }
-                format!("Successfully replaced text in {path_str}")
-            }
-            Err(e) => format!("Error: Cannot write file: {e}"),
+        let result = prepared.apply();
+        if !result.is_error
+            && let Ok(mut journal) = self.file_journal.lock()
+        {
+            journal.record_after(
+                prepared.path(),
+                "server-str-replace",
+                prepared.new_content_bytes(),
+            );
         }
+        result.output
     }
 
     fn server_delete_file(&self, args: &Value) -> String {
-        let path_str = match args.get("path").and_then(|v| v.as_str()) {
-            Some(p) => p,
-            None => return "Error: Missing 'path' parameter".to_string(),
+        let prepared = match astra_tools::fs_ops::prepare_delete_file(&self.workspace_root, args) {
+            Ok(prepared) => prepared,
+            Err(error) => return error.output,
         };
-        let path = match self.resolve_path(path_str) {
-            Ok(p) => p,
-            Err(e) => return e,
-        };
-
-        if !path.exists() {
-            return format!("Error: File not found: {path_str}");
-        }
-
-        let before_content = match std::fs::read(&path) {
-            Ok(content) => content,
-            Err(e) => return format!("Error: Cannot read file before delete: {e}"),
-        };
+        let path = prepared.path().to_path_buf();
         let turn_idx = self.journal_turn_index.load(Ordering::Relaxed);
 
-        match std::fs::remove_file(&path) {
-            Ok(()) => {
-                if let Ok(mut journal) = self.file_journal.lock() {
-                    journal.record_delete(&path, "server-delete", turn_idx, before_content);
-                }
-                format!("Successfully deleted {path_str}")
-            }
-            Err(e) => format!("Error: Cannot delete file: {e}"),
+        let result = prepared.apply();
+        if !result.is_error
+            && let Ok(mut journal) = self.file_journal.lock()
+        {
+            journal.record_delete(
+                &path,
+                "server-delete",
+                turn_idx,
+                prepared.into_before_content(),
+            );
         }
+        result.output
     }
 
     fn rollback_display_path(&self, path: &Path) -> String {

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
@@ -575,6 +575,104 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn server_fallback_surfaces_read_file_large_file_guard() {
+        let mut harness = PipelineHarness::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("large.txt"),
+            "0123456789abcdef\n".repeat(6_000),
+        )
+        .unwrap();
+        let server_exec = crate::server::server_tool_executor::ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            "test-session".into(),
+            None,
+            None,
+        );
+        let mut pipeline = harness.pipeline_with_server_executor(2, Some(&server_exec));
+        let args = json!({"path": "large.txt"});
+        let permitted = PermittedExecution {
+            execution: HeadlessResolvedExecution {
+                id: "call-read-large".into(),
+                name: "read_file".into(),
+                args: args.clone(),
+                result_str: "Error: headless edge protocol: no matching edge result".into(),
+                tool_result_fields: None,
+                edge_duration_ms: 0,
+                is_edge_tool: false,
+                early_exit_ms: 0,
+            },
+            idem_key: IdempotencyKey::semantic("read_file", &args),
+        };
+
+        let executed = pipeline.execute_execution(permitted).await;
+        assert!(executed.is_err, "got: {}", executed.execution.result_str);
+        assert!(
+            executed.execution.result_str.contains("file is too large"),
+            "got: {}",
+            executed.execution.result_str
+        );
+        assert!(
+            executed.execution.result_str.contains("outline=true"),
+            "got: {}",
+            executed.execution.result_str
+        );
+    }
+
+    #[tokio::test]
+    async fn server_fallback_surfaces_bash_timeout_partial_output() {
+        let mut harness = PipelineHarness::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let server_exec = crate::server::server_tool_executor::ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            "test-session".into(),
+            None,
+            None,
+        );
+        let mut pipeline = harness.pipeline_with_server_executor(4, Some(&server_exec));
+        let args = json!({
+            "command": "printf 'start\\n'; sleep 1; printf 'done\\n'",
+            "timeout": 0.2
+        });
+        let permitted = PermittedExecution {
+            execution: HeadlessResolvedExecution {
+                id: "call-bash-timeout".into(),
+                name: "bash".into(),
+                args: args.clone(),
+                result_str: "Error: headless edge protocol: no matching edge result".into(),
+                tool_result_fields: None,
+                edge_duration_ms: 0,
+                is_edge_tool: false,
+                early_exit_ms: 0,
+            },
+            idem_key: IdempotencyKey::semantic("bash", &args),
+        };
+
+        let executed = pipeline.execute_execution(permitted).await;
+        assert!(executed.is_err, "got: {}", executed.execution.result_str);
+        assert!(
+            executed.execution.result_str.contains("start"),
+            "got: {}",
+            executed.execution.result_str
+        );
+        assert!(
+            executed
+                .execution
+                .result_str
+                .contains("timed out after 0.2s"),
+            "got: {}",
+            executed.execution.result_str
+        );
+        assert!(
+            !executed.execution.result_str.contains("done"),
+            "got: {}",
+            executed.execution.result_str
+        );
+    }
+
     // ── Unknown tool health tracking tests ───────────────────────────
 
     /// Helper: push a server tool_call JSON for an unknown tool and run validate_slot.


### PR DESCRIPTION
## Summary
- move runtime write_file/str_replace/delete_file onto shared astra-tools fs_ops prepare/apply helpers while preserving rollback journaling
- delegate runtime path resolution to shared fs_ops so write-side sandbox semantics cannot drift
- add no-edge headless pipeline regressions for read_file large-file refusal and bash timeout partial output server fallback

## Testing
- cargo fmt --all
- cargo test -p astra-tools
- cargo test -p astra-runtime write_file_
- cargo test -p astra-runtime str_replace_
- cargo test -p astra-runtime delete_file_
- cargo test -p astra-runtime rollback_file_edits_
- cargo test -p astra-runtime bash_timeout_
- cargo test -p astra-runtime server_fallback_
- make format
- make check