### PR TITLE
fix: expose sleep in server mode

### DIFF
--- a/rust/crates/astra-tools/src/executor.rs
+++ b/rust/crates/astra-tools/src/executor.rs
@@ -248,10 +248,15 @@ impl DefaultToolExecutor {
             // ── Sleep ────────────────────────────────────────────────
             "sleep" => {
                 let secs = args
-                    .get("seconds")
-                    .and_then(|v| v.as_f64())
-                    .unwrap_or(1.0)
-                    .clamp(0.0, 30.0);
+                    .get("duration_ms")
+                    .and_then(Value::as_u64)
+                    .map(|ms| (ms.min(300_000) as f64) / 1000.0)
+                    .or_else(|| {
+                        args.get("seconds")
+                            .and_then(Value::as_f64)
+                            .map(|s| s.clamp(0.0, 300.0))
+                    })
+                    .unwrap_or(1.0);
                 tokio::time::sleep(std::time::Duration::from_secs_f64(secs)).await;
                 ToolResult::text(format!("Slept for {secs:.1}s"))
             }
@@ -705,11 +710,23 @@ mod tests {
         let (_tmp, exec) = test_executor();
         let start = std::time::Instant::now();
         let result = exec
-            .execute("sleep", &serde_json::json!({"seconds": 0.1}))
+            .execute("sleep", &serde_json::json!({"duration_ms": 100}))
             .await;
         assert!(!result.is_error);
         assert!(result.output.contains("Slept"));
         assert!(start.elapsed().as_millis() >= 90);
+    }
+
+    #[tokio::test]
+    async fn dispatch_sleep_accepts_legacy_seconds() {
+        let (_tmp, exec) = test_executor();
+        let start = std::time::Instant::now();
+        let result = exec
+            .execute("sleep", &serde_json::json!({"seconds": 0.05}))
+            .await;
+        assert!(!result.is_error);
+        assert!(result.output.contains("Slept"));
+        assert!(start.elapsed().as_millis() >= 40);
     }
 
     #[tokio::test]

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -43,6 +43,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "task_get",
     "task_update",
     "task_stop",
+    "sleep",
     "mo_query",
     "rollback_database_snapshots",
     "grep",
@@ -1936,6 +1937,7 @@ mod tests {
         assert!(names.contains(&"task_get"));
         assert!(names.contains(&"task_update"));
         assert!(names.contains(&"task_stop"));
+        assert!(names.contains(&"sleep"));
         assert!(names.contains(&"mo_query"));
         assert!(names.contains(&"rollback_database_snapshots"));
         assert!(names.contains(&"memory_retrieve"));

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -1224,6 +1224,7 @@ impl ServerToolExecutor {
             "task_get" => tool_result_from_output(self.task_get(args)),
             "task_update" => tool_result_from_output(self.task_update(args)),
             "task_stop" => tool_result_from_output(self.task_stop(args)),
+            "sleep" => self.default_executor.execute("sleep", args).await,
             // ── MatrixOne operations ────────────────────────────────────
             "mo_query" => self.server_mo_query(args),
             "rollback_database_snapshots" => {
@@ -1260,8 +1261,9 @@ impl ServerToolExecutor {
                 "Error: Tool '{name}' is not available in server-side execution mode. \
                      Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
                      list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
-                     rollback_session_state, task_*, mo_query, rollback_database_snapshots, grep, glob, git_status, \
-                     git_diff, git_log, git_show, git_blame, symbols, git_commit, git_revert_commit, memory_*, web_search"
+                     rollback_session_state, task_*, sleep, mo_query, rollback_database_snapshots, grep, glob, \
+                     git_status, git_diff, git_log, git_show, git_blame, symbols, git_commit, git_revert_commit, \
+                     memory_*, web_search"
             )),
         };
 
@@ -3603,6 +3605,16 @@ esac
             .execute("grep", &json!({"pattern": "ZZZZNOTFOUND"}))
             .await;
         assert!(result.contains("No matches found"));
+    }
+
+    #[tokio::test]
+    async fn sleep_is_available_in_server_mode() {
+        let (exec, _dir) = test_executor();
+        let start = std::time::Instant::now();
+        let result = exec.execute("sleep", &json!({"duration_ms": 20})).await;
+        assert!(result.contains("Slept"), "{result}");
+        assert!(start.elapsed().as_millis() >= 15);
+        assert!(!result.contains("not available in server-side execution mode"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- expose sleep in the server executor surface
- align the sleep implementation with the duration_ms schema while keeping backward compatibility for legacy seconds calls
- add regression coverage in astra-tools and server executor tests

## Testing
- cargo fmt
- cargo clippy -p astra-tools -p astra-runtime --all-targets
- cargo test -p astra-tools
- cargo test -p astra-runtime server_tool_executor::tests::