### PR TITLE
feat(learning): persist ToolQualityTracker across sessions

### DIFF
--- a/rust/crates/astra-cli/src/cli/repl_startup.rs
+++ b/rust/crates/astra-cli/src/cli/repl_startup.rs
@@ -131,10 +131,28 @@ pub(crate) async fn complete_repl_startup(
     }
     tracer.phase("config_load");
 
-    // Session-scoped quality tracker: tools that work well get boosted over time
-    let quality_tracker = std::sync::Arc::new(std::sync::Mutex::new(
-        tool_registry::ToolQualityTracker::new(),
-    ));
+    // Session-scoped quality tracker: tools that work well get boosted over time.
+    // Seed from prior session snapshot (if any) so boost factors don't reset.
+    let profile_name_for_quality = profile.unwrap_or("default");
+    let persisted_quality =
+        astra_runtime::pipeline::persistence::load_tool_quality(profile_name_for_quality);
+    let quality_tracker = {
+        let mut tracker = tool_registry::ToolQualityTracker::new();
+        if !persisted_quality.is_empty() {
+            tracker.merge(&persisted_quality);
+            eprintln!(
+                "{}",
+                format!(
+                    "  ✓ Restored tool quality ({} tools tracked)",
+                    persisted_quality.len()
+                )
+                .dim()
+            );
+        }
+        std::sync::Arc::new(std::sync::Mutex::new(tracker))
+    };
+    let quality_tracker_for_save = quality_tracker.clone();
+    state.tool_quality_tracker = Some(quality_tracker_for_save);
     // Session-scoped confidence calibrator: thresholds adapt to correction rates
     let confidence_calibrator =
         std::sync::Arc::new(astra_runtime::turn::routing_metrics::ConfidenceCalibrator::default());

--- a/rust/crates/astra-cli/src/cli/repl_state.rs
+++ b/rust/crates/astra-cli/src/cli/repl_state.rs
@@ -12,6 +12,7 @@ use crate::prompts;
 use crate::skill_instructions;
 use crate::slash_team;
 use astra_runtime::plan_decompose;
+use astra_runtime::tool_registry;
 use astra_services::session_journal;
 
 /// Verbosity level for explain mode.
@@ -136,6 +137,10 @@ pub(crate) struct ReplState {
     pub tool_health_entries: Vec<astra_runtime::pipeline::persistence::ToolHealthEntry>,
     /// Last successfully synced tool health snapshot, used to compute deltas.
     pub synced_tool_health_entries: Vec<astra_runtime::pipeline::persistence::ToolHealthEntry>,
+    /// Cross-session quality tracker shared with the tool selector so REPL
+    /// save path can export cumulative per-tool selection/quality counters.
+    pub tool_quality_tracker:
+        Option<std::sync::Arc<std::sync::Mutex<tool_registry::ToolQualityTracker>>>,
     /// Plan-only chat (`/plan on`): normal REPL turns omit edge tools; model plans without executing.
     pub chat_plan_only: bool,
     /// Plan Mode state — when Some, REPL is in interactive plan editing mode.
@@ -369,6 +374,7 @@ impl Default for ReplState {
             task_service: None,
             tool_health_entries: Vec::new(),
             synced_tool_health_entries: Vec::new(),
+            tool_quality_tracker: None,
             chat_plan_only: false,
             plan_mode: None,
             executing_plan: None,

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -892,12 +892,19 @@ async fn run_chat_repl(
         .await;
 
         let profile_name = profile.unwrap_or("default");
-        if let Err(e) = astra_runtime::pipeline::persistence::save_learning_state_with_health(
+        let tool_quality_entries = state
+            .tool_quality_tracker
+            .as_ref()
+            .and_then(|t| t.lock().ok().map(|g| g.export()))
+            .unwrap_or_default();
+        if let Err(e) = astra_runtime::pipeline::persistence::save_learning_state_full(
             profile_name,
             &pipeline_modules.entity_graph,
             &pipeline_modules.pattern_library,
             &pipeline_modules.calibrator,
             &state.tool_health_entries,
+            &tool_quality_entries,
+            None,
         ) {
             eprintln!(
                 "{}",

--- a/rust/crates/astra-evolution/src/persistence.rs
+++ b/rust/crates/astra-evolution/src/persistence.rs
@@ -89,12 +89,17 @@ pub struct LearningSnapshot {
     /// Persistent tool health data (cross-session error budgets).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tool_health: Vec<ToolHealthEntry>,
+    /// Per-tool quality/use tracking carried across sessions so selector
+    /// boost factors don't reset to neutral on every restart.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_quality: Vec<ToolQualityPersistEntry>,
     /// Active canary state needed to continue bounded promotion/rollback after restart.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_canary: Option<PersistedActiveCanary>,
 }
 
 pub use astra_pipeline::ToolHealthEntry;
+pub use astra_turn_core::tool_registry_report::{ToolQualityEntry, ToolQualityPersistEntry};
 
 /// Local-only sync metadata for cross-session delta sync bookkeeping.
 ///
@@ -117,6 +122,7 @@ impl Default for LearningSnapshot {
             patterns: Vec::new(),
             calibration: None,
             tool_health: Vec::new(),
+            tool_quality: Vec::new(),
             active_canary: None,
         }
     }
@@ -241,6 +247,29 @@ pub fn export_from_modules_with_health_and_canary(
     tool_health: &[ToolHealthEntry],
     active_canary: Option<PersistedActiveCanary>,
 ) -> LearningSnapshot {
+    export_from_modules_full(
+        entity_graph,
+        pattern_library,
+        calibrator,
+        tool_health,
+        &[],
+        active_canary,
+    )
+}
+
+/// Export all learning modules including per-tool quality entries.
+///
+/// Preferred entry point for callers that want to persist `ToolQualityTracker`
+/// state (CLI `main`). Existing callers can keep using the simpler variants
+/// which pass an empty quality slice.
+pub fn export_from_modules_full(
+    entity_graph: &Arc<Mutex<EntityGraph>>,
+    pattern_library: &Arc<Mutex<PatternLibrary>>,
+    calibrator: &Arc<Mutex<ProgressiveCalibrator>>,
+    tool_health: &[ToolHealthEntry],
+    tool_quality: &[ToolQualityPersistEntry],
+    active_canary: Option<PersistedActiveCanary>,
+) -> LearningSnapshot {
     let entities = entity_graph.lock().map(|g| g.export()).unwrap_or_default();
     let patterns = pattern_library
         .lock()
@@ -259,6 +288,7 @@ pub fn export_from_modules_with_health_and_canary(
         patterns,
         calibration,
         tool_health: tool_health.to_vec(),
+        tool_quality: tool_quality.to_vec(),
         active_canary,
     }
 }
@@ -424,11 +454,33 @@ pub fn save_learning_state_with_health_and_canary(
     tool_health: &[ToolHealthEntry],
     active_canary: Option<PersistedActiveCanary>,
 ) -> Result<(), String> {
-    let snapshot = export_from_modules_with_health_and_canary(
+    save_learning_state_full(
+        profile,
         entity_graph,
         pattern_library,
         calibrator,
         tool_health,
+        &[],
+        active_canary,
+    )
+}
+
+/// Save learning state including per-tool quality entries.
+pub fn save_learning_state_full(
+    profile: &str,
+    entity_graph: &Arc<Mutex<EntityGraph>>,
+    pattern_library: &Arc<Mutex<PatternLibrary>>,
+    calibrator: &Arc<Mutex<ProgressiveCalibrator>>,
+    tool_health: &[ToolHealthEntry],
+    tool_quality: &[ToolQualityPersistEntry],
+    active_canary: Option<PersistedActiveCanary>,
+) -> Result<(), String> {
+    let snapshot = export_from_modules_full(
+        entity_graph,
+        pattern_library,
+        calibrator,
+        tool_health,
+        tool_quality,
         active_canary,
     );
     // Only save if there's something to persist
@@ -436,6 +488,7 @@ pub fn save_learning_state_with_health_and_canary(
         && snapshot.patterns.is_empty()
         && snapshot.calibration.is_none()
         && snapshot.tool_health.is_empty()
+        && snapshot.tool_quality.is_empty()
         && snapshot.active_canary.is_none()
     {
         return Ok(());
@@ -465,6 +518,14 @@ pub fn load_learning_state(
 pub fn load_tool_health(profile: &str) -> Vec<ToolHealthEntry> {
     load_snapshot(profile)
         .map(|s| s.tool_health)
+        .unwrap_or_default()
+}
+
+/// Load per-tool quality entries from a profile's learning snapshot.
+/// Returns empty vec on missing/corrupt file (graceful degradation).
+pub fn load_tool_quality(profile: &str) -> Vec<ToolQualityPersistEntry> {
+    load_snapshot(profile)
+        .map(|s| s.tool_quality)
         .unwrap_or_default()
 }
 
@@ -783,6 +844,7 @@ mod tests {
             patterns: vec![],
             calibration: None,
             tool_health: Vec::new(),
+            tool_quality: Vec::new(),
             active_canary: None,
         };
         let json = serde_json::to_string(&snapshot).unwrap();
@@ -1028,6 +1090,7 @@ mod tests {
                     recent_outcomes: vec![],
                 },
             ],
+            tool_quality: Vec::new(),
             active_canary: None,
         };
         let json = serde_json::to_string(&snapshot).unwrap();
@@ -1035,6 +1098,61 @@ mod tests {
         assert_eq!(loaded.tool_health.len(), 2);
         assert_eq!(loaded.tool_health[0].name, "bash");
         assert!((loaded.tool_health[0].failure_rate - 0.3).abs() < 0.01);
+    }
+
+    #[test]
+    fn tool_quality_roundtrip_in_snapshot() {
+        let snapshot = LearningSnapshot {
+            version: 1,
+            snapshot_epoch: 0,
+            entities: vec![],
+            patterns: vec![],
+            calibration: None,
+            tool_health: vec![],
+            tool_quality: vec![
+                ToolQualityPersistEntry {
+                    name: "bash".to_string(),
+                    entry: ToolQualityEntry {
+                        selections: 12,
+                        uses: 10,
+                        quality_sum: 8.4,
+                    },
+                },
+                ToolQualityPersistEntry {
+                    name: "grep".to_string(),
+                    entry: ToolQualityEntry {
+                        selections: 5,
+                        uses: 5,
+                        quality_sum: 4.2,
+                    },
+                },
+            ],
+            active_canary: None,
+        };
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let loaded: LearningSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.tool_quality.len(), 2);
+        assert_eq!(loaded.tool_quality[0].name, "bash");
+        assert_eq!(loaded.tool_quality[0].entry.selections, 12);
+        assert!((loaded.tool_quality[0].entry.quality_sum - 8.4).abs() < 1e-9);
+    }
+
+    #[test]
+    fn tool_quality_empty_not_serialized() {
+        let snapshot = LearningSnapshot::default();
+        let json = serde_json::to_string(&snapshot).unwrap();
+        assert!(
+            !json.contains("tool_quality"),
+            "empty tool_quality should be skipped in JSON: {json}"
+        );
+    }
+
+    #[test]
+    fn tool_quality_backward_compatible_load() {
+        // Old snapshot without the field should still parse.
+        let legacy_json = r#"{"version":1,"snapshot_epoch":0,"entities":[],"patterns":[]}"#;
+        let loaded: LearningSnapshot = serde_json::from_str(legacy_json).unwrap();
+        assert!(loaded.tool_quality.is_empty());
     }
 
     #[test]
@@ -1046,6 +1164,7 @@ mod tests {
             patterns: vec![],
             calibration: None,
             tool_health: Vec::new(),
+            tool_quality: Vec::new(),
             active_canary: Some(PersistedActiveCanary {
                 proposal: crate::types::EvolutionProposal {
                     id: "canary-1".into(),
@@ -1126,6 +1245,7 @@ mod tests {
                 last_updated_epoch: 0,
                 recent_outcomes: vec![],
             }],
+            tool_quality: Vec::new(),
             active_canary: None,
         };
         save_snapshot_to(&path, &snapshot).unwrap();

--- a/rust/crates/astra-pipeline/src/feedback_store.rs
+++ b/rust/crates/astra-pipeline/src/feedback_store.rs
@@ -5,6 +5,17 @@
 //! the feedback loop: detect → extract → store → inject.
 //!
 //! Rules are isolated per session_id — no cross-session leakage.
+//!
+//! # Why not persist across sessions?
+//!
+//! Feedback rules capture raw user corrections that may contain private or
+//! project-specific context (filenames, commands, identities). Persisting
+//! them would leak signal across unrelated sessions and risk re-injecting
+//! obsolete or private guidance into fresh conversations. Cross-session
+//! learning is expressed instead via aggregated, anonymised channels:
+//! `PatternLibrary`, `ProgressiveCalibrator`, `ToolHealthTracker`, and
+//! `ToolQualityTracker` — all of which are merged/sanitised before being
+//! written to the learning snapshot on disk.
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::Mutex;

--- a/rust/crates/astra-sync-adapters/src/lib.rs
+++ b/rust/crates/astra-sync-adapters/src/lib.rs
@@ -10,7 +10,9 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
-use astra_evolution::persistence::{self, LearningSnapshot, ToolHealthEntry};
+use astra_evolution::persistence::{
+    self, LearningSnapshot, ToolHealthEntry, ToolQualityPersistEntry,
+};
 use astra_pipeline::calibration::ProgressiveCalibrator;
 use astra_pipeline::entity::EntityGraph;
 use astra_pipeline::pattern::PatternLibrary;
@@ -70,6 +72,7 @@ impl LearningAdapter {
             + snapshot.patterns.len() as u32
             + if snapshot.calibration.is_some() { 1 } else { 0 }
             + snapshot.tool_health.len() as u32
+            + snapshot.tool_quality.len() as u32
     }
 }
 
@@ -250,6 +253,33 @@ impl DomainAdapter for LearningAdapter {
             }
         }
 
+        // Tool-quality entries are cumulative counters. Merging across devices
+        // should sum observations so neither side loses signal. If the same
+        // tool is present on both, pick the larger counters per field (max
+        // rather than sum) to avoid double-counting when both devices shared
+        // a common ancestor snapshot that was already merged previously.
+        let mut quality_map: std::collections::HashMap<String, ToolQualityPersistEntry> =
+            remote_snap
+                .tool_quality
+                .into_iter()
+                .map(|q| (q.name.clone(), q))
+                .collect();
+        for local_q in local_snap.tool_quality.drain(..) {
+            match quality_map.get_mut(&local_q.name) {
+                Some(existing) => {
+                    existing.entry.selections =
+                        existing.entry.selections.max(local_q.entry.selections);
+                    existing.entry.uses = existing.entry.uses.max(local_q.entry.uses);
+                    if local_q.entry.quality_sum > existing.entry.quality_sum {
+                        existing.entry.quality_sum = local_q.entry.quality_sum;
+                    }
+                }
+                None => {
+                    quality_map.insert(local_q.name.clone(), local_q);
+                }
+            }
+        }
+
         let merged = LearningSnapshot {
             version: 1,
             snapshot_epoch: std::time::SystemTime::now()
@@ -260,6 +290,7 @@ impl DomainAdapter for LearningAdapter {
             patterns: merged_patterns,
             calibration: remote_snap.calibration.or(local_snap.calibration),
             tool_health: health_map.into_values().collect(),
+            tool_quality: quality_map.into_values().collect(),
             // Active canaries are runtime-local rollback state. Keep them in the
             // local learning snapshot for restart recovery, but never merge or
             // sync them across devices.
@@ -1275,6 +1306,7 @@ mod tests {
                 last_updated_epoch: 200,
                 recent_outcomes: vec![],
             }],
+            tool_quality: Vec::new(),
             active_canary: None,
         };
         let data = serde_json::to_vec(&remote_snapshot).unwrap();

--- a/rust/crates/astra-turn-core/src/tool_registry_report.rs
+++ b/rust/crates/astra-turn-core/src/tool_registry_report.rs
@@ -73,6 +73,18 @@ pub struct ToolQualityEntry {
     pub quality_sum: f64,
 }
 
+/// Persistence-friendly view of a single tracker entry.
+///
+/// `ToolQualityTracker` stores entries in a `HashMap` (iteration order
+/// non-deterministic). For persisted snapshots we flatten into a stable
+/// sorted `Vec` so byte-for-byte comparisons and cloud-merge behave.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ToolQualityPersistEntry {
+    pub name: String,
+    #[serde(flatten)]
+    pub entry: ToolQualityEntry,
+}
+
 impl ToolQualityEntry {
     /// Effectiveness score: how often this tool is actually used when selected.
     /// Range: 0.0 to 1.0.
@@ -143,6 +155,40 @@ impl ToolQualityTracker {
     /// Get all tracked tool quality entries.
     pub fn all_entries(&self) -> &std::collections::HashMap<String, ToolQualityEntry> {
         &self.scores
+    }
+
+    /// Export all entries as a sorted list suitable for persistence.
+    ///
+    /// Sorted by tool name for deterministic byte output and stable diffs
+    /// when merging local/cloud snapshots.
+    pub fn export(&self) -> Vec<ToolQualityPersistEntry> {
+        let mut out: Vec<ToolQualityPersistEntry> = self
+            .scores
+            .iter()
+            .map(|(name, entry)| ToolQualityPersistEntry {
+                name: name.clone(),
+                entry: entry.clone(),
+            })
+            .collect();
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        out
+    }
+
+    /// Additive merge of persisted entries into this tracker.
+    ///
+    /// For each incoming `(name, entry)` pair, counters (`selections`, `uses`,
+    /// `quality_sum`) are summed into the existing entry, or inserted if
+    /// unseen. This matches `record_selection` / `record_feedback` semantics:
+    /// historical observations accumulate across sessions.
+    pub fn merge(&mut self, entries: &[ToolQualityPersistEntry]) {
+        for incoming in entries {
+            let existing = self.scores.entry(incoming.name.clone()).or_default();
+            existing.selections = existing
+                .selections
+                .saturating_add(incoming.entry.selections);
+            existing.uses = existing.uses.saturating_add(incoming.entry.uses);
+            existing.quality_sum += incoming.entry.quality_sum;
+        }
     }
 }
 
@@ -289,5 +335,47 @@ mod tests {
             high_boost > low_boost,
             "high quality {high_boost} should beat low quality {low_boost}"
         );
+    }
+
+    #[test]
+    fn export_sorts_by_name_and_round_trips_through_merge() {
+        let mut tracker = ToolQualityTracker::new();
+        tracker.record_selection(&["grep".into(), "bash".into(), "apply_patch".into()]);
+        tracker.record_feedback(&SelectionFeedback {
+            tools_used: vec!["grep".into()],
+            unused_count: 2,
+            precision: 1.0 / 3.0,
+            recall: 1.0,
+        });
+        tracker.record_quality("grep", 0.9);
+
+        let exported = tracker.export();
+        let names: Vec<_> = exported.iter().map(|e| e.name.clone()).collect();
+        assert_eq!(names, vec!["apply_patch", "bash", "grep"]);
+
+        let mut fresh = ToolQualityTracker::new();
+        fresh.merge(&exported);
+        let restored_grep = fresh.all_entries().get("grep").expect("grep entry");
+        assert_eq!(restored_grep.selections, 1);
+        assert_eq!(restored_grep.uses, 1);
+        assert!((restored_grep.quality_sum - 0.9).abs() < 1e-9);
+    }
+
+    #[test]
+    fn merge_is_additive_across_sessions() {
+        let mut session_one = ToolQualityTracker::new();
+        session_one.record_selection(&["bash".into()]);
+        session_one.record_selection(&["bash".into()]);
+        session_one.record_quality("bash", 0.8);
+
+        let mut session_two = ToolQualityTracker::new();
+        session_two.record_selection(&["bash".into()]);
+        session_two.record_quality("bash", 0.6);
+        // Rehydrate session_two from session_one's snapshot.
+        session_two.merge(&session_one.export());
+
+        let entry = session_two.all_entries().get("bash").expect("bash entry");
+        assert_eq!(entry.selections, 3);
+        assert!((entry.quality_sum - (0.8 + 0.6)).abs() < 1e-9);
     }
 }

--- a/rust/crates/runtime/tests/improvement_proofs.rs
+++ b/rust/crates/runtime/tests/improvement_proofs.rs
@@ -5558,6 +5558,7 @@ mod hardening_proofs {
                     recent_outcomes: vec![],
                 },
             ],
+            tool_quality: Vec::new(),
             active_canary: None,
         };
         save_snapshot_to(&path, &snapshot).unwrap();


### PR DESCRIPTION
## Problem

`ToolQualityTracker` holds per-tool selection/quality counters that feed
the selector's boost factor. Before this change, it was session-scoped:
every REPL launch started every tool at a neutral 1.0 boost and had to
re-learn from scratch — the selector wasted evidence from previous
sessions.

## Change

Persist the tracker inside `LearningSnapshot` using a backward-compatible
field, load it at REPL startup, and merge it across devices in cloud
sync (additive with max-per-field to avoid double-counting when both
sides already saw a common ancestor).

### Key points
- **New type** `ToolQualityPersistEntry` in `astra-turn-core`, plus
  `export()` and additive `merge()` on the tracker.
- **Schema** `LearningSnapshot.tool_quality: Vec<ToolQualityPersistEntry>`
  with `#[serde(default, skip_serializing_if = "Vec::is_empty")]` — old
  snapshots still parse and re-serialize unchanged.
- **New save/export API** `save_learning_state_full` /
  `export_from_modules_full` takes a quality slice; older variants still
  work by forwarding with an empty slice. Lower-risk migration than a
  breaking change.
- **Cloud merge** `astra-sync-adapters` takes the max of each counter
  across the local and remote snapshot so shared history isn't
  double-counted.
- **CLI wiring** `repl_startup.rs` seeds the tracker from disk; `main.rs`
  exports it on shutdown. Tracker lives on `ReplState` so the save path
  can reach it without re-plumbing arguments.
- **Doc upgrade** clarified in `feedback_store.rs` that `FeedbackStore`
  is intentionally session-scoped (privacy). Pattern library,
  calibrator, tool health, and tool quality remain the sanitised
  cross-session channels.

## Tests

- `tool_registry_report::tests::export_sorts_by_name_and_round_trips_through_merge`
- `tool_registry_report::tests::merge_is_additive_across_sessions`
- `persistence::tests::tool_quality_roundtrip_in_snapshot`
- `persistence::tests::tool_quality_empty_not_serialized`
- `persistence::tests::tool_quality_backward_compatible_load`

`make check` and `make test-offline` (73 runtime tests) green.

## Scope notes

- `FeedbackStore` remains session-scoped by policy, now documented.
- `§5 P0` (implicit-feedback → calibrator signal chain) is already closed
  by #114 — verified via `e2e_correction_flows_through_side_effects_to_calibrator`.
  This PR closes `§5 P1` (persistence).