### PR TITLE
fix: expose web_fetch in server mode

### DIFF
--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -55,6 +55,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "symbols",
     "git_commit",
     "git_revert_commit",
+    "web_fetch",
     "web_search",
     "memory_retrieve",
     "memory_store",
@@ -1915,6 +1916,7 @@ mod tests {
         assert!(names.contains(&"git_revert_commit"));
         assert!(!names.contains(&"symbols"));
         assert!(!names.contains(&"rollback_file_edits"));
+        assert!(!names.contains(&"web_fetch"));
         assert!(!names.contains(&"memory_store"));
         assert!(!names.contains(&"powershell"));
         assert!(!names.contains(&"multi_edit"));
@@ -1940,6 +1942,7 @@ mod tests {
         assert!(names.contains(&"rollback_database_snapshots"));
         assert!(names.contains(&"memory_retrieve"));
         assert!(names.contains(&"symbols"));
+        assert!(names.contains(&"web_fetch"));
         assert!(names.contains(&"memory_store"));
         assert!(names.contains(&"git_revert_commit"));
         assert!(!names.contains(&"rollback_turn_actions"));

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -1206,6 +1206,7 @@ impl ServerToolExecutor {
             // ── File operations ─────────────────────────────────────────
             // Write operations use server-specific journal recording.
             // Read-only operations delegate to DefaultToolExecutor.
+            "web_fetch" => self.default_executor.execute("web_fetch", args).await,
             "read_file" => self.default_executor.execute("read_file", args).await,
             "write_file" => tool_result_from_output(self.server_write_file(args)),
             "str_replace" => tool_result_from_output(self.server_str_replace(args)),
@@ -1261,7 +1262,7 @@ impl ServerToolExecutor {
                      Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
                      list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
                      rollback_session_state, task_*, mo_query, rollback_database_snapshots, grep, glob, git_status, \
-                     git_diff, git_log, git_show, git_blame, symbols, git_commit, git_revert_commit, memory_*, web_search"
+                     git_diff, git_log, git_show, git_blame, symbols, git_commit, git_revert_commit, memory_*, web_fetch, web_search"
             )),
         };
 
@@ -3496,6 +3497,17 @@ esac
         let (exec, _dir) = test_executor();
         let result = exec.execute("nonexistent_tool", &json!({})).await;
         assert!(result.contains("not available"));
+    }
+
+    #[tokio::test]
+    async fn web_fetch_is_available_in_server_mode() {
+        let (exec, _dir) = test_executor();
+        let result = exec.execute("web_fetch", &json!({})).await;
+        assert!(result.contains("Missing 'url'"), "{result}");
+        assert!(
+            !result.contains("not available in server-side execution mode"),
+            "{result}"
+        );
     }
 
     // ── Bash execution ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add `web_fetch` to the server executor allowlist so web sessions can see it in `server_executor_tool_schemas()`
- route server-side `web_fetch` execution through the existing default executor implementation
- add regression coverage in both schema and server executor tests

## Motivation
The 54175a25 parity-analysis session called out `web_fetch` as a core missing capability for a serious web agent backend. The implementation already exists, but the server surface never exposed it.

## Validation
- cargo fmt
- cargo clippy -p astra-tools -p astra-runtime --all-targets
- cargo test -p astra-tools
- cargo test -p astra-runtime server_tool_executor::tests::