### PR TITLE
fix: require approval for git_revert_commit

### DIFF
--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -391,6 +391,7 @@ pub const APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "multi_edit",
     "delete_file",
     "git_commit",
+    "git_revert_commit",
     "git_stash",
     "github_create_issue",
 ];
@@ -814,6 +815,7 @@ mod tests {
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"multi_edit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"delete_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_commit"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_revert_commit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_stash"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"github_create_issue"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"read_file"));

--- a/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
+++ b/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
@@ -10,6 +10,7 @@ pub const CLOUD_APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "create_file",
     "edit_file",
     "exec",
+    "git_revert_commit",
     "git_stash",
     "github_create_issue",
     "multi_edit",
@@ -371,6 +372,14 @@ mod tests {
     fn git_stash_is_write_gated() {
         assert_eq!(
             cloud_gated_tool_kind("git_stash"),
+            Some(CloudGatedToolKind::Write)
+        );
+    }
+
+    #[test]
+    fn git_revert_commit_is_write_gated() {
+        assert_eq!(
+            cloud_gated_tool_kind("git_revert_commit"),
             Some(CloudGatedToolKind::Write)
         );
     }

--- a/rust/crates/astra-turn-core/src/tool_result_semantics.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_semantics.rs
@@ -641,6 +641,12 @@ if let Err(e) = writeln!(file, "{line}") {
             ToolErrorSeverity::HardError
         );
 
+        // git_revert_commit timeout
+        assert_eq!(
+            classify_tool_error("git_revert_commit", output),
+            ToolErrorSeverity::HardError
+        );
+
         // git_stash timeout
         assert_eq!(
             classify_tool_error("git_stash", output),


### PR DESCRIPTION
## Summary
- require approval for git_revert_commit in server-side tool gating
- classify git_revert_commit as a cloud-gated write operation
- treat git_revert_commit timeouts as mutation errors in tool result semantics

## Validation
- make format
- make check
- cargo test -p astra-tools approval_required_tools_includes_dangerous_ops --lib
- cargo test -p astra-turn-core cloud_approval_policy --lib
- cargo test -p astra-turn-core classify_timeout_hard_for_mutation_tool --lib