### PR TITLE
fix: bundle approval and rollback follow-ups

### DIFF
--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -1570,6 +1570,10 @@ mod tests {
             PermissionManager::classify("str_replace"),
             SideEffect::Write
         );
+        assert_eq!(
+            PermissionManager::classify("delete_file"),
+            SideEffect::Write
+        );
     }
 
     #[test]

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -391,6 +391,7 @@ pub const APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "multi_edit",
     "delete_file",
     "git_commit",
+    "git_revert_commit",
     "git_stash",
     "github_create_issue",
 ];
@@ -814,6 +815,7 @@ mod tests {
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"multi_edit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"delete_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_commit"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_revert_commit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_stash"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"github_create_issue"));
         assert!(!APPROVAL_REQUIRED_TOOLS.contains(&"read_file"));

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -390,6 +390,8 @@ pub const APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "str_replace",
     "multi_edit",
     "delete_file",
+    "rollback_file_edits",
+    "rollback_database_snapshots",
     "git_commit",
     "git_revert_commit",
     "git_stash",
@@ -814,6 +816,8 @@ mod tests {
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"write_file"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"multi_edit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"delete_file"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"rollback_file_edits"));
+        assert!(APPROVAL_REQUIRED_TOOLS.contains(&"rollback_database_snapshots"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_commit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_revert_commit"));
         assert!(APPROVAL_REQUIRED_TOOLS.contains(&"git_stash"));

--- a/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
+++ b/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
@@ -10,6 +10,7 @@ pub const CLOUD_APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "create_file",
     "edit_file",
     "exec",
+    "git_commit",
     "git_revert_commit",
     "git_stash",
     "github_create_issue",
@@ -377,9 +378,15 @@ mod tests {
     }
 
     #[test]
+<<<<<<< HEAD
     fn git_revert_commit_is_write_gated() {
         assert_eq!(
             cloud_gated_tool_kind("git_revert_commit"),
+=======
+    fn git_commit_is_write_gated() {
+        assert_eq!(
+            cloud_gated_tool_kind("git_commit"),
+>>>>>>> fab4bf5d (fix: require cloud approval for git_commit)
             Some(CloudGatedToolKind::Write)
         );
     }

--- a/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
+++ b/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
@@ -8,6 +8,7 @@
 pub const CLOUD_APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "bash",
     "create_file",
+    "delete_file",
     "edit_file",
     "exec",
     "git_commit",
@@ -378,15 +379,25 @@ mod tests {
     }
 
     #[test]
-<<<<<<< HEAD
-    fn git_revert_commit_is_write_gated() {
-        assert_eq!(
-            cloud_gated_tool_kind("git_revert_commit"),
-=======
     fn git_commit_is_write_gated() {
         assert_eq!(
             cloud_gated_tool_kind("git_commit"),
->>>>>>> fab4bf5d (fix: require cloud approval for git_commit)
+            Some(CloudGatedToolKind::Write)
+        );
+    }
+
+    #[test]
+    fn git_revert_commit_is_write_gated() {
+        assert_eq!(
+            cloud_gated_tool_kind("git_revert_commit"),
+            Some(CloudGatedToolKind::Write)
+        );
+    }
+
+    #[test]
+    fn delete_file_is_write_gated() {
+        assert_eq!(
+            cloud_gated_tool_kind("delete_file"),
             Some(CloudGatedToolKind::Write)
         );
     }

--- a/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
+++ b/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
@@ -10,6 +10,7 @@ pub const CLOUD_APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "create_file",
     "edit_file",
     "exec",
+    "git_revert_commit",
     "git_stash",
     "github_create_issue",
     "multi_edit",
@@ -371,6 +372,14 @@ mod tests {
     fn git_stash_is_write_gated() {
         assert_eq!(
             cloud_gated_tool_kind("git_stash"),
+            Some(CloudGatedToolKind::Write)
+        );
+    }
+
+    #[test]
+    fn git_revert_commit_is_write_gated() {
+        assert_eq!(
+            cloud_gated_tool_kind("git_revert_commit"),
             Some(CloudGatedToolKind::Write)
         );
     }

--- a/rust/crates/astra-turn-core/src/tool_result_semantics.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_semantics.rs
@@ -653,6 +653,12 @@ if let Err(e) = writeln!(file, "{line}") {
             ToolErrorSeverity::HardError
         );
 
+        // delete_file timeout
+        assert_eq!(
+            classify_tool_error("delete_file", output),
+            ToolErrorSeverity::HardError
+        );
+
         // git_stash timeout
         assert_eq!(
             classify_tool_error("git_stash", output),

--- a/rust/crates/astra-turn-core/src/tool_result_semantics.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_semantics.rs
@@ -641,6 +641,12 @@ if let Err(e) = writeln!(file, "{line}") {
             ToolErrorSeverity::HardError
         );
 
+        // git_commit timeout
+        assert_eq!(
+            classify_tool_error("git_commit", output),
+            ToolErrorSeverity::HardError
+        );
+
         // git_revert_commit timeout
         assert_eq!(
             classify_tool_error("git_revert_commit", output),

--- a/rust/crates/astra-turn-core/src/tool_result_semantics.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_semantics.rs
@@ -641,6 +641,12 @@ if let Err(e) = writeln!(file, "{line}") {
             ToolErrorSeverity::HardError
         );
 
+        // git_revert_commit timeout
+        assert_eq!(
+            classify_tool_error("git_revert_commit", output),
+            ToolErrorSeverity::HardError
+        );
+
         // git_stash timeout
         assert_eq!(
             classify_tool_error("git_stash", output),

--- a/rust/crates/astra-turn-core/src/ws_approval_gate.rs
+++ b/rust/crates/astra-turn-core/src/ws_approval_gate.rs
@@ -225,6 +225,8 @@ mod tests {
         assert!(gate.requires_approval("bash"));
         assert!(gate.requires_approval("write_file"));
         assert!(gate.requires_approval("delete_file"));
+        assert!(gate.requires_approval("rollback_file_edits"));
+        assert!(gate.requires_approval("rollback_database_snapshots"));
         assert!(!gate.requires_approval("read_file"));
         assert!(!gate.requires_approval("list_dir"));
         assert!(!gate.requires_approval("grep"));

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
@@ -212,6 +212,7 @@ pub(crate) fn is_server_mutator_tool_name(name: &str) -> bool {
         // file
         "write_file"
             | "str_replace"
+            | "multi_edit"
             | "delete_file"
             // database
             | "mo_query"
@@ -234,7 +235,7 @@ fn server_file_mutator_in_round(tool_calls: &[Value]) -> bool {
     tool_calls.iter().any(|tool_call| {
         matches!(
             tool_call_name(tool_call),
-            Some("write_file" | "str_replace" | "delete_file")
+            Some("write_file" | "str_replace" | "multi_edit" | "delete_file")
         )
     })
 }
@@ -1728,6 +1729,76 @@ esac
     }
 
     #[tokio::test]
+    async fn server_file_boundary_aborts_and_rolls_back_when_multi_edit_fails() {
+        let session_id = format!("server-file-boundary-multi-edit-{}", uuid::Uuid::new_v4());
+        let dir = tempfile::TempDir::new().unwrap();
+        let executor = crate::server::server_tool_executor::ServerToolExecutor::new(
+            dir.path().to_path_buf(),
+            "test-user".into(),
+            session_id.clone(),
+            None,
+            None,
+        );
+        executor.set_turn_index(15);
+
+        let active = open_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            15,
+            &[
+                json!({"function": {"name": "write_file", "arguments": "{}"}}),
+                json!({"function": {"name": "multi_edit", "arguments": "{}"}}),
+            ],
+        )
+        .expect("boundary should open for file mutators");
+
+        let write_out = executor
+            .execute(
+                "write_file",
+                &json!({"path": "turn.txt", "content": "hello"}),
+            )
+            .await;
+        assert!(write_out.contains("Successfully wrote"));
+        assert!(dir.path().join("turn.txt").exists());
+
+        finalize_server_rollback_boundary(
+            Some(&session_id),
+            &executor,
+            &active,
+            &[
+                tool_record("write_file", true),
+                tool_record("multi_edit", false),
+            ],
+            &[],
+        )
+        .await;
+
+        let events = read_journal_events(&session_id);
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].event_type,
+            JournalEventType::ExecutionBoundaryOpened
+        );
+        assert_eq!(
+            events[1].event_type,
+            JournalEventType::ExecutionBoundaryAborted
+        );
+        let boundary = &events[1].metadata.as_ref().unwrap()["execution_boundary"];
+        assert_eq!(boundary["kind"].as_str(), Some("turn_rollback"));
+        assert_eq!(boundary["reason"].as_str(), Some("tool_error"));
+        assert_eq!(boundary["trigger_tool_name"].as_str(), Some("multi_edit"));
+        assert_eq!(
+            boundary["rollback"]["file_edits"]["reverted"]
+                .as_array()
+                .map(Vec::len),
+            Some(1)
+        );
+        assert!(!dir.path().join("turn.txt").exists());
+
+        cleanup_session_artifacts(&session_id);
+    }
+
+    #[tokio::test]
     async fn server_git_boundary_aborts_and_reverts_failed_turn() {
         let session_id = format!("server-git-boundary-{}", uuid::Uuid::new_v4());
         let dir = tempfile::TempDir::new().unwrap();
@@ -1990,6 +2061,7 @@ esac
         // File mutators
         assert!(is_server_mutator_tool_name("write_file"));
         assert!(is_server_mutator_tool_name("str_replace"));
+        assert!(is_server_mutator_tool_name("multi_edit"));
         assert!(is_server_mutator_tool_name("delete_file"));
         // Database mutators
         assert!(is_server_mutator_tool_name("mo_query"));


### PR DESCRIPTION
## Summary
- bundle PRs #167 through #171 onto one branch from latest main
- align server/cloud approval gating for git_revert_commit, git_commit, rollback tools, and delete_file
- keep server turn rollback scoping in sync so failed multi_edit rolls back co-scheduled file writes

## Included PRs
- #167 require approval for git_revert_commit
- #168 require approval for rollback tools
- #169 require cloud approval for git_commit
- #170 roll back server turns when multi_edit fails
- #171 require cloud approval for delete_file

## Validation
- git rebase origin/main
- make format
- make check
- cargo test -p astra-tools approval_required_tools_includes_dangerous_ops --lib
- cargo test -p astra-turn-core requires_approval_for_dangerous_tools --lib
- cargo test -p astra-turn-core git_commit_is_write_gated --lib
- cargo test -p astra-turn-core git_revert_commit_is_write_gated --lib
- cargo test -p astra-turn-core delete_file_is_write_gated --lib
- cargo test -p astra-turn-core classify_timeout_hard_for_mutation_tool --lib
- cargo test -p astra-runtime server_file_boundary_aborts_and_rolls_back_when_multi_edit_fails --lib
- cargo test -p astra-cli classify_write_file_as_write