### PR TITLE
ci: fix actions/checkout for fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
@@ -101,8 +99,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
@@ -120,8 +116,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
@@ -137,8 +131,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
@@ -154,8 +146,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2

--- a/rust/crates/astra-plan/src/decompose.rs
+++ b/rust/crates/astra-plan/src/decompose.rs
@@ -4496,7 +4496,27 @@ Done!"#;
             .and_then(|p| p.parent())
             .expect("should find repo root");
         let ctx = analyze_project(root);
-        assert!(ctx.git_branch.is_some(), "should detect git branch");
+
+        // analyze_project only populates git_branch when HEAD points to a named
+        // ref. CI PR checkouts (refs/pull/<N>/merge) and other detached-HEAD
+        // states are valid but leave git_branch = None. Assert the two must
+        // stay consistent rather than forcing branch detection.
+        let head = std::fs::read_to_string(root.join(".git/HEAD")).ok();
+        let head_is_ref = head
+            .as_deref()
+            .is_some_and(|h| h.trim_start().starts_with("ref: refs/heads/"));
+        if head_is_ref {
+            assert!(
+                ctx.git_branch.is_some(),
+                "HEAD points to a named ref but git_branch was not detected"
+            );
+        } else {
+            assert!(
+                ctx.git_branch.is_none(),
+                "HEAD is detached but git_branch = {:?}",
+                ctx.git_branch
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Every `actions/checkout@v4` step in `test.yml` sets:
```yaml
ref: ${{ github.head_ref || github.ref_name }}
```
This forces the action to fetch a branch name from the base repo (the default for `repository:`). For fork PRs the branch only exists on the fork, so the fetch fails and every offline job dies with `exit code 1` before any test runs. Same-repo PRs are fine.

Dropping the `ref` lets `actions/checkout` use its default. On a `pull_request` event that's `refs/pull/<N>/merge` — a ref GitHub auto-creates on the base repo for every PR, including cross-fork ones. Same-repo PRs keep working because the default also resolves correctly for them.

## Context
Fork PR #102 failed for exactly this reason — CI fetch log:
```
git fetch origin +refs/heads/chore/memoria-ollama-test-fix*:...   # against matrixorigin/astra
The process '/usr/bin/git' failed with exit code 1
```
Merging this PR unblocks #102.

## Test plan
- [ ] Offline jobs (astra-cli, astra-runtime, astra-services, bridge-e2e-hooks, core crates) check out and run successfully on this PR
- [ ] After merge, rerun #102's CI — offline jobs should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)