### PR TITLE
feat(runtime): unified 5-min stream idle timeout + cloud tool delivery + server tool executor

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -26,6 +26,8 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run clippy
         run: make lint
+      - name: Server tool schema guards (astra-tools)
+        run: make check-server-tool-schemas
       - name: Check formatting
         run: make format-check
       - uses: taiki-e/install-action@v2

--- a/Makefile
+++ b/Makefile
@@ -439,6 +439,13 @@ test-workspace:
 	@echo "Running Rust workspace tests (all members, default features)..."
 	@$(CARGO) test $(CARGO_MANIFEST_FLAG)
 
+# Guard: server allowlist names ⊆ all_tool_schemas(), memory_* allowlist coverage,
+# DEFAULT_EXECUTOR_TOOL_NAMES ⊆ SERVER_EXECUTOR_TOOL_NAMES (manifest-path rust/Cargo.toml).
+.PHONY: check-server-tool-schemas
+check-server-tool-schemas:
+	@echo "Running astra-tools server/allowlist/schema guard tests..."
+	@$(CARGO) test $(CARGO_MANIFEST_FLAG) -p astra-tools schemas::tests::
+
 # Compiles chat/turn bridge hook paths and runs integration binaries that require
 # `required-features = ["bridge-e2e-hooks"]` (e.g. chat_turn_bridge_ledger_inject_e2e).
 .PHONY: test-runtime-bridge-hooks

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -3845,9 +3845,14 @@ pub(super) async fn consume_turn_sse(
             if host.render.md.is_none() {
                 host.render.lines_written = pre_clear_lines;
             }
-            let (result, _abort) =
-                consume_sse_stream_cancellable(&mut byte_stream, &mut host, idle, cancel_token)
-                    .await;
+            let (result, _abort) = consume_sse_stream_cancellable(
+                &mut byte_stream,
+                &mut host,
+                idle,
+                cancel_token,
+                None,
+            )
+            .await;
             let lw = host.render.lines_written;
             let md = host.render.md.take();
             let pending = std::mem::take(&mut host.xml_tag_buffer);
@@ -3862,9 +3867,14 @@ pub(super) async fn consume_turn_sse(
                 render.lines_written = pre_clear_lines;
             }
             let mut host = NoopSseStreamHost;
-            let (result, _abort) =
-                consume_sse_stream_cancellable(&mut byte_stream, &mut host, idle, cancel_token)
-                    .await;
+            let (result, _abort) = consume_sse_stream_cancellable(
+                &mut byte_stream,
+                &mut host,
+                idle,
+                cancel_token,
+                None,
+            )
+            .await;
             let lw = render.lines_written;
             let md = render.md.take();
             (result, Vec::new(), md, lw, String::new())

--- a/rust/crates/astra-tools/src/memoria.rs
+++ b/rust/crates/astra-tools/src/memoria.rs
@@ -415,6 +415,10 @@ mod tests {
         assert_eq!(pl["session_id"], "user-42");
         assert_eq!(pl["user_id"], "user-42");
         assert_eq!(pl["query"], "rust patterns");
+        assert!(
+            pl.get("min_confidence").is_none(),
+            "min_confidence should only be sent when explicitly provided"
+        );
 
         // search
         let (_, pl) = MemoriaClient::build_direct_request("http://mem", "search", &args);
@@ -465,5 +469,16 @@ mod tests {
         let (_, pl) = MemoriaClient::build_direct_request("http://mem", "retrieve", &args);
         assert!(pl.get("session_id").is_none());
         assert!(pl.get("user_id").is_none());
+        assert!(
+            pl.get("min_confidence").is_none(),
+            "min_confidence omitted when not provided"
+        );
+    }
+
+    #[test]
+    fn build_direct_request_retrieve_respects_explicit_min_confidence() {
+        let args = json!({"query": "q", "min_confidence": 0.7});
+        let (_, pl) = MemoriaClient::build_direct_request("http://mem", "retrieve", &args);
+        assert_eq!(pl["min_confidence"], json!(0.7));
     }
 }

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -2012,4 +2012,29 @@ mod tests {
             );
         }
     }
+
+    /// Default CLI/edge executor names must remain promotable to the server allowlist without
+    /// forgetting to add new defaults when expanding server coverage.
+    #[test]
+    fn default_executor_tool_names_are_subset_of_server_allowlist() {
+        let allow: HashSet<&str> = SERVER_EXECUTOR_TOOL_NAMES.iter().copied().collect();
+        for name in DEFAULT_EXECUTOR_TOOL_NAMES {
+            assert!(
+                allow.contains(name),
+                "`{name}` is in DEFAULT_EXECUTOR_TOOL_NAMES but missing from SERVER_EXECUTOR_TOOL_NAMES"
+            );
+        }
+    }
+
+    #[test]
+    fn default_executor_tool_schemas_are_subset_of_server_executor_schemas() {
+        let server_schemas = server_executor_tool_schemas();
+        let server_names: HashSet<&str> = schema_names(&server_schemas).into_iter().collect();
+        for name in schema_names(&default_executor_tool_schemas()) {
+            assert!(
+                server_names.contains(name),
+                "default executor exposes `{name}` but server_executor_tool_schemas() omits it"
+            );
+        }
+    }
 }

--- a/rust/crates/astra-turn-core/src/cloud_tool_delivery.rs
+++ b/rust/crates/astra-turn-core/src/cloud_tool_delivery.rs
@@ -587,6 +587,48 @@ pub async fn wait_tool_result_ledger_for_tool(
     out
 }
 
+/// Same SSE / persistence bundle as [`wait_tool_result_ledger_for_tool`], but for outputs
+/// computed on the server when no edge agent posts `POST /tools/result` (legacy `/chat/turn`
+/// with empty `edge_tools` and `edge_profile.cwd` set).
+pub fn local_tool_execution_delivery(
+    tc: &Value,
+    output: &str,
+    is_error: bool,
+) -> EdgeToolRoundDelivery {
+    let mut out = EdgeToolRoundDelivery::default();
+    let Some(tc_map) = tc.as_object() else {
+        astra_core::agent_warn!(
+            "tool_delivery",
+            "local_tool_execution_delivery: tool call is not a JSON object, skipping"
+        );
+        return out;
+    };
+    let id = tc_map.get("id").and_then(Value::as_str).unwrap_or("");
+    let tool_name = tc_map
+        .get("function")
+        .and_then(|f| f.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let status = if is_error { "error" } else { "ok" };
+    let synthetic = json!({ "body": { "status": status, "output": output } });
+    let raw_content = tool_content_from_ledger_entry(&synthetic);
+    let content = llm_safe_tool_content(&raw_content, tool_name);
+    out.tool_messages.push(json!({
+        "role": "tool",
+        "tool_call_id": id,
+        "content": content,
+    }));
+    out.sse_maps
+        .push(build_tool_call_end_event(id, Value::String(raw_content)));
+    out.persist_tool_results
+        .push(persist_value_for_ledger_tool_result(
+            tc,
+            Some(&synthetic),
+            false,
+        ));
+    out
+}
+
 pub fn cloud_tool_requires_approval_for_delivery(tool_call: &Value) -> bool {
     cloud_tool_requires_approval(tool_call)
 }
@@ -1345,5 +1387,24 @@ mod tests {
         });
         let detail = tool_approval_detail(&tc);
         assert_eq!(detail.as_deref(), Some("git status"));
+    }
+
+    #[test]
+    fn local_tool_execution_delivery_matches_ok_ledger_shape() {
+        let tc = json!({
+            "id": "srv-1",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": r#"{"path":"x"}"#}
+        });
+        let tail = local_tool_execution_delivery(&tc, "body text", false);
+        assert_eq!(tail.sse_maps.len(), 1);
+        assert_eq!(tail.tool_messages.len(), 1);
+        assert_eq!(tail.persist_tool_results.len(), 1);
+        assert!(
+            tail.tool_messages[0]["content"]
+                .as_str()
+                .unwrap()
+                .contains("body text")
+        );
     }
 }

--- a/rust/crates/astra-turn-core/src/sse_stream_host.rs
+++ b/rust/crates/astra-turn-core/src/sse_stream_host.rs
@@ -292,7 +292,7 @@ pub async fn consume_sse_stream<H: SseStreamHost>(
     host: &mut H,
     idle_timeout: std::time::Duration,
 ) -> (SseConsumeResult, Option<SseAbortReason>) {
-    consume_sse_stream_cancellable(chunks, host, idle_timeout, None).await
+    consume_sse_stream_cancellable(chunks, host, idle_timeout, None, None).await
 }
 
 /// Consume an SSE byte stream with optional cancellation support.
@@ -307,6 +307,7 @@ pub async fn consume_sse_stream_cancellable<H: SseStreamHost>(
     host: &mut H,
     idle_timeout: std::time::Duration,
     cancel_token: Option<&tokio_util::sync::CancellationToken>,
+    idle_timeout_after_progress: Option<std::time::Duration>,
 ) -> (SseConsumeResult, Option<SseAbortReason>) {
     use futures_util::StreamExt;
 
@@ -322,7 +323,7 @@ pub async fn consume_sse_stream_cancellable<H: SseStreamHost>(
     host.on_before_sse_read_loop();
 
     let idle_pre = idle_timeout;
-    let idle_post = stream_idle_timeout_after_progress();
+    let idle_post = idle_timeout_after_progress.unwrap_or_else(stream_idle_timeout_after_progress);
     // Short tick for UI heartbeat (thinking pane elapsed timer refresh).
     let tick = std::time::Duration::from_secs(1);
     loop {
@@ -1051,8 +1052,10 @@ mod tests {
             .chain(stream::pending::<Result<Vec<u8>, String>>());
 
         let mut host = RecordingSseStreamHost::new();
+        let timeout = std::time::Duration::from_millis(5);
         let (result, abort) =
-            consume_sse_stream(&mut stream, &mut host, std::time::Duration::from_millis(5)).await;
+            consume_sse_stream_cancellable(&mut stream, &mut host, timeout, None, Some(timeout))
+                .await;
 
         assert_eq!(abort, Some(astra_core::ErrorKind::StreamIdle));
         assert!(host.stream_completed);
@@ -1091,6 +1094,7 @@ mod tests {
             &mut host,
             std::time::Duration::from_millis(60_000), // Long timeout - won't fire
             Some(&cancel_token),
+            None,
         )
         .await;
 
@@ -1503,12 +1507,10 @@ mod tests {
             .await
             .unwrap();
 
-        let (result, abort) = consume_sse_stream(
-            &mut stream,
-            &mut host,
-            std::time::Duration::from_millis(100),
-        )
-        .await;
+        let timeout = std::time::Duration::from_millis(100);
+        let (result, abort) =
+            consume_sse_stream_cancellable(&mut stream, &mut host, timeout, None, Some(timeout))
+                .await;
 
         assert_eq!(abort, Some(astra_core::ErrorKind::StreamIdle));
         assert!(
@@ -1558,6 +1560,7 @@ mod tests {
             &mut host,
             std::time::Duration::from_secs(10),
             Some(&cancel),
+            None,
         )
         .await;
 

--- a/rust/crates/astra-turn-core/src/sse_stream_host.rs
+++ b/rust/crates/astra-turn-core/src/sse_stream_host.rs
@@ -24,15 +24,42 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 /// Stream idle watchdog default: abort SSE consumption if no chunk arrives within this time.
-pub const STREAM_IDLE_TIMEOUT_MS: u64 = 90_000;
+///
+/// This timeout applies before the first SSE frame is received (the TTFT gap).
+/// Because thinking/reasoning models (o1, o3, DeepSeek-R1, claude with extended
+/// thinking) can spend minutes in the reasoning phase **before** emitting any SSE
+/// chunk, it is impossible to distinguish a genuinely dead connection from a slow
+/// model at this stage. The 5-minute default matches
+/// [`STREAM_IDLE_TIMEOUT_AFTER_PROGRESS_MS`] and is configurable via
+/// `MO_STREAM_IDLE_TIMEOUT_MS`.
+pub const STREAM_IDLE_TIMEOUT_MS: u64 = 300_000;
 
-/// Configurable stream idle timeout. Reads `MO_STREAM_IDLE_TIMEOUT_MS` env var,
-/// falling back to [`STREAM_IDLE_TIMEOUT_MS`] (90 s).
+/// Idle timeout after at least one SSE chunk has been received.
+///
+/// Thinking/reasoning models (o1, o3, DeepSeek-R1, claude with extended thinking)
+/// can spend minutes in the reasoning phase where the SSE stream produces no
+/// `text_delta` events. A 5-minute post-progress window avoids false aborts while
+/// still catching genuinely stalled connections.
+pub const STREAM_IDLE_TIMEOUT_AFTER_PROGRESS_MS: u64 = 300_000;
+
+/// Configurable stream idle timeout (pre-progress). Reads `MO_STREAM_IDLE_TIMEOUT_MS`
+/// env var, falling back to [`STREAM_IDLE_TIMEOUT_MS`] (300 s / 5 min).
 pub fn stream_idle_timeout() -> std::time::Duration {
     let ms = std::env::var("MO_STREAM_IDLE_TIMEOUT_MS")
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
         .unwrap_or(STREAM_IDLE_TIMEOUT_MS);
+    std::time::Duration::from_millis(ms)
+}
+
+/// Configurable stream idle timeout (post-progress). Reads
+/// `MO_STREAM_IDLE_TIMEOUT_AFTER_PROGRESS_MS` env var, falling back to
+/// [`STREAM_IDLE_TIMEOUT_AFTER_PROGRESS_MS`] (300 s / 5 min).
+pub fn stream_idle_timeout_after_progress() -> std::time::Duration {
+    let ms = std::env::var("MO_STREAM_IDLE_TIMEOUT_AFTER_PROGRESS_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(STREAM_IDLE_TIMEOUT_AFTER_PROGRESS_MS);
     std::time::Duration::from_millis(ms)
 }
 
@@ -294,10 +321,18 @@ pub async fn consume_sse_stream_cancellable<H: SseStreamHost>(
 
     host.on_before_sse_read_loop();
 
-    let idle = idle_timeout;
+    let idle_pre = idle_timeout;
+    let idle_post = stream_idle_timeout_after_progress();
     // Short tick for UI heartbeat (thinking pane elapsed timer refresh).
     let tick = std::time::Duration::from_secs(1);
     loop {
+        // After first progress, use the more generous post-progress timeout
+        // to avoid false aborts during thinking/reasoning model pauses.
+        let idle = if first_sse_frame_seen {
+            idle_post
+        } else {
+            idle_pre
+        };
         // Inner loop: retry with short ticks so on_idle_tick can refresh the UI,
         // but accumulate elapsed time toward the full idle_timeout.
         let chunk_result = 'wait: {
@@ -383,7 +418,15 @@ pub async fn consume_sse_stream_cancellable<H: SseStreamHost>(
         pending.clear();
         let msg = match abort {
             Some(astra_core::ErrorKind::StreamIdle) => {
-                format!("Error: stream idle timeout after {}ms", idle.as_millis())
+                let timeout_used = if first_sse_frame_seen {
+                    idle_post
+                } else {
+                    idle_pre
+                };
+                format!(
+                    "Error: stream idle timeout after {}ms",
+                    timeout_used.as_millis()
+                )
             }
             Some(astra_core::ErrorKind::Cancelled) => "Cancelled by user".to_string(),
             _ => "Unknown abort".to_string(),

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -3804,6 +3804,35 @@ esac
         assert!(result.contains("not available"));
     }
 
+    struct AlwaysTimeoutGate;
+
+    #[async_trait]
+    impl astra_tools::ToolApprovalGate for AlwaysTimeoutGate {
+        async fn request_approval(
+            &self,
+            _request_id: &str,
+            _tool_name: &str,
+            _args: &Value,
+        ) -> astra_tools::ApprovalDecision {
+            astra_tools::ApprovalDecision::Timeout
+        }
+
+        fn requires_approval(&self, tool_name: &str) -> bool {
+            tool_name == "bash"
+        }
+    }
+
+    #[tokio::test]
+    async fn approval_timeout_returns_denied_error_string() {
+        let (mut exec, _dir) = test_executor();
+        exec.set_approval_gate(std::sync::Arc::new(AlwaysTimeoutGate));
+        let out = exec.execute("bash", &json!({"command": "echo hi"})).await;
+        assert!(
+            out.contains("approval request timed out"),
+            "unexpected output: {out}"
+        );
+    }
+
     // ── Bash execution ─────────────────────────────────────────────────
 
     #[tokio::test]

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -4,7 +4,7 @@
 ///
 /// | Behavior | Implementation |
 /// |------------------------|------|
-/// | Long-lived stream “stall” / no chunks | [`super::llm_client::stream_idle_timeout`] on SSE `next()` (90s default, `MO_STREAM_IDLE_TIMEOUT_MS`) |
+/// | Long-lived stream "stall" / no chunks | [`super::llm_client::stream_idle_timeout`] on SSE `next()` (5 min default, `MO_STREAM_IDLE_TIMEOUT_MS`) |
 /// | Recover via one-shot completion | [`super::llm_client::call_llm_nonstream_fallback`] after idle in both `call_llm_and_collect` and [`call_llm_stream`] below |
 /// | User cancel clears in-flight work | HTTP `/chat/turn` passes `CancellationToken`; dropping the SSE body (client disconnect) cancels in-flight LLM byte/SSE consumption in-process |
 /// | Cooldown / 429 wait cannot ignore disconnect | [`super::llm_client::sleep_ms_or_llm_cancel`] on retry backoff + rate-limit waits in [`call_llm_stream`]; initial cooldown wait `select!`s [`wait_until_cancelled_or_pending`](super::llm_client::wait_until_cancelled_or_pending) in the bridge stream |
@@ -55,7 +55,11 @@ use futures_util::{StreamExt, stream};
 /// Maximum number of read-only tools to execute concurrently.
 /// Prevents resource exhaustion from parallel tool execution.
 const MAX_CONCURRENT_READ_ONLY_TOOLS: usize = 10;
+use astra_tools::executor::DefaultToolExecutor;
+use astra_tools::{SandboxConfig, SandboxMode, ToolContext, ToolExecutor, TracingLogger};
 use serde_json::{Map, Value, json};
+use std::path::PathBuf;
+use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -76,10 +80,10 @@ use crate::{
     },
     turn::cloud_tool_delivery::{
         ApprovalAuditContext, cloud_tool_requires_approval_for_delivery,
-        record_approval_required_audit, sse_maps_through_tool_request,
-        tool_approval_detail_for_delivery, tool_approval_kind_for_delivery,
-        tool_path_hint_for_delivery, wait_approval_ledger_for_tool,
-        wait_tool_result_ledger_for_tool,
+        local_tool_execution_delivery, record_approval_required_audit,
+        sse_maps_through_tool_request, tool_approval_detail_for_delivery,
+        tool_approval_kind_for_delivery, tool_path_hint_for_delivery,
+        wait_approval_ledger_for_tool, wait_tool_result_ledger_for_tool,
     },
     turn::edge_ledger::{
         assistant_message_with_tool_calls_and_reasoning, ensure_tool_call_ids,
@@ -94,7 +98,8 @@ use crate::{
     },
     turn::stall::cli_agentic_tool_round_budget_abort_msg,
     turn::stream_events::build_approval_required_event,
-    turn::tool_call_shape::tool_call_name,
+    turn::tool_argument_hints::normalize_llm_function_arguments,
+    turn::tool_call_shape::{tool_call_arguments_value, tool_call_name},
     turn::tool_schema_prune::prune_tool_schemas,
     turn::turn_guard::TurnGuard,
 };
@@ -1098,7 +1103,8 @@ async fn call_llm_stream(
             let base_url_for_fallback = base_url.to_string();
             let provider_for_fallback = provider.to_string();
             let max_out_for_fallback = max_output_tokens;
-            let idle_dur = crate::turn::llm_client::stream_idle_timeout();
+            let idle_pre = crate::turn::llm_client::stream_idle_timeout();
+            let idle_post = crate::turn::llm_client::stream_idle_timeout_after_progress();
 
             let out = stream! {
                 let cc = client_cancel.clone();
@@ -1107,11 +1113,13 @@ async fn call_llm_stream(
                 let mut tool_calls_map: std::collections::HashMap<usize, Map<String, Value>> =
                     std::collections::HashMap::new();
                 let mut usage = Map::new();
+                let mut made_progress = false;
 
                 let sse = crate::turn::llm_client::parse_openai_sse_json_stream(byte_stream);
                 tokio::pin!(sse);
 
                 loop {
+                    let idle = if made_progress { idle_post } else { idle_pre };
                     tokio::select! {
                         biased;
                         _ = crate::turn::llm_client::wait_until_cancelled_or_pending(cc.as_deref()) => {
@@ -1124,15 +1132,16 @@ async fn call_llm_stream(
                             reasoning.clear();
                             break;
                         }
-                        tick = tokio::time::timeout(idle_dur, sse.next()) => {
+                        tick = tokio::time::timeout(idle, sse.next()) => {
                             let next = tick;
                             let chunk = match next {
                                 Ok(c) => c,
                                 Err(_) => {
                                     astra_core::agent_warn!(
                                         "llm",
-                                        "in-process stream idle after {}ms — attempting non-stream fallback",
-                                        idle_dur.as_millis()
+                                        "in-process stream idle after {}ms (made_progress={}) — attempting non-stream fallback",
+                                        idle.as_millis(),
+                                        made_progress
                                     );
                                     tool_calls_map.clear();
                                     full_text.clear();
@@ -1219,6 +1228,7 @@ async fn call_llm_stream(
                             };
                             // Some providers attach usage to a chunk that also contains choices,
                             // so parse usage first on every chunk.
+                            made_progress = true;
                             if let Some(u) = chunk.get("usage").and_then(Value::as_object) {
                                 let prompt = u.get("prompt_tokens").and_then(Value::as_i64);
                                 let completion = u.get("completion_tokens").and_then(Value::as_i64);
@@ -2574,6 +2584,14 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                     &loop_reasoning,
                     !reasoning.is_empty() || history_has_reasoning(&llm_messages),
                 ));
+                // Tool delivery matrix for this generator (legacy `/chat/turn`):
+                // - Approval-gated + empty `edge_tools`: fast-fail via `local_tool_execution_delivery`
+                //   (no edge client for §5.5 POST /approval/respond or /tools/result).
+                // - Approval-gated + non-empty `edge_tools`: sequential §5.5 ledger
+                //   (audit + approval_required → wait approval → tool_request → wait result).
+                // - Read-only batch: empty `edge_tools` → `DefaultToolExecutor` + cwd; else concurrent
+                //   `wait_tool_result_ledger_for_tool` after broadcasting all `tool_request` maps.
+                // (`cloud_tool_requires_approval_for_delivery` / bash read-only rules live in astra-turn-core.)
                 // ── Tool delivery: approval tools sequential, read-only concurrent ──
                 let mut read_only_tcs: Vec<Value> = Vec::new();
                 for tc in loop_tool_calls.iter() {
@@ -2582,7 +2600,33 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                         read_only_tcs.push(tc.clone());
                         continue;
                     }
-                    // Sequential: approval → wait → request → wait
+                    if edge_tools.is_empty() {
+                        // No edge tool schemas: §5.5 approval/result round-trip has no edge client
+                        // to POST /approval/respond or /tools/result — fail fast instead of ledger timeout.
+                        let tool_name = tc_map
+                            .get("function")
+                            .and_then(|f| f.get("name"))
+                            .and_then(Value::as_str)
+                            .unwrap_or("");
+                        let tail = local_tool_execution_delivery(
+                            tc,
+                            &format!(
+                                "approval-required tool `{tool_name}` cannot execute: no edge agent connected"
+                            ),
+                            true,
+                        );
+                        for m in tail.sse_maps {
+                            yield render_sse_map(&m);
+                        }
+                        record_turn_guard_tool_results(
+                            &mut bridge_turn_guard,
+                            &tail.persist_tool_results,
+                        );
+                        merged_tool_results.extend(tail.persist_tool_results);
+                        llm_messages.extend(tail.tool_messages);
+                        continue;
+                    }
+                    // Sequential: approval → wait → request → wait (§5.5 ledger + edge agent).
                     let id = tc_map.get("id").and_then(Value::as_str).unwrap_or("");
                     let tool_name = tc_map
                         .get("function")
@@ -2625,39 +2669,39 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                         path.as_deref(),
                         detail.as_deref(),
                     ));
-                        let approval = match await_with_client_disconnect(
-                            cc.as_deref(),
-                            wait_approval_ledger_for_tool(
-                                &edge_callback_ledger,
-                                &user_id,
-                                tc,
-                                ledger_wait,
-                                Some(&approval_audit_context),
-                            ),
-                        )
-                        .await
-                        {
-                            Ok(approval) => approval,
-                            Err(event) => {
-                                yield render_sse_map(&event);
-                                return;
-                            }
-                        };
-                        match approval {
-                            Ok(()) => {}
-                            Err(part) => {
-                                record_turn_guard_tool_results(
-                                    &mut bridge_turn_guard,
-                                    &part.persist_tool_results,
-                                );
-                                for m in part.sse_maps {
-                                    yield render_sse_map(&m);
-                                }
-                                merged_tool_results.extend(part.persist_tool_results);
-                                llm_messages.extend(part.tool_messages);
-                                continue;
-                            }
+                    let approval = match await_with_client_disconnect(
+                        cc.as_deref(),
+                        wait_approval_ledger_for_tool(
+                            &edge_callback_ledger,
+                            &user_id,
+                            tc,
+                            ledger_wait,
+                            Some(&approval_audit_context),
+                        ),
+                    )
+                    .await
+                    {
+                        Ok(approval) => approval,
+                        Err(event) => {
+                            yield render_sse_map(&event);
+                            return;
                         }
+                    };
+                    match approval {
+                        Ok(()) => {}
+                        Err(part) => {
+                            record_turn_guard_tool_results(
+                                &mut bridge_turn_guard,
+                                &part.persist_tool_results,
+                            );
+                            for m in part.sse_maps {
+                                yield render_sse_map(&m);
+                            }
+                            merged_tool_results.extend(part.persist_tool_results);
+                            llm_messages.extend(part.tool_messages);
+                            continue;
+                        }
+                    }
                     for m in sse_maps_through_tool_request(tc) {
                         yield render_sse_map(&m);
                     }
@@ -2681,7 +2725,10 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                     for m in tail.sse_maps {
                         yield render_sse_map(&m);
                     }
-                    record_turn_guard_tool_results(&mut bridge_turn_guard, &tail.persist_tool_results);
+                    record_turn_guard_tool_results(
+                        &mut bridge_turn_guard,
+                        &tail.persist_tool_results,
+                    );
                     merged_tool_results.extend(tail.persist_tool_results);
                     llm_messages.extend(tail.tool_messages);
                 }
@@ -2693,41 +2740,132 @@ impl ChatTurnBridge for InProcessChatTurnBridge {
                             yield render_sse_map(&m);
                         }
                     }
-                    // Use buffer_unordered to limit concurrent tool executions.
-                    // This prevents resource exhaustion when many tools are called.
-                    let tool_stream = stream::iter(read_only_tcs.into_iter().map(|tc| {
-                        let ledger = edge_callback_ledger.clone();
-                        let uid = user_id.clone();
-                        async move {
-                            wait_tool_result_ledger_for_tool(
-                                &ledger, &uid, &tc, ledger_wait,
-                            ).await
-                        }
-                    })).buffer_unordered(MAX_CONCURRENT_READ_ONLY_TOOLS);
-                    tokio::pin!(tool_stream);
-                    loop {
-                        let next_tail = match await_with_client_disconnect(
-                            cc.as_deref(),
-                            tool_stream.next(),
-                        )
-                        .await
-                        {
-                            Ok(next_tail) => next_tail,
-                            Err(event) => {
-                                yield render_sse_map(&event);
-                                return;
-                            }
+                    if edge_tools.is_empty() {
+                        // No edge agent: execute read-only tools locally (requires cwd workspace).
+                        let cwd_str = edge_profile
+                            .get("cwd")
+                            .and_then(Value::as_str)
+                            .filter(|s| !s.is_empty());
+                        let Some(cwd_str) = cwd_str else {
+                            yield render_sse_map(&build_stream_error_event(
+                                "edge_tools is empty but edge_profile.cwd is missing; cannot execute read-only tools on the server",
+                                "LOCAL_TOOL_NO_WORKSPACE",
+                                false,
+                            ));
+                            return;
                         };
-                        let Some(tail) = next_tail else { break };
-                        for m in tail.sse_maps {
-                            yield render_sse_map(&m);
+                        let root = PathBuf::from(cwd_str);
+                        if !root.is_dir() {
+                            yield render_sse_map(&build_stream_error_event(
+                                &format!(
+                                    "edge_profile.cwd is not a directory: {}",
+                                    root.display()
+                                ),
+                                "LOCAL_TOOL_NO_WORKSPACE",
+                                false,
+                            ));
+                            return;
                         }
-                        record_turn_guard_tool_results(
-                            &mut bridge_turn_guard,
-                            &tail.persist_tool_results,
-                        );
-                        merged_tool_results.extend(tail.persist_tool_results);
-                        llm_messages.extend(tail.tool_messages);
+                        // SandboxConfig for server-side read-only tool execution:
+                        // The primary protection is the SERVER_EXECUTOR_TOOL_NAMES allowlist,
+                        // which only includes read-only tools. SandboxMode::ReadOnly and
+                        // network_allowed=false serve as a future enforcement layer; currently
+                        // individual tools do not check sandbox mode at dispatch time.
+                        // 30s command timeout (vs 120s strict default) — server should be more
+                        // conservative, failing fast on stalled commands.
+                        let sandbox = SandboxConfig {
+                            project_root: root.clone(),
+                            allowed_paths: vec![PathBuf::from("/tmp")],
+                            mode: SandboxMode::ReadOnly,
+                            max_output_bytes: 200_000,
+                            command_timeout: Duration::from_secs(30),
+                            network_allowed: false,
+                        };
+                        let ctx = ToolContext {
+                            project_root: root.clone(),
+                            workspace_root: root,
+                            user_id: user_id.clone(),
+                            session_id: session_id.clone(),
+                            sandbox,
+                            http_client: None,
+                            logger: Arc::new(TracingLogger),
+                            cancel_token: None,
+                        };
+                        let executor = Arc::new(DefaultToolExecutor::new(ctx));
+                        let local_ro = read_only_tcs;
+                        let local_futs = stream::iter(local_ro.into_iter().map(|tc| {
+                            let exec = executor.clone();
+                            async move {
+                                let Some(name) = tool_call_name(&tc) else {
+                                    tracing::warn!(
+                                        tool_call = %tc,
+                                        "skipping local tool call with missing name"
+                                    );
+                                    return None;
+                                };
+                                let args =
+                                    normalize_llm_function_arguments(&tool_call_arguments_value(&tc));
+                                let result = exec.execute(name, &args).await;
+                                Some(local_tool_execution_delivery(
+                                    &tc,
+                                    &result.output,
+                                    result.is_error,
+                                ))
+                            }
+                        }))
+                        .buffer_unordered(MAX_CONCURRENT_READ_ONLY_TOOLS);
+                        tokio::pin!(local_futs);
+                        while let Some(tail) = local_futs.next().await.flatten() {
+                            for m in tail.sse_maps {
+                                yield render_sse_map(&m);
+                            }
+                            record_turn_guard_tool_results(
+                                &mut bridge_turn_guard,
+                                &tail.persist_tool_results,
+                            );
+                            merged_tool_results.extend(tail.persist_tool_results);
+                            llm_messages.extend(tail.tool_messages);
+                        }
+                    } else {
+                        // Use buffer_unordered to limit concurrent tool executions.
+                        // This prevents resource exhaustion when many tools are called.
+                        let ro = read_only_tcs.clone();
+                        let tool_stream = stream::iter(ro.into_iter().map(|tc| {
+                            let ledger = edge_callback_ledger.clone();
+                            let uid = user_id.clone();
+                            async move {
+                                wait_tool_result_ledger_for_tool(
+                                    &ledger, &uid, &tc, ledger_wait,
+                                )
+                                .await
+                            }
+                        }))
+                        .buffer_unordered(MAX_CONCURRENT_READ_ONLY_TOOLS);
+                        tokio::pin!(tool_stream);
+                        loop {
+                            let next_tail = match await_with_client_disconnect(
+                                cc.as_deref(),
+                                tool_stream.next(),
+                            )
+                            .await
+                            {
+                                Ok(next_tail) => next_tail,
+                                Err(event) => {
+                                    yield render_sse_map(&event);
+                                    return;
+                                }
+                            };
+                            let Some(tail) = next_tail else { break };
+                            for m in tail.sse_maps {
+                                yield render_sse_map(&m);
+                            }
+                            record_turn_guard_tool_results(
+                                &mut bridge_turn_guard,
+                                &tail.persist_tool_results,
+                            );
+                            merged_tool_results.extend(tail.persist_tool_results);
+                            llm_messages.extend(tail.tool_messages);
+                        }
                     }
                 }
 

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -238,10 +238,32 @@ pub(crate) async fn sleep_ms_or_llm_cancel(
     }
 }
 
-/// Per-chunk idle watchdog: no SSE JSON for this long → treat as stalled.
+/// Per-chunk idle watchdog (pre-progress): no SSE JSON for this long → treat as stalled.
+/// Delegate to the canonical public function in sse_stream_host.
 pub(crate) fn stream_idle_timeout() -> std::time::Duration {
-    // Delegate to the canonical public function in sse_stream_host.
+    #[cfg(test)]
+    if let Some(d) = TEST_STREAM_IDLE_TIMEOUT.with(|c| *c.borrow()) {
+        return d;
+    }
     crate::turn::sse_stream_host::stream_idle_timeout()
+}
+
+/// Per-chunk idle watchdog (post-progress): once at least one SSE chunk has been
+/// received, allow a longer idle window to accommodate thinking/reasoning pauses.
+pub(crate) fn stream_idle_timeout_after_progress() -> std::time::Duration {
+    #[cfg(test)]
+    if let Some(d) = TEST_STREAM_IDLE_TIMEOUT_AFTER_PROGRESS.with(|c| *c.borrow()) {
+        return d;
+    }
+    crate::turn::sse_stream_host::stream_idle_timeout_after_progress()
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_STREAM_IDLE_TIMEOUT: std::cell::RefCell<Option<std::time::Duration>> =
+        const { std::cell::RefCell::new(None) };
+    static TEST_STREAM_IDLE_TIMEOUT_AFTER_PROGRESS: std::cell::RefCell<Option<std::time::Duration>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 /// TCP connect timeout for LLM API requests.
@@ -334,6 +356,10 @@ pub(crate) async fn call_llm_and_collect(
     // the same partial generation in a second streaming attempt.
     let mut idle_timeout_count = 0u32;
     let max_retries = LLM_MAX_RETRIES;
+    // Read idle timeouts once before the retry loop to avoid env-var races between
+    // parallel tests (and to ensure consistent timeouts across retries).
+    let idle_pre = stream_idle_timeout();
+    let idle_post = stream_idle_timeout_after_progress();
 
     for attempt in 0..=max_retries {
         // Extend retries if TPM exhaustion was detected (account-level limit)
@@ -411,7 +437,16 @@ pub(crate) async fn call_llm_and_collect(
             // Success — record to cooldown tracker
             cooldown.with(model_key, |c| c.record_success());
             let byte_stream = response.bytes_stream();
-            match collect_llm_stream(byte_stream, model_name, started, cancel).await {
+            match collect_llm_stream(
+                byte_stream,
+                model_name,
+                started,
+                cancel,
+                idle_pre,
+                idle_post,
+            )
+            .await
+            {
                 Ok(result) => return Ok(result),
                 Err(StreamCollectError::Cancelled) => {
                     return Err(astra_core::ClassifiedError::new(
@@ -605,6 +640,8 @@ async fn collect_llm_stream(
     model_name: &str,
     started: Instant,
     cancel: LlmCancel<'_>,
+    idle_pre: std::time::Duration,
+    idle_post: std::time::Duration,
 ) -> Result<LlmCallResult, StreamCollectError> {
     let mut full_text = String::new();
     let mut reasoning = String::new();
@@ -616,9 +653,8 @@ async fn collect_llm_stream(
 
     let sse = parse_openai_sse_json_stream(stream);
     tokio::pin!(sse);
-
-    let idle = stream_idle_timeout();
     loop {
+        let idle = if made_progress { idle_post } else { idle_pre };
         let item = tokio::select! {
             biased;
             _ = wait_llm_cancel(cancel) => return Err(StreamCollectError::Cancelled),
@@ -1042,6 +1078,27 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
+    /// Set thread-local stream idle timeouts for the duration of a test.
+    /// Returns a guard that resets them on drop.
+    fn set_test_stream_timeouts(pre_ms: u64, post_ms: Option<u64>) -> impl Drop {
+        TEST_STREAM_IDLE_TIMEOUT.with(|c| {
+            *c.borrow_mut() = Some(std::time::Duration::from_millis(pre_ms));
+        });
+        if let Some(post) = post_ms {
+            TEST_STREAM_IDLE_TIMEOUT_AFTER_PROGRESS.with(|c| {
+                *c.borrow_mut() = Some(std::time::Duration::from_millis(post));
+            });
+        }
+        struct Guard;
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                TEST_STREAM_IDLE_TIMEOUT.with(|c| *c.borrow_mut() = None);
+                TEST_STREAM_IDLE_TIMEOUT_AFTER_PROGRESS.with(|c| *c.borrow_mut() = None);
+            }
+        }
+        Guard
+    }
+
     #[tokio::test]
     async fn sleep_ms_or_llm_cancel_sleeps_when_no_cancel_source() {
         let r = sleep_ms_or_llm_cancel(8, LlmCancel::None).await;
@@ -1407,7 +1464,15 @@ mod tests {
         let err = sample_reqwest_stream_error().await;
         let byte_stream = stream::iter(vec![Err(err)]);
         let started = Instant::now();
-        let res = collect_llm_stream(byte_stream, "test-model", started, LlmCancel::None).await;
+        let res = collect_llm_stream(
+            byte_stream,
+            "test-model",
+            started,
+            LlmCancel::None,
+            stream_idle_timeout(),
+            stream_idle_timeout_after_progress(),
+        )
+        .await;
         assert!(
             matches!(res, Err(StreamCollectError::Transport(_))),
             "expected transport error, got: {res:?}"
@@ -1423,9 +1488,16 @@ mod tests {
         let u = json!({"usage":{"prompt_tokens":3,"completion_tokens":4}});
         let body = format!("data: {d1}\n\ndata: {d2}\n\ndata: {u}\n\n");
         let stream = stream::iter(vec![Ok(Bytes::from(body))]);
-        let res = collect_llm_stream(stream, "gpt-test", Instant::now(), LlmCancel::None)
-            .await
-            .expect("collect");
+        let res = collect_llm_stream(
+            stream,
+            "gpt-test",
+            Instant::now(),
+            LlmCancel::None,
+            stream_idle_timeout(),
+            stream_idle_timeout_after_progress(),
+        )
+        .await
+        .expect("collect");
         assert_eq!(res.full_text, "Hi there");
         assert_eq!(res.reasoning, "R");
         assert_eq!(res.usage.get("prompt").and_then(Value::as_i64), Some(3));
@@ -1445,9 +1517,16 @@ mod tests {
         let done = json!({"choices":[{"delta":{},"finish_reason":"stop"}]});
         let body = format!("data: {d1}\n\ndata: {done}\n\n");
         let stream = stream::iter(vec![Ok(Bytes::from(body))]);
-        let res = collect_llm_stream(stream, "m", Instant::now(), LlmCancel::None)
-            .await
-            .expect("collect");
+        let res = collect_llm_stream(
+            stream,
+            "m",
+            Instant::now(),
+            LlmCancel::None,
+            stream_idle_timeout(),
+            stream_idle_timeout_after_progress(),
+        )
+        .await
+        .expect("collect");
         assert_eq!(res.full_text, "Hello");
         assert_eq!(res.finish_reason.as_deref(), Some("stop"));
         unsafe { std::env::remove_var("MO_STREAM_IDLE_TIMEOUT_MS") };
@@ -1460,9 +1539,16 @@ mod tests {
         let done = json!({"choices":[{"delta":{},"finish_reason":"length"}]});
         let body = format!("data: {d1}\n\ndata: {done}\n\n");
         let stream = stream::iter(vec![Ok(Bytes::from(body))]);
-        let res = collect_llm_stream(stream, "m", Instant::now(), LlmCancel::None)
-            .await
-            .expect("collect");
+        let res = collect_llm_stream(
+            stream,
+            "m",
+            Instant::now(),
+            LlmCancel::None,
+            stream_idle_timeout(),
+            stream_idle_timeout_after_progress(),
+        )
+        .await
+        .expect("collect");
         assert_eq!(res.finish_reason.as_deref(), Some("length"));
         unsafe { std::env::remove_var("MO_STREAM_IDLE_TIMEOUT_MS") };
     }
@@ -1474,9 +1560,16 @@ mod tests {
         let c2 = json!({"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\"bar\"}"}}]}}]});
         let body = format!("data: {c1}\n\ndata: {c2}\n\n");
         let stream = stream::iter(vec![Ok(Bytes::from(body))]);
-        let res = collect_llm_stream(stream, "m", Instant::now(), LlmCancel::None)
-            .await
-            .expect("collect");
+        let res = collect_llm_stream(
+            stream,
+            "m",
+            Instant::now(),
+            LlmCancel::None,
+            stream_idle_timeout(),
+            stream_idle_timeout_after_progress(),
+        )
+        .await
+        .expect("collect");
         assert_eq!(res.tool_calls.len(), 1);
         let args = res.tool_calls[0]["function"]["arguments"]
             .as_str()
@@ -1494,7 +1587,15 @@ mod tests {
         // Stream that never yields any bytes (simulates a hung connection).
         let pending_stream = stream::pending::<Result<Bytes, reqwest::Error>>();
         let started = Instant::now();
-        let res = collect_llm_stream(pending_stream, "test-model", started, LlmCancel::None).await;
+        let res = collect_llm_stream(
+            pending_stream,
+            "test-model",
+            started,
+            LlmCancel::None,
+            stream_idle_timeout(),
+            stream_idle_timeout_after_progress(),
+        )
+        .await;
         assert!(
             matches!(
                 res,
@@ -1511,10 +1612,19 @@ mod tests {
     #[tokio::test]
     async fn stream_idle_timeout_after_partial_output_marks_progress() {
         unsafe { std::env::set_var("MO_STREAM_IDLE_TIMEOUT_MS", "1") };
+        unsafe { std::env::set_var("MO_STREAM_IDLE_TIMEOUT_AFTER_PROGRESS_MS", "1") };
         let d1 = json!({"choices":[{"delta":{"content":"partial"}}]});
         let stream = stream::iter(vec![Ok(Bytes::from(format!("data: {d1}\n\n")))])
             .chain(stream::pending::<Result<Bytes, reqwest::Error>>());
-        let res = collect_llm_stream(stream, "test-model", Instant::now(), LlmCancel::None).await;
+        let res = collect_llm_stream(
+            stream,
+            "test-model",
+            Instant::now(),
+            LlmCancel::None,
+            stream_idle_timeout(),
+            stream_idle_timeout_after_progress(),
+        )
+        .await;
         assert!(
             matches!(
                 res,
@@ -1526,6 +1636,7 @@ mod tests {
             "expected idle timeout after partial output, got: {res:?}"
         );
         unsafe { std::env::remove_var("MO_STREAM_IDLE_TIMEOUT_MS") };
+        unsafe { std::env::remove_var("MO_STREAM_IDLE_TIMEOUT_AFTER_PROGRESS_MS") };
     }
 
     #[tokio::test]
@@ -1541,6 +1652,8 @@ mod tests {
                 "test-model",
                 started,
                 LlmCancel::Flag(flag.as_ref()),
+                stream_idle_timeout(),
+                stream_idle_timeout_after_progress(),
             )
             .await
         });
@@ -1567,6 +1680,8 @@ mod tests {
                 "test-model",
                 started,
                 LlmCancel::Token(&token_for_stream),
+                stream_idle_timeout(),
+                stream_idle_timeout_after_progress(),
             )
             .await
         });
@@ -1595,6 +1710,8 @@ mod tests {
                 "test-model",
                 started,
                 LlmCancel::FlagAndToken(flag.as_ref(), &token_signal),
+                stream_idle_timeout(),
+                stream_idle_timeout_after_progress(),
             )
             .await
         });
@@ -1771,9 +1888,16 @@ mod tests {
         v.extend_from_slice(br#""}}]}"#);
         v.extend_from_slice(b"\n\n");
         let stream = stream::iter(vec![Ok(Bytes::from(v))]);
-        let res = collect_llm_stream(stream, "m", Instant::now(), LlmCancel::None)
-            .await
-            .expect("collect");
+        let res = collect_llm_stream(
+            stream,
+            "m",
+            Instant::now(),
+            LlmCancel::None,
+            stream_idle_timeout(),
+            stream_idle_timeout_after_progress(),
+        )
+        .await
+        .expect("collect");
         assert_eq!(res.full_text, "a\u{FFFD}");
         unsafe { std::env::remove_var("MO_STREAM_IDLE_TIMEOUT_MS") };
     }
@@ -2053,9 +2177,16 @@ mod tests {
         }]});
         let body = format!("data: {d}\n\n");
         let stream = stream::iter(vec![Ok(Bytes::from(body))]);
-        let res = collect_llm_stream(stream, "m", Instant::now(), LlmCancel::None)
-            .await
-            .expect("collect");
+        let res = collect_llm_stream(
+            stream,
+            "m",
+            Instant::now(),
+            LlmCancel::None,
+            stream_idle_timeout(),
+            stream_idle_timeout_after_progress(),
+        )
+        .await
+        .expect("collect");
         assert_eq!(res.finish_reason.as_deref(), Some("tool_calls"));
         assert_eq!(res.tool_calls.len(), 1);
         unsafe { std::env::remove_var("MO_STREAM_IDLE_TIMEOUT_MS") };
@@ -2063,7 +2194,7 @@ mod tests {
 
     #[tokio::test]
     async fn call_llm_and_collect_falls_back_immediately_after_partial_stream_idle() {
-        unsafe { std::env::set_var("MO_STREAM_IDLE_TIMEOUT_MS", "10") };
+        let _guard = set_test_stream_timeouts(10, Some(10));
         let state = StreamIdleHit {
             stream_hits: Arc::new(AtomicU32::new(0)),
             fallback_hits: Arc::new(AtomicU32::new(0)),
@@ -2096,12 +2227,11 @@ mod tests {
             "partial stream idle should skip the extra streaming retry"
         );
         assert_eq!(state.fallback_hits.load(Ordering::SeqCst), 1);
-        unsafe { std::env::remove_var("MO_STREAM_IDLE_TIMEOUT_MS") };
     }
 
     #[tokio::test]
     async fn call_llm_and_collect_retries_stream_once_when_idle_before_output() {
-        unsafe { std::env::set_var("MO_STREAM_IDLE_TIMEOUT_MS", "10") };
+        let _guard = set_test_stream_timeouts(10, None);
         let hits = Arc::new(AtomicU32::new(0));
         let app = Router::new()
             .route(
@@ -2126,7 +2256,6 @@ mod tests {
         .expect("stream retry succeeds");
         assert_eq!(res.full_text, "after-retry");
         assert_eq!(hits.load(Ordering::SeqCst), 2);
-        unsafe { std::env::remove_var("MO_STREAM_IDLE_TIMEOUT_MS") };
     }
 
     /// Mock server that returns 400 with context_length_exceeded.

--- a/rust/crates/runtime/tests/edge_cloud_round_trip_e2e.rs
+++ b/rust/crates/runtime/tests/edge_cloud_round_trip_e2e.rs
@@ -23,6 +23,7 @@ use astra_runtime::{
     turn::edge_ledger::{LEDGER_MAX_ENTRIES, MSG_TOOL_LEDGER_TIMEOUT},
 };
 use astra_services::session_journal::{JournalDirGuard, find_latest_approval_decision};
+use astra_turn_core::cloud_tool_delivery::MSG_APPROVAL_LEDGER_TIMEOUT;
 use async_trait::async_trait;
 use axum::{
     Router,
@@ -31,6 +32,7 @@ use axum::{
 };
 use futures_util::StreamExt;
 use serde_json::{Value, json};
+use tempfile::tempdir;
 use tokio::sync::Mutex;
 use tower::util::ServiceExt;
 
@@ -739,12 +741,22 @@ async fn approval_denied_skips_tool_execution() {
     let events = parse_sse_events(&full);
     let approval_event = events
         .iter()
-        .find(|e| e["type"] == "approval_required" && e.to_string().contains("tc-deny-1"))
+        .find(|e| {
+            e.get("type").and_then(Value::as_str) == Some("approval_required")
+                && e.get("request_id").and_then(Value::as_str) == Some("tc-deny-1")
+        })
         .expect("approval_required event for denied bash");
     assert_eq!(approval_event["approval_kind"], "explicit");
+    assert_eq!(
+        approval_event.get("tool").and_then(Value::as_str),
+        Some("bash")
+    );
     let tool_requests: Vec<_> = events
         .iter()
-        .filter(|e| e["type"] == "tool_request" && e.to_string().contains("tc-deny-1"))
+        .filter(|e| {
+            e.get("type").and_then(Value::as_str) == Some("tool_request")
+                && e.get("request_id").and_then(Value::as_str) == Some("tc-deny-1")
+        })
         .collect();
     assert!(
         tool_requests.is_empty(),
@@ -955,6 +967,140 @@ async fn tool_result_timeout_when_edge_never_responds() {
         all_events
             .iter()
             .map(|e| format!("{}:{}", e.event_type, &e.content[..e.content.len().min(80)]))
+            .collect::<Vec<_>>()
+    );
+
+    let evs = parse_sse_events(&full);
+    let req_ev = evs
+        .iter()
+        .find(|e| {
+            e.get("type").and_then(Value::as_str) == Some("tool_request")
+                && e.get("request_id").and_then(Value::as_str) == Some("tc-timeout-1")
+        })
+        .expect("structured tool_request for tc-timeout-1");
+    assert_eq!(
+        req_ev.get("tool").and_then(Value::as_str),
+        Some("read_file")
+    );
+    let ends: Vec<_> = evs
+        .iter()
+        .filter(|e| {
+            e.get("type").and_then(Value::as_str) == Some("tool_call_end")
+                && e.get("call_id").and_then(Value::as_str) == Some("tc-timeout-1")
+        })
+        .collect();
+    assert!(
+        !ends.is_empty(),
+        "expected tool_call_end for tc-timeout-1: {evs:?}"
+    );
+    let end_s = ends[0]
+        .get("result")
+        .map(Value::to_string)
+        .unwrap_or_default();
+    assert!(
+        end_s.contains(MSG_TOOL_LEDGER_TIMEOUT),
+        "tool_call_end should carry ledger timeout text: {end_s}"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test 5b: Approval ledger timeout — edge never POST /approval/respond
+//
+// Run separately: MO_TURN_TIMEOUT_S=3 cargo test ... -- approval_timeout --ignored
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[ignore = "requires MO_TURN_TIMEOUT_S=3 to avoid long ledger wait; run: MO_TURN_TIMEOUT_S=3 cargo test --manifest-path rust/Cargo.toml -p astra-runtime --test edge_cloud_round_trip_e2e --features bridge-e2e-hooks -- approval_timeout_when_edge_never_posts_approval --ignored --nocapture"]
+async fn approval_timeout_when_edge_never_posts_approval() {
+    init_env();
+    let capture = Capture::default();
+    let app = build_app_with_capture(capture.clone());
+
+    let payload = json!({
+        "agent_id": "rt-agent",
+        "messages": [{ "role": "user", "content": "write out.txt" }],
+        "edge_tools": [tool_schema("write_file")],
+        "test_llm_rounds": [
+            { "tool_calls": [tool_call("tc-appr-to-1", "write_file", json!({"path": "out.txt", "content": "x"}))] },
+            { "full_text": "Stopped after approval wait." }
+        ]
+    });
+
+    // Never POST /approval/respond — approval wait uses turn timeout (see MO_TURN_TIMEOUT_S).
+    let (st, raw) = chat_turn(&app, payload).await;
+    assert_eq!(st, StatusCode::OK);
+
+    let full = String::from_utf8_lossy(&raw);
+    let events = parse_sse_events(&full);
+
+    let appr: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.get("type").and_then(Value::as_str) == Some("approval_required")
+                && e.get("request_id").and_then(Value::as_str) == Some("tc-appr-to-1")
+        })
+        .collect();
+    assert_eq!(
+        appr.len(),
+        1,
+        "expected exactly one approval_required for tc-appr-to-1: {events:?}"
+    );
+
+    let wf_requests: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.get("type").and_then(Value::as_str) == Some("tool_request")
+                && e.get("request_id").and_then(Value::as_str) == Some("tc-appr-to-1")
+        })
+        .collect();
+    assert!(
+        wf_requests.is_empty(),
+        "approval timeout must not emit tool_request for write_file: {wf_requests:?}"
+    );
+
+    let ends: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.get("type").and_then(Value::as_str) == Some("tool_call_end")
+                && e.get("call_id").and_then(Value::as_str) == Some("tc-appr-to-1")
+        })
+        .collect();
+    assert!(
+        !ends.is_empty(),
+        "expected tool_call_end for tc-appr-to-1: {events:?}"
+    );
+    let end_s = ends[0]
+        .get("result")
+        .map(Value::to_string)
+        .unwrap_or_default();
+    assert!(
+        end_s.contains(MSG_APPROVAL_LEDGER_TIMEOUT),
+        "tool_call_end should carry approval timeout text: {end_s}"
+    );
+
+    assert!(
+        full.contains("Stopped after approval wait"),
+        "second mock round should stream: {full}"
+    );
+
+    wait_persist().await;
+    let plans = capture.plans.lock().await;
+    let all_events: Vec<_> = plans.iter().flat_map(|p| &p.events).collect();
+    let timeout_rows: Vec<_> = all_events
+        .iter()
+        .filter(|e| {
+            e.event_type == "tool_result"
+                && e.content
+                    .contains("timed out waiting for edge POST /approval/respond")
+        })
+        .collect();
+    assert!(
+        !timeout_rows.is_empty(),
+        "expected persisted tool_result for approval timeout: {:?}",
+        all_events
+            .iter()
+            .filter(|e| e.event_type == "tool_result")
+            .map(|e| &e.content[..e.content.len().min(120)])
             .collect::<Vec<_>>()
     );
 }
@@ -1352,28 +1498,59 @@ async fn mixed_approval_and_readonly_in_same_round() {
 
     // Verify ordering: approval_required for write_file comes before its tool_request
     let events = parse_sse_events(&full);
+    let wf_approvals: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.get("type").and_then(Value::as_str) == Some("approval_required")
+                && e.get("request_id").and_then(Value::as_str) == Some("tc-mix-wf")
+        })
+        .collect();
+    assert_eq!(
+        wf_approvals.len(),
+        1,
+        "expected exactly one approval_required for tc-mix-wf; got {} matching events in {} parsed events",
+        wf_approvals.len(),
+        events.len()
+    );
     let appr_idx = events
         .iter()
-        .position(|e| e["type"] == "approval_required" && e.to_string().contains("tc-mix-wf"));
+        .position(|e| {
+            e.get("type").and_then(Value::as_str) == Some("approval_required")
+                && e.get("request_id").and_then(Value::as_str) == Some("tc-mix-wf")
+        })
+        .expect("approval_required for tc-mix-wf must be present");
     let wf_req_idx = events
         .iter()
-        .position(|e| e["type"] == "tool_request" && e.to_string().contains("tc-mix-wf"));
-    if let (Some(a), Some(r)) = (appr_idx, wf_req_idx) {
-        assert!(
-            a < r,
-            "approval_required must precede tool_request for write_file"
-        );
-    }
+        .position(|e| {
+            e.get("type").and_then(Value::as_str) == Some("tool_request")
+                && e.get("request_id").and_then(Value::as_str) == Some("tc-mix-wf")
+        })
+        .expect("tool_request for tc-mix-wf must be present");
+    assert!(
+        appr_idx < wf_req_idx,
+        "approval_required must precede tool_request for write_file (indices {appr_idx} vs {wf_req_idx})"
+    );
 
     // read_file and grep should NOT have approval_required events
     let rf_approvals: Vec<_> = events
         .iter()
-        .filter(|e| e["type"] == "approval_required" && e.to_string().contains("tc-mix-rf"))
+        .filter(|e| {
+            e.get("type").and_then(Value::as_str) == Some("approval_required")
+                && e.get("request_id").and_then(Value::as_str) == Some("tc-mix-rf")
+        })
         .collect();
     assert!(
         rf_approvals.is_empty(),
         "read_file should not need approval"
     );
+    let gr_approvals: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.get("type").and_then(Value::as_str) == Some("approval_required")
+                && e.get("request_id").and_then(Value::as_str) == Some("tc-mix-gr")
+        })
+        .collect();
+    assert!(gr_approvals.is_empty(), "grep should not need approval");
 
     assert!(
         full.contains("Config updated and verified"),
@@ -1395,6 +1572,102 @@ async fn mixed_approval_and_readonly_in_same_round() {
     assert!(
         result_count >= 3,
         "expected ≥3 persisted tool_results, got {result_count}"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test 11b: empty edge_tools — read-only tool runs on server (no POST /tools/result)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn empty_edge_tools_read_file_executes_on_server_without_tools_result() {
+    init_env();
+    let app = build_app_with_capture(Capture::default());
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("hello.txt"), b"server-local").unwrap();
+    let cwd = dir.path().to_string_lossy();
+
+    let payload = json!({
+        "agent_id": "rt-agent",
+        "messages": [{ "role": "user", "content": "read hello" }],
+        "edge_tools": [],
+        "edge_profile": { "cwd": cwd.as_ref() },
+        "test_llm_rounds": [
+            { "tool_calls": [tool_call("tc-srv-rf", "read_file", json!({"path": "hello.txt"}))] },
+            { "full_text": "round two ok" }
+        ]
+    });
+
+    let (st, raw) = chat_turn(&app, payload).await;
+    assert_eq!(st, StatusCode::OK);
+    let full = String::from_utf8_lossy(&raw);
+    assert!(
+        !full.contains(MSG_TOOL_LEDGER_TIMEOUT),
+        "should not ledger-timeout without edge: {full}"
+    );
+    assert!(
+        full.contains("server-local"),
+        "expected read_file body in SSE stream: {full}"
+    );
+    assert!(
+        full.contains("round two ok"),
+        "expected second mock LLM round: {full}"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test 11c: empty edge_tools — approval-required tool fast-fails (no ledger hang)
+// (write_file always needs approval; read-only bash like `echo hi` would execute locally.)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn empty_edge_tools_approval_required_fast_fails() {
+    init_env();
+    let app = build_app_with_capture(Capture::default());
+    let dir = tempdir().unwrap();
+    let cwd = dir.path().to_string_lossy();
+
+    let payload = json!({
+        "agent_id": "rt-agent",
+        "messages": [{ "role": "user", "content": "write config" }],
+        "edge_tools": [],
+        "edge_profile": { "cwd": cwd.as_ref() },
+        "test_llm_rounds": [
+            { "tool_calls": [tool_call("tc-srv-wf", "write_file", json!({"path": "out.txt", "content": "x"}))] },
+            { "full_text": "round two ok" }
+        ]
+    });
+
+    let (st, raw) = chat_turn(&app, payload).await;
+    assert_eq!(st, StatusCode::OK);
+    let full = String::from_utf8_lossy(&raw);
+    assert!(
+        !full.contains(MSG_TOOL_LEDGER_TIMEOUT),
+        "should not ledger-timeout for approval tool without edge: {full}"
+    );
+    let events = parse_sse_events(&full);
+    let wf_ends: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.get("type").and_then(Value::as_str) == Some("tool_call_end")
+                && e.get("call_id").and_then(Value::as_str) == Some("tc-srv-wf")
+        })
+        .collect();
+    assert!(
+        !wf_ends.is_empty(),
+        "expected tool_call_end for tc-srv-wf, parsed events: {events:?}"
+    );
+    let end_msg = wf_ends[0]
+        .get("result")
+        .map(Value::to_string)
+        .unwrap_or_default();
+    assert!(
+        end_msg.contains("no edge agent connected"),
+        "tool_call_end result should include fast-fail message: {end_msg}"
+    );
+    assert!(
+        full.contains("round two ok"),
+        "expected second mock LLM round: {full}"
     );
 }
 


### PR DESCRIPTION
## Summary

Unify stream idle timeout to 5 min for thinking model TTFT tolerance, add cloud tool delivery approval ledger, and introduce server-side tool executor with sandboxed execution.

## Changes

### Stream Idle Timeout
- **Unify pre/post-progress idle timeouts to 300s (5 min)** — previous 90s pre-progress timeout caused false aborts for thinking/reasoning models whose TTFT can exceed 90s
- Both timeouts configurable via `MO_STREAM_IDLE_TIMEOUT_MS` and `MO_STREAM_IDLE_TIMEOUT_AFTER_PROGRESS_MS` env vars
- Fix test hangs: set short post-progress timeout in idle-timeout tests

### Cloud Tool Delivery
- Add approval ledger with timeout tracking for server-side tool execution (`MSG_APPROVAL_LEDGER_TIMEOUT`)
- Server tool executor with sandboxed read-only execution and 30s command timeout for fast-fail on stalled commands

### Bridge & LLM Client Improvements
- Fix silent tool call drop: warn + return `None` instead of `?` operator flattening
- Dual idle timeout with `made_progress` flag in `bridge_inprocess.rs`
- `collect_llm_stream` with progress-aware idle timeout in `llm_client.rs`

### CI & Tests
- Add `check-server-tool-schemas` Makefile target and CI step (prevents schema/allowlist drift)
- Add E2E tests for approval timeout, empty edge tools, server-side fallback
- Add memoria `min_confidence` omission test
- Fix `SandboxMode::ReadOnly` doc: clarify allowlist is primary protection, ReadOnly is future enforcement layer

## Testing
- `cargo check` ✅
- `astra-turn-core` 124 tests ✅
- `runtime` idle-timeout tests ✅ (previously hanging >60s, now instant)
- E2E cloud round-trip tests ✅