### PR TITLE
ci: run online tests in parallel with offline + add 20min timeout to all shards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
+
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -72,6 +73,7 @@ jobs:
     name: "Test: astra-runtime"
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -109,6 +111,7 @@ jobs:
     name: "Test: turn-core + services"
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -128,6 +131,7 @@ jobs:
     name: "Test: core crates + bridge hooks"
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -152,10 +156,10 @@ jobs:
           cargo nextest run --manifest-path rust/Cargo.toml -p astra-runtime
           --features bridge-e2e-hooks --profile ci
 
-  # ── Stage 3: online tests (needs DB, runs after offline passes) ────
+  # ── Stage 3: online tests (needs DB, runs in parallel with offline) ──
   test-online:
     name: "Test: online (DB)"
-    needs: [shard-a, shard-b, shard-c, shard-d]
+    needs: [build]
     runs-on: ubuntu-latest
     env:
       MATRIXONE_HOST: localhost


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## What this PR does / why we need it:

Two CI improvements:

1. **Online tests run in parallel with offline shards** — `test-online` now depends only on `build` instead of all four offline shards. This means DB tests start as soon as compilation finishes, without waiting for offline to complete. A stuck offline shard no longer blocks online tests.

2. **20-minute timeout on all offline shards** — shard-a already had `timeout-minutes: 20`; this adds the same to shard-b, shard-c, and shard-d. Any stuck shard will be killed after 20 minutes instead of hanging indefinitely.