### PR TITLE
fix: expose git_stash in server mode

### DIFF
--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -356,6 +356,7 @@ pub const APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "str_replace",
     "delete_file",
     "git_commit",
+    "git_stash",
 ];
 
 // ─── Output management utilities ────────────────────────────────────────────
@@ -776,6 +777,7 @@ mod tests {
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"write_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"delete_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_commit"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_stash"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"read_file"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"grep"));
     }

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -59,6 +59,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "git_blame",
     "symbols",
     "git_commit",
+    "git_stash",
     "git_revert_commit",
     "github_list_prs",
     "github_get_pr",
@@ -1960,6 +1961,7 @@ mod tests {
         assert!(names.contains(&"git_log_search"));
         assert!(names.contains(&"github_list_prs"));
         assert!(names.contains(&"github_ci_status"));
+        assert!(names.contains(&"git_stash"));
         assert!(names.contains(&"web_fetch"));
         assert!(names.contains(&"memory_retrieve"));
         assert!(names.contains(&"symbols"));

--- a/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
+++ b/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
@@ -10,6 +10,7 @@ pub const CLOUD_APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "create_file",
     "edit_file",
     "exec",
+    "git_stash",
     "multi_edit",
     "rollback_database_snapshots",
     "rollback_file_edits",
@@ -363,6 +364,14 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn git_stash_is_write_gated() {
+        assert_eq!(
+            cloud_gated_tool_kind("git_stash"),
+            Some(CloudGatedToolKind::Write)
+        );
     }
 
     // ── bash_command_is_read_only tests ──

--- a/rust/crates/astra-turn-core/src/tool_result_semantics.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_semantics.rs
@@ -640,6 +640,12 @@ if let Err(e) = writeln!(file, "{line}") {
             classify_tool_error("write_file", output),
             ToolErrorSeverity::HardError
         );
+
+        // git_stash timeout
+        assert_eq!(
+            classify_tool_error("git_stash", output),
+            ToolErrorSeverity::HardError
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -1262,6 +1262,7 @@ impl ServerToolExecutor {
             "git_blame" => self.default_executor.execute("git_blame", args).await,
             "symbols" => self.default_executor.execute("symbols", args).await,
             "git_commit" => self.default_executor.execute("git_commit", args).await,
+            "git_stash" => self.default_executor.execute("git_stash", args).await,
             "git_revert_commit" => {
                 self.default_executor
                     .execute("git_revert_commit", args)
@@ -1304,7 +1305,7 @@ impl ServerToolExecutor {
                      list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
                      rollback_session_state, task_*, sleep, tool_search, mo_query, rollback_database_snapshots, \
                      grep, glob, git_status, git_diff, git_log, git_file_history, git_contributors, git_log_search, \
-                     git_show, git_blame, symbols, git_commit, git_revert_commit, github_list_prs, github_get_pr, \
+                     git_show, git_blame, symbols, git_commit, git_stash, git_revert_commit, github_list_prs, github_get_pr, \
                      github_ci_status, github_list_issues, github_get_issue, github_repo_stats, memory_*, web_fetch, \
                      web_search"
             )),
@@ -3790,6 +3791,34 @@ esac
         assert!(
             contributors.contains("## Top Contributors"),
             "{contributors}"
+        );
+    }
+
+    #[tokio::test]
+    async fn git_stash_is_available_in_server_mode() {
+        let (exec, dir) = test_executor();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+
+        let stash_list = exec.execute("git_stash", &json!({"action": "list"})).await;
+        assert!(
+            stash_list.contains("No stashes found")
+                || stash_list.contains("stash@")
+                || stash_list.is_empty(),
+            "{stash_list}"
         );
     }
 


### PR DESCRIPTION
## Summary
- expose git_stash in the server executor surface
- delegate server git_stash execution through the existing DefaultToolExecutor git path
- align approval and mutation classification for git_stash and add regression coverage

## Testing
- make format
- make check
- cargo test -p astra-tools approval_required_tools_includes_dangerous_ops --lib
- cargo test -p astra-tools server_executor_tool_schemas_match_server_supported_surface --lib
- cargo test -p astra-turn-core git_stash_is_write_gated --lib
- cargo test -p astra-turn-core classify_timeout_hard_for_mutation_tool --lib
- cargo test -p astra-runtime git_stash_is_available_in_server_mode --lib