### PR TITLE
fix: require approval for rollback tools

### DIFF
--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -390,6 +390,8 @@ pub const APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "str_replace",
     "multi_edit",
     "delete_file",
+    "rollback_file_edits",
+    "rollback_database_snapshots",
     "git_commit",
     "git_stash",
     "github_create_issue",
@@ -813,6 +815,8 @@ mod tests {
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"write_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"multi_edit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"delete_file"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"rollback_file_edits"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"rollback_database_snapshots"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_commit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_stash"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"github_create_issue"));

--- a/rust/crates/astra-turn-core/src/ws_approval_gate.rs
+++ b/rust/crates/astra-turn-core/src/ws_approval_gate.rs
@@ -225,6 +225,8 @@ mod tests {
         assert!(gate.requires_approval("bash"));
         assert!(gate.requires_approval("write_file"));
         assert!(gate.requires_approval("delete_file"));
+        assert!(gate.requires_approval("rollback_file_edits"));
+        assert!(gate.requires_approval("rollback_database_snapshots"));
         assert!(!gate.requires_approval("read_file"));
         assert!(!gate.requires_approval("list_dir"));
         assert!(!gate.requires_approval("grep"));


### PR DESCRIPTION
## Summary
- require approval for rollback_file_edits and rollback_database_snapshots in server mode
- align the WebSocket approval gate test with the expanded destructive-tool set

## Validation
- make format
- make check
- cargo test -p astra-tools approval_required_tools_includes_dangerous_ops --lib
- cargo test -p astra-turn-core requires_approval_for_dangerous_tools --lib