### PR TITLE
refactor(pipeline): rename PatternLibrary::suggest → top_patterns; drop dead exploration variant

### DIFF
--- a/rust/crates/astra-evolution/src/persistence.rs
+++ b/rust/crates/astra-evolution/src/persistence.rs
@@ -992,7 +992,7 @@ mod tests {
 
         // Verify pattern library has patterns from session 1
         let lib = pl2.lock().unwrap();
-        let suggestions = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+        let suggestions = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
         assert!(!suggestions.is_empty());
 
         // Verify calibrator has data from session 1

--- a/rust/crates/astra-pipeline/src/pattern.rs
+++ b/rust/crates/astra-pipeline/src/pattern.rs
@@ -1,23 +1,20 @@
 //! Tool Chain Pattern Library — learns successful tool sequences for reuse.
 //!
 //! Records which tool combinations succeed or fail for each task type and domain,
-//! then suggests the best patterns for similar future queries.
+//! then ranks the best patterns for similar future queries.
 //!
-//! **Note**: The pattern recording and drift signals remain active, but the
-//! L3 adaptive suggestion/exploration layer is being deprecated in favor of
-//! `SelfModel` + LLM reasoning.
+//! **Note**: The L3 adaptive LLM-facing suggestion layer has been retired in favor
+//! of `SelfModel` + LLM reasoning. What remains (`top_patterns`, `boost_terms_for`,
+//! `blocked_tool_names`) are structural internal ranking helpers used by the
+//! TF-IDF router and learned-context prompt summaries — not model-facing
+//! suggestions.
 //!
 //! # Learning flow
 //!
 //! 1. User asks "show me PRs for matrixorigin" → routes to Fetch + GitHub
 //! 2. Agent uses [github_search, github_list_prs] → succeeds (quality 0.9)
 //! 3. Pattern recorded: signature="github_list_prs|github_search", task=Fetch, domain=GitHub
-//! 4. Next similar query → suggest() returns this pattern → boost these tools
-//!
-//! # Exploration
-//!
-//! To prevent pattern drift and discover new tools, `suggest_with_exploration()`
-//! uses epsilon-greedy: 10% chance to include a low-frequency or stale pattern.
+//! 4. Next similar query → `top_patterns()` returns this pattern → boost these tools
 //!
 //! # Integration
 //!
@@ -26,7 +23,7 @@
 //! library.record_outcome(&tools_used, TaskType::Fetch, Some(DomainHint::GitHub), true, 0.9, None);
 //!
 //! // At turn start (Plan):
-//! let suggestions = library.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 3);
+//! let top = library.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 3);
 //! let boost_terms = library.boost_terms_for(TaskType::Fetch, Some(DomainHint::GitHub));
 //! ```
 
@@ -47,8 +44,6 @@ pub enum PatternAction {
 const DECAY_GRACE_DAYS: u64 = 7;
 /// Half-life in days for exponential decay after grace period.
 const DECAY_HALF_LIFE_DAYS: f64 = 30.0;
-/// Probability of including an exploration pattern (epsilon-greedy).
-const EXPLORATION_EPSILON: f64 = 0.1;
 /// Window size for recent outcomes used in drift detection.
 const DRIFT_WINDOW_SIZE: usize = 10;
 /// Drift threshold: if recent success rate drops this much below historical, flag as drifting.
@@ -480,16 +475,17 @@ impl PatternLibrary {
         count
     }
 
-    /// Suggest best patterns for a task type + optional domain filter.
+    /// Top-ranked patterns for a task type + optional domain filter.
     ///
     /// Returns up to `limit` patterns sorted by time-decayed score (descending).
     /// If domain is Some, only returns patterns matching that domain.
     /// Stale patterns are ranked lower even if historically successful.
-    #[deprecated(
-        since = "0.9.0",
-        note = "Superseded by SelfModel + LLM reasoning. Keep pattern recording, but let the model reason over self-awareness instead of precomputed suggestions."
-    )]
-    pub fn suggest(
+    ///
+    /// This is an internal ranking helper used by TF-IDF boost terms,
+    /// learned-context prompt summaries, and task-level tool suggestions.
+    /// It is **not** a model-facing "suggestion" — the LLM reasons over
+    /// the `SelfModel` snapshot instead.
+    pub fn top_patterns(
         &self,
         task_type: TaskType,
         domain: Option<DomainHint>,
@@ -523,86 +519,19 @@ impl PatternLibrary {
         candidates
     }
 
-    /// Suggest patterns with epsilon-greedy exploration.
+    /// Top patterns with forced exploration (for testing).
     ///
-    /// With probability EXPLORATION_EPSILON (10%), includes a low-frequency or
-    /// stale pattern among the suggestions. This helps rediscover tools that
-    /// may have been deprecated due to time decay but are still valuable.
-    ///
-    /// Returns up to `limit` patterns, with the exploration slot (if triggered)
-    /// replacing the last regular suggestion.
-    #[deprecated(
-        since = "0.9.0",
-        note = "Superseded by SelfModel + LLM reasoning. Use self-awareness-driven exploration instead of epsilon-greedy pattern hints."
-    )]
-    pub fn suggest_with_exploration(
-        &self,
-        task_type: TaskType,
-        domain: Option<DomainHint>,
-        limit: usize,
-    ) -> Vec<&ToolChainPattern> {
-        let mut suggestions = self.suggest(task_type, domain, limit);
-
-        // Roll for exploration using timestamp-based pseudo-randomness
-        // Using nanos % 100 gives 0-99, so < 10 is ~10% probability
-        let roll = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.subsec_nanos() % 100)
-            .unwrap_or(50);
-        let should_explore = (roll as f64) < (EXPLORATION_EPSILON * 100.0);
-
-        if !should_explore || limit == 0 {
-            return suggestions;
-        }
-
-        // Find exploration candidates: patterns not in top suggestions, sorted by staleness
-        let top_sigs: std::collections::HashSet<_> =
-            suggestions.iter().map(|p| &p.signature).collect();
-
-        let keys = match self.type_index.get(&task_type) {
-            Some(keys) => keys,
-            None => return suggestions,
-        };
-
-        let mut exploration_candidates: Vec<&ToolChainPattern> = keys
-            .iter()
-            .filter_map(|k| self.patterns.get(k))
-            .filter(|p| !top_sigs.contains(&p.signature))
-            .filter(|p| match domain {
-                Some(d) => p.domain == Some(d) || p.domain.is_none(),
-                None => true,
-            })
-            .filter(|p| p.success_rate() >= 0.3) // Must have some success history
-            .collect();
-
-        if exploration_candidates.is_empty() {
-            return suggestions;
-        }
-
-        // Sort by staleness (oldest first) to prioritize rediscovery
-        exploration_candidates.sort_by_key(|a| a.last_used_at);
-
-        // Replace last suggestion with exploration pick
-        if suggestions.len() >= limit {
-            suggestions.pop();
-        }
-        suggestions.push(exploration_candidates[0]);
-
-        suggestions
-    }
-
-    /// Suggest patterns with forced exploration (for testing).
-    ///
-    /// Same as `suggest_with_exploration` but always triggers exploration
-    /// if exploration candidates exist.
+    /// Always triggers exploration if exploration candidates exist. Replaces
+    /// the epsilon-greedy `suggest_with_exploration` that was retired along
+    /// with the LLM-facing suggestion layer.
     #[cfg(test)]
-    pub fn suggest_with_forced_exploration(
+    pub fn top_patterns_with_forced_exploration(
         &self,
         task_type: TaskType,
         domain: Option<DomainHint>,
         limit: usize,
     ) -> Vec<&ToolChainPattern> {
-        let mut suggestions = self.suggest(task_type, domain, limit);
+        let mut suggestions = self.top_patterns(task_type, domain, limit);
 
         if limit == 0 {
             return suggestions;
@@ -646,7 +575,7 @@ impl PatternLibrary {
     /// Returns tool names from top patterns (success_rate > 0.5) for use as
     /// TF-IDF boost terms in routing.
     pub fn boost_terms_for(&self, task_type: TaskType, domain: Option<DomainHint>) -> Vec<String> {
-        let suggestions = self.suggest(task_type, domain, 3);
+        let suggestions = self.top_patterns(task_type, domain, 3);
         let mut terms: Vec<String> = Vec::new();
         let mut seen = std::collections::HashSet::new();
 
@@ -1268,7 +1197,7 @@ mod tests {
             lib.record_outcome(&tools(&["bash"]), TaskType::Code, None, true, 0.8, None);
         }
 
-        let fetch_suggestions = lib.suggest(TaskType::Fetch, None, 5);
+        let fetch_suggestions = lib.top_patterns(TaskType::Fetch, None, 5);
         assert_eq!(fetch_suggestions.len(), 1);
         assert!(
             fetch_suggestions[0]
@@ -1276,7 +1205,7 @@ mod tests {
                 .contains(&"github_search".to_string())
         );
 
-        let code_suggestions = lib.suggest(TaskType::Code, None, 5);
+        let code_suggestions = lib.top_patterns(TaskType::Code, None, 5);
         assert_eq!(code_suggestions.len(), 1);
         assert!(code_suggestions[0].tools.contains(&"bash".to_string()));
     }
@@ -1305,11 +1234,11 @@ mod tests {
             );
         }
 
-        let github = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+        let github = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
         assert_eq!(github.len(), 1);
         assert!(github[0].tools.contains(&"github_api".to_string()));
 
-        let system = lib.suggest(TaskType::Fetch, Some(DomainHint::System), 5);
+        let system = lib.top_patterns(TaskType::Fetch, Some(DomainHint::System), 5);
         assert_eq!(system.len(), 1);
         assert!(system[0].tools.contains(&"bash".to_string()));
     }
@@ -1319,7 +1248,7 @@ mod tests {
         let mut lib = PatternLibrary::new();
         lib.record_outcome(&tools(&["bash"]), TaskType::Code, None, true, 0.9, None);
         // Only 1 observation → not suggested
-        assert!(lib.suggest(TaskType::Code, None, 5).is_empty());
+        assert!(lib.top_patterns(TaskType::Code, None, 5).is_empty());
     }
 
     #[test]
@@ -1369,7 +1298,7 @@ mod tests {
             );
         }
 
-        let suggestions = lib.suggest(TaskType::Fetch, None, 3);
+        let suggestions = lib.top_patterns(TaskType::Fetch, None, 3);
         assert!(suggestions.len() >= 2);
         // First should be pattern_a (highest score)
         assert!(suggestions[0].score() >= suggestions[1].score());
@@ -1391,14 +1320,14 @@ mod tests {
                 );
             }
         }
-        let suggestions = lib.suggest(TaskType::Code, None, 2);
+        let suggestions = lib.top_patterns(TaskType::Code, None, 2);
         assert_eq!(suggestions.len(), 2);
     }
 
     #[test]
     fn suggest_empty_for_unknown_type() {
         let lib = PatternLibrary::new();
-        assert!(lib.suggest(TaskType::Memory, None, 5).is_empty());
+        assert!(lib.top_patterns(TaskType::Memory, None, 5).is_empty());
     }
 
     // ── Boost terms ──
@@ -1499,7 +1428,7 @@ mod tests {
         lib2.merge(&exported);
         assert_eq!(lib2.len(), 1);
 
-        let suggestions = lib2.suggest(TaskType::Code, None, 5);
+        let suggestions = lib2.top_patterns(TaskType::Code, None, 5);
         assert_eq!(suggestions.len(), 1);
         assert_eq!(suggestions[0].success_count, 5);
     }
@@ -1549,7 +1478,7 @@ mod tests {
 
         // Phase 1: No patterns → no suggestions
         assert!(
-            lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 3)
+            lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 3)
                 .is_empty()
         );
 
@@ -1566,7 +1495,7 @@ mod tests {
         }
 
         // Phase 3: Suggestions now available
-        let suggestions = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 3);
+        let suggestions = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 3);
         assert_eq!(suggestions.len(), 1);
         assert!(suggestions[0].score() > 0.8);
         assert_eq!(suggestions[0].tools.len(), 2);
@@ -1990,7 +1919,7 @@ mod tests {
             None,
         );
 
-        let suggestions = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 2);
+        let suggestions = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 2);
 
         // Recent pattern should rank higher due to time decay
         if suggestions.len() >= 2 {
@@ -2053,14 +1982,14 @@ mod tests {
         }
 
         // Normal suggest should not include old_tool (decayed score too low)
-        let normal = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 2);
+        let normal = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 2);
         let has_old_in_normal = normal
             .iter()
             .any(|p| p.tools.contains(&"old_tool".to_string()));
 
         // Forced exploration should include old_tool
         let explored =
-            lib.suggest_with_forced_exploration(TaskType::Fetch, Some(DomainHint::GitHub), 2);
+            lib.top_patterns_with_forced_exploration(TaskType::Fetch, Some(DomainHint::GitHub), 2);
         let has_old_in_explored = explored
             .iter()
             .any(|p| p.tools.contains(&"old_tool".to_string()));
@@ -2101,7 +2030,7 @@ mod tests {
         }
 
         // Exploration should pick the oldest (old_60)
-        let explored = lib.suggest_with_forced_exploration(TaskType::Fetch, None, 1);
+        let explored = lib.top_patterns_with_forced_exploration(TaskType::Fetch, None, 1);
         let picked = explored.iter().find(|p| {
             p.tools.contains(&"old_60".to_string()) || p.tools.contains(&"old_30".to_string())
         });
@@ -2153,11 +2082,11 @@ mod tests {
         }
 
         // Normal suggest returns top 2 by decayed_score (good_a and good_b)
-        let normal = lib.suggest(TaskType::Fetch, None, 2);
+        let normal = lib.top_patterns(TaskType::Fetch, None, 2);
         let has_bad_in_normal = normal.iter().any(|p| p.tools.contains(&"bad".to_string()));
 
         // Forced exploration: bad pattern excluded because success_rate < 0.3
-        let explored = lib.suggest_with_forced_exploration(TaskType::Fetch, None, 2);
+        let explored = lib.top_patterns_with_forced_exploration(TaskType::Fetch, None, 2);
         let has_bad_in_explored = explored
             .iter()
             .any(|p| p.tools.contains(&"bad".to_string()));
@@ -2181,8 +2110,8 @@ mod tests {
             lib.record_outcome(&tools(&["only"]), TaskType::Fetch, None, true, 0.9, None);
         }
 
-        let normal = lib.suggest(TaskType::Fetch, None, 2);
-        let explored = lib.suggest_with_forced_exploration(TaskType::Fetch, None, 2);
+        let normal = lib.top_patterns(TaskType::Fetch, None, 2);
+        let explored = lib.top_patterns_with_forced_exploration(TaskType::Fetch, None, 2);
 
         // With no exploration candidates, both should return the same
         assert_eq!(normal.len(), explored.len());

--- a/rust/crates/astra-pipeline/src/task_learning.rs
+++ b/rust/crates/astra-pipeline/src/task_learning.rs
@@ -313,7 +313,7 @@ impl TaskLearningBridge for PipelineTaskLearningBridge {
         // Pattern-based suggestions: find top patterns for this task type
         if let Some(pl) = &self.pattern_library {
             let lib = pl.lock().unwrap_or_else(|e| e.into_inner());
-            let patterns = lib.suggest(tt, domain, 3);
+            let patterns = lib.top_patterns(tt, domain, 3);
             for pattern in patterns {
                 suggestions.extend(pattern.tools.iter().cloned());
             }

--- a/rust/crates/astra-turn-core/src/pipeline_learning.rs
+++ b/rust/crates/astra-turn-core/src/pipeline_learning.rs
@@ -867,7 +867,7 @@ mod tests {
         }
 
         let l = lib.lock().unwrap();
-        let suggestions = l.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+        let suggestions = l.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
         assert!(
             !suggestions.is_empty(),
             "pattern library should have learned the tool chain"

--- a/rust/crates/runtime/src/tool_selector.rs
+++ b/rust/crates/runtime/src/tool_selector.rs
@@ -423,7 +423,7 @@ impl TfIdfSelector {
                 Ok(p) => p,
                 Err(e) => e.into_inner(),
             };
-            for pattern in patterns.suggest(routing.task_type, routing.domain_hint, 2) {
+            for pattern in patterns.top_patterns(routing.task_type, routing.domain_hint, 2) {
                 learned.pattern_hints.push(format!(
                     "Successful tool chain for {:?}/{:?}: {} (success {:.0}%, quality {:.2})",
                     pattern.task_type,
@@ -2941,7 +2941,7 @@ mod tests {
         // Verify PatternLibrary recorded the outcome
         {
             let l = lib.lock().unwrap();
-            let suggestions = l.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+            let suggestions = l.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
             assert!(
                 !suggestions.is_empty(),
                 "pattern library should have recorded the outcome"
@@ -3049,7 +3049,7 @@ mod tests {
         }
         {
             let l = lib.lock().unwrap();
-            let suggestions = l.suggest(TaskType::Fetch, None, 5);
+            let suggestions = l.top_patterns(TaskType::Fetch, None, 5);
             assert!(
                 !suggestions.is_empty(),
                 "pattern library should still record chains without domain"

--- a/rust/crates/runtime/tests/improvement_proofs.rs
+++ b/rust/crates/runtime/tests/improvement_proofs.rs
@@ -2409,8 +2409,8 @@ mod state_convergence {
         assert_eq!(graph.domain_for("mo_tables"), Some(DomainHint::Database));
 
         let lib = pl_a.lock().unwrap();
-        let github_suggestions = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
-        let db_suggestions = lib.suggest(TaskType::Mutate, Some(DomainHint::Database), 5);
+        let github_suggestions = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+        let db_suggestions = lib.top_patterns(TaskType::Mutate, Some(DomainHint::Database), 5);
         assert!(
             !github_suggestions.is_empty(),
             "should have GitHub patterns"
@@ -3662,7 +3662,7 @@ mod learning_improves_selection {
         merge_into_modules(&snapshot, &eg2, &pl2, &cal2);
 
         let lib = pl2.lock().unwrap();
-        let suggestions = lib.suggest(TaskType::Reasoning, Some(DomainHint::Git), 5);
+        let suggestions = lib.top_patterns(TaskType::Reasoning, Some(DomainHint::Git), 5);
         assert!(
             !suggestions.is_empty(),
             "session 2 should have pattern suggestions from session 1"
@@ -3743,7 +3743,7 @@ mod learning_improves_selection {
         );
 
         let lib = pl2.lock().unwrap();
-        let suggestions = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+        let suggestions = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
         assert!(
             !suggestions.is_empty(),
             "pattern suggestions survived roundtrip"
@@ -4677,7 +4677,7 @@ mod security_safety_gaps {
         assert!(!pref_keys::LANGUAGE.is_empty());
     }
 
-    /// PROOF: PatternLibrary.suggest() returns relevant patterns.
+    /// PROOF: PatternLibrary.top_patterns() returns relevant patterns.
     ///
     /// OLD: suggest() was only tested, never called in production.
     /// NEW: boost_terms_for() (which calls suggest internally) IS wired
@@ -4694,7 +4694,7 @@ mod security_safety_gaps {
         lib.record_outcome(&tools, TaskType::Code, None, true, 0.9, None);
         lib.record_outcome(&tools, TaskType::Code, None, true, 0.7, None);
 
-        let suggestions = lib.suggest(TaskType::Code, None, 5);
+        let suggestions = lib.top_patterns(TaskType::Code, None, 5);
         assert!(
             !suggestions.is_empty(),
             "should return at least one pattern"


### PR DESCRIPTION
## Why

`plans/self-evolution-gaps.todo §6` flagged that `PatternLibrary::suggest()` and `suggest_with_exploration()` were tagged `#[deprecated(since = "0.9.0")]` ("Superseded by SelfModel + LLM reasoning"), but production code still relies on them:

- `tool_selector.rs:426` — learned-context prompt fragment
- `pattern.rs:649` — `boost_terms_for()` / TF-IDF boost terms
- `task_learning.rs:316` — `record_task_outcome` tool suggestions

The original intent was to retire the **model-facing** suggestion layer while keeping the internal ranking helper alive. Fix the API surface to match that intent.

## What

- `PatternLibrary::suggest()` → `top_patterns()` (deprecation removed; docstring clarifies it is an internal ranking helper, not LLM-facing).
- `suggest_with_exploration()` **deleted** — zero callers since 0.9.0.
- `suggest_with_forced_exploration()` (test-only) → `top_patterns_with_forced_exploration()`.
- `EXPLORATION_EPSILON` constant removed (unused).
- Module doc rewritten: retained mechanisms vs retired LLM-facing layer.
- All callers updated across `astra-pipeline`, `astra-turn-core`, `astra-evolution`, `runtime`, and tests.

**No behavior change.** Pure API rename + dead-code removal.

## Tests

- `make check` ✅
- `make test-offline` ✅ (all existing tests pass)