### PR TITLE
fix(cli): preflight stale resumable sessions

### DIFF
--- a/rust/crates/astra-cli/src/cli/cli_utils.rs
+++ b/rust/crates/astra-cli/src/cli/cli_utils.rs
@@ -110,6 +110,68 @@ pub(super) fn resumable_last_session_id(cli_profile: Option<&str>) -> Option<Str
         .filter(|session_id| session_is_resumable(session_id))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SessionResumePreflight {
+    Valid,
+    Missing,
+    Unknown,
+}
+
+pub(super) fn clear_profile_last_session_if_matches(
+    cli_profile: Option<&str>,
+    session_id: &str,
+) -> Result<bool, String> {
+    let mut creds = load_credentials();
+    let name = profile_name(cli_profile, &creds);
+    let Some(entry) = creds.profiles.get_mut(&name) else {
+        return Ok(false);
+    };
+    if entry.last_session_id.as_deref() != Some(session_id) {
+        return Ok(false);
+    }
+    entry.last_session_id = None;
+    save_credentials(&creds)?;
+    Ok(true)
+}
+
+pub(super) async fn preflight_remote_resume_session(
+    api: &astra_thin_client::ThinClient,
+    cli_profile: Option<&str>,
+    session_id: &str,
+) -> SessionResumePreflight {
+    let creds = load_credentials();
+    let name = profile_name(cli_profile, &creds);
+    let Some(token) = creds
+        .profiles
+        .get(&name)
+        .and_then(|profile| profile.access_token.as_deref())
+    else {
+        return SessionResumePreflight::Unknown;
+    };
+
+    match api.get_session(Some(token), session_id).await {
+        Ok(_) => SessionResumePreflight::Valid,
+        Err(astra_thin_client::ThinClientError::Api { status, .. }) if status.as_u16() == 404 => {
+            SessionResumePreflight::Missing
+        }
+        Err(_) => SessionResumePreflight::Unknown,
+    }
+}
+
+pub(super) async fn validated_resumable_last_session_id(
+    api: &astra_thin_client::ThinClient,
+    cli_profile: Option<&str>,
+) -> Option<String> {
+    let session_id = resumable_last_session_id(cli_profile)?;
+    match preflight_remote_resume_session(api, cli_profile, &session_id).await {
+        SessionResumePreflight::Valid | SessionResumePreflight::Unknown => Some(session_id),
+        SessionResumePreflight::Missing => {
+            let _ = clear_profile_last_session_if_matches(cli_profile, &session_id);
+            None
+        }
+    }
+}
+
 pub(super) fn read_api_error(status: u16, body: &str) -> String {
     // Try to extract user-friendly message from JSON error response
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(body) {
@@ -479,7 +541,55 @@ pub(super) fn urlencoding(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use astra_services::session_journal::{self, JournalDirGuard};
     use tempfile::tempdir;
+    use wiremock::matchers::{header_exists, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn isolated_sessions_dir() -> (tempfile::TempDir, JournalDirGuard) {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions = tmp.path().join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        let guard = JournalDirGuard::new(&sessions);
+        (tmp, guard)
+    }
+
+    fn write_resumable_session(session_id: &str) {
+        let writer = session_journal::JournalWriter::new(session_id).unwrap();
+        writer
+            .append(&session_journal::JournalEvent::session_start(
+                Some(session_id),
+                Some("gpt-5"),
+            ))
+            .unwrap();
+        writer
+            .append(&session_journal::JournalEvent::interruption_recorded(
+                Some(session_id),
+                1,
+                serde_json::json!({
+                    "kind": "rate_limited",
+                    "resumable": true,
+                    "has_checkpoint": true,
+                    "tool_calls_completed": 1,
+                    "turns_completed": 1,
+                    "remaining_turns": 4,
+                }),
+            ))
+            .unwrap();
+    }
+
+    fn write_profile_with_token(session_id: &str) {
+        let mut creds = CredentialsFile::default();
+        creds.profiles.insert(
+            "default".to_string(),
+            Profile {
+                access_token: Some("test-token".into()),
+                last_session_id: Some(session_id.to_string()),
+                ..Default::default()
+            },
+        );
+        save_credentials(&creds).unwrap();
+    }
 
     // ── urlencoding ───────────────────────────────────────────────────────────
 
@@ -545,6 +655,7 @@ mod tests {
 
     #[test]
     fn session_is_not_resumable_after_clean_end() {
+        let (_tmp, _guard) = isolated_sessions_dir();
         let sid = format!("test-ended-{}", uuid::Uuid::new_v4());
         let writer = session_journal::JournalWriter::new(&sid).unwrap();
         writer
@@ -562,10 +673,8 @@ mod tests {
 
     #[test]
     fn resumable_last_session_id_filters_ended_sessions() {
-        let creds_dir = tempdir().unwrap();
-        unsafe {
-            std::env::set_var("ASTRA_CREDENTIALS_DIR", creds_dir.path());
-        }
+        let (_tmp, _guard) = isolated_sessions_dir();
+        let _creds_guard = crate::tests::isolate_credentials();
 
         let sid = format!("test-profile-ended-{}", uuid::Uuid::new_v4());
         let writer = session_journal::JournalWriter::new(&sid).unwrap();
@@ -590,10 +699,97 @@ mod tests {
         save_credentials(&creds).unwrap();
 
         assert_eq!(resumable_last_session_id(None), None);
+    }
 
-        unsafe {
-            std::env::remove_var("ASTRA_CREDENTIALS_DIR");
-        }
+    #[tokio::test]
+    async fn validated_resumable_last_session_id_keeps_live_session() {
+        let (_tmp, _guard) = isolated_sessions_dir();
+        let _creds_guard = crate::tests::isolate_credentials();
+        let session_id = format!("live-session-{}", uuid::Uuid::new_v4());
+        write_resumable_session(&session_id);
+        write_profile_with_token(&session_id);
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/sessions/{session_id}")))
+            .and(header_exists("authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "session_id": session_id,
+                "status": "active"
+            })))
+            .mount(&server)
+            .await;
+
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).unwrap();
+        let resolved = validated_resumable_last_session_id(&api, None).await;
+        assert_eq!(resolved.as_deref(), Some(session_id.as_str()));
+        assert_eq!(
+            load_credentials()
+                .profiles
+                .get("default")
+                .and_then(|profile| profile.last_session_id.as_deref()),
+            Some(session_id.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn validated_resumable_last_session_id_drops_stale_404_session() {
+        let (_tmp, _guard) = isolated_sessions_dir();
+        let _creds_guard = crate::tests::isolate_credentials();
+        let session_id = format!("stale-session-{}", uuid::Uuid::new_v4());
+        write_resumable_session(&session_id);
+        write_profile_with_token(&session_id);
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/sessions/{session_id}")))
+            .and(header_exists("authorization"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "detail": "Session not found"
+            })))
+            .mount(&server)
+            .await;
+
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).unwrap();
+        let resolved = validated_resumable_last_session_id(&api, None).await;
+        assert_eq!(resolved, None);
+        assert_eq!(
+            load_credentials()
+                .profiles
+                .get("default")
+                .and_then(|profile| profile.last_session_id.as_deref()),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn validated_resumable_last_session_id_keeps_session_on_transient_server_error() {
+        let (_tmp, _guard) = isolated_sessions_dir();
+        let _creds_guard = crate::tests::isolate_credentials();
+        let session_id = format!("transient-session-{}", uuid::Uuid::new_v4());
+        write_resumable_session(&session_id);
+        write_profile_with_token(&session_id);
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/sessions/{session_id}")))
+            .and(header_exists("authorization"))
+            .respond_with(ResponseTemplate::new(503).set_body_json(serde_json::json!({
+                "detail": "Service temporarily unavailable"
+            })))
+            .mount(&server)
+            .await;
+
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).unwrap();
+        let resolved = validated_resumable_last_session_id(&api, None).await;
+        assert_eq!(resolved.as_deref(), Some(session_id.as_str()));
+        assert_eq!(
+            load_credentials()
+                .profiles
+                .get("default")
+                .and_then(|profile| profile.last_session_id.as_deref()),
+            Some(session_id.as_str())
+        );
     }
 
     #[test]
@@ -616,10 +812,7 @@ mod tests {
 
     #[test]
     fn test_credentials_file_permissions() {
-        let tmp = tempfile::tempdir().unwrap();
-        unsafe {
-            std::env::set_var("ASTRA_CREDENTIALS_DIR", tmp.path());
-        }
+        let _creds_guard = crate::tests::isolate_credentials();
         let creds = CredentialsFile {
             current_profile: Some("default".into()),
             profiles: HashMap::new(),
@@ -629,12 +822,9 @@ mod tests {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let path = tmp.path().join("credentials.json");
+            let path = credentials_path();
             let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
             assert_eq!(mode, 0o600, "credentials.json must be 0600, got {mode:o}");
-        }
-        unsafe {
-            std::env::remove_var("ASTRA_CREDENTIALS_DIR");
         }
     }
 }

--- a/rust/crates/astra-cli/src/cli/cli_utils.rs
+++ b/rust/crates/astra-cli/src/cli/cli_utils.rs
@@ -542,7 +542,6 @@ pub(super) fn urlencoding(s: &str) -> String {
 mod tests {
     use super::*;
     use astra_services::session_journal::{self, JournalDirGuard};
-    use tempfile::tempdir;
     use wiremock::matchers::{header_exists, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -404,7 +404,7 @@ pub(super) async fn execute_cli_command(
             let raw_message = words.join(" ");
             let message = apply_system_prompt(&raw_message, system_prompt.as_deref());
             let (mut creds, name, _, token) = get_profile_and_token(profile.as_deref())?;
-            let session_id = resumable_last_session_id(profile.as_deref());
+            let session_id = validated_resumable_last_session_id(api, profile.as_deref()).await;
             let selector = create_tool_selector(api, profile.as_deref());
             let mut pm = PermissionManager::with_project(
                 auto_approve,
@@ -596,7 +596,7 @@ pub(super) async fn execute_cli_command(
         Some(Command::Plan(plan_cmd)) => match plan_cmd {
             PlanCmd::Decompose { goal, json, quiet } => {
                 let (_, _, _, token) = get_profile_and_token(profile.as_deref())?;
-                let session_id = resumable_last_session_id(profile.as_deref());
+                let session_id = validated_resumable_last_session_id(api, profile.as_deref()).await;
                 let plan = crate::slash_memory::headless_plan_decompose(
                     api,
                     &token,
@@ -778,9 +778,10 @@ pub(super) async fn execute_cli_command(
             };
 
             let (mut creds, name, _, token) = get_profile_and_token(profile.as_deref())?;
-            let session_id = args
-                .session_id
-                .or_else(|| resumable_last_session_id(profile.as_deref()));
+            let session_id = match args.session_id {
+                Some(session_id) => Some(session_id),
+                None => validated_resumable_last_session_id(api, profile.as_deref()).await,
+            };
             let is_tty = terminal::size().is_ok();
             let selector = create_tool_selector(api, profile.as_deref());
             let mut pm = {
@@ -1263,7 +1264,7 @@ pub(super) async fn run_print_mode(
     let message = apply_system_prompt(&raw_message, system_prompt);
 
     let (mut creds, name, _, token) = get_profile_and_token(profile)?;
-    let session_id = resumable_last_session_id(profile);
+    let session_id = validated_resumable_last_session_id(api, profile).await;
     let selector = create_tool_selector(api, profile);
     let mut pm = PermissionManager::with_project(
         true, // print mode is headless, always auto-approve

--- a/rust/crates/astra-cli/src/cli/repl_startup.rs
+++ b/rust/crates/astra-cli/src/cli/repl_startup.rs
@@ -16,6 +16,23 @@ pub(crate) struct ReplStartupArtifacts {
     pub shutdown_signal_rx: tokio::sync::watch::Receiver<Option<session_guard::ShutdownSignal>>,
 }
 
+async fn prune_stale_pending_recovery(
+    api: &astra_thin_client::ThinClient,
+    profile: Option<&str>,
+    state: &mut ReplState,
+) {
+    let Some(session_id) = state.pending_recovery.clone() else {
+        return;
+    };
+    if matches!(
+        preflight_remote_resume_session(api, profile, &session_id).await,
+        SessionResumePreflight::Missing
+    ) {
+        let _ = clear_profile_last_session_if_matches(profile, &session_id);
+        state.pending_recovery = None;
+    }
+}
+
 pub(crate) async fn complete_repl_startup(
     state: &mut ReplState,
     tracer: &mut StartupTracer,
@@ -260,11 +277,12 @@ pub(crate) async fn complete_repl_startup(
         }
     }
     tracer.phase("model_check");
+    prune_stale_pending_recovery(api, profile, state).await;
 
     if state.session_id.is_none()
         && let Some(sid) = resume_session_id
     {
-        slash_session::restore_session_into_state(sid, profile, state).await?;
+        slash_session::restore_session_into_state(sid, profile, api, state).await?;
     }
 
     print_repl_banner(profile, state);
@@ -329,4 +347,121 @@ pub(crate) async fn complete_repl_startup(
         pinned_skills_path,
         shutdown_signal_rx,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astra_services::session_journal::{self, JournalDirGuard};
+    use wiremock::matchers::{header_exists, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn isolated_sessions_dir() -> (tempfile::TempDir, JournalDirGuard) {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions = tmp.path().join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        let guard = JournalDirGuard::new(&sessions);
+        (tmp, guard)
+    }
+
+    fn write_resumable_session(session_id: &str) {
+        let writer = session_journal::JournalWriter::new(session_id).unwrap();
+        writer
+            .append(&session_journal::JournalEvent::session_start(
+                Some(session_id),
+                Some("gpt-5"),
+            ))
+            .unwrap();
+        writer
+            .append(&session_journal::JournalEvent::interruption_recorded(
+                Some(session_id),
+                1,
+                serde_json::json!({
+                    "kind": "rate_limited",
+                    "resumable": true,
+                    "has_checkpoint": true,
+                    "tool_calls_completed": 1,
+                    "turns_completed": 1,
+                    "remaining_turns": 4,
+                }),
+            ))
+            .unwrap();
+    }
+
+    fn write_profile_with_token(session_id: &str) {
+        let mut creds = crate::cli_utils::CredentialsFile::default();
+        creds.profiles.insert(
+            "default".to_string(),
+            crate::cli_utils::Profile {
+                access_token: Some("test-token".into()),
+                last_session_id: Some(session_id.to_string()),
+                ..Default::default()
+            },
+        );
+        crate::cli_utils::save_credentials(&creds).unwrap();
+    }
+
+    #[tokio::test]
+    async fn prune_stale_pending_recovery_clears_stale_last_session() {
+        let (_tmp, _guard) = isolated_sessions_dir();
+        let _creds_guard = crate::tests::isolate_credentials();
+        let session_id = format!("pending-stale-{}", uuid::Uuid::new_v4());
+        write_resumable_session(&session_id);
+        write_profile_with_token(&session_id);
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/sessions/{session_id}")))
+            .and(header_exists("authorization"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "detail": "Session not found"
+            })))
+            .mount(&server)
+            .await;
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).unwrap();
+
+        let mut state = ReplState {
+            pending_recovery: Some(session_id.clone()),
+            ..Default::default()
+        };
+        prune_stale_pending_recovery(&api, None, &mut state).await;
+
+        assert_eq!(state.pending_recovery, None);
+        assert_eq!(
+            crate::cli_utils::load_credentials()
+                .profiles
+                .get("default")
+                .and_then(|profile| profile.last_session_id.as_deref()),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_stale_pending_recovery_keeps_live_session() {
+        let (_tmp, _guard) = isolated_sessions_dir();
+        let _creds_guard = crate::tests::isolate_credentials();
+        let session_id = format!("pending-live-{}", uuid::Uuid::new_v4());
+        write_resumable_session(&session_id);
+        write_profile_with_token(&session_id);
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/sessions/{session_id}")))
+            .and(header_exists("authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "session_id": session_id,
+                "status": "active"
+            })))
+            .mount(&server)
+            .await;
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).unwrap();
+
+        let mut state = ReplState {
+            pending_recovery: Some(session_id.clone()),
+            ..Default::default()
+        };
+        prune_stale_pending_recovery(&api, None, &mut state).await;
+
+        assert_eq!(state.pending_recovery.as_deref(), Some(session_id.as_str()));
+    }
 }

--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -274,7 +274,8 @@ pub(super) async fn handle_chat_input(
     {
         if is_short_continuation_prompt(&line) {
             if let Err(e) =
-                slash_session::restore_session_into_state(&session_id, ctx.profile, state).await
+                slash_session::restore_session_into_state(&session_id, ctx.profile, ctx.api, state)
+                    .await
             {
                 eprintln!("  {} {}", theme::icon_err(), e.red());
                 return Ok(());

--- a/rust/crates/astra-cli/src/cli/slash_router.rs
+++ b/rust/crates/astra-cli/src/cli/slash_router.rs
@@ -410,7 +410,7 @@ pub(super) async fn handle_slash_command(
         }
 
         "/resume" => {
-            slash_session::handle_resume_command(arg, profile, state).await;
+            slash_session::handle_resume_command(arg, profile, api, state).await;
         }
 
         "/stats" => {

--- a/rust/crates/astra-cli/src/cli/slash_session.rs
+++ b/rust/crates/astra-cli/src/cli/slash_session.rs
@@ -4737,8 +4737,19 @@ async fn apply_restored_session(
 pub(super) async fn restore_session_into_state(
     session_id: &str,
     profile: Option<&str>,
+    api: &astra_thin_client::ThinClient,
     state: &mut ReplState,
 ) -> Result<(), String> {
+    if matches!(
+        preflight_remote_resume_session(api, profile, session_id).await,
+        SessionResumePreflight::Missing
+    ) {
+        let _ = clear_profile_last_session_if_matches(profile, session_id);
+        return Err(format!(
+            "Session {session_id} no longer exists on the server and cannot be resumed for new chat turns."
+        ));
+    }
+
     let svc = resume_restore_service(state);
     let restored = svc
         .restore_session(session_id)
@@ -4754,7 +4765,12 @@ pub(super) async fn restore_session_into_state(
 
 // ═══════════════════════════════════════════════════════════ Resume ═══════
 
-pub(super) async fn handle_resume_command(arg: &str, profile: Option<&str>, state: &mut ReplState) {
+pub(super) async fn handle_resume_command(
+    arg: &str,
+    profile: Option<&str>,
+    api: &astra_thin_client::ThinClient,
+    state: &mut ReplState,
+) {
     let user_id = state.ingestion_user_id.as_deref().unwrap_or("local");
     let svc = resume_restore_service(state);
 
@@ -5140,10 +5156,11 @@ pub(super) async fn handle_resume_command(arg: &str, profile: Option<&str>, stat
         }
     }
 
-    if let Err(e) = restore_session_into_state(&session_id, profile, state).await {
+    if let Err(e) = restore_session_into_state(&session_id, profile, api, state).await {
         let hint = if e.to_string().contains("not found")
             || e.to_string()
                 .contains("no resumable workspace/checkpoint state")
+            || e.to_string().contains("no longer exists on the server")
         {
             "Use /resume to see available sessions."
         } else {
@@ -5151,5 +5168,151 @@ pub(super) async fn handle_resume_command(arg: &str, profile: Option<&str>, stat
         };
         eprintln!("  {} {}", theme::icon_err(), e.red());
         eprintln!("{}", format!("  {hint}").dim());
+    }
+}
+
+#[cfg(test)]
+mod resume_tests {
+    use super::*;
+    use astra_services::session_journal::{self, JournalDirGuard};
+    use wiremock::matchers::{header_exists, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn isolated_sessions_dir() -> (tempfile::TempDir, JournalDirGuard) {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions = tmp.path().join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        let guard = JournalDirGuard::new(&sessions);
+        (tmp, guard)
+    }
+
+    fn write_local_resumable_session(session_id: &str, turn_count: u32) {
+        let writer = session_journal::JournalWriter::new(session_id).unwrap();
+        writer
+            .append(&session_journal::JournalEvent::session_start(
+                Some(session_id),
+                Some("gpt-5"),
+            ))
+            .unwrap();
+        writer
+            .append(&session_journal::JournalEvent::turn(
+                Some(session_id),
+                turn_count,
+                Some("gpt-5"),
+                "continue",
+                "restored",
+                0,
+                15,
+                7,
+                8,
+            ))
+            .unwrap();
+        writer
+            .append(&session_journal::JournalEvent::interruption_recorded(
+                Some(session_id),
+                turn_count,
+                serde_json::json!({
+                    "kind": "rate_limited",
+                    "resumable": true,
+                    "has_checkpoint": true,
+                    "tool_calls_completed": 1,
+                    "turns_completed": turn_count,
+                    "remaining_turns": 4,
+                }),
+            ))
+            .unwrap();
+
+        let cwd = std::env::current_dir().unwrap();
+        let mut ws = session_workspace::WorkspaceMetadata::with_context(
+            session_id,
+            "gpt-5",
+            &cwd.display().to_string(),
+            Some("main"),
+        );
+        ws.turn_count = turn_count;
+        ws.total_tokens_in = 15;
+        ws.total_tokens_out = 7;
+        ws.status = "active".to_string();
+        session_workspace::write_workspace(&ws).unwrap();
+    }
+
+    fn write_profile_with_token(session_id: &str) {
+        let mut creds = crate::cli_utils::CredentialsFile::default();
+        creds.profiles.insert(
+            "default".to_string(),
+            crate::cli_utils::Profile {
+                access_token: Some("test-token".into()),
+                last_session_id: Some(session_id.to_string()),
+                ..Default::default()
+            },
+        );
+        crate::cli_utils::save_credentials(&creds).unwrap();
+    }
+
+    #[tokio::test]
+    async fn restore_session_into_state_rejects_stale_remote_session_before_local_restore() {
+        let (_tmp, _guard) = isolated_sessions_dir();
+        let _creds_guard = crate::tests::isolate_credentials();
+        let session_id = format!("resume-stale-{}", uuid::Uuid::new_v4());
+        write_local_resumable_session(&session_id, 3);
+        write_profile_with_token(&session_id);
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/sessions/{session_id}")))
+            .and(header_exists("authorization"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "detail": "Session not found"
+            })))
+            .mount(&server)
+            .await;
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).unwrap();
+
+        let mut state = ReplState::default();
+        let err = restore_session_into_state(&session_id, None, &api, &mut state)
+            .await
+            .unwrap_err();
+
+        assert!(err.contains("no longer exists on the server"), "got: {err}");
+        assert_eq!(state.session_id, None);
+        assert_eq!(state.turn, 0);
+        assert_eq!(
+            crate::cli_utils::load_credentials()
+                .profiles
+                .get("default")
+                .and_then(|profile| profile.last_session_id.as_deref()),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_session_into_state_restores_live_remote_session_from_local_workspace() {
+        let (_tmp, _guard) = isolated_sessions_dir();
+        let _creds_guard = crate::tests::isolate_credentials();
+        let session_id = format!("resume-live-{}", uuid::Uuid::new_v4());
+        write_local_resumable_session(&session_id, 2);
+        write_profile_with_token(&session_id);
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/sessions/{session_id}")))
+            .and(header_exists("authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "session_id": session_id,
+                "status": "active"
+            })))
+            .mount(&server)
+            .await;
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).unwrap();
+
+        let mut state = ReplState::default();
+        restore_session_into_state(&session_id, None, &api, &mut state)
+            .await
+            .unwrap();
+
+        assert_eq!(state.session_id.as_deref(), Some(session_id.as_str()));
+        assert_eq!(state.turn, 2);
+        assert_eq!(state.total_prompt_tokens, 15);
+        assert_eq!(state.total_completion_tokens, 7);
     }
 }

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -208,9 +208,11 @@ use astra_runtime::turn::chat_turn_heuristics::{
 use auth_flow::{clear_profile_last_session, do_login, do_register};
 use chat_stream::{ChatTurnParams, stream_chat_sse};
 use cli_utils::{
-    compact_or_raw, get_profile_and_token, interactive_select, load_credentials, map_thin_err,
-    prefix_chars, print_json_or_raw, profile_name, prompt_or, prompt_password_masked,
-    resumable_last_session_id, save_credentials, truncate_str, urlencoding,
+    SessionResumePreflight, clear_profile_last_session_if_matches, compact_or_raw,
+    get_profile_and_token, interactive_select, load_credentials, map_thin_err, prefix_chars,
+    preflight_remote_resume_session, print_json_or_raw, profile_name, prompt_or,
+    prompt_password_masked, resumable_last_session_id, save_credentials, truncate_str, urlencoding,
+    validated_resumable_last_session_id,
 };
 use command_router::{ExitCode, execute_cli_command, run_print_mode};
 use dynamic_completions::refresh_dynamic_completions;

--- a/rust/crates/runtime/src/self_model.rs
+++ b/rust/crates/runtime/src/self_model.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::auto_tuning::{FeedbackSignal, SignalType};
 use crate::runtime_config::RuntimeConfig;
+use crate::str_preview::truncate_str;
 use crate::turn::context_assembly_trace::TokenBudgetTrace;
 use crate::turn::goal_tracker::{GoalProgress, Milestone};
 use crate::turn::tool_health::ToolHealthTracker;
@@ -372,11 +373,7 @@ impl SelfModel {
 
         // ── Goal progress ──
         if let Some(ref goal) = self.goals.goal {
-            let truncated = if goal.len() > 100 {
-                format!("{}...", &goal[..97])
-            } else {
-                goal.clone()
-            };
+            let truncated = truncate_str(goal, 100);
             let _ = write!(s, "Goal: \"{}\"", truncated);
             if self.goals.goal_source != "none" && self.goals.goal_source != "session_goal" {
                 let _ = write!(s, " [{}]", self.goals.goal_source);
@@ -861,6 +858,49 @@ mod tests {
         assert!(section.contains("Fix the auth bug"));
         assert!(section.contains("5 available"));
         assert!(section.contains("1 skills"));
+    }
+
+    #[test]
+    fn system_prompt_section_handles_multibyte_goal_without_panicking() {
+        let config = RuntimeConfig::default();
+        let goal = "在tmp目录下面生成一个非常漂亮的介绍astra的web文档,内容丰富,动态展示,科技风格";
+        assert!(
+            goal.len() > 100,
+            "regression requires byte length > 100 to trigger the old slicing bug"
+        );
+        assert!(
+            goal.chars().count() < 100,
+            "regression requires char count < 100 so UTF-8 bytes, not logical length, caused truncation"
+        );
+
+        let model = SelfModel::snapshot(
+            &["bash", "write_file"],
+            &[],
+            &[],
+            &[],
+            None,
+            3,
+            None,
+            None,
+            None,
+            240,
+            0,
+            0,
+            Some(goal),
+            None,
+            None,
+            None,
+            None,
+            &[],
+            &config,
+        );
+
+        let section = model.to_system_prompt_section();
+        assert!(section.contains("Goal:"));
+        assert!(
+            section.contains(goal),
+            "goal should remain intact when it is under the char limit even if its UTF-8 byte length exceeds 100: {section}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The CLI was treating a session as resumable based only on **local** state:

- `session_journal::classify_session_end_state()` says resumable
- `workspace.yaml` still matches the current project

That missed the third requirement: the **backend session must still exist for the current authenticated user**.

This created the user-visible mismatch from session `721df7da-e7c4-4a27-9f09-3777d90554bc`:

- `/session` still showed local `workspace.yaml` status like `active`
- startup still offered pending recovery / resume
- the first real turn then hit `Session not found. Creating a new session…`

So the CLI discovered staleness **one turn too late**.

## Fix

Introduce a shared remote preflight around `ThinClient::get_session()` and treat only confirmed `404` responses as stale:

- **200** -> keep resume behavior
- **404** -> clear the matching stored `last_session_id` and suppress reuse
- **401 / 5xx / transport errors** -> keep current behavior (do **not** misclassify transient outages as stale sessions)

Wire that helper into all relevant CLI resume paths:

1. **REPL startup**: stale `pending_recovery` is pruned before the REPL offers resume
2. **`/resume`**: stale remote sessions fail early instead of restoring local state and then breaking on the next turn
3. **Implicit resumable-session reuse** for inline / print / headless plan flows that previously called `resumable_last_session_id()` directly
4. **short-continue restoration** (`continue` / `resume` / `继续`) via the existing restore path

The existing first-turn fallback remains in place as a safety net.

## Why this is a clean/systemic fix

This PR does **not** special-case a single REPL branch. It moves the staleness decision to a single shared preflight helper and then reuses it across all entry points that can silently inherit a persisted session id.

That closes the gap between:

- **local resumability** (journal/workspace)
- **remote resumability** (session service still has the session)

instead of letting them drift until runtime.

## Tests

Added wiremock-backed regression coverage for the real HTTP preflight path:

- `validated_resumable_last_session_id_keeps_live_session`
- `validated_resumable_last_session_id_drops_stale_404_session`
- `validated_resumable_last_session_id_keeps_session_on_transient_server_error`
- `prune_stale_pending_recovery_clears_stale_last_session`
- `prune_stale_pending_recovery_keeps_live_session`
- `restore_session_into_state_rejects_stale_remote_session_before_local_restore`
- `restore_session_into_state_restores_live_remote_session_from_local_workspace`

These cover both **auto-recovery startup** and **explicit resume** paths, plus the 200/404/5xx preflight semantics.

## Validation

- `cargo test -p astra-cli`
- `make test-offline`
