### PR TITLE
fix: expose multi_edit in server mode

### DIFF
--- a/rust/crates/astra-tools/src/fs_ops.rs
+++ b/rust/crates/astra-tools/src/fs_ops.rs
@@ -674,6 +674,117 @@ pub fn str_replace(workspace_root: &Path, args: &Value) -> ToolResult {
 }
 
 #[derive(Debug)]
+pub struct PreparedMultiEdit {
+    path: PathBuf,
+    path_str: String,
+    new_content: String,
+    edit_count: usize,
+    dry_run: bool,
+}
+
+impl PreparedMultiEdit {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn new_content_bytes(&self) -> &[u8] {
+        self.new_content.as_bytes()
+    }
+
+    pub fn apply(&self) -> ToolResult {
+        if self.dry_run {
+            return ToolResult::text(format!(
+                "Dry run: {} edit(s) would be applied to {}",
+                self.edit_count, self.path_str
+            ));
+        }
+
+        match std::fs::write(&self.path, &self.new_content) {
+            Ok(()) => ToolResult::text(format!(
+                "Successfully applied {} edit(s) to {}",
+                self.edit_count, self.path_str
+            )),
+            Err(e) => ToolResult::error(format!("Error: Cannot write file: {e}")),
+        }
+    }
+}
+
+pub fn prepare_multi_edit(
+    workspace_root: &Path,
+    args: &Value,
+) -> Result<PreparedMultiEdit, ToolResult> {
+    let path_str = match args.get("path").and_then(|v| v.as_str()) {
+        Some(p) => p,
+        None => return Err(ToolResult::error("Error: Missing 'path' parameter".into())),
+    };
+    let edits = match args.get("edits").and_then(|v| v.as_array()) {
+        Some(e) => e,
+        None => return Err(ToolResult::error("Error: Missing 'edits' array".into())),
+    };
+    if edits.is_empty() {
+        return Err(ToolResult::error("Error: 'edits' array is empty".into()));
+    }
+    let dry_run = args
+        .get("dry_run")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let path = match resolve_path(workspace_root, path_str) {
+        Ok(p) => p,
+        Err(e) => return Err(ToolResult::error(e)),
+    };
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) => return Err(ToolResult::error(format!("Error: Cannot read file: {e}"))),
+    };
+
+    let mut working = content;
+    for (i, edit) in edits.iter().enumerate() {
+        let old_str = match edit.get("old_str").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => {
+                return Err(ToolResult::error(format!(
+                    "Error: edit[{i}] missing 'old_str'"
+                )));
+            }
+        };
+        let new_str = match edit.get("new_str").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => {
+                return Err(ToolResult::error(format!(
+                    "Error: edit[{i}] missing 'new_str'"
+                )));
+            }
+        };
+        if old_str == new_str {
+            return Err(ToolResult::error(format!(
+                "Error: edit[{i}] old_str and new_str are identical"
+            )));
+        }
+        let count = working.matches(old_str).count();
+        if count == 0 {
+            return Err(ToolResult::error(format!(
+                "Error: edit[{i}] old_str not found in {path_str}"
+            )));
+        }
+        if count > 1 {
+            return Err(ToolResult::error(format!(
+                "Error: edit[{i}] old_str found {count} times in {path_str}. Must match exactly once."
+            )));
+        }
+        working = working.replacen(old_str, new_str, 1);
+    }
+
+    Ok(PreparedMultiEdit {
+        path,
+        path_str: path_str.to_string(),
+        new_content: working,
+        edit_count: edits.len(),
+        dry_run,
+    })
+}
+
+#[derive(Debug)]
 pub struct PreparedDeleteFile {
     path: PathBuf,
     path_str: String,
@@ -787,72 +898,9 @@ pub fn list_dir(workspace_root: &Path, args: &Value) -> ToolResult {
 /// Each edit must have `old_str` and `new_str`. All edits are validated
 /// first (no partial application). `old_str` must match exactly once.
 pub fn multi_edit(workspace_root: &Path, args: &Value) -> ToolResult {
-    let path_str = match args.get("path").and_then(|v| v.as_str()) {
-        Some(p) => p,
-        None => return ToolResult::error("Error: Missing 'path' parameter".into()),
-    };
-    let edits = match args.get("edits").and_then(|v| v.as_array()) {
-        Some(e) => e,
-        None => return ToolResult::error("Error: Missing 'edits' array".into()),
-    };
-    if edits.is_empty() {
-        return ToolResult::error("Error: 'edits' array is empty".into());
-    }
-    let dry_run = args
-        .get("dry_run")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-
-    let path = match resolve_path(workspace_root, path_str) {
-        Ok(p) => p,
-        Err(e) => return ToolResult::error(e),
-    };
-    let content = match std::fs::read_to_string(&path) {
-        Ok(c) => c,
-        Err(e) => return ToolResult::error(format!("Error: Cannot read file: {e}")),
-    };
-
-    // Validate all edits first (atomic: all or nothing)
-    let mut working = content.clone();
-    for (i, edit) in edits.iter().enumerate() {
-        let old_str = match edit.get("old_str").and_then(|v| v.as_str()) {
-            Some(s) => s,
-            None => return ToolResult::error(format!("Error: edit[{i}] missing 'old_str'")),
-        };
-        let new_str = match edit.get("new_str").and_then(|v| v.as_str()) {
-            Some(s) => s,
-            None => return ToolResult::error(format!("Error: edit[{i}] missing 'new_str'")),
-        };
-        if old_str == new_str {
-            return ToolResult::error(format!(
-                "Error: edit[{i}] old_str and new_str are identical"
-            ));
-        }
-        let count = working.matches(old_str).count();
-        if count == 0 {
-            return ToolResult::error(format!("Error: edit[{i}] old_str not found in {path_str}"));
-        }
-        if count > 1 {
-            return ToolResult::error(format!(
-                "Error: edit[{i}] old_str found {count} times in {path_str}. Must match exactly once."
-            ));
-        }
-        working = working.replacen(old_str, new_str, 1);
-    }
-
-    if dry_run {
-        return ToolResult::text(format!(
-            "Dry run: {} edit(s) would be applied to {path_str}",
-            edits.len()
-        ));
-    }
-
-    match std::fs::write(&path, &working) {
-        Ok(()) => ToolResult::text(format!(
-            "Successfully applied {} edit(s) to {path_str}",
-            edits.len()
-        )),
-        Err(e) => ToolResult::error(format!("Error: Cannot write file: {e}")),
+    match prepare_multi_edit(workspace_root, args) {
+        Ok(prepared) => prepared.apply(),
+        Err(error) => error,
     }
 }
 

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -354,6 +354,7 @@ pub const APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "bash",
     "write_file",
     "str_replace",
+    "multi_edit",
     "delete_file",
     "git_commit",
 ];
@@ -774,6 +775,7 @@ mod tests {
     fn approval_required_tools_includes_dangerous_ops() {
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"bash"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"write_file"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"multi_edit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"delete_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_commit"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"read_file"));

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -29,6 +29,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "read_file",
     "write_file",
     "str_replace",
+    "multi_edit",
     "delete_file",
     "rollback_file_edits",
     "list_dir",
@@ -1968,7 +1969,7 @@ mod tests {
         assert!(!names.contains(&"rollback_turn_actions"));
         assert!(!names.contains(&"powershell"));
         assert!(!names.contains(&"memory_feedback"));
-        assert!(!names.contains(&"multi_edit"));
+        assert!(names.contains(&"multi_edit"));
     }
 
     #[test]

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -1310,7 +1310,7 @@ mod tests {
                 .contains("rollback_database_snapshots")
         );
         assert!(host.valid_tool_names().contains("memory_store"));
-        assert!(!host.valid_tool_names().contains("multi_edit"));
+        assert!(host.valid_tool_names().contains("multi_edit"));
         assert!(!host.valid_tool_names().contains("powershell"));
         assert!(host.emitted_events.is_empty());
     }

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -1210,6 +1210,7 @@ impl ServerToolExecutor {
             "read_file" => self.default_executor.execute("read_file", args).await,
             "write_file" => tool_result_from_output(self.server_write_file(args)),
             "str_replace" => tool_result_from_output(self.server_str_replace(args)),
+            "multi_edit" => tool_result_from_output(self.server_multi_edit(args)),
             "delete_file" => tool_result_from_output(self.server_delete_file(args)),
             "rollback_file_edits" => tool_result_from_output(self.rollback_file_edits(args)),
             "list_dir" => self.default_executor.execute("list_dir", args).await,
@@ -1299,11 +1300,11 @@ impl ServerToolExecutor {
             // ── Unknown tool fallback ──────────────────────────────────
             _ => astra_tools::ToolResult::error(format!(
                 "Error: Tool '{name}' is not available in server-side execution mode. \
-                     Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
-                     list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
-                     rollback_session_state, task_*, sleep, tool_search, mo_query, rollback_database_snapshots, \
-                     grep, glob, git_status, git_diff, git_log, git_file_history, git_contributors, git_log_search, \
-                     git_show, git_blame, symbols, git_commit, git_revert_commit, github_list_prs, github_get_pr, \
+                      Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
+                      multi_edit, list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
+                      rollback_session_state, task_*, sleep, tool_search, mo_query, rollback_database_snapshots, \
+                      grep, glob, git_status, git_diff, git_log, git_file_history, git_contributors, git_log_search, \
+                      git_show, git_blame, symbols, git_commit, git_revert_commit, github_list_prs, github_get_pr, \
                      github_ci_status, github_list_issues, github_get_issue, github_repo_stats, memory_*, web_fetch, \
                      web_search"
             )),
@@ -2683,6 +2684,39 @@ impl ServerToolExecutor {
         result.output
     }
 
+    fn server_multi_edit(&self, args: &Value) -> String {
+        let prepared = match astra_tools::fs_ops::prepare_multi_edit(&self.workspace_root, args) {
+            Ok(prepared) => prepared,
+            Err(error) => return error.output,
+        };
+
+        if !args
+            .get("dry_run")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            && let Ok(mut journal) = self.file_journal.lock()
+        {
+            let turn_idx = self.journal_turn_index.load(Ordering::Relaxed);
+            journal.record_before_patch(prepared.path(), "server-multi-edit", turn_idx);
+        }
+
+        let result = prepared.apply();
+        if !result.is_error
+            && !args
+                .get("dry_run")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            && let Ok(mut journal) = self.file_journal.lock()
+        {
+            journal.record_after(
+                prepared.path(),
+                "server-multi-edit",
+                prepared.new_content_bytes(),
+            );
+        }
+        result.output
+    }
+
     fn server_delete_file(&self, args: &Value) -> String {
         let prepared = match astra_tools::fs_ops::prepare_delete_file(&self.workspace_root, args) {
             Ok(prepared) => prepared,
@@ -3481,6 +3515,41 @@ esac
     }
 
     #[tokio::test]
+    async fn rollback_file_edits_current_turn_reverts_server_multi_edit() {
+        let (exec, dir) = test_executor();
+        exec.set_turn_index(8);
+        let target = dir.path().join("edit.txt");
+        std::fs::write(&target, "aaa bbb ccc").unwrap();
+
+        let edited = exec
+            .execute(
+                "multi_edit",
+                &json!({
+                    "path": "edit.txt",
+                    "edits": [
+                        {"old_str": "aaa", "new_str": "AAA"},
+                        {"old_str": "ccc", "new_str": "CCC"}
+                    ]
+                }),
+            )
+            .await;
+        assert!(edited.contains("Successfully applied"));
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "AAA bbb CCC");
+
+        let rollback = exec
+            .execute("rollback_file_edits", &json!({"scope": "current_turn"}))
+            .await;
+        let rollback_json: Value = serde_json::from_str(&rollback).unwrap();
+        assert_eq!(
+            rollback_json["success"].as_bool(),
+            Some(true),
+            "got: {rollback}"
+        );
+        assert_eq!(rollback_json["turn_index"].as_u64(), Some(8));
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "aaa bbb ccc");
+    }
+
+    #[tokio::test]
     async fn rollback_file_edits_file_scope_restores_deleted_file() {
         let (exec, dir) = test_executor();
         let target = dir.path().join("gone.txt");
@@ -3658,6 +3727,32 @@ esac
             !result.contains("not available in server-side execution mode"),
             "{result}"
         );
+    }
+
+    #[tokio::test]
+    async fn multi_edit_is_available_in_server_mode() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("edit.txt"), "foo bar baz").unwrap();
+
+        let result = exec
+            .execute(
+                "multi_edit",
+                &json!({
+                    "path": "edit.txt",
+                    "edits": [
+                        {"old_str": "foo", "new_str": "FOO"},
+                        {"old_str": "baz", "new_str": "BAZ"}
+                    ]
+                }),
+            )
+            .await;
+
+        assert!(result.contains("Successfully applied"), "{result}");
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("edit.txt")).unwrap(),
+            "FOO bar BAZ"
+        );
+        assert!(!result.contains("not available in server-side execution mode"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- expose multi_edit in the server executor tool surface
- refactor multi_edit through prepare_multi_edit() so server execution can reuse validation while recording file-journal state
- route server multi_edit through rollback-aware journaling and add regression coverage for execution and current-turn rollback

## Testing
- make format
- make check
- cargo test -p astra-tools multi_edit --lib
- cargo test -p astra-runtime multi_edit --lib
- cargo test -p astra-runtime rollback_file_edits_current_turn_reverts_server_multi_edit --lib
