### PR TITLE
feat(e2e): Matrix HTTP system tests — branches, delegation, admin + journey split

### DIFF
--- a/docs/testing/coverage-matrix.md
+++ b/docs/testing/coverage-matrix.md
@@ -15,8 +15,9 @@ Legend: **E2E** = `rust/crates/runtime/tests/system_matrix_http_e2e/` with `ASTR
 | Capability | E2E (`system_matrix_http_e2e`) | Removed stub tests (replaced by E2E) | Other |
 |------------|-------------------------------|--------------------------------------|-------|
 | Register / login / refresh / me / logout | `harness::bootstrap`, `journey_full` | `auth_contract` | — |
+| `GET /`, `GET /health` (metadata + DB + persist counters) | `e2e_matrix_meta_health` | — | — |
 | Auth errors (no session token, duplicate user, bad password) | `journey_extended::run_auth_and_session_negative_paths` | `auth_contract` (stub errors) | — |
-| Sessions list/get/put, close/resume, activity | `journey_full` + DB `agent_sessions` | `session_contract` | — |
+| Sessions list/get/put, close/resume, activity | `journey_full` + DB `agent_sessions`; focused `GET`/`PUT` vs row in `e2e_matrix_session_http_db` | `session_contract` | — |
 | Session cancel + delete + 404 | `journey_extended` + DB | `session_contract` | — |
 | Agents CRUD + DB | `journey_full` + `agent_agents` | `agent_crud_contract` | — |
 | Events create/get/list/causal chain | `journey_full` | `event_crud_contract` | — |
@@ -25,19 +26,23 @@ Legend: **E2E** = `rust/crates/runtime/tests/system_matrix_http_e2e/` with `ASTR
 
 | Capability | E2E | Removed stub tests |
 |------------|-----|-------------------|
-| Context + decisions + DB | `journey_full` | `context_contract`, `decisions_contract` |
+| Context + decisions + DB | `journey_full` + `e2e_matrix_context_decision_chain` (dedicated event→context→decision + `ctx_*` SQL) | `context_contract`, `decisions_contract` |
 | Memory proxy isolation (`user_id` / `session_id` overwrite) | `journey_extended::run_memory_proxy_user_isolation` | `memory_contract` |
 | Skills + introspection reads | `journey_full` | `skills_contract`, `introspection_contract` |
 | Jobs + webhook | `journey_full` | `jobs_contract` |
 | Workflows list | `journey_full` | `workflows_contract` |
+| Evaluation read paths (x-user-id, trust/SLO/observability need agent) | `e2e_matrix_evaluation_reads` | — |
 | Sandbox CRUD + DB | `journey_full` | `sandbox_contract` |
 | Triggers + fire + delete + DB | `journey_full` | `triggers_contract` |
 | Marketplace probe | `journey_full` | `marketplace_contract` |
 | Data versioning lineage | `journey_full` | `data_versioning_contract` |
 | Replay compare | `journey_full` | `replay_contract` |
-| `POST /chat/route` (shape + auth path) | `journey_full` + unit tests in `runtime/src/server/chat_route.rs` | `chat_route_contract` |
-| `GET /models` (authenticated list) | `journey_full` | — |
+| `POST /chat/route` (shape + auth path) | `journey_full` + `e2e_matrix_chat_route_models` | `chat_route_contract` |
+| `GET /models` (authenticated list) | `journey_full` + `e2e_matrix_chat_route_models` | — |
 | Models admin CRUD + `infra_llm_models` | `journey_extended::run_models_admin_crud_with_db` (`provider: mock`, `grant_astra_admin_role`) | `model_crud_contract` |
+| `POST /branches/cost-estimate` (JWT + estimate fields; 401 without auth) | `e2e_matrix_branches_cost_estimate_http` | `branches_contract` (stub; different surface) |
+| `GET /admin/tokens` (403 → grant `astra_admin` → 200 array) | `e2e_matrix_admin_tokens_smoke` | — |
+| Delegation `GET .../delegations` + `POST .../delegate` validation failure (`400`) | `e2e_matrix_delegate_http_boundaries` | — |
 | Reflect + decision-trace (authenticated) | `journey_full` (`GET .../reflect`, `GET .../decision-trace`) | `reflect_contract` (stub) |
 | Learning feedback POST | `journey_full` (`POST /api/v1/learning/feedback` with real `event_id` after `chat/turn`) | `reflect_contract` (stub) |
 | Skill config CRUD (in-memory stub) | — (future E2E or `astra-runtime` unit tests) | `skill_config_contract` |
@@ -80,11 +85,11 @@ Legend: **E2E** = `rust/crates/runtime/tests/system_matrix_http_e2e/` with `ASTR
 
 | Capability | E2E (`system_matrix_http_e2e`) | Stub / integration | Other |
 |------------|-------------------------------|----------------------|-------|
-| Team CRUD, validation, executions, snapshots (HTTP) | — (not in system matrix yet; see [`system-e2e-matrix.md`](./system-e2e-matrix.md)) | `rust/crates/runtime/tests/team_api_integration.rs` (Tower oneshot, `InMemoryTeamStore`, no DB) | — |
-| `POST /teams/{name}/execute` (HTTP → `TeamExecutionOrchestrator`, mock `SubRunExecutor`) | — | `team_execute_http_integration.rs` includes built-in **`review`** + task `review the latest commit` (CLI parity with `/team run review review the latest commit`) happy + failing executor paths | Handler: `team_handlers::execute_team_handler` |
+| Team CRUD + list/detail + upsert + delete; empty executions list; snapshots create/list/delete; HTTP negatives (401/404/400 validation); HTTP↔DB column fidelity + cross-user isolation | `journey_team_crud_matrix.rs`, `journey_team_snapshots_matrix.rs`, `journey_team_http_negatives_matrix.rs`, `journey_team_data_fidelity_matrix.rs`, `journey_team_isolation_matrix.rs` (`e2e_matrix_team_*` tests); DB: `team_definitions`, `team_snapshots` | `rust/crates/runtime/tests/team_api_integration.rs` (Tower oneshot, `InMemoryTeamStore`, no DB) | — |
+| `POST /teams/{name}/execute` (HTTP → `TeamExecutionOrchestrator`, mock `SubRunExecutor`) | — (prod server uses real `ServerSubRunExecutor`; keep execute coverage offline) | `team_execute_http_integration.rs` includes built-in **`review`** + task `review the latest commit` (CLI parity with `/team run review review the latest commit`) happy + failing executor paths | Handler: `team_handlers::execute_team_handler` |
 | `TeamExecutionOrchestrator` + `DelegationEngine` (coordination modes, gates, failure paths) | — | `rust/crates/runtime/tests/team_delegation_integration.rs` (`StubSubRunExecutor` + custom `SubRunExecutor` fakes) | `rust/crates/runtime/src/server/team_orchestrator.rs` `#[cfg(test)]` |
 | Sub-run uses scripted `MockHost` + `run_agentic_loop_with_host` (non-zero usage vs `StubSubRunExecutor`) | — | — | `team_orchestrator.rs` `mock_host_subrun_*` tests |
-| Team definitions + execution history (SQL store) | — | — | `team_persistence_integration` (MatrixOne, `#[ignore]`) |
+| Team definitions + execution history (SQL store) | CRUD + snapshots SQL in team journeys above | — | `team_persistence_integration` (MatrixOne, `#[ignore]`, direct service API) |
 | Delegation mailbox with team-shaped agent ids | — | — | `rust/crates/runtime/src/messaging/orchestrator_mailbox_tests.rs` |
 
 ## How to run

--- a/docs/testing/system-e2e-matrix.md
+++ b/docs/testing/system-e2e-matrix.md
@@ -2,7 +2,7 @@
 
 This document maps **user-visible capabilities** to **HTTP routes**, **persistence (MatrixOne tables or in-process stores)**, and the **integration tests** that assert them. It complements `router_builder.rs` unit tests (route registration only).
 
-**Layout (system E2E plan):** the integration binary is `rust/crates/runtime/tests/system_matrix_http_e2e/main.rs` with shared **`harness.rs`** (env gate, HTTP, `sqlx`, `bootstrap`) and **`journey_full.rs` / `journey_tasks_runs.rs` / `journey_extended.rs`**. `Cargo.toml` names the test target `system_matrix_http_e2e` and enables `bridge-e2e-hooks`.
+**Layout (system E2E plan):** the integration binary is `rust/crates/runtime/tests/system_matrix_http_e2e/main.rs` with shared **`harness.rs`** (env gate, HTTP, `sqlx`, `bootstrap`) and journey modules such as **`journey_full.rs`**, **`journey_tasks_runs.rs`**, **`journey_extended.rs`**, **`journey_branches_matrix.rs`**, **`journey_delegate_http_matrix.rs`**, **`journey_admin_smoke_matrix.rs`**, and other `journey_*.rs` files. `Cargo.toml` names the test target `system_matrix_http_e2e` and enables `bridge-e2e-hooks`.
 
 ## How to run
 
@@ -63,8 +63,21 @@ Ignored tests in `system_matrix_http_e2e` avoid overlap with the full journey (e
 | `e2e_matrix_models_admin_crud` | `journey_extended.rs` | Mode-aware: `local_jwt` runs SQL `astra_admin` role grant + `POST/PUT/DELETE /models` with DB checks; `trusted_moi` asserts current admin path rejects the call (admin auth still local-JWT based) |
 | `e2e_matrix_audit_cross_session_analytics_http` | `journey_audit_cross_session.rs` | Seed `agent_sessions` / `agent_events` / `ctx_decision_audits`; `GET /audit/stats`, `GET /audit/mutations`, `GET /audit/promotions` JSON assertions |
 | `e2e_matrix_trusted_moi_user_system_integration` | `journey_trusted_moi.rs` | Startup in `trusted_moi`; external JWT `/auth/me`; local auth endpoints disabled (`/auth/register|login|refresh`=403); `POST /sessions` + DB owner and memory proxy identity isolation bound to upstream user ID |
+| `e2e_matrix_team_crud_and_db` | `journey_team_crud_matrix.rs` | Team CRUD + upsert via second `POST /teams`, empty `GET .../executions`, SQL `team_definitions` |
+| `e2e_matrix_team_snapshots_and_db` | `journey_team_snapshots_matrix.rs` | `POST/GET .../snapshots`, `DELETE /teams/snapshots/{id}`, SQL `team_snapshots` |
+| `e2e_matrix_team_http_negative_paths` | `journey_team_http_negatives_matrix.rs` | Auth 401, GET/DELETE 404, validation 400 (empty members, duplicate roles, bad budget, adversarial size) |
+| `e2e_matrix_team_http_db_fidelity` | `journey_team_data_fidelity_matrix.rs` | `GET` detail vs `team_definitions` JSON columns; list `len` = SQL `COUNT(*)`; snapshot blob + list fields; `executions?limit=` |
+| `e2e_matrix_team_cross_user_isolation` | `journey_team_isolation_matrix.rs` | Second user: 404 on other user's team; list has no foreign team name |
+| `e2e_matrix_meta_health` | `journey_meta_matrix.rs` | `GET /`, `GET /health` (root metadata, DB connected, persist counters) |
+| `e2e_matrix_session_http_db` | `journey_session_http_db_matrix.rs` | `GET`/`PUT /sessions/{id}` vs `agent_sessions` (`title`, `user_id`) |
+| `e2e_matrix_evaluation_reads` | `journey_evaluation_reads_matrix.rs` | Evaluation GET smoke (`x-user-id`), seed agent for trust/SLO/observability; learning health/signals |
+| `e2e_matrix_context_decision_chain` | `journey_context_decision_chain_matrix.rs` | Event → context → decision chain + `ctx_snapshots` / `ctx_decision_audits` SQL |
+| `e2e_matrix_chat_route_models` | `journey_chat_route_models_matrix.rs` | `POST /chat/route`, `GET /models` |
+| `e2e_matrix_branches_cost_estimate_http` | `journey_branches_matrix.rs` | `POST /branches/cost-estimate` (+ 401 without auth); no DDL branch/create |
+| `e2e_matrix_delegate_http_boundaries` | `journey_delegate_http_matrix.rs` | `POST /chat` → `run_id`; `GET /chat/runs/{id}/delegations`; `POST .../delegate` validation `400` |
+| `e2e_matrix_admin_tokens_smoke` | `journey_admin_smoke_matrix.rs` | `GET /admin/tokens`: `403` → grant `astra_admin` → `200` JSON array |
 
-Shared helpers: `tests/system_matrix_http_e2e/harness.rs` (`bootstrap`, `bootstrap_trusted_moi`, `grant_astra_admin_role`, HTTP helpers, `cleanup_*`, row getters, SSE helpers, `wait_for_agent_event_types` — polls `agent_events` after `chat/turn` instead of a fixed sleep).
+Shared helpers: `tests/system_matrix_http_e2e/harness.rs` (`bootstrap`, `bootstrap_trusted_moi`, `grant_astra_admin_role`, `revoke_astra_admin_role`, HTTP helpers, `cleanup_*`, row getters, SSE helpers, `wait_for_agent_event_types` — polls `agent_events` after `chat/turn` instead of a fixed sleep).
 
 ## Database isolation
 
@@ -79,15 +92,15 @@ Legend: **DB** = SQL assertion on MatrixOne; **HTTP** = response-only; **—** =
 
 | Group | P | Representative routes | Persistence check | Test(s) |
 |-------|---|----------------------|-------------------|---------|
-| Meta | P0 | `GET /health`, `GET /` | — | `product_matrix_*` |
+| Meta | P0 | `GET /health`, `GET /` | — | `product_matrix_*`, `e2e_matrix_meta_health` |
 | Auth | P0 | `/auth/register`, `/login`, `/refresh`, `/me`, `/logout` | `auth_users` | Every test uses `bootstrap` (register/login); `product_matrix_*` also hits `/auth/refresh` and `/logout` |
-| Sessions | P0 | `/sessions`, `.../close`, `.../resume`, `.../cancel`, `DELETE ...`, `.../activity` | `agent_sessions` | `product_matrix_*` + `e2e_matrix_session_cancel_delete` |
+| Sessions | P0 | `/sessions`, `.../close`, `.../resume`, `.../cancel`, `DELETE ...`, `.../activity` | `agent_sessions` | `product_matrix_*` + `e2e_matrix_session_cancel_delete` + `e2e_matrix_session_http_db` |
 | Session audit | P0 | `/sessions/{id}/audit/*`, `/audit/*` | mostly HTTP | `product_matrix_*`; `e2e_matrix_audit_cross_session_analytics_http` (`/audit/stats`, `/audit/mutations`, `/audit/promotions` + DB seed) |
 | Agents | P0 | `/agents` CRUD | `agent_agents` | `product_matrix_*` |
-| Models | P1 | `GET /models`, admin `POST/PUT/DELETE /models` | `infra_llm_models` | `product_matrix_*` (list); `e2e_matrix_models_admin_crud` (admin CRUD + DB) |
+| Models | P1 | `GET /models`, admin `POST/PUT/DELETE /models` | `infra_llm_models` | `product_matrix_*` (list), `e2e_matrix_chat_route_models` (list); `e2e_matrix_models_admin_crud` (admin CRUD + DB) |
 | Events | P0 | `/events`, causal chain, session events | `agent_events` | `product_matrix_*` |
-| Context | P0 | `/context` | `ctx_snapshots` | `product_matrix_*` |
-| Decisions | P0 | `/decisions`, audit | `ctx_decision_audits` | `product_matrix_*` |
+| Context | P0 | `/context` | `ctx_snapshots` | `product_matrix_*`, `e2e_matrix_context_decision_chain` |
+| Decisions | P0 | `/decisions`, audit | `ctx_decision_audits` | `product_matrix_*`, `e2e_matrix_context_decision_chain` |
 | Memory proxy | P1 | `/memory/*` | Memoria stub calls | `product_matrix_*` |
 | Edge §5.5 | P0 | `/agents/edge`, `/tools/result`, `/approval/respond` | `edge_agent_registry` | `product_matrix_*`, tasks lease (edge register), `e2e_matrix_approval_respond_invalid_session_id`, `e2e_matrix_edge_callback_http_boundary_failures`, `e2e_matrix_duplicate_tool_result_idempotency`, `e2e_matrix_duplicate_approval_response_idempotency` |
 | Jobs | P1 | `/jobs`, `/jobs/webhook` | service persistence | `product_matrix_*` |
@@ -95,7 +108,7 @@ Legend: **DB** = SQL assertion on MatrixOne; **HTTP** = response-only; **—** =
 | Triggers | P1 | `/triggers`, fire, delete | `wf_triggers` | `product_matrix_*` |
 | Skills / introspection | P1 | `/skills`, `/introspection/*` | mixed | `product_matrix_*` |
 | Learning | P1 | `/api/v1/learning/*` | — | `product_matrix_*` |
-| Evaluation | P1 | `/evaluation/*` reads | — | `product_matrix_*` |
+| Evaluation | P1 | `/evaluation/*` reads | — | `product_matrix_*`, `e2e_matrix_evaluation_reads` |
 | Evaluation (writes) | P1 | `POST` gate/validate, drift/run, loop | — | — (no system E2E; add when implementations return success) |
 | Marketplace | P1 | quality report, stats, search | marketplace stats tables | `product_matrix_*` |
 | Chat turn (SSE) | P0 | `POST /chat/turn` + bridge secret | `agent_events` | `product_matrix_*`, `e2e_matrix_edge_callback_http_boundary_failures`, `e2e_matrix_duplicate_tool_result_idempotency`, `e2e_matrix_duplicate_approval_response_idempotency`, `e2e_matrix_chat_turn_partial_batch_failure`, `e2e_matrix_chat_turn_out_of_order_tool_results`, `e2e_matrix_same_session_concurrent_turns_isolated`, `e2e_matrix_same_session_waiting_turn_overlap_isolated` |
@@ -105,11 +118,11 @@ Legend: **DB** = SQL assertion on MatrixOne; **HTTP** = response-only; **—** =
 | Workflows | P1 | `GET /workflows` | — | `product_matrix_*` |
 | Data versioning | P1 | lineage GETs | — | `product_matrix_*` |
 | Replay | P1 | `/sessions/{id}/replay/compare` | — | `product_matrix_*` |
-| Branches | — | `/branches/*` | — | — |
-| Admin | — | `/admin/*` | — | — |
+| Branches | P1 | `/branches/cost-estimate` (HTTP; no DDL in this journey) | — | `e2e_matrix_branches_cost_estimate_http` |
+| Admin | P1 | `GET /admin/tokens` | — | `e2e_matrix_admin_tokens_smoke` |
 | WebSocket | — | `/chat/ws` | — | — |
-| Delegation | — | `/chat/runs/.../delegate` | — | — |
-| Team | — | `/teams`, `/teams/{name}`, `/teams/{name}/execute`, `/teams/{name}/executions`, `/teams/.../snapshots` | `team_definitions` / related tables when using DB-backed store | Offline HTTP: `team_api_integration` + **`team_execute_http_integration`** (mock delegation); no `system_matrix_http_e2e` journey yet — see [`coverage-matrix.md`](./coverage-matrix.md) **Team** |
+| Delegation | P1 | `GET .../delegations`, `POST .../delegate` (validation-only path) | **In-memory** tracker | `e2e_matrix_delegate_http_boundaries` |
+| Team | P1 | `/teams`, `/teams/{name}`, `/teams/{name}/executions`, `/teams/.../snapshots` (+ HTTP negatives, DB fidelity, user isolation) | `team_definitions`, `team_snapshots` | `e2e_matrix_team_crud_and_db`, `e2e_matrix_team_snapshots_and_db`, `e2e_matrix_team_http_negative_paths`, `e2e_matrix_team_http_db_fidelity`, `e2e_matrix_team_cross_user_isolation`; **`POST .../execute`** stays offline (**`team_execute_http_integration`**, mock `SubRunExecutor`) |
 
 ## CI
 
@@ -123,23 +136,23 @@ Same prefixes as [`router_builder` `all_api_groups_have_routes`](../../rust/crat
 | Group (`router_builder`) | Prefix | System E2E | Notes |
 |--------------------------|--------|------------|--------|
 | auth | `/auth/` | Yes | `auth_users` in bootstrap / `product_matrix_*` |
-| chat | `/chat` | Partial | `/chat/turn` + SSE + `agent_events` in `product_matrix_*`, plus callback HTTP-boundary failures in `e2e_matrix_edge_callback_http_boundary_failures`, duplicate callback handoff coverage in `e2e_matrix_duplicate_tool_result_idempotency` / `e2e_matrix_duplicate_approval_response_idempotency`, mixed-success handoff coverage in `e2e_matrix_chat_turn_partial_batch_failure`, out-of-order callback handoff coverage in `e2e_matrix_chat_turn_out_of_order_tool_results`, concurrent same-session isolation in `e2e_matrix_same_session_concurrent_turns_isolated`, and waiting-turn overlap isolation in `e2e_matrix_same_session_waiting_turn_overlap_isolated`; `POST /chat` + run pause/resume in `e2e_matrix_chat_run_pause_resume_http`; `/chat/stream` smoke in `e2e_matrix_chat_stream_session_info`; no `/chat/ws` E2E |
+| chat | `/chat` | Partial | `/chat/turn` + SSE + `agent_events` in `product_matrix_*`, plus callback HTTP-boundary failures in `e2e_matrix_edge_callback_http_boundary_failures`, duplicate callback handoff coverage in `e2e_matrix_duplicate_tool_result_idempotency` / `e2e_matrix_duplicate_approval_response_idempotency`, mixed-success handoff coverage in `e2e_matrix_chat_turn_partial_batch_failure`, out-of-order callback handoff coverage in `e2e_matrix_chat_turn_out_of_order_tool_results`, concurrent same-session isolation in `e2e_matrix_same_session_concurrent_turns_isolated`, and waiting-turn overlap isolation in `e2e_matrix_same_session_waiting_turn_overlap_isolated`; `POST /chat` + run pause/resume in `e2e_matrix_chat_run_pause_resume_http`; `/chat/stream` smoke in `e2e_matrix_chat_stream_session_info`; delegation list + `POST .../delegate` validation boundary in `e2e_matrix_delegate_http_boundaries`; no `/chat/ws` E2E |
 | sessions | `/sessions` | Yes | CRUD/close/resume/activity + DB |
-| admin | `/admin/` | No | Needs admin bootstrap |
+| admin | `/admin/` | Partial | `GET /admin/tokens` smoke in `e2e_matrix_admin_tokens_smoke` |
 | learning | `/api/v1/learning/` | Yes (reads) | Health/signals/stats in `product_matrix_*` |
 | agents | `/agents` | Yes | Includes edge register path |
 | events | `/events` | Yes | |
 | skills | `/skills` | Partial | List/status; not publish/config/resources E2E |
 | evaluation | `/evaluation/` | Partial | Reads in `product_matrix_*`; POST write paths not covered in system E2E until implemented; training-data extract/export not in system E2E |
 | introspection | `/introspection/` | Yes | |
-| branches | `/branches` | No | |
+| branches | `/branches` | Partial | `POST /branches/cost-estimate` in `e2e_matrix_branches_cost_estimate_http`; create/merge/diff not in system E2E |
 | marketplace | `/marketplace/` | Partial | Quality report / stats / search; not full install/upgrade/rollback/credentials |
 | sandbox | `/sandbox` | Yes | |
 | workflows | `/workflows` | Partial | `GET /workflows` only |
 | platform | `/platform/` | Partial | `GET /platform/snapshot` in `product_matrix_*` |
 | runs | `/runs` | Partial | List in `product_matrix_*`; lifecycle in `e2e_matrix_chat_run_pause_resume_http` |
 | tasks | `/tasks` | Yes | `e2e_matrix_tasks_lease_and_db_assertions` |
-| teams | `/teams` | No | `team_api_integration` + `team_execute_http_integration` (`POST .../execute` with mock executor); Matrix-backed team execute not in system E2E yet |
+| teams | `/teams` | Partial | CRUD + snapshots + negatives + `team_definitions` / `team_snapshots` in `e2e_matrix_team_*`; `POST .../execute` still covered only in offline `team_execute_http_integration` (mock executor) — not in system E2E |
 
 Additional route families in `router_builder` not named above: **memory** (`/memory/*`), **context** (`/context`), **decisions** (`/decisions`), **models** (`/models`), **jobs** (`/jobs`), **triggers** (`/triggers`), **data-versioning** (`/data-versioning`), **replay** (`/sessions/.../replay`), **reflect** (`/chat/session/.../reflect`), **completions** (`/v1/chat/completions`) — see the P0/P1 table above for E2E status.
 
@@ -147,6 +160,7 @@ Additional route families in `router_builder` not named above: **memory** (`/mem
 
 - **Runs + DB**: when `RunStateStore` is backed by Matrix for `build_server_state`, add SQL assertions alongside `e2e_matrix_chat_run_pause_resume_http`.
 - **Evaluation writes**: add a focused test when `validate_gate` / `run_drift_pipeline` / `run_closed_loop` return **200** with stable response shapes.
-- **Branches, admin, WS, delegation**: add focused journeys + rows in this matrix.
-- **Teams**: optional `system_matrix_http_e2e` journey for `/teams` (including `POST /teams/{name}/execute`) with DB assertions when team store is Matrix-backed in test harness.
+- **Branches / admin HTTP** (beyond cost estimate + token list): optional deeper journeys when routes stabilize.
+- **`/chat/ws`**, **successful delegation execute** (long-running): optional fixtures; validation-only delegation is in `e2e_matrix_delegate_http_boundaries`.
+- **Teams execute**: optional `system_matrix_http_e2e` for `POST /teams/{name}/execute` with real `ServerSubRunExecutor` (long-running; not added by default). CRUD/snapshots/DB for `/teams` are in `e2e_matrix_team_*`.
 - **Real Memoria**: optional second target with a Memoria test double URL instead of the stub forwarder.

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/harness.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/harness.rs
@@ -593,6 +593,19 @@ pub async fn grant_astra_admin_role(pool: &sqlx::MySqlPool, user_id: &str) {
     );
 }
 
+/// Remove the `astra_admin` role from `user_id` if present (admin smoke tests start non-admin).
+pub async fn revoke_astra_admin_role(pool: &sqlx::MySqlPool, user_id: &str) {
+    sqlx::query(
+        "DELETE ur FROM auth_user_roles ur \
+         INNER JOIN auth_roles r ON ur.role_id = r.role_id \
+         WHERE ur.user_id = ? AND r.role_name = 'astra_admin'",
+    )
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("revoke_astra_admin_role delete");
+}
+
 /// Build app, connect pool, register user, refresh token, create session (with cleanup of stale rows).
 pub async fn bootstrap() -> BootstrapResult {
     match current_auth_mode() {

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_admin_smoke_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_admin_smoke_matrix.rs
@@ -1,0 +1,36 @@
+//! `GET /admin/tokens` — 403 without `astra_admin`, then 200 JSON array after role grant.
+use axum::http::StatusCode;
+
+use super::harness::{
+    bootstrap, get_json, grant_astra_admin_role, revoke_astra_admin_role,
+};
+
+pub async fn run_admin_tokens_smoke() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth = &b.auth_header;
+    let app = &ctx.app;
+    let pool = &ctx.pool;
+    let user_id = ctx.user_id.as_str();
+
+    revoke_astra_admin_role(pool, user_id).await;
+
+    let (st_denied, denied_j) =
+        get_json(app, "/admin/tokens", Some(auth.as_str()), &[]).await;
+    assert_eq!(
+        st_denied,
+        StatusCode::FORBIDDEN,
+        "admin tokens without role: {denied_j}"
+    );
+
+    grant_astra_admin_role(pool, user_id).await;
+
+    let (st_ok, body) = get_json(app, "/admin/tokens", Some(auth.as_str()), &[]).await;
+    assert_eq!(st_ok, StatusCode::OK, "admin tokens: {body}");
+    assert!(
+        body.as_array().is_some(),
+        "GET /admin/tokens should return a JSON array: {body}"
+    );
+
+    ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_admin_smoke_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_admin_smoke_matrix.rs
@@ -1,9 +1,7 @@
 //! `GET /admin/tokens` — 403 without `astra_admin`, then 200 JSON array after role grant.
 use axum::http::StatusCode;
 
-use super::harness::{
-    bootstrap, get_json, grant_astra_admin_role, revoke_astra_admin_role,
-};
+use super::harness::{bootstrap, get_json, grant_astra_admin_role, revoke_astra_admin_role};
 
 pub async fn run_admin_tokens_smoke() {
     let b = bootstrap().await;
@@ -15,8 +13,7 @@ pub async fn run_admin_tokens_smoke() {
 
     revoke_astra_admin_role(pool, user_id).await;
 
-    let (st_denied, denied_j) =
-        get_json(app, "/admin/tokens", Some(auth.as_str()), &[]).await;
+    let (st_denied, denied_j) = get_json(app, "/admin/tokens", Some(auth.as_str()), &[]).await;
     assert_eq!(
         st_denied,
         StatusCode::FORBIDDEN,

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_branches_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_branches_matrix.rs
@@ -1,0 +1,78 @@
+//! `POST /branches/cost-estimate` — JWT auth + numeric response shape (no DDL branch creation).
+use axum::http::StatusCode;
+use serde_json::json;
+
+use super::harness::{bootstrap, post_json};
+
+pub async fn run_branches_cost_estimate_http() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth = &b.auth_header;
+    let app = &ctx.app;
+
+    let (st_no_auth, no_auth_j) = post_json(
+        app,
+        "/branches/cost-estimate",
+        None,
+        json!({
+            "operation": "merge",
+            "model": "mock-estimate",
+        }),
+    )
+    .await;
+    assert_eq!(
+        st_no_auth,
+        StatusCode::UNAUTHORIZED,
+        "cost-estimate withoutAuthorization: {no_auth_j}"
+    );
+
+    let (st_ok, body) = post_json(
+        app,
+        "/branches/cost-estimate",
+        Some(auth.as_str()),
+        json!({
+            "operation": "merge",
+            "model": format!("mock-{}", ctx.suffix),
+            "session_count": 2,
+            "budget_remaining": 100.0
+        }),
+    )
+    .await;
+    assert_eq!(st_ok, StatusCode::OK, "cost-estimate: {body}");
+    assert_eq!(body["operation"].as_str(), Some("merge"));
+    let want_model = format!("mock-{}", ctx.suffix);
+    assert_eq!(body["model"].as_str(), Some(want_model.as_str()));
+    let est_tokens = body["estimated_tokens"].as_i64().expect("estimated_tokens");
+    assert_eq!(est_tokens, 2000, "session_count 2 × 1000: {body}");
+    let est_cost = body["estimated_cost"].as_f64().expect("estimated_cost");
+    assert!(
+        (est_cost - 0.02).abs() < 1e-9,
+        "expected cost 0.02, got {est_cost}: {body}"
+    );
+    assert_eq!(
+        body["exceeds_budget"].as_bool(),
+        Some(false),
+        "within budget: {body}"
+    );
+
+    let (st_over, over_j) = post_json(
+        app,
+        "/branches/cost-estimate",
+        Some(auth.as_str()),
+        json!({
+            "operation": "diff",
+            "model": "mock-tiny-budget",
+            "session_count": 10,
+            "budget_remaining": 0.0001
+        }),
+    )
+    .await;
+    assert_eq!(st_over, StatusCode::OK, "cost-estimate exceeds: {over_j}");
+    assert_eq!(
+        over_j["exceeds_budget"].as_bool(),
+        Some(true),
+        "should exceed tiny budget: {over_j}"
+    );
+
+    ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_chat_route_models_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_chat_route_models_matrix.rs
@@ -1,0 +1,34 @@
+//! `POST /chat/route` response shape + authenticated `GET /models` list.
+
+use axum::http::StatusCode;
+use serde_json::json;
+
+use super::harness::{bootstrap, get_json, post_json};
+
+pub async fn run_chat_route_and_models_smoke() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth = &b.auth_header;
+
+    let (st_route, route_j) = post_json(
+        &ctx.app,
+        "/chat/route",
+        Some(auth),
+        json!({ "query": "run cargo test and fix compile errors" }),
+    )
+    .await;
+    assert_eq!(st_route, StatusCode::OK, "chat/route: {route_j}");
+    assert!(
+        route_j.get("tool_filter").is_some() && route_j.get("task_type").is_some(),
+        "chat/route shape: {route_j}"
+    );
+
+    let (st_models, models_j) = get_json(&ctx.app, "/models", Some(auth), &[]).await;
+    assert_eq!(st_models, StatusCode::OK, "models: {models_j}");
+    assert!(
+        models_j.as_array().is_some(),
+        "GET /models array: {models_j}"
+    );
+
+    b.ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_context_decision_chain_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_context_decision_chain_matrix.rs
@@ -1,0 +1,115 @@
+//! Event → context snapshot → decision: HTTP + `ctx_snapshots` / `ctx_decision_audits` rows.
+
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::Row;
+
+use super::harness::{bootstrap, get_json, post_json};
+
+pub async fn run_context_decision_chain_db() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth = &b.auth_header;
+    let session_id = ctx.session_id.as_str();
+
+    let (st_ev, ev_j) = post_json(
+        &ctx.app,
+        "/events",
+        Some(auth),
+        json!({
+            "session_id": session_id,
+            "event_type": "e2e_ctx_chain",
+            "content": "anchor for context/decision",
+            "metadata": { "suite": "matrix_ctx_chain" }
+        }),
+    )
+    .await;
+    assert_eq!(st_ev, StatusCode::CREATED, "create event: {ev_j}");
+    let event_id = ev_j["event_id"].as_str().expect("event_id");
+
+    let (st_ctx, ctx_j) = post_json(
+        &ctx.app,
+        "/context",
+        Some(auth),
+        json!({
+            "session_id": session_id,
+            "event_id": event_id,
+            "context_data": { "probe": "matrix", "n": ctx.suffix.as_str() }
+        }),
+    )
+    .await;
+    assert_eq!(st_ctx, StatusCode::CREATED, "context: {ctx_j}");
+    let capture_id = ctx_j["context_capture_id"]
+        .as_str()
+        .expect("context_capture_id");
+
+    let snap = sqlx::query(
+        "SELECT session_id, event_id FROM ctx_snapshots WHERE context_capture_id = ?",
+    )
+    .bind(capture_id)
+    .fetch_optional(&ctx.pool)
+    .await
+    .expect("ctx_snapshots")
+    .expect("ctx_snapshots row");
+    assert_eq!(snap.get::<String, _>("session_id"), session_id);
+    assert_eq!(snap.get::<String, _>("event_id"), event_id);
+
+    let (st_dec, dec_j) = post_json(
+        &ctx.app,
+        "/decisions",
+        Some(auth),
+        json!({
+            "session_id": session_id,
+            "event_id": event_id,
+            "context_capture_id": capture_id,
+            "decision_type": "e2e_matrix_ctx_chain_decision",
+            "decision_output": { "picked": "a" },
+            "model_params": { "temperature": 0.2 }
+        }),
+    )
+    .await;
+    assert_eq!(st_dec, StatusCode::CREATED, "decision: {dec_j}");
+    let decision_id = dec_j["decision_id"].as_str().expect("decision_id");
+
+    let dec_row = sqlx::query(
+        "SELECT session_id, decision_type, context_capture_id FROM ctx_decision_audits WHERE decision_id = ?",
+    )
+    .bind(decision_id)
+    .fetch_optional(&ctx.pool)
+    .await
+    .expect("ctx_decision_audits")
+    .expect("decision row");
+    assert_eq!(dec_row.get::<String, _>("session_id"), session_id);
+    assert_eq!(
+        dec_row.get::<String, _>("decision_type"),
+        "e2e_matrix_ctx_chain_decision"
+    );
+    assert_eq!(
+        dec_row.get::<String, _>("context_capture_id"),
+        capture_id
+    );
+
+    let (st_gctx, got_ctx) = get_json(
+        &ctx.app,
+        &format!("/context/{capture_id}"),
+        Some(auth),
+        &[],
+    )
+    .await;
+    assert_eq!(st_gctx, StatusCode::OK, "GET context: {got_ctx}");
+
+    let (st_gdec, got_dec) = get_json(
+        &ctx.app,
+        &format!("/decisions/{decision_id}"),
+        Some(auth),
+        &[],
+    )
+    .await;
+    assert_eq!(st_gdec, StatusCode::OK, "GET decision: {got_dec}");
+    assert_eq!(
+        got_dec["decision_type"].as_str(),
+        Some("e2e_matrix_ctx_chain_decision")
+    );
+
+    b.ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_context_decision_chain_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_context_decision_chain_matrix.rs
@@ -43,14 +43,13 @@ pub async fn run_context_decision_chain_db() {
         .as_str()
         .expect("context_capture_id");
 
-    let snap = sqlx::query(
-        "SELECT session_id, event_id FROM ctx_snapshots WHERE context_capture_id = ?",
-    )
-    .bind(capture_id)
-    .fetch_optional(&ctx.pool)
-    .await
-    .expect("ctx_snapshots")
-    .expect("ctx_snapshots row");
+    let snap =
+        sqlx::query("SELECT session_id, event_id FROM ctx_snapshots WHERE context_capture_id = ?")
+            .bind(capture_id)
+            .fetch_optional(&ctx.pool)
+            .await
+            .expect("ctx_snapshots")
+            .expect("ctx_snapshots row");
     assert_eq!(snap.get::<String, _>("session_id"), session_id);
     assert_eq!(snap.get::<String, _>("event_id"), event_id);
 
@@ -84,18 +83,10 @@ pub async fn run_context_decision_chain_db() {
         dec_row.get::<String, _>("decision_type"),
         "e2e_matrix_ctx_chain_decision"
     );
-    assert_eq!(
-        dec_row.get::<String, _>("context_capture_id"),
-        capture_id
-    );
+    assert_eq!(dec_row.get::<String, _>("context_capture_id"), capture_id);
 
-    let (st_gctx, got_ctx) = get_json(
-        &ctx.app,
-        &format!("/context/{capture_id}"),
-        Some(auth),
-        &[],
-    )
-    .await;
+    let (st_gctx, got_ctx) =
+        get_json(&ctx.app, &format!("/context/{capture_id}"), Some(auth), &[]).await;
     assert_eq!(st_gctx, StatusCode::OK, "GET context: {got_ctx}");
 
     let (st_gdec, got_dec) = get_json(

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_delegate_http_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_delegate_http_matrix.rs
@@ -1,0 +1,80 @@
+//! Delegation HTTP boundaries: list delegations on a chat run + `POST .../delegate` rejected at
+//! validation (400) without executing `ServerSubRunExecutor`.
+use axum::http::StatusCode;
+use serde_json::json;
+
+use super::harness::{bootstrap, get_json, post_json};
+
+pub async fn run_delegate_http_boundaries() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth = &b.auth_header;
+    let app = &ctx.app;
+    let session_id = ctx.session_id.clone();
+    let user_id = ctx.user_id.clone();
+    let mock_model = format!("mock-{}", ctx.suffix);
+
+    let (st_chat, chat_j) = post_json(
+        app,
+        "/chat",
+        Some(auth.as_str()),
+        json!({
+            "message": "matrix e2e delegation boundary",
+            "session_id": session_id,
+            "model": mock_model,
+            "max_candidates": 1
+        }),
+    )
+    .await;
+    assert_eq!(st_chat, StatusCode::OK, "POST /chat: {chat_j}");
+    let run_id = chat_j["run_id"].as_str().expect("run_id").to_string();
+
+    let (st_list, list_j) = get_json(
+        app,
+        &format!("/chat/runs/{run_id}/delegations"),
+        Some(auth.as_str()),
+        &[],
+    )
+    .await;
+    assert_eq!(st_list, StatusCode::OK, "list delegations: {list_j}");
+    assert_eq!(
+        list_j["parent_run_id"].as_str(),
+        Some(run_id.as_str()),
+        "{list_j}"
+    );
+    let subs = list_j["sub_run_ids"].as_array().expect("sub_run_ids array");
+    assert!(
+        subs.is_empty() || subs.iter().all(|v| v.is_string()),
+        "sub_run_ids should be strings: {list_j}"
+    );
+
+    // Valid `DelegationRequest` JSON; validation fails before execute (default source agent id
+    // `"main"` is not registered in `AgentProfileRegistry`).
+    let (st_del, del_j) = post_json(
+        app,
+        &format!("/chat/runs/{run_id}/delegate"),
+        Some(auth.as_str()),
+        json!({
+            "delegation_id": format!("del-e2e-{}", ctx.suffix),
+            "parent_run_id": run_id,
+            "task": "noop delegation probe",
+            "pattern": {
+                "pattern": "fan_out",
+                "agent_ids": ["coder"],
+                "aggregation": "all_results",
+                "timeout_sec": 60
+            },
+            "user_id": user_id,
+            "depth": 0,
+            "context": {}
+        }),
+    )
+    .await;
+    assert_eq!(
+        st_del,
+        StatusCode::BAD_REQUEST,
+        "delegate should fail validation: {del_j}"
+    );
+
+    ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_evaluation_reads_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_evaluation_reads_matrix.rs
@@ -28,7 +28,11 @@ pub async fn run_evaluation_read_http_smoke() {
         }),
     )
     .await;
-    assert_eq!(st_ag, StatusCode::CREATED, "seed agent for eval reads: {ag_j}");
+    assert_eq!(
+        st_ag,
+        StatusCode::CREATED,
+        "seed agent for eval reads: {ag_j}"
+    );
     let agent_id = ag_j["agent_id"].as_str().expect("agent_id");
 
     let endpoints: &[&str] = &[
@@ -51,8 +55,7 @@ pub async fn run_evaluation_read_http_smoke() {
         );
     }
 
-    let trust_path =
-        format!("/evaluation/trust-report?agent_id={agent_id}&days=7");
+    let trust_path = format!("/evaluation/trust-report?agent_id={agent_id}&days=7");
     let (st_trust, trust_j) = get_json(&ctx.app, &trust_path, None, xuid).await;
     assert_eq!(st_trust, StatusCode::OK, "trust-report: {trust_j}");
 
@@ -60,8 +63,7 @@ pub async fn run_evaluation_read_http_smoke() {
     let (st_slo_h, slo_h_j) = get_json(&ctx.app, &slo_hist, None, xuid).await;
     assert_eq!(st_slo_h, StatusCode::OK, "slo history: {slo_h_j}");
 
-    let obs_path =
-        format!("/evaluation/observability/metrics?agent_id={agent_id}&days=7");
+    let obs_path = format!("/evaluation/observability/metrics?agent_id={agent_id}&days=7");
     let (st_obs, obs_j) = get_json(&ctx.app, &obs_path, None, xuid).await;
     assert_eq!(st_obs, StatusCode::OK, "observability: {obs_j}");
 

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_evaluation_reads_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_evaluation_reads_matrix.rs
@@ -1,0 +1,75 @@
+//! Evaluation **read** routes that use `x-user-id` (evaluation service) plus a few JWT-only probes.
+//!
+//! Seeds a minimal `/agents` row because `trust-report` and observability routes require `agent_id`.
+
+use axum::http::StatusCode;
+use serde_json::json;
+
+use super::harness::{bootstrap, get_json, post_json};
+
+pub async fn run_evaluation_read_http_smoke() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth = &b.auth_header;
+    let uid = ctx.user_id.as_str();
+    let xuid = &[("x-user-id", uid)];
+
+    let (st_ag, ag_j) = post_json(
+        &ctx.app,
+        "/agents",
+        Some(auth),
+        json!({
+            "name": format!("eval_smoke_agent_{}", ctx.suffix),
+            "agent_config": { "suite": "matrix_eval_smoke" },
+            "data_source": {
+                "type": "matrixone",
+                "database": ctx.matrixone_database.clone()
+            }
+        }),
+    )
+    .await;
+    assert_eq!(st_ag, StatusCode::CREATED, "seed agent for eval reads: {ag_j}");
+    let agent_id = ag_j["agent_id"].as_str().expect("agent_id");
+
+    let endpoints: &[&str] = &[
+        "/evaluation/gates?limit=10",
+        "/evaluation/calibration?days=7",
+        "/evaluation/sessions/scores?limit=10&min_score=0",
+        "/evaluation/quality/trend?days=7",
+        "/evaluation/slo/dashboard?period_days=7",
+        "/evaluation/memory-health",
+        "/evaluation/memory-metrics",
+        "/evaluation/drift",
+    ];
+
+    for path in endpoints {
+        let (st, j) = get_json(&ctx.app, path, None, xuid).await;
+        assert_eq!(st, StatusCode::OK, "{path}: {j}");
+        assert!(
+            j.as_object().is_some(),
+            "{path} should return JSON object: {j}"
+        );
+    }
+
+    let trust_path =
+        format!("/evaluation/trust-report?agent_id={agent_id}&days=7");
+    let (st_trust, trust_j) = get_json(&ctx.app, &trust_path, None, xuid).await;
+    assert_eq!(st_trust, StatusCode::OK, "trust-report: {trust_j}");
+
+    let slo_hist = format!("/evaluation/slo/{agent_id}/history?days=7");
+    let (st_slo_h, slo_h_j) = get_json(&ctx.app, &slo_hist, None, xuid).await;
+    assert_eq!(st_slo_h, StatusCode::OK, "slo history: {slo_h_j}");
+
+    let obs_path =
+        format!("/evaluation/observability/metrics?agent_id={agent_id}&days=7");
+    let (st_obs, obs_j) = get_json(&ctx.app, &obs_path, None, xuid).await;
+    assert_eq!(st_obs, StatusCode::OK, "observability: {obs_j}");
+
+    let (st_learn_h, learn_h) = get_json(&ctx.app, "/api/v1/learning/health", None, &[]).await;
+    assert_eq!(st_learn_h, StatusCode::OK, "learning health: {learn_h}");
+
+    let (st_sig, sig) = get_json(&ctx.app, "/api/v1/learning/signals", Some(auth), &[]).await;
+    assert_eq!(st_sig, StatusCode::OK, "learning signals: {sig}");
+
+    b.ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_meta_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_meta_matrix.rs
@@ -1,0 +1,38 @@
+//! `GET /` and `GET /health` on the real app (no auth) — service metadata + DB + persist counters.
+
+use axum::http::StatusCode;
+use serde_json::Value;
+
+use super::harness::{bootstrap, get_json};
+
+pub async fn run_meta_root_and_health() {
+    let b = bootstrap().await;
+    let app = &b.ctx.app;
+
+    let (st_root, root): (StatusCode, Value) = get_json(app, "/", None, &[]).await;
+    assert_eq!(st_root, StatusCode::OK);
+    assert!(
+        root["name"].as_str().is_some_and(|s| !s.is_empty()),
+        "root.name: {root}"
+    );
+    assert!(
+        root["version"].as_str().is_some_and(|s| !s.is_empty()),
+        "root.version: {root}"
+    );
+
+    let (st_h, health) = get_json(app, "/health", None, &[]).await;
+    assert_eq!(st_h, StatusCode::OK, "health: {health}");
+    assert_eq!(health["status"].as_str(), Some("healthy"));
+    assert_eq!(health["database"].as_str(), Some("connected"));
+
+    assert!(
+        health["persist_ok"].as_u64().is_some(),
+        "persist_ok counter: {health}"
+    );
+    assert!(
+        health["persist_fail"].as_u64().is_some(),
+        "persist_fail counter: {health}"
+    );
+
+    b.ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_session_http_db_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_session_http_db_matrix.rs
@@ -14,14 +14,12 @@ pub async fn run_session_http_matches_agent_sessions_row() {
     let session_id = &ctx.session_id;
     let path = format!("/sessions/{session_id}");
 
-    let row = sqlx::query(
-        "SELECT title, user_id, status FROM agent_sessions WHERE session_id = ?",
-    )
-    .bind(session_id.as_str())
-    .fetch_optional(&ctx.pool)
-    .await
-    .expect("agent_sessions SELECT bootstrap")
-    .expect("session row should exist after bootstrap POST /sessions");
+    let row = sqlx::query("SELECT title, user_id, status FROM agent_sessions WHERE session_id = ?")
+        .bind(session_id.as_str())
+        .fetch_optional(&ctx.pool)
+        .await
+        .expect("agent_sessions SELECT bootstrap")
+        .expect("session row should exist after bootstrap POST /sessions");
 
     let db_title = row.try_get::<String, _>("title").ok();
     let db_uid = row.get::<String, _>("user_id");
@@ -52,14 +50,13 @@ pub async fn run_session_http_matches_agent_sessions_row() {
     assert_eq!(st_put, StatusCode::OK);
     assert_eq!(put_j["title"].as_str(), Some(new_title.as_str()));
 
-    let title_sql: String = sqlx::query_scalar(
-        "SELECT title FROM agent_sessions WHERE session_id = ? AND user_id = ?",
-    )
-    .bind(session_id.as_str())
-    .bind(&ctx.user_id)
-    .fetch_one(&ctx.pool)
-    .await
-    .expect("title after PUT");
+    let title_sql: String =
+        sqlx::query_scalar("SELECT title FROM agent_sessions WHERE session_id = ? AND user_id = ?")
+            .bind(session_id.as_str())
+            .bind(&ctx.user_id)
+            .fetch_one(&ctx.pool)
+            .await
+            .expect("title after PUT");
     assert_eq!(title_sql, new_title);
     assert_eq!(db_uid, ctx.user_id);
 

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_session_http_db_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_session_http_db_matrix.rs
@@ -1,0 +1,67 @@
+//! Session `GET`/`PUT` HTTP responses aligned with `agent_sessions` (`title`, `user_id`, `status`).
+
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::Row;
+
+use super::harness::{bootstrap, get_json, put_json};
+
+pub async fn run_session_http_matches_agent_sessions_row() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth = &b.auth_header;
+
+    let session_id = &ctx.session_id;
+    let path = format!("/sessions/{session_id}");
+
+    let row = sqlx::query(
+        "SELECT title, user_id, status FROM agent_sessions WHERE session_id = ?",
+    )
+    .bind(session_id.as_str())
+    .fetch_optional(&ctx.pool)
+    .await
+    .expect("agent_sessions SELECT bootstrap")
+    .expect("session row should exist after bootstrap POST /sessions");
+
+    let db_title = row.try_get::<String, _>("title").ok();
+    let db_uid = row.get::<String, _>("user_id");
+    let db_status = row.get::<String, _>("status");
+
+    let (st_get, got) = get_json(&ctx.app, &path, Some(auth), &[]).await;
+    assert_eq!(st_get, StatusCode::OK);
+    assert_eq!(
+        got["session_id"].as_str(),
+        Some(session_id.as_str()),
+        "{got}"
+    );
+    assert_eq!(
+        got["title"].as_str(),
+        db_title.as_deref(),
+        "HTTP title vs DB"
+    );
+    assert_eq!(got["status"].as_str(), Some(db_status.as_str()));
+
+    let new_title = format!("matrix_db_title_{}", ctx.suffix);
+    let (st_put, put_j) = put_json(
+        &ctx.app,
+        &path,
+        Some(auth),
+        json!({ "title": new_title.clone() }),
+    )
+    .await;
+    assert_eq!(st_put, StatusCode::OK);
+    assert_eq!(put_j["title"].as_str(), Some(new_title.as_str()));
+
+    let title_sql: String = sqlx::query_scalar(
+        "SELECT title FROM agent_sessions WHERE session_id = ? AND user_id = ?",
+    )
+    .bind(session_id.as_str())
+    .bind(&ctx.user_id)
+    .fetch_one(&ctx.pool)
+    .await
+    .expect("title after PUT");
+    assert_eq!(title_sql, new_title);
+    assert_eq!(db_uid, ctx.user_id);
+
+    b.ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_crud_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_crud_matrix.rs
@@ -1,0 +1,124 @@
+//! Team CRUD Matrix E2E: `POST/GET/DELETE /teams`, `GET .../executions`, `team_definitions` rows.
+//!
+//! Runs against real [`astra_services::team_persistence::MatrixOneTeamStore`] via `build_server_state`.
+
+use axum::http::StatusCode;
+use serde_json::{Value, json};
+use sqlx::Row;
+
+use super::harness::{bootstrap, delete_json, get_json, post_json};
+
+fn minimal_team_payload(name: &str, description: &str) -> Value {
+    json!({
+        "name": name,
+        "description": description,
+        "coordination": { "type": "pipeline" },
+        "members": [
+            {
+                "role": "coder",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            },
+            {
+                "role": "reviewer",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            }
+        ],
+        "context": { "suite": "matrix_team_crud" },
+        "worktree_mode": "shared",
+        "max_parallel": 1
+    })
+}
+
+pub async fn run_team_crud_db() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth = &b.auth_header;
+
+    let team_name = format!("e2e_mx_team_{}", ctx.suffix);
+
+    let payload_v1 = minimal_team_payload(&team_name, "matrix e2e team crud v1");
+    let (st, body) = post_json(&ctx.app, "/teams", Some(auth), payload_v1.clone()).await;
+    assert_eq!(st, StatusCode::OK, "POST /teams create: {body}");
+    let team_id = body["team_id"].as_str().expect("team_id").to_string();
+    assert_eq!(body["user_id"].as_str(), Some(ctx.user_id.as_str()));
+    assert_eq!(body["name"].as_str(), Some(team_name.as_str()));
+
+    let (st_list, list_j) = get_json(&ctx.app, "/teams", Some(auth), &[]).await;
+    assert_eq!(st_list, StatusCode::OK, "GET /teams: {list_j}");
+    let teams = list_j["teams"].as_array().expect("teams array");
+    assert!(
+        teams.iter().any(|t| t["name"].as_str() == Some(team_name.as_str())),
+        "list should include our team: {list_j}"
+    );
+
+    let path_detail = format!("/teams/{team_name}");
+    let (st_get, get_j) = get_json(&ctx.app, &path_detail, Some(auth), &[]).await;
+    assert_eq!(st_get, StatusCode::OK, "GET team: {get_j}");
+    assert_eq!(get_j["team_id"].as_str(), Some(team_id.as_str()));
+
+    let path_exec = format!("/teams/{team_name}/executions");
+    let (st_ex, ex_j) = get_json(&ctx.app, &path_exec, Some(auth), &[]).await;
+    assert_eq!(st_ex, StatusCode::OK, "GET executions: {ex_j}");
+    assert_eq!(
+        ex_j["executions"].as_array().map(|a| a.len()),
+        Some(0),
+        "no runs yet: {ex_j}"
+    );
+
+    let row = sqlx::query(
+        "SELECT team_id, user_id, name FROM team_definitions WHERE user_id = ? AND name = ?",
+    )
+    .bind(&ctx.user_id)
+    .bind(&team_name)
+    .fetch_optional(&ctx.pool)
+    .await
+    .expect("team_definitions SELECT");
+    let row = row.expect("team_definitions row after POST");
+    assert_eq!(row.get::<String, _>("team_id"), team_id);
+    assert_eq!(row.get::<String, _>("user_id"), ctx.user_id);
+
+    let payload_v2 = minimal_team_payload(&team_name, "matrix e2e team crud v2 upsert");
+    let (st2, body2) = post_json(&ctx.app, "/teams", Some(auth), payload_v2).await;
+    assert_eq!(st2, StatusCode::OK, "POST /teams upsert: {body2}");
+    assert_eq!(
+        body2["team_id"].as_str(),
+        Some(team_id.as_str()),
+        "upsert keeps logical team_id from first create"
+    );
+    assert_eq!(
+        body2["description"].as_str(),
+        Some("matrix e2e team crud v2 upsert")
+    );
+
+    let desc_db: String = sqlx::query_scalar(
+        "SELECT description FROM team_definitions WHERE user_id = ? AND name = ?",
+    )
+    .bind(&ctx.user_id)
+    .bind(&team_name)
+    .fetch_one(&ctx.pool)
+    .await
+    .expect("description after upsert");
+    assert_eq!(desc_db, "matrix e2e team crud v2 upsert");
+
+    let (st_del, del_j) = delete_json(&ctx.app, &path_detail, Some(auth)).await;
+    assert_eq!(st_del, StatusCode::OK, "DELETE team: {del_j}");
+    assert_eq!(del_j["deleted"].as_bool(), Some(true));
+
+    let n: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM team_definitions WHERE user_id = ? AND name = ?",
+    )
+    .bind(&ctx.user_id)
+    .bind(&team_name)
+    .fetch_one(&ctx.pool)
+    .await
+    .expect("count after delete");
+    assert_eq!(n, 0, "team_definitions row removed");
+
+    b.ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_crud_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_crud_matrix.rs
@@ -53,7 +53,9 @@ pub async fn run_team_crud_db() {
     assert_eq!(st_list, StatusCode::OK, "GET /teams: {list_j}");
     let teams = list_j["teams"].as_array().expect("teams array");
     assert!(
-        teams.iter().any(|t| t["name"].as_str() == Some(team_name.as_str())),
+        teams
+            .iter()
+            .any(|t| t["name"].as_str() == Some(team_name.as_str())),
         "list should include our team: {list_j}"
     );
 
@@ -110,14 +112,13 @@ pub async fn run_team_crud_db() {
     assert_eq!(st_del, StatusCode::OK, "DELETE team: {del_j}");
     assert_eq!(del_j["deleted"].as_bool(), Some(true));
 
-    let n: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM team_definitions WHERE user_id = ? AND name = ?",
-    )
-    .bind(&ctx.user_id)
-    .bind(&team_name)
-    .fetch_one(&ctx.pool)
-    .await
-    .expect("count after delete");
+    let n: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM team_definitions WHERE user_id = ? AND name = ?")
+            .bind(&ctx.user_id)
+            .bind(&team_name)
+            .fetch_one(&ctx.pool)
+            .await
+            .expect("count after delete");
     assert_eq!(n, 0, "team_definitions row removed");
 
     b.ctx.pool.close().await;

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_data_fidelity_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_data_fidelity_matrix.rs
@@ -1,0 +1,227 @@
+//! Team HTTP ↔ Matrix row fidelity: JSON columns match GET responses; snapshot blob matches definition;
+//! list length vs SQL count; executions `limit` query still OK when empty.
+
+use axum::http::StatusCode;
+use serde_json::{Value, json};
+use sqlx::Row;
+
+use super::harness::{bootstrap, delete_json, get_json, post_json};
+
+fn fidelity_team_payload(name: &str) -> Value {
+    json!({
+        "name": name,
+        "description": "data fidelity probe",
+        "coordination": { "type": "pipeline" },
+        "members": [
+            {
+                "role": "coder",
+                "system_prompt": "Do coding",
+                "skills": ["read"],
+                "model_override": null,
+                "mcp_servers": [],
+                "agent_id": null,
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            },
+            {
+                "role": "reviewer",
+                "system_prompt": null,
+                "skills": [],
+                "mcp_servers": [],
+                "agent_id": "custom-rev",
+                "can_delegate": true,
+                "max_delegation_depth": 1
+            }
+        ],
+        "context": { "suite": "matrix_team_data_fidelity", "k": "v" },
+        "worktree_mode": "isolated",
+        "max_parallel": 2,
+        "budget": {
+            "max_cost_usd": 10.0,
+            "max_tokens": 50000,
+            "max_duration_secs": 600
+        }
+    })
+}
+
+pub async fn run_team_http_db_fidelity() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth = &b.auth_header;
+
+    let team_name = format!("e2e_mx_fidelity_{}", ctx.suffix);
+
+    let payload = fidelity_team_payload(&team_name);
+    let (st, detail) = post_json(&ctx.app, "/teams", Some(auth), payload).await;
+    assert_eq!(st, StatusCode::OK, "POST team: {detail}");
+
+    let path_detail = format!("/teams/{team_name}");
+    let (st_get, get_j) = get_json(&ctx.app, &path_detail, Some(auth), &[]).await;
+    assert_eq!(st_get, StatusCode::OK, "GET detail: {get_j}");
+
+    let row = sqlx::query(
+        "SELECT description, coordination, members_json, context_json, \
+                worktree_mode, budget_json, max_parallel \
+         FROM team_definitions WHERE user_id = ? AND name = ?",
+    )
+    .bind(&ctx.user_id)
+    .bind(&team_name)
+    .fetch_one(&ctx.pool)
+    .await
+    .expect("team_definitions fidelity row");
+
+    assert_eq!(
+        row.get::<String, _>("description"),
+        get_j["description"].as_str().unwrap_or("")
+    );
+
+    let coord_db: String = row.get("coordination");
+    let coord_http = get_j["coordination"].clone();
+    let coord_parsed: Value =
+        serde_json::from_str(&coord_db).expect("coordination JSON from DB");
+    assert_eq!(
+        coord_parsed, coord_http,
+        "coordination DB vs GET detail mismatch"
+    );
+
+    let members_db: String = row.get("members_json");
+    let members_parsed: Value =
+        serde_json::from_str(&members_db).expect("members_json from DB");
+    assert_eq!(
+        members_parsed,
+        get_j["members"].clone(),
+        "members_json DB vs GET detail mismatch"
+    );
+
+    let ctx_db: Option<String> = row.try_get("context_json").ok();
+    let ctx_str = ctx_db.unwrap_or_default();
+    let ctx_parsed: Value = if ctx_str.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_str(&ctx_str).expect("context_json")
+    };
+    assert_eq!(
+        ctx_parsed,
+        get_j["context"].clone(),
+        "context_json DB vs GET detail mismatch"
+    );
+
+    assert_eq!(
+        row.get::<String, _>("worktree_mode").to_ascii_lowercase(),
+        get_j["worktree_mode"]
+            .as_str()
+            .unwrap_or("")
+            .to_ascii_lowercase(),
+        "worktree_mode DB vs GET"
+    );
+
+    let budget_db: Option<String> = row.try_get("budget_json").ok().flatten();
+    match (budget_db.as_deref(), get_j.get("budget")) {
+        (Some(bs), Some(bv)) if !bs.is_empty() => {
+            let bv_db: Value = serde_json::from_str(bs).expect("budget_json");
+            assert_eq!(bv_db, *bv, "budget_json DB vs GET");
+        }
+        _ => panic!("budget roundtrip missing: db={budget_db:?} http={:?}", get_j.get("budget")),
+    }
+
+    let mp_db: i64 = row
+        .try_get::<i64, _>("max_parallel")
+        .or_else(|_| row.try_get::<u32, _>("max_parallel").map(|x| x as i64))
+        .unwrap_or(0);
+    assert_eq!(
+        mp_db,
+        get_j["max_parallel"].as_i64().unwrap_or_else(|| {
+            get_j["max_parallel"]
+                .as_u64()
+                .expect("max_parallel") as i64
+        }),
+        "max_parallel DB vs GET"
+    );
+
+    let (st_list, list_j) = get_json(&ctx.app, "/teams", Some(auth), &[]).await;
+    assert_eq!(st_list, StatusCode::OK);
+    let listed = list_j["teams"].as_array().expect("teams");
+    let sql_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM team_definitions WHERE user_id = ?",
+    )
+    .bind(&ctx.user_id)
+    .fetch_one(&ctx.pool)
+    .await
+    .expect("COUNT team_definitions");
+    assert_eq!(
+        listed.len() as i64,
+        sql_count,
+        "GET /teams len should match SQL COUNT(*) for user"
+    );
+
+    let path_exec_limited = format!(
+        "/teams/{team_name}/executions?limit=3",
+    );
+    let (st_ex, ex_j) = get_json(&ctx.app, &path_exec_limited, Some(auth), &[]).await;
+    assert_eq!(st_ex, StatusCode::OK, "GET executions limited: {ex_j}");
+    assert!(
+        ex_j["executions"].as_array().map(|a| a.is_empty()).unwrap_or(false),
+        "still no executions: {ex_j}"
+    );
+
+    let snap_body = json!({
+        "label": "fidelity-snap",
+        "session_id": ctx.session_id,
+        "git_commit": "cafef00d"
+    });
+    let (st_sn, sn_j) = post_json(
+        &ctx.app,
+        &format!("/teams/{team_name}/snapshots"),
+        Some(auth),
+        snap_body,
+    )
+    .await;
+    assert_eq!(st_sn, StatusCode::OK, "snapshot: {sn_j}");
+    let snapshot_id = sn_j["snapshot_id"].as_str().expect("snapshot_id");
+
+    let blob: Option<String> = sqlx::query_scalar(
+        "SELECT team_definition_json FROM team_snapshots WHERE snapshot_id = ? AND user_id = ?",
+    )
+    .bind(snapshot_id)
+    .bind(&ctx.user_id)
+    .fetch_optional(&ctx.pool)
+    .await
+    .expect("team_definition_json SELECT")
+    .flatten();
+    let blob_str = blob.expect("team_definition_json present");
+    let blob_val: Value = serde_json::from_str(&blob_str).expect("team_definition_json parse");
+    assert_eq!(
+        blob_val["team_id"].as_str(),
+        detail["team_id"].as_str(),
+        "snapshot blob team_id matches create response"
+    );
+    assert_eq!(
+        blob_val["name"].as_str(),
+        Some(team_name.as_str()),
+        "snapshot blob name matches"
+    );
+    assert_eq!(
+        blob_val["user_id"].as_str(),
+        Some(ctx.user_id.as_str()),
+        "snapshot blob user_id matches JWT subject"
+    );
+
+    let path_snaps = format!("/teams/{team_name}/snapshots");
+    let (st_sn_list, snaps_j) = get_json(&ctx.app, &path_snaps, Some(auth), &[]).await;
+    assert_eq!(st_sn_list, StatusCode::OK);
+    let snaps = snaps_j["snapshots"].as_array().expect("snapshots");
+    assert_eq!(snaps.len(), 1);
+    assert_eq!(snaps[0]["snapshot_id"].as_str(), Some(snapshot_id));
+    assert_eq!(snaps[0]["label"].as_str(), Some("fidelity-snap"));
+    assert_eq!(
+        snaps[0]["session_id"].as_str(),
+        Some(ctx.session_id.as_str())
+    );
+    assert_eq!(snaps[0]["git_commit"].as_str(), Some("cafef00d"));
+
+    let (_, _) =
+        delete_json(&ctx.app, &format!("/teams/snapshots/{snapshot_id}"), Some(auth)).await;
+    let (_, _) = delete_json(&ctx.app, &path_detail, Some(auth)).await;
+
+    b.ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_data_fidelity_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_data_fidelity_matrix.rs
@@ -77,16 +77,14 @@ pub async fn run_team_http_db_fidelity() {
 
     let coord_db: String = row.get("coordination");
     let coord_http = get_j["coordination"].clone();
-    let coord_parsed: Value =
-        serde_json::from_str(&coord_db).expect("coordination JSON from DB");
+    let coord_parsed: Value = serde_json::from_str(&coord_db).expect("coordination JSON from DB");
     assert_eq!(
         coord_parsed, coord_http,
         "coordination DB vs GET detail mismatch"
     );
 
     let members_db: String = row.get("members_json");
-    let members_parsed: Value =
-        serde_json::from_str(&members_db).expect("members_json from DB");
+    let members_parsed: Value = serde_json::from_str(&members_db).expect("members_json from DB");
     assert_eq!(
         members_parsed,
         get_j["members"].clone(),
@@ -121,7 +119,10 @@ pub async fn run_team_http_db_fidelity() {
             let bv_db: Value = serde_json::from_str(bs).expect("budget_json");
             assert_eq!(bv_db, *bv, "budget_json DB vs GET");
         }
-        _ => panic!("budget roundtrip missing: db={budget_db:?} http={:?}", get_j.get("budget")),
+        _ => panic!(
+            "budget roundtrip missing: db={budget_db:?} http={:?}",
+            get_j.get("budget")
+        ),
     }
 
     let mp_db: i64 = row
@@ -130,37 +131,35 @@ pub async fn run_team_http_db_fidelity() {
         .unwrap_or(0);
     assert_eq!(
         mp_db,
-        get_j["max_parallel"].as_i64().unwrap_or_else(|| {
-            get_j["max_parallel"]
-                .as_u64()
-                .expect("max_parallel") as i64
-        }),
+        get_j["max_parallel"]
+            .as_i64()
+            .unwrap_or_else(|| { get_j["max_parallel"].as_u64().expect("max_parallel") as i64 }),
         "max_parallel DB vs GET"
     );
 
     let (st_list, list_j) = get_json(&ctx.app, "/teams", Some(auth), &[]).await;
     assert_eq!(st_list, StatusCode::OK);
     let listed = list_j["teams"].as_array().expect("teams");
-    let sql_count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM team_definitions WHERE user_id = ?",
-    )
-    .bind(&ctx.user_id)
-    .fetch_one(&ctx.pool)
-    .await
-    .expect("COUNT team_definitions");
+    let sql_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM team_definitions WHERE user_id = ?")
+            .bind(&ctx.user_id)
+            .fetch_one(&ctx.pool)
+            .await
+            .expect("COUNT team_definitions");
     assert_eq!(
         listed.len() as i64,
         sql_count,
         "GET /teams len should match SQL COUNT(*) for user"
     );
 
-    let path_exec_limited = format!(
-        "/teams/{team_name}/executions?limit=3",
-    );
+    let path_exec_limited = format!("/teams/{team_name}/executions?limit=3",);
     let (st_ex, ex_j) = get_json(&ctx.app, &path_exec_limited, Some(auth), &[]).await;
     assert_eq!(st_ex, StatusCode::OK, "GET executions limited: {ex_j}");
     assert!(
-        ex_j["executions"].as_array().map(|a| a.is_empty()).unwrap_or(false),
+        ex_j["executions"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(false),
         "still no executions: {ex_j}"
     );
 
@@ -219,8 +218,12 @@ pub async fn run_team_http_db_fidelity() {
     );
     assert_eq!(snaps[0]["git_commit"].as_str(), Some("cafef00d"));
 
-    let (_, _) =
-        delete_json(&ctx.app, &format!("/teams/snapshots/{snapshot_id}"), Some(auth)).await;
+    let (_, _) = delete_json(
+        &ctx.app,
+        &format!("/teams/snapshots/{snapshot_id}"),
+        Some(auth),
+    )
+    .await;
     let (_, _) = delete_json(&ctx.app, &path_detail, Some(auth)).await;
 
     b.ctx.pool.close().await;

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_http_negatives_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_http_negatives_matrix.rs
@@ -18,13 +18,7 @@ pub async fn run_team_http_negative_paths() {
     );
 
     let ghost = format!("no_such_team_{}", ctx.suffix);
-    let (st_404_get, _) = get_json(
-        &ctx.app,
-        &format!("/teams/{ghost}"),
-        Some(auth),
-        &[],
-    )
-    .await;
+    let (st_404_get, _) = get_json(&ctx.app, &format!("/teams/{ghost}"), Some(auth), &[]).await;
     assert_eq!(st_404_get, StatusCode::NOT_FOUND);
 
     let (st_404_del, _) = delete_json(&ctx.app, &format!("/teams/{ghost}"), Some(auth)).await;
@@ -149,7 +143,8 @@ pub async fn run_team_http_negative_paths() {
             }
         ]
     });
-    let (st_adv, adv_j) = post_json(&ctx.app, "/teams", Some(auth), adversarial_three_members).await;
+    let (st_adv, adv_j) =
+        post_json(&ctx.app, "/teams", Some(auth), adversarial_three_members).await;
     assert_eq!(
         st_adv,
         StatusCode::BAD_REQUEST,

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_http_negatives_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_http_negatives_matrix.rs
@@ -1,0 +1,160 @@
+//! Team HTTP negative paths on Matrix stack: auth, 404, validation (`validate_team`).
+
+use axum::http::StatusCode;
+use serde_json::{Value, json};
+
+use super::harness::{bootstrap, delete_json, get_json, post_json};
+
+pub async fn run_team_http_negative_paths() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth = &b.auth_header;
+
+    let (st_noauth, _) = get_json(&ctx.app, "/teams", None, &[]).await;
+    assert_eq!(
+        st_noauth,
+        StatusCode::UNAUTHORIZED,
+        "GET /teams without Authorization"
+    );
+
+    let ghost = format!("no_such_team_{}", ctx.suffix);
+    let (st_404_get, _) = get_json(
+        &ctx.app,
+        &format!("/teams/{ghost}"),
+        Some(auth),
+        &[],
+    )
+    .await;
+    assert_eq!(st_404_get, StatusCode::NOT_FOUND);
+
+    let (st_404_del, _) = delete_json(&ctx.app, &format!("/teams/{ghost}"), Some(auth)).await;
+    assert_eq!(st_404_del, StatusCode::NOT_FOUND);
+
+    let bad_empty_members: Value = json!({
+        "name": format!("bad_empty_{}", ctx.suffix),
+        "description": "should fail validation",
+        "coordination": { "type": "pipeline" },
+        "members": []
+    });
+    let (st_bad, bad_j) = post_json(&ctx.app, "/teams", Some(auth), bad_empty_members).await;
+    assert_eq!(st_bad, StatusCode::BAD_REQUEST, "empty members: {bad_j}");
+
+    let dup_roles: Value = json!({
+        "name": format!("bad_dup_roles_{}", ctx.suffix),
+        "description": "duplicate roles",
+        "coordination": { "type": "pipeline" },
+        "members": [
+            {
+                "role": "twin",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            },
+            {
+                "role": "twin",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            }
+        ]
+    });
+    let (st_dup, dup_j) = post_json(&ctx.app, "/teams", Some(auth), dup_roles).await;
+    assert_eq!(st_dup, StatusCode::BAD_REQUEST, "duplicate roles: {dup_j}");
+
+    let budget_all_zero: Value = json!({
+        "name": format!("bad_budget_all_zero_{}", ctx.suffix),
+        "description": "invalid budget",
+        "coordination": { "type": "pipeline" },
+        "members": [
+            {
+                "role": "only",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            },
+            {
+                "role": "second",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            }
+        ],
+        "budget": {
+            "max_cost_usd": 0.0,
+            "max_tokens": 0,
+            "max_duration_secs": 0
+        }
+    });
+    let (st_bz, bz_j) = post_json(&ctx.app, "/teams", Some(auth), budget_all_zero).await;
+    assert_eq!(st_bz, StatusCode::BAD_REQUEST, "budget all zero: {bz_j}");
+
+    let budget_negative: Value = json!({
+        "name": format!("bad_budget_neg_{}", ctx.suffix),
+        "description": "negative usd",
+        "coordination": { "type": "pipeline" },
+        "members": [
+            {
+                "role": "x1",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            },
+            {
+                "role": "x2",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            }
+        ],
+        "budget": {
+            "max_cost_usd": -1.0,
+            "max_tokens": 100,
+            "max_duration_secs": 60
+        }
+    });
+    let (st_bn, bn_j) = post_json(&ctx.app, "/teams", Some(auth), budget_negative).await;
+    assert_eq!(st_bn, StatusCode::BAD_REQUEST, "negative budget: {bn_j}");
+
+    let adversarial_three_members: Value = json!({
+        "name": format!("bad_adv_count_{}", ctx.suffix),
+        "description": "adversarial needs exactly 2 members",
+        "coordination": { "type": "adversarial", "max_rounds": 3, "threshold": 0.8 },
+        "members": [
+            {
+                "role": "p",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            },
+            {
+                "role": "r",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            },
+            {
+                "role": "extra",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            }
+        ]
+    });
+    let (st_adv, adv_j) = post_json(&ctx.app, "/teams", Some(auth), adversarial_three_members).await;
+    assert_eq!(
+        st_adv,
+        StatusCode::BAD_REQUEST,
+        "adversarial member count: {adv_j}"
+    );
+
+    b.ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_isolation_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_isolation_matrix.rs
@@ -1,0 +1,106 @@
+//! Cross-user isolation: user B cannot load or delete team rows owned by user A (404 + list).
+
+use axum::http::StatusCode;
+use serde_json::json;
+use uuid::Uuid;
+
+use super::harness::{
+    E2E_PASSWORD, bootstrap, delete_json, get_json, post_json,
+};
+
+pub async fn run_team_cross_user_isolation() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth_a = &b.auth_header;
+
+    let team_name = format!("e2e_mx_iso_{}", ctx.suffix);
+
+    let payload = json!({
+        "name": team_name,
+        "description": "owner A only",
+        "coordination": { "type": "pipeline" },
+        "members": [
+            {
+                "role": "a1",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            },
+            {
+                "role": "a2",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            }
+        ],
+        "context": {},
+        "worktree_mode": "shared",
+        "max_parallel": 1
+    });
+
+    let (st_up, _) = post_json(&ctx.app, "/teams", Some(auth_a), payload).await;
+    assert_eq!(st_up, StatusCode::OK);
+
+    let b_suffix = Uuid::new_v4().simple().to_string();
+    let b_username = format!("prod_matrix_iso_{b_suffix}");
+    let b_email = format!("prod_matrix_iso_{b_suffix}@e2e.test");
+
+    let (st_reg, reg_b) = post_json(
+        &ctx.app,
+        "/auth/register",
+        None,
+        json!({
+            "username": b_username,
+            "email": b_email,
+            "password": E2E_PASSWORD,
+            "display_name": "Team isolation B"
+        }),
+    )
+    .await;
+    assert_eq!(st_reg, StatusCode::CREATED, "register B: {reg_b}");
+
+    let (st_login, login_j) = post_json(
+        &ctx.app,
+        "/auth/login",
+        None,
+        json!({ "username": b_username, "password": E2E_PASSWORD }),
+    )
+    .await;
+    assert_eq!(st_login, StatusCode::OK, "login B: {login_j}");
+    let access_b = login_j["access_token"]
+        .as_str()
+        .expect("B access_token");
+    let auth_b = format!("Bearer {access_b}");
+
+    let path_t = format!("/teams/{team_name}");
+    let (st_g, _) = get_json(&ctx.app, &path_t, Some(&auth_b), &[]).await;
+    assert_eq!(
+        st_g,
+        StatusCode::NOT_FOUND,
+        "B must not see A team by name"
+    );
+
+    let (st_d, _) = delete_json(&ctx.app, &path_t, Some(&auth_b)).await;
+    assert_eq!(
+        st_d,
+        StatusCode::NOT_FOUND,
+        "B must not delete A team"
+    );
+
+    let (st_list_b, list_b) = get_json(&ctx.app, "/teams", Some(&auth_b), &[]).await;
+    assert_eq!(st_list_b, StatusCode::OK);
+    let teams_b = list_b["teams"].as_array().expect("teams B");
+    assert!(
+        !teams_b
+            .iter()
+            .any(|t| t["name"].as_str() == Some(team_name.as_str())),
+        "B list must not contain A team: {list_b}"
+    );
+
+    let (st_del_a, _) = delete_json(&ctx.app, &path_t, Some(auth_a)).await;
+    assert_eq!(st_del_a, StatusCode::OK);
+
+    b.ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_isolation_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_isolation_matrix.rs
@@ -4,9 +4,7 @@ use axum::http::StatusCode;
 use serde_json::json;
 use uuid::Uuid;
 
-use super::harness::{
-    E2E_PASSWORD, bootstrap, delete_json, get_json, post_json,
-};
+use super::harness::{E2E_PASSWORD, bootstrap, delete_json, get_json, post_json};
 
 pub async fn run_team_cross_user_isolation() {
     let b = bootstrap().await;
@@ -69,25 +67,15 @@ pub async fn run_team_cross_user_isolation() {
     )
     .await;
     assert_eq!(st_login, StatusCode::OK, "login B: {login_j}");
-    let access_b = login_j["access_token"]
-        .as_str()
-        .expect("B access_token");
+    let access_b = login_j["access_token"].as_str().expect("B access_token");
     let auth_b = format!("Bearer {access_b}");
 
     let path_t = format!("/teams/{team_name}");
     let (st_g, _) = get_json(&ctx.app, &path_t, Some(&auth_b), &[]).await;
-    assert_eq!(
-        st_g,
-        StatusCode::NOT_FOUND,
-        "B must not see A team by name"
-    );
+    assert_eq!(st_g, StatusCode::NOT_FOUND, "B must not see A team by name");
 
     let (st_d, _) = delete_json(&ctx.app, &path_t, Some(&auth_b)).await;
-    assert_eq!(
-        st_d,
-        StatusCode::NOT_FOUND,
-        "B must not delete A team"
-    );
+    assert_eq!(st_d, StatusCode::NOT_FOUND, "B must not delete A team");
 
     let (st_list_b, list_b) = get_json(&ctx.app, "/teams", Some(&auth_b), &[]).await;
     assert_eq!(st_list_b, StatusCode::OK);

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_snapshots_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_team_snapshots_matrix.rs
@@ -1,0 +1,114 @@
+//! Team snapshots Matrix E2E: `GET/POST .../snapshots`, `DELETE /teams/snapshots/{id}`, `team_snapshots` SQL.
+
+use axum::http::StatusCode;
+use serde_json::{Value, json};
+use sqlx::Row;
+
+use super::harness::{bootstrap, delete_json, get_json, post_json};
+
+fn minimal_team_payload(name: &str, description: &str) -> Value {
+    json!({
+        "name": name,
+        "description": description,
+        "coordination": { "type": "pipeline" },
+        "members": [
+            {
+                "role": "alpha",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            },
+            {
+                "role": "beta",
+                "skills": [],
+                "mcp_servers": [],
+                "can_delegate": false,
+                "max_delegation_depth": 0
+            }
+        ],
+        "context": { "suite": "matrix_team_snapshots" },
+        "worktree_mode": "shared",
+        "max_parallel": 1
+    })
+}
+
+pub async fn run_team_snapshots_db() {
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let auth = &b.auth_header;
+
+    let team_name = format!("e2e_mx_snap_team_{}", ctx.suffix);
+
+    let (st_create, _) = post_json(
+        &ctx.app,
+        "/teams",
+        Some(auth),
+        minimal_team_payload(&team_name, "snapshot journey"),
+    )
+    .await;
+    assert_eq!(st_create, StatusCode::OK);
+
+    let snap_body = json!({
+        "label": "matrix-e2e-label",
+        "session_id": ctx.session_id,
+        "git_commit": "deadbeef"
+    });
+
+    let path_snap_post = format!("/teams/{team_name}/snapshots");
+    let (st_sn, sn_j) = post_json(&ctx.app, &path_snap_post, Some(auth), snap_body).await;
+    assert_eq!(st_sn, StatusCode::OK, "POST snapshot: {sn_j}");
+    let snapshot_id = sn_j["snapshot_id"]
+        .as_str()
+        .expect("snapshot_id")
+        .to_string();
+
+    let path_snap_list = format!("/teams/{team_name}/snapshots");
+    let (st_li, li_j) = get_json(&ctx.app, &path_snap_list, Some(auth), &[]).await;
+    assert_eq!(st_li, StatusCode::OK, "GET snapshots: {li_j}");
+    let snaps = li_j["snapshots"].as_array().expect("snapshots");
+    assert_eq!(snaps.len(), 1);
+    assert_eq!(snaps[0]["snapshot_id"].as_str(), Some(snapshot_id.as_str()));
+
+    let row = sqlx::query(
+        "SELECT snapshot_id, user_id, team_name, label FROM team_snapshots \
+         WHERE snapshot_id = ? AND user_id = ?",
+    )
+    .bind(&snapshot_id)
+    .bind(&ctx.user_id)
+    .fetch_optional(&ctx.pool)
+    .await
+    .expect("team_snapshots SELECT");
+    let row = row.expect("snapshot row");
+    assert_eq!(row.get::<String, _>("team_name"), team_name);
+    assert_eq!(row.get::<String, _>("label"), "matrix-e2e-label");
+
+    let path_snap_del = format!("/teams/snapshots/{snapshot_id}");
+    let (st_del, del_j) = delete_json(&ctx.app, &path_snap_del, Some(auth)).await;
+    assert_eq!(st_del, StatusCode::OK, "DELETE snapshot: {del_j}");
+    assert_eq!(del_j["deleted"].as_bool(), Some(true));
+
+    let n: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM team_snapshots WHERE snapshot_id = ? AND user_id = ?",
+    )
+    .bind(&snapshot_id)
+    .bind(&ctx.user_id)
+    .fetch_one(&ctx.pool)
+    .await
+    .expect("count after snapshot delete");
+    assert_eq!(n, 0);
+
+    let (st_li2, li2_j) = get_json(&ctx.app, &path_snap_list, Some(auth), &[]).await;
+    assert_eq!(st_li2, StatusCode::OK);
+    assert_eq!(
+        li2_j["snapshots"].as_array().map(|a| a.len()),
+        Some(0),
+        "list empty after delete: {li2_j}"
+    );
+
+    let path_team = format!("/teams/{team_name}");
+    let (st_team_del, _) = delete_json(&ctx.app, &path_team, Some(auth)).await;
+    assert_eq!(st_team_del, StatusCode::OK);
+
+    b.ctx.pool.close().await;
+}

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/main.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/main.rs
@@ -58,6 +58,31 @@
 //!   `context_trace_signal` event written to `agent_events` with valid causal chain.
 //! - **`e2e_matrix_stream_multi_turn_persistence`** — two sequential `POST /chat/stream` to same
 //!   session → verify event counts increment, distinct causal chains, both runs completed.
+//! - **`e2e_matrix_team_crud_and_db`** — `POST/GET/DELETE /teams`, list + detail + empty executions,
+//!   upsert second `POST`, `team_definitions` SQL assertions (`user_id`, `name`, delete removes row).
+//! - **`e2e_matrix_team_snapshots_and_db`** — `POST/GET .../snapshots`, `DELETE /teams/snapshots/{id}`,
+//!   `team_snapshots` SQL; cleans up team row after.
+//! - **`e2e_matrix_team_http_negative_paths`** — `GET /teams` without auth (401), unknown team GET/DELETE
+//!   (404), `POST /teams` empty members + duplicate roles → 400 (`validate_team`), invalid budget +
+//!   adversarial member-count validation.
+//! - **`e2e_matrix_team_http_db_fidelity`** — HTTP `GET /teams/{name}` matches `team_definitions`
+//!   JSON columns (`coordination`, `members_json`, `context_json`, `budget_json`, …); `GET /teams` count =
+//!   SQL `COUNT(*)`; snapshot `team_definition_json` + list fields vs DB; `GET .../executions?limit=`.
+//! - **`e2e_matrix_team_cross_user_isolation`** — second registered user cannot GET/DELETE another user's
+//!   team (404); team name absent from foreigner's list.
+//! - **`e2e_matrix_meta_health`** — `GET /` + `GET /health` (service metadata, DB connected, persist counters).
+//! - **`e2e_matrix_session_http_db`** — `GET`/`PUT /sessions/{id}` vs `agent_sessions` (`title`, `user_id`).
+//! - **`e2e_matrix_evaluation_reads`** — evaluation GETs (`x-user-id`), optional agent seed for trust/SLO/
+//!   observability, plus learning health/signals.
+//! - **`e2e_matrix_context_decision_chain`** — `POST /events` → `/context` → `/decisions` + `ctx_snapshots` /
+//!   `ctx_decision_audits` SQL.
+//! - **`e2e_matrix_chat_route_models`** — `POST /chat/route` shape + `GET /models`.
+//! - **`e2e_matrix_branches_cost_estimate_http`** — `POST /branches/cost-estimate` (JWT, numeric
+//!   estimate fields); 401 without auth (no DDL branch ops).
+//! - **`e2e_matrix_delegate_http_boundaries`** — `POST /chat` → `run_id`; `GET .../delegations`;
+//!   `POST .../delegate` fails at validation (`400`) without executing sub-runs.
+//! - **`e2e_matrix_admin_tokens_smoke`** — `GET /admin/tokens`: `403` without `astra_admin`,
+//!   then `200` + JSON array after `grant_astra_admin_role`.
 //!
 //! Session list/get/put, close/resume, activity, and DB checks for close/resume live only in the full
 //! journey (not duplicated in a separate test).
@@ -81,12 +106,25 @@
 //! parallelism (`make test` / `ASTRA_SYSTEM_MATRIX_E2E_TEST_THREADS`).
 
 mod harness;
+mod journey_admin_smoke_matrix;
 mod journey_audit_cross_session;
+mod journey_branches_matrix;
+mod journey_chat_route_models_matrix;
+mod journey_context_decision_chain_matrix;
+mod journey_delegate_http_matrix;
+mod journey_evaluation_reads_matrix;
 mod journey_extended;
 mod journey_full;
+mod journey_meta_matrix;
 mod journey_remote_skills;
+mod journey_session_http_db_matrix;
 mod journey_stream_persistence;
 mod journey_tasks_runs;
+mod journey_team_crud_matrix;
+mod journey_team_data_fidelity_matrix;
+mod journey_team_http_negatives_matrix;
+mod journey_team_isolation_matrix;
+mod journey_team_snapshots_matrix;
 mod journey_trusted_moi;
 
 use harness::require_system_e2e_env;
@@ -251,4 +289,95 @@ async fn e2e_matrix_stream_context_trace_persistence() {
 async fn e2e_matrix_stream_multi_turn_persistence() {
     require_system_e2e_env();
     journey_stream_persistence::run_stream_multi_turn_persistence().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_team_crud_and_db() {
+    require_system_e2e_env();
+    journey_team_crud_matrix::run_team_crud_db().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_team_snapshots_and_db() {
+    require_system_e2e_env();
+    journey_team_snapshots_matrix::run_team_snapshots_db().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_team_http_negative_paths() {
+    require_system_e2e_env();
+    journey_team_http_negatives_matrix::run_team_http_negative_paths().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_team_http_db_fidelity() {
+    require_system_e2e_env();
+    journey_team_data_fidelity_matrix::run_team_http_db_fidelity().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_team_cross_user_isolation() {
+    require_system_e2e_env();
+    journey_team_isolation_matrix::run_team_cross_user_isolation().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_meta_health() {
+    require_system_e2e_env();
+    journey_meta_matrix::run_meta_root_and_health().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_session_http_db() {
+    require_system_e2e_env();
+    journey_session_http_db_matrix::run_session_http_matches_agent_sessions_row().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_evaluation_reads() {
+    require_system_e2e_env();
+    journey_evaluation_reads_matrix::run_evaluation_read_http_smoke().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_context_decision_chain() {
+    require_system_e2e_env();
+    journey_context_decision_chain_matrix::run_context_decision_chain_db().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_chat_route_models() {
+    require_system_e2e_env();
+    journey_chat_route_models_matrix::run_chat_route_and_models_smoke().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_branches_cost_estimate_http() {
+    require_system_e2e_env();
+    journey_branches_matrix::run_branches_cost_estimate_http().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_delegate_http_boundaries() {
+    require_system_e2e_env();
+    journey_delegate_http_matrix::run_delegate_http_boundaries().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_SYSTEM_MATRIX_E2E=1 — see module doc"]
+async fn e2e_matrix_admin_tokens_smoke() {
+    require_system_e2e_env();
+    journey_admin_smoke_matrix::run_admin_tokens_smoke().await;
 }


### PR DESCRIPTION
## Summary

Expands `system_matrix_http_e2e` with focused journey modules (including Teams/Meta/session/evaluation/context/chat-route splits already wired in main), adds **Branches** (`POST /branches/cost-estimate`), **Delegation** (list + validation-only `POST .../delegate`), and **Admin** (`GET /admin/tokens` 403 → grant → 200).

## Changes

- New journeys: `journey_branches_matrix.rs`, `journey_delegate_http_matrix.rs`, `journey_admin_smoke_matrix.rs`
- Harness: `revoke_astra_admin_role` for admin smoke (paired with existing grant)
- Docs: `system-e2e-matrix.md`, `coverage-matrix.md` updated for routes/tests
- Rustfmt pass on journey modules

## Verification

```bash
cd rust && ASTRA_SYSTEM_MATRIX_E2E=1 ASTRA_BRIDGE_TEST_SECRET=system-matrix-e2e-secret \
  cargo test -p astra-runtime --test system_matrix_http_e2e --features bridge-e2e-hooks \
  e2e_matrix_branches_cost_estimate_http -- --ignored --nocapture
```

(repeat for `e2e_matrix_delegate_http_boundaries`, `e2e_matrix_admin_tokens_smoke`; filter must appear **before** `--`.)


Made with [Cursor](https://cursor.com)