### PR TITLE
fix(cli): complete skill publish flow

### DIFF
--- a/rust/crates/astra-cli/src/cli/command_registry.rs
+++ b/rust/crates/astra-cli/src/cli/command_registry.rs
@@ -153,6 +153,7 @@ const SKILL_SUBCOMMANDS: &[(&str, &str)] = &[
     ("list", "List skills"),
     ("new", "Create skill"),
     ("pin", "Pin skill to always load"),
+    ("publish", "Publish to marketplace"),
     ("search", "Keyword search catalog"),
     ("stats", "Learning summary"),
     ("surfacing", "Agent catalog surfacing (dynamic/min/cap)"),
@@ -592,11 +593,11 @@ pub static COMMANDS: &[CommandMeta] = &[
     // ── Skills ────────────────────────────────────────────────────────────
     CommandMeta::new(
         "/skill",
-        "Skills: list|info|search|surfacing|health|new|test|dev|system|…",
+        "Skills: browse|list|info|install|publish|search|new|test|dev|system|…",
         CommandGroup::Skills,
     )
     .with_subcommands(SKILL_SUBCOMMANDS)
-    .with_arg_hint("[list|info|search|new|test|dev|feedback|…]"),
+    .with_arg_hint("[browse|list|info|install|publish|search|new|test|dev|feedback|…]"),
     // ── MCP ───────────────────────────────────────────────────────────────
     CommandMeta::new(
         "/mcp",
@@ -902,6 +903,7 @@ mod tests {
         let subs = subs.unwrap();
         assert!(subs.iter().any(|(tok, _)| *tok == "list"));
         assert!(subs.iter().any(|(tok, _)| *tok == "info"));
+        assert!(subs.iter().any(|(tok, _)| *tok == "publish"));
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/repl_ui.rs
+++ b/rust/crates/astra-cli/src/cli/repl_ui.rs
@@ -109,6 +109,7 @@ const DYN_SECOND_TOKEN: &[(&str, &str, DynKey)] = &[
     ("/skill", "info", DynKey::SkillName),
     ("/skill", "feedback", DynKey::SkillName),
     ("/skill", "pin", DynKey::SkillName),
+    ("/skill", "publish", DynKey::SkillName),
     ("/skill", "unpin", DynKey::SkillName),
     ("/mcp", "ping", DynKey::McpServer),
     ("/mcp", "log-level", DynKey::McpServer),
@@ -838,7 +839,7 @@ fn slash_argument_hint(command: &str) -> Option<&'static str> {
         "/skill info" => Some("<name> [--raw]"),
         "/skill search" => Some("<query>"),
         "/skill surfacing" => Some("[show|dynamic <on|off>|min <n>|cap <n>]"),
-        "/skill new" | "/skill create" => Some("<name>"),
+        "/skill new" | "/skill create" | "/skill publish" => Some("<name>"),
         "/skill test" => Some("<name> [json_args]"),
         "/skill dev" => Some("<name|off>"),
         "/skill health" => None, // no args

--- a/rust/crates/astra-cli/src/cli/slash_skill.rs
+++ b/rust/crates/astra-cli/src/cli/slash_skill.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+fn default_skill_category(category: Option<&str>) -> String {
+    category
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("general")
+        .to_string()
+}
+
 // ── Catalog surfacing (SkillSearchSettings → agent context; was /skill-search) ──
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -663,6 +671,14 @@ Follow these steps:
                 "\u{2713}".green(),
                 skill_dir.display().to_string().cyan()
             );
+            match state.unified_skill_registry.discover_all().await {
+                Ok(_) => eprintln!("  {}", "Skill registry refreshed.".dim()),
+                Err(err) => eprintln!(
+                    "  {} {}",
+                    "Warning:".yellow(),
+                    format!("Skill registry refresh failed: {err}").dim()
+                ),
+            }
             eprintln!("  {} SKILL.md", "Files created:".dim());
             eprintln!("  {}", format!("Dev mode: /skill dev {name}").dim());
         }
@@ -2334,6 +2350,14 @@ Skill auto-generated from session {session_short}.
         "\n  {}",
         format!("  Edit: {}/SKILL.md", skill_dir.display()).dim()
     );
+    match state.unified_skill_registry.discover_all().await {
+        Ok(_) => eprintln!("  {}", "  Skill registry refreshed.".dim()),
+        Err(err) => eprintln!(
+            "  {} {}",
+            "Warning:".yellow(),
+            format!("Skill registry refresh failed: {err}").dim()
+        ),
+    }
     eprintln!("  {}", format!("  Dev mode: /skill dev {name}").dim());
     eprintln!("  {}", format!("  Test: /skill test {name}").dim());
     eprintln!();
@@ -3099,6 +3123,15 @@ mod tests {
             let pre: Version = "2.0.0-beta".parse().unwrap();
             assert!(release > pre, "release should be greater than pre-release");
         }
+
+        #[test]
+        fn default_skill_category_falls_back_to_general() {
+            assert_eq!(super::default_skill_category(None), "general");
+            assert_eq!(super::default_skill_category(Some("")), "general");
+            assert_eq!(super::default_skill_category(Some("   ")), "general");
+            assert_eq!(super::default_skill_category(Some("automation")), "automation");
+        }
+
     }
 }
 
@@ -3549,6 +3582,7 @@ async fn publish_skill_to_marketplace(
         name.cyan().bold(),
         manifest.version.to_string().dim()
     );
+    let category = default_skill_category(manifest.category.as_deref());
 
     // Try bundle publish if we have a local directory
     if let Some(ref dir) = skill_dir {
@@ -3562,7 +3596,7 @@ async fn publish_skill_to_marketplace(
                     "name": bundle_manifest.name,
                     "version": bundle_manifest.version,
                     "description": bundle_manifest.description,
-                    "category": manifest.category,
+                    "category": category,
                     "tags": manifest.tags,
                     "bundle": encoded,
                     "bundle_sha256": bundle_manifest.skill_md_sha256,
@@ -3618,7 +3652,7 @@ async fn publish_skill_to_marketplace(
         "triggers": manifest.triggers,
         "dependencies": manifest.dependencies,
         "manifest": loaded.instructions,
-        "category": manifest.category,
+        "category": category,
     });
 
     match api


### PR DESCRIPTION
## Summary
- add `/skill publish` to slash-command completion and argument hints
- default missing skill publish categories to `general` so marketplace publish succeeds
- refresh the local skill registry after `/skill new` and `/skill create`, surfacing refresh failures instead of silently swallowing them

## Validation
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli subcommand_completions_work --release`
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli default_skill_category_falls_back_to_general --release`
- `cargo build --manifest-path rust/Cargo.toml -p astra-cli --release --bin astra`
- manually verified on 55: `/skill new -> /skill publish -> /skill browse -> /skill install`
