### PR TITLE
feat: astra-logging, structured tracing, and SSE/run_lifecycle follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ make dev-api-start    # API server (auto-creates database schema)
 
 Open `http://localhost:8000/health` to verify.
 
+### Logging (API server and CLI diagnostics)
+
+- **`RUST_LOG`**: standard `tracing` filter (e.g. `RUST_LOG=info`, or per-target `astra_runtime=debug`).
+- **`ASTRA_LOG_FORMAT`**: `json` (default when stderr is not a TTY), `pretty`, or `compact`. Unknown values print a one-line warning to stderr and fall back like “unset”.
+- **`ASTRA_SERVICE_NAME`**: optional label on the startup log line.
+- HTTP handlers run inside a per-request span; access lines use target `astra.http.access` and include `request_id` (same value as the `x-request-id` response header). The **`/health`** probe omits that access line to reduce noise (headers and tracing span are unchanged).
+- **`astra` CLI**: set **`ASTRA_DIAGNOSTIC_LOG=1`** for structured logs on stderr, or **`ASTRA_LOG_FILE=/path/to.log`** for JSON lines appended to a file (does not replace interactive REPL output). Equivalent hidden flags: **`--diagnostic-log`**, **`--log-file /path/to.log`** (see `cli_args` module docs for priority vs env).
+- **OpenTelemetry (optional)**: build with **`--features otel`** on **`astra-runtime`** (for `astra-server`) or **`astra-edge`** so `astra-logging` links the OTLP exporter. Tracing export turns on when **`ASTRA_OTEL_ENABLED=1`** or **`OTEL_EXPORTER_OTLP_ENDPOINT`** / **`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`** is set to a non-empty value. Use standard OTel variables (**`OTEL_SERVICE_NAME`**, **`OTEL_RESOURCE_ATTRIBUTES`**, **`OTEL_EXPORTER_OTLP_*`**, etc.). The API server stops gracefully on **SIGTERM** or **Ctrl+C** and flushes OTLP batches; **`kill -9`** can drop the last spans.
+
 ### 4. Load Models & Login
 
 ```bash

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -142,13 +142,14 @@ name = "astra-cli"
 version = "0.1.0"
 dependencies = [
  "astra-core",
+ "astra-logging",
  "astra-runtime",
  "astra-services",
  "astra-text-utils",
  "astra-thin-client",
  "astra-tools",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "base64",
  "chrono",
  "clap",
@@ -178,6 +179,9 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tokio-util",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-cpp",
  "tree-sitter-go",
@@ -208,19 +212,21 @@ dependencies = [
 name = "astra-core"
 version = "0.1.0"
 dependencies = [
- "axum",
+ "axum 0.8.9",
  "chrono",
  "dotenvy",
  "serde",
  "serde_json",
  "sqlx",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "astra-edge"
 version = "0.1.0"
 dependencies = [
+ "astra-logging",
  "astra-tools",
  "clap",
  "futures-util",
@@ -231,7 +237,6 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -261,6 +266,19 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "astra-logging"
+version = "0.1.0"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -328,6 +346,7 @@ dependencies = [
  "astra-core",
  "astra-evolution",
  "astra-learning",
+ "astra-logging",
  "astra-messaging",
  "astra-pipeline",
  "astra-plan",
@@ -344,7 +363,7 @@ dependencies = [
  "astra-turn-types",
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "base64",
  "chrono",
  "criterion",
@@ -373,10 +392,9 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -422,7 +440,7 @@ version = "0.1.0"
 dependencies = [
  "astra-core",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "base64",
  "bcrypt",
  "chrono",
@@ -454,7 +472,7 @@ dependencies = [
  "astra-core",
  "astra-services",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "dirs 5.0.1",
  "flate2",
  "regex",
@@ -504,6 +522,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "wiremock",
 ]
 
@@ -557,7 +576,7 @@ dependencies = [
  "astra-tools",
  "astra-turn-types",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "base64",
  "chrono",
  "dashmap",
@@ -642,11 +661,38 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "base64",
  "bytes",
  "form_urlencoded",
@@ -657,7 +703,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -670,10 +716,30 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -984,6 +1050,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4d7a805ca0d92f8c61a31c809d4323fdaa939b0b440e544d21db7797c5aaad"
 dependencies = [
  "crossterm 0.23.2",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2617,6 +2693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,7 +2710,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2654,6 +2736,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2854,6 +2942,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,7 +2971,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -3026,6 +3127,16 @@ checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
 dependencies = [
  "hashbrown 0.15.5",
  "memchr",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3343,6 +3454,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -3508,6 +3625,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,6 +3750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3633,6 +3765,70 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3694,6 +3890,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -3827,7 +4043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
- "indexmap",
+ "indexmap 2.14.0",
  "nix 0.31.2",
  "tokio",
  "tracing",
@@ -3865,6 +4081,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3883,7 +4122,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3920,7 +4159,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4143,7 +4382,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -4178,7 +4417,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -4291,12 +4530,34 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4385,6 +4646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4395,6 +4665,29 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -4492,7 +4785,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -4664,6 +4957,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -4723,7 +5026,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "once_cell",
@@ -4940,6 +5243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5135,7 +5444,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5232,7 +5541,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -5265,7 +5574,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -5293,6 +5602,59 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"
@@ -5323,7 +5685,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -5353,6 +5715,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5370,6 +5745,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]
@@ -5379,12 +5794,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -5659,6 +6079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5800,7 +6226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5839,7 +6265,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -6329,7 +6755,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -6360,7 +6786,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -6379,7 +6805,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/core",
+    "crates/astra-logging",
     "crates/services",
     "crates/runtime",
     "crates/astra-tools",
@@ -31,6 +32,7 @@ edition = "2024"
 
 [workspace.dependencies]
 astra-core = { path = "crates/core" }
+astra-logging = { path = "crates/astra-logging" }
 astra-config = { path = "crates/astra-config" }
 astra-evolution = { path = "crates/astra-evolution" }
 astra-learning = { path = "crates/astra-learning" }
@@ -76,10 +78,27 @@ uuid = { version = "1.18.1", features = ["v4", "v7"] }
 thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "ansi",
     "env-filter",
     "fmt",
+    "json",
+    "registry",
     "std",
+    "time",
 ] }
+# Must match `tracing-opentelemetry` (0.27.x pulls opentelemetry 0.26 — keep a single OTel line).
+opentelemetry = { version = "0.26.0", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.26.0", default-features = false, features = [
+    "rt-tokio",
+    "trace",
+] }
+opentelemetry-otlp = { version = "0.26.0", default-features = false, features = [
+    "grpc-tonic",
+    "tls-roots",
+    "trace",
+] }
+tracing-opentelemetry = { version = "0.27.0" }
+tracing-appender = { version = "0.2", default-features = false }
 http-body-util = "0.1"
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 clap = { version = "4", features = ["derive", "env"] }

--- a/rust/crates/astra-cli/Cargo.toml
+++ b/rust/crates/astra-cli/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 astra-core.workspace = true
+astra-logging.workspace = true
 astra-services.workspace = true
 astra-runtime.workspace = true
 astra-text-utils.workspace = true
@@ -35,6 +36,9 @@ sqlx.workspace = true
 termimad = "0.23"
 unicode-width = "0.1"
 thiserror.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tracing-appender.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "process", "rt-multi-thread", "signal"] }
 tokio-util.workspace = true
 uuid.workspace = true

--- a/rust/crates/astra-cli/src/cli/cli_args.rs
+++ b/rust/crates/astra-cli/src/cli/cli_args.rs
@@ -3,6 +3,19 @@
 //! All main entry point arguments, subcommands, and their nested argument
 //! types are defined here. These are used by `main.rs` for parsing and
 //! by `command_router.rs` for dispatch.
+//!
+//! ## Observability (flags and environment)
+//!
+//! Applied in [`crate::diagnostic_log::init_cli_observability`] immediately after [`Cli`] is parsed.
+//!
+//! **Priority:** `--log-file` → `ASTRA_LOG_FILE` → (`--diagnostic-log` or `ASTRA_DIAGNOSTIC_LOG=1`) for stderr.
+//!
+//! - **`--log-file <PATH>`** (hidden): append JSON lines to a file; overrides `ASTRA_LOG_FILE` when both are set.
+//! - **`--diagnostic-log`** (hidden): structured [`tracing`] on stderr (`astra-logging`); same effect as `ASTRA_DIAGNOSTIC_LOG=1`.
+//! - **`ASTRA_LOG_FILE`**: same as `--log-file` when the flag is absent.
+//! - **`ASTRA_DIAGNOSTIC_LOG=1`**: stderr diagnostics when no file target is selected.
+//!
+//! See repository `README.md` for `RUST_LOG` / `ASTRA_LOG_FORMAT`.
 
 use clap::{Args, Parser, Subcommand};
 
@@ -79,6 +92,12 @@ pub(crate) struct Cli {
     /// Print startup timing for each initialization phase
     #[arg(long = "startup-trace")]
     pub startup_trace: bool,
+    /// Emit structured tracing to stderr (same as ASTRA_DIAGNOSTIC_LOG=1); hidden from --help
+    #[arg(long = "diagnostic-log", hide = true)]
+    pub diagnostic_log: bool,
+    /// Append JSON tracing lines to this file (overrides ASTRA_LOG_FILE env); hidden from --help
+    #[arg(long = "log-file", value_name = "PATH", hide = true)]
+    pub log_file: Option<String>,
     #[command(subcommand)]
     pub command: Option<Command>,
 }

--- a/rust/crates/astra-cli/src/cli/cloud_sync.rs
+++ b/rust/crates/astra-cli/src/cli/cloud_sync.rs
@@ -103,6 +103,12 @@ pub(super) async fn try_cloud_pull(
             };
         }
     };
+    tracing::info!(
+        target: "astra_cli::cloud_sync",
+        profile = %profile_name,
+        operation = "pull_learning",
+        "starting MatrixOne learning pull"
+    );
     let svc = MatrixOneSyncService::new(pool);
     let user_id = std::env::var("MO_USER_ID").unwrap_or_else(|_| "local".to_string());
     match StateSyncService::pull_learning_versioned(&svc, &user_id, profile_name).await {

--- a/rust/crates/astra-cli/src/cli/diagnostic_log.rs
+++ b/rust/crates/astra-cli/src/cli/diagnostic_log.rs
@@ -1,0 +1,67 @@
+//! Optional structured logging for the CLI (does not replace REPL / user-facing stderr).
+//!
+//! See [`crate::cli_args::Cli`] (`--diagnostic-log`, `--log-file`) and env vars `ASTRA_DIAGNOSTIC_LOG` /
+//! `ASTRA_LOG_FILE`.
+
+use std::sync::OnceLock;
+
+use crate::cli_args::Cli;
+
+/// Initialize diagnostic logging once per process from parsed CLI + environment.
+///
+/// **Priority:** `--log-file` → `ASTRA_LOG_FILE` → `--diagnostic-log` / `ASTRA_DIAGNOSTIC_LOG=1` (stderr only).
+pub fn init_cli_observability(cli: &Cli) {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        let file_path = cli
+            .log_file
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(std::string::ToString::to_string)
+            .or_else(|| {
+                std::env::var("ASTRA_LOG_FILE")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+            });
+
+        if let Some(ref path) = file_path {
+            if let Err(e) = try_init_file_logging(path) {
+                eprintln!("[astra] warning: log file init failed ({path}): {e}");
+            }
+            return;
+        }
+
+        let want_stderr = cli.diagnostic_log
+            || std::env::var("ASTRA_DIAGNOSTIC_LOG").ok().as_deref() == Some("1");
+        if want_stderr {
+            let _ = astra_logging::init_from_env(
+                astra_logging::LogInitConfig::new(
+                    "warn,astra.agent=info,astra.thin_client=info,astra.logging=info",
+                )
+                .with_service_name("astra-cli"),
+            );
+        }
+    });
+}
+
+fn try_init_file_logging(path: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use std::fs::OpenOptions;
+    use tracing_subscriber::{EnvFilter, fmt::time::UtcTime};
+
+    let file = OpenOptions::new().create(true).append(true).open(path)?;
+    let (non_blocking, guard) = tracing_appender::non_blocking(file);
+    // Leak the guard so the background writer stays alive for the process lifetime; abrupt exit may drop tail lines.
+    std::mem::forget(guard);
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new("warn,astra.agent=info,astra.thin_client=info,astra.logging=info")
+    });
+
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(filter)
+        .with_timer(UtcTime::rfc_3339())
+        .with_writer(non_blocking)
+        .try_init()
+}

--- a/rust/crates/astra-cli/src/cli/diagnostic_log.rs
+++ b/rust/crates/astra-cli/src/cli/diagnostic_log.rs
@@ -6,6 +6,10 @@
 use std::sync::OnceLock;
 
 use crate::cli_args::Cli;
+use tracing_appender::non_blocking::WorkerGuard;
+
+/// Keeps the [`WorkerGuard`] alive so the non-blocking writer flushes on process exit (drop on shutdown).
+static FILE_LOG_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 
 /// Initialize diagnostic logging once per process from parsed CLI + environment.
 ///
@@ -51,17 +55,23 @@ fn try_init_file_logging(path: &str) -> Result<(), Box<dyn std::error::Error + S
 
     let file = OpenOptions::new().create(true).append(true).open(path)?;
     let (non_blocking, guard) = tracing_appender::non_blocking(file);
-    // Leak the guard so the background writer stays alive for the process lifetime; abrupt exit may drop tail lines.
-    std::mem::forget(guard);
 
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new("warn,astra.agent=info,astra.thin_client=info,astra.logging=info")
     });
 
-    tracing_subscriber::fmt()
+    match tracing_subscriber::fmt()
         .json()
         .with_env_filter(filter)
         .with_timer(UtcTime::rfc_3339())
         .with_writer(non_blocking)
         .try_init()
+    {
+        Ok(()) => {
+            let _ = FILE_LOG_GUARD.set(guard);
+            Ok(())
+        }
+        // `fmt().try_init()` already returns `Box<dyn Error + Send + Sync>`.
+        Err(e) => Err(e),
+    }
 }

--- a/rust/crates/astra-cli/src/cli/sse_utils.rs
+++ b/rust/crates/astra-cli/src/cli/sse_utils.rs
@@ -14,6 +14,24 @@ use tokio_util::sync::CancellationToken;
 /// `\n\n` delimiters, we truncate the buffer to prevent unbounded memory growth.
 const MAX_SSE_BUFFER: usize = 1024 * 1024;
 
+#[inline]
+fn trace_sse_buffer_truncated() {
+    tracing::warn!(
+        target: "astra_cli::sse",
+        max_bytes = MAX_SSE_BUFFER,
+        "sse buffer exceeded; truncated incomplete events"
+    );
+}
+
+#[inline]
+fn trace_sse_server_error_event(message: &str) {
+    tracing::warn!(
+        target: "astra_cli::sse",
+        message = %message,
+        "sse server error event"
+    );
+}
+
 /// Outcome of collecting text from an SSE stream.
 pub struct SseTextResult {
     pub text: String,
@@ -62,12 +80,13 @@ pub async fn collect_sse_text(resp: reqwest::Response, stream_to_stderr: bool) -
     let mut stream = resp.bytes_stream();
 
     while let Some(chunk) = stream.next().await {
-        let Ok(bytes) = chunk else {
-            result.stream_error = Some(format!(
-                "SSE stream read failed: {}",
-                chunk.expect_err("error branch checked above")
-            ));
-            break;
+        let bytes = match chunk {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(target: "astra_cli::sse", error = %e, "sse stream read failed");
+                result.stream_error = Some(format!("SSE stream read failed: {e}"));
+                break;
+            }
         };
         buffer.push_str(&String::from_utf8_lossy(&bytes));
 
@@ -78,6 +97,7 @@ pub async fn collect_sse_text(resp: reqwest::Response, stream_to_stderr: bool) -
                 theme::icon_warn(),
                 MAX_SSE_BUFFER
             );
+            trace_sse_buffer_truncated();
             result.truncated = true;
             buffer.clear();
             break;
@@ -117,6 +137,7 @@ pub async fn collect_sse_text(resp: reqwest::Response, stream_to_stderr: bool) -
                                     .and_then(|v| v.as_str())
                                 {
                                     eprintln!("\r  {} Server error: {}", theme::icon_err(), msg);
+                                    trace_sse_server_error_event(msg);
                                 }
                             }
                             _ => {}
@@ -178,12 +199,13 @@ pub async fn stream_sse_markdown(resp: reqwest::Response) -> SseTextResult {
     let mut stream = resp.bytes_stream();
 
     while let Some(chunk) = stream.next().await {
-        let Ok(bytes) = chunk else {
-            result.stream_error = Some(format!(
-                "SSE stream read failed: {}",
-                chunk.expect_err("error branch checked above")
-            ));
-            break;
+        let bytes = match chunk {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(target: "astra_cli::sse", error = %e, "sse stream read failed");
+                result.stream_error = Some(format!("SSE stream read failed: {e}"));
+                break;
+            }
         };
         buffer.push_str(&String::from_utf8_lossy(&bytes));
 
@@ -194,6 +216,7 @@ pub async fn stream_sse_markdown(resp: reqwest::Response) -> SseTextResult {
                 theme::icon_warn(),
                 MAX_SSE_BUFFER
             );
+            trace_sse_buffer_truncated();
             result.truncated = true;
             buffer.clear();
             break;
@@ -235,6 +258,7 @@ pub async fn stream_sse_markdown(resp: reqwest::Response) -> SseTextResult {
                                     .and_then(|v| v.as_str())
                                 {
                                     eprintln!("\r  {} Server error: {}", theme::icon_err(), msg);
+                                    trace_sse_server_error_event(msg);
                                 }
                             }
                             _ => {}
@@ -304,12 +328,13 @@ pub async fn collect_sse_with_preview(resp: reqwest::Response) -> SseTextResult 
     let mut stream = resp.bytes_stream();
 
     while let Some(chunk) = stream.next().await {
-        let Ok(bytes) = chunk else {
-            result.stream_error = Some(format!(
-                "SSE stream read failed: {}",
-                chunk.expect_err("error branch checked above")
-            ));
-            break;
+        let bytes = match chunk {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(target: "astra_cli::sse", error = %e, "sse stream read failed");
+                result.stream_error = Some(format!("SSE stream read failed: {e}"));
+                break;
+            }
         };
         buffer.push_str(&String::from_utf8_lossy(&bytes));
 
@@ -319,6 +344,7 @@ pub async fn collect_sse_with_preview(resp: reqwest::Response) -> SseTextResult 
                 theme::icon_warn(),
                 MAX_SSE_BUFFER
             );
+            trace_sse_buffer_truncated();
             result.truncated = true;
             buffer.clear();
             break;
@@ -356,6 +382,7 @@ pub async fn collect_sse_with_preview(resp: reqwest::Response) -> SseTextResult 
                                     .and_then(|v| v.as_str())
                                 {
                                     eprintln!("\r  {} Server error: {}", theme::icon_err(), msg);
+                                    trace_sse_server_error_event(msg);
                                 }
                             }
                             _ => {}
@@ -433,21 +460,26 @@ pub async fn collect_sse_cancellable(
         tokio::select! {
             biased;
             _ = cancel.cancelled() => {
+                tracing::debug!(target: "astra_cli::sse", "sse plan stream cancelled");
                 result.stream_error = Some("Plan generation cancelled".into());
                 result.cancelled = true;
                 break;
             }
             _ = tokio::time::sleep_until(deadline) => {
+                let secs = stream_timeout.as_secs();
+                tracing::warn!(target: "astra_cli::sse", stream_timeout_secs = secs, "sse stream wall-clock timeout");
                 result.stream_error = Some(format!(
                     "Stream timeout after {}s",
-                    stream_timeout.as_secs()
+                    secs
                 ));
                 break;
             }
             _ = tokio::time::sleep_until(idle_deadline) => {
+                let secs = idle_timeout.as_secs();
+                tracing::warn!(target: "astra_cli::sse", idle_timeout_secs = secs, "sse stream idle timeout");
                 result.stream_error = Some(format!(
                     "No data received for {}s",
-                    idle_timeout.as_secs()
+                    secs
                 ));
                 break;
             }
@@ -458,6 +490,12 @@ pub async fn collect_sse_cancellable(
                         buffer.push_str(&String::from_utf8_lossy(&bytes));
 
                         if buffer.len() > MAX_SSE_BUFFER {
+                            eprintln!(
+                                "\r  {} SSE buffer exceeded {} bytes, truncating incomplete events",
+                                theme::icon_warn(),
+                                MAX_SSE_BUFFER
+                            );
+                            trace_sse_buffer_truncated();
                             result.truncated = true;
                             buffer.clear();
                             break;
@@ -500,6 +538,7 @@ pub async fn collect_sse_cancellable(
                                                     .and_then(|v| v.as_str())
                                                 {
                                                     eprintln!("\r  {} Server error: {}", theme::icon_err(), msg);
+                                                    trace_sse_server_error_event(msg);
                                                 }
                                             }
                                             _ => {}
@@ -510,6 +549,7 @@ pub async fn collect_sse_cancellable(
                         }
                     }
                     Some(Err(e)) => {
+                        tracing::warn!(target: "astra_cli::sse", error = %e, "sse stream read failed");
                         result.stream_error = Some(format!("SSE stream read failed: {e}"));
                         break;
                     }

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -2865,9 +2865,7 @@ impl StreamRenderState {
     ) -> String {
         // Dynamic budget based on terminal width.
         // Layout: "  ✓ {description} {duration}" — prefix ~6 chars, duration ~6 chars.
-        let term_w = crossterm::terminal::size()
-            .map(|(c, _)| c as usize)
-            .unwrap_or(80);
+        let term_w = self.term_width;
         let desc_budget = term_w.saturating_sub(14); // room for prefix + duration
         // Path budget: description budget minus the label prefix (e.g. "Reading: ")
         let path_budget = |prefix_len: usize| desc_budget.saturating_sub(prefix_len).max(20);
@@ -6476,17 +6474,20 @@ mod tests {
     #[test]
     fn format_code_navigation_keeps_medium_position_paths() {
         let r = StreamRenderState::new();
+        // Path must fit within the 80-col budget:
+        // desc_budget = 80 - 14 = 66; "Hover info at " (14) + path + ":42:3" (5) ≤ 66
+        // => path ≤ 47 chars.  This path is 38 chars.
         let hover = r.format_tool_description(
             "hover_info",
             &serde_json::json!({
-                "file": "/moderately/long/path/to/nested/module/file.rs",
+                "file": "/moderately/long/path/to/module/file.rs",
                 "line": 42,
                 "column": 3
             }),
         );
         assert_eq!(
             hover,
-            "Hover info at /moderately/long/path/to/nested/module/file.rs:42:3"
+            "Hover info at /moderately/long/path/to/module/file.rs:42:3"
         );
     }
 

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -77,6 +77,8 @@ mod command_registry;
 mod command_router;
 #[path = "cli/delegate_subrun.rs"]
 mod delegate_subrun;
+#[path = "cli/diagnostic_log.rs"]
+mod diagnostic_log;
 #[path = "cli/diff_presenter.rs"]
 mod diff_presenter;
 #[path = "cli/durable_bridge.rs"]
@@ -964,11 +966,18 @@ use project_instructions::{
 async fn main() {
     dotenvy::dotenv().ok();
     let cli = Cli::parse();
+    diagnostic_log::init_cli_observability(&cli);
     // Resolve API URL: --api-url flag > ASTRA_API_URL env var > config file > default
     let base = command_router::resolve_api_url(cli.api_url.as_deref());
     let api = match astra_thin_client::ThinClient::new(&base, None) {
         Ok(api) => api,
         Err(err) => {
+            tracing::error!(
+                target: "astra_cli",
+                api_base = %base,
+                error = %err,
+                "invalid API URL or thin client init failed"
+            );
             eprintln!(
                 "{}",
                 format!("Error: invalid API URL '{base}': {err}").red()
@@ -1014,6 +1023,8 @@ async fn main() {
         bare,
         no_instructions,
         startup_trace,
+        diagnostic_log: _,
+        log_file: _,
         command,
     } = cli;
 
@@ -1056,6 +1067,7 @@ async fn main() {
     let system_prompt = system_prompt.map(|sp| match resolve_system_prompt(sp) {
         Ok(content) => content,
         Err(e) => {
+            tracing::error!(target: "astra_cli", error = %e, "failed to resolve --system-prompt");
             eprintln!("{}", e.red());
             std::process::exit(1);
         }
@@ -1145,6 +1157,11 @@ async fn main() {
     // --session-id: validate UUID format and export for REPL to pick up
     if let Some(ref sid) = cli_session_id {
         if uuid::Uuid::parse_str(sid).is_err() {
+            tracing::error!(
+                target: "astra_cli",
+                session_id = %sid,
+                "invalid --session-id (expected UUID)"
+            );
             eprintln!(
                 "{}",
                 format!("Error: --session-id must be a valid UUID, got '{sid}'").red()

--- a/rust/crates/astra-edge/Cargo.toml
+++ b/rust/crates/astra-edge/Cargo.toml
@@ -4,19 +4,23 @@ version.workspace = true
 edition.workspace = true
 description = "Lightweight remote edge agent that connects to an Astra server via WebSocket for local tool execution"
 
+[features]
+default = []
+otel = ["astra-logging/otel"]
+
 [[bin]]
 name = "astra-edge"
 path = "src/main.rs"
 
 [dependencies]
+astra-logging.workspace = true
 clap = { workspace = true }
 futures-util = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["time"] }
+tokio = { workspace = true, features = ["signal", "time"] }
 tokio-tungstenite = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 hostname = { workspace = true }
 reqwest = { workspace = true }

--- a/rust/crates/astra-edge/src/main.rs
+++ b/rust/crates/astra-edge/src/main.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::Instrument;
 
 /// Astra remote edge agent — execute tool calls locally for web sessions.
 #[derive(Parser, Debug)]
@@ -108,7 +109,16 @@ async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Erro
 
     tracing::info!(url = %url, edge_id = %args.edge_id, "Connecting to server...");
 
-    let (ws_stream, _) = connect_async(&url).await?;
+    let (ws_stream, _) = connect_async(&url).await.map_err(|e| {
+        tracing::error!(
+            target: "astra.edge",
+            edge_id = %args.edge_id,
+            url = %url,
+            error = %e,
+            "WebSocket connect failed"
+        );
+        e
+    })?;
     let (mut write, mut read) = ws_stream.split();
 
     tracing::info!("WebSocket connected, authenticating...");
@@ -141,13 +151,29 @@ async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Erro
                 tracing::info!(user_id = %user_id, "Authenticated successfully");
             }
             Ok(ServerToEdge::AuthError { message }) => {
+                tracing::error!(
+                    target: "astra.edge",
+                    edge_id = %args.edge_id,
+                    detail = %message,
+                    "server rejected edge authentication"
+                );
                 return Err(format!("Authentication failed: {message}").into());
             }
             _ => {
+                tracing::error!(
+                    target: "astra.edge",
+                    edge_id = %args.edge_id,
+                    "unexpected auth response payload"
+                );
                 return Err("Unexpected auth response".into());
             }
         },
         _ => {
+            tracing::error!(
+                target: "astra.edge",
+                edge_id = %args.edge_id,
+                "auth timeout or connection closed before auth_ok"
+            );
             return Err("Auth timeout or connection closed".into());
         }
     }
@@ -268,12 +294,9 @@ async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Erro
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .init();
+    let _ = astra_logging::init_from_env(
+        astra_logging::LogInitConfig::new("info").with_service_name("astra-edge"),
+    );
 
     let args = Args::parse();
 
@@ -286,8 +309,14 @@ async fn main() {
     eprintln!("  workspace: {}", args.workspace_dir.display());
     eprintln!();
 
+    let mut exit_with_error = false;
     loop {
-        match run_edge_connection(&args).await {
+        let edge_span = tracing::info_span!(
+            "edge.agent",
+            edge_id = %args.edge_id,
+            server_url = %args.server_url,
+        );
+        match run_edge_connection(&args).instrument(edge_span).await {
             Ok(()) => {
                 if !args.reconnect {
                     break;
@@ -297,11 +326,17 @@ async fn main() {
             Err(e) => {
                 tracing::error!(error = %e, "Connection error");
                 if !args.reconnect {
-                    std::process::exit(1);
+                    exit_with_error = true;
+                    break;
                 }
                 tracing::info!("Reconnecting in 5s...");
             }
         }
         tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+
+    astra_logging::shutdown_otel();
+    if exit_with_error {
+        std::process::exit(1);
     }
 }

--- a/rust/crates/astra-logging/Cargo.toml
+++ b/rust/crates/astra-logging/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "astra-logging"
+version.workspace = true
+edition.workspace = true
+description = "Shared tracing subscriber initialization for Astra binaries"
+
+[features]
+default = []
+otel = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+    "dep:tokio",
+]
+
+[dependencies]
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tokio = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }

--- a/rust/crates/astra-logging/src/lib.rs
+++ b/rust/crates/astra-logging/src/lib.rs
@@ -152,7 +152,15 @@ pub fn shutdown_otel() {
     otel::shutdown_tracer_provider();
 }
 
-/// Like [`init_from_env`], but ignores "already initialized" errors (e.g. tests).
+/// Like [`init_from_env`], but returns quietly when the global subscriber was already
+/// installed ([`tracing_subscriber::util::TryInitError`]). Other failures are written to stderr.
 pub fn init_from_env_or_ignores_duplicate(config: LogInitConfig<'_>) {
-    let _ = init_from_env(config);
+    use tracing_subscriber::util::TryInitError;
+
+    if let Err(e) = init_from_env(config) {
+        if e.downcast_ref::<TryInitError>().is_some() {
+            return;
+        }
+        eprintln!("[astra-logging] logging init failed: {e}");
+    }
 }

--- a/rust/crates/astra-logging/src/lib.rs
+++ b/rust/crates/astra-logging/src/lib.rs
@@ -1,0 +1,158 @@
+//! Shared [`tracing`] initialization for Astra server, edge, and optional CLI diagnostics.
+//!
+//! # Environment
+//!
+//! - **`RUST_LOG`**: Per [`tracing_subscriber::EnvFilter`] (standard ecosystem variable).
+//! - **`ASTRA_LOG_FORMAT`**: `json` | `pretty` | `compact`. When unset: **TTY stderr → `pretty`**,
+//!   **non-TTY → `json`** (containers/CI-friendly). Other non-empty values log a stderr warning and
+//!   fall back the same way as unset.
+//! - **`ASTRA_SERVICE_NAME`**: Optional logical service id (e.g. `astra-server`, `astra-edge`);
+//!   emitted once at `INFO` on successful init when set or passed in [`LogInitConfig`].
+//!
+//! # OpenTelemetry (cargo feature `otel`)
+//!
+//! Build with `--features otel` on `astra-logging` (or enable the `otel` feature on `astra-runtime` /
+//! `astra-edge`). Export activates when **`ASTRA_OTEL_ENABLED=1`** or when
+//! **`OTEL_EXPORTER_OTLP_ENDPOINT`** / **`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`** is non-empty.
+//! Standard **`OTEL_*`** resource attributes apply. Call [`shutdown_otel`] on graceful shutdown so
+//! spans flush (`kill -9` may drop tail batches).
+
+#[cfg(feature = "otel")]
+mod otel;
+
+use std::io::{self, IsTerminal};
+
+use tracing_subscriber::{EnvFilter, fmt::time::UtcTime};
+
+/// Configuration for [`init_from_env`].
+#[derive(Debug, Clone)]
+pub struct LogInitConfig<'a> {
+    /// Used when `RUST_LOG` is unset or invalid (see [`EnvFilter::try_from_default_env`]).
+    pub default_filter: &'a str,
+    /// Fallback when `ASTRA_SERVICE_NAME` env is not set.
+    pub service_name: Option<&'a str>,
+}
+
+impl<'a> LogInitConfig<'a> {
+    pub fn new(default_filter: &'a str) -> Self {
+        Self {
+            default_filter,
+            service_name: None,
+        }
+    }
+
+    pub fn with_service_name(mut self, name: &'a str) -> Self {
+        self.service_name = Some(name);
+        self
+    }
+}
+
+pub(crate) fn resolve_format() -> LogFormat {
+    let raw = std::env::var("ASTRA_LOG_FORMAT").unwrap_or_default();
+    let lower = raw.to_lowercase();
+    match lower.as_str() {
+        "json" => LogFormat::Json,
+        "pretty" => LogFormat::Pretty,
+        "compact" => LogFormat::Compact,
+        "" => {
+            if io::stderr().is_terminal() {
+                LogFormat::Pretty
+            } else {
+                LogFormat::Json
+            }
+        }
+        _ => {
+            if !raw.trim().is_empty() {
+                let fallback = if io::stderr().is_terminal() {
+                    "pretty"
+                } else {
+                    "json"
+                };
+                eprintln!(
+                    "[astra-logging] unknown ASTRA_LOG_FORMAT={raw:?}; expected json, pretty, or compact; using {fallback}"
+                );
+            }
+            if io::stderr().is_terminal() {
+                LogFormat::Pretty
+            } else {
+                LogFormat::Json
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LogFormat {
+    Json,
+    Pretty,
+    Compact,
+}
+
+/// Error returned when the global subscriber could not be installed (e.g. already initialized).
+pub type InitError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Install a global subscriber: JSON or human-readable, UTC RFC3339 timestamps on stderr.
+///
+/// Safe to call once per process; a second call typically fails with "already been set".
+pub fn init_from_env(config: LogInitConfig<'_>) -> Result<(), InitError> {
+    #[cfg(feature = "otel")]
+    if otel::wants_otel_export() {
+        return match otel::init_with_otel(&config) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                eprintln!(
+                    "[astra-logging] OTLP init failed ({e}); falling back to stderr logging only"
+                );
+                init_fmt_only(&config)
+            }
+        };
+    }
+
+    init_fmt_only(&config)
+}
+
+fn init_fmt_only(config: &LogInitConfig<'_>) -> Result<(), InitError> {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(config.default_filter));
+
+    let timer = UtcTime::rfc_3339();
+    let format = resolve_format();
+
+    let base = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_timer(timer)
+        .with_writer(io::stderr)
+        .with_target(true)
+        .with_thread_ids(false)
+        .with_file(false)
+        .with_line_number(false);
+
+    let res = match format {
+        LogFormat::Json => base.json().try_init(),
+        LogFormat::Pretty => base.pretty().try_init(),
+        LogFormat::Compact => base.compact().try_init(),
+    };
+
+    if res.is_ok() {
+        let name = std::env::var("ASTRA_SERVICE_NAME")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .or_else(|| config.service_name.map(str::to_owned));
+        if let Some(ref svc) = name {
+            tracing::info!(target: "astra.logging", service_name = %svc, "logging initialized");
+        }
+    }
+
+    res
+}
+
+/// Flush OTLP exporters when the `otel` feature is enabled; no-op otherwise.
+pub fn shutdown_otel() {
+    #[cfg(feature = "otel")]
+    otel::shutdown_tracer_provider();
+}
+
+/// Like [`init_from_env`], but ignores "already initialized" errors (e.g. tests).
+pub fn init_from_env_or_ignores_duplicate(config: LogInitConfig<'_>) {
+    let _ = init_from_env(config);
+}

--- a/rust/crates/astra-logging/src/otel.rs
+++ b/rust/crates/astra-logging/src/otel.rs
@@ -1,0 +1,169 @@
+//! OTLP trace export (feature `otel`). Enabled when `ASTRA_OTEL_ENABLED=1` or OTLP endpoint env is set.
+
+use std::time::Duration;
+
+use opentelemetry::global;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::{
+    Resource,
+    resource::{EnvResourceDetector, SdkProvidedResourceDetector},
+    runtime,
+    trace::Config as TraceConfig,
+};
+use tracing_subscriber::{
+    EnvFilter, fmt::time::UtcTime, layer::Layer, prelude::*, registry::Registry,
+    util::SubscriberInitExt,
+};
+
+use crate::{InitError, LogFormat, LogInitConfig, resolve_format};
+
+/// Whether OTLP export should be activated (OTel feature compiled in).
+pub(crate) fn wants_otel_export() -> bool {
+    if std::env::var("ASTRA_OTEL_ENABLED").ok().as_deref() == Some("1") {
+        return true;
+    }
+    fn nonempty(name: &str) -> bool {
+        std::env::var(name)
+            .ok()
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false)
+    }
+    nonempty("OTEL_EXPORTER_OTLP_ENDPOINT") || nonempty("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+}
+
+fn build_resource(config: &LogInitConfig<'_>) -> Resource {
+    use opentelemetry::KeyValue;
+
+    let mut resource = Resource::from_detectors(
+        Duration::from_secs(0),
+        vec![
+            Box::new(SdkProvidedResourceDetector),
+            Box::new(EnvResourceDetector::new()),
+        ],
+    );
+    if let Some(name) = config.service_name.filter(|s| !s.is_empty()) {
+        let merged = Resource::new(vec![KeyValue::new("service.name", name.to_string())]);
+        resource = resource.merge(&merged);
+    } else if let Ok(name) = std::env::var("ASTRA_SERVICE_NAME")
+        && !name.trim().is_empty()
+    {
+        let merged = Resource::new(vec![KeyValue::new("service.name", name)]);
+        resource = resource.merge(&merged);
+    }
+    resource
+}
+
+/// Install OTLP batch exporter, register the global tracer provider, and return an SDK tracer for `tracing-opentelemetry`.
+fn install_otlp_tracer(
+    config: &LogInitConfig<'_>,
+) -> Result<opentelemetry_sdk::trace::Tracer, InitError> {
+    let resource = build_resource(config);
+    let exporter = opentelemetry_otlp::new_exporter().tonic();
+
+    let provider = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(exporter)
+        .with_trace_config(TraceConfig::default().with_resource(resource))
+        .install_batch(runtime::Tokio)
+        .map_err(|e| -> InitError { Box::new(e) })?;
+
+    global::set_tracer_provider(provider.clone());
+    Ok(provider.tracer("astra"))
+}
+
+fn make_filter(config: &LogInitConfig<'_>) -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(config.default_filter))
+}
+
+/// `OpenTelemetryLayer` stacks on [`Registry`]; apply the same [`EnvFilter`] to otel + fmt via per-layer filtering.
+fn registry_with_fmt<L>(
+    config: &LogInitConfig<'_>,
+    format: LogFormat,
+    otel_layer: L,
+) -> Result<(), InitError>
+where
+    L: Layer<Registry> + Send + Sync + 'static,
+{
+    let filter = make_filter(config);
+    let timer = UtcTime::rfc_3339();
+
+    match format {
+        LogFormat::Json => Registry::default()
+            .with(otel_layer.with_filter(filter.clone()))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_timer(timer)
+                    .with_writer(std::io::stderr)
+                    .with_target(true)
+                    .with_thread_ids(false)
+                    .with_file(false)
+                    .with_line_number(false)
+                    .json()
+                    .with_filter(filter),
+            )
+            .try_init()
+            .map_err(|e| -> InitError { Box::new(e) }),
+        LogFormat::Pretty => Registry::default()
+            .with(otel_layer.with_filter(filter.clone()))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_timer(timer)
+                    .with_writer(std::io::stderr)
+                    .with_target(true)
+                    .with_thread_ids(false)
+                    .with_file(false)
+                    .with_line_number(false)
+                    .pretty()
+                    .with_filter(filter),
+            )
+            .try_init()
+            .map_err(|e| -> InitError { Box::new(e) }),
+        LogFormat::Compact => Registry::default()
+            .with(otel_layer.with_filter(filter.clone()))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_timer(timer)
+                    .with_writer(std::io::stderr)
+                    .with_target(true)
+                    .with_thread_ids(false)
+                    .with_file(false)
+                    .with_line_number(false)
+                    .compact()
+                    .with_filter(filter),
+            )
+            .try_init()
+            .map_err(|e| -> InitError { Box::new(e) }),
+    }
+}
+
+/// Install Registry + OpenTelemetry + fmt with matching env filters. Call [`crate::shutdown_otel`] on graceful exit when possible.
+pub(crate) fn init_with_otel(config: &LogInitConfig<'_>) -> Result<(), InitError> {
+    let format = resolve_format();
+    let tracer = install_otlp_tracer(config)?;
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    let res = registry_with_fmt(config, format, otel_layer);
+
+    if res.is_ok() {
+        let name = std::env::var("ASTRA_SERVICE_NAME")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .or_else(|| config.service_name.map(str::to_owned));
+        if let Some(ref svc) = name {
+            tracing::info!(
+                target: "astra.logging",
+                service_name = %svc,
+                "logging initialized (OTLP + stderr)"
+            );
+        } else {
+            tracing::info!(target: "astra.logging", "logging initialized (OTLP + stderr)");
+        }
+    }
+
+    res
+}
+
+/// Flush and shutdown the global OpenTelemetry tracer provider.
+pub(crate) fn shutdown_tracer_provider() {
+    let _ = global::shutdown_tracer_provider();
+}

--- a/rust/crates/astra-thin-client/Cargo.toml
+++ b/rust/crates/astra-thin-client/Cargo.toml
@@ -12,6 +12,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util"] }

--- a/rust/crates/astra-thin-client/src/client.rs
+++ b/rust/crates/astra-thin-client/src/client.rs
@@ -832,6 +832,14 @@ impl ThinClient {
                         let delay_secs =
                             parse_retry_after(resp.headers()).unwrap_or(2u64 << attempt);
                         if !quiet {
+                            tracing::warn!(
+                                target: "astra.thin_client",
+                                status = 429u16,
+                                delay_secs,
+                                attempt = attempt + 1,
+                                max_attempts,
+                                "rate limited, retrying"
+                            );
                             eprintln!("  ⏳ Rate limited (429), retrying in {delay_secs}s…");
                         }
                         tokio::time::sleep(Duration::from_secs(delay_secs)).await;
@@ -843,6 +851,14 @@ impl ThinClient {
                     if attempt + 1 < max_attempts && e.is_transport() {
                         let delay_secs = 1u64 << attempt; // 1s, 2s, 4s…
                         if !quiet {
+                            tracing::warn!(
+                                target: "astra.thin_client",
+                                error = %e,
+                                delay_secs,
+                                attempt = attempt + 1,
+                                max_attempts,
+                                "transport error, retrying"
+                            );
                             eprintln!("  ⏳ Transport error, retrying in {delay_secs}s… ({e})");
                         }
                         tokio::time::sleep(Duration::from_secs(delay_secs)).await;

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -10,6 +10,7 @@ dotenvy.workspace = true
 serde.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -15,6 +15,10 @@ pub mod drift;
 pub mod error_kind;
 pub mod log;
 pub mod runtime_limits;
+
+/// Re-export for [`crate::agent_*!`] macros (call sites do not need a direct `tracing` dependency).
+#[doc(hidden)]
+pub use tracing;
 pub mod session_env_overlay;
 pub mod sync_poison;
 pub use confidence::ConfidenceInterval;

--- a/rust/crates/core/src/log.rs
+++ b/rust/crates/core/src/log.rs
@@ -1,8 +1,9 @@
 //! Structured logging via [`tracing`] for consistent levels, targets, and fields.
 //!
 //! All agent-facing diagnostics use target **`astra.agent`** so operators can tune
-//! `RUST_LOG` (e.g. `astra.agent=debug`). Legacy **`MO_DEBUG=1`** still forces
-//! [`agent_debug!`] to echo a line to stderr when no subscriber is configured.
+//! `RUST_LOG` (e.g. `astra.agent=debug`). Legacy **`MO_DEBUG=1`** makes [`agent_debug!`]
+//! echo stderr only while [`tracing::dispatcher::has_been_set`] is false (before
+//! `set_global_default`), avoiding duplicate lines once CLI or server logging installs a subscriber.
 
 /// Log an error-level message with component tag.
 #[macro_export]
@@ -45,16 +46,22 @@ macro_rules! agent_info {
 
 /// Log a debug-level message with component tag.
 ///
-/// When **`MO_DEBUG`** is set, also prints to stderr (for CLIs without a tracing subscriber).
-/// When a subscriber is present, [`tracing::debug!`] respects `RUST_LOG`.
+/// [`tracing::debug!`] respects `RUST_LOG`. If **`MO_DEBUG`** is set and
+/// [`tracing::dispatcher::has_been_set`] is false, also prints one line to stderr
+/// (legacy CLIs with no global subscriber).
 #[macro_export]
 macro_rules! agent_debug {
     ($component:expr, $($arg:tt)*) => {{
-        let msg = format!($($arg)*);
-        if std::env::var("MO_DEBUG").is_ok() {
-            eprintln!("[{}] DEBUG: {}", $component, msg);
+        if std::env::var("MO_DEBUG").is_ok()
+            && !$crate::tracing::dispatcher::has_been_set()
+        {
+            eprintln!("[{}] DEBUG: {}", $component, format!($($arg)*));
         }
-        $crate::tracing::debug!(target: "astra.agent", component = $component, "{}", msg);
+        $crate::tracing::debug!(
+            target: "astra.agent",
+            component = $component,
+            $($arg)*
+        );
     }};
 }
 
@@ -118,6 +125,7 @@ mod tests {
         agent_error!("test", "something failed: {}", "reason");
         agent_warn!("test", "low disk space");
         agent_info!("test", "session started");
+        agent_debug!("test", "dbg {}", 1);
     }
 
     #[test]

--- a/rust/crates/core/src/log.rs
+++ b/rust/crates/core/src/log.rs
@@ -1,21 +1,19 @@
-//! Structured logging helpers for consistent diagnostic output.
+//! Structured logging via [`tracing`] for consistent levels, targets, and fields.
 //!
-//! All runtime log output goes through these helpers to ensure consistent
-//! formatting: `[component] LEVEL: message`.  This enables grep-based
-//! filtering and future migration to a structured logging framework.
-//!
-//! # Format
-//! ```text
-//! [journal] ERROR: disk full, journal event lost
-//! [bridge] WARN: Turn exceeded max_tool_rounds (10), forcing completion
-//! [memory] ERROR: fetch error: connection refused
-//! ```
+//! All agent-facing diagnostics use target **`astra.agent`** so operators can tune
+//! `RUST_LOG` (e.g. `astra.agent=debug`). Legacy **`MO_DEBUG=1`** still forces
+//! [`agent_debug!`] to echo a line to stderr when no subscriber is configured.
 
 /// Log an error-level message with component tag.
 #[macro_export]
 macro_rules! agent_error {
     ($component:expr, $($arg:tt)*) => {
-        eprintln!("[{}] ERROR: {}", $component, format_args!($($arg)*))
+        $crate::tracing::error!(
+            target: "astra.agent",
+            component = $component,
+            "{}",
+            format_args!($($arg)*)
+        );
     };
 }
 
@@ -23,7 +21,12 @@ macro_rules! agent_error {
 #[macro_export]
 macro_rules! agent_warn {
     ($component:expr, $($arg:tt)*) => {
-        eprintln!("[{}] WARN: {}", $component, format_args!($($arg)*))
+        $crate::tracing::warn!(
+            target: "astra.agent",
+            component = $component,
+            "{}",
+            format_args!($($arg)*)
+        );
     };
 }
 
@@ -31,43 +34,45 @@ macro_rules! agent_warn {
 #[macro_export]
 macro_rules! agent_info {
     ($component:expr, $($arg:tt)*) => {
-        eprintln!("[{}] INFO: {}", $component, format_args!($($arg)*))
+        $crate::tracing::info!(
+            target: "astra.agent",
+            component = $component,
+            "{}",
+            format_args!($($arg)*)
+        );
     };
 }
 
 /// Log a debug-level message with component tag.
-/// Only emitted when `MO_DEBUG=1` or `RUST_LOG` is set.
+///
+/// When **`MO_DEBUG`** is set, also prints to stderr (for CLIs without a tracing subscriber).
+/// When a subscriber is present, [`tracing::debug!`] respects `RUST_LOG`.
 #[macro_export]
 macro_rules! agent_debug {
-    ($component:expr, $($arg:tt)*) => {
-        if std::env::var("MO_DEBUG").is_ok() || std::env::var("RUST_LOG").is_ok() {
-            eprintln!("[{}] DEBUG: {}", $component, format_args!($($arg)*))
+    ($component:expr, $($arg:tt)*) => {{
+        let msg = format!($($arg)*);
+        if std::env::var("MO_DEBUG").is_ok() {
+            eprintln!("[{}] DEBUG: {}", $component, msg);
         }
-    };
+        $crate::tracing::debug!(target: "astra.agent", component = $component, "{}", msg);
+    }};
 }
 
 /// Structured persistence failure log with key=value fields.
-/// Used for critical data-loss paths where structured parsing matters.
 #[macro_export]
 macro_rules! agent_persist_fail {
     ($component:expr, $($key:ident = $val:expr),+ $(,)?) => {
-        eprint!("[{}] PERSIST_FAIL", $component);
-        $(eprint!(" {}={}", stringify!($key), $val);)+
-        eprintln!();
+        $crate::tracing::error!(
+            target: "astra.agent",
+            component = $component,
+            kind = "PERSIST_FAIL",
+            $($key = ?$val),+,
+            "persist failure"
+        );
     };
 }
 
 /// Log-and-discard helper for best-effort persistence calls.
-///
-/// Evaluates `$expr` (an async `Result`). On `Err`, logs a warning with the
-/// component tag, operation label, run ID, and error — then continues.
-/// Persistence failures must not abort control flow, but silent discard
-/// (`let _ = ...`) hides diagnostics.
-///
-/// # Example
-/// ```ignore
-/// log_persist!(engine.persist_status(&id, "running", None, None).await, "bridge", &id, "status");
-/// ```
 #[macro_export]
 macro_rules! log_persist {
     ($expr:expr, $component:expr, $run_id:expr, $op:expr) => {
@@ -78,44 +83,31 @@ macro_rules! log_persist {
 }
 
 /// Structured tool event log with key=value fields.
-/// Used for tool errors, retries, and escalations.
-///
-/// # Example
-/// ```ignore
-/// agent_tool_event!("runtime", "tool_error",
-///     tool = "bash",
-///     category = "Transient",
-///     attempt = 1,
-///     error = "timeout"
-/// );
-/// ```
 #[macro_export]
 macro_rules! agent_tool_event {
     ($component:expr, $event:expr, $($key:ident = $val:expr),+ $(,)?) => {
-        eprint!("[{}] TOOL_EVENT event={}", $component, $event);
-        $(eprint!(" {}={}", stringify!($key), $val);)+
-        eprintln!();
+        $crate::tracing::warn!(
+            target: "astra.agent",
+            component = $component,
+            kind = "TOOL_EVENT",
+            event_kind = %$event,
+            $($key = ?$val),+,
+            "tool event"
+        );
     };
 }
 
 /// Structured escalation event log.
-/// Used when turn guard escalates to Warning or Critical.
-///
-/// # Example
-/// ```ignore
-/// agent_escalation!("turnguard",
-///     severity = "Critical",
-///     nudge_count = 5,
-///     error_count = 3,
-///     force_stop = true
-/// );
-/// ```
 #[macro_export]
 macro_rules! agent_escalation {
     ($component:expr, $($key:ident = $val:expr),+ $(,)?) => {
-        eprint!("[{}] ESCALATION", $component);
-        $(eprint!(" {}={}", stringify!($key), $val);)+
-        eprintln!();
+        $crate::tracing::warn!(
+            target: "astra.agent",
+            component = $component,
+            kind = "ESCALATION",
+            $($key = ?$val),+,
+            "escalation"
+        );
     };
 }
 
@@ -123,7 +115,6 @@ macro_rules! agent_escalation {
 mod tests {
     #[test]
     fn macros_compile_and_format_correctly() {
-        // Just verify they don't panic — output goes to stderr
         agent_error!("test", "something failed: {}", "reason");
         agent_warn!("test", "low disk space");
         agent_info!("test", "session started");
@@ -131,7 +122,12 @@ mod tests {
 
     #[test]
     fn persist_fail_macro_formats_kv() {
-        agent_persist_fail!("bridge", session = "abc123", events = 42, error = "timeout");
+        agent_persist_fail!(
+            "bridge",
+            session = "abc123",
+            events = 42usize,
+            error = "timeout"
+        );
     }
 
     #[test]
@@ -141,7 +137,7 @@ mod tests {
             "tool_error",
             tool = "bash",
             category = "Transient",
-            attempt = 1
+            attempt = 1usize
         );
     }
 
@@ -150,7 +146,7 @@ mod tests {
         agent_escalation!(
             "turnguard",
             severity = "Critical",
-            nudge_count = 5,
+            nudge_count = 5usize,
             force_stop = true
         );
     }

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -7,6 +7,8 @@ edition.workspace = true
 default = []
 # Full `/chat/turn` ledger inject tests (see `tests/chat_turn_bridge_ledger_inject_e2e.rs`).
 bridge-e2e-hooks = []
+# Enables OTLP trace export via `astra-logging` (build with `--features otel`).
+otel = ["astra-logging/otel"]
 
 [[test]]
 name = "chat_turn_bridge_ledger_inject_e2e"
@@ -31,6 +33,7 @@ path = "src/main.rs"
 dirs = "6.0.0"
 fastrand = "2"
 percent-encoding = "2.3"
+astra-logging.workspace = true
 astra-config.workspace = true
 astra-evolution.workspace = true
 astra-core.workspace = true
@@ -69,7 +72,6 @@ tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 http-body-util.workspace = true
 uuid.workspace = true
 thiserror.workspace = true

--- a/rust/crates/runtime/src/app_state.rs
+++ b/rust/crates/runtime/src/app_state.rs
@@ -148,7 +148,11 @@ impl AppState {
             fernet_encryptor: FernetTokenEncryptor::new("dev-key-not-for-production")
                 .or_else(|_| FernetTokenEncryptor::new("0123456789abcdef"))
                 .unwrap_or_else(|e| {
-                    eprintln!("  ⚠ fallback encryption init failed: {e}; using insecure default");
+                    tracing::warn!(
+                        target: "astra_runtime::app_state",
+                        error = %e,
+                        "fallback encryption init failed; using insecure default key"
+                    );
                     // Last resort: use a deterministic key so the app doesn't crash.
                     FernetTokenEncryptor::new("abcdefghijklmnop").expect("hardcoded key must work")
                 }),

--- a/rust/crates/runtime/src/server/auth_handlers.rs
+++ b/rust/crates/runtime/src/server/auth_handlers.rs
@@ -1,6 +1,9 @@
+use axum::extract::Extension;
+
 use super::*;
 
 pub(super) async fn auth_register_handler(
+    Extension(trace): Extension<RequestTrace>,
     State(state): State<AppState>,
     Json(request): Json<AuthRegisterRequest>,
 ) -> Result<(StatusCode, Json<AuthRegisterResponse>), (StatusCode, Json<ErrorResponse>)> {
@@ -19,6 +22,12 @@ pub(super) async fn auth_register_handler(
         .auth_service
         .login(AuthLoginRequestData { username, password })
         .await?;
+    tracing::info!(
+        target: "astra_runtime::auth",
+        request_id = %trace.request_id,
+        user_id = %user.user_id,
+        "user registered"
+    );
     Ok((
         StatusCode::CREATED,
         Json(AuthRegisterResponse {
@@ -35,6 +44,7 @@ pub(super) async fn auth_register_handler(
 }
 
 pub(super) async fn auth_login_handler(
+    Extension(trace): Extension<RequestTrace>,
     State(state): State<AppState>,
     Json(request): Json<AuthLoginRequest>,
 ) -> Result<Json<AuthTokenResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -45,10 +55,17 @@ pub(super) async fn auth_login_handler(
             password: request.password,
         })
         .await?;
+    // Intentionally omit username: avoid PII in application logs (correlate via request_id / JWT).
+    tracing::info!(
+        target: "astra_runtime::auth",
+        request_id = %trace.request_id,
+        "login succeeded"
+    );
     Ok(Json(AuthTokenResponse::from(tokens)))
 }
 
 pub(super) async fn auth_refresh_handler(
+    Extension(trace): Extension<RequestTrace>,
     State(state): State<AppState>,
     Json(request): Json<AuthRefreshRequest>,
 ) -> Result<Json<AuthTokenResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -58,10 +75,16 @@ pub(super) async fn auth_refresh_handler(
             refresh_token: request.refresh_token,
         })
         .await?;
+    tracing::info!(
+        target: "astra_runtime::auth",
+        request_id = %trace.request_id,
+        "access token refreshed"
+    );
     Ok(Json(AuthTokenResponse::from(tokens)))
 }
 
 pub(super) async fn auth_logout_handler(
+    Extension(trace): Extension<RequestTrace>,
     State(state): State<AppState>,
     Json(request): Json<AuthRefreshRequest>,
 ) -> Result<Json<AuthLogoutResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -71,6 +94,11 @@ pub(super) async fn auth_logout_handler(
             refresh_token: request.refresh_token,
         })
         .await?;
+    tracing::info!(
+        target: "astra_runtime::auth",
+        request_id = %trace.request_id,
+        "logout"
+    );
     Ok(Json(AuthLogoutResponse {
         message: "Logged out successfully".to_string(),
     }))
@@ -111,6 +139,12 @@ async fn memory_proxy_call(
         .await
         .map(Json)
         .map_err(|error| {
+            tracing::warn!(
+                target: "astra_runtime::auth",
+                endpoint = endpoint,
+                error = %error,
+                "memory proxy forward failed"
+            );
             if error.contains("not configured") {
                 error_response(StatusCode::SERVICE_UNAVAILABLE, &error)
             } else {

--- a/rust/crates/runtime/src/server/edge_callback_handlers.rs
+++ b/rust/crates/runtime/src/server/edge_callback_handlers.rs
@@ -5,6 +5,8 @@
 //! [`crate::turn::cloud_tool_delivery`] poll and `remove` keys until `turn_timeout_s` (user id from
 //! `x-mo-user-id` on the chat turn).
 
+use axum::extract::Extension;
+
 use super::*;
 
 use astra_services::session_journal::{
@@ -59,6 +61,7 @@ fn insert_approval_ledger_entry(
 }
 
 pub(super) async fn post_tool_result_handler(
+    Extension(trace): Extension<RequestTrace>,
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(body): Json<astra_thin_client::ToolResultRequest>,
@@ -78,6 +81,15 @@ pub(super) async fn post_tool_result_handler(
         }),
     )
     .map_err(|()| ledger_capacity_error())?;
+    tracing::info!(
+        target: "astra_runtime::edge_callback",
+        request_id = %trace.request_id,
+        user_id = %user.user_id,
+        edge_id = %edge_id,
+        callback_request_id = %body.request_id,
+        kind = "tool_result",
+        "edge tool result callback recorded"
+    );
     Ok(Json(serde_json::json!({
         "ok": true,
         "request_id": body.request_id,
@@ -85,6 +97,7 @@ pub(super) async fn post_tool_result_handler(
 }
 
 pub(super) async fn post_approval_respond_handler(
+    Extension(trace): Extension<RequestTrace>,
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(body): Json<astra_thin_client::ApprovalRespondRequest>,
@@ -144,6 +157,16 @@ pub(super) async fn post_approval_respond_handler(
         body.session_id.is_some(),
     )
     .map_err(|()| ledger_capacity_error())?;
+    tracing::info!(
+        target: "astra_runtime::edge_callback",
+        request_id = %trace.request_id,
+        user_id = %user.user_id,
+        edge_id = %edge_id,
+        callback_request_id = %body.request_id,
+        kind = "approval_respond",
+        ledger_enqueued,
+        "edge approval callback recorded"
+    );
     Ok(Json(serde_json::json!({
         "ok": true,
         "request_id": body.request_id,

--- a/rust/crates/runtime/src/server/edge_ws_handler.rs
+++ b/rust/crates/runtime/src/server/edge_ws_handler.rs
@@ -65,6 +65,10 @@ async fn handle_edge_connection(socket: WebSocket, state: AppState) {
     let (token, edge_agent_id, hostname, workspace_dir) = match auth_result {
         Ok(Some(auth)) => auth,
         _ => {
+            tracing::warn!(
+                target: "astra_runtime::edge_ws",
+                "edge WebSocket auth timeout or closed before edge_auth"
+            );
             let _ = send_edge_msg(
                 &ws_sink,
                 EdgeServerMessage::AuthError {
@@ -84,6 +88,11 @@ async fn handle_edge_connection(socket: WebSocket, state: AppState) {
     let user = match state.auth_service.current_user(&headers).await {
         Ok(user) => user,
         Err(_) => {
+            tracing::warn!(
+                target: "astra_runtime::edge_ws",
+                edge_agent_id = %edge_agent_id,
+                "edge WebSocket auth failed: invalid token"
+            );
             let _ = send_edge_msg(
                 &ws_sink,
                 EdgeServerMessage::AuthError {

--- a/rust/crates/runtime/src/server/mod.rs
+++ b/rust/crates/runtime/src/server/mod.rs
@@ -97,13 +97,10 @@ pub fn build_app(state: AppState) -> Router {
 pub async fn serve(addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
     static TRACING: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     TRACING.get_or_init(|| {
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                    tracing_subscriber::EnvFilter::new("warn,astra_runtime=info")
-                }),
-            )
-            .try_init();
+        let _ = astra_logging::init_from_env(
+            astra_logging::LogInitConfig::new("warn,astra_runtime=info,astra.http.access=info")
+                .with_service_name("astra-server"),
+        );
     });
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
@@ -114,9 +111,10 @@ pub async fn serve(addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
     if let Ok(proxy) = std::env::var("http_proxy").or_else(|_| std::env::var("HTTP_PROXY"))
         && !proxy.is_empty()
     {
-        eprintln!(
-            "[warn] HTTP proxy detected: {proxy}. \
-             Local callers should set NO_PROXY=127.0.0.1,localhost or use --noproxy."
+        tracing::warn!(
+            target: "astra_runtime::serve",
+            http_proxy = %proxy,
+            "HTTP proxy set; local callers should set NO_PROXY=127.0.0.1,localhost or use --noproxy"
         );
     }
 
@@ -126,8 +124,39 @@ pub async fn serve(addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
         astra_services::session_reaper::spawn_session_reaper(pool.clone());
     }
 
-    axum::serve(listener, build_app(state)).await?;
+    axum::serve(listener, build_app(state))
+        .with_graceful_shutdown(http_shutdown_signal())
+        .await?;
+    astra_logging::shutdown_otel();
     Ok(())
+}
+
+/// Completes on SIGTERM (Unix) or Ctrl+C so `axum::serve` can exit cleanly and OTLP can flush.
+async fn http_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    target: "astra_runtime::serve",
+                    error = %e,
+                    "failed to register SIGTERM; graceful stop uses Ctrl+C only"
+                );
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = sigterm.recv() => {}
+            _ = tokio::signal::ctrl_c() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }
 
 /// Spawn a background task that periodically cleans up expired data.
@@ -151,14 +180,17 @@ fn spawn_data_cleanup(pool: astra_core::SharedPool) {
             let results = astra_services::cleanup_expired_data(pool.get(), &policy).await;
             let total: u64 = results.iter().map(|r| r.rows_deleted).sum();
             if total > 0 {
-                eprintln!(
-                    "[cleanup] Purged {total} expired rows: {}",
-                    results
-                        .iter()
-                        .filter(|r| r.rows_deleted > 0)
-                        .map(|r| format!("{}={}", r.table, r.rows_deleted))
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                let detail = results
+                    .iter()
+                    .filter(|r| r.rows_deleted > 0)
+                    .map(|r| format!("{}={}", r.table, r.rows_deleted))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                tracing::info!(
+                    target: "astra_runtime::cleanup",
+                    rows_purged = total,
+                    tables = %detail,
+                    "expired data cleanup"
                 );
             }
         }

--- a/rust/crates/runtime/src/server/request_trace.rs
+++ b/rust/crates/runtime/src/server/request_trace.rs
@@ -4,6 +4,8 @@
 //! - Fill `request_id` on [`astra_core::ErrorResponse`] bodies, or
 //! - Insert `request_id` on top-level JSON **objects** that omit it (generic errors).
 
+use std::time::Instant;
+
 use axum::body::Body;
 use axum::extract::Request;
 use axum::http::header::CONTENT_TYPE;
@@ -11,10 +13,16 @@ use axum::http::{HeaderMap, HeaderValue};
 use axum::middleware::Next;
 use axum::response::Response;
 use http_body_util::BodyExt;
+use tracing::Instrument;
 use uuid::Uuid;
 
 /// Maximum length for a client-supplied `x-request-id` (after trim).
 const MAX_REQUEST_ID_LEN: usize = 128;
+
+/// High-frequency probe paths: skip the `astra.http.access` line to cut log volume (span + headers unchanged).
+fn should_emit_http_access_line(path: &str) -> bool {
+    path != "/health"
+}
 
 /// Populated by [`request_trace_middleware`] for handlers that need explicit access.
 #[derive(Clone, Debug)]
@@ -130,16 +138,43 @@ fn try_enrich_json_body(collected: &[u8], request_id: &str) -> Option<Vec<u8>> {
 
 /// Ensures every request has a `RequestTrace` extension and echoes `x-request-id`.
 ///
+/// Installs a per-request [`tracing::Span`] (`http.request`) with `request_id`, HTTP method,
+/// and path so nested `tracing` events correlate with the request. Emits one access line per
+/// request at target `astra.http.access` (latency + status).
+///
 /// For `4xx`/`5xx` responses with `Content-Type: application/json`, attempts to attach
 /// `request_id` to structured error bodies (see module docs).
 pub async fn request_trace_middleware(mut req: Request, next: Next) -> Response {
     let request_id = resolve_request_id(req.headers());
+    let method = req.method().clone();
+    let path = req.uri().path().to_owned();
 
     req.extensions_mut().insert(RequestTrace {
         request_id: request_id.clone(),
     });
 
-    let mut res = next.run(req).await;
+    let span = tracing::info_span!(
+        "http.request",
+        request_id = %request_id,
+        http.method = %method.as_str(),
+        http.route = %path,
+    );
+
+    let start = Instant::now();
+    let mut res = next.run(req).instrument(span).await;
+    let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+    if should_emit_http_access_line(path.as_str()) {
+        tracing::info!(
+            target: "astra.http.access",
+            request_id = %request_id,
+            http.method = %method.as_str(),
+            http.route = %path,
+            status = res.status().as_u16(),
+            latency_ms,
+            "http request"
+        );
+    }
 
     if let Ok(val) = HeaderValue::from_str(&request_id) {
         res.headers_mut()
@@ -202,6 +237,12 @@ mod tests {
                 }),
             )
             .layer(axum::middleware::from_fn(request_trace_middleware))
+    }
+
+    #[test]
+    fn health_probe_skips_access_log_line() {
+        assert!(!should_emit_http_access_line("/health"));
+        assert!(should_emit_http_access_line("/api/v1/sessions"));
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -450,10 +450,20 @@ fn persist_turn_evaluation_journal(session_id: &str, source: &str, state: &Agent
     match astra_services::session_journal::JournalWriter::new(session_id) {
         Ok(journal) => {
             if let Err(err) = journal.append(&event) {
-                eprintln!("  ⚠ turn evaluation journal append failed: {err}");
+                tracing::warn!(
+                    target: "astra_runtime::run_lifecycle",
+                    session_id = %session_id,
+                    error = %err,
+                    "turn evaluation journal append failed"
+                );
             }
         }
-        Err(err) => eprintln!("  ⚠ turn evaluation journal init failed: {err}"),
+        Err(err) => tracing::warn!(
+            target: "astra_runtime::run_lifecycle",
+            session_id = %session_id,
+            error = %err,
+            "turn evaluation journal init failed"
+        ),
     }
 }
 
@@ -581,9 +591,12 @@ async fn configure_runtime_controllers(
         {
             Ok(context) => Some(context),
             Err((status, response)) => {
-                eprintln!(
-                    "[promotion-signals] failed to preload evaluation summaries for {user_id}: {status} {}",
-                    response.0.detail
+                tracing::warn!(
+                    target: "astra_runtime::run_lifecycle",
+                    user_id = %user_id,
+                    status = %status,
+                    detail = %response.0.detail,
+                    "promotion-signals preload failed"
                 );
                 None
             }
@@ -631,9 +644,11 @@ async fn persist_runtime_promotion_events(
         let metadata = match serde_json::to_value(promotion) {
             Ok(value) => Some(value),
             Err(err) => {
-                eprintln!(
-                    "[runtime-promotion] failed to serialize promotion event {}: {err}",
-                    promotion.subject_id
+                tracing::warn!(
+                    target: "astra_runtime::run_lifecycle",
+                    subject_id = %promotion.subject_id,
+                    error = %err,
+                    "runtime promotion event serialize failed"
                 );
                 continue;
             }
@@ -658,9 +673,12 @@ async fn persist_runtime_promotion_events(
             )
             .await
         {
-            eprintln!(
-                "[runtime-promotion] failed to persist promotion event {}: {status} {}",
-                promotion.subject_id, response.0.detail
+            tracing::warn!(
+                target: "astra_runtime::run_lifecycle",
+                subject_id = %promotion.subject_id,
+                status = %status,
+                detail = %response.0.detail,
+                "runtime promotion event persist failed"
             );
         }
     }

--- a/rust/crates/runtime/src/server/state_builder.rs
+++ b/rust/crates/runtime/src/server/state_builder.rs
@@ -286,7 +286,11 @@ pub async fn build_server_state(
     let resource_governor =
         astra_services::resource_governor::DatabaseResourceGovernor::new(shared_pool.clone());
     if let Err(e) = resource_governor.ensure_tables().await {
-        eprintln!("[state_builder] resource_governor table init failed: {e}");
+        tracing::warn!(
+            target: "astra_runtime::state_builder",
+            error = %e,
+            "resource_governor table init failed"
+        );
     }
     let resource_governor: std::sync::Arc<dyn astra_services::resource_governor::ResourceGovernor> =
         std::sync::Arc::new(resource_governor);
@@ -309,7 +313,12 @@ pub async fn build_server_state(
         astra_services::team_persistence::MatrixOneTeamStore::new(shared_pool.get().clone());
     let user_id = std::env::var("MO_USER_ID").unwrap_or_else(|_| "local".to_string());
     if let Err(e) = team_store.ensure_builtins(&user_id).await {
-        eprintln!("[state_builder] team builtins seed failed: {e}");
+        tracing::warn!(
+            target: "astra_runtime::state_builder",
+            error = %e,
+            user_id = %user_id,
+            "team builtins seed failed"
+        );
     }
     let team_store: Arc<dyn astra_services::team_persistence::TeamPersistenceService> =
         Arc::new(team_store);

--- a/rust/crates/runtime/src/server/ws_handler.rs
+++ b/rust/crates/runtime/src/server/ws_handler.rs
@@ -396,6 +396,10 @@ async fn authenticate(
             Err(())
         }
         Err(_) => {
+            tracing::warn!(
+                target: "astra_runtime::ws_handler",
+                "browser WebSocket auth timeout waiting for first message"
+            );
             send_msg(
                 socket,
                 &WsServerMessage::AuthError {
@@ -450,6 +454,11 @@ async fn authenticate_with_token(
             })
         }
         Err((_status, error)) => {
+            tracing::warn!(
+                target: "astra_runtime::ws_handler",
+                detail = %error.0.detail,
+                "browser WebSocket token rejected"
+            );
             send_msg(
                 socket,
                 &WsServerMessage::AuthError {

--- a/rust/crates/services/src/event_ingestion.rs
+++ b/rust/crates/services/src/event_ingestion.rs
@@ -296,9 +296,10 @@ impl IngestionSender {
     pub fn enqueue(&self, event: IngestionEvent) {
         if let Err(mpsc::error::TrySendError::Full(_)) = self.tx.try_send(event) {
             let n = self.overflow_count.fetch_add(1, Ordering::Relaxed) + 1;
-            astra_core::agent_warn!(
-                "event_ingestion",
-                "channel full, event dropped (overflow_count={n})"
+            tracing::warn!(
+                target: "astra_services::event_ingestion",
+                overflow_count = n,
+                "ingestion channel full; event dropped"
             );
         }
     }
@@ -380,6 +381,14 @@ impl EventIngestionWorker {
         let stats_clone = stats.clone();
         let notify = Arc::new(tokio::sync::Notify::new());
 
+        tracing::info!(
+            target: "astra_services::event_ingestion",
+            batch_size = config.batch_size,
+            flush_interval_secs = config.flush_interval_secs,
+            channel_capacity = config.channel_capacity,
+            "event ingestion worker spawned"
+        );
+
         let worker = Self {
             rx,
             pool,
@@ -404,6 +413,11 @@ impl EventIngestionWorker {
         let mut buffer: Vec<IngestionEvent> = Vec::with_capacity(self.config.batch_size);
         let flush_interval = tokio::time::Duration::from_secs(self.config.flush_interval_secs);
 
+        tracing::debug!(
+            target: "astra_services::event_ingestion",
+            "event ingestion worker run loop started"
+        );
+
         loop {
             let deadline = tokio::time::sleep(flush_interval);
             tokio::pin!(deadline);
@@ -420,6 +434,10 @@ impl EventIngestionWorker {
                     if !buffer.is_empty() {
                         self.flush_batch_once(&mut buffer).await;
                     }
+                    tracing::info!(
+                        target: "astra_services::event_ingestion",
+                        "event ingestion worker stopped after shutdown signal"
+                    );
                     break;
                 }
                 Some(event) = self.rx.recv() => {
@@ -441,6 +459,10 @@ impl EventIngestionWorker {
                     if !buffer.is_empty() {
                         self.flush_batch_once(&mut buffer).await;
                     }
+                    tracing::info!(
+                        target: "astra_services::event_ingestion",
+                        "event ingestion worker stopped (channel closed)"
+                    );
                     break;
                 }
             }
@@ -467,6 +489,14 @@ impl EventIngestionWorker {
                 Err(e) => {
                     if attempt + 1 < self.config.max_retries {
                         let delay = std::time::Duration::from_millis(500 * (1 << attempt));
+                        tracing::debug!(
+                            target: "astra_services::event_ingestion",
+                            attempt = attempt + 1,
+                            max_retries = self.config.max_retries,
+                            event_count = count,
+                            error = %e,
+                            "batch flush retry after transient error"
+                        );
                         tokio::time::sleep(delay).await;
                     } else {
                         if let Ok(mut s) = self.stats.lock() {
@@ -476,6 +506,13 @@ impl EventIngestionWorker {
                                 self.config.max_retries
                             ));
                         }
+                        tracing::warn!(
+                            target: "astra_services::event_ingestion",
+                            event_count = count,
+                            max_retries = self.config.max_retries,
+                            error = %e,
+                            "batch flush failed after retries"
+                        );
                     }
                 }
             }
@@ -502,6 +539,12 @@ impl EventIngestionWorker {
                     s.errors += 1;
                     s.last_error = Some(format!("shutdown flush failed: {e}"));
                 }
+                tracing::warn!(
+                    target: "astra_services::event_ingestion",
+                    event_count = count,
+                    error = %e,
+                    "shutdown flush failed (single attempt)"
+                );
             }
         }
     }

--- a/rust/crates/services/src/session_reaper.rs
+++ b/rust/crates/services/src/session_reaper.rs
@@ -172,9 +172,13 @@ pub fn spawn_session_reaper(pool: astra_core::SharedPool) {
             let r = reap_sessions(pool.get(), &policy).await;
             let total = r.marked_idle + r.marked_ended + r.deleted;
             if total > 0 {
-                eprintln!(
-                    "[session-reaper] sweep: idle={} ended={} deleted={} workspaces_removed={}",
-                    r.marked_idle, r.marked_ended, r.deleted, r.workspaces_removed,
+                tracing::info!(
+                    target: "astra_services::session_reaper",
+                    marked_idle = r.marked_idle,
+                    marked_ended = r.marked_ended,
+                    deleted = r.deleted,
+                    workspaces_removed = r.workspaces_removed,
+                    "session reaper sweep"
                 );
             }
         }

--- a/rust/crates/services/src/state_sync.rs
+++ b/rust/crates/services/src/state_sync.rs
@@ -651,11 +651,13 @@ impl StateSyncService for MatrixOneSyncService {
                         }
                         Err(e) => {
                             if attempt < MAX_RETRIES && is_retryable_error(&e) {
-                                eprintln!(
-                                    "  ↻ push_learning_versioned retry {} of {}: {}",
-                                    attempt + 1,
-                                    MAX_RETRIES,
-                                    &e
+                                tracing::debug!(
+                                    target: "astra_services::state_sync",
+                                    operation = "push_learning_versioned",
+                                    attempt = attempt + 1,
+                                    max_retries = MAX_RETRIES,
+                                    error = %e,
+                                    "retry after transient DB error"
                                 );
                                 tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
                                 backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);
@@ -742,11 +744,13 @@ impl StateSyncService for MatrixOneSyncService {
                             }
                             // Check for retryable network error
                             if attempt < MAX_RETRIES && is_retryable_error(&e) {
-                                eprintln!(
-                                    "  ↻ push_learning_versioned (new) retry {} of {}: {}",
-                                    attempt + 1,
-                                    MAX_RETRIES,
-                                    &e
+                                tracing::debug!(
+                                    target: "astra_services::state_sync",
+                                    operation = "push_learning_versioned_new",
+                                    attempt = attempt + 1,
+                                    max_retries = MAX_RETRIES,
+                                    error = %e,
+                                    "retry after transient DB error"
                                 );
                                 tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
                                 backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);
@@ -825,11 +829,13 @@ impl StateSyncService for MatrixOneSyncService {
                 Ok(None) => return Ok(None),
                 Err(e) => {
                     if attempt < MAX_RETRIES && is_retryable_error(&e) {
-                        eprintln!(
-                            "  ↻ pull_learning_versioned retry {} of {}: {}",
-                            attempt + 1,
-                            MAX_RETRIES,
-                            &e
+                        tracing::debug!(
+                            target: "astra_services::state_sync",
+                            operation = "pull_learning_versioned",
+                            attempt = attempt + 1,
+                            max_retries = MAX_RETRIES,
+                            error = %e,
+                            "retry after transient DB error"
                         );
                         tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
                         backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);

--- a/rust/crates/services/src/sync_engine.rs
+++ b/rust/crates/services/src/sync_engine.rs
@@ -538,7 +538,7 @@ pub struct SyncEvent {
     pub timestamp: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SyncOperation {
     Pull,
@@ -599,7 +599,16 @@ impl SyncOrchestrator {
 
     /// Check cloud health and update availability flag.
     pub async fn check_health(&mut self) -> bool {
+        let prev = self.cloud_available;
         self.cloud_available = self.transport.health_check().await;
+        if prev != self.cloud_available {
+            tracing::info!(
+                target: "astra_services::sync_engine",
+                user_id = %self.user_id,
+                cloud_available = self.cloud_available,
+                "cloud transport health changed"
+            );
+        }
         self.cloud_available
     }
 
@@ -768,6 +777,14 @@ impl SyncOrchestrator {
                 .unwrap_or(false)
                 && attempt < max_retries
             {
+                tracing::info!(
+                    target: "astra_services::sync_engine",
+                    user_id = %self.user_id,
+                    domain = %domain,
+                    attempt = attempt + 1,
+                    max_retries,
+                    "push conflict; pulling fresh data before retry"
+                );
                 // Pull fresh data, merge, then retry
                 let _pull_result = self.pull_domain(domain).await;
                 // After pull+merge, the adapter now has merged state → re-export and push
@@ -971,6 +988,27 @@ impl SyncOrchestrator {
             error: error.map(|s| s.to_string()),
             timestamp: epoch_secs(),
         });
+        if !success {
+            tracing::warn!(
+                target: "astra_services::sync_engine",
+                user_id = %self.user_id,
+                domain = %domain,
+                ?op,
+                duration_ms,
+                err = error.unwrap_or(""),
+                "external sync event failed"
+            );
+        } else {
+            tracing::debug!(
+                target: "astra_services::sync_engine",
+                user_id = %self.user_id,
+                domain = %domain,
+                ?op,
+                duration_ms,
+                bytes,
+                "external sync event ok"
+            );
+        }
     }
 
     fn log_event(
@@ -982,6 +1020,7 @@ impl SyncOrchestrator {
         bytes: u64,
         error: Option<&str>,
     ) {
+        let duration_ms = start.elapsed().as_millis() as u64;
         // Keep bounded event log (last 100 events)
         if self.event_log.len() >= 100 {
             self.event_log.remove(0);
@@ -990,13 +1029,34 @@ impl SyncOrchestrator {
             domain,
             operation: op,
             success,
-            duration_ms: start.elapsed().as_millis() as u64,
+            duration_ms,
             bytes_transferred: bytes,
             version_before: None,
             version_after: None,
             error: error.map(|s| s.to_string()),
             timestamp: epoch_secs(),
         });
+        if !success {
+            tracing::warn!(
+                target: "astra_services::sync_engine",
+                user_id = %self.user_id,
+                domain = %domain,
+                ?op,
+                duration_ms,
+                err = error.unwrap_or(""),
+                "sync operation failed"
+            );
+        } else {
+            tracing::debug!(
+                target: "astra_services::sync_engine",
+                user_id = %self.user_id,
+                domain = %domain,
+                ?op,
+                duration_ms,
+                bytes,
+                "sync operation succeeded"
+            );
+        }
     }
 }
 

--- a/rust/crates/services/src/task_orchestrator.rs
+++ b/rust/crates/services/src/task_orchestrator.rs
@@ -538,6 +538,14 @@ impl TaskService for MatrixOneTaskService {
         .await
         .map_err(|e| format!("create_task: {e}"))?;
 
+        tracing::info!(
+            target: "astra_services::task_orchestrator",
+            task_id = %task_id,
+            user_id,
+            session_id,
+            "durable task created"
+        );
+
         Ok(task_id)
     }
 
@@ -610,6 +618,14 @@ impl TaskService for MatrixOneTaskService {
             .await
             .map_err(|e| format!("update_status: {e}"))?;
         }
+        if status.is_terminal() {
+            tracing::info!(
+                target: "astra_services::task_orchestrator",
+                task_id,
+                status = status.as_str(),
+                "task status terminal"
+            );
+        }
         Ok(())
     }
 
@@ -681,6 +697,13 @@ impl TaskService for MatrixOneTaskService {
         .execute(&self.pool)
         .await
         .map_err(|e| format!("fail_task: {e}"))?;
+        let preview: String = error.chars().take(200).collect();
+        tracing::warn!(
+            target: "astra_services::task_orchestrator",
+            task_id,
+            error = %preview,
+            "task marked failed"
+        );
         Ok(())
     }
 
@@ -693,6 +716,11 @@ impl TaskService for MatrixOneTaskService {
         .execute(&self.pool)
         .await
         .map_err(|e| format!("complete_task: {e}"))?;
+        tracing::info!(
+            target: "astra_services::task_orchestrator",
+            task_id,
+            "task completed"
+        );
         Ok(())
     }
 
@@ -717,6 +745,15 @@ impl TaskService for MatrixOneTaskService {
         .execute(&self.pool)
         .await
         .map_err(|e| format!("complete_plan_run: {e}"))?;
+        tracing::info!(
+            target: "astra_services::task_orchestrator",
+            task_id,
+            outcome = outcome.as_str(),
+            progress_pct,
+            items_done,
+            items_total,
+            "plan run completed"
+        );
         Ok(())
     }
 

--- a/web/app/(dashboard)/error.tsx
+++ b/web/app/(dashboard)/error.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from 'react';
 
+import { logger } from '@/lib/logger';
+
 export default function DashboardError({
   error,
   reset,
@@ -10,7 +12,11 @@ export default function DashboardError({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error('[dashboard error]', error);
+    logger.error('dashboard error boundary', {
+      name: error.name,
+      message: error.message,
+      digest: error.digest,
+    });
   }, [error]);
 
   return (

--- a/web/app/(dashboard)/workspace/error.tsx
+++ b/web/app/(dashboard)/workspace/error.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from 'react';
 import Link from 'next/link';
 
+import { logger } from '@/lib/logger';
+
 export default function WorkspaceError({
   error,
   reset,
@@ -11,7 +13,11 @@ export default function WorkspaceError({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error('[workspace error]', error);
+    logger.error('workspace error boundary', {
+      name: error.name,
+      message: error.message,
+      digest: error.digest,
+    });
   }, [error]);
 
   return (

--- a/web/lib/logger.ts
+++ b/web/lib/logger.ts
@@ -1,0 +1,67 @@
+/**
+ * Single-line JSON logs for the admin dashboard (browser console + server components).
+ * Avoid putting secrets or tokens in `context`.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogRecord {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  context?: Record<string, unknown>;
+}
+
+function emit(record: LogRecord): void {
+  const line = JSON.stringify(record);
+  switch (record.level) {
+    case 'debug':
+      // eslint-disable-next-line no-console -- intentional structured logging
+      console.debug(line);
+      break;
+    case 'info':
+      // eslint-disable-next-line no-console -- intentional structured logging
+      console.info(line);
+      break;
+    case 'warn':
+      // eslint-disable-next-line no-console -- intentional structured logging
+      console.warn(line);
+      break;
+    case 'error':
+      // eslint-disable-next-line no-console -- intentional structured logging
+      console.error(line);
+      break;
+    default: {
+      const _exhaustive: never = record.level;
+      return _exhaustive;
+    }
+  }
+}
+
+function base(
+  level: LogLevel,
+  message: string,
+  context?: Record<string, unknown>,
+): void {
+  emit({
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...(context && Object.keys(context).length > 0 ? { context } : {}),
+  });
+}
+
+export const logger = {
+  debug(message: string, context?: Record<string, unknown>): void {
+    base('debug', message, context);
+  },
+  info(message: string, context?: Record<string, unknown>): void {
+    base('info', message, context);
+  },
+  warn(message: string, context?: Record<string, unknown>): void {
+    base('warn', message, context);
+  },
+  error(message: string, context?: Record<string, unknown>): void {
+    base('error', message, context);
+  },
+};

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,10 +42,15 @@
       "name": "@astra/sdk",
       "version": "0.1.0",
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/jest": "^29.5.0",
         "@types/react": "^19.0.12",
+        "@types/react-dom": "^19.2.3",
         "jest": "^30.3.0",
+        "jest-environment-jsdom": "^30.3.0",
         "react": "^19.0.0",
+        "react-dom": "^19.2.5",
         "ts-jest": "^29.4.6",
         "tsup": "^8.4.0",
         "typescript": "^5.8.3"


### PR DESCRIPTION
## What type of PR is this?

- [x] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes #

## What this PR does / why we need it

Introduces **`astra-logging`**: shared `tracing` subscriber init (JSON/pretty/compact via env), optional **OTLP** export behind the `otel` feature, and graceful shutdown hooks so traces can flush.

- **Runtime:** HTTP request spans, `astra.http.access` lines (with `/health` omitted for noise), structured logs on auth/edge callbacks/ws, services (ingestion, sync, tasks, reaper), SIGTERM-aware server shutdown.
- **CLI / edge / thin-client:** diagnostic logging flags and env (`ASTRA_DIAGNOSTIC_LOG`, `--log-file`), edge connection errors, thin-client retries.
- **Core:** `agent_*!` macros use `tracing` target `astra.agent`.
- **Web:** JSON `logger` for error boundaries.

**Follow-up commit:** SSE (`sse_utils`) uses correct `Err` handling, adds `astra_cli::sse` tracing for transport errors, buffer truncation, timeouts, and server error events; replaces remaining `eprintln!` in **`app_state`** (fallback Fernet) and **`run_lifecycle`** (journal / promotion paths) with structured `tracing::warn!`.
