### PR TITLE
fix: require cloud approval for git_commit

### DIFF
--- a/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
+++ b/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
@@ -10,6 +10,7 @@ pub const CLOUD_APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "create_file",
     "edit_file",
     "exec",
+    "git_commit",
     "git_stash",
     "github_create_issue",
     "multi_edit",
@@ -371,6 +372,14 @@ mod tests {
     fn git_stash_is_write_gated() {
         assert_eq!(
             cloud_gated_tool_kind("git_stash"),
+            Some(CloudGatedToolKind::Write)
+        );
+    }
+
+    #[test]
+    fn git_commit_is_write_gated() {
+        assert_eq!(
+            cloud_gated_tool_kind("git_commit"),
             Some(CloudGatedToolKind::Write)
         );
     }

--- a/rust/crates/astra-turn-core/src/tool_result_semantics.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_semantics.rs
@@ -641,6 +641,12 @@ if let Err(e) = writeln!(file, "{line}") {
             ToolErrorSeverity::HardError
         );
 
+        // git_commit timeout
+        assert_eq!(
+            classify_tool_error("git_commit", output),
+            ToolErrorSeverity::HardError
+        );
+
         // git_stash timeout
         assert_eq!(
             classify_tool_error("git_stash", output),


### PR DESCRIPTION
## Summary
- add git_commit to CLOUD_APPROVAL_REQUIRED_TOOLS
- classify git_commit as a cloud-gated write operation in tests
- treat git_commit timeouts as mutation errors in tool result semantics

## Validation
- make format
- make check
- cargo test -p astra-turn-core cloud_approval_policy --lib
- cargo test -p astra-turn-core classify_timeout_hard_for_mutation_tool --lib