### PR TITLE
fix(runtime): filter surgical-removal records and gate scenario detection after user cancel

### DIFF
--- a/rust/crates/runtime/src/observability_integration.rs
+++ b/rust/crates/runtime/src/observability_integration.rs
@@ -112,6 +112,17 @@ pub struct ObservabilitySession {
 
     /// Turn at which the last per-turn token budget change occurred.
     pub last_token_budget_change_turn: Option<u32>,
+
+    /// Set to `true` when the previous turn ended in a `UserCancelled`
+    /// interruption. The adaptive-tuning layer consumes this flag at the
+    /// start of the next turn to *skip* scenario re-detection: the tool
+    /// history of a cancelled turn is an aborted plan, not evidence of a
+    /// deliberate agent behavior pattern (e.g. "exploration"). Without this
+    /// gate, a Ctrl+C during a focused read-only task leaks into the
+    /// detector as many `glob`/`grep`/`view` calls and falsely boosts the
+    /// `Exploration` scenario, which in turn inflates the tool budget for
+    /// the *next* turn.
+    pub previous_turn_user_cancelled: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -222,6 +233,7 @@ impl ObservabilitySession {
             last_scenario_change_turn: None,
             last_token_budget_direction: 0,
             last_token_budget_change_turn: None,
+            previous_turn_user_cancelled: false,
         }
     }
 
@@ -254,6 +266,7 @@ impl ObservabilitySession {
             last_scenario_change_turn: None,
             last_token_budget_direction: 0,
             last_token_budget_change_turn: None,
+            previous_turn_user_cancelled: false,
         }
     }
 

--- a/rust/crates/runtime/src/pipeline/evaluation.rs
+++ b/rust/crates/runtime/src/pipeline/evaluation.rs
@@ -180,8 +180,14 @@ pub fn evaluate_tool_call_records(
     verdict_warning: bool,
     budget_pressure: f64,
 ) -> TurnEvaluation {
+    // Synthetic placeholders (skill skipped/deferred, surgically removed
+    // parallel tool calls) are audit-only records that do NOT represent real
+    // tool execution. Filtering them here is the single choke-point that
+    // keeps tool_error_rate, RepeatToolCall, EmptyToolOutput, and the
+    // success/quality verdict honest.
     let tool_calls = tool_call_records
         .iter()
+        .filter(|record| !record.is_synthetic_placeholder())
         .map(|record| ToolCallInfo {
             name: record.name.clone(),
             ok: record.ok,
@@ -499,5 +505,116 @@ mod tests {
         assert_eq!(metadata["signal_count"], 2);
         assert_eq!(metadata["signals"][0]["kind"], "tool_error_rate");
         assert_eq!(metadata["signals"][1]["kind"], "all_tools_healthy");
+    }
+
+    #[test]
+    fn evaluate_records_skips_synthetic_placeholders() {
+        use astra_services::session_journal::{SURGICAL_REMOVAL_TOOL_NAME, ToolCallRecord};
+
+        let rec = |name: &str, ok: bool, preview: Option<&str>| ToolCallRecord {
+            name: name.to_string(),
+            ok,
+            ms: 50,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(200),
+            args_preview: None,
+            result_preview: preview.map(ToString::to_string),
+            file_path: None,
+        };
+
+        // 1 real successful tool + 3 synthetic placeholders (skipped,
+        // deferred, surgically_removed). A naive counter would see
+        // error_rate = 3/4 = 0.75 and quality collapse. With filtering,
+        // only the real success is counted and the turn scores as healthy.
+        let records = vec![
+            rec("git_show", true, Some("diff contents here")),
+            rec(
+                SURGICAL_REMOVAL_TOOL_NAME,
+                true,
+                Some("(removed from context — skill covered this work)"),
+            ),
+            rec("read_file", false, Some("Skipped: skill routed")),
+            rec("read_file", false, Some("Deferred: skill invoked")),
+        ];
+
+        let eval = evaluate_tool_call_records(
+            "review commit 179afcb",
+            &["git_show".to_string()],
+            &records,
+            0,
+            false,
+            0.1,
+        );
+
+        // Must contain exactly one error_rate=0.0 signal AND AllToolsHealthy
+        // — proves surgical/skipped/deferred were filtered before analysis.
+        let has_zero_error = eval.signals.iter().any(|s| {
+            matches!(s, EvalSignal::ToolErrorRate(rate) if (*rate - 0.0).abs() < f64::EPSILON)
+        });
+        assert!(
+            has_zero_error,
+            "expected ToolErrorRate(0.0) after filtering synthetic placeholders, got {:?}",
+            eval.signals
+        );
+        assert!(
+            eval.signals
+                .iter()
+                .any(|s| matches!(s, EvalSignal::AllToolsHealthy)),
+            "expected AllToolsHealthy signal, got {:?}",
+            eval.signals
+        );
+        assert!(
+            eval.success,
+            "turn with one real success and synthetic placeholders must be success=true"
+        );
+        assert!(
+            eval.quality > 0.6,
+            "quality should be high after filtering, got {}",
+            eval.quality
+        );
+    }
+
+    #[test]
+    fn repeat_tool_call_ignores_surgical_removals() {
+        use astra_services::session_journal::{SURGICAL_REMOVAL_TOOL_NAME, ToolCallRecord};
+
+        // Four surgically_removed records in a single turn used to surface
+        // as RepeatToolCall("(surgically_removed)") — a false "retry loop"
+        // signal. After filtering they must not appear at all.
+        let records: Vec<ToolCallRecord> = (0..4)
+            .map(|_| ToolCallRecord {
+                name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+                ok: true,
+                ms: 0,
+                error: None,
+                input_bytes: None,
+                output_bytes: Some(0),
+                args_preview: None,
+                result_preview: Some("(removed from context — skill covered this work)".into()),
+                file_path: None,
+            })
+            .chain(std::iter::once(ToolCallRecord {
+                name: "git_show".to_string(),
+                ok: true,
+                ms: 20,
+                error: None,
+                input_bytes: None,
+                output_bytes: Some(400),
+                args_preview: None,
+                result_preview: Some("diff".into()),
+                file_path: None,
+            }))
+            .collect();
+
+        let eval = evaluate_tool_call_records("noop", &[], &records, 0, false, 0.1);
+        assert!(
+            !eval
+                .signals
+                .iter()
+                .any(|s| matches!(s, EvalSignal::RepeatToolCall(_))),
+            "no RepeatToolCall signal should be emitted for synthetic placeholders, got {:?}",
+            eval.signals
+        );
     }
 }

--- a/rust/crates/runtime/src/pipeline/evaluation.rs
+++ b/rust/crates/runtime/src/pipeline/evaluation.rs
@@ -549,9 +549,9 @@ mod tests {
 
         // Must contain exactly one error_rate=0.0 signal AND AllToolsHealthy
         // — proves surgical/skipped/deferred were filtered before analysis.
-        let has_zero_error = eval.signals.iter().any(|s| {
-            matches!(s, EvalSignal::ToolErrorRate(rate) if (*rate - 0.0).abs() < f64::EPSILON)
-        });
+        let has_zero_error = eval.signals.iter().any(
+            |s| matches!(s, EvalSignal::ToolErrorRate(rate) if (*rate - 0.0).abs() < f64::EPSILON),
+        );
         assert!(
             has_zero_error,
             "expected ToolErrorRate(0.0) after filtering synthetic placeholders, got {:?}",

--- a/rust/crates/runtime/src/turn/agentic_adaptive_tuning.rs
+++ b/rust/crates/runtime/src/turn/agentic_adaptive_tuning.rs
@@ -195,6 +195,18 @@ pub(crate) fn apply_adaptive_execution_profile(state: &mut AgenticLoopState) {
         Err(_) => return,
     };
 
+    // If the *previous* turn ended in a user cancellation, skip scenario
+    // re-detection for this turn. The tool history of a cancelled turn is
+    // an aborted plan, not evidence of a deliberate behavior pattern, and
+    // would otherwise leak into ScenarioDetector (e.g. many `glob`/`grep`/
+    // `view` calls from an interrupted review falsely score as
+    // `Exploration`, ratcheting the tool budget). Consume the flag so this
+    // is a one-turn suppression only.
+    if session_guard.previous_turn_user_cancelled {
+        session_guard.previous_turn_user_cancelled = false;
+        return;
+    }
+
     let mut detector = crate::user_profile::ScenarioDetector::new();
     for query in &session_guard.recent_queries {
         detector.observe_query(query);

--- a/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
@@ -380,6 +380,24 @@ pub async fn run_agentic_loop_with_host<H: AgenticLoopHost>(
                 let _ = writer.append(&evt);
             }
         }
+
+        // Carry `UserCancelled` forward so the adaptive-tuning layer can
+        // skip scenario re-detection on the next turn. Without this gate,
+        // the aborted tool history leaks into ScenarioDetector and can
+        // falsely trigger an `Exploration` scenario (ratcheting the tool
+        // budget). Any non-UserCancelled interruption (timeout, error,
+        // stream_error, …) does NOT set the flag — only an explicit user
+        // cancel invalidates the tool-history-as-evidence signal.
+        if matches!(
+            interruption.kind,
+            astra_turn_core::interruption::InterruptionKind::UserCancelled
+        ) {
+            if let Some(ref session) = state.telemetry.observability_session {
+                if let Ok(mut guard) = session.write() {
+                    guard.previous_turn_user_cancelled = true;
+                }
+            }
+        }
     }
 
     if let Some(evo) = state.evolution_service.clone() {

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -770,6 +770,7 @@ pub(crate) mod tests {
     use astra_core::confidence::ConfidenceInterval;
     use astra_services::evaluation::types::ValueInterval;
     use astra_services::session_audit::RuntimePromotionOutcome;
+    use astra_services::session_journal::SURGICAL_REMOVAL_TOOL_NAME;
     use serde_json::json;
 
     // ── Flexible mock host for multi-turn scenarios ─────────────────────────
@@ -4127,8 +4128,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 ),
             ),
             tool_record(
-                "(surgically_removed)",
-                false,
+                SURGICAL_REMOVAL_TOOL_NAME,
+                true,
                 Some("(removed from context — skill covered this work)"),
             ),
             tool_record(
@@ -4319,6 +4320,96 @@ print(json.dumps({'context': 'user said: ' + msg}))
             Some(crate::user_profile::Scenario::Debugging)
         );
         assert!(state.max_turn_input_tokens >= 100_000);
+    }
+
+    #[test]
+    fn adaptive_profile_skips_scenario_after_user_cancellation() {
+        // Regression for session 721df7da: after the user hits Ctrl+C on a
+        // focused review task, the tool history of the cancelled turn was
+        // leaking into ScenarioDetector and falsely triggering the
+        // `Exploration` scenario (ratcheting tool_budget 722 → 1000).
+        // The fix gates `apply_adaptive_execution_profile` on the
+        // `previous_turn_user_cancelled` flag and consumes it after one
+        // turn.
+        let hub = make_hub();
+        let session = make_session();
+        let mut state = make_state();
+        state.telemetry.observability_hub = Some(hub);
+        state.telemetry.observability_session = Some(session.clone());
+        state.message = "继续啊".into();
+        // Exploratory tool history from the cancelled turn — would
+        // normally push the detector toward Exploration.
+        state.recent_tools = vec![
+            "glob".into(),
+            "grep".into(),
+            "view".into(),
+            "read_file".into(),
+            "git_show".into(),
+            "git_show".into(),
+            "view".into(),
+            "grep".into(),
+        ];
+
+        let scenario_before;
+        {
+            let mut guard = session.write().unwrap_or_else(|e| e.into_inner());
+            guard.previous_turn_user_cancelled = true;
+            scenario_before = guard.profile.current_scenario;
+        }
+
+        apply_adaptive_execution_profile(&mut state);
+
+        let guard = session.read().unwrap_or_else(|e| e.into_inner());
+        // Flag must be consumed (one-turn suppression only).
+        assert!(
+            !guard.previous_turn_user_cancelled,
+            "previous_turn_user_cancelled flag must be cleared after being consumed"
+        );
+        // Scenario must NOT have changed as a side-effect of the cancelled
+        // turn's tool history.
+        assert_eq!(
+            guard.profile.current_scenario, scenario_before,
+            "scenario should not be re-detected on the turn after a user cancellation"
+        );
+    }
+
+    #[test]
+    fn adaptive_profile_resumes_on_turn_after_cancellation_cleared() {
+        // Verifies the suppression is strictly one turn: the second
+        // apply_adaptive_execution_profile call after a cancellation must
+        // behave normally (i.e. detect Debugging for a matching query).
+        let hub = make_hub();
+        let session = make_session();
+        let mut state = make_state();
+        state.telemetry.observability_hub = Some(hub);
+        state.telemetry.observability_session = Some(session.clone());
+        state.message = "fix the bug in the parser".into();
+        state.recent_tools = vec!["bash".into(), "view".into()];
+
+        {
+            let mut guard = session.write().unwrap_or_else(|e| e.into_inner());
+            for _ in 0..5 {
+                guard.record_query("fix the bug in the parser");
+            }
+            guard.previous_turn_user_cancelled = true;
+        }
+
+        // First call: suppressed (flag was true) — scenario unchanged.
+        apply_adaptive_execution_profile(&mut state);
+        {
+            let guard = session.read().unwrap_or_else(|e| e.into_inner());
+            assert!(!guard.previous_turn_user_cancelled);
+            assert_eq!(guard.profile.current_scenario, None);
+        }
+
+        // Second call: normal detection path runs.
+        apply_adaptive_execution_profile(&mut state);
+        let guard = session.read().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(
+            guard.profile.current_scenario,
+            Some(crate::user_profile::Scenario::Debugging),
+            "scenario detection must resume on the turn after the cancellation flag is consumed"
+        );
     }
 
     #[test]
@@ -6927,12 +7018,14 @@ print(json.dumps({'context': 'user said: ' + msg}))
             "skill result should note the surgically removed calls, got: {skill_content}"
         );
 
-        // Stall detector should still have records for the removed calls.
+        // Stall detector should still have records for the removed calls
+        // (now as synthetic placeholders with ok=true — they are intentional
+        // context optimizations, not failures).
         let removed_records: Vec<_> = state
             .stall
             .tool_call_records
             .iter()
-            .filter(|r| r.name == "(surgically_removed)")
+            .filter(|r| r.name == SURGICAL_REMOVAL_TOOL_NAME)
             .collect();
         assert_eq!(
             removed_records.len(),
@@ -6941,7 +7034,16 @@ print(json.dumps({'context': 'user said: ' + msg}))
             removed_records.len()
         );
         for r in &removed_records {
-            assert!(!r.ok, "surgically_removed records should have ok=false");
+            assert!(
+                r.ok,
+                "surgically_removed records should have ok=true (they are \
+                 intentional context optimizations, not tool failures)"
+            );
+            assert!(
+                r.is_synthetic_placeholder(),
+                "surgically_removed records must be classified as synthetic \
+                 placeholders so evaluation/analytics skip them"
+            );
         }
 
         // skill_produced_output flag should be set

--- a/rust/crates/runtime/src/turn/agentic_tool_interception.rs
+++ b/rust/crates/runtime/src/turn/agentic_tool_interception.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use astra_services::session_journal::ToolCallRecord;
+use astra_services::session_journal::{SURGICAL_REMOVAL_TOOL_NAME, ToolCallRecord};
 use serde_json::Value;
 
 use crate::turn::sse_stream_host::EdgeToolExecResult;
@@ -48,12 +48,16 @@ pub(crate) async fn prepare_intercepted_tool_round(
         });
     }
 
-    // Record surgically removed calls in telemetry (ok=false so stall detector
-    // counts them correctly) but do NOT add to pre_resolved_results.
+    // Record surgically removed calls as audit-only synthetic placeholders.
+    // These are intentional context optimizations (skill took over the work),
+    // NOT tool failures — so ok=true and they are filtered out of
+    // evaluation/analytics via ToolCallRecord::is_synthetic_placeholder().
+    // The stall detector does NOT treat synthetic placeholders as real
+    // attempts either, matching the existing skipped/deferred behavior.
     for id in &surgically_removed_ids {
         state.stall.tool_call_records.push(ToolCallRecord {
-            name: "(surgically_removed)".to_string(),
-            ok: false,
+            name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+            ok: true,
             ms: 0,
             error: None,
             input_bytes: None,

--- a/rust/crates/services/src/session_analytics.rs
+++ b/rust/crates/services/src/session_analytics.rs
@@ -56,17 +56,27 @@ pub fn compute_session_stats(session_id: &str, events: &[JournalEvent]) -> Sessi
                 stats.total_cache_read += event.cache_read_tokens.unwrap_or(0);
                 stats.total_cache_creation += event.cache_creation_tokens.unwrap_or(0);
                 stats.total_duration_ms += event.duration_ms.unwrap_or(0);
-                stats.total_tool_calls += event.tool_count.unwrap_or(0);
-                if let Some(ref tools) = event.tools_used {
-                    for t in tools {
-                        tools_set.insert(t.clone());
-                    }
-                }
+                // Synthetic placeholders (skill skipped/deferred, surgically
+                // removed parallel calls) are not real tool executions — skip
+                // them from total + failed counts so tool_error_rate reflects
+                // actual tool reliability.
                 if let Some(ref calls) = event.tool_calls {
-                    for tc in calls {
+                    let real_calls: Vec<_> = calls
+                        .iter()
+                        .filter(|tc| !tc.is_synthetic_placeholder())
+                        .collect();
+                    stats.total_tool_calls += real_calls.len() as u32;
+                    for tc in &real_calls {
                         if !tc.ok {
                             stats.failed_tool_calls += 1;
                         }
+                    }
+                } else {
+                    stats.total_tool_calls += event.tool_count.unwrap_or(0);
+                }
+                if let Some(ref tools) = event.tools_used {
+                    for t in tools {
+                        tools_set.insert(t.clone());
                     }
                 }
             }

--- a/rust/crates/services/src/session_journal.rs
+++ b/rust/crates/services/src/session_journal.rs
@@ -3227,7 +3227,9 @@ mod tests {
     #[test]
     fn real_tool_records_are_not_synthetic_placeholders() {
         assert!(!base_tool_record("git_show", true, Some("diff")).is_synthetic_placeholder());
-        assert!(!base_tool_record("grep", false, Some("error: bad regex")).is_synthetic_placeholder());
+        assert!(
+            !base_tool_record("grep", false, Some("error: bad regex")).is_synthetic_placeholder()
+        );
         assert!(!base_tool_record("read_file", true, None).is_synthetic_placeholder());
     }
 

--- a/rust/crates/services/src/session_journal.rs
+++ b/rust/crates/services/src/session_journal.rs
@@ -490,10 +490,25 @@ pub struct ToolCallRecord {
     pub file_path: Option<String>,
 }
 
+/// Tool call name sentinel used for assistant messages that had parallel tool
+/// calls surgically removed from context (see
+/// `runtime::turn::agentic_tool_interception`). These are intentional context
+/// optimizations — **not** tool failures — and are filtered out of
+/// evaluation/analytics by [`ToolCallRecord::is_synthetic_placeholder`].
+pub const SURGICAL_REMOVAL_TOOL_NAME: &str = "(surgically_removed)";
+
 impl ToolCallRecord {
     /// Synthetic placeholders are audit-only records emitted when skill routing
-    /// suppresses a tool call without actually executing it.
+    /// suppresses a tool call without actually executing it, **or** when a
+    /// parallel tool call was surgically removed from context after a skill
+    /// took over its work. Neither case represents real tool execution or
+    /// failure, so these records must be filtered out before computing
+    /// analytics (tool_error_rate, repeat_tool_call, failed_tool_calls, …).
     pub fn is_synthetic_placeholder(&self) -> bool {
+        if self.name == SURGICAL_REMOVAL_TOOL_NAME {
+            return true;
+        }
+
         let Some(result_preview) = self.result_preview.as_deref() else {
             return false;
         };
@@ -3160,6 +3175,61 @@ mod tests {
     use super::*;
     use astra_core::{DriftCause, DriftEvidence, EvidenceType};
     use tempfile::tempdir;
+
+    fn base_tool_record(name: &str, ok: bool, preview: Option<&str>) -> ToolCallRecord {
+        ToolCallRecord {
+            name: name.to_string(),
+            ok,
+            ms: 0,
+            error: None,
+            input_bytes: None,
+            output_bytes: None,
+            args_preview: None,
+            result_preview: preview.map(ToString::to_string),
+            file_path: None,
+        }
+    }
+
+    #[test]
+    fn surgical_removal_record_is_synthetic_placeholder() {
+        let rec = base_tool_record(
+            SURGICAL_REMOVAL_TOOL_NAME,
+            true,
+            Some("(removed from context — skill covered this work)"),
+        );
+        assert!(
+            rec.is_synthetic_placeholder(),
+            "surgically_removed records must be classified as synthetic \
+             placeholders so evaluation/analytics skip them"
+        );
+    }
+
+    #[test]
+    fn skipped_deferred_and_skill_records_remain_synthetic_placeholders() {
+        assert!(
+            base_tool_record("read_file", false, Some("Skipped: skill routed"))
+                .is_synthetic_placeholder()
+        );
+        assert!(
+            base_tool_record("read_file", false, Some("Deferred: skill invoked"))
+                .is_synthetic_placeholder()
+        );
+        assert!(
+            base_tool_record(
+                "skill",
+                true,
+                Some("Skill 'debug' was already loaded (turn 2). Follow those instructions.")
+            )
+            .is_synthetic_placeholder()
+        );
+    }
+
+    #[test]
+    fn real_tool_records_are_not_synthetic_placeholders() {
+        assert!(!base_tool_record("git_show", true, Some("diff")).is_synthetic_placeholder());
+        assert!(!base_tool_record("grep", false, Some("error: bad regex")).is_synthetic_placeholder());
+        assert!(!base_tool_record("read_file", true, None).is_synthetic_placeholder());
+    }
 
     #[test]
     fn journal_dir_guard_overrides_local_sessions_dir_nested() {


### PR DESCRIPTION
## Problem

Session analysis of `~/.astra/sessions/721df7da-e7c4-4a27-9f09-3777d90554bc.jsonl` surfaced two systemic telemetry bugs:

### Bug 1 — surgical-removal records polluted evaluation & analytics
`(surgically_removed)` records are audit-only placeholders emitted when a skill takes over a parallel tool call's work. They were written with `ok=false`, so downstream they:
- inflated `tool_error_rate` (weight 0.875 on otherwise healthy turns)
- triggered bogus `RepeatToolCall(\"(surgically_removed)\")` signals
- collapsed `turn_evaluation.quality` to 0.15 on a successful turn (L13 of the session, following a 49k-token success turn at L12)
- inflated `failed_tool_calls` and `tool_error_rate` in the analytics crate

### Bug 2 — user Ctrl+C leaked into ScenarioDetector
After the user cancelled a focused review task (many `glob`/`grep`/`view`/`git_show` calls), the next turn started with L8:
```
adaptive_scenario_applied: Exploration, tool_budget 722→1000, confidence=0.7
```
The cancelled turn's tool history was leaking into `ScenarioDetector` and falsely scoring Exploration. This cascaded: turn 4 selected 25 tools, turn 5 selected 14 — tool-set churn + budget inflation.

## Fix (clean, no compat shims)

### Surgical records → synthetic placeholders (single choke-point)
- `SURGICAL_REMOVAL_TOOL_NAME` constant in `session_journal` unifies the three literal copies.
- `ToolCallRecord::is_synthetic_placeholder()` now recognizes surgical records alongside the existing `Skipped:`/`Deferred:`/already-loaded-skill patterns.
- Flip `ok=false` → `ok=true` at the emission site — these are intentional context optimizations, not failures.
- `evaluate_tool_call_records` filters synthetic placeholders before building `ToolCallInfo`, so `tool_error_rate`, `RepeatToolCall`, `EmptyToolOutput`, and the success verdict all become honest.
- Analytics aggregation (`session_analytics.rs`) filters synthetic placeholders from `total_tool_calls`/`failed_tool_calls`.

### User-cancel scenario gate
- New `previous_turn_user_cancelled: bool` on `ObservabilitySession`.
- Set in `run_agentic_loop_with_host` **only** when `state.interruption.kind == InterruptionKind::UserCancelled` (timeouts, stream errors, etc. do **not** trip it — they don't invalidate the tool-history signal).
- Consumed + early-return in `apply_adaptive_execution_profile`. The suppression is strictly one turn: on the following turn, detection resumes normally.

## Tests

- **session_journal**: `is_synthetic_placeholder` covers surgical, skipped, deferred, already-loaded skill, and real-tool cases.
- **pipeline/evaluation**: a mix of 1 real success + 3 synthetic records yields `ToolErrorRate(0.0)` + `AllToolsHealthy` + `success=true`; four surgical records do **not** produce a `RepeatToolCall` signal.
- **agentic_loop_host**: existing surgical-records assertion updated to `ok=true` and `is_synthetic_placeholder==true`. Two new adaptive-tuning tests:
  - scenario does **not** change on the first post-cancel turn and the flag is consumed
  - scenario detection resumes on the next turn

## Validation
- `cargo test -p astra-runtime --lib` — 2284 passed, 0 failed
- `cargo test -p astra-services --lib` — 1161 passed, 0 failed
- `make test-offline` — all green