### PR TITLE
fix: auth retry dedup, Auto mode logging, skill surgery target

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/mod.rs
@@ -12,6 +12,7 @@ mod sse_loop;
 mod tests;
 
 pub(crate) use edge_executor::edge_executor_instance_id;
+pub(crate) use params::BasicCliChatContext;
 pub(crate) use params::ChatTurnParams;
 pub(crate) use params::{ApprovalRequest, ApprovalRequestTx, StreamEvent, StreamEventTx};
 pub(crate) use sse_loop::stream_chat_sse;

--- a/rust/crates/astra-cli/src/cli/chat_stream/params.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/params.rs
@@ -153,3 +153,82 @@ pub(crate) struct ChatTurnParams<'a> {
     /// Shared evolution service for multi-axis self-evolution.
     pub(crate) evolution_service: Option<Arc<astra_runtime::evolution::service::EvolutionService>>,
 }
+
+/// Bundle of "basic CLI" fields shared across one-shot CLI chat invocations
+/// (non-REPL, non-plan-subtask paths). These are the fields that vary per
+/// caller context but stay identical across auth-refresh / session-not-found
+/// retries within the same call site.
+///
+/// Used via [`ChatTurnParams::basic_cli`] to avoid repeating ~30 default fields
+/// at each retry site in `command_router.rs`.
+pub(crate) struct BasicCliChatContext<'a> {
+    pub api: &'a astra_thin_client::ThinClient,
+    pub message: &'a str,
+    pub model: Option<&'a str>,
+    pub explain: ExplainMode,
+    pub render_md: bool,
+    pub verbose_mode: bool,
+    pub render_policy: super::super::stream_render::RenderPolicy,
+    pub selector: &'a dyn ToolSelector,
+    pub unified_skill_registry: &'a std::sync::Arc<astra_runtime::skills::UnifiedSkillRegistry>,
+    pub skill_search: &'a astra_core::SkillSearchSettings,
+}
+
+impl<'a> ChatTurnParams<'a> {
+    /// Build a `ChatTurnParams` for a basic one-shot CLI chat invocation with
+    /// optional session-id and a freshly-borrowed `PermissionManager` /
+    /// `SkillQualityTracker` / token. All multi-agent / observability /
+    /// journal fields default to `None`.
+    pub(crate) fn basic_cli(
+        ctx: &'a BasicCliChatContext<'a>,
+        token: &'a str,
+        session_id: Option<&'a str>,
+        perm_manager: &'a mut PermissionManager,
+        skill_quality_tracker: &'a mut astra_runtime::skills::quality::SkillQualityTracker,
+    ) -> ChatTurnParams<'a> {
+        ChatTurnParams {
+            api: ctx.api,
+            token,
+            message: ctx.message,
+            session_id,
+            model: ctx.model,
+            explain: ctx.explain,
+            render_md: ctx.render_md,
+            history: &[],
+            perm_manager,
+            verbose_mode: ctx.verbose_mode,
+            render_policy: ctx.render_policy,
+            selector: ctx.selector,
+            recent_tools: &[],
+            tool_health_entries: &[],
+            unified_skill_registry: ctx.unified_skill_registry,
+            plan_only_chat: false,
+            is_plan_subtask: false,
+            plan_subtask_id: None,
+            delegation_engine: None,
+            cancel_token: None,
+            plan_assemble_line_release: None,
+            stream_event_tx: None,
+            approval_request_tx: None,
+            mcp_manager: None,
+            skill_search: ctx.skill_search,
+            skill_quality_tracker,
+            discovered_skills: None,
+            messaging_metrics: None,
+            agent_spawner: None,
+            root_agent_id: None,
+            root_mailbox_slot: None,
+            observability_hub: None,
+            observability_session: None,
+            file_journal: None,
+            database_snapshot_journal: None,
+            git_stash_journal: None,
+            git_commit_journal: None,
+            git_worktree_journal: None,
+            session_state_journal: None,
+            task_manager: None,
+            turn_index: 0,
+            evolution_service: None,
+        }
+    }
+}

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -412,99 +412,37 @@ pub(super) async fn execute_cli_command(
             );
             let mut skill_qt = astra_runtime::skills::quality::SkillQualityTracker::new();
             let skill_search = astra_core::SkillSearchSettings::default();
-            let sr = match stream_chat_sse(ChatTurnParams {
+            let chat_ctx = crate::chat_stream::BasicCliChatContext {
                 api,
-                token: &token,
                 message: &message,
-                session_id: session_id.as_deref(),
                 model: global_model.as_deref(),
                 explain: ExplainMode::Off,
                 render_md: terminal::size().is_ok(),
-                history: &[],
-                perm_manager: &mut pm,
                 verbose_mode: true,
                 render_policy: crate::stream_render::RenderPolicy::Stream,
                 selector: &*selector.0,
-                recent_tools: &[],
-                tool_health_entries: &[],
                 unified_skill_registry: astra_runtime::skills::default_unified_registry(),
-                plan_only_chat: false,
-                is_plan_subtask: false,
-                plan_subtask_id: None,
-                delegation_engine: None,
-                cancel_token: None,
-                plan_assemble_line_release: None,
-                stream_event_tx: None,
-                approval_request_tx: None,
-                mcp_manager: None,
                 skill_search: &skill_search,
-                skill_quality_tracker: &mut skill_qt,
-                discovered_skills: None,
-                messaging_metrics: None,
-                agent_spawner: None,
-                root_agent_id: None,
-                root_mailbox_slot: None,
-                observability_hub: None,
-                observability_session: None,
-                file_journal: None,
-                database_snapshot_journal: None,
-                git_stash_journal: None,
-                git_commit_journal: None,
-                git_worktree_journal: None,
-                session_state_journal: None,
-                task_manager: None,
-                turn_index: 0,
-                evolution_service: None,
-            })
+            };
+            let sr = match stream_chat_sse(ChatTurnParams::basic_cli(
+                &chat_ctx,
+                &token,
+                session_id.as_deref(),
+                &mut pm,
+                &mut skill_qt,
+            ))
             .await
             {
                 Ok(sr) => sr,
                 Err(e) if is_session_not_found_error(&e.error) && session_id.is_some() => {
                     let _ = clear_profile_last_session(profile.as_deref());
-                    stream_chat_sse(ChatTurnParams {
-                        api,
-                        token: &token,
-                        message: &message,
-                        session_id: None,
-                        model: global_model.as_deref(),
-                        explain: ExplainMode::Off,
-                        render_md: terminal::size().is_ok(),
-                        history: &[],
-                        perm_manager: &mut pm,
-                        verbose_mode: true,
-                        render_policy: crate::stream_render::RenderPolicy::Stream,
-                        selector: &*selector.0,
-                        recent_tools: &[],
-                        tool_health_entries: &[],
-                        unified_skill_registry: astra_runtime::skills::default_unified_registry(),
-                        plan_only_chat: false,
-                        is_plan_subtask: false,
-                        plan_subtask_id: None,
-                        delegation_engine: None,
-                        cancel_token: None,
-                        plan_assemble_line_release: None,
-                        stream_event_tx: None,
-                        approval_request_tx: None,
-                        mcp_manager: None,
-                        skill_search: &skill_search,
-                        skill_quality_tracker: &mut skill_qt,
-                        discovered_skills: None,
-                        messaging_metrics: None,
-                        agent_spawner: None,
-                        root_agent_id: None,
-                        root_mailbox_slot: None,
-                        observability_hub: None,
-                        observability_session: None,
-                        file_journal: None,
-                        database_snapshot_journal: None,
-                        git_stash_journal: None,
-                        git_commit_journal: None,
-                        git_worktree_journal: None,
-                        session_state_journal: None,
-                        task_manager: None,
-                        turn_index: 0,
-                        evolution_service: None,
-                    })
+                    stream_chat_sse(ChatTurnParams::basic_cli(
+                        &chat_ctx,
+                        &token,
+                        None,
+                        &mut pm,
+                        &mut skill_qt,
+                    ))
                     .await
                     .map_err(|f| f.error)?
                 }
@@ -514,51 +452,13 @@ pub(super) async fn execute_cli_command(
                             repl_runtime::current_access_token(profile.as_deref())
                         {
                             eprintln!("  {} Token refreshed, retrying…", crate::theme::icon_ok());
-                            stream_chat_sse(ChatTurnParams {
-                                api,
-                                token: &new_token,
-                                message: &message,
-                                session_id: session_id.as_deref(),
-                                model: global_model.as_deref(),
-                                explain: ExplainMode::Off,
-                                render_md: terminal::size().is_ok(),
-                                history: &[],
-                                perm_manager: &mut pm,
-                                verbose_mode: true,
-                                render_policy: crate::stream_render::RenderPolicy::Stream,
-                                selector: &*selector.0,
-                                recent_tools: &[],
-                                tool_health_entries: &[],
-                                unified_skill_registry:
-                                    astra_runtime::skills::default_unified_registry(),
-                                plan_only_chat: false,
-                                is_plan_subtask: false,
-                                plan_subtask_id: None,
-                                delegation_engine: None,
-                                cancel_token: None,
-                                plan_assemble_line_release: None,
-                                stream_event_tx: None,
-                                approval_request_tx: None,
-                                mcp_manager: None,
-                                skill_search: &skill_search,
-                                skill_quality_tracker: &mut skill_qt,
-                                discovered_skills: None,
-                                messaging_metrics: None,
-                                agent_spawner: None,
-                                root_agent_id: None,
-                                root_mailbox_slot: None,
-                                observability_hub: None,
-                                observability_session: None,
-                                file_journal: None,
-                                database_snapshot_journal: None,
-                                git_stash_journal: None,
-                                git_commit_journal: None,
-                                git_worktree_journal: None,
-                                session_state_journal: None,
-                                task_manager: None,
-                                turn_index: 0,
-                                evolution_service: None,
-                            })
+                            stream_chat_sse(ChatTurnParams::basic_cli(
+                                &chat_ctx,
+                                &new_token,
+                                session_id.as_deref(),
+                                &mut pm,
+                                &mut skill_qt,
+                            ))
                             .await
                             .map_err(|f| f.error)?
                         } else {
@@ -911,107 +811,42 @@ pub(super) async fn execute_cli_command(
 
             let mut skill_qt = astra_runtime::skills::quality::SkillQualityTracker::new();
             let skill_search = astra_core::SkillSearchSettings::default();
-            let sr = match stream_chat_sse(ChatTurnParams {
+            let render_policy = if quiet {
+                crate::stream_render::RenderPolicy::Silent
+            } else {
+                crate::stream_render::RenderPolicy::Stream
+            };
+            let chat_ctx = crate::chat_stream::BasicCliChatContext {
                 api,
-                token: &token,
                 message: &message,
-                session_id: session_id.as_deref(),
                 model: args.model.as_deref().or(global_model.as_deref()),
                 explain: explain_mode,
                 render_md,
-                history: &[],
-                perm_manager: &mut pm,
                 verbose_mode: !quiet,
-                render_policy: if quiet {
-                    crate::stream_render::RenderPolicy::Silent
-                } else {
-                    crate::stream_render::RenderPolicy::Stream
-                },
+                render_policy,
                 selector: &*selector.0,
-                recent_tools: &[],
-                tool_health_entries: &[],
                 unified_skill_registry: astra_runtime::skills::default_unified_registry(),
-                plan_only_chat: false,
-                is_plan_subtask: false,
-                plan_subtask_id: None,
-                delegation_engine: None,
-                cancel_token: None,
-                plan_assemble_line_release: None,
-                stream_event_tx: None,
-                approval_request_tx: None,
-                mcp_manager: None,
                 skill_search: &skill_search,
-                skill_quality_tracker: &mut skill_qt,
-                discovered_skills: None,
-                messaging_metrics: None,
-                agent_spawner: None,
-                root_agent_id: None,
-                root_mailbox_slot: None,
-                observability_hub: None,
-                observability_session: None,
-                file_journal: None,
-                database_snapshot_journal: None,
-                git_stash_journal: None,
-                git_commit_journal: None,
-                git_worktree_journal: None,
-                session_state_journal: None,
-                task_manager: None,
-                turn_index: 0,
-                evolution_service: None,
-            })
+            };
+            let sr = match stream_chat_sse(ChatTurnParams::basic_cli(
+                &chat_ctx,
+                &token,
+                session_id.as_deref(),
+                &mut pm,
+                &mut skill_qt,
+            ))
             .await
             {
                 Ok(sr) => sr,
                 Err(e) if is_session_not_found_error(&e.error) && session_id.is_some() => {
                     let _ = clear_profile_last_session(profile.as_deref());
-                    stream_chat_sse(ChatTurnParams {
-                        api,
-                        token: &token,
-                        message: &message,
-                        session_id: None,
-                        model: args.model.as_deref().or(global_model.as_deref()),
-                        explain: explain_mode,
-                        render_md,
-                        history: &[],
-                        perm_manager: &mut pm,
-                        verbose_mode: !quiet,
-                        render_policy: if quiet {
-                            crate::stream_render::RenderPolicy::Silent
-                        } else {
-                            crate::stream_render::RenderPolicy::Stream
-                        },
-                        selector: &*selector.0,
-                        recent_tools: &[],
-                        tool_health_entries: &[],
-                        unified_skill_registry: astra_runtime::skills::default_unified_registry(),
-                        plan_only_chat: false,
-                        is_plan_subtask: false,
-                        plan_subtask_id: None,
-                        delegation_engine: None,
-                        cancel_token: None,
-                        plan_assemble_line_release: None,
-                        stream_event_tx: None,
-                        approval_request_tx: None,
-                        mcp_manager: None,
-                        skill_search: &skill_search,
-                        skill_quality_tracker: &mut skill_qt,
-                        discovered_skills: None,
-                        messaging_metrics: None,
-                        agent_spawner: None,
-                        root_agent_id: None,
-                        root_mailbox_slot: None,
-                        observability_hub: None,
-                        observability_session: None,
-                        file_journal: None,
-                        database_snapshot_journal: None,
-                        git_stash_journal: None,
-                        git_commit_journal: None,
-                        git_worktree_journal: None,
-                        session_state_journal: None,
-                        task_manager: None,
-                        turn_index: 0,
-                        evolution_service: None,
-                    })
+                    stream_chat_sse(ChatTurnParams::basic_cli(
+                        &chat_ctx,
+                        &token,
+                        None,
+                        &mut pm,
+                        &mut skill_qt,
+                    ))
                     .await
                     .map_err(|f| f.error)?
                 }
@@ -1437,103 +1272,40 @@ pub(super) async fn run_print_mode(
     let mut skill_qt = astra_runtime::skills::quality::SkillQualityTracker::new();
     let skill_search = astra_core::SkillSearchSettings::default();
 
-    let sr = match stream_chat_sse(ChatTurnParams {
+    let chat_ctx = crate::chat_stream::BasicCliChatContext {
         api,
-        token: &token,
         message: &message,
-        session_id: session_id.as_deref(),
         model,
         explain: ExplainMode::Off,
         render_md: false,
-        history: &[],
-        perm_manager: &mut pm,
         verbose_mode: std::env::var("ASTRA_VERBOSE")
             .map(|v| v == "1")
             .unwrap_or(false),
         render_policy: crate::stream_render::RenderPolicy::Silent,
         selector: &*selector.0,
-        recent_tools: &[],
-        tool_health_entries: &[],
         unified_skill_registry: astra_runtime::skills::default_unified_registry(),
-        plan_only_chat: false,
-        is_plan_subtask: false,
-        plan_subtask_id: None,
-        delegation_engine: None,
-        cancel_token: None,
-        plan_assemble_line_release: None,
-        stream_event_tx: None,
-        approval_request_tx: None,
-        mcp_manager: None,
         skill_search: &skill_search,
-        skill_quality_tracker: &mut skill_qt,
-        discovered_skills: None,
-        messaging_metrics: None,
-        agent_spawner: None,
-        root_agent_id: None,
-        root_mailbox_slot: None,
-        observability_hub: None,
-        observability_session: None,
-        file_journal: None,
-        database_snapshot_journal: None,
-        git_stash_journal: None,
-        git_commit_journal: None,
-        git_worktree_journal: None,
-        session_state_journal: None,
-        task_manager: None,
-        turn_index: 0,
-        evolution_service: None,
-    })
+    };
+
+    let sr = match stream_chat_sse(ChatTurnParams::basic_cli(
+        &chat_ctx,
+        &token,
+        session_id.as_deref(),
+        &mut pm,
+        &mut skill_qt,
+    ))
     .await
     {
         Ok(sr) => sr,
         Err(e) if is_session_not_found_error(&e.error) && session_id.is_some() => {
             let _ = clear_profile_last_session(profile);
-            stream_chat_sse(ChatTurnParams {
-                api,
-                token: &token,
-                message: &message,
-                session_id: None,
-                model,
-                explain: ExplainMode::Off,
-                render_md: false,
-                history: &[],
-                perm_manager: &mut pm,
-                verbose_mode: std::env::var("ASTRA_VERBOSE")
-                    .map(|v| v == "1")
-                    .unwrap_or(false),
-                render_policy: crate::stream_render::RenderPolicy::Silent,
-                selector: &*selector.0,
-                recent_tools: &[],
-                tool_health_entries: &[],
-                unified_skill_registry: astra_runtime::skills::default_unified_registry(),
-                plan_only_chat: false,
-                is_plan_subtask: false,
-                plan_subtask_id: None,
-                delegation_engine: None,
-                cancel_token: None,
-                plan_assemble_line_release: None,
-                stream_event_tx: None,
-                approval_request_tx: None,
-                mcp_manager: None,
-                skill_search: &skill_search,
-                skill_quality_tracker: &mut skill_qt,
-                discovered_skills: None,
-                messaging_metrics: None,
-                agent_spawner: None,
-                root_agent_id: None,
-                root_mailbox_slot: None,
-                observability_hub: None,
-                observability_session: None,
-                file_journal: None,
-                database_snapshot_journal: None,
-                git_stash_journal: None,
-                git_commit_journal: None,
-                git_worktree_journal: None,
-                session_state_journal: None,
-                task_manager: None,
-                turn_index: 0,
-                evolution_service: None,
-            })
+            stream_chat_sse(ChatTurnParams::basic_cli(
+                &chat_ctx,
+                &token,
+                None,
+                &mut pm,
+                &mut skill_qt,
+            ))
             .await
             .map_err(|f| f.error)?
         }

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -1270,7 +1270,13 @@ impl PermissionManager {
         // Step 5: Dangerous file path — respects Auto mode (user explicitly opted in).
         if let Some(warning) = Self::check_dangerous_path(name, args) {
             match self.mode {
-                PermissionMode::Auto => return PermissionDecision::Allow,
+                PermissionMode::Auto => {
+                    astra_core::agent_warn!(
+                        "permission",
+                        "Auto mode allowed write to sensitive path: tool={name} warning={warning}"
+                    );
+                    return PermissionDecision::Allow;
+                }
                 PermissionMode::Deny => {
                     return PermissionDecision::Deny("Sensitive path (deny mode)".into());
                 }

--- a/rust/crates/astra-cli/src/cli/repl_runtime.rs
+++ b/rust/crates/astra-cli/src/cli/repl_runtime.rs
@@ -377,6 +377,7 @@ pub(super) async fn check_server_has_models(
 }
 
 /// Outcome of `try_refresh_token` for deciding whether on-disk credentials may still be valid.
+#[derive(Debug)]
 enum SilentRefreshError {
     Thin(astra_thin_client::ThinClientError),
     /// HTTP 200 body was not usable; keep existing tokens.
@@ -524,7 +525,8 @@ async fn try_refresh_token(
 /// Attempt to refresh an expired token mid-session.
 ///
 /// Returns `true` (and persists new credentials) on success.
-/// On failure, also tries the refresh-race recovery path before giving up.
+/// On failure, logs the underlying reason before returning `false`, so users
+/// can see why a refresh did not recover their session.
 pub(super) async fn attempt_token_refresh(
     api: &astra_thin_client::ThinClient,
     profile: Option<&str>,
@@ -536,6 +538,10 @@ pub(super) async fn attempt_token_refresh(
         .get(&name)
         .and_then(|p| p.refresh_token.as_ref())
     else {
+        astra_core::agent_warn!(
+            "auth",
+            "token refresh skipped: no refresh_token stored for profile '{name}'"
+        );
         return false;
     };
     let refresh_str = refresh.clone();
@@ -544,9 +550,25 @@ pub(super) async fn attempt_token_refresh(
         Ok(()) => true,
         Err(err) => {
             if err.keep_credentials() {
+                astra_core::agent_warn!(
+                    "auth",
+                    "token refresh failed (credentials preserved): {err:?}"
+                );
                 return false;
             }
-            recover_credentials_after_refresh_race(api, profile, &refresh_str).await
+            astra_core::agent_warn!(
+                "auth",
+                "token refresh failed, attempting race-recovery path: {err:?}"
+            );
+            let recovered =
+                recover_credentials_after_refresh_race(api, profile, &refresh_str).await;
+            if !recovered {
+                astra_core::agent_warn!(
+                    "auth",
+                    "token refresh race-recovery also failed for profile '{name}'"
+                );
+            }
+            recovered
         }
     }
 }

--- a/rust/crates/astra-tools/src/git_gix.rs
+++ b/rust/crates/astra-tools/src/git_gix.rs
@@ -808,7 +808,7 @@ pub fn git_show(
 
     // When viewing many per-file diffs from the same commit, nudge the model
     // to wrap up early rather than exhausting the aggregate budget.
-    if file_filter.is_some() && aggregate_bytes > super::AGGREGATE_SOFT_LIMIT / 2 {
+    if file_filter.is_some() && aggregate_bytes > super::AGGREGATE_HINT_THRESHOLD {
         result.push_str(
             "\n[hint: aggregate output is high — finish reviewing with the files \
              already read, or use stat_only:true to prioritize remaining files]",

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -387,6 +387,10 @@ pub const AGGREGATE_OUTPUT_BUDGET: usize = 200_000;
 /// Soft threshold for aggregate-aware gating.
 pub const AGGREGATE_SOFT_LIMIT: usize = 120_000;
 
+/// Hint threshold: when aggregate bytes exceed this while a file filter is set,
+/// suggest narrowing further before hitting the hard soft-limit.
+pub const AGGREGATE_HINT_THRESHOLD: usize = AGGREGATE_SOFT_LIMIT / 2;
+
 /// Per-tool persistence threshold (chars).
 pub const PERSIST_THRESHOLD: usize = 50_000;
 

--- a/rust/crates/runtime/src/turn/agentic_tool_interception.rs
+++ b/rust/crates/runtime/src/turn/agentic_tool_interception.rs
@@ -281,7 +281,14 @@ async fn intercept_skill_calls(
                 surgically_removed_ids.insert(call_id.to_string());
             }
             // Append a note to the skill result so the model knows what was dropped.
-            if let Some(skill_result) = skill_results.iter_mut().find(|r| r.result.len() > 500) {
+            // Prefer the most recently-added large result (the one that triggered
+            // the interception) — `sr` is appended last, so iterating in reverse
+            // picks the newly-run skill output rather than a leftover dedup entry.
+            if let Some(skill_result) = skill_results
+                .iter_mut()
+                .rev()
+                .find(|r| r.result.len() > 500)
+            {
                 skill_result.result.push_str(&format!(
                     "\n\n[{} parallel tool call(s) were dropped: [{}]. \
                      The skill output above is your complete context — do NOT re-invoke \


### PR DESCRIPTION
Addresses code review findings across 5 files:

## 🔴 Critical
- **command_router.rs** — Auth-refresh retry duplicated a 30+ field `ChatTurnParams` struct 7 times across 3 call sites. Extracted `ChatTurnParams::basic_cli(ctx, token, session_id, ...)` + `BasicCliChatContext` bundle so retry sites only pass the varying inputs. Net −166 lines, new fields only need to be added in one place.

## 🟡 Important
- **permission_manager.rs** — Auto mode still shortcuts to `Allow` for dangerous paths (`.git/config`, `.ssh/authorized_keys`, etc.), but now emits a `agent_warn!` so silent writes are observable. Preserves the opt-in Auto semantics while restoring visibility of the prior safety intent.
- **agentic_tool_interception.rs** — Surgery note now targets the most recently-added large skill result (`.iter_mut().rev().find(...)`), which is the skill that triggered interception. Previously the first large result won, which could be an unrelated dedup entry.

## 💡 Suggestions
- **git_gix.rs / astra-tools/lib.rs** — Replaced `AGGREGATE_SOFT_LIMIT / 2` magic number with named `AGGREGATE_HINT_THRESHOLD` constant.
- **repl_runtime.rs** — `attempt_token_refresh` now logs the underlying failure reason (no refresh_token, thin-client error, race-recovery failure) via `agent_warn!` so users can see why a refresh did not recover their session. Signature unchanged (`bool`) to avoid rippling through 3 callers.

## Verification
- `make check` passes (format + clippy + compile)
