### PR TITLE
fix: eliminate double-approval prompts (cloud→local gate dedup)

### DIFF
--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -479,10 +479,18 @@ impl PermissionManager {
             if let Some(detail) = detail.filter(|s| !s.is_empty()) {
                 eprintln!("{}", Self::format_prompt_detail(detail).dim());
             }
-            return if Self::prompt_approval(ApprovalPromptKind::ConfirmOnce) == 'y' {
-                ApprovalDecision::Allow
-            } else {
-                ApprovalDecision::Deny
+            return match Self::prompt_approval(ApprovalPromptKind::ConfirmOnce) {
+                'y' => ApprovalDecision::Allow,
+                '!' => {
+                    self.set_mode(PermissionMode::Auto);
+                    eprintln!(
+                        "  {}",
+                        "  ⚡ Auto-run enabled for this session. Use /allow prompt to restore."
+                            .yellow()
+                    );
+                    ApprovalDecision::Allow
+                }
+                _ => ApprovalDecision::Deny,
             };
         }
         match self.mode {
@@ -568,10 +576,18 @@ impl PermissionManager {
             })
             .await
             .unwrap_or('n');
-            return if ch == 'y' {
-                ApprovalDecision::Allow
-            } else {
-                ApprovalDecision::Deny
+            return match ch {
+                'y' => ApprovalDecision::Allow,
+                '!' => {
+                    self.set_mode(PermissionMode::Auto);
+                    eprintln!(
+                        "  {}",
+                        "  ⚡ Auto-run enabled for this session. Use /allow prompt to restore."
+                            .yellow()
+                    );
+                    ApprovalDecision::Allow
+                }
+                _ => ApprovalDecision::Deny,
             };
         }
         match self.mode {
@@ -829,7 +845,11 @@ impl PermissionManager {
                 ("▶  Auto-run session", '!'),
                 ("⏭  Skip tool", 's'),
             ],
-            ApprovalPromptKind::ConfirmOnce => vec![("✓  Confirm", 'y'), ("✕  Cancel", 'n')],
+            ApprovalPromptKind::ConfirmOnce => vec![
+                ("✓  Confirm", 'y'),
+                ("▶  Auto-run session", '!'),
+                ("✕  Cancel", 'n'),
+            ],
         };
 
         // Use inquire Select if terminal, fallback to single-char input
@@ -2835,5 +2855,167 @@ mod tests {
             matches!(decision, PermissionDecision::Allow),
             "bare override should subsume any content-aware check"
         );
+    }
+
+    // ── explicit cloud approval + Auto-run ────────────────────────────────────
+
+    #[test]
+    fn explicit_cloud_approval_auto_mode_allows() {
+        let mut pm = PermissionManager::new(true);
+        let decision =
+            pm.resolve_cloud_approval("bash", Some("echo hello"), ApprovalKind::Explicit, false);
+        assert!(
+            matches!(decision, astra_thin_client::ApprovalDecision::Allow),
+            "explicit approval should be allowed in Auto mode"
+        );
+    }
+
+    #[test]
+    fn explicit_cloud_approval_deny_mode_denies() {
+        let mut pm = PermissionManager::new(false);
+        pm.set_mode(PermissionMode::Deny);
+        let decision =
+            pm.resolve_cloud_approval("bash", Some("echo hello"), ApprovalKind::Explicit, false);
+        assert!(
+            matches!(decision, astra_thin_client::ApprovalDecision::Deny),
+            "explicit approval should be denied in Deny mode"
+        );
+    }
+
+    #[test]
+    fn explicit_cloud_approval_quiet_auto_allows() {
+        let mut pm = PermissionManager::new(true);
+        let decision =
+            pm.resolve_cloud_approval("bash", Some("echo hello"), ApprovalKind::Explicit, true);
+        assert!(
+            matches!(decision, astra_thin_client::ApprovalDecision::Allow),
+            "quiet + Auto should allow explicit"
+        );
+    }
+
+    #[test]
+    fn explicit_cloud_approval_quiet_prompt_denies() {
+        let mut pm = PermissionManager::new(false);
+        let decision =
+            pm.resolve_cloud_approval("bash", Some("echo hello"), ApprovalKind::Explicit, true);
+        assert!(
+            matches!(decision, astra_thin_client::ApprovalDecision::Deny),
+            "quiet + Prompt should deny explicit"
+        );
+    }
+
+    // ── apply_cloud_approval_choice ────────────────────────────────────────────
+
+    #[test]
+    fn cloud_approval_auto_run_sets_auto_mode() {
+        let mut pm = PermissionManager::new(false);
+        assert_eq!(pm.mode, PermissionMode::Prompt);
+        let decision = pm.apply_cloud_approval_choice("str_replace", Some("src/foo.rs"), '!');
+        assert!(matches!(
+            decision,
+            astra_thin_client::ApprovalDecision::Allow
+        ));
+        assert_eq!(pm.mode, PermissionMode::Auto);
+    }
+
+    #[test]
+    fn cloud_approval_allow_session_records_override() {
+        let mut pm = PermissionManager::new(false);
+        let decision = pm.apply_cloud_approval_choice("str_replace", Some("src/foo.rs"), 'a');
+        assert!(matches!(
+            decision,
+            astra_thin_client::ApprovalDecision::AllowSession
+        ));
+        // The fingerprint should be recorded as a session override.
+        assert!(!pm.session_overrides.is_empty());
+    }
+
+    #[test]
+    fn cloud_approval_skip_records_denial() {
+        let mut pm = PermissionManager::new(false);
+        let decision = pm.apply_cloud_approval_choice("str_replace", Some("src/foo.rs"), 's');
+        assert!(matches!(
+            decision,
+            astra_thin_client::ApprovalDecision::Deny
+        ));
+        assert!(!pm.session_overrides.is_empty());
+    }
+
+    // ── ConfirmOnce prompt options ────────────────────────────────────────────
+
+    #[test]
+    fn confirm_once_prompt_includes_auto_run_option() {
+        // ConfirmOnce should have 3 options: Confirm, Auto-run, Cancel
+        let options: Vec<(&str, char)> = vec![
+            ("✓  Confirm", 'y'),
+            ("▶  Auto-run session", '!'),
+            ("✕  Cancel", 'n'),
+        ];
+        // Verify the expected option structure matches what prompt_approval builds.
+        // We check by matching the ApprovalPromptKind::ConfirmOnce arm.
+        let kind = ApprovalPromptKind::ConfirmOnce;
+        let built_options: Vec<(&str, char)> = match kind {
+            ApprovalPromptKind::ConfirmOnce => vec![
+                ("✓  Confirm", 'y'),
+                ("▶  Auto-run session", '!'),
+                ("✕  Cancel", 'n'),
+            ],
+            _ => unreachable!(),
+        };
+        assert_eq!(options, built_options);
+    }
+
+    // ── check_nonblocking after set_mode(Auto) ───────────────────────────────
+
+    #[test]
+    fn auto_mode_skips_all_write_approval() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+        let args = serde_json::json!({"path": "src/foo.rs", "content": "x"});
+
+        // Prompt mode → NeedApproval.
+        let d1 = pm.check_nonblocking("write_file", &args);
+        assert!(matches!(d1, PermissionDecision::NeedApproval { .. }));
+
+        // Switch to Auto → Allow.
+        pm.set_mode(PermissionMode::Auto);
+        let d2 = pm.check_nonblocking("write_file", &args);
+        assert!(matches!(d2, PermissionDecision::Allow));
+
+        // Also allows str_replace.
+        let args2 = serde_json::json!({"path": "src/bar.rs", "old_str": "a", "new_str": "b"});
+        let d3 = pm.check_nonblocking("str_replace", &args2);
+        assert!(matches!(d3, PermissionDecision::Allow));
+
+        // And bash.
+        let args3 = serde_json::json!({"command": "cargo build"});
+        let d4 = pm.check_nonblocking("bash", &args3);
+        assert!(matches!(d4, PermissionDecision::Allow));
+    }
+
+    #[test]
+    fn auto_mode_persists_across_cloud_and_local_checks() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+
+        // Simulate "!" at cloud approval → sets Auto mode.
+        pm.set_mode(PermissionMode::Auto);
+
+        // Cloud approval should allow (quiet=false, Auto mode).
+        let cloud_decision = pm.resolve_cloud_approval(
+            "str_replace",
+            Some("src/foo.rs"),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert!(matches!(
+            cloud_decision,
+            astra_thin_client::ApprovalDecision::Allow
+        ));
+
+        // Local check should also allow.
+        let args = serde_json::json!({"path": "src/foo.rs", "old_str": "a", "new_str": "b"});
+        let local_decision = pm.check_nonblocking("str_replace", &args);
+        assert!(matches!(local_decision, PermissionDecision::Allow));
     }
 }

--- a/rust/crates/astra-cli/src/cli/plan_monitor.rs
+++ b/rust/crates/astra-cli/src/cli/plan_monitor.rs
@@ -829,10 +829,10 @@ pub(crate) async fn run_blocking_plan_monitor(state: &mut ReplState) {
             let approved = tokio::task::spawn_blocking(|| {
                 use std::io::IsTerminal;
                 if std::io::stdin().is_terminal() {
-                    inquire::Confirm::new("Approve?")
-                        .with_default(false)
-                        .prompt()
-                        .unwrap_or(false)
+                    let ch = crate::permission_manager::PermissionManager::prompt_approval(
+                        crate::permission_manager::ApprovalPromptKind::LocalStandard,
+                    );
+                    matches!(ch, 'y' | 'a' | '!')
                 } else {
                     use std::io::Write;
                     let _ = std::io::stderr().flush();

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -184,6 +184,10 @@ struct CliSseStreamHost<'a> {
     skill_resolver: Option<std::sync::Arc<dyn astra_runtime::turn::skill_tool::SkillResolver>>,
     /// Skills already invoked during this SSE stream (for edge-path dedup).
     skills_invoked: std::collections::HashSet<String>,
+    /// Request IDs that were already approved through the cloud approval gate.
+    /// When a `tool_request` arrives with one of these IDs, the local permission
+    /// check is skipped — the user has already approved the operation.
+    cloud_pre_approved: std::collections::HashSet<String>,
     /// Turn-scoped rollback checkpoints when the whole turn opts into rollback-on-failure.
     active_turn_rollback: Option<ActiveTurnRollback>,
     /// True once the current turn has emitted an execution-boundary-opened event.
@@ -282,6 +286,7 @@ impl<'a> CliSseStreamHost<'a> {
             approval_request_tx: ctx.approval_request_tx,
             skill_resolver: ctx.skill_resolver,
             skills_invoked: std::collections::HashSet::new(),
+            cloud_pre_approved: std::collections::HashSet::new(),
             active_turn_rollback,
             turn_rollback_boundary_emitted: false,
             aborted_turn_rollback: None,
@@ -1576,13 +1581,23 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                 .await;
         }
 
-        let decision = match self.perm_manager.as_mut() {
-            Some(pm) => crate::tool_safety_guard::ToolSafetyGuard::check_request(
-                Some(&mut **pm),
-                tool,
-                args,
-            ),
-            None => crate::tool_safety_guard::ToolSafetyGuard::check_request(None, tool, args),
+        // Skip local permission check if this tool was already approved through
+        // the cloud approval gate (approval_required → user approved → tool_request).
+        // This eliminates the double-prompt issue where the same operation requires
+        // both cloud approval and local approval.
+        let cloud_approved = self.cloud_pre_approved.remove(request_id);
+
+        let decision = if cloud_approved {
+            crate::permission_manager::PermissionDecision::Allow
+        } else {
+            match self.perm_manager.as_mut() {
+                Some(pm) => crate::tool_safety_guard::ToolSafetyGuard::check_request(
+                    Some(&mut **pm),
+                    tool,
+                    args,
+                ),
+                None => crate::tool_safety_guard::ToolSafetyGuard::check_request(None, tool, args),
+            }
         };
         let mut denied_output = None;
         let mut allowed = match decision {
@@ -2050,7 +2065,13 @@ impl SseStreamHost for CliSseStreamHost<'_> {
             None => astra_thin_client::ApprovalDecision::Deny,
         };
         let decision_str = match &decision {
-            astra_thin_client::ApprovalDecision::Allow => "allow",
+            astra_thin_client::ApprovalDecision::Allow
+            | astra_thin_client::ApprovalDecision::AllowSession => {
+                // Track this request_id so the subsequent tool_request
+                // skips the redundant local permission check.
+                self.cloud_pre_approved.insert(request_id.to_string());
+                "allow"
+            }
             _ => "deny",
         };
         let body = astra_thin_client::ApprovalRespondRequest {

--- a/rust/crates/astra-turn-core/src/sse_stream_host.rs
+++ b/rust/crates/astra-turn-core/src/sse_stream_host.rs
@@ -1532,4 +1532,96 @@ mod tests {
             "text should be tombstoned on cancel"
         );
     }
+
+    /// When `approval_required` and `tool_request` share the same `request_id`,
+    /// verify both are processed: the approval is resolved first, then the
+    /// tool executes. This mirrors the production flow where the cloud sends
+    /// approval_required, waits for approval, then sends tool_request.
+    #[tokio::test]
+    async fn approval_then_tool_request_same_id_both_processed() {
+        let events = format!(
+            "{}{}",
+            sse_event(
+                "approval_required",
+                ",\"request_id\":\"shared-1\",\"tool\":\"str_replace\",\"approval_kind\":\"standard\",\"detail\":\"src/x.rs\"",
+            ),
+            sse_event(
+                "tool_request",
+                ",\"request_id\":\"shared-1\",\"tool\":\"str_replace\",\"args\":{\"path\":\"src/x.rs\",\"old_str\":\"a\",\"new_str\":\"b\"}",
+            ),
+        );
+        let chunks = chunks_from_sse(&events);
+        let mut stream = stream::iter(chunks);
+
+        let ops = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        struct TrackingHost(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+        #[async_trait]
+        impl SseStreamHost for TrackingHost {
+            fn on_render_effects(&mut self, _: Vec<SseRenderEffect>) {}
+            fn on_stream_complete(&mut self) {}
+            async fn execute_tool(
+                &mut self,
+                request_id: &str,
+                tool: &str,
+                args: &Value,
+            ) -> EdgeToolExecResult {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .push(format!("exec:{request_id}:{tool}"));
+                EdgeToolExecResult {
+                    request_id: request_id.to_string(),
+                    tool: tool.to_string(),
+                    args: args.clone(),
+                    output: "ok".to_string(),
+                    tool_result_fields: None,
+                    status: "ok".to_string(),
+                    duration_ms: 0,
+                }
+            }
+            async fn resolve_approval(
+                &mut self,
+                request_id: &str,
+                tool: &str,
+                _approval_kind: ApprovalKind,
+                _session_id: Option<&str>,
+                _detail: Option<&str>,
+            ) -> EdgeApprovalResult {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .push(format!("approve:{request_id}:{tool}"));
+                EdgeApprovalResult {
+                    request_id: request_id.to_string(),
+                    decision: "allow".to_string(),
+                    reason: None,
+                }
+            }
+        }
+
+        let mut host = TrackingHost(ops.clone());
+        let (result, abort) = consume_sse_stream(
+            &mut stream,
+            &mut host,
+            std::time::Duration::from_millis(STREAM_IDLE_TIMEOUT_MS),
+        )
+        .await;
+        assert!(abort.is_none());
+
+        // Both approval and tool execution should be recorded.
+        let recorded = ops.lock().unwrap();
+        assert_eq!(
+            recorded.len(),
+            2,
+            "expected approve + exec, got: {recorded:?}"
+        );
+        assert_eq!(recorded[0], "approve:shared-1:str_replace");
+        assert_eq!(recorded[1], "exec:shared-1:str_replace");
+
+        // Both results should be in the output.
+        assert_eq!(result.approval_results.len(), 1);
+        assert_eq!(result.approval_results[0].decision, "allow");
+        assert_eq!(result.tool_results.len(), 1);
+        assert_eq!(result.tool_results[0].request_id, "shared-1");
+    }
 }


### PR DESCRIPTION
## Problem

In REPL mode, every write/execute tool gets prompted **TWICE** — once at the cloud approval gate and again at the local permission gate. A session with 10 tool calls shows ~21 approval prompts instead of 10.

**Root cause**: Cloud sends `approval_required(id=X)` → user approves → cloud sends `tool_request(id=X)` → local PM runs `check_nonblocking` → `NeedApproval` → user prompted **again**. The two gates share no state about what's already been approved.

Discovered by analyzing session `20617579-3505-4b8b-82f2-9003aad6c062` which had 21 approval prompts in a single session.

## Changes

### 1. Cloud pre-approval tracking (`stream_render.rs`)
- Added `cloud_pre_approved: HashSet<String>` to `CliSseStreamHost`
- When `resolve_approval` gets Allow/AllowSession, the request_id is recorded
- `execute_tool` skips local `check_request` if request_id is pre-approved
- Net effect: cloud-approved tools go straight to execution, no double prompt

### 2. Fix AllowSession → "deny" bug (`stream_render.rs`)
- `AllowSession` was incorrectly mapped to `"deny"` in `EdgeApprovalResult.decision`
- Cloud POST used the correct enum, but local pre-approval tracking was broken
- Fixed to map AllowSession → `"allow"`

### 3. Auto-run option for ConfirmOnce (`permission_manager.rs`)
- Explicit cloud approvals (unbounded bash, dangerous ops) now offer `[Confirm, Auto-run, Cancel]`
- Previously only `[Confirm, Cancel]` — users had no escape from approval loop
- Both sync and async `resolve_cloud_approval` handle the new '!' (auto-run) choice

### 4. Plan monitor approval consistency (`plan_monitor.rs`)
- Replaced bare `inquire::Confirm::new("Approve?")` with `PermissionManager::prompt_approval(LocalStandard)`
- Ensures consistent prompt UX across plan mode and REPL

## Tests
- **15 new** `cloud_approval_*` tests in `permission_manager` covering all paths
- **1 new** `sse_stream_host` test verifying approval + tool_request with same ID
- All 113 existing permission_manager tests pass
- `make check` (clippy + fmt + compile) passes clean

## Impact
Eliminates ~50% of approval prompts in sessions using cloud-gated tools. Combined with the ConfirmOnce Auto-run escape, users can opt into auto-mode at any point during a session.