### PR TITLE
feat(perception): surface failure category into outcome memory (L1 Gap 1)

### DIFF
--- a/rust/crates/astra-evolution/src/persistence.rs
+++ b/rust/crates/astra-evolution/src/persistence.rs
@@ -357,7 +357,7 @@ fn merge_recent_outcomes(
             by_signature
                 .entry(entry.signature.clone())
                 .or_default()
-                .extend(entry.outcomes.iter().copied());
+                .extend(entry.outcomes.iter().cloned());
         }
     }
 
@@ -1342,6 +1342,7 @@ mod tests {
                     latency_ms: 10,
                     result_hash: 111,
                     at_epoch: 10,
+                    failure_category: None,
                 }],
             }],
         }];
@@ -1358,6 +1359,7 @@ mod tests {
                     latency_ms: 12,
                     result_hash: 222,
                     at_epoch: 20,
+                    failure_category: None,
                 }],
             }],
         }];

--- a/rust/crates/astra-pipeline/src/tool_health_types.rs
+++ b/rust/crates/astra-pipeline/src/tool_health_types.rs
@@ -6,12 +6,17 @@ use serde::{Deserialize, Serialize};
 pub const TOOL_OUTCOME_RING_CAPACITY: usize = 8;
 
 /// Persisted per-call outcome for a specific tool signature.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolOutcome {
     pub success: bool,
     pub latency_ms: u64,
     pub result_hash: u64,
     pub at_epoch: u64,
+    /// Structured failure category tag (snake_case) when the call failed;
+    /// `None` on success or when the failure could not be classified.
+    /// Stored as a plain string to keep this crate free of turn-core dependencies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_category: Option<String>,
 }
 
 /// Persisted ring of outcomes for a canonical tool signature.

--- a/rust/crates/astra-turn-core/src/tool_health.rs
+++ b/rust/crates/astra-turn-core/src/tool_health.rs
@@ -8,6 +8,7 @@
 //! ends. It complements the cross-session `ToolQualityTracker` which
 //! tracks long-term tool reliability.
 
+use crate::action_compensation::{FailureCategory, classify_execution_outcome};
 use std::collections::{HashMap, VecDeque};
 use std::hash::{DefaultHasher, Hash, Hasher};
 
@@ -30,6 +31,11 @@ pub struct ToolOutcome {
     pub result_hash: u64,
     /// Unix epoch seconds when the outcome was recorded.
     pub at_epoch: u64,
+    /// Structured failure class when `success == false`; `None` otherwise.
+    /// Surfaced back into the agent's self-awareness prompt so identical
+    /// failures can be reasoned about by *kind* (timeout / perm / net / …)
+    /// rather than only by signature.
+    pub failure_category: Option<FailureCategory>,
 }
 
 /// Compact view of the latest known outcome for a canonical tool signature.
@@ -39,6 +45,7 @@ pub struct RecentOutcomeHint {
     pub signature: String,
     pub success: bool,
     pub at_epoch: u64,
+    pub failure_category: Option<FailureCategory>,
 }
 
 impl ToolOutcome {
@@ -47,8 +54,28 @@ impl ToolOutcome {
     /// `success` should be `false` iff the result was classified as an error
     /// by `tool_result_semantics::classify_result`. Callers typically know
     /// this already; exposing it explicitly keeps this helper pure.
+    ///
+    /// When `success == false`, the failure category is derived automatically
+    /// from the result text via [`classify_execution_outcome`]. Callers that
+    /// already have a category handy should prefer [`ToolOutcome::with_category`].
     #[must_use]
     pub fn new(success: bool, latency_ms: u64, result_str: &str) -> Self {
+        let failure_category = if success {
+            None
+        } else {
+            classify_execution_outcome(result_str, true, latency_ms, false).failure_category
+        };
+        Self::with_category(success, latency_ms, result_str, failure_category)
+    }
+
+    /// Build a `ToolOutcome` with an explicit, already-classified failure category.
+    #[must_use]
+    pub fn with_category(
+        success: bool,
+        latency_ms: u64,
+        result_str: &str,
+        failure_category: Option<FailureCategory>,
+    ) -> Self {
         let mut hasher = DefaultHasher::new();
         result_str.hash(&mut hasher);
         let result_hash = hasher.finish();
@@ -61,8 +88,48 @@ impl ToolOutcome {
             latency_ms,
             result_hash,
             at_epoch,
+            failure_category: if success { None } else { failure_category },
         }
     }
+}
+
+/// Stable snake_case tag for a [`FailureCategory`], suitable for prompt
+/// rendering and cross-process serialization.
+#[must_use]
+pub fn failure_category_tag(category: FailureCategory) -> &'static str {
+    match category {
+        FailureCategory::CompileError => "compile_error",
+        FailureCategory::TestFailure => "test_failure",
+        FailureCategory::PermissionDenied => "permission_denied",
+        FailureCategory::ResourceNotFound => "resource_not_found",
+        FailureCategory::NetworkError => "network_error",
+        FailureCategory::SyntaxError => "syntax_error",
+        FailureCategory::RuntimeError => "runtime_error",
+        FailureCategory::Timeout => "timeout",
+        FailureCategory::ResourceExhaustion => "resource_exhaustion",
+        FailureCategory::ValidationError => "validation_error",
+        FailureCategory::Unknown => "unknown",
+    }
+}
+
+/// Parse a snake_case tag back into a [`FailureCategory`]; `None` on
+/// unrecognized input.
+#[must_use]
+pub fn failure_category_from_tag(tag: &str) -> Option<FailureCategory> {
+    Some(match tag {
+        "compile_error" => FailureCategory::CompileError,
+        "test_failure" => FailureCategory::TestFailure,
+        "permission_denied" => FailureCategory::PermissionDenied,
+        "resource_not_found" => FailureCategory::ResourceNotFound,
+        "network_error" => FailureCategory::NetworkError,
+        "syntax_error" => FailureCategory::SyntaxError,
+        "runtime_error" => FailureCategory::RuntimeError,
+        "timeout" => FailureCategory::Timeout,
+        "resource_exhaustion" => FailureCategory::ResourceExhaustion,
+        "validation_error" => FailureCategory::ValidationError,
+        "unknown" => FailureCategory::Unknown,
+        _ => return None,
+    })
 }
 
 /// Maximum consecutive failures before a tool is deprioritized.
@@ -476,7 +543,7 @@ impl ToolHealthTracker {
                 let ring: VecDeque<_> = outcome_entry
                     .outcomes
                     .iter()
-                    .copied()
+                    .cloned()
                     .rev()
                     .take(OUTCOME_RING_CAPACITY)
                     .collect::<Vec<_>>()
@@ -487,6 +554,10 @@ impl ToolHealthTracker {
                         latency_ms: outcome.latency_ms,
                         result_hash: outcome.result_hash,
                         at_epoch: outcome.at_epoch,
+                        failure_category: outcome
+                            .failure_category
+                            .as_deref()
+                            .and_then(failure_category_from_tag),
                     })
                     .collect();
                 if !ring.is_empty() {
@@ -517,6 +588,9 @@ impl ToolHealthTracker {
                         latency_ms: outcome.latency_ms,
                         result_hash: outcome.result_hash,
                         at_epoch: outcome.at_epoch,
+                        failure_category: outcome
+                            .failure_category
+                            .map(|c| failure_category_tag(c).to_string()),
                     })
                     .collect(),
             })
@@ -738,6 +812,7 @@ impl ToolHealthTracker {
                     signature: signature.clone(),
                     success: outcome.success,
                     at_epoch: outcome.at_epoch,
+                    failure_category: outcome.failure_category,
                 })
             })
             .collect();
@@ -1329,12 +1404,14 @@ mod tests {
                         latency_ms: 12,
                         result_hash: 11,
                         at_epoch: 10,
+                        failure_category: None,
                     },
                     ToolOutcome {
                         success: true,
                         latency_ms: 8,
                         result_hash: 22,
                         at_epoch: 20,
+                        failure_category: None,
                     },
                 ],
             }],
@@ -1355,6 +1432,58 @@ mod tests {
     }
 
     // ─── Outcome cache (P3.2) ─────────────────────────────────────────────
+
+    #[test]
+    fn tool_outcome_new_auto_classifies_failure_category() {
+        let ok = ToolOutcome::new(true, 5, "whatever");
+        assert_eq!(ok.failure_category, None);
+
+        let timeout = ToolOutcome::new(false, 130_000, "Error: operation timed out after 120s");
+        assert_eq!(timeout.failure_category, Some(FailureCategory::Timeout));
+
+        let perm = ToolOutcome::new(false, 4, "Error: Permission denied (EACCES)");
+        assert_eq!(
+            perm.failure_category,
+            Some(FailureCategory::PermissionDenied)
+        );
+    }
+
+    #[test]
+    fn failure_category_tag_roundtrip_is_stable() {
+        for cat in [
+            FailureCategory::CompileError,
+            FailureCategory::TestFailure,
+            FailureCategory::PermissionDenied,
+            FailureCategory::ResourceNotFound,
+            FailureCategory::NetworkError,
+            FailureCategory::SyntaxError,
+            FailureCategory::RuntimeError,
+            FailureCategory::Timeout,
+            FailureCategory::ResourceExhaustion,
+            FailureCategory::ValidationError,
+            FailureCategory::Unknown,
+        ] {
+            let tag = failure_category_tag(cat);
+            assert_eq!(failure_category_from_tag(tag), Some(cat));
+        }
+        assert_eq!(failure_category_from_tag("bogus"), None);
+    }
+
+    #[test]
+    fn latest_outcomes_propagate_failure_category() {
+        let mut tracker = ToolHealthTracker::new();
+        tracker.record_outcome(
+            r#"bash:{"command":"curl https://x"}"#,
+            ToolOutcome::new(false, 3_000, "Error: connection refused by server"),
+        );
+        let hints = tracker.latest_outcomes(1);
+        assert_eq!(hints.len(), 1);
+        assert!(!hints[0].success);
+        assert_eq!(
+            hints[0].failure_category,
+            Some(FailureCategory::NetworkError)
+        );
+    }
 
     #[test]
     fn outcome_cache_records_and_recalls_most_recent() {
@@ -1409,6 +1538,7 @@ mod tests {
                 latency_ms: 1,
                 result_hash: 1,
                 at_epoch: 10,
+                failure_category: None,
             },
         );
         tracker.record_outcome(
@@ -1418,6 +1548,7 @@ mod tests {
                 latency_ms: 2,
                 result_hash: 2,
                 at_epoch: 20,
+                failure_category: None,
             },
         );
 
@@ -1443,6 +1574,7 @@ mod tests {
                 latency_ms: 1,
                 result_hash: 1,
                 at_epoch: now,
+                failure_category: None,
             },
         );
         tracker.record_outcome(
@@ -1452,6 +1584,7 @@ mod tests {
                 latency_ms: 1,
                 result_hash: 2,
                 at_epoch: now,
+                failure_category: None,
             },
         );
         tracker.record_outcome(
@@ -1461,6 +1594,7 @@ mod tests {
                 latency_ms: 2,
                 result_hash: 3,
                 at_epoch: now,
+                failure_category: None,
             },
         );
         tracker.record_outcome(
@@ -1470,6 +1604,7 @@ mod tests {
                 latency_ms: 2,
                 result_hash: 4,
                 at_epoch: now,
+                failure_category: None,
             },
         );
 
@@ -1491,6 +1626,7 @@ mod tests {
                 latency_ms: 1,
                 result_hash: 1,
                 at_epoch: 10, // far in the past
+                failure_category: None,
             },
         );
         let bias = tracker.outcome_bias_by_tool(3600);

--- a/rust/crates/runtime/src/self_model.rs
+++ b/rust/crates/runtime/src/self_model.rs
@@ -114,6 +114,11 @@ pub struct OutcomeMemoryHint {
     pub tool_name: String,
     pub signature: String,
     pub success: bool,
+    /// Stable snake_case tag of the structured failure class when the
+    /// recorded outcome was a failure (e.g. `"timeout"`, `"permission_denied"`).
+    /// Always `None` for successes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_category: Option<String>,
 }
 
 /// Current execution state.
@@ -316,6 +321,9 @@ impl SelfModel {
                     tool_name: hint.tool_name,
                     signature: hint.signature,
                     success: hint.success,
+                    failure_category: hint
+                        .failure_category
+                        .map(|c| astra_turn_core::tool_health::failure_category_tag(c).to_string()),
                 })
                 .collect();
         }
@@ -472,11 +480,14 @@ fn goal_tracking_status(effective_goal: Option<&str>, tracked_goal: Option<&str>
 }
 
 fn render_outcome_memory_hint(hint: &OutcomeMemoryHint) -> String {
-    format!(
-        "{} {}",
-        if hint.success { "ok" } else { "fail" },
-        truncate_str(&hint.signature, 56)
-    )
+    let status = if hint.success {
+        "ok".to_string()
+    } else if let Some(ref cat) = hint.failure_category {
+        format!("fail[{cat}]")
+    } else {
+        "fail".to_string()
+    };
+    format!("{} {}", status, truncate_str(&hint.signature, 56))
 }
 
 // ─── System Prompt Rendering ────────────────────────────────────────────────
@@ -1068,6 +1079,7 @@ mod tests {
                 latency_ms: 9,
                 result_hash: 11,
                 at_epoch: 10,
+                failure_category: None,
             },
         );
         health.record_outcome(
@@ -1077,6 +1089,9 @@ mod tests {
                 latency_ms: 12,
                 result_hash: 22,
                 at_epoch: 20,
+                failure_category: Some(
+                    astra_turn_core::action_compensation::FailureCategory::Timeout,
+                ),
             },
         );
 
@@ -1119,6 +1134,10 @@ mod tests {
         assert!(
             section.contains(r#"bash:{"command":"pwd"}"#),
             "got: {section}"
+        );
+        assert!(
+            section.contains("fail[timeout]"),
+            "failure category tag should be rendered alongside signature, got: {section}"
         );
     }
 

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
@@ -1183,6 +1183,7 @@ mod tests {
                 latency_ms: 10,
                 result_hash: 1,
                 at_epoch: now_epoch,
+                failure_category: None,
             },
         );
         harness.turn_guard.health.record_outcome(
@@ -1192,6 +1193,7 @@ mod tests {
                 latency_ms: 12,
                 result_hash: 2,
                 at_epoch: now_epoch,
+                failure_category: None,
             },
         );
 
@@ -1229,6 +1231,7 @@ mod tests {
                 latency_ms: 10,
                 result_hash: 1,
                 at_epoch: now_epoch,
+                failure_category: None,
             },
         );
         harness.turn_guard.health.record_outcome(
@@ -1238,6 +1241,7 @@ mod tests {
                 latency_ms: 8,
                 result_hash: 2,
                 at_epoch: now_epoch,
+                failure_category: None,
             },
         );
 
@@ -1270,6 +1274,7 @@ mod tests {
                 latency_ms: 10,
                 result_hash: 1,
                 at_epoch: now_epoch,
+                failure_category: None,
             },
         );
         session_one_guard.health.record_outcome(
@@ -1279,6 +1284,7 @@ mod tests {
                 latency_ms: 12,
                 result_hash: 2,
                 at_epoch: now_epoch,
+                failure_category: None,
             },
         );
 
@@ -1399,6 +1405,7 @@ mod tests {
                 latency_ms: 10,
                 result_hash: 1,
                 at_epoch: now_epoch,
+                failure_category: None,
             },
         );
         prior_guard.health.record_outcome(
@@ -1408,6 +1415,7 @@ mod tests {
                 latency_ms: 11,
                 result_hash: 2,
                 at_epoch: now_epoch,
+                failure_category: None,
             },
         );
         let restored =

--- a/rust/crates/runtime/tests/improvement_proofs.rs
+++ b/rust/crates/runtime/tests/improvement_proofs.rs
@@ -7464,6 +7464,7 @@ mod learning_sync_cloud_proofs {
                     latency_ms: 9,
                     result_hash: 42,
                     at_epoch: 100,
+                    failure_category: None,
                 }],
             }],
         }];


### PR DESCRIPTION
First slice of the post-PR-#193 5-pillar gap audit.

## Gap (L1 — observable truth)

\`ToolOutcome\` already classifies every failed tool call into a structured \`FailureCategory\` (Timeout / PermissionDenied / NetworkError / …) at record time, but the category was dropped before reaching the next-turn system prompt. The agent saw \`fail bash:{\"command\":\"...\"}\` with no *why*, so it couldn't distinguish \"retry this timeout\" from \"need different tool for permission error.\"

## Fix

- \`ToolOutcome\` (session + persisted pipeline type) + \`RecentOutcomeHint\` + \`OutcomeMemoryHint\` all carry the category through to prompt rendering.
- \`ToolOutcome::new\` auto-classifies via the existing \`classify_execution_outcome\` — zero new call-site work for producers.
- \`render_outcome_memory_hint\` now emits \`fail[timeout] bash:{\"command\":\"...\"}\` so the agent perceives the failure *kind* alongside the signature.
- Cloud-sync / cross-session persistence preserves the tag (schema-additive, skip-if-none).

## Hard-requirement fit

1. High-density signal: one extra bracketed tag, zero prompt bloat.
2. Structured hook: enum → stable snake_case tag, one call site.
3. Preserves hard boundary: no policy change, purely a read-side enrichment.

## Tests

- 3 new \`astra-turn-core\` unit tests (auto-classify on new, tag roundtrip, propagation through \`latest_outcomes\`).
- Extended \`self_model::system_prompt_section_surfaces_outcome_memory\` to assert \`fail[timeout]\` is rendered.
- \`make format\` ✅, \`make check\` ✅.
- \`cargo test -p astra-turn-core -p astra-evolution --lib\` → 2273 + 41 passed / 0 failed.

Part of a phase-by-phase series addressing 6 gaps from the perception audit (see PR #193 for the L2/L5 slice).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>