### PR TITLE
chore: let memoria reach host ollama + fix aggregate test path extraction

### DIFF
--- a/deployment/all-in-one/docker-compose.deps.yml
+++ b/deployment/all-in-one/docker-compose.deps.yml
@@ -69,6 +69,8 @@ services:
       - EMBEDDING_BASE_URL=${MEMORIA_EMBEDDING_BASE_URL:-}
       - EMBEDDING_ENDPOINTS=${MEMORIA_EMBEDDING_ENDPOINTS:-}
       - RUST_LOG=${RUST_LOG:-info}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       matrixone:
         condition: service_healthy

--- a/rust/crates/astra-cli/src/edge_tools/tests/aggregate_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/aggregate_tests.rs
@@ -125,12 +125,9 @@ fn persist_to_disk_triggers_when_aggregate_high_and_output_large() {
     );
 
     // Verify file was actually written
-    let path_start = result.find("tool-results/").unwrap();
-    let path_line = result[path_start - 20..].lines().next().unwrap();
-    let file_path = path_line
-        .split_whitespace()
-        .find(|s| s.contains("tool-results/"))
-        .unwrap();
+    let marker = "Full output saved to: ";
+    let path_start = result.find(marker).unwrap() + marker.len();
+    let file_path = result[path_start..].lines().next().unwrap().trim();
     assert!(
         std::path::Path::new(file_path).exists(),
         "persisted file should exist: {file_path}"


### PR DESCRIPTION
## Summary
- **docker-compose.deps.yml**: add `extra_hosts: host.docker.internal:host-gateway` to the `memoria` service so it can reach host-bound services (local Ollama at `:11434`, etc.) from inside the `mo-net` bridge network.
- **aggregate_tests.rs**: fix `persist_to_disk_triggers_when_aggregate_high_and_output_large`. The old path extraction sliced `result[path_start - 20..]`, dropping the leading `/` on absolute paths like `/home/user/.astra/tool-results/...`, so `Path::exists()` asserted against a relative fragment. Anchor on the stable `"Full output saved to: "` marker instead.

## Test plan
- [x] `cargo test -p astra-cli persist_to_disk_triggers_when_aggregate_high_and_output_large` passes
- [x] `make test-offline` passes 2508/2508
- [ ] `make dev-deps-up` brings up memoria; memoria container can resolve `host.docker.internal` and reach a host-bound Ollama at `http://host.docker.internal:11434/v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)