### PR TITLE
fix: journal accuracy — surgical removal flag, tool_call_count, turn numbering

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_sse_loop.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_sse_loop.rs
@@ -330,6 +330,8 @@ mod tests {
             args_preview: None,
             result_preview: result_preview.map(str::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 

--- a/rust/crates/astra-cli/src/cli/chat_stream/tests.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/tests.rs
@@ -18,6 +18,8 @@ fn tool_call_record_covers_early_exit_paths() {
         args_preview: Some("src/main.rs".to_string()),
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     };
     assert!(dup.ok);
     assert_eq!(dup.ms, 0);
@@ -33,6 +35,8 @@ fn tool_call_record_covers_early_exit_paths() {
         args_preview: Some("/TODO/ in src/".to_string()),
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     };
     assert!(cached.ok);
 
@@ -47,6 +51,8 @@ fn tool_call_record_covers_early_exit_paths() {
         args_preview: None,
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     };
     assert!(!unknown.ok);
     assert!(unknown.error.as_ref().unwrap().starts_with("unknown_tool:"));
@@ -62,6 +68,8 @@ fn tool_call_record_covers_early_exit_paths() {
         args_preview: Some("rm -rf /".to_string()),
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     };
     assert!(!denied.ok);
 
@@ -89,6 +97,8 @@ fn tool_call_record_json_roundtrip() {
         args_preview: Some("https://example.com".to_string()),
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     };
     let json = serde_json::to_string(&original).unwrap();
     let restored: ToolCallRecord = serde_json::from_str(&json).unwrap();

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -2479,6 +2479,8 @@ mod exit_code_tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             });
         assert_eq!(compute_exit_code(&sr), ExitCode::ToolFailure);
     }
@@ -2497,6 +2499,8 @@ mod exit_code_tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             });
         sr.verdict_events.push(VerdictEvent {
             turn: 1,
@@ -2530,6 +2534,8 @@ mod exit_code_tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             });
         sr.tool_call_records
             .push(astra_services::session_journal::ToolCallRecord {
@@ -2542,6 +2548,8 @@ mod exit_code_tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             });
         assert_eq!(compute_exit_code(&sr), ExitCode::Success);
     }

--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -968,10 +968,12 @@ fn commit_turn_journal_workspace_and_sidecars(
         enqueue_ingestion(state, &turn_event);
 
         // Emit deferred context_assembly_recorded — only on successful turn commit.
-        if let Some((turn_num, trace_json)) = &result.pending_context_assembly_trace {
+        if let Some((_internal_turn, trace_json)) = &result.pending_context_assembly_trace {
+            // Use the REPL's user-visible turn number, not the internal agentic
+            // loop counter that was stored in the trace.
             let assembly_event = session_journal::JournalEvent::context_assembly_recorded(
                 state.session_id.as_deref(),
-                *turn_num,
+                state.turn,
                 trace_json.clone(),
             );
             if let Err(e) = journal.append(&assembly_event) {
@@ -3386,6 +3388,8 @@ mod tests {
             args_preview: None,
             result_preview: result_preview.map(str::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 
@@ -3503,6 +3507,8 @@ mod tests {
             args_preview: None,
             result_preview: Some("clean".into()),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }];
 
         let learning =

--- a/rust/crates/astra-cli/src/cli/self_command.rs
+++ b/rust/crates/astra-cli/src/cli/self_command.rs
@@ -1835,6 +1835,8 @@ mod tests {
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 }]),
                 budget_used: Some(7000),
                 budget_pressure: Some(0.7),
@@ -1987,6 +1989,8 @@ mod tests {
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 },
                 ToolCallRecord {
                     name: "rg".to_string(),
@@ -1998,6 +2002,8 @@ mod tests {
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 },
             ]);
             if !bash_ok {
@@ -2136,6 +2142,8 @@ mod tests {
                         args_preview: None,
                         result_preview: None,
                         file_path: None,
+                        surgically_removed: None,
+                        original_tool_name: None,
                     },
                     ToolCallRecord {
                         name: "rg".to_string(),
@@ -2147,6 +2155,8 @@ mod tests {
                         args_preview: None,
                         result_preview: None,
                         file_path: None,
+                        surgically_removed: None,
+                        original_tool_name: None,
                     },
                 ]),
                 budget_used: Some(9100),
@@ -2424,6 +2434,8 @@ mod tests {
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 }]),
                 budget_used: Some(9100),
                 budget_pressure: Some(0.91),

--- a/rust/crates/astra-cli/src/cli/slash_session.rs
+++ b/rust/crates/astra-cli/src/cli/slash_session.rs
@@ -4109,6 +4109,8 @@ mod export_tests {
             args_preview: Some("pattern in src/".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }];
         let block = format_tool_calls_md(&calls);
         assert!(block.contains("<details>"));

--- a/rust/crates/astra-cli/src/cli/streaming_types.rs
+++ b/rust/crates/astra-cli/src/cli/streaming_types.rs
@@ -147,6 +147,8 @@ mod tests {
             args_preview: None,
             result_preview: result_preview.map(str::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 

--- a/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
@@ -102,6 +102,8 @@ async fn execute_reflect_uses_local_surface_with_session() {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             }]),
             budget_used: Some(8500),
             budget_pressure: Some(0.85),

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -2798,6 +2798,8 @@ total_tokens_out: 500
                 args_preview: Some("npm test".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             session_journal::ToolCallRecord {
                 name: "bash".into(),
@@ -2809,6 +2811,8 @@ total_tokens_out: 500
                 args_preview: Some("cargo build".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             session_journal::ToolCallRecord {
                 name: "grep".into(),
@@ -2820,6 +2824,8 @@ total_tokens_out: 500
                 args_preview: Some("/error/ in src/".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ]);
         writer.append(&event).unwrap();

--- a/rust/crates/astra-cli/src/tests/stats_tools_tests.rs
+++ b/rust/crates/astra-cli/src/tests/stats_tools_tests.rs
@@ -186,6 +186,8 @@ fn tools_reads_tool_calls_from_journal() {
             args_preview: Some("npm test".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         },
         session_journal::ToolCallRecord {
             name: "bash".into(),
@@ -197,6 +199,8 @@ fn tools_reads_tool_calls_from_journal() {
             args_preview: Some("cargo build".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         },
         session_journal::ToolCallRecord {
             name: "grep".into(),
@@ -208,6 +212,8 @@ fn tools_reads_tool_calls_from_journal() {
             args_preview: Some("/error/ in src/".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         },
     ]);
     writer.append(&event).unwrap();

--- a/rust/crates/astra-evolution/src/reflection.rs
+++ b/rust/crates/astra-evolution/src/reflection.rs
@@ -1338,6 +1338,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "bash".into(),
@@ -1349,6 +1351,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "web_fetch".into(),
@@ -1360,6 +1364,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ];
 

--- a/rust/crates/astra-turn-core/src/cloud_session_facts.rs
+++ b/rust/crates/astra-turn-core/src/cloud_session_facts.rs
@@ -267,6 +267,8 @@ mod tests {
             args_preview: args.map(|s| s.to_string()),
             result_preview: None,
             file_path: file_path.map(|s| s.to_string()),
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 

--- a/rust/crates/astra-turn-core/src/evaluation.rs
+++ b/rust/crates/astra-turn-core/src/evaluation.rs
@@ -272,7 +272,12 @@ pub fn build_turn_evaluation_journal_event(
         budget_pressure,
         stall_count,
         verdict_warning,
-        tool_call_records.len(),
+        // Exclude synthetic placeholders (surgical removals, skipped skills) from
+        // the user-visible tool_call_count — they are audit-only records.
+        tool_call_records
+            .iter()
+            .filter(|r| !r.is_synthetic_placeholder())
+            .count(),
         eval_signals_to_json(&eval.signals),
     )
 }
@@ -325,6 +330,8 @@ mod tests {
             args_preview: None,
             result_preview: Some("ok".to_string()),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 
@@ -521,6 +528,8 @@ mod tests {
             args_preview: None,
             result_preview: preview.map(ToString::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
 
         // 1 real successful tool + 3 synthetic placeholders (skipped,
@@ -593,6 +602,8 @@ mod tests {
                 args_preview: None,
                 result_preview: Some("(removed from context — skill covered this work)".into()),
                 file_path: None,
+                surgically_removed: Some(true),
+                original_tool_name: Some("read_file".to_string()),
             })
             .chain(std::iter::once(ToolCallRecord {
                 name: "git_show".to_string(),
@@ -604,6 +615,8 @@ mod tests {
                 args_preview: None,
                 result_preview: Some("diff".into()),
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             }))
             .collect();
 
@@ -616,5 +629,120 @@ mod tests {
             "no RepeatToolCall signal should be emitted for synthetic placeholders, got {:?}",
             eval.signals
         );
+    }
+
+    #[test]
+    fn tool_call_count_excludes_synthetic_placeholders() {
+        use astra_services::session_journal::{SURGICAL_REMOVAL_TOOL_NAME, ToolCallRecord};
+
+        // 3 real tool calls + 2 surgical removals = 5 records total,
+        // but tool_call_count should be 3 (only real).
+        let real = || ToolCallRecord {
+            name: "read_file".to_string(),
+            ok: true,
+            ms: 50,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(200),
+            args_preview: None,
+            result_preview: Some("content".into()),
+            file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
+        };
+        let surgical = || ToolCallRecord {
+            name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+            ok: true,
+            ms: 0,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(0),
+            args_preview: None,
+            result_preview: Some("(removed)".into()),
+            file_path: None,
+            surgically_removed: Some(true),
+            original_tool_name: Some("glob".to_string()),
+        };
+        let records = vec![real(), surgical(), real(), surgical(), real()];
+
+        let event = build_turn_evaluation_journal_event(
+            Some("sess-1"),
+            Some(1),
+            "test-model",
+            "do something",
+            &[],
+            &records,
+            0,
+            false,
+            0.5,
+            &TurnEvaluation {
+                success: true,
+                quality: 0.8,
+                confidence: 0.9,
+                signals: vec![],
+            },
+        );
+
+        // Extract tool_call_count from the metadata JSON.
+        let metadata = event.metadata.as_ref().expect("metadata should be present");
+        let tool_call_count = metadata["tool_call_count"].as_u64().unwrap();
+        assert_eq!(
+            tool_call_count, 3,
+            "tool_call_count must exclude synthetic placeholders, got {}",
+            tool_call_count
+        );
+    }
+
+    #[test]
+    fn is_synthetic_placeholder_via_flag() {
+        use astra_services::session_journal::{SURGICAL_REMOVAL_TOOL_NAME, ToolCallRecord};
+
+        // New-style: surgically_removed flag set
+        let flagged = ToolCallRecord {
+            name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+            ok: true,
+            ms: 0,
+            error: None,
+            input_bytes: None,
+            output_bytes: None,
+            args_preview: None,
+            result_preview: None,
+            file_path: None,
+            surgically_removed: Some(true),
+            original_tool_name: Some("bash".to_string()),
+        };
+        assert!(flagged.is_synthetic_placeholder());
+
+        // Backward-compat: legacy sentinel name only (no flag)
+        let legacy = ToolCallRecord {
+            name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+            ok: true,
+            ms: 0,
+            error: None,
+            input_bytes: None,
+            output_bytes: None,
+            args_preview: None,
+            result_preview: None,
+            file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
+        };
+        assert!(legacy.is_synthetic_placeholder());
+
+        // Normal tool call: neither flag nor sentinel name
+        let normal = ToolCallRecord {
+            name: "read_file".to_string(),
+            ok: true,
+            ms: 50,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(200),
+            args_preview: None,
+            result_preview: None,
+            file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
+        };
+        assert!(!normal.is_synthetic_placeholder());
     }
 }

--- a/rust/crates/astra-turn-core/src/headless_tool_journal.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_journal.rs
@@ -17,6 +17,8 @@ pub fn journal_record_duplicate_within_turn(
         args_preview,
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 
@@ -36,6 +38,8 @@ pub fn journal_record_cross_turn_cache_hit(
         args_preview,
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 
@@ -51,6 +55,8 @@ pub fn journal_record_unknown_tool(name: String, tool_elapsed_ms: u64) -> ToolCa
         args_preview: None,
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 
@@ -71,6 +77,8 @@ pub fn journal_record_blocked_tool(
         args_preview,
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 
@@ -111,6 +119,8 @@ pub fn journal_record_executed_tool_call(
         args_preview,
         result_preview,
         file_path,
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 

--- a/rust/crates/astra-turn-core/tests/journal_accuracy_e2e.rs
+++ b/rust/crates/astra-turn-core/tests/journal_accuracy_e2e.rs
@@ -1,0 +1,832 @@
+//! End-to-end tests for journal telemetry accuracy.
+//!
+//! These tests simulate realistic agentic turn scenarios — including skill
+//! interception, surgical removal, multi-turn sessions, and various unhappy
+//! paths — then verify the entire pipeline from ToolCallRecord creation
+//! through journal persistence to turn evaluation.
+
+use astra_services::session_journal::{
+    self, JournalDirGuard, JournalEvent, JournalEventType, JournalWriter,
+    SURGICAL_REMOVAL_TOOL_NAME, ToolCallRecord,
+};
+use astra_turn_core::evaluation::build_turn_evaluation_journal_event;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn real_tool(name: &str, ok: bool, ms: u64) -> ToolCallRecord {
+    ToolCallRecord {
+        name: name.to_string(),
+        ok,
+        ms,
+        error: if ok { None } else { Some("tool error".into()) },
+        input_bytes: Some(100),
+        output_bytes: Some(if ok { 500 } else { 0 }),
+        args_preview: Some(format!("{name} args...")),
+        result_preview: Some(if ok { "ok result".into() } else { "error".into() }),
+        file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
+    }
+}
+
+fn surgical_removal(original_name: &str) -> ToolCallRecord {
+    ToolCallRecord {
+        name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+        ok: true,
+        ms: 0,
+        error: None,
+        input_bytes: None,
+        output_bytes: Some(0),
+        args_preview: None,
+        result_preview: Some("(removed from context — skill covered this work)".into()),
+        file_path: None,
+        surgically_removed: Some(true),
+        original_tool_name: Some(original_name.to_string()),
+    }
+}
+
+fn legacy_surgical_removal() -> ToolCallRecord {
+    // Old-format record: no surgically_removed flag, just the sentinel name
+    ToolCallRecord {
+        name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+        ok: true,
+        ms: 0,
+        error: None,
+        input_bytes: None,
+        output_bytes: Some(0),
+        args_preview: None,
+        result_preview: Some("(removed from context — skill covered this work)".into()),
+        file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
+    }
+}
+
+fn skipped_tool(name: &str) -> ToolCallRecord {
+    ToolCallRecord {
+        name: name.to_string(),
+        ok: false,
+        ms: 0,
+        error: None,
+        input_bytes: None,
+        output_bytes: Some(0),
+        args_preview: None,
+        result_preview: Some("Skipped: skill routed".into()),
+        file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
+    }
+}
+
+fn deferred_tool(name: &str) -> ToolCallRecord {
+    ToolCallRecord {
+        name: name.to_string(),
+        ok: false,
+        ms: 0,
+        error: None,
+        input_bytes: None,
+        output_bytes: Some(0),
+        args_preview: None,
+        result_preview: Some("Deferred: skill invoked".into()),
+        file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
+    }
+}
+
+fn make_eval(success: bool, quality: f64) -> astra_turn_core::evaluation::TurnEvaluation {
+    astra_turn_core::evaluation::TurnEvaluation {
+        success,
+        quality,
+        confidence: 0.8,
+        signals: vec![],
+    }
+}
+
+fn extract_tool_call_count(event: &JournalEvent) -> usize {
+    event
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("tool_call_count"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize
+}
+
+// ─── E2E: Full pipeline — skill interception → journal → evaluation ─────────
+
+#[test]
+fn e2e_skill_interception_produces_accurate_journal_and_evaluation() {
+    // Simulates a real turn where a skill (e.g. git review) intercepts
+    // some parallel tool calls. The agent originally requested 8 tool calls,
+    // but the skill handled 5 of them. 3 real calls remain + 5 surgical removals.
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-skill-interception";
+
+    // --- Phase 1: Build tool call records as agentic_tool_interception would ---
+    let records = vec![
+        // Skill result (real call — the skill itself)
+        real_tool("skill", true, 3200),
+        // Surgical removals for the parallel calls the skill covered
+        surgical_removal("read_file"),
+        surgical_removal("read_file"),
+        surgical_removal("glob"),
+        surgical_removal("grep"),
+        surgical_removal("git_show"),
+        // Real calls that ran alongside the skill
+        real_tool("write_file", true, 45),
+        real_tool("bash", true, 120),
+    ];
+
+    // --- Phase 2: Write turn event with tool_calls to journal ---
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("gpt-5.4"),
+        "Review the PR changes",
+        "I've reviewed the PR...",
+        records.len() as u32,
+        50000,
+        2000,
+        5000,
+    )
+    .with_tool_calls(records.clone());
+    writer.append(&turn_event).unwrap();
+
+    // --- Phase 3: Build evaluation (as evaluation.rs would) ---
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "gpt-5.4",
+        "Review the PR changes",
+        &["skill".into(), "write_file".into(), "bash".into()],
+        &records,
+        0,
+        false,
+        0.2,
+        &make_eval(true, 0.85),
+    );
+    writer.append(&eval_event).unwrap();
+
+    // --- Phase 4: Read back and verify ---
+    let events = session_journal::read_journal(session_id).unwrap();
+    assert_eq!(events.len(), 2, "should have turn + evaluation events");
+
+    // Verify turn event has all 8 records (including surgical removals for audit)
+    let turn = &events[0];
+    assert_eq!(turn.event_type, JournalEventType::Turn);
+    let tool_calls = turn.tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 8, "all 8 records persisted for audit trail");
+
+    // Verify surgical removal records roundtrip correctly
+    let surgical_records: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| r.is_synthetic_placeholder())
+        .collect();
+    assert_eq!(surgical_records.len(), 5, "5 surgical removals survived serde");
+    for rec in &surgical_records {
+        assert_eq!(rec.surgically_removed, Some(true));
+        assert!(rec.original_tool_name.is_some());
+    }
+
+    // Verify real records are intact
+    let real_records: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| !r.is_synthetic_placeholder())
+        .collect();
+    assert_eq!(real_records.len(), 3, "3 real tool calls");
+    assert!(real_records.iter().all(|r| r.surgically_removed.is_none()));
+
+    // Verify evaluation event has correct tool_call_count (EXCLUDES synthetics)
+    let eval = &events[1];
+    assert_eq!(eval.event_type, JournalEventType::TurnEvaluation);
+    let tool_call_count = extract_tool_call_count(eval);
+    assert_eq!(
+        tool_call_count, 3,
+        "tool_call_count must be 3 (only real calls), not 8"
+    );
+}
+
+// ─── E2E: Multi-turn session with correct turn numbering ────────────────────
+
+#[test]
+fn e2e_multi_turn_session_turn_numbering_consistent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-multi-turn";
+
+    let writer = JournalWriter::new(session_id).unwrap();
+
+    // Simulate 3 user turns with context assembly events
+    for turn_num in 1..=3u32 {
+        let records = vec![real_tool("read_file", true, 30), real_tool("bash", true, 200)];
+
+        // Context assembly uses REPL turn number (the fix)
+        let assembly = JournalEvent::context_assembly_recorded(
+            Some(session_id),
+            turn_num, // <-- This is the REPL counter, not internal loop counter
+            serde_json::json!({
+                "turn_id": format!("turn-{turn_num}"),
+                "system_prompt_tokens": 1200,
+                "tools_available": 15,
+            }),
+        );
+        writer.append(&assembly).unwrap();
+
+        // Turn event
+        let turn_event = JournalEvent::turn(
+            Some(session_id),
+            turn_num,
+            Some("gpt-5.4"),
+            &format!("User message {turn_num}"),
+            &format!("Response {turn_num}"),
+            records.len() as u32,
+            30000 + turn_num as u64 * 5000,
+            1000,
+            2000,
+        )
+        .with_tool_calls(records.clone());
+        writer.append(&turn_event).unwrap();
+
+        // Turn evaluation
+        let eval = build_turn_evaluation_journal_event(
+            Some(session_id),
+            Some(turn_num),
+            "gpt-5.4",
+            &format!("User message {turn_num}"),
+            &["read_file".into(), "bash".into()],
+            &records,
+            0,
+            false,
+            0.1 * turn_num as f64,
+            &make_eval(true, 0.9 - turn_num as f64 * 0.1),
+        );
+        writer.append(&eval).unwrap();
+    }
+
+    // Read back and verify turn numbering consistency
+    let events = session_journal::read_journal(session_id).unwrap();
+    assert_eq!(events.len(), 9, "3 turns × 3 events each");
+
+    // Verify all turn numbers are 1, 2, 3 (never internal loop counters like 5, 10, 15)
+    let turn_numbers: Vec<u32> = events.iter().filter_map(|e| e.turn).collect();
+    assert_eq!(
+        turn_numbers,
+        vec![1, 1, 1, 2, 2, 2, 3, 3, 3],
+        "all events should have REPL turn numbers 1-3, not internal loop counters"
+    );
+
+    // Verify context_assembly turn IDs match their turn numbers
+    let assemblies: Vec<_> = events
+        .iter()
+        .filter(|e| e.event_type == JournalEventType::ContextAssemblyRecorded)
+        .collect();
+    assert_eq!(assemblies.len(), 3);
+    for (i, asm) in assemblies.iter().enumerate() {
+        let expected_turn = (i + 1) as u32;
+        assert_eq!(asm.turn, Some(expected_turn));
+        let trace = asm.context_assembly_trace.as_ref().unwrap();
+        let turn_id = trace["turn_id"].as_str().unwrap();
+        assert_eq!(turn_id, format!("turn-{expected_turn}"));
+    }
+}
+
+// ─── Unhappy path: mixed legacy + new surgical removal records ──────────────
+
+#[test]
+fn e2e_mixed_legacy_and_new_surgical_records_both_filtered() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-mixed-legacy";
+
+    // Simulate a scenario where journal has been migrated mid-session:
+    // some records use old sentinel-name-only, others use new flag.
+    let records = vec![
+        real_tool("read_file", true, 30),
+        legacy_surgical_removal(), // old format: no flag, just name
+        surgical_removal("glob"),  // new format: flag + original_tool_name
+        real_tool("bash", true, 100),
+        skipped_tool("grep"),      // skill-routed skip
+        deferred_tool("git_show"), // skill-routed defer
+        real_tool("write_file", true, 50),
+    ];
+
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("qwen3.6-plus"),
+        "Fix the bug",
+        "Done.",
+        7,
+        40000,
+        1500,
+        3000,
+    )
+    .with_tool_calls(records.clone());
+    writer.append(&turn_event).unwrap();
+
+    // Build evaluation
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "qwen3.6-plus",
+        "Fix the bug",
+        &[],
+        &records,
+        0,
+        false,
+        0.3,
+        &make_eval(true, 0.7),
+    );
+    writer.append(&eval_event).unwrap();
+
+    // Read back
+    let events = session_journal::read_journal(session_id).unwrap();
+    let turn = &events[0];
+    let tool_calls = turn.tool_calls.as_ref().unwrap();
+
+    // ALL synthetic types should be detected
+    let real: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| !r.is_synthetic_placeholder())
+        .collect();
+    let synthetic: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| r.is_synthetic_placeholder())
+        .collect();
+    assert_eq!(real.len(), 3, "3 real: read_file, bash, write_file");
+    assert_eq!(
+        synthetic.len(),
+        4,
+        "4 synthetic: legacy surgical, new surgical, skipped, deferred"
+    );
+
+    // tool_call_count in evaluation should match real count
+    let eval = &events[1];
+    assert_eq!(extract_tool_call_count(eval), 3);
+}
+
+// ─── Unhappy path: ALL records are surgical removals (edge case) ────────────
+
+#[test]
+fn e2e_all_surgical_removals_zero_real_tool_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-all-surgical";
+
+    // Edge case: skill handled everything, all parallel calls were removed
+    let records = vec![
+        surgical_removal("read_file"),
+        surgical_removal("glob"),
+        surgical_removal("grep"),
+        surgical_removal("git_show"),
+    ];
+
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("gpt-5.4"),
+        "Review code",
+        "Reviewed.",
+        4,
+        20000,
+        500,
+        1000,
+    )
+    .with_tool_calls(records.clone());
+    writer.append(&turn_event).unwrap();
+
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "gpt-5.4",
+        "Review code",
+        &[],
+        &records,
+        0,
+        false,
+        0.1,
+        &make_eval(true, 0.5),
+    );
+    writer.append(&eval_event).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+    let eval = &events[1];
+
+    // tool_call_count should be 0, not 4
+    assert_eq!(
+        extract_tool_call_count(eval),
+        0,
+        "all surgical removals → tool_call_count must be 0"
+    );
+}
+
+// ─── Unhappy path: zero tool calls (conversational turn) ────────────────────
+
+#[test]
+fn e2e_zero_tool_calls_conversational() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-no-tools";
+
+    let records: Vec<ToolCallRecord> = vec![];
+
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("gpt-5.4"),
+        "Hello!",
+        "Hi there!",
+        0,
+        5000,
+        200,
+        500,
+    );
+    // No .with_tool_calls() — empty turns should not have the field
+    writer.append(&turn_event).unwrap();
+
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "gpt-5.4",
+        "Hello!",
+        &[],
+        &records,
+        0,
+        false,
+        0.0,
+        &make_eval(true, 0.6),
+    );
+    writer.append(&eval_event).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+    let turn = &events[0];
+    assert!(turn.tool_calls.is_none(), "no tool_calls field for empty turns");
+    assert_eq!(extract_tool_call_count(&events[1]), 0);
+}
+
+// ─── Unhappy path: backward compat — deserialize legacy JSONL without new fields
+
+#[test]
+fn e2e_legacy_journal_without_surgical_fields_deserializes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-legacy-compat";
+
+    // Write raw JSONL as it would appear from an old version (no surgical fields)
+    let legacy_turn = serde_json::json!({
+        "type": "turn",
+        "ts": "2026-04-17T07:20:00Z",
+        "session_id": session_id,
+        "turn": 1,
+        "model": "MiniMax-M2.7",
+        "user_input": "Check the files",
+        "assistant_output": "Found issues.",
+        "tool_count": 3,
+        "tokens_in": 70000,
+        "tokens_out": 7700,
+        "duration_ms": 8000,
+        "tool_calls": [
+            {
+                "name": "read_file",
+                "ok": true,
+                "ms": 30,
+                "output_bytes": 500
+            },
+            {
+                "name": "(surgically_removed)",
+                "ok": true,
+                "ms": 0,
+                "output_bytes": 0,
+                "result_preview": "(removed from context — skill covered this work)"
+            },
+            {
+                "name": "bash",
+                "ok": false,
+                "ms": 100,
+                "error": "command not found"
+            }
+        ]
+    });
+
+    let path = tmp.path().join(format!("{session_id}.jsonl"));
+    std::fs::write(&path, format!("{}\n", legacy_turn)).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+    assert_eq!(events.len(), 1);
+
+    let tool_calls = events[0].tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 3);
+
+    // Legacy surgical removal should still be detected as synthetic
+    assert!(tool_calls[1].is_synthetic_placeholder());
+    // surgically_removed field should be None (not in legacy JSON)
+    assert_eq!(tool_calls[1].surgically_removed, None);
+    assert_eq!(tool_calls[1].original_tool_name, None);
+
+    // Real calls should not be synthetic
+    assert!(!tool_calls[0].is_synthetic_placeholder());
+    assert!(!tool_calls[2].is_synthetic_placeholder());
+
+    // Build evaluation using the deserialized records — should count correctly
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "MiniMax-M2.7",
+        "Check the files",
+        &[],
+        tool_calls,
+        0,
+        false,
+        0.3,
+        &make_eval(false, 0.4),
+    );
+    // Only 2 real calls (read_file OK + bash FAIL), not 3
+    assert_eq!(
+        extract_tool_call_count(&eval_event),
+        2,
+        "legacy surgical removal must still be excluded from tool_call_count"
+    );
+}
+
+// ─── E2E: Realistic session 3f4389fe scenario (the original bug report) ─────
+
+#[test]
+fn e2e_session_3f4389fe_scenario_turn1_surgical_removal_accuracy() {
+    // Recreates the exact scenario from session 3f4389fe turn 1:
+    // MiniMax-M2.7 model, 21 tool calls where 9 were surgical removals.
+    // Before the fix: tool_call_count was 21. After fix: should be 12.
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-3f4389fe-turn1";
+
+    let writer = JournalWriter::new(session_id).unwrap();
+
+    // Build the 21 records: 12 real + 9 surgical
+    let mut records = Vec::new();
+    // 12 real tool calls (mix of tools a code review session would use)
+    for tool in &[
+        "skill",
+        "read_file",
+        "read_file",
+        "read_file",
+        "glob",
+        "grep",
+        "git_show",
+        "git_show",
+        "bash",
+        "write_file",
+        "write_file",
+        "bash",
+    ] {
+        records.push(real_tool(tool, true, 50));
+    }
+    // 9 surgical removals (parallel calls the skill handled)
+    for tool in &[
+        "read_file",
+        "read_file",
+        "read_file",
+        "glob",
+        "glob",
+        "grep",
+        "grep",
+        "git_show",
+        "git_show",
+    ] {
+        records.push(surgical_removal(tool));
+    }
+    assert_eq!(records.len(), 21);
+
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("MiniMax-M2.7"),
+        "Review the PR changes and provide feedback",
+        "I've reviewed all changes...",
+        21,
+        70000,
+        7700,
+        8000,
+    )
+    .with_tool_calls(records.clone());
+    writer.append(&turn_event).unwrap();
+
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "MiniMax-M2.7",
+        "Review the PR changes and provide feedback",
+        &[
+            "skill".into(),
+            "read_file".into(),
+            "glob".into(),
+            "grep".into(),
+            "git_show".into(),
+            "bash".into(),
+            "write_file".into(),
+        ],
+        &records,
+        0,
+        false,
+        0.2,
+        &make_eval(true, 0.85),
+    );
+    writer.append(&eval_event).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+
+    // Journal should persist ALL 21 records for audit
+    let tool_calls = events[0].tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 21);
+
+    // But evaluation tool_call_count should be 12 (only real)
+    let eval = &events[1];
+    assert_eq!(
+        extract_tool_call_count(eval),
+        12,
+        "session 3f4389fe turn 1: 21 total records but only 12 real tool calls"
+    );
+
+    // Verify original_tool_name is preserved for analytics
+    let surgical: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| r.surgically_removed == Some(true))
+        .collect();
+    assert_eq!(surgical.len(), 9);
+    let original_names: Vec<_> = surgical
+        .iter()
+        .filter_map(|r| r.original_tool_name.as_deref())
+        .collect();
+    assert!(original_names.contains(&"read_file"));
+    assert!(original_names.contains(&"glob"));
+    assert!(original_names.contains(&"grep"));
+    assert!(original_names.contains(&"git_show"));
+}
+
+// ─── Unhappy path: all tool calls fail (worst case turn) ────────────────────
+
+#[test]
+fn e2e_all_tools_fail_with_surgical_removals_worst_case() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-worst-case";
+
+    let records = vec![
+        real_tool("bash", false, 200),       // real failure
+        real_tool("write_file", false, 30),   // real failure
+        surgical_removal("read_file"),        // not a failure
+        surgical_removal("glob"),             // not a failure
+        skipped_tool("grep"),                 // skill-routed, not a failure
+    ];
+
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "test-model",
+        "do something",
+        &[],
+        &records,
+        3, // stalls
+        true, // verdict warning
+        0.9, // high budget pressure
+        &make_eval(false, 0.1),
+    );
+
+    // tool_call_count: only 2 real calls (both failed)
+    assert_eq!(
+        extract_tool_call_count(&eval_event),
+        2,
+        "only 2 real tool calls (both failed) — surgical/skipped excluded"
+    );
+
+    // Verify the evaluation event still has correct metadata structure
+    let meta = eval_event.metadata.as_ref().unwrap();
+    assert_eq!(meta["stall_count"], 3);
+    assert_eq!(meta["verdict_warning"], true);
+    assert!(meta["budget_pressure"].as_f64().unwrap() > 0.8);
+    assert_eq!(meta["success"], false);
+}
+
+// ─── Unhappy path: Unicode in tool names and error messages ─────────────────
+
+#[test]
+fn e2e_unicode_in_tool_records_survives_journal_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-unicode";
+
+    let records = vec![
+        ToolCallRecord {
+            name: "bash".to_string(),
+            ok: false,
+            ms: 50,
+            error: Some("命令未找到: 科技风格".into()),
+            input_bytes: Some(200),
+            output_bytes: Some(0),
+            args_preview: Some("echo '在tmp目录下面生成文档'".into()),
+            result_preview: Some("错误：路径不存在 /tmp/科技".into()),
+            file_path: Some("/tmp/科技风格/index.html".into()),
+            surgically_removed: None,
+            original_tool_name: None,
+        },
+        surgical_removal("read_file"),
+    ];
+
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("qwen3.6-plus"),
+        "在tmp目录下面生成文档",
+        "已完成",
+        2,
+        95000,
+        5900,
+        10000,
+    )
+    .with_tool_calls(records);
+    writer.append(&turn_event).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+    let tool_calls = events[0].tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 2);
+
+    // Verify Chinese characters survived JSON roundtrip
+    assert_eq!(tool_calls[0].error.as_deref(), Some("命令未找到: 科技风格"));
+    assert_eq!(
+        tool_calls[0].file_path.as_deref(),
+        Some("/tmp/科技风格/index.html")
+    );
+    assert!(tool_calls[1].is_synthetic_placeholder());
+}
+
+// ─── Unhappy path: very large number of surgical removals ───────────────────
+
+#[test]
+fn e2e_many_surgical_removals_performance_and_accuracy() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-many-removals";
+
+    // Extreme case: 50 surgical removals + 5 real calls
+    let mut records: Vec<ToolCallRecord> = (0..50)
+        .map(|i| surgical_removal(&format!("tool_{i}")))
+        .collect();
+    for i in 0..5 {
+        records.push(real_tool(&format!("real_tool_{i}"), true, 100));
+    }
+    assert_eq!(records.len(), 55);
+
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("gpt-5.4"),
+        "Complex task",
+        "Done",
+        55,
+        100000,
+        5000,
+        15000,
+    )
+    .with_tool_calls(records.clone());
+    writer.append(&turn_event).unwrap();
+
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "gpt-5.4",
+        "Complex task",
+        &[],
+        &records,
+        0,
+        false,
+        0.5,
+        &make_eval(true, 0.7),
+    );
+    writer.append(&eval_event).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+    let tool_calls = events[0].tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 55, "all 55 records persisted");
+
+    let surgical: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| r.is_synthetic_placeholder())
+        .collect();
+    assert_eq!(surgical.len(), 50);
+
+    // Verify each surgical removal preserved its original name
+    for (i, rec) in surgical.iter().enumerate() {
+        assert_eq!(
+            rec.original_tool_name.as_deref(),
+            Some(format!("tool_{i}").as_str()),
+        );
+    }
+
+    assert_eq!(extract_tool_call_count(&events[1]), 5);
+}

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -2686,6 +2686,8 @@ mod tests {
             args_preview: None,
             result_preview: Some("clean".into()),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         });
 
         let event = build_runtime_turn_evaluation_event("session-1", "server_runtime", &state);

--- a/rust/crates/runtime/src/turn/agentic_delegate_interception.rs
+++ b/rust/crates/runtime/src/turn/agentic_delegate_interception.rs
@@ -179,6 +179,8 @@ pub(crate) async fn intercept_delegations<H: AgenticLoopHost>(
                 args_preview: Some(result.call_id.clone()),
                 result_preview: Some(result.summary.chars().take(500).collect::<String>()),
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             });
         }
         if !quiet {

--- a/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
@@ -706,6 +706,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: Some("src/main.rs".to_string()),
+                surgically_removed: None,
+                original_tool_name: None,
             },
             astra_services::session_journal::ToolCallRecord {
                 name: "str_replace".to_string(),
@@ -717,6 +719,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: Some("src/lib.rs".to_string()),
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ];
         state.total_prompt = 5000;
@@ -761,6 +765,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }];
         state.total_prompt = 15000;
 

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -3963,6 +3963,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
             args_preview: None,
             result_preview: result_preview.map(str::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 
@@ -5895,6 +5897,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: Some("npm test".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             astra_services::session_journal::ToolCallRecord {
                 name: "bash".into(),
@@ -5906,6 +5910,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: Some("npm test".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ];
 
@@ -6048,6 +6054,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: Some("ls -la".into()),
                 result_preview: Some("error".into()),
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "bash".into(),
@@ -6059,6 +6067,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: Some("cat foo".into()),
                 result_preview: Some("not found".into()),
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "bash".into(),
@@ -6070,6 +6080,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: Some("rm bar".into()),
                 result_preview: Some("permission denied".into()),
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ];
 
@@ -6628,6 +6640,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 },
                 ToolCallRecord {
                     name: "rg".to_string(),
@@ -6639,6 +6653,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 },
             ]);
             if !bash_ok {
@@ -6694,6 +6710,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 }]),
                 budget_used: None,
                 budget_pressure: None,
@@ -6780,6 +6798,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "bash".into(),
@@ -6791,6 +6811,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "web_fetch".into(),
@@ -6802,6 +6824,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ];
         state.recent_tactical_actions = vec![

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
@@ -169,7 +169,10 @@ fn refresh_runtime_promotion_signals_from_turn(
         .then(|| {
             RuntimeTurnEvaluationSignal::from_turn_evaluation(
                 &evaluation,
-                tool_call_records.len(),
+                tool_call_records
+                    .iter()
+                    .filter(|r| !r.is_synthetic_placeholder())
+                    .count(),
                 stall_count,
                 verdict_warning,
             )
@@ -1344,6 +1347,8 @@ mod tests {
             args_preview: Some("{\"command\":\"echo hi\"}".into()),
             result_preview: result_preview.map(str::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 
@@ -1399,6 +1404,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 

--- a/rust/crates/runtime/src/turn/agentic_tool_interception.rs
+++ b/rust/crates/runtime/src/turn/agentic_tool_interception.rs
@@ -46,6 +46,8 @@ pub(crate) async fn prepare_intercepted_tool_round(
             args_preview: Some(result.tool_call_id.clone()),
             result_preview: Some(result.result.chars().take(500).collect::<String>()),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         });
     }
 
@@ -55,7 +57,22 @@ pub(crate) async fn prepare_intercepted_tool_round(
     // evaluation/analytics via ToolCallRecord::is_synthetic_placeholder().
     // The stall detector does NOT treat synthetic placeholders as real
     // attempts either, matching the existing skipped/deferred behavior.
+
+    // Build id→name lookup so we can preserve the original tool name.
+    let tool_name_by_id: HashMap<&str, &str> = tool_calls
+        .iter()
+        .filter_map(|tc| {
+            let id = tc.get("id").and_then(Value::as_str)?;
+            let name = tc
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(Value::as_str)?;
+            Some((id, name))
+        })
+        .collect();
+
     for id in &surgically_removed_ids {
+        let original_name = tool_name_by_id.get(id.as_str()).map(|s| s.to_string());
         state.stall.tool_call_records.push(ToolCallRecord {
             name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
             ok: true,
@@ -66,6 +83,8 @@ pub(crate) async fn prepare_intercepted_tool_round(
             args_preview: Some(id.clone()),
             result_preview: Some("(removed from context — skill covered this work)".to_string()),
             file_path: None,
+            surgically_removed: Some(true),
+            original_tool_name: original_name,
         });
     }
 

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -229,6 +229,8 @@ fn build_bridge_tool_call_records(
                 .map(|arguments| preview_chars(arguments, 80)),
             result_preview: output.as_deref().map(|output| preview_chars(output, 500)),
             file_path,
+            surgically_removed: None,
+            original_tool_name: None,
         });
     }
 
@@ -248,6 +250,8 @@ fn build_bridge_tool_call_records(
                 .map(|arguments| preview_chars(arguments, 80)),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         });
     }
 

--- a/rust/crates/runtime/tests/session_facts_e2e.rs
+++ b/rust/crates/runtime/tests/session_facts_e2e.rs
@@ -95,6 +95,8 @@ fn make_tc(name: &str, ok: bool, file_path: Option<&str>) -> ToolCallRecord {
         args_preview: None,
         result_preview: None,
         file_path: file_path.map(String::from),
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 

--- a/rust/crates/services/src/event_ingestion.rs
+++ b/rust/crates/services/src/event_ingestion.rs
@@ -1079,6 +1079,8 @@ mod tests {
                 args_preview: Some("HEAD~10".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             crate::session_journal::ToolCallRecord {
                 name: "read_file".into(),
@@ -1090,6 +1092,8 @@ mod tests {
                 args_preview: Some("missing.txt".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ]);
 
@@ -1145,6 +1149,8 @@ mod tests {
             args_preview: Some("npm test".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }]);
 
         let events = IngestionEvent::expand_journal_event(&journal, "u1");
@@ -1169,6 +1175,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }]);
 
         let a = IngestionEvent::expand_journal_event(&journal, "u1");

--- a/rust/crates/services/src/self_surface.rs
+++ b/rust/crates/services/src/self_surface.rs
@@ -2323,6 +2323,8 @@ mod tests {
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 }]),
                 budget_used: Some(8300),
                 budget_pressure: Some(0.83),

--- a/rust/crates/services/src/session_analytics.rs
+++ b/rust/crates/services/src/session_analytics.rs
@@ -402,6 +402,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             crate::session_journal::ToolCallRecord {
                 name: "grep".into(),
@@ -413,6 +415,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             crate::session_journal::ToolCallRecord {
                 name: "write_file".into(),
@@ -424,6 +428,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ]);
         let stats = compute_session_stats("s1", &[turn]);
@@ -507,6 +513,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 

--- a/rust/crates/services/src/session_journal.rs
+++ b/rust/crates/services/src/session_journal.rs
@@ -488,6 +488,16 @@ pub struct ToolCallRecord {
     /// More reliable than parsing `args_preview` (which is truncated to ~80 chars).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub file_path: Option<String>,
+    /// Explicit flag for surgically removed tool calls. When `true`, this record
+    /// is an audit-only placeholder — the parallel tool call was removed from
+    /// context because a skill covered the work. Prefer this over checking
+    /// `name == SURGICAL_REMOVAL_TOOL_NAME`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub surgically_removed: Option<bool>,
+    /// Original tool name before surgical removal replaced it with the sentinel.
+    /// Only set when `surgically_removed == Some(true)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_tool_name: Option<String>,
 }
 
 /// Tool call name sentinel used for assistant messages that had parallel tool
@@ -505,6 +515,9 @@ impl ToolCallRecord {
     /// failure, so these records must be filtered out before computing
     /// analytics (tool_error_rate, repeat_tool_call, failed_tool_calls, …).
     pub fn is_synthetic_placeholder(&self) -> bool {
+        if self.surgically_removed == Some(true) {
+            return true;
+        }
         if self.name == SURGICAL_REMOVAL_TOOL_NAME {
             return true;
         }
@@ -3263,6 +3276,8 @@ mod tests {
             args_preview: None,
             result_preview: preview.map(ToString::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 
@@ -3850,6 +3865,8 @@ mod tests {
             args_preview: Some("owner/repo".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let json = serde_json::to_string(&record).unwrap();
         assert!(json.contains("\"ok\":true"));
@@ -3873,6 +3890,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let json = serde_json::to_string(&record).unwrap();
         assert!(json.contains("\"ok\":false"));
@@ -3897,6 +3916,8 @@ mod tests {
                     .into(),
             ),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let deferred = ToolCallRecord {
             name: "bash".into(),
@@ -3911,6 +3932,8 @@ mod tests {
                     .into(),
             ),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let dedup = ToolCallRecord {
             name: "skill".into(),
@@ -3925,6 +3948,8 @@ mod tests {
                     .into(),
             ),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let actual_failure = ToolCallRecord {
             name: "skill".into(),
@@ -3936,6 +3961,8 @@ mod tests {
             args_preview: None,
             result_preview: Some("Unknown skill 'debug'.".into()),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
 
         assert!(skipped.is_synthetic_placeholder());
@@ -3973,6 +4000,8 @@ mod tests {
             args_preview: Some("owner/repo".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }]);
         let json = serde_json::to_string(&evt).unwrap();
         let parsed: JournalEvent = serde_json::from_str(&json).unwrap();
@@ -4022,6 +4051,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             })
             .collect();
         let json = serde_json::to_string(&records).unwrap();
@@ -4043,6 +4074,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let json = serde_json::to_string(&record).unwrap();
         let parsed: ToolCallRecord = serde_json::from_str(&json).unwrap();
@@ -4061,6 +4094,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let json = serde_json::to_string(&record).unwrap();
         let parsed: ToolCallRecord = serde_json::from_str(&json).unwrap();
@@ -5015,5 +5050,77 @@ mod tests {
         assert_eq!(result.sessions_deleted, 0);
         assert_eq!(result.journals_compressed, 0);
         assert_eq!(result.bytes_freed, 0);
+    }
+
+    #[test]
+    fn tool_call_record_serde_roundtrip_with_surgical_fields() {
+        // New-style record with both surgical fields populated
+        let rec = ToolCallRecord {
+            name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+            ok: true,
+            ms: 0,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(0),
+            args_preview: None,
+            result_preview: Some("(removed)".into()),
+            file_path: None,
+            surgically_removed: Some(true),
+            original_tool_name: Some("read_file".to_string()),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        assert!(json.contains("\"surgically_removed\":true"));
+        assert!(json.contains("\"original_tool_name\":\"read_file\""));
+        let deser: ToolCallRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(deser.surgically_removed, Some(true));
+        assert_eq!(deser.original_tool_name.as_deref(), Some("read_file"));
+        assert!(deser.is_synthetic_placeholder());
+    }
+
+    #[test]
+    fn tool_call_record_serde_omits_none_surgical_fields() {
+        // Normal record: surgical fields should be omitted from JSON
+        let rec = base_tool_record("bash", true, Some("ok"));
+        let json = serde_json::to_string(&rec).unwrap();
+        assert!(
+            !json.contains("surgically_removed"),
+            "None surgical fields should be skipped in serialization"
+        );
+        assert!(
+            !json.contains("original_tool_name"),
+            "None original_tool_name should be skipped in serialization"
+        );
+    }
+
+    #[test]
+    fn tool_call_record_backward_compat_deserialize() {
+        // Legacy JSON without the new fields — should deserialize with defaults
+        let legacy_json = r#"{"name":"read_file","ok":true,"ms":10}"#;
+        let rec: ToolCallRecord = serde_json::from_str(legacy_json).unwrap();
+        assert_eq!(rec.surgically_removed, None);
+        assert_eq!(rec.original_tool_name, None);
+        assert!(!rec.is_synthetic_placeholder());
+    }
+
+    #[test]
+    fn is_synthetic_placeholder_flag_takes_priority() {
+        // Even if name is normal, flag=true marks as synthetic
+        let rec = ToolCallRecord {
+            name: "read_file".to_string(),
+            ok: true,
+            ms: 50,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(100),
+            args_preview: None,
+            result_preview: Some("content".into()),
+            file_path: None,
+            surgically_removed: Some(true),
+            original_tool_name: Some("read_file".to_string()),
+        };
+        assert!(
+            rec.is_synthetic_placeholder(),
+            "surgically_removed=true must classify as synthetic regardless of name"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Three systemic fixes for journal telemetry accuracy, identified from session `3f4389fe` analysis.

### 1. Surgical removal explicit flag
- Added `surgically_removed: Option<bool>` and `original_tool_name: Option<String>` fields to `ToolCallRecord`
- Previously, surgical removals were only detectable via magic sentinel name `(surgically_removed)`
- New fields enable reliable detection and preserve the original tool name for analytics
- `is_synthetic_placeholder()` checks the flag first, falls back to sentinel name for backward compatibility
- Serde: `skip_serializing_if = "Option::is_none"` + `serde(default)` — zero-cost for normal records, backward-compatible with old journals

### 2. tool_call_count excludes synthetic placeholders
- `build_turn_evaluation_journal_event()` was using `tool_call_records.len()` which included surgical removals and other synthetic placeholders
- Now filters via `is_synthetic_placeholder()` before counting
- Example impact: session 3f4389fe turn 1 reported 21 tool calls but only 12 were real

### 3. Turn numbering uses REPL counter
- `context_assembly_recorded` event was using the internal agentic loop counter (`max_turns - remaining_turns`) instead of the REPL's user-visible turn number
- This caused context_assembly to show turn=3 when the user was on turn=1
- Fix: override stored `turn_num` with `state.turn` (the REPL counter)

## Tests Added (6 new)
- `tool_call_count_excludes_synthetic_placeholders` — verifies metadata count filters synthetics
- `is_synthetic_placeholder_via_flag` — new flag, legacy sentinel, and normal records
- `tool_call_record_serde_roundtrip_with_surgical_fields` — serialize/deserialize with new fields
- `tool_call_record_serde_omits_none_surgical_fields` — normal records don't emit new fields
- `tool_call_record_backward_compat_deserialize` — old JSON without new fields still works
- `is_synthetic_placeholder_flag_takes_priority` — flag overrides name check

## Validation
- `make format` ✅
- `make check` ✅
- Full `cargo test` — 6,437+ tests pass, 0 failures ✅

## Files Changed (26 files)
Core fixes in 3 files, mechanical field additions in 23 files across all crates that construct `ToolCallRecord`.