### PR TITLE
fix: Harden cloud sync restore and display follow-ups

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "astra-core",
  "astra-runtime",
  "astra-services",
+ "astra-text-utils",
  "astra-thin-client",
  "astra-tools",
  "async-trait",

--- a/rust/crates/astra-cli/Cargo.toml
+++ b/rust/crates/astra-cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 astra-core.workspace = true
 astra-services.workspace = true
 astra-runtime.workspace = true
+astra-text-utils.workspace = true
 astra-tools.workspace = true
 astra-thin-client.workspace = true
 async-trait.workspace = true

--- a/rust/crates/astra-cli/src/cli/cli_formatting.rs
+++ b/rust/crates/astra-cli/src/cli/cli_formatting.rs
@@ -7,6 +7,8 @@ use crossterm::style::Stylize;
 use serde_json::Value;
 use std::borrow::Cow;
 
+pub use astra_text_utils::str_preview::{github_repo_display, shorten_path};
+
 /// Unified diff for CLI summaries: `str_replace` / `multi_edit` sentinels, or `write_file` JSON field.
 pub fn extract_cli_diff_block(output: &str) -> Option<Cow<'_, str>> {
     let start_marker = "<<<ASTRA_UNIFIED_DIFF>>>";
@@ -132,32 +134,6 @@ pub fn truncate_line(s: &str, max_chars: usize) -> String {
         let truncated: String = line.chars().take(max_chars.saturating_sub(1)).collect();
         format!("{truncated}…")
     }
-}
-
-/// Shorten a path by keeping the filename and truncating dir prefix with "...".
-pub fn shorten_path(path: &str, max_chars: usize) -> String {
-    if path.chars().count() <= max_chars {
-        return path.to_string();
-    }
-    // Keep the filename (last component)
-    let parts: Vec<&str> = path.split('/').collect();
-    if parts.is_empty() {
-        return truncate_line(path, max_chars);
-    }
-    let filename = parts.last().unwrap_or(&"");
-    if filename.chars().count() >= max_chars.saturating_sub(4) {
-        // Filename itself is too long, just truncate
-        return truncate_line(filename, max_chars);
-    }
-    // Try to keep one parent dir
-    if parts.len() >= 2 {
-        let parent = parts[parts.len() - 2];
-        let short = format!(".../{parent}/{filename}");
-        if short.chars().count() <= max_chars {
-            return short;
-        }
-    }
-    format!(".../{filename}")
 }
 
 /// Simple syntax highlighting for code preview.

--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -1031,7 +1031,7 @@ fn commit_turn_journal_workspace_and_sidecars(
                     let user_id_owned = user_id.to_string();
                     let cp_clone = cp.clone();
                     let cp_number = cp.number;
-                    tokio::spawn(async move {
+                    mc.spawn_session_sync_task(async move {
                         if let Err(e) = astra_services::session_restore::push_checkpoint_to_cloud(
                             &pool,
                             &sid_owned,
@@ -1091,7 +1091,7 @@ fn commit_turn_journal_workspace_and_sidecars(
                         )
                     }
                 };
-                tokio::spawn(async move {
+                mc.spawn_session_sync_task(async move {
                     if let Err(e) = astra_services::session_restore::push_step_checkpoint_to_cloud(
                         &pool,
                         &sid_owned,
@@ -1121,14 +1121,21 @@ fn commit_turn_journal_workspace_and_sidecars(
                 let sid_owned = sid.to_string();
                 let user_id_owned = user_id.to_string();
                 let trace_signal = trace_signal.clone();
-                tokio::spawn(async move {
-                    let _ = astra_services::session_restore::push_context_trace_signal_to_cloud(
-                        &pool,
-                        &sid_owned,
-                        &user_id_owned,
-                        &trace_signal,
-                    )
-                    .await;
+                mc.spawn_session_sync_task(async move {
+                    if let Err(e) =
+                        astra_services::session_restore::push_context_trace_signal_to_cloud(
+                            &pool,
+                            &sid_owned,
+                            &user_id_owned,
+                            &trace_signal,
+                        )
+                        .await
+                    {
+                        astra_core::agent_warn!(
+                            "context_trace_sync",
+                            "failed to push context trace signal to cloud for session {sid_owned}: {e}"
+                        );
+                    }
                 });
             }
 
@@ -1141,20 +1148,40 @@ fn commit_turn_journal_workspace_and_sidecars(
             {
                 let pool = mc.shared_pool().get().clone();
                 let sid_owned = sid.to_string();
+                let user_id = state
+                    .ingestion_user_id
+                    .as_deref()
+                    .unwrap_or("anonymous")
+                    .to_string();
                 let plan_json = ws.executing_plan_json.clone();
                 let goal = ws.plan_goal.clone();
                 let config = ws.plan_config_json.clone();
                 let rounds = ws.plan_execution_rounds;
-                tokio::spawn(async move {
-                    let _ = astra_services::session_restore::push_session_state_to_cloud(
+                let git_branch = ws.git_branch.clone();
+                let model = if ws.model.is_empty() {
+                    None
+                } else {
+                    Some(ws.model.clone())
+                };
+                mc.spawn_session_sync_task(async move {
+                    if let Err(e) = astra_services::session_restore::push_session_state_to_cloud(
                         &pool,
                         &sid_owned,
+                        &user_id,
                         plan_json.as_deref(),
                         goal.as_deref(),
                         config.as_deref(),
                         rounds,
+                        git_branch.as_deref(),
+                        model.as_deref(),
                     )
-                    .await;
+                    .await
+                    {
+                        astra_core::agent_warn!(
+                            "session_state_sync",
+                            "failed to push session state to cloud for session {sid_owned}: {e}"
+                        );
+                    }
                 });
             }
 
@@ -2150,7 +2177,7 @@ fn spawn_manual_checkpoint_cloud_uploads(
     let pool = mc.shared_pool().get().clone();
     let sid_owned = sid.to_string();
     let cp_clone = session_cp.clone();
-    tokio::spawn(async move {
+    mc.spawn_session_sync_task(async move {
         if let Err(e) = astra_services::session_restore::push_checkpoint_to_cloud(
             &pool, &sid_owned, &user_id, &cp_clone,
         )
@@ -2166,7 +2193,7 @@ fn spawn_manual_checkpoint_cloud_uploads(
     let state_json = serde_json::to_string(step_cp).unwrap_or_default();
     let tools_json =
         serde_json::to_string(&state.recent_tools).unwrap_or_else(|_| "[]".to_string());
-    tokio::spawn(async move {
+    mc.spawn_session_sync_task(async move {
         if let Err(e) = astra_services::session_restore::push_step_checkpoint_to_cloud(
             &pool2,
             &sid_step,

--- a/rust/crates/astra-cli/src/cli/slash_session.rs
+++ b/rust/crates/astra-cli/src/cli/slash_session.rs
@@ -4408,6 +4408,117 @@ fn combine_resume_guidance(
     }
 }
 
+fn build_step_resume_guidance(
+    interruption: Option<&serde_json::Value>,
+    compaction_state: Option<&serde_json::Value>,
+) -> Option<String> {
+    let compaction_ctx =
+        compaction_state.map(
+            |cs| astra_runtime::turn::interruption::CompactionResumeContext {
+                compaction_attempts: cs
+                    .get("attempt_count")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0) as u32,
+                total_tokens_freed: cs
+                    .get("cumulative_tokens_freed")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0),
+                last_was_insufficient: cs
+                    .get("last_was_insufficient")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            },
+        );
+    interruption.and_then(|irj| {
+        astra_runtime::turn::interruption::build_resume_guidance_with_context(
+            irj,
+            compaction_ctx.as_ref(),
+        )
+    })
+}
+
+fn history_pairs_from_messages(messages: &[serde_json::Value]) -> Vec<(String, String)> {
+    let mut pairs = Vec::new();
+    let mut last_user = String::new();
+    for msg in messages {
+        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+        let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
+        match role {
+            "user" => last_user = content.to_string(),
+            "assistant" if !last_user.is_empty() => {
+                pairs.push((last_user.clone(), content.to_string()));
+                last_user.clear();
+            }
+            _ => {}
+        }
+    }
+    pairs
+}
+
+fn apply_heavy_state_fallback(
+    state: &mut ReplState,
+    blocked_tools: &[String],
+    recent_tools: &[String],
+    messages: &[serde_json::Value],
+    approval_overrides: Option<&serde_json::Value>,
+) {
+    for tool in blocked_tools {
+        if !state.tool_health_entries.iter().any(|e| e.name == *tool) {
+            state
+                .tool_health_entries
+                .push(astra_runtime::pipeline::persistence::ToolHealthEntry {
+                    name: tool.clone(),
+                    total_calls: 3,
+                    total_failures: 3,
+                    failure_rate: 1.0,
+                    last_updated_epoch: 0,
+                });
+        }
+    }
+    if let Some(ao_json) = approval_overrides {
+        state.perm_manager.merge_restored_overrides(ao_json);
+    }
+    if state.recent_tools.is_empty() {
+        state.recent_tools = recent_tools.to_vec();
+    }
+    if state.history.is_empty() {
+        let pairs = history_pairs_from_messages(messages);
+        if !pairs.is_empty() {
+            state.history = pairs;
+        }
+    }
+}
+
+fn apply_heavy_checkpoint_fallback(
+    state: &mut ReplState,
+    heavy: &astra_runtime::pipeline::step_protocol::HeavyCheckpoint,
+) {
+    apply_heavy_state_fallback(
+        state,
+        &heavy.blocked_tools,
+        &heavy.recent_tools,
+        &heavy.messages,
+        heavy.approval_overrides.as_ref(),
+    );
+}
+
+fn apply_restored_cloud_heavy_state(state: &mut ReplState, restored: &RestoredSession) {
+    apply_heavy_state_fallback(
+        state,
+        &restored.blocked_tools,
+        &restored.recent_tools,
+        &restored.conversation_messages,
+        restored.approval_overrides.as_ref(),
+    );
+}
+
+fn restore_journal_history_if_available(state: &mut ReplState, session_id: &str) {
+    let history = repl_runtime::restore_history_from_journal(session_id);
+    if !history.is_empty() || state.history.is_empty() {
+        state.history = history;
+    }
+}
+
 async fn apply_restored_session(
     profile: Option<&str>,
     state: &mut ReplState,
@@ -4427,7 +4538,7 @@ async fn apply_restored_session(
     state.turn = restored.turn_count;
     state.total_prompt_tokens = restored.total_tokens_in;
     state.total_completion_tokens = restored.total_tokens_out;
-    state.recent_tools = restored.recent_tools;
+    state.recent_tools = restored.recent_tools.clone();
 
     apply_restored_workspace_state(state, &restored.session_id);
 
@@ -4451,28 +4562,10 @@ async fn apply_restored_session(
         if state.recent_tools.is_empty() {
             state.recent_tools = step_restored.recent_tools;
         }
-        let step_guidance = step_restored.interruption.as_ref().and_then(|irj| {
-            let compaction_ctx = step_restored.compaction_state.as_ref().map(|cs| {
-                astra_runtime::turn::interruption::CompactionResumeContext {
-                    compaction_attempts: cs
-                        .get("attempt_count")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0) as u32,
-                    total_tokens_freed: cs
-                        .get("cumulative_tokens_freed")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0),
-                    last_was_insufficient: cs
-                        .get("last_was_insufficient")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false),
-                }
-            });
-            astra_runtime::turn::interruption::build_resume_guidance_with_context(
-                irj,
-                compaction_ctx.as_ref(),
-            )
-        });
+        let step_guidance = build_step_resume_guidance(
+            step_restored.interruption.as_ref(),
+            step_restored.compaction_state.as_ref(),
+        );
         state.resume_guidance = combine_resume_guidance(
             step_guidance,
             build_session_memory_resume_guidance(&restored.session_id),
@@ -4484,13 +4577,29 @@ async fn apply_restored_session(
     } else if let Ok(Some(heavy)) =
         astra_runtime::pipeline::step_checkpoint::read_latest_heavy_checkpoint(&restored.session_id)
     {
-        if state.recent_tools.is_empty() {
-            state.recent_tools = heavy.recent_tools;
-        }
+        apply_heavy_checkpoint_fallback(state, &heavy);
         state.resume_guidance = combine_resume_guidance(
-            None,
+            build_step_resume_guidance(
+                heavy.interruption.as_ref(),
+                heavy.compaction_state.as_ref(),
+            ),
             build_session_memory_resume_guidance(&restored.session_id),
         );
+    } else if !restored.conversation_messages.is_empty()
+        || !restored.blocked_tools.is_empty()
+        || restored.approval_overrides.is_some()
+        || restored.interruption.is_some()
+        || restored.compaction_state.is_some()
+    {
+        apply_restored_cloud_heavy_state(state, &restored);
+        state.resume_guidance = combine_resume_guidance(
+            build_step_resume_guidance(
+                restored.interruption.as_ref(),
+                restored.compaction_state.as_ref(),
+            ),
+            build_session_memory_resume_guidance(&restored.session_id),
+        );
+        eprintln!("  {} Restored step checkpoint from cloud", "☁".cyan());
     } else if let Some(ref mc) = state.matrix_runtime {
         let pool = mc.shared_pool().get();
         match astra_services::session_restore::pull_step_checkpoint_from_cloud(
@@ -4500,59 +4609,31 @@ async fn apply_restored_session(
         .await
         {
             Ok(Some(state_json)) => {
-                match serde_json::from_str::<astra_runtime::pipeline::step_protocol::StepCheckpoint>(
+                match astra_services::session_restore::parse_cloud_heavy_checkpoint_state(
                     &state_json,
                 ) {
-                    Ok(astra_runtime::pipeline::step_protocol::StepCheckpoint::Heavy(heavy)) => {
-                        for tool in &heavy.blocked_tools {
-                            if !state.tool_health_entries.iter().any(|e| e.name == *tool) {
-                                state.tool_health_entries.push(
-                                    astra_runtime::pipeline::persistence::ToolHealthEntry {
-                                        name: tool.clone(),
-                                        total_calls: 3,
-                                        total_failures: 3,
-                                        failure_rate: 1.0,
-                                        last_updated_epoch: 0,
-                                    },
-                                );
-                            }
-                        }
-                        if state.recent_tools.is_empty() {
-                            state.recent_tools = heavy.recent_tools;
-                        }
-                        if state.history.is_empty() && !heavy.messages.is_empty() {
-                            let mut pairs = Vec::new();
-                            let mut last_user = String::new();
-                            for msg in &heavy.messages {
-                                let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
-                                let content =
-                                    msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
-                                match role {
-                                    "user" => last_user = content.to_string(),
-                                    "assistant" if !last_user.is_empty() => {
-                                        pairs.push((last_user.clone(), content.to_string()));
-                                        last_user.clear();
-                                    }
-                                    _ => {}
-                                }
-                            }
-                            if !pairs.is_empty() {
-                                state.history = pairs;
-                            }
-                        }
+                    Some(heavy) => {
+                        apply_heavy_state_fallback(
+                            state,
+                            &heavy.blocked_tools,
+                            &heavy.recent_tools,
+                            &heavy.messages,
+                            heavy.approval_overrides.as_ref(),
+                        );
                         state.resume_guidance = combine_resume_guidance(
-                            None,
+                            build_step_resume_guidance(
+                                heavy.interruption.as_ref(),
+                                heavy.compaction_state.as_ref(),
+                            ),
                             build_session_memory_resume_guidance(&restored.session_id),
                         );
                         eprintln!("  {} Restored step checkpoint from cloud", "☁".cyan());
                     }
-                    Ok(_) => {}
-                    Err(e) => {
+                    None => {
                         eprintln!(
                             "  {} Cloud checkpoint corrupted, skipping",
                             theme::icon_warn()
                         );
-                        eprintln!("{}", format!("     ({e})").dim());
                     }
                 }
             }
@@ -4591,7 +4672,7 @@ async fn apply_restored_session(
         state.learning_snapshot = Some(learning_json.clone());
     }
 
-    state.history = repl_runtime::restore_history_from_journal(&restored.session_id);
+    restore_journal_history_if_available(state, &restored.session_id);
 
     if let Ok(events) = session_journal::read_journal(&restored.session_id) {
         state.last_turn_event = events
@@ -5249,6 +5330,85 @@ mod resume_tests {
             },
         );
         crate::cli_utils::save_credentials(&creds).unwrap();
+    }
+
+    #[test]
+    fn apply_heavy_checkpoint_fallback_restores_history_and_approval_overrides() {
+        use astra_runtime::turn::approval_fingerprint::{
+            ApprovalFingerprint, FingerprintedOverrides,
+        };
+
+        let mut state = ReplState::default();
+        let mut overrides = FingerprintedOverrides::default();
+        overrides.insert(
+            ApprovalFingerprint::shell("bash", "git commit -m 'wip'", false),
+            true,
+        );
+        let approval_json = overrides.to_json().expect("non-empty overrides");
+
+        let mut heavy = match astra_runtime::pipeline::step_protocol::StepCheckpoint::heavy(
+            "step-1".into(),
+            "task-1".into(),
+            "agent-1".into(),
+            Default::default(),
+        ) {
+            astra_runtime::pipeline::step_protocol::StepCheckpoint::Heavy(heavy) => *heavy,
+            _ => unreachable!("heavy checkpoint constructor should yield Heavy"),
+        };
+        heavy.messages = vec![
+            serde_json::json!({"role": "user", "content": "continue"}),
+            serde_json::json!({"role": "assistant", "content": "done"}),
+        ];
+        heavy.recent_tools = vec!["rg".into()];
+        heavy.blocked_tools = vec!["bash".into()];
+        heavy.approval_overrides = Some(approval_json.clone());
+
+        apply_heavy_checkpoint_fallback(&mut state, &heavy);
+
+        assert_eq!(
+            state.history,
+            vec![("continue".to_string(), "done".to_string())]
+        );
+        assert_eq!(state.recent_tools, vec!["rg".to_string()]);
+        assert!(
+            state
+                .tool_health_entries
+                .iter()
+                .any(|entry| entry.name == "bash")
+        );
+        let exported = state
+            .perm_manager
+            .export_session_overrides()
+            .expect("restored approval overrides");
+        assert_eq!(serde_json::to_value(exported).unwrap(), approval_json);
+    }
+
+    #[test]
+    fn restore_journal_history_if_available_preserves_existing_history_when_journal_missing() {
+        let (_tmp, _guard) = isolated_sessions_dir();
+        let mut state = ReplState::default();
+        state.history = vec![("from-cloud".to_string(), "still-here".to_string())];
+
+        restore_journal_history_if_available(&mut state, "missing-session");
+
+        assert_eq!(
+            state.history,
+            vec![("from-cloud".to_string(), "still-here".to_string())]
+        );
+    }
+
+    #[test]
+    fn restore_journal_history_if_available_prefers_local_history_when_present() {
+        let (_tmp, _guard) = isolated_sessions_dir();
+        let session_id = format!("resume-history-{}", uuid::Uuid::new_v4());
+        write_local_resumable_session(&session_id, 1);
+
+        let mut state = ReplState::default();
+        state.history = vec![("from-cloud".to_string(), "old".to_string())];
+
+        restore_journal_history_if_available(&mut state, &session_id);
+
+        assert_eq!(state.history, vec![("continue".into(), "restored".into())]);
     }
 
     #[tokio::test]

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -6268,7 +6268,6 @@ mod tests {
         assert!(outcome.output.contains("Tool execution panicked: boom"));
         assert!(outcome.tool_result_fields.is_none());
     }
-
     // ── Skill/MCP output summary tests ──
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -29,7 +29,7 @@ use std::time::Instant;
 // CLI formatting utilities
 use super::cli_formatting::{
     colorize_diff_summary, extract_cli_diff_block, format_byte_size, format_duration_suffix,
-    shorten_path, truncate_line,
+    github_repo_display, shorten_path, truncate_line,
 };
 
 // Effects module types
@@ -3147,32 +3147,20 @@ impl StreamRenderState {
             "github_get_pr" => {
                 let owner = args.get("owner").and_then(Value::as_str);
                 let repo = args.get("repo").and_then(Value::as_str);
-                let repo_display = match (owner, repo) {
-                    (Some(owner), Some(repo)) if !repo.contains('/') => format!("{owner}/{repo}"),
-                    (_, Some(repo)) => repo.to_string(),
-                    _ => String::new(),
-                };
+                let repo_display = github_repo_display(owner, repo).unwrap_or_default();
                 let num = args.get("pr_number").and_then(Value::as_u64).unwrap_or(0);
                 format!("Getting PR: {repo_display}#{num}")
             }
             "github_list_prs" => {
                 let owner = args.get("owner").and_then(Value::as_str);
                 let repo = args.get("repo").and_then(Value::as_str);
-                let repo_display = match (owner, repo) {
-                    (Some(owner), Some(repo)) if !repo.contains('/') => format!("{owner}/{repo}"),
-                    (_, Some(repo)) => repo.to_string(),
-                    _ => String::new(),
-                };
+                let repo_display = github_repo_display(owner, repo).unwrap_or_default();
                 format!("Listing PRs: {repo_display}")
             }
             "github_get_issue" => {
                 let owner = args.get("owner").and_then(Value::as_str);
                 let repo = args.get("repo").and_then(Value::as_str);
-                let repo_display = match (owner, repo) {
-                    (Some(owner), Some(repo)) if !repo.contains('/') => format!("{owner}/{repo}"),
-                    (_, Some(repo)) => repo.to_string(),
-                    _ => String::new(),
-                };
+                let repo_display = github_repo_display(owner, repo).unwrap_or_default();
                 let num = args
                     .get("issue_number")
                     .and_then(Value::as_u64)
@@ -3182,31 +3170,19 @@ impl StreamRenderState {
             "github_list_issues" => {
                 let owner = args.get("owner").and_then(Value::as_str);
                 let repo = args.get("repo").and_then(Value::as_str);
-                let repo_display = match (owner, repo) {
-                    (Some(owner), Some(repo)) if !repo.contains('/') => format!("{owner}/{repo}"),
-                    (_, Some(repo)) => repo.to_string(),
-                    _ => String::new(),
-                };
+                let repo_display = github_repo_display(owner, repo).unwrap_or_default();
                 format!("Listing issues: {repo_display}")
             }
             "github_repo_stats" => {
                 let owner = args.get("owner").and_then(Value::as_str);
                 let repo = args.get("repo").and_then(Value::as_str);
-                let repo_display = match (owner, repo) {
-                    (Some(owner), Some(repo)) if !repo.contains('/') => format!("{owner}/{repo}"),
-                    (_, Some(repo)) => repo.to_string(),
-                    _ => String::new(),
-                };
+                let repo_display = github_repo_display(owner, repo).unwrap_or_default();
                 format!("GitHub stats: {repo_display}")
             }
             "github_ci_status" => {
                 let owner = args.get("owner").and_then(Value::as_str);
                 let repo = args.get("repo").and_then(Value::as_str);
-                let repo_display = match (owner, repo) {
-                    (Some(owner), Some(repo)) if !repo.contains('/') => format!("{owner}/{repo}"),
-                    (_, Some(repo)) => repo.to_string(),
-                    _ => String::new(),
-                };
+                let repo_display = github_repo_display(owner, repo).unwrap_or_default();
                 format!("GitHub CI: {repo_display}")
             }
             "get_agent_info" => {
@@ -3490,11 +3466,7 @@ impl StreamRenderState {
             "github_create_issue" => {
                 let owner = args.get("owner").and_then(Value::as_str);
                 let repo = args.get("repo").and_then(Value::as_str);
-                let repo_display = match (owner, repo) {
-                    (Some(owner), Some(repo)) if !repo.contains('/') => format!("{owner}/{repo}"),
-                    (_, Some(repo)) => repo.to_string(),
-                    _ => String::new(),
-                };
+                let repo_display = github_repo_display(owner, repo).unwrap_or_default();
                 let title = args.get("title").and_then(Value::as_str).unwrap_or("");
                 format!(
                     "Creating issue: {} \"{}\"",
@@ -3990,11 +3962,7 @@ impl StreamRenderState {
             "github_get_pr" | "github_get_issue" => {
                 let owner = args.get("owner").and_then(Value::as_str);
                 let repo = args.get("repo").and_then(Value::as_str);
-                let repo_display = match (owner, repo) {
-                    (Some(owner), Some(repo)) if !repo.contains('/') => format!("{owner}/{repo}"),
-                    (_, Some(repo)) => repo.to_string(),
-                    _ => String::new(),
-                };
+                let repo_display = github_repo_display(owner, repo).unwrap_or_default();
                 let number = args
                     .get("number")
                     .or_else(|| args.get("pr_number"))
@@ -4008,20 +3976,12 @@ impl StreamRenderState {
             "github_list_prs" | "github_list_issues" | "github_repo_stats" | "github_ci_status" => {
                 let owner = args.get("owner").and_then(Value::as_str);
                 let repo = args.get("repo").and_then(Value::as_str);
-                Some(match (owner, repo) {
-                    (Some(owner), Some(repo)) if !repo.contains('/') => format!("{owner}/{repo}"),
-                    (_, Some(repo)) => repo.to_string(),
-                    _ => String::new(),
-                })
+                Some(github_repo_display(owner, repo).unwrap_or_default())
             }
             "github_create_issue" => {
                 let owner = args.get("owner").and_then(Value::as_str);
                 let repo = args.get("repo").and_then(Value::as_str);
-                let repo_display = match (owner, repo) {
-                    (Some(owner), Some(repo)) if !repo.contains('/') => format!("{owner}/{repo}"),
-                    (_, Some(repo)) => repo.to_string(),
-                    _ => String::new(),
-                };
+                let repo_display = github_repo_display(owner, repo).unwrap_or_default();
                 let title = args.get("title").and_then(Value::as_str);
                 match title {
                     Some(title) => Some(format!(
@@ -4903,7 +4863,7 @@ where
                 ),
                 tool_result_fields: None,
             },
-            0,
+            t0.elapsed().as_millis() as u64,
         ),
     }
 }
@@ -6261,10 +6221,11 @@ mod tests {
     #[tokio::test]
     async fn catch_tool_execution_panic_reports_error_output() {
         let (outcome, duration_ms) = catch_tool_execution_panic(async {
+            std::thread::sleep(std::time::Duration::from_millis(10));
             panic!("boom");
         })
         .await;
-        assert_eq!(duration_ms, 0);
+        assert!(duration_ms >= 10);
         assert!(outcome.output.contains("Tool execution panicked: boom"));
         assert!(outcome.tool_result_fields.is_none());
     }

--- a/rust/crates/astra-text-utils/src/str_preview.rs
+++ b/rust/crates/astra-text-utils/src/str_preview.rs
@@ -17,6 +17,52 @@ pub fn truncate_str(s: &str, max: usize) -> String {
     }
 }
 
+fn truncate_to_width(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        truncate_str(s, max_chars.saturating_sub(1))
+    }
+}
+
+/// Shorten a path by keeping the filename and truncating the directory prefix with "...".
+#[must_use]
+pub fn shorten_path(path: &str, max_chars: usize) -> String {
+    if path.chars().count() <= max_chars {
+        return path.to_string();
+    }
+
+    let parts: Vec<&str> = path.split('/').collect();
+    if parts.is_empty() {
+        return truncate_to_width(path, max_chars);
+    }
+
+    let filename = parts.last().copied().unwrap_or("");
+    if filename.chars().count() >= max_chars.saturating_sub(4) {
+        return truncate_to_width(filename, max_chars);
+    }
+
+    if parts.len() >= 2 {
+        let parent = parts[parts.len() - 2];
+        let short = format!(".../{parent}/{filename}");
+        if short.chars().count() <= max_chars {
+            return short;
+        }
+    }
+
+    format!(".../{filename}")
+}
+
+/// Format the most readable GitHub repository display for tool previews.
+#[must_use]
+pub fn github_repo_display(owner: Option<&str>, repo: Option<&str>) -> Option<String> {
+    match (owner, repo) {
+        (Some(owner), Some(repo)) if !repo.contains('/') => Some(format!("{owner}/{repo}")),
+        (_, Some(repo)) => Some(repo.to_string()),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -46,5 +92,26 @@ mod tests {
     #[test]
     fn prefix_chars_respects_utf8_scalars() {
         assert_eq!(prefix_chars("数据—flow", 3), "数据—");
+    }
+
+    #[test]
+    fn shorten_path_keeps_filename_when_possible() {
+        assert_eq!(shorten_path("short.txt", 20), "short.txt");
+        assert_eq!(shorten_path("/a/b/c/d/e/file.txt", 15), ".../e/file.txt");
+        assert_eq!(shorten_path("/a/very_long_filename.txt", 10), "very_long…");
+        assert_eq!(shorten_path("/a/b/c/short.txt", 14), ".../short.txt");
+    }
+
+    #[test]
+    fn github_repo_display_prefers_owner_repo_pair() {
+        assert_eq!(
+            github_repo_display(Some("matrixorigin"), Some("astra")).as_deref(),
+            Some("matrixorigin/astra")
+        );
+        assert_eq!(
+            github_repo_display(None, Some("matrixorigin/astra")).as_deref(),
+            Some("matrixorigin/astra")
+        );
+        assert_eq!(github_repo_display(Some("matrixorigin"), None), None);
     }
 }

--- a/rust/crates/astra-turn-core/src/evaluation.rs
+++ b/rust/crates/astra-turn-core/src/evaluation.rs
@@ -25,7 +25,7 @@ pub enum EvalSignal {
     StallDetected,
     /// Budget pressure exceeded 0.8 (agent struggling to fit in budget).
     HighBudgetPressure,
-    /// Same tool called 3+ times — possible retry loop.
+    /// Same tool/target called 3+ times — possible retry loop.
     RepeatToolCall(String),
     /// TurnGuard issued a warning or higher verdict.
     VerdictWarning,
@@ -52,6 +52,7 @@ pub struct TurnEvaluation {
 #[derive(Debug, Clone)]
 pub struct ToolCallInfo {
     pub name: String,
+    pub repeat_key: String,
     pub ok: bool,
     pub ms: u64,
     pub error: Option<String>,
@@ -130,13 +131,17 @@ pub fn evaluate_turn(
     }
 
     // ─── Repeat tool detection (retry loops) ────────────────────────────
-    let mut call_counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    let mut call_counts: std::collections::HashMap<&str, (&str, usize)> =
+        std::collections::HashMap::new();
     for tc in tool_calls {
-        *call_counts.entry(tc.name.as_str()).or_default() += 1;
+        let entry = call_counts
+            .entry(tc.repeat_key.as_str())
+            .or_insert((tc.name.as_str(), 0));
+        entry.1 += 1;
     }
-    for (name, count) in &call_counts {
+    for (name, count) in call_counts.values() {
         if *count >= 3 {
-            signals.push(EvalSignal::RepeatToolCall(name.to_string()));
+            signals.push(EvalSignal::RepeatToolCall((*name).to_string()));
             quality -= 0.15;
         }
     }
@@ -190,6 +195,13 @@ pub fn evaluate_tool_call_records(
         .filter(|record| !record.is_synthetic_placeholder())
         .map(|record| ToolCallInfo {
             name: record.name.clone(),
+            repeat_key: record
+                .args_preview
+                .as_deref()
+                .map(str::trim)
+                .filter(|preview| !preview.is_empty())
+                .map(|preview| format!("{}::{preview}", record.name))
+                .unwrap_or_else(|| record.name.clone()),
             ok: record.ok,
             ms: record.ms,
             error: record.error.clone(),
@@ -292,6 +304,7 @@ mod tests {
     fn ok_call(name: &str) -> ToolCallInfo {
         ToolCallInfo {
             name: name.to_string(),
+            repeat_key: name.to_string(),
             ok: true,
             ms: 100,
             error: None,
@@ -302,6 +315,7 @@ mod tests {
     fn err_call(name: &str) -> ToolCallInfo {
         ToolCallInfo {
             name: name.to_string(),
+            repeat_key: name.to_string(),
             ok: false,
             ms: 50,
             error: Some("tool error".to_string()),
@@ -312,6 +326,7 @@ mod tests {
     fn empty_call(name: &str) -> ToolCallInfo {
         ToolCallInfo {
             name: name.to_string(),
+            repeat_key: name.to_string(),
             ok: true,
             ms: 100,
             error: None,
@@ -627,6 +642,72 @@ mod tests {
                 .iter()
                 .any(|s| matches!(s, EvalSignal::RepeatToolCall(_))),
             "no RepeatToolCall signal should be emitted for synthetic placeholders, got {:?}",
+            eval.signals
+        );
+    }
+
+    #[test]
+    fn repeat_tool_call_distinguishes_distinct_args_preview() {
+        use astra_services::session_journal::ToolCallRecord;
+
+        let record = |name: &str, args_preview: &str| ToolCallRecord {
+            name: name.to_string(),
+            ok: true,
+            ms: 20,
+            error: None,
+            input_bytes: None,
+            output_bytes: Some(120),
+            args_preview: Some(args_preview.to_string()),
+            result_preview: Some("ok".into()),
+            file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
+        };
+
+        let distinct_greps = vec![
+            record("grep", "/catch_tool_execution_panic/ in ."),
+            record("grep", "/CLOUD_APPROVAL_REQUIRED_TOOLS/ in ."),
+            record(
+                "grep",
+                "/struct ToolExecutionOutcome/ in rust/crates/astra-cli/src",
+            ),
+            record("grep", "/struct ToolExecutionOutcome/ in ."),
+        ];
+        let eval = evaluate_tool_call_records(
+            "review latest commit",
+            &["grep".to_string()],
+            &distinct_greps,
+            0,
+            false,
+            0.1,
+        );
+        assert!(
+            !eval
+                .signals
+                .iter()
+                .any(|s| matches!(s, EvalSignal::RepeatToolCall(name) if name == "grep")),
+            "distinct grep queries should not be treated as a retry loop: {:?}",
+            eval.signals
+        );
+
+        let repeated_git_show = vec![
+            record("git_show", "6f2f96e"),
+            record("git_show", "6f2f96e"),
+            record("git_show", "6f2f96e"),
+        ];
+        let eval = evaluate_tool_call_records(
+            "review latest commit",
+            &["git_show".to_string()],
+            &repeated_git_show,
+            0,
+            false,
+            0.1,
+        );
+        assert!(
+            eval.signals
+                .iter()
+                .any(|s| matches!(s, EvalSignal::RepeatToolCall(name) if name == "git_show")),
+            "identical git_show targets should still surface as repeat loops: {:?}",
             eval.signals
         );
     }

--- a/rust/crates/astra-turn-core/src/headless_tool_status_display.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_status_display.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{Map, Value};
 
-use astra_text_utils::str_preview::truncate_str;
+use astra_text_utils::str_preview::{github_repo_display, shorten_path, truncate_str};
 
 #[derive(Debug, Clone, Copy)]
 enum ToolCat {
@@ -16,32 +16,6 @@ enum ToolCat {
     Memory,
     Utility,
     Other,
-}
-
-fn shorten_path(path: &str, max_chars: usize) -> String {
-    if path.chars().count() <= max_chars {
-        return path.to_string();
-    }
-
-    let parts: Vec<&str> = path.split('/').collect();
-    if parts.is_empty() {
-        return truncate_str(path, max_chars);
-    }
-
-    let filename = parts.last().copied().unwrap_or("");
-    if filename.chars().count() >= max_chars.saturating_sub(4) {
-        return truncate_str(filename, max_chars);
-    }
-
-    if parts.len() >= 2 {
-        let parent = parts[parts.len() - 2];
-        let short = format!(".../{parent}/{filename}");
-        if short.chars().count() <= max_chars {
-            return short;
-        }
-    }
-
-    format!(".../{filename}")
 }
 
 fn format_path_location(
@@ -119,11 +93,7 @@ fn categorize(name: &str) -> ToolCat {
 fn fmt_github_tool(name: &str, obj: &Map<String, Value>) -> Option<String> {
     let owner = obj.get("owner").and_then(|v| v.as_str());
     let repo = obj.get("repo").and_then(|v| v.as_str());
-    let repo_display = match (owner, repo) {
-        (Some(owner), Some(repo)) if !repo.contains('/') => Some(format!("{owner}/{repo}")),
-        (_, Some(repo)) => Some(repo.to_string()),
-        _ => None,
-    };
+    let repo_display = github_repo_display(owner, repo);
     let number = obj
         .get("number")
         .or_else(|| obj.get("pr_number"))

--- a/rust/crates/runtime/src/matrix_cloud_runtime.rs
+++ b/rust/crates/runtime/src/matrix_cloud_runtime.rs
@@ -3,9 +3,11 @@
 //! [`AppState`] and by the CLI [`ReplState`] as a single `Arc` attachment.
 
 use std::collections::{BTreeMap, HashSet};
+use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::Mutex as TokioMutex;
+use tokio::task::JoinSet;
 
 use astra_core::{MatrixOneSettings, SharedPool, resolve_database_name};
 use astra_services::{
@@ -51,6 +53,10 @@ pub struct MatrixCloudRuntime {
     ingestion_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Notify-based shutdown signal — works even when cloned senders are still alive.
     ingestion_shutdown: astra_services::event_ingestion::IngestionShutdownHandle,
+    /// Session/cloud sync tasks spawned from the CLI (checkpoint, session-state,
+    /// context-trace pushes). Awaited on graceful shutdown so short sessions do not
+    /// silently lose the final cloud sidecars.
+    session_sync_tasks: Mutex<JoinSet<()>>,
     /// Live ingestion stats (events_received, events_flushed, errors).
     ingestion_stats: Arc<std::sync::Mutex<astra_services::event_ingestion::IngestionStats>>,
     sync_orchestrator: TokioMutex<SyncOrchestrator>,
@@ -135,6 +141,7 @@ impl MatrixCloudRuntime {
             ingestion: Mutex::new(Some(sender)),
             ingestion_handle: Mutex::new(Some(ingestion_jh)),
             ingestion_shutdown,
+            session_sync_tasks: Mutex::new(JoinSet::new()),
             ingestion_stats,
             sync_orchestrator: TokioMutex::new(orch),
             preference_store,
@@ -204,6 +211,26 @@ impl MatrixCloudRuntime {
         self.ingestion.lock().ok()?.as_ref().cloned()
     }
 
+    /// Spawn a session/cloud sync sidecar task and track it for graceful shutdown.
+    pub fn spawn_session_sync_task<F>(&self, task: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        if let Ok(mut tasks) = self.session_sync_tasks.lock() {
+            while let Some(result) = tasks.try_join_next() {
+                if let Err(error) = result {
+                    astra_core::agent_warn!(
+                        "session_sync",
+                        "session sync task join failed: {error}"
+                    );
+                }
+            }
+            tasks.spawn(task);
+        } else {
+            tokio::spawn(task);
+        }
+    }
+
     /// Expand a journal event and enqueue for async DB flush (no-op if ingestion shut down).
     pub fn enqueue_journal_events(&self, user_id: &str, event: &JournalEvent) {
         let Ok(guard) = self.ingestion.lock() else {
@@ -218,8 +245,7 @@ impl MatrixCloudRuntime {
     }
 
     /// Flush and stop the ingestion worker, then **wait** for the background
-    /// worker to drain its buffer and exit. Use this on graceful exit paths
-    /// to ensure short sessions don't lose their final events.
+    /// worker plus tracked session/cloud sync tasks to drain before process exit.
     pub async fn shutdown_ingestion_and_wait(&self) {
         // Signal the worker to exit via Notify — works even when cloned senders
         // are still alive (the channel-close approach fails in that case).
@@ -240,6 +266,35 @@ impl MatrixCloudRuntime {
                     astra_core::agent_warn!(
                         "ingestion",
                         "worker flush timed out after {INGESTION_SHUTDOWN_TIMEOUT:?}, some events may be lost"
+                    );
+                }
+            }
+        }
+
+        let mut session_sync_tasks = self
+            .session_sync_tasks
+            .lock()
+            .ok()
+            .map(|mut tasks| std::mem::take(&mut *tasks))
+            .unwrap_or_default();
+        if !session_sync_tasks.is_empty() {
+            match tokio::time::timeout(INGESTION_SHUTDOWN_TIMEOUT, async {
+                while let Some(result) = session_sync_tasks.join_next().await {
+                    if let Err(error) = result {
+                        astra_core::agent_warn!(
+                            "session_sync",
+                            "session sync task join failed: {error}"
+                        );
+                    }
+                }
+            })
+            .await
+            {
+                Ok(()) => {}
+                Err(_) => {
+                    astra_core::agent_warn!(
+                        "session_sync",
+                        "session sync drain timed out after {INGESTION_SHUTDOWN_TIMEOUT:?}, some sync sidecars may be lost"
                     );
                 }
             }
@@ -336,5 +391,35 @@ mod tests {
         assert!(domains.contains(&SyncDomain::Templates));
         assert!(domains.contains(&SyncDomain::Preferences));
         assert!(domains.contains(&SyncDomain::Tasks));
+    }
+
+    #[test]
+    fn matrix_runtime_tracks_session_sync_tasks() {
+        let source = include_str!("matrix_cloud_runtime.rs");
+        assert!(
+            source.contains("session_sync_tasks: Mutex<JoinSet<()>>"),
+            "MatrixCloudRuntime should keep a tracked JoinSet for session sync sidecars"
+        );
+        assert!(
+            source.contains("pub fn spawn_session_sync_task"),
+            "MatrixCloudRuntime should expose a helper for tracked session sync spawns"
+        );
+        assert!(
+            source.contains("tasks.try_join_next()"),
+            "spawn_session_sync_task should opportunistically reap completed sync tasks"
+        );
+    }
+
+    #[test]
+    fn shutdown_waits_for_session_sync_tasks() {
+        let source = include_str!("matrix_cloud_runtime.rs");
+        assert!(
+            source.contains("std::mem::take(&mut *tasks)"),
+            "shutdown_ingestion_and_wait should drain tracked session sync tasks"
+        );
+        assert!(
+            source.contains("session_sync_tasks.join_next().await"),
+            "shutdown_ingestion_and_wait should await tracked session sync tasks before exit"
+        );
     }
 }

--- a/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
@@ -51,10 +51,13 @@ pub(crate) async fn finalize_turn_trace(state: &mut AgenticLoopState) {
     }
     if collector.has_data() {
         // Defer journal write to turn-commit path to prevent ghost assemblies.
-        // Store the trace data so the caller can emit `context_assembly_recorded`
-        // only when the turn actually commits (not on aborts/retries).
-        state.telemetry.pending_context_assembly_trace =
-            Some((session_turn, trace.to_json_value()));
+        // Store only the first trace for this outer turn so the journal records
+        // the initial context assembly, not a later internal iteration after
+        // tool-call messages have already been appended.
+        if state.telemetry.pending_context_assembly_trace.is_none() {
+            state.telemetry.pending_context_assembly_trace =
+                Some((session_turn, trace.to_json_value()));
+        }
     }
     persist_latest_context_trace_signal(state).await;
 }
@@ -686,6 +689,59 @@ mod tests {
             .expect("pending_context_assembly_trace should be set");
         assert_eq!(*turn_num, 3);
         assert_eq!(trace_json["turn_id"], "turn-3");
+    }
+
+    #[tokio::test]
+    async fn finalize_turn_trace_preserves_first_pending_trace_within_outer_turn() {
+        let mut state = make_state();
+        state.max_turns = 40;
+        state.remaining_turns = 39; // outer turn 1
+        state.current_session_id = Some("s1".to_string());
+        state.max_turn_input_tokens = 100_000;
+        state.last_measured_prompt_tokens = Some(12_000);
+
+        let first = crate::turn::turn_trace_collector::TurnTraceCollector::new(
+            "turn-0".to_string(),
+            "s1".to_string(),
+        );
+        first.set_history_retained(&[]);
+        first.record_token_budget_estimate(5_000, 0, 0, 2_000, 100, 7_100, 100_000, 0.071);
+        state.telemetry.turn_trace_collector = Some(first);
+        finalize_turn_trace(&mut state).await;
+
+        let first_pending = state
+            .telemetry
+            .pending_context_assembly_trace
+            .clone()
+            .expect("first pending trace should be set");
+        assert_eq!(first_pending.0, 1);
+        assert_eq!(first_pending.1["history"]["total_turns_available"], 0);
+        assert_eq!(
+            first_pending.1["history"]["turns_retained"]
+                .as_array()
+                .expect("turns_retained should be an array")
+                .len(),
+            0
+        );
+
+        let second = crate::turn::turn_trace_collector::TurnTraceCollector::new(
+            "turn-1".to_string(),
+            "s1".to_string(),
+        );
+        second.set_history_retained(&[crate::turn::context_assembly_trace::TurnRetention {
+            turn_index: 0,
+            role: "assistant".to_string(),
+            tokens: 123,
+            has_tool_calls: true,
+        }]);
+        second.record_token_budget_estimate(5_000, 123, 0, 2_000, 100, 7_223, 100_000, 0.07223);
+        state.telemetry.turn_trace_collector = Some(second);
+        finalize_turn_trace(&mut state).await;
+
+        assert_eq!(
+            state.telemetry.pending_context_assembly_trace,
+            Some(first_pending)
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/services/src/event_ingestion.rs
+++ b/rust/crates/services/src/event_ingestion.rs
@@ -576,8 +576,13 @@ impl EventIngestionWorker {
         // Additionally, record last_event_sync_at to help diagnose future issues.
         let mut session_counts: std::collections::HashMap<&str, usize> =
             std::collections::HashMap::new();
+        let mut session_users: std::collections::HashMap<&str, &str> =
+            std::collections::HashMap::new();
         for event in events {
             *session_counts.entry(&event.session_id).or_default() += 1;
+            session_users
+                .entry(&event.session_id)
+                .or_insert(event.user_id.as_str());
         }
 
         // Log if duplicates were detected (useful for debugging)
@@ -593,15 +598,19 @@ impl EventIngestionWorker {
         // Always reconcile from actual row count to prevent drift from concurrent flushes.
         // This is more expensive than increment but guarantees accuracy.
         for session_id in session_counts.keys() {
-            sqlx::query(
-                "UPDATE agent_sessions SET \
-                 event_count = (SELECT COUNT(*) FROM agent_events WHERE session_id = ?), \
-                 updated_at = NOW() \
-                 WHERE session_id = ?",
+            let user_id = session_users
+                .get(session_id)
+                .copied()
+                .ok_or_else(|| format!("missing user_id for session {session_id}"))?;
+            let event_count = crate::storage::load_agent_event_count(&mut *tx, session_id)
+                .await
+                .map_err(|e| format!("event_count load for {session_id}: {e}"))?;
+            crate::storage::upsert_agent_session_event_count(
+                &mut *tx,
+                session_id,
+                user_id,
+                event_count,
             )
-            .bind(*session_id)
-            .bind(*session_id)
-            .execute(&mut *tx)
             .await
             .map_err(|e| format!("event_count reconcile for {session_id}: {e}"))?;
         }
@@ -1387,8 +1396,16 @@ mod tests {
             "insert_batch must check rows_affected to detect INSERT IGNORE skips"
         );
         assert!(
-            source.contains("SELECT COUNT(*) FROM agent_events WHERE session_id"),
-            "insert_batch must reconcile event_count from actual row count on duplicate detection"
+            source.contains("load_agent_event_count"),
+            "insert_batch must load actual persisted agent_event counts before reconciling event_count"
+        );
+        assert!(
+            source.contains("upsert_agent_session_event_count"),
+            "insert_batch must reuse the shared agent_sessions upsert helper before reconciling event_count"
+        );
+        assert!(
+            source.contains("rows_affected()"),
+            "insert_batch must still preserve duplicate-detection logic while reconciling via the shared helper"
         );
     }
 

--- a/rust/crates/services/src/events.rs
+++ b/rust/crates/services/src/events.rs
@@ -9,6 +9,7 @@ use astra_core::{
 };
 
 use crate::pagination::clamp_api_list_pagination;
+use crate::storage::{load_agent_event_count, upsert_agent_session_event_count};
 
 const MAX_CAUSAL_CHAIN_EVENTS: i64 = 500;
 
@@ -308,18 +309,14 @@ impl EventService for DatabaseEventService {
 
         // BUG FIX (Session 7875e355 diagnostic): Use COUNT(*) reconcile instead of
         // increment to prevent drift from concurrent requests or duplicate detection.
-        // This matches the fix in event_ingestion.rs flush_batch().
-        query(
-            "UPDATE agent_sessions SET \
-             event_count = (SELECT COUNT(*) FROM agent_events WHERE session_id = ?), \
-             updated_at = NOW() \
-             WHERE session_id = ?",
-        )
-        .bind(&session_id)
-        .bind(&session_id)
-        .execute(&mut *tx)
-        .await
-        .map_err(internal_error)?;
+        // MatrixOne rejects the earlier subquery-in-upsert form, so count first and
+        // then upsert with bound values.
+        let event_count = load_agent_event_count(&mut *tx, &session_id)
+            .await
+            .map_err(internal_error)?;
+        upsert_agent_session_event_count(&mut *tx, &session_id, &user_id, event_count)
+            .await
+            .map_err(internal_error)?;
 
         let select_sql = format!(
             "SELECT {} FROM agent_events WHERE event_id = ?",
@@ -844,6 +841,19 @@ mod tests {
         let resp = EventListResponse::from(record);
         assert_eq!(resp.events.len(), 1);
         assert_eq!(resp.total, 42);
+    }
+
+    #[test]
+    fn create_event_upserts_agent_session_count() {
+        let source = include_str!("events.rs");
+        assert!(
+            source.contains("load_agent_event_count"),
+            "create event flow should count actual persisted agent_events before reconciling event_count"
+        );
+        assert!(
+            source.contains("upsert_agent_session_event_count"),
+            "create event flow should reuse the shared agent_sessions upsert helper when reconciling event_count"
+        );
     }
 
     // --- query deserialization defaults ---

--- a/rust/crates/services/src/session_audit.rs
+++ b/rust/crates/services/src/session_audit.rs
@@ -41,7 +41,7 @@ fn runtime_promotion_record_from_row(
 }
 
 /// `SUBSTRING(..., 1, N)` caps for `agent_events.content` to avoid full LONGTEXT reads.
-/// JSON columns (`metadata`, `token_usage`) are left intact so parsing stays valid.
+/// JSON columns are cast to `CHAR` at the SQL edge so MatrixOne returns parseable text.
 mod agent_events_content_cap {
     pub const TURN_LIST_PREVIEW: u32 = 200;
     pub const TURN_DETAIL_CHILD: u32 = 65_536;
@@ -1048,7 +1048,8 @@ impl SessionAuditService for DatabaseSessionAuditService {
         let turn_sql = format!(
             "SELECT event_id, \
              SUBSTRING(COALESCE(CAST(content AS CHAR), ''), 1, {}) AS content, \
-             token_usage, llm_model_used, metadata, created_at \
+             CAST(token_usage AS CHAR) AS token_usage, llm_model_used, \
+             CAST(metadata AS CHAR) AS metadata, CAST(created_at AS CHAR) AS created_at \
              FROM agent_events \
              WHERE session_id = ? AND user_id = ? AND event_type = 'user_query' \
              ORDER BY created_at ASC \
@@ -1140,7 +1141,8 @@ impl SessionAuditService for DatabaseSessionAuditService {
         // This avoids fetching the full event content for every turn in the session.
         let offset = turn.saturating_sub(1);
         let row = query(
-            "SELECT event_id, content, token_usage, llm_model_used, metadata, created_at \
+            "SELECT event_id, content, CAST(token_usage AS CHAR) AS token_usage, \
+             llm_model_used, CAST(metadata AS CHAR) AS metadata, CAST(created_at AS CHAR) AS created_at \
              FROM agent_events \
              WHERE session_id = ? AND user_id = ? AND event_type = 'user_query' \
              ORDER BY created_at ASC \
@@ -1181,7 +1183,7 @@ impl SessionAuditService for DatabaseSessionAuditService {
         let child_sql = format!(
             "SELECT event_id, event_type, \
              SUBSTRING(COALESCE(CAST(content AS CHAR), ''), 1, {}) AS content, \
-             metadata, created_at \
+             CAST(metadata AS CHAR) AS metadata, CAST(created_at AS CHAR) AS created_at \
              FROM agent_events \
              WHERE session_id = ? AND user_id = ? AND parent_event_id = ? \
              ORDER BY created_at ASC",
@@ -1364,7 +1366,7 @@ impl SessionAuditService for DatabaseSessionAuditService {
         let list_err_sql = format!(
             "SELECT event_id, event_type, \
              SUBSTRING(COALESCE(CAST(content AS CHAR), ''), 1, {}) AS content, \
-             metadata, created_at \
+             CAST(metadata AS CHAR) AS metadata, CAST(created_at AS CHAR) AS created_at \
              FROM agent_events \
              WHERE session_id = ? AND user_id = ? \
                AND event_type IN ('turn_error', 'stall_detected', 'error', 'turn_guard_verdict', 'tool_error') \

--- a/rust/crates/services/src/session_restore.rs
+++ b/rust/crates/services/src/session_restore.rs
@@ -19,6 +19,8 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+const STEP_CHECKPOINT_NUMBER_OFFSET: u32 = 1_000_000_000;
+
 // ─── Restored Session State ─────────────────────────────────────────────────
 
 /// The reconstructed state needed to resume a session.
@@ -54,6 +56,15 @@ pub struct RestoredSession {
     /// Blocked/deprioritized tools from checkpoint.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub blocked_tools: Vec<String>,
+    /// Serialized approval overrides restored from a heavy checkpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_overrides: Option<serde_json::Value>,
+    /// Structured interruption payload restored from a heavy checkpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interruption: Option<serde_json::Value>,
+    /// Serialized compaction-state payload restored from a heavy checkpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compaction_state: Option<serde_json::Value>,
     /// Active plan being executed (JSON-serialized TaskPlan).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub executing_plan_json: Option<String>,
@@ -83,6 +94,18 @@ pub struct SessionMetadataState {
     pub plan_goal: Option<String>,
     pub plan_config_json: Option<String>,
     pub plan_execution_rounds: usize,
+    pub git_branch: Option<String>,
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CloudHeavyCheckpointState {
+    pub messages: Vec<serde_json::Value>,
+    pub blocked_tools: Vec<String>,
+    pub recent_tools: Vec<String>,
+    pub approval_overrides: Option<serde_json::Value>,
+    pub interruption: Option<serde_json::Value>,
+    pub compaction_state: Option<serde_json::Value>,
 }
 
 /// A restored checkpoint entry (lightweight, for listing).
@@ -221,9 +244,17 @@ impl HybridRestoreService {
         };
 
         let row = sqlx::query(
-            "SELECT session_id, user_id, title, status, event_count, metadata, \
+            "SELECT session_id, user_id, title, status, event_count, CAST(metadata AS CHAR) AS metadata_json, \
+             (SELECT COUNT(*) FROM agent_events ae WHERE ae.session_id = agent_sessions.session_id AND event_type = 'user_query') AS turn_count, \
+             (SELECT COALESCE(SUM(CASE WHEN event_type = 'user_query' AND token_usage IS NOT NULL \
+                 THEN COALESCE(token_input, 0) ELSE 0 END), 0) \
+               FROM agent_events ae WHERE ae.session_id = agent_sessions.session_id) AS total_tokens_in, \
+             (SELECT COALESCE(SUM(CASE WHEN event_type = 'user_query' AND token_usage IS NOT NULL \
+                THEN COALESCE(token_output, 0) ELSE 0 END), 0) \
+               FROM agent_events ae WHERE ae.session_id = agent_sessions.session_id) AS total_tokens_out, \
+             (SELECT COUNT(*) FROM session_checkpoints sc WHERE sc.session_id = agent_sessions.session_id AND state_json IS NULL) AS checkpoint_count, \
              created_at, updated_at \
-             FROM agent_sessions WHERE session_id = ?",
+              FROM agent_sessions WHERE session_id = ?",
         )
         .bind(session_id)
         .fetch_optional(pool)
@@ -233,23 +264,61 @@ impl HybridRestoreService {
         match row {
             Some(row) => {
                 use sqlx::Row;
+                let user_id: String = row.try_get("user_id").unwrap_or_default();
                 let status: String = row.try_get("status").unwrap_or_default();
                 let title: Option<String> = row.try_get("title").ok().flatten();
-                let event_count: i64 = row.try_get("event_count").unwrap_or(0);
+                let turn_count: i64 = row.try_get("turn_count").unwrap_or(0);
+                let total_tokens_in: i64 = row.try_get("total_tokens_in").unwrap_or(0);
+                let total_tokens_out: i64 = row.try_get("total_tokens_out").unwrap_or(0);
+                let checkpoint_count: i64 = row.try_get("checkpoint_count").unwrap_or(0);
 
                 // Extract plan state from metadata JSON
-                let metadata_str: Option<String> = row.try_get("metadata").ok().flatten();
+                let metadata_str: Option<String> = row.try_get("metadata_json").ok().flatten();
                 let metadata_state = metadata_str
                     .as_deref()
                     .filter(|m| !m.is_empty())
                     .map(extract_session_state_from_metadata)
                     .unwrap_or_default();
 
+                let heavy_state = self
+                    .restore_latest_heavy_checkpoint_state(session_id)
+                    .await
+                    .ok()
+                    .flatten();
+
                 let last_context_trace = self
                     .restore_latest_context_trace_signal(session_id)
                     .await
                     .ok()
                     .flatten();
+                let mut recent_tools = self
+                    .restore_recent_tools(session_id)
+                    .await
+                    .unwrap_or_default();
+                if recent_tools.is_empty()
+                    && let Some(heavy) = heavy_state.as_ref()
+                {
+                    append_unique_tools(
+                        &mut recent_tools,
+                        heavy.recent_tools.iter().map(String::as_str),
+                    );
+                }
+                if recent_tools.is_empty() {
+                    recent_tools = recent_tools_from_context_trace(last_context_trace.as_ref());
+                }
+                let model = metadata_state.model.clone().or(self
+                    .restore_latest_model_used(session_id)
+                    .await
+                    .ok()
+                    .flatten());
+                let learning_snapshot_json = if user_id.is_empty() {
+                    None
+                } else {
+                    self.restore_learning(&user_id, "default")
+                        .await
+                        .ok()
+                        .flatten()
+                };
 
                 // Load active contract from task_contracts table
                 let mut contract_json = Self::load_cloud_contract(pool, session_id)
@@ -269,10 +338,34 @@ impl HybridRestoreService {
 
                 Ok(Some(RestoredSession {
                     session_id: session_id.to_string(),
-                    turn_count: event_count as u32,
+                    turn_count: turn_count as u32,
+                    total_tokens_in: total_tokens_in.max(0) as u64,
+                    total_tokens_out: total_tokens_out.max(0) as u64,
                     last_status: status,
                     title,
                     restored_from_cloud: true,
+                    recent_tools,
+                    learning_snapshot_json,
+                    checkpoint_count: checkpoint_count.max(0) as u32,
+                    git_branch: metadata_state.git_branch.clone(),
+                    model,
+                    conversation_messages: heavy_state
+                        .as_ref()
+                        .map(|heavy| heavy.messages.clone())
+                        .unwrap_or_default(),
+                    blocked_tools: heavy_state
+                        .as_ref()
+                        .map(|heavy| heavy.blocked_tools.clone())
+                        .unwrap_or_default(),
+                    approval_overrides: heavy_state
+                        .as_ref()
+                        .and_then(|heavy| heavy.approval_overrides.clone()),
+                    interruption: heavy_state
+                        .as_ref()
+                        .and_then(|heavy| heavy.interruption.clone()),
+                    compaction_state: heavy_state
+                        .as_ref()
+                        .and_then(|heavy| heavy.compaction_state.clone()),
                     executing_plan_json: metadata_state.executing_plan_json,
                     plan_goal: metadata_state.plan_goal,
                     plan_config_json: metadata_state.plan_config_json,
@@ -355,15 +448,40 @@ impl HybridRestoreService {
         }
     }
 
-    /// Restore recent tools from the last N events in MatrixOne.
+    /// Restore recent tools from recent cloud checkpoints, with a legacy turn-complete fallback.
     async fn restore_recent_tools(&self, session_id: &str) -> Result<Vec<String>, String> {
         let pool = match &self.pool {
             Some(p) => p,
             None => return Ok(Vec::new()),
         };
 
-        let rows = sqlx::query(
-            "SELECT metadata FROM agent_events \
+        use sqlx::Row;
+
+        let checkpoint_rows = sqlx::query(
+            "SELECT CAST(tools_json AS CHAR) AS tools_json FROM session_checkpoints \
+             WHERE session_id = ? AND state_json IS NULL \
+             ORDER BY number DESC LIMIT 5",
+        )
+        .bind(session_id)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| format!("restore_recent_tools: {e}"))?;
+
+        let mut tools = Vec::new();
+        for row in &checkpoint_rows {
+            if let Ok(Some(tools_json)) = row.try_get::<Option<String>, _>("tools_json")
+                && let Ok(used) = serde_json::from_str::<Vec<String>>(&tools_json)
+            {
+                append_unique_tools(&mut tools, used.iter().map(String::as_str));
+            }
+        }
+
+        if !tools.is_empty() {
+            return Ok(tools);
+        }
+
+        let legacy_rows = sqlx::query(
+            "SELECT CAST(metadata AS CHAR) AS metadata_json FROM agent_events \
              WHERE session_id = ? AND event_type = 'turn_complete' \
              ORDER BY created_at DESC LIMIT 5",
         )
@@ -372,20 +490,12 @@ impl HybridRestoreService {
         .await
         .map_err(|e| format!("restore_recent_tools: {e}"))?;
 
-        use sqlx::Row;
-        let mut tools = Vec::new();
-        for row in &rows {
-            if let Ok(Some(meta_str)) = row.try_get::<Option<String>, _>("metadata")
+        for row in &legacy_rows {
+            if let Ok(Some(meta_str)) = row.try_get::<Option<String>, _>("metadata_json")
                 && let Ok(meta) = serde_json::from_str::<serde_json::Value>(&meta_str)
                 && let Some(used) = meta.get("tools_used").and_then(|v| v.as_array())
             {
-                for t in used {
-                    if let Some(name) = t.as_str()
-                        && !tools.contains(&name.to_string())
-                    {
-                        tools.push(name.to_string());
-                    }
-                }
+                append_unique_tools(&mut tools, used.iter().filter_map(|tool| tool.as_str()));
             }
         }
         Ok(tools)
@@ -402,7 +512,7 @@ impl HybridRestoreService {
         };
 
         let row = sqlx::query(
-            "SELECT metadata FROM agent_events \
+            "SELECT CAST(metadata AS CHAR) AS metadata_json FROM agent_events \
              WHERE session_id = ? AND event_type = 'context_trace_signal' \
              ORDER BY created_at DESC LIMIT 1",
         )
@@ -413,7 +523,7 @@ impl HybridRestoreService {
 
         use sqlx::Row;
         Ok(row.and_then(|row| {
-            row.try_get::<Option<String>, _>("metadata")
+            row.try_get::<Option<String>, _>("metadata_json")
                 .ok()
                 .flatten()
                 .and_then(|meta| serde_json::from_str(&meta).ok())
@@ -454,6 +564,49 @@ impl HybridRestoreService {
         }
     }
 
+    async fn restore_latest_model_used(&self, session_id: &str) -> Result<Option<String>, String> {
+        let pool = match &self.pool {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+
+        let row = sqlx::query(
+            "SELECT llm_model_used FROM agent_events \
+             WHERE session_id = ? AND llm_model_used IS NOT NULL AND llm_model_used != '' \
+             ORDER BY created_at DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| format!("restore_latest_model_used: {e}"))?;
+
+        match row {
+            Some(row) => {
+                use sqlx::Row;
+                Ok(row
+                    .try_get::<Option<String>, _>("llm_model_used")
+                    .ok()
+                    .flatten())
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn restore_latest_heavy_checkpoint_state(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<CloudHeavyCheckpointState>, String> {
+        let pool = match &self.pool {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+
+        let state_json = pull_step_checkpoint_from_cloud(pool, session_id).await?;
+        Ok(state_json
+            .as_deref()
+            .and_then(parse_cloud_heavy_checkpoint_state))
+    }
+
     /// List checkpoints from MatrixOne.
     async fn cloud_checkpoints(&self, session_id: &str) -> Result<Vec<RestoredCheckpoint>, String> {
         let pool = match &self.pool {
@@ -463,7 +616,9 @@ impl HybridRestoreService {
 
         let rows = sqlx::query(
             "SELECT number, turn, title, summary, total_tokens, contract_state_json \
-             FROM session_checkpoints WHERE session_id = ? ORDER BY number",
+             FROM session_checkpoints \
+             WHERE session_id = ? AND state_json IS NULL \
+             ORDER BY number",
         )
         .bind(session_id)
         .fetch_all(pool)
@@ -525,18 +680,90 @@ fn parse_heavy_checkpoint_number(session_state_ref: &str) -> Option<u32> {
         .and_then(|prefix| prefix.parse().ok())
 }
 
+fn append_unique_tools<'a>(tools: &mut Vec<String>, candidates: impl IntoIterator<Item = &'a str>) {
+    for name in candidates {
+        if !tools.iter().any(|existing| existing == name) {
+            tools.push(name.to_string());
+        }
+    }
+}
+
+fn recent_tools_from_context_trace(
+    trace: Option<&super::session_workspace::ContextTraceSignal>,
+) -> Vec<String> {
+    let mut tools = Vec::new();
+    if let Some(selected_tools) = trace
+        .and_then(|signal| signal.tool_selection.as_ref())
+        .map(|selection| selection.selected_tools.iter().map(String::as_str))
+    {
+        append_unique_tools(&mut tools, selected_tools);
+    }
+    tools
+}
+
+fn cloud_heavy_payload(root: &serde_json::Value) -> Option<&serde_json::Value> {
+    if let Some(heavy) = root.get("Heavy") {
+        return Some(heavy);
+    }
+    if root.get("messages").is_some()
+        || root.get("blocked_tools").is_some()
+        || root.get("recent_tools").is_some()
+        || root.get("approval_overrides").is_some()
+        || root.get("interruption").is_some()
+        || root.get("compaction_state").is_some()
+    {
+        return Some(root);
+    }
+    None
+}
+
+/// Parse cloud step-checkpoint JSON into the heavy-state fields needed for restore.
+/// Accepts both the current externally tagged `{"Heavy": ...}` shape and legacy
+/// rows that stored the heavy payload unwrapped.
+pub fn parse_cloud_heavy_checkpoint_state(state_json: &str) -> Option<CloudHeavyCheckpointState> {
+    let root = serde_json::from_str::<serde_json::Value>(state_json).ok()?;
+    let heavy = cloud_heavy_payload(&root)?;
+    Some(CloudHeavyCheckpointState {
+        messages: heavy
+            .get("messages")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default(),
+        blocked_tools: heavy
+            .get("blocked_tools")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default(),
+        recent_tools: heavy
+            .get("recent_tools")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default(),
+        approval_overrides: heavy
+            .get("approval_overrides")
+            .cloned()
+            .filter(|v| !v.is_null()),
+        interruption: heavy.get("interruption").cloned().filter(|v| !v.is_null()),
+        compaction_state: heavy
+            .get("compaction_state")
+            .cloned()
+            .filter(|v| !v.is_null()),
+    })
+}
+
 #[async_trait]
 impl SessionRestoreService for HybridRestoreService {
     async fn restore_session(&self, session_id: &str) -> Result<Option<RestoredSession>, String> {
         // Step 1: Try local workspace metadata first
         if let Some(ws) = self.restore_local_workspace(session_id) {
-            let recent_tools = if self.pool.is_some() {
+            let mut recent_tools = if self.pool.is_some() {
                 self.restore_recent_tools(session_id)
                     .await
                     .unwrap_or_default()
             } else {
                 Vec::new()
             };
+            if recent_tools.is_empty() {
+                recent_tools = recent_tools_from_context_trace(ws.last_context_trace.as_ref());
+            }
 
             // Try local learning file
             let learning = self
@@ -663,7 +890,8 @@ impl SessionRestoreService for HybridRestoreService {
         };
 
         let rows = sqlx::query(
-            "SELECT session_id, title, status, event_count \
+            "SELECT session_id, title, status, CAST(metadata AS CHAR) AS metadata_json, \
+             (SELECT COUNT(*) FROM agent_events WHERE session_id = agent_sessions.session_id AND event_type = 'user_query') AS turn_count \
              FROM agent_sessions \
              WHERE user_id = ? AND status IN ('active', 'paused') \
              ORDER BY updated_at DESC LIMIT 20",
@@ -674,24 +902,42 @@ impl SessionRestoreService for HybridRestoreService {
         .map_err(|e| format!("list_resumable: {e}"))?;
 
         use sqlx::Row;
-        let sessions = rows
-            .iter()
-            .filter_map(|row| {
-                let session_id: String = row.try_get("session_id").ok()?;
-                let title: Option<String> = row.try_get("title").ok().flatten();
-                let status: String = row.try_get("status").ok()?;
-                let event_count: i64 = row.try_get("event_count").unwrap_or(0);
+        let mut sessions = Vec::new();
+        for row in &rows {
+            let session_id: String = match row.try_get("session_id") {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+            let title: Option<String> = row.try_get("title").ok().flatten();
+            let status: String = match row.try_get("status") {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+            let turn_count: i64 = row.try_get("turn_count").unwrap_or(0);
+            let metadata_state = row
+                .try_get::<Option<String>, _>("metadata_json")
+                .ok()
+                .flatten()
+                .as_deref()
+                .map(extract_session_state_from_metadata)
+                .unwrap_or_default();
+            let model = metadata_state.model.clone().or(self
+                .restore_latest_model_used(&session_id)
+                .await
+                .ok()
+                .flatten());
 
-                Some(RestoredSession {
-                    session_id,
-                    turn_count: event_count as u32,
-                    last_status: status,
-                    title,
-                    restored_from_cloud: true,
-                    ..Default::default()
-                })
-            })
-            .collect();
+            sessions.push(RestoredSession {
+                session_id,
+                turn_count: turn_count as u32,
+                last_status: status,
+                title,
+                git_branch: metadata_state.git_branch.clone(),
+                model,
+                restored_from_cloud: true,
+                ..Default::default()
+            });
+        }
         Ok(sessions)
     }
 
@@ -795,6 +1041,7 @@ pub async fn push_checkpoint_to_cloud(
             pool,
             user_id,
             session_id,
+            "checkpoint",
             checkpoint.number,
             size,
             status,
@@ -886,21 +1133,18 @@ pub async fn push_checkpoint_to_cloud(
     log_and_return(Ok(()), payload_size).await
 }
 
-/// Log checkpoint sync to session_sync_log for audit trail.
-/// This helps diagnose sync issues like Session 7875e355 where cloud had 0 checkpoints.
-/// Now includes payload_size tracking and retention pruning (reuses state_sync infra).
-async fn log_checkpoint_sync(
+/// Log session sync activity to session_sync_log for audit trail.
+/// This helps diagnose sync issues like Session 7875e355 where cloud work reached
+/// MatrixOne through some paths but left no sync-log breadcrumb.
+async fn log_session_sync(
     pool: &sqlx::Pool<sqlx::MySql>,
     user_id: &str,
     session_id: &str,
-    checkpoint_number: u32,
+    sync_type: &str,
     payload_size: usize,
     status: &str,
     error_msg: Option<&str>,
 ) -> Result<(), String> {
-    // Use fixed sync_type "checkpoint" for easy aggregation.
-    // Include checkpoint number in error_message for debugging if needed.
-    let error_with_number = error_msg.map(|e| format!("[checkpoint #{}] {}", checkpoint_number, e));
     let inserted = sqlx::query(
         "INSERT INTO session_sync_log \
          (sync_id, user_id, session_id, sync_type, sync_direction, payload_size, status, error_message, created_at) \
@@ -909,14 +1153,14 @@ async fn log_checkpoint_sync(
     .bind(uuid::Uuid::new_v4().to_string())
     .bind(user_id)
     .bind(session_id)
-    .bind("checkpoint") // Fixed sync_type for easy aggregation
+    .bind(sync_type)
     .bind("push")
     .bind(payload_size as i64)
     .bind(status)
-    .bind(error_with_number.as_deref().or(error_msg))
+    .bind(error_msg)
     .execute(pool)
     .await
-    .map_err(|e| format!("log_checkpoint_sync: {e}"))?;
+    .map_err(|e| format!("log_session_sync: {e}"))?;
 
     // Apply retention pruning using the same policy as state_sync.
     // This prevents unbounded sync_log growth for long-running sessions.
@@ -926,14 +1170,41 @@ async fn log_checkpoint_sync(
         let _ = sqlx::query(crate::state_sync::build_sync_log_prune_query())
             .bind(user_id)
             .bind(status)
+            .bind(sync_type)
             .bind(user_id)
             .bind(status)
+            .bind(sync_type)
             .bind(retain as i64)
             .execute(pool)
             .await;
     }
 
     Ok(())
+}
+
+/// Log checkpoint sync with checkpoint-number context preserved in the error field.
+#[allow(clippy::too_many_arguments)]
+async fn log_checkpoint_sync(
+    pool: &sqlx::Pool<sqlx::MySql>,
+    user_id: &str,
+    session_id: &str,
+    sync_type: &str,
+    checkpoint_number: u32,
+    payload_size: usize,
+    status: &str,
+    error_msg: Option<&str>,
+) -> Result<(), String> {
+    let error_with_number = error_msg.map(|e| format!("[checkpoint #{}] {}", checkpoint_number, e));
+    log_session_sync(
+        pool,
+        user_id,
+        session_id,
+        sync_type,
+        payload_size,
+        status,
+        error_with_number.as_deref().or(error_msg),
+    )
+    .await
 }
 
 /// Push a Step Protocol checkpoint to MatrixOne with full state_json.
@@ -952,8 +1223,28 @@ pub async fn push_step_checkpoint_to_cloud(
     state_json: &str,
 ) -> Result<(), String> {
     let checkpoint_id = uuid::Uuid::new_v4().to_string();
+    let cloud_number = cloud_step_checkpoint_number(checkpoint_number)?;
+    let payload_size = title.len() + tier.len() + tools_json.len() + state_json.len();
+    let log_and_return = |result: Result<(), String>, size: usize| async move {
+        let (status, error_msg) = match &result {
+            Ok(()) => ("success", None),
+            Err(e) => ("error", Some(e.as_str())),
+        };
+        let _ = log_checkpoint_sync(
+            pool,
+            user_id,
+            session_id,
+            "step_checkpoint",
+            checkpoint_number,
+            size,
+            status,
+            error_msg,
+        )
+        .await;
+        result
+    };
 
-    let updated = sqlx::query(
+    let updated = match sqlx::query(
         "UPDATE session_checkpoints SET \
             turn = ?, title = ?, summary = ?, tools_json = ?, state_json = ? \
          WHERE session_id = ? AND number = ?",
@@ -964,10 +1255,16 @@ pub async fn push_step_checkpoint_to_cloud(
     .bind(tools_json)
     .bind(state_json)
     .bind(session_id)
-    .bind(checkpoint_number as i32)
+    .bind(cloud_number)
     .execute(pool)
     .await
-    .map_err(|e| format!("push_step_checkpoint update: {e}"))?;
+    {
+        Ok(updated) => updated,
+        Err(e) => {
+            let err = format!("push_step_checkpoint update: {e}");
+            return log_and_return(Err(err), payload_size).await;
+        }
+    };
 
     if updated.rows_affected() == 0 {
         let inserted = sqlx::query(
@@ -979,7 +1276,7 @@ pub async fn push_step_checkpoint_to_cloud(
         .bind(&checkpoint_id)
         .bind(session_id)
         .bind(user_id)
-        .bind(checkpoint_number as i32)
+        .bind(cloud_number)
         .bind(turn as i32)
         .bind(title)
         .bind(tier)
@@ -990,7 +1287,7 @@ pub async fn push_step_checkpoint_to_cloud(
 
         if let Err(e) = inserted {
             if is_duplicate_key_error(&e) {
-                sqlx::query(
+                if let Err(err) = sqlx::query(
                     "UPDATE session_checkpoints SET \
                         turn = ?, title = ?, summary = ?, tools_json = ?, state_json = ? \
                      WHERE session_id = ? AND number = ?",
@@ -1001,17 +1298,21 @@ pub async fn push_step_checkpoint_to_cloud(
                 .bind(tools_json)
                 .bind(state_json)
                 .bind(session_id)
-                .bind(checkpoint_number as i32)
+                .bind(cloud_number)
                 .execute(pool)
                 .await
-                .map_err(|err| format!("push_step_checkpoint retry update: {err}"))?;
+                {
+                    let err = format!("push_step_checkpoint retry update: {err}");
+                    return log_and_return(Err(err), payload_size).await;
+                }
             } else {
-                return Err(format!("push_step_checkpoint insert: {e}"));
+                let err = format!("push_step_checkpoint insert: {e}");
+                return log_and_return(Err(err), payload_size).await;
             }
         }
     }
 
-    Ok(())
+    log_and_return(Ok(()), payload_size).await
 }
 
 /// Pull the latest Heavy step checkpoint JSON from MatrixOne for session recovery.
@@ -1023,7 +1324,7 @@ pub async fn pull_step_checkpoint_from_cloud(
     use sqlx::Row;
 
     let row = sqlx::query(
-        "SELECT state_json FROM session_checkpoints \
+        "SELECT CAST(state_json AS CHAR) AS state_json_json FROM session_checkpoints \
          WHERE session_id = ? AND summary = 'heavy' AND state_json IS NOT NULL \
          ORDER BY number DESC LIMIT 1",
     )
@@ -1035,7 +1336,7 @@ pub async fn pull_step_checkpoint_from_cloud(
     match row {
         Some(row) => {
             let json: String = row
-                .try_get("state_json")
+                .try_get("state_json_json")
                 .map_err(|e| format!("read state_json: {e}"))?;
             Ok(Some(json))
         }
@@ -1047,50 +1348,81 @@ pub async fn pull_step_checkpoint_from_cloud(
 
 /// Push resumable session state to cloud via the agent_sessions.metadata JSON column.
 /// Called at checkpoint boundaries and session end to enable cross-device restore.
+#[allow(clippy::too_many_arguments)]
 pub async fn push_session_state_to_cloud(
     pool: &sqlx::Pool<sqlx::MySql>,
     session_id: &str,
+    user_id: &str,
     executing_plan_json: Option<&str>,
     plan_goal: Option<&str>,
     plan_config_json: Option<&str>,
     plan_execution_rounds: usize,
+    git_branch: Option<&str>,
+    model: Option<&str>,
 ) -> Result<(), String> {
-    let mut metadata = serde_json::Map::new();
-    if let Some(plan) = executing_plan_json {
-        metadata.insert(
-            "executing_plan".to_string(),
-            serde_json::Value::String(plan.to_string()),
-        );
-    }
-    if let Some(goal) = plan_goal {
-        metadata.insert(
-            "plan_goal".to_string(),
-            serde_json::Value::String(goal.to_string()),
-        );
-    }
-    if let Some(config) = plan_config_json {
-        metadata.insert(
-            "plan_config".to_string(),
-            serde_json::Value::String(config.to_string()),
-        );
-    }
-    if plan_execution_rounds > 0 {
-        metadata.insert(
-            "plan_execution_rounds".to_string(),
-            serde_json::Value::Number(serde_json::Number::from(plan_execution_rounds)),
-        );
-    }
+    use sqlx::Row;
 
-    let metadata_json = serde_json::Value::Object(metadata).to_string();
+    let existing_metadata_json = sqlx::query(
+        "SELECT CAST(metadata AS CHAR) AS metadata_json \
+         FROM agent_sessions WHERE session_id = ? LIMIT 1",
+    )
+    .bind(session_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| format!("load session metadata: {e}"))?
+    .and_then(|row| {
+        row.try_get::<Option<String>, _>("metadata_json")
+            .ok()
+            .flatten()
+    });
 
-    sqlx::query("UPDATE agent_sessions SET metadata = ?, updated_at = NOW() WHERE session_id = ?")
-        .bind(&metadata_json)
-        .bind(session_id)
-        .execute(pool)
-        .await
-        .map_err(|e| format!("push_session_state: {e}"))?;
+    let metadata_json = merge_session_state_metadata(
+        existing_metadata_json.as_deref(),
+        executing_plan_json,
+        plan_goal,
+        plan_config_json,
+        plan_execution_rounds,
+        git_branch,
+        model,
+    );
+    let payload_size = metadata_json.len();
+    let log_and_return = |result: Result<(), String>, size: usize| async move {
+        let (status, error_msg) = match &result {
+            Ok(()) => ("success", None),
+            Err(e) => ("error", Some(e.as_str())),
+        };
+        let _ = log_session_sync(
+            pool,
+            user_id,
+            session_id,
+            "session_state",
+            size,
+            status,
+            error_msg,
+        )
+        .await;
+        result
+    };
 
-    Ok(())
+    match sqlx::query(
+        "INSERT INTO agent_sessions \
+         (session_id, user_id, status, metadata, created_at, updated_at, last_active_at) \
+         VALUES (?, ?, 'active', ?, NOW(), NOW(), NOW()) \
+         ON DUPLICATE KEY UPDATE metadata = ?, updated_at = NOW(), last_active_at = NOW()",
+    )
+    .bind(session_id)
+    .bind(user_id)
+    .bind(&metadata_json)
+    .bind(&metadata_json)
+    .execute(pool)
+    .await
+    {
+        Ok(_) => log_and_return(Ok(()), payload_size).await,
+        Err(e) => {
+            let err = format!("push_session_state: {e}");
+            log_and_return(Err(err), payload_size).await
+        }
+    }
 }
 
 /// Push a structured context-trace signal as a first-class cloud event.
@@ -1114,8 +1446,26 @@ pub async fn push_context_trace_signal_to_cloud(
             preview
         }
     };
+    let payload_size = metadata_json.len() + content.len();
+    let log_and_return = |result: Result<(), String>, size: usize| async move {
+        let (status, error_msg) = match &result {
+            Ok(()) => ("success", None),
+            Err(e) => ("error", Some(e.as_str())),
+        };
+        let _ = log_session_sync(
+            pool,
+            user_id,
+            session_id,
+            "context_trace",
+            size,
+            status,
+            error_msg,
+        )
+        .await;
+        result
+    };
 
-    sqlx::query(
+    if let Err(e) = sqlx::query(
         "INSERT INTO agent_events \
          (event_id, session_id, user_id, agent_id, agent_version, event_type, content, \
           parent_event_id, causal_chain_id, metadata, reasoning_content, meta_tool_name, \
@@ -1142,9 +1492,109 @@ pub async fn push_context_trace_signal_to_cloud(
     .bind(duration_ms)
     .execute(pool)
     .await
-    .map_err(|e| format!("push_context_trace_signal: {e}"))?;
+    {
+        let err = format!("push_context_trace_signal: {e}");
+        return log_and_return(Err(err), payload_size).await;
+    }
 
+    if let Err(e) = reconcile_session_event_count(pool, session_id, user_id).await {
+        return log_and_return(Err(e), payload_size).await;
+    }
+
+    log_and_return(Ok(()), payload_size).await
+}
+
+async fn reconcile_session_event_count(
+    pool: &sqlx::Pool<sqlx::MySql>,
+    session_id: &str,
+    user_id: &str,
+) -> Result<(), String> {
+    let event_count = crate::storage::load_agent_event_count(pool, session_id)
+        .await
+        .map_err(|e| format!("reconcile_session_event_count load: {e}"))?;
+    crate::storage::upsert_agent_session_event_count(pool, session_id, user_id, event_count)
+        .await
+        .map_err(|e| format!("reconcile_session_event_count: {e}"))?;
     Ok(())
+}
+
+fn cloud_step_checkpoint_number(checkpoint_number: u32) -> Result<i32, String> {
+    let namespaced = STEP_CHECKPOINT_NUMBER_OFFSET
+        .checked_add(checkpoint_number)
+        .ok_or_else(|| format!("step checkpoint number overflow: {checkpoint_number}"))?;
+    i32::try_from(namespaced)
+        .map_err(|_| format!("step checkpoint number out of range: {namespaced}"))
+}
+
+fn merge_session_state_metadata(
+    existing_metadata_json: Option<&str>,
+    executing_plan_json: Option<&str>,
+    plan_goal: Option<&str>,
+    plan_config_json: Option<&str>,
+    plan_execution_rounds: usize,
+    git_branch: Option<&str>,
+    model: Option<&str>,
+) -> String {
+    let mut metadata = existing_metadata_json
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+
+    if let Some(plan) = executing_plan_json {
+        metadata.insert(
+            "executing_plan".to_string(),
+            serde_json::Value::String(plan.to_string()),
+        );
+    } else {
+        metadata.remove("executing_plan");
+    }
+
+    if let Some(goal) = plan_goal {
+        metadata.insert(
+            "plan_goal".to_string(),
+            serde_json::Value::String(goal.to_string()),
+        );
+    } else {
+        metadata.remove("plan_goal");
+    }
+
+    if let Some(config) = plan_config_json {
+        metadata.insert(
+            "plan_config".to_string(),
+            serde_json::Value::String(config.to_string()),
+        );
+    } else {
+        metadata.remove("plan_config");
+    }
+
+    if plan_execution_rounds > 0 {
+        metadata.insert(
+            "plan_execution_rounds".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(plan_execution_rounds)),
+        );
+    } else {
+        metadata.remove("plan_execution_rounds");
+    }
+
+    if let Some(branch) = git_branch {
+        metadata.insert(
+            "git_branch".to_string(),
+            serde_json::Value::String(branch.to_string()),
+        );
+    } else {
+        metadata.remove("git_branch");
+    }
+
+    if let Some(model) = model {
+        metadata.insert(
+            "model".to_string(),
+            serde_json::Value::String(model.to_string()),
+        );
+    } else {
+        metadata.remove("model");
+    }
+
+    serde_json::Value::Object(metadata).to_string()
 }
 
 /// Extract plan state from the metadata JSON returned by agent_sessions.
@@ -1185,6 +1635,14 @@ pub fn extract_session_state_from_metadata(metadata_json: &str) -> SessionMetada
             .get("plan_execution_rounds")
             .and_then(|v| v.as_u64())
             .unwrap_or(0) as usize,
+        git_branch: obj
+            .get("git_branch")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        model: obj
+            .get("model")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
     }
 }
 
@@ -1205,6 +1663,7 @@ pub fn extract_plan_from_metadata(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session_workspace;
 
     // ── RestoredSession ──
 
@@ -1552,9 +2011,72 @@ mod tests {
     }
 
     #[test]
+    fn merge_session_state_metadata_preserves_unrelated_fields() {
+        let merged = merge_session_state_metadata(
+            Some(r#"{"agent_id":"astra-server","note":"keep me"}"#),
+            Some("{\"subtasks\":[]}"),
+            Some("finish migration"),
+            None,
+            2,
+            Some("main"),
+            Some("gpt-5.4"),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&merged).unwrap();
+        assert_eq!(
+            parsed.get("agent_id").and_then(|v| v.as_str()),
+            Some("astra-server")
+        );
+        assert_eq!(parsed.get("note").and_then(|v| v.as_str()), Some("keep me"));
+        assert_eq!(
+            parsed.get("plan_goal").and_then(|v| v.as_str()),
+            Some("finish migration")
+        );
+        assert_eq!(
+            parsed.get("plan_execution_rounds").and_then(|v| v.as_u64()),
+            Some(2)
+        );
+        assert_eq!(
+            parsed.get("git_branch").and_then(|v| v.as_str()),
+            Some("main")
+        );
+        assert_eq!(
+            parsed.get("model").and_then(|v| v.as_str()),
+            Some("gpt-5.4")
+        );
+    }
+
+    #[test]
+    fn merge_session_state_metadata_clears_absent_plan_fields() {
+        let merged = merge_session_state_metadata(
+            Some(
+                r#"{"agent_id":"astra-server","executing_plan":"{}","plan_goal":"stale","plan_config":"{}","plan_execution_rounds":3,"git_branch":"stale-branch","model":"stale-model"}"#,
+            ),
+            None,
+            None,
+            None,
+            0,
+            None,
+            None,
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&merged).unwrap();
+        assert_eq!(
+            parsed.get("agent_id").and_then(|v| v.as_str()),
+            Some("astra-server")
+        );
+        assert!(parsed.get("executing_plan").is_none());
+        assert!(parsed.get("plan_goal").is_none());
+        assert!(parsed.get("plan_config").is_none());
+        assert!(parsed.get("plan_execution_rounds").is_none());
+        assert!(parsed.get("git_branch").is_none());
+        assert!(parsed.get("model").is_none());
+    }
+
+    #[test]
     fn extract_session_state_from_metadata_ignores_non_plan_trace_fields() {
         let metadata = r#"{
             "executing_plan": "{\"subtasks\":[]}",
+            "git_branch": "feature/cloud-sync",
+            "model": "gpt-5.4",
             "last_context_trace": {
                 "turn_id": "turn-9",
                 "selected_tools": ["lsp", "view"],
@@ -1571,6 +2093,8 @@ mod tests {
         let state = extract_session_state_from_metadata(metadata);
         assert!(state.executing_plan_json.is_some());
         assert_eq!(state.plan_execution_rounds, 0);
+        assert_eq!(state.git_branch.as_deref(), Some("feature/cloud-sync"));
+        assert_eq!(state.model.as_deref(), Some("gpt-5.4"));
     }
 
     #[test]
@@ -1784,5 +2308,434 @@ mod tests {
         assert!(!json.contains("conversation_messages"));
         assert!(!json.contains("blocked_tools"));
         assert!(!json.contains("plan_corrections"));
+    }
+
+    #[test]
+    fn push_step_checkpoint_sync_logs_audit_records() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("pub async fn push_step_checkpoint_to_cloud")
+            .expect("step checkpoint push function");
+        let end = source
+            .find("/// Pull the latest Heavy step checkpoint JSON from MatrixOne for session recovery.")
+            .expect("step checkpoint function end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("log_checkpoint_sync("),
+            "push_step_checkpoint_to_cloud should log sync attempts for audit trails"
+        );
+        assert!(
+            snippet.contains("\"step_checkpoint\""),
+            "step checkpoint sync log should use a dedicated sync_type"
+        );
+    }
+
+    #[test]
+    fn push_context_trace_signal_reconciles_session_event_count() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("pub async fn push_context_trace_signal_to_cloud")
+            .expect("context trace push function");
+        let end = source
+            .find("/// Extract plan state from the metadata JSON returned by agent_sessions.")
+            .expect("context trace function end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("reconcile_session_event_count(pool, session_id, user_id).await"),
+            "context trace cloud inserts must reconcile agent_sessions.event_count"
+        );
+    }
+
+    #[test]
+    fn cloud_step_checkpoint_number_uses_disjoint_namespace() {
+        assert_eq!(
+            cloud_step_checkpoint_number(1).unwrap(),
+            1_000_000_001,
+            "step checkpoints should avoid the session-checkpoint number range"
+        );
+    }
+
+    #[test]
+    fn restore_cloud_session_uses_user_query_count_for_turns() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("async fn restore_cloud_session")
+            .expect("restore cloud session function");
+        let end = source
+            .find("/// List checkpoints from MatrixOne.")
+            .expect("restore cloud session end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("event_type = 'user_query'"),
+            "cloud restore should derive turn_count from user_query events"
+        );
+        assert!(
+            snippet.contains("AS turn_count"),
+            "cloud restore query should materialize a turn_count column"
+        );
+    }
+
+    #[test]
+    fn list_resumable_sessions_uses_user_query_count_for_turns() {
+        let source = include_str!("session_restore.rs");
+        assert!(
+            source.contains(
+                "(SELECT COUNT(*) FROM agent_events WHERE session_id = agent_sessions.session_id AND event_type = 'user_query') AS turn_count"
+            ),
+            "resumable session listing should derive turn_count from user_query events"
+        );
+        assert!(
+            source.contains("turn_count: turn_count as u32"),
+            "resumable session listing should populate RestoredSession.turn_count from the derived turn_count column"
+        );
+    }
+
+    #[test]
+    fn list_resumable_sessions_restores_resume_identity_fields() {
+        let source = include_str!("session_restore.rs");
+        assert!(
+            source.contains("CAST(metadata AS CHAR) AS metadata_json"),
+            "resumable session listing should read session metadata so git_branch/model can survive cloud-only resume lists"
+        );
+        assert!(
+            source.contains("restore_latest_model_used(&session_id)"),
+            "resumable session listing should fall back to the latest llm_model_used helper for older cloud sessions"
+        );
+        assert!(
+            source.contains("git_branch: metadata_state.git_branch.clone()"),
+            "resumable session listing should populate RestoredSession.git_branch from session metadata"
+        );
+    }
+
+    #[test]
+    fn recent_tools_from_context_trace_uses_selected_tools() {
+        let trace = session_workspace::ContextTraceSignal {
+            turn_id: "turn-7".into(),
+            captured_at: None,
+            tool_selection: Some(session_workspace::ContextTraceToolSelection {
+                tools_available: 8,
+                selected_tools: vec!["bash".into(), "grep".into(), "bash".into()],
+                rejected_tools: 0,
+                strategy: "recent_tools".into(),
+                confidence: 0.91,
+                latency_ms: 12,
+            }),
+            memory: None,
+            history: None,
+            budget: None,
+            timing: None,
+            explanations: Vec::new(),
+        };
+
+        assert_eq!(
+            recent_tools_from_context_trace(Some(&trace)),
+            vec!["bash".to_string(), "grep".to_string()]
+        );
+        assert!(recent_tools_from_context_trace(None).is_empty());
+    }
+
+    #[test]
+    fn parse_cloud_heavy_checkpoint_state_accepts_tagged_and_legacy_shapes() {
+        let messages = vec![serde_json::json!({"role":"user","content":"hi"})];
+        let approval_overrides = serde_json::json!({"rules": []});
+        let interruption = serde_json::json!({"kind":"rate_limited"});
+        let compaction_state = serde_json::json!({"attempt_count": 2});
+        let expected = CloudHeavyCheckpointState {
+            messages: messages.clone(),
+            blocked_tools: vec!["bash".into()],
+            recent_tools: vec!["rg".into()],
+            approval_overrides: Some(approval_overrides.clone()),
+            interruption: Some(interruption.clone()),
+            compaction_state: Some(compaction_state.clone()),
+        };
+        let tagged = serde_json::json!({
+            "Heavy": {
+                "light": {},
+                "messages": messages,
+                "blocked_tools": ["bash"],
+                "recent_tools": ["rg"],
+                "approval_overrides": approval_overrides,
+                "interruption": interruption,
+                "compaction_state": compaction_state
+            }
+        })
+        .to_string();
+        let legacy = serde_json::json!({
+            "messages": expected.messages.clone(),
+            "blocked_tools": expected.blocked_tools.clone(),
+            "recent_tools": expected.recent_tools.clone(),
+            "approval_overrides": expected.approval_overrides.clone(),
+            "interruption": expected.interruption.clone(),
+            "compaction_state": expected.compaction_state.clone()
+        })
+        .to_string();
+
+        assert_eq!(
+            parse_cloud_heavy_checkpoint_state(&tagged),
+            Some(expected.clone())
+        );
+        assert_eq!(parse_cloud_heavy_checkpoint_state(&legacy), Some(expected));
+    }
+
+    #[test]
+    fn restore_recent_tools_prefers_checkpoint_tools_json() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("async fn restore_recent_tools")
+            .expect("restore recent tools function");
+        let end = source
+            .find("/// Restore the latest structured context-trace signal from cloud events.")
+            .expect("restore recent tools end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("CAST(tools_json AS CHAR) AS tools_json"),
+            "recent tool restore should decode authoritative tools_json from cloud checkpoints using a MatrixOne-compatible string cast"
+        );
+        assert!(
+            snippet.contains("state_json IS NULL"),
+            "recent tool restore should ignore state-bearing step checkpoint rows"
+        );
+        assert!(
+            snippet.contains("CAST(metadata AS CHAR) AS metadata_json"),
+            "legacy turn_complete metadata fallback should decode JSON through a MatrixOne-compatible string cast"
+        );
+    }
+
+    #[test]
+    fn restore_cloud_session_populates_recent_tools() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("async fn restore_cloud_session")
+            .expect("restore cloud session function");
+        let end = source
+            .find("/// List checkpoints from MatrixOne.")
+            .expect("restore cloud session end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("restore_recent_tools(session_id)"),
+            "cloud restore should recover recent tools instead of always returning an empty list"
+        );
+        assert!(
+            snippet.contains("recent_tools,"),
+            "cloud restore should populate RestoredSession.recent_tools"
+        );
+    }
+
+    #[test]
+    fn restore_cloud_session_restores_cloud_summary_fields() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("async fn restore_cloud_session")
+            .expect("restore cloud session function");
+        let end = source
+            .find("/// List checkpoints from MatrixOne.")
+            .expect("restore cloud session end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("token_input"),
+            "cloud restore should recover prompt-token totals from agent_events"
+        );
+        assert!(
+            snippet.contains("token_output"),
+            "cloud restore should recover completion-token totals from agent_events"
+        );
+        assert!(
+            snippet.contains(
+                "session_checkpoints sc WHERE sc.session_id = agent_sessions.session_id AND state_json IS NULL"
+            ),
+            "cloud restore should recover ordinary checkpoint counts from session_checkpoints"
+        );
+        assert!(
+            snippet.contains("restore_learning(&user_id, \"default\")"),
+            "cloud restore should recover the latest cloud learning snapshot for the user"
+        );
+    }
+
+    #[test]
+    fn restore_cloud_session_restores_resume_identity_fields() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("async fn restore_cloud_session")
+            .expect("restore cloud session function");
+        let end = source
+            .find("/// List checkpoints from MatrixOne.")
+            .expect("restore cloud session end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("restore_latest_model_used(session_id)"),
+            "cloud restore should fall back to the latest llm_model_used when metadata lacks model"
+        );
+        assert!(
+            snippet.contains("CAST(metadata AS CHAR) AS metadata_json"),
+            "cloud restore should decode session metadata through a MatrixOne-compatible string cast"
+        );
+        assert!(
+            snippet.contains("git_branch: metadata_state.git_branch.clone()"),
+            "cloud restore should restore git_branch from session metadata"
+        );
+    }
+
+    #[test]
+    fn restore_latest_context_trace_signal_uses_matrixone_json_cast() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("async fn restore_latest_context_trace_signal")
+            .expect("restore latest context trace function");
+        let end = source
+            .find("/// Pull learning snapshot from MatrixOne.")
+            .expect("restore latest context trace end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("CAST(metadata AS CHAR) AS metadata_json"),
+            "context trace restore should decode JSON metadata through a MatrixOne-compatible string cast"
+        );
+    }
+
+    #[test]
+    fn pull_step_checkpoint_from_cloud_uses_matrixone_json_cast() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("pub async fn pull_step_checkpoint_from_cloud")
+            .expect("pull_step_checkpoint function");
+        let end = source
+            .find("// ─── Plan State Cloud Sync")
+            .expect("pull_step_checkpoint end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("CAST(state_json AS CHAR) AS state_json_json"),
+            "heavy step checkpoint restore should decode state_json through a MatrixOne-compatible string cast"
+        );
+    }
+
+    #[test]
+    fn push_session_state_cloud_upserts_agent_session_row() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("pub async fn push_session_state_to_cloud")
+            .expect("session state push function");
+        let end = source
+            .find("/// Push a structured context-trace signal as a first-class cloud event.")
+            .expect("session state function end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("INSERT INTO agent_sessions"),
+            "push_session_state_to_cloud should create missing agent_sessions rows"
+        );
+        assert!(
+            snippet.contains("ON DUPLICATE KEY UPDATE metadata = ?"),
+            "push_session_state_to_cloud should upsert metadata for existing sessions"
+        );
+    }
+
+    #[test]
+    fn push_session_state_cloud_merges_resume_identity_metadata() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("pub async fn push_session_state_to_cloud")
+            .expect("session state push function");
+        let end = source
+            .find("/// Push a structured context-trace signal as a first-class cloud event.")
+            .expect("session state function end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("git_branch"),
+            "session state cloud sync should persist git_branch in metadata"
+        );
+        assert!(
+            snippet.contains("model"),
+            "session state cloud sync should persist model in metadata"
+        );
+    }
+
+    #[test]
+    fn push_session_state_sync_logs_audit_records() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("pub async fn push_session_state_to_cloud")
+            .expect("session state push function");
+        let end = source
+            .find("/// Push a structured context-trace signal as a first-class cloud event.")
+            .expect("session state function end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("log_session_sync("),
+            "push_session_state_to_cloud should record sync attempts in session_sync_log"
+        );
+        assert!(
+            snippet.contains("\"session_state\""),
+            "push_session_state_to_cloud should log with sync_type=session_state"
+        );
+    }
+
+    #[test]
+    fn push_context_trace_sync_logs_audit_records() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("pub async fn push_context_trace_signal_to_cloud")
+            .expect("context trace push function");
+        let end = source
+            .find("async fn reconcile_session_event_count")
+            .expect("context trace function end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("log_session_sync("),
+            "push_context_trace_signal_to_cloud should record sync attempts in session_sync_log"
+        );
+        assert!(
+            snippet.contains("\"context_trace\""),
+            "push_context_trace_signal_to_cloud should log with sync_type=context_trace"
+        );
+    }
+
+    #[test]
+    fn reconcile_session_event_count_uses_matrixone_compatible_bound_counts() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("async fn reconcile_session_event_count")
+            .expect("reconcile helper");
+        let end = source
+            .find("fn cloud_step_checkpoint_number")
+            .expect("reconcile helper end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("load_agent_event_count"),
+            "reconcile_session_event_count should load event_count before upserting so MatrixOne does not need a subquery in ON DUPLICATE KEY UPDATE"
+        );
+        assert!(
+            snippet.contains("upsert_agent_session_event_count"),
+            "reconcile_session_event_count should use the shared bound-value upsert helper"
+        );
+    }
+
+    #[test]
+    fn cloud_checkpoints_excludes_step_rows() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("async fn cloud_checkpoints")
+            .expect("cloud checkpoints function");
+        let end = source
+            .find("/// Restore composite state (data snapshot + git commit) from local files.")
+            .expect("cloud checkpoints function end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("state_json IS NULL"),
+            "cloud_checkpoints should only restore session checkpoints, not step checkpoint rows"
+        );
+    }
+
+    #[test]
+    fn push_step_checkpoint_uses_namespaced_cloud_number() {
+        let source = include_str!("session_restore.rs");
+        let start = source
+            .find("pub async fn push_step_checkpoint_to_cloud")
+            .expect("step checkpoint push function");
+        let end = source
+            .find("/// Pull the latest Heavy step checkpoint JSON from MatrixOne for session recovery.")
+            .expect("step checkpoint function end marker");
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("cloud_step_checkpoint_number(checkpoint_number)?"),
+            "step checkpoint cloud writes should use a disjoint number namespace"
+        );
     }
 }

--- a/rust/crates/services/src/state_sync.rs
+++ b/rust/crates/services/src/state_sync.rs
@@ -116,15 +116,15 @@ pub(crate) fn sync_log_retain_limit(status: &str) -> Option<usize> {
 /// Exposed for checkpoint sync to reuse the same pruning policy.
 pub(crate) fn build_sync_log_prune_query() -> &'static str {
     "DELETE FROM session_sync_log \
-     WHERE user_id = ? AND status = ? \
+     WHERE user_id = ? AND status = ? AND sync_type = ? \
        AND sync_id NOT IN ( \
-           SELECT sync_id FROM ( \
-               SELECT sync_id FROM session_sync_log \
-               WHERE user_id = ? AND status = ? \
-               ORDER BY created_at DESC \
-               LIMIT ? \
-           ) AS keepers \
-       )"
+            SELECT sync_id FROM ( \
+                SELECT sync_id FROM session_sync_log \
+                WHERE user_id = ? AND status = ? AND sync_type = ? \
+                ORDER BY created_at DESC \
+                LIMIT ? \
+            ) AS keepers \
+        )"
 }
 
 // ─── Sync Types ─────────────────────────────────────────────────────────────
@@ -543,16 +543,19 @@ impl MatrixOneSyncService {
         if inserted.is_ok()
             && let Some(retain) = sync_log_retain_limit(status)
         {
-            self.prune_sync_logs(user_id, status, retain).await;
+            self.prune_sync_logs(user_id, sync_type, status, retain)
+                .await;
         }
     }
 
-    async fn prune_sync_logs(&self, user_id: &str, status: &str, retain: usize) {
+    async fn prune_sync_logs(&self, user_id: &str, sync_type: &str, status: &str, retain: usize) {
         let _ = sqlx::query(build_sync_log_prune_query())
             .bind(user_id)
             .bind(status)
+            .bind(sync_type)
             .bind(user_id)
             .bind(status)
+            .bind(sync_type)
             .bind(retain as i64)
             .execute(&self.pool)
             .await;
@@ -1529,11 +1532,11 @@ mod tests {
     }
 
     #[test]
-    fn prune_query_keeps_latest_rows_for_user_and_status() {
+    fn prune_query_keeps_latest_rows_for_user_status_and_sync_type() {
         let query = build_sync_log_prune_query();
 
         assert!(query.contains("DELETE FROM session_sync_log"));
-        assert!(query.contains("WHERE user_id = ? AND status = ?"));
+        assert!(query.contains("WHERE user_id = ? AND status = ? AND sync_type = ?"));
         assert!(query.contains("SELECT sync_id FROM session_sync_log"));
         assert!(query.contains("ORDER BY created_at DESC"));
         assert!(query.contains("LIMIT ?"));

--- a/rust/crates/services/src/storage.rs
+++ b/rust/crates/services/src/storage.rs
@@ -3,7 +3,7 @@ use crate::auth::session::SessionRecord;
 use astra_core::{ErrorResponse, MatrixOneSettings, connect_matrixone, internal_error};
 use axum::{Json, http::StatusCode};
 use fs2::FileExt;
-use sqlx::{MySql, QueryBuilder, Row, query};
+use sqlx::{Executor, MySql, QueryBuilder, Row, query};
 use std::collections::HashSet;
 use std::collections::{BTreeSet, HashMap};
 use std::fs::OpenOptions;
@@ -92,6 +92,47 @@ pub fn normalized_parent_event_ids(
     }
 
     out
+}
+
+pub async fn load_agent_event_count<'e, E>(
+    executor: E,
+    session_id: &str,
+) -> Result<i64, sqlx::Error>
+where
+    E: Executor<'e, Database = MySql>,
+{
+    let row = query("SELECT COUNT(*) AS event_count FROM agent_events WHERE session_id = ?")
+        .bind(session_id)
+        .fetch_one(executor)
+        .await?;
+    Ok(row.try_get::<i64, _>("event_count").unwrap_or(0))
+}
+
+pub async fn upsert_agent_session_event_count<'e, E>(
+    executor: E,
+    session_id: &str,
+    user_id: &str,
+    event_count: i64,
+) -> Result<(), sqlx::Error>
+where
+    E: Executor<'e, Database = MySql>,
+{
+    query(
+        "INSERT INTO agent_sessions \
+         (session_id, user_id, status, event_count, created_at, updated_at, last_active_at) \
+         VALUES (?, ?, 'active', ?, NOW(), NOW(), NOW()) \
+         ON DUPLICATE KEY UPDATE \
+         event_count = ?, \
+         updated_at = NOW(), \
+         last_active_at = NOW()",
+    )
+    .bind(session_id)
+    .bind(user_id)
+    .bind(event_count)
+    .bind(event_count)
+    .execute(executor)
+    .await?;
+    Ok(())
 }
 
 pub async fn insert_agent_event_edges<'e, E>(

--- a/rust/crates/services/tests/services_db_integration.rs
+++ b/rust/crates/services/tests/services_db_integration.rs
@@ -13,17 +13,25 @@
 //! (ignores duplicate-name errors) so the listing path is validated against the intended DDL.
 
 use astra_core::{DEV_MATRIXONE_PASSWORD, MatrixOneSettings, SharedPool, resolve_database_name};
+use astra_services::event_ingestion::{EventIngestionWorker, IngestionConfig, IngestionEvent};
+use astra_services::session_audit::TurnListParams;
 use astra_services::session_audit::{
     AuditSessionListParams, CrossSessionMutationListParams, CrossSessionRuntimePromotionListParams,
     CrossSessionStatsParams, DatabaseSessionAuditService, RUNTIME_PROMOTION_EVENT_TYPE,
     RuntimePromotionController, RuntimePromotionOutcome, RuntimePromotionRecommendation,
     SessionAuditService,
 };
+use astra_services::session_restore::{
+    HybridRestoreService, SessionRestoreService, pull_step_checkpoint_from_cloud,
+    push_checkpoint_to_cloud, push_context_trace_signal_to_cloud, push_session_state_to_cloud,
+    push_step_checkpoint_to_cloud,
+};
+use astra_services::session_workspace::{ContextTraceSignal, ContextTraceToolSelection};
 use astra_services::{
     AdminAuditFilter, AdminAuditReader, DatabaseAdminAuditReader, DatabaseDecisionService,
     DatabaseEventService, DatabaseMarketplaceStatsService, DatabaseSessionService,
     DatabaseSkillService, DecisionListFilter, DecisionService, DurableTaskLifecycle,
-    EventListFilter, EventService, MAX_API_LIST_LIMIT, MAX_API_LIST_OFFSET,
+    EventCreateRequestData, EventListFilter, EventService, MAX_API_LIST_LIMIT, MAX_API_LIST_OFFSET,
     MAX_MARKETPLACE_SEARCH_OFFSET, MarketplaceStatsService, MatrixOneDurableTaskLifecycle,
     SessionListFilter, SessionService, SkillSearchQuery, SkillService, StagedMutationState,
     ensure_core_schema,
@@ -463,6 +471,37 @@ async fn cleanup_task_contract_and_results(
         .bind(task_id)
         .execute(pool)
         .await;
+}
+
+async fn cleanup_restore_fixture(
+    pool: &sqlx::Pool<sqlx::MySql>,
+    user_id: &str,
+    session_ids: &[String],
+) {
+    for sid in session_ids {
+        let _ = sqlx::query("DELETE FROM session_sync_log WHERE session_id = ?")
+            .bind(sid)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM session_checkpoints WHERE session_id = ?")
+            .bind(sid)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM agent_events WHERE session_id = ?")
+            .bind(sid)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM agent_sessions WHERE session_id = ?")
+            .bind(sid)
+            .execute(pool)
+            .await;
+    }
+    let _ = sqlx::query(
+        "DELETE FROM learning_snapshots WHERE user_id = ? AND profile_name = 'default'",
+    )
+    .bind(user_id)
+    .execute(pool)
+    .await;
 }
 
 #[tokio::test]
@@ -1085,6 +1124,157 @@ async fn cross_session_mutations_db_roundtrip() {
 
 #[tokio::test]
 #[ignore = "ASTRA_SERVICES_DB_IT=1 and live MatrixOne"]
+async fn session_audit_turn_views_decode_json_columns_on_live_matrixone() {
+    let (shared, settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let session_id = Uuid::new_v4().to_string();
+    let turn_event_id = Uuid::new_v4().to_string();
+    let child_event_id = Uuid::new_v4().to_string();
+    let error_event_id = Uuid::new_v4().to_string();
+
+    sqlx::query(
+        "INSERT INTO agent_sessions (session_id, user_id, title, status, event_count) \
+         VALUES (?, ?, 'audit-turn-it', 'active', 3)",
+    )
+    .bind(&session_id)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("insert audit session");
+
+    let turn_metadata = serde_json::json!({
+        "turn": 1,
+        "assistant_output": "assistant reply",
+        "tools_selected": ["bash", "rg"],
+        "tools_used": ["bash"],
+        "duration_ms": 987,
+        "ttft_ms": 42,
+        "context_ms": 18,
+        "selector_ms": 7,
+        "selector_strategy": "ranked",
+        "budget_pressure": 0.25,
+        "tool_calls": [
+            {"name": "bash", "ok": true, "ms": 123}
+        ]
+    });
+    sqlx::query(
+        "INSERT INTO agent_events \
+         (event_id, session_id, user_id, event_type, content, token_usage, llm_model_used, metadata, created_at) \
+         VALUES (?, ?, ?, 'user_query', ?, CAST(? AS JSON), ?, CAST(? AS JSON), '2026-09-05 09:00:00.000000')",
+    )
+    .bind(&turn_event_id)
+    .bind(&session_id)
+    .bind(&user_id)
+    .bind("show audit turn")
+    .bind(serde_json::json!({"input": 21, "output": 8, "total": 29}).to_string())
+    .bind("gpt-5.4")
+    .bind(turn_metadata.to_string())
+    .execute(&pool)
+    .await
+    .expect("insert audit turn event");
+
+    sqlx::query(
+        "INSERT INTO agent_events \
+         (event_id, session_id, user_id, event_type, parent_event_id, content, metadata, created_at) \
+         VALUES (?, ?, ?, 'tool_call', ?, 'tool child', CAST(? AS JSON), '2026-09-05 09:00:01.000000')",
+    )
+    .bind(&child_event_id)
+    .bind(&session_id)
+    .bind(&user_id)
+    .bind(&turn_event_id)
+    .bind(serde_json::json!({"tool_name": "bash", "ok": true}).to_string())
+    .execute(&pool)
+    .await
+    .expect("insert audit child event");
+
+    sqlx::query(
+        "INSERT INTO agent_events \
+         (event_id, session_id, user_id, event_type, content, metadata, created_at) \
+         VALUES (?, ?, ?, 'turn_error', 'turn failed', CAST(? AS JSON), '2026-09-05 09:00:02.000000')",
+    )
+    .bind(&error_event_id)
+    .bind(&session_id)
+    .bind(&user_id)
+    .bind(serde_json::json!({"turn": 1, "error": "boom"}).to_string())
+    .execute(&pool)
+    .await
+    .expect("insert audit error event");
+
+    let audit = DatabaseSessionAuditService::new(settings.clone()).with_pool(shared.clone());
+    let turns = audit
+        .list_turns(
+            &user_id,
+            &session_id,
+            &TurnListParams {
+                page: 1,
+                per_page: 20,
+            },
+        )
+        .await
+        .expect("list turns");
+    assert_eq!(turns.total, 1);
+    assert_eq!(turns.turns.len(), 1);
+    assert_eq!(turns.turns[0].turn, 1);
+    assert_eq!(turns.turns[0].tokens_in, 21);
+    assert_eq!(turns.turns[0].tokens_out, 8);
+    assert_eq!(turns.turns[0].duration_ms, 987);
+    assert_eq!(turns.turns[0].model.as_deref(), Some("gpt-5.4"));
+    assert_eq!(turns.turns[0].tool_calls.len(), 1);
+    assert_eq!(turns.turns[0].tool_calls[0].name, "bash");
+
+    let detail = audit
+        .get_turn_detail(&user_id, &session_id, 1)
+        .await
+        .expect("get turn detail");
+    assert_eq!(detail.turn, 1);
+    assert_eq!(detail.user_input, "show audit turn");
+    assert_eq!(detail.assistant_output, "assistant reply");
+    assert_eq!(detail.tokens_in, 21);
+    assert_eq!(detail.tokens_out, 8);
+    assert_eq!(detail.duration_ms, 987);
+    assert_eq!(detail.ttft_ms, Some(42));
+    assert_eq!(detail.context_ms, Some(18));
+    assert_eq!(detail.selector_ms, Some(7));
+    assert_eq!(detail.selector_strategy.as_deref(), Some("ranked"));
+    assert_eq!(detail.budget_pressure, Some(0.25));
+    assert_eq!(
+        detail.tools_selected,
+        vec!["bash".to_string(), "rg".to_string()]
+    );
+    assert_eq!(detail.tools_used, vec!["bash".to_string()]);
+    assert_eq!(detail.child_events.len(), 1);
+    assert_eq!(detail.child_events[0].event_id, child_event_id);
+    assert_eq!(
+        detail.child_events[0].metadata.get("tool_name"),
+        Some(&serde_json::json!("bash"))
+    );
+
+    let errors = audit
+        .list_errors(&user_id, &session_id)
+        .await
+        .expect("list errors");
+    assert_eq!(errors.total, 1);
+    assert_eq!(errors.errors.len(), 1);
+    assert_eq!(errors.errors[0].event_id, error_event_id);
+    assert_eq!(errors.errors[0].turn, Some(1));
+    assert_eq!(
+        errors.errors[0].metadata.get("error"),
+        Some(&serde_json::json!("boom"))
+    );
+
+    cleanup_agent_sessions_and_events(
+        &pool,
+        std::slice::from_ref(&session_id),
+        &[turn_event_id, child_event_id, error_event_id],
+        &[],
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "ASTRA_SERVICES_DB_IT=1 and live MatrixOne"]
 async fn durable_task_resume_loads_verification_history_from_db() {
     let (shared, _settings) = setup_pool_and_settings().await;
     let pool = shared.get().clone();
@@ -1208,4 +1398,1348 @@ async fn durable_task_resume_loads_verification_history_from_db() {
     );
 
     cleanup_task_contract_and_results(&pool, &task_id, &result_ids).await;
+}
+
+#[tokio::test]
+#[ignore = "ASTRA_SERVICES_DB_IT=1 and live MatrixOne"]
+async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
+    let (shared, _settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let session_a = Uuid::new_v4().to_string();
+    let session_b = Uuid::new_v4().to_string();
+    let checkpoint_id = Uuid::new_v4().to_string();
+    let learning_snapshot_id = Uuid::new_v4().to_string();
+    let plan_a_json =
+        serde_json::json!({"subtasks":[{"id":"a1","title":"checkpoint"}]}).to_string();
+    let plan_a_config = serde_json::json!({"mode":"checkpoint"}).to_string();
+    let plan_b_json = serde_json::json!({"subtasks":[{"id":"b1","title":"fallback"}]}).to_string();
+    let plan_b_config = serde_json::json!({"mode":"resume"}).to_string();
+    let existing_metadata_a =
+        serde_json::json!({"agent_id":"astra-server","note":"keep me"}).to_string();
+
+    cleanup_restore_fixture(&pool, &user_id, &[session_a.clone(), session_b.clone()]).await;
+
+    let learning_json =
+        serde_json::json!({"entities":["Rust","MatrixOne"],"patterns":["*.rs"]}).to_string();
+    sqlx::query(
+        "INSERT INTO learning_snapshots \
+         (snapshot_id, user_id, profile_name, snapshot_json, entity_count, pattern_count, has_calibration, version) \
+         VALUES (?, ?, 'default', ?, 2, 1, 0, 1)",
+    )
+    .bind(&learning_snapshot_id)
+    .bind(&user_id)
+    .bind(&learning_json)
+    .execute(&pool)
+    .await
+    .expect("insert learning snapshot");
+
+    sqlx::query(
+        "INSERT INTO agent_sessions \
+         (session_id, user_id, title, status, event_count, metadata, created_at, updated_at, last_active_at) \
+         VALUES (?, ?, 'Cloud restore A', 'active', 0, CAST(? AS JSON), NOW(), NOW(), NOW())",
+    )
+    .bind(&session_a)
+    .bind(&user_id)
+    .bind(&existing_metadata_a)
+    .execute(&pool)
+    .await
+    .expect("insert existing session A");
+
+    push_session_state_to_cloud(
+        &pool,
+        &session_a,
+        &user_id,
+        Some(&plan_a_json),
+        Some("finish session A"),
+        Some(&plan_a_config),
+        3,
+        Some("feature/cloud-sync"),
+        Some("gpt-5.4"),
+    )
+    .await
+    .expect("push session state A");
+    push_session_state_to_cloud(
+        &pool,
+        &session_b,
+        &user_id,
+        Some(&plan_b_json),
+        Some("finish session B"),
+        Some(&plan_b_config),
+        2,
+        Some("legacy-fallback"),
+        None,
+    )
+    .await
+    .expect("push session state B");
+    push_session_state_to_cloud(
+        &pool,
+        &session_a,
+        &user_id,
+        None,
+        None,
+        None,
+        0,
+        Some("feature/cloud-sync"),
+        Some("gpt-5.4"),
+    )
+    .await
+    .expect("clear session state A plan fields");
+
+    let metadata_a_json: Option<String> = sqlx::query(
+        "SELECT CAST(metadata AS CHAR) AS metadata_json FROM agent_sessions WHERE session_id = ?",
+    )
+    .bind(&session_a)
+    .fetch_one(&pool)
+    .await
+    .expect("load session A metadata")
+    .try_get("metadata_json")
+    .expect("session A metadata json");
+    let metadata_a: serde_json::Value = serde_json::from_str(
+        metadata_a_json
+            .as_deref()
+            .expect("session A metadata should exist"),
+    )
+    .expect("parse session A metadata");
+    assert_eq!(
+        metadata_a
+            .get("agent_id")
+            .and_then(serde_json::Value::as_str),
+        Some("astra-server")
+    );
+    assert_eq!(
+        metadata_a.get("note").and_then(serde_json::Value::as_str),
+        Some("keep me")
+    );
+    assert!(metadata_a.get("executing_plan").is_none());
+    assert!(metadata_a.get("plan_goal").is_none());
+    assert!(metadata_a.get("plan_config").is_none());
+    assert!(metadata_a.get("plan_execution_rounds").is_none());
+    assert_eq!(
+        metadata_a
+            .get("git_branch")
+            .and_then(serde_json::Value::as_str),
+        Some("feature/cloud-sync")
+    );
+    assert_eq!(
+        metadata_a.get("model").and_then(serde_json::Value::as_str),
+        Some("gpt-5.4")
+    );
+
+    for (session_id, title) in [
+        (&session_a, "Cloud restore A"),
+        (&session_b, "Cloud restore B"),
+    ] {
+        sqlx::query("UPDATE agent_sessions SET title = ? WHERE session_id = ?")
+            .bind(title)
+            .bind(session_id)
+            .execute(&pool)
+            .await
+            .expect("update title");
+    }
+
+    for (event_id, session_id, content, token_in, token_out, model, ts) in [
+        (
+            Uuid::new_v4().to_string(),
+            session_a.clone(),
+            "first turn",
+            120_i64,
+            30_i64,
+            "gpt-5.4".to_string(),
+            "2026-09-01 10:00:00.000000".to_string(),
+        ),
+        (
+            Uuid::new_v4().to_string(),
+            session_a.clone(),
+            "second turn",
+            80_i64,
+            20_i64,
+            "gpt-5.4".to_string(),
+            "2026-09-01 10:01:00.000000".to_string(),
+        ),
+        (
+            Uuid::new_v4().to_string(),
+            session_b.clone(),
+            "legacy turn",
+            40_i64,
+            10_i64,
+            "claude-sonnet-4.5".to_string(),
+            "2026-09-02 08:00:00.000000".to_string(),
+        ),
+    ] {
+        let token_total = token_in + token_out;
+        let token_usage =
+            serde_json::json!({"input": token_in, "output": token_out, "total": token_total})
+                .to_string();
+        sqlx::query(
+            "INSERT INTO agent_events \
+             (event_id, session_id, user_id, event_type, content, token_usage, llm_model_used, \
+              token_input, token_output, token_total, created_at) \
+             VALUES (?, ?, ?, 'user_query', ?, CAST(? AS JSON), ?, ?, ?, ?, ?)",
+        )
+        .bind(&event_id)
+        .bind(&session_id)
+        .bind(&user_id)
+        .bind(content)
+        .bind(&token_usage)
+        .bind(&model)
+        .bind(token_in)
+        .bind(token_out)
+        .bind(token_total)
+        .bind(&ts)
+        .execute(&pool)
+        .await
+        .expect("insert user_query");
+    }
+
+    sqlx::query(
+        "INSERT INTO session_checkpoints \
+         (checkpoint_id, session_id, user_id, number, turn, title, summary, tools_json, total_tokens, created_at) \
+         VALUES (?, ?, ?, 1, 2, 'checkpoint-a', 'cloud checkpoint', CAST(? AS JSON), 250, '2026-09-01 10:02:00.000000')",
+    )
+    .bind(&checkpoint_id)
+    .bind(&session_a)
+    .bind(&user_id)
+    .bind(serde_json::json!(["bash", "rg"]).to_string())
+    .execute(&pool)
+    .await
+    .expect("insert session checkpoint");
+
+    let trace_a = ContextTraceSignal {
+        turn_id: "turn-a".into(),
+        captured_at: Some("2026-09-01T10:02:30Z".into()),
+        tool_selection: Some(ContextTraceToolSelection {
+            tools_available: 8,
+            selected_tools: vec!["view".into()],
+            rejected_tools: 1,
+            strategy: "selector".into(),
+            confidence: 0.92,
+            latency_ms: 11,
+        }),
+        memory: None,
+        history: None,
+        budget: None,
+        timing: None,
+        explanations: vec!["trace-a".into()],
+    };
+    let trace_b = ContextTraceSignal {
+        turn_id: "turn-b".into(),
+        captured_at: Some("2026-09-02T08:00:30Z".into()),
+        tool_selection: Some(ContextTraceToolSelection {
+            tools_available: 6,
+            selected_tools: vec!["grep".into(), "view".into()],
+            rejected_tools: 0,
+            strategy: "fallback".into(),
+            confidence: 0.88,
+            latency_ms: 9,
+        }),
+        memory: None,
+        history: None,
+        budget: None,
+        timing: None,
+        explanations: vec!["trace-b".into()],
+    };
+
+    push_context_trace_signal_to_cloud(&pool, &session_a, &user_id, &trace_a)
+        .await
+        .expect("push trace A");
+    push_context_trace_signal_to_cloud(&pool, &session_b, &user_id, &trace_b)
+        .await
+        .expect("push trace B");
+
+    let session_a_event_count: i64 =
+        sqlx::query("SELECT event_count FROM agent_sessions WHERE session_id = ?")
+            .bind(&session_a)
+            .fetch_one(&pool)
+            .await
+            .expect("load session A event_count")
+            .try_get("event_count")
+            .expect("session A event_count");
+    let session_b_event_count: i64 =
+        sqlx::query("SELECT event_count FROM agent_sessions WHERE session_id = ?")
+            .bind(&session_b)
+            .fetch_one(&pool)
+            .await
+            .expect("load session B event_count")
+            .try_get("event_count")
+            .expect("session B event_count");
+    assert_eq!(
+        session_a_event_count, 3,
+        "context-trace push should reconcile event_count to the real cloud event total"
+    );
+    assert_eq!(
+        session_b_event_count, 2,
+        "context-trace push should reconcile event_count for sessions without checkpoints too"
+    );
+
+    let restore = HybridRestoreService::new(pool.clone());
+    let restored_a = restore
+        .restore_session(&session_a)
+        .await
+        .expect("restore session A")
+        .expect("session A restored");
+    assert!(restored_a.restored_from_cloud);
+    assert_eq!(restored_a.turn_count, 2);
+    assert_eq!(restored_a.total_tokens_in, 200);
+    assert_eq!(restored_a.total_tokens_out, 50);
+    assert_eq!(restored_a.checkpoint_count, 1);
+    assert_eq!(
+        restored_a.recent_tools,
+        vec!["bash".to_string(), "rg".to_string()]
+    );
+    assert_eq!(
+        restored_a.learning_snapshot_json.as_deref(),
+        Some(learning_json.as_str())
+    );
+    assert_eq!(
+        restored_a.git_branch.as_deref(),
+        Some("feature/cloud-sync"),
+        "cloud restore should recover git_branch from session metadata"
+    );
+    assert_eq!(restored_a.model.as_deref(), Some("gpt-5.4"));
+    assert_eq!(
+        restored_a
+            .last_context_trace
+            .as_ref()
+            .map(|trace| trace.turn_id.as_str()),
+        Some("turn-a")
+    );
+    assert!(restored_a.executing_plan_json.is_none());
+    assert!(restored_a.plan_goal.is_none());
+    assert!(restored_a.plan_config_json.is_none());
+    assert_eq!(restored_a.plan_execution_rounds, 0);
+
+    let restored_b = restore
+        .restore_session(&session_b)
+        .await
+        .expect("restore session B")
+        .expect("session B restored");
+    assert!(restored_b.restored_from_cloud);
+    assert_eq!(restored_b.turn_count, 1);
+    assert_eq!(restored_b.total_tokens_in, 40);
+    assert_eq!(restored_b.total_tokens_out, 10);
+    assert_eq!(restored_b.checkpoint_count, 0);
+    assert_eq!(
+        restored_b.recent_tools,
+        vec!["grep".to_string(), "view".to_string()],
+        "cloud restore should fall back to context-trace selected tools when no ordinary checkpoint exists"
+    );
+    assert_eq!(restored_b.git_branch.as_deref(), Some("legacy-fallback"));
+    assert_eq!(
+        restored_b.model.as_deref(),
+        Some("claude-sonnet-4.5"),
+        "older sessions should fall back to latest llm_model_used when metadata lacks model"
+    );
+    assert_eq!(
+        restored_b.executing_plan_json.as_deref(),
+        Some(plan_b_json.as_str())
+    );
+    assert_eq!(restored_b.plan_goal.as_deref(), Some("finish session B"));
+    assert_eq!(
+        restored_b.plan_config_json.as_deref(),
+        Some(plan_b_config.as_str())
+    );
+    assert_eq!(restored_b.plan_execution_rounds, 2);
+
+    let resumable = restore
+        .list_resumable_sessions(&user_id)
+        .await
+        .expect("list resumable sessions");
+    let listed_a = resumable
+        .iter()
+        .find(|session| session.session_id == session_a)
+        .expect("session A listed");
+    assert_eq!(listed_a.turn_count, 2);
+    assert_eq!(listed_a.model.as_deref(), Some("gpt-5.4"));
+    assert_eq!(listed_a.git_branch.as_deref(), Some("feature/cloud-sync"));
+    let listed_b = resumable
+        .iter()
+        .find(|session| session.session_id == session_b)
+        .expect("session B listed");
+    assert_eq!(listed_b.turn_count, 1);
+    assert_eq!(listed_b.model.as_deref(), Some("claude-sonnet-4.5"));
+    assert_eq!(listed_b.git_branch.as_deref(), Some("legacy-fallback"));
+
+    let session_a_state_syncs: i64 = sqlx::query(
+        "SELECT COUNT(*) AS c FROM session_sync_log \
+         WHERE session_id = ? AND sync_type = 'session_state' AND status = 'success'",
+    )
+    .bind(&session_a)
+    .fetch_one(&pool)
+    .await
+    .expect("load session A session_state sync log count")
+    .try_get("c")
+    .expect("session A session_state sync log count");
+    let session_b_state_syncs: i64 = sqlx::query(
+        "SELECT COUNT(*) AS c FROM session_sync_log \
+         WHERE session_id = ? AND sync_type = 'session_state' AND status = 'success'",
+    )
+    .bind(&session_b)
+    .fetch_one(&pool)
+    .await
+    .expect("load session B session_state sync log count")
+    .try_get("c")
+    .expect("session B session_state sync log count");
+    let context_trace_syncs: i64 = sqlx::query(
+        "SELECT COUNT(*) AS c FROM session_sync_log \
+         WHERE user_id = ? AND sync_type = 'context_trace' AND status = 'success'",
+    )
+    .bind(&user_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load context_trace sync log count")
+    .try_get("c")
+    .expect("context_trace sync log count");
+    assert_eq!(session_a_state_syncs, 2);
+    assert_eq!(session_b_state_syncs, 1);
+    assert_eq!(context_trace_syncs, 2);
+
+    cleanup_restore_fixture(&pool, &user_id, &[session_a, session_b]).await;
+}
+
+#[tokio::test]
+#[ignore = "ASTRA_SERVICES_DB_IT=1 and live MatrixOne"]
+async fn session_sync_log_prune_partitions_by_sync_type_on_live_matrixone() {
+    let (shared, _settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let session_id = Uuid::new_v4().to_string();
+
+    cleanup_restore_fixture(&pool, &user_id, std::slice::from_ref(&session_id)).await;
+
+    push_session_state_to_cloud(
+        &pool,
+        &session_id,
+        &user_id,
+        None,
+        None,
+        None,
+        0,
+        Some("feature/prune"),
+        Some("gpt-5.4"),
+    )
+    .await
+    .expect("push session state");
+    push_checkpoint_to_cloud(
+        &pool,
+        &session_id,
+        &user_id,
+        &astra_services::session_checkpoint::Checkpoint {
+            number: 1,
+            turn: 1,
+            title: "session-ckpt".into(),
+            summary: "ordinary checkpoint".into(),
+            tools_used: vec!["bash".into()],
+            total_tokens: 50,
+            had_stalls: false,
+            error_count: 0,
+            contract_state_json: None,
+        },
+    )
+    .await
+    .expect("push checkpoint");
+
+    for idx in 0..205 {
+        let trace = ContextTraceSignal {
+            turn_id: format!("turn-{idx}"),
+            captured_at: Some(format!("2026-09-03T10:{:02}:00Z", idx % 60)),
+            tool_selection: Some(ContextTraceToolSelection {
+                tools_available: 8,
+                selected_tools: vec!["view".into()],
+                rejected_tools: 0,
+                strategy: "prune-test".into(),
+                confidence: 0.9,
+                latency_ms: 7,
+            }),
+            memory: None,
+            history: None,
+            budget: None,
+            timing: None,
+            explanations: vec![format!("trace-{idx}")],
+        };
+        push_context_trace_signal_to_cloud(&pool, &session_id, &user_id, &trace)
+            .await
+            .expect("push context trace");
+    }
+
+    let session_state_count: i64 = sqlx::query(
+        "SELECT COUNT(*) AS c FROM session_sync_log \
+         WHERE user_id = ? AND status = 'success' AND sync_type = 'session_state'",
+    )
+    .bind(&user_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load session_state sync count")
+    .try_get("c")
+    .expect("session_state sync count");
+    let checkpoint_count: i64 = sqlx::query(
+        "SELECT COUNT(*) AS c FROM session_sync_log \
+         WHERE user_id = ? AND status = 'success' AND sync_type = 'checkpoint'",
+    )
+    .bind(&user_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load checkpoint sync count")
+    .try_get("c")
+    .expect("checkpoint sync count");
+    let context_trace_count: i64 = sqlx::query(
+        "SELECT COUNT(*) AS c FROM session_sync_log \
+         WHERE user_id = ? AND status = 'success' AND sync_type = 'context_trace'",
+    )
+    .bind(&user_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load context_trace sync count")
+    .try_get("c")
+    .expect("context_trace sync count");
+    let total_success_count: i64 = sqlx::query(
+        "SELECT COUNT(*) AS c FROM session_sync_log \
+         WHERE user_id = ? AND status = 'success'",
+    )
+    .bind(&user_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load total success sync count")
+    .try_get("c")
+    .expect("total success sync count");
+
+    assert_eq!(session_state_count, 1);
+    assert_eq!(checkpoint_count, 1);
+    assert_eq!(
+        context_trace_count, 200,
+        "context_trace sync logs should prune to the success retain limit"
+    );
+    assert_eq!(
+        total_success_count, 202,
+        "high-volume context_trace success logs must not evict rarer sync types"
+    );
+
+    cleanup_restore_fixture(&pool, &user_id, &[session_id]).await;
+}
+
+#[tokio::test]
+#[ignore = "ASTRA_SERVICES_DB_IT=1 and live MatrixOne"]
+async fn restore_recent_tools_falls_back_to_legacy_turn_complete_metadata_on_live_matrixone() {
+    let (shared, _settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let session_id = Uuid::new_v4().to_string();
+
+    cleanup_restore_fixture(&pool, &user_id, std::slice::from_ref(&session_id)).await;
+
+    push_session_state_to_cloud(
+        &pool,
+        &session_id,
+        &user_id,
+        None,
+        None,
+        None,
+        0,
+        Some("feature/legacy-tools"),
+        Some("gpt-5.4"),
+    )
+    .await
+    .expect("push session state");
+
+    sqlx::query(
+        "INSERT INTO agent_events \
+         (event_id, session_id, user_id, event_type, content, token_usage, token_input, token_output, token_total, created_at) \
+         VALUES (?, ?, ?, 'user_query', 'legacy recent tools turn', CAST(? AS JSON), 20, 10, 30, '2026-09-05 08:00:00.000000')",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(&session_id)
+    .bind(&user_id)
+    .bind(serde_json::json!({"input": 20, "output": 10, "total": 30}).to_string())
+    .execute(&pool)
+    .await
+    .expect("insert user_query");
+
+    for (event_id, created_at, tools_used) in [
+        (
+            Uuid::new_v4().to_string(),
+            "2026-09-05 08:01:00.000000",
+            serde_json::json!(["bash", "rg"]),
+        ),
+        (
+            Uuid::new_v4().to_string(),
+            "2026-09-05 08:02:00.000000",
+            serde_json::json!(["view", "rg"]),
+        ),
+    ] {
+        let metadata_json = serde_json::json!({ "tools_used": tools_used }).to_string();
+        sqlx::query(
+            "INSERT INTO agent_events \
+             (event_id, session_id, user_id, event_type, content, metadata, created_at) \
+             VALUES (?, ?, ?, 'turn_complete', 'legacy tool summary', CAST(? AS JSON), ?)",
+        )
+        .bind(event_id)
+        .bind(&session_id)
+        .bind(&user_id)
+        .bind(metadata_json)
+        .bind(created_at)
+        .execute(&pool)
+        .await
+        .expect("insert legacy turn_complete");
+    }
+
+    let restore = HybridRestoreService::new(pool.clone());
+    let restored = restore
+        .restore_session(&session_id)
+        .await
+        .expect("restore session")
+        .expect("session restored");
+
+    assert_eq!(restored.turn_count, 1);
+    assert_eq!(restored.checkpoint_count, 0);
+    assert_eq!(
+        restored.recent_tools,
+        vec!["view".to_string(), "rg".to_string(), "bash".to_string()],
+        "cloud restore should still recover recent tools from legacy turn_complete metadata"
+    );
+    assert!(restored.last_context_trace.is_none());
+
+    cleanup_restore_fixture(&pool, &user_id, &[session_id]).await;
+}
+
+#[tokio::test]
+#[ignore = "ASTRA_SERVICES_DB_IT=1 and live MatrixOne"]
+async fn context_trace_push_lazily_creates_session_row_on_live_matrixone() {
+    let (shared, _settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let session_id = Uuid::new_v4().to_string();
+
+    cleanup_restore_fixture(&pool, &user_id, std::slice::from_ref(&session_id)).await;
+
+    let trace = ContextTraceSignal {
+        turn_id: "turn-missing-row".into(),
+        captured_at: Some("2026-09-06T09:00:00Z".into()),
+        tool_selection: Some(ContextTraceToolSelection {
+            tools_available: 8,
+            selected_tools: vec!["rg".into(), "view".into()],
+            rejected_tools: 1,
+            strategy: "lazy-create".into(),
+            confidence: 0.95,
+            latency_ms: 5,
+        }),
+        memory: None,
+        history: None,
+        budget: None,
+        timing: None,
+        explanations: vec!["missing row".into()],
+    };
+
+    push_context_trace_signal_to_cloud(&pool, &session_id, &user_id, &trace)
+        .await
+        .expect("push context trace");
+
+    let session_row =
+        sqlx::query("SELECT user_id, event_count FROM agent_sessions WHERE session_id = ?")
+            .bind(&session_id)
+            .fetch_one(&pool)
+            .await
+            .expect("load lazily created session row");
+    assert_eq!(
+        session_row
+            .try_get::<String, _>("user_id")
+            .expect("session user_id"),
+        user_id
+    );
+    assert_eq!(
+        session_row
+            .try_get::<i64, _>("event_count")
+            .expect("session event_count"),
+        1,
+        "context trace reconcile should create the missing session row with the correct event count"
+    );
+
+    let restore = HybridRestoreService::new(pool.clone());
+    let restored = restore
+        .restore_session(&session_id)
+        .await
+        .expect("restore session")
+        .expect("session restored");
+    assert!(restored.restored_from_cloud);
+    assert_eq!(restored.turn_count, 0);
+    assert_eq!(restored.checkpoint_count, 0);
+    assert_eq!(
+        restored.recent_tools,
+        vec!["rg".to_string(), "view".to_string()]
+    );
+    assert_eq!(
+        restored
+            .last_context_trace
+            .as_ref()
+            .map(|saved| saved.turn_id.as_str()),
+        Some("turn-missing-row")
+    );
+
+    let context_trace_syncs: i64 = sqlx::query(
+        "SELECT COUNT(*) AS c FROM session_sync_log \
+         WHERE session_id = ? AND sync_type = 'context_trace' AND status = 'success'",
+    )
+    .bind(&session_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load context_trace sync count")
+    .try_get("c")
+    .expect("context_trace sync count");
+    assert_eq!(context_trace_syncs, 1);
+
+    cleanup_restore_fixture(&pool, &user_id, &[session_id]).await;
+}
+
+#[tokio::test]
+#[ignore = "ASTRA_SERVICES_DB_IT=1 and live MatrixOne"]
+async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live_matrixone() {
+    let (shared, _settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let session_id = Uuid::new_v4().to_string();
+    let heavy_only_session = Uuid::new_v4().to_string();
+    let legacy_heavy_session = Uuid::new_v4().to_string();
+
+    let heavy_state_json = |messages: serde_json::Value,
+                            blocked_tools: serde_json::Value,
+                            recent_tools: serde_json::Value,
+                            approval_overrides: serde_json::Value,
+                            interruption: serde_json::Value,
+                            compaction_state: serde_json::Value| {
+        serde_json::json!({
+            "Heavy": {
+                "light": {},
+                "messages": messages,
+                "blocked_tools": blocked_tools,
+                "recent_tools": recent_tools,
+                "approval_overrides": approval_overrides,
+                "interruption": interruption,
+                "compaction_state": compaction_state
+            }
+        })
+        .to_string()
+    };
+    let legacy_heavy_state_json =
+        |messages: serde_json::Value,
+         blocked_tools: serde_json::Value,
+         recent_tools: serde_json::Value,
+         approval_overrides: serde_json::Value,
+         interruption: serde_json::Value,
+         compaction_state: serde_json::Value| {
+            serde_json::json!({
+                "messages": messages,
+                "blocked_tools": blocked_tools,
+                "recent_tools": recent_tools,
+                "approval_overrides": approval_overrides,
+                "interruption": interruption,
+                "compaction_state": compaction_state
+            })
+            .to_string()
+        };
+
+    cleanup_restore_fixture(
+        &pool,
+        &user_id,
+        &[
+            session_id.clone(),
+            heavy_only_session.clone(),
+            legacy_heavy_session.clone(),
+        ],
+    )
+    .await;
+
+    sqlx::query(
+        "INSERT INTO agent_sessions (session_id, user_id, title, status, event_count) \
+         VALUES (?, ?, 'checkpoint-it', 'active', 1)",
+    )
+    .bind(&session_id)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("insert checkpoint session");
+
+    sqlx::query(
+        "INSERT INTO agent_events \
+         (event_id, session_id, user_id, event_type, content, token_usage, token_input, token_output, token_total, created_at) \
+         VALUES (?, ?, ?, 'user_query', 'checkpoint turn', CAST(? AS JSON), 10, 5, 15, '2026-09-04 09:00:00.000000')",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(&session_id)
+    .bind(&user_id)
+    .bind(serde_json::json!({"input": 10, "output": 5, "total": 15}).to_string())
+    .execute(&pool)
+    .await
+    .expect("insert checkpoint user_query");
+
+    sqlx::query(
+        "INSERT INTO agent_sessions (session_id, user_id, title, status, event_count) \
+         VALUES (?, ?, 'checkpoint-heavy-only', 'active', 1)",
+    )
+    .bind(&heavy_only_session)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("insert heavy-only session");
+
+    sqlx::query(
+        "INSERT INTO agent_events \
+         (event_id, session_id, user_id, event_type, content, token_usage, token_input, token_output, token_total, created_at) \
+         VALUES (?, ?, ?, 'user_query', 'heavy-only turn', CAST(? AS JSON), 11, 4, 15, '2026-09-04 09:10:00.000000')",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(&heavy_only_session)
+    .bind(&user_id)
+    .bind(serde_json::json!({"input": 11, "output": 4, "total": 15}).to_string())
+    .execute(&pool)
+    .await
+    .expect("insert heavy-only user_query");
+
+    sqlx::query(
+        "INSERT INTO agent_sessions (session_id, user_id, title, status, event_count) \
+         VALUES (?, ?, 'checkpoint-legacy-heavy', 'active', 1)",
+    )
+    .bind(&legacy_heavy_session)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("insert legacy-heavy session");
+
+    sqlx::query(
+        "INSERT INTO agent_events \
+         (event_id, session_id, user_id, event_type, content, token_usage, token_input, token_output, token_total, created_at) \
+         VALUES (?, ?, ?, 'user_query', 'legacy-heavy turn', CAST(? AS JSON), 9, 3, 12, '2026-09-04 09:20:00.000000')",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(&legacy_heavy_session)
+    .bind(&user_id)
+    .bind(serde_json::json!({"input": 9, "output": 3, "total": 12}).to_string())
+    .execute(&pool)
+    .await
+    .expect("insert legacy-heavy user_query");
+
+    push_checkpoint_to_cloud(
+        &pool,
+        &session_id,
+        &user_id,
+        &astra_services::session_checkpoint::Checkpoint {
+            number: 1,
+            turn: 1,
+            title: "session-ckpt".into(),
+            summary: "ordinary checkpoint".into(),
+            tools_used: vec!["bash".into(), "rg".into()],
+            total_tokens: 150,
+            had_stalls: false,
+            error_count: 0,
+            contract_state_json: None,
+        },
+    )
+    .await
+    .expect("push ordinary checkpoint");
+
+    push_step_checkpoint_to_cloud(
+        &pool,
+        &session_id,
+        &user_id,
+        1,
+        2,
+        "heavy",
+        "step-heavy-v1",
+        &serde_json::json!(["step-one"]).to_string(),
+        &heavy_state_json(
+            serde_json::json!([{"role":"user","content":"first"}]),
+            serde_json::json!(["dangerous_tool"]),
+            serde_json::json!(["step-one"]),
+            serde_json::json!(null),
+            serde_json::json!({"kind":"rate_limited","resumable":true}),
+            serde_json::json!({"attempt_count":1,"cumulative_tokens_freed":50,"last_was_insufficient":false}),
+        ),
+    )
+    .await
+    .expect("push first step checkpoint");
+    let approval_overrides = serde_json::json!({
+        "rules": [[{
+            "tool_name": "bash",
+            "command_prefix": "git commit",
+            "path_pattern": null,
+            "side_effect": "execute"
+        }, true]]
+    });
+    push_step_checkpoint_to_cloud(
+        &pool,
+        &session_id,
+        &user_id,
+        1,
+        3,
+        "heavy",
+        "step-heavy-v2",
+        &serde_json::json!(["step-two"]).to_string(),
+        &heavy_state_json(
+            serde_json::json!([
+                {"role":"user","content":"first"},
+                {"role":"assistant","content":"reply"},
+                {"role":"user","content":"follow-up"},
+                {"role":"assistant","content":"done"}
+            ]),
+            serde_json::json!(["dangerous_tool","web_fetch"]),
+            serde_json::json!(["step-two"]),
+            approval_overrides.clone(),
+            serde_json::json!({"kind":"rate_limited","resumable":true}),
+            serde_json::json!({"attempt_count":2,"cumulative_tokens_freed":120,"last_was_insufficient":false}),
+        ),
+    )
+    .await
+    .expect("update step checkpoint");
+    push_step_checkpoint_to_cloud(
+        &pool,
+        &heavy_only_session,
+        &user_id,
+        1,
+        1,
+        "heavy",
+        "heavy-only-v1",
+        &serde_json::json!(["heavy-only-tool"]).to_string(),
+        &heavy_state_json(
+            serde_json::json!([
+                {"role":"user","content":"heavy-only user"},
+                {"role":"assistant","content":"heavy-only answer"}
+            ]),
+            serde_json::json!(["grep"]),
+            serde_json::json!(["heavy-only-tool"]),
+            serde_json::json!(null),
+            serde_json::json!({"kind":"context_window","resumable":true}),
+            serde_json::json!({"attempt_count":1,"cumulative_tokens_freed":80,"last_was_insufficient":true}),
+        ),
+    )
+    .await
+    .expect("push heavy-only step checkpoint");
+
+    let legacy_approval_overrides = serde_json::json!({
+        "rules": [[
+            {
+                "tool_name": "bash",
+                "command_prefix": "git stash",
+                "side_effect": "execute",
+                "path_pattern": null
+            },
+            true
+        ]]
+    });
+    push_step_checkpoint_to_cloud(
+        &pool,
+        &legacy_heavy_session,
+        &user_id,
+        1,
+        1,
+        "heavy",
+        "legacy-heavy-v1",
+        &serde_json::json!(["legacy-heavy-tool"]).to_string(),
+        &legacy_heavy_state_json(
+            serde_json::json!([
+                {"role":"user","content":"legacy user"},
+                {"role":"assistant","content":"legacy answer"}
+            ]),
+            serde_json::json!(["git_stash"]),
+            serde_json::json!(["legacy-heavy-tool"]),
+            legacy_approval_overrides.clone(),
+            serde_json::json!({"kind":"legacy_resume","resumable":true}),
+            serde_json::json!({"attempt_count":3,"cumulative_tokens_freed":64,"last_was_insufficient":false}),
+        ),
+    )
+    .await
+    .expect("push legacy heavy step checkpoint");
+
+    let rows = sqlx::query(
+        "SELECT number, title, summary, CAST(tools_json AS CHAR) AS tools_json, state_json \
+         FROM session_checkpoints WHERE session_id = ? ORDER BY number",
+    )
+    .bind(&session_id)
+    .fetch_all(&pool)
+    .await
+    .expect("load checkpoint rows");
+    assert_eq!(
+        rows.len(),
+        2,
+        "ordinary and step checkpoints should coexist"
+    );
+
+    let ordinary = &rows[0];
+    assert_eq!(
+        ordinary
+            .try_get::<i32, _>("number")
+            .expect("ordinary number"),
+        1
+    );
+    assert_eq!(
+        ordinary
+            .try_get::<String, _>("title")
+            .expect("ordinary title"),
+        "session-ckpt"
+    );
+    assert_eq!(
+        ordinary
+            .try_get::<String, _>("summary")
+            .expect("ordinary summary"),
+        "ordinary checkpoint"
+    );
+    assert_eq!(
+        ordinary
+            .try_get::<Option<String>, _>("state_json")
+            .expect("ordinary state"),
+        None
+    );
+
+    let step = &rows[1];
+    assert_eq!(
+        step.try_get::<i32, _>("number").expect("step number"),
+        1_000_000_001,
+        "step checkpoints should use the cloud namespace offset and avoid colliding with ordinary checkpoints"
+    );
+    assert_eq!(
+        step.try_get::<String, _>("title").expect("step title"),
+        "step-heavy-v2"
+    );
+    assert_eq!(
+        step.try_get::<String, _>("summary").expect("step summary"),
+        "heavy"
+    );
+    assert_eq!(
+        step.try_get::<Option<String>, _>("tools_json")
+            .expect("step tools")
+            .as_deref(),
+        Some(r#"["step-two"]"#)
+    );
+    let pulled_step = pull_step_checkpoint_from_cloud(&pool, &session_id)
+        .await
+        .expect("pull heavy step checkpoint");
+    assert_eq!(
+        step.try_get::<Option<String>, _>("state_json")
+            .expect("step state")
+            .as_deref(),
+        pulled_step.as_deref()
+    );
+    assert!(
+        pulled_step
+            .as_deref()
+            .unwrap_or_default()
+            .contains(r#""follow-up""#),
+        "pulled heavy checkpoint should return the latest StepCheckpoint JSON"
+    );
+
+    let restore = HybridRestoreService::new(pool.clone());
+    let checkpoints = restore
+        .list_checkpoints(&session_id)
+        .await
+        .expect("list checkpoints");
+    assert_eq!(
+        checkpoints.len(),
+        1,
+        "cloud checkpoint listing should exclude namespaced step checkpoint rows"
+    );
+    assert_eq!(checkpoints[0].number, 1);
+    assert_eq!(checkpoints[0].title, "session-ckpt");
+
+    let restored = restore
+        .restore_session(&session_id)
+        .await
+        .expect("restore checkpoint session")
+        .expect("checkpoint session restored");
+    assert_eq!(restored.turn_count, 1);
+    assert_eq!(restored.checkpoint_count, 1);
+    assert_eq!(
+        restored.recent_tools,
+        vec!["bash".to_string(), "rg".to_string()]
+    );
+    assert_eq!(restored.conversation_messages.len(), 4);
+    assert_eq!(restored.conversation_messages[0]["role"], "user");
+    assert_eq!(restored.conversation_messages[3]["content"], "done");
+    assert_eq!(
+        restored.blocked_tools,
+        vec!["dangerous_tool".to_string(), "web_fetch".to_string()]
+    );
+    assert_eq!(
+        restored.approval_overrides.as_ref(),
+        Some(&approval_overrides)
+    );
+    assert_eq!(
+        restored
+            .interruption
+            .as_ref()
+            .and_then(|json| json.get("kind"))
+            .and_then(serde_json::Value::as_str),
+        Some("rate_limited")
+    );
+    assert_eq!(
+        restored
+            .compaction_state
+            .as_ref()
+            .and_then(|json| json.get("attempt_count"))
+            .and_then(serde_json::Value::as_u64),
+        Some(2)
+    );
+
+    let restored_heavy_only = restore
+        .restore_session(&heavy_only_session)
+        .await
+        .expect("restore heavy-only session")
+        .expect("heavy-only session restored");
+    assert_eq!(restored_heavy_only.checkpoint_count, 0);
+    assert_eq!(
+        restored_heavy_only.recent_tools,
+        vec!["heavy-only-tool".to_string()],
+        "cloud restore should fall back to heavy checkpoint recent_tools when no ordinary checkpoint exists"
+    );
+    assert_eq!(restored_heavy_only.blocked_tools, vec!["grep".to_string()]);
+    assert_eq!(restored_heavy_only.conversation_messages.len(), 2);
+    assert_eq!(
+        restored_heavy_only
+            .interruption
+            .as_ref()
+            .and_then(|json| json.get("kind"))
+            .and_then(serde_json::Value::as_str),
+        Some("context_window")
+    );
+
+    let restored_legacy_heavy = restore
+        .restore_session(&legacy_heavy_session)
+        .await
+        .expect("restore legacy-heavy session")
+        .expect("legacy-heavy session restored");
+    assert_eq!(restored_legacy_heavy.checkpoint_count, 0);
+    assert_eq!(
+        restored_legacy_heavy.recent_tools,
+        vec!["legacy-heavy-tool".to_string()],
+        "cloud restore should accept legacy unwrapped heavy checkpoint JSON too"
+    );
+    assert_eq!(
+        restored_legacy_heavy.blocked_tools,
+        vec!["git_stash".to_string()]
+    );
+    assert_eq!(restored_legacy_heavy.conversation_messages.len(), 2);
+    assert_eq!(
+        restored_legacy_heavy.approval_overrides.as_ref(),
+        Some(&legacy_approval_overrides)
+    );
+    assert_eq!(
+        restored_legacy_heavy
+            .interruption
+            .as_ref()
+            .and_then(|json| json.get("kind"))
+            .and_then(serde_json::Value::as_str),
+        Some("legacy_resume")
+    );
+    assert_eq!(
+        restored_legacy_heavy
+            .compaction_state
+            .as_ref()
+            .and_then(|json| json.get("attempt_count"))
+            .and_then(serde_json::Value::as_u64),
+        Some(3)
+    );
+
+    let sync_successes = sqlx::query(
+        "SELECT COUNT(*) AS c FROM session_sync_log \
+         WHERE session_id = ? AND sync_type = 'step_checkpoint' AND status = 'success'",
+    )
+    .bind(&session_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load step checkpoint sync log count")
+    .try_get::<i64, _>("c")
+    .expect("decode step checkpoint sync log count");
+    assert_eq!(sync_successes, 2);
+    let checkpoint_sync_successes = sqlx::query(
+        "SELECT COUNT(*) AS c FROM session_sync_log \
+         WHERE session_id = ? AND sync_type = 'checkpoint' AND status = 'success'",
+    )
+    .bind(&session_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load ordinary checkpoint sync log count")
+    .try_get::<i64, _>("c")
+    .expect("decode ordinary checkpoint sync log count");
+    assert_eq!(checkpoint_sync_successes, 1);
+
+    cleanup_restore_fixture(&pool, &user_id, &[session_id, heavy_only_session]).await;
+}
+
+#[tokio::test]
+#[ignore = "ASTRA_SERVICES_DB_IT=1 and live MatrixOne"]
+async fn event_write_paths_reconcile_event_count_on_live_matrixone() {
+    let (shared, settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let service_session = Uuid::new_v4().to_string();
+    let ingestion_session = Uuid::new_v4().to_string();
+    let dup_event_id = Uuid::new_v4().to_string();
+    let unique_event_id = Uuid::new_v4().to_string();
+
+    sqlx::query(
+        "INSERT INTO agent_sessions (session_id, user_id, title, status, event_count) \
+         VALUES (?, ?, 'write-path-it', 'active', 0)",
+    )
+    .bind(&service_session)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("insert service session");
+
+    let event_service = DatabaseEventService::new(settings.clone()).with_pool(shared.clone());
+    let created_one = event_service
+        .create_event(
+            user_id.clone(),
+            EventCreateRequestData {
+                session_id: service_session.clone(),
+                event_type: "it_create".into(),
+                content: "first".into(),
+                agent_id: None,
+                agent_version: None,
+                parent_event_id: None,
+                parent_event_ids: None,
+                causal_chain_id: None,
+                metadata: Some(serde_json::json!({"ordinal": 1})),
+            },
+        )
+        .await
+        .expect("create first event");
+    let created_two = event_service
+        .create_event(
+            user_id.clone(),
+            EventCreateRequestData {
+                session_id: service_session.clone(),
+                event_type: "it_create".into(),
+                content: "second".into(),
+                agent_id: None,
+                agent_version: None,
+                parent_event_id: None,
+                parent_event_ids: None,
+                causal_chain_id: None,
+                metadata: Some(serde_json::json!({"ordinal": 2})),
+            },
+        )
+        .await
+        .expect("create second event");
+
+    let service_count = sqlx::query("SELECT event_count FROM agent_sessions WHERE session_id = ?")
+        .bind(&service_session)
+        .fetch_one(&pool)
+        .await
+        .expect("load service session count")
+        .try_get::<i64, _>("event_count")
+        .expect("decode service event_count");
+    assert_eq!(
+        service_count, 2,
+        "DatabaseEventService::create_event should reconcile event_count from actual persisted rows"
+    );
+
+    let config = IngestionConfig {
+        batch_size: 50,
+        flush_interval_secs: 300,
+        channel_capacity: 8,
+        ..Default::default()
+    };
+    let (sender, shutdown, stats, join) = EventIngestionWorker::spawn(pool.clone(), config);
+
+    for event in [
+        IngestionEvent {
+            event_id: dup_event_id.clone(),
+            session_id: ingestion_session.clone(),
+            user_id: user_id.clone(),
+            event_type: "it_ingest".into(),
+            content: Some("dup-one".into()),
+            token_usage: None,
+            llm_model_used: None,
+            skill_name: None,
+            metadata: None,
+            created_at: "2026-09-03T08:00:00Z".into(),
+            parent_event_id: None,
+            parent_event_ids: Vec::new(),
+            causal_chain_id: None,
+        },
+        IngestionEvent {
+            event_id: dup_event_id.clone(),
+            session_id: ingestion_session.clone(),
+            user_id: user_id.clone(),
+            event_type: "it_ingest".into(),
+            content: Some("dup-two".into()),
+            token_usage: None,
+            llm_model_used: None,
+            skill_name: None,
+            metadata: None,
+            created_at: "2026-09-03T08:00:01Z".into(),
+            parent_event_id: None,
+            parent_event_ids: Vec::new(),
+            causal_chain_id: None,
+        },
+        IngestionEvent {
+            event_id: unique_event_id.clone(),
+            session_id: ingestion_session.clone(),
+            user_id: user_id.clone(),
+            event_type: "it_ingest".into(),
+            content: Some("unique".into()),
+            token_usage: None,
+            llm_model_used: None,
+            skill_name: None,
+            metadata: None,
+            created_at: "2026-09-03T08:00:02Z".into(),
+            parent_event_id: None,
+            parent_event_ids: Vec::new(),
+            causal_chain_id: None,
+        },
+    ] {
+        sender.enqueue_async(event).await;
+    }
+    shutdown.signal();
+    sender.shutdown();
+    tokio::time::timeout(std::time::Duration::from_secs(10), join)
+        .await
+        .expect("ingestion worker join timeout")
+        .expect("ingestion worker join");
+    let last_error = {
+        let stats = stats.lock().expect("ingestion stats");
+        stats.last_error.clone()
+    };
+    assert!(
+        last_error.is_none(),
+        "live ingestion should not record MatrixOne errors after reconcile fix: {:?}",
+        last_error
+    );
+
+    let ingestion_count =
+        sqlx::query("SELECT event_count FROM agent_sessions WHERE session_id = ?")
+            .bind(&ingestion_session)
+            .fetch_one(&pool)
+            .await
+            .expect("load ingestion session count")
+            .try_get::<i64, _>("event_count")
+            .expect("decode ingestion event_count");
+    assert_eq!(
+        ingestion_count, 2,
+        "ingestion reconcile should count only persisted unique rows after INSERT IGNORE duplicates"
+    );
+    let actual_events = sqlx::query("SELECT COUNT(*) AS c FROM agent_events WHERE session_id = ?")
+        .bind(&ingestion_session)
+        .fetch_one(&pool)
+        .await
+        .expect("load ingestion actual count")
+        .try_get::<i64, _>("c")
+        .expect("decode actual event count");
+    assert_eq!(actual_events, 2);
+
+    cleanup_agent_sessions_and_events(
+        &pool,
+        &[service_session, ingestion_session],
+        &[
+            created_one.event_id,
+            created_two.event_id,
+            dup_event_id,
+            unique_event_id,
+        ],
+        &[],
+    )
+    .await;
 }

--- a/skills/review_changes/SKILL.md
+++ b/skills/review_changes/SKILL.md
@@ -44,6 +44,7 @@ $ARGUMENTS
 | `staged` | `git_diff(staged: true)` |
 | `branch:<name>` | `git_diff(ref: "main")` |
 | `commit:<sha>` | `git_show(sha)` |
+| `latest commit` / `review latest commit` | `git_log()` once to resolve the SHA, then `git_show(resolved_sha)` once |
 | `pr:<number>` | See PR workflow below |
 | GitHub PR URL | See PR workflow below |
 | Stat overview | `git_diff(stat_only: true)` first, then per-file |
@@ -58,7 +59,14 @@ $ARGUMENTS
 
 No changes? Check `git_status`, try `staged: true`. Still nothing? Ask user.
 
-### 1.2 Strategy Router
+### 1.2 Reuse gathered evidence
+
+- For `latest commit`, resolve the SHA once and reuse that same commit diff for the rest of the review.
+- **Do not call `git_show` on the same commit more than once** unless you truly need a different object than the full diff you already fetched.
+- When searching changed symbols, prefer one decisive `grep` over a scoped `grep` followed by the same repo-wide `grep`.
+- Once the diff already identified the file to inspect, prefer `read_file` for local context instead of re-reading the whole commit diff.
+
+### 1.3 Strategy Router
 
 After reading the diff, route based on **signals** in the diff:
 


### PR DESCRIPTION
## Summary
- harden cloud/session restore, sync-log handling, and MatrixOne compatibility across restore and ingestion paths
- expand live MatrixOne coverage for checkpoint restore, session_state/context_trace roundtrips, legacy fallbacks, and sync-log pruning
- land coupled CLI/display/evaluation follow-ups that keep restored state and headless/tool rendering behavior aligned

## Validation
- make format
- make check