### PR TITLE
fix(cli): execute model picker on enter

### DIFF
--- a/rust/crates/astra-cli/src/cli/repl_ui.rs
+++ b/rust/crates/astra-cli/src/cli/repl_ui.rs
@@ -903,6 +903,19 @@ fn slash_inline_hint(line: &str) -> Option<String> {
     None
 }
 
+fn should_execute_slash_picker_on_enter(current: &str, selected_cmd: &str) -> bool {
+    if current == selected_cmd || current == format!("{selected_cmd} ") {
+        return true;
+    }
+
+    // `/model` opens an interactive chooser when invoked without args, so once the
+    // picker has uniquely narrowed to `/model`, Enter should run it instead of only
+    // filling in the command text.
+    selected_cmd == "/model"
+        && current.starts_with('/')
+        && selected_cmd.starts_with(current.trim_end())
+}
+
 pub(super) fn prompt_inline_hint(line: &str) -> Option<String> {
     if line.is_empty()
         && !is_slash_picker_active()
@@ -1927,7 +1940,7 @@ impl ConditionalEventHandler for SlashStartCompleteHandler {
                 let selected = get_slash_picker_selected();
 
                 if let Some((cmd, _)) = rows.get(selected) {
-                    if current == *cmd || current == format!("{cmd} ") {
+                    if should_execute_slash_picker_on_enter(current, cmd) {
                         // Exact match — execute immediately.
                         clear_slash_overlay();
                         set_slash_pending_execute(Some(cmd.to_string()));
@@ -2824,6 +2837,20 @@ mod tests {
         // Drain any leftover from other tests
         let _ = take_slash_pending_execute();
         assert_eq!(take_slash_pending_execute(), None);
+    }
+
+    #[test]
+    fn model_picker_enter_executes_on_prefix() {
+        assert!(should_execute_slash_picker_on_enter("/mo", "/model"));
+        assert!(should_execute_slash_picker_on_enter("/mode", "/model"));
+        assert!(should_execute_slash_picker_on_enter("/model", "/model"));
+    }
+
+    #[test]
+    fn non_model_picker_enter_still_requires_exact_match() {
+        assert!(!should_execute_slash_picker_on_enter("/sk", "/skill"));
+        assert!(!should_execute_slash_picker_on_enter("/sess", "/session"));
+        assert!(should_execute_slash_picker_on_enter("/skill", "/skill"));
     }
 
     // ── Print group reorganization ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- make slash picker `Enter` execute `/model` once the typed prefix uniquely narrows to that command, instead of only filling in `/model `
- keep the existing picker semantics for every other slash command, so non-`/model` entries still require an exact match before `Enter` executes them
- add focused `repl_ui` tests to lock both the new `/model` behavior and the non-`/model` regression guard into place

## Why
`/model` is unusual among slash commands: invoking it without arguments opens an interactive model chooser. In the slash picker, though, pressing `Enter` on a unique `/model` prefix only completed the line to `/model ` and stopped there, which meant users had to press `Enter` again before the chooser appeared.

That extra step made `/model` feel broken compared with the rest of the picker UX. This change keeps the fix intentionally narrow: once the picker has uniquely narrowed to `/model`, `Enter` dispatches it immediately so the chooser opens right away.

The rest of the slash picker stays unchanged. Commands like `/skill` and `/session` still preserve the existing behavior where `Enter` completes a prefix first and only executes on an exact command match.

## Implementation Notes
- add a small helper in `repl_ui.rs` to decide whether picker `Enter` should dispatch immediately
- preserve the existing exact-match rule for all commands by default
- add a `/model`-only exception because `/model` without args is itself a complete interactive action
- cover both sides of the behavior with unit tests:
  - `/model` prefixes like `/mo` and `/mode` now execute
  - other commands like `/sk` and `/sess` still do not execute early

## Testing
Performed on 55 (`mo@10.222.1.55`):

- `cargo test --manifest-path rust/Cargo.toml -p astra-cli model_picker_enter_executes_on_prefix`
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli non_model_picker_enter_still_requires_exact_match`

Manual verification on 55:
- rebuilt `astra-cli` release binary
- launched the CLI and entered `/mo` followed by `Enter`
- confirmed the flow reached `Select model (type to search):`, which demonstrates that `/model` now dispatches directly from the picker once uniquely selected
