### PR TITLE
fix(cli): align slash registry with runtime subcommands

### DIFF
--- a/rust/crates/astra-cli/src/cli/command_registry.rs
+++ b/rust/crates/astra-cli/src/cli/command_registry.rs
@@ -149,16 +149,22 @@ const SKILL_SUBCOMMANDS: &[(&str, &str)] = &[
     ("feedback", "Record user feedback (+/-)"),
     ("health", "Skill catalog health"),
     ("info", "Skill details"),
+    ("installed", "List installed marketplace skills"),
     ("install", "Install from marketplace"),
     ("list", "List skills"),
     ("new", "Create skill"),
     ("pin", "Pin skill to always load"),
     ("publish", "Publish to marketplace"),
+    ("rollback", "Rollback installed skill version"),
     ("search", "Keyword search catalog"),
     ("stats", "Learning summary"),
     ("surfacing", "Agent catalog surfacing (dynamic/min/cap)"),
     ("system", "System skill helpers"),
     ("test", "Run skill test"),
+    ("trending", "Show trending marketplace skills"),
+    ("uninstall", "Remove local skill"),
+    ("unpin", "Remove pinned skill"),
+    ("upgrade", "Upgrade installed skill version"),
 ];
 
 const MCP_SUBCOMMANDS: &[(&str, &str)] = &[
@@ -212,6 +218,8 @@ const MEMORY_SUBCOMMANDS: &[(&str, &str)] = &[
 const SESSION_SUBCOMMANDS: &[(&str, &str)] = &[
     ("analyze", "Deep session diagnostics"),
     ("cleanup", "Clean stale sessions"),
+    ("context", "Show context assembly trace"),
+    ("drift", "Inspect session drift signals"),
     ("errors", "Session errors"),
     ("export", "Export session"),
     ("fork", "Fork session"),
@@ -901,9 +909,25 @@ mod tests {
         let subs = subcommand_completions("/skill");
         assert!(subs.is_some());
         let subs = subs.unwrap();
+        assert!(subs.iter().any(|(tok, _)| *tok == "browse"));
+        assert!(subs.iter().any(|(tok, _)| *tok == "installed"));
         assert!(subs.iter().any(|(tok, _)| *tok == "list"));
         assert!(subs.iter().any(|(tok, _)| *tok == "info"));
         assert!(subs.iter().any(|(tok, _)| *tok == "publish"));
+        assert!(subs.iter().any(|(tok, _)| *tok == "rollback"));
+        assert!(subs.iter().any(|(tok, _)| *tok == "trending"));
+        assert!(subs.iter().any(|(tok, _)| *tok == "uninstall"));
+        assert!(subs.iter().any(|(tok, _)| *tok == "unpin"));
+        assert!(subs.iter().any(|(tok, _)| *tok == "upgrade"));
+    }
+
+    #[test]
+    fn session_subcommand_completions_include_runtime_tools() {
+        let subs = subcommand_completions("/session");
+        assert!(subs.is_some());
+        let subs = subs.unwrap();
+        assert!(subs.iter().any(|(tok, _)| *tok == "context"));
+        assert!(subs.iter().any(|(tok, _)| *tok == "drift"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- align `/skill` registry metadata with subcommands that are already implemented in `slash_skill.rs`, so help and completion expose `installed`, `rollback`, `trending`, `uninstall`, `unpin`, and `upgrade`
- align `/session` registry metadata with runtime-backed subcommands that are already handled in `slash_session.rs`, so `context` and `drift` show up in discovery flows
- extend command registry tests to lock the newly exposed `/skill` and `/session` subcommands into completion coverage

## Why
The CLI currently supports more `/skill` and `/session` actions than it advertises through the slash registry. That makes command discovery inconsistent: users can execute these handlers if they already know the names, but they do not appear in registry-backed help or subcommand completion.

This change keeps the first UX pass intentionally small by only updating the registry layer and its tests. It does not change handler behavior or server-side logic.

## Testing
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli command_registry::tests::subcommand_completions_work -- --exact` on 55
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli command_registry::tests::session_subcommand_completions_include_runtime_tools -- --exact` on 55
