### PR TITLE
fix: add missing derives on extracted compression and permission types

### DIFF
--- a/rust/crates/astra-turn-core/src/compression_types.rs
+++ b/rust/crates/astra-turn-core/src/compression_types.rs
@@ -7,6 +7,7 @@
 use serde_json::Value;
 
 /// Token budget for a single turn.
+#[derive(Debug, Clone)]
 pub struct TokenBudget {
     /// Maximum prompt tokens for the current turn.
     pub max_prompt_tokens: u64,

--- a/rust/crates/astra-turn-core/src/permission_types.rs
+++ b/rust/crates/astra-turn-core/src/permission_types.rs
@@ -398,6 +398,7 @@ pub struct PermissionTelemetry {
     pub recent_denials: Vec<String>,
 }
 
+#[derive(Debug, Clone, Default)]
 pub struct PermissionSyncContext {
     /// Permissions inherited from parent agent.
     pub inherited: InheritedPermissions,


### PR DESCRIPTION
## Changes

- `TokenBudget`: add `#[derive(Debug, Clone)]` — was bare struct after extraction from `context_compression.rs`, breaking downstream Clone/Debug usage
- `PermissionSyncContext`: add `#[derive(Debug, Clone, Default)]` — for API consistency with other permission types

## Verification
- `make check` passes (clippy + fmt + compile)
- All turn-core tests pass