### PR TITLE
refactor: extract team_orchestrator traits and types to astra-server-types

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -377,9 +377,11 @@ version = "0.1.0"
 dependencies = [
  "astra-core",
  "astra-services",
+ "async-trait",
  "regex",
  "serde",
  "serde_json",
+ "tokio-util",
 ]
 
 [[package]]

--- a/rust/crates/astra-server-types/Cargo.toml
+++ b/rust/crates/astra-server-types/Cargo.toml
@@ -10,3 +10,5 @@ astra-services.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+async-trait.workspace = true
+tokio-util.workspace = true

--- a/rust/crates/astra-server-types/src/lib.rs
+++ b/rust/crates/astra-server-types/src/lib.rs
@@ -1,5 +1,7 @@
 mod chat_route;
 mod edge_ws_protocol;
+pub mod team_orchestrator_traits;
+pub mod team_orchestrator_types;
 
 use astra_services::auth::SessionActivityRecord;
 use astra_services::{

--- a/rust/crates/astra-server-types/src/team_orchestrator_traits.rs
+++ b/rust/crates/astra-server-types/src/team_orchestrator_traits.rs
@@ -1,0 +1,132 @@
+//! Trait abstractions for team orchestration dependencies.
+//!
+//! These traits decouple `TeamExecutionOrchestrator` from concrete runtime types
+//! (DelegationEngine, DelegationTracker, RunEngine) so the orchestrator can live
+//! in `astra-server-types` while implementations stay in the runtime crate.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use astra_core::SubRunState;
+use astra_services::coordination::{DelegationRequest, DelegationResult};
+
+// ─── Types that must live here for trait signatures ─────────────────────
+
+/// Tracks parent→child relationships for delegation hierarchies.
+#[derive(Debug, Clone)]
+pub struct SubRunRecord {
+    /// The sub-run's own ID.
+    pub run_id: String,
+    /// Parent run that spawned this sub-run.
+    pub parent_run_id: String,
+    /// Delegation this sub-run belongs to.
+    pub delegation_id: String,
+    /// Agent executing this sub-run.
+    pub agent_id: String,
+    /// Current depth in the delegation tree.
+    pub depth: u32,
+    /// Lifecycle state (enforced state machine).
+    pub state: SubRunState,
+    /// If this run is a gate-retry, links to the original run_id.
+    pub retry_of: Option<String>,
+}
+
+/// Real-time progress snapshot for an active delegation.
+#[derive(Debug, Clone)]
+pub struct DelegationProgress {
+    pub delegation_id: String,
+    /// Per-agent current state.
+    pub agent_states: HashMap<String, SubRunState>,
+    /// When execution started.
+    pub started_at: std::time::Instant,
+    /// Number of completed (terminal) sub-runs.
+    pub completed_count: usize,
+    /// Total sub-runs expected.
+    pub total_count: usize,
+}
+
+// ─── Traits ─────────────────────────────────────────────────────────────────
+
+/// Executes a multi-agent delegation and reports progress.
+#[async_trait]
+pub trait DelegationExecutor: Send + Sync {
+    /// Execute a delegation request, returning the aggregated result.
+    async fn execute_delegation(
+        &self,
+        request: DelegationRequest,
+        source_agent_id: &str,
+        cancel_token: Option<Arc<tokio_util::sync::CancellationToken>>,
+    ) -> Result<DelegationResult, String>;
+
+    /// Get real-time progress for an active delegation.
+    async fn get_delegation_progress(
+        &self,
+        delegation_id: &str,
+    ) -> Option<DelegationProgress>;
+}
+
+/// Tracks delegation hierarchies and pause state.
+#[async_trait]
+pub trait DelegationTracking: Send + Sync {
+    /// Get all sub-runs for a delegation.
+    async fn get_sub_runs(&self, delegation_id: &str) -> Vec<SubRunRecord>;
+
+    /// Check if a sub-run is currently paused.
+    async fn is_run_paused(&self, run_id: &str) -> bool;
+
+    /// Pause all sub-runs in a delegation. Returns count paused.
+    async fn pause_delegation(&self, delegation_id: &str) -> usize;
+
+    /// Resume all sub-runs in a delegation. Returns count resumed.
+    async fn resume_delegation(&self, delegation_id: &str) -> usize;
+
+    /// Cleanup all state for a completed delegation.
+    async fn cleanup_delegation(&self, delegation_id: &str) -> Result<(), String>;
+}
+
+/// Persists durable run state (events, status, checkpoints, usage).
+#[async_trait]
+pub trait RunPersistence: Send + Sync {
+    /// Create a durable run record with delegation metadata.
+    async fn start_run_ext(
+        &self,
+        run_id: &str,
+        user_id: &str,
+        session_id: &str,
+        parent_run_id: Option<&str>,
+        delegation_id: Option<&str>,
+        agent_id: Option<&str>,
+        retry_of: Option<&str>,
+    ) -> Result<(), String>;
+
+    /// Persist a status change.
+    async fn persist_status(
+        &self,
+        run_id: &str,
+        status: &str,
+        waiting_for: Option<&str>,
+        error_message: Option<&str>,
+    ) -> Result<bool, String>;
+
+    /// Persist token/tool usage counters.
+    async fn persist_usage(
+        &self,
+        run_id: &str,
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        tool_calls: u32,
+    ) -> Result<bool, String>;
+
+    /// Save a checkpoint for crash recovery.
+    async fn persist_checkpoint(
+        &self,
+        run_id: &str,
+        checkpoint_json: &str,
+    ) -> Result<bool, String>;
+
+    /// Append an event to the durable event log.
+    async fn append_event(&self, run_id: &str, event: Value) -> Result<(), String>;
+}

--- a/rust/crates/astra-server-types/src/team_orchestrator_types.rs
+++ b/rust/crates/astra-server-types/src/team_orchestrator_types.rs
@@ -1,0 +1,222 @@
+//! Pure types and helper functions extracted from team_orchestrator.
+//!
+//! These types have no dependency on runtime internals and can be shared
+//! across crates via `astra-server-types`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use astra_services::coordination::{AgentResult, DelegationResult};
+use astra_services::learning_merge::{AgentLearning, MergedLearning, VersionVector, merge_agent_learnings};
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/// Progress phases emitted during team execution.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExecutionPhase {
+    /// Team loaded and validated, profiles resolved.
+    Preparing {
+        team_name: String,
+        member_count: usize,
+    },
+    /// Worktrees created (only for Isolated mode).
+    WorktreesCreated { agent_ids: Vec<String> },
+    /// Delegation started via DelegationEngine.
+    Executing { delegation_id: String },
+    /// Real-time agent state update within a delegation.
+    AgentProgress {
+        delegation_id: String,
+        /// agent_id → current state
+        agent_states: HashMap<String, String>,
+        completed_count: usize,
+        total_count: usize,
+    },
+    /// Delegation completed, merging worktrees.
+    Merging { agent_count: usize },
+    /// Merge complete, producing final report.
+    Reporting { status: TeamExecutionStatus },
+}
+
+/// Callback for reporting execution progress to the UI layer.
+pub type ProgressCallback = Arc<dyn Fn(ExecutionPhase) + Send + Sync>;
+
+/// Configuration for creating a TeamExecutionOrchestrator.
+pub struct OrchestratorConfig {
+    pub user_id: String,
+    pub session_id: String,
+    /// Source agent ID requesting the team execution (for delegation validation).
+    pub source_agent_id: String,
+    /// Optional progress callback for UI integration.
+    pub progress: Option<ProgressCallback>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TeamExecutionStatus {
+    Completed,
+    Partial,
+    CompletedWithConflicts,
+    CompletedOverBudget,
+    Failed,
+}
+
+impl std::fmt::Display for TeamExecutionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Completed => write!(f, "completed"),
+            Self::Partial => write!(f, "partial"),
+            Self::CompletedWithConflicts => write!(f, "completed_with_conflicts"),
+            Self::CompletedOverBudget => write!(f, "completed_over_budget"),
+            Self::Failed => write!(f, "failed"),
+        }
+    }
+}
+
+// ─── Helper Functions ───────────────────────────────────────────────────────
+
+/// Sum token usage across all agent results.
+pub fn sum_usage(result: &DelegationResult) -> (u64, u64, u32) {
+    let mut prompt = 0u64;
+    let mut completion = 0u64;
+    let mut tools = 0u32;
+    for r in &result.agent_results {
+        prompt += r.prompt_tokens;
+        completion += r.completion_tokens;
+        tools += r.tool_calls;
+    }
+    (prompt, completion, tools)
+}
+
+/// Build a human-readable summary of failed agents.
+pub fn summarize_failed_agents(result: &DelegationResult) -> String {
+    if result.agent_results.is_empty() {
+        return "delegation produced no agent results".to_string();
+    }
+
+    let failed: Vec<&AgentResult> = result
+        .agent_results
+        .iter()
+        .filter(|agent| !agent.is_success())
+        .collect();
+    if failed.is_empty() {
+        return "delegation did not produce a successful result".to_string();
+    }
+
+    let details: Vec<String> = failed
+        .iter()
+        .take(3)
+        .map(|agent| {
+            let reason = agent
+                .error
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or(agent.status.as_str());
+            format!("{}: {}", agent.agent_id, reason)
+        })
+        .collect();
+    let remainder = failed.len().saturating_sub(details.len());
+    let suffix = if remainder > 0 {
+        format!(" (+{} more)", remainder)
+    } else {
+        String::new()
+    };
+
+    format!(
+        "{} of {} agents failed ({}){suffix}",
+        failed.len(),
+        result.agent_results.len(),
+        details.join("; "),
+    )
+}
+
+/// Append merge conflict info to a summary string.
+pub fn append_merge_conflict_summary(summary: String, conflict_count: usize) -> String {
+    if conflict_count == 0 {
+        return summary;
+    }
+    format!("{summary}; merge produced {conflict_count} conflict(s)")
+}
+
+/// Derive team execution status from delegation result and merge conflicts.
+pub fn derive_team_status(
+    result: &DelegationResult,
+    conflict_count: usize,
+) -> (TeamExecutionStatus, Option<String>) {
+    match result.status.as_str() {
+        "completed" => {
+            let status = if conflict_count > 0 {
+                TeamExecutionStatus::CompletedWithConflicts
+            } else {
+                TeamExecutionStatus::Completed
+            };
+            let error = if conflict_count > 0 {
+                Some(format!("merge produced {conflict_count} conflict(s)"))
+            } else {
+                None
+            };
+            (status, error)
+        }
+        "partial" => (
+            TeamExecutionStatus::Partial,
+            Some(append_merge_conflict_summary(
+                summarize_failed_agents(result),
+                conflict_count,
+            )),
+        ),
+        "failed" => (
+            TeamExecutionStatus::Failed,
+            Some(append_merge_conflict_summary(
+                summarize_failed_agents(result),
+                conflict_count,
+            )),
+        ),
+        other => (
+            TeamExecutionStatus::Failed,
+            Some(append_merge_conflict_summary(
+                format!("delegation ended in unexpected status \'{other}\'"),
+                conflict_count,
+            )),
+        ),
+    }
+}
+
+/// Extract a synthetic AgentLearning from an agent result.
+pub fn extract_learning_from_result(result: &AgentResult) -> AgentLearning {
+    let mut version = VersionVector::new();
+    version.increment(&result.agent_id);
+
+    AgentLearning {
+        agent_id: result.agent_id.clone(),
+        session_id: result.run_id.clone(),
+        version,
+        successful_patterns: vec![],
+        failed_patterns: vec![],
+        discovered_facts: vec![],
+        quality_score: if result.is_success() { 0.8 } else { 0.2 },
+    }
+}
+
+/// Aggregate learnings from all successful agents in a delegation result.
+pub fn merge_team_learnings(agent_results: &[AgentResult]) -> Option<MergedLearning> {
+    let learnings: Vec<AgentLearning> = agent_results
+        .iter()
+        .filter(|r| r.is_success())
+        .map(|r| extract_learning_from_result(r))
+        .collect();
+    if learnings.is_empty() {
+        None
+    } else {
+        Some(merge_agent_learnings(&learnings))
+    }
+}
+
+// ─── warn_persist! macro ────────────────────────────────────────────────────
+
+/// Log a warning when a best-effort persistence operation fails.
+#[macro_export]
+macro_rules! warn_persist {
+    ($op:expr, $label:expr) => {
+        if let Err(e) = $op {
+            astra_core::agent_warn!("orchestrator", "{}: {e}", $label);
+        }
+    };
+}

--- a/rust/crates/runtime/src/server/delegation_engine.rs
+++ b/rust/crates/runtime/src/server/delegation_engine.rs
@@ -353,40 +353,12 @@ pub trait CheckpointGate: Send + Sync {
     }
 }
 
-// ─── Sub-run Tracking ───────────────────────────────────────────────────────
+// ─── Sub-run Tracking ─────────────────────────────────────────────────────────────
 
-/// Tracks parent→child relationships for delegation hierarchies.
-#[derive(Debug, Clone)]
-pub struct SubRunRecord {
-    /// The sub-run's own ID.
-    pub run_id: String,
-    /// Parent run that spawned this sub-run.
-    pub parent_run_id: String,
-    /// Delegation this sub-run belongs to.
-    pub delegation_id: String,
-    /// Agent executing this sub-run.
-    pub agent_id: String,
-    /// Current depth in the delegation tree.
-    pub depth: u32,
-    /// Lifecycle state (enforced state machine).
-    pub state: SubRunState,
-    /// If this run is a gate-retry, links to the original run_id.
-    pub retry_of: Option<String>,
-}
-
-/// Real-time progress snapshot for an active delegation.
-#[derive(Debug, Clone)]
-pub struct DelegationProgress {
-    pub delegation_id: String,
-    /// Per-agent current state.
-    pub agent_states: HashMap<String, SubRunState>,
-    /// When execution started.
-    pub started_at: std::time::Instant,
-    /// Number of completed (terminal) sub-runs.
-    pub completed_count: usize,
-    /// Total sub-runs expected.
-    pub total_count: usize,
-}
+// SubRunRecord and DelegationProgress are now defined in astra-server-types.
+pub use astra_server_types::team_orchestrator_traits::{
+    DelegationProgress, SubRunRecord,
+};
 
 /// In-memory tracker for delegation hierarchies and pause state.
 ///
@@ -3249,6 +3221,55 @@ impl DelegationEngine {
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
+
+// ─── Trait Implementations ────────────────────────────────────────────────────────
+
+use astra_server_types::team_orchestrator_traits::{
+    DelegationExecutor, DelegationTracking,
+};
+
+#[async_trait::async_trait]
+impl DelegationExecutor for DelegationEngine {
+    async fn execute_delegation(
+        &self,
+        request: DelegationRequest,
+        source_agent_id: &str,
+        cancel_token: Option<Arc<tokio_util::sync::CancellationToken>>,
+    ) -> Result<DelegationResult, String> {
+        self.execute(request, source_agent_id, cancel_token).await
+    }
+
+    async fn get_delegation_progress(
+        &self,
+        delegation_id: &str,
+    ) -> Option<DelegationProgress> {
+        self.tracker().get_progress(delegation_id).await
+    }
+}
+
+#[async_trait::async_trait]
+impl DelegationTracking for DelegationTracker {
+    async fn get_sub_runs(&self, delegation_id: &str) -> Vec<SubRunRecord> {
+        DelegationTracker::get_sub_runs(self, delegation_id).await
+    }
+
+    async fn is_run_paused(&self, run_id: &str) -> bool {
+        self.is_paused(run_id).await
+    }
+
+    async fn pause_delegation(&self, delegation_id: &str) -> usize {
+        DelegationTracker::pause_delegation(self, delegation_id).await
+    }
+
+    async fn resume_delegation(&self, delegation_id: &str) -> usize {
+        DelegationTracker::resume_delegation(self, delegation_id).await
+    }
+
+    async fn cleanup_delegation(&self, delegation_id: &str) -> Result<(), String> {
+        DelegationTracker::cleanup_delegation(self, delegation_id).await
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/rust/crates/runtime/src/server/run_engine.rs
+++ b/rust/crates/runtime/src/server/run_engine.rs
@@ -204,6 +204,57 @@ impl RunEngine {
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
+// ─── Trait Implementation ─────────────────────────────────────────────────────────
+
+#[async_trait::async_trait]
+impl astra_server_types::team_orchestrator_traits::RunPersistence for RunEngine {
+    async fn start_run_ext(
+        &self,
+        run_id: &str,
+        user_id: &str,
+        session_id: &str,
+        parent_run_id: Option<&str>,
+        delegation_id: Option<&str>,
+        agent_id: Option<&str>,
+        retry_of: Option<&str>,
+    ) -> Result<(), String> {
+        RunEngine::start_run_ext(self, run_id, user_id, session_id, parent_run_id, delegation_id, agent_id, retry_of).await
+    }
+
+    async fn persist_status(
+        &self,
+        run_id: &str,
+        status: &str,
+        waiting_for: Option<&str>,
+        error_message: Option<&str>,
+    ) -> Result<bool, String> {
+        RunEngine::persist_status(self, run_id, status, waiting_for, error_message).await
+    }
+
+    async fn persist_usage(
+        &self,
+        run_id: &str,
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        tool_calls: u32,
+    ) -> Result<bool, String> {
+        RunEngine::persist_usage(self, run_id, prompt_tokens, completion_tokens, tool_calls).await
+    }
+
+    async fn persist_checkpoint(
+        &self,
+        run_id: &str,
+        checkpoint_json: &str,
+    ) -> Result<bool, String> {
+        RunEngine::persist_checkpoint(self, run_id, checkpoint_json).await
+    }
+
+    async fn append_event(&self, run_id: &str, event: serde_json::Value) -> Result<(), String> {
+        RunEngine::append_event(self, run_id, event).await
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/crates/runtime/src/server/team_orchestrator.rs
+++ b/rust/crates/runtime/src/server/team_orchestrator.rs
@@ -15,64 +15,27 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use astra_services::coordination::{
-    AgentProfile, AgentProfileRegistry, AgentResult, AgentTier, DelegationResult,
+    AgentProfile, AgentProfileRegistry, AgentTier, DelegationResult,
 };
-use astra_services::learning_merge::{AgentLearning, MergedLearning, merge_agent_learnings};
+use astra_services::learning_merge::MergedLearning;
 use astra_services::team_persistence::{TeamPersistenceService, WorktreeMode, resolve_team};
 
-use super::delegation_engine::{DelegationEngine, DelegationTracker};
-use super::run_engine::RunEngine;
-use super::worktree_isolation::{MergeResult, RepoLock, WorktreeManager};
+use astra_server_types::team_orchestrator_traits::{
+    DelegationExecutor, DelegationTracking, RunPersistence,
+};
+pub use astra_server_types::team_orchestrator_types::{
+    ExecutionPhase, OrchestratorConfig, ProgressCallback, TeamExecutionStatus,
+    append_merge_conflict_summary, derive_team_status, extract_learning_from_result,
+    merge_team_learnings, sum_usage, summarize_failed_agents,
+};
+use astra_server_types::warn_persist;
 
-/// Log a warning when a best-effort persistence operation fails.
-macro_rules! warn_persist {
-    ($op:expr, $label:expr) => {
-        if let Err(e) = $op {
-            astra_core::agent_warn!("orchestrator", "{}: {e}", $label);
-        }
-    };
-}
+use super::worktree_isolation::{MergeResult, RepoLock, WorktreeManager};
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-/// Progress phases emitted during team execution.
-#[derive(Debug, Clone, PartialEq)]
-pub enum ExecutionPhase {
-    /// Team loaded and validated, profiles resolved.
-    Preparing {
-        team_name: String,
-        member_count: usize,
-    },
-    /// Worktrees created (only for Isolated mode).
-    WorktreesCreated { agent_ids: Vec<String> },
-    /// Delegation started via DelegationEngine.
-    Executing { delegation_id: String },
-    /// Real-time agent state update within a delegation.
-    AgentProgress {
-        delegation_id: String,
-        /// agent_id → current state
-        agent_states: std::collections::HashMap<String, String>,
-        completed_count: usize,
-        total_count: usize,
-    },
-    /// Delegation completed, merging worktrees.
-    Merging { agent_count: usize },
-    /// Merge complete, producing final report.
-    Reporting { status: TeamExecutionStatus },
-}
-
-/// Callback for reporting execution progress to the UI layer.
-pub type ProgressCallback = Arc<dyn Fn(ExecutionPhase) + Send + Sync>;
-
-/// Configuration for creating a TeamExecutionOrchestrator.
-pub struct OrchestratorConfig {
-    pub user_id: String,
-    pub session_id: String,
-    /// Source agent ID requesting the team execution (for delegation validation).
-    pub source_agent_id: String,
-    /// Optional progress callback for UI integration.
-    pub progress: Option<ProgressCallback>,
-}
+// ExecutionPhase, ProgressCallback, OrchestratorConfig, TeamExecutionStatus
+// are re-exported from astra_server_types above.
 
 /// Outcome of a full team execution lifecycle.
 #[derive(Debug)]
@@ -87,26 +50,6 @@ pub struct TeamExecutionReport {
     pub error: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum TeamExecutionStatus {
-    Completed,
-    Partial,
-    CompletedWithConflicts,
-    CompletedOverBudget,
-    Failed,
-}
-
-impl std::fmt::Display for TeamExecutionStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Completed => write!(f, "completed"),
-            Self::Partial => write!(f, "partial"),
-            Self::CompletedWithConflicts => write!(f, "completed_with_conflicts"),
-            Self::CompletedOverBudget => write!(f, "completed_over_budget"),
-            Self::Failed => write!(f, "failed"),
-        }
-    }
-}
 
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
@@ -116,9 +59,9 @@ impl std::fmt::Display for TeamExecutionStatus {
 /// passed in via constructor args.
 pub struct TeamExecutionOrchestrator {
     team_store: Arc<dyn TeamPersistenceService>,
-    delegation_engine: Arc<DelegationEngine>,
-    delegation_tracker: Arc<DelegationTracker>,
-    run_engine: Arc<RunEngine>,
+    delegation_engine: Arc<dyn DelegationExecutor>,
+    delegation_tracker: Arc<dyn DelegationTracking>,
+    run_engine: Arc<dyn RunPersistence>,
     profile_registry: Arc<RwLock<AgentProfileRegistry>>,
     config: OrchestratorConfig,
     repo_lock: RepoLock,
@@ -129,9 +72,9 @@ pub struct TeamExecutionOrchestrator {
 impl TeamExecutionOrchestrator {
     pub fn new(
         team_store: Arc<dyn TeamPersistenceService>,
-        delegation_engine: Arc<DelegationEngine>,
-        delegation_tracker: Arc<DelegationTracker>,
-        run_engine: Arc<RunEngine>,
+        delegation_engine: Arc<dyn DelegationExecutor>,
+        delegation_tracker: Arc<dyn DelegationTracking>,
+        run_engine: Arc<dyn RunPersistence>,
         profile_registry: Arc<RwLock<AgentProfileRegistry>>,
         config: OrchestratorConfig,
     ) -> Self {
@@ -397,7 +340,7 @@ impl TeamExecutionOrchestrator {
         // instead of being orphaned when the delegation future is dropped.
         let cancel_token = Arc::new(tokio_util::sync::CancellationToken::new());
 
-        let delegation_future = self.delegation_engine.execute(
+        let delegation_future = self.delegation_engine.execute_delegation(
             effective_request,
             &self.config.source_agent_id,
             Some(cancel_token.clone()),
@@ -440,8 +383,7 @@ impl TeamExecutionOrchestrator {
                     // Poll and emit intermediate progress
                     if let Some(progress) = self
                         .delegation_engine
-                        .tracker()
-                        .get_progress(&delegation_id)
+                        .get_delegation_progress(&delegation_id)
                         .await
                     {
                         let agent_states: std::collections::HashMap<String, String> = progress
@@ -512,8 +454,7 @@ impl TeamExecutionOrchestrator {
         // Emit final agent progress snapshot
         if let Some(progress) = self
             .delegation_engine
-            .tracker()
-            .get_progress(&delegation_id)
+            .get_delegation_progress(&delegation_id)
             .await
         {
             let agent_states: std::collections::HashMap<String, String> = progress
@@ -598,17 +539,7 @@ impl TeamExecutionOrchestrator {
         };
 
         // Aggregate learnings from agent results
-        let learnings: Vec<AgentLearning> = delegation_result
-            .agent_results
-            .iter()
-            .filter(|r: &&AgentResult| r.is_success())
-            .map(|r| extract_learning_from_result(r))
-            .collect();
-        let merged_learning = if learnings.is_empty() {
-            None
-        } else {
-            Some(merge_agent_learnings(&learnings))
-        };
+        let merged_learning = aggregate_learnings(&delegation_result);
 
         // ── Phase 4: Report ─────────────────────────────────────────────
         let conflict_count = merge_result
@@ -734,7 +665,7 @@ impl TeamExecutionOrchestrator {
         }
         // Paused if any sub-run is paused
         for sr in &sub_runs {
-            if self.delegation_tracker.is_paused(&sr.run_id).await {
+            if self.delegation_tracker.is_run_paused(&sr.run_id).await {
                 return true;
             }
         }
@@ -767,132 +698,12 @@ impl TeamExecutionOrchestrator {
     }
 }
 
-// ─── Helpers ────────────────────────────────────────────────────────────────
+// Helper functions (sum_usage, summarize_failed_agents, derive_team_status, etc.)
+// are re-exported from astra_server_types::team_orchestrator_types via `pub use` above.
 
-/// Sum token usage across all agent results.
-fn sum_usage(result: &DelegationResult) -> (u64, u64, u32) {
-    let mut prompt = 0u64;
-    let mut completion = 0u64;
-    let mut tools = 0u32;
-    for r in &result.agent_results {
-        prompt += r.prompt_tokens;
-        completion += r.completion_tokens;
-        tools += r.tool_calls;
-    }
-    (prompt, completion, tools)
-}
-
-fn summarize_failed_agents(result: &DelegationResult) -> String {
-    if result.agent_results.is_empty() {
-        return "delegation produced no agent results".to_string();
-    }
-
-    let failed: Vec<&AgentResult> = result
-        .agent_results
-        .iter()
-        .filter(|agent| !agent.is_success())
-        .collect();
-    if failed.is_empty() {
-        return "delegation did not produce a successful result".to_string();
-    }
-
-    let details: Vec<String> = failed
-        .iter()
-        .take(3)
-        .map(|agent| {
-            let reason = agent
-                .error
-                .as_deref()
-                .filter(|value| !value.trim().is_empty())
-                .unwrap_or(agent.status.as_str());
-            format!("{}: {}", agent.agent_id, reason)
-        })
-        .collect();
-    let remainder = failed.len().saturating_sub(details.len());
-    let suffix = if remainder > 0 {
-        format!(" (+{} more)", remainder)
-    } else {
-        String::new()
-    };
-
-    format!(
-        "{} of {} agents failed ({}){}",
-        failed.len(),
-        result.agent_results.len(),
-        details.join("; "),
-        suffix
-    )
-}
-
-fn append_merge_conflict_summary(summary: String, conflict_count: usize) -> String {
-    if conflict_count == 0 {
-        return summary;
-    }
-
-    format!("{summary}; merge produced {conflict_count} conflict(s)")
-}
-
-fn derive_team_status(
-    result: &DelegationResult,
-    conflict_count: usize,
-) -> (TeamExecutionStatus, Option<String>) {
-    match result.status.as_str() {
-        "completed" => {
-            let status = if conflict_count > 0 {
-                TeamExecutionStatus::CompletedWithConflicts
-            } else {
-                TeamExecutionStatus::Completed
-            };
-            let error = if conflict_count > 0 {
-                Some(format!("merge produced {conflict_count} conflict(s)"))
-            } else {
-                None
-            };
-            (status, error)
-        }
-        "partial" => (
-            TeamExecutionStatus::Partial,
-            Some(append_merge_conflict_summary(
-                summarize_failed_agents(result),
-                conflict_count,
-            )),
-        ),
-        "failed" => (
-            TeamExecutionStatus::Failed,
-            Some(append_merge_conflict_summary(
-                summarize_failed_agents(result),
-                conflict_count,
-            )),
-        ),
-        other => (
-            TeamExecutionStatus::Failed,
-            Some(append_merge_conflict_summary(
-                format!("delegation ended in unexpected status '{other}'"),
-                conflict_count,
-            )),
-        ),
-    }
-}
-
-/// Extract a synthetic AgentLearning from an agent result.
-///
-/// Real implementations would parse structured output from the agent's
-/// response. This creates a minimal placeholder.
-fn extract_learning_from_result(result: &AgentResult) -> AgentLearning {
-    use astra_services::learning_merge::VersionVector;
-
-    let mut version = VersionVector::new();
-    version.increment(&result.agent_id);
-
-    AgentLearning {
-        agent_id: result.agent_id.clone(),
-        session_id: result.run_id.clone(),
-        version,
-        successful_patterns: vec![],
-        failed_patterns: vec![],
-        discovered_facts: vec![],
-        quality_score: if result.is_success() { 0.8 } else { 0.2 },
-    }
+/// Aggregate learnings from delegation agent results.
+fn aggregate_learnings(delegation_result: &DelegationResult) -> Option<MergedLearning> {
+    merge_team_learnings(&delegation_result.agent_results)
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -900,8 +711,9 @@ fn extract_learning_from_result(result: &AgentResult) -> AgentLearning {
 #[cfg(test)]
 mod tests {
     use super::super::delegation_engine::{
-        DelegationTracker, StubSubRunExecutor, SubRunConfig, SubRunExecutor,
+        DelegationEngine, DelegationTracker, StubSubRunExecutor, SubRunConfig, SubRunExecutor,
     };
+    use super::super::run_engine::RunEngine;
     use super::*;
     use astra_services::coordination::{AgentResult, AgentTier};
     use astra_services::runs::InMemoryRunStateStore;


### PR DESCRIPTION
## Summary

Extract trait abstractions and pure types from `team_orchestrator.rs` into `astra-server-types`, decoupling the orchestrator from concrete runtime types.

### Changes

**New files in astra-server-types:**
- `team_orchestrator_traits.rs` — 3 traits (`DelegationExecutor`, `DelegationTracking`, `RunPersistence`) + 2 relocated types (`SubRunRecord`, `DelegationProgress`)

**Runtime changes:**
- `team_orchestrator.rs`: struct fields now use trait objects (`Arc<dyn Trait>`) instead of concrete types; local types/helpers removed, re-exported from server-types
- `delegation_engine.rs`: `SubRunRecord`/`DelegationProgress` replaced with re-exports; added `DelegationExecutor` + `DelegationTracking` trait impls
- `run_engine.rs`: Added `RunPersistence` trait impl

### Stats
- ~190 LOC moved from runtime to shared crate
- 16/16 team_orchestrator tests pass
- 77/77 delegation_engine tests pass
- 13/13 run_engine tests pass
- Zero warnings