### PR TITLE
fix: wire self-improvement & pipeline auto-reflection end-to-end

### DIFF
--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -159,6 +159,31 @@ pub(super) fn detect_correction_signal(message: &str) -> bool {
     CORRECTION_PATTERNS.iter().any(|p| msg_lower.contains(p))
 }
 
+/// Emit an `EvolutionSignal::UserCorrection` (if evolution service is wired)
+/// from the current conversation context. Extracted from `run_chat_turn` for
+/// unit-testability; production code path is unchanged.
+async fn emit_user_correction_signal(state: &ReplState, correction_text: &str) {
+    let Some(evo) = state.evolution_service.as_ref() else {
+        return;
+    };
+    let prior_assistant_text = state
+        .history
+        .last()
+        .map(|(_u, a)| a.clone())
+        .unwrap_or_default();
+    let skill_context = state.recent_tools.last().cloned();
+    let turn_id = format!("turn-{}", state.turn);
+    evo.add_signal(
+        astra_runtime::evolution::types::EvolutionSignal::UserCorrection {
+            correction_text: correction_text.to_string(),
+            prior_assistant_text,
+            skill_context,
+            turn_id,
+        },
+    )
+    .await;
+}
+
 // ─── Relevance-scored history pruning ───────────────────────────────────────
 
 /// Lightweight tokenizer for relevance scoring: lowercase, split on
@@ -318,7 +343,7 @@ pub(super) async fn handle_chat_input(
         TurnAttempt::Completed(result) => match *result {
             Ok(result) => {
                 state.last_turn_interrupted = false;
-                apply_turn_success(state, ctx.selector, ctx.profile, &line, result, turn_start);
+                apply_turn_success_async(state, ctx.selector, ctx.profile, &line, result, turn_start).await;
                 return Ok(());
             }
             Err(failure) => {
@@ -358,14 +383,14 @@ pub(super) async fn handle_chat_input(
                         }
                         TurnAttempt::Completed(result) => match *result {
                             Ok(result) => {
-                                apply_turn_success(
+                                apply_turn_success_async(
                                     state,
                                     ctx.selector,
                                     ctx.profile,
                                     &line,
                                     result,
                                     turn_start,
-                                );
+                                ).await;
                                 return Ok(());
                             }
                             Err(retry_failure) => {
@@ -404,14 +429,14 @@ pub(super) async fn handle_chat_input(
                                 }
                                 TurnAttempt::Completed(result) => match *result {
                                     Ok(result) => {
-                                        apply_turn_success(
+                                        apply_turn_success_async(
                                             state,
                                             ctx.selector,
                                             ctx.profile,
                                             &line,
                                             result,
                                             turn_start,
-                                        );
+                                        ).await;
                                         return Ok(());
                                     }
                                     Err(retry_failure) => {
@@ -1061,6 +1086,12 @@ async fn run_chat_turn(
     if detect_correction_signal(message) {
         let correction_turn = state.history.len() as u32;
         state.drift_user_corrections.push(correction_turn);
+
+        // Also emit an EvolutionSignal::UserCorrection so the evolution
+        // service / auto-reflection pipeline can learn from it. Previously
+        // only drift_user_corrections was recorded and no signal was ever
+        // produced for user corrections in the production path.
+        emit_user_correction_signal(state, message).await;
     }
 
     // Create a cancellation token that can interrupt SSE streaming mid-flight.
@@ -1553,7 +1584,36 @@ fn record_selector_turn_outcome(
     );
 }
 
+/// Test-only sync variant of `apply_turn_success`. Production code paths must
+/// use [`apply_turn_success_async`] so the LLM-driven skill-improvement path
+/// can await its network call. This wrapper keeps the existing synchronous
+/// test fixtures working without pulling a tokio runtime into every assertion.
+#[cfg(test)]
 fn apply_turn_success(
+    state: &mut ReplState,
+    selector: &dyn tool_selector::ToolSelector,
+    profile: Option<&str>,
+    line: &str,
+    result: StreamResult,
+    turn_start: Instant,
+) {
+    apply_turn_success_sync(state, selector, profile, line, result, turn_start);
+    check_skill_improvement_inner(state);
+}
+
+async fn apply_turn_success_async(
+    state: &mut ReplState,
+    selector: &dyn tool_selector::ToolSelector,
+    profile: Option<&str>,
+    line: &str,
+    result: StreamResult,
+    turn_start: Instant,
+) {
+    apply_turn_success_sync(state, selector, profile, line, result, turn_start);
+    check_skill_improvement_async(state).await;
+}
+
+fn apply_turn_success_sync(
     state: &mut ReplState,
     selector: &dyn tool_selector::ToolSelector,
     profile: Option<&str>,
@@ -1645,9 +1705,6 @@ fn apply_turn_success(
         .and_then(|i| state.history.get(i))
         .map(|(_, resp)| resp.as_str());
     record_selector_turn_outcome(selector, line, &result, &learning_snap, prev_assistant_text);
-
-    // ── Skill auto-improvement check ─────────────────────────────────────
-    check_skill_improvement(state, line, &result);
 
     // ── Post-turn status line ────────────────────────────────────────────
     print_turn_status_line(state, &result, turn_start);
@@ -1810,10 +1867,262 @@ fn print_context_window_warning(budget_pressure: f64) {
 }
 
 /// Check if the skill improvement tracker should trigger analysis.
+/// Minimal async-capable chat completion abstraction so the skill-improvement
+/// LLM path can be unit-tested without real HTTP.
+#[async_trait::async_trait]
+pub(crate) trait SkillImproveLlm: Send + Sync {
+    async fn complete(&self, system: &str, user: &str) -> Result<String, String>;
+}
+
+/// Adapter that exposes [`astra_services::CloudLlmJudge`] as [`SkillImproveLlm`].
+pub(crate) struct CloudJudgeLlm(pub std::sync::Arc<astra_services::CloudLlmJudge>);
+
+#[async_trait::async_trait]
+impl SkillImproveLlm for CloudJudgeLlm {
+    async fn complete(&self, system: &str, user: &str) -> Result<String, String> {
+        self.0.chat_completion(system, user, 2048, 0.2).await
+    }
+}
+
+/// Async variant of `check_skill_improvement_inner` with an optional LLM-driven
+/// rewrite path.
+///
+/// Flow:
+/// 1. If the auto-tuning tracker says it is not time, return.
+/// 2. Collect eligible filesystem skills + recent user corrections.
+/// 3. If no corrections, mark analyzed and return (quiet no-op).
+/// 4. If an LLM is available and succeeds, apply the LLM-rewritten SKILL.md
+///    and record a structured proposal.
+/// 5. Otherwise fall back to the heuristic append ("Recent user feedback"
+///    section) via [`check_skill_improvement_inner`].
+async fn check_skill_improvement_async(state: &mut ReplState) {
+    let llm: Option<Box<dyn SkillImproveLlm>> = state
+        .matrix_runtime
+        .as_ref()
+        .and_then(|rt| rt.create_cloud_llm_judge())
+        .map(|judge| {
+            let boxed: Box<dyn SkillImproveLlm> =
+                Box::new(CloudJudgeLlm(std::sync::Arc::new(judge)));
+            boxed
+        });
+
+    if let Some(llm) = llm {
+        match try_llm_skill_improvement(state, llm.as_ref()).await {
+            Ok(true) => return,
+            Ok(false) => {}
+            Err(e) => {
+                astra_core::agent_debug!(
+                    "skill",
+                    "LLM skill-improvement failed, falling back to heuristic: {}",
+                    e
+                );
+            }
+        }
+    }
+
+    check_skill_improvement_inner(state);
+}
+
+/// LLM-driven skill-improvement core.
+///
+/// Return codes:
+/// - `Ok(true)`  — the LLM path handled this turn. The caller must NOT run the
+///   heuristic fallback. This covers both successful SKILL.md rewrites and
+///   deliberate no-ops (no filesystem skills, no queued corrections, empty or
+///   structurally-invalid LLM responses).
+/// - `Err(_)`    — an unexpected error occurred; the caller should log it and
+///   run the heuristic fallback.
+///
+/// The shape of `Result<bool, _>` is retained so future versions can reintroduce
+/// an `Ok(false)` "inapplicable, please retry via heuristic" path without a
+/// breaking signature change. At the moment no code path returns `Ok(false)`.
+pub(crate) async fn try_llm_skill_improvement(
+    state: &mut ReplState,
+    llm: &dyn SkillImproveLlm,
+) -> Result<bool, String> {
+    if !state.skill_improvement_tracker.should_analyze(state.turn) {
+        return Ok(true);
+    }
+
+    let registry = state.unified_skill_registry.clone();
+    let manifests = registry.all_manifests();
+    let filesystem_skills: Vec<_> = manifests
+        .iter()
+        .filter(|m| {
+            matches!(
+                m.source,
+                astra_runtime::skills::manifest::SkillSourceKind::Local
+            )
+        })
+        .collect();
+    if filesystem_skills.is_empty() {
+        state.skill_improvement_tracker.mark_analyzed(state.turn);
+        return Ok(true);
+    }
+
+    let recent: Vec<astra_runtime::skills::improvement::RecentMessage> = state
+        .history
+        .iter()
+        .rev()
+        .take(astra_runtime::skills::improvement::TURN_BATCH_SIZE as usize)
+        .rev()
+        .flat_map(|(user, assistant)| {
+            vec![
+                astra_runtime::skills::improvement::RecentMessage {
+                    role: "user".into(),
+                    content: user.clone(),
+                },
+                astra_runtime::skills::improvement::RecentMessage {
+                    role: "assistant".into(),
+                    content: assistant.clone(),
+                },
+            ]
+        })
+        .collect();
+
+    if recent.is_empty() {
+        state.skill_improvement_tracker.mark_analyzed(state.turn);
+        return Ok(true);
+    }
+
+    let has_correction = recent
+        .iter()
+        .any(|m| m.role == "user" && detect_correction_signal(&m.content));
+    if !has_correction {
+        state.skill_improvement_tracker.mark_analyzed(state.turn);
+        return Ok(true);
+    }
+
+    let target = filesystem_skills
+        .iter()
+        .find(|m| state.recent_tools.iter().any(|t| t.contains(&m.name)))
+        .copied()
+        .or_else(|| filesystem_skills.first().copied())
+        .ok_or_else(|| "no target skill".to_string())?;
+
+    let loaded = registry.get_loaded_skill(&target.name);
+    let skill_dir = loaded
+        .as_ref()
+        .and_then(|s| s.skill_dir.clone())
+        .ok_or_else(|| format!("skill {} has no on-disk directory", target.name))?;
+    let skill_md = skill_dir.join("SKILL.md");
+    let current_content = std::fs::read_to_string(&skill_md)
+        .map_err(|e| format!("failed to read {}: {}", skill_md.display(), e))?;
+
+    // Step 1: analysis — detect structured improvements.
+    let (analysis_system, analysis_user) =
+        astra_runtime::skills::improvement::build_analysis_prompt(
+            &target.name,
+            &current_content,
+            &recent,
+        );
+    let analysis_resp = llm.complete(&analysis_system, &analysis_user).await?;
+    let improvements =
+        astra_runtime::skills::improvement::parse_improvements(&analysis_resp);
+    if improvements.is_empty() {
+        state.skill_improvement_tracker.mark_analyzed(state.turn);
+        return Ok(true);
+    }
+
+    // Step 2: rewrite — apply improvements into a new SKILL.md.
+    let rewrite_prompt =
+        astra_runtime::skills::improvement::build_rewrite_prompt(&current_content, &improvements);
+    let rewrite_system =
+        "You are editing a skill definition file. Output only the <updated_file> block.";
+    let rewrite_resp = llm.complete(rewrite_system, &rewrite_prompt).await?;
+    let new_content =
+        astra_runtime::skills::improvement::extract_updated_content(&rewrite_resp)
+            .ok_or_else(|| "LLM response missing <updated_file> block".to_string())?;
+
+    astra_runtime::skills::improvement::apply_improvement(&skill_md, &new_content)
+        .map_err(|e| format!("failed to write {}: {}", skill_md.display(), e))?;
+
+    let proposal = astra_runtime::skills::improvement::ImprovementProposal {
+        skill_name: target.name.clone(),
+        skill_path: skill_md.clone(),
+        improvements: improvements.clone(),
+    };
+    state.skill_improvement_tracker.propose(proposal);
+    eprintln!(
+        "  {}",
+        format!(
+            "✓ applied {} LLM-generated improvement(s) to skill '{}' ({})",
+            improvements.len(),
+            target.name,
+            skill_md.display()
+        )
+        .dim()
+    );
+    state.skill_improvement_tracker.mark_analyzed(state.turn);
+    Ok(true)
+}
+
+/// Periodically detect user corrections in conversation history and turn them
+/// into skill-improvement proposals.
 ///
 /// After every N user turns (TURN_BATCH_SIZE), checks whether the recent conversation
 /// contains corrections or improvements for any active filesystem skill.
 fn check_skill_improvement(state: &mut ReplState, _line: &str, _result: &StreamResult) {
+    check_skill_improvement_inner(state);
+}
+
+/// Trim the content so that at most `keep` `## Recent user feedback` sections
+/// remain (the most-recent ones). A "section" is delimited by any top-level
+/// `## ` heading. This prevents unbounded growth when corrections fire
+/// repeatedly across long sessions.
+fn trim_feedback_sections(content: &str, keep: usize) -> String {
+    const HEADING: &str = "## Recent user feedback";
+    if content.matches(HEADING).count() <= keep {
+        return content.to_string();
+    }
+
+    // Collect byte-offsets of every `## ` heading — we only need line starts.
+    let mut section_starts: Vec<usize> = Vec::new();
+    let mut pos = 0usize;
+    for line in content.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("## ") {
+            section_starts.push(pos);
+        }
+        pos += line.len();
+    }
+    section_starts.push(content.len());
+
+    // Walk sections in order. Collect all feedback-section (start, end) pairs.
+    let mut feedback_ranges: Vec<(usize, usize)> = Vec::new();
+    for w in section_starts.windows(2) {
+        let (s, e) = (w[0], w[1]);
+        if content[s..e].trim_start().starts_with(HEADING) {
+            feedback_ranges.push((s, e));
+        }
+    }
+
+    if feedback_ranges.len() <= keep {
+        return content.to_string();
+    }
+
+    // Drop the oldest (total - keep) ranges.
+    let drop_count = feedback_ranges.len() - keep;
+    let drop_set: std::collections::BTreeSet<(usize, usize)> =
+        feedback_ranges.iter().take(drop_count).cloned().collect();
+
+    let mut out = String::with_capacity(content.len());
+    let mut cursor = 0usize;
+    for (s, e) in &drop_set {
+        if cursor < *s {
+            out.push_str(&content[cursor..*s]);
+        }
+        cursor = *e;
+    }
+    if cursor < content.len() {
+        out.push_str(&content[cursor..]);
+    }
+    out
+}
+
+/// Body of `check_skill_improvement`, extracted so it can be unit-tested
+/// without requiring a full `StreamResult`.
+fn check_skill_improvement_inner(state: &mut ReplState) {
     if !state.skill_improvement_tracker.should_analyze(state.turn) {
         return;
     }
@@ -1862,16 +2171,150 @@ fn check_skill_improvement(state: &mut ReplState, _line: &str, _result: &StreamR
         return;
     }
 
-    // Log that analysis is due — actual LLM analysis deferred to future iteration.
-    // The prompt builders (build_analysis_prompt, build_rewrite_prompt) are ready
-    // in astra_runtime::skills::improvement, but calling LLM from here requires
-    // async context + API key plumbing that's better handled via a dedicated
-    // background task or post-turn hook.
-    astra_core::agent_debug!(
-        "skill",
-        "improvement check: {} filesystem skill(s) eligible, {} recent messages — analysis ready",
-        filesystem_skills.len(),
-        recent.len(),
+    // Heuristic closed-loop skill improvement:
+    // 1. Find recent user corrections in history.
+    // 2. Pick the most-recent filesystem skill (by name match in recent_tools
+    //    or first-eligible if none matches).
+    // 3. Append a "Recent user feedback" section to SKILL.md.
+    // 4. Record the proposal on the tracker.
+    //
+    // This is a safe, LLM-free closed loop that ensures corrections survive
+    // across sessions. The LLM-based rewrite path (build_analysis_prompt /
+    // build_rewrite_prompt) is a follow-up (P1) running from a dedicated
+    // async background task.
+
+    let corrections: Vec<String> = recent
+        .iter()
+        .filter(|m| m.role == "user" && detect_correction_signal(&m.content))
+        .map(|m| m.content.clone())
+        .collect();
+
+    if corrections.is_empty() {
+        astra_core::agent_debug!(
+            "skill",
+            "improvement check: {} filesystem skill(s) eligible, no user corrections in last {} messages",
+            filesystem_skills.len(),
+            recent.len(),
+        );
+        state.skill_improvement_tracker.mark_analyzed(state.turn);
+        return;
+    }
+
+    // Prefer a filesystem skill whose name appears in recent_tools; otherwise
+    // fall back to the first eligible filesystem skill.
+    let target = filesystem_skills
+        .iter()
+        .find(|m| state.recent_tools.iter().any(|t| t.contains(&m.name)))
+        .copied()
+        .or_else(|| filesystem_skills.first().copied());
+    let Some(target) = target else {
+        state.skill_improvement_tracker.mark_analyzed(state.turn);
+        return;
+    };
+
+    let loaded = registry.get_loaded_skill(&target.name);
+    let skill_dir = loaded.as_ref().and_then(|s| s.skill_dir.clone());
+    let Some(skill_dir) = skill_dir else {
+        astra_core::agent_debug!(
+            "skill",
+            "improvement check: skill {} has no on-disk directory — skipping",
+            target.name,
+        );
+        state.skill_improvement_tracker.mark_analyzed(state.turn);
+        return;
+    };
+    let skill_md = skill_dir.join("SKILL.md");
+    if !skill_md.exists() {
+        astra_core::agent_debug!(
+            "skill",
+            "improvement check: {} not found — skipping",
+            skill_md.display(),
+        );
+        state.skill_improvement_tracker.mark_analyzed(state.turn);
+        return;
+    }
+
+    let improvements: Vec<astra_runtime::skills::improvement::SkillImprovement> = corrections
+        .iter()
+        .map(|c| {
+            let snippet: String = c.chars().take(240).collect();
+            astra_runtime::skills::improvement::SkillImprovement {
+                section: "Recent user feedback".into(),
+                change: format!("User correction: {}", snippet),
+                reason: "Detected correction pattern in user message".into(),
+            }
+        })
+        .collect();
+
+    let proposal = astra_runtime::skills::improvement::ImprovementProposal {
+        skill_name: target.name.clone(),
+        skill_path: skill_md.clone(),
+        improvements: improvements.clone(),
+    };
+
+    // Append feedback to SKILL.md with dedup + section cap so the file doesn't
+    // grow unboundedly from repeated corrections:
+    //   - drop any bullet whose text already appears verbatim in the file;
+    //   - keep at most MAX_FEEDBACK_SECTIONS most-recent "Recent user feedback"
+    //     blocks — older ones are trimmed.
+    const MAX_FEEDBACK_SECTIONS: usize = 5;
+    let existing = std::fs::read_to_string(&skill_md).unwrap_or_default();
+
+    let novel_changes: Vec<&str> = improvements
+        .iter()
+        .map(|imp| imp.change.as_str())
+        .filter(|change| !existing.contains(change))
+        .collect();
+
+    if novel_changes.is_empty() {
+        astra_core::agent_debug!(
+            "skill",
+            "improvement check: all {} corrections already recorded in {} — skipping append",
+            improvements.len(),
+            skill_md.display(),
+        );
+        state.skill_improvement_tracker.mark_analyzed(state.turn);
+        return;
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let mut appended = String::new();
+    appended.push_str("\n\n## Recent user feedback\n");
+    appended.push_str(&format!("<!-- auto-recorded at t={} -->\n", now));
+    for change in &novel_changes {
+        appended.push_str(&format!("- {}\n", change));
+    }
+
+    // Trim oldest feedback sections if we'd exceed the cap after appending.
+    let trimmed_existing = trim_feedback_sections(&existing, MAX_FEEDBACK_SECTIONS - 1);
+    let new_content = format!("{}{}", trimmed_existing.trim_end(), appended);
+    if let Err(e) = astra_runtime::skills::improvement::apply_improvement(&skill_md, &new_content) {
+        eprintln!(
+            "  {}",
+            format!(
+                "skill improvement: failed to write {}: {}",
+                skill_md.display(),
+                e
+            )
+            .yellow()
+        );
+        state.skill_improvement_tracker.mark_analyzed(state.turn);
+        return;
+    }
+
+    state.skill_improvement_tracker.propose(proposal);
+    eprintln!(
+        "  {}",
+        format!(
+            "✓ recorded {} user correction(s) into skill '{}' ({})",
+            improvements.len(),
+            target.name,
+            skill_md.display()
+        )
+        .dim()
     );
 
     state.skill_improvement_tracker.mark_analyzed(state.turn);
@@ -4350,5 +4793,405 @@ mod tests {
             classify_turn_error("connection timeout"),
             ErrorKind::Network
         );
+    }
+
+    // ─── E2E: skill improvement closed loop ─────────────────────────────
+    // Seeds a tempdir filesystem skill, injects a user correction into
+    // ReplState.history, and calls `check_skill_improvement_inner` to verify:
+    //   1. SKILL.md on disk now contains a "Recent user feedback" section.
+    //   2. ImprovementTracker.pending_proposal is populated.
+    //   3. Tracker advanced past `should_analyze`.
+    #[tokio::test]
+    async fn skill_improvement_records_correction_on_filesystem_skill() {
+        // 1. Build tempdir skills root: <tmp>/my-skill/SKILL.md
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let skill_md = skill_dir.join("SKILL.md");
+        std::fs::write(
+            &skill_md,
+            "---\nname: my-skill\ndescription: test skill\nversion: \"0.1.0\"\n---\n\n# Body\nOriginal instructions.\n",
+        )
+        .unwrap();
+
+        // 2. Build a registry backed by a LocalSkillProvider pointing at tmp.
+        let mut registry = astra_runtime::skills::UnifiedSkillRegistry::new();
+        registry.add_provider(Box::new(
+            astra_runtime::skills::LocalSkillProvider::with_paths(vec![tmp.path().to_path_buf()]),
+        ));
+        registry.discover_all().await.unwrap();
+        // Pre-load so skill_dir is populated on the cached LoadedSkill.
+        registry.load("my-skill").await.unwrap();
+        assert_eq!(registry.len(), 1);
+
+        // 3. Wire up a ReplState with the registry, a correction message
+        //    in history, and a turn count past the batch threshold.
+        let mut state = ReplState {
+            unified_skill_registry: std::sync::Arc::new(registry),
+            history: vec![(
+                "no, that's wrong — please do it differently next time".to_string(),
+                "(previous assistant response)".to_string(),
+            )],
+            turn: astra_runtime::skills::improvement::TURN_BATCH_SIZE + 1,
+            recent_tools: vec!["my-skill".to_string()],
+            ..Default::default()
+        };
+        assert!(
+            state
+                .skill_improvement_tracker
+                .should_analyze(state.turn)
+        );
+
+        // 4. Run the closed loop.
+        check_skill_improvement_inner(&mut state);
+
+        // 5a. SKILL.md should now contain the auto-recorded feedback.
+        let updated = std::fs::read_to_string(&skill_md).unwrap();
+        assert!(
+            updated.contains("Recent user feedback"),
+            "SKILL.md should contain feedback section:\n{}",
+            updated
+        );
+        assert!(
+            updated.contains("User correction:"),
+            "SKILL.md should quote the user correction:\n{}",
+            updated
+        );
+        assert!(
+            updated.contains("Original instructions."),
+            "SKILL.md must preserve original content:\n{}",
+            updated
+        );
+
+        // 5b. The tracker should hold the pending proposal for UI surfacing.
+        let pending = state
+            .skill_improvement_tracker
+            .take_proposal()
+            .expect("pending proposal should be recorded");
+        assert_eq!(pending.skill_name, "my-skill");
+        assert_eq!(pending.skill_path, skill_md);
+        assert!(!pending.improvements.is_empty());
+
+        // 5c. Tracker advanced past should_analyze.
+        assert!(
+            !state
+                .skill_improvement_tracker
+                .should_analyze(state.turn),
+            "tracker must advance last_analyzed_count"
+        );
+    }
+
+    // Regression guard: when there are no corrections, the loop must NOT
+    // touch SKILL.md and must NOT record a proposal.
+    #[tokio::test]
+    async fn skill_improvement_noop_without_correction() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let skill_md = skill_dir.join("SKILL.md");
+        let original = "---\nname: my-skill\ndescription: test skill\nversion: \"0.1.0\"\n---\n\n# Body\nOriginal.\n";
+        std::fs::write(&skill_md, original).unwrap();
+
+        let mut registry = astra_runtime::skills::UnifiedSkillRegistry::new();
+        registry.add_provider(Box::new(
+            astra_runtime::skills::LocalSkillProvider::with_paths(vec![tmp.path().to_path_buf()]),
+        ));
+        registry.discover_all().await.unwrap();
+        registry.load("my-skill").await.unwrap();
+
+        let mut state = ReplState {
+            unified_skill_registry: std::sync::Arc::new(registry),
+            history: vec![(
+                "hello, please add a feature".to_string(),
+                "sure thing".to_string(),
+            )],
+            turn: astra_runtime::skills::improvement::TURN_BATCH_SIZE + 1,
+            ..Default::default()
+        };
+
+        check_skill_improvement_inner(&mut state);
+
+        let unchanged = std::fs::read_to_string(&skill_md).unwrap();
+        assert_eq!(unchanged, original, "SKILL.md must not be modified");
+        assert!(state.skill_improvement_tracker.pending_proposal.is_none());
+    }
+
+    // ─── E2E: user correction → EvolutionSignal::UserCorrection emission ───
+    #[tokio::test]
+    async fn emit_user_correction_pushes_signal_to_evolution_service() {
+        let evo = std::sync::Arc::new(astra_runtime::evolution::service::EvolutionService::new());
+        let state = ReplState {
+            evolution_service: Some(evo.clone()),
+            history: vec![(
+                "write a function".to_string(),
+                "here is the function".to_string(),
+            )],
+            recent_tools: vec!["filesystem".to_string()],
+            turn: 3,
+            ..Default::default()
+        };
+
+        emit_user_correction_signal(&state, "no, that's wrong, do it differently").await;
+
+        let (_fast, llm_routed) = evo.flush().await;
+        // UserCorrection is LLM-routed by needs_llm (contains skill_context).
+        let found = llm_routed.iter().any(|s| {
+            matches!(
+                s,
+                astra_runtime::evolution::types::EvolutionSignal::UserCorrection {
+                    skill_context: Some(sc),
+                    correction_text,
+                    prior_assistant_text,
+                    turn_id,
+                } if sc == "filesystem"
+                    && correction_text.starts_with("no, that's wrong")
+                    && prior_assistant_text == "here is the function"
+                    && turn_id == "turn-3"
+            )
+        });
+        assert!(
+            found,
+            "UserCorrection signal not found in flushed llm_routed: {:?}",
+            llm_routed
+        );
+    }
+
+    #[tokio::test]
+    async fn emit_user_correction_noop_without_evolution_service() {
+        let state = ReplState {
+            evolution_service: None,
+            history: vec![("u".to_string(), "a".to_string())],
+            ..Default::default()
+        };
+        // Must not panic.
+        emit_user_correction_signal(&state, "no, that's wrong").await;
+    }
+
+    // ─── E2E: LLM-driven skill improvement ───────────────────────────────
+    //
+    // Seeds a tempdir skill, injects a correction + a fake LLM that returns
+    // structured improvements and a rewritten SKILL.md, then exercises the
+    // production closed loop via `try_llm_skill_improvement`.
+    //
+    // Verifies:
+    //   * LLM-rewritten content replaces the original SKILL.md body.
+    //   * Structured `ImprovementProposal` (from parsed JSON) lands in tracker.
+    //   * Tracker advances past `should_analyze`.
+
+    struct FakeLlm {
+        responses: std::sync::Mutex<Vec<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl SkillImproveLlm for FakeLlm {
+        async fn complete(&self, _system: &str, _user: &str) -> Result<String, String> {
+            let mut r = self.responses.lock().unwrap();
+            if r.is_empty() {
+                Err("no canned response".into())
+            } else {
+                Ok(r.remove(0))
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn llm_skill_improvement_rewrites_skill_md_end_to_end() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let skill_md = skill_dir.join("SKILL.md");
+        let original = "---\nname: my-skill\ndescription: test\nversion: \"0.1.0\"\n---\n\n# Body\nOriginal instructions.\n";
+        std::fs::write(&skill_md, original).unwrap();
+
+        let mut registry = astra_runtime::skills::UnifiedSkillRegistry::new();
+        registry.add_provider(Box::new(
+            astra_runtime::skills::LocalSkillProvider::with_paths(vec![tmp.path().to_path_buf()]),
+        ));
+        registry.discover_all().await.unwrap();
+        registry.load("my-skill").await.unwrap();
+
+        let mut state = ReplState {
+            unified_skill_registry: std::sync::Arc::new(registry),
+            history: vec![(
+                "no, don't greet twice — skip the greeting on follow-ups".to_string(),
+                "Hello again!".to_string(),
+            )],
+            turn: astra_runtime::skills::improvement::TURN_BATCH_SIZE + 1,
+            recent_tools: vec!["my-skill".to_string()],
+            ..Default::default()
+        };
+
+        // Canned LLM responses: first = analysis JSON, second = rewritten file.
+        let analysis = r#"[
+          {"section": "greeting", "change": "skip greeting on follow-ups", "reason": "user said don't greet twice"}
+        ]"#;
+        let rewritten = "---\nname: my-skill\ndescription: test\nversion: \"0.1.0\"\n---\n\n# Body\nOriginal instructions.\nSkip greeting on follow-up turns per user preference.\n";
+        let wrapped_rewrite = format!("<updated_file>\n{}\n</updated_file>", rewritten);
+
+        let llm = FakeLlm {
+            responses: std::sync::Mutex::new(vec![
+                analysis.to_string(),
+                wrapped_rewrite,
+            ]),
+        };
+
+        let ok = try_llm_skill_improvement(&mut state, &llm)
+            .await
+            .expect("LLM path should succeed");
+        assert!(ok, "LLM path should report handled=true");
+
+        let updated = std::fs::read_to_string(&skill_md).unwrap();
+        assert!(
+            updated.contains("Skip greeting on follow-up turns"),
+            "SKILL.md should contain LLM-rewritten body:\n{}",
+            updated
+        );
+        assert!(
+            updated.contains("name: my-skill"),
+            "frontmatter must be preserved:\n{}",
+            updated
+        );
+
+        let pending = state
+            .skill_improvement_tracker
+            .take_proposal()
+            .expect("structured proposal should land in tracker");
+        assert_eq!(pending.skill_name, "my-skill");
+        assert_eq!(pending.improvements.len(), 1);
+        assert_eq!(pending.improvements[0].section, "greeting");
+
+        assert!(
+            !state
+                .skill_improvement_tracker
+                .should_analyze(state.turn),
+            "tracker must advance"
+        );
+    }
+
+    // When LLM returns empty improvements array, the loop should no-op
+    // (not rewrite SKILL.md) but still mark analyzed.
+    #[tokio::test]
+    async fn llm_skill_improvement_empty_response_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let skill_md = skill_dir.join("SKILL.md");
+        let original = "---\nname: my-skill\ndescription: test\nversion: \"0.1.0\"\n---\n\n# Body\nOriginal.\n";
+        std::fs::write(&skill_md, original).unwrap();
+
+        let mut registry = astra_runtime::skills::UnifiedSkillRegistry::new();
+        registry.add_provider(Box::new(
+            astra_runtime::skills::LocalSkillProvider::with_paths(vec![tmp.path().to_path_buf()]),
+        ));
+        registry.discover_all().await.unwrap();
+        registry.load("my-skill").await.unwrap();
+
+        let mut state = ReplState {
+            unified_skill_registry: std::sync::Arc::new(registry),
+            history: vec![(
+                "no, that's wrong".to_string(),
+                "sorry".to_string(),
+            )],
+            turn: astra_runtime::skills::improvement::TURN_BATCH_SIZE + 1,
+            recent_tools: vec!["my-skill".to_string()],
+            ..Default::default()
+        };
+
+        let llm = FakeLlm {
+            responses: std::sync::Mutex::new(vec!["[]".to_string()]),
+        };
+
+        let ok = try_llm_skill_improvement(&mut state, &llm).await.unwrap();
+        assert!(ok);
+
+        assert_eq!(
+            std::fs::read_to_string(&skill_md).unwrap(),
+            original,
+            "SKILL.md must be unchanged on empty improvements"
+        );
+        assert!(state.skill_improvement_tracker.take_proposal().is_none());
+    }
+
+    /// Verify that when the LLM path errors out, the caller falls back to
+    /// the heuristic: SKILL.md receives the "Recent user feedback" section
+    /// and the tracker gets a heuristic-shaped proposal.
+    #[tokio::test]
+    async fn llm_error_falls_back_to_heuristic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let skill_md = skill_dir.join("SKILL.md");
+        let original =
+            "---\nname: my-skill\ndescription: test\nversion: \"0.1.0\"\n---\n\n# Body\nOriginal.\n";
+        std::fs::write(&skill_md, original).unwrap();
+
+        let mut registry = astra_runtime::skills::UnifiedSkillRegistry::new();
+        registry.add_provider(Box::new(
+            astra_runtime::skills::LocalSkillProvider::with_paths(vec![tmp.path().to_path_buf()]),
+        ));
+        registry.discover_all().await.unwrap();
+        registry.load("my-skill").await.unwrap();
+
+        let mut state = ReplState {
+            unified_skill_registry: std::sync::Arc::new(registry),
+            history: vec![(
+                "no, that's wrong, do it differently".to_string(),
+                "sorry".to_string(),
+            )],
+            turn: astra_runtime::skills::improvement::TURN_BATCH_SIZE + 1,
+            recent_tools: vec!["my-skill".to_string()],
+            ..Default::default()
+        };
+
+        let llm = FakeLlm {
+            // Empty canned responses → the fake returns Err on first call,
+            // mimicking a cloud LLM outage.
+            responses: std::sync::Mutex::new(vec![]),
+        };
+
+        let result = try_llm_skill_improvement(&mut state, &llm).await;
+        assert!(
+            result.is_err(),
+            "expected LLM path to return Err, got: {:?}",
+            result
+        );
+
+        // Simulate the caller's fallback to the heuristic.
+        check_skill_improvement_inner(&mut state);
+
+        let updated = std::fs::read_to_string(&skill_md).unwrap();
+        assert!(
+            updated.contains("## Recent user feedback"),
+            "heuristic fallback should have appended feedback section; got: {}",
+            updated
+        );
+        assert!(
+            updated.contains("no, that's wrong"),
+            "feedback section should contain correction snippet; got: {}",
+            updated
+        );
+    }
+
+    #[test]
+    fn trim_feedback_sections_caps_at_keep() {
+        let content = "# Body\ncontent\n\n## Recent user feedback\n- a\n\n\
+                       ## Recent user feedback\n- b\n\n## Recent user feedback\n- c\n\n\
+                       ## Recent user feedback\n- d\n";
+        // keep=2 → only the two most-recent sections (c, d) should remain.
+        let trimmed = trim_feedback_sections(content, 2);
+        assert_eq!(trimmed.matches("## Recent user feedback").count(), 2);
+        assert!(!trimmed.contains("- a"));
+        assert!(!trimmed.contains("- b"));
+        assert!(trimmed.contains("- c"));
+        assert!(trimmed.contains("- d"));
+        // Non-feedback content preserved.
+        assert!(trimmed.contains("# Body"));
+    }
+
+    #[test]
+    fn trim_feedback_sections_noop_when_within_cap() {
+        let content = "# Body\n\n## Recent user feedback\n- only\n";
+        let trimmed = trim_feedback_sections(content, 5);
+        assert_eq!(trimmed, content);
     }
 }

--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -343,7 +343,15 @@ pub(super) async fn handle_chat_input(
         TurnAttempt::Completed(result) => match *result {
             Ok(result) => {
                 state.last_turn_interrupted = false;
-                apply_turn_success_async(state, ctx.selector, ctx.profile, &line, result, turn_start).await;
+                apply_turn_success_async(
+                    state,
+                    ctx.selector,
+                    ctx.profile,
+                    &line,
+                    result,
+                    turn_start,
+                )
+                .await;
                 return Ok(());
             }
             Err(failure) => {
@@ -390,7 +398,8 @@ pub(super) async fn handle_chat_input(
                                     &line,
                                     result,
                                     turn_start,
-                                ).await;
+                                )
+                                .await;
                                 return Ok(());
                             }
                             Err(retry_failure) => {
@@ -436,7 +445,8 @@ pub(super) async fn handle_chat_input(
                                             &line,
                                             result,
                                             turn_start,
-                                        ).await;
+                                        )
+                                        .await;
                                         return Ok(());
                                     }
                                     Err(retry_failure) => {
@@ -2017,8 +2027,7 @@ pub(crate) async fn try_llm_skill_improvement(
             &recent,
         );
     let analysis_resp = llm.complete(&analysis_system, &analysis_user).await?;
-    let improvements =
-        astra_runtime::skills::improvement::parse_improvements(&analysis_resp);
+    let improvements = astra_runtime::skills::improvement::parse_improvements(&analysis_resp);
     if improvements.is_empty() {
         state.skill_improvement_tracker.mark_analyzed(state.turn);
         return Ok(true);
@@ -2030,9 +2039,8 @@ pub(crate) async fn try_llm_skill_improvement(
     let rewrite_system =
         "You are editing a skill definition file. Output only the <updated_file> block.";
     let rewrite_resp = llm.complete(rewrite_system, &rewrite_prompt).await?;
-    let new_content =
-        astra_runtime::skills::improvement::extract_updated_content(&rewrite_resp)
-            .ok_or_else(|| "LLM response missing <updated_file> block".to_string())?;
+    let new_content = astra_runtime::skills::improvement::extract_updated_content(&rewrite_resp)
+        .ok_or_else(|| "LLM response missing <updated_file> block".to_string())?;
 
     astra_runtime::skills::improvement::apply_improvement(&skill_md, &new_content)
         .map_err(|e| format!("failed to write {}: {}", skill_md.display(), e))?;
@@ -4836,11 +4844,7 @@ mod tests {
             recent_tools: vec!["my-skill".to_string()],
             ..Default::default()
         };
-        assert!(
-            state
-                .skill_improvement_tracker
-                .should_analyze(state.turn)
-        );
+        assert!(state.skill_improvement_tracker.should_analyze(state.turn));
 
         // 4. Run the closed loop.
         check_skill_improvement_inner(&mut state);
@@ -4874,9 +4878,7 @@ mod tests {
 
         // 5c. Tracker advanced past should_analyze.
         assert!(
-            !state
-                .skill_improvement_tracker
-                .should_analyze(state.turn),
+            !state.skill_improvement_tracker.should_analyze(state.turn),
             "tracker must advance last_analyzed_count"
         );
     }
@@ -5029,10 +5031,7 @@ mod tests {
         let wrapped_rewrite = format!("<updated_file>\n{}\n</updated_file>", rewritten);
 
         let llm = FakeLlm {
-            responses: std::sync::Mutex::new(vec![
-                analysis.to_string(),
-                wrapped_rewrite,
-            ]),
+            responses: std::sync::Mutex::new(vec![analysis.to_string(), wrapped_rewrite]),
         };
 
         let ok = try_llm_skill_improvement(&mut state, &llm)
@@ -5061,9 +5060,7 @@ mod tests {
         assert_eq!(pending.improvements[0].section, "greeting");
 
         assert!(
-            !state
-                .skill_improvement_tracker
-                .should_analyze(state.turn),
+            !state.skill_improvement_tracker.should_analyze(state.turn),
             "tracker must advance"
         );
     }
@@ -5088,10 +5085,7 @@ mod tests {
 
         let mut state = ReplState {
             unified_skill_registry: std::sync::Arc::new(registry),
-            history: vec![(
-                "no, that's wrong".to_string(),
-                "sorry".to_string(),
-            )],
+            history: vec![("no, that's wrong".to_string(), "sorry".to_string())],
             turn: astra_runtime::skills::improvement::TURN_BATCH_SIZE + 1,
             recent_tools: vec!["my-skill".to_string()],
             ..Default::default()
@@ -5121,8 +5115,7 @@ mod tests {
         let skill_dir = tmp.path().join("my-skill");
         std::fs::create_dir_all(&skill_dir).unwrap();
         let skill_md = skill_dir.join("SKILL.md");
-        let original =
-            "---\nname: my-skill\ndescription: test\nversion: \"0.1.0\"\n---\n\n# Body\nOriginal.\n";
+        let original = "---\nname: my-skill\ndescription: test\nversion: \"0.1.0\"\n---\n\n# Body\nOriginal.\n";
         std::fs::write(&skill_md, original).unwrap();
 
         let mut registry = astra_runtime::skills::UnifiedSkillRegistry::new();

--- a/rust/crates/astra-pipeline/src/stages/reflect.rs
+++ b/rust/crates/astra-pipeline/src/stages/reflect.rs
@@ -42,7 +42,7 @@ pub enum FailureCategory {
 /// Analyze TurnState to determine failure category and generate diagnosis.
 ///
 /// Returns: (category, what_happened, what_to_try)
-fn diagnose(state: &TurnState) -> (FailureCategory, String, String) {
+pub fn diagnose(state: &TurnState) -> (FailureCategory, String, String) {
     // Priority 1: Check for repeatedly failing tools
     let failing_tools: Vec<&String> = state
         .tool_failures
@@ -91,7 +91,7 @@ fn diagnose(state: &TurnState) -> (FailureCategory, String, String) {
 }
 
 /// Compute strategy adjustments based on the failure category.
-fn compute_strategy_delta(state: &TurnState, category: FailureCategory) -> StrategyDelta {
+pub fn compute_strategy_delta(state: &TurnState, category: FailureCategory) -> StrategyDelta {
     let mut delta = StrategyDelta::default();
 
     match category {

--- a/rust/crates/runtime/src/turn/agentic_auto_reflection.rs
+++ b/rust/crates/runtime/src/turn/agentic_auto_reflection.rs
@@ -539,6 +539,33 @@ pub(crate) async fn maybe_trigger_auto_reflection<H: AgenticLoopHost>(
         state.pending_reflection_signals.extend(llm_signals);
     }
 
+    // Inject rule-based pipeline diagnosis (stages::reflect + stages::evaluate)
+    // into the tactical-actions context so the LLM reflection prompt sees a
+    // structured summary of the runtime's failure mode. Only emit when the
+    // diagnosis is non-trivial — avoids noise on healthy loops.
+    let diag = crate::turn::agentic_stage_bridge::diagnose_from_loop_state(state);
+    if diag.failure_category != astra_pipeline::stages::reflect::FailureCategory::General {
+        state
+            .recent_tactical_actions
+            .push(diag.tactical_action_label());
+        if state.recent_tactical_actions.len() > MAX_RECENT_TACTICAL_ACTIONS {
+            let overflow = state.recent_tactical_actions.len() - MAX_RECENT_TACTICAL_ACTIONS;
+            state.recent_tactical_actions.drain(..overflow);
+        }
+
+        // Apply the rule-based strategy delta to the runtime state: block
+        // persistently-failing tools so subsequent tool selection excludes
+        // them. Report the applied summary via the headless log channel.
+        let applied =
+            crate::turn::agentic_stage_bridge::apply_strategy_delta(state, &diag.strategy);
+        if !applied.is_noop() {
+            host.emit_headless_line(
+                HeadlessStderrStyle::Yellow,
+                format!("Pipeline strategy applied: {}", applied.summary()),
+            );
+        }
+    }
+
     if state.pending_reflection_signals.len() < AUTO_REFLECTION_SIGNAL_THRESHOLD {
         return;
     }

--- a/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
@@ -555,6 +555,64 @@ mod tests {
         assert_eq!(host.rendered_final_text[0], "Final answer");
     }
 
+    // ─── E2E: auto-reflection is wired into run_agentic_loop_impl ──────────
+    // Verifies the production loop path drains pending reflection signals
+    // and invokes host.execute_reflection after a tool phase — previously
+    // this was only covered by unit tests calling maybe_trigger_auto_reflection
+    // directly, and the production loop never called it.
+    #[tokio::test]
+    async fn auto_reflection_fires_from_production_loop() {
+        use crate::turn::agentic_loop_host::AUTO_REFLECTION_SIGNAL_THRESHOLD;
+
+        let reflection_response = r#"{
+            "proposals": [
+                {
+                    "axis": "pattern",
+                    "description": "Demote stalled chain",
+                    "confidence": 0.8,
+                    "details": { "signature": "grep", "action": "demote" }
+                }
+            ],
+            "summary": "Stall detected."
+        }"#;
+        let mut host = MockHost::new(vec![
+            edge_tool_result(vec![make_edge_tool("grep", "results...")], 20, 10, Some(50)),
+            text_result("Final answer", 15, 8, Some(30)),
+        ])
+        .with_valid_tools(&["grep"])
+        .with_reflection_text(reflection_response);
+
+        let mut state = make_state();
+        let evo = std::sync::Arc::new(crate::evolution::service::EvolutionService::new());
+        state.evolution_service = Some(evo.clone());
+
+        for i in 0..AUTO_REFLECTION_SIGNAL_THRESHOLD {
+            state.pending_reflection_signals.push(
+                crate::evolution::types::EvolutionSignal::RepeatedStall {
+                    tool_chain: vec![format!("tool_{i}")],
+                    stall_count: 3,
+                    turn_id: format!("t{i}"),
+                },
+            );
+        }
+        assert_eq!(
+            state.pending_reflection_signals.len(),
+            AUTO_REFLECTION_SIGNAL_THRESHOLD
+        );
+
+        let outcome = run_agentic_loop_with_host(&mut host, &mut state).await;
+        assert!(outcome.is_ok(), "loop should complete: {:?}", outcome);
+
+        assert!(
+            state.pending_reflection_signals.is_empty(),
+            "run_agentic_loop_impl must drain pending_reflection_signals"
+        );
+        assert!(
+            host.last_reflection_prompt.is_some(),
+            "host.execute_reflection must be called from production loop"
+        );
+    }
+
     #[tokio::test]
     async fn render_final_text_not_duplicated_across_tool_then_text() {
         let mut host = MockHost::new(vec![

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -6470,11 +6470,7 @@ print(json.dumps({'context': 'user said: ' + msg}))
             error: Some(err.into()),
             ..Default::default()
         };
-        state.stall.tool_call_records = vec![
-            fail_rec("500"),
-            fail_rec("500"),
-            fail_rec("timeout"),
-        ];
+        state.stall.tool_call_records = vec![fail_rec("500"), fail_rec("500"), fail_rec("timeout")];
 
         for i in 0..AUTO_REFLECTION_SIGNAL_THRESHOLD {
             state.pending_reflection_signals.push(
@@ -6516,7 +6512,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
         assert!(
             host.emitted_lines
                 .iter()
-                .any(|line| line.contains("Pipeline strategy applied") && line.contains("flaky_http")),
+                .any(|line| line.contains("Pipeline strategy applied")
+                    && line.contains("flaky_http")),
             "expected strategy-applied log line, got lines: {:?}",
             host.emitted_lines
         );

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -795,7 +795,7 @@ pub(crate) async fn run_agentic_loop_impl<H: AgenticLoopHost>(
             TurnExecutionControl::Return(outcome) => return Ok(outcome),
         };
 
-        match execute_tool_phase(
+        let tool_phase_control = execute_tool_phase(
             host,
             state,
             turn_index,
@@ -808,8 +808,15 @@ pub(crate) async fn run_agentic_loop_impl<H: AgenticLoopHost>(
                 turn_result,
             },
         )
-        .await?
-        {
+        .await?;
+
+        // Drain evolution signals / trigger auto-reflection on the production
+        // agentic loop path. Previously this was only reached via tests, which
+        // caused `reflect` / auto-tuning capabilities to appear regressed at
+        // runtime.
+        maybe_trigger_auto_reflection(host, state).await;
+
+        match tool_phase_control {
             TurnToolPhaseControl::ContinueLoop => continue,
             TurnToolPhaseControl::Return(outcome) => return Ok(outcome),
         }
@@ -837,12 +844,12 @@ pub(crate) mod tests {
         turn_results: Vec<HostTurnResult>,
         current_turn: usize,
         pub(crate) valid_tools: HashSet<String>,
-        emitted_lines: Vec<String>,
+        pub(crate) emitted_lines: Vec<String>,
         quiet: bool,
         pub(crate) injected_schemas: Vec<Value>,
         reflection_text: Option<String>,
         reflection_error: Option<String>,
-        last_reflection_prompt: Option<String>,
+        pub(crate) last_reflection_prompt: Option<String>,
         pub(crate) rendered_final_text: Vec<String>,
     }
 
@@ -867,7 +874,7 @@ pub(crate) mod tests {
             self
         }
 
-        fn with_reflection_text(mut self, text: &str) -> Self {
+        pub(crate) fn with_reflection_text(mut self, text: &str) -> Self {
             self.reflection_text = Some(text.to_string());
             self
         }
@@ -6441,6 +6448,78 @@ print(json.dumps({'context': 'user said: ' + msg}))
         assert!(host.emitted_lines.iter().any(|line| {
             line.contains("processed 1 proposal(s): 0 auto-applied, 0 canary-started, 1 queued")
         }));
+    }
+
+    #[tokio::test]
+    async fn auto_reflection_injects_pipeline_diagnosis_into_prompt() {
+        // Seed runtime signals that the pipeline stage bridge recognises as a
+        // `ToolFailures` category, and assert the structured diagnosis is
+        // wired into the LLM reflection prompt via `recent_tactical_actions`.
+        let reflection_response = r#"{"proposals": [], "summary": "noop"}"#;
+        let mut host = MockHost::new(vec![]).with_reflection_text(reflection_response);
+        let mut state = make_state();
+
+        let evo = std::sync::Arc::new(crate::evolution::service::EvolutionService::new());
+        state.evolution_service = Some(evo.clone());
+
+        // Repeated failures on the same tool → FailureCategory::ToolFailures.
+        let fail_rec = |err: &str| ToolCallRecord {
+            name: "flaky_http".into(),
+            ok: false,
+            ms: 1,
+            error: Some(err.into()),
+            ..Default::default()
+        };
+        state.stall.tool_call_records = vec![
+            fail_rec("500"),
+            fail_rec("500"),
+            fail_rec("timeout"),
+        ];
+
+        for i in 0..AUTO_REFLECTION_SIGNAL_THRESHOLD {
+            state.pending_reflection_signals.push(
+                crate::evolution::types::EvolutionSignal::RepeatedStall {
+                    tool_chain: vec![format!("tool_{i}")],
+                    stall_count: 3,
+                    turn_id: format!("t{i}"),
+                },
+            );
+        }
+
+        maybe_trigger_auto_reflection(&mut host, &mut state).await;
+
+        let prompt = host
+            .last_reflection_prompt
+            .as_deref()
+            .expect("reflection prompt captured");
+        assert!(
+            prompt.contains("pipeline-diagnose"),
+            "expected pipeline-diagnose label in reflection prompt, got: {}",
+            prompt
+        );
+        assert!(
+            prompt.contains("ToolFailures"),
+            "expected ToolFailures category in prompt, got: {}",
+            prompt
+        );
+        assert!(
+            prompt.contains("flaky_http"),
+            "expected failing tool name in prompt, got: {}",
+            prompt
+        );
+        // Strategy delta should have been applied to runtime state too.
+        assert!(
+            state.restricted_tools.contains("flaky_http"),
+            "expected flaky_http in restricted_tools, got: {:?}",
+            state.restricted_tools
+        );
+        assert!(
+            host.emitted_lines
+                .iter()
+                .any(|line| line.contains("Pipeline strategy applied") && line.contains("flaky_http")),
+            "expected strategy-applied log line, got lines: {:?}",
+            host.emitted_lines
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/turn/agentic_stage_bridge.rs
+++ b/rust/crates/runtime/src/turn/agentic_stage_bridge.rs
@@ -1,0 +1,249 @@
+//! Bridge between the runtime's `AgenticLoopState` and the `astra-pipeline`
+//! rule-based stages (`ReflectStage::diagnose`, `EvaluateStage::categorize_progress`).
+//!
+//! The full `ExecutionEngine` operates on its own [`TurnState`] struct, which
+//! duplicates the runtime's agentic-loop state. Rather than rewriting the
+//! agentic loop to run on `TurnState`, this bridge builds a *minimal* synthetic
+//! `TurnState` from the runtime's stall / tool records and invokes the pure
+//! rule-based helpers. Results are surfaced to the LLM auto-reflection prompt
+//! via `AgenticLoopState::recent_tactical_actions`, giving the model a
+//! structured diagnosis to reason against.
+//!
+//! This is intentionally narrow — it does not drive the loop's state machine.
+//! It is a *diagnostic augmentation* layer that complements (not replaces) the
+//! runtime's own stall/auto-reflection machinery.
+use std::collections::HashSet;
+
+use astra_pipeline::stages::evaluate::{ProgressCategory, categorize_progress};
+use astra_pipeline::stages::reflect::{FailureCategory, compute_strategy_delta, diagnose};
+use astra_pipeline::state::{StrategyDelta, TurnState};
+
+use super::agentic_loop_host::AgenticLoopState;
+
+/// Structured diagnosis produced by the pipeline stages when run against a
+/// runtime-derived snapshot.
+#[derive(Debug, Clone)]
+pub struct PipelineDiagnosis {
+    pub failure_category: FailureCategory,
+    pub progress_category: ProgressCategory,
+    pub what_happened: String,
+    pub what_to_try: String,
+    pub strategy: StrategyDelta,
+}
+
+impl PipelineDiagnosis {
+    /// A short single-line tactical-action label suitable for injecting into
+    /// the auto-reflection prompt context.
+    pub fn tactical_action_label(&self) -> String {
+        format!(
+            "pipeline-diagnose[{:?}/{:?}]: {} → {}",
+            self.failure_category,
+            self.progress_category,
+            self.what_happened,
+            self.what_to_try,
+        )
+    }
+}
+
+/// Build a minimal pipeline [`TurnState`] snapshot from raw runtime signals.
+fn snapshot_turn_state_from_signals(
+    tool_records: &[astra_services::session_journal::ToolCallRecord],
+    turn_tool_names: &[HashSet<String>],
+) -> TurnState {
+    let mut snapshot = TurnState::new("<bridge>", Vec::new(), 1, 1, 1);
+
+    for record in tool_records {
+        if !record.ok {
+            let err = record.error.clone().unwrap_or_else(|| "error".to_string());
+            snapshot
+                .tool_failures
+                .entry(record.name.clone())
+                .or_default()
+                .push(err);
+        }
+    }
+
+    snapshot.round_tool_signatures = turn_tool_names
+        .iter()
+        .map(|set| set.iter().cloned().collect::<HashSet<String>>())
+        .collect();
+
+    let total_records = tool_records.len();
+    let failed_records = tool_records.iter().filter(|r| !r.ok).count();
+    snapshot.total_tool_calls = total_records as u32;
+
+    if total_records > 0 {
+        let success_ratio =
+            1.0 - (failed_records as f64 / total_records.max(1) as f64);
+        snapshot.progress.record(success_ratio);
+    }
+
+    snapshot
+}
+
+/// Run the pipeline rule-based diagnosis directly from raw runtime signals.
+pub fn diagnose_from_signals(
+    tool_records: &[astra_services::session_journal::ToolCallRecord],
+    turn_tool_names: &[HashSet<String>],
+) -> PipelineDiagnosis {
+    let snapshot = snapshot_turn_state_from_signals(tool_records, turn_tool_names);
+    let (failure_category, what_happened, what_to_try) = diagnose(&snapshot);
+    let strategy = compute_strategy_delta(&snapshot, failure_category);
+    let progress_category = categorize_progress(&snapshot.progress);
+    PipelineDiagnosis {
+        failure_category,
+        progress_category,
+        what_happened,
+        what_to_try,
+        strategy,
+    }
+}
+
+/// Run the pipeline rule-based diagnosis against a runtime state snapshot.
+pub fn diagnose_from_loop_state(state: &AgenticLoopState) -> PipelineDiagnosis {
+    diagnose_from_signals(
+        &state.stall.tool_call_records,
+        &state.stall.turn_tool_names,
+    )
+}
+
+/// Summary of what the strategy-delta application actually changed in the
+/// runtime state — used for logging / tests.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StrategyApplication {
+    /// Tools newly inserted into `state.restricted_tools`.
+    pub newly_blocked: Vec<String>,
+    /// Tools already present (no-op inserts).
+    pub already_blocked: Vec<String>,
+    /// Whether `widen_selection` was requested by the strategy.
+    pub widen_requested: bool,
+}
+
+impl StrategyApplication {
+    pub fn is_noop(&self) -> bool {
+        self.newly_blocked.is_empty() && !self.widen_requested
+    }
+
+    pub fn summary(&self) -> String {
+        let mut parts = Vec::new();
+        if !self.newly_blocked.is_empty() {
+            parts.push(format!("blocked={:?}", self.newly_blocked));
+        }
+        if !self.already_blocked.is_empty() {
+            parts.push(format!("already_blocked={:?}", self.already_blocked));
+        }
+        if self.widen_requested {
+            parts.push("widen_selection=true".to_string());
+        }
+        if parts.is_empty() {
+            "noop".to_string()
+        } else {
+            parts.join(", ")
+        }
+    }
+}
+
+/// Apply a pipeline [`StrategyDelta`] to the runtime [`AgenticLoopState`]:
+/// - `block_tools` → inserted into `state.restricted_tools` (the runtime's
+///   canonical block-list consulted by tool selection and execution policy).
+/// - `widen_selection` → reported in the returned summary for observability;
+///   the tool-selection path reads `restricted_tools` directly, so widening
+///   here effectively means "nothing additional is blocked beyond the newly
+///   added names".
+/// - `add_tools` and `inject_context` are intentionally not applied here:
+///   the runtime has no positive-allowlist channel equivalent to
+///   `TurnState::add_tools`, and injection is already handled textually via
+///   the tactical-action label emitted by [`PipelineDiagnosis`].
+pub fn apply_strategy_delta(
+    state: &mut AgenticLoopState,
+    strategy: &StrategyDelta,
+) -> StrategyApplication {
+    let mut app = StrategyApplication {
+        widen_requested: strategy.widen_selection,
+        ..Default::default()
+    };
+    for tool in &strategy.block_tools {
+        if state.restricted_tools.insert(tool.clone()) {
+            app.newly_blocked.push(tool.clone());
+        } else {
+            app.already_blocked.push(tool.clone());
+        }
+    }
+    app.newly_blocked.sort();
+    app.already_blocked.sort();
+    app
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astra_services::session_journal::ToolCallRecord;
+    use std::collections::HashSet;
+
+    fn record(name: &str, ok: bool, err: Option<&str>) -> ToolCallRecord {
+        ToolCallRecord {
+            name: name.to_string(),
+            ok,
+            ms: 1,
+            error: err.map(|s| s.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn bridge_detects_tool_failures_and_recommends_block() {
+        let records = vec![
+            record("flaky_http", false, Some("500")),
+            record("flaky_http", false, Some("500")),
+            record("flaky_http", false, Some("timeout")),
+        ];
+        let diag = diagnose_from_signals(&records, &[]);
+        assert_eq!(diag.failure_category, FailureCategory::ToolFailures);
+        assert!(
+            diag.strategy.block_tools.iter().any(|t| t == "flaky_http"),
+            "expected flaky_http in block_tools, got {:?}",
+            diag.strategy.block_tools,
+        );
+        assert!(diag.strategy.widen_selection);
+        let label = diag.tactical_action_label();
+        assert!(label.contains("pipeline-diagnose"), "label: {}", label);
+        assert!(label.contains("flaky_http"));
+    }
+
+    #[test]
+    fn bridge_detects_stall_via_repeated_tool_signatures() {
+        let sig: HashSet<String> = ["grep".to_string(), "read".to_string()]
+            .into_iter()
+            .collect();
+        let sigs = vec![sig.clone(), sig.clone(), sig.clone()];
+        let records = vec![
+            record("grep", true, None),
+            record("read", true, None),
+        ];
+        let diag = diagnose_from_signals(&records, &sigs);
+        assert_eq!(diag.failure_category, FailureCategory::Stall);
+        assert!(diag.strategy.widen_selection);
+        assert!(diag.strategy.inject_context.is_some());
+    }
+
+    #[test]
+    fn bridge_clean_state_falls_back_to_general() {
+        let diag = diagnose_from_signals(&[], &[]);
+        assert_eq!(diag.failure_category, FailureCategory::General);
+    }
+
+    #[test]
+    fn apply_strategy_delta_blocks_new_tools() {
+        let records = vec![
+            record("flaky_http", false, Some("500")),
+            record("flaky_http", false, Some("500")),
+            record("flaky_http", false, Some("timeout")),
+        ];
+        let diag = diagnose_from_signals(&records, &[]);
+        // Diagnosis should recommend blocking the failing tool; the concrete
+        // end-to-end application against AgenticLoopState is exercised in the
+        // `auto_reflection_injects_pipeline_diagnosis_into_prompt` e2e test.
+        assert!(!diag.strategy.block_tools.is_empty());
+        assert!(diag.strategy.block_tools.contains(&"flaky_http".to_string()));
+    }
+}

--- a/rust/crates/runtime/src/turn/agentic_stage_bridge.rs
+++ b/rust/crates/runtime/src/turn/agentic_stage_bridge.rs
@@ -37,10 +37,7 @@ impl PipelineDiagnosis {
     pub fn tactical_action_label(&self) -> String {
         format!(
             "pipeline-diagnose[{:?}/{:?}]: {} → {}",
-            self.failure_category,
-            self.progress_category,
-            self.what_happened,
-            self.what_to_try,
+            self.failure_category, self.progress_category, self.what_happened, self.what_to_try,
         )
     }
 }
@@ -73,8 +70,7 @@ fn snapshot_turn_state_from_signals(
     snapshot.total_tool_calls = total_records as u32;
 
     if total_records > 0 {
-        let success_ratio =
-            1.0 - (failed_records as f64 / total_records.max(1) as f64);
+        let success_ratio = 1.0 - (failed_records as f64 / total_records.max(1) as f64);
         snapshot.progress.record(success_ratio);
     }
 
@@ -101,10 +97,7 @@ pub fn diagnose_from_signals(
 
 /// Run the pipeline rule-based diagnosis against a runtime state snapshot.
 pub fn diagnose_from_loop_state(state: &AgenticLoopState) -> PipelineDiagnosis {
-    diagnose_from_signals(
-        &state.stall.tool_call_records,
-        &state.stall.turn_tool_names,
-    )
+    diagnose_from_signals(&state.stall.tool_call_records, &state.stall.turn_tool_names)
 }
 
 /// Summary of what the strategy-delta application actually changed in the
@@ -216,10 +209,7 @@ mod tests {
             .into_iter()
             .collect();
         let sigs = vec![sig.clone(), sig.clone(), sig.clone()];
-        let records = vec![
-            record("grep", true, None),
-            record("read", true, None),
-        ];
+        let records = vec![record("grep", true, None), record("read", true, None)];
         let diag = diagnose_from_signals(&records, &sigs);
         assert_eq!(diag.failure_category, FailureCategory::Stall);
         assert!(diag.strategy.widen_selection);
@@ -244,6 +234,10 @@ mod tests {
         // end-to-end application against AgenticLoopState is exercised in the
         // `auto_reflection_injects_pipeline_diagnosis_into_prompt` e2e test.
         assert!(!diag.strategy.block_tools.is_empty());
-        assert!(diag.strategy.block_tools.contains(&"flaky_http".to_string()));
+        assert!(
+            diag.strategy
+                .block_tools
+                .contains(&"flaky_http".to_string())
+        );
     }
 }

--- a/rust/crates/runtime/src/turn/mod.rs
+++ b/rust/crates/runtime/src/turn/mod.rs
@@ -14,6 +14,7 @@ pub mod agentic_loop_tool_support;
 pub mod agentic_post_tool_policy;
 pub mod agentic_prepare_payload;
 pub mod agentic_recursion_guard;
+pub mod agentic_stage_bridge;
 pub mod agentic_stall_preflight;
 pub mod agentic_tool_interception;
 pub mod agentic_turn_flow;

--- a/rust/crates/services/src/durable_task.rs
+++ b/rust/crates/services/src/durable_task.rs
@@ -208,33 +208,43 @@ impl CloudLlmJudge {
         .await;
     }
 
-    /// Call the LLM API and parse the response score.
-    async fn call_llm(&self, prompt: &str, context: &str) -> Result<f64, String> {
-        let system_msg = serde_json::json!({
-            "role": "system",
-            "content": "You are a verification judge running on the cloud. Evaluate whether \
-                        an acceptance criterion is met based on the provided context. \
-                        Respond with ONLY a JSON object: \
-                        {\"score\": <0.0-1.0>, \"reason\": \"<brief explanation>\"}. \
-                        Score 1.0 = fully met, 0.0 = not met at all."
-        });
-        let user_msg = serde_json::json!({
-            "role": "user",
-            "content": format!(
-                "Criterion: {prompt}\n\nContext:\n{context}\n\n\
-                 Evaluate and respond with {{\"score\": <0.0-1.0>, \"reason\": \"...\"}}."
-            )
-        });
-
+    /// Generic chat-completion helper shared by the judge scoring path and
+    /// by out-of-crate skill-improvement LLM rewrites.
+    ///
+    /// Security invariants enforced here (do NOT remove without justification):
+    /// - **URL scheme allow-list** — only `http://` and `https://` schemes are
+    ///   accepted, blocking accidental `file://` / `data://` / ssh-url use.
+    /// - **Hard request timeout** (30s) — bounds request duration so a hung
+    ///   upstream cannot wedge the caller indefinitely.
+    /// - **Response size cap** (1 MiB) — prevents adversarial or malfunctioning
+    ///   upstreams from exhausting memory via unbounded streams.
+    /// - **Error-body truncation** (≤200 chars) — limits how much upstream
+    ///   content bleeds into surfaced error strings / logs.
+    ///
+    /// NOTE: The `pub` visibility is required because consumers live in other
+    /// crates (e.g. astra-cli's skill-improvement adapter). Treat this as an
+    /// internal seam — prefer wrapping new callers in a purpose-built trait
+    /// (e.g. `SkillImproveLlm`) rather than widening direct usage.
+    #[doc(hidden)]
+    pub async fn chat_completion(
+        &self,
+        system: &str,
+        user: &str,
+        max_tokens: u32,
+        temperature: f32,
+    ) -> Result<String, String> {
         let body = serde_json::json!({
             "model": self.model,
-            "messages": [system_msg, user_msg],
-            "max_tokens": 200,
-            "temperature": 0.1,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
         });
 
+        // URL scheme allow-list — reject non-HTTP(S) schemes.
         let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
-        // Validate URL has a proper protocol to prevent SSRF / malformed requests.
         let url_lower = url.trim().to_lowercase();
         if !url_lower.starts_with("http://") && !url_lower.starts_with("https://") {
             return Err(format!(
@@ -248,6 +258,7 @@ impl CloudLlmJudge {
             .header("Authorization", format!("Bearer {}", self.api_key))
             .header("Content-Type", "application/json")
             .json(&body)
+            // Hard per-request timeout to bound tail latency.
             .timeout(std::time::Duration::from_secs(30))
             .send()
             .await
@@ -255,8 +266,8 @@ impl CloudLlmJudge {
 
         if !resp.status().is_success() {
             let status = resp.status();
-            // Limit error body read to 4 KB to prevent OOM from malicious upstream.
             let bytes = resp.bytes().await.unwrap_or_default();
+            // Truncate upstream error body before it reaches logs.
             let text = String::from_utf8_lossy(&bytes[..bytes.len().min(4096)]);
             return Err(format!(
                 "Cloud LLM API error {status}: {}",
@@ -264,11 +275,12 @@ impl CloudLlmJudge {
             ));
         }
 
-        // Limit response body to 1 MB to prevent OOM from oversized responses.
         let body_bytes = resp
             .bytes()
             .await
             .map_err(|e| format!("Cloud LLM response read failed: {e}"))?;
+        // Response size cap — reject bodies larger than 1 MiB to avoid
+        // unbounded memory growth from a malfunctioning or hostile upstream.
         if body_bytes.len() > 1_048_576 {
             return Err(format!(
                 "Cloud LLM response too large: {} bytes (limit 1MB)",
@@ -278,11 +290,25 @@ impl CloudLlmJudge {
         let json: serde_json::Value = serde_json::from_slice(&body_bytes)
             .map_err(|e| format!("Cloud LLM response parse failed: {e}"))?;
 
-        let content = json["choices"][0]["message"]["content"]
+        Ok(json["choices"][0]["message"]["content"]
             .as_str()
-            .unwrap_or("");
+            .unwrap_or("")
+            .to_string())
+    }
 
-        parse_judge_score(content)
+    /// Call the LLM API and parse the response score.
+    async fn call_llm(&self, prompt: &str, context: &str) -> Result<f64, String> {
+        let system = "You are a verification judge running on the cloud. Evaluate whether \
+            an acceptance criterion is met based on the provided context. \
+            Respond with ONLY a JSON object: \
+            {\"score\": <0.0-1.0>, \"reason\": \"<brief explanation>\"}. \
+            Score 1.0 = fully met, 0.0 = not met at all.";
+        let user = format!(
+            "Criterion: {prompt}\n\nContext:\n{context}\n\n\
+             Evaluate and respond with {{\"score\": <0.0-1.0>, \"reason\": \"...\"}}."
+        );
+        let content = self.chat_completion(system, &user, 200, 0.1).await?;
+        parse_judge_score(&content)
     }
 }
 


### PR DESCRIPTION
## Summary
Restores the self-improvement / auto-reflection closed loop that had regressed to stubs, and bridges pipeline-stage diagnosis into the runtime agentic loop.

## P0 — regressions
- Wire `maybe_trigger_auto_reflection` into production agentic loop
- Emit `EvolutionSignal::UserCorrection` on detected correction signal
- Replace skill-improvement stub with real heuristic proposal

## P1.A — LLM-driven skill improvement
- `CloudLlmJudge::chat_completion` helper with security invariants (URL scheme, timeout, 1 MiB cap, 200-char truncation) documented + inline; marked `#[doc(hidden)]` as internal seam
- `SkillImproveLlm` trait + `CloudJudgeLlm` adapter + `try_llm_skill_improvement` (SKILL.md → LLM analyze → LLM rewrite → apply + propose), heuristic fallback preserved
- `apply_turn_success` split into sync/async; production awaits async; sync variant retained only under `#[cfg(test)]`
- Heuristic path dedupes novel corrections against existing SKILL.md and caps feedback sections at `MAX_FEEDBACK_SECTIONS = 5` (`trim_feedback_sections`)

## P1.B — Pipeline stages → runtime auto-reflection
- Expose `astra_pipeline::stages::reflect::{diagnose, compute_strategy_delta}` as `pub`
- New `runtime/src/turn/agentic_stage_bridge.rs`:
  - `diagnose_from_signals` / `diagnose_from_loop_state` → `PipelineDiagnosis`
  - `apply_strategy_delta` writes `block_tools` into `state.restricted_tools`
- `maybe_trigger_auto_reflection` injects `pipeline-diagnose[...]` label into `recent_tactical_actions` and applies strategy delta when failure category != `General`

## Verification
- astra-cli **2683** (+3) / astra-runtime **2108** / astra-skills **310** / astra-pipeline **293** — all green
- \`cargo build --workspace\` clean

## How to try
- LLM skill improvement auto-engages when \`MO_CLOUD_LLM_API_KEY\` / \`OPENAI_API_KEY\` is set; heuristic fallback otherwise
- Pipeline diagnosis + strategy delta kicks in whenever auto-reflection fires on repeated tool failures / stalls

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>