### PR TITLE
feat: add websocket ask_user protocol

### DIFF
--- a/rust/crates/astra-server-types/src/lib.rs
+++ b/rust/crates/astra-server-types/src/lib.rs
@@ -878,6 +878,7 @@ pub fn chat_request_into_data(mut request: ChatRequest) -> ChatRequestData {
         forward_headers: std::collections::HashMap::new(),
         max_candidates: request.max_candidates,
         explain: request.explain,
+        interactive_client: false,
     }
 }
 

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -331,6 +331,40 @@ pub trait ToolApprovalGate: Send + Sync {
     fn requires_approval(&self, tool_name: &str) -> bool;
 }
 
+// ─── ask_user gate ────────────────────────────────────────────────────────────
+
+/// Final answer returned from an interactive ask_user prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AskUserResponse {
+    pub answer: String,
+    pub was_custom: bool,
+}
+
+/// Result from an ask_user gate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AskUserDecision {
+    /// User provided an answer.
+    Answer(AskUserResponse),
+    /// The prompt timed out before the user responded.
+    Timeout,
+    /// The prompt could not be delivered or decoded.
+    Error(String),
+}
+
+/// Trait for routing ask_user prompts through an interactive frontend.
+#[async_trait]
+pub trait AskUserGate: Send + Sync {
+    /// Ask the user a question and wait for their response.
+    async fn request_user_input(
+        &self,
+        request_id: &str,
+        question: &str,
+        choices: &[String],
+        default: Option<&str>,
+        context: Option<&str>,
+    ) -> AskUserDecision;
+}
+
 // ─── Tool progress callback ─────────────────────────────────────────────────
 
 /// Callback for streaming tool execution progress to the frontend.

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -56,6 +56,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "git_commit",
     "git_revert_commit",
     "web_search",
+    "ask_user",
     "memory_retrieve",
     "memory_store",
     "memory_search",

--- a/rust/crates/astra-turn-core/src/edge_ledger.rs
+++ b/rust/crates/astra-turn-core/src/edge_ledger.rs
@@ -39,6 +39,11 @@ pub fn approval_callback_key(user_id: &str, request_id: &str) -> String {
     format!("{user_id}:approval:{request_id}")
 }
 
+#[inline]
+pub fn user_prompt_callback_key(user_id: &str, request_id: &str) -> String {
+    format!("{user_id}:user_prompt:{request_id}")
+}
+
 /// Remove and return the value for `key`, waiting up to `timeout` (50ms polling).
 pub async fn take_ledger_entry(
     ledger: &Arc<tokio::sync::Mutex<HashMap<String, Value>>>,

--- a/rust/crates/astra-turn-core/src/lib.rs
+++ b/rust/crates/astra-turn-core/src/lib.rs
@@ -171,3 +171,4 @@ pub mod tool_registry_plugin;
 pub mod tool_registry_selection_edge_hints;
 pub mod turn_guard;
 pub mod ws_approval_gate;
+pub mod ws_user_prompt_gate;

--- a/rust/crates/astra-turn-core/src/ws_user_prompt_gate.rs
+++ b/rust/crates/astra-turn-core/src/ws_user_prompt_gate.rs
@@ -1,0 +1,188 @@
+//! WebSocket-based ask_user gate.
+//!
+//! Bridges the [`astra_tools::AskUserGate`] trait with the WebSocket protocol.
+//! Outbound prompt requests are sent via an `mpsc` channel that the WS handler
+//! drains during its polling loop. Inbound responses arrive through the shared
+//! §5.5 edge callback ledger.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use astra_tools::{AskUserDecision, AskUserGate, AskUserResponse};
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::Mutex as TokioMutex;
+use tokio::sync::mpsc;
+
+use crate::edge_ledger::{take_ledger_entry, user_prompt_callback_key};
+
+/// Default timeout for ask_user prompts (matches frontend 60s countdown).
+const USER_PROMPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// An outbound ask_user request to be forwarded over WebSocket.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserPromptOutboundRequest {
+    pub request_id: String,
+    pub question: String,
+    pub choices: Vec<String>,
+    pub default: Option<String>,
+    pub context: Option<String>,
+}
+
+/// [`AskUserGate`] implementation backed by WebSocket messaging.
+pub struct WebSocketUserPromptGate {
+    user_id: String,
+    edge_callback_ledger: Arc<TokioMutex<HashMap<String, Value>>>,
+    request_tx: mpsc::UnboundedSender<Value>,
+    timeout: Duration,
+}
+
+impl WebSocketUserPromptGate {
+    pub fn new(
+        user_id: String,
+        edge_callback_ledger: Arc<TokioMutex<HashMap<String, Value>>>,
+        request_tx: mpsc::UnboundedSender<Value>,
+    ) -> Self {
+        Self {
+            user_id,
+            edge_callback_ledger,
+            request_tx,
+            timeout: USER_PROMPT_TIMEOUT,
+        }
+    }
+}
+
+#[async_trait]
+impl AskUserGate for WebSocketUserPromptGate {
+    async fn request_user_input(
+        &self,
+        request_id: &str,
+        question: &str,
+        choices: &[String],
+        default: Option<&str>,
+        context: Option<&str>,
+    ) -> AskUserDecision {
+        let request = serde_json::json!({
+            "request_id": request_id,
+            "question": question,
+            "choices": choices,
+            "default": default,
+            "context": context,
+        });
+
+        if self.request_tx.send(request).is_err() {
+            return AskUserDecision::Error("WebSocket connection closed".into());
+        }
+
+        let key = user_prompt_callback_key(&self.user_id, request_id);
+        match take_ledger_entry(&self.edge_callback_ledger, &key, self.timeout).await {
+            Some(value) => {
+                let Some(answer) = value
+                    .get("answer")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+                else {
+                    return AskUserDecision::Error(
+                        "Invalid user prompt response: missing answer".into(),
+                    );
+                };
+                AskUserDecision::Answer(AskUserResponse {
+                    answer,
+                    was_custom: value
+                        .get("was_custom")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false),
+                })
+            }
+            None => AskUserDecision::Timeout,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn answered_via_ledger() {
+        let ledger = Arc::new(TokioMutex::new(HashMap::new()));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let gate = WebSocketUserPromptGate {
+            user_id: "u1".into(),
+            edge_callback_ledger: ledger.clone(),
+            request_tx: tx,
+            timeout: Duration::from_secs(5),
+        };
+
+        let ledger_bg = ledger.clone();
+        tokio::spawn(async move {
+            let req = rx.recv().await.unwrap();
+            assert_eq!(req["question"].as_str().unwrap(), "Continue?");
+            assert_eq!(req["choices"].as_array().unwrap().len(), 2);
+
+            let key = user_prompt_callback_key("u1", req["request_id"].as_str().unwrap());
+            let mut g = ledger_bg.lock().await;
+            g.insert(key, json!({"answer": "yes", "was_custom": false}));
+        });
+
+        let decision = gate
+            .request_user_input(
+                "req-1",
+                "Continue?",
+                &["yes".to_string(), "no".to_string()],
+                Some("yes"),
+                Some("Pick one"),
+            )
+            .await;
+        assert_eq!(
+            decision,
+            AskUserDecision::Answer(AskUserResponse {
+                answer: "yes".into(),
+                was_custom: false,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_when_no_response() {
+        let ledger = Arc::new(TokioMutex::new(HashMap::new()));
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let gate = WebSocketUserPromptGate {
+            user_id: "u1".into(),
+            edge_callback_ledger: ledger,
+            request_tx: tx,
+            timeout: Duration::from_millis(100),
+        };
+
+        let decision = gate
+            .request_user_input("req-2", "Continue?", &[], None, None)
+            .await;
+        assert_eq!(decision, AskUserDecision::Timeout);
+    }
+
+    #[tokio::test]
+    async fn channel_closed_returns_error() {
+        let ledger = Arc::new(TokioMutex::new(HashMap::new()));
+        let (tx, rx) = mpsc::unbounded_channel();
+        drop(rx);
+
+        let gate = WebSocketUserPromptGate {
+            user_id: "u1".into(),
+            edge_callback_ledger: ledger,
+            request_tx: tx,
+            timeout: Duration::from_secs(5),
+        };
+
+        let decision = gate
+            .request_user_input("req-3", "Continue?", &[], None, None)
+            .await;
+        assert_eq!(
+            decision,
+            AskUserDecision::Error("WebSocket connection closed".into())
+        );
+    }
+}

--- a/rust/crates/runtime/src/server/chat_handlers.rs
+++ b/rust/crates/runtime/src/server/chat_handlers.rs
@@ -461,6 +461,7 @@ mod tests {
             forward_headers: std::collections::HashMap::new(),
             max_candidates: 3,
             explain: true,
+            interactive_client: false,
         });
         let obj = payload.as_object().unwrap();
         assert!(obj.contains_key("messages"));
@@ -499,6 +500,7 @@ mod tests {
             forward_headers: std::collections::HashMap::new(),
             max_candidates: 3,
             explain: true,
+            interactive_client: false,
         });
         let obj = payload.as_object().unwrap();
         assert_eq!(obj["allow_skills"], serde_json::json!(["analyze", "plan"]));

--- a/rust/crates/runtime/src/server/mod.rs
+++ b/rust/crates/runtime/src/server/mod.rs
@@ -58,6 +58,7 @@ pub mod worktree_isolation;
 pub mod ws_approval_gate;
 mod ws_handler;
 pub mod ws_progress_callback;
+pub mod ws_user_prompt_gate;
 
 use self::{
     bridge_prep::prepare_chat_turn_bridge_body,

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -695,6 +695,10 @@ pub struct AgenticRunLifecycleService {
     /// Per-run approval request channel receivers (Phase E).
     /// Key: run_id → receiver that the WS handler drains.
     approval_channels: Arc<TokioMutex<HashMap<String, mpsc::UnboundedReceiver<serde_json::Value>>>>,
+    /// Per-run ask_user prompt channel receivers.
+    /// Key: run_id → receiver that the WS handler drains.
+    user_prompt_channels:
+        Arc<TokioMutex<HashMap<String, mpsc::UnboundedReceiver<serde_json::Value>>>>,
     /// Per-run progress event channel receivers (Phase F.3).
     /// Key: run_id → receiver that the WS handler drains.
     progress_channels: Arc<TokioMutex<HashMap<String, mpsc::UnboundedReceiver<ProgressEvent>>>>,
@@ -719,6 +723,7 @@ impl AgenticRunLifecycleService {
             skill_service: None,
             server_skill_resolver_cache: std::sync::OnceLock::new(),
             approval_channels: Arc::new(TokioMutex::new(HashMap::new())),
+            user_prompt_channels: Arc::new(TokioMutex::new(HashMap::new())),
             progress_channels: Arc::new(TokioMutex::new(HashMap::new())),
         }
     }
@@ -958,7 +963,8 @@ impl AgenticRunLifecycleService {
         .with_model(request.model.clone())
         .with_edge_tools(edge_tools)
         .with_edge_profile(edge_profile)
-        .with_edge_callback_ledger(self.edge_callback_ledger.clone());
+        .with_edge_callback_ledger(self.edge_callback_ledger.clone())
+        .with_interactive_client(request.interactive_client);
 
         if let Some(pool) = &self.shared_pool {
             builder = builder.with_pool(pool.clone());
@@ -1392,6 +1398,20 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 .await
                 .insert(run_id.clone(), approval_rx);
 
+            if request.interactive_client {
+                let (user_prompt_tx, user_prompt_rx) = mpsc::unbounded_channel();
+                let user_prompt_gate = super::ws_user_prompt_gate::WebSocketUserPromptGate::new(
+                    user_id.clone(),
+                    self.edge_callback_ledger.clone(),
+                    user_prompt_tx,
+                );
+                executor.set_ask_user_gate(std::sync::Arc::new(user_prompt_gate));
+                self.user_prompt_channels
+                    .lock()
+                    .await
+                    .insert(run_id.clone(), user_prompt_rx);
+            }
+
             // ── Phase F.3: Wire WebSocket progress callback ─────────
             let (progress_tx, progress_rx) = mpsc::unbounded_channel();
             let progress_cb =
@@ -1407,6 +1427,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
 
         // Clone handles we need inside the spawned task.
         let bg_approval_channels = self.approval_channels.clone();
+        let bg_user_prompt_channels = self.user_prompt_channels.clone();
         let bg_progress_channels = self.progress_channels.clone();
         let runs = self.runs_handle();
         let run_engine = self.run_engine.clone();
@@ -1423,6 +1444,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
 
             // Clean up channels for this run.
             bg_approval_channels.lock().await.remove(&bg_run_id);
+            bg_user_prompt_channels.lock().await.remove(&bg_run_id);
             bg_progress_channels.lock().await.remove(&bg_run_id);
             let terminal_events = terminal_events_for_persistence(&events);
 
@@ -1737,6 +1759,18 @@ impl RunLifecycleService for AgenticRunLifecycleService {
 
     async fn drain_approval_requests(&self, run_id: &str) -> Vec<serde_json::Value> {
         let mut channels = self.approval_channels.lock().await;
+        let Some(rx) = channels.get_mut(run_id) else {
+            return vec![];
+        };
+        let mut requests = Vec::new();
+        while let Ok(req) = rx.try_recv() {
+            requests.push(req);
+        }
+        requests
+    }
+
+    async fn drain_user_prompt_requests(&self, run_id: &str) -> Vec<serde_json::Value> {
+        let mut channels = self.user_prompt_channels.lock().await;
         let Some(rx) = channels.get_mut(run_id) else {
             return vec![];
         };
@@ -2461,6 +2495,7 @@ mod tests {
             forward_headers: HashMap::new(),
             max_candidates: 5,
             explain: false,
+            interactive_client: false,
         }
     }
 
@@ -3078,6 +3113,7 @@ mod tests {
             forward_headers: HashMap::new(),
             max_candidates: 5,
             explain: false,
+            interactive_client: false,
         };
         let tools = AgenticRunLifecycleService::extract_edge_tools(&req);
         assert_eq!(tools.len(), 1);
@@ -3108,6 +3144,7 @@ mod tests {
             forward_headers: HashMap::new(),
             max_candidates: 5,
             explain: false,
+            interactive_client: false,
         };
         let profile = AgenticRunLifecycleService::extract_edge_profile(&req);
         assert_eq!(profile["cwd"], "/tmp");

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -83,6 +83,8 @@ pub struct ServerAgenticLoopHost {
     selection_confidence: f64,
     /// `true` when tools were auto-populated from astra-tools (no CLI connected).
     server_side_tools: bool,
+    /// `true` when the connected client can answer ask_user prompts.
+    interactive_client: bool,
 
     // ── Tool execution (used by RunLifecycleService wiring) ──
     #[allow(dead_code)] // needed once RunLifecycleService uses ledger-based tool execution
@@ -113,6 +115,7 @@ pub struct ServerAgenticLoopHostBuilder {
     user_id: String,
     session_id: String,
     progress_broadcaster: Option<Arc<crate::orchestration::ProgressBroadcaster>>,
+    interactive_client: bool,
 }
 
 impl ServerAgenticLoopHostBuilder {
@@ -134,6 +137,7 @@ impl ServerAgenticLoopHostBuilder {
             user_id,
             session_id,
             progress_broadcaster: None,
+            interactive_client: false,
         }
     }
 
@@ -178,6 +182,11 @@ impl ServerAgenticLoopHostBuilder {
         self
     }
 
+    pub fn with_interactive_client(mut self, interactive_client: bool) -> Self {
+        self.interactive_client = interactive_client;
+        self
+    }
+
     pub fn build(self) -> ServerAgenticLoopHost {
         // When no edge tools are provided (web-only mode), populate with
         // server-side tool schemas from astra-tools so the LLM knows what's available.
@@ -210,6 +219,7 @@ impl ServerAgenticLoopHostBuilder {
             valid_tools,
             selection_confidence: self.selection_confidence,
             server_side_tools,
+            interactive_client: self.interactive_client,
             edge_callback_ledger: self.edge_callback_ledger,
             user_id: self.user_id,
             session_id: self.session_id,
@@ -220,6 +230,14 @@ impl ServerAgenticLoopHostBuilder {
 }
 
 impl ServerAgenticLoopHost {
+    fn turn_interaction_mode(&self) -> TurnInteractionMode {
+        if self.interactive_client {
+            TurnInteractionMode::Prompt
+        } else {
+            TurnInteractionMode::Headless
+        }
+    }
+
     fn push_reasoning_events(emitted_events: &mut Vec<Value>, reasoning: &str) {
         if reasoning.is_empty() {
             return;
@@ -818,9 +836,8 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
         merge_deprioritized_tools_into_restricted(&state.turn_guard, &mut state.restricted_tools);
         let mut effective_restricted = state.restricted_tools.clone();
         effective_restricted.extend(self.effective_allowlist_restrictions(state));
-        effective_restricted.extend(interaction_scoped_tool_restrictions(
-            TurnInteractionMode::Headless,
-        ));
+        let interaction_mode = self.turn_interaction_mode();
+        effective_restricted.extend(interaction_scoped_tool_restrictions(interaction_mode));
         let visible_tools = self.filtered_turn_tools(&effective_restricted);
         self.sync_valid_tools_to_visible(&visible_tools);
 
@@ -869,7 +886,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
         // Annotate tool schemas with cache_control for Anthropic.
         annotate_tool_schemas_for_caching(&mut final_tools, &cache_cfg);
         state.last_turn_policy =
-            TurnInteractionPolicy::from_tool_schemas(TurnInteractionMode::Headless, &final_tools);
+            TurnInteractionPolicy::from_tool_schemas(interaction_mode, &final_tools);
 
         let llm_cancel = llm_cancel_for_state(state);
 
@@ -1789,6 +1806,45 @@ mod tests {
         );
         assert_eq!(policy.evidence_tool_names, policy.visible_tool_names);
         assert!(!policy.allow_ask_user);
+    }
+
+    #[test]
+    fn interactive_turn_policy_keeps_ask_user_in_final_tools() {
+        let host = ServerAgenticLoopHostBuilder::new(
+            mock_matrixone(),
+            mock_encryptor(),
+            "u".to_string(),
+            "s".to_string(),
+        )
+        .with_edge_tools(sample_edge_tools_with_ask_user())
+        .with_interactive_client(true)
+        .build();
+
+        let mut state = create_test_state();
+        merge_deprioritized_tools_into_restricted(&state.turn_guard, &mut state.restricted_tools);
+        let mut effective_restricted = state.restricted_tools.clone();
+        effective_restricted.extend(interaction_scoped_tool_restrictions(
+            host.turn_interaction_mode(),
+        ));
+        let visible_tools = host.filtered_turn_tools(&effective_restricted);
+        let final_tools =
+            prune_tool_schemas(&visible_tools, crate::prompts::CompactionTier::Normal);
+        let policy =
+            TurnInteractionPolicy::from_tool_schemas(host.turn_interaction_mode(), &final_tools);
+
+        assert_eq!(
+            policy.visible_tool_names,
+            vec![
+                "bash".to_string(),
+                "read_file".to_string(),
+                "ask_user".to_string()
+            ]
+        );
+        assert_eq!(
+            policy.evidence_tool_names,
+            vec!["bash".to_string(), "read_file".to_string()]
+        );
+        assert!(policy.allow_ask_user);
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant, SystemTime};
 use serde_json::{Value, json};
 
 use astra_tools::executor::DefaultToolExecutor;
-use astra_tools::{ToolContext, ToolExecutor};
+use astra_tools::{AskUserDecision, AskUserGate, ToolContext, ToolExecutor};
 use async_trait::async_trait;
 
 use crate::tool_sandbox::{
@@ -46,6 +46,14 @@ struct DatabaseSnapshotRollbackEntry {
 struct DatabaseSnapshotRollbackJournal {
     entries: Vec<DatabaseSnapshotRollbackEntry>,
     next_sequence: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AskUserRequest {
+    question: String,
+    choices: Vec<String>,
+    default: Option<String>,
+    context: Option<String>,
 }
 
 impl DatabaseSnapshotRollbackJournal {
@@ -957,6 +965,8 @@ pub struct ServerToolExecutor {
     url_cache: Mutex<HashMap<String, (String, Instant)>>,
     /// Optional approval gate for dangerous tool execution.
     approval_gate: Option<Arc<dyn astra_tools::ToolApprovalGate>>,
+    /// Optional ask_user gate for interactive client prompts.
+    ask_user_gate: Option<Arc<dyn AskUserGate>>,
     /// Optional progress callback for streaming tool output.
     progress_callback: Option<Arc<dyn astra_tools::ToolProgressCallback>>,
     /// Optional resource governor for usage tracking (Phase 5).
@@ -1053,6 +1063,7 @@ impl ServerToolExecutor {
             http_client,
             url_cache: Mutex::new(HashMap::new()),
             approval_gate: None,
+            ask_user_gate: None,
             progress_callback: None,
             resource_governor: None,
             edge_connection_pool: None,
@@ -1066,6 +1077,11 @@ impl ServerToolExecutor {
     /// Set the approval gate for interactive tool execution.
     pub fn set_approval_gate(&mut self, gate: Arc<dyn astra_tools::ToolApprovalGate>) {
         self.approval_gate = Some(gate);
+    }
+
+    /// Set the ask_user gate for interactive user prompts.
+    pub fn set_ask_user_gate(&mut self, gate: Arc<dyn AskUserGate>) {
+        self.ask_user_gate = Some(gate);
     }
 
     /// Set the progress callback for streaming tool output.
@@ -1203,6 +1219,7 @@ impl ServerToolExecutor {
                     astra_tools::ToolResult::text(output)
                 }
             }
+            "ask_user" => self.server_ask_user(args).await,
             // ── File operations ─────────────────────────────────────────
             // Write operations use server-specific journal recording.
             // Read-only operations delegate to DefaultToolExecutor.
@@ -1258,10 +1275,10 @@ impl ServerToolExecutor {
             // ── Unknown tool fallback ──────────────────────────────────
             _ => astra_tools::ToolResult::error(format!(
                 "Error: Tool '{name}' is not available in server-side execution mode. \
-                     Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
-                     list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
-                     rollback_session_state, task_*, mo_query, rollback_database_snapshots, grep, glob, git_status, \
-                     git_diff, git_log, git_show, git_blame, symbols, git_commit, git_revert_commit, memory_*, web_search"
+                      Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
+                      list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
+                      rollback_session_state, task_*, mo_query, rollback_database_snapshots, grep, glob, git_status, \
+                      git_diff, git_log, git_show, git_blame, symbols, git_commit, git_revert_commit, memory_*, web_search, ask_user"
             )),
         };
 
@@ -1280,6 +1297,48 @@ impl ServerToolExecutor {
         }
 
         result
+    }
+
+    async fn server_ask_user(&self, args: &Value) -> astra_tools::ToolResult {
+        let request = match parse_ask_user_request(args) {
+            Ok(request) => request,
+            Err(error) => return astra_tools::ToolResult::error(error),
+        };
+
+        let Some(gate) = &self.ask_user_gate else {
+            return astra_tools::ToolResult::error(
+                "Error: ask_user requires an interactive client connection".into(),
+            );
+        };
+
+        let request_id = format!("ask-{}-{}", self.session_id, uuid_v4_short());
+        match gate
+            .request_user_input(
+                &request_id,
+                &request.question,
+                &request.choices,
+                request.default.as_deref(),
+                request.context.as_deref(),
+            )
+            .await
+        {
+            AskUserDecision::Answer(response) => {
+                let mut body = json!({
+                    "answer": response.answer,
+                    "question": request.question,
+                });
+                if !request.choices.is_empty() {
+                    body["was_custom"] = Value::Bool(response.was_custom);
+                }
+                astra_tools::ToolResult::text(body.to_string())
+            }
+            AskUserDecision::Timeout => astra_tools::ToolResult::error(
+                "Error: ask_user timed out waiting for user response".into(),
+            ),
+            AskUserDecision::Error(message) => {
+                astra_tools::ToolResult::error(format!("Error: ask_user failed: {message}"))
+            }
+        }
     }
 
     /// Set the current turn index for journal entries.
@@ -2968,6 +3027,42 @@ fn edit_type_label(edit_type: EditType) -> &'static str {
     }
 }
 
+fn parse_ask_user_request(args: &Value) -> Result<AskUserRequest, String> {
+    let question = match args.get("question").and_then(Value::as_str) {
+        Some(question) if !question.trim().is_empty() => question.to_string(),
+        _ => return Err("Error: 'question' is required".into()),
+    };
+
+    let choices: Vec<String> = args
+        .get("choices")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if !choices.is_empty() && !(2..=9).contains(&choices.len()) {
+        return Err("Error: choices must contain 2-9 options".into());
+    }
+
+    Ok(AskUserRequest {
+        question,
+        choices,
+        default: args
+            .get("default")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        context: args
+            .get("context")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+    })
+}
+
 fn tool_result_from_output(output: String) -> astra_tools::ToolResult {
     let parsed = serde_json::from_str::<Value>(&output).ok();
     let json_error = parsed
@@ -3020,6 +3115,8 @@ mod tests {
     use std::sync::{Mutex as StdMutex, MutexGuard, OnceLock};
 
     use super::*;
+    use astra_tools::{AskUserDecision, AskUserGate, AskUserResponse};
+    use async_trait::async_trait;
     use serde_json::json;
     use tempfile::TempDir;
 
@@ -3144,7 +3241,96 @@ esac
         (exec, dir, session_id, session)
     }
 
+    #[derive(Clone)]
+    struct StaticAskUserGate {
+        expected_question: &'static str,
+        expected_choices: Vec<&'static str>,
+        decision: AskUserDecision,
+    }
+
+    #[async_trait]
+    impl AskUserGate for StaticAskUserGate {
+        async fn request_user_input(
+            &self,
+            _request_id: &str,
+            question: &str,
+            choices: &[String],
+            _default: Option<&str>,
+            _context: Option<&str>,
+        ) -> AskUserDecision {
+            assert_eq!(question, self.expected_question);
+            assert_eq!(
+                choices,
+                &self
+                    .expected_choices
+                    .iter()
+                    .map(|choice| choice.to_string())
+                    .collect::<Vec<_>>()
+            );
+            self.decision.clone()
+        }
+    }
+
     // ── Path traversal security ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn ask_user_returns_structured_response_from_gate() {
+        let (mut exec, _dir) = test_executor();
+        exec.set_ask_user_gate(Arc::new(StaticAskUserGate {
+            expected_question: "Which option?",
+            expected_choices: vec!["first", "second"],
+            decision: AskUserDecision::Answer(AskUserResponse {
+                answer: "custom".into(),
+                was_custom: true,
+            }),
+        }));
+
+        let result = exec
+            .execute_with_metadata(
+                "ask_user",
+                &json!({
+                    "question": "Which option?",
+                    "choices": ["first", "second"],
+                    "default": "first"
+                }),
+            )
+            .await;
+
+        assert!(!result.is_error);
+        assert_eq!(
+            serde_json::from_str::<Value>(&result.output).unwrap(),
+            json!({
+                "answer": "custom",
+                "question": "Which option?",
+                "was_custom": true
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn ask_user_requires_interactive_gate() {
+        let (exec, _dir) = test_executor();
+        let result = exec
+            .execute_with_metadata("ask_user", &json!({"question": "Continue?"}))
+            .await;
+
+        assert!(result.is_error);
+        assert!(result.output.contains("interactive client connection"));
+    }
+
+    #[tokio::test]
+    async fn ask_user_rejects_invalid_choice_count() {
+        let (exec, _dir) = test_executor();
+        let result = exec
+            .execute_with_metadata(
+                "ask_user",
+                &json!({"question": "Pick one", "choices": ["only-one"]}),
+            )
+            .await;
+
+        assert!(result.is_error);
+        assert!(result.output.contains("choices must contain 2-9 options"));
+    }
 
     #[tokio::test]
     async fn resolve_path_allows_relative_inside_workspace() {

--- a/rust/crates/runtime/src/server/ws_handler.rs
+++ b/rust/crates/runtime/src/server/ws_handler.rs
@@ -131,6 +131,15 @@ pub(super) enum WsClientMessage {
         reason: Option<String>,
     },
 
+    /// Respond to an ask_user prompt.
+    #[serde(rename = "user_prompt")]
+    UserPrompt {
+        request_id: String,
+        answer: String,
+        #[serde(default)]
+        was_custom: bool,
+    },
+
     /// Client heartbeat.
     #[serde(rename = "ping")]
     Ping,
@@ -195,6 +204,18 @@ pub(super) enum WsServerMessage {
         request_id: String,
         tool: String,
         args: serde_json::Value,
+    },
+
+    /// ask_user requires a frontend response before the turn can continue.
+    #[serde(rename = "user_prompt_request")]
+    UserPromptRequest {
+        request_id: String,
+        question: String,
+        choices: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        default: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        context: Option<String>,
     },
 
     /// Tool execution started on server.
@@ -503,6 +524,20 @@ async fn message_loop(socket: &mut WebSocket, state: &AppState, mut conn: WsConn
                                 )
                                 .await;
                             }
+                            Ok(WsClientMessage::UserPrompt {
+                                request_id,
+                                answer,
+                                was_custom,
+                            }) => {
+                                handle_user_prompt_response(
+                                    state,
+                                    &conn,
+                                    &request_id,
+                                    answer,
+                                    was_custom,
+                                )
+                                .await;
+                            }
                             Ok(WsClientMessage::Ping) => {
                                 send_msg(socket, &WsServerMessage::Pong).await;
                             }
@@ -791,6 +826,26 @@ async fn handle_tool_approval(
     guard.insert(key, value);
 }
 
+/// Store an ask_user response in the edge callback ledger.
+async fn handle_user_prompt_response(
+    state: &AppState,
+    conn: &WsConnection,
+    request_id: &str,
+    answer: String,
+    was_custom: bool,
+) {
+    use crate::turn::edge_ledger::user_prompt_callback_key;
+
+    let key = user_prompt_callback_key(&conn.user.user_id, request_id);
+    let value = serde_json::json!({
+        "answer": answer,
+        "was_custom": was_custom,
+    });
+    let ledger = state.edge_callback_ledger.clone();
+    let mut guard = ledger.lock().await;
+    guard.insert(key, value);
+}
+
 fn build_bridge_chat_payload(
     session_id: Option<String>,
     content: &str,
@@ -858,6 +913,7 @@ fn build_ws_chat_request(
         forward_headers: std::collections::HashMap::new(),
         max_candidates,
         explain,
+        interactive_client: true,
     }
 }
 
@@ -1135,6 +1191,20 @@ async fn stream_run_over_websocket(
                             Ok(WsClientMessage::ToolApproval { request_id, approved, reason }) => {
                                 handle_tool_approval(state, conn, &request_id, approved, reason).await;
                             }
+                            Ok(WsClientMessage::UserPrompt {
+                                request_id,
+                                answer,
+                                was_custom,
+                            }) => {
+                                handle_user_prompt_response(
+                                    state,
+                                    conn,
+                                    &request_id,
+                                    answer,
+                                    was_custom,
+                                )
+                                .await;
+                            }
                             Ok(WsClientMessage::Ping) => {
                                 send_msg(socket, &WsServerMessage::Pong).await;
                             }
@@ -1211,6 +1281,47 @@ async fn stream_run_over_websocket(
                                 .unwrap_or_default()
                                 .to_string(),
                             args: req.get("args").cloned().unwrap_or_default(),
+                        },
+                    )
+                    .await;
+                }
+
+                for req in state
+                    .run_lifecycle_service
+                    .drain_user_prompt_requests(run_id)
+                    .await
+                {
+                    send_msg(
+                        socket,
+                        &WsServerMessage::UserPromptRequest {
+                            request_id: req
+                                .get("request_id")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string(),
+                            question: req
+                                .get("question")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string(),
+                            choices: req
+                                .get("choices")
+                                .and_then(|v| v.as_array())
+                                .map(|items| {
+                                    items
+                                        .iter()
+                                        .filter_map(|item| item.as_str().map(ToString::to_string))
+                                        .collect::<Vec<_>>()
+                                })
+                                .unwrap_or_default(),
+                            default: req
+                                .get("default")
+                                .and_then(|v| v.as_str())
+                                .map(ToString::to_string),
+                            context: req
+                                .get("context")
+                                .and_then(|v| v.as_str())
+                                .map(ToString::to_string),
                         },
                     )
                     .await;
@@ -2100,6 +2211,20 @@ async fn stream_sse_response_as_ws(
                             Ok(WsClientMessage::ToolApproval { request_id, approved, reason }) => {
                                 handle_tool_approval(state, conn, &request_id, approved, reason).await;
                             }
+                            Ok(WsClientMessage::UserPrompt {
+                                request_id,
+                                answer,
+                                was_custom,
+                            }) => {
+                                handle_user_prompt_response(
+                                    state,
+                                    conn,
+                                    &request_id,
+                                    answer,
+                                    was_custom,
+                                )
+                                .await;
+                            }
                             Ok(WsClientMessage::Ping) => {
                                 send_msg(socket, &WsServerMessage::Pong).await;
                             }
@@ -2607,6 +2732,7 @@ mod tests {
         assert_eq!(request.context.as_ref().unwrap()["is_plan_subtask"], true);
         assert_eq!(request.max_candidates, 7);
         assert!(request.explain);
+        assert!(request.interactive_client);
     }
 
     #[test]
@@ -4166,6 +4292,25 @@ mod tests {
     }
 
     #[test]
+    fn parse_user_prompt_response() {
+        let json =
+            r#"{"type":"user_prompt","request_id":"req-3","answer":"custom","was_custom":true}"#;
+        let msg: WsClientMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            WsClientMessage::UserPrompt {
+                request_id,
+                answer,
+                was_custom,
+            } => {
+                assert_eq!(request_id, "req-3");
+                assert_eq!(answer, "custom");
+                assert!(was_custom);
+            }
+            _ => panic!("expected UserPrompt"),
+        }
+    }
+
+    #[test]
     fn serialize_run_started() {
         let msg = WsServerMessage::RunStarted {
             run_id: "r1".into(),
@@ -4326,6 +4471,22 @@ mod tests {
     }
 
     #[test]
+    fn serialize_user_prompt_request() {
+        let msg = WsServerMessage::UserPromptRequest {
+            request_id: "req-2".into(),
+            question: "Continue?".into(),
+            choices: vec!["yes".into(), "no".into()],
+            default: Some("yes".into()),
+            context: Some("Need confirmation".into()),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"user_prompt_request""#));
+        assert!(json.contains(r#""question":"Continue?""#));
+        assert!(json.contains(r#""choices":["yes","no"]"#));
+        assert!(json.contains(r#""default":"yes""#));
+    }
+
+    #[test]
     fn all_server_message_variants_serialize() {
         let variants: Vec<WsServerMessage> = vec![
             WsServerMessage::AuthOk {
@@ -4357,6 +4518,13 @@ mod tests {
                 tool: "bash".into(),
                 args: serde_json::json!({}),
             },
+            WsServerMessage::UserPromptRequest {
+                request_id: "req-2".into(),
+                question: "Continue?".into(),
+                choices: vec!["yes".into(), "no".into()],
+                default: Some("yes".into()),
+                context: None,
+            },
             WsServerMessage::Error {
                 message: "err".into(),
                 code: "E".into(),
@@ -4385,6 +4553,7 @@ mod tests {
             r#"{"type":"message","content":"hello"}"#,
             r#"{"type":"cancel_run","run_id":"r1"}"#,
             r#"{"type":"tool_approval","request_id":"req-1","approved":true}"#,
+            r#"{"type":"user_prompt","request_id":"req-2","answer":"yes","was_custom":false}"#,
             r#"{"type":"ping"}"#,
         ];
         for json in &inputs {
@@ -4409,6 +4578,15 @@ mod tests {
 
         // Missing request_id
         let json = r#"{"type":"tool_approval","approved":true}"#;
+        assert!(serde_json::from_str::<WsClientMessage>(json).is_err());
+    }
+
+    #[test]
+    fn user_prompt_requires_request_id_and_answer() {
+        let json = r#"{"type":"user_prompt","answer":"yes"}"#;
+        assert!(serde_json::from_str::<WsClientMessage>(json).is_err());
+
+        let json = r#"{"type":"user_prompt","request_id":"req-1"}"#;
         assert!(serde_json::from_str::<WsClientMessage>(json).is_err());
     }
 }

--- a/rust/crates/runtime/src/server/ws_user_prompt_gate.rs
+++ b/rust/crates/runtime/src/server/ws_user_prompt_gate.rs
@@ -1,0 +1,2 @@
+//! Re-export from astra-turn-core.
+pub use astra_turn_core::ws_user_prompt_gate::*;

--- a/rust/crates/services/src/runs.rs
+++ b/rust/crates/services/src/runs.rs
@@ -84,6 +84,17 @@ pub trait RunLifecycleService: Send + Sync {
         vec![]
     }
 
+    /// Drain pending ask_user prompt requests for a run.
+    ///
+    /// Returns JSON objects with `request_id`, `question`, `choices`, `default`,
+    /// and `context` fields. The WS handler calls this during its polling loop to
+    /// forward prompts to the client.
+    ///
+    /// Default: no-op (returns empty vec).
+    async fn drain_user_prompt_requests(&self, _run_id: &str) -> Vec<serde_json::Value> {
+        vec![]
+    }
+
     /// Drain pending tool progress events for a run.
     ///
     /// Returns JSON objects with `kind` field (`started`, `delta`, `completed`).
@@ -109,6 +120,7 @@ pub struct ChatRequestData {
     pub forward_headers: std::collections::HashMap<String, String>,
     pub max_candidates: u32,
     pub explain: bool,
+    pub interactive_client: bool,
 }
 
 fn redacted_forward_header_names(headers: &std::collections::HashMap<String, String>) -> Vec<&str> {
@@ -150,6 +162,7 @@ impl std::fmt::Debug for ChatRequestData {
             )
             .field("max_candidates", &self.max_candidates)
             .field("explain", &self.explain)
+            .field("interactive_client", &self.interactive_client)
             .finish()
     }
 }
@@ -875,6 +888,7 @@ mod tests {
             forward_headers,
             max_candidates: 10,
             explain: false,
+            interactive_client: false,
         };
 
         let rendered = format!("{request:?}");
@@ -903,6 +917,7 @@ mod tests {
                     forward_headers: std::collections::HashMap::new(),
                     max_candidates: 25,
                     explain: false,
+                    interactive_client: false,
                 },
             )
             .await


### PR DESCRIPTION
## Summary
- add a shared AskUserGate contract and websocket-backed ask_user delivery over the edge ledger
- execute ask_user directly in ServerToolExecutor and preserve the CLI-compatible JSON result shape
- expose ask_user only for interactive websocket runs while keeping ordinary headless/http runs filtered

## Testing
- make format
- make check
- targeted cargo tests for ask_user/user_prompt coverage