### PR TITLE
fix: expose github_create_issue in server mode

### DIFF
--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -356,6 +356,7 @@ pub const APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "str_replace",
     "delete_file",
     "git_commit",
+    "github_create_issue",
 ];
 
 // ─── Output management utilities ────────────────────────────────────────────
@@ -776,6 +777,7 @@ mod tests {
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"write_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"delete_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_commit"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"github_create_issue"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"read_file"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"grep"));
     }

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -66,6 +66,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "github_list_issues",
     "github_get_issue",
     "github_repo_stats",
+    "github_create_issue",
     "web_fetch",
     "web_search",
     "memory_retrieve",
@@ -1960,6 +1961,7 @@ mod tests {
         assert!(names.contains(&"git_log_search"));
         assert!(names.contains(&"github_list_prs"));
         assert!(names.contains(&"github_ci_status"));
+        assert!(names.contains(&"github_create_issue"));
         assert!(names.contains(&"web_fetch"));
         assert!(names.contains(&"memory_retrieve"));
         assert!(names.contains(&"symbols"));

--- a/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
+++ b/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
@@ -10,6 +10,7 @@ pub const CLOUD_APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "create_file",
     "edit_file",
     "exec",
+    "github_create_issue",
     "multi_edit",
     "rollback_database_snapshots",
     "rollback_file_edits",
@@ -363,6 +364,14 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn github_create_issue_is_write_gated() {
+        assert_eq!(
+            cloud_gated_tool_kind("github_create_issue"),
+            Some(CloudGatedToolKind::Write)
+        );
     }
 
     // ── bash_command_is_read_only tests ──

--- a/rust/crates/astra-turn-core/src/tool_result_semantics.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_semantics.rs
@@ -640,6 +640,12 @@ if let Err(e) = writeln!(file, "{line}") {
             classify_tool_error("write_file", output),
             ToolErrorSeverity::HardError
         );
+
+        // github_create_issue timeout
+        assert_eq!(
+            classify_tool_error("github_create_issue", output),
+            ToolErrorSeverity::HardError
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -1268,7 +1268,7 @@ impl ServerToolExecutor {
                     .await
             }
             // ── GitHub operations ────────────────────────────────────────
-            // Read-only GitHub tools delegate to DefaultToolExecutor.
+            // GitHub tools delegate to DefaultToolExecutor.
             "github_list_prs" => self.default_executor.execute("github_list_prs", args).await,
             "github_get_pr" => self.default_executor.execute("github_get_pr", args).await,
             "github_ci_status" => {
@@ -1291,6 +1291,11 @@ impl ServerToolExecutor {
                     .execute("github_repo_stats", args)
                     .await
             }
+            "github_create_issue" => {
+                self.default_executor
+                    .execute("github_create_issue", args)
+                    .await
+            }
             // ── Delegation placeholder ─────────────────────────────────
             "delegate" => astra_tools::ToolResult::text(
                 "Delegation request acknowledged. The delegation engine will execute \
@@ -1305,7 +1310,7 @@ impl ServerToolExecutor {
                      rollback_session_state, task_*, sleep, tool_search, mo_query, rollback_database_snapshots, \
                      grep, glob, git_status, git_diff, git_log, git_file_history, git_contributors, git_log_search, \
                      git_show, git_blame, symbols, git_commit, git_revert_commit, github_list_prs, github_get_pr, \
-                     github_ci_status, github_list_issues, github_get_issue, github_repo_stats, memory_*, web_fetch, \
+                     github_ci_status, github_list_issues, github_get_issue, github_repo_stats, github_create_issue, memory_*, web_fetch, \
                      web_search"
             )),
         };
@@ -3972,24 +3977,50 @@ esac
 
     #[tokio::test]
     async fn github_tools_delegate_to_default_executor() {
+        let _guard = env_guard();
+        let _github_token_guard = EnvVarGuard {
+            key: "GITHUB_TOKEN",
+            previous: std::env::var_os("GITHUB_TOKEN"),
+        };
+        unsafe {
+            std::env::remove_var("GITHUB_TOKEN");
+        }
+        let empty_path = TempDir::new().unwrap();
+        let _path_guard = set_env_var("PATH", empty_path.path().as_os_str().to_os_string());
+
         let (exec, _dir) = test_executor();
-        let result = exec
-            .execute_with_metadata(
+        for (tool, args) in [
+            (
                 "github_list_prs",
-                &json!({"repo": "matrixorigin/mo-agent-runtime"}),
-            )
-            .await;
-        assert!(result.is_error);
-        assert!(
-            result
-                .output
-                .contains("requires a configured GitHub client")
-        );
-        assert!(
-            !result
-                .output
-                .contains("not available in server-side execution mode")
-        );
+                json!({"repo": "matrixorigin/mo-agent-runtime"}),
+            ),
+            (
+                "github_create_issue",
+                json!({
+                    "repo": "matrixorigin/mo-agent-runtime",
+                    "title": "server parity regression test"
+                }),
+            ),
+        ] {
+            let result = exec.execute_with_metadata(tool, &args).await;
+            assert!(
+                result.is_error,
+                "{tool} should error without a GitHub client"
+            );
+            assert!(
+                result
+                    .output
+                    .contains("requires a configured GitHub client"),
+                "{tool} should delegate to the GitHub executor path, got: {}",
+                result.output
+            );
+            assert!(
+                !result
+                    .output
+                    .contains("not available in server-side execution mode"),
+                "{tool} should be exposed in server mode"
+            );
+        }
     }
 
     // ── Output management ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- expose github_create_issue in the server executor surface
- route server execution through the existing DefaultToolExecutor GitHub path
- require approval for github_create_issue in server/cloud mutation classification and add regression coverage

## Testing
- make format
- make check
- cargo test -p astra-tools approval_required_tools_includes_dangerous_ops --lib
- cargo test -p astra-tools server_executor_tool_schemas_match_server_supported_surface --lib
- cargo test -p astra-turn-core github_create_issue_is_write_gated --lib
- cargo test -p astra-turn-core classify_timeout_hard_for_mutation_tool --lib
- cargo test -p astra-runtime github_tools_delegate_to_default_executor --lib