### PR TITLE
fix: multi-provider LLM compatibility — URL routing, message sanitization, think tag extraction

### DIFF
--- a/rust/crates/astra-admin/src/cli_args.rs
+++ b/rust/crates/astra-admin/src/cli_args.rs
@@ -83,6 +83,9 @@ pub(crate) enum ModelCmd {
     Add(ModelAddArgs),
     Show(ModelShowArgs),
     Delete(ModelDeleteArgs),
+    /// Probe upstream LLM connectivity; on success sets `is_active=true`, on failure `false` (HTTP `POST /models/{name}/check`).
+    /// This is the supported way to "try activate" from credentials already stored on the server.
+    #[command(alias = "probe", visible_alias = "verify")]
     Check(ModelShowArgs),
     Load(ModelLoadArgs),
     /// Update model fields (api-key, base-url, quirks, active status).
@@ -108,6 +111,7 @@ pub(crate) struct ModelUpdateArgs {
     pub api_key: Option<String>,
     #[arg(long)]
     pub base_url: Option<String>,
+    /// Set stored `is_active` without re-probing. Prefer `model check` to activate only when connectivity succeeds.
     #[arg(long)]
     pub active: Option<bool>,
     /// JSON string for quirks, e.g. '{"fallback_model":"gpt-4o-mini"}'
@@ -128,6 +132,11 @@ pub(crate) struct ModelDeleteArgs {
 #[derive(Args, Debug)]
 pub(crate) struct ModelLoadArgs {
     pub path: String,
+    /// When the server already has this model name, `POST /models` is skipped. With this flag,
+    /// push `api_key` and optional `base_url` from the YAML via `PUT /models/{name}` so the
+    /// server re-runs connectivity and refreshes `is_active`.
+    #[arg(long)]
+    pub update_existing: bool,
 }
 
 #[derive(Args, Debug)]

--- a/rust/crates/astra-admin/src/http_helpers.rs
+++ b/rust/crates/astra-admin/src/http_helpers.rs
@@ -4,10 +4,22 @@ pub(crate) fn read_api_error(status: u16, body: &str) -> String {
     format!("request failed ({status}): {}", compact_or_raw(body))
 }
 
+fn append_model_not_found_hint(status: u16, body: &str, message: &mut String) {
+    if status == 404 && body.contains("Model") && body.contains("not found") {
+        message.push_str(
+            "\n  hint: `model_name` must match the server row exactly (case-sensitive). \
+             MiniMax IDs look like `MiniMax-M2.5` / `MiniMax-M2.7` (note the `M` before the version). \
+             Run: astra-admin model list",
+        );
+    }
+}
+
 pub(crate) fn map_thin_err(e: astra_thin_client::ThinClientError) -> String {
     match e {
         astra_thin_client::ThinClientError::Api { status, body } => {
-            read_api_error(status.as_u16(), &body)
+            let mut out = read_api_error(status.as_u16(), &body);
+            append_model_not_found_hint(status.as_u16(), &body, &mut out);
+            out
         }
         other => other.to_string(),
     }
@@ -68,6 +80,18 @@ mod tests {
         let err = read_api_error(403, "{\"detail\":\"denied\"}");
         assert!(err.contains("403"), "got: {err}");
         assert!(err.contains("denied"), "got: {err}");
+    }
+
+    #[test]
+    fn append_model_not_found_hint_for_typo_body() {
+        let body = r#"{"detail":"Model 'MiniMax-2.5' not found"}"#;
+        let mut out = read_api_error(404, body);
+        super::append_model_not_found_hint(404, body, &mut out);
+        assert!(
+            out.contains("MiniMax-M2.5"),
+            "hint should mention correct id pattern: {out}"
+        );
+        assert!(out.contains("model list"), "{out}");
     }
 
     #[test]

--- a/rust/crates/astra-admin/src/main.rs
+++ b/rust/crates/astra-admin/src/main.rs
@@ -18,6 +18,32 @@ use http_helpers::*;
 use input::*;
 use interactive::run_interactive;
 
+/// Parse `POST /models` or `PUT /models/{name}` JSON and print `is_active` / `connectivity`.
+fn print_model_load_server_result(body: &str, model_name: &str) {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        println!("  (non-JSON response, len {} bytes)", body.len());
+        return;
+    };
+    let active = value
+        .get("is_active")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true); // fail-open: treat missing/invalid as active so user proceeds
+    println!("  is_active: {active}");
+    if let Some(c) = value
+        .get("connectivity")
+        .and_then(serde_json::Value::as_str)
+    {
+        println!("  connectivity: {c}");
+    } else if !active {
+        println!("  connectivity: (not in response; run: astra-admin model check {model_name})");
+    }
+    if !active {
+        eprintln!(
+            "  warning: model is inactive — server probe failed or was skipped; fix YAML then `astra-admin model load <file> --update-existing`, or `astra-admin model check {model_name}`"
+        );
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), String> {
     let cli = Cli::parse();
@@ -295,11 +321,41 @@ async fn main() -> Result<(), String> {
                     .post_bearer_path_json_text(&token, paths::MODELS, &payload)
                     .await
                 {
-                    Ok(_) => println!("loaded model: {model_name}"),
+                    Ok(body) => {
+                        println!("loaded model: {model_name}");
+                        print_model_load_server_result(&body, model_name);
+                    }
                     Err(astra_thin_client::ThinClientError::Api { body, .. })
                         if body.contains("already exists") =>
                     {
-                        println!("skipped (already exists): {model_name}");
+                        if args.update_existing {
+                            if api_key.is_empty() {
+                                eprintln!(
+                                    "skipped (already exists): {model_name} — need non-empty api_key in YAML to use --update-existing"
+                                );
+                            } else {
+                                let mut upd =
+                                    serde_json::json!({ "api_key": api_key, "provider": provider });
+                                if let Some(ref u) = base_url {
+                                    upd["base_url"] = serde_json::json!(u);
+                                }
+                                let body = api
+                                    .put_bearer_path_json_text(
+                                        &token,
+                                        &paths::model(model_name),
+                                        &upd,
+                                    )
+                                    .await
+                                    .map_err(map_thin_err)?;
+                                println!("re-synced existing model: {model_name}");
+                                print_model_load_server_result(&body, model_name);
+                            }
+                        } else {
+                            println!(
+                                "skipped (already exists): {model_name} — use `astra-admin model load {} --update-existing` to push YAML credentials and re-run connectivity",
+                                args.path
+                            );
+                        }
                     }
                     Err(e) => return Err(map_thin_err(e)),
                 }

--- a/rust/crates/astra-cli/src/cli/slash_router.rs
+++ b/rust/crates/astra-cli/src/cli/slash_router.rs
@@ -2,6 +2,46 @@
 
 use super::*;
 
+/// GET `/models` returns `ModelListItemResponse` with field `is_active` (snake_case).
+/// Accept legacy `active` if present; if neither is a bool, treat as active for unknown servers.
+fn model_list_entry_is_active(entry: &serde_json::Value) -> bool {
+    if let Some(v) = entry.get("is_active") {
+        if let Some(b) = v.as_bool() {
+            return b;
+        }
+        // Some gateways / hand-written JSON use 0/1 instead of booleans.
+        if let Some(n) = v.as_i64() {
+            return n != 0;
+        }
+        if let Some(n) = v.as_u64() {
+            return n != 0;
+        }
+    }
+    if let Some(b) = entry.get("active").and_then(|v| v.as_bool()) {
+        return b;
+    }
+    if let Some(n) = entry.get("active").and_then(|v| v.as_i64()) {
+        return n != 0;
+    }
+    true
+}
+
+fn model_list_entry_name(entry: &serde_json::Value) -> Option<&str> {
+    entry
+        .get("name")
+        .or_else(|| entry.get("model_name"))
+        .and_then(|v| v.as_str())
+}
+
+fn find_model_list_entry<'a>(
+    models: &'a [serde_json::Value],
+    name: &str,
+) -> Option<&'a serde_json::Value> {
+    models
+        .iter()
+        .find(|m| model_list_entry_name(m).is_some_and(|n| n.eq_ignore_ascii_case(name)))
+}
+
 /// Returns `true` when the REPL should exit.
 pub(super) async fn handle_slash_command(
     line: &str,
@@ -75,12 +115,8 @@ pub(super) async fn handle_slash_command(
                 let items: Vec<(String, String)> = models
                     .iter()
                     .filter_map(|m| {
-                        let name = m
-                            .get("name")
-                            .or_else(|| m.get("model_name"))
-                            .and_then(|v| v.as_str())?;
-                        let active = m.get("active").and_then(|v| v.as_bool()).unwrap_or(true);
-                        if !active {
+                        let name = model_list_entry_name(m)?;
+                        if !model_list_entry_is_active(m) {
                             return None;
                         }
                         let desc = m
@@ -127,16 +163,30 @@ pub(super) async fn handle_slash_command(
                             .or_else(|| value.get("models").and_then(|v| v.as_array()).cloned())
                             .unwrap_or_default();
 
+                        if let Some(entry) = find_model_list_entry(&models, arg) {
+                            if !model_list_entry_is_active(entry) {
+                                eprintln!(
+                                    "{}",
+                                    format!(
+                                        "  Model '{}' is registered but inactive (server will not use it). \
+                                         Activate it in the admin UI or fix connectivity, then retry.",
+                                        arg
+                                    )
+                                    .yellow()
+                                );
+                                return Ok(false);
+                            }
+                        }
+
                         let available: Vec<String> = models
                             .iter()
                             .filter_map(|m| {
-                                let name = m
-                                    .get("name")
-                                    .or_else(|| m.get("model_name"))
-                                    .and_then(|v| v.as_str())?;
-                                let active =
-                                    m.get("active").and_then(|v| v.as_bool()).unwrap_or(true);
-                                if active { Some(name.to_string()) } else { None }
+                                let name = model_list_entry_name(m)?;
+                                if model_list_entry_is_active(m) {
+                                    Some(name.to_string())
+                                } else {
+                                    None
+                                }
                             })
                             .collect();
 
@@ -150,6 +200,16 @@ pub(super) async fn handle_slash_command(
                                 arg,
                                 &refs,
                                 Some("/model to see available models"),
+                            );
+                            return Ok(false);
+                        }
+
+                        if !model_exists && available.is_empty() && !models.is_empty() {
+                            eprintln!(
+                                "{}",
+                                "  No active models returned by the server. \
+                                 Add or activate a model (admin), or run a connectivity check."
+                                    .yellow()
                             );
                             return Ok(false);
                         }
@@ -453,4 +513,39 @@ pub(super) async fn handle_slash_command(
     }
 
     Ok(false)
+}
+
+#[cfg(test)]
+mod model_list_json_tests {
+    use super::*;
+
+    #[test]
+    fn respects_is_active_false() {
+        let v = serde_json::json!({"name": "m", "is_active": false});
+        assert!(!model_list_entry_is_active(&v));
+    }
+
+    #[test]
+    fn respects_legacy_active_false() {
+        let v = serde_json::json!({"name": "m", "active": false});
+        assert!(!model_list_entry_is_active(&v));
+    }
+
+    #[test]
+    fn is_active_wins_over_active_when_both_present() {
+        let v = serde_json::json!({"name": "m", "is_active": false, "active": true});
+        assert!(!model_list_entry_is_active(&v));
+    }
+
+    #[test]
+    fn missing_flags_defaults_true_for_unknown_servers() {
+        let v = serde_json::json!({"name": "m"});
+        assert!(model_list_entry_is_active(&v));
+    }
+
+    #[test]
+    fn is_active_numeric_zero_means_inactive() {
+        let v = serde_json::json!({"name": "m", "is_active": 0});
+        assert!(!model_list_entry_is_active(&v));
+    }
 }

--- a/rust/crates/runtime/src/models.rs
+++ b/rust/crates/runtime/src/models.rs
@@ -81,6 +81,7 @@ pub async fn update_model_handler(
             ModelUpdateRequestData {
                 api_key: request.api_key,
                 base_url: request.base_url,
+                provider: request.provider,
                 description: request.description,
                 context_window: request.context_window,
                 max_completion_tokens: request.max_completion_tokens,

--- a/rust/crates/runtime/src/server/completions.rs
+++ b/rust/crates/runtime/src/server/completions.rs
@@ -104,9 +104,9 @@ pub(super) async fn completions_handler(
         body["max_completion_tokens"] = serde_json::json!(request.max_tokens);
     }
 
-    let url = format!(
-        "{}/chat/completions",
-        resolved.base_url.trim_end_matches('/')
+    let url = crate::turn::llm_client::llm_completions_url_for_provider(
+        &resolved.base_url,
+        &resolved.provider,
     );
 
     let client = reqwest::Client::builder()

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -1034,6 +1034,8 @@ async fn call_llm_stream(
         .build()
         .map_err(|e| e.to_string())?;
 
+    let messages = crate::turn::llm_client::consolidate_system_messages(messages);
+
     let mut body = json!({
         "model": model_name,
         "messages": messages,
@@ -1058,7 +1060,7 @@ async fn call_llm_stream(
         body["tool_choice"] = Value::String("auto".to_string());
     }
 
-    let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
+    let url = crate::turn::llm_client::llm_completions_url_for_provider(base_url, provider);
 
     // Retry loop for transient errors (429 rate limit, 5xx server errors, network)
     let mut last_err = String::new();
@@ -1110,6 +1112,7 @@ async fn call_llm_stream(
                 let cc = client_cancel.clone();
                 let mut full_text = String::new();
                 let mut reasoning = String::new();
+                let mut in_think_block = false;
                 let mut tool_calls_map: std::collections::HashMap<usize, Map<String, Value>> =
                     std::collections::HashMap::new();
                 let mut usage = Map::new();
@@ -1273,11 +1276,19 @@ async fn call_llm_stream(
                                 .and_then(Value::as_object)
                             else { continue };
 
-                            // Text content
+                            // Text content — split out <think>...</think> blocks into reasoning_delta.
+                            // Models like MiniMax embed thinking in content with <think> tags.
                             if let Some(content) = delta.get("content").and_then(Value::as_str)
                                 && !content.is_empty() {
-                                    full_text.push_str(content);
-                                    yield render_sse(&json!({"type": "text_delta", "content": content}));
+                                    for (chunk, is_think) in crate::turn::llm_client::split_think_chunks(content, &mut in_think_block) {
+                                        if is_think {
+                                            reasoning.push_str(&chunk);
+                                            yield render_sse(&json!({"type": "reasoning_delta", "content": chunk}));
+                                        } else {
+                                            full_text.push_str(&chunk);
+                                            yield render_sse(&json!({"type": "text_delta", "content": chunk}));
+                                        }
+                                    }
                                 }
 
                             // Reasoning (DeepSeek / o1 style)

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -293,12 +293,187 @@ fn llm_total_budget() -> std::time::Duration {
     std::time::Duration::from_secs(s)
 }
 
-fn llm_completions_url(base_url: &str, override_url: Option<&str>) -> String {
+fn llm_completions_url(base_url: &str, override_url: Option<&str>, provider: &str) -> String {
     override_url
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(String::from)
-        .unwrap_or_else(|| format!("{}/chat/completions", base_url.trim_end_matches('/')))
+        .unwrap_or_else(|| llm_completions_url_for_provider(base_url, provider))
+}
+
+/// Build the default completions URL for a given provider (no override).
+///
+/// Anthropic uses `/v1/messages`, all others use `/chat/completions`.
+pub(crate) fn llm_completions_url_for_provider(base_url: &str, provider: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    if provider == "anthropic" {
+        // Match anthropic_messages_probe_url logic in services/models.rs
+        if base.ends_with("/v1") {
+            format!("{base}/messages")
+        } else {
+            format!("{base}/v1/messages")
+        }
+    } else {
+        format!("{base}/chat/completions")
+    }
+}
+
+/// Merge all system-role messages into a single leading system message.
+///
+/// Some providers (e.g. MiniMax) reject conversations where system messages
+/// appear after the first position. This function collects every system
+/// message, concatenates their content with `\n\n`, and places the result
+/// as the first message. All non-system messages keep their original order.
+pub(crate) fn consolidate_system_messages(messages: &[Value]) -> Vec<Value> {
+    let mut system_parts: Vec<&str> = Vec::new();
+    let mut rest: Vec<Value> = Vec::new();
+
+    for msg in messages {
+        if msg.get("role").and_then(|r| r.as_str()) == Some("system") {
+            if let Some(text) = msg.get("content").and_then(|c| c.as_str()) {
+                if !text.is_empty() {
+                    system_parts.push(text);
+                }
+            }
+        } else {
+            rest.push(msg.clone());
+        }
+    }
+
+    let mut out = Vec::with_capacity(1 + rest.len());
+    if !system_parts.is_empty() {
+        out.push(json!({"role": "system", "content": system_parts.join("\n\n")}));
+    }
+    out.extend(rest);
+
+    // Sanitize assistant messages: fix tool_calls with empty function names.
+    // Some providers (e.g. MiniMax) reject messages containing tool_calls
+    // where the function name is empty (can happen when skill interception
+    // captures a call before the streaming name chunk arrives).
+    //
+    // Build a lookup from tool_call_id → tool name from tool-result messages
+    // so we can recover the correct name when possible.
+    let tool_name_by_id: HashMap<String, String> = out
+        .iter()
+        .filter(|m| m.get("role").and_then(|r| r.as_str()) == Some("tool"))
+        .filter_map(|m| {
+            let id = m.get("tool_call_id").and_then(Value::as_str)?.to_string();
+            let name = m.get("name").and_then(Value::as_str)?.to_string();
+            Some((id, name))
+        })
+        .collect();
+
+    for msg in &mut out {
+        if msg.get("role").and_then(|r| r.as_str()) != Some("assistant") {
+            continue;
+        }
+        let Some(tcs) = msg.get_mut("tool_calls").and_then(Value::as_array_mut) else {
+            continue;
+        };
+        for tc in tcs.iter_mut() {
+            let call_id = tc
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            if let Some(func) = tc.get_mut("function") {
+                let name = func.get("name").and_then(Value::as_str).unwrap_or("");
+                if name.is_empty() {
+                    let recovered = tool_name_by_id
+                        .get(&call_id)
+                        .map(|s| s.as_str())
+                        .unwrap_or("_unknown");
+                    if let Some(f) = func.as_object_mut() {
+                        f.insert("name".to_string(), Value::String(recovered.to_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    out
+}
+
+/// Split a streaming content chunk into (text, is_reasoning) segments,
+/// tracking whether we're inside a `<think>` block across chunks.
+///
+/// Returns a vec of (chunk_str, is_reasoning) pairs. Callers should route
+/// is_reasoning=true chunks to `reasoning_delta` and false to `text_delta`.
+pub(crate) fn split_think_chunks(content: &str, in_think: &mut bool) -> Vec<(String, bool)> {
+    let mut out = Vec::new();
+    let mut pos = 0;
+    let len = content.len();
+
+    while pos < len {
+        if *in_think {
+            if let Some(end) = content[pos..].find("</think>") {
+                let abs_end = pos + end;
+                if abs_end > pos {
+                    out.push((content[pos..abs_end].to_string(), true));
+                }
+                *in_think = false;
+                pos = abs_end + "</think>".len();
+            } else {
+                out.push((content[pos..].to_string(), true));
+                pos = len;
+            }
+        } else {
+            if let Some(start) = content[pos..].find("<think>") {
+                let abs_start = pos + start;
+                if abs_start > pos {
+                    out.push((content[pos..abs_start].to_string(), false));
+                }
+                *in_think = true;
+                pos = abs_start + "<think>".len();
+            } else {
+                out.push((content[pos..].to_string(), false));
+                pos = len;
+            }
+        }
+    }
+    out
+}
+
+/// Extract `<think>...</think>` blocks from text, returning (reasoning, cleaned_text).
+///
+/// Some models (e.g. MiniMax) embed reasoning in content using `<think>` tags
+/// instead of a separate `reasoning_content` streaming field. This extracts
+/// all `<think>` blocks into reasoning and returns the remaining text.
+fn extract_think_tags(text: &str) -> Option<(String, String)> {
+    if !text.contains("<think>") {
+        return None;
+    }
+    let mut reasoning = String::new();
+    let mut cleaned = String::new();
+    let mut pos = 0;
+    while let Some(start) = text[pos..].find("<think>") {
+        let abs_start = pos + start;
+        cleaned.push_str(&text[pos..abs_start]);
+        if let Some(end) = text[abs_start..].find("</think>") {
+            let abs_end = abs_start + end + "</think>".len();
+            let inner = &text[abs_start + "<think>".len()..abs_start + end];
+            if !reasoning.is_empty() {
+                reasoning.push('\n');
+            }
+            reasoning.push_str(inner.trim());
+            pos = abs_end;
+        } else {
+            // Unclosed <think> — treat rest as reasoning
+            let inner = &text[abs_start + "<think>".len()..];
+            if !reasoning.is_empty() {
+                reasoning.push('\n');
+            }
+            reasoning.push_str(inner.trim());
+            pos = text.len();
+        }
+    }
+    cleaned.push_str(&text[pos..]);
+    let cleaned = cleaned.trim().to_string();
+    if reasoning.is_empty() {
+        None
+    } else {
+        Some((reasoning, cleaned))
+    }
 }
 
 fn apply_llm_header_overrides(
@@ -403,6 +578,11 @@ pub(crate) async fn call_llm_and_collect_with_request_overrides(
     let total_budget = llm_total_budget();
     let client = global_llm_client();
 
+    // Consolidate system messages: merge all system-role messages into the first
+    // one, converting extras to a single leading system message. Some providers
+    // (e.g. MiniMax) reject system messages after the first position.
+    let messages = consolidate_system_messages(messages);
+
     let mut body = json!({
         "model": model_name,
         "messages": messages,
@@ -423,7 +603,7 @@ pub(crate) async fn call_llm_and_collect_with_request_overrides(
         body["tool_choice"] = Value::String("auto".to_string());
     }
 
-    let url = llm_completions_url(base_url, completions_url_override);
+    let url = llm_completions_url(base_url, completions_url_override, provider);
 
     let mut last_err = String::new();
     let mut last_kind = astra_core::ErrorKind::Unknown;
@@ -597,7 +777,7 @@ pub(crate) async fn call_llm_and_collect_with_request_overrides(
                     );
                     return call_llm_nonstream_fallback_with_request_overrides(
                         client,
-                        messages,
+                        &messages,
                         tools,
                         model_name,
                         api_key,
@@ -916,6 +1096,16 @@ async fn collect_llm_stream(
         }
     }
 
+    // Extract <think>...</think> blocks from content into reasoning.
+    // Models like MiniMax embed thinking in content with <think> tags
+    // instead of using a separate reasoning_content field.
+    if reasoning.is_empty() {
+        if let Some((extracted_reasoning, cleaned_text)) = extract_think_tags(&full_text) {
+            reasoning = extracted_reasoning;
+            full_text = cleaned_text;
+        }
+    }
+
     Ok(LlmCallResult {
         full_text,
         reasoning,
@@ -1010,6 +1200,9 @@ pub(crate) async fn call_llm_nonstream_fallback_with_request_overrides(
     request_timeout: Option<std::time::Duration>,
 ) -> Result<LlmCallResult, astra_core::ClassifiedError> {
     let started = Instant::now();
+
+    let messages = consolidate_system_messages(messages);
+
     let mut body = json!({
         "model": model_name,
         "messages": messages,
@@ -1027,7 +1220,7 @@ pub(crate) async fn call_llm_nonstream_fallback_with_request_overrides(
         body["tool_choice"] = Value::String("auto".to_string());
     }
 
-    let url = llm_completions_url(base_url, completions_url_override);
+    let url = llm_completions_url(base_url, completions_url_override, provider);
     let mut req = client.post(&url).header("content-type", "application/json");
     if provider == "anthropic" {
         if !has_llm_auth_override(provider, header_overrides) {
@@ -1140,6 +1333,13 @@ fn parse_nonstream_response(v: &Value, model_name: &str, started: Instant) -> Ll
             );
             full_text = super::xml_tool_call_fallback::strip_degraded_tool_calls(&full_text);
             tool_calls = parsed;
+        }
+    }
+
+    if reasoning.is_empty() {
+        if let Some((extracted_reasoning, cleaned_text)) = extract_think_tags(&full_text) {
+            reasoning = extracted_reasoning;
+            full_text = cleaned_text;
         }
     }
 
@@ -2551,5 +2751,432 @@ mod tests {
         .expect_err("should fail with auth");
         assert_eq!(err.kind, astra_core::ErrorKind::Auth);
         unsafe { std::env::remove_var("MO_STREAM_IDLE_TIMEOUT_MS") };
+    }
+
+    #[test]
+    fn completions_url_openai_default() {
+        assert_eq!(
+            llm_completions_url("https://api.openai.com/v1", None, "openai"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn completions_url_openai_trailing_slash() {
+        assert_eq!(
+            llm_completions_url("https://api.openai.com/v1/", None, "openai"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn completions_url_anthropic_without_v1() {
+        assert_eq!(
+            llm_completions_url("https://api.minimaxi.com/anthropic", None, "anthropic"),
+            "https://api.minimaxi.com/anthropic/v1/messages"
+        );
+    }
+
+    #[test]
+    fn completions_url_anthropic_with_v1() {
+        assert_eq!(
+            llm_completions_url("https://api.anthropic.com/v1", None, "anthropic"),
+            "https://api.anthropic.com/v1/messages"
+        );
+    }
+
+    #[test]
+    fn completions_url_override_takes_precedence() {
+        assert_eq!(
+            llm_completions_url(
+                "https://api.openai.com/v1",
+                Some("https://custom.proxy/llm"),
+                "openai"
+            ),
+            "https://custom.proxy/llm"
+        );
+    }
+
+    #[test]
+    fn consolidate_system_messages_merges_multiple() {
+        let msgs = vec![
+            json!({"role": "system", "content": "A"}),
+            json!({"role": "system", "content": "B"}),
+            json!({"role": "user", "content": "hi"}),
+            json!({"role": "system", "content": "C"}),
+        ];
+        let out = consolidate_system_messages(&msgs);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0]["role"], "system");
+        assert_eq!(out[0]["content"], "A\n\nB\n\nC");
+        assert_eq!(out[1]["role"], "user");
+        assert_eq!(out[1]["content"], "hi");
+    }
+
+    #[test]
+    fn consolidate_system_messages_single_system_unchanged() {
+        let msgs = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hi"}),
+        ];
+        let out = consolidate_system_messages(&msgs);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0]["content"], "sys");
+    }
+
+    #[test]
+    fn consolidate_system_messages_no_system() {
+        let msgs = vec![json!({"role": "user", "content": "hi"})];
+        let out = consolidate_system_messages(&msgs);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["role"], "user");
+    }
+
+    #[test]
+    fn consolidate_fixes_empty_tool_call_name() {
+        let msgs = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "", "arguments": "{}"}}]
+            }),
+            json!({"role": "tool", "tool_call_id": "c1", "name": "skill", "content": "result"}),
+        ];
+        let out = consolidate_system_messages(&msgs);
+        // assistant tool_call name should be recovered from tool result
+        let tc_name = out[1]["tool_calls"][0]["function"]["name"]
+            .as_str()
+            .unwrap();
+        assert_eq!(tc_name, "skill");
+    }
+
+    #[test]
+    fn consolidate_fixes_empty_tool_call_name_unknown_fallback() {
+        let msgs = vec![json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "", "arguments": "{}"}}]
+        })];
+        let out = consolidate_system_messages(&msgs);
+        let tc_name = out[0]["tool_calls"][0]["function"]["name"]
+            .as_str()
+            .unwrap();
+        assert_eq!(tc_name, "_unknown");
+    }
+
+    #[test]
+    fn for_provider_openai() {
+        assert_eq!(
+            llm_completions_url_for_provider("https://api.openai.com/v1", "openai"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn for_provider_anthropic_without_v1() {
+        assert_eq!(
+            llm_completions_url_for_provider("https://api.minimaxi.com/anthropic", "anthropic"),
+            "https://api.minimaxi.com/anthropic/v1/messages"
+        );
+    }
+
+    #[test]
+    fn for_provider_anthropic_with_v1() {
+        assert_eq!(
+            llm_completions_url_for_provider("https://api.anthropic.com/v1", "anthropic"),
+            "https://api.anthropic.com/v1/messages"
+        );
+    }
+
+    // ── Golden cases: real provider SSE fixtures ──────────────────────────────
+    //
+    // Fixtures captured from live APIs and stored in testdata/. Each test
+    // feeds the raw SSE bytes through collect_llm_stream and asserts on the
+    // parsed LlmCallResult, providing regression coverage for:
+    //   - <think> tag extraction (MiniMax M2.5/M2.7)
+    //   - reasoning_content field (Qwen3.6-plus, Kimi-k2.5)
+    //   - tool_call streaming accumulation (MiniMax M2.5, Qwen-plus)
+    //   - full_text / reasoning split correctness
+
+    fn load_fixture(name: &str) -> Bytes {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/turn/testdata")
+            .join(name);
+        Bytes::from(std::fs::read(path).expect("fixture file missing"))
+    }
+
+    async fn parse_fixture(name: &str) -> LlmCallResult {
+        unsafe { std::env::set_var("MO_STREAM_IDLE_TIMEOUT_MS", "60000") };
+        let bytes = load_fixture(name);
+        let stream = stream::iter(vec![Ok::<_, reqwest::Error>(bytes)]);
+        let result = collect_llm_stream(
+            stream,
+            "test-model",
+            Instant::now(),
+            LlmCancel::None,
+            stream_idle_timeout(),
+            stream_idle_timeout_after_progress(),
+        )
+        .await
+        .expect("collect");
+        unsafe { std::env::remove_var("MO_STREAM_IDLE_TIMEOUT_MS") };
+        result
+    }
+
+    #[tokio::test]
+    #[serial(stream_idle_env)]
+    async fn golden_minimax_m25_simple_think_extracted() {
+        // MiniMax M2.5: <think> in delta.content → reasoning extracted, full_text clean
+        let res = parse_fixture("minimax_m25_simple.sse").await;
+        assert!(
+            !res.reasoning.is_empty(),
+            "reasoning should be extracted from <think> tags"
+        );
+        assert!(
+            !res.full_text.contains("<think>"),
+            "full_text must not contain <think>"
+        );
+        assert!(
+            !res.full_text.contains("</think>"),
+            "full_text must not contain </think>"
+        );
+        assert!(
+            !res.full_text.is_empty(),
+            "full_text should have the answer"
+        );
+        assert!(res.tool_calls.is_empty());
+    }
+
+    #[tokio::test]
+    #[serial(stream_idle_env)]
+    async fn golden_minimax_m27_simple_think_extracted() {
+        // MiniMax M2.7: same <think> pattern, verify reasoning/text split
+        let res = parse_fixture("minimax_m27_simple.sse").await;
+        assert!(
+            !res.reasoning.is_empty(),
+            "reasoning should be extracted from <think> tags"
+        );
+        assert!(
+            !res.full_text.contains("<think>"),
+            "full_text must not contain <think>"
+        );
+        assert!(
+            !res.full_text.contains("</think>"),
+            "full_text must not contain </think>"
+        );
+        assert!(
+            !res.full_text.is_empty(),
+            "full_text should have the answer"
+        );
+    }
+
+    #[tokio::test]
+    #[serial(stream_idle_env)]
+    async fn golden_qwen36plus_reasoning_content_field() {
+        // Qwen3.6-plus: reasoning via delta.reasoning_content (not <think> tags)
+        let res = parse_fixture("qwen36plus_simple.sse").await;
+        assert!(
+            !res.reasoning.is_empty(),
+            "reasoning_content field should be captured"
+        );
+        assert!(
+            !res.full_text.is_empty(),
+            "full_text should have the answer"
+        );
+        assert!(res.full_text.contains('4'), "answer to 2+2 should be 4");
+        assert!(
+            !res.full_text.contains("<think>"),
+            "no think tags in qwen output"
+        );
+    }
+
+    #[tokio::test]
+    #[serial(stream_idle_env)]
+    async fn golden_kimi_k25_reasoning_content_field() {
+        // Kimi-k2.5: reasoning via delta.reasoning_content
+        let res = parse_fixture("kimi_k25_simple.sse").await;
+        assert!(
+            !res.reasoning.is_empty(),
+            "reasoning_content field should be captured"
+        );
+        assert!(
+            !res.full_text.is_empty(),
+            "full_text should have the answer"
+        );
+        assert!(res.full_text.contains('4'), "answer to 2+2 should be 4");
+    }
+
+    #[tokio::test]
+    #[serial(stream_idle_env)]
+    async fn golden_minimax_m25_tool_call_with_think() {
+        // MiniMax M2.5 tool call: <think> in content + tool_calls in delta
+        let res = parse_fixture("minimax_m25_tool_call.sse").await;
+        assert!(!res.tool_calls.is_empty(), "should have tool calls");
+        let tc = &res.tool_calls[0];
+        let name = tc["function"]["name"].as_str().unwrap_or("");
+        assert_eq!(name, "bash", "tool name should be bash");
+        let args = tc["function"]["arguments"].as_str().unwrap_or("");
+        assert!(
+            args.contains("command"),
+            "args must contain 'command' key, got: {args:?}"
+        );
+        // think content should be in reasoning, not full_text
+        assert!(
+            !res.full_text.contains("<think>"),
+            "full_text must not contain <think>"
+        );
+    }
+
+    #[tokio::test]
+    #[serial(stream_idle_env)]
+    async fn golden_qwen_plus_tool_call_no_reasoning() {
+        // Qwen-plus: pure tool call, no reasoning
+        let res = parse_fixture("qwen_plus_tool_call.sse").await;
+        assert!(!res.tool_calls.is_empty(), "should have tool calls");
+        let tc = &res.tool_calls[0];
+        let name = tc["function"]["name"].as_str().unwrap_or("");
+        assert!(!name.is_empty(), "tool name must not be empty");
+        assert!(
+            res.reasoning.is_empty(),
+            "qwen-plus tool call should have no reasoning"
+        );
+    }
+
+    // ── split_think_chunks (real MiniMax M2.7 streaming patterns) ────────────
+
+    #[test]
+    fn split_think_chunks_think_in_first_chunk() {
+        // MiniMax M2.7 real: first chunk starts with <think>
+        let mut in_think = false;
+        let chunks = split_think_chunks("<think>\nThe user says \"hi\".", &mut in_think);
+        assert!(in_think, "should be inside think block");
+        assert_eq!(chunks, vec![("\nThe user says \"hi\".".to_string(), true)]);
+    }
+
+    #[test]
+    fn split_think_chunks_think_closes_mid_chunk() {
+        // MiniMax M2.7 real: last chunk closes </think> and has reply
+        let mut in_think = true;
+        let chunks = split_think_chunks(
+            " Use friendly tone.\n</think>\n\nHello! How can I help you today?",
+            &mut in_think,
+        );
+        assert!(!in_think, "should be outside think block after close");
+        assert_eq!(
+            chunks,
+            vec![
+                (" Use friendly tone.\n".to_string(), true),
+                ("\n\nHello! How can I help you today?".to_string(), false),
+            ]
+        );
+    }
+
+    #[test]
+    fn split_think_chunks_no_think_tags() {
+        // Normal model response without thinking
+        let mut in_think = false;
+        let chunks = split_think_chunks("Hello! How can I help?", &mut in_think);
+        assert!(!in_think);
+        assert_eq!(chunks, vec![("Hello! How can I help?".to_string(), false)]);
+    }
+
+    #[test]
+    fn split_think_chunks_full_think_in_one_chunk() {
+        // Entire think block in a single chunk (non-streaming scenario)
+        let mut in_think = false;
+        let chunks = split_think_chunks("<think>reasoning here</think>\n\nAnswer.", &mut in_think);
+        assert!(!in_think);
+        assert_eq!(
+            chunks,
+            vec![
+                ("reasoning here".to_string(), true),
+                ("\n\nAnswer.".to_string(), false),
+            ]
+        );
+    }
+
+    #[test]
+    fn split_think_chunks_state_persists_across_calls() {
+        // Simulate MiniMax M2.7 multi-chunk stream
+        let mut in_think = false;
+        // chunk 1: opens think
+        let c1 = split_think_chunks("<think>\nThe user says \"hi\".", &mut in_think);
+        assert!(in_think);
+        assert!(c1[0].1);
+        // chunk 2: still inside think
+        let c2 = split_think_chunks(" Should be concise.", &mut in_think);
+        assert!(in_think);
+        assert_eq!(c2, vec![(" Should be concise.".to_string(), true)]);
+        // chunk 3: closes think and has reply
+        let c3 = split_think_chunks("</think>\n\nHello!", &mut in_think);
+        assert!(!in_think);
+        assert_eq!(c3, vec![("\n\nHello!".to_string(), false),]);
+    }
+
+    #[test]
+    fn split_think_chunks_multi_phase_reasoning() {
+        // Some models emit multiple <think> phases in one stream.
+        // Verify in_think correctly toggles false→true→false→true→false.
+        let mut in_think = false;
+        // Phase 1
+        let c1 = split_think_chunks("<think>phase one</think>text one", &mut in_think);
+        assert!(!in_think);
+        assert_eq!(
+            c1,
+            vec![
+                ("phase one".to_string(), true),
+                ("text one".to_string(), false),
+            ]
+        );
+        // Phase 2 — in_think was false, starts a new think block
+        let c2 = split_think_chunks("<think>phase two</think>text two", &mut in_think);
+        assert!(!in_think);
+        assert_eq!(
+            c2,
+            vec![
+                ("phase two".to_string(), true),
+                ("text two".to_string(), false),
+            ]
+        );
+        // Phase 3 — split across chunks
+        let c3a = split_think_chunks("<think>phase three start", &mut in_think);
+        assert!(in_think);
+        assert_eq!(c3a, vec![("phase three start".to_string(), true)]);
+        let c3b = split_think_chunks(" phase three end</think>final", &mut in_think);
+        assert!(!in_think);
+        assert_eq!(
+            c3b,
+            vec![
+                (" phase three end".to_string(), true),
+                ("final".to_string(), false),
+            ]
+        );
+    }
+
+    // ── extract_think_tags (post-collection cleanup) ──────────────────────────
+
+    #[test]
+    fn extract_think_tags_minimax_real_pattern() {
+        // Real MiniMax M2.7 full_text after stream collection
+        let text = "<think>\nThe user says \"hi\". Should be concise.\n</think>\n\nHello! How can I help you today?";
+        let (reasoning, cleaned) = extract_think_tags(text).unwrap();
+        assert_eq!(reasoning, "The user says \"hi\". Should be concise.");
+        assert_eq!(cleaned, "Hello! How can I help you today?");
+    }
+
+    #[test]
+    fn extract_think_tags_no_think_returns_none() {
+        assert!(extract_think_tags("Hello! How can I help?").is_none());
+    }
+
+    #[test]
+    fn extract_think_tags_skips_when_reasoning_already_set() {
+        // extract_think_tags is only called when reasoning.is_empty(),
+        // so this just verifies the function itself works correctly
+        let text = "<think>step 1</think>answer";
+        let (r, c) = extract_think_tags(text).unwrap();
+        assert_eq!(r, "step 1");
+        assert_eq!(c, "answer");
     }
 }

--- a/rust/crates/runtime/src/turn/testdata/kimi_k25_simple.sse
+++ b/rust/crates/runtime/src/turn/testdata/kimi_k25_simple.sse
@@ -1,0 +1,392 @@
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "The"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " user"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " is"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " asking"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " a"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " simple"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " math"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " question"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ":"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " \""}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "What"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " is"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " "}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "2"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "+"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "2"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "?\""}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " This"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " is"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " a"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " straightforward"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " arithmetic"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " problem"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "."}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " The"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " answer"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " is"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " "}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "4"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ".\n\n"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "However"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ","}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " I"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " should"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " consider"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " if"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " there's"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " any"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " trick"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " or"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " nu"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "ance"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " here"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "."}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " Sometimes"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " this"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " question"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " is"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " used"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " to"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " test"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ":\n"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "1"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "."}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " Basic"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " arithmetic"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " capabilities"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "\n"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "2"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "."}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " Whether"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " the"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " AI"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " will"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " give"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " a"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " straightforward"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " answer"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "\n"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "3"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "."}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " Potential"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " for"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " \""}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "2"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "+"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "2"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "="}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "5"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "\""}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " type"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " references"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " ("}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "from"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " Or"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "well"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "'s"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " "}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "198"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "4"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " or"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " as"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " a"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " joke"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " about"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " authoritarian"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "ism"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "/ob"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "vious"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " false"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "hood"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "s"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ")\n\n"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "Given"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " that"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " this"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " is"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " likely"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " a"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " simple"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " test"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " question"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " or"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " a"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " genuine"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " query"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ","}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " I"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " should"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " provide"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " the"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " correct"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " mathematical"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " answer"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ":"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " "}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "4"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ".\n\n"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "I"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " should"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " be"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " direct"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " and"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " helpful"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "."}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " No"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " need"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " for"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " over"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "com"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "plication"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " unless"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " the"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " user"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " is"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " clearly"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " looking"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " for"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " something"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " else"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " ("}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "like"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " a"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " discussion"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " about"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " base"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " systems"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ","}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " where"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " "}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "2"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "+"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "2"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " could"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " equal"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " other"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " values"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " in"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " different"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " bases"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ","}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " but"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " that's"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " likely"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " over"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "thinking"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " it"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ").\n\n"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "Simple"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " answer"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": ":"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": " "}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "4"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"reasoning_content": "."}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"content": "2"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"content": " +"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"content": " "}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"content": "2"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"content": " ="}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"content": " **"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"content": "4"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {"content": "**"}, "finish_reason": null}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop", "usage": {"prompt_tokens": 14, "completion_tokens": 195, "total_tokens": 209, "cached_tokens": 14, "prompt_tokens_details": {"cached_tokens": 14}}}], "system_fingerprint": "fpv0_9b99c4d3"}
+
+data: {"id": "test-id-redacted", "object": "chat.completion.chunk", "created": 0, "model": "kimi-k2.5", "choices": [], "usage": {"prompt_tokens": 14, "completion_tokens": 195, "total_tokens": 209, "cached_tokens": 14, "prompt_tokens_details": {"cached_tokens": 14}}}
+
+data: [DONE]
+

--- a/rust/crates/runtime/src/turn/testdata/minimax_m25_simple.sse
+++ b/rust/crates/runtime/src/turn/testdata/minimax_m25_simple.sse
@@ -1,0 +1,18 @@
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": "<think>", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": "The user asks: \"What is 2+2?\" It's a simple arithmetic question. Should answer 4. There's no policy issue. Just respond with answer: 2+2 = 4.\n\nWe must consider whether any special context: no. So answer is 4. Probably include a short explanation? There's", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": " no policy restrictions. Just answer.\n\nThus final answer: The sum of 2 and 2 is 4.\n", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": "</think>", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": "", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": "\n\nThe sum of 2 and 2 is 4.", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"finish_reason": "stop", "index": 0, "delta": {"role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": {"total_tokens": 148, "total_characters": 0, "prompt_tokens": 45, "completion_tokens": 103, "prompt_tokens_details": {"cached_tokens": 16}}, "base_resp": {"status_code": 0, "status_msg": ""}}
+

--- a/rust/crates/runtime/src/turn/testdata/minimax_m25_tool_call.sse
+++ b/rust/crates/runtime/src/turn/testdata/minimax_m25_tool_call.sse
@@ -1,0 +1,22 @@
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": "<think>", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": "The user is asking me to list files in the /tmp directory. I need to run a shell command to do this. I'll use the `ls` command with the `-la` flags to show all files including hidden ones with detailed", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": " information.\n", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": "</think>", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": "", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": "\n\n\n", "role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"role": "assistant", "tool_calls": [{"id": "call_function_7d8nzyix424r_1", "type": "function", "function": {"name": "bash", "arguments": ""}, "index": 0}]}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"role": "assistant", "tool_calls": [{"function": {"arguments": "{\"command\": \"ls -la /tmp\"}"}, "index": 0}]}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"finish_reason": "tool_calls", "index": 0, "delta": {"role": "assistant"}}], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [], "created": 0, "model": "MiniMax-M2.5", "object": "chat.completion.chunk", "usage": {"total_tokens": 265, "total_characters": 0, "prompt_tokens": 187, "completion_tokens": 78, "prompt_tokens_details": {"cached_tokens": 48}}, "base_resp": {"status_code": 0, "status_msg": ""}}
+

--- a/rust/crates/runtime/src/turn/testdata/minimax_m27_simple.sse
+++ b/rust/crates/runtime/src/turn/testdata/minimax_m27_simple.sse
@@ -1,0 +1,10 @@
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": "<think>\nThe user", "role": "assistant", "name": "MiniMax AI", "audio_content": ""}}], "created": 0, "model": "MiniMax-M2.7", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": " asks \"What is 2+2?\" Simple arithmetic. The answer is 4.\n\nI", "role": "assistant", "name": "MiniMax AI", "audio_content": ""}}], "created": 0, "model": "MiniMax-M2.7", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"index": 0, "delta": {"content": " should respond concisely: \"2 + 2 = 4.\"\n\nGiven the user likely expects a direct answer.\n\nCheck for any policy issues: none.\n\nI'll respond.", "role": "assistant", "name": "MiniMax AI", "audio_content": ""}}], "created": 0, "model": "MiniMax-M2.7", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [{"finish_reason": "stop", "index": 0, "delta": {"content": "\n</think>\n\n\\(2 + 2 = 4\\)", "role": "assistant", "name": "MiniMax AI", "audio_content": ""}}], "created": 0, "model": "MiniMax-M2.7", "object": "chat.completion.chunk", "usage": null, "input_sensitive": false, "output_sensitive": false, "input_sensitive_type": 0, "output_sensitive_type": 0, "output_sensitive_int": 0}
+
+data: {"id": "test-id-redacted", "choices": [], "created": 0, "model": "MiniMax-M2.7", "object": "chat.completion.chunk", "usage": {"total_tokens": 116, "total_characters": 0, "prompt_tokens": 48, "completion_tokens": 68, "completion_tokens_details": {"reasoning_tokens": 58}}, "base_resp": {"status_code": 0, "status_msg": ""}}
+

--- a/rust/crates/runtime/src/turn/testdata/qwen36plus_simple.sse
+++ b/rust/crates/runtime/src/turn/testdata/qwen36plus_simple.sse
@@ -1,0 +1,74 @@
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "Here", "role": "assistant"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "'s a thinking process"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": ":\n\n1."}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "  **Analyze"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " User Input:** The"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " user asks \""}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "What is 2"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "+2?\"\n"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "2.  **"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "Identify Core Task"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": ":** This is a"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " basic arithmetic"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " question.\n3"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": ".  **Perform"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " Calculation:** 2"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " + 2 ="}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " 4.\n"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "4.  **"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "Formulate Response:**"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " State the answer clearly"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " and concisely"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": ".\n"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "5.  **"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "Final"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " Output Generation:** \""}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": "2 + 2"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " = 4\""}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " or \"The answer"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " is 4.\""}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " (Keep it simple"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": null, "reasoning_content": " and direct).\n"}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": "2 +", "reasoning_content": null}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": " 2 = ", "reasoning_content": null}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"delta": {"content": "4", "reasoning_content": null}, "finish_reason": null, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [{"finish_reason": "stop", "delta": {"content": "", "reasoning_content": null}, "index": 0, "logprobs": null}], "object": "chat.completion.chunk", "usage": null, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: {"choices": [], "object": "chat.completion.chunk", "usage": {"prompt_tokens": 17, "completion_tokens": 124, "total_tokens": 141, "completion_tokens_details": {"reasoning_tokens": 112, "text_tokens": 124}, "prompt_tokens_details": {"text_tokens": 17}}, "created": 0, "system_fingerprint": null, "model": "qwen3.6-plus", "id": "test-id-redacted"}
+
+data: [DONE]
+

--- a/rust/crates/runtime/src/turn/testdata/qwen_plus_tool_call.sse
+++ b/rust/crates/runtime/src/turn/testdata/qwen_plus_tool_call.sse
@@ -1,0 +1,14 @@
+data: {"model": "qwen-plus", "id": "test-id-redacted", "created": 0, "object": "chat.completion.chunk", "usage": null, "choices": [{"logprobs": null, "index": 0, "delta": {"content": "", "role": "assistant", "tool_calls": [{"index": 0, "id": "call_ab87038c7d8a4a338bea4b", "type": "function", "function": {"name": "bash", "arguments": ""}}]}}]}
+
+data: {"model": "qwen-plus", "id": "test-id-redacted", "choices": [{"delta": {"content": "", "tool_calls": [{"index": 0, "id": "call_ab87038c7d8a4a338bea4b", "type": "function", "function": {"name": "", "arguments": "{\"command\": \"ls"}}], "role": null}, "index": 0}], "created": 0, "object": "chat.completion.chunk", "usage": null}
+
+data: {"model": "qwen-plus", "id": "test-id-redacted", "choices": [{"delta": {"content": "", "tool_calls": [{"index": 0, "id": "", "type": "function", "function": {"arguments": " -la /tmp\"}"}}], "role": null}, "index": 0}], "created": 0, "object": "chat.completion.chunk", "usage": null}
+
+data: {"model": "qwen-plus", "id": "test-id-redacted", "choices": [{"delta": {"tool_calls": [{"function": {"arguments": null}, "index": 0, "id": "", "type": "function"}], "content": ""}, "index": 0}], "created": 0, "object": "chat.completion.chunk", "usage": null}
+
+data: {"model": "qwen-plus", "id": "test-id-redacted", "choices": [{"delta": {}, "index": 0, "finish_reason": "tool_calls"}], "created": 0, "object": "chat.completion.chunk", "usage": null}
+
+data: {"model": "qwen-plus", "id": "test-id-redacted", "choices": [], "created": 0, "object": "chat.completion.chunk", "usage": {"total_tokens": 169, "completion_tokens": 22, "prompt_tokens": 147, "prompt_tokens_details": {"cached_tokens": 0}}}
+
+data: [DONE]
+

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -67,6 +67,7 @@ pub struct ModelCreateRequestData {
 pub struct ModelUpdateRequestData {
     pub api_key: Option<String>,
     pub base_url: Option<String>,
+    pub provider: Option<String>,
     pub description: Option<String>,
     pub context_window: Option<i32>,
     pub max_completion_tokens: Option<i32>,
@@ -123,62 +124,10 @@ pub struct ResolvedActiveLlmModel {
     pub fallback_model: Option<String>,
 }
 
-/// Resolve the active LLM model from the database for in-process / server-side callers.
-///
-/// If `preferred` is `Some(name)`, selects that model when `is_active = 1`; otherwise uses
-/// the lexicographically first active model. When `pool` is `None`, opens an ephemeral
-/// single-connection pool from `matrixone`.
-///
-/// Also extracts `fallback_model` from the `quirks` JSON column (cloud-managed config).
-pub async fn resolve_active_llm_model(
-    matrixone: &MatrixOneSettings,
+fn build_resolved_active_llm_from_row(
+    row: &sqlx::mysql::MySqlRow,
     encryptor: &FernetTokenEncryptor,
-    preferred: Option<&str>,
-    pool: Option<&sqlx::Pool<sqlx::MySql>>,
 ) -> Result<ResolvedActiveLlmModel, String> {
-    let ephemeral;
-    let pool: &sqlx::Pool<sqlx::MySql> = match pool {
-        Some(p) => p,
-        None => {
-            ephemeral = sqlx::mysql::MySqlPoolOptions::new()
-                .max_connections(1)
-                .connect(&matrixone.database_url())
-                .await
-                .map_err(|e| format!("DB connect: {e}"))?;
-            &ephemeral
-        }
-    };
-
-    let row = if let Some(name) = preferred {
-        sqlx::query(
-            "SELECT model_name, api_key_encrypted, base_url, provider, \
-                    IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json \
-             FROM infra_llm_models WHERE model_name = ? AND is_active = 1 LIMIT 1",
-        )
-        .bind(name)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| format!("DB query: {e}"))?
-    } else {
-        None
-    };
-
-    let row = if row.is_none() {
-        sqlx::query(
-            "SELECT model_name, api_key_encrypted, base_url, provider, \
-                    IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json \
-             FROM infra_llm_models WHERE is_active = 1 ORDER BY model_name LIMIT 1",
-        )
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| format!("DB query fallback: {e}"))?
-    } else {
-        row
-    };
-
-    let row = row
-        .ok_or_else(|| "No active LLM model configured. Run: astra-admin model add".to_string())?;
-
     let model_name: String = row.try_get("model_name").map_err(|e| e.to_string())?;
     let encrypted: String = row
         .try_get("api_key_encrypted")
@@ -215,6 +164,79 @@ pub async fn resolve_active_llm_model(
         provider,
         fallback_model,
     })
+}
+
+/// Resolve the active LLM model from the database for in-process / server-side callers.
+///
+/// When `preferred` is `Some(name)`, the row **must** exist and be active — otherwise this
+/// returns an error (no silent fallback to another model). When `preferred` is `None`, uses
+/// the lexicographically first active model. When `pool` is `None`, opens an ephemeral
+/// single-connection pool from `matrixone`.
+///
+/// Also extracts `fallback_model` from the `quirks` JSON column (cloud-managed config).
+pub async fn resolve_active_llm_model(
+    matrixone: &MatrixOneSettings,
+    encryptor: &FernetTokenEncryptor,
+    preferred: Option<&str>,
+    pool: Option<&sqlx::Pool<sqlx::MySql>>,
+) -> Result<ResolvedActiveLlmModel, String> {
+    let ephemeral;
+    let pool: &sqlx::Pool<sqlx::MySql> = match pool {
+        Some(p) => p,
+        None => {
+            ephemeral = sqlx::mysql::MySqlPoolOptions::new()
+                .max_connections(1)
+                .connect(&matrixone.database_url())
+                .await
+                .map_err(|e| format!("DB connect: {e}"))?;
+            &ephemeral
+        }
+    };
+
+    let pref = preferred.map(str::trim).filter(|s| !s.is_empty());
+
+    if let Some(name) = pref {
+        let row = sqlx::query(
+            "SELECT model_name, api_key_encrypted, base_url, provider, \
+                    IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, is_active \
+             FROM infra_llm_models WHERE model_name = ? LIMIT 1",
+        )
+        .bind(name)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| format!("DB query: {e}"))?;
+
+        let row = row.ok_or_else(|| {
+            format!(
+                "Model '{name}' is not configured on this server (no infra_llm_models row). \
+                 Omit the model override or choose a configured active model."
+            )
+        })?;
+
+        let is_active_int: i16 = row.try_get("is_active").unwrap_or(0);
+        if is_active_int == 0 {
+            return Err(format!(
+                "Model '{name}' is inactive (connectivity failed or disabled). \
+                 Run `astra-admin model check {name}` or pick an active model; the server will not substitute another model."
+            ));
+        }
+
+        return build_resolved_active_llm_from_row(&row, encryptor);
+    }
+
+    let row = sqlx::query(
+        "SELECT model_name, api_key_encrypted, base_url, provider, \
+                IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json \
+         FROM infra_llm_models WHERE is_active = 1 ORDER BY model_name LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| format!("DB query fallback: {e}"))?;
+
+    let row = row
+        .ok_or_else(|| "No active LLM model configured. Run: astra-admin model add".to_string())?;
+
+    build_resolved_active_llm_from_row(&row, encryptor)
 }
 
 // ── Trait ─────────────────────────────────────────────────────────────────────
@@ -516,7 +538,7 @@ impl ModelService for DatabaseModelService {
         let pool = self.get_pool().await.map_err(internal_error)?;
 
         let existing =
-            query("SELECT model_id, base_url FROM infra_llm_models WHERE model_name = ?")
+            query("SELECT model_id, base_url, provider FROM infra_llm_models WHERE model_name = ?")
                 .bind(&model_name)
                 .fetch_optional(&pool)
                 .await
@@ -528,6 +550,13 @@ impl ModelService for DatabaseModelService {
             )
         })?;
         let _model_id: String = existing.try_get("model_id").map_err(internal_error)?;
+        let stored_provider: String = existing
+            .try_get("provider")
+            .unwrap_or_else(|_| {
+                tracing::warn!(model = %model_name, "provider column NULL or missing, defaulting to openai");
+                "openai".to_string()
+            });
+        let effective_provider = request.provider.as_deref().unwrap_or(&stored_provider);
 
         let mut conn_result: Option<String> = None;
 
@@ -537,7 +566,13 @@ impl ModelService for DatabaseModelService {
                 .base_url
                 .clone()
                 .or_else(|| existing.try_get("base_url").ok());
-            let check = validate_connectivity("", &model_name, api_key, base_url.as_deref()).await;
+            let check = validate_connectivity(
+                effective_provider,
+                &model_name,
+                api_key,
+                base_url.as_deref(),
+            )
+            .await;
 
             query("UPDATE infra_llm_models SET api_key_encrypted = ?, updated_at = NOW() WHERE model_name = ?")
                 .bind(&encrypted)
@@ -573,6 +608,7 @@ impl ModelService for DatabaseModelService {
                 }
             };
         }
+        update_field!(provider, "provider");
         update_field!(base_url, "base_url");
         update_field!(description, "description");
         update_field!(context_window, "context_window");
@@ -693,6 +729,26 @@ pub fn resolve_provider_base_url(provider: &str) -> Option<String> {
     }
 }
 
+/// Full URL for a minimal Anthropic Messages API probe (`POST`, JSON body).
+///
+/// - Official Anthropic: `https://api.anthropic.com` → `.../v1/messages`.
+/// - Custom roots (e.g. MiniMax China `https://api.minimaxi.com/anthropic`): append `/v1/messages`.
+/// - If the base already ends with `/v1` (some clients), append `/messages` only.
+fn anthropic_messages_probe_url(base_url: Option<&str>) -> String {
+    const DEFAULT: &str = "https://api.anthropic.com";
+    let base = base_url
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(DEFAULT)
+        .trim_end_matches('/')
+        .to_string();
+    if base.ends_with("/v1") {
+        format!("{}/messages", base)
+    } else {
+        format!("{}/v1/messages", base)
+    }
+}
+
 pub async fn validate_connectivity(
     provider: &str,
     model_name: &str,
@@ -711,9 +767,10 @@ pub async fn validate_connectivity(
         Err(e) => return Some(format!("Client error: {}", e)),
     };
 
-    let result = if provider == "anthropic" && base_url.is_none() {
-        client
-            .post("https://api.anthropic.com/v1/messages")
+    let result = if provider == "anthropic" {
+        let probe = anthropic_messages_probe_url(base_url);
+        let send_result = client
+            .post(&probe)
             .header("x-api-key", api_key)
             .header("anthropic-version", "2023-06-01")
             .header("content-type", "application/json")
@@ -723,13 +780,27 @@ pub async fn validate_connectivity(
                 "messages": [{"role": "user", "content": "hi"}]
             }))
             .send()
-            .await
+            .await;
+        (send_result, probe)
     } else {
-        let url = base_url
-            .unwrap_or("https://api.openai.com/v1")
-            .trim_end_matches('/');
-        client
-            .post(format!("{}/chat/completions", url))
+        let base_trim = base_url.map(str::trim).filter(|s| !s.is_empty());
+        let url = match base_trim {
+            Some(b) => b.trim_end_matches('/').to_string(),
+            None if provider == "openai" => "https://api.openai.com/v1".to_string(),
+            // Deliberately refuse to guess for unknown providers with no base_url —
+            // the admin must specify base_url for any non-OpenAI provider.
+            // This aligns with the runtime's guarantee that base_url is always set
+            // from the DB row before calling llm_completions_url_for_provider.
+            None => {
+                return Some(format!(
+                    "No base_url for provider '{provider}'. \
+                         Set base_url (e.g. DashScope/Moonshot compatible-mode /v1 root).",
+                ));
+            }
+        };
+        let probe = format!("{}/chat/completions", url);
+        let send_result = client
+            .post(&probe)
             .header("authorization", format!("Bearer {}", api_key))
             .header("content-type", "application/json")
             .json(&serde_json::json!({
@@ -738,12 +809,13 @@ pub async fn validate_connectivity(
                 "messages": [{"role": "user", "content": "hi"}]
             }))
             .send()
-            .await
+            .await;
+        (send_result, probe)
     };
 
     match result {
-        Ok(resp) if resp.status().as_u16() < 400 => None,
-        Ok(resp) => {
+        (Ok(resp), _) if resp.status().as_u16() < 400 => None,
+        (Ok(resp), _) => {
             let status = resp.status().as_u16();
             let text = resp.text().await.unwrap_or_default();
             let detail = serde_json::from_str::<serde_json::Value>(&text)
@@ -757,7 +829,16 @@ pub async fn validate_connectivity(
                 .unwrap_or_else(|| text.chars().take(200).collect());
             Some(format!("HTTP {}: {}", status, detail))
         }
-        Err(e) => Some(format!("Connection failed: {}", e)),
+        (Err(e), probe) => {
+            let mut msg = format!("Connection failed for {probe}: {e}");
+            if provider != "anthropic" {
+                msg.push_str(
+                    " — host unreachable (firewall/DNS/TLS) or region blocks; \
+                     point base_url at an API gateway you can reach, or fix outbound HTTPS/proxy.",
+                );
+            }
+            Some(msg)
+        }
     }
 }
 
@@ -835,6 +916,7 @@ fn default_text_vec() -> Vec<String> {
 pub struct ModelUpdateRequest {
     pub api_key: Option<String>,
     pub base_url: Option<String>,
+    pub provider: Option<String>,
     pub description: Option<String>,
     pub context_window: Option<i32>,
     pub max_completion_tokens: Option<i32>,
@@ -1102,6 +1184,52 @@ mod tests {
         assert!(resp.architecture.is_none());
     }
 
+    /// CLI and other clients must read `is_active` from GET /models — not `active`.
+    #[test]
+    fn anthropic_probe_url_minimax_china_style_base() {
+        assert_eq!(
+            super::anthropic_messages_probe_url(Some("https://api.minimaxi.com/anthropic")),
+            "https://api.minimaxi.com/anthropic/v1/messages"
+        );
+    }
+
+    #[test]
+    fn anthropic_probe_url_official_default() {
+        assert_eq!(
+            super::anthropic_messages_probe_url(None),
+            "https://api.anthropic.com/v1/messages"
+        );
+    }
+
+    #[test]
+    fn anthropic_probe_url_when_base_already_has_v1_suffix() {
+        assert_eq!(
+            super::anthropic_messages_probe_url(Some("https://api.anthropic.com/v1")),
+            "https://api.anthropic.com/v1/messages"
+        );
+    }
+
+    #[test]
+    fn model_list_item_response_json_uses_is_active_snake_case() {
+        let item = ModelListItem {
+            model_id: "m3".into(),
+            name: "probe".into(),
+            provider: "openai".into(),
+            description: None,
+            is_active: false,
+            context_window: 128000,
+            max_completion_tokens: None,
+            architecture: None,
+        };
+        let resp = ModelListItemResponse::from(item);
+        let v = serde_json::to_value(&resp).expect("serialize ModelListItemResponse");
+        assert_eq!(v.get("is_active"), Some(&serde_json::Value::Bool(false)));
+        assert!(
+            v.get("active").is_none(),
+            "legacy key `active` must not be emitted; clients should use is_active"
+        );
+    }
+
     // -- PricingData edge cases used in cost calculation --
 
     #[test]
@@ -1124,5 +1252,21 @@ mod tests {
         )
         .unwrap();
         assert!(p.prompt > 100.0);
+    }
+
+    #[tokio::test]
+    async fn validate_connectivity_mock_provider_skips_network() {
+        let result = super::validate_connectivity("mock", "any-model", "key", None).await;
+        assert!(
+            result.is_none(),
+            "mock provider should short-circuit to success"
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_connectivity_unknown_provider_no_base_url_errors() {
+        let result = super::validate_connectivity("dashscope", "qwen-plus", "key", None).await;
+        let msg = result.expect("should return an error");
+        assert!(msg.contains("No base_url"), "got: {msg}");
     }
 }


### PR DESCRIPTION
## Summary

Fix multiple LLM provider compatibility issues discovered when adding MiniMax M2.5/M2.7 support.

## Bug Fixes

- **Anthropic provider URL mismatch**: connectivity check used `/v1/messages` but actual LLM calls used `/chat/completions`. Now consistent across all call sites (`llm_client`, `bridge_inprocess`, `completions` proxy).
- **Multiple system messages rejected**: some providers (MiniMax) reject system messages after the first position. All system messages are now consolidated into one leading message before sending.
- **Empty function names in tool_calls**: when skill interception captures a call before the streaming name chunk arrives, the recorded tool_call has `name: ""`. Now recovered from tool result messages or filled with `_unknown`.
- **`--update-existing` ignores provider changes**: PUT payload now includes `provider` field so `astra-admin model load --update-existing` can change a model's provider.
- **Silent NULL provider fallback**: now logs a warning instead of silently defaulting to `openai`.

## Features

- **`<think>` tag extraction**: models like MiniMax embed reasoning in `delta.content` with `<think>...</think>` tags instead of using `reasoning_content`. Now extracted into the `reasoning` field post-collection, and routed to `reasoning_delta` in bridge streaming for thinking preview.
- **Improved error messages**: removed confrontational wording in connectivity check errors.

## Tests

- **6 golden case fixtures** from real provider SSE responses:
  - MiniMax M2.5 (simple + tool call) — `<think>` tag extraction
  - MiniMax M2.7 (simple) — `<think>` tag extraction
  - Qwen3.6-plus — `reasoning_content` field
  - Kimi-k2.5 — `reasoning_content` field
  - Qwen-plus — tool call without reasoning
- Unit tests for `llm_completions_url`, `consolidate_system_messages`, `split_think_chunks`, `extract_think_tags`, `validate_connectivity`

## Files Changed

| File | Change |
|------|--------|
| `llm_client.rs` | URL routing, message consolidation, think tag extraction, golden tests |
| `bridge_inprocess.rs` | URL fix, think tag streaming routing |
| `completions.rs` | URL fix |
| `services/models.rs` | Provider update support, connectivity tests, warning log |
| `runtime/models.rs` | Provider field in update handler |
| `astra-admin/main.rs` | Provider in PUT payload |
| `testdata/*.sse` | 6 golden case fixtures |