### PR TITLE
feat: runtime support trusted moi llm routing and controls

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -532,6 +532,7 @@ pub(crate) async fn stream_chat_sse(
             teammate_idle_hook_runs: 0,
             workspace_root_hint: Some(project_root.to_string_lossy().into_owned()),
             forward_headers: std::collections::HashMap::new(),
+            llm_token_service: None,
         },
         messaging: MessagingState {
             mailbox: root_mailbox,

--- a/rust/crates/astra-server-types/src/http_type_tests.rs
+++ b/rust/crates/astra-server-types/src/http_type_tests.rs
@@ -54,6 +54,7 @@ fn chat_request_defaults_applied() {
     assert!(req.session_id.is_none());
     assert!(req.agent_id.is_none());
     assert!(req.model.is_none());
+    assert!(req.llm_token_service.is_none());
     assert!(req.context.is_none());
 }
 
@@ -127,6 +128,10 @@ fn chat_request_all_fields() {
         "session_id": "s1",
         "agent_id": "a1",
         "model": "gpt-4",
+        "llm_token_service": {
+            "url": "http://catalog:8081/api/v1/llm-token",
+            "timeout_ms": 2500
+        },
         "context": {"key": "value"},
         "max_candidates": 10,
         "explain": true
@@ -136,6 +141,14 @@ fn chat_request_all_fields() {
     assert_eq!(req.session_id.as_deref(), Some("s1"));
     assert_eq!(req.agent_id.as_deref(), Some("a1"));
     assert_eq!(req.model.as_deref(), Some("gpt-4"));
+    assert_eq!(
+        req.llm_token_service.as_ref().map(|v| v.url.as_str()),
+        Some("http://catalog:8081/api/v1/llm-token")
+    );
+    assert_eq!(
+        req.llm_token_service.as_ref().and_then(|v| v.timeout_ms),
+        Some(2500)
+    );
     assert_eq!(req.max_candidates, 10);
     assert!(req.explain);
     let ctx = req.context.unwrap();
@@ -878,6 +891,10 @@ fn chat_request_into_data_maps_all_fields() {
         session_id: Some("s1".into()),
         agent_id: Some("a1".into()),
         model: Some("gpt-4".into()),
+        llm_token_service: Some(astra_services::LlmTokenServiceRequest {
+            url: "http://catalog:8081/api/v1/llm-token".into(),
+            timeout_ms: Some(2500),
+        }),
         skill_search: Some(astra_core::SkillSearchSettings::default()),
         allow_skills: None,
         allow_tools: None,
@@ -892,6 +909,14 @@ fn chat_request_into_data_maps_all_fields() {
     assert_eq!(data.session_id.as_deref(), Some("s1"));
     assert_eq!(data.agent_id.as_deref(), Some("a1"));
     assert_eq!(data.model.as_deref(), Some("gpt-4"));
+    assert_eq!(
+        data.llm_token_service.as_ref().map(|v| v.url.as_str()),
+        Some("http://catalog:8081/api/v1/llm-token")
+    );
+    assert_eq!(
+        data.llm_token_service.as_ref().and_then(|v| v.timeout_ms),
+        Some(2500)
+    );
     assert_eq!(
         data.skill_search,
         Some(astra_core::SkillSearchSettings::default())
@@ -909,6 +934,7 @@ fn chat_request_into_data_maps_defaults() {
     assert!(data.session_id.is_none());
     assert!(data.agent_id.is_none());
     assert!(data.model.is_none());
+    assert!(data.llm_token_service.is_none());
     assert!(data.context.is_none());
     assert_eq!(data.max_candidates, 5);
     assert!(!data.explain);
@@ -921,6 +947,7 @@ fn chat_request_into_data_merges_plan_subtask_into_context() {
         session_id: None,
         agent_id: None,
         model: None,
+        llm_token_service: None,
         skill_search: None,
         allow_skills: None,
         allow_tools: None,

--- a/rust/crates/astra-server-types/src/lib.rs
+++ b/rust/crates/astra-server-types/src/lib.rs
@@ -63,6 +63,8 @@ pub struct ChatRequest {
     pub agent_id: Option<String>,
     pub model: Option<String>,
     #[serde(default)]
+    pub llm_token_service: Option<astra_services::LlmTokenServiceRequest>,
+    #[serde(default)]
     pub skill_search: Option<astra_core::SkillSearchSettings>,
     #[serde(default)]
     pub allow_skills: Option<Vec<String>>,
@@ -871,6 +873,7 @@ pub fn chat_request_into_data(mut request: ChatRequest) -> ChatRequestData {
         session_id: request.session_id,
         agent_id: request.agent_id,
         model: request.model,
+        llm_token_service: request.llm_token_service.map(Into::into),
         skill_search: request.skill_search,
         allow_skills: request.allow_skills,
         allow_tools: request.allow_tools,

--- a/rust/crates/runtime/src/app_state.rs
+++ b/rust/crates/runtime/src/app_state.rs
@@ -49,6 +49,8 @@ pub struct AppState {
     pub(crate) streaming_service: Arc<dyn StreamingService>,
     pub(crate) skill_service: Arc<dyn SkillService>,
     pub(crate) skill_config_service: Arc<dyn SkillConfigService>,
+    pub(crate) llm_trusted_domain_service:
+        Arc<dyn astra_services::llm_trusted_domains::LlmTrustedDomainService>,
     pub(crate) evaluation_service: Arc<dyn EvaluationService>,
     pub(crate) introspection_service: Arc<dyn IntrospectionService>,
     pub(crate) reflect_service: Arc<dyn ReflectService>,
@@ -136,6 +138,9 @@ impl AppState {
             streaming_service: Arc::new(UnconfiguredStreamingService),
             skill_service: Arc::new(UnconfiguredSkillService),
             skill_config_service: Arc::new(UnconfiguredSkillConfigService),
+            llm_trusted_domain_service: Arc::new(
+                astra_services::llm_trusted_domains::UnconfiguredLlmTrustedDomainService,
+            ),
             evaluation_service: Arc::new(UnconfiguredEvaluationService),
             introspection_service: Arc::new(UnconfiguredIntrospectionService),
             reflect_service: Arc::new(UnconfiguredReflectService),
@@ -332,6 +337,14 @@ impl AppState {
         skill_config_service: Arc<dyn SkillConfigService>,
     ) -> Self {
         self.skill_config_service = skill_config_service;
+        self
+    }
+
+    pub fn with_llm_trusted_domain_service(
+        mut self,
+        service: Arc<dyn astra_services::llm_trusted_domains::LlmTrustedDomainService>,
+    ) -> Self {
+        self.llm_trusted_domain_service = service;
         self
     }
 

--- a/rust/crates/runtime/src/server/chat_handlers.rs
+++ b/rust/crates/runtime/src/server/chat_handlers.rs
@@ -85,6 +85,10 @@ fn chat_stream_bridge_fallback_payload(
         "session_id": chat_data.session_id.as_deref(),
         "agent_id": chat_data.agent_id.as_deref(),
         "model": chat_data.model.as_deref(),
+        "llm_token_service": chat_data
+            .llm_token_service
+            .as_ref()
+            .map(|config| serde_json::json!(config)),
         "skill_search": chat_data.skill_search.as_ref(),
         "allow_skills": allow_skills,
         "allow_tools": allow_tools,
@@ -450,6 +454,10 @@ mod tests {
             session_id: Some("s1".to_string()),
             agent_id: Some("a1".to_string()),
             model: Some("gpt-4".to_string()),
+            llm_token_service: Some(astra_services::LlmTokenServiceConfig {
+                url: "http://catalog:8081/api/v1/llm-token".to_string(),
+                timeout_ms: Some(2500),
+            }),
             skill_search: Some(SkillSearchSettings {
                 dynamic_surface: false,
                 min_catalog_size: 12,
@@ -471,6 +479,11 @@ mod tests {
         assert_eq!(obj["skill_search"]["dynamic_surface"], false);
         assert_eq!(obj["skill_search"]["min_catalog_size"], 12);
         assert_eq!(obj["skill_search"]["surface_cap"], 20);
+        assert_eq!(
+            obj["llm_token_service"]["url"],
+            "http://catalog:8081/api/v1/llm-token"
+        );
+        assert_eq!(obj["llm_token_service"]["timeout_ms"], 2500);
         assert_eq!(obj["allow_skills"], serde_json::json!(["plan"]));
         assert_eq!(obj["allow_tools"], serde_json::json!(["bash"]));
         let messages = obj["messages"].as_array().unwrap();
@@ -485,6 +498,7 @@ mod tests {
             session_id: Some("s1".to_string()),
             agent_id: Some("a1".to_string()),
             model: Some("gpt-4".to_string()),
+            llm_token_service: None,
             skill_search: None,
             allow_skills: Some(vec![
                 " plan ".to_string(),

--- a/rust/crates/runtime/src/server/delegation_engine.rs
+++ b/rust/crates/runtime/src/server/delegation_engine.rs
@@ -24,6 +24,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 
+use astra_services::LlmTokenServiceConfig;
 use astra_services::coordination::{
     AgentProfile, AgentProfileRegistry, AgentResult, AggregationStrategy, CoordinationPattern,
     DelegationRequest, DelegationResult, aggregate_results,
@@ -90,6 +91,8 @@ pub struct SubRunConfig {
     pub context: HashMap<String, serde_json::Value>,
     /// Trusted forwarded headers propagated out-of-band for child remote skills.
     pub forward_headers: HashMap<String, String>,
+    /// Optional request-scoped LLM token service for child loop model resolution.
+    pub llm_token_service: Option<LlmTokenServiceConfig>,
     /// Request-scoped capability constraints inherited from the parent runtime request.
     pub request_constraints: RequestConstraints,
     /// Current nested agent/sub-run depth for the child loop.
@@ -115,6 +118,7 @@ impl std::fmt::Debug for SubRunConfig {
             .field("user_id", &self.user_id)
             .field("previous_output", &self.previous_output)
             .field("forward_headers", &!self.forward_headers.is_empty())
+            .field("llm_token_service", &self.llm_token_service.is_some())
             .field("request_constraints", &self.request_constraints)
             .field("recursion_depth", &self.recursion_depth)
             .field("pause_flag", &self.pause_flag.is_some())
@@ -1464,8 +1468,14 @@ impl DelegationEngine {
         source_agent_id: &str,
         cancel_token: Option<Arc<tokio_util::sync::CancellationToken>>,
     ) -> Result<DelegationResult, String> {
-        self.execute_with_forward_headers(request, source_agent_id, cancel_token, HashMap::new())
-            .await
+        self.execute_with_forward_headers(
+            request,
+            source_agent_id,
+            cancel_token,
+            HashMap::new(),
+            None,
+        )
+        .await
     }
 
     pub async fn execute_with_forward_headers(
@@ -1474,6 +1484,7 @@ impl DelegationEngine {
         source_agent_id: &str,
         cancel_token: Option<Arc<tokio_util::sync::CancellationToken>>,
         forward_headers: HashMap<String, String>,
+        llm_token_service: Option<LlmTokenServiceConfig>,
     ) -> Result<DelegationResult, String> {
         request
             .context
@@ -1582,6 +1593,7 @@ impl DelegationEngine {
                     agent_ids,
                     aggregation,
                     &forward_headers,
+                    llm_token_service.as_ref(),
                     &request_constraints,
                     child_recursion_depth,
                     *timeout_sec,
@@ -1599,6 +1611,7 @@ impl DelegationEngine {
                     &agent_ids,
                     false,
                     &forward_headers,
+                    llm_token_service.as_ref(),
                     &request_constraints,
                     child_recursion_depth,
                     *timeout_sec,
@@ -1616,6 +1629,7 @@ impl DelegationEngine {
                     agent_ids,
                     *stop_on_success,
                     &forward_headers,
+                    llm_token_service.as_ref(),
                     &request_constraints,
                     child_recursion_depth,
                     *timeout_sec,
@@ -1636,6 +1650,7 @@ impl DelegationEngine {
                     reviewer_id,
                     *max_rounds,
                     &forward_headers,
+                    llm_token_service.as_ref(),
                     &request_constraints,
                     child_recursion_depth,
                     *timeout_sec,
@@ -1657,6 +1672,7 @@ impl DelegationEngine {
                     *max_turns,
                     aggregation,
                     &forward_headers,
+                    llm_token_service.as_ref(),
                     &request_constraints,
                     child_recursion_depth,
                     *timeout_sec,
@@ -1726,6 +1742,7 @@ impl DelegationEngine {
         agent_ids: &[String],
         aggregation: &AggregationStrategy,
         forward_headers: &HashMap<String, String>,
+        llm_token_service: Option<&LlmTokenServiceConfig>,
         request_constraints: &RequestConstraints,
         child_recursion_depth: u8,
         timeout_sec: u64,
@@ -1854,6 +1871,7 @@ impl DelegationEngine {
                 previous_output: None,
                 context: request.context.clone(),
                 forward_headers: forward_headers.clone(),
+                llm_token_service: llm_token_service.cloned(),
                 request_constraints: request_constraints.clone(),
                 recursion_depth: child_recursion_depth,
                 pause_flag: Some(pause_flag),
@@ -2119,6 +2137,7 @@ impl DelegationEngine {
                                 previous_output: None,
                                 context: ctx,
                                 forward_headers: forward_headers.clone(),
+                                llm_token_service: llm_token_service.cloned(),
                                 request_constraints: request_constraints.clone(),
                                 recursion_depth: child_recursion_depth,
                                 pause_flag: None,
@@ -2150,6 +2169,7 @@ impl DelegationEngine {
         agent_ids: &[String],
         stop_on_success: bool,
         forward_headers: &HashMap<String, String>,
+        llm_token_service: Option<&LlmTokenServiceConfig>,
         request_constraints: &RequestConstraints,
         child_recursion_depth: u8,
         timeout_sec: u64,
@@ -2285,6 +2305,7 @@ impl DelegationEngine {
                 previous_output: previous_output.clone(),
                 context: request.context.clone(),
                 forward_headers: forward_headers.clone(),
+                llm_token_service: llm_token_service.cloned(),
                 request_constraints: request_constraints.clone(),
                 recursion_depth: child_recursion_depth,
                 pause_flag: Some(pause_flag),
@@ -2391,6 +2412,7 @@ impl DelegationEngine {
                         previous_output: prev.clone(),
                         context: ctx.clone(),
                         forward_headers: forward_headers.clone(),
+                        llm_token_service: llm_token_service.cloned(),
                         request_constraints: request_constraints.clone(),
                         recursion_depth: child_recursion_depth,
                         pause_flag: None,
@@ -2429,6 +2451,7 @@ impl DelegationEngine {
         reviewer_id: &str,
         max_rounds: u32,
         forward_headers: &HashMap<String, String>,
+        llm_token_service: Option<&LlmTokenServiceConfig>,
         request_constraints: &RequestConstraints,
         child_recursion_depth: u8,
         timeout_sec: u64,
@@ -2571,6 +2594,7 @@ impl DelegationEngine {
                 previous_output: last_producer_output.clone(),
                 context: request.context.clone(),
                 forward_headers: forward_headers.clone(),
+                llm_token_service: llm_token_service.cloned(),
                 request_constraints: request_constraints.clone(),
                 recursion_depth: child_recursion_depth,
                 pause_flag: Some(prod_pause.clone()),
@@ -2671,6 +2695,7 @@ impl DelegationEngine {
                         previous_output: prev.clone(),
                         context: ctx.clone(),
                         forward_headers: forward_headers.clone(),
+                        llm_token_service: llm_token_service.cloned(),
                         request_constraints: request_constraints.clone(),
                         recursion_depth: child_recursion_depth,
                         pause_flag: None,
@@ -2773,6 +2798,7 @@ impl DelegationEngine {
                 previous_output: last_producer_output.clone(),
                 context: request.context.clone(),
                 forward_headers: forward_headers.clone(),
+                llm_token_service: llm_token_service.cloned(),
                 request_constraints: request_constraints.clone(),
                 recursion_depth: child_recursion_depth,
                 pause_flag: Some(rev_pause),
@@ -2867,6 +2893,7 @@ impl DelegationEngine {
         _max_turns: u32,
         _aggregation: &AggregationStrategy,
         forward_headers: &HashMap<String, String>,
+        llm_token_service: Option<&LlmTokenServiceConfig>,
         request_constraints: &RequestConstraints,
         child_recursion_depth: u8,
         timeout_sec: u64,
@@ -3004,6 +3031,7 @@ impl DelegationEngine {
                 previous_output: None,
                 context: fork_context,
                 forward_headers: forward_headers.clone(),
+                llm_token_service: llm_token_service.cloned(),
                 request_constraints: request_constraints.clone(),
                 recursion_depth: child_recursion_depth,
                 pause_flag: Some(pause_flag),
@@ -4074,12 +4102,80 @@ mod tests {
                     "authorization".to_string(),
                     "Bearer trusted-token".to_string(),
                 )]),
+                None,
             )
             .await
             .unwrap();
         assert_eq!(
             result.agent_results[0].output.as_deref(),
             Some("auth_present=true;context_key_present=false")
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_with_forward_headers_passes_llm_token_service_sideband() {
+        struct LlmTokenServiceCheckExecutor;
+
+        #[async_trait]
+        impl SubRunExecutor for LlmTokenServiceCheckExecutor {
+            async fn execute(&self, config: SubRunConfig) -> Result<AgentResult, String> {
+                let encoded = config
+                    .llm_token_service
+                    .as_ref()
+                    .map(|service| format!("{}|{}", service.url, service.timeout_ms.unwrap_or(0)))
+                    .unwrap_or_else(|| "none".to_string());
+                Ok(AgentResult {
+                    agent_id: config.agent_profile.agent_id,
+                    run_id: config.run_id,
+                    status: "completed".to_string(),
+                    output: Some(encoded),
+                    error: None,
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                    tool_calls: 0,
+                })
+            }
+        }
+
+        let (reg, engine, tracker) = setup();
+        let de = DelegationEngine::with_executor(
+            reg,
+            engine,
+            tracker,
+            Arc::new(LlmTokenServiceCheckExecutor),
+        );
+
+        let req = DelegationRequest {
+            delegation_id: "llm-token-test".into(),
+            parent_run_id: "p".into(),
+            task: "check llm token service".into(),
+            pattern: CoordinationPattern::Sequential {
+                agent_ids: vec!["coder".into()],
+                stop_on_success: false,
+                timeout_sec: 0,
+            },
+            user_id: "u".into(),
+            depth: 0,
+            context: HashMap::new(),
+        };
+
+        let result = de
+            .execute_with_forward_headers(
+                req,
+                "orch",
+                None,
+                HashMap::new(),
+                Some(LlmTokenServiceConfig {
+                    url: "http://catalog:8081/api/v1/chat/completions".to_string(),
+                    timeout_ms: Some(2500),
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.agent_results[0].output.as_deref(),
+            Some("http://catalog:8081/api/v1/chat/completions|2500")
         );
     }
 
@@ -4276,6 +4372,7 @@ mod tests {
             previous_output: None,
             context: HashMap::new(),
             forward_headers: HashMap::new(),
+            llm_token_service: None,
             request_constraints: Default::default(),
             recursion_depth: 1,
             pause_flag: None,

--- a/rust/crates/runtime/src/server/delegation_handlers.rs
+++ b/rust/crates/runtime/src/server/delegation_handlers.rs
@@ -42,7 +42,7 @@ pub(super) async fn delegate_run_handler(
 
     // Execute the delegation.
     let result = engine
-        .execute_with_forward_headers(request, &source_agent_id, None, forward_headers)
+        .execute_with_forward_headers(request, &source_agent_id, None, forward_headers, None)
         .await
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, e))?;
 

--- a/rust/crates/runtime/src/server/llm_trusted_domains_handlers.rs
+++ b/rust/crates/runtime/src/server/llm_trusted_domains_handlers.rs
@@ -1,0 +1,55 @@
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+
+use astra_core::ErrorResponse;
+use astra_services::llm_trusted_domains::{
+    LlmTrustedDomainDeleteResponse, LlmTrustedDomainRecord, LlmTrustedDomainUpsertRequest,
+    LlmTrustedDomainUpsertRequestData,
+};
+
+use crate::app_state::AppState;
+
+pub(super) async fn list_llm_trusted_domains_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<LlmTrustedDomainRecord>>, (StatusCode, Json<ErrorResponse>)> {
+    state.admin_authorizer.require_admin(&headers).await?;
+    let records = state
+        .llm_trusted_domain_service
+        .list_trusted_domains()
+        .await?;
+    Ok(Json(records))
+}
+
+pub(super) async fn upsert_llm_trusted_domain_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<LlmTrustedDomainUpsertRequest>,
+) -> Result<Json<LlmTrustedDomainRecord>, (StatusCode, Json<ErrorResponse>)> {
+    let authenticated = state.admin_authorizer.require_admin(&headers).await?;
+    let request = LlmTrustedDomainUpsertRequestData {
+        domain_host: body.domain_host,
+        domain_port: body.domain_port,
+        is_enabled: body.is_enabled,
+        description: body.description,
+    };
+    let record = state
+        .llm_trusted_domain_service
+        .upsert_trusted_domain(Some(authenticated.user_id.as_str()), request)
+        .await?;
+    Ok(Json(record))
+}
+
+pub(super) async fn delete_llm_trusted_domain_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(domain_id): Path<String>,
+) -> Result<Json<LlmTrustedDomainDeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
+    state.admin_authorizer.require_admin(&headers).await?;
+    let response = state
+        .llm_trusted_domain_service
+        .delete_trusted_domain(&domain_id)
+        .await?;
+    Ok(Json(response))
+}

--- a/rust/crates/runtime/src/server/mod.rs
+++ b/rust/crates/runtime/src/server/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod header_utils;
 mod http_helpers;
 mod http_types;
 mod learning_handlers;
+mod llm_trusted_domains_handlers;
 mod meta_handlers;
 mod platform_handlers;
 mod reflect_handlers;

--- a/rust/crates/runtime/src/server/router_builder.rs
+++ b/rust/crates/runtime/src/server/router_builder.rs
@@ -177,6 +177,15 @@ pub(super) fn build_router(state: AppState) -> Router {
             post(admin_handlers::admin_cleanup_handler),
         )
         .route(
+            "/admin/llm/trusted-domains",
+            get(llm_trusted_domains_handlers::list_llm_trusted_domains_handler)
+                .put(llm_trusted_domains_handlers::upsert_llm_trusted_domain_handler),
+        )
+        .route(
+            "/admin/llm/trusted-domains/{domain_id}",
+            delete(llm_trusted_domains_handlers::delete_llm_trusted_domain_handler),
+        )
+        .route(
             "/api/v1/learning/health",
             get(learning_handlers::learning_health_handler),
         )

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -22,7 +22,7 @@ use super::ws_progress_callback::ProgressEvent;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use astra_core::{ErrorResponse, SharedPool, error_response};
+use astra_core::{ErrorResponse, SharedPool, connect_matrixone, error_response};
 use astra_services::EdgeContext;
 use astra_services::runs::{
     CancelRunRecord, ChatRequestData, ChatRunRecord, ChatStreamRecord, DurableRunRecord,
@@ -30,6 +30,7 @@ use astra_services::runs::{
 };
 use astra_services::session_audit::{RUNTIME_PROMOTION_EVENT_TYPE, RuntimePromotionEventData};
 use astra_services::skills::SkillService;
+use sqlx::Row;
 
 use crate::FernetTokenEncryptor;
 use crate::MatrixOneSettings;
@@ -56,6 +57,7 @@ use super::run_engine::RunEngine;
 use super::server_loop_host::ServerAgenticLoopHostBuilder;
 
 const RUNTIME_CONTEXT_TRACE_AGENT_ID: &str = "astra-server";
+const LLM_TOKEN_SERVICE_TRUSTED_DOMAINS_TABLE: &str = "runtime_llm_trusted_domains";
 
 // ─── Skill wiring for server paths ──────────────────────────────────────────
 
@@ -136,6 +138,113 @@ fn normalize_request_allowlist(
         normalized.insert(normalize_allowlist_entry(entry, field)?);
     }
     Ok(Some(normalized))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+struct TrustedLlmDomain {
+    host: String,
+    port: Option<u16>,
+}
+
+fn normalize_trusted_llm_domain_host(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("trusted domain host must not be empty".to_string());
+    }
+    if trimmed.contains("://") {
+        return Err(format!(
+            "trusted domain host '{trimmed}' must not include URL scheme"
+        ));
+    }
+    let parsed = reqwest::Url::parse(&format!("http://{trimmed}"))
+        .map_err(|error| format!("invalid trusted domain host '{trimmed}': {error}"))?;
+    if parsed.username() != ""
+        || parsed.password().is_some()
+        || parsed.path() != "/"
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+        || parsed.port().is_some()
+    {
+        return Err(format!("trusted domain host '{trimmed}' must be host only"));
+    }
+    let Some(host) = parsed.host_str() else {
+        return Err(format!(
+            "trusted domain host '{trimmed}' must include a host"
+        ));
+    };
+    Ok(host.to_ascii_lowercase())
+}
+
+fn trusted_llm_domain_from_db_values(
+    host_raw: &str,
+    port_raw: Option<i64>,
+) -> Result<TrustedLlmDomain, String> {
+    let host = normalize_trusted_llm_domain_host(host_raw)?;
+    let port = match port_raw {
+        Some(port) if !(1..=65_535).contains(&port) => {
+            return Err(format!(
+                "trusted domain host '{host_raw}' has invalid port value {port}"
+            ));
+        }
+        Some(port) => Some(port as u16),
+        None => None,
+    };
+    Ok(TrustedLlmDomain { host, port })
+}
+
+fn llm_token_service_domain_is_trusted(
+    url: &reqwest::Url,
+    trusted_domains: &[TrustedLlmDomain],
+) -> bool {
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    let normalized_host = host.to_ascii_lowercase();
+    let resolved_port = url.port_or_known_default();
+    trusted_domains.iter().any(|trusted| {
+        if trusted.host != normalized_host {
+            return false;
+        }
+        match trusted.port {
+            Some(port) => resolved_port == Some(port),
+            None => true,
+        }
+    })
+}
+
+fn validate_llm_token_service_config(
+    config: Option<&astra_services::LlmTokenServiceConfig>,
+    trusted_domains: &[TrustedLlmDomain],
+) -> Result<(), String> {
+    let Some(config) = config else {
+        return Ok(());
+    };
+    let raw_url = config.url.trim();
+    if raw_url.is_empty() {
+        return Err("llm_token_service.url must not be empty".to_string());
+    }
+    let parsed = reqwest::Url::parse(raw_url)
+        .map_err(|error| format!("llm_token_service.url must be a valid URL: {error}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err("llm_token_service.url must use http or https scheme".to_string());
+    }
+    if parsed.host_str().is_none() {
+        return Err("llm_token_service.url must include a host".to_string());
+    }
+    if config.timeout_ms == Some(0) {
+        return Err("llm_token_service.timeout_ms must be greater than 0".to_string());
+    }
+    if trusted_domains.is_empty() {
+        return Err(format!(
+            "llm_token_service.url is not allowed without trusted domains configured in table {LLM_TOKEN_SERVICE_TRUSTED_DOMAINS_TABLE}"
+        ));
+    }
+    if !llm_token_service_domain_is_trusted(&parsed, trusted_domains) {
+        return Err(format!(
+            "llm_token_service.url host must match trusted domains configured in table {LLM_TOKEN_SERVICE_TRUSTED_DOMAINS_TABLE}"
+        ));
+    }
+    Ok(())
 }
 
 fn skill_tool_names(skill: &crate::turn::skill_tool::SkillToolInfo) -> Vec<String> {
@@ -261,6 +370,7 @@ fn build_server_skill_executor(
     encryptor: &Arc<FernetTokenEncryptor>,
     shared_pool: Option<&SharedPool>,
     model_override: Option<&str>,
+    llm_token_service: Option<&astra_services::LlmTokenServiceConfig>,
     edge_tools: &[Value],
     edge_profile: &Map<String, Value>,
     forward_headers: &HashMap<String, String>,
@@ -279,6 +389,7 @@ fn build_server_skill_executor(
     )
     .with_pool(shared_pool.cloned())
     .with_default_model(model_override.map(String::from))
+    .with_llm_token_service(llm_token_service.cloned())
     .with_edge_tools(edge_tools.to_vec())
     .with_edge_profile(edge_profile.clone())
     .with_forward_headers(forward_headers.clone())
@@ -927,10 +1038,93 @@ impl AgenticRunLifecycleService {
         (events, final_status, error_msg)
     }
 
-    fn validate_request_constraints(
+    async fn load_trusted_llm_token_service_domains(
+        &self,
+    ) -> Result<Vec<TrustedLlmDomain>, (StatusCode, Json<ErrorResponse>)> {
+        let pool = if let Some(pool) = &self.shared_pool {
+            pool.get().clone()
+        } else {
+            connect_matrixone(&self.matrixone).await.map_err(|error| {
+                error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("failed to connect database for trusted domains query: {error}"),
+                )
+            })?
+        };
+        let rows = sqlx::query(
+            "SELECT domain_host, domain_port \
+             FROM runtime_llm_trusted_domains \
+             WHERE is_enabled = 1",
+        )
+        .fetch_all(&pool)
+        .await
+        .map_err(|error| {
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "failed to query trusted domains from table {LLM_TOKEN_SERVICE_TRUSTED_DOMAINS_TABLE}: {error}"
+                ),
+            )
+        })?;
+        let mut trusted_domains = Vec::new();
+        let mut seen = HashSet::new();
+        for row in rows {
+            let host: String = row.try_get("domain_host").map_err(|error| {
+                error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "failed to decode domain_host from table {LLM_TOKEN_SERVICE_TRUSTED_DOMAINS_TABLE}: {error}"
+                    ),
+                )
+            })?;
+            let port: Option<i64> = row.try_get("domain_port").map_err(|error| {
+                error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "failed to decode domain_port from table {LLM_TOKEN_SERVICE_TRUSTED_DOMAINS_TABLE}: {error}"
+                    ),
+                )
+            })?;
+            let domain = trusted_llm_domain_from_db_values(&host, port).map_err(|detail| {
+                error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "invalid trusted domain row in table {LLM_TOKEN_SERVICE_TRUSTED_DOMAINS_TABLE}: {detail}"
+                    ),
+                )
+            })?;
+            let key = format!(
+                "{}:{}",
+                domain.host,
+                domain
+                    .port
+                    .map(|value| value.to_string())
+                    .unwrap_or_default()
+            );
+            if seen.insert(key) {
+                trusted_domains.push(domain);
+            }
+        }
+        if trusted_domains.is_empty() {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "table {LLM_TOKEN_SERVICE_TRUSTED_DOMAINS_TABLE} has no enabled trusted domains"
+                ),
+            ));
+        }
+        Ok(trusted_domains)
+    }
+
+    async fn validate_request_constraints(
         &self,
         request: &ChatRequestData,
     ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+        if request.llm_token_service.is_some() {
+            let trusted_domains = self.load_trusted_llm_token_service_domains().await?;
+            validate_llm_token_service_config(request.llm_token_service.as_ref(), &trusted_domains)
+                .map_err(|detail| error_response(StatusCode::BAD_REQUEST, detail))?;
+        }
         normalize_request_allowlist(request.allow_tools.as_deref(), "allow_tools")
             .map_err(|detail| error_response(StatusCode::BAD_REQUEST, detail))?;
         let (_, resolver) = build_server_skill_resolver(
@@ -961,6 +1155,7 @@ impl AgenticRunLifecycleService {
             session_id.to_string(),
         )
         .with_model(request.model.clone())
+        .with_llm_token_service(request.llm_token_service.clone())
         .with_edge_tools(edge_tools)
         .with_edge_profile(edge_profile)
         .with_edge_callback_ledger(self.edge_callback_ledger.clone())
@@ -1052,6 +1247,7 @@ impl AgenticRunLifecycleService {
             &self.encryptor,
             self.shared_pool.as_ref(),
             request.model.as_deref(),
+            request.llm_token_service.as_ref(),
             &edge_tools,
             &edge_profile,
             &request.forward_headers,
@@ -1112,6 +1308,7 @@ impl AgenticRunLifecycleService {
                 teammate_idle_hooks: hook_sets.teammate_idle_hooks,
                 workspace_root_hint,
                 forward_headers: request.forward_headers.clone(),
+                llm_token_service: request.llm_token_service.clone(),
                 ..Default::default()
             },
             cancellation: Default::default(),
@@ -1304,7 +1501,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         user_id: String,
         request: ChatRequestData,
     ) -> Result<ChatRunRecord, (StatusCode, Json<ErrorResponse>)> {
-        self.validate_request_constraints(&request)?;
+        self.validate_request_constraints(&request).await?;
 
         // ── Resource governance check (Phase 5) ─────────────────────
         if let Some(ref gov) = self.resource_governor {
@@ -1593,7 +1790,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         user_id: String,
         request: ChatRequestData,
     ) -> Result<ChatStreamRecord, (StatusCode, Json<ErrorResponse>)> {
-        self.validate_request_constraints(&request)?;
+        self.validate_request_constraints(&request).await?;
 
         let run_id = Uuid::new_v4().to_string();
         let session_id = request
@@ -2163,6 +2360,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
             config.session_id.clone(),
         )
         .with_model(config.agent_profile.model_override.clone())
+        .with_llm_token_service(config.llm_token_service.clone())
         .with_edge_profile(edge_profile)
         .with_edge_callback_ledger(self.edge_callback_ledger.clone());
 
@@ -2258,6 +2456,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
                 teammate_idle_hooks: hook_sets.teammate_idle_hooks,
                 workspace_root_hint,
                 forward_headers: config.forward_headers.clone(),
+                llm_token_service: config.llm_token_service.clone(),
                 ..Default::default()
             },
             cancellation: CancellationState {
@@ -2493,6 +2692,7 @@ mod tests {
             session_id: None,
             agent_id: None,
             model: None,
+            llm_token_service: None,
             skill_search: None,
             allow_skills: None,
             allow_tools: None,
@@ -3113,6 +3313,7 @@ mod tests {
             session_id: None,
             agent_id: None,
             model: None,
+            llm_token_service: None,
             skill_search: None,
             allow_skills: None,
             allow_tools: None,
@@ -3132,6 +3333,97 @@ mod tests {
         assert!(AgenticRunLifecycleService::extract_edge_tools(&test_request("hi")).is_empty());
     }
 
+    fn trusted_domains_for_tests() -> Vec<super::TrustedLlmDomain> {
+        vec![super::TrustedLlmDomain {
+            host: "catalog".to_string(),
+            port: Some(8081),
+        }]
+    }
+
+    #[test]
+    fn validate_llm_token_service_config_accepts_http_url() {
+        let config = astra_services::LlmTokenServiceConfig {
+            url: "http://catalog:8081/api/v1/llm-token".to_string(),
+            timeout_ms: Some(2500),
+        };
+        let trusted = trusted_domains_for_tests();
+        assert!(super::validate_llm_token_service_config(Some(&config), &trusted).is_ok());
+    }
+
+    #[test]
+    fn validate_llm_token_service_config_rejects_invalid_url() {
+        let config = astra_services::LlmTokenServiceConfig {
+            url: "not-a-url".to_string(),
+            timeout_ms: Some(2500),
+        };
+        let trusted = trusted_domains_for_tests();
+        let err = super::validate_llm_token_service_config(Some(&config), &trusted)
+            .expect_err("invalid url should fail");
+        assert!(err.contains("valid URL"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_llm_token_service_config_rejects_untrusted_url() {
+        let config = astra_services::LlmTokenServiceConfig {
+            url: "http://evil.example.com/v1/chat/completions".to_string(),
+            timeout_ms: Some(2500),
+        };
+        let trusted = trusted_domains_for_tests();
+        let err = super::validate_llm_token_service_config(Some(&config), &trusted)
+            .expect_err("untrusted url should fail");
+        assert!(
+            err.contains("trusted domains"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_llm_token_service_config_rejects_when_trusted_domains_unconfigured() {
+        let config = astra_services::LlmTokenServiceConfig {
+            url: "http://catalog:8081/api/v1/llm-token".to_string(),
+            timeout_ms: Some(2500),
+        };
+        let err = super::validate_llm_token_service_config(Some(&config), &[])
+            .expect_err("missing trusted domains should fail");
+        assert!(
+            err.contains(super::LLM_TOKEN_SERVICE_TRUSTED_DOMAINS_TABLE),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_llm_token_service_config_enforces_host_port_boundary_for_trusted_domains() {
+        let config = astra_services::LlmTokenServiceConfig {
+            url: "http://catalog:8082/api/v1/chat".to_string(),
+            timeout_ms: Some(2500),
+        };
+        let trusted = trusted_domains_for_tests();
+        let err = super::validate_llm_token_service_config(Some(&config), &trusted)
+            .expect_err("host:port boundary should be enforced");
+        assert!(
+            err.contains("trusted domains"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn trusted_llm_domain_from_db_values_accepts_valid_host_and_port() {
+        let parsed = super::trusted_llm_domain_from_db_values("catalog", Some(8081))
+            .expect("host+port should parse");
+        assert_eq!(parsed.host, "catalog");
+        assert_eq!(parsed.port, Some(8081));
+    }
+
+    #[test]
+    fn trusted_llm_domain_from_db_values_rejects_invalid_host_or_port() {
+        let host_err = super::trusted_llm_domain_from_db_values("http://catalog:8081", Some(8081))
+            .expect_err("host should not include scheme");
+        assert!(host_err.contains("host"));
+        let port_err = super::trusted_llm_domain_from_db_values("catalog", Some(70000))
+            .expect_err("port out of range should fail");
+        assert!(port_err.contains("port"));
+    }
+
     #[test]
     fn extract_edge_profile_from_context() {
         let mut ctx = serde_json::Map::new();
@@ -3144,6 +3436,7 @@ mod tests {
             session_id: None,
             agent_id: None,
             model: None,
+            llm_token_service: None,
             skill_search: None,
             allow_skills: None,
             allow_tools: None,

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -177,17 +177,17 @@ fn normalize_trusted_llm_domain_host(raw: &str) -> Result<String, String> {
 
 fn trusted_llm_domain_from_db_values(
     host_raw: &str,
-    port_raw: Option<i64>,
+    port_raw: i64,
 ) -> Result<TrustedLlmDomain, String> {
     let host = normalize_trusted_llm_domain_host(host_raw)?;
     let port = match port_raw {
-        Some(port) if !(1..=65_535).contains(&port) => {
+        0 => None,
+        port if !(1..=65_535).contains(&port) => {
             return Err(format!(
                 "trusted domain host '{host_raw}' has invalid port value {port}"
             ));
         }
-        Some(port) => Some(port as u16),
-        None => None,
+        port => Some(port as u16),
     };
     Ok(TrustedLlmDomain { host, port })
 }
@@ -1052,7 +1052,7 @@ impl AgenticRunLifecycleService {
             })?
         };
         let rows = sqlx::query(
-            "SELECT domain_host, domain_port \
+            "SELECT domain_host, IFNULL(domain_port, 0) AS domain_port \
              FROM runtime_llm_trusted_domains \
              WHERE is_enabled = 1",
         )
@@ -1077,7 +1077,7 @@ impl AgenticRunLifecycleService {
                     ),
                 )
             })?;
-            let port: Option<i64> = row.try_get("domain_port").map_err(|error| {
+            let port: i64 = row.try_get("domain_port").map_err(|error| {
                 error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!(
@@ -1107,7 +1107,7 @@ impl AgenticRunLifecycleService {
         }
         if trusted_domains.is_empty() {
             return Err(error_response(
-                StatusCode::BAD_REQUEST,
+                StatusCode::SERVICE_UNAVAILABLE,
                 format!(
                     "table {LLM_TOKEN_SERVICE_TRUSTED_DOMAINS_TABLE} has no enabled trusted domains"
                 ),
@@ -3408,18 +3408,21 @@ mod tests {
 
     #[test]
     fn trusted_llm_domain_from_db_values_accepts_valid_host_and_port() {
-        let parsed = super::trusted_llm_domain_from_db_values("catalog", Some(8081))
+        let parsed = super::trusted_llm_domain_from_db_values("catalog", 8081)
             .expect("host+port should parse");
         assert_eq!(parsed.host, "catalog");
         assert_eq!(parsed.port, Some(8081));
+        let wildcard = super::trusted_llm_domain_from_db_values("catalog", 0)
+            .expect("sentinel port should represent wildcard");
+        assert_eq!(wildcard.port, None);
     }
 
     #[test]
     fn trusted_llm_domain_from_db_values_rejects_invalid_host_or_port() {
-        let host_err = super::trusted_llm_domain_from_db_values("http://catalog:8081", Some(8081))
+        let host_err = super::trusted_llm_domain_from_db_values("http://catalog:8081", 8081)
             .expect_err("host should not include scheme");
         assert!(host_err.contains("host"));
-        let port_err = super::trusted_llm_domain_from_db_values("catalog", Some(70000))
+        let port_err = super::trusted_llm_domain_from_db_values("catalog", 70000)
             .expect_err("port out of range should fail");
         assert!(port_err.contains("port"));
     }

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -16,7 +16,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::OnceLock;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use serde_json::{Map, Value, json};
@@ -34,12 +34,15 @@ use crate::turn::bridge_inprocess::{
 };
 use crate::turn::chat_turn_sse_dispatch::ChatTurnSseAccum;
 use crate::turn::llm_client::{
-    LlmCallResult, LlmCancel, cached_system_prompt, call_llm_and_collect, sleep_ms_or_llm_cancel,
+    LlmCallResult, LlmCancel, cached_system_prompt, call_llm_and_collect_with_request_overrides,
+    call_llm_nonstream_fallback_with_request_overrides, llm_connect_timeout, llm_fallback_timeout,
+    sleep_ms_or_llm_cancel,
 };
 use crate::turn::tool_schema_prune::{filter_tool_schemas_by_excluded_names, prune_tool_schemas};
 use crate::turn::turn_guard::merge_deprioritized_tools_into_restricted;
 use crate::{FernetTokenEncryptor, MatrixOneSettings};
 use astra_core::SharedPool;
+use astra_services::LlmTokenServiceConfig;
 
 // ── Rate-Limit Cooldown ──────────────────────────────────────────────────────
 /// Per-model rate-limit cooldown tracker (shared with llm_client).
@@ -55,6 +58,117 @@ fn llm_cancel_for_state(state: &AgenticLoopState) -> LlmCancel<'_> {
         (None, Some(t)) => LlmCancel::Token(t.as_ref()),
         (None, None) => LlmCancel::None,
     }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedTurnLlmConfig {
+    model_name: String,
+    api_key: String,
+    base_url: String,
+    provider: String,
+    fallback_model: Option<String>,
+    header_overrides: HashMap<String, String>,
+    completions_url_override: Option<String>,
+    request_timeout: Option<Duration>,
+}
+
+#[derive(Debug, Clone)]
+struct RequestAwareSummaryClient {
+    model_name: String,
+    api_key: String,
+    base_url: String,
+    provider: String,
+    max_output_tokens: usize,
+    header_overrides: HashMap<String, String>,
+    completions_url_override: Option<String>,
+    request_timeout: Option<Duration>,
+}
+
+#[async_trait]
+impl crate::turn::cloud::summary::SummaryLlmClient for RequestAwareSummaryClient {
+    async fn summarize(
+        &self,
+        messages: &[Value],
+    ) -> Result<crate::turn::cloud::summary::SummaryResponse, String> {
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .connect_timeout(llm_connect_timeout())
+            .timeout(llm_fallback_timeout())
+            .build()
+            .map_err(|error| error.to_string())?;
+
+        match call_llm_nonstream_fallback_with_request_overrides(
+            &client,
+            messages,
+            &[],
+            &self.model_name,
+            &self.api_key,
+            &self.base_url,
+            &self.provider,
+            Some(self.max_output_tokens),
+            llm_fallback_timeout(),
+            (!self.header_overrides.is_empty()).then_some(&self.header_overrides),
+            self.completions_url_override.as_deref(),
+            self.request_timeout,
+        )
+        .await
+        {
+            Ok(result) => Ok(crate::turn::cloud::summary::SummaryResponse {
+                text: result.full_text,
+                is_ptl_error: false,
+            }),
+            Err(error) if error.kind == astra_core::ErrorKind::ContextWindow => {
+                Ok(crate::turn::cloud::summary::SummaryResponse {
+                    text: String::new(),
+                    is_ptl_error: true,
+                })
+            }
+            Err(error) => Err(error.to_string()),
+        }
+    }
+}
+
+fn normalize_request_model(preferred_model: Option<&str>) -> Option<String> {
+    preferred_model
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(String::from)
+}
+
+async fn resolve_llm_model_for_turn(
+    matrixone: &MatrixOneSettings,
+    encryptor: &FernetTokenEncryptor,
+    preferred_model: Option<&str>,
+    pool: Option<&sqlx::Pool<sqlx::MySql>>,
+    llm_token_service: Option<&LlmTokenServiceConfig>,
+    forward_headers: &HashMap<String, String>,
+) -> Result<ResolvedTurnLlmConfig, String> {
+    if let Some(config) = llm_token_service {
+        return Ok(ResolvedTurnLlmConfig {
+            model_name: normalize_request_model(preferred_model)
+                .unwrap_or_else(|| "gpt-4o-mini".to_string()),
+            api_key: String::new(),
+            base_url: "https://api.openai.com/v1".to_string(),
+            provider: "openai".to_string(),
+            fallback_model: None,
+            header_overrides: forward_headers.clone(),
+            completions_url_override: Some(config.url.clone()),
+            request_timeout: config.timeout_ms.map(Duration::from_millis),
+        });
+    }
+    let resolved =
+        astra_services::resolve_active_llm_model(matrixone, encryptor, preferred_model, pool)
+            .await?;
+    Ok(ResolvedTurnLlmConfig {
+        model_name: resolved.model_name,
+        api_key: resolved.api_key,
+        base_url: resolved.base_url,
+        provider: resolved.provider,
+        fallback_model: resolved.fallback_model,
+        header_overrides: HashMap::new(),
+        completions_url_override: None,
+        request_timeout: None,
+    })
 }
 
 /// Server-side host for the runtime agentic loop.
@@ -75,6 +189,7 @@ pub struct ServerAgenticLoopHost {
     encryptor: Arc<FernetTokenEncryptor>,
     shared_pool: Option<SharedPool>,
     model_override: Option<String>,
+    llm_token_service: Option<LlmTokenServiceConfig>,
 
     // ── Context ──
     edge_tools: Vec<Value>,
@@ -108,6 +223,7 @@ pub struct ServerAgenticLoopHostBuilder {
     encryptor: Arc<FernetTokenEncryptor>,
     shared_pool: Option<SharedPool>,
     model_override: Option<String>,
+    llm_token_service: Option<LlmTokenServiceConfig>,
     edge_tools: Vec<Value>,
     edge_profile: Map<String, Value>,
     selection_confidence: f64,
@@ -130,6 +246,7 @@ impl ServerAgenticLoopHostBuilder {
             encryptor,
             shared_pool: None,
             model_override: None,
+            llm_token_service: None,
             edge_tools: Vec::new(),
             edge_profile: Map::new(),
             selection_confidence: 1.0,
@@ -148,6 +265,14 @@ impl ServerAgenticLoopHostBuilder {
 
     pub fn with_model(mut self, model: Option<String>) -> Self {
         self.model_override = model;
+        self
+    }
+
+    pub fn with_llm_token_service(
+        mut self,
+        llm_token_service: Option<LlmTokenServiceConfig>,
+    ) -> Self {
+        self.llm_token_service = llm_token_service;
         self
     }
 
@@ -214,6 +339,7 @@ impl ServerAgenticLoopHostBuilder {
             encryptor: self.encryptor,
             shared_pool: self.shared_pool,
             model_override: self.model_override,
+            llm_token_service: self.llm_token_service,
             edge_tools,
             edge_profile: self.edge_profile,
             valid_tools,
@@ -554,6 +680,9 @@ impl ServerAgenticLoopHost {
         api_key: &str,
         base_url: &str,
         provider: &str,
+        header_overrides: &HashMap<String, String>,
+        completions_url_override: Option<&str>,
+        request_timeout: Option<Duration>,
         cache_cfg: &PromptCacheConfig,
     ) -> Vec<Value> {
         let mut llm_messages = system_messages;
@@ -609,15 +738,16 @@ impl ServerAgenticLoopHost {
 
         // Build summary client for LLM-based compaction (uses same model as main LLM)
         let compact_config = crate::prompts::CompactConfig::from_env();
-        let summary_client = crate::turn::cloud::summary::HttpSummaryClient::new(
-            crate::turn::cloud::summary::LlmConnParams {
-                model_name: model_name.to_string(),
-                api_key: api_key.to_string(),
-                base_url: base_url.to_string(),
-                provider: provider.to_string(),
-                max_output_tokens: compact_config.summary_token_budget,
-            },
-        );
+        let summary_client = RequestAwareSummaryClient {
+            model_name: model_name.to_string(),
+            api_key: api_key.to_string(),
+            base_url: base_url.to_string(),
+            provider: provider.to_string(),
+            max_output_tokens: compact_config.summary_token_budget,
+            header_overrides: header_overrides.clone(),
+            completions_url_override: completions_url_override.map(String::from),
+            request_timeout,
+        };
 
         let compact_result = crate::turn::cloud::memoria_compact::compact_with_memoria(
             &micro_compacted_messages,
@@ -731,34 +861,29 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
             .as_deref()
             .or(self.model_override.as_deref());
         let pool_ref = self.shared_pool.as_ref().map(|sp| sp.get());
-        let (mut model_name, mut api_key, mut base_url, mut provider, fallback_model_name) =
-            match astra_services::resolve_active_llm_model(
-                &self.matrixone,
-                self.encryptor.as_ref(),
-                effective_model_override,
-                pool_ref,
-            )
-            .await
-            {
-                Ok(m) => (
-                    m.model_name,
-                    m.api_key,
-                    m.base_url,
-                    m.provider,
-                    m.fallback_model,
-                ),
-                Err(e) => {
-                    return Err(astra_core::ClassifiedError::new(
-                        astra_core::ErrorKind::Unknown,
-                        format!("Model resolution failed: {e}"),
-                    ));
-                }
-            };
-        let has_fallback = fallback_model_name.is_some();
+        let mut llm_cfg = match resolve_llm_model_for_turn(
+            &self.matrixone,
+            self.encryptor.as_ref(),
+            effective_model_override,
+            pool_ref,
+            self.llm_token_service.as_ref(),
+            &state.hooks.forward_headers,
+        )
+        .await
+        {
+            Ok(m) => m,
+            Err(e) => {
+                return Err(astra_core::ClassifiedError::new(
+                    astra_core::ErrorKind::Unknown,
+                    format!("Model resolution failed: {e}"),
+                ));
+            }
+        };
+        let has_fallback = llm_cfg.fallback_model.is_some();
 
         // ── 1b. Check rate-limit cooldown and handle fallback model resolution ──
         let cooldown = rate_limit_cooldown();
-        match cooldown.with(&model_name, |c| c.check_request(has_fallback)) {
+        match cooldown.with(&llm_cfg.model_name, |c| c.check_request(has_fallback)) {
             RateLimitAction::Proceed => {}
             RateLimitAction::WaitAndRetry { delay_ms } => {
                 astra_core::agent_info!(
@@ -768,7 +893,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 sleep_ms_or_llm_cancel(delay_ms, llm_cancel_for_state(state)).await?;
             }
             RateLimitAction::UseFallback { reason } => {
-                if let Some(ref fb_name) = fallback_model_name {
+                if let Some(ref fb_name) = llm_cfg.fallback_model {
                     astra_core::agent_info!(
                         "llm",
                         "rate-limit cooldown: switching to fallback model '{}' ({})",
@@ -776,20 +901,17 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                         reason.as_str()
                     );
                     // Resolve fallback model credentials
-                    match astra_services::resolve_active_llm_model(
+                    match resolve_llm_model_for_turn(
                         &self.matrixone,
                         self.encryptor.as_ref(),
                         Some(fb_name.as_str()),
                         pool_ref,
+                        self.llm_token_service.as_ref(),
+                        &state.hooks.forward_headers,
                     )
                     .await
                     {
-                        Ok(fb) => {
-                            model_name = fb.model_name;
-                            api_key = fb.api_key;
-                            base_url = fb.base_url;
-                            provider = fb.provider;
-                        }
+                        Ok(fb) => llm_cfg = fb,
                         Err(e) => {
                             astra_core::agent_warn!(
                                 "llm",
@@ -843,7 +965,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
 
         // Latch prompt cache config from provider info (once per turn is fine;
         // provider doesn't change within a turn).
-        let cache_cfg = PromptCacheConfig::latch(&provider, &model_name);
+        let cache_cfg = PromptCacheConfig::latch(&llm_cfg.provider, &llm_cfg.model_name);
 
         let (system_messages, system_prompt_plain) =
             self.build_system_messages_cached(&user_content, &visible_tools, state, &cache_cfg);
@@ -853,16 +975,19 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 system_messages,
                 state,
                 &visible_tools,
-                &model_name,
-                &api_key,
-                &base_url,
-                &provider,
+                &llm_cfg.model_name,
+                &llm_cfg.api_key,
+                &llm_cfg.base_url,
+                &llm_cfg.provider,
+                &llm_cfg.header_overrides,
+                llm_cfg.completions_url_override.as_deref(),
+                llm_cfg.request_timeout,
                 &cache_cfg,
             )
             .await;
 
         // ── 3. Call LLM ─────────────────────────────────────────────────
-        let budget = crate::prompts::budget_for_model(Some(&model_name));
+        let budget = crate::prompts::budget_for_model(Some(&llm_cfg.model_name));
         let max_output_tokens = crate::prompts::capped_output_tokens(&budget);
 
         let tool_schema_tokens: usize = visible_tools
@@ -894,16 +1019,19 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
         // with a higher max_output_tokens (up to 4× the initial budget).
         let mut effective_max_output = max_output_tokens;
         let result = loop {
-            let r = call_llm_and_collect(
+            let r = call_llm_and_collect_with_request_overrides(
                 &llm_messages,
                 &final_tools,
-                &model_name,
-                &api_key,
-                &base_url,
-                &provider,
+                &llm_cfg.model_name,
+                &llm_cfg.api_key,
+                &llm_cfg.base_url,
+                &llm_cfg.provider,
                 Some(effective_max_output),
                 has_fallback,
                 llm_cancel,
+                (!llm_cfg.header_overrides.is_empty()).then_some(&llm_cfg.header_overrides),
+                llm_cfg.completions_url_override.as_deref(),
+                llm_cfg.request_timeout,
             )
             .await;
 
@@ -988,45 +1116,39 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
             .as_deref()
             .or(self.model_override.as_deref());
         let pool_ref = self.shared_pool.as_ref().map(|sp| sp.get());
-        let (mut model_name, mut api_key, mut base_url, mut provider, fallback_model_name) =
-            match astra_services::resolve_active_llm_model(
-                &self.matrixone,
-                self.encryptor.as_ref(),
-                effective_model_override,
-                pool_ref,
-            )
-            .await
-            {
-                Ok(m) => (
-                    m.model_name,
-                    m.api_key,
-                    m.base_url,
-                    m.provider,
-                    m.fallback_model,
-                ),
-                Err(e) => return Err(format!("Model resolution failed: {e}").into()),
-            };
-        let has_fallback = fallback_model_name.is_some();
+        let mut llm_cfg = match resolve_llm_model_for_turn(
+            &self.matrixone,
+            self.encryptor.as_ref(),
+            effective_model_override,
+            pool_ref,
+            self.llm_token_service.as_ref(),
+            &state.hooks.forward_headers,
+        )
+        .await
+        {
+            Ok(m) => m,
+            Err(e) => return Err(format!("Model resolution failed: {e}").into()),
+        };
+        let has_fallback = llm_cfg.fallback_model.is_some();
 
-        match rate_limit_cooldown().with(&model_name, |c| c.check_request(has_fallback)) {
+        match rate_limit_cooldown().with(&llm_cfg.model_name, |c| c.check_request(has_fallback)) {
             RateLimitAction::Proceed => {}
             RateLimitAction::WaitAndRetry { delay_ms } => {
                 sleep_ms_or_llm_cancel(delay_ms, llm_cancel_for_state(state)).await?;
             }
             RateLimitAction::UseFallback { .. } => {
-                if let Some(ref fb_name) = fallback_model_name
-                    && let Ok(fb) = astra_services::resolve_active_llm_model(
+                if let Some(ref fb_name) = llm_cfg.fallback_model
+                    && let Ok(fb) = resolve_llm_model_for_turn(
                         &self.matrixone,
                         self.encryptor.as_ref(),
                         Some(fb_name.as_str()),
                         pool_ref,
+                        self.llm_token_service.as_ref(),
+                        &state.hooks.forward_headers,
                     )
                     .await
                 {
-                    model_name = fb.model_name;
-                    api_key = fb.api_key;
-                    base_url = fb.base_url;
-                    provider = fb.provider;
+                    llm_cfg = fb;
                 }
             }
             RateLimitAction::Reject {
@@ -1048,16 +1170,19 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
             json!({"role": "system", "content": request.system_prompt}),
             json!({"role": "user", "content": request.user_prompt}),
         ];
-        let result = call_llm_and_collect(
+        let result = call_llm_and_collect_with_request_overrides(
             &reflection_messages,
             &[],
-            &model_name,
-            &api_key,
-            &base_url,
-            &provider,
+            &llm_cfg.model_name,
+            &llm_cfg.api_key,
+            &llm_cfg.base_url,
+            &llm_cfg.provider,
             request.max_output_tokens,
             has_fallback,
             llm_cancel_for_state(state),
+            (!llm_cfg.header_overrides.is_empty()).then_some(&llm_cfg.header_overrides),
+            llm_cfg.completions_url_override.as_deref(),
+            llm_cfg.request_timeout,
         )
         .await?;
         let accum = Self::result_to_accum(&result);
@@ -1228,6 +1353,7 @@ mod tests {
     use super::*;
     use crate::turn::agentic_loop_host::ASK_USER_TOOL_NAME;
     use crate::turn::agentic_loop_host::run_agentic_loop_with_host;
+    use crate::turn::cloud::summary::SummaryLlmClient;
     use crate::turn::sse_stream_host::EdgeToolExecResult;
 
     fn mock_matrixone() -> MatrixOneSettings {
@@ -1550,6 +1676,9 @@ mod tests {
                 "sk-test",
                 "https://api.test.com",
                 "openai",
+                &HashMap::new(),
+                None,
+                None,
                 &PromptCacheConfig::latch("openai", "gpt-4"),
             )
             .await;
@@ -2042,6 +2171,158 @@ mod tests {
         assert!(!super::llm_cancel_for_state(&s).is_triggered());
         token.cancel();
         assert!(super::llm_cancel_for_state(&s).is_triggered());
+    }
+
+    #[tokio::test]
+    async fn llm_token_service_uses_gateway_url_and_forwarded_headers() {
+        let mut forward_headers = HashMap::new();
+        forward_headers.insert("authorization".to_string(), "Bearer moi-token".to_string());
+        forward_headers.insert("x-workspace-id".to_string(), "ws-001".to_string());
+        forward_headers.insert("__astra_connection_tokens".to_string(), "x-hop".to_string());
+
+        let resolved = resolve_llm_model_for_turn(
+            &mock_matrixone(),
+            mock_encryptor().as_ref(),
+            Some("gpt-5-mini"),
+            None,
+            Some(&LlmTokenServiceConfig {
+                url: "http://catalog:8081/api/v1/chat/completions".to_string(),
+                timeout_ms: Some(2000),
+            }),
+            &forward_headers,
+        )
+        .await
+        .expect("resolve via llm token service gateway");
+
+        assert_eq!(resolved.model_name, "gpt-5-mini");
+        assert_eq!(resolved.provider, "openai");
+        assert_eq!(resolved.base_url, "https://api.openai.com/v1");
+        assert_eq!(
+            resolved.completions_url_override.as_deref(),
+            Some("http://catalog:8081/api/v1/chat/completions")
+        );
+        assert_eq!(
+            resolved
+                .header_overrides
+                .get("authorization")
+                .map(String::as_str),
+            Some("Bearer moi-token")
+        );
+        assert_eq!(
+            resolved
+                .header_overrides
+                .get("x-workspace-id")
+                .map(String::as_str),
+            Some("ws-001")
+        );
+        assert_eq!(resolved.request_timeout, Some(Duration::from_millis(2000)));
+    }
+
+    #[tokio::test]
+    async fn llm_token_service_without_model_uses_default_model_name() {
+        let resolved = resolve_llm_model_for_turn(
+            &mock_matrixone(),
+            mock_encryptor().as_ref(),
+            None,
+            None,
+            Some(&LlmTokenServiceConfig {
+                url: "http://catalog:8081/api/v1/chat/completions".to_string(),
+                timeout_ms: None,
+            }),
+            &HashMap::new(),
+        )
+        .await
+        .expect("resolve via llm token service gateway");
+        assert_eq!(resolved.model_name, "gpt-4o-mini");
+        assert!(resolved.request_timeout.is_none());
+    }
+
+    #[tokio::test]
+    async fn summary_client_uses_gateway_override_and_forwarded_headers() {
+        use axum::{Router, extract::State, routing::post};
+        use tokio::net::TcpListener;
+
+        #[derive(Default)]
+        struct RequestCapture {
+            authorization: tokio::sync::Mutex<Option<String>>,
+            workspace_id: tokio::sync::Mutex<Option<String>>,
+            path: tokio::sync::Mutex<Option<String>>,
+        }
+
+        async fn handler(
+            State(capture): State<Arc<RequestCapture>>,
+            headers: axum::http::HeaderMap,
+            request: axum::extract::Request,
+        ) -> axum::Json<Value> {
+            *capture.path.lock().await = Some(request.uri().path().to_string());
+            *capture.authorization.lock().await = headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                .map(String::from);
+            *capture.workspace_id.lock().await = headers
+                .get("x-workspace-id")
+                .and_then(|value| value.to_str().ok())
+                .map(String::from);
+            axum::Json(json!({
+                "choices": [
+                    {
+                        "message": { "content": "gateway summary" },
+                        "finish_reason": "stop"
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            }))
+        }
+
+        let capture = Arc::new(RequestCapture::default());
+        let app = Router::new()
+            .route("/gateway/chat/completions", post(handler))
+            .with_state(capture.clone());
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("test server should run");
+        });
+
+        let mut forwarded = HashMap::new();
+        forwarded.insert("authorization".to_string(), "Bearer moi-token".to_string());
+        forwarded.insert("x-workspace-id".to_string(), "ws-001".to_string());
+        let client = RequestAwareSummaryClient {
+            model_name: "gpt-4o-mini".to_string(),
+            api_key: String::new(),
+            base_url: "https://api.openai.com/v1".to_string(),
+            provider: "openai".to_string(),
+            max_output_tokens: 128,
+            header_overrides: forwarded,
+            completions_url_override: Some(format!("http://{addr}/gateway/chat/completions")),
+            request_timeout: Some(Duration::from_secs(2)),
+        };
+
+        let response = client
+            .summarize(&[
+                json!({"role": "system", "content": "summarize"}),
+                json!({"role": "user", "content": "payload"}),
+            ])
+            .await
+            .expect("summary should succeed");
+        assert_eq!(response.text, "gateway summary");
+        assert!(!response.is_ptl_error);
+
+        assert_eq!(
+            capture.authorization.lock().await.as_deref(),
+            Some("Bearer moi-token")
+        );
+        assert_eq!(capture.workspace_id.lock().await.as_deref(), Some("ws-001"));
+        assert_eq!(
+            capture.path.lock().await.as_deref(),
+            Some("/gateway/chat/completions")
+        );
+
+        server.abort();
     }
 
     // ── progress_event_to_sse tests ──

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -51,6 +51,21 @@ fn rate_limit_cooldown() -> &'static PerModelCooldown {
     COOLDOWN.get_or_init(PerModelCooldown::new)
 }
 
+fn request_aware_summary_http_client() -> Result<reqwest::Client, String> {
+    static CLIENT: OnceLock<Result<reqwest::Client, String>> = OnceLock::new();
+    match CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .no_proxy()
+            .connect_timeout(llm_connect_timeout())
+            .timeout(llm_fallback_timeout())
+            .build()
+            .map_err(|error| error.to_string())
+    }) {
+        Ok(client) => Ok(client.clone()),
+        Err(error) => Err(error.clone()),
+    }
+}
+
 fn llm_cancel_for_state(state: &AgenticLoopState) -> LlmCancel<'_> {
     match (&state.cancellation.flag, &state.cancellation.token) {
         (Some(f), Some(t)) => LlmCancel::FlagAndToken(f.as_ref(), t.as_ref()),
@@ -90,12 +105,7 @@ impl crate::turn::cloud::summary::SummaryLlmClient for RequestAwareSummaryClient
         &self,
         messages: &[Value],
     ) -> Result<crate::turn::cloud::summary::SummaryResponse, String> {
-        let client = reqwest::Client::builder()
-            .no_proxy()
-            .connect_timeout(llm_connect_timeout())
-            .timeout(llm_fallback_timeout())
-            .build()
-            .map_err(|error| error.to_string())?;
+        let client = request_aware_summary_http_client()?;
 
         match call_llm_nonstream_fallback_with_request_overrides(
             &client,

--- a/rust/crates/runtime/src/server/server_skill_subrun.rs
+++ b/rust/crates/runtime/src/server/server_skill_subrun.rs
@@ -16,6 +16,7 @@ use serde_json::{Map, Value, json};
 use tokio::sync::Mutex as TokioMutex;
 
 use astra_core::SharedPool;
+use astra_services::LlmTokenServiceConfig;
 
 use crate::FernetTokenEncryptor;
 use crate::MatrixOneSettings;
@@ -48,6 +49,8 @@ pub struct ServerSkillSubRunExecutor {
     shared_pool: Option<SharedPool>,
     /// Default model to use when the skill manifest doesn't specify one.
     default_model: Option<String>,
+    /// Optional request-scoped LLM token service config inherited from parent run.
+    llm_token_service: Option<LlmTokenServiceConfig>,
     /// Edge tools available to sub-runs (inherited from parent host).
     edge_tools: Vec<Value>,
     /// Edge profile (cwd, git_branch, etc.) inherited from parent.
@@ -78,6 +81,7 @@ impl ServerSkillSubRunExecutor {
             encryptor,
             shared_pool: None,
             default_model: None,
+            llm_token_service: None,
             edge_tools: Vec::new(),
             edge_profile: Map::new(),
             skill_resolver: None,
@@ -96,6 +100,11 @@ impl ServerSkillSubRunExecutor {
 
     pub fn with_default_model(mut self, model: Option<String>) -> Self {
         self.default_model = model;
+        self
+    }
+
+    pub fn with_llm_token_service(mut self, service: Option<LlmTokenServiceConfig>) -> Self {
+        self.llm_token_service = service;
         self
     }
 
@@ -212,6 +221,7 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
             subrun_session_id.clone(),
         )
         .with_model(effective_model)
+        .with_llm_token_service(self.llm_token_service.clone())
         .with_edge_tools(self.edge_tools.clone())
         .with_edge_profile(self.edge_profile.clone())
         .with_edge_callback_ledger(Arc::new(TokioMutex::new(HashMap::new())));
@@ -317,6 +327,7 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
             hooks: StopHookState {
                 workspace_root_hint,
                 forward_headers: self.forward_headers.clone(),
+                llm_token_service: self.llm_token_service.clone(),
                 ..Default::default()
             },
             cancellation: CancellationState {
@@ -429,6 +440,7 @@ mod tests {
         );
         assert!(executor.cancel_token.is_none());
         assert!(executor.skill_resolver.is_none());
+        assert!(executor.llm_token_service.is_none());
     }
 
     #[test]
@@ -439,12 +451,17 @@ mod tests {
             "test-session".to_string(),
         )
         .with_default_model(Some("claude-sonnet-4-20250514".to_string()))
+        .with_llm_token_service(Some(LlmTokenServiceConfig {
+            url: "http://catalog:8081/api/v1/chat/completions".to_string(),
+            timeout_ms: Some(2500),
+        }))
         .with_edge_tools(vec![
             json!({"type": "function", "function": {"name": "bash"}}),
         ])
         .with_cancel_token(Some(Arc::new(tokio_util::sync::CancellationToken::new())));
 
         assert!(executor.default_model.is_some());
+        assert!(executor.llm_token_service.is_some());
         assert_eq!(executor.edge_tools.len(), 1);
         assert!(executor.cancel_token.is_some());
     }

--- a/rust/crates/runtime/src/server/state_builder.rs
+++ b/rust/crates/runtime/src/server/state_builder.rs
@@ -100,6 +100,10 @@ pub async fn build_server_state(
     .with_skill_config_service(Arc::new(
         DatabaseSkillConfigService::new(settings.matrixone.clone()).with_pool(shared_pool.clone()),
     ))
+    .with_llm_trusted_domain_service(Arc::new(
+        astra_services::DatabaseLlmTrustedDomainService::new(settings.matrixone.clone())
+            .with_pool(shared_pool.clone()),
+    ))
     .with_fernet_encryptor(
         FernetTokenEncryptor::from_env().map_err(Box::<dyn std::error::Error>::from)?,
     )

--- a/rust/crates/runtime/src/server/ws_handler.rs
+++ b/rust/crates/runtime/src/server/ws_handler.rs
@@ -906,6 +906,7 @@ fn build_ws_chat_request(
         session_id,
         agent_id,
         model,
+        llm_token_service: None,
         skill_search,
         allow_skills,
         allow_tools,

--- a/rust/crates/runtime/src/turn/agentic_delegate_interception.rs
+++ b/rust/crates/runtime/src/turn/agentic_delegate_interception.rs
@@ -87,6 +87,7 @@ pub(crate) async fn intercept_delegations<H: AgenticLoopHost>(
             "orchestrator",
             state.hooks.workspace_root_hint.as_deref(),
             &state.hooks.forward_headers,
+            state.hooks.llm_token_service.as_ref(),
             &state.skills.request_constraints,
             &state.skills.search,
             adaptive_delegation_context.as_ref(),
@@ -615,6 +616,7 @@ pub(crate) async fn partition_and_execute_delegations(
     source_agent_id: &str,
     workspace_hint: Option<&str>,
     forward_headers: &std::collections::HashMap<String, String>,
+    llm_token_service: Option<&astra_services::LlmTokenServiceConfig>,
     request_constraints: &RequestConstraints,
     skill_search: &astra_core::SkillSearchSettings,
     adaptive_context: Option<&DelegationAdaptiveContext>,
@@ -666,6 +668,7 @@ pub(crate) async fn partition_and_execute_delegations(
                             source_agent_id,
                             None,
                             forward_headers.clone(),
+                            llm_token_service.cloned(),
                         )
                         .await
                     {
@@ -1506,6 +1509,7 @@ mod tests {
             "orchestrator",
             None,
             &std::collections::HashMap::new(),
+            None,
             &RequestConstraints::default(),
             &astra_core::SkillSearchSettings::default(),
             None,
@@ -1542,6 +1546,7 @@ mod tests {
             "orchestrator",
             None,
             &std::collections::HashMap::new(),
+            None,
             &RequestConstraints::default(),
             &astra_core::SkillSearchSettings::default(),
             None,
@@ -1569,6 +1574,7 @@ mod tests {
             "orchestrator",
             None,
             &std::collections::HashMap::new(),
+            None,
             &RequestConstraints::default(),
             &astra_core::SkillSearchSettings::default(),
             None,

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -440,6 +440,8 @@ pub struct StopHookState {
     /// Inbound request headers eligible for remote skill forwarding.
     /// Header names are normalized to lowercase.
     pub forward_headers: HashMap<String, String>,
+    /// Request-scoped LLM token service config propagated to nested sub-runs.
+    pub llm_token_service: Option<astra_services::LlmTokenServiceConfig>,
 }
 
 /// Cancellation state for the agentic loop.

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -293,6 +293,54 @@ fn llm_total_budget() -> std::time::Duration {
     std::time::Duration::from_secs(s)
 }
 
+fn llm_completions_url(base_url: &str, override_url: Option<&str>) -> String {
+    override_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(String::from)
+        .unwrap_or_else(|| format!("{}/chat/completions", base_url.trim_end_matches('/')))
+}
+
+fn apply_llm_header_overrides(
+    mut req: reqwest::RequestBuilder,
+    header_overrides: Option<&HashMap<String, String>>,
+) -> reqwest::RequestBuilder {
+    let Some(header_overrides) = header_overrides else {
+        return req;
+    };
+    for (name, value) in header_overrides {
+        if name.starts_with("__astra_") {
+            continue;
+        }
+        let Ok(header_name) = reqwest::header::HeaderName::from_bytes(name.as_bytes()) else {
+            continue;
+        };
+        let Ok(header_value) = reqwest::header::HeaderValue::from_str(value) else {
+            continue;
+        };
+        req = req.header(header_name, header_value);
+    }
+    req
+}
+
+fn has_llm_auth_override(
+    provider: &str,
+    header_overrides: Option<&HashMap<String, String>>,
+) -> bool {
+    let Some(header_overrides) = header_overrides else {
+        return false;
+    };
+    if provider == "anthropic" {
+        header_overrides
+            .keys()
+            .any(|name| name.eq_ignore_ascii_case("x-api-key"))
+    } else {
+        header_overrides
+            .keys()
+            .any(|name| name.eq_ignore_ascii_case("authorization"))
+    }
+}
+
 /// Call the LLM streaming API, collect the full response, and return a structured result.
 ///
 /// Unlike `call_llm_stream` (which returns raw SSE bytes), this function
@@ -315,6 +363,38 @@ pub(crate) async fn call_llm_and_collect(
     max_output_tokens: Option<usize>,
     has_fallback: bool,
     cancel: LlmCancel<'_>,
+) -> Result<LlmCallResult, astra_core::ClassifiedError> {
+    call_llm_and_collect_with_request_overrides(
+        messages,
+        tools,
+        model_name,
+        api_key,
+        base_url,
+        provider,
+        max_output_tokens,
+        has_fallback,
+        cancel,
+        None,
+        None,
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn call_llm_and_collect_with_request_overrides(
+    messages: &[Value],
+    tools: &[Value],
+    model_name: &str,
+    api_key: &str,
+    base_url: &str,
+    provider: &str,
+    max_output_tokens: Option<usize>,
+    has_fallback: bool,
+    cancel: LlmCancel<'_>,
+    header_overrides: Option<&HashMap<String, String>>,
+    completions_url_override: Option<&str>,
+    request_timeout: Option<std::time::Duration>,
 ) -> Result<LlmCallResult, astra_core::ClassifiedError> {
     let cooldown = rate_limit_cooldown();
     let model_key = model_name;
@@ -343,7 +423,7 @@ pub(crate) async fn call_llm_and_collect(
         body["tool_choice"] = Value::String("auto".to_string());
     }
 
-    let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
+    let url = llm_completions_url(base_url, completions_url_override);
 
     let mut last_err = String::new();
     let mut last_kind = astra_core::ErrorKind::Unknown;
@@ -416,11 +496,16 @@ pub(crate) async fn call_llm_and_collect(
 
         let mut req = client.post(&url).header("content-type", "application/json");
         if provider == "anthropic" {
-            req = req
-                .header("x-api-key", api_key)
-                .header("anthropic-version", "2023-06-01");
-        } else {
+            if !has_llm_auth_override(provider, header_overrides) {
+                req = req.header("x-api-key", api_key);
+            }
+            req = req.header("anthropic-version", "2023-06-01");
+        } else if !has_llm_auth_override(provider, header_overrides) {
             req = req.header("authorization", format!("Bearer {api_key}"));
+        }
+        req = apply_llm_header_overrides(req, header_overrides);
+        if let Some(timeout) = request_timeout {
+            req = req.timeout(timeout);
         }
 
         let response = match req.json(&body).send().await {
@@ -510,7 +595,7 @@ pub(crate) async fn call_llm_and_collect(
                         made_progress,
                         fb_timeout.as_secs()
                     );
-                    return call_llm_nonstream_fallback(
+                    return call_llm_nonstream_fallback_with_request_overrides(
                         client,
                         messages,
                         tools,
@@ -520,6 +605,9 @@ pub(crate) async fn call_llm_and_collect(
                         provider,
                         max_output_tokens,
                         fb_timeout,
+                        header_overrides,
+                        completions_url_override,
+                        request_timeout,
                     )
                     .await;
                 }
@@ -889,6 +977,38 @@ pub(crate) async fn call_llm_nonstream_fallback(
     max_output_tokens: Option<usize>,
     timeout: std::time::Duration,
 ) -> Result<LlmCallResult, astra_core::ClassifiedError> {
+    call_llm_nonstream_fallback_with_request_overrides(
+        client,
+        messages,
+        tools,
+        model_name,
+        api_key,
+        base_url,
+        provider,
+        max_output_tokens,
+        timeout,
+        None,
+        None,
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn call_llm_nonstream_fallback_with_request_overrides(
+    client: &reqwest::Client,
+    messages: &[Value],
+    tools: &[Value],
+    model_name: &str,
+    api_key: &str,
+    base_url: &str,
+    provider: &str,
+    max_output_tokens: Option<usize>,
+    timeout: std::time::Duration,
+    header_overrides: Option<&HashMap<String, String>>,
+    completions_url_override: Option<&str>,
+    request_timeout: Option<std::time::Duration>,
+) -> Result<LlmCallResult, astra_core::ClassifiedError> {
     let started = Instant::now();
     let mut body = json!({
         "model": model_name,
@@ -907,26 +1027,36 @@ pub(crate) async fn call_llm_nonstream_fallback(
         body["tool_choice"] = Value::String("auto".to_string());
     }
 
-    let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
+    let url = llm_completions_url(base_url, completions_url_override);
     let mut req = client.post(&url).header("content-type", "application/json");
     if provider == "anthropic" {
-        req = req
-            .header("x-api-key", api_key)
-            .header("anthropic-version", "2023-06-01");
-    } else {
+        if !has_llm_auth_override(provider, header_overrides) {
+            req = req.header("x-api-key", api_key);
+        }
+        req = req.header("anthropic-version", "2023-06-01");
+    } else if !has_llm_auth_override(provider, header_overrides) {
         req = req.header("authorization", format!("Bearer {api_key}"));
     }
+    req = apply_llm_header_overrides(req, header_overrides);
 
     // Apply per-request timeout (overrides the client-level default).
-    let resp = req.timeout(timeout).json(&body).send().await.map_err(|e| {
-        astra_core::ClassifiedError::new(
-            astra_core::ErrorKind::Network,
-            format!(
-                "LLM fallback request failed (timeout {}s): {e}",
-                timeout.as_secs()
-            ),
-        )
-    })?;
+    let effective_timeout = request_timeout
+        .map(|value| value.min(timeout))
+        .unwrap_or(timeout);
+    let resp = req
+        .timeout(effective_timeout)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| {
+            astra_core::ClassifiedError::new(
+                astra_core::ErrorKind::Network,
+                format!(
+                    "LLM fallback request failed (timeout {}s): {e}",
+                    effective_timeout.as_secs()
+                ),
+            )
+        })?;
     if !resp.status().is_success() {
         let status = resp.status().as_u16();
         let text = resp.text().await.unwrap_or_default();
@@ -1070,6 +1200,7 @@ mod tests {
     use axum::Router;
     use axum::body::Body;
     use axum::extract::State;
+    use axum::http::HeaderMap;
     use axum::response::Response;
     use axum::routing::post;
     use futures_util::StreamExt;
@@ -1077,6 +1208,7 @@ mod tests {
     use serde_json::json;
     use serial_test::serial;
     use std::sync::Arc;
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
     /// Set thread-local stream idle timeouts for the duration of a test.
@@ -1262,6 +1394,76 @@ mod tests {
             err.message.contains("timeout") || err.message.contains("Timeout"),
             "error should mention timeout: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn call_llm_with_request_overrides_uses_direct_gateway_url_and_headers() {
+        #[derive(Clone, Default)]
+        struct Capture {
+            auth: Option<String>,
+            workspace: Option<String>,
+            model: Option<String>,
+        }
+
+        async fn gateway_handler(
+            State(capture): State<Arc<Mutex<Capture>>>,
+            headers: HeaderMap,
+            axum::Json(body): axum::Json<Value>,
+        ) -> Response {
+            *capture.lock().expect("capture lock") = Capture {
+                auth: headers
+                    .get("authorization")
+                    .and_then(|value| value.to_str().ok())
+                    .map(String::from),
+                workspace: headers
+                    .get("x-workspace-id")
+                    .and_then(|value| value.to_str().ok())
+                    .map(String::from),
+                model: body.get("model").and_then(Value::as_str).map(String::from),
+            };
+            let payload = json!({"choices":[{"delta":{"content":"from-gateway"}}]});
+            let body = format!("data: {}\n\ndata: [DONE]\n\n", payload);
+            Response::builder()
+                .status(200)
+                .header("content-type", "text/event-stream")
+                .body(Body::from(body))
+                .expect("gateway response")
+        }
+
+        let capture = Arc::new(Mutex::new(Capture::default()));
+        let app = Router::new()
+            .route("/gateway", post(gateway_handler))
+            .with_state(capture.clone());
+        let base = spawn_local_http_server(app).await;
+        let gateway_url = format!("{base}/gateway");
+
+        let mut overrides = HashMap::new();
+        overrides.insert("authorization".to_string(), "Bearer moi-token".to_string());
+        overrides.insert("x-workspace-id".to_string(), "ws-001".to_string());
+        overrides.insert("__astra_connection_tokens".to_string(), "x-hop".to_string());
+
+        let result = call_llm_and_collect_with_request_overrides(
+            &[json!({"role":"user","content":"hi"})],
+            &[],
+            "gpt-5-mini",
+            "",
+            "https://api.openai.com/v1",
+            "openai",
+            None,
+            false,
+            LlmCancel::None,
+            Some(&overrides),
+            Some(&gateway_url),
+            None,
+        )
+        .await
+        .expect("gateway llm call");
+
+        assert_eq!(result.full_text, "from-gateway");
+        let seen = capture.lock().expect("capture lock").clone();
+        assert_eq!(seen.auth.as_deref(), Some("Bearer moi-token"));
+        assert_eq!(seen.workspace.as_deref(), Some("ws-001"));
+        assert_eq!(seen.model.as_deref(), Some("gpt-5-mini"));
     }
 
     #[test]

--- a/rust/crates/runtime/tests/admin_llm_trusted_domains.rs
+++ b/rust/crates/runtime/tests/admin_llm_trusted_domains.rs
@@ -1,0 +1,289 @@
+use std::sync::Arc;
+
+use astra_runtime::{
+    AdminAuthorizer, AppState, AuthenticatedUser, ErrorResponse, HealthChecker, ServiceInfo,
+    build_app,
+};
+use astra_services::llm_trusted_domains::{
+    LlmTrustedDomainDeleteResponse, LlmTrustedDomainRecord, LlmTrustedDomainService,
+    LlmTrustedDomainUpsertRequestData,
+};
+use async_trait::async_trait;
+use axum::{
+    Json, Router, body,
+    http::{HeaderMap, Request, StatusCode},
+};
+use tokio::sync::Mutex;
+use tower::util::ServiceExt;
+
+#[derive(Clone)]
+struct StubHealthChecker;
+
+#[async_trait]
+impl HealthChecker for StubHealthChecker {
+    async fn database_healthy(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Clone)]
+struct StubAdminAuthorizer;
+
+#[async_trait]
+impl AdminAuthorizer for StubAdminAuthorizer {
+    async fn require_admin(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthenticatedUser, (StatusCode, Json<ErrorResponse>)> {
+        match headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+        {
+            Some("Bearer admin-token") => Ok(AuthenticatedUser {
+                user_id: "admin-1".to_string(),
+                username: Some("admin".to_string()),
+            }),
+            Some("Bearer user-token") => Err((
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse::new("Admin role required".to_string())),
+            )),
+            _ => Err((
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorResponse::new("Not authenticated".to_string())),
+            )),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct StubLlmTrustedDomainService {
+    records: Arc<Mutex<Vec<LlmTrustedDomainRecord>>>,
+    last_updated_by: Arc<Mutex<Option<String>>>,
+}
+
+impl StubLlmTrustedDomainService {
+    fn new() -> Self {
+        Self {
+            records: Arc::new(Mutex::new(vec![LlmTrustedDomainRecord {
+                domain_id: "domain-1".to_string(),
+                domain_host: "trusted.example.com".to_string(),
+                domain_port: None,
+                is_enabled: true,
+                description: Some("seed".to_string()),
+                created_at: "2026-02-01T00:00:00.000000Z".to_string(),
+                updated_at: "2026-02-01T00:00:00.000000Z".to_string(),
+            }])),
+            last_updated_by: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmTrustedDomainService for StubLlmTrustedDomainService {
+    async fn list_trusted_domains(
+        &self,
+    ) -> Result<Vec<LlmTrustedDomainRecord>, (StatusCode, Json<ErrorResponse>)> {
+        Ok(self.records.lock().await.clone())
+    }
+
+    async fn upsert_trusted_domain(
+        &self,
+        updated_by: Option<&str>,
+        request: LlmTrustedDomainUpsertRequestData,
+    ) -> Result<LlmTrustedDomainRecord, (StatusCode, Json<ErrorResponse>)> {
+        let domain_host = request.domain_host.trim().to_ascii_lowercase();
+        if domain_host.is_empty() {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new(
+                    "domain_host must not be empty".to_string(),
+                )),
+            ));
+        }
+
+        let mut last_updated_by = self.last_updated_by.lock().await;
+        *last_updated_by = updated_by
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(String::from);
+        drop(last_updated_by);
+
+        let mut records = self.records.lock().await;
+        if let Some(existing) = records.iter_mut().find(|record| {
+            record.domain_host == domain_host && record.domain_port == request.domain_port
+        }) {
+            existing.is_enabled = request.is_enabled;
+            existing.description = request.description;
+            existing.updated_at = "2026-02-02T00:00:00.000000Z".to_string();
+            return Ok(existing.clone());
+        }
+
+        let domain_id = format!("domain-{}", records.len() + 1);
+        let created = LlmTrustedDomainRecord {
+            domain_id,
+            domain_host,
+            domain_port: request.domain_port,
+            is_enabled: request.is_enabled,
+            description: request.description,
+            created_at: "2026-02-02T00:00:00.000000Z".to_string(),
+            updated_at: "2026-02-02T00:00:00.000000Z".to_string(),
+        };
+        records.push(created.clone());
+        Ok(created)
+    }
+
+    async fn delete_trusted_domain(
+        &self,
+        domain_id: &str,
+    ) -> Result<LlmTrustedDomainDeleteResponse, (StatusCode, Json<ErrorResponse>)> {
+        let mut records = self.records.lock().await;
+        if let Some(index) = records
+            .iter()
+            .position(|record| record.domain_id == domain_id)
+        {
+            records.remove(index);
+            return Ok(LlmTrustedDomainDeleteResponse {
+                status: "deleted".to_string(),
+            });
+        }
+        Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new(format!(
+                "trusted domain '{domain_id}' not found"
+            ))),
+        ))
+    }
+}
+
+fn build_app_with_admin(service: Arc<StubLlmTrustedDomainService>) -> Router {
+    build_app(
+        AppState::new(ServiceInfo::default(), Arc::new(StubHealthChecker))
+            .with_admin_authorizer(Arc::new(StubAdminAuthorizer))
+            .with_llm_trusted_domain_service(service),
+    )
+}
+
+fn build_request(
+    method: &str,
+    path: &str,
+    headers: &[(&str, &str)],
+    payload: Option<serde_json::Value>,
+) -> Request<body::Body> {
+    let mut builder = Request::builder().method(method).uri(path);
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    if let Some(payload) = payload {
+        builder = builder.header("content-type", "application/json");
+        builder.body(body::Body::from(payload.to_string())).unwrap()
+    } else {
+        builder.body(body::Body::empty()).unwrap()
+    }
+}
+
+async fn send_json(
+    app: Router,
+    method: &str,
+    path: &str,
+    headers: &[(&str, &str)],
+    payload: Option<serde_json::Value>,
+) -> (StatusCode, serde_json::Value) {
+    let response = app
+        .oneshot(build_request(method, path, headers, payload))
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = serde_json::from_slice(&bytes).unwrap();
+    (status, json)
+}
+
+#[tokio::test]
+async fn llm_trusted_domains_require_admin_role() {
+    let service = Arc::new(StubLlmTrustedDomainService::new());
+    let app = build_app_with_admin(service);
+
+    let (status, json) =
+        send_json(app.clone(), "GET", "/admin/llm/trusted-domains", &[], None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(json["detail"], "Not authenticated");
+
+    let (status, json) = send_json(
+        app,
+        "PUT",
+        "/admin/llm/trusted-domains",
+        &[("authorization", "Bearer user-token")],
+        Some(serde_json::json!({"domain_host":"catalog.local"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(json["detail"], "Admin role required");
+}
+
+#[tokio::test]
+async fn llm_trusted_domains_admin_crud_flow() {
+    let service = Arc::new(StubLlmTrustedDomainService::new());
+    let app = build_app_with_admin(service.clone());
+    let admin_headers = &[
+        ("authorization", "Bearer admin-token"),
+        ("x-user-id", "spoofed-user-id"),
+    ];
+
+    let (status, json) = send_json(
+        app.clone(),
+        "GET",
+        "/admin/llm/trusted-domains",
+        &[("authorization", "Bearer admin-token")],
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json.as_array().map(Vec::len), Some(1));
+
+    let (status, json) = send_json(
+        app.clone(),
+        "PUT",
+        "/admin/llm/trusted-domains",
+        admin_headers,
+        Some(
+            serde_json::json!({"domain_host":"CATALOG.local","domain_port":8081,"description":"catalog","is_enabled":true}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["domain_host"], "catalog.local");
+    assert_eq!(json["domain_port"], 8081);
+    let created_domain_id = json["domain_id"]
+        .as_str()
+        .expect("domain_id should be present")
+        .to_string();
+
+    let last_updated_by = service.last_updated_by.lock().await.clone();
+    assert_eq!(last_updated_by.as_deref(), Some("admin-1"));
+
+    let delete_path = format!("/admin/llm/trusted-domains/{created_domain_id}");
+    let (status, json) = send_json(
+        app.clone(),
+        "DELETE",
+        &delete_path,
+        &[("authorization", "Bearer admin-token")],
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["status"], "deleted");
+
+    let (status, json) = send_json(
+        app,
+        "GET",
+        "/admin/llm/trusted-domains",
+        &[("authorization", "Bearer admin-token")],
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json.as_array().map(Vec::len), Some(1));
+    assert_eq!(json[0]["domain_id"], "domain-1");
+}

--- a/rust/crates/services/src/lib.rs
+++ b/rust/crates/services/src/lib.rs
@@ -16,6 +16,7 @@ pub mod introspection;
 pub mod jobs;
 pub mod learning;
 pub mod learning_merge;
+pub mod llm_trusted_domains;
 pub mod marketplace;
 pub mod marketplace_stats;
 pub mod models;
@@ -120,6 +121,11 @@ pub use learning::{
     DatabaseLearningFeedbackService, LearningFeedbackRecord, LearningFeedbackRequestData,
     LearningFeedbackService, UnconfiguredLearningFeedbackService,
 };
+pub use llm_trusted_domains::{
+    DatabaseLlmTrustedDomainService, LlmTrustedDomainDeleteResponse, LlmTrustedDomainRecord,
+    LlmTrustedDomainService, LlmTrustedDomainUpsertRequest, LlmTrustedDomainUpsertRequestData,
+    UnconfiguredLlmTrustedDomainService,
+};
 pub use marketplace::{
     DatabaseMarketplaceService, MarketplaceService, UnconfiguredMarketplaceService,
 };
@@ -163,8 +169,9 @@ pub use reflect::{
 pub use replay::{DatabaseReplayService, ReplayService, UnconfiguredReplayService};
 pub use runs::{
     CancelRunRecord, ChatRequestData, ChatRunRecord, ChatStreamRecord, DurableRunRecord,
-    InMemoryRunStateStore, RunLifecycleService, RunListRecord, RunMutationRecord, RunStateStore,
-    RunStatusRecord, UnconfiguredRunLifecycleService, transform_run_event_for_client,
+    InMemoryRunStateStore, LlmTokenServiceConfig, LlmTokenServiceRequest, RunLifecycleService,
+    RunListRecord, RunMutationRecord, RunStateStore, RunStatusRecord,
+    UnconfiguredRunLifecycleService, transform_run_event_for_client,
 };
 pub use sandbox::{
     DatabaseSandboxService, SandboxRecord, SandboxService, UnconfiguredSandboxService,

--- a/rust/crates/services/src/llm_trusted_domains.rs
+++ b/rust/crates/services/src/llm_trusted_domains.rs
@@ -134,26 +134,30 @@ impl DatabaseLlmTrustedDomainService {
         Ok(host.to_ascii_lowercase())
     }
 
-    fn map_row(row: &sqlx::mysql::MySqlRow) -> Result<LlmTrustedDomainRecord, sqlx::Error> {
-        let domain_port_raw: Option<i64> = row.try_get("domain_port")?;
-        let domain_port = if let Some(raw) = domain_port_raw {
-            if (1..=65_535).contains(&raw) {
-                Some(raw as u16)
-            } else {
-                None
+    fn map_row(
+        row: &sqlx::mysql::MySqlRow,
+    ) -> Result<LlmTrustedDomainRecord, (StatusCode, Json<ErrorResponse>)> {
+        let domain_id: String = row.try_get("domain_id").map_err(internal_error)?;
+        let domain_host: String = row.try_get("domain_host").map_err(internal_error)?;
+        let domain_port_raw: i64 = row.try_get("domain_port").map_err(internal_error)?;
+        let domain_port = match domain_port_raw {
+            0 => None,
+            raw if (1..=65_535).contains(&raw) => Some(raw as u16),
+            raw => {
+                return Err(internal_error(format!(
+                    "trusted domain '{domain_id}' has invalid domain_port value {raw}"
+                )));
             }
-        } else {
-            None
         };
-        let is_enabled: i16 = row.try_get("is_enabled")?;
+        let is_enabled: i16 = row.try_get("is_enabled").map_err(internal_error)?;
         Ok(LlmTrustedDomainRecord {
-            domain_id: row.try_get("domain_id")?,
-            domain_host: row.try_get("domain_host")?,
+            domain_id,
+            domain_host,
             domain_port,
             is_enabled: is_enabled == 1,
-            description: row.try_get("description")?,
-            created_at: row.try_get("created_at")?,
-            updated_at: row.try_get("updated_at")?,
+            description: row.try_get("description").map_err(internal_error)?,
+            created_at: row.try_get("created_at").map_err(internal_error)?,
+            updated_at: row.try_get("updated_at").map_err(internal_error)?,
         })
     }
 
@@ -163,7 +167,7 @@ impl DatabaseLlmTrustedDomainService {
         domain_id: &str,
     ) -> Result<LlmTrustedDomainRecord, (StatusCode, Json<ErrorResponse>)> {
         let row = query(
-            "SELECT domain_id, domain_host, domain_port, is_enabled, description, \
+            "SELECT domain_id, domain_host, IFNULL(domain_port, 0) AS domain_port, is_enabled, description, \
                     DATE_FORMAT(created_at, '%Y-%m-%dT%H:%i:%s.%fZ') AS created_at, \
                     DATE_FORMAT(updated_at, '%Y-%m-%dT%H:%i:%s.%fZ') AS updated_at \
              FROM runtime_llm_trusted_domains \
@@ -179,7 +183,7 @@ impl DatabaseLlmTrustedDomainService {
                 format!("trusted domain '{domain_id}' not found"),
             )
         })?;
-        Self::map_row(&row).map_err(internal_error)
+        Self::map_row(&row)
     }
 }
 
@@ -190,7 +194,7 @@ impl LlmTrustedDomainService for DatabaseLlmTrustedDomainService {
     ) -> Result<Vec<LlmTrustedDomainRecord>, (StatusCode, Json<ErrorResponse>)> {
         let pool = self.get_pool().await.map_err(internal_error)?;
         let rows = query(
-            "SELECT domain_id, domain_host, domain_port, is_enabled, description, \
+            "SELECT domain_id, domain_host, IFNULL(domain_port, 0) AS domain_port, is_enabled, description, \
                     DATE_FORMAT(created_at, '%Y-%m-%dT%H:%i:%s.%fZ') AS created_at, \
                     DATE_FORMAT(updated_at, '%Y-%m-%dT%H:%i:%s.%fZ') AS updated_at \
              FROM runtime_llm_trusted_domains \
@@ -202,7 +206,6 @@ impl LlmTrustedDomainService for DatabaseLlmTrustedDomainService {
         rows.iter()
             .map(Self::map_row)
             .collect::<Result<Vec<_>, _>>()
-            .map_err(internal_error)
     }
 
     async fn upsert_trusted_domain(
@@ -218,7 +221,9 @@ impl LlmTrustedDomainService for DatabaseLlmTrustedDomainService {
                 "domain_port must be between 1 and 65535 when provided",
             ));
         }
-        let domain_port = request.domain_port.map(i64::from);
+        // Persist absent port as sentinel `0` so `(domain_host, domain_port)` uniqueness
+        // also applies to host-only records.
+        let domain_port = i64::from(request.domain_port.unwrap_or(0));
         let description = request
             .description
             .map(|value| value.trim().to_string())
@@ -232,7 +237,7 @@ impl LlmTrustedDomainService for DatabaseLlmTrustedDomainService {
         let existing = query(
             "SELECT domain_id \
              FROM runtime_llm_trusted_domains \
-             WHERE domain_host = ? AND domain_port <=> ? \
+             WHERE domain_host = ? AND IFNULL(domain_port, 0) = ? \
              LIMIT 1",
         )
         .bind(&domain_host)

--- a/rust/crates/services/src/llm_trusted_domains.rs
+++ b/rust/crates/services/src/llm_trusted_domains.rs
@@ -1,0 +1,348 @@
+use async_trait::async_trait;
+use axum::{Json, http::StatusCode};
+use serde::{Deserialize, Serialize};
+use sqlx::{Row, query};
+use uuid::Uuid;
+
+use astra_core::{
+    ErrorResponse, MatrixOneSettings, SharedPool, connect_matrixone, error_response, internal_error,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LlmTrustedDomainRecord {
+    pub domain_id: String,
+    pub domain_host: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain_port: Option<u16>,
+    pub is_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LlmTrustedDomainUpsertRequestData {
+    pub domain_host: String,
+    pub domain_port: Option<u16>,
+    pub is_enabled: bool,
+    pub description: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LlmTrustedDomainDeleteResponse {
+    pub status: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LlmTrustedDomainUpsertRequest {
+    pub domain_host: String,
+    #[serde(default)]
+    pub domain_port: Option<u16>,
+    #[serde(default = "default_enabled")]
+    pub is_enabled: bool,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+#[async_trait]
+pub trait LlmTrustedDomainService: Send + Sync {
+    async fn list_trusted_domains(
+        &self,
+    ) -> Result<Vec<LlmTrustedDomainRecord>, (StatusCode, Json<ErrorResponse>)>;
+
+    async fn upsert_trusted_domain(
+        &self,
+        updated_by: Option<&str>,
+        request: LlmTrustedDomainUpsertRequestData,
+    ) -> Result<LlmTrustedDomainRecord, (StatusCode, Json<ErrorResponse>)>;
+
+    async fn delete_trusted_domain(
+        &self,
+        domain_id: &str,
+    ) -> Result<LlmTrustedDomainDeleteResponse, (StatusCode, Json<ErrorResponse>)>;
+}
+
+#[derive(Clone, Debug)]
+pub struct DatabaseLlmTrustedDomainService {
+    matrixone: MatrixOneSettings,
+    pool: Option<SharedPool>,
+}
+
+impl DatabaseLlmTrustedDomainService {
+    pub fn new(matrixone: MatrixOneSettings) -> Self {
+        Self {
+            matrixone,
+            pool: None,
+        }
+    }
+
+    pub fn with_pool(mut self, pool: SharedPool) -> Self {
+        self.pool = Some(pool);
+        self
+    }
+
+    async fn get_pool(&self) -> Result<sqlx::Pool<sqlx::MySql>, sqlx::Error> {
+        if let Some(ref pool) = self.pool {
+            return Ok(pool.get().clone());
+        }
+        connect_matrixone(&self.matrixone).await
+    }
+
+    fn normalize_domain_host(raw: &str) -> Result<String, (StatusCode, Json<ErrorResponse>)> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "domain_host must not be empty",
+            ));
+        }
+        if trimmed.contains("://") {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "domain_host must be host only (without URL scheme)",
+            ));
+        }
+        let parsed = reqwest::Url::parse(&format!("http://{trimmed}")).map_err(|error| {
+            error_response(
+                StatusCode::BAD_REQUEST,
+                format!("domain_host is invalid: {error}"),
+            )
+        })?;
+        if parsed.username() != ""
+            || parsed.password().is_some()
+            || parsed.path() != "/"
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+            || parsed.port().is_some()
+        {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "domain_host must be host only (without path/query/port)",
+            ));
+        }
+        let Some(host) = parsed.host_str() else {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "domain_host must include a host",
+            ));
+        };
+        Ok(host.to_ascii_lowercase())
+    }
+
+    fn map_row(row: &sqlx::mysql::MySqlRow) -> Result<LlmTrustedDomainRecord, sqlx::Error> {
+        let domain_port_raw: Option<i64> = row.try_get("domain_port")?;
+        let domain_port = if let Some(raw) = domain_port_raw {
+            if (1..=65_535).contains(&raw) {
+                Some(raw as u16)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let is_enabled: i16 = row.try_get("is_enabled")?;
+        Ok(LlmTrustedDomainRecord {
+            domain_id: row.try_get("domain_id")?,
+            domain_host: row.try_get("domain_host")?,
+            domain_port,
+            is_enabled: is_enabled == 1,
+            description: row.try_get("description")?,
+            created_at: row.try_get("created_at")?,
+            updated_at: row.try_get("updated_at")?,
+        })
+    }
+
+    async fn fetch_by_id(
+        &self,
+        pool: &sqlx::Pool<sqlx::MySql>,
+        domain_id: &str,
+    ) -> Result<LlmTrustedDomainRecord, (StatusCode, Json<ErrorResponse>)> {
+        let row = query(
+            "SELECT domain_id, domain_host, domain_port, is_enabled, description, \
+                    DATE_FORMAT(created_at, '%Y-%m-%dT%H:%i:%s.%fZ') AS created_at, \
+                    DATE_FORMAT(updated_at, '%Y-%m-%dT%H:%i:%s.%fZ') AS updated_at \
+             FROM runtime_llm_trusted_domains \
+             WHERE domain_id = ?",
+        )
+        .bind(domain_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(internal_error)?;
+        let row = row.ok_or_else(|| {
+            error_response(
+                StatusCode::NOT_FOUND,
+                format!("trusted domain '{domain_id}' not found"),
+            )
+        })?;
+        Self::map_row(&row).map_err(internal_error)
+    }
+}
+
+#[async_trait]
+impl LlmTrustedDomainService for DatabaseLlmTrustedDomainService {
+    async fn list_trusted_domains(
+        &self,
+    ) -> Result<Vec<LlmTrustedDomainRecord>, (StatusCode, Json<ErrorResponse>)> {
+        let pool = self.get_pool().await.map_err(internal_error)?;
+        let rows = query(
+            "SELECT domain_id, domain_host, domain_port, is_enabled, description, \
+                    DATE_FORMAT(created_at, '%Y-%m-%dT%H:%i:%s.%fZ') AS created_at, \
+                    DATE_FORMAT(updated_at, '%Y-%m-%dT%H:%i:%s.%fZ') AS updated_at \
+             FROM runtime_llm_trusted_domains \
+             ORDER BY domain_host ASC, domain_port ASC, domain_id ASC",
+        )
+        .fetch_all(&pool)
+        .await
+        .map_err(internal_error)?;
+        rows.iter()
+            .map(Self::map_row)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(internal_error)
+    }
+
+    async fn upsert_trusted_domain(
+        &self,
+        updated_by: Option<&str>,
+        request: LlmTrustedDomainUpsertRequestData,
+    ) -> Result<LlmTrustedDomainRecord, (StatusCode, Json<ErrorResponse>)> {
+        let pool = self.get_pool().await.map_err(internal_error)?;
+        let domain_host = Self::normalize_domain_host(&request.domain_host)?;
+        if request.domain_port == Some(0) {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "domain_port must be between 1 and 65535 when provided",
+            ));
+        }
+        let domain_port = request.domain_port.map(i64::from);
+        let description = request
+            .description
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let is_enabled: i16 = if request.is_enabled { 1 } else { 0 };
+        let updated_by = updated_by
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(String::from);
+
+        let existing = query(
+            "SELECT domain_id \
+             FROM runtime_llm_trusted_domains \
+             WHERE domain_host = ? AND domain_port <=> ? \
+             LIMIT 1",
+        )
+        .bind(&domain_host)
+        .bind(domain_port)
+        .fetch_optional(&pool)
+        .await
+        .map_err(internal_error)?;
+
+        let domain_id = if let Some(row) = existing {
+            let domain_id: String = row.try_get("domain_id").map_err(internal_error)?;
+            query(
+                "UPDATE runtime_llm_trusted_domains \
+                 SET is_enabled = ?, description = ?, updated_by = ? \
+                 WHERE domain_id = ?",
+            )
+            .bind(is_enabled)
+            .bind(&description)
+            .bind(&updated_by)
+            .bind(&domain_id)
+            .execute(&pool)
+            .await
+            .map_err(internal_error)?;
+            domain_id
+        } else {
+            let domain_id = Uuid::new_v4().to_string();
+            query(
+                "INSERT INTO runtime_llm_trusted_domains \
+                 (domain_id, domain_host, domain_port, is_enabled, description, created_by, updated_by) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&domain_id)
+            .bind(&domain_host)
+            .bind(domain_port)
+            .bind(is_enabled)
+            .bind(&description)
+            .bind(&updated_by)
+            .bind(&updated_by)
+            .execute(&pool)
+            .await
+            .map_err(internal_error)?;
+            domain_id
+        };
+
+        self.fetch_by_id(&pool, &domain_id).await
+    }
+
+    async fn delete_trusted_domain(
+        &self,
+        domain_id: &str,
+    ) -> Result<LlmTrustedDomainDeleteResponse, (StatusCode, Json<ErrorResponse>)> {
+        let pool = self.get_pool().await.map_err(internal_error)?;
+        let domain_id = domain_id.trim();
+        if domain_id.is_empty() {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "domain_id must not be empty",
+            ));
+        }
+        let result = query("DELETE FROM runtime_llm_trusted_domains WHERE domain_id = ?")
+            .bind(domain_id)
+            .execute(&pool)
+            .await
+            .map_err(internal_error)?;
+        if result.rows_affected() == 0 {
+            return Err(error_response(
+                StatusCode::NOT_FOUND,
+                format!("trusted domain '{domain_id}' not found"),
+            ));
+        }
+        Ok(LlmTrustedDomainDeleteResponse {
+            status: "deleted".to_string(),
+        })
+    }
+}
+
+pub struct UnconfiguredLlmTrustedDomainService;
+
+#[async_trait]
+impl LlmTrustedDomainService for UnconfiguredLlmTrustedDomainService {
+    async fn list_trusted_domains(
+        &self,
+    ) -> Result<Vec<LlmTrustedDomainRecord>, (StatusCode, Json<ErrorResponse>)> {
+        Err(internal_error("llm trusted domain service not configured"))
+    }
+
+    async fn upsert_trusted_domain(
+        &self,
+        _: Option<&str>,
+        _: LlmTrustedDomainUpsertRequestData,
+    ) -> Result<LlmTrustedDomainRecord, (StatusCode, Json<ErrorResponse>)> {
+        Err(internal_error("llm trusted domain service not configured"))
+    }
+
+    async fn delete_trusted_domain(
+        &self,
+        _: &str,
+    ) -> Result<LlmTrustedDomainDeleteResponse, (StatusCode, Json<ErrorResponse>)> {
+        Err(internal_error("llm trusted domain service not configured"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_request_defaults_enabled() {
+        let req: LlmTrustedDomainUpsertRequest =
+            serde_json::from_str(r#"{"domain_host":"catalog"}"#).expect("request should parse");
+        assert!(req.is_enabled);
+        assert_eq!(req.domain_port, None);
+    }
+}

--- a/rust/crates/services/src/runs.rs
+++ b/rust/crates/services/src/runs.rs
@@ -1,6 +1,7 @@
 use astra_core::{ErrorResponse, error_response, error_response_coded};
 use async_trait::async_trait;
 use axum::{Json, http::StatusCode};
+use serde::{Deserialize, Serialize};
 
 pub const RUN_LIFECYCLE_UNCONFIGURED_ERROR_CODE: &str = "run_lifecycle_unconfigured";
 
@@ -107,12 +108,45 @@ pub trait RunLifecycleService: Send + Sync {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LlmTokenServiceConfig {
+    pub url: String,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LlmTokenServiceRequest {
+    pub url: String,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+impl From<LlmTokenServiceRequest> for LlmTokenServiceConfig {
+    fn from(value: LlmTokenServiceRequest) -> Self {
+        Self {
+            url: value.url,
+            timeout_ms: value.timeout_ms,
+        }
+    }
+}
+
+impl From<LlmTokenServiceConfig> for LlmTokenServiceRequest {
+    fn from(value: LlmTokenServiceConfig) -> Self {
+        Self {
+            url: value.url,
+            timeout_ms: value.timeout_ms,
+        }
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct ChatRequestData {
     pub message: String,
     pub session_id: Option<String>,
     pub agent_id: Option<String>,
     pub model: Option<String>,
+    pub llm_token_service: Option<LlmTokenServiceConfig>,
     pub skill_search: Option<astra_core::SkillSearchSettings>,
     pub allow_skills: Option<Vec<String>>,
     pub allow_tools: Option<Vec<String>>,
@@ -152,6 +186,7 @@ impl std::fmt::Debug for ChatRequestData {
             .field("session_id", &self.session_id)
             .field("agent_id", &self.agent_id)
             .field("model", &self.model)
+            .field("llm_token_service", &self.llm_token_service)
             .field("skill_search", &self.skill_search)
             .field("allow_skills", &self.allow_skills)
             .field("allow_tools", &self.allow_tools)
@@ -881,6 +916,7 @@ mod tests {
             session_id: Some("sess-1".to_string()),
             agent_id: None,
             model: None,
+            llm_token_service: None,
             skill_search: None,
             allow_skills: None,
             allow_tools: None,
@@ -910,6 +946,7 @@ mod tests {
                     session_id: None,
                     agent_id: None,
                     model: None,
+                    llm_token_service: None,
                     skill_search: None,
                     allow_skills: None,
                     allow_tools: None,

--- a/rust/crates/services/src/storage.rs
+++ b/rust/crates/services/src/storage.rs
@@ -959,6 +959,24 @@ pub async fn ensure_core_schema(settings: &MatrixOneSettings) -> Result<(), sqlx
     .await?;
 
     query(
+        "CREATE TABLE IF NOT EXISTS runtime_llm_trusted_domains (
+            domain_id     VARCHAR(36) PRIMARY KEY,
+            domain_host   VARCHAR(255) NOT NULL,
+            domain_port   INT,
+            is_enabled    SMALLINT NOT NULL DEFAULT 1,
+            description   VARCHAR(255),
+            created_by    VARCHAR(36),
+            updated_by    VARCHAR(36),
+            created_at    DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+            updated_at    DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+            UNIQUE INDEX idx_rld_host_port (domain_host, domain_port),
+            INDEX idx_rld_enabled (is_enabled)
+        )",
+    )
+    .execute(&pool)
+    .await?;
+
+    query(
         "CREATE TABLE IF NOT EXISTS skill_resource_bindings (
             binding_id    VARCHAR(36) PRIMARY KEY,
             user_id       VARCHAR(36) NOT NULL,

--- a/rust/crates/services/src/storage.rs
+++ b/rust/crates/services/src/storage.rs
@@ -962,7 +962,7 @@ pub async fn ensure_core_schema(settings: &MatrixOneSettings) -> Result<(), sqlx
         "CREATE TABLE IF NOT EXISTS runtime_llm_trusted_domains (
             domain_id     VARCHAR(36) PRIMARY KEY,
             domain_host   VARCHAR(255) NOT NULL,
-            domain_port   INT,
+            domain_port   INT NOT NULL DEFAULT 0,
             is_enabled    SMALLINT NOT NULL DEFAULT 1,
             description   VARCHAR(255),
             created_by    VARCHAR(36),


### PR DESCRIPTION
## Summary
- add request-scoped `llm_token_service` support on chat/http/stream and enforce trusted-domain validation from DB
- add admin APIs to manage trusted domains (`/admin/llm/trusted-domains`) with dedicated service/table
- add request-scoped allowlists (`allow_skills` / `allow_tools`) on chat endpoints and keep constraints through delegation and sub-runs
- ensure remote-skill forwarding uses configured headers and nested flows preserve forwarding state
- propagate `llm_token_service` through delegation and skill sub-runs so child loops keep the same gateway routing

## Testing
- `cargo check -p astra-runtime -p astra-services -p astra-server-types`
- `cargo test -p astra-runtime validate_llm_token_service_config --lib`
- `cargo test -p astra-runtime llm_token_service_uses_gateway_url_and_forwarded_headers --lib`
- `cargo test -p astra-runtime summary_client_uses_gateway_override_and_forwarded_headers --lib`
- `cargo test -p astra-runtime execute_with_forward_headers_passes_llm_token_service_sideband --lib`
- `cargo test -p astra-runtime partition_handles_all_delegate_calls --lib`
- `cargo test -p astra-runtime server_skill_subrun_executor_with_builders --lib`
- `cargo test -p astra-runtime --test admin_llm_trusted_domains`
