### PR TITLE
fix: bundle server parity and journal accuracy follow-ups

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_sse_loop.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_sse_loop.rs
@@ -330,6 +330,8 @@ mod tests {
             args_preview: None,
             result_preview: result_preview.map(str::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 

--- a/rust/crates/astra-cli/src/cli/chat_stream/tests.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/tests.rs
@@ -18,6 +18,8 @@ fn tool_call_record_covers_early_exit_paths() {
         args_preview: Some("src/main.rs".to_string()),
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     };
     assert!(dup.ok);
     assert_eq!(dup.ms, 0);
@@ -33,6 +35,8 @@ fn tool_call_record_covers_early_exit_paths() {
         args_preview: Some("/TODO/ in src/".to_string()),
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     };
     assert!(cached.ok);
 
@@ -47,6 +51,8 @@ fn tool_call_record_covers_early_exit_paths() {
         args_preview: None,
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     };
     assert!(!unknown.ok);
     assert!(unknown.error.as_ref().unwrap().starts_with("unknown_tool:"));
@@ -62,6 +68,8 @@ fn tool_call_record_covers_early_exit_paths() {
         args_preview: Some("rm -rf /".to_string()),
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     };
     assert!(!denied.ok);
 
@@ -89,6 +97,8 @@ fn tool_call_record_json_roundtrip() {
         args_preview: Some("https://example.com".to_string()),
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     };
     let json = serde_json::to_string(&original).unwrap();
     let restored: ToolCallRecord = serde_json::from_str(&json).unwrap();

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -2479,6 +2479,8 @@ mod exit_code_tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             });
         assert_eq!(compute_exit_code(&sr), ExitCode::ToolFailure);
     }
@@ -2497,6 +2499,8 @@ mod exit_code_tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             });
         sr.verdict_events.push(VerdictEvent {
             turn: 1,
@@ -2530,6 +2534,8 @@ mod exit_code_tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             });
         sr.tool_call_records
             .push(astra_services::session_journal::ToolCallRecord {
@@ -2542,6 +2548,8 @@ mod exit_code_tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             });
         assert_eq!(compute_exit_code(&sr), ExitCode::Success);
     }

--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -968,10 +968,12 @@ fn commit_turn_journal_workspace_and_sidecars(
         enqueue_ingestion(state, &turn_event);
 
         // Emit deferred context_assembly_recorded — only on successful turn commit.
-        if let Some((turn_num, trace_json)) = &result.pending_context_assembly_trace {
+        if let Some((_internal_turn, trace_json)) = &result.pending_context_assembly_trace {
+            // Use the REPL's user-visible turn number, not the internal agentic
+            // loop counter that was stored in the trace.
             let assembly_event = session_journal::JournalEvent::context_assembly_recorded(
                 state.session_id.as_deref(),
-                *turn_num,
+                state.turn,
                 trace_json.clone(),
             );
             if let Err(e) = journal.append(&assembly_event) {
@@ -3386,6 +3388,8 @@ mod tests {
             args_preview: None,
             result_preview: result_preview.map(str::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 
@@ -3503,6 +3507,8 @@ mod tests {
             args_preview: None,
             result_preview: Some("clean".into()),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }];
 
         let learning =

--- a/rust/crates/astra-cli/src/cli/self_command.rs
+++ b/rust/crates/astra-cli/src/cli/self_command.rs
@@ -1835,6 +1835,8 @@ mod tests {
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 }]),
                 budget_used: Some(7000),
                 budget_pressure: Some(0.7),
@@ -1987,6 +1989,8 @@ mod tests {
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 },
                 ToolCallRecord {
                     name: "rg".to_string(),
@@ -1998,6 +2002,8 @@ mod tests {
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 },
             ]);
             if !bash_ok {
@@ -2136,6 +2142,8 @@ mod tests {
                         args_preview: None,
                         result_preview: None,
                         file_path: None,
+                        surgically_removed: None,
+                        original_tool_name: None,
                     },
                     ToolCallRecord {
                         name: "rg".to_string(),
@@ -2147,6 +2155,8 @@ mod tests {
                         args_preview: None,
                         result_preview: None,
                         file_path: None,
+                        surgically_removed: None,
+                        original_tool_name: None,
                     },
                 ]),
                 budget_used: Some(9100),
@@ -2424,6 +2434,8 @@ mod tests {
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 }]),
                 budget_used: Some(9100),
                 budget_pressure: Some(0.91),

--- a/rust/crates/astra-cli/src/cli/slash_session.rs
+++ b/rust/crates/astra-cli/src/cli/slash_session.rs
@@ -4109,6 +4109,8 @@ mod export_tests {
             args_preview: Some("pattern in src/".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }];
         let block = format_tool_calls_md(&calls);
         assert!(block.contains("<details>"));

--- a/rust/crates/astra-cli/src/cli/streaming_types.rs
+++ b/rust/crates/astra-cli/src/cli/streaming_types.rs
@@ -147,6 +147,8 @@ mod tests {
             args_preview: None,
             result_preview: result_preview.map(str::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 

--- a/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
@@ -102,6 +102,8 @@ async fn execute_reflect_uses_local_surface_with_session() {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             }]),
             budget_used: Some(8500),
             budget_pressure: Some(0.85),

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -2798,6 +2798,8 @@ total_tokens_out: 500
                 args_preview: Some("npm test".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             session_journal::ToolCallRecord {
                 name: "bash".into(),
@@ -2809,6 +2811,8 @@ total_tokens_out: 500
                 args_preview: Some("cargo build".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             session_journal::ToolCallRecord {
                 name: "grep".into(),
@@ -2820,6 +2824,8 @@ total_tokens_out: 500
                 args_preview: Some("/error/ in src/".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ]);
         writer.append(&event).unwrap();

--- a/rust/crates/astra-cli/src/tests/stats_tools_tests.rs
+++ b/rust/crates/astra-cli/src/tests/stats_tools_tests.rs
@@ -186,6 +186,8 @@ fn tools_reads_tool_calls_from_journal() {
             args_preview: Some("npm test".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         },
         session_journal::ToolCallRecord {
             name: "bash".into(),
@@ -197,6 +199,8 @@ fn tools_reads_tool_calls_from_journal() {
             args_preview: Some("cargo build".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         },
         session_journal::ToolCallRecord {
             name: "grep".into(),
@@ -208,6 +212,8 @@ fn tools_reads_tool_calls_from_journal() {
             args_preview: Some("/error/ in src/".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         },
     ]);
     writer.append(&event).unwrap();

--- a/rust/crates/astra-evolution/src/reflection.rs
+++ b/rust/crates/astra-evolution/src/reflection.rs
@@ -1338,6 +1338,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "bash".into(),
@@ -1349,6 +1351,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "web_fetch".into(),
@@ -1360,6 +1364,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ];
 

--- a/rust/crates/astra-server-types/src/lib.rs
+++ b/rust/crates/astra-server-types/src/lib.rs
@@ -878,6 +878,7 @@ pub fn chat_request_into_data(mut request: ChatRequest) -> ChatRequestData {
         forward_headers: std::collections::HashMap::new(),
         max_candidates: request.max_candidates,
         explain: request.explain,
+        interactive_client: false,
     }
 }
 

--- a/rust/crates/astra-tools/src/fs_ops.rs
+++ b/rust/crates/astra-tools/src/fs_ops.rs
@@ -674,6 +674,117 @@ pub fn str_replace(workspace_root: &Path, args: &Value) -> ToolResult {
 }
 
 #[derive(Debug)]
+pub struct PreparedMultiEdit {
+    path: PathBuf,
+    path_str: String,
+    new_content: String,
+    edit_count: usize,
+    dry_run: bool,
+}
+
+impl PreparedMultiEdit {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn new_content_bytes(&self) -> &[u8] {
+        self.new_content.as_bytes()
+    }
+
+    pub fn apply(&self) -> ToolResult {
+        if self.dry_run {
+            return ToolResult::text(format!(
+                "Dry run: {} edit(s) would be applied to {}",
+                self.edit_count, self.path_str
+            ));
+        }
+
+        match std::fs::write(&self.path, &self.new_content) {
+            Ok(()) => ToolResult::text(format!(
+                "Successfully applied {} edit(s) to {}",
+                self.edit_count, self.path_str
+            )),
+            Err(e) => ToolResult::error(format!("Error: Cannot write file: {e}")),
+        }
+    }
+}
+
+pub fn prepare_multi_edit(
+    workspace_root: &Path,
+    args: &Value,
+) -> Result<PreparedMultiEdit, ToolResult> {
+    let path_str = match args.get("path").and_then(|v| v.as_str()) {
+        Some(p) => p,
+        None => return Err(ToolResult::error("Error: Missing 'path' parameter".into())),
+    };
+    let edits = match args.get("edits").and_then(|v| v.as_array()) {
+        Some(e) => e,
+        None => return Err(ToolResult::error("Error: Missing 'edits' array".into())),
+    };
+    if edits.is_empty() {
+        return Err(ToolResult::error("Error: 'edits' array is empty".into()));
+    }
+    let dry_run = args
+        .get("dry_run")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let path = match resolve_path(workspace_root, path_str) {
+        Ok(p) => p,
+        Err(e) => return Err(ToolResult::error(e)),
+    };
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) => return Err(ToolResult::error(format!("Error: Cannot read file: {e}"))),
+    };
+
+    let mut working = content;
+    for (i, edit) in edits.iter().enumerate() {
+        let old_str = match edit.get("old_str").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => {
+                return Err(ToolResult::error(format!(
+                    "Error: edit[{i}] missing 'old_str'"
+                )));
+            }
+        };
+        let new_str = match edit.get("new_str").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => {
+                return Err(ToolResult::error(format!(
+                    "Error: edit[{i}] missing 'new_str'"
+                )));
+            }
+        };
+        if old_str == new_str {
+            return Err(ToolResult::error(format!(
+                "Error: edit[{i}] old_str and new_str are identical"
+            )));
+        }
+        let count = working.matches(old_str).count();
+        if count == 0 {
+            return Err(ToolResult::error(format!(
+                "Error: edit[{i}] old_str not found in {path_str}"
+            )));
+        }
+        if count > 1 {
+            return Err(ToolResult::error(format!(
+                "Error: edit[{i}] old_str found {count} times in {path_str}. Must match exactly once."
+            )));
+        }
+        working = working.replacen(old_str, new_str, 1);
+    }
+
+    Ok(PreparedMultiEdit {
+        path,
+        path_str: path_str.to_string(),
+        new_content: working,
+        edit_count: edits.len(),
+        dry_run,
+    })
+}
+
+#[derive(Debug)]
 pub struct PreparedDeleteFile {
     path: PathBuf,
     path_str: String,
@@ -787,72 +898,9 @@ pub fn list_dir(workspace_root: &Path, args: &Value) -> ToolResult {
 /// Each edit must have `old_str` and `new_str`. All edits are validated
 /// first (no partial application). `old_str` must match exactly once.
 pub fn multi_edit(workspace_root: &Path, args: &Value) -> ToolResult {
-    let path_str = match args.get("path").and_then(|v| v.as_str()) {
-        Some(p) => p,
-        None => return ToolResult::error("Error: Missing 'path' parameter".into()),
-    };
-    let edits = match args.get("edits").and_then(|v| v.as_array()) {
-        Some(e) => e,
-        None => return ToolResult::error("Error: Missing 'edits' array".into()),
-    };
-    if edits.is_empty() {
-        return ToolResult::error("Error: 'edits' array is empty".into());
-    }
-    let dry_run = args
-        .get("dry_run")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-
-    let path = match resolve_path(workspace_root, path_str) {
-        Ok(p) => p,
-        Err(e) => return ToolResult::error(e),
-    };
-    let content = match std::fs::read_to_string(&path) {
-        Ok(c) => c,
-        Err(e) => return ToolResult::error(format!("Error: Cannot read file: {e}")),
-    };
-
-    // Validate all edits first (atomic: all or nothing)
-    let mut working = content.clone();
-    for (i, edit) in edits.iter().enumerate() {
-        let old_str = match edit.get("old_str").and_then(|v| v.as_str()) {
-            Some(s) => s,
-            None => return ToolResult::error(format!("Error: edit[{i}] missing 'old_str'")),
-        };
-        let new_str = match edit.get("new_str").and_then(|v| v.as_str()) {
-            Some(s) => s,
-            None => return ToolResult::error(format!("Error: edit[{i}] missing 'new_str'")),
-        };
-        if old_str == new_str {
-            return ToolResult::error(format!(
-                "Error: edit[{i}] old_str and new_str are identical"
-            ));
-        }
-        let count = working.matches(old_str).count();
-        if count == 0 {
-            return ToolResult::error(format!("Error: edit[{i}] old_str not found in {path_str}"));
-        }
-        if count > 1 {
-            return ToolResult::error(format!(
-                "Error: edit[{i}] old_str found {count} times in {path_str}. Must match exactly once."
-            ));
-        }
-        working = working.replacen(old_str, new_str, 1);
-    }
-
-    if dry_run {
-        return ToolResult::text(format!(
-            "Dry run: {} edit(s) would be applied to {path_str}",
-            edits.len()
-        ));
-    }
-
-    match std::fs::write(&path, &working) {
-        Ok(()) => ToolResult::text(format!(
-            "Successfully applied {} edit(s) to {path_str}",
-            edits.len()
-        )),
-        Err(e) => ToolResult::error(format!("Error: Cannot write file: {e}")),
+    match prepare_multi_edit(workspace_root, args) {
+        Ok(prepared) => prepared.apply(),
+        Err(error) => error,
     }
 }
 

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -331,6 +331,40 @@ pub trait ToolApprovalGate: Send + Sync {
     fn requires_approval(&self, tool_name: &str) -> bool;
 }
 
+// ─── ask_user gate ────────────────────────────────────────────────────────────
+
+/// Final answer returned from an interactive ask_user prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AskUserResponse {
+    pub answer: String,
+    pub was_custom: bool,
+}
+
+/// Result from an ask_user gate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AskUserDecision {
+    /// User provided an answer.
+    Answer(AskUserResponse),
+    /// The prompt timed out before the user responded.
+    Timeout,
+    /// The prompt could not be delivered or decoded.
+    Error(String),
+}
+
+/// Trait for routing ask_user prompts through an interactive frontend.
+#[async_trait]
+pub trait AskUserGate: Send + Sync {
+    /// Ask the user a question and wait for their response.
+    async fn request_user_input(
+        &self,
+        request_id: &str,
+        question: &str,
+        choices: &[String],
+        default: Option<&str>,
+        context: Option<&str>,
+    ) -> AskUserDecision;
+}
+
 // ─── Tool progress callback ─────────────────────────────────────────────────
 
 /// Callback for streaming tool execution progress to the frontend.

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -391,6 +391,7 @@ pub const APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "multi_edit",
     "delete_file",
     "git_commit",
+    "github_create_issue",
 ];
 
 // ─── Output management utilities ────────────────────────────────────────────
@@ -812,6 +813,7 @@ mod tests {
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"multi_edit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"delete_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_commit"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"github_create_issue"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"read_file"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"grep"));
     }

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -391,6 +391,7 @@ pub const APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "multi_edit",
     "delete_file",
     "git_commit",
+    "git_stash",
     "github_create_issue",
 ];
 
@@ -813,6 +814,7 @@ mod tests {
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"multi_edit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"delete_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_commit"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_stash"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"github_create_issue"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"read_file"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"grep"));

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -388,6 +388,7 @@ pub const APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "bash",
     "write_file",
     "str_replace",
+    "multi_edit",
     "delete_file",
     "git_commit",
 ];
@@ -808,6 +809,7 @@ mod tests {
     fn approval_required_tools_includes_dangerous_ops() {
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"bash"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"write_file"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"multi_edit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"delete_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_commit"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"read_file"));

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -29,6 +29,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "read_file",
     "write_file",
     "str_replace",
+    "multi_edit",
     "delete_file",
     "rollback_file_edits",
     "list_dir",
@@ -1969,7 +1970,7 @@ mod tests {
         assert!(!names.contains(&"rollback_turn_actions"));
         assert!(!names.contains(&"powershell"));
         assert!(!names.contains(&"memory_feedback"));
-        assert!(!names.contains(&"multi_edit"));
+        assert!(names.contains(&"multi_edit"));
     }
 
     #[test]

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -60,6 +60,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "git_blame",
     "symbols",
     "git_commit",
+    "git_stash",
     "git_revert_commit",
     "github_list_prs",
     "github_get_pr",
@@ -1963,6 +1964,7 @@ mod tests {
         assert!(names.contains(&"git_log_search"));
         assert!(names.contains(&"github_list_prs"));
         assert!(names.contains(&"github_ci_status"));
+        assert!(names.contains(&"git_stash"));
         assert!(names.contains(&"github_create_issue"));
         assert!(names.contains(&"web_fetch"));
         assert!(names.contains(&"memory_retrieve"));

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -67,6 +67,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "github_list_issues",
     "github_get_issue",
     "github_repo_stats",
+    "github_create_issue",
     "web_fetch",
     "web_search",
     "ask_user",
@@ -1962,6 +1963,7 @@ mod tests {
         assert!(names.contains(&"git_log_search"));
         assert!(names.contains(&"github_list_prs"));
         assert!(names.contains(&"github_ci_status"));
+        assert!(names.contains(&"github_create_issue"));
         assert!(names.contains(&"web_fetch"));
         assert!(names.contains(&"memory_retrieve"));
         assert!(names.contains(&"symbols"));

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -68,6 +68,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "github_repo_stats",
     "web_fetch",
     "web_search",
+    "ask_user",
     "memory_retrieve",
     "memory_store",
     "memory_search",

--- a/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
+++ b/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
@@ -10,6 +10,7 @@ pub const CLOUD_APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "create_file",
     "edit_file",
     "exec",
+    "github_create_issue",
     "multi_edit",
     "rollback_database_snapshots",
     "rollback_file_edits",
@@ -363,6 +364,14 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn github_create_issue_is_write_gated() {
+        assert_eq!(
+            cloud_gated_tool_kind("github_create_issue"),
+            Some(CloudGatedToolKind::Write)
+        );
     }
 
     // ── bash_command_is_read_only tests ──

--- a/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
+++ b/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
@@ -10,6 +10,7 @@ pub const CLOUD_APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "create_file",
     "edit_file",
     "exec",
+    "git_stash",
     "github_create_issue",
     "multi_edit",
     "rollback_database_snapshots",
@@ -364,6 +365,14 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn git_stash_is_write_gated() {
+        assert_eq!(
+            cloud_gated_tool_kind("git_stash"),
+            Some(CloudGatedToolKind::Write)
+        );
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/cloud_session_facts.rs
+++ b/rust/crates/astra-turn-core/src/cloud_session_facts.rs
@@ -267,6 +267,8 @@ mod tests {
             args_preview: args.map(|s| s.to_string()),
             result_preview: None,
             file_path: file_path.map(|s| s.to_string()),
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 

--- a/rust/crates/astra-turn-core/src/edge_ledger.rs
+++ b/rust/crates/astra-turn-core/src/edge_ledger.rs
@@ -39,6 +39,11 @@ pub fn approval_callback_key(user_id: &str, request_id: &str) -> String {
     format!("{user_id}:approval:{request_id}")
 }
 
+#[inline]
+pub fn user_prompt_callback_key(user_id: &str, request_id: &str) -> String {
+    format!("{user_id}:user_prompt:{request_id}")
+}
+
 /// Remove and return the value for `key`, waiting up to `timeout` (50ms polling).
 pub async fn take_ledger_entry(
     ledger: &Arc<tokio::sync::Mutex<HashMap<String, Value>>>,

--- a/rust/crates/astra-turn-core/src/evaluation.rs
+++ b/rust/crates/astra-turn-core/src/evaluation.rs
@@ -272,7 +272,12 @@ pub fn build_turn_evaluation_journal_event(
         budget_pressure,
         stall_count,
         verdict_warning,
-        tool_call_records.len(),
+        // Exclude synthetic placeholders (surgical removals, skipped skills) from
+        // the user-visible tool_call_count — they are audit-only records.
+        tool_call_records
+            .iter()
+            .filter(|r| !r.is_synthetic_placeholder())
+            .count(),
         eval_signals_to_json(&eval.signals),
     )
 }
@@ -325,6 +330,8 @@ mod tests {
             args_preview: None,
             result_preview: Some("ok".to_string()),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 
@@ -521,6 +528,8 @@ mod tests {
             args_preview: None,
             result_preview: preview.map(ToString::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
 
         // 1 real successful tool + 3 synthetic placeholders (skipped,
@@ -593,6 +602,8 @@ mod tests {
                 args_preview: None,
                 result_preview: Some("(removed from context — skill covered this work)".into()),
                 file_path: None,
+                surgically_removed: Some(true),
+                original_tool_name: Some("read_file".to_string()),
             })
             .chain(std::iter::once(ToolCallRecord {
                 name: "git_show".to_string(),
@@ -604,6 +615,8 @@ mod tests {
                 args_preview: None,
                 result_preview: Some("diff".into()),
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             }))
             .collect();
 
@@ -616,5 +629,120 @@ mod tests {
             "no RepeatToolCall signal should be emitted for synthetic placeholders, got {:?}",
             eval.signals
         );
+    }
+
+    #[test]
+    fn tool_call_count_excludes_synthetic_placeholders() {
+        use astra_services::session_journal::{SURGICAL_REMOVAL_TOOL_NAME, ToolCallRecord};
+
+        // 3 real tool calls + 2 surgical removals = 5 records total,
+        // but tool_call_count should be 3 (only real).
+        let real = || ToolCallRecord {
+            name: "read_file".to_string(),
+            ok: true,
+            ms: 50,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(200),
+            args_preview: None,
+            result_preview: Some("content".into()),
+            file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
+        };
+        let surgical = || ToolCallRecord {
+            name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+            ok: true,
+            ms: 0,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(0),
+            args_preview: None,
+            result_preview: Some("(removed)".into()),
+            file_path: None,
+            surgically_removed: Some(true),
+            original_tool_name: Some("glob".to_string()),
+        };
+        let records = vec![real(), surgical(), real(), surgical(), real()];
+
+        let event = build_turn_evaluation_journal_event(
+            Some("sess-1"),
+            Some(1),
+            "test-model",
+            "do something",
+            &[],
+            &records,
+            0,
+            false,
+            0.5,
+            &TurnEvaluation {
+                success: true,
+                quality: 0.8,
+                confidence: 0.9,
+                signals: vec![],
+            },
+        );
+
+        // Extract tool_call_count from the metadata JSON.
+        let metadata = event.metadata.as_ref().expect("metadata should be present");
+        let tool_call_count = metadata["tool_call_count"].as_u64().unwrap();
+        assert_eq!(
+            tool_call_count, 3,
+            "tool_call_count must exclude synthetic placeholders, got {}",
+            tool_call_count
+        );
+    }
+
+    #[test]
+    fn is_synthetic_placeholder_via_flag() {
+        use astra_services::session_journal::{SURGICAL_REMOVAL_TOOL_NAME, ToolCallRecord};
+
+        // New-style: surgically_removed flag set
+        let flagged = ToolCallRecord {
+            name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+            ok: true,
+            ms: 0,
+            error: None,
+            input_bytes: None,
+            output_bytes: None,
+            args_preview: None,
+            result_preview: None,
+            file_path: None,
+            surgically_removed: Some(true),
+            original_tool_name: Some("bash".to_string()),
+        };
+        assert!(flagged.is_synthetic_placeholder());
+
+        // Backward-compat: legacy sentinel name only (no flag)
+        let legacy = ToolCallRecord {
+            name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+            ok: true,
+            ms: 0,
+            error: None,
+            input_bytes: None,
+            output_bytes: None,
+            args_preview: None,
+            result_preview: None,
+            file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
+        };
+        assert!(legacy.is_synthetic_placeholder());
+
+        // Normal tool call: neither flag nor sentinel name
+        let normal = ToolCallRecord {
+            name: "read_file".to_string(),
+            ok: true,
+            ms: 50,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(200),
+            args_preview: None,
+            result_preview: None,
+            file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
+        };
+        assert!(!normal.is_synthetic_placeholder());
     }
 }

--- a/rust/crates/astra-turn-core/src/headless_tool_journal.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_journal.rs
@@ -17,6 +17,8 @@ pub fn journal_record_duplicate_within_turn(
         args_preview,
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 
@@ -36,6 +38,8 @@ pub fn journal_record_cross_turn_cache_hit(
         args_preview,
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 
@@ -51,6 +55,8 @@ pub fn journal_record_unknown_tool(name: String, tool_elapsed_ms: u64) -> ToolCa
         args_preview: None,
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 
@@ -71,6 +77,8 @@ pub fn journal_record_blocked_tool(
         args_preview,
         result_preview: None,
         file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 
@@ -111,6 +119,8 @@ pub fn journal_record_executed_tool_call(
         args_preview,
         result_preview,
         file_path,
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 

--- a/rust/crates/astra-turn-core/src/lib.rs
+++ b/rust/crates/astra-turn-core/src/lib.rs
@@ -171,3 +171,4 @@ pub mod tool_registry_plugin;
 pub mod tool_registry_selection_edge_hints;
 pub mod turn_guard;
 pub mod ws_approval_gate;
+pub mod ws_user_prompt_gate;

--- a/rust/crates/astra-turn-core/src/tool_result_semantics.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_semantics.rs
@@ -640,6 +640,12 @@ if let Err(e) = writeln!(file, "{line}") {
             classify_tool_error("write_file", output),
             ToolErrorSeverity::HardError
         );
+
+        // github_create_issue timeout
+        assert_eq!(
+            classify_tool_error("github_create_issue", output),
+            ToolErrorSeverity::HardError
+        );
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/tool_result_semantics.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_semantics.rs
@@ -641,6 +641,12 @@ if let Err(e) = writeln!(file, "{line}") {
             ToolErrorSeverity::HardError
         );
 
+        // git_stash timeout
+        assert_eq!(
+            classify_tool_error("git_stash", output),
+            ToolErrorSeverity::HardError
+        );
+
         // github_create_issue timeout
         assert_eq!(
             classify_tool_error("github_create_issue", output),

--- a/rust/crates/astra-turn-core/src/ws_user_prompt_gate.rs
+++ b/rust/crates/astra-turn-core/src/ws_user_prompt_gate.rs
@@ -1,0 +1,188 @@
+//! WebSocket-based ask_user gate.
+//!
+//! Bridges the [`astra_tools::AskUserGate`] trait with the WebSocket protocol.
+//! Outbound prompt requests are sent via an `mpsc` channel that the WS handler
+//! drains during its polling loop. Inbound responses arrive through the shared
+//! §5.5 edge callback ledger.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use astra_tools::{AskUserDecision, AskUserGate, AskUserResponse};
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::Mutex as TokioMutex;
+use tokio::sync::mpsc;
+
+use crate::edge_ledger::{take_ledger_entry, user_prompt_callback_key};
+
+/// Default timeout for ask_user prompts (matches frontend 60s countdown).
+const USER_PROMPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// An outbound ask_user request to be forwarded over WebSocket.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserPromptOutboundRequest {
+    pub request_id: String,
+    pub question: String,
+    pub choices: Vec<String>,
+    pub default: Option<String>,
+    pub context: Option<String>,
+}
+
+/// [`AskUserGate`] implementation backed by WebSocket messaging.
+pub struct WebSocketUserPromptGate {
+    user_id: String,
+    edge_callback_ledger: Arc<TokioMutex<HashMap<String, Value>>>,
+    request_tx: mpsc::UnboundedSender<Value>,
+    timeout: Duration,
+}
+
+impl WebSocketUserPromptGate {
+    pub fn new(
+        user_id: String,
+        edge_callback_ledger: Arc<TokioMutex<HashMap<String, Value>>>,
+        request_tx: mpsc::UnboundedSender<Value>,
+    ) -> Self {
+        Self {
+            user_id,
+            edge_callback_ledger,
+            request_tx,
+            timeout: USER_PROMPT_TIMEOUT,
+        }
+    }
+}
+
+#[async_trait]
+impl AskUserGate for WebSocketUserPromptGate {
+    async fn request_user_input(
+        &self,
+        request_id: &str,
+        question: &str,
+        choices: &[String],
+        default: Option<&str>,
+        context: Option<&str>,
+    ) -> AskUserDecision {
+        let request = serde_json::json!({
+            "request_id": request_id,
+            "question": question,
+            "choices": choices,
+            "default": default,
+            "context": context,
+        });
+
+        if self.request_tx.send(request).is_err() {
+            return AskUserDecision::Error("WebSocket connection closed".into());
+        }
+
+        let key = user_prompt_callback_key(&self.user_id, request_id);
+        match take_ledger_entry(&self.edge_callback_ledger, &key, self.timeout).await {
+            Some(value) => {
+                let Some(answer) = value
+                    .get("answer")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+                else {
+                    return AskUserDecision::Error(
+                        "Invalid user prompt response: missing answer".into(),
+                    );
+                };
+                AskUserDecision::Answer(AskUserResponse {
+                    answer,
+                    was_custom: value
+                        .get("was_custom")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false),
+                })
+            }
+            None => AskUserDecision::Timeout,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn answered_via_ledger() {
+        let ledger = Arc::new(TokioMutex::new(HashMap::new()));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let gate = WebSocketUserPromptGate {
+            user_id: "u1".into(),
+            edge_callback_ledger: ledger.clone(),
+            request_tx: tx,
+            timeout: Duration::from_secs(5),
+        };
+
+        let ledger_bg = ledger.clone();
+        tokio::spawn(async move {
+            let req = rx.recv().await.unwrap();
+            assert_eq!(req["question"].as_str().unwrap(), "Continue?");
+            assert_eq!(req["choices"].as_array().unwrap().len(), 2);
+
+            let key = user_prompt_callback_key("u1", req["request_id"].as_str().unwrap());
+            let mut g = ledger_bg.lock().await;
+            g.insert(key, json!({"answer": "yes", "was_custom": false}));
+        });
+
+        let decision = gate
+            .request_user_input(
+                "req-1",
+                "Continue?",
+                &["yes".to_string(), "no".to_string()],
+                Some("yes"),
+                Some("Pick one"),
+            )
+            .await;
+        assert_eq!(
+            decision,
+            AskUserDecision::Answer(AskUserResponse {
+                answer: "yes".into(),
+                was_custom: false,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_when_no_response() {
+        let ledger = Arc::new(TokioMutex::new(HashMap::new()));
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let gate = WebSocketUserPromptGate {
+            user_id: "u1".into(),
+            edge_callback_ledger: ledger,
+            request_tx: tx,
+            timeout: Duration::from_millis(100),
+        };
+
+        let decision = gate
+            .request_user_input("req-2", "Continue?", &[], None, None)
+            .await;
+        assert_eq!(decision, AskUserDecision::Timeout);
+    }
+
+    #[tokio::test]
+    async fn channel_closed_returns_error() {
+        let ledger = Arc::new(TokioMutex::new(HashMap::new()));
+        let (tx, rx) = mpsc::unbounded_channel();
+        drop(rx);
+
+        let gate = WebSocketUserPromptGate {
+            user_id: "u1".into(),
+            edge_callback_ledger: ledger,
+            request_tx: tx,
+            timeout: Duration::from_secs(5),
+        };
+
+        let decision = gate
+            .request_user_input("req-3", "Continue?", &[], None, None)
+            .await;
+        assert_eq!(
+            decision,
+            AskUserDecision::Error("WebSocket connection closed".into())
+        );
+    }
+}

--- a/rust/crates/astra-turn-core/tests/journal_accuracy_e2e.rs
+++ b/rust/crates/astra-turn-core/tests/journal_accuracy_e2e.rs
@@ -22,7 +22,11 @@ fn real_tool(name: &str, ok: bool, ms: u64) -> ToolCallRecord {
         input_bytes: Some(100),
         output_bytes: Some(if ok { 500 } else { 0 }),
         args_preview: Some(format!("{name} args...")),
-        result_preview: Some(if ok { "ok result".into() } else { "error".into() }),
+        result_preview: Some(if ok {
+            "ok result".into()
+        } else {
+            "error".into()
+        }),
         file_path: None,
         surgically_removed: None,
         original_tool_name: None,
@@ -177,14 +181,22 @@ fn e2e_skill_interception_produces_accurate_journal_and_evaluation() {
     let turn = &events[0];
     assert_eq!(turn.event_type, JournalEventType::Turn);
     let tool_calls = turn.tool_calls.as_ref().unwrap();
-    assert_eq!(tool_calls.len(), 8, "all 8 records persisted for audit trail");
+    assert_eq!(
+        tool_calls.len(),
+        8,
+        "all 8 records persisted for audit trail"
+    );
 
     // Verify surgical removal records roundtrip correctly
     let surgical_records: Vec<_> = tool_calls
         .iter()
         .filter(|r| r.is_synthetic_placeholder())
         .collect();
-    assert_eq!(surgical_records.len(), 5, "5 surgical removals survived serde");
+    assert_eq!(
+        surgical_records.len(),
+        5,
+        "5 surgical removals survived serde"
+    );
     for rec in &surgical_records {
         assert_eq!(rec.surgically_removed, Some(true));
         assert!(rec.original_tool_name.is_some());
@@ -220,7 +232,10 @@ fn e2e_multi_turn_session_turn_numbering_consistent() {
 
     // Simulate 3 user turns with context assembly events
     for turn_num in 1..=3u32 {
-        let records = vec![real_tool("read_file", true, 30), real_tool("bash", true, 200)];
+        let records = vec![
+            real_tool("read_file", true, 30),
+            real_tool("bash", true, 200),
+        ];
 
         // Context assembly uses REPL turn number (the fix)
         let assembly = JournalEvent::context_assembly_recorded(
@@ -465,7 +480,10 @@ fn e2e_zero_tool_calls_conversational() {
 
     let events = session_journal::read_journal(session_id).unwrap();
     let turn = &events[0];
-    assert!(turn.tool_calls.is_none(), "no tool_calls field for empty turns");
+    assert!(
+        turn.tool_calls.is_none(),
+        "no tool_calls field for empty turns"
+    );
     assert_eq!(extract_tool_call_count(&events[1]), 0);
 }
 
@@ -676,11 +694,11 @@ fn e2e_all_tools_fail_with_surgical_removals_worst_case() {
     let session_id = "e2e-worst-case";
 
     let records = vec![
-        real_tool("bash", false, 200),       // real failure
-        real_tool("write_file", false, 30),   // real failure
-        surgical_removal("read_file"),        // not a failure
-        surgical_removal("glob"),             // not a failure
-        skipped_tool("grep"),                 // skill-routed, not a failure
+        real_tool("bash", false, 200),      // real failure
+        real_tool("write_file", false, 30), // real failure
+        surgical_removal("read_file"),      // not a failure
+        surgical_removal("glob"),           // not a failure
+        skipped_tool("grep"),               // skill-routed, not a failure
     ];
 
     let eval_event = build_turn_evaluation_journal_event(
@@ -690,9 +708,9 @@ fn e2e_all_tools_fail_with_surgical_removals_worst_case() {
         "do something",
         &[],
         &records,
-        3, // stalls
+        3,    // stalls
         true, // verdict warning
-        0.9, // high budget pressure
+        0.9,  // high budget pressure
         &make_eval(false, 0.1),
     );
 

--- a/rust/crates/astra-turn-core/tests/journal_accuracy_e2e.rs
+++ b/rust/crates/astra-turn-core/tests/journal_accuracy_e2e.rs
@@ -1,0 +1,832 @@
+//! End-to-end tests for journal telemetry accuracy.
+//!
+//! These tests simulate realistic agentic turn scenarios — including skill
+//! interception, surgical removal, multi-turn sessions, and various unhappy
+//! paths — then verify the entire pipeline from ToolCallRecord creation
+//! through journal persistence to turn evaluation.
+
+use astra_services::session_journal::{
+    self, JournalDirGuard, JournalEvent, JournalEventType, JournalWriter,
+    SURGICAL_REMOVAL_TOOL_NAME, ToolCallRecord,
+};
+use astra_turn_core::evaluation::build_turn_evaluation_journal_event;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn real_tool(name: &str, ok: bool, ms: u64) -> ToolCallRecord {
+    ToolCallRecord {
+        name: name.to_string(),
+        ok,
+        ms,
+        error: if ok { None } else { Some("tool error".into()) },
+        input_bytes: Some(100),
+        output_bytes: Some(if ok { 500 } else { 0 }),
+        args_preview: Some(format!("{name} args...")),
+        result_preview: Some(if ok { "ok result".into() } else { "error".into() }),
+        file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
+    }
+}
+
+fn surgical_removal(original_name: &str) -> ToolCallRecord {
+    ToolCallRecord {
+        name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+        ok: true,
+        ms: 0,
+        error: None,
+        input_bytes: None,
+        output_bytes: Some(0),
+        args_preview: None,
+        result_preview: Some("(removed from context — skill covered this work)".into()),
+        file_path: None,
+        surgically_removed: Some(true),
+        original_tool_name: Some(original_name.to_string()),
+    }
+}
+
+fn legacy_surgical_removal() -> ToolCallRecord {
+    // Old-format record: no surgically_removed flag, just the sentinel name
+    ToolCallRecord {
+        name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+        ok: true,
+        ms: 0,
+        error: None,
+        input_bytes: None,
+        output_bytes: Some(0),
+        args_preview: None,
+        result_preview: Some("(removed from context — skill covered this work)".into()),
+        file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
+    }
+}
+
+fn skipped_tool(name: &str) -> ToolCallRecord {
+    ToolCallRecord {
+        name: name.to_string(),
+        ok: false,
+        ms: 0,
+        error: None,
+        input_bytes: None,
+        output_bytes: Some(0),
+        args_preview: None,
+        result_preview: Some("Skipped: skill routed".into()),
+        file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
+    }
+}
+
+fn deferred_tool(name: &str) -> ToolCallRecord {
+    ToolCallRecord {
+        name: name.to_string(),
+        ok: false,
+        ms: 0,
+        error: None,
+        input_bytes: None,
+        output_bytes: Some(0),
+        args_preview: None,
+        result_preview: Some("Deferred: skill invoked".into()),
+        file_path: None,
+        surgically_removed: None,
+        original_tool_name: None,
+    }
+}
+
+fn make_eval(success: bool, quality: f64) -> astra_turn_core::evaluation::TurnEvaluation {
+    astra_turn_core::evaluation::TurnEvaluation {
+        success,
+        quality,
+        confidence: 0.8,
+        signals: vec![],
+    }
+}
+
+fn extract_tool_call_count(event: &JournalEvent) -> usize {
+    event
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("tool_call_count"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize
+}
+
+// ─── E2E: Full pipeline — skill interception → journal → evaluation ─────────
+
+#[test]
+fn e2e_skill_interception_produces_accurate_journal_and_evaluation() {
+    // Simulates a real turn where a skill (e.g. git review) intercepts
+    // some parallel tool calls. The agent originally requested 8 tool calls,
+    // but the skill handled 5 of them. 3 real calls remain + 5 surgical removals.
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-skill-interception";
+
+    // --- Phase 1: Build tool call records as agentic_tool_interception would ---
+    let records = vec![
+        // Skill result (real call — the skill itself)
+        real_tool("skill", true, 3200),
+        // Surgical removals for the parallel calls the skill covered
+        surgical_removal("read_file"),
+        surgical_removal("read_file"),
+        surgical_removal("glob"),
+        surgical_removal("grep"),
+        surgical_removal("git_show"),
+        // Real calls that ran alongside the skill
+        real_tool("write_file", true, 45),
+        real_tool("bash", true, 120),
+    ];
+
+    // --- Phase 2: Write turn event with tool_calls to journal ---
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("gpt-5.4"),
+        "Review the PR changes",
+        "I've reviewed the PR...",
+        records.len() as u32,
+        50000,
+        2000,
+        5000,
+    )
+    .with_tool_calls(records.clone());
+    writer.append(&turn_event).unwrap();
+
+    // --- Phase 3: Build evaluation (as evaluation.rs would) ---
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "gpt-5.4",
+        "Review the PR changes",
+        &["skill".into(), "write_file".into(), "bash".into()],
+        &records,
+        0,
+        false,
+        0.2,
+        &make_eval(true, 0.85),
+    );
+    writer.append(&eval_event).unwrap();
+
+    // --- Phase 4: Read back and verify ---
+    let events = session_journal::read_journal(session_id).unwrap();
+    assert_eq!(events.len(), 2, "should have turn + evaluation events");
+
+    // Verify turn event has all 8 records (including surgical removals for audit)
+    let turn = &events[0];
+    assert_eq!(turn.event_type, JournalEventType::Turn);
+    let tool_calls = turn.tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 8, "all 8 records persisted for audit trail");
+
+    // Verify surgical removal records roundtrip correctly
+    let surgical_records: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| r.is_synthetic_placeholder())
+        .collect();
+    assert_eq!(surgical_records.len(), 5, "5 surgical removals survived serde");
+    for rec in &surgical_records {
+        assert_eq!(rec.surgically_removed, Some(true));
+        assert!(rec.original_tool_name.is_some());
+    }
+
+    // Verify real records are intact
+    let real_records: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| !r.is_synthetic_placeholder())
+        .collect();
+    assert_eq!(real_records.len(), 3, "3 real tool calls");
+    assert!(real_records.iter().all(|r| r.surgically_removed.is_none()));
+
+    // Verify evaluation event has correct tool_call_count (EXCLUDES synthetics)
+    let eval = &events[1];
+    assert_eq!(eval.event_type, JournalEventType::TurnEvaluation);
+    let tool_call_count = extract_tool_call_count(eval);
+    assert_eq!(
+        tool_call_count, 3,
+        "tool_call_count must be 3 (only real calls), not 8"
+    );
+}
+
+// ─── E2E: Multi-turn session with correct turn numbering ────────────────────
+
+#[test]
+fn e2e_multi_turn_session_turn_numbering_consistent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-multi-turn";
+
+    let writer = JournalWriter::new(session_id).unwrap();
+
+    // Simulate 3 user turns with context assembly events
+    for turn_num in 1..=3u32 {
+        let records = vec![real_tool("read_file", true, 30), real_tool("bash", true, 200)];
+
+        // Context assembly uses REPL turn number (the fix)
+        let assembly = JournalEvent::context_assembly_recorded(
+            Some(session_id),
+            turn_num, // <-- This is the REPL counter, not internal loop counter
+            serde_json::json!({
+                "turn_id": format!("turn-{turn_num}"),
+                "system_prompt_tokens": 1200,
+                "tools_available": 15,
+            }),
+        );
+        writer.append(&assembly).unwrap();
+
+        // Turn event
+        let turn_event = JournalEvent::turn(
+            Some(session_id),
+            turn_num,
+            Some("gpt-5.4"),
+            &format!("User message {turn_num}"),
+            &format!("Response {turn_num}"),
+            records.len() as u32,
+            30000 + turn_num as u64 * 5000,
+            1000,
+            2000,
+        )
+        .with_tool_calls(records.clone());
+        writer.append(&turn_event).unwrap();
+
+        // Turn evaluation
+        let eval = build_turn_evaluation_journal_event(
+            Some(session_id),
+            Some(turn_num),
+            "gpt-5.4",
+            &format!("User message {turn_num}"),
+            &["read_file".into(), "bash".into()],
+            &records,
+            0,
+            false,
+            0.1 * turn_num as f64,
+            &make_eval(true, 0.9 - turn_num as f64 * 0.1),
+        );
+        writer.append(&eval).unwrap();
+    }
+
+    // Read back and verify turn numbering consistency
+    let events = session_journal::read_journal(session_id).unwrap();
+    assert_eq!(events.len(), 9, "3 turns × 3 events each");
+
+    // Verify all turn numbers are 1, 2, 3 (never internal loop counters like 5, 10, 15)
+    let turn_numbers: Vec<u32> = events.iter().filter_map(|e| e.turn).collect();
+    assert_eq!(
+        turn_numbers,
+        vec![1, 1, 1, 2, 2, 2, 3, 3, 3],
+        "all events should have REPL turn numbers 1-3, not internal loop counters"
+    );
+
+    // Verify context_assembly turn IDs match their turn numbers
+    let assemblies: Vec<_> = events
+        .iter()
+        .filter(|e| e.event_type == JournalEventType::ContextAssemblyRecorded)
+        .collect();
+    assert_eq!(assemblies.len(), 3);
+    for (i, asm) in assemblies.iter().enumerate() {
+        let expected_turn = (i + 1) as u32;
+        assert_eq!(asm.turn, Some(expected_turn));
+        let trace = asm.context_assembly_trace.as_ref().unwrap();
+        let turn_id = trace["turn_id"].as_str().unwrap();
+        assert_eq!(turn_id, format!("turn-{expected_turn}"));
+    }
+}
+
+// ─── Unhappy path: mixed legacy + new surgical removal records ──────────────
+
+#[test]
+fn e2e_mixed_legacy_and_new_surgical_records_both_filtered() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-mixed-legacy";
+
+    // Simulate a scenario where journal has been migrated mid-session:
+    // some records use old sentinel-name-only, others use new flag.
+    let records = vec![
+        real_tool("read_file", true, 30),
+        legacy_surgical_removal(), // old format: no flag, just name
+        surgical_removal("glob"),  // new format: flag + original_tool_name
+        real_tool("bash", true, 100),
+        skipped_tool("grep"),      // skill-routed skip
+        deferred_tool("git_show"), // skill-routed defer
+        real_tool("write_file", true, 50),
+    ];
+
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("qwen3.6-plus"),
+        "Fix the bug",
+        "Done.",
+        7,
+        40000,
+        1500,
+        3000,
+    )
+    .with_tool_calls(records.clone());
+    writer.append(&turn_event).unwrap();
+
+    // Build evaluation
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "qwen3.6-plus",
+        "Fix the bug",
+        &[],
+        &records,
+        0,
+        false,
+        0.3,
+        &make_eval(true, 0.7),
+    );
+    writer.append(&eval_event).unwrap();
+
+    // Read back
+    let events = session_journal::read_journal(session_id).unwrap();
+    let turn = &events[0];
+    let tool_calls = turn.tool_calls.as_ref().unwrap();
+
+    // ALL synthetic types should be detected
+    let real: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| !r.is_synthetic_placeholder())
+        .collect();
+    let synthetic: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| r.is_synthetic_placeholder())
+        .collect();
+    assert_eq!(real.len(), 3, "3 real: read_file, bash, write_file");
+    assert_eq!(
+        synthetic.len(),
+        4,
+        "4 synthetic: legacy surgical, new surgical, skipped, deferred"
+    );
+
+    // tool_call_count in evaluation should match real count
+    let eval = &events[1];
+    assert_eq!(extract_tool_call_count(eval), 3);
+}
+
+// ─── Unhappy path: ALL records are surgical removals (edge case) ────────────
+
+#[test]
+fn e2e_all_surgical_removals_zero_real_tool_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-all-surgical";
+
+    // Edge case: skill handled everything, all parallel calls were removed
+    let records = vec![
+        surgical_removal("read_file"),
+        surgical_removal("glob"),
+        surgical_removal("grep"),
+        surgical_removal("git_show"),
+    ];
+
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("gpt-5.4"),
+        "Review code",
+        "Reviewed.",
+        4,
+        20000,
+        500,
+        1000,
+    )
+    .with_tool_calls(records.clone());
+    writer.append(&turn_event).unwrap();
+
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "gpt-5.4",
+        "Review code",
+        &[],
+        &records,
+        0,
+        false,
+        0.1,
+        &make_eval(true, 0.5),
+    );
+    writer.append(&eval_event).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+    let eval = &events[1];
+
+    // tool_call_count should be 0, not 4
+    assert_eq!(
+        extract_tool_call_count(eval),
+        0,
+        "all surgical removals → tool_call_count must be 0"
+    );
+}
+
+// ─── Unhappy path: zero tool calls (conversational turn) ────────────────────
+
+#[test]
+fn e2e_zero_tool_calls_conversational() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-no-tools";
+
+    let records: Vec<ToolCallRecord> = vec![];
+
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("gpt-5.4"),
+        "Hello!",
+        "Hi there!",
+        0,
+        5000,
+        200,
+        500,
+    );
+    // No .with_tool_calls() — empty turns should not have the field
+    writer.append(&turn_event).unwrap();
+
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "gpt-5.4",
+        "Hello!",
+        &[],
+        &records,
+        0,
+        false,
+        0.0,
+        &make_eval(true, 0.6),
+    );
+    writer.append(&eval_event).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+    let turn = &events[0];
+    assert!(turn.tool_calls.is_none(), "no tool_calls field for empty turns");
+    assert_eq!(extract_tool_call_count(&events[1]), 0);
+}
+
+// ─── Unhappy path: backward compat — deserialize legacy JSONL without new fields
+
+#[test]
+fn e2e_legacy_journal_without_surgical_fields_deserializes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-legacy-compat";
+
+    // Write raw JSONL as it would appear from an old version (no surgical fields)
+    let legacy_turn = serde_json::json!({
+        "type": "turn",
+        "ts": "2026-04-17T07:20:00Z",
+        "session_id": session_id,
+        "turn": 1,
+        "model": "MiniMax-M2.7",
+        "user_input": "Check the files",
+        "assistant_output": "Found issues.",
+        "tool_count": 3,
+        "tokens_in": 70000,
+        "tokens_out": 7700,
+        "duration_ms": 8000,
+        "tool_calls": [
+            {
+                "name": "read_file",
+                "ok": true,
+                "ms": 30,
+                "output_bytes": 500
+            },
+            {
+                "name": "(surgically_removed)",
+                "ok": true,
+                "ms": 0,
+                "output_bytes": 0,
+                "result_preview": "(removed from context — skill covered this work)"
+            },
+            {
+                "name": "bash",
+                "ok": false,
+                "ms": 100,
+                "error": "command not found"
+            }
+        ]
+    });
+
+    let path = tmp.path().join(format!("{session_id}.jsonl"));
+    std::fs::write(&path, format!("{}\n", legacy_turn)).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+    assert_eq!(events.len(), 1);
+
+    let tool_calls = events[0].tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 3);
+
+    // Legacy surgical removal should still be detected as synthetic
+    assert!(tool_calls[1].is_synthetic_placeholder());
+    // surgically_removed field should be None (not in legacy JSON)
+    assert_eq!(tool_calls[1].surgically_removed, None);
+    assert_eq!(tool_calls[1].original_tool_name, None);
+
+    // Real calls should not be synthetic
+    assert!(!tool_calls[0].is_synthetic_placeholder());
+    assert!(!tool_calls[2].is_synthetic_placeholder());
+
+    // Build evaluation using the deserialized records — should count correctly
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "MiniMax-M2.7",
+        "Check the files",
+        &[],
+        tool_calls,
+        0,
+        false,
+        0.3,
+        &make_eval(false, 0.4),
+    );
+    // Only 2 real calls (read_file OK + bash FAIL), not 3
+    assert_eq!(
+        extract_tool_call_count(&eval_event),
+        2,
+        "legacy surgical removal must still be excluded from tool_call_count"
+    );
+}
+
+// ─── E2E: Realistic session 3f4389fe scenario (the original bug report) ─────
+
+#[test]
+fn e2e_session_3f4389fe_scenario_turn1_surgical_removal_accuracy() {
+    // Recreates the exact scenario from session 3f4389fe turn 1:
+    // MiniMax-M2.7 model, 21 tool calls where 9 were surgical removals.
+    // Before the fix: tool_call_count was 21. After fix: should be 12.
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-3f4389fe-turn1";
+
+    let writer = JournalWriter::new(session_id).unwrap();
+
+    // Build the 21 records: 12 real + 9 surgical
+    let mut records = Vec::new();
+    // 12 real tool calls (mix of tools a code review session would use)
+    for tool in &[
+        "skill",
+        "read_file",
+        "read_file",
+        "read_file",
+        "glob",
+        "grep",
+        "git_show",
+        "git_show",
+        "bash",
+        "write_file",
+        "write_file",
+        "bash",
+    ] {
+        records.push(real_tool(tool, true, 50));
+    }
+    // 9 surgical removals (parallel calls the skill handled)
+    for tool in &[
+        "read_file",
+        "read_file",
+        "read_file",
+        "glob",
+        "glob",
+        "grep",
+        "grep",
+        "git_show",
+        "git_show",
+    ] {
+        records.push(surgical_removal(tool));
+    }
+    assert_eq!(records.len(), 21);
+
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("MiniMax-M2.7"),
+        "Review the PR changes and provide feedback",
+        "I've reviewed all changes...",
+        21,
+        70000,
+        7700,
+        8000,
+    )
+    .with_tool_calls(records.clone());
+    writer.append(&turn_event).unwrap();
+
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "MiniMax-M2.7",
+        "Review the PR changes and provide feedback",
+        &[
+            "skill".into(),
+            "read_file".into(),
+            "glob".into(),
+            "grep".into(),
+            "git_show".into(),
+            "bash".into(),
+            "write_file".into(),
+        ],
+        &records,
+        0,
+        false,
+        0.2,
+        &make_eval(true, 0.85),
+    );
+    writer.append(&eval_event).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+
+    // Journal should persist ALL 21 records for audit
+    let tool_calls = events[0].tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 21);
+
+    // But evaluation tool_call_count should be 12 (only real)
+    let eval = &events[1];
+    assert_eq!(
+        extract_tool_call_count(eval),
+        12,
+        "session 3f4389fe turn 1: 21 total records but only 12 real tool calls"
+    );
+
+    // Verify original_tool_name is preserved for analytics
+    let surgical: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| r.surgically_removed == Some(true))
+        .collect();
+    assert_eq!(surgical.len(), 9);
+    let original_names: Vec<_> = surgical
+        .iter()
+        .filter_map(|r| r.original_tool_name.as_deref())
+        .collect();
+    assert!(original_names.contains(&"read_file"));
+    assert!(original_names.contains(&"glob"));
+    assert!(original_names.contains(&"grep"));
+    assert!(original_names.contains(&"git_show"));
+}
+
+// ─── Unhappy path: all tool calls fail (worst case turn) ────────────────────
+
+#[test]
+fn e2e_all_tools_fail_with_surgical_removals_worst_case() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-worst-case";
+
+    let records = vec![
+        real_tool("bash", false, 200),       // real failure
+        real_tool("write_file", false, 30),   // real failure
+        surgical_removal("read_file"),        // not a failure
+        surgical_removal("glob"),             // not a failure
+        skipped_tool("grep"),                 // skill-routed, not a failure
+    ];
+
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "test-model",
+        "do something",
+        &[],
+        &records,
+        3, // stalls
+        true, // verdict warning
+        0.9, // high budget pressure
+        &make_eval(false, 0.1),
+    );
+
+    // tool_call_count: only 2 real calls (both failed)
+    assert_eq!(
+        extract_tool_call_count(&eval_event),
+        2,
+        "only 2 real tool calls (both failed) — surgical/skipped excluded"
+    );
+
+    // Verify the evaluation event still has correct metadata structure
+    let meta = eval_event.metadata.as_ref().unwrap();
+    assert_eq!(meta["stall_count"], 3);
+    assert_eq!(meta["verdict_warning"], true);
+    assert!(meta["budget_pressure"].as_f64().unwrap() > 0.8);
+    assert_eq!(meta["success"], false);
+}
+
+// ─── Unhappy path: Unicode in tool names and error messages ─────────────────
+
+#[test]
+fn e2e_unicode_in_tool_records_survives_journal_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-unicode";
+
+    let records = vec![
+        ToolCallRecord {
+            name: "bash".to_string(),
+            ok: false,
+            ms: 50,
+            error: Some("命令未找到: 科技风格".into()),
+            input_bytes: Some(200),
+            output_bytes: Some(0),
+            args_preview: Some("echo '在tmp目录下面生成文档'".into()),
+            result_preview: Some("错误：路径不存在 /tmp/科技".into()),
+            file_path: Some("/tmp/科技风格/index.html".into()),
+            surgically_removed: None,
+            original_tool_name: None,
+        },
+        surgical_removal("read_file"),
+    ];
+
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("qwen3.6-plus"),
+        "在tmp目录下面生成文档",
+        "已完成",
+        2,
+        95000,
+        5900,
+        10000,
+    )
+    .with_tool_calls(records);
+    writer.append(&turn_event).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+    let tool_calls = events[0].tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 2);
+
+    // Verify Chinese characters survived JSON roundtrip
+    assert_eq!(tool_calls[0].error.as_deref(), Some("命令未找到: 科技风格"));
+    assert_eq!(
+        tool_calls[0].file_path.as_deref(),
+        Some("/tmp/科技风格/index.html")
+    );
+    assert!(tool_calls[1].is_synthetic_placeholder());
+}
+
+// ─── Unhappy path: very large number of surgical removals ───────────────────
+
+#[test]
+fn e2e_many_surgical_removals_performance_and_accuracy() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "e2e-many-removals";
+
+    // Extreme case: 50 surgical removals + 5 real calls
+    let mut records: Vec<ToolCallRecord> = (0..50)
+        .map(|i| surgical_removal(&format!("tool_{i}")))
+        .collect();
+    for i in 0..5 {
+        records.push(real_tool(&format!("real_tool_{i}"), true, 100));
+    }
+    assert_eq!(records.len(), 55);
+
+    let writer = JournalWriter::new(session_id).unwrap();
+    let turn_event = JournalEvent::turn(
+        Some(session_id),
+        1,
+        Some("gpt-5.4"),
+        "Complex task",
+        "Done",
+        55,
+        100000,
+        5000,
+        15000,
+    )
+    .with_tool_calls(records.clone());
+    writer.append(&turn_event).unwrap();
+
+    let eval_event = build_turn_evaluation_journal_event(
+        Some(session_id),
+        Some(1),
+        "gpt-5.4",
+        "Complex task",
+        &[],
+        &records,
+        0,
+        false,
+        0.5,
+        &make_eval(true, 0.7),
+    );
+    writer.append(&eval_event).unwrap();
+
+    let events = session_journal::read_journal(session_id).unwrap();
+    let tool_calls = events[0].tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 55, "all 55 records persisted");
+
+    let surgical: Vec<_> = tool_calls
+        .iter()
+        .filter(|r| r.is_synthetic_placeholder())
+        .collect();
+    assert_eq!(surgical.len(), 50);
+
+    // Verify each surgical removal preserved its original name
+    for (i, rec) in surgical.iter().enumerate() {
+        assert_eq!(
+            rec.original_tool_name.as_deref(),
+            Some(format!("tool_{i}").as_str()),
+        );
+    }
+
+    assert_eq!(extract_tool_call_count(&events[1]), 5);
+}

--- a/rust/crates/runtime/src/server/chat_handlers.rs
+++ b/rust/crates/runtime/src/server/chat_handlers.rs
@@ -461,6 +461,7 @@ mod tests {
             forward_headers: std::collections::HashMap::new(),
             max_candidates: 3,
             explain: true,
+            interactive_client: false,
         });
         let obj = payload.as_object().unwrap();
         assert!(obj.contains_key("messages"));
@@ -499,6 +500,7 @@ mod tests {
             forward_headers: std::collections::HashMap::new(),
             max_candidates: 3,
             explain: true,
+            interactive_client: false,
         });
         let obj = payload.as_object().unwrap();
         assert_eq!(obj["allow_skills"], serde_json::json!(["analyze", "plan"]));

--- a/rust/crates/runtime/src/server/mod.rs
+++ b/rust/crates/runtime/src/server/mod.rs
@@ -58,6 +58,7 @@ pub mod worktree_isolation;
 pub mod ws_approval_gate;
 mod ws_handler;
 pub mod ws_progress_callback;
+pub mod ws_user_prompt_gate;
 
 use self::{
     bridge_prep::prepare_chat_turn_bridge_body,

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -2721,6 +2721,8 @@ mod tests {
             args_preview: None,
             result_preview: Some("clean".into()),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         });
 
         let event = build_runtime_turn_evaluation_event("session-1", "server_runtime", &state);

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -695,6 +695,10 @@ pub struct AgenticRunLifecycleService {
     /// Per-run approval request channel receivers (Phase E).
     /// Key: run_id → receiver that the WS handler drains.
     approval_channels: Arc<TokioMutex<HashMap<String, mpsc::UnboundedReceiver<serde_json::Value>>>>,
+    /// Per-run ask_user prompt channel receivers.
+    /// Key: run_id → receiver that the WS handler drains.
+    user_prompt_channels:
+        Arc<TokioMutex<HashMap<String, mpsc::UnboundedReceiver<serde_json::Value>>>>,
     /// Per-run progress event channel receivers (Phase F.3).
     /// Key: run_id → receiver that the WS handler drains.
     progress_channels: Arc<TokioMutex<HashMap<String, mpsc::UnboundedReceiver<ProgressEvent>>>>,
@@ -719,6 +723,7 @@ impl AgenticRunLifecycleService {
             skill_service: None,
             server_skill_resolver_cache: std::sync::OnceLock::new(),
             approval_channels: Arc::new(TokioMutex::new(HashMap::new())),
+            user_prompt_channels: Arc::new(TokioMutex::new(HashMap::new())),
             progress_channels: Arc::new(TokioMutex::new(HashMap::new())),
         }
     }
@@ -958,7 +963,8 @@ impl AgenticRunLifecycleService {
         .with_model(request.model.clone())
         .with_edge_tools(edge_tools)
         .with_edge_profile(edge_profile)
-        .with_edge_callback_ledger(self.edge_callback_ledger.clone());
+        .with_edge_callback_ledger(self.edge_callback_ledger.clone())
+        .with_interactive_client(request.interactive_client);
 
         if let Some(pool) = &self.shared_pool {
             builder = builder.with_pool(pool.clone());
@@ -1392,6 +1398,20 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 .await
                 .insert(run_id.clone(), approval_rx);
 
+            if request.interactive_client {
+                let (user_prompt_tx, user_prompt_rx) = mpsc::unbounded_channel();
+                let user_prompt_gate = super::ws_user_prompt_gate::WebSocketUserPromptGate::new(
+                    user_id.clone(),
+                    self.edge_callback_ledger.clone(),
+                    user_prompt_tx,
+                );
+                executor.set_ask_user_gate(std::sync::Arc::new(user_prompt_gate));
+                self.user_prompt_channels
+                    .lock()
+                    .await
+                    .insert(run_id.clone(), user_prompt_rx);
+            }
+
             // ── Phase F.3: Wire WebSocket progress callback ─────────
             let (progress_tx, progress_rx) = mpsc::unbounded_channel();
             let progress_cb =
@@ -1407,6 +1427,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
 
         // Clone handles we need inside the spawned task.
         let bg_approval_channels = self.approval_channels.clone();
+        let bg_user_prompt_channels = self.user_prompt_channels.clone();
         let bg_progress_channels = self.progress_channels.clone();
         let runs = self.runs_handle();
         let run_engine = self.run_engine.clone();
@@ -1423,6 +1444,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
 
             // Clean up channels for this run.
             bg_approval_channels.lock().await.remove(&bg_run_id);
+            bg_user_prompt_channels.lock().await.remove(&bg_run_id);
             bg_progress_channels.lock().await.remove(&bg_run_id);
             let terminal_events = terminal_events_for_persistence(&events);
 
@@ -1737,6 +1759,18 @@ impl RunLifecycleService for AgenticRunLifecycleService {
 
     async fn drain_approval_requests(&self, run_id: &str) -> Vec<serde_json::Value> {
         let mut channels = self.approval_channels.lock().await;
+        let Some(rx) = channels.get_mut(run_id) else {
+            return vec![];
+        };
+        let mut requests = Vec::new();
+        while let Ok(req) = rx.try_recv() {
+            requests.push(req);
+        }
+        requests
+    }
+
+    async fn drain_user_prompt_requests(&self, run_id: &str) -> Vec<serde_json::Value> {
+        let mut channels = self.user_prompt_channels.lock().await;
         let Some(rx) = channels.get_mut(run_id) else {
             return vec![];
         };
@@ -2461,6 +2495,7 @@ mod tests {
             forward_headers: HashMap::new(),
             max_candidates: 5,
             explain: false,
+            interactive_client: false,
         }
     }
 
@@ -3078,6 +3113,7 @@ mod tests {
             forward_headers: HashMap::new(),
             max_candidates: 5,
             explain: false,
+            interactive_client: false,
         };
         let tools = AgenticRunLifecycleService::extract_edge_tools(&req);
         assert_eq!(tools.len(), 1);
@@ -3108,6 +3144,7 @@ mod tests {
             forward_headers: HashMap::new(),
             max_candidates: 5,
             explain: false,
+            interactive_client: false,
         };
         let profile = AgenticRunLifecycleService::extract_edge_profile(&req);
         assert_eq!(profile["cwd"], "/tmp");

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -83,6 +83,8 @@ pub struct ServerAgenticLoopHost {
     selection_confidence: f64,
     /// `true` when tools were auto-populated from astra-tools (no CLI connected).
     server_side_tools: bool,
+    /// `true` when the connected client can answer ask_user prompts.
+    interactive_client: bool,
 
     // ── Tool execution (used by RunLifecycleService wiring) ──
     #[allow(dead_code)] // needed once RunLifecycleService uses ledger-based tool execution
@@ -113,6 +115,7 @@ pub struct ServerAgenticLoopHostBuilder {
     user_id: String,
     session_id: String,
     progress_broadcaster: Option<Arc<crate::orchestration::ProgressBroadcaster>>,
+    interactive_client: bool,
 }
 
 impl ServerAgenticLoopHostBuilder {
@@ -134,6 +137,7 @@ impl ServerAgenticLoopHostBuilder {
             user_id,
             session_id,
             progress_broadcaster: None,
+            interactive_client: false,
         }
     }
 
@@ -178,6 +182,11 @@ impl ServerAgenticLoopHostBuilder {
         self
     }
 
+    pub fn with_interactive_client(mut self, interactive_client: bool) -> Self {
+        self.interactive_client = interactive_client;
+        self
+    }
+
     pub fn build(self) -> ServerAgenticLoopHost {
         // When no edge tools are provided (web-only mode), populate with
         // server-side tool schemas from astra-tools so the LLM knows what's available.
@@ -210,6 +219,7 @@ impl ServerAgenticLoopHostBuilder {
             valid_tools,
             selection_confidence: self.selection_confidence,
             server_side_tools,
+            interactive_client: self.interactive_client,
             edge_callback_ledger: self.edge_callback_ledger,
             user_id: self.user_id,
             session_id: self.session_id,
@@ -220,6 +230,14 @@ impl ServerAgenticLoopHostBuilder {
 }
 
 impl ServerAgenticLoopHost {
+    fn turn_interaction_mode(&self) -> TurnInteractionMode {
+        if self.interactive_client {
+            TurnInteractionMode::Prompt
+        } else {
+            TurnInteractionMode::Headless
+        }
+    }
+
     fn push_reasoning_events(emitted_events: &mut Vec<Value>, reasoning: &str) {
         if reasoning.is_empty() {
             return;
@@ -818,9 +836,8 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
         merge_deprioritized_tools_into_restricted(&state.turn_guard, &mut state.restricted_tools);
         let mut effective_restricted = state.restricted_tools.clone();
         effective_restricted.extend(self.effective_allowlist_restrictions(state));
-        effective_restricted.extend(interaction_scoped_tool_restrictions(
-            TurnInteractionMode::Headless,
-        ));
+        let interaction_mode = self.turn_interaction_mode();
+        effective_restricted.extend(interaction_scoped_tool_restrictions(interaction_mode));
         let visible_tools = self.filtered_turn_tools(&effective_restricted);
         self.sync_valid_tools_to_visible(&visible_tools);
 
@@ -869,7 +886,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
         // Annotate tool schemas with cache_control for Anthropic.
         annotate_tool_schemas_for_caching(&mut final_tools, &cache_cfg);
         state.last_turn_policy =
-            TurnInteractionPolicy::from_tool_schemas(TurnInteractionMode::Headless, &final_tools);
+            TurnInteractionPolicy::from_tool_schemas(interaction_mode, &final_tools);
 
         let llm_cancel = llm_cancel_for_state(state);
 
@@ -1789,6 +1806,45 @@ mod tests {
         );
         assert_eq!(policy.evidence_tool_names, policy.visible_tool_names);
         assert!(!policy.allow_ask_user);
+    }
+
+    #[test]
+    fn interactive_turn_policy_keeps_ask_user_in_final_tools() {
+        let host = ServerAgenticLoopHostBuilder::new(
+            mock_matrixone(),
+            mock_encryptor(),
+            "u".to_string(),
+            "s".to_string(),
+        )
+        .with_edge_tools(sample_edge_tools_with_ask_user())
+        .with_interactive_client(true)
+        .build();
+
+        let mut state = create_test_state();
+        merge_deprioritized_tools_into_restricted(&state.turn_guard, &mut state.restricted_tools);
+        let mut effective_restricted = state.restricted_tools.clone();
+        effective_restricted.extend(interaction_scoped_tool_restrictions(
+            host.turn_interaction_mode(),
+        ));
+        let visible_tools = host.filtered_turn_tools(&effective_restricted);
+        let final_tools =
+            prune_tool_schemas(&visible_tools, crate::prompts::CompactionTier::Normal);
+        let policy =
+            TurnInteractionPolicy::from_tool_schemas(host.turn_interaction_mode(), &final_tools);
+
+        assert_eq!(
+            policy.visible_tool_names,
+            vec![
+                "bash".to_string(),
+                "read_file".to_string(),
+                "ask_user".to_string()
+            ]
+        );
+        assert_eq!(
+            policy.evidence_tool_names,
+            vec!["bash".to_string(), "read_file".to_string()]
+        );
+        assert!(policy.allow_ask_user);
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -1327,7 +1327,7 @@ mod tests {
                 .contains("rollback_database_snapshots")
         );
         assert!(host.valid_tool_names().contains("memory_store"));
-        assert!(!host.valid_tool_names().contains("multi_edit"));
+        assert!(host.valid_tool_names().contains("multi_edit"));
         assert!(!host.valid_tool_names().contains("powershell"));
         assert!(host.emitted_events.is_empty());
     }

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -1280,6 +1280,7 @@ impl ServerToolExecutor {
             "git_blame" => self.default_executor.execute("git_blame", args).await,
             "symbols" => self.default_executor.execute("symbols", args).await,
             "git_commit" => self.default_executor.execute("git_commit", args).await,
+            "git_stash" => self.default_executor.execute("git_stash", args).await,
             "git_revert_commit" => {
                 self.default_executor
                     .execute("git_revert_commit", args)
@@ -1327,7 +1328,7 @@ impl ServerToolExecutor {
                      multi_edit, list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
                      rollback_session_state, task_*, sleep, tool_search, mo_query, rollback_database_snapshots, \
                      grep, glob, git_status, git_diff, git_log, git_file_history, git_contributors, git_log_search, \
-                     git_show, git_blame, symbols, git_commit, git_revert_commit, github_list_prs, github_get_pr, \
+                     git_show, git_blame, symbols, git_commit, git_stash, git_revert_commit, github_list_prs, github_get_pr, \
                      github_ci_status, github_list_issues, github_get_issue, github_repo_stats, github_create_issue, memory_*, web_fetch, \
                      web_search, ask_user"
             )),
@@ -4076,6 +4077,34 @@ esac
         assert!(
             contributors.contains("## Top Contributors"),
             "{contributors}"
+        );
+    }
+
+    #[tokio::test]
+    async fn git_stash_is_available_in_server_mode() {
+        let (exec, dir) = test_executor();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+
+        let stash_list = exec.execute("git_stash", &json!({"action": "list"})).await;
+        assert!(
+            stash_list.contains("No stashes found")
+                || stash_list.contains("stash@")
+                || stash_list.is_empty(),
+            "{stash_list}"
         );
     }
 

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant, SystemTime};
 use serde_json::{Value, json};
 
 use astra_tools::executor::DefaultToolExecutor;
-use astra_tools::{ToolContext, ToolExecutor};
+use astra_tools::{AskUserDecision, AskUserGate, ToolContext, ToolExecutor};
 use async_trait::async_trait;
 
 use crate::tool_sandbox::{
@@ -46,6 +46,14 @@ struct DatabaseSnapshotRollbackEntry {
 struct DatabaseSnapshotRollbackJournal {
     entries: Vec<DatabaseSnapshotRollbackEntry>,
     next_sequence: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AskUserRequest {
+    question: String,
+    choices: Vec<String>,
+    default: Option<String>,
+    context: Option<String>,
 }
 
 impl DatabaseSnapshotRollbackJournal {
@@ -957,6 +965,8 @@ pub struct ServerToolExecutor {
     url_cache: Mutex<HashMap<String, (String, Instant)>>,
     /// Optional approval gate for dangerous tool execution.
     approval_gate: Option<Arc<dyn astra_tools::ToolApprovalGate>>,
+    /// Optional ask_user gate for interactive client prompts.
+    ask_user_gate: Option<Arc<dyn AskUserGate>>,
     /// Optional progress callback for streaming tool output.
     progress_callback: Option<Arc<dyn astra_tools::ToolProgressCallback>>,
     /// Optional resource governor for usage tracking (Phase 5).
@@ -1054,6 +1064,7 @@ impl ServerToolExecutor {
             http_client,
             url_cache: Mutex::new(HashMap::new()),
             approval_gate: None,
+            ask_user_gate: None,
             progress_callback: None,
             resource_governor: None,
             edge_connection_pool: None,
@@ -1067,6 +1078,11 @@ impl ServerToolExecutor {
     /// Set the approval gate for interactive tool execution.
     pub fn set_approval_gate(&mut self, gate: Arc<dyn astra_tools::ToolApprovalGate>) {
         self.approval_gate = Some(gate);
+    }
+
+    /// Set the ask_user gate for interactive user prompts.
+    pub fn set_ask_user_gate(&mut self, gate: Arc<dyn AskUserGate>) {
+        self.ask_user_gate = Some(gate);
     }
 
     /// Set the progress callback for streaming tool output.
@@ -1204,6 +1220,7 @@ impl ServerToolExecutor {
                     astra_tools::ToolResult::text(output)
                 }
             }
+            "ask_user" => self.server_ask_user(args).await,
             // ── File operations ─────────────────────────────────────────
             // Write operations use server-specific journal recording.
             // Read-only operations delegate to DefaultToolExecutor.
@@ -1306,7 +1323,7 @@ impl ServerToolExecutor {
                      grep, glob, git_status, git_diff, git_log, git_file_history, git_contributors, git_log_search, \
                      git_show, git_blame, symbols, git_commit, git_revert_commit, github_list_prs, github_get_pr, \
                      github_ci_status, github_list_issues, github_get_issue, github_repo_stats, memory_*, web_fetch, \
-                     web_search"
+                     web_search, ask_user"
             )),
         };
 
@@ -1325,6 +1342,48 @@ impl ServerToolExecutor {
         }
 
         result
+    }
+
+    async fn server_ask_user(&self, args: &Value) -> astra_tools::ToolResult {
+        let request = match parse_ask_user_request(args) {
+            Ok(request) => request,
+            Err(error) => return astra_tools::ToolResult::error(error),
+        };
+
+        let Some(gate) = &self.ask_user_gate else {
+            return astra_tools::ToolResult::error(
+                "Error: ask_user requires an interactive client connection".into(),
+            );
+        };
+
+        let request_id = format!("ask-{}-{}", self.session_id, uuid_v4_short());
+        match gate
+            .request_user_input(
+                &request_id,
+                &request.question,
+                &request.choices,
+                request.default.as_deref(),
+                request.context.as_deref(),
+            )
+            .await
+        {
+            AskUserDecision::Answer(response) => {
+                let mut body = json!({
+                    "answer": response.answer,
+                    "question": request.question,
+                });
+                if !request.choices.is_empty() {
+                    body["was_custom"] = Value::Bool(response.was_custom);
+                }
+                astra_tools::ToolResult::text(body.to_string())
+            }
+            AskUserDecision::Timeout => astra_tools::ToolResult::error(
+                "Error: ask_user timed out waiting for user response".into(),
+            ),
+            AskUserDecision::Error(message) => {
+                astra_tools::ToolResult::error(format!("Error: ask_user failed: {message}"))
+            }
+        }
     }
 
     /// Set the current turn index for journal entries.
@@ -3013,6 +3072,42 @@ fn edit_type_label(edit_type: EditType) -> &'static str {
     }
 }
 
+fn parse_ask_user_request(args: &Value) -> Result<AskUserRequest, String> {
+    let question = match args.get("question").and_then(Value::as_str) {
+        Some(question) if !question.trim().is_empty() => question.to_string(),
+        _ => return Err("Error: 'question' is required".into()),
+    };
+
+    let choices: Vec<String> = args
+        .get("choices")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if !choices.is_empty() && !(2..=9).contains(&choices.len()) {
+        return Err("Error: choices must contain 2-9 options".into());
+    }
+
+    Ok(AskUserRequest {
+        question,
+        choices,
+        default: args
+            .get("default")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        context: args
+            .get("context")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+    })
+}
+
 fn tool_result_from_output(output: String) -> astra_tools::ToolResult {
     let parsed = serde_json::from_str::<Value>(&output).ok();
     let json_error = parsed
@@ -3065,6 +3160,8 @@ mod tests {
     use std::sync::{Mutex as StdMutex, MutexGuard, OnceLock};
 
     use super::*;
+    use astra_tools::{AskUserDecision, AskUserGate, AskUserResponse};
+    use async_trait::async_trait;
     use serde_json::json;
     use tempfile::TempDir;
 
@@ -3189,7 +3286,96 @@ esac
         (exec, dir, session_id, session)
     }
 
+    #[derive(Clone)]
+    struct StaticAskUserGate {
+        expected_question: &'static str,
+        expected_choices: Vec<&'static str>,
+        decision: AskUserDecision,
+    }
+
+    #[async_trait]
+    impl AskUserGate for StaticAskUserGate {
+        async fn request_user_input(
+            &self,
+            _request_id: &str,
+            question: &str,
+            choices: &[String],
+            _default: Option<&str>,
+            _context: Option<&str>,
+        ) -> AskUserDecision {
+            assert_eq!(question, self.expected_question);
+            assert_eq!(
+                choices,
+                &self
+                    .expected_choices
+                    .iter()
+                    .map(|choice| choice.to_string())
+                    .collect::<Vec<_>>()
+            );
+            self.decision.clone()
+        }
+    }
+
     // ── Path traversal security ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn ask_user_returns_structured_response_from_gate() {
+        let (mut exec, _dir) = test_executor();
+        exec.set_ask_user_gate(Arc::new(StaticAskUserGate {
+            expected_question: "Which option?",
+            expected_choices: vec!["first", "second"],
+            decision: AskUserDecision::Answer(AskUserResponse {
+                answer: "custom".into(),
+                was_custom: true,
+            }),
+        }));
+
+        let result = exec
+            .execute_with_metadata(
+                "ask_user",
+                &json!({
+                    "question": "Which option?",
+                    "choices": ["first", "second"],
+                    "default": "first"
+                }),
+            )
+            .await;
+
+        assert!(!result.is_error);
+        assert_eq!(
+            serde_json::from_str::<Value>(&result.output).unwrap(),
+            json!({
+                "answer": "custom",
+                "question": "Which option?",
+                "was_custom": true
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn ask_user_requires_interactive_gate() {
+        let (exec, _dir) = test_executor();
+        let result = exec
+            .execute_with_metadata("ask_user", &json!({"question": "Continue?"}))
+            .await;
+
+        assert!(result.is_error);
+        assert!(result.output.contains("interactive client connection"));
+    }
+
+    #[tokio::test]
+    async fn ask_user_rejects_invalid_choice_count() {
+        let (exec, _dir) = test_executor();
+        let result = exec
+            .execute_with_metadata(
+                "ask_user",
+                &json!({"question": "Pick one", "choices": ["only-one"]}),
+            )
+            .await;
+
+        assert!(result.is_error);
+        assert!(result.output.contains("choices must contain 2-9 options"));
+    }
 
     #[tokio::test]
     async fn resolve_path_allows_relative_inside_workspace() {

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -1228,6 +1228,7 @@ impl ServerToolExecutor {
             "read_file" => self.default_executor.execute("read_file", args).await,
             "write_file" => tool_result_from_output(self.server_write_file(args)),
             "str_replace" => tool_result_from_output(self.server_str_replace(args)),
+            "multi_edit" => tool_result_from_output(self.server_multi_edit(args)),
             "delete_file" => tool_result_from_output(self.server_delete_file(args)),
             "rollback_file_edits" => tool_result_from_output(self.rollback_file_edits(args)),
             "list_dir" => self.default_executor.execute("list_dir", args).await,
@@ -1317,11 +1318,11 @@ impl ServerToolExecutor {
             // ── Unknown tool fallback ──────────────────────────────────
             _ => astra_tools::ToolResult::error(format!(
                 "Error: Tool '{name}' is not available in server-side execution mode. \
-                     Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
-                     list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
-                     rollback_session_state, task_*, sleep, tool_search, mo_query, rollback_database_snapshots, \
-                     grep, glob, git_status, git_diff, git_log, git_file_history, git_contributors, git_log_search, \
-                     git_show, git_blame, symbols, git_commit, git_revert_commit, github_list_prs, github_get_pr, \
+                      Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
+                      multi_edit, list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
+                      rollback_session_state, task_*, sleep, tool_search, mo_query, rollback_database_snapshots, \
+                      grep, glob, git_status, git_diff, git_log, git_file_history, git_contributors, git_log_search, \
+                      git_show, git_blame, symbols, git_commit, git_revert_commit, github_list_prs, github_get_pr, \
                      github_ci_status, github_list_issues, github_get_issue, github_repo_stats, memory_*, web_fetch, \
                      web_search, ask_user"
             )),
@@ -2743,6 +2744,39 @@ impl ServerToolExecutor {
         result.output
     }
 
+    fn server_multi_edit(&self, args: &Value) -> String {
+        let prepared = match astra_tools::fs_ops::prepare_multi_edit(&self.workspace_root, args) {
+            Ok(prepared) => prepared,
+            Err(error) => return error.output,
+        };
+
+        if !args
+            .get("dry_run")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            && let Ok(mut journal) = self.file_journal.lock()
+        {
+            let turn_idx = self.journal_turn_index.load(Ordering::Relaxed);
+            journal.record_before_patch(prepared.path(), "server-multi-edit", turn_idx);
+        }
+
+        let result = prepared.apply();
+        if !result.is_error
+            && !args
+                .get("dry_run")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            && let Ok(mut journal) = self.file_journal.lock()
+        {
+            journal.record_after(
+                prepared.path(),
+                "server-multi-edit",
+                prepared.new_content_bytes(),
+            );
+        }
+        result.output
+    }
+
     fn server_delete_file(&self, args: &Value) -> String {
         let prepared = match astra_tools::fs_ops::prepare_delete_file(&self.workspace_root, args) {
             Ok(prepared) => prepared,
@@ -3668,6 +3702,41 @@ esac
     }
 
     #[tokio::test]
+    async fn rollback_file_edits_current_turn_reverts_server_multi_edit() {
+        let (exec, dir) = test_executor();
+        exec.set_turn_index(8);
+        let target = dir.path().join("edit.txt");
+        std::fs::write(&target, "aaa bbb ccc").unwrap();
+
+        let edited = exec
+            .execute(
+                "multi_edit",
+                &json!({
+                    "path": "edit.txt",
+                    "edits": [
+                        {"old_str": "aaa", "new_str": "AAA"},
+                        {"old_str": "ccc", "new_str": "CCC"}
+                    ]
+                }),
+            )
+            .await;
+        assert!(edited.contains("Successfully applied"));
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "AAA bbb CCC");
+
+        let rollback = exec
+            .execute("rollback_file_edits", &json!({"scope": "current_turn"}))
+            .await;
+        let rollback_json: Value = serde_json::from_str(&rollback).unwrap();
+        assert_eq!(
+            rollback_json["success"].as_bool(),
+            Some(true),
+            "got: {rollback}"
+        );
+        assert_eq!(rollback_json["turn_index"].as_u64(), Some(8));
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "aaa bbb ccc");
+    }
+
+    #[tokio::test]
     async fn rollback_file_edits_file_scope_restores_deleted_file() {
         let (exec, dir) = test_executor();
         let target = dir.path().join("gone.txt");
@@ -3845,6 +3914,32 @@ esac
             !result.contains("not available in server-side execution mode"),
             "{result}"
         );
+    }
+
+    #[tokio::test]
+    async fn multi_edit_is_available_in_server_mode() {
+        let (exec, dir) = test_executor();
+        std::fs::write(dir.path().join("edit.txt"), "foo bar baz").unwrap();
+
+        let result = exec
+            .execute(
+                "multi_edit",
+                &json!({
+                    "path": "edit.txt",
+                    "edits": [
+                        {"old_str": "foo", "new_str": "FOO"},
+                        {"old_str": "baz", "new_str": "BAZ"}
+                    ]
+                }),
+            )
+            .await;
+
+        assert!(result.contains("Successfully applied"), "{result}");
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("edit.txt")).unwrap(),
+            "FOO bar BAZ"
+        );
+        assert!(!result.contains("not available in server-side execution mode"));
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -1286,7 +1286,7 @@ impl ServerToolExecutor {
                     .await
             }
             // ── GitHub operations ────────────────────────────────────────
-            // Read-only GitHub tools delegate to DefaultToolExecutor.
+            // GitHub tools delegate to DefaultToolExecutor.
             "github_list_prs" => self.default_executor.execute("github_list_prs", args).await,
             "github_get_pr" => self.default_executor.execute("github_get_pr", args).await,
             "github_ci_status" => {
@@ -1309,6 +1309,11 @@ impl ServerToolExecutor {
                     .execute("github_repo_stats", args)
                     .await
             }
+            "github_create_issue" => {
+                self.default_executor
+                    .execute("github_create_issue", args)
+                    .await
+            }
             // ── Delegation placeholder ─────────────────────────────────
             "delegate" => astra_tools::ToolResult::text(
                 "Delegation request acknowledged. The delegation engine will execute \
@@ -1318,12 +1323,12 @@ impl ServerToolExecutor {
             // ── Unknown tool fallback ──────────────────────────────────
             _ => astra_tools::ToolResult::error(format!(
                 "Error: Tool '{name}' is not available in server-side execution mode. \
-                      Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
-                      multi_edit, list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
-                      rollback_session_state, task_*, sleep, tool_search, mo_query, rollback_database_snapshots, \
-                      grep, glob, git_status, git_diff, git_log, git_file_history, git_contributors, git_log_search, \
-                      git_show, git_blame, symbols, git_commit, git_revert_commit, github_list_prs, github_get_pr, \
-                     github_ci_status, github_list_issues, github_get_issue, github_repo_stats, memory_*, web_fetch, \
+                     Available: bash, read_file, write_file, str_replace, delete_file, rollback_file_edits, \
+                     multi_edit, list_dir, adjust_config, prioritize_tool, deprioritize_tool, set_goal, compress_context, \
+                     rollback_session_state, task_*, sleep, tool_search, mo_query, rollback_database_snapshots, \
+                     grep, glob, git_status, git_diff, git_log, git_file_history, git_contributors, git_log_search, \
+                     git_show, git_blame, symbols, git_commit, git_revert_commit, github_list_prs, github_get_pr, \
+                     github_ci_status, github_list_issues, github_get_issue, github_repo_stats, github_create_issue, memory_*, web_fetch, \
                      web_search, ask_user"
             )),
         };
@@ -4253,24 +4258,50 @@ esac
 
     #[tokio::test]
     async fn github_tools_delegate_to_default_executor() {
+        let _guard = env_guard();
+        let _github_token_guard = EnvVarGuard {
+            key: "GITHUB_TOKEN",
+            previous: std::env::var_os("GITHUB_TOKEN"),
+        };
+        unsafe {
+            std::env::remove_var("GITHUB_TOKEN");
+        }
+        let empty_path = TempDir::new().unwrap();
+        let _path_guard = set_env_var("PATH", empty_path.path().as_os_str().to_os_string());
+
         let (exec, _dir) = test_executor();
-        let result = exec
-            .execute_with_metadata(
+        for (tool, args) in [
+            (
                 "github_list_prs",
-                &json!({"repo": "matrixorigin/mo-agent-runtime"}),
-            )
-            .await;
-        assert!(result.is_error);
-        assert!(
-            result
-                .output
-                .contains("requires a configured GitHub client")
-        );
-        assert!(
-            !result
-                .output
-                .contains("not available in server-side execution mode")
-        );
+                json!({"repo": "matrixorigin/mo-agent-runtime"}),
+            ),
+            (
+                "github_create_issue",
+                json!({
+                    "repo": "matrixorigin/mo-agent-runtime",
+                    "title": "server parity regression test"
+                }),
+            ),
+        ] {
+            let result = exec.execute_with_metadata(tool, &args).await;
+            assert!(
+                result.is_error,
+                "{tool} should error without a GitHub client"
+            );
+            assert!(
+                result
+                    .output
+                    .contains("requires a configured GitHub client"),
+                "{tool} should delegate to the GitHub executor path, got: {}",
+                result.output
+            );
+            assert!(
+                !result
+                    .output
+                    .contains("not available in server-side execution mode"),
+                "{tool} should be exposed in server mode"
+            );
+        }
     }
 
     // ── Output management ──────────────────────────────────────────────

--- a/rust/crates/runtime/src/server/ws_handler.rs
+++ b/rust/crates/runtime/src/server/ws_handler.rs
@@ -131,6 +131,15 @@ pub(super) enum WsClientMessage {
         reason: Option<String>,
     },
 
+    /// Respond to an ask_user prompt.
+    #[serde(rename = "user_prompt")]
+    UserPrompt {
+        request_id: String,
+        answer: String,
+        #[serde(default)]
+        was_custom: bool,
+    },
+
     /// Client heartbeat.
     #[serde(rename = "ping")]
     Ping,
@@ -195,6 +204,18 @@ pub(super) enum WsServerMessage {
         request_id: String,
         tool: String,
         args: serde_json::Value,
+    },
+
+    /// ask_user requires a frontend response before the turn can continue.
+    #[serde(rename = "user_prompt_request")]
+    UserPromptRequest {
+        request_id: String,
+        question: String,
+        choices: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        default: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        context: Option<String>,
     },
 
     /// Tool execution started on server.
@@ -503,6 +524,20 @@ async fn message_loop(socket: &mut WebSocket, state: &AppState, mut conn: WsConn
                                 )
                                 .await;
                             }
+                            Ok(WsClientMessage::UserPrompt {
+                                request_id,
+                                answer,
+                                was_custom,
+                            }) => {
+                                handle_user_prompt_response(
+                                    state,
+                                    &conn,
+                                    &request_id,
+                                    answer,
+                                    was_custom,
+                                )
+                                .await;
+                            }
                             Ok(WsClientMessage::Ping) => {
                                 send_msg(socket, &WsServerMessage::Pong).await;
                             }
@@ -791,6 +826,26 @@ async fn handle_tool_approval(
     guard.insert(key, value);
 }
 
+/// Store an ask_user response in the edge callback ledger.
+async fn handle_user_prompt_response(
+    state: &AppState,
+    conn: &WsConnection,
+    request_id: &str,
+    answer: String,
+    was_custom: bool,
+) {
+    use crate::turn::edge_ledger::user_prompt_callback_key;
+
+    let key = user_prompt_callback_key(&conn.user.user_id, request_id);
+    let value = serde_json::json!({
+        "answer": answer,
+        "was_custom": was_custom,
+    });
+    let ledger = state.edge_callback_ledger.clone();
+    let mut guard = ledger.lock().await;
+    guard.insert(key, value);
+}
+
 fn build_bridge_chat_payload(
     session_id: Option<String>,
     content: &str,
@@ -858,6 +913,7 @@ fn build_ws_chat_request(
         forward_headers: std::collections::HashMap::new(),
         max_candidates,
         explain,
+        interactive_client: true,
     }
 }
 
@@ -1135,6 +1191,20 @@ async fn stream_run_over_websocket(
                             Ok(WsClientMessage::ToolApproval { request_id, approved, reason }) => {
                                 handle_tool_approval(state, conn, &request_id, approved, reason).await;
                             }
+                            Ok(WsClientMessage::UserPrompt {
+                                request_id,
+                                answer,
+                                was_custom,
+                            }) => {
+                                handle_user_prompt_response(
+                                    state,
+                                    conn,
+                                    &request_id,
+                                    answer,
+                                    was_custom,
+                                )
+                                .await;
+                            }
                             Ok(WsClientMessage::Ping) => {
                                 send_msg(socket, &WsServerMessage::Pong).await;
                             }
@@ -1211,6 +1281,47 @@ async fn stream_run_over_websocket(
                                 .unwrap_or_default()
                                 .to_string(),
                             args: req.get("args").cloned().unwrap_or_default(),
+                        },
+                    )
+                    .await;
+                }
+
+                for req in state
+                    .run_lifecycle_service
+                    .drain_user_prompt_requests(run_id)
+                    .await
+                {
+                    send_msg(
+                        socket,
+                        &WsServerMessage::UserPromptRequest {
+                            request_id: req
+                                .get("request_id")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string(),
+                            question: req
+                                .get("question")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string(),
+                            choices: req
+                                .get("choices")
+                                .and_then(|v| v.as_array())
+                                .map(|items| {
+                                    items
+                                        .iter()
+                                        .filter_map(|item| item.as_str().map(ToString::to_string))
+                                        .collect::<Vec<_>>()
+                                })
+                                .unwrap_or_default(),
+                            default: req
+                                .get("default")
+                                .and_then(|v| v.as_str())
+                                .map(ToString::to_string),
+                            context: req
+                                .get("context")
+                                .and_then(|v| v.as_str())
+                                .map(ToString::to_string),
                         },
                     )
                     .await;
@@ -2100,6 +2211,20 @@ async fn stream_sse_response_as_ws(
                             Ok(WsClientMessage::ToolApproval { request_id, approved, reason }) => {
                                 handle_tool_approval(state, conn, &request_id, approved, reason).await;
                             }
+                            Ok(WsClientMessage::UserPrompt {
+                                request_id,
+                                answer,
+                                was_custom,
+                            }) => {
+                                handle_user_prompt_response(
+                                    state,
+                                    conn,
+                                    &request_id,
+                                    answer,
+                                    was_custom,
+                                )
+                                .await;
+                            }
                             Ok(WsClientMessage::Ping) => {
                                 send_msg(socket, &WsServerMessage::Pong).await;
                             }
@@ -2607,6 +2732,7 @@ mod tests {
         assert_eq!(request.context.as_ref().unwrap()["is_plan_subtask"], true);
         assert_eq!(request.max_candidates, 7);
         assert!(request.explain);
+        assert!(request.interactive_client);
     }
 
     #[test]
@@ -4166,6 +4292,25 @@ mod tests {
     }
 
     #[test]
+    fn parse_user_prompt_response() {
+        let json =
+            r#"{"type":"user_prompt","request_id":"req-3","answer":"custom","was_custom":true}"#;
+        let msg: WsClientMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            WsClientMessage::UserPrompt {
+                request_id,
+                answer,
+                was_custom,
+            } => {
+                assert_eq!(request_id, "req-3");
+                assert_eq!(answer, "custom");
+                assert!(was_custom);
+            }
+            _ => panic!("expected UserPrompt"),
+        }
+    }
+
+    #[test]
     fn serialize_run_started() {
         let msg = WsServerMessage::RunStarted {
             run_id: "r1".into(),
@@ -4326,6 +4471,22 @@ mod tests {
     }
 
     #[test]
+    fn serialize_user_prompt_request() {
+        let msg = WsServerMessage::UserPromptRequest {
+            request_id: "req-2".into(),
+            question: "Continue?".into(),
+            choices: vec!["yes".into(), "no".into()],
+            default: Some("yes".into()),
+            context: Some("Need confirmation".into()),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"user_prompt_request""#));
+        assert!(json.contains(r#""question":"Continue?""#));
+        assert!(json.contains(r#""choices":["yes","no"]"#));
+        assert!(json.contains(r#""default":"yes""#));
+    }
+
+    #[test]
     fn all_server_message_variants_serialize() {
         let variants: Vec<WsServerMessage> = vec![
             WsServerMessage::AuthOk {
@@ -4357,6 +4518,13 @@ mod tests {
                 tool: "bash".into(),
                 args: serde_json::json!({}),
             },
+            WsServerMessage::UserPromptRequest {
+                request_id: "req-2".into(),
+                question: "Continue?".into(),
+                choices: vec!["yes".into(), "no".into()],
+                default: Some("yes".into()),
+                context: None,
+            },
             WsServerMessage::Error {
                 message: "err".into(),
                 code: "E".into(),
@@ -4385,6 +4553,7 @@ mod tests {
             r#"{"type":"message","content":"hello"}"#,
             r#"{"type":"cancel_run","run_id":"r1"}"#,
             r#"{"type":"tool_approval","request_id":"req-1","approved":true}"#,
+            r#"{"type":"user_prompt","request_id":"req-2","answer":"yes","was_custom":false}"#,
             r#"{"type":"ping"}"#,
         ];
         for json in &inputs {
@@ -4409,6 +4578,15 @@ mod tests {
 
         // Missing request_id
         let json = r#"{"type":"tool_approval","approved":true}"#;
+        assert!(serde_json::from_str::<WsClientMessage>(json).is_err());
+    }
+
+    #[test]
+    fn user_prompt_requires_request_id_and_answer() {
+        let json = r#"{"type":"user_prompt","answer":"yes"}"#;
+        assert!(serde_json::from_str::<WsClientMessage>(json).is_err());
+
+        let json = r#"{"type":"user_prompt","request_id":"req-1"}"#;
         assert!(serde_json::from_str::<WsClientMessage>(json).is_err());
     }
 }

--- a/rust/crates/runtime/src/server/ws_user_prompt_gate.rs
+++ b/rust/crates/runtime/src/server/ws_user_prompt_gate.rs
@@ -1,0 +1,2 @@
+//! Re-export from astra-turn-core.
+pub use astra_turn_core::ws_user_prompt_gate::*;

--- a/rust/crates/runtime/src/turn/agentic_delegate_interception.rs
+++ b/rust/crates/runtime/src/turn/agentic_delegate_interception.rs
@@ -179,6 +179,8 @@ pub(crate) async fn intercept_delegations<H: AgenticLoopHost>(
                 args_preview: Some(result.call_id.clone()),
                 result_preview: Some(result.summary.chars().take(500).collect::<String>()),
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             });
         }
         if !quiet {

--- a/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
@@ -706,6 +706,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: Some("src/main.rs".to_string()),
+                surgically_removed: None,
+                original_tool_name: None,
             },
             astra_services::session_journal::ToolCallRecord {
                 name: "str_replace".to_string(),
@@ -717,6 +719,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: Some("src/lib.rs".to_string()),
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ];
         state.total_prompt = 5000;
@@ -761,6 +765,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }];
         state.total_prompt = 15000;
 

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -3963,6 +3963,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
             args_preview: None,
             result_preview: result_preview.map(str::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 
@@ -5895,6 +5897,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: Some("npm test".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             astra_services::session_journal::ToolCallRecord {
                 name: "bash".into(),
@@ -5906,6 +5910,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: Some("npm test".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ];
 
@@ -6048,6 +6054,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: Some("ls -la".into()),
                 result_preview: Some("error".into()),
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "bash".into(),
@@ -6059,6 +6067,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: Some("cat foo".into()),
                 result_preview: Some("not found".into()),
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "bash".into(),
@@ -6070,6 +6080,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: Some("rm bar".into()),
                 result_preview: Some("permission denied".into()),
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ];
 
@@ -6628,6 +6640,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 },
                 ToolCallRecord {
                     name: "rg".to_string(),
@@ -6639,6 +6653,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 },
             ]);
             if !bash_ok {
@@ -6694,6 +6710,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 }]),
                 budget_used: None,
                 budget_pressure: None,
@@ -6780,6 +6798,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "bash".into(),
@@ -6791,6 +6811,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             ToolCallRecord {
                 name: "web_fetch".into(),
@@ -6802,6 +6824,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ];
         state.recent_tactical_actions = vec![

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
@@ -169,7 +169,10 @@ fn refresh_runtime_promotion_signals_from_turn(
         .then(|| {
             RuntimeTurnEvaluationSignal::from_turn_evaluation(
                 &evaluation,
-                tool_call_records.len(),
+                tool_call_records
+                    .iter()
+                    .filter(|r| !r.is_synthetic_placeholder())
+                    .count(),
                 stall_count,
                 verdict_warning,
             )
@@ -1344,6 +1347,8 @@ mod tests {
             args_preview: Some("{\"command\":\"echo hi\"}".into()),
             result_preview: result_preview.map(str::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 
@@ -1399,6 +1404,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 

--- a/rust/crates/runtime/src/turn/agentic_tool_interception.rs
+++ b/rust/crates/runtime/src/turn/agentic_tool_interception.rs
@@ -46,6 +46,8 @@ pub(crate) async fn prepare_intercepted_tool_round(
             args_preview: Some(result.tool_call_id.clone()),
             result_preview: Some(result.result.chars().take(500).collect::<String>()),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         });
     }
 
@@ -55,7 +57,22 @@ pub(crate) async fn prepare_intercepted_tool_round(
     // evaluation/analytics via ToolCallRecord::is_synthetic_placeholder().
     // The stall detector does NOT treat synthetic placeholders as real
     // attempts either, matching the existing skipped/deferred behavior.
+
+    // Build id→name lookup so we can preserve the original tool name.
+    let tool_name_by_id: HashMap<&str, &str> = tool_calls
+        .iter()
+        .filter_map(|tc| {
+            let id = tc.get("id").and_then(Value::as_str)?;
+            let name = tc
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(Value::as_str)?;
+            Some((id, name))
+        })
+        .collect();
+
     for id in &surgically_removed_ids {
+        let original_name = tool_name_by_id.get(id.as_str()).map(|s| s.to_string());
         state.stall.tool_call_records.push(ToolCallRecord {
             name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
             ok: true,
@@ -66,6 +83,8 @@ pub(crate) async fn prepare_intercepted_tool_round(
             args_preview: Some(id.clone()),
             result_preview: Some("(removed from context — skill covered this work)".to_string()),
             file_path: None,
+            surgically_removed: Some(true),
+            original_tool_name: original_name,
         });
     }
 

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -229,6 +229,8 @@ fn build_bridge_tool_call_records(
                 .map(|arguments| preview_chars(arguments, 80)),
             result_preview: output.as_deref().map(|output| preview_chars(output, 500)),
             file_path,
+            surgically_removed: None,
+            original_tool_name: None,
         });
     }
 
@@ -248,6 +250,8 @@ fn build_bridge_tool_call_records(
                 .map(|arguments| preview_chars(arguments, 80)),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         });
     }
 

--- a/rust/crates/runtime/tests/session_facts_e2e.rs
+++ b/rust/crates/runtime/tests/session_facts_e2e.rs
@@ -95,6 +95,8 @@ fn make_tc(name: &str, ok: bool, file_path: Option<&str>) -> ToolCallRecord {
         args_preview: None,
         result_preview: None,
         file_path: file_path.map(String::from),
+        surgically_removed: None,
+        original_tool_name: None,
     }
 }
 

--- a/rust/crates/services/src/event_ingestion.rs
+++ b/rust/crates/services/src/event_ingestion.rs
@@ -1079,6 +1079,8 @@ mod tests {
                 args_preview: Some("HEAD~10".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             crate::session_journal::ToolCallRecord {
                 name: "read_file".into(),
@@ -1090,6 +1092,8 @@ mod tests {
                 args_preview: Some("missing.txt".into()),
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ]);
 
@@ -1145,6 +1149,8 @@ mod tests {
             args_preview: Some("npm test".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }]);
 
         let events = IngestionEvent::expand_journal_event(&journal, "u1");
@@ -1169,6 +1175,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }]);
 
         let a = IngestionEvent::expand_journal_event(&journal, "u1");

--- a/rust/crates/services/src/runs.rs
+++ b/rust/crates/services/src/runs.rs
@@ -84,6 +84,17 @@ pub trait RunLifecycleService: Send + Sync {
         vec![]
     }
 
+    /// Drain pending ask_user prompt requests for a run.
+    ///
+    /// Returns JSON objects with `request_id`, `question`, `choices`, `default`,
+    /// and `context` fields. The WS handler calls this during its polling loop to
+    /// forward prompts to the client.
+    ///
+    /// Default: no-op (returns empty vec).
+    async fn drain_user_prompt_requests(&self, _run_id: &str) -> Vec<serde_json::Value> {
+        vec![]
+    }
+
     /// Drain pending tool progress events for a run.
     ///
     /// Returns JSON objects with `kind` field (`started`, `delta`, `completed`).
@@ -109,6 +120,7 @@ pub struct ChatRequestData {
     pub forward_headers: std::collections::HashMap<String, String>,
     pub max_candidates: u32,
     pub explain: bool,
+    pub interactive_client: bool,
 }
 
 fn redacted_forward_header_names(headers: &std::collections::HashMap<String, String>) -> Vec<&str> {
@@ -150,6 +162,7 @@ impl std::fmt::Debug for ChatRequestData {
             )
             .field("max_candidates", &self.max_candidates)
             .field("explain", &self.explain)
+            .field("interactive_client", &self.interactive_client)
             .finish()
     }
 }
@@ -875,6 +888,7 @@ mod tests {
             forward_headers,
             max_candidates: 10,
             explain: false,
+            interactive_client: false,
         };
 
         let rendered = format!("{request:?}");
@@ -903,6 +917,7 @@ mod tests {
                     forward_headers: std::collections::HashMap::new(),
                     max_candidates: 25,
                     explain: false,
+                    interactive_client: false,
                 },
             )
             .await

--- a/rust/crates/services/src/self_surface.rs
+++ b/rust/crates/services/src/self_surface.rs
@@ -2323,6 +2323,8 @@ mod tests {
                     args_preview: None,
                     result_preview: None,
                     file_path: None,
+                    surgically_removed: None,
+                    original_tool_name: None,
                 }]),
                 budget_used: Some(8300),
                 budget_pressure: Some(0.83),

--- a/rust/crates/services/src/session_analytics.rs
+++ b/rust/crates/services/src/session_analytics.rs
@@ -402,6 +402,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             crate::session_journal::ToolCallRecord {
                 name: "grep".into(),
@@ -413,6 +415,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
             crate::session_journal::ToolCallRecord {
                 name: "write_file".into(),
@@ -424,6 +428,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             },
         ]);
         let stats = compute_session_stats("s1", &[turn]);
@@ -507,6 +513,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 

--- a/rust/crates/services/src/session_journal.rs
+++ b/rust/crates/services/src/session_journal.rs
@@ -488,6 +488,16 @@ pub struct ToolCallRecord {
     /// More reliable than parsing `args_preview` (which is truncated to ~80 chars).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub file_path: Option<String>,
+    /// Explicit flag for surgically removed tool calls. When `true`, this record
+    /// is an audit-only placeholder — the parallel tool call was removed from
+    /// context because a skill covered the work. Prefer this over checking
+    /// `name == SURGICAL_REMOVAL_TOOL_NAME`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub surgically_removed: Option<bool>,
+    /// Original tool name before surgical removal replaced it with the sentinel.
+    /// Only set when `surgically_removed == Some(true)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_tool_name: Option<String>,
 }
 
 /// Tool call name sentinel used for assistant messages that had parallel tool
@@ -505,6 +515,9 @@ impl ToolCallRecord {
     /// failure, so these records must be filtered out before computing
     /// analytics (tool_error_rate, repeat_tool_call, failed_tool_calls, …).
     pub fn is_synthetic_placeholder(&self) -> bool {
+        if self.surgically_removed == Some(true) {
+            return true;
+        }
         if self.name == SURGICAL_REMOVAL_TOOL_NAME {
             return true;
         }
@@ -3263,6 +3276,8 @@ mod tests {
             args_preview: None,
             result_preview: preview.map(ToString::to_string),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }
     }
 
@@ -3850,6 +3865,8 @@ mod tests {
             args_preview: Some("owner/repo".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let json = serde_json::to_string(&record).unwrap();
         assert!(json.contains("\"ok\":true"));
@@ -3873,6 +3890,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let json = serde_json::to_string(&record).unwrap();
         assert!(json.contains("\"ok\":false"));
@@ -3897,6 +3916,8 @@ mod tests {
                     .into(),
             ),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let deferred = ToolCallRecord {
             name: "bash".into(),
@@ -3911,6 +3932,8 @@ mod tests {
                     .into(),
             ),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let dedup = ToolCallRecord {
             name: "skill".into(),
@@ -3925,6 +3948,8 @@ mod tests {
                     .into(),
             ),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let actual_failure = ToolCallRecord {
             name: "skill".into(),
@@ -3936,6 +3961,8 @@ mod tests {
             args_preview: None,
             result_preview: Some("Unknown skill 'debug'.".into()),
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
 
         assert!(skipped.is_synthetic_placeholder());
@@ -3973,6 +4000,8 @@ mod tests {
             args_preview: Some("owner/repo".into()),
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         }]);
         let json = serde_json::to_string(&evt).unwrap();
         let parsed: JournalEvent = serde_json::from_str(&json).unwrap();
@@ -4022,6 +4051,8 @@ mod tests {
                 args_preview: None,
                 result_preview: None,
                 file_path: None,
+                surgically_removed: None,
+                original_tool_name: None,
             })
             .collect();
         let json = serde_json::to_string(&records).unwrap();
@@ -4043,6 +4074,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let json = serde_json::to_string(&record).unwrap();
         let parsed: ToolCallRecord = serde_json::from_str(&json).unwrap();
@@ -4061,6 +4094,8 @@ mod tests {
             args_preview: None,
             result_preview: None,
             file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
         };
         let json = serde_json::to_string(&record).unwrap();
         let parsed: ToolCallRecord = serde_json::from_str(&json).unwrap();
@@ -5015,5 +5050,77 @@ mod tests {
         assert_eq!(result.sessions_deleted, 0);
         assert_eq!(result.journals_compressed, 0);
         assert_eq!(result.bytes_freed, 0);
+    }
+
+    #[test]
+    fn tool_call_record_serde_roundtrip_with_surgical_fields() {
+        // New-style record with both surgical fields populated
+        let rec = ToolCallRecord {
+            name: SURGICAL_REMOVAL_TOOL_NAME.to_string(),
+            ok: true,
+            ms: 0,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(0),
+            args_preview: None,
+            result_preview: Some("(removed)".into()),
+            file_path: None,
+            surgically_removed: Some(true),
+            original_tool_name: Some("read_file".to_string()),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        assert!(json.contains("\"surgically_removed\":true"));
+        assert!(json.contains("\"original_tool_name\":\"read_file\""));
+        let deser: ToolCallRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(deser.surgically_removed, Some(true));
+        assert_eq!(deser.original_tool_name.as_deref(), Some("read_file"));
+        assert!(deser.is_synthetic_placeholder());
+    }
+
+    #[test]
+    fn tool_call_record_serde_omits_none_surgical_fields() {
+        // Normal record: surgical fields should be omitted from JSON
+        let rec = base_tool_record("bash", true, Some("ok"));
+        let json = serde_json::to_string(&rec).unwrap();
+        assert!(
+            !json.contains("surgically_removed"),
+            "None surgical fields should be skipped in serialization"
+        );
+        assert!(
+            !json.contains("original_tool_name"),
+            "None original_tool_name should be skipped in serialization"
+        );
+    }
+
+    #[test]
+    fn tool_call_record_backward_compat_deserialize() {
+        // Legacy JSON without the new fields — should deserialize with defaults
+        let legacy_json = r#"{"name":"read_file","ok":true,"ms":10}"#;
+        let rec: ToolCallRecord = serde_json::from_str(legacy_json).unwrap();
+        assert_eq!(rec.surgically_removed, None);
+        assert_eq!(rec.original_tool_name, None);
+        assert!(!rec.is_synthetic_placeholder());
+    }
+
+    #[test]
+    fn is_synthetic_placeholder_flag_takes_priority() {
+        // Even if name is normal, flag=true marks as synthetic
+        let rec = ToolCallRecord {
+            name: "read_file".to_string(),
+            ok: true,
+            ms: 50,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(100),
+            args_preview: None,
+            result_preview: Some("content".into()),
+            file_path: None,
+            surgically_removed: Some(true),
+            original_tool_name: Some("read_file".to_string()),
+        };
+        assert!(
+            rec.is_synthetic_placeholder(),
+            "surgically_removed=true must classify as synthetic regardless of name"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- bundle the changes from PRs #161, #162, #163, #164, and #165 onto the latest main
- keep websocket ask_user, multi_edit, github_create_issue, and git_stash server parity together with the journal accuracy fixes and tests
- resolve the overlapping server tool surface / approval / mutation classification conflicts in one reviewed branch

## Included work
- #161 websocket ask_user protocol for interactive server runs
- #162 server multi_edit parity plus approval requirement
- #163 journal accuracy fixes and end-to-end tests
- #164 server github_create_issue parity plus approval / mutation alignment
- #165 server git_stash parity plus approval / mutation alignment

## Validation
- make format
- make check
- cargo test -p astra-tools approval_required_tools_includes_dangerous_ops --lib
- cargo test -p astra-tools server_executor_tool_schemas_match_server_supported_surface --lib
- cargo test -p astra-tools multi_edit --lib
- cargo test -p astra-turn-core --test journal_accuracy_e2e
- cargo test -p astra-turn-core github_create_issue_is_write_gated --lib
- cargo test -p astra-turn-core git_stash_is_write_gated --lib
- cargo test -p astra-turn-core classify_timeout_hard_for_mutation_tool --lib
- cargo test -p astra-runtime ask_user --lib
- cargo test -p astra-runtime user_prompt --lib
- cargo test -p astra-runtime multi_edit --lib
- cargo test -p astra-runtime github_tools_delegate_to_default_executor --lib
- cargo test -p astra-runtime git_stash_is_available_in_server_mode --lib