### PR TITLE
fix: expose symbols in server mode

### DIFF
--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -52,6 +52,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "git_log",
     "git_show",
     "git_blame",
+    "symbols",
     "git_commit",
     "git_revert_commit",
     "web_search",
@@ -1912,6 +1913,7 @@ mod tests {
         let schemas = default_executor_tool_schemas();
         let names = schema_names(&schemas);
         assert!(names.contains(&"git_revert_commit"));
+        assert!(!names.contains(&"symbols"));
         assert!(!names.contains(&"rollback_file_edits"));
         assert!(!names.contains(&"memory_store"));
         assert!(!names.contains(&"powershell"));
@@ -1937,6 +1939,7 @@ mod tests {
         assert!(names.contains(&"mo_query"));
         assert!(names.contains(&"rollback_database_snapshots"));
         assert!(names.contains(&"memory_retrieve"));
+        assert!(names.contains(&"symbols"));
         assert!(names.contains(&"memory_store"));
         assert!(names.contains(&"git_revert_commit"));
         assert!(!names.contains(&"rollback_turn_actions"));

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -1242,6 +1242,7 @@ impl ServerToolExecutor {
             "git_log" => self.default_executor.execute("git_log", args).await,
             "git_show" => self.default_executor.execute("git_show", args).await,
             "git_blame" => self.default_executor.execute("git_blame", args).await,
+            "symbols" => self.default_executor.execute("symbols", args).await,
             "git_commit" => self.default_executor.execute("git_commit", args).await,
             "git_revert_commit" => {
                 self.default_executor
@@ -1260,7 +1261,7 @@ impl ServerToolExecutor {
                      Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
                      list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
                      rollback_session_state, task_*, mo_query, rollback_database_snapshots, grep, glob, git_status, \
-                     git_diff, git_log, git_show, git_blame, git_commit, git_revert_commit, memory_*, web_search"
+                     git_diff, git_log, git_show, git_blame, symbols, git_commit, git_revert_commit, memory_*, web_search"
             )),
         };
 
@@ -3602,6 +3603,19 @@ esac
             .execute("grep", &json!({"pattern": "ZZZZNOTFOUND"}))
             .await;
         assert!(result.contains("No matches found"));
+    }
+
+    #[tokio::test]
+    async fn symbols_extracts_rust_symbols() {
+        let (exec, dir) = test_executor();
+        std::fs::write(
+            dir.path().join("sample.rs"),
+            "fn hello() {}\nstruct Foo {}\n",
+        )
+        .unwrap();
+        let result = exec.execute("symbols", &json!({"path": "sample.rs"})).await;
+        assert!(result.contains("hello"));
+        assert!(result.contains("Foo"));
     }
 
     // ── Git operations ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- expose the existing symbols tool in the server executor surface
- delegate server-side symbol extraction through the default executor
- add schema and server executor regression coverage

## Testing
- cargo fmt
- cargo clippy -p astra-tools -p astra-runtime --all-targets
- cargo test -p astra-tools
- cargo test -p astra-runtime server_tool_executor::tests::