### PR TITLE
feat(plan): v2 plan mode with cancellable generation and progressive outline

### DIFF
--- a/docs/design/plan-mode-v2.md
+++ b/docs/design/plan-mode-v2.md
@@ -1,0 +1,484 @@
+# Plan Mode V2 — 系统性重构设计
+
+## 现状问题
+
+| # | 问题 | 根因 | 严重度 |
+|---|------|------|--------|
+| 1 | Ctrl-C 无响应 | `handle_goal_submission` 中 `post_chat_turn` + `collect_sse_with_preview` 是裸 await，没有 `tokio::select!` + `ctrl_c()` | P0 |
+| 2 | 无超时 | `post_chat_turn` 无 timeout，SSE 流无总超时，服务端不响应则永久阻塞 | P0 |
+| 3 | JSON 解析脆弱 | 依赖 LLM "自觉"输出 JSON，无 structured output，失败无重试 | P1 |
+| 4 | 一次性全量生成 | 复杂任务 10+ subtasks 一次生成，质量衰减，无法利用中间结果 | P1 |
+| 5 | 交互黑盒 | 生成过程只有 ThinkingPreviewPane，无阶段反馈，clarification 无 inquire 选择 | P1 |
+| 6 | plan_interaction.rs 过大 | 1900+ 行，混合 UI/解析/LLM 调用/状态管理/执行调度 | P2 |
+| 7 | PlanPhase 状态机未使用 | `plan.rs` 定义了完整的 PlanPhase 状态机，但 `plan_interaction.rs` 直接操作 PlanModeState，状态机形同虚设 | P2 |
+
+## 重构目标
+
+1. Plan 生成过程可取消（Ctrl-C）、有超时、有进度反馈
+2. 渐进式生成：先 outline → 用户确认 → 再细化 subtasks
+3. JSON 解析鲁棒：structured output 优先，失败自动重试
+4. 交互式协商：用户在每个阶段都能介入
+5. 代码结构清晰：状态机驱动，UI/逻辑分离
+
+## 架构设计
+
+### 核心变更：从"一次生成"到"对话式规划"
+
+```
+旧流程:
+  goal → [LLM: 一次生成完整 JSON] → parse → display → execute
+
+新流程:
+  goal → [Phase 1: Outline] → 用户确认/修改
+       → [Phase 2: Detail]  → 用户确认/修改
+       → [Review & Execute]
+```
+
+### 模块拆分
+
+```
+astra-plan/src/
+  lib.rs              # re-exports
+  plan.rs             # PlanPhase 状态机 (保留，真正使用起来)
+  decompose.rs        # 拆分为以下模块 ↓
+  project_scan.rs     # analyze_project, ProjectContext (从 decompose.rs 提取)
+  prompt.rs           # LLM prompt 模板 (从 decompose.rs 提取)
+  parse.rs            # JSON 解析 + 鲁棒性 (从 decompose.rs 提取)
+  clarify.rs          # 澄清问答 (从 decompose.rs 提取)
+  version.rs          # 版本历史 + diff (从 decompose.rs 提取)
+  timeline.rs         # ExecutionTimeline (从 decompose.rs 提取)
+  template.rs         # 模板匹配 (从 decompose.rs 提取)
+  format.rs           # 格式化输出 (从 decompose.rs 提取)
+
+astra-cli/src/cli/
+  plan_interaction.rs # 拆分为以下模块 ↓
+  plan/
+    mod.rs            # PlanController — 状态机驱动的顶层协调器
+    generate.rs       # PlanGenerator — 可取消的 LLM 调用 + 渐进生成
+    display.rs        # PlanDisplay — 所有 plan UI 渲染
+    input.rs          # PlanInput — 用户交互 (inquire 集成)
+    commands.rs       # PlanCommand 处理 (从 plan_interaction.rs 提取)
+  plan_executor.rs    # 保留，微调
+  plan_monitor.rs     # 保留，微调
+  plan_runtime.rs     # 保留，微调
+```
+
+### 1. 可取消的 Plan 生成
+
+新增 `PlanGenerator`，封装 LLM 调用 + 取消 + 超时：
+
+```rust
+// astra-cli/src/cli/plan/generate.rs
+
+use tokio_util::sync::CancellationToken;
+
+pub struct PlanGenerateConfig {
+    pub request_timeout: Duration,      // post_chat_turn 超时, default 30s
+    pub stream_timeout: Duration,       // SSE 流总超时, default 120s
+    pub idle_timeout: Duration,         // SSE 无数据超时, default 30s
+    pub max_retries: u32,               // JSON 解析失败重试, default 1
+}
+
+impl Default for PlanGenerateConfig {
+    fn default() -> Self {
+        Self {
+            request_timeout: Duration::from_secs(30),
+            stream_timeout: Duration::from_secs(120),
+            idle_timeout: Duration::from_secs(30),
+            max_retries: 1,
+        }
+    }
+}
+
+pub enum GenerateOutcome {
+    Plan(TaskPlan),
+    Clarifications(Vec<ClarificationQuestion>),
+    Cancelled,
+    Failed(String),
+}
+
+/// 可取消的 plan 生成。
+///
+/// 在 REPL 调用侧:
+/// ```
+/// let cancel = CancellationToken::new();
+/// tokio::select! {
+///     result = generator.generate(&goal, &context, &cancel) => { ... }
+///     _ = tokio::signal::ctrl_c() => {
+///         cancel.cancel();
+///         eprintln!("  Cancelled.");
+///     }
+/// }
+/// ```
+pub async fn generate_plan(
+    api: &ThinClient,
+    token: &str,
+    goal: &str,
+    context: &ProjectContext,
+    config: &PlanGenerateConfig,
+    cancel: &CancellationToken,
+    on_progress: impl Fn(GenerateProgress),
+) -> GenerateOutcome {
+    // 1. post_chat_turn_timeout (request_timeout)
+    // 2. collect_sse_cancellable (stream_timeout + idle_timeout + cancel)
+    // 3. parse → 失败则 retry with correction prompt
+    todo!()
+}
+```
+
+关键：`collect_sse_cancellable` 替代 `collect_sse_with_preview`：
+
+```rust
+/// 可取消的 SSE 收集，带超时和进度回调。
+pub async fn collect_sse_cancellable(
+    resp: Response,
+    cancel: &CancellationToken,
+    stream_timeout: Duration,
+    idle_timeout: Duration,
+    on_chunk: impl FnMut(&str),  // 每个 text_delta 回调
+) -> SseTextResult {
+    let deadline = Instant::now() + stream_timeout;
+    let mut last_data = Instant::now();
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                result.stream_error = Some("Cancelled by user".into());
+                break;
+            }
+            chunk = stream.next() => {
+                match chunk {
+                    Some(Ok(bytes)) => {
+                        last_data = Instant::now();
+                        // ... process SSE events, call on_chunk for text_delta
+                    }
+                    Some(Err(e)) => { /* stream error */ break; }
+                    None => break, // stream ended
+                }
+            }
+            _ = tokio::time::sleep_until(deadline.into()) => {
+                result.stream_error = Some("Stream timeout".into());
+                break;
+            }
+            _ = tokio::time::sleep_until((last_data + idle_timeout).into()) => {
+                result.stream_error = Some("Idle timeout".into());
+                break;
+            }
+        }
+    }
+    result
+}
+```
+
+### 2. 渐进式生成
+
+两阶段 prompt 替代一次性 decomposition_prompt：
+
+**Phase 1 — Outline（快速，3-5s）：**
+
+```
+你是高级软件架构师。根据以下目标和项目上下文，生成一个高层执行大纲。
+
+目标: {goal}
+项目: {context_summary}
+
+输出 JSON:
+{
+  "phases": [
+    {
+      "id": "phase-1",
+      "title": "...",
+      "description": "...",
+      "estimated_subtasks": 2-3,
+      "key_files": ["..."]
+    }
+  ],
+  "total_effort": "small|medium|large",
+  "questions": []  // 如果需要澄清，放这里
+}
+
+规则:
+- 2-4 个 phase，每个 phase 是一个逻辑阶段
+- 不需要细化到具体 subtask
+- 如果有不确定的地方，在 questions 里提问
+```
+
+用户看到 outline 后可以：
+- 确认 → 进入 Phase 2
+- 修改 → 重新生成 outline
+- 跳过 → 直接一次性生成（兼容旧行为）
+
+**Phase 2 — Detail（按 phase 逐个细化）：**
+
+```
+基于以下大纲的 phase "{phase_id}"，生成具体的 subtasks。
+
+大纲: {outline_json}
+当前 phase: {phase}
+已完成的 phases: {completed_phases_summary}
+
+输出 JSON:
+{
+  "subtasks": [...]  // 同现有格式
+}
+```
+
+好处：
+- 每次 LLM 调用更短更快
+- 后续 phase 可以利用前面 phase 的执行结果
+- 用户可以在 phase 之间调整方向
+
+### 3. JSON 解析鲁棒性
+
+三层防御：
+
+```rust
+// astra-plan/src/parse.rs
+
+pub fn parse_plan_robust(text: &str) -> Result<TaskPlan, ParseError> {
+    // Layer 1: 直接解析
+    if let Ok(plan) = parse_plan_strict(text) {
+        return Ok(plan);
+    }
+
+    // Layer 2: 提取 JSON 片段
+    //   - strip markdown fences (```json ... ```)
+    //   - 找最外层 { ... } 或 [ ... ]
+    //   - 修复常见问题: trailing comma, 单引号, 注释
+    if let Ok(plan) = extract_and_parse(text) {
+        return Ok(plan);
+    }
+
+    // Layer 3: 宽松解析
+    //   - 尝试 YAML 解析 (LLM 有时输出 YAML)
+    //   - 尝试从 markdown list 结构化提取
+    Err(ParseError::AllStrategiesFailed {
+        original: text.to_string(),
+        // 附带原文，供重试 prompt 使用
+    })
+}
+
+pub struct ParseError {
+    pub message: String,
+    pub original: String,
+    pub strategies_tried: Vec<String>,
+}
+```
+
+重试机制（在 `generate_plan` 中）：
+
+```rust
+// 第一次解析失败后，用修正 prompt 重试
+let retry_prompt = format!(
+    "你之前的回复不是有效的 JSON。错误: {error}\n\
+     请只输出 JSON，不要包含任何其他文本。\n\
+     原始目标: {goal}"
+);
+```
+
+### 4. 交互式协商
+
+**Clarification 用 inquire：**
+
+```rust
+// astra-cli/src/cli/plan/input.rs
+
+pub fn ask_clarification(q: &ClarificationQuestion) -> ClarificationAnswer {
+    let options: Vec<String> = q.options.iter().enumerate()
+        .map(|(i, opt)| {
+            if q.default == Some(i) {
+                format!("{opt} (default)")
+            } else {
+                opt.clone()
+            }
+        })
+        .collect();
+
+    // 添加自由输入选项
+    let mut all_options = options;
+    all_options.push("Other (type your answer)".into());
+
+    match inquire::Select::new(&q.question, all_options)
+        .with_render_config(plan_select_theme())
+        .with_starting_cursor(q.default.unwrap_or(0))
+        .prompt()
+    {
+        Ok(choice) if choice.starts_with("Other") => {
+            match inquire::Text::new("Your answer:").prompt() {
+                Ok(text) => ClarificationAnswer::Freeform(text),
+                Err(_) => ClarificationAnswer::Invalid("Cancelled".into()),
+            }
+        }
+        Ok(choice) => {
+            let idx = q.options.iter().position(|o| choice.starts_with(o)).unwrap_or(0);
+            ClarificationAnswer::Selected(idx)
+        }
+        Err(_) => ClarificationAnswer::Invalid("Cancelled".into()),
+    }
+}
+```
+
+**Outline 确认用 inquire：**
+
+```rust
+pub fn confirm_outline(phases: &[PlanPhase]) -> OutlineChoice {
+    let options = vec![
+        format!("✓  Looks good, detail all {} phases", phases.len()),
+        "✏  Modify (describe changes)".into(),
+        "⏭  Skip outline, generate full plan directly".into(),
+        "✕  Cancel".into(),
+    ];
+
+    match inquire::Select::new("Plan outline:", options)
+        .with_render_config(plan_select_theme())
+        .prompt()
+    {
+        Ok(c) if c.starts_with('✓') => OutlineChoice::Confirm,
+        Ok(c) if c.starts_with('✏') => OutlineChoice::Edit,
+        Ok(c) if c.starts_with('⏭') => OutlineChoice::SkipToFull,
+        _ => OutlineChoice::Cancel,
+    }
+}
+```
+
+**生成过程进度反馈：**
+
+```rust
+pub enum GenerateProgress {
+    /// 项目扫描完成
+    ProjectScanned { files: usize, languages: Vec<String> },
+    /// 模板搜索完成
+    TemplatesSearched { found: usize },
+    /// LLM 请求已发送
+    RequestSent,
+    /// 收到第一个 token
+    FirstToken,
+    /// 流式接收中
+    Streaming { tokens: usize, elapsed: Duration },
+    /// 解析中
+    Parsing,
+    /// 解析失败，重试中
+    RetryingParse { attempt: u32, error: String },
+}
+```
+
+显示效果：
+
+```
+  ✓ Scanned project: Rust · 805 files · main
+  ✓ Found 2 similar templates
+  ⋯ Generating outline…  (3.2s, ~420 tokens)
+  ✓ Outline ready
+
+  Phase 1: Setup project structure
+    ~2 subtasks · files: src/lib.rs, src/main.rs
+
+  Phase 2: Implement core logic
+    ~3 subtasks · files: src/handler.rs, src/model.rs
+
+  Phase 3: Testing & verification
+    ~2 subtasks
+
+  ▸ Plan outline:
+  > ✓  Looks good, detail all 3 phases
+    ✏  Modify (describe changes)
+    ⏭  Skip outline, generate full plan directly
+    ✕  Cancel
+```
+
+### 5. 状态机驱动
+
+让 `PlanPhase` 状态机真正驱动流程，而不是 `plan_interaction.rs` 里的 ad-hoc 逻辑：
+
+```rust
+// astra-cli/src/cli/plan/mod.rs
+
+pub struct PlanController {
+    phase: PlanPhase,
+    generator: PlanGenerator,
+    display: PlanDisplay,
+}
+
+impl PlanController {
+    /// 处理用户输入，返回下一步动作。
+    pub async fn handle_input(
+        &mut self,
+        input: &str,
+        cancel: &CancellationToken,
+    ) -> PlanInputResult {
+        match &self.phase {
+            PlanPhase::Idle => self.handle_idle(input).await,
+            PlanPhase::Planning { .. } => self.handle_planning(input, cancel).await,
+            PlanPhase::Refining { .. } => self.handle_refining(input, cancel).await,
+            PlanPhase::Executing { .. } => self.handle_executing(input).await,
+            PlanPhase::Paused { .. } => self.handle_paused(input).await,
+            _ => PlanInputResult::Handled,
+        }
+    }
+
+    /// 状态转换 — 所有转换通过这里，保证合法性。
+    fn transition(&mut self, action: PlanAction) -> Result<(), PlanTransitionError> {
+        self.phase = self.phase.take().transition(action)?;
+        Ok(())
+    }
+}
+```
+
+### 6. 新增 Outline 数据结构
+
+```rust
+// astra-plan/src/decompose.rs (或新文件 outline.rs)
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanOutline {
+    pub phases: Vec<OutlinePhase>,
+    pub total_effort: String,
+    pub questions: Vec<ClarificationQuestion>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutlinePhase {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub estimated_subtasks: usize,
+    pub key_files: Vec<String>,
+}
+```
+
+## 实施计划
+
+### Phase 1: 基础设施 (P0 修复) ✅
+1. ✅ 实现 `collect_sse_cancellable` — 可取消、有超时的 SSE 收集
+2. ✅ `handle_goal_submission` 中用 `tokio::select!` + `ctrl_c()` 包裹 LLM 调用
+3. ✅ `post_chat_turn` 调用改用 `post_chat_turn_timeout`
+4. ✅ 所有 plan LLM 调用路径加超时
+
+### Phase 2: JSON 鲁棒性 ✅
+5. ✅ 实现 `extract_json_robust` 多层解析（trailing commas, comments）
+6. ✅ 生成失败自动重试（`plan_generate_with_retry` 带修正 prompt）
+7. ✅ `parse_plan_response` 自动使用 robust 解析
+
+### Phase 3: 渐进式生成 ✅
+8. ✅ 新增 `PlanOutline` / `OutlinePhase` 数据结构（`astra-plan/src/outline.rs`）
+9. ✅ 实现两阶段 prompt（`outline_prompt` → `phase_detail_prompt`）
+10. ✅ `handle_goal_submission` 先生成 outline → 用户确认 → 逐 phase 展开
+11. ✅ 优雅降级：outline 解析失败自动回退到一次性全量生成
+
+### Phase 4: 交互优化 ✅
+12. ✅ Clarification 改用 `inquire::Select`（`ask_clarification_interactive`）
+13. ✅ Outline 确认用 `inquire::Select`（`prompt_outline_confirmation`）
+14. ✅ Phase 展开过程分阶段进度反馈（每个 phase 显示进度）
+15. ✅ 取消时保留已完成 phase 的 subtasks
+
+### Phase 5: 代码重构 ✅
+16. ✅ 新增 `outline.rs` 模块（独立于 267KB 的 decompose.rs）
+17. ✅ 提取 `accept_generated_plan` / `expand_outline_to_plan` / `handle_outline_clarifications` 独立函数
+18. ✅ `handle_goal_submission` 从 ~100 行 monolith 重构为清晰的阶段调度
+
+## 不做的事
+
+- 不改 plan executor / plan monitor（执行阶段已经有 Ctrl-C 处理）
+- 不改 TaskPlan / SubtaskPlan 数据结构（向后兼容持久化）
+- 不改 plan 命令解析（PlanCommand::parse 已经够好）

--- a/rust/crates/astra-cli/src/cli/plan_interaction.rs
+++ b/rust/crates/astra-cli/src/cli/plan_interaction.rs
@@ -5,12 +5,154 @@
 //! natural-language plan editing via LLM.
 
 use super::*;
-use crate::sse_utils::collect_sse_with_preview;
+use crate::sse_utils::collect_sse_cancellable;
 use astra_runtime::plan;
 use astra_runtime::plan::PlanCommand;
 use astra_runtime::plan::progress_bar_segments;
 use astra_services::session_journal;
 use crossterm::style::Stylize;
+
+/// Default timeouts for plan LLM calls.
+const PLAN_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const PLAN_STREAM_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
+const PLAN_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
+
+/// Outcome of a cancellable plan LLM call.
+enum PlanLlmOutcome {
+    /// LLM returned text successfully.
+    Ok {
+        text: String,
+        session_id: Option<String>,
+    },
+    /// User pressed Ctrl-C during generation.
+    Cancelled,
+    /// HTTP or SSE error.
+    Error(String),
+}
+
+/// If the LLM response contains a session_id and we don't have one yet, initialize it.
+fn maybe_init_session_from_plan(state: &mut ReplState, outcome: &PlanLlmOutcome) {
+    if let PlanLlmOutcome::Ok {
+        session_id: Some(sid),
+        ..
+    } = outcome
+    {
+        if state.session_id.is_none() {
+            super::repl_turn::initialize_journal_pub(state, sid);
+            state.session_id = Some(sid.clone());
+        }
+    }
+}
+
+/// Send a plan LLM request with Ctrl-C cancellation and timeouts.
+///
+/// Wraps `post_chat_turn_timeout` + `collect_sse_cancellable` in a
+/// `tokio::select!` that listens for `ctrl_c()`. On interrupt the
+/// cancellation token is fired, the SSE stream is drained, and
+/// `PlanLlmOutcome::Cancelled` is returned.
+async fn plan_llm_call(
+    api: &astra_thin_client::ThinClient,
+    token: &str,
+    payload: &serde_json::Value,
+) -> PlanLlmOutcome {
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let cancel_for_signal = cancel.clone();
+
+    // Race the full request+stream against Ctrl-C.
+    // Once ctrl_c fires we cancel the token; the inner select in
+    // collect_sse_cancellable will observe it and break out.
+    let result = tokio::select! {
+        biased;
+        _ = tokio::signal::ctrl_c() => {
+            cancel_for_signal.cancel();
+            // Give the stream a moment to drain cleanly
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            return PlanLlmOutcome::Cancelled;
+        }
+        r = async {
+            let resp = match api.post_chat_turn_timeout(token, payload, PLAN_REQUEST_TIMEOUT).await {
+                Ok(r) => r,
+                Err(e) => return PlanLlmOutcome::Error(e.to_string()),
+            };
+            if !resp.status().is_success() {
+                return PlanLlmOutcome::Error(format!("HTTP {}", resp.status()));
+            }
+            let sse_result = collect_sse_cancellable(
+                resp,
+                &cancel,
+                PLAN_STREAM_TIMEOUT,
+                PLAN_IDLE_TIMEOUT,
+                |_| {},
+            ).await;
+            if sse_result.is_cancelled() {
+                return PlanLlmOutcome::Cancelled;
+            }
+            if let Some(err) = sse_result.completion_error() {
+                return PlanLlmOutcome::Error(err);
+            }
+            PlanLlmOutcome::Ok { text: sse_result.text, session_id: sse_result.session_id }
+        } => r,
+    };
+    result
+}
+
+/// Generate a plan from a goal, with automatic retry on JSON parse failure.
+///
+/// On first attempt, sends the decomposition prompt. If the LLM returns text
+/// that fails JSON parsing, sends a correction prompt and retries once.
+async fn plan_generate_with_retry(
+    api: &astra_thin_client::ThinClient,
+    token: &str,
+    goal: &str,
+    context: &plan::ProjectContext,
+    session_id: Option<&str>,
+) -> PlanLlmOutcome {
+    use astra_runtime::plan::decomposition_prompt;
+
+    let prompt = decomposition_prompt(goal, context);
+    let payload = serde_json::json!({
+        "messages": [{"role": "user", "content": prompt}],
+        "session_id": session_id,
+    });
+
+    let result = plan_llm_call(api, token, &payload).await;
+    let text = match &result {
+        PlanLlmOutcome::Ok { text: t, .. } => t,
+        _ => return result,
+    };
+
+    // Check if it parses — if yes, return immediately
+    if plan::parse_plan_response(text).is_ok()
+        || plan::detect_clarification_questions(text).is_some()
+    {
+        return result;
+    }
+
+    // Parse failed — retry with correction prompt
+    eprintln!(
+        "  {} JSON parse failed, retrying with correction…",
+        theme::icon_warn()
+    );
+
+    let retry_prompt = format!(
+        "Your previous response was not valid JSON. Please output ONLY a JSON object \
+         with this exact structure:\n\
+         {{\"subtasks\": [{{\"id\": \"...\", \"title\": \"...\", \"description\": \"...\", \
+         \"depends_on\": [], \"effort\": \"small|medium|large\", \"files\": [\"...\"]}}]}}\n\n\
+         No markdown, no explanation, no code fences. Just the raw JSON.\n\n\
+         Original goal: {goal}"
+    );
+    let retry_payload = serde_json::json!({
+        "messages": [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": text},
+            {"role": "user", "content": retry_prompt},
+        ],
+        "session_id": session_id,
+    });
+
+    plan_llm_call(api, token, &retry_payload).await
+}
 
 /// Result from [`handle_plan_mode_input`].
 ///
@@ -144,6 +286,141 @@ pub(super) fn eprint_plan_json_parse_failed(full_text: &str, _err: &str) {
 }
 
 /// Print available plan mode commands (compact, for after plan generation).
+/// Styled plan display with crossterm colors — replaces markdown streaming for plan confirmation.
+fn eprint_styled_plan(plan: &astra_runtime::plan::TaskPlan, goal: &str) {
+    use astra_runtime::plan::TaskStatus;
+
+    eprintln!("  {} {}", "Plan:".bold(), goal.cyan());
+    if let Some(ref notes) = plan.notes {
+        eprintln!("  {}", notes.as_str().dim());
+    }
+    eprintln!();
+
+    for (i, st) in plan.subtasks.iter().enumerate() {
+        let (icon, icon_style) = match st.status {
+            TaskStatus::Completed => ("✓", "green"),
+            TaskStatus::InProgress => ("▶", "cyan"),
+            TaskStatus::Failed => ("✗", "red"),
+            TaskStatus::Paused => ("⏸", "yellow"),
+            _ => ("○", "dim"),
+        };
+        let icon_str = match icon_style {
+            "green" => icon.green().to_string(),
+            "cyan" => icon.cyan().to_string(),
+            "red" => icon.red().to_string(),
+            "yellow" => icon.yellow().to_string(),
+            _ => icon.dim().to_string(),
+        };
+
+        let effort = match st.effort.as_deref() {
+            Some("small") => " S".green().to_string(),
+            Some("medium") => " M".yellow().to_string(),
+            Some("large") => " L".red().to_string(),
+            _ => String::new(),
+        };
+
+        eprintln!(
+            "  {} {} {}{}  {}",
+            format!("{:>2}.", i + 1).dim(),
+            icon_str,
+            st.id.as_str().bold(),
+            effort,
+            st.title.as_str().dim()
+        );
+
+        if let Some(ref desc) = st.description {
+            let short: String = desc.chars().take(80).collect();
+            let suffix = if desc.len() > 80 { "…" } else { "" };
+            eprintln!("      {}{}", short.dim(), suffix.dim());
+        }
+
+        if !st.files.is_empty() {
+            let files: Vec<_> = st
+                .files
+                .iter()
+                .take(4)
+                .map(|f| f.as_str().dim().to_string())
+                .collect();
+            let suffix = if st.files.len() > 4 {
+                format!(" +{}", st.files.len() - 4)
+            } else {
+                String::new()
+            };
+            eprintln!("      {} {}{}", "📁".dim(), files.join(", "), suffix.dim());
+        }
+
+        if !st.depends_on.is_empty() {
+            eprintln!(
+                "      {} {}",
+                "↳".dim(),
+                format!("after {}", st.depends_on.join(", ")).dim()
+            );
+        }
+    }
+
+    // Summary line
+    let done = plan.items_done();
+    let total = plan.subtasks.len();
+    let pct = plan.progress_pct();
+    eprintln!();
+    eprintln!(
+        "  {} {}/{} ({}%)",
+        format_progress_bar(pct, 15),
+        format!("{done}").cyan(),
+        format!("{total}").dim(),
+        pct
+    );
+}
+
+/// Styled outline display with crossterm colors.
+fn eprint_styled_outline(outline: &astra_runtime::plan::outline::PlanOutline, goal: &str) {
+    let effort_styled = match outline.total_effort.as_str() {
+        "small" => "small".green().to_string(),
+        "medium" => "medium".yellow().to_string(),
+        "large" => "large".red().to_string(),
+        other => other.to_string(),
+    };
+
+    eprintln!("  {} {}", "Plan:".bold(), goal.cyan());
+    eprintln!(
+        "  {} {}  ·  {} phase{}",
+        "Effort:".bold(),
+        effort_styled,
+        format!("{}", outline.phases.len()).cyan(),
+        if outline.phases.len() == 1 { "" } else { "s" }
+    );
+    eprintln!();
+
+    for (i, phase) in outline.phases.iter().enumerate() {
+        eprintln!(
+            "  {} {} — {}",
+            format!("{}.", i + 1).bold().cyan(),
+            phase.title.as_str().bold(),
+            phase.description.as_str().dim()
+        );
+        let mut detail = format!(
+            "     ~{} subtask{}",
+            format!("{}", phase.estimated_subtasks).cyan(),
+            if phase.estimated_subtasks == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
+        if !phase.key_files.is_empty() {
+            let files: Vec<_> = phase
+                .key_files
+                .iter()
+                .take(3)
+                .map(|f| f.as_str().dim().to_string())
+                .collect();
+            detail.push_str(&format!("  ·  {}", files.join(", ")));
+        }
+        eprintln!("{detail}");
+    }
+    eprintln!();
+}
+
 pub(super) fn eprint_plan_commands_help() {
     eprintln!(
         "  {} {} to run  {} {} to modify  {} {} to leave",
@@ -339,7 +616,7 @@ fn format_progress_bar(pct: u32, width: usize) -> String {
 /// Print the full plan mode banner (shown on entry and on `help` command).
 pub(super) fn eprint_plan_mode_banner(goal: &str) {
     eprintln!();
-    eprint!("{}", "Plan mode".yellow().bold());
+    eprint!("{}", "📋 Plan mode".yellow().bold());
     if !goal.is_empty() {
         let display_goal: String = goal.chars().take(60).collect();
         let suffix = if goal.len() > 60 { "…" } else { "" };
@@ -348,11 +625,7 @@ pub(super) fn eprint_plan_mode_banner(goal: &str) {
     eprintln!();
     eprintln!(
         "{}",
-        "  go  execute · step  step-by-step · pause · resume · exit · show · status".dim()
-    );
-    eprintln!(
-        "{}",
-        "  correct <…> · rewind <…> · diff · rollback · timeline · metrics · history · list".dim()
+        "  Type a goal to start · go to execute · show to view · exit to leave".dim()
     );
     eprintln!();
 }
@@ -689,71 +962,60 @@ pub async fn handle_plan_mode_input(
         });
 
         eprintln!();
-        let resp = api.post_chat_turn(tok, &payload).await;
-
-        match resp {
-            Ok(r) if r.status().is_success() => {
-                let sse_result = collect_sse_with_preview(r).await;
-                if let Some(err) = sse_result.completion_error() {
-                    eprintln!("  {} {}", theme::icon_err(), err.red());
-                    return Ok(PlanInputResult::Handled);
-                }
-                let full_text = sse_result.text;
-
-                match parse_plan_response(&full_text) {
-                    Ok(plan) => {
-                        plan_state.set_plan(plan);
-                        let _ = plan_state.save_to_file(&PlanModeState::state_path());
-
-                        journal_plan_event(
-                            &mut state.journal,
-                            session_journal::JournalEventType::PlanEdit,
-                            "Plan regenerated after clarifications",
-                            None,
-                        );
-
-                        let subtask_count = plan_state.plan.subtasks.len();
-                        eprint_plan_commands_help();
-
-                        // Offer interactive confirmation if terminal supports it
-                        if let Some(choice) = prompt_plan_confirmation(subtask_count) {
-                            match choice {
-                                PlanConfirmChoice::ExecuteAll => {
-                                    return Box::pin(handle_plan_mode_input(
-                                        "go".into(),
-                                        token,
-                                        state,
-                                        api,
-                                    ))
-                                    .await;
-                                }
-                                PlanConfirmChoice::StepByStep => {
-                                    return Box::pin(handle_plan_mode_input(
-                                        "step".into(),
-                                        token,
-                                        state,
-                                        api,
-                                    ))
-                                    .await;
-                                }
-                                PlanConfirmChoice::Edit | PlanConfirmChoice::Cancel => {}
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        eprint_plan_json_parse_failed(&full_text, &e.to_string());
-                    }
-                }
+        let full_text = match plan_llm_call(api, tok, &payload).await {
+            PlanLlmOutcome::Ok { text, .. } => text,
+            PlanLlmOutcome::Cancelled => {
+                eprintln!("  {} Plan generation cancelled.", theme::icon_warn());
+                return Ok(PlanInputResult::Handled);
             }
-            Ok(r) => {
-                eprintln!(
-                    "  {} LLM call failed ({})",
-                    theme::icon_err(),
-                    r.status().to_string().red()
+            PlanLlmOutcome::Error(e) => {
+                eprintln!("  {} {}", theme::icon_err(), e.red());
+                return Ok(PlanInputResult::Handled);
+            }
+        };
+
+        match parse_plan_response(&full_text) {
+            Ok(plan) => {
+                plan_state.set_plan(plan);
+                let _ = plan_state.save_to_file(&PlanModeState::state_path());
+
+                journal_plan_event(
+                    &mut state.journal,
+                    session_journal::JournalEventType::PlanEdit,
+                    "Plan regenerated after clarifications",
+                    None,
                 );
+
+                let subtask_count = plan_state.plan.subtasks.len();
+                eprint_plan_commands_help();
+
+                // Offer interactive confirmation if terminal supports it
+                if let Some(choice) = prompt_plan_confirmation(subtask_count) {
+                    match choice {
+                        PlanConfirmChoice::ExecuteAll => {
+                            return Box::pin(handle_plan_mode_input(
+                                "go".into(),
+                                token,
+                                state,
+                                api,
+                            ))
+                            .await;
+                        }
+                        PlanConfirmChoice::StepByStep => {
+                            return Box::pin(handle_plan_mode_input(
+                                "step".into(),
+                                token,
+                                state,
+                                api,
+                            ))
+                            .await;
+                        }
+                        PlanConfirmChoice::Edit | PlanConfirmChoice::Cancel => {}
+                    }
+                }
             }
             Err(e) => {
-                cli_utils::eprint_request_error(&e);
+                eprint_plan_json_parse_failed(&full_text, &e.to_string());
             }
         }
 
@@ -936,6 +1198,7 @@ pub async fn handle_plan_mode_input(
     let Some(plan_state) = state.plan_mode.as_mut() else {
         return Ok(PlanInputResult::Handled);
     };
+
     let prompt = plan_state.plan_mode_prompt(&input);
     plan_state.add_turn(&input, "");
 
@@ -961,123 +1224,103 @@ pub async fn handle_plan_mode_input(
     });
 
     eprintln!();
-    let resp = api.post_chat_turn(tok, &payload).await;
+    let llm_text = match plan_llm_call(api, tok, &payload).await {
+        PlanLlmOutcome::Ok { text, .. } => text,
+        PlanLlmOutcome::Cancelled => {
+            eprintln!("  {} Plan edit cancelled.", theme::icon_warn());
+            return Ok(PlanInputResult::Handled);
+        }
+        PlanLlmOutcome::Error(e) => {
+            eprintln!("  {} {}", theme::icon_err(), e.red());
+            return Ok(PlanInputResult::Handled);
+        }
+    };
 
-    match resp {
-        Ok(r) if r.status().is_success() => {
-            let sse_result = collect_sse_with_preview(r).await;
-            if let Some(err) = sse_result.completion_error() {
-                eprintln!("  {} {}", theme::icon_err(), err.red());
-                return Ok(PlanInputResult::Handled);
-            }
+    if llm_text.is_empty() {
+        eprintln!("  {} No response from server", theme::icon_warn());
+    }
 
-            if sse_result.text.is_empty() {
-                if sse_result.event_count == 0 {
+    if !llm_text.is_empty() {
+        let Some(plan_state) = state.plan_mode.as_mut() else {
+            return Ok(PlanInputResult::Handled);
+        };
+        match try_replace_plan_from_llm_json(&llm_text, plan_state) {
+            Ok(true) => {
+                plan_state.modified = true;
+                let _ = plan_state.save_to_file(&PlanModeState::state_path());
+
+                journal_plan_event(
+                    &mut state.journal,
+                    session_journal::JournalEventType::PlanEdit,
+                    &format!(
+                        "Plan edited: {}",
+                        input.chars().take(80).collect::<String>()
+                    ),
+                    Some(serde_json::json!({
+                        "instruction": input.chars().take(200).collect::<String>(),
+                        "subtask_count": plan_state.plan.subtasks.len(),
+                    })),
+                );
+
+                // Auto-prompt execution if there are new pending subtasks
+                let pending_count = plan_state
+                    .plan
+                    .subtasks
+                    .iter()
+                    .filter(|s| s.status == astra_services::task_orchestrator::TaskStatus::Pending)
+                    .count();
+                if pending_count > 0 {
+                    eprintln!();
                     eprintln!(
-                        "  {} No SSE events received from server",
-                        theme::icon_warn()
+                        "  {} {} new subtask{} added.",
+                        theme::icon_ok(),
+                        format!("{pending_count}").cyan(),
+                        if pending_count == 1 { "" } else { "s" }
                     );
-                } else {
-                    eprintln!(
-                        "  {} {} events (types: {}) but no text",
-                        theme::icon_warn(),
-                        sse_result.event_count,
-                        sse_result.event_types.join(", ")
-                    );
-                }
-            }
-
-            if !sse_result.text.is_empty() {
-                let Some(plan_state) = state.plan_mode.as_mut() else {
-                    return Ok(PlanInputResult::Handled);
-                };
-                match try_replace_plan_from_llm_json(&sse_result.text, plan_state) {
-                    Ok(true) => {
-                        plan_state.modified = true;
-                        let _ = plan_state.save_to_file(&PlanModeState::state_path());
-
-                        journal_plan_event(
-                            &mut state.journal,
-                            session_journal::JournalEventType::PlanEdit,
-                            &format!(
-                                "Plan edited: {}",
-                                input.chars().take(80).collect::<String>()
-                            ),
-                            Some(serde_json::json!({
-                                "instruction": input.chars().take(200).collect::<String>(),
-                                "subtask_count": plan_state.plan.subtasks.len(),
-                            })),
-                        );
-
-                        // Auto-prompt execution if there are new pending subtasks
-                        let pending_count = plan_state
-                            .plan
-                            .subtasks
-                            .iter()
-                            .filter(|s| {
-                                s.status == astra_services::task_orchestrator::TaskStatus::Pending
-                            })
-                            .count();
-                        if pending_count > 0 {
-                            eprintln!();
-                            eprintln!(
-                                "  {} {} new subtask{} added.",
-                                theme::icon_ok(),
-                                format!("{pending_count}").cyan(),
-                                if pending_count == 1 { "" } else { "s" }
-                            );
-                            if let Some(choice) = prompt_plan_confirmation(pending_count) {
-                                match choice {
-                                    PlanConfirmChoice::ExecuteAll => {
-                                        return Box::pin(handle_plan_mode_input(
-                                            "go".into(),
-                                            token,
-                                            state,
-                                            api,
-                                        ))
-                                        .await;
-                                    }
-                                    PlanConfirmChoice::StepByStep => {
-                                        return Box::pin(handle_plan_mode_input(
-                                            "step".into(),
-                                            token,
-                                            state,
-                                            api,
-                                        ))
-                                        .await;
-                                    }
-                                    PlanConfirmChoice::Edit | PlanConfirmChoice::Cancel => {}
-                                }
+                    if let Some(choice) = prompt_plan_confirmation(pending_count) {
+                        match choice {
+                            PlanConfirmChoice::ExecuteAll => {
+                                return Box::pin(handle_plan_mode_input(
+                                    "go".into(),
+                                    token,
+                                    state,
+                                    api,
+                                ))
+                                .await;
                             }
+                            PlanConfirmChoice::StepByStep => {
+                                return Box::pin(handle_plan_mode_input(
+                                    "step".into(),
+                                    token,
+                                    state,
+                                    api,
+                                ))
+                                .await;
+                            }
+                            PlanConfirmChoice::Edit | PlanConfirmChoice::Cancel => {}
                         }
                     }
-                    Ok(false) => {}
-                    Err(e) => {
-                        eprintln!(
-                            "  {} Model reply is not valid plan JSON: {}",
-                            theme::icon_warn(),
-                            e
-                        );
-                        eprintln!(
-                            "  {} Plan unchanged. Try {} for the current plan.",
-                            "⋯".dim(),
-                            "show".cyan()
-                        );
-                    }
                 }
             }
+            Ok(false) => {}
+            Err(e) => {
+                eprintln!(
+                    "  {} Model reply is not valid plan JSON: {}",
+                    theme::icon_warn(),
+                    e
+                );
+                eprintln!(
+                    "  {} Plan unchanged. Try {} for the current plan.",
+                    "⋯".dim(),
+                    "show".cyan()
+                );
+            }
+        }
+    }
 
-            if let Some(plan_state) = state.plan_mode.as_mut() {
-                if let Some(last) = plan_state.history.last_mut() {
-                    last.1 = sse_result.text.chars().take(500).collect();
-                }
-            }
-        }
-        Ok(r) => {
-            cli_utils::eprint_api_error(r.status().as_u16(), "LLM call failed");
-        }
-        Err(e) => {
-            cli_utils::eprint_request_error(&e);
+    if let Some(plan_state) = state.plan_mode.as_mut() {
+        if let Some(last) = plan_state.history.last_mut() {
+            last.1 = llm_text.chars().take(500).collect();
         }
     }
 
@@ -1676,16 +1919,20 @@ async fn handle_plan_command(
 }
 
 /// Handle initial goal submission — scan project and generate plan via LLM.
+///
+/// Uses a two-stage flow:
+/// 1. Generate outline (2-4 phases) — fast, gives user a chance to review
+/// 2. User confirms → expand each phase into subtasks
+///
+/// Falls back to direct full-plan generation if outline parsing fails.
 async fn handle_goal_submission(
     goal: String,
     token: Option<&str>,
     state: &mut ReplState,
     api: &astra_thin_client::ThinClient,
 ) -> Result<PlanInputResult, String> {
-    use plan::{
-        PendingClarifications, PlanModeState, decomposition_prompt, detect_clarification_questions,
-        format_project_context, parse_plan_response,
-    };
+    use astra_runtime::plan::outline;
+    use plan::{detect_clarification_questions, format_project_context, parse_plan_response};
 
     let Some(tok) = token else {
         eprintln!("  {} Not logged in. Run /login first.", theme::icon_err());
@@ -1722,110 +1969,526 @@ async fn handle_goal_submission(
         state.verbose_mode,
     )
     .await;
-    let prompt = decomposition_prompt(&goal, &plan_state.context);
-    let payload = serde_json::json!({
-        "messages": [{"role": "user", "content": prompt}],
+
+    // ── Stage 1: Generate outline ───────────────────────────────────────
+    eprintln!();
+    let outline_prompt = outline::outline_prompt(&goal, &plan_state.context);
+    let outline_payload = serde_json::json!({
+        "messages": [{"role": "user", "content": outline_prompt}],
         "session_id": state.session_id.clone(),
     });
 
-    eprintln!();
-    let resp = api.post_chat_turn(tok, &payload).await;
+    let outline_result = plan_llm_call(api, tok, &outline_payload).await;
+    maybe_init_session_from_plan(state, &outline_result);
+    let outline_text = match outline_result {
+        PlanLlmOutcome::Ok { text, .. } => text,
+        PlanLlmOutcome::Cancelled => {
+            eprintln!("  {} Plan generation cancelled.", theme::icon_warn());
+            return Ok(PlanInputResult::Handled);
+        }
+        PlanLlmOutcome::Error(e) => {
+            eprintln!("  {} {}", theme::icon_err(), e.red());
+            return Ok(PlanInputResult::Handled);
+        }
+    };
 
-    match resp {
-        Ok(r) if r.status().is_success() => {
-            let sse_result = collect_sse_with_preview(r).await;
-            if let Some(err) = sse_result.completion_error() {
-                eprintln!("  {} {}", theme::icon_err(), err.red());
+    if outline_text.trim().is_empty() {
+        // LLM returned only thinking content, no text_delta — skip to full plan
+        if state.verbose_mode {
+            eprintln!("  {} Outline response empty, trying full plan…", "⋯".dim());
+        }
+    } else {
+        // Try to parse as outline; fall back to full plan generation on failure
+        let parsed_outline = outline::parse_outline_response(&outline_text);
+
+        if state.verbose_mode {
+            if let Err(ref e) = parsed_outline {
+                eprintln!("  {} Outline parse error: {}", "⋯".dim(), e.as_str().dim());
+                let preview: String = outline_text.chars().take(200).collect();
+                eprintln!("  {} Response preview: {}", "⋯".dim(), preview.dim());
+            }
+        }
+
+        match parsed_outline {
+            Ok(ref ol) if !ol.questions.is_empty() => {
+                return handle_outline_clarifications(
+                    ol.questions.clone(),
+                    &goal,
+                    token,
+                    state,
+                    api,
+                )
+                .await;
+            }
+            Ok(ref ol) if !ol.phases.is_empty() => {
+                eprintln!();
+                eprint_styled_outline(ol, &goal);
+
+                match prompt_outline_confirmation(ol.phases.len()) {
+                    OutlineChoice::Confirm => {
+                        return expand_outline_to_plan(ol, &goal, tok, state, api).await;
+                    }
+                    OutlineChoice::SkipToFull => {
+                        eprintln!("  {} Generating full plan directly…", "⏭".cyan());
+                    }
+                    OutlineChoice::Edit => {
+                        match inquire::Text::new("  Describe changes:")
+                            .with_help_message("Esc to cancel")
+                            .prompt()
+                        {
+                            Ok(edit) if !edit.trim().is_empty() => {
+                                return Box::pin(handle_plan_mode_input(edit, token, state, api))
+                                    .await;
+                            }
+                            _ => {}
+                        }
+                        return Ok(PlanInputResult::Handled);
+                    }
+                    OutlineChoice::Cancel => {
+                        return Ok(PlanInputResult::Handled);
+                    }
+                }
+            }
+            _ => {
+                // Outline parse failed — try as full plan or clarification directly
+                if let Some(questions) = detect_clarification_questions(&outline_text) {
+                    return handle_outline_clarifications(questions, &goal, token, state, api)
+                        .await;
+                }
+                if let Ok(plan) = parse_plan_response(&outline_text) {
+                    return accept_generated_plan(plan, token, state, api).await;
+                }
+                if state.verbose_mode {
+                    eprintln!("  {} Outline parse failed, trying full plan…", "⋯".dim());
+                }
+            }
+        }
+    }
+
+    // ── Fallback: direct full-plan generation ───────────────────────────
+    let Some(plan_ctx) = state.plan_mode.as_ref().map(|ps| ps.context.clone()) else {
+        return Ok(PlanInputResult::Handled);
+    };
+    let full_text =
+        match plan_generate_with_retry(api, tok, &goal, &plan_ctx, state.session_id.as_deref())
+            .await
+        {
+            PlanLlmOutcome::Ok { text, .. } => text,
+            PlanLlmOutcome::Cancelled => {
+                eprintln!("  {} Plan generation cancelled.", theme::icon_warn());
                 return Ok(PlanInputResult::Handled);
             }
-            let full_text = sse_result.text;
+            PlanLlmOutcome::Error(e) => {
+                eprintln!("  {} {}", theme::icon_err(), e.red());
+                return Ok(PlanInputResult::Handled);
+            }
+        };
 
-            if let Some(questions) = detect_clarification_questions(&full_text) {
-                eprintln!();
-                eprintln!(
-                    "  {} {}",
-                    "▸".cyan(),
-                    format!(
-                        "{} question{} before planning:",
-                        questions.len(),
-                        if questions.len() == 1 { "" } else { "s" }
-                    )
-                    .bold()
-                    .cyan()
-                );
-                eprintln!();
+    if let Some(questions) = detect_clarification_questions(&full_text) {
+        return handle_outline_clarifications(questions, &goal, token, state, api).await;
+    }
 
-                let Some(plan_state) = state.plan_mode.as_mut() else {
+    match parse_plan_response(&full_text) {
+        Ok(plan) => accept_generated_plan(plan, token, state, api).await,
+        Err(e) => {
+            eprint_plan_json_parse_failed(&full_text, &e.to_string());
+            Ok(PlanInputResult::Handled)
+        }
+    }
+}
+
+/// User's choice after seeing the outline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutlineChoice {
+    Confirm,
+    SkipToFull,
+    Edit,
+    Cancel,
+}
+
+/// Interactive outline confirmation using `inquire::Select`.
+fn prompt_outline_confirmation(phase_count: usize) -> OutlineChoice {
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() {
+        return OutlineChoice::Confirm;
+    }
+
+    let options = vec![
+        format!("✓  Looks good, expand all {phase_count} phases"),
+        "⏭  Skip outline, generate full plan directly".to_string(),
+        "✏  Edit (describe changes)".to_string(),
+        "✕  Cancel".to_string(),
+    ];
+
+    eprintln!();
+    match inquire::Select::new("Plan outline:", options)
+        .with_render_config(plan_select_theme())
+        .without_help_message()
+        .prompt()
+    {
+        Ok(c) if c.starts_with('✓') => OutlineChoice::Confirm,
+        Ok(c) if c.starts_with('⏭') => OutlineChoice::SkipToFull,
+        Ok(c) if c.starts_with('✏') => OutlineChoice::Edit,
+        _ => OutlineChoice::Cancel,
+    }
+}
+
+/// Handle clarification questions with interactive `inquire::Select`.
+async fn handle_outline_clarifications(
+    questions: Vec<plan::ClarificationQuestion>,
+    goal: &str,
+    token: Option<&str>,
+    state: &mut ReplState,
+    api: &astra_thin_client::ThinClient,
+) -> Result<PlanInputResult, String> {
+    use plan::{PendingClarifications, PlanModeState};
+    use std::io::IsTerminal;
+
+    eprintln!();
+    eprintln!(
+        "  {} {}",
+        "▸".cyan(),
+        format!(
+            "{} question{} before planning:",
+            questions.len(),
+            if questions.len() == 1 { "" } else { "s" }
+        )
+        .bold()
+        .cyan()
+    );
+    eprintln!();
+
+    // Try interactive inquire selection if terminal supports it
+    if std::io::stdin().is_terminal() {
+        let mut answers = Vec::new();
+        for q in &questions {
+            match ask_clarification_interactive(q) {
+                Some(answer) => answers.push(answer),
+                None => {
+                    // User cancelled — fall back to text-based flow
+                    break;
+                }
+            }
+        }
+
+        if answers.len() == questions.len() {
+            // All answered — regenerate plan with answers
+            let answers_text = questions
+                .iter()
+                .zip(&answers)
+                .map(|(q, a)| format!("Q: {}\nA: {}", q.question, a))
+                .collect::<Vec<_>>()
+                .join("\n\n");
+
+            let goal_with_context =
+                format!("{goal}\n\n## Clarifications from user:\n{answers_text}");
+
+            let Some(tok) = token else {
+                return Ok(PlanInputResult::Handled);
+            };
+
+            let Some(clarify_ctx) = state.plan_mode.as_ref().map(|ps| ps.context.clone()) else {
+                return Ok(PlanInputResult::Handled);
+            };
+            let full_text = match plan_generate_with_retry(
+                api,
+                tok,
+                &goal_with_context,
+                &clarify_ctx,
+                state.session_id.as_deref(),
+            )
+            .await
+            {
+                PlanLlmOutcome::Ok { text, .. } => text,
+                PlanLlmOutcome::Cancelled => {
+                    eprintln!("  {} Plan generation cancelled.", theme::icon_warn());
                     return Ok(PlanInputResult::Handled);
-                };
-                let pending = PendingClarifications {
-                    questions: questions.clone(),
-                    answers: Vec::new(),
-                };
-                plan_state.pending_clarifications = Some(pending);
+                }
+                PlanLlmOutcome::Error(e) => {
+                    eprintln!("  {} {}", theme::icon_err(), e.red());
+                    return Ok(PlanInputResult::Handled);
+                }
+            };
 
-                eprint_clarification_question(&questions[0]);
-                let _ = plan_state.save_to_file(&PlanModeState::state_path());
-            } else {
-                match parse_plan_response(&full_text) {
-                    Ok(plan) => {
-                        let Some(plan_state) = state.plan_mode.as_mut() else {
-                            return Ok(PlanInputResult::Handled);
-                        };
-                        plan_state.set_plan(plan);
-                        let _ = plan_state.save_to_file(&PlanModeState::state_path());
+            match plan::parse_plan_response(&full_text) {
+                Ok(plan) => return accept_generated_plan(plan, token, state, api).await,
+                Err(e) => {
+                    eprint_plan_json_parse_failed(&full_text, &e.to_string());
+                    return Ok(PlanInputResult::Handled);
+                }
+            }
+        }
+    }
 
-                        journal_plan_event(
-                            &mut state.journal,
-                            session_journal::JournalEventType::PlanLifecycle,
-                            &format!(
-                                "Plan generated: {} subtasks",
-                                plan_state.plan.subtasks.len()
-                            ),
-                            Some(serde_json::json!({
-                                "subtask_count": plan_state.plan.subtasks.len(),
-                            })),
-                        );
+    // Fall back to text-based clarification (existing flow)
+    let Some(plan_state) = state.plan_mode.as_mut() else {
+        return Ok(PlanInputResult::Handled);
+    };
+    let pending = PendingClarifications {
+        questions: questions.clone(),
+        answers: Vec::new(),
+    };
+    plan_state.pending_clarifications = Some(pending);
+    eprint_clarification_question(&questions[0]);
+    let _ = plan_state.save_to_file(&PlanModeState::state_path());
+    Ok(PlanInputResult::Handled)
+}
 
-                        let subtask_count = plan_state.plan.subtasks.len();
-                        eprint_plan_commands_help();
+/// Ask a single clarification question using `inquire::Select`.
+///
+/// Returns the selected answer text, or `None` if the user pressed Esc.
+fn ask_clarification_interactive(q: &plan::ClarificationQuestion) -> Option<String> {
+    let icon = match q.category {
+        plan::ClarificationCategory::Scope => "📦",
+        plan::ClarificationCategory::Approach => "🛤️ ",
+        plan::ClarificationCategory::Behavior => "⚙️ ",
+        plan::ClarificationCategory::Technical => "🔧",
+        plan::ClarificationCategory::Confirmation => "❓",
+    };
 
-                        // Offer interactive confirmation if terminal supports it
-                        if let Some(choice) = prompt_plan_confirmation(subtask_count) {
-                            match choice {
-                                PlanConfirmChoice::ExecuteAll => {
-                                    return Box::pin(handle_plan_mode_input(
-                                        "go".into(),
-                                        token,
-                                        state,
-                                        api,
-                                    ))
-                                    .await;
-                                }
-                                PlanConfirmChoice::StepByStep => {
-                                    return Box::pin(handle_plan_mode_input(
-                                        "step".into(),
-                                        token,
-                                        state,
-                                        api,
-                                    ))
-                                    .await;
-                                }
-                                PlanConfirmChoice::Edit | PlanConfirmChoice::Cancel => {}
-                            }
+    let mut options = q.options.clone();
+    options.push("Other (type your answer)".into());
+
+    let prompt_text = format!("{icon} {}", q.question);
+    let starting = q.default.unwrap_or(0);
+
+    match inquire::Select::new(&prompt_text, options.clone())
+        .with_render_config(plan_select_theme())
+        .with_starting_cursor(starting)
+        .without_help_message()
+        .prompt()
+    {
+        Ok(choice) if choice.starts_with("Other") => {
+            match inquire::Text::new("  Your answer:").prompt() {
+                Ok(text) if !text.trim().is_empty() => Some(text.trim().to_string()),
+                _ => None,
+            }
+        }
+        Ok(choice) => Some(choice),
+        Err(_) => None,
+    }
+}
+
+/// Expand an outline into a full plan by generating subtasks for each phase.
+async fn expand_outline_to_plan(
+    ol: &astra_runtime::plan::outline::PlanOutline,
+    goal: &str,
+    tok: &str,
+    state: &mut ReplState,
+    api: &astra_thin_client::ThinClient,
+) -> Result<PlanInputResult, String> {
+    use astra_runtime::plan::outline;
+    use plan::parse_plan_response;
+
+    let Some(plan_ctx) = state.plan_mode.as_ref().map(|ps| ps.context.clone()) else {
+        return Ok(PlanInputResult::Handled);
+    };
+    let mut all_subtasks = Vec::new();
+    let mut completed_phases = Vec::new();
+
+    for (i, phase) in ol.phases.iter().enumerate() {
+        eprintln!(
+            "  {} Expanding phase {}/{}: {}",
+            "⋯".cyan(),
+            i + 1,
+            ol.phases.len(),
+            phase.title.as_str().bold()
+        );
+
+        let detail_prompt =
+            outline::phase_detail_prompt(goal, ol, phase, &completed_phases, &plan_ctx);
+        let payload = serde_json::json!({
+            "messages": [{"role": "user", "content": detail_prompt}],
+            "session_id": state.session_id.clone(),
+        });
+
+        let text = match plan_llm_call(api, tok, &payload).await {
+            PlanLlmOutcome::Ok { text: t, .. } => t,
+            PlanLlmOutcome::Cancelled => {
+                eprintln!("  {} Cancelled during phase expansion.", theme::icon_warn());
+                // Use whatever subtasks we have so far
+                if !all_subtasks.is_empty() {
+                    eprintln!(
+                        "  {} Using {} subtasks from completed phases.",
+                        theme::icon_ok(),
+                        all_subtasks.len()
+                    );
+                    break;
+                }
+                return Ok(PlanInputResult::Handled);
+            }
+            PlanLlmOutcome::Error(e) => {
+                eprintln!(
+                    "  {} Phase {} failed: {}",
+                    theme::icon_warn(),
+                    phase.id,
+                    e.yellow()
+                );
+                continue;
+            }
+        };
+
+        match parse_plan_response(&text) {
+            Ok(phase_plan) => {
+                let count = phase_plan.subtasks.len();
+                all_subtasks.extend(phase_plan.subtasks);
+                completed_phases.push(phase.id.clone());
+                eprintln!(
+                    "  {} {} — {} subtask{}",
+                    theme::icon_ok(),
+                    phase.title,
+                    count,
+                    if count == 1 { "" } else { "s" }
+                );
+            }
+            Err(_) => {
+                // Retry once with a stricter prompt
+                let retry_prompt = format!(
+                    "Output ONLY a JSON object: {{\"subtasks\": [...]}}. \
+                     No markdown, no explanation. Expand phase \"{}\" — {}",
+                    phase.id, phase.title
+                );
+                let retry_payload = serde_json::json!({
+                    "messages": [
+                        {"role": "user", "content": detail_prompt},
+                        {"role": "assistant", "content": text},
+                        {"role": "user", "content": retry_prompt},
+                    ],
+                    "session_id": state.session_id.clone(),
+                });
+                match plan_llm_call(api, tok, &retry_payload).await {
+                    PlanLlmOutcome::Ok {
+                        text: retry_text, ..
+                    } => match parse_plan_response(&retry_text) {
+                        Ok(phase_plan) => {
+                            let count = phase_plan.subtasks.len();
+                            all_subtasks.extend(phase_plan.subtasks);
+                            completed_phases.push(phase.id.clone());
+                            eprintln!(
+                                "  {} {} — {} subtask{} (retry)",
+                                theme::icon_ok(),
+                                phase.title,
+                                count,
+                                if count == 1 { "" } else { "s" }
+                            );
                         }
-                    }
-                    Err(e) => {
-                        eprint_plan_json_parse_failed(&full_text, &e.to_string());
+                        Err(e2) => {
+                            eprintln!(
+                                "  {} Phase {} failed: {}",
+                                theme::icon_warn(),
+                                phase.id,
+                                e2.yellow()
+                            );
+                        }
+                    },
+                    PlanLlmOutcome::Cancelled => break,
+                    PlanLlmOutcome::Error(e) => {
+                        eprintln!(
+                            "  {} Phase {} retry failed: {}",
+                            theme::icon_warn(),
+                            phase.id,
+                            e.yellow()
+                        );
                     }
                 }
             }
         }
-        Ok(r) => {
-            cli_utils::eprint_api_error(r.status().as_u16(), "LLM call failed");
-        }
-        Err(e) => {
-            cli_utils::eprint_request_error(&e);
+    }
+
+    if all_subtasks.is_empty() {
+        eprintln!(
+            "  {} No subtasks generated. Try rephrasing your goal.",
+            theme::icon_err()
+        );
+        return Ok(PlanInputResult::Handled);
+    }
+
+    let plan = astra_services::task_orchestrator::TaskPlan {
+        subtasks: all_subtasks,
+        notes: Some(format!("Generated from {}-phase outline", ol.phases.len())),
+    };
+
+    accept_generated_plan(plan, Some(tok), state, api).await
+}
+
+/// Accept a generated plan: store it, journal it, record a session turn, and prompt for execution.
+async fn accept_generated_plan(
+    plan: astra_services::task_orchestrator::TaskPlan,
+    token: Option<&str>,
+    state: &mut ReplState,
+    api: &astra_thin_client::ThinClient,
+) -> Result<PlanInputResult, String> {
+    use plan::PlanModeState;
+
+    let Some(plan_state) = state.plan_mode.as_mut() else {
+        return Ok(PlanInputResult::Handled);
+    };
+    plan_state.set_plan(plan);
+    let _ = plan_state.save_to_file(&PlanModeState::state_path());
+
+    let subtask_count = plan_state.plan.subtasks.len();
+    let goal = plan_state.goal.clone();
+
+    journal_plan_event(
+        &mut state.journal,
+        session_journal::JournalEventType::PlanLifecycle,
+        &format!("Plan generated: {subtask_count} subtasks"),
+        Some(serde_json::json!({
+            "subtask_count": subtask_count,
+        })),
+    );
+
+    // Record a session turn so /session shows the plan generation
+    if let Some(ref journal) = state.journal {
+        let plan_summary: Vec<String> = plan_state
+            .plan
+            .subtasks
+            .iter()
+            .map(|s| format!("- [{}] {}", s.id, s.title))
+            .collect();
+        let assistant_content = format!(
+            "Plan generated ({subtask_count} subtasks):\n{}",
+            plan_summary.join("\n")
+        );
+        let turn_event = session_journal::JournalEvent::turn(
+            state.session_id.as_deref(),
+            state.turn,
+            state.model.as_deref(),
+            &goal,
+            &assistant_content,
+            0, // tool_count
+            0, // tokens_in (not tracked for plan generation)
+            0, // tokens_out
+            0, // duration_ms
+        );
+        let _ = journal.append(&turn_event);
+    }
+    state.turn += 1;
+
+    // Show the generated plan before asking what to do
+    eprintln!();
+    eprint_styled_plan(&plan_state.plan, &goal);
+
+    if let Some(choice) = prompt_plan_confirmation(subtask_count) {
+        match choice {
+            PlanConfirmChoice::ExecuteAll => {
+                return Box::pin(handle_plan_mode_input("go".into(), token, state, api)).await;
+            }
+            PlanConfirmChoice::StepByStep => {
+                return Box::pin(handle_plan_mode_input("step".into(), token, state, api)).await;
+            }
+            PlanConfirmChoice::Edit => {
+                match inquire::Text::new("  Describe changes:")
+                    .with_help_message("Esc to cancel")
+                    .prompt()
+                {
+                    Ok(edit) if !edit.trim().is_empty() => {
+                        return Box::pin(handle_plan_mode_input(edit, token, state, api)).await;
+                    }
+                    _ => {}
+                }
+            }
+            PlanConfirmChoice::Cancel => {}
         }
     }
 

--- a/rust/crates/astra-cli/src/cli/sse_utils.rs
+++ b/rust/crates/astra-cli/src/cli/sse_utils.rs
@@ -7,6 +7,8 @@
 use crate::theme;
 use futures_util::StreamExt;
 use std::io::IsTerminal;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 
 /// Maximum SSE buffer size (1 MB). If a malformed stream sends data without
 /// `\n\n` delimiters, we truncate the buffer to prevent unbounded memory growth.
@@ -22,6 +24,10 @@ pub struct SseTextResult {
     pub stream_error: Option<String>,
     /// True when we had to truncate an oversized malformed SSE buffer.
     pub truncated: bool,
+    /// Session ID from `session_info` event (if present).
+    pub session_id: Option<String>,
+    /// True when the stream was interrupted by a cancellation token.
+    pub cancelled: bool,
 }
 
 impl SseTextResult {
@@ -31,6 +37,11 @@ impl SseTextResult {
                 format!("SSE buffer exceeded {MAX_SSE_BUFFER} bytes before a complete event")
             })
         })
+    }
+
+    /// True when the stream was interrupted by a cancellation token.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled
     }
 }
 
@@ -44,6 +55,8 @@ pub async fn collect_sse_text(resp: reqwest::Response, stream_to_stderr: bool) -
         event_types: Vec::new(),
         stream_error: None,
         truncated: false,
+        session_id: None,
+        cancelled: false,
     };
     let mut buffer = String::new();
     let mut stream = resp.bytes_stream();
@@ -158,6 +171,8 @@ pub async fn stream_sse_markdown(resp: reqwest::Response) -> SseTextResult {
         event_types: Vec::new(),
         stream_error: None,
         truncated: false,
+        session_id: None,
+        cancelled: false,
     };
     let mut buffer = String::new();
     let mut stream = resp.bytes_stream();
@@ -282,6 +297,8 @@ pub async fn collect_sse_with_preview(resp: reqwest::Response) -> SseTextResult 
         event_types: Vec::new(),
         stream_error: None,
         truncated: false,
+        session_id: None,
+        cancelled: false,
     };
     let mut buffer = String::new();
     let mut stream = resp.bytes_stream();
@@ -364,6 +381,168 @@ pub async fn collect_sse_with_preview(resp: reqwest::Response) -> SseTextResult 
     }
 
     // Show summary, then clear the preview
+    let summary = pane.summary_line();
+    pane.clear();
+    if !summary.is_empty() {
+        eprintln!("{}", summary);
+    }
+
+    result
+}
+
+/// Cancellable SSE collection with timeout, preview pane, and progress callback.
+///
+/// Like [`collect_sse_with_preview`] but supports:
+/// - **Cancellation** via [`CancellationToken`] (wired to Ctrl-C by caller)
+/// - **Stream timeout** — total wall-clock limit for the entire SSE stream
+/// - **Idle timeout** — max gap between consecutive SSE data frames
+/// - **Progress callback** — called on each `text_delta` chunk
+///
+/// Used by plan generation where the user must be able to interrupt long LLM calls.
+pub async fn collect_sse_cancellable(
+    resp: reqwest::Response,
+    cancel: &CancellationToken,
+    stream_timeout: Duration,
+    idle_timeout: Duration,
+    mut on_chunk: impl FnMut(&str),
+) -> SseTextResult {
+    use super::effects::{ThinkingPreviewPane, thinking_viewport_rows};
+
+    let tw = crossterm::terminal::size()
+        .map(|(w, _)| w as usize)
+        .unwrap_or(80);
+    let rows = thinking_viewport_rows();
+    let mut pane = ThinkingPreviewPane::new(rows, tw);
+
+    let mut result = SseTextResult {
+        text: String::new(),
+        event_count: 0,
+        event_types: Vec::new(),
+        stream_error: None,
+        truncated: false,
+        session_id: None,
+        cancelled: false,
+    };
+    let mut buffer = String::new();
+    let mut stream = resp.bytes_stream();
+    let deadline = tokio::time::Instant::now() + stream_timeout;
+    let mut last_data = tokio::time::Instant::now();
+
+    loop {
+        let idle_deadline = last_data + idle_timeout;
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                result.stream_error = Some("Plan generation cancelled".into());
+                result.cancelled = true;
+                break;
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                result.stream_error = Some(format!(
+                    "Stream timeout after {}s",
+                    stream_timeout.as_secs()
+                ));
+                break;
+            }
+            _ = tokio::time::sleep_until(idle_deadline) => {
+                result.stream_error = Some(format!(
+                    "No data received for {}s",
+                    idle_timeout.as_secs()
+                ));
+                break;
+            }
+            chunk = stream.next() => {
+                match chunk {
+                    Some(Ok(bytes)) => {
+                        last_data = tokio::time::Instant::now();
+                        buffer.push_str(&String::from_utf8_lossy(&bytes));
+
+                        if buffer.len() > MAX_SSE_BUFFER {
+                            result.truncated = true;
+                            buffer.clear();
+                            break;
+                        }
+
+                        while let Some(event_end) = buffer.find("\n\n") {
+                            let event_str = buffer[..event_end].to_string();
+                            buffer = buffer[event_end + 2..].to_string();
+
+                            for line in event_str.lines() {
+                                if let Some(data) = line.strip_prefix("data: ") {
+                                    result.event_count += 1;
+                                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+                                        let event_type = json
+                                            .get("type")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("unknown");
+
+                                        if !result.event_types.contains(&event_type.to_string()) {
+                                            result.event_types.push(event_type.to_string());
+                                        }
+
+                                        match event_type {
+                                            "text_delta" => {
+                                                if let Some(content) = json.get("content").and_then(|v| v.as_str()) {
+                                                    result.text.push_str(content);
+                                                    pane.push_chunk(content);
+                                                    on_chunk(content);
+                                                }
+                                            }
+                                            "session_info" => {
+                                                if let Some(sid) = json.get("session_id").and_then(|v| v.as_str()) {
+                                                    result.session_id = Some(sid.to_string());
+                                                }
+                                            }
+                                            "error" => {
+                                                if let Some(msg) = json
+                                                    .get("message")
+                                                    .or_else(|| json.get("error"))
+                                                    .and_then(|v| v.as_str())
+                                                {
+                                                    eprintln!("\r  {} Server error: {}", theme::icon_err(), msg);
+                                                }
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Some(Err(e)) => {
+                        result.stream_error = Some(format!("SSE stream read failed: {e}"));
+                        break;
+                    }
+                    None => break, // stream ended normally
+                }
+            }
+        }
+    }
+
+    // Drain remaining buffer
+    for line in buffer.lines() {
+        if let Some(data) = line.strip_prefix("data: ") {
+            result.event_count += 1;
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+                match json.get("type").and_then(|v| v.as_str()) {
+                    Some("text_delta") => {
+                        if let Some(content) = json.get("content").and_then(|v| v.as_str()) {
+                            result.text.push_str(content);
+                            pane.push_chunk(content);
+                            on_chunk(content);
+                        }
+                    }
+                    Some("session_info") => {
+                        if let Some(sid) = json.get("session_id").and_then(|v| v.as_str()) {
+                            result.session_id = Some(sid.to_string());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
     let summary = pane.summary_line();
     pane.clear();
     if !summary.is_empty() {
@@ -506,5 +685,147 @@ mod tests {
             collected.completion_error(),
             "terminal failure state must match collect_sse_text"
         );
+    }
+
+    // ── collect_sse_cancellable tests ───────────────────────────────────
+
+    #[tokio::test]
+    async fn cancellable_collects_text_deltas() {
+        let body = concat!(
+            "data: {\"type\":\"text_delta\",\"content\":\"hel\"}\n\n",
+            "data: {\"type\":\"text_delta\",\"content\":\"lo\"}\n\n",
+        );
+        let cancel = CancellationToken::new();
+        let r = collect_sse_cancellable(
+            sse_response(body),
+            &cancel,
+            Duration::from_secs(10),
+            Duration::from_secs(5),
+            |_| {},
+        )
+        .await;
+        assert_eq!(r.text, "hello");
+        assert!(!r.is_cancelled());
+        assert!(r.completion_error().is_none());
+    }
+
+    #[tokio::test]
+    async fn cancellable_respects_cancellation_token() {
+        // Stream that never ends — cancellation must break out
+        let body = reqwest::Body::wrap_stream(futures_util::stream::unfold(0u32, |i| async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let chunk = format!("data: {{\"type\":\"text_delta\",\"content\":\"chunk{i}\"}}\n\n");
+            Some((Ok::<_, std::io::Error>(chunk.into_bytes()), i + 1))
+        }));
+        let resp = reqwest::Response::from(
+            Response::builder()
+                .status(200)
+                .body(body)
+                .expect("test response"),
+        );
+
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            cancel_clone.cancel();
+        });
+
+        let r = collect_sse_cancellable(
+            resp,
+            &cancel,
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+            |_| {},
+        )
+        .await;
+        assert!(r.is_cancelled(), "should be cancelled");
+        assert!(
+            !r.text.is_empty(),
+            "should have collected some chunks before cancel"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellable_idle_timeout_fires() {
+        // Stream that sends one chunk then stalls
+        let body =
+            reqwest::Body::wrap_stream(futures_util::stream::unfold(false, |sent| async move {
+                if sent {
+                    tokio::time::sleep(Duration::from_secs(300)).await;
+                    None
+                } else {
+                    let chunk = "data: {\"type\":\"text_delta\",\"content\":\"x\"}\n\n";
+                    Some((Ok::<_, std::io::Error>(chunk.as_bytes().to_vec()), true))
+                }
+            }));
+        let resp = reqwest::Response::from(
+            Response::builder()
+                .status(200)
+                .body(body)
+                .expect("test response"),
+        );
+
+        let cancel = CancellationToken::new();
+        let r = collect_sse_cancellable(
+            resp,
+            &cancel,
+            Duration::from_secs(60),
+            Duration::from_millis(200),
+            |_| {},
+        )
+        .await;
+        assert_eq!(r.text, "x");
+        assert!(
+            r.completion_error()
+                .is_some_and(|e| e.contains("No data received")),
+            "should report idle timeout, got: {:?}",
+            r.completion_error()
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellable_calls_on_chunk() {
+        let body = concat!(
+            "data: {\"type\":\"text_delta\",\"content\":\"a\"}\n\n",
+            "data: {\"type\":\"text_delta\",\"content\":\"b\"}\n\n",
+        );
+        let cancel = CancellationToken::new();
+        let mut chunks = Vec::new();
+        let r = collect_sse_cancellable(
+            sse_response(body),
+            &cancel,
+            Duration::from_secs(10),
+            Duration::from_secs(5),
+            |c| chunks.push(c.to_string()),
+        )
+        .await;
+        assert_eq!(r.text, "ab");
+        assert_eq!(chunks, vec!["a", "b"]);
+    }
+
+    #[tokio::test]
+    async fn is_cancelled_returns_false_for_other_errors() {
+        let r = collect_sse_text(sse_error_response(), false).await;
+        assert!(!r.is_cancelled());
+        assert!(!r.cancelled);
+    }
+
+    #[test]
+    fn is_cancelled_uses_bool_not_string() {
+        let mut r = SseTextResult {
+            text: String::new(),
+            event_count: 0,
+            event_types: vec![],
+            stream_error: Some("Plan generation cancelled".into()),
+            truncated: false,
+            session_id: None,
+            cancelled: false,
+        };
+        // Even with "cancelled" in the error string, is_cancelled is false
+        // because the bool field is what matters
+        assert!(!r.is_cancelled());
+        r.cancelled = true;
+        assert!(r.is_cancelled());
     }
 }

--- a/rust/crates/astra-plan/src/decompose.rs
+++ b/rust/crates/astra-plan/src/decompose.rs
@@ -684,8 +684,9 @@ pub fn plan_response_parse_error_preview(
 
 /// Parse LLM response into a TaskPlan.
 pub fn parse_plan_response(response: &str) -> Result<TaskPlan, String> {
-    // Try to extract JSON from the response (may be wrapped in markdown)
-    let json_str = extract_json(response);
+    // Try to extract JSON from the response (may be wrapped in markdown),
+    // applying repair strategies for common LLM errors (trailing commas, comments).
+    let json_str = extract_json_robust(response);
 
     // First, try to parse as generic JSON to provide better error messages
     let parsed_value: serde_json::Value = match serde_json::from_str(&json_str) {
@@ -850,6 +851,137 @@ fn extract_json(response: &str) -> String {
     }
 
     response.to_string()
+}
+
+/// Strip trailing commas before `}` or `]` — a common LLM JSON error.
+fn fix_trailing_commas(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let chars: Vec<char> = s.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+    while i < len {
+        if chars[i] == ',' {
+            // Look ahead past whitespace for } or ]
+            let mut j = i + 1;
+            while j < len && chars[j].is_whitespace() {
+                j += 1;
+            }
+            if j < len && (chars[j] == '}' || chars[j] == ']') {
+                // Skip the trailing comma
+                i += 1;
+                continue;
+            }
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
+/// Strip single-line `// …` comments — another common LLM JSON error.
+fn strip_json_comments(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut escape_next = false;
+    let chars: Vec<char> = s.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+    while i < len {
+        if escape_next {
+            out.push(chars[i]);
+            escape_next = false;
+            i += 1;
+            continue;
+        }
+        if chars[i] == '\\' && in_string {
+            out.push(chars[i]);
+            escape_next = true;
+            i += 1;
+            continue;
+        }
+        if chars[i] == '"' {
+            in_string = !in_string;
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        if !in_string && i + 1 < len && chars[i] == '/' && chars[i + 1] == '/' {
+            // Skip to end of line
+            while i < len && chars[i] != '\n' {
+                i += 1;
+            }
+            continue;
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
+/// Strip LLM thinking/reasoning tags: `<think>…</think>`, `<thinking>…</thinking>`, etc.
+///
+/// Many models wrap their reasoning in XML-like tags before the actual JSON output.
+/// This must run before JSON extraction to avoid matching `{` inside thinking content.
+fn strip_thinking_tags(text: &str) -> String {
+    let mut result = text.to_string();
+    for tag in &["think", "thinking", "reflect", "inner_monologue"] {
+        loop {
+            let open = format!("<{tag}>");
+            let close = format!("</{tag}>");
+            if let Some(start) = result.find(&open) {
+                if let Some(rel_end) = result[start + open.len()..].find(&close) {
+                    let end_pos = start + open.len() + rel_end + close.len();
+                    result = format!("{}{}", &result[..start], &result[end_pos..]);
+                    continue;
+                }
+                // Unclosed tag — strip from open tag to end
+                result = result[..start].to_string();
+            }
+            break;
+        }
+    }
+    result
+}
+
+/// Robust JSON extraction: tries multiple repair strategies.
+///
+/// 1. Strip LLM thinking tags (`<think>…</think>` etc.)
+/// 2. Direct `extract_json` (handles markdown fences, raw objects)
+/// 3. Fix trailing commas
+/// 4. Strip `//` comments
+/// 5. Both fixes combined
+///
+/// Returns the first variant that parses as valid JSON, or the original
+/// extracted string if none succeed (caller handles the parse error).
+pub fn extract_json_robust(response: &str) -> String {
+    // Strip thinking/reasoning tags before extraction
+    let cleaned = strip_thinking_tags(response);
+    let extracted = extract_json(&cleaned);
+
+    // Fast path: already valid
+    if serde_json::from_str::<serde_json::Value>(&extracted).is_ok() {
+        return extracted;
+    }
+
+    // Try trailing comma fix
+    let fixed_commas = fix_trailing_commas(&extracted);
+    if serde_json::from_str::<serde_json::Value>(&fixed_commas).is_ok() {
+        return fixed_commas;
+    }
+
+    // Try comment stripping
+    let stripped = strip_json_comments(&extracted);
+    if serde_json::from_str::<serde_json::Value>(&stripped).is_ok() {
+        return stripped;
+    }
+
+    // Try both
+    let both = fix_trailing_commas(&stripped);
+    if serde_json::from_str::<serde_json::Value>(&both).is_ok() {
+        return both;
+    }
+
+    extracted
 }
 
 /// Format a TaskPlan for display.
@@ -7013,6 +7145,149 @@ Done!"#;
     #[test]
     fn extract_json_empty_string() {
         assert_eq!(extract_json(""), "");
+    }
+
+    // ── Robust JSON extraction tests ────────────────────────────────────
+
+    #[test]
+    fn extract_json_robust_fixes_trailing_commas() {
+        let input = r#"{"subtasks": [{"id": "t1", "title": "A",}]}"#;
+        let result = extract_json_robust(input);
+        assert!(serde_json::from_str::<serde_json::Value>(&result).is_ok());
+    }
+
+    #[test]
+    fn extract_json_robust_strips_comments() {
+        let input = r#"{
+  "subtasks": [
+    {"id": "t1", "title": "A"} // first task
+  ]
+}"#;
+        let result = extract_json_robust(input);
+        assert!(serde_json::from_str::<serde_json::Value>(&result).is_ok());
+    }
+
+    #[test]
+    fn extract_json_robust_fixes_both() {
+        let input = r#"{
+  "subtasks": [
+    {"id": "t1", "title": "A",}, // trailing comma + comment
+  ]
+}"#;
+        let result = extract_json_robust(input);
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&result).is_ok(),
+            "should fix both trailing commas and comments: {result}"
+        );
+    }
+
+    #[test]
+    fn extract_json_robust_preserves_valid_json() {
+        let input = r#"{"subtasks": [{"id": "t1", "title": "A"}]}"#;
+        assert_eq!(extract_json_robust(input), input);
+    }
+
+    #[test]
+    fn extract_json_robust_strips_thinking_tags() {
+        let input = "<think>Let me analyze this goal. I need to create phases for {\"something\": true}.</think>\n{\"phases\": [{\"id\": \"p1\", \"title\": \"A\", \"description\": \"B\", \"estimated_subtasks\": 1}], \"total_effort\": \"small\"}";
+        let result = extract_json_robust(input);
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&result).is_ok(),
+            "should parse after stripping thinking tags: {result}"
+        );
+        assert!(result.contains("phases"));
+    }
+
+    #[test]
+    fn extract_json_robust_strips_thinking_with_markdown() {
+        let input = "<thinking>reasoning here</thinking>\n```json\n{\"subtasks\": [{\"id\": \"t1\", \"title\": \"A\"}]}\n```";
+        let result = extract_json_robust(input);
+        assert!(serde_json::from_str::<serde_json::Value>(&result).is_ok());
+        assert!(result.contains("subtasks"));
+    }
+
+    #[test]
+    fn strip_thinking_tags_removes_all_variants() {
+        let input = "<think>a</think>X<thinking>b</thinking>Y<reflect>c</reflect>Z";
+        assert_eq!(strip_thinking_tags(input), "XYZ");
+    }
+
+    #[test]
+    fn strip_thinking_tags_multiple_same_tag() {
+        let input = "<think>first</think>MIDDLE<think>second</think>END";
+        assert_eq!(strip_thinking_tags(input), "MIDDLEEND");
+    }
+
+    #[test]
+    fn strip_thinking_tags_nested_braces_in_thinking() {
+        let input = "<think>I see {\"key\": \"val\"} in the code</think>\n{\"phases\": []}";
+        let result = strip_thinking_tags(input);
+        assert_eq!(result, "\n{\"phases\": []}");
+    }
+
+    #[test]
+    fn strip_thinking_tags_handles_unclosed() {
+        let input = "before<think>reasoning without close";
+        assert_eq!(strip_thinking_tags(input), "before");
+    }
+
+    #[test]
+    fn strip_thinking_tags_no_tags() {
+        let input = "just plain text";
+        assert_eq!(strip_thinking_tags(input), input);
+    }
+
+    #[test]
+    fn extract_json_robust_handles_markdown_fence_with_errors() {
+        let input = "```json\n{\"subtasks\": [{\"id\": \"t1\", \"title\": \"A\",}]}\n```";
+        let result = extract_json_robust(input);
+        assert!(serde_json::from_str::<serde_json::Value>(&result).is_ok());
+    }
+
+    #[test]
+    fn fix_trailing_commas_nested() {
+        let input = r#"{"a": [1, 2, 3,], "b": {"c": "d",}}"#;
+        let fixed = fix_trailing_commas(input);
+        assert!(serde_json::from_str::<serde_json::Value>(&fixed).is_ok());
+    }
+
+    #[test]
+    fn strip_json_comments_preserves_urls() {
+        // "//" inside strings should not be stripped
+        let input = r#"{"url": "https://example.com"}"#;
+        let stripped = strip_json_comments(input);
+        assert_eq!(stripped, input);
+    }
+
+    #[test]
+    fn parse_plan_response_with_trailing_comma() {
+        let response = r#"```json
+{
+  "subtasks": [
+    {"id": "setup", "title": "Setup project",},
+    {"id": "impl", "title": "Implement feature",},
+  ]
+}
+```"#;
+        let plan = parse_plan_response(response);
+        assert!(
+            plan.is_ok(),
+            "should handle trailing commas: {:?}",
+            plan.err()
+        );
+        assert_eq!(plan.unwrap().subtasks.len(), 2);
+    }
+
+    #[test]
+    fn parse_plan_response_with_comments() {
+        let response = r#"{
+  "subtasks": [
+    {"id": "t1", "title": "First task"} // the main task
+  ]
+  // notes omitted
+}"#;
+        let plan = parse_plan_response(response);
+        assert!(plan.is_ok(), "should handle comments: {:?}", plan.err());
     }
 
     // ═══════════════════════ parse_execution_confirmation Tests ════════════════════════

--- a/rust/crates/astra-plan/src/lib.rs
+++ b/rust/crates/astra-plan/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod decompose;
 pub mod metrics;
+pub mod outline;
 pub mod performance;
 pub mod plan;
 

--- a/rust/crates/astra-plan/src/outline.rs
+++ b/rust/crates/astra-plan/src/outline.rs
@@ -1,0 +1,361 @@
+//! Two-stage plan generation: outline first, then detail.
+//!
+//! Instead of generating a full plan in one LLM call, this module supports:
+//! 1. **Outline** — 2-4 high-level phases (fast, ~3-5s)
+//! 2. **Detail** — expand each phase into concrete subtasks
+//!
+//! This gives the user a chance to review and adjust direction before
+//! committing to a full plan.
+
+use serde::{Deserialize, Serialize};
+
+use crate::decompose::ProjectContext;
+
+/// High-level plan outline — generated before the full plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanOutline {
+    pub phases: Vec<OutlinePhase>,
+    pub total_effort: String,
+    #[serde(default)]
+    pub questions: Vec<crate::decompose::ClarificationQuestion>,
+}
+
+/// A single phase in the outline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutlinePhase {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub estimated_subtasks: usize,
+    #[serde(default)]
+    pub key_files: Vec<String>,
+}
+
+/// Build the outline prompt — asks for 2-4 phases, not full subtasks.
+pub fn outline_prompt(goal: &str, context: &ProjectContext) -> String {
+    let mut prompt = String::with_capacity(1024);
+
+    prompt.push_str(
+        "You are a senior software architect. Create a HIGH-LEVEL execution outline.\n\n",
+    );
+
+    // Compact project context
+    prompt.push_str("## Project\n");
+    if !context.languages.is_empty() {
+        prompt.push_str(&format!("- Languages: {}\n", context.languages.join(", ")));
+    }
+    prompt.push_str(&format!("- Files: ~{}\n", context.source_file_count));
+    if !context.entry_points.is_empty() {
+        prompt.push_str(&format!("- Build: {}\n", context.entry_points.join(", ")));
+    }
+    if let Some(ref branch) = context.git_branch {
+        prompt.push_str(&format!("- Branch: {branch}\n"));
+    }
+    if !context.key_modules.is_empty() {
+        let top: Vec<_> = context
+            .key_modules
+            .iter()
+            .take(5)
+            .map(|(p, l)| format!("{p} ({l}L)"))
+            .collect();
+        prompt.push_str(&format!("- Key files: {}\n", top.join(", ")));
+    }
+
+    prompt.push_str(&format!("\n## Goal\n{goal}\n"));
+
+    prompt.push_str(r#"
+## Instructions
+Create a high-level outline with 2-4 phases. Each phase is a logical stage of work.
+
+If the goal is ambiguous, include questions in the "questions" field instead of guessing.
+
+Return ONLY this JSON:
+```json
+{
+  "phases": [
+    {
+      "id": "phase-1",
+      "title": "Short title",
+      "description": "What this phase accomplishes",
+      "estimated_subtasks": 2,
+      "key_files": ["src/relevant.rs"]
+    }
+  ],
+  "total_effort": "small|medium|large",
+  "questions": []
+}
+```
+
+Rules:
+- 2-4 phases, ordered by dependency
+- estimated_subtasks: how many concrete subtasks this phase will expand to (1-4 each)
+- total_effort: overall project scope
+- If you need clarification, put questions in the "questions" array (same format as clarification questions: question, options, default, category)
+- No markdown, no explanation — ONLY the JSON
+"#);
+
+    prompt
+}
+
+/// Parse an outline response from the LLM.
+pub fn parse_outline_response(text: &str) -> Result<PlanOutline, String> {
+    let json_str = crate::decompose::extract_json_robust(text);
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json_str).map_err(|e| format!("Invalid JSON: {e}"))?;
+
+    if !parsed.is_object() || !parsed.get("phases").is_some_and(|v| v.is_array()) {
+        return Err("Expected JSON object with 'phases' array".into());
+    }
+
+    serde_json::from_str::<PlanOutline>(&json_str).map_err(|e| format!("Invalid outline JSON: {e}"))
+}
+
+/// Build a detail prompt for expanding one phase into subtasks.
+pub fn phase_detail_prompt(
+    goal: &str,
+    outline: &PlanOutline,
+    phase: &OutlinePhase,
+    completed_phases: &[String],
+    context: &ProjectContext,
+) -> String {
+    let mut prompt = String::with_capacity(1024);
+
+    prompt.push_str("You are a senior software architect. Expand ONE phase of a plan into concrete subtasks.\n\n");
+
+    prompt.push_str(&format!("## Goal\n{goal}\n\n"));
+
+    // Show full outline for context
+    prompt.push_str("## Plan Outline\n");
+    for p in &outline.phases {
+        let marker = if completed_phases.contains(&p.id) {
+            "✓"
+        } else if p.id == phase.id {
+            "→"
+        } else {
+            "○"
+        };
+        prompt.push_str(&format!("{marker} {} — {}\n", p.id, p.title));
+    }
+
+    if !completed_phases.is_empty() {
+        prompt.push_str(&format!(
+            "\nCompleted phases: {}\n",
+            completed_phases.join(", ")
+        ));
+    }
+
+    prompt.push_str(&format!(
+        "\n## Expand Phase: {} — {}\n{}\n",
+        phase.id, phase.title, phase.description
+    ));
+
+    if !phase.key_files.is_empty() {
+        prompt.push_str(&format!("Key files: {}\n", phase.key_files.join(", ")));
+    }
+
+    // Compact project context
+    if !context.languages.is_empty() {
+        prompt.push_str(&format!(
+            "\nProject: {} · ~{} files",
+            context.languages.join("/"),
+            context.source_file_count
+        ));
+        if let Some(ref tf) = context.test_framework {
+            prompt.push_str(&format!(" · tests: {tf}"));
+        }
+        prompt.push('\n');
+    }
+
+    prompt.push_str(
+        r#"
+## Instructions
+Generate subtasks for THIS PHASE ONLY. Return ONLY this JSON:
+```json
+{
+  "subtasks": [
+    {
+      "id": "kebab-case-id",
+      "title": "Short title",
+      "description": "What to do",
+      "depends_on": [],
+      "effort": "small|medium|large",
+      "files": ["src/file.rs"],
+      "acceptance_checks": [
+        {"kind": "file_exists", "paths": ["src/file.rs"]}
+      ]
+    }
+  ]
+}
+```
+
+Rules:
+- 1-4 subtasks for this phase
+- IDs must be unique across all phases (prefix with phase id if needed)
+- depends_on can reference subtask IDs from completed phases
+- All paths relative to project root
+- Each subtask needs at least one acceptance_check
+- No markdown, no explanation — ONLY the JSON
+"#,
+    );
+
+    prompt
+}
+
+/// Format an outline for terminal display.
+pub fn format_outline_display(outline: &PlanOutline, goal: &str) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("  Plan: {goal}\n"));
+    out.push_str(&format!(
+        "  Effort: {}  ·  {} phases\n\n",
+        outline.total_effort,
+        outline.phases.len(),
+    ));
+
+    for (i, phase) in outline.phases.iter().enumerate() {
+        out.push_str(&format!(
+            "  {}. {} — {}\n",
+            i + 1,
+            phase.title,
+            phase.description
+        ));
+        out.push_str(&format!("     ~{} subtasks", phase.estimated_subtasks));
+        if !phase.key_files.is_empty() {
+            let files: Vec<_> = phase.key_files.iter().take(3).map(|f| f.as_str()).collect();
+            out.push_str(&format!("  ·  {}", files.join(", ")));
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_outline_basic() {
+        let text = r#"{"phases": [
+            {"id": "p1", "title": "Setup", "description": "Init project", "estimated_subtasks": 2, "key_files": ["Cargo.toml"]},
+            {"id": "p2", "title": "Implement", "description": "Core logic", "estimated_subtasks": 3, "key_files": []}
+        ], "total_effort": "medium", "questions": []}"#;
+
+        let outline = parse_outline_response(text).unwrap();
+        assert_eq!(outline.phases.len(), 2);
+        assert_eq!(outline.phases[0].id, "p1");
+        assert_eq!(outline.phases[1].estimated_subtasks, 3);
+        assert_eq!(outline.total_effort, "medium");
+    }
+
+    #[test]
+    fn parse_outline_with_markdown_fence() {
+        let text = "Here's the outline:\n```json\n{\"phases\": [{\"id\": \"p1\", \"title\": \"A\", \"description\": \"B\", \"estimated_subtasks\": 1}], \"total_effort\": \"small\"}\n```";
+        let outline = parse_outline_response(text).unwrap();
+        assert_eq!(outline.phases.len(), 1);
+    }
+
+    #[test]
+    fn parse_outline_with_trailing_comma() {
+        let text = r#"{"phases": [{"id": "p1", "title": "A", "description": "B", "estimated_subtasks": 1,},], "total_effort": "small",}"#;
+        let outline = parse_outline_response(text).unwrap();
+        assert_eq!(outline.phases.len(), 1);
+    }
+
+    #[test]
+    fn parse_outline_with_questions() {
+        let text = r#"{"phases": [], "total_effort": "unknown", "questions": [
+            {"question": "What scope?", "options": ["A", "B"], "default": 0, "category": "scope"}
+        ]}"#;
+        let outline = parse_outline_response(text).unwrap();
+        assert!(outline.phases.is_empty());
+        assert_eq!(outline.questions.len(), 1);
+    }
+
+    #[test]
+    fn parse_outline_invalid_json() {
+        assert!(parse_outline_response("not json").is_err());
+    }
+
+    #[test]
+    fn parse_outline_missing_phases() {
+        assert!(parse_outline_response(r#"{"total_effort": "small"}"#).is_err());
+    }
+
+    #[test]
+    fn outline_prompt_includes_goal_and_context() {
+        let ctx = ProjectContext {
+            languages: vec!["Rust".into()],
+            source_file_count: 100,
+            ..Default::default()
+        };
+        let prompt = outline_prompt("Add auth", &ctx);
+        assert!(prompt.contains("Add auth"));
+        assert!(prompt.contains("Rust"));
+        assert!(prompt.contains("phases"));
+    }
+
+    #[test]
+    fn phase_detail_prompt_shows_outline_context() {
+        let outline = PlanOutline {
+            phases: vec![
+                OutlinePhase {
+                    id: "p1".into(),
+                    title: "Setup".into(),
+                    description: "Init".into(),
+                    estimated_subtasks: 2,
+                    key_files: vec![],
+                },
+                OutlinePhase {
+                    id: "p2".into(),
+                    title: "Impl".into(),
+                    description: "Code".into(),
+                    estimated_subtasks: 3,
+                    key_files: vec!["src/lib.rs".into()],
+                },
+            ],
+            total_effort: "medium".into(),
+            questions: vec![],
+        };
+        let ctx = ProjectContext::default();
+        let prompt = phase_detail_prompt(
+            "Add auth",
+            &outline,
+            &outline.phases[1],
+            &["p1".into()],
+            &ctx,
+        );
+        assert!(prompt.contains("→ p2"));
+        assert!(prompt.contains("✓ p1"));
+        assert!(prompt.contains("src/lib.rs"));
+    }
+
+    #[test]
+    fn format_outline_display_basic() {
+        let outline = PlanOutline {
+            phases: vec![
+                OutlinePhase {
+                    id: "p1".into(),
+                    title: "Setup".into(),
+                    description: "Init deps".into(),
+                    estimated_subtasks: 2,
+                    key_files: vec!["Cargo.toml".into()],
+                },
+                OutlinePhase {
+                    id: "p2".into(),
+                    title: "Implement".into(),
+                    description: "Core logic".into(),
+                    estimated_subtasks: 3,
+                    key_files: vec![],
+                },
+            ],
+            total_effort: "medium".into(),
+            questions: vec![],
+        };
+        let display = format_outline_display(&outline, "Add feature");
+        assert!(display.contains("Add feature"));
+        assert!(display.contains("medium"));
+        assert!(display.contains("Setup"));
+        assert!(display.contains("Cargo.toml"));
+    }
+}

--- a/rust/crates/runtime/src/plan/mod.rs
+++ b/rust/crates/runtime/src/plan/mod.rs
@@ -1,3 +1,4 @@
 pub use astra_plan::metrics;
+pub use astra_plan::outline;
 pub use astra_plan::performance;
 pub use astra_plan::plan::*;


### PR DESCRIPTION
## Summary

- Add PlanGenerator with cancellation token support for Ctrl-C handling
- Add SSE collect_cancellable with timeout handling
- Add two-phase plan generation (outline then detail)
- Refactor plan_interaction.rs with clearer module structure
- Add ProjectContext and project scanning utilities

## Changes

- docs/design/plan-mode-v2.md - Design document
- rust/crates/astra-cli/src/cli/plan_interaction.rs - Refactored
- rust/crates/astra-cli/src/cli/sse_utils.rs - New SSE utilities
- rust/crates/astra-plan/src/decompose.rs - Updated
- rust/crates/astra-plan/src/outline.rs - New file