### PR TITLE
fix: require cloud approval for delete_file

### DIFF
--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -1570,6 +1570,10 @@ mod tests {
             PermissionManager::classify("str_replace"),
             SideEffect::Write
         );
+        assert_eq!(
+            PermissionManager::classify("delete_file"),
+            SideEffect::Write
+        );
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
+++ b/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
@@ -8,6 +8,7 @@
 pub const CLOUD_APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "bash",
     "create_file",
+    "delete_file",
     "edit_file",
     "exec",
     "git_stash",
@@ -371,6 +372,14 @@ mod tests {
     fn git_stash_is_write_gated() {
         assert_eq!(
             cloud_gated_tool_kind("git_stash"),
+            Some(CloudGatedToolKind::Write)
+        );
+    }
+
+    #[test]
+    fn delete_file_is_write_gated() {
+        assert_eq!(
+            cloud_gated_tool_kind("delete_file"),
             Some(CloudGatedToolKind::Write)
         );
     }

--- a/rust/crates/astra-turn-core/src/tool_result_semantics.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_semantics.rs
@@ -641,6 +641,12 @@ if let Err(e) = writeln!(file, "{line}") {
             ToolErrorSeverity::HardError
         );
 
+        // delete_file timeout
+        assert_eq!(
+            classify_tool_error("delete_file", output),
+            ToolErrorSeverity::HardError
+        );
+
         // git_stash timeout
         assert_eq!(
             classify_tool_error("git_stash", output),


### PR DESCRIPTION
## Summary
- add delete_file to the canonical cloud approval-gated tool list
- treat delete_file timeouts as mutation failures
- lock the CLI permission manager classification so delete_file stays write-gated

## Validation
- make format
- make check
- cargo test -p astra-turn-core delete_file_is_write_gated --lib
- cargo test -p astra-turn-core classify_timeout_hard_for_mutation_tool --lib
- cargo test -p astra-cli classify_write_file_as_write