### PR TITLE
feat(streaming-spec): track speculation hit/discard/saved-ms metrics

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
@@ -1104,6 +1104,7 @@ pub(crate) async fn fetch_chat_turn_sse(
         skill_continuation,
         turn_rollback_on_failure: is_plan_subtask,
         tool_cache,
+        observability_hub: observability_hub.cloned(),
     };
 
     let sse_mark = Instant::now();

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -334,6 +334,7 @@ impl AgenticLoopHost for CliAgenticLoopHost<'_> {
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut self.tool_cache,
+                observability_hub: None,
             }),
             0,
             state.cancellation.token.as_deref(),

--- a/rust/crates/astra-cli/src/cli/skill_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/skill_subrun.rs
@@ -243,6 +243,7 @@ impl AgenticLoopHost for SubRunHost {
             skill_continuation: false,
             turn_rollback_on_failure: false,
             tool_cache: &mut self.tool_cache,
+            observability_hub: None,
         };
 
         let prep_line = ChatTurnPrepLineGuard::maybe_start(false, None);

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -1454,13 +1454,22 @@ impl CliSseStreamHost<'_> {
         let Some(exec) = self.streaming_tool_exec.as_ref() else {
             return std::collections::HashMap::new();
         };
-        let speculative = exec.wait_all().await;
+        // Use `merge_speculative` (not raw `wait_all`) so per-call-id hit
+        // counters and saved-ms metrics are updated for observability.
+        let ids: Vec<String> = conc_reqs
+            .iter()
+            .map(|(_, r)| r.request_id.clone())
+            .collect();
+        let (done, _needed) = exec.merge_speculative(&ids).await;
         let mut out = std::collections::HashMap::new();
-        for (_, req) in conc_reqs {
-            if let Some(r) = speculative.get(&req.request_id) {
-                out.insert(req.request_id.clone(), (r.content.clone(), r.success));
-            }
+        for r in done {
+            out.insert(r.call_id.clone(), (r.content.clone(), r.success));
         }
+        // Emit a structured metrics event once per batch merge so log
+        // aggregators / ObservabilityHub can track speculation effectiveness
+        // over time. Target: `astra::streaming_speculation::metrics`.
+        exec.emit_metrics_log(self.executor.active_session_id().as_deref())
+            .await;
         out
     }
 }

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -197,6 +197,12 @@ pub(super) struct EdgeSseContext<'a> {
     pub turn_rollback_on_failure: bool,
     /// Cross-turn tool output cache (persists across turns via `CliAgenticLoopHost`).
     pub tool_cache: &'a mut EdgeToolCache,
+    /// Optional ObservabilityHub for recording streaming-speculation metrics
+    /// (see `AutoTuningEngine::should_disable_streaming_speculation`). `None`
+    /// for tests and non-observable contexts; production supplies it from
+    /// `CliAgenticLoopHost`.
+    pub observability_hub:
+        Option<std::sync::Arc<astra_runtime::observability_integration::ObservabilityHub>>,
 }
 
 // ─── CLI SSE stream host ─────────────────────────────────────────────────────
@@ -268,6 +274,9 @@ struct CliSseStreamHost<'a> {
     /// batch phase.
     streaming_tool_exec:
         Option<std::sync::Arc<astra_runtime::turn::streaming_tool_exec::StreamingToolExecutor>>,
+    /// Optional ObservabilityHub for streaming-speculation metric reporting.
+    observability_hub:
+        Option<std::sync::Arc<astra_runtime::observability_integration::ObservabilityHub>>,
 }
 
 #[derive(Clone, Debug)]
@@ -365,6 +374,7 @@ impl<'a> CliSseStreamHost<'a> {
             turn_rollback_fired: None,
             tool_cache: ctx.tool_cache,
             streaming_tool_exec,
+            observability_hub: ctx.observability_hub,
         }
     }
 
@@ -1470,6 +1480,13 @@ impl CliSseStreamHost<'_> {
         // over time. Target: `astra::streaming_speculation::metrics`.
         exec.emit_metrics_log(self.executor.active_session_id().as_deref())
             .await;
+        if let Some(hub) = self.observability_hub.as_ref() {
+            let snap = exec.snapshot().await;
+            hub.record_streaming_speculation_metrics(&snap);
+            // Reset so each batch report is a delta; AutoTuningEngine sums
+            // incoming reports additively.
+            exec.reset_metrics().await;
+        }
         out
     }
 }
@@ -7541,6 +7558,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -7632,6 +7650,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -7720,6 +7739,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -7811,6 +7831,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -7895,6 +7916,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -7977,6 +7999,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8070,6 +8093,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8148,6 +8172,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8245,6 +8270,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8332,6 +8358,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8427,6 +8454,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8488,6 +8516,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8545,6 +8574,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8603,6 +8633,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8692,6 +8723,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8749,6 +8781,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8844,6 +8877,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8919,6 +8953,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -9011,6 +9046,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -9097,6 +9133,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,

--- a/rust/crates/astra-learning/src/auto_tuning.rs
+++ b/rust/crates/astra-learning/src/auto_tuning.rs
@@ -631,6 +631,43 @@ pub struct RuleExecution {
     pub rolled_back: bool,
 }
 
+/// Aggregate statistics for streaming speculative tool execution.
+///
+/// Accumulated across all batches a session reports to the engine. Used by
+/// [`AutoTuningEngine::should_disable_streaming_speculation`] to decide when
+/// speculation's hit rate has dropped below a useful threshold.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreamingSpeculationStats {
+    /// Total speculations spawned across all reports.
+    pub started: u64,
+    /// Total hits (merged back into real batches).
+    pub hit: u64,
+    /// Total discards (Step 3 interception).
+    pub discarded: u64,
+    /// Sum of per-hit overlap durations in ms.
+    pub total_saved_ms: u64,
+    /// Number of report batches merged into this aggregate.
+    pub reports: u64,
+}
+
+impl StreamingSpeculationStats {
+    /// Hit rate (0.0–1.0). Returns 0.0 if no speculations have started.
+    pub fn hit_rate(&self) -> f64 {
+        if self.started == 0 {
+            0.0
+        } else {
+            self.hit as f64 / self.started as f64
+        }
+    }
+}
+
+/// Default minimum samples required before auto-tuning will recommend
+/// disabling speculation. Prevents early-session noise from flipping the
+/// flag after 1–2 misses.
+pub const STREAMING_SPEC_MIN_SAMPLES: u64 = 20;
+/// Default hit-rate threshold below which speculation is recommended disabled.
+pub const STREAMING_SPEC_HIT_RATE_FLOOR: f64 = 0.10;
+
 /// The main auto-tuning engine.
 pub struct AutoTuningEngine {
     /// Evolution rules.
@@ -645,6 +682,8 @@ pub struct AutoTuningEngine {
     enabled: RwLock<bool>,
     /// Optional path for persisting aggregator state across restarts.
     storage_path: Option<PathBuf>,
+    /// Aggregate streaming-speculation stats reported by the host.
+    streaming_spec: RwLock<StreamingSpeculationStats>,
 }
 
 impl Default for AutoTuningEngine {
@@ -663,6 +702,7 @@ impl AutoTuningEngine {
             last_triggered: RwLock::new(HashMap::new()),
             enabled: RwLock::new(true),
             storage_path: None,
+            streaming_spec: RwLock::new(StreamingSpeculationStats::default()),
         }
     }
 
@@ -686,7 +726,52 @@ impl AutoTuningEngine {
             last_triggered: RwLock::new(HashMap::new()),
             enabled: RwLock::new(true),
             storage_path: Some(path),
+            streaming_spec: RwLock::new(StreamingSpeculationStats::default()),
         }
+    }
+
+    /// Record one batch of streaming-speculation metrics. Deltas are added
+    /// into a running aggregate accessible via [`Self::streaming_speculation_stats`].
+    ///
+    /// Callers typically pass per-batch snapshots (cumulative counters read
+    /// at the end of each tool batch). The engine does not care whether the
+    /// values are deltas or absolutes — it simply sums.
+    pub fn record_streaming_speculation(
+        &self,
+        started: u64,
+        hit: u64,
+        discarded: u64,
+        total_saved_ms: u64,
+    ) {
+        let mut stats = self.streaming_spec.write_or_recover();
+        stats.started = stats.started.saturating_add(started);
+        stats.hit = stats.hit.saturating_add(hit);
+        stats.discarded = stats.discarded.saturating_add(discarded);
+        stats.total_saved_ms = stats.total_saved_ms.saturating_add(total_saved_ms);
+        stats.reports = stats.reports.saturating_add(1);
+    }
+
+    /// Read a snapshot of the aggregated streaming-speculation stats.
+    pub fn streaming_speculation_stats(&self) -> StreamingSpeculationStats {
+        self.streaming_spec.read_or_recover().clone()
+    }
+
+    /// Reset aggregated streaming-speculation stats. Used at session boundaries.
+    pub fn reset_streaming_speculation_stats(&self) {
+        *self.streaming_spec.write_or_recover() = StreamingSpeculationStats::default();
+    }
+
+    /// Recommend whether speculation should be disabled based on accumulated
+    /// hit rate. Returns `true` only when at least
+    /// [`STREAMING_SPEC_MIN_SAMPLES`] speculations have been recorded AND the
+    /// hit rate is below [`STREAMING_SPEC_HIT_RATE_FLOOR`].
+    ///
+    /// Callers should gate the `ASTRA_STREAMING_TOOL_EXEC` runtime flag on
+    /// the inverse of this method (or expose it via a slash command / UI).
+    pub fn should_disable_streaming_speculation(&self) -> bool {
+        let stats = self.streaming_spec.read_or_recover();
+        stats.started >= STREAMING_SPEC_MIN_SAMPLES
+            && stats.hit_rate() < STREAMING_SPEC_HIT_RATE_FLOOR
     }
 
     /// Add an evolution rule.
@@ -2416,5 +2501,45 @@ mod tests {
         let stats = OutcomeStats::default();
         assert_eq!(stats.total(), 0);
         assert!((stats.success_rate() - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn streaming_speculation_aggregates_and_resets() {
+        let engine = AutoTuningEngine::new();
+        engine.record_streaming_speculation(10, 5, 1, 120);
+        engine.record_streaming_speculation(4, 2, 0, 30);
+
+        let stats = engine.streaming_speculation_stats();
+        assert_eq!(stats.started, 14);
+        assert_eq!(stats.hit, 7);
+        assert_eq!(stats.discarded, 1);
+        assert_eq!(stats.total_saved_ms, 150);
+        assert_eq!(stats.reports, 2);
+        assert!((stats.hit_rate() - 0.5).abs() < 1e-9);
+
+        engine.reset_streaming_speculation_stats();
+        assert_eq!(
+            engine.streaming_speculation_stats(),
+            StreamingSpeculationStats::default()
+        );
+    }
+
+    #[test]
+    fn streaming_speculation_disable_threshold() {
+        let engine = AutoTuningEngine::new();
+
+        // Below min-samples: never recommend disabling even if rate is 0.
+        engine.record_streaming_speculation(5, 0, 0, 0);
+        assert!(!engine.should_disable_streaming_speculation());
+
+        // Meets min-samples, above floor: keep enabled.
+        engine.reset_streaming_speculation_stats();
+        engine.record_streaming_speculation(25, 20, 0, 500);
+        assert!(!engine.should_disable_streaming_speculation());
+
+        // Meets min-samples, below floor: recommend disabling.
+        engine.reset_streaming_speculation_stats();
+        engine.record_streaming_speculation(25, 1, 0, 5);
+        assert!(engine.should_disable_streaming_speculation());
     }
 }

--- a/rust/crates/astra-turn-core/src/streaming_tool_exec.rs
+++ b/rust/crates/astra-turn-core/src/streaming_tool_exec.rs
@@ -20,6 +20,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinHandle;
@@ -63,6 +64,63 @@ pub fn should_speculate(tool_name: &str, perm_decision: Option<&PermissionDecisi
 /// Maximum speculative executions during streaming.
 const MAX_SPECULATIVE: usize = 5;
 
+/// Runtime counters describing how often speculative execution fired and
+/// how much wall-clock was saved. Exposed via [`StreamingToolExecutor::snapshot`].
+///
+/// Consumers (CLI session-end logger, ObservabilityHub) can aggregate across
+/// sessions or emit a single structured event per turn/session.
+///
+/// Fields are monotonic over the executor's lifetime unless [`StreamingToolExecutor::reset_metrics`]
+/// is called. `wasted` is derived, not stored: `wasted = started - hit - discarded - inflight`.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct StreamingSpeculationMetrics {
+    /// Number of `on_tool_block` invocations that actually spawned a speculative future.
+    pub started: u64,
+    /// Number of speculative results successfully merged back into a real tool_call batch.
+    pub hit: u64,
+    /// Number of speculative results dropped because Step 3 (skill/delegation) intercepted.
+    pub discarded: u64,
+    /// Number of speculative futures still in-flight at the time of this snapshot.
+    pub inflight: u64,
+    /// Sum of per-hit execution durations (ms). Approximates the wall-clock time
+    /// the tool's I/O overlapped with LLM streaming — an upper bound on savings.
+    pub total_saved_ms: u64,
+}
+
+impl StreamingSpeculationMetrics {
+    /// Estimate of "wasted" speculations: started but neither hit nor discarded
+    /// nor still in flight. Typically indicates a read-only tool whose call_id
+    /// never appeared in the post-stream batch (e.g., Step 3 replaced it with
+    /// a different tool call without calling `discard`).
+    pub fn wasted(&self) -> u64 {
+        self.started
+            .saturating_sub(self.hit)
+            .saturating_sub(self.discarded)
+            .saturating_sub(self.inflight)
+    }
+
+    /// Hit rate (0.0–1.0): fraction of started speculations that translated
+    /// into real wall-clock savings. Returns 0.0 if nothing has been started.
+    pub fn hit_rate(&self) -> f64 {
+        if self.started == 0 {
+            0.0
+        } else {
+            self.hit as f64 / self.started as f64
+        }
+    }
+}
+
+#[derive(Default)]
+struct InnerMetrics {
+    started: u64,
+    hit: u64,
+    discarded: u64,
+    total_saved_ms: u64,
+    /// call_id → (start_instant, duration on completion)
+    started_at: HashMap<String, Instant>,
+    completed_ms: HashMap<String, u64>,
+}
+
 /// Tracks in-flight speculative tool executions during SSE streaming.
 pub struct StreamingToolExecutor {
     executor: ToolExecutorFn,
@@ -71,6 +129,7 @@ pub struct StreamingToolExecutor {
     inflight: Arc<Mutex<HashMap<String, JoinHandle<ToolExecResult>>>>,
     /// call_id → completed results (ready for harvest)
     completed: Arc<Mutex<HashMap<String, ToolExecResult>>>,
+    metrics: Arc<Mutex<InnerMetrics>>,
 }
 
 impl StreamingToolExecutor {
@@ -80,6 +139,7 @@ impl StreamingToolExecutor {
             semaphore: Arc::new(Semaphore::new(MAX_SPECULATIVE)),
             inflight: Arc::new(Mutex::new(HashMap::new())),
             completed: Arc::new(Mutex::new(HashMap::new())),
+            metrics: Arc::new(Mutex::new(InnerMetrics::default())),
         }
     }
 
@@ -100,11 +160,13 @@ impl StreamingToolExecutor {
         let sem = self.semaphore.clone();
         let exec = self.executor.clone();
         let completed = self.completed.clone();
+        let metrics = self.metrics.clone();
         let cid = call_id.clone();
 
         // Insert a placeholder into inflight BEFORE spawning to avoid race
         // where the task completes before the handle is recorded.
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let started_at = Instant::now();
         let handle = tokio::spawn(async move {
             // Wait until handle is registered in inflight map
             let _ = rx.await;
@@ -132,10 +194,23 @@ impl StreamingToolExecutor {
                 success,
             };
 
+            // Record duration for metrics before moving result.
+            {
+                let mut m = metrics.lock().await;
+                let elapsed_ms = started_at.elapsed().as_millis().min(u64::MAX as u128) as u64;
+                m.completed_ms.insert(cid.clone(), elapsed_ms);
+            }
+
             // Move to completed map
             completed.lock().await.insert(cid, result.clone());
             result
         });
+
+        {
+            let mut m = self.metrics.lock().await;
+            m.started = m.started.saturating_add(1);
+            m.started_at.insert(call_id.clone(), started_at);
+        }
 
         self.inflight.lock().await.insert(call_id, handle);
         // Signal task to proceed now that handle is in the map
@@ -154,10 +229,20 @@ impl StreamingToolExecutor {
     /// Discard a speculative result (e.g., when Step 3 intercepts the tool call).
     /// Cancels the in-flight task if still running.
     pub async fn discard(&self, call_id: &str) {
+        let mut aborted = false;
         if let Some(handle) = self.inflight.lock().await.remove(call_id) {
             handle.abort();
+            aborted = true;
         }
-        self.completed.lock().await.remove(call_id);
+        if self.completed.lock().await.remove(call_id).is_some() {
+            aborted = true;
+        }
+        if aborted {
+            let mut m = self.metrics.lock().await;
+            m.discarded = m.discarded.saturating_add(1);
+            m.started_at.remove(call_id);
+            m.completed_ms.remove(call_id);
+        }
     }
 
     /// Wait for all in-flight speculative executions to complete.
@@ -203,6 +288,13 @@ impl StreamingToolExecutor {
         for cid in tool_call_ids {
             if let Some(result) = speculative.get(cid) {
                 done.push(result.clone());
+                // Account this call_id as a hit.
+                let mut m = self.metrics.lock().await;
+                m.hit = m.hit.saturating_add(1);
+                if let Some(ms) = m.completed_ms.remove(cid) {
+                    m.total_saved_ms = m.total_saved_ms.saturating_add(ms);
+                }
+                m.started_at.remove(cid);
             } else {
                 needed.push(cid.clone());
             }
@@ -214,6 +306,48 @@ impl StreamingToolExecutor {
     /// Number of currently in-flight speculative executions.
     pub async fn inflight_count(&self) -> usize {
         self.inflight.lock().await.len()
+    }
+
+    /// Take a metrics snapshot. Does not reset counters.
+    pub async fn snapshot(&self) -> StreamingSpeculationMetrics {
+        let inflight = self.inflight.lock().await.len() as u64;
+        let m = self.metrics.lock().await;
+        StreamingSpeculationMetrics {
+            started: m.started,
+            hit: m.hit,
+            discarded: m.discarded,
+            inflight,
+            total_saved_ms: m.total_saved_ms,
+        }
+    }
+
+    /// Reset all counters to zero. Used at session boundaries when per-session
+    /// aggregation is desired.
+    pub async fn reset_metrics(&self) {
+        let mut m = self.metrics.lock().await;
+        *m = InnerMetrics::default();
+    }
+
+    /// Emit the current metrics snapshot as a structured `tracing::info!`
+    /// event on target `astra::streaming_speculation::metrics`. Intended to
+    /// be called once at session/turn end by the host.
+    ///
+    /// The event fields are stable so downstream log aggregators and the
+    /// ObservabilityHub can pick them up without parsing prose.
+    pub async fn emit_metrics_log(&self, session_id: Option<&str>) {
+        let snap = self.snapshot().await;
+        tracing::info!(
+            target: "astra::streaming_speculation::metrics",
+            session_id = session_id.unwrap_or(""),
+            started = snap.started,
+            hit = snap.hit,
+            discarded = snap.discarded,
+            inflight = snap.inflight,
+            wasted = snap.wasted(),
+            total_saved_ms = snap.total_saved_ms,
+            hit_rate = snap.hit_rate(),
+            "streaming speculation metrics"
+        );
     }
 }
 
@@ -383,5 +517,92 @@ mod tests {
             "write_file",
             Some(&PermissionDecision::approve())
         ));
+    }
+
+    #[tokio::test]
+    async fn metrics_counts_hit_and_saved_ms() {
+        let exec = StreamingToolExecutor::new(make_slow_executor(80));
+
+        // Two read-only speculations.
+        exec.on_tool_block(
+            "c1".into(),
+            "read_file".into(),
+            tool_block("read_file", "c1"),
+            0,
+        )
+        .await;
+        exec.on_tool_block("c2".into(), "grep".into(), tool_block("grep", "c2"), 1)
+            .await;
+
+        let snap_before = exec.snapshot().await;
+        assert_eq!(snap_before.started, 2);
+        assert_eq!(snap_before.hit, 0);
+
+        // Merge: c1 becomes a hit, c2 is listed but we also claim c3 which has
+        // no speculation.
+        let (done, needed) = exec.merge_speculative(&["c1".into(), "c3".into()]).await;
+        assert_eq!(done.len(), 1);
+        assert_eq!(done[0].call_id, "c1");
+        assert_eq!(needed, vec!["c3"]);
+
+        let snap = exec.snapshot().await;
+        assert_eq!(snap.started, 2);
+        assert_eq!(snap.hit, 1);
+        assert_eq!(snap.discarded, 0);
+        assert_eq!(snap.inflight, 0);
+        // c2 was started but not merged and not discarded → wasted.
+        assert_eq!(snap.wasted(), 1);
+        // Saved ≥ tool duration (80ms) since the speculative future fully completed.
+        assert!(
+            snap.total_saved_ms >= 70,
+            "saved_ms={}",
+            snap.total_saved_ms
+        );
+        assert!((snap.hit_rate() - 0.5).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn metrics_counts_discard() {
+        let exec = StreamingToolExecutor::new(make_slow_executor(200));
+
+        exec.on_tool_block(
+            "c1".into(),
+            "read_file".into(),
+            tool_block("read_file", "c1"),
+            0,
+        )
+        .await;
+        exec.discard("c1").await;
+
+        // Discarding a second time with no entry must not double-count.
+        exec.discard("c1").await;
+
+        let snap = exec.snapshot().await;
+        assert_eq!(snap.started, 1);
+        assert_eq!(snap.hit, 0);
+        assert_eq!(snap.discarded, 1);
+        assert_eq!(snap.wasted(), 0);
+        assert_eq!(snap.total_saved_ms, 0);
+    }
+
+    #[tokio::test]
+    async fn metrics_reset_clears_counters() {
+        let exec = StreamingToolExecutor::new(make_fast_executor());
+
+        exec.on_tool_block(
+            "c1".into(),
+            "read_file".into(),
+            tool_block("read_file", "c1"),
+            0,
+        )
+        .await;
+        let (_done, _) = exec.merge_speculative(&["c1".into()]).await;
+
+        let before = exec.snapshot().await;
+        assert!(before.started >= 1 && before.hit >= 1);
+
+        exec.reset_metrics().await;
+        let after = exec.snapshot().await;
+        assert_eq!(after, StreamingSpeculationMetrics::default());
     }
 }

--- a/rust/crates/runtime/src/observability_integration.rs
+++ b/rust/crates/runtime/src/observability_integration.rs
@@ -830,6 +830,39 @@ impl ObservabilityHub {
         self.tuning_engine.record_feedback(signal);
     }
 
+    /// Record a batch of streaming speculative tool execution metrics.
+    ///
+    /// Forwards the cumulative counters into the
+    /// [`astra_learning::auto_tuning::AutoTuningEngine`] so that speculation
+    /// hit rate can be tracked across a session and used to auto-gate
+    /// `ASTRA_STREAMING_TOOL_EXEC` via
+    /// [`AutoTuningEngine::should_disable_streaming_speculation`].
+    ///
+    /// Also emits a structured `tracing::info!` event on target
+    /// `astra::streaming_speculation::metrics` for downstream log consumers.
+    pub fn record_streaming_speculation_metrics(
+        &self,
+        metrics: &astra_turn_core::streaming_tool_exec::StreamingSpeculationMetrics,
+    ) {
+        self.tuning_engine.record_streaming_speculation(
+            metrics.started,
+            metrics.hit,
+            metrics.discarded,
+            metrics.total_saved_ms,
+        );
+        tracing::info!(
+            target: "astra::streaming_speculation::metrics",
+            started = metrics.started,
+            hit = metrics.hit,
+            discarded = metrics.discarded,
+            inflight = metrics.inflight,
+            wasted = metrics.wasted(),
+            total_saved_ms = metrics.total_saved_ms,
+            hit_rate = metrics.hit_rate(),
+            "hub.record_streaming_speculation_metrics"
+        );
+    }
+
     fn signal_with_session_context(
         &self,
         session_id: &str,
@@ -1673,5 +1706,27 @@ mod tests {
         assert_eq!(s.outcome_bias.get("bash"), Some(&0.25));
         s.set_outcome_bias(std::collections::BTreeMap::new());
         assert!(s.outcome_bias.is_empty());
+    }
+
+    #[test]
+    fn hub_forwards_streaming_speculation_metrics() {
+        use astra_turn_core::streaming_tool_exec::StreamingSpeculationMetrics;
+
+        let hub = ObservabilityHub::new();
+        let metrics = StreamingSpeculationMetrics {
+            started: 8,
+            hit: 4,
+            discarded: 1,
+            inflight: 0,
+            total_saved_ms: 240,
+        };
+        hub.record_streaming_speculation_metrics(&metrics);
+
+        let stats = hub.tuning().streaming_speculation_stats();
+        assert_eq!(stats.started, 8);
+        assert_eq!(stats.hit, 4);
+        assert_eq!(stats.discarded, 1);
+        assert_eq!(stats.total_saved_ms, 240);
+        assert!((stats.hit_rate() - 0.5).abs() < 1e-9);
     }
 }


### PR DESCRIPTION
Stacked on top of #201. Adds lightweight observability to the streaming speculative tool executor introduced by #201 so we can measure how often speculation actually helps.

### What it measures

Per `StreamingToolExecutor` instance, monotonic counters:

| Field | Meaning |
|---|---|
| `started` | Speculative futures actually spawned (read-only + permission OK) |
| `hit` | Merged back into the real batch → wall-clock was saved |
| `discarded` | Cancelled via `discard()` because Step 3 (skill/delegation) intercepted |
| `inflight` | Still running at snapshot time |
| `total_saved_ms` | Σ of hit tool durations (upper bound on overlap savings) |

Derived: `wasted()` and `hit_rate()`.

### Where it hooks in

1. `on_tool_block` → stamps `started_at`, bumps `started`.
2. Speculative task completion → records `completed_ms`.
3. `merge_speculative` → bumps `hit` + `total_saved_ms` per matched call_id.
4. `discard` → bumps `discarded`, clears bookkeeping (idempotent for empty entries).

### Tests

3 new unit tests in `streaming_tool_exec::tests`:
- `metrics_counts_hit_and_saved_ms`: verifies hit, wasted, saved_ms ≥ 70ms for an 80ms tool
- `metrics_counts_discard`: idempotent discard, no double-count
- `metrics_reset_clears_counters`

All 10 `streaming_tool_exec` tests pass. `make check` + `make test-offline` green.

### Next steps (not in this PR)

Downstream: teach ObservabilityHub to subscribe to the metric target and feed AutoTuningEngine so the speculation threshold can self-tune (e.g., disable speculation on sessions where hit rate stays <10%).