### PR TITLE
feat(self-evolution): streaming-spec metrics + PatternLibrary rename + tool-quality persistence (bundle of #203/#204/#205)

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
@@ -1104,6 +1104,7 @@ pub(crate) async fn fetch_chat_turn_sse(
         skill_continuation,
         turn_rollback_on_failure: is_plan_subtask,
         tool_cache,
+        observability_hub: observability_hub.cloned(),
     };
 
     let sse_mark = Instant::now();

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -334,6 +334,7 @@ impl AgenticLoopHost for CliAgenticLoopHost<'_> {
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut self.tool_cache,
+                observability_hub: None,
             }),
             0,
             state.cancellation.token.as_deref(),

--- a/rust/crates/astra-cli/src/cli/repl_startup.rs
+++ b/rust/crates/astra-cli/src/cli/repl_startup.rs
@@ -131,10 +131,28 @@ pub(crate) async fn complete_repl_startup(
     }
     tracer.phase("config_load");
 
-    // Session-scoped quality tracker: tools that work well get boosted over time
-    let quality_tracker = std::sync::Arc::new(std::sync::Mutex::new(
-        tool_registry::ToolQualityTracker::new(),
-    ));
+    // Session-scoped quality tracker: tools that work well get boosted over time.
+    // Seed from prior session snapshot (if any) so boost factors don't reset.
+    let profile_name_for_quality = profile.unwrap_or("default");
+    let persisted_quality =
+        astra_runtime::pipeline::persistence::load_tool_quality(profile_name_for_quality);
+    let quality_tracker = {
+        let mut tracker = tool_registry::ToolQualityTracker::new();
+        if !persisted_quality.is_empty() {
+            tracker.merge(&persisted_quality);
+            eprintln!(
+                "{}",
+                format!(
+                    "  ✓ Restored tool quality ({} tools tracked)",
+                    persisted_quality.len()
+                )
+                .dim()
+            );
+        }
+        std::sync::Arc::new(std::sync::Mutex::new(tracker))
+    };
+    let quality_tracker_for_save = quality_tracker.clone();
+    state.tool_quality_tracker = Some(quality_tracker_for_save);
     // Session-scoped confidence calibrator: thresholds adapt to correction rates
     let confidence_calibrator =
         std::sync::Arc::new(astra_runtime::turn::routing_metrics::ConfidenceCalibrator::default());

--- a/rust/crates/astra-cli/src/cli/repl_state.rs
+++ b/rust/crates/astra-cli/src/cli/repl_state.rs
@@ -12,6 +12,7 @@ use crate::prompts;
 use crate::skill_instructions;
 use crate::slash_team;
 use astra_runtime::plan_decompose;
+use astra_runtime::tool_registry;
 use astra_services::session_journal;
 
 /// Verbosity level for explain mode.
@@ -136,6 +137,10 @@ pub(crate) struct ReplState {
     pub tool_health_entries: Vec<astra_runtime::pipeline::persistence::ToolHealthEntry>,
     /// Last successfully synced tool health snapshot, used to compute deltas.
     pub synced_tool_health_entries: Vec<astra_runtime::pipeline::persistence::ToolHealthEntry>,
+    /// Cross-session quality tracker shared with the tool selector so REPL
+    /// save path can export cumulative per-tool selection/quality counters.
+    pub tool_quality_tracker:
+        Option<std::sync::Arc<std::sync::Mutex<tool_registry::ToolQualityTracker>>>,
     /// Plan-only chat (`/plan on`): normal REPL turns omit edge tools; model plans without executing.
     pub chat_plan_only: bool,
     /// Plan Mode state — when Some, REPL is in interactive plan editing mode.
@@ -369,6 +374,7 @@ impl Default for ReplState {
             task_service: None,
             tool_health_entries: Vec::new(),
             synced_tool_health_entries: Vec::new(),
+            tool_quality_tracker: None,
             chat_plan_only: false,
             plan_mode: None,
             executing_plan: None,

--- a/rust/crates/astra-cli/src/cli/skill_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/skill_subrun.rs
@@ -243,6 +243,7 @@ impl AgenticLoopHost for SubRunHost {
             skill_continuation: false,
             turn_rollback_on_failure: false,
             tool_cache: &mut self.tool_cache,
+            observability_hub: None,
         };
 
         let prep_line = ChatTurnPrepLineGuard::maybe_start(false, None);

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -1454,13 +1454,22 @@ impl CliSseStreamHost<'_> {
         let Some(exec) = self.streaming_tool_exec.as_ref() else {
             return std::collections::HashMap::new();
         };
-        let speculative = exec.wait_all().await;
+        // Use `merge_speculative` (not raw `wait_all`) so per-call-id hit
+        // counters and saved-ms metrics are updated for observability.
+        let ids: Vec<String> = conc_reqs
+            .iter()
+            .map(|(_, r)| r.request_id.clone())
+            .collect();
+        let (done, _needed) = exec.merge_speculative(&ids).await;
         let mut out = std::collections::HashMap::new();
-        for (_, req) in conc_reqs {
-            if let Some(r) = speculative.get(&req.request_id) {
-                out.insert(req.request_id.clone(), (r.content.clone(), r.success));
-            }
+        for r in done {
+            out.insert(r.call_id.clone(), (r.content.clone(), r.success));
         }
+        // Emit a structured metrics event once per batch merge so log
+        // aggregators / ObservabilityHub can track speculation effectiveness
+        // over time. Target: `astra::streaming_speculation::metrics`.
+        exec.emit_metrics_log(self.executor.active_session_id().as_deref())
+            .await;
         out
     }
 }

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -197,6 +197,12 @@ pub(super) struct EdgeSseContext<'a> {
     pub turn_rollback_on_failure: bool,
     /// Cross-turn tool output cache (persists across turns via `CliAgenticLoopHost`).
     pub tool_cache: &'a mut EdgeToolCache,
+    /// Optional ObservabilityHub for recording streaming-speculation metrics
+    /// (see `AutoTuningEngine::should_disable_streaming_speculation`). `None`
+    /// for tests and non-observable contexts; production supplies it from
+    /// `CliAgenticLoopHost`.
+    pub observability_hub:
+        Option<std::sync::Arc<astra_runtime::observability_integration::ObservabilityHub>>,
 }
 
 // ─── CLI SSE stream host ─────────────────────────────────────────────────────
@@ -268,6 +274,9 @@ struct CliSseStreamHost<'a> {
     /// batch phase.
     streaming_tool_exec:
         Option<std::sync::Arc<astra_runtime::turn::streaming_tool_exec::StreamingToolExecutor>>,
+    /// Optional ObservabilityHub for streaming-speculation metric reporting.
+    observability_hub:
+        Option<std::sync::Arc<astra_runtime::observability_integration::ObservabilityHub>>,
 }
 
 #[derive(Clone, Debug)]
@@ -365,6 +374,7 @@ impl<'a> CliSseStreamHost<'a> {
             turn_rollback_fired: None,
             tool_cache: ctx.tool_cache,
             streaming_tool_exec,
+            observability_hub: ctx.observability_hub,
         }
     }
 
@@ -1470,6 +1480,13 @@ impl CliSseStreamHost<'_> {
         // over time. Target: `astra::streaming_speculation::metrics`.
         exec.emit_metrics_log(self.executor.active_session_id().as_deref())
             .await;
+        if let Some(hub) = self.observability_hub.as_ref() {
+            let snap = exec.snapshot().await;
+            hub.record_streaming_speculation_metrics(&snap);
+            // Reset so each batch report is a delta; AutoTuningEngine sums
+            // incoming reports additively.
+            exec.reset_metrics().await;
+        }
         out
     }
 }
@@ -7541,6 +7558,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -7632,6 +7650,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -7720,6 +7739,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -7811,6 +7831,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -7895,6 +7916,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -7977,6 +7999,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8070,6 +8093,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8148,6 +8172,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8245,6 +8270,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8332,6 +8358,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8427,6 +8454,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8488,6 +8516,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8545,6 +8574,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8603,6 +8633,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8692,6 +8723,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8749,6 +8781,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8844,6 +8877,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -8919,6 +8953,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: true,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -9011,6 +9046,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,
@@ -9097,6 +9133,7 @@ diff --git a/src/a.rs b/src/a.rs\n\
                 skill_continuation: false,
                 turn_rollback_on_failure: false,
                 tool_cache: &mut tool_cache,
+                observability_hub: None,
             },
             80,
             false,

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -892,12 +892,19 @@ async fn run_chat_repl(
         .await;
 
         let profile_name = profile.unwrap_or("default");
-        if let Err(e) = astra_runtime::pipeline::persistence::save_learning_state_with_health(
+        let tool_quality_entries = state
+            .tool_quality_tracker
+            .as_ref()
+            .and_then(|t| t.lock().ok().map(|g| g.export()))
+            .unwrap_or_default();
+        if let Err(e) = astra_runtime::pipeline::persistence::save_learning_state_full(
             profile_name,
             &pipeline_modules.entity_graph,
             &pipeline_modules.pattern_library,
             &pipeline_modules.calibrator,
             &state.tool_health_entries,
+            &tool_quality_entries,
+            None,
         ) {
             eprintln!(
                 "{}",

--- a/rust/crates/astra-evolution/src/persistence.rs
+++ b/rust/crates/astra-evolution/src/persistence.rs
@@ -992,7 +992,7 @@ mod tests {
 
         // Verify pattern library has patterns from session 1
         let lib = pl2.lock().unwrap();
-        let suggestions = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+        let suggestions = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
         assert!(!suggestions.is_empty());
 
         // Verify calibrator has data from session 1

--- a/rust/crates/astra-evolution/src/persistence.rs
+++ b/rust/crates/astra-evolution/src/persistence.rs
@@ -89,12 +89,17 @@ pub struct LearningSnapshot {
     /// Persistent tool health data (cross-session error budgets).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tool_health: Vec<ToolHealthEntry>,
+    /// Per-tool quality/use tracking carried across sessions so selector
+    /// boost factors don't reset to neutral on every restart.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_quality: Vec<ToolQualityPersistEntry>,
     /// Active canary state needed to continue bounded promotion/rollback after restart.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_canary: Option<PersistedActiveCanary>,
 }
 
 pub use astra_pipeline::ToolHealthEntry;
+pub use astra_turn_core::tool_registry_report::{ToolQualityEntry, ToolQualityPersistEntry};
 
 /// Local-only sync metadata for cross-session delta sync bookkeeping.
 ///
@@ -117,6 +122,7 @@ impl Default for LearningSnapshot {
             patterns: Vec::new(),
             calibration: None,
             tool_health: Vec::new(),
+            tool_quality: Vec::new(),
             active_canary: None,
         }
     }
@@ -241,6 +247,29 @@ pub fn export_from_modules_with_health_and_canary(
     tool_health: &[ToolHealthEntry],
     active_canary: Option<PersistedActiveCanary>,
 ) -> LearningSnapshot {
+    export_from_modules_full(
+        entity_graph,
+        pattern_library,
+        calibrator,
+        tool_health,
+        &[],
+        active_canary,
+    )
+}
+
+/// Export all learning modules including per-tool quality entries.
+///
+/// Preferred entry point for callers that want to persist `ToolQualityTracker`
+/// state (CLI `main`). Existing callers can keep using the simpler variants
+/// which pass an empty quality slice.
+pub fn export_from_modules_full(
+    entity_graph: &Arc<Mutex<EntityGraph>>,
+    pattern_library: &Arc<Mutex<PatternLibrary>>,
+    calibrator: &Arc<Mutex<ProgressiveCalibrator>>,
+    tool_health: &[ToolHealthEntry],
+    tool_quality: &[ToolQualityPersistEntry],
+    active_canary: Option<PersistedActiveCanary>,
+) -> LearningSnapshot {
     let entities = entity_graph.lock().map(|g| g.export()).unwrap_or_default();
     let patterns = pattern_library
         .lock()
@@ -259,6 +288,7 @@ pub fn export_from_modules_with_health_and_canary(
         patterns,
         calibration,
         tool_health: tool_health.to_vec(),
+        tool_quality: tool_quality.to_vec(),
         active_canary,
     }
 }
@@ -424,11 +454,33 @@ pub fn save_learning_state_with_health_and_canary(
     tool_health: &[ToolHealthEntry],
     active_canary: Option<PersistedActiveCanary>,
 ) -> Result<(), String> {
-    let snapshot = export_from_modules_with_health_and_canary(
+    save_learning_state_full(
+        profile,
         entity_graph,
         pattern_library,
         calibrator,
         tool_health,
+        &[],
+        active_canary,
+    )
+}
+
+/// Save learning state including per-tool quality entries.
+pub fn save_learning_state_full(
+    profile: &str,
+    entity_graph: &Arc<Mutex<EntityGraph>>,
+    pattern_library: &Arc<Mutex<PatternLibrary>>,
+    calibrator: &Arc<Mutex<ProgressiveCalibrator>>,
+    tool_health: &[ToolHealthEntry],
+    tool_quality: &[ToolQualityPersistEntry],
+    active_canary: Option<PersistedActiveCanary>,
+) -> Result<(), String> {
+    let snapshot = export_from_modules_full(
+        entity_graph,
+        pattern_library,
+        calibrator,
+        tool_health,
+        tool_quality,
         active_canary,
     );
     // Only save if there's something to persist
@@ -436,6 +488,7 @@ pub fn save_learning_state_with_health_and_canary(
         && snapshot.patterns.is_empty()
         && snapshot.calibration.is_none()
         && snapshot.tool_health.is_empty()
+        && snapshot.tool_quality.is_empty()
         && snapshot.active_canary.is_none()
     {
         return Ok(());
@@ -465,6 +518,14 @@ pub fn load_learning_state(
 pub fn load_tool_health(profile: &str) -> Vec<ToolHealthEntry> {
     load_snapshot(profile)
         .map(|s| s.tool_health)
+        .unwrap_or_default()
+}
+
+/// Load per-tool quality entries from a profile's learning snapshot.
+/// Returns empty vec on missing/corrupt file (graceful degradation).
+pub fn load_tool_quality(profile: &str) -> Vec<ToolQualityPersistEntry> {
+    load_snapshot(profile)
+        .map(|s| s.tool_quality)
         .unwrap_or_default()
 }
 
@@ -783,6 +844,7 @@ mod tests {
             patterns: vec![],
             calibration: None,
             tool_health: Vec::new(),
+            tool_quality: Vec::new(),
             active_canary: None,
         };
         let json = serde_json::to_string(&snapshot).unwrap();
@@ -1028,6 +1090,7 @@ mod tests {
                     recent_outcomes: vec![],
                 },
             ],
+            tool_quality: Vec::new(),
             active_canary: None,
         };
         let json = serde_json::to_string(&snapshot).unwrap();
@@ -1035,6 +1098,61 @@ mod tests {
         assert_eq!(loaded.tool_health.len(), 2);
         assert_eq!(loaded.tool_health[0].name, "bash");
         assert!((loaded.tool_health[0].failure_rate - 0.3).abs() < 0.01);
+    }
+
+    #[test]
+    fn tool_quality_roundtrip_in_snapshot() {
+        let snapshot = LearningSnapshot {
+            version: 1,
+            snapshot_epoch: 0,
+            entities: vec![],
+            patterns: vec![],
+            calibration: None,
+            tool_health: vec![],
+            tool_quality: vec![
+                ToolQualityPersistEntry {
+                    name: "bash".to_string(),
+                    entry: ToolQualityEntry {
+                        selections: 12,
+                        uses: 10,
+                        quality_sum: 8.4,
+                    },
+                },
+                ToolQualityPersistEntry {
+                    name: "grep".to_string(),
+                    entry: ToolQualityEntry {
+                        selections: 5,
+                        uses: 5,
+                        quality_sum: 4.2,
+                    },
+                },
+            ],
+            active_canary: None,
+        };
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let loaded: LearningSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.tool_quality.len(), 2);
+        assert_eq!(loaded.tool_quality[0].name, "bash");
+        assert_eq!(loaded.tool_quality[0].entry.selections, 12);
+        assert!((loaded.tool_quality[0].entry.quality_sum - 8.4).abs() < 1e-9);
+    }
+
+    #[test]
+    fn tool_quality_empty_not_serialized() {
+        let snapshot = LearningSnapshot::default();
+        let json = serde_json::to_string(&snapshot).unwrap();
+        assert!(
+            !json.contains("tool_quality"),
+            "empty tool_quality should be skipped in JSON: {json}"
+        );
+    }
+
+    #[test]
+    fn tool_quality_backward_compatible_load() {
+        // Old snapshot without the field should still parse.
+        let legacy_json = r#"{"version":1,"snapshot_epoch":0,"entities":[],"patterns":[]}"#;
+        let loaded: LearningSnapshot = serde_json::from_str(legacy_json).unwrap();
+        assert!(loaded.tool_quality.is_empty());
     }
 
     #[test]
@@ -1046,6 +1164,7 @@ mod tests {
             patterns: vec![],
             calibration: None,
             tool_health: Vec::new(),
+            tool_quality: Vec::new(),
             active_canary: Some(PersistedActiveCanary {
                 proposal: crate::types::EvolutionProposal {
                     id: "canary-1".into(),
@@ -1126,6 +1245,7 @@ mod tests {
                 last_updated_epoch: 0,
                 recent_outcomes: vec![],
             }],
+            tool_quality: Vec::new(),
             active_canary: None,
         };
         save_snapshot_to(&path, &snapshot).unwrap();

--- a/rust/crates/astra-learning/src/auto_tuning.rs
+++ b/rust/crates/astra-learning/src/auto_tuning.rs
@@ -631,6 +631,43 @@ pub struct RuleExecution {
     pub rolled_back: bool,
 }
 
+/// Aggregate statistics for streaming speculative tool execution.
+///
+/// Accumulated across all batches a session reports to the engine. Used by
+/// [`AutoTuningEngine::should_disable_streaming_speculation`] to decide when
+/// speculation's hit rate has dropped below a useful threshold.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreamingSpeculationStats {
+    /// Total speculations spawned across all reports.
+    pub started: u64,
+    /// Total hits (merged back into real batches).
+    pub hit: u64,
+    /// Total discards (Step 3 interception).
+    pub discarded: u64,
+    /// Sum of per-hit overlap durations in ms.
+    pub total_saved_ms: u64,
+    /// Number of report batches merged into this aggregate.
+    pub reports: u64,
+}
+
+impl StreamingSpeculationStats {
+    /// Hit rate (0.0–1.0). Returns 0.0 if no speculations have started.
+    pub fn hit_rate(&self) -> f64 {
+        if self.started == 0 {
+            0.0
+        } else {
+            self.hit as f64 / self.started as f64
+        }
+    }
+}
+
+/// Default minimum samples required before auto-tuning will recommend
+/// disabling speculation. Prevents early-session noise from flipping the
+/// flag after 1–2 misses.
+pub const STREAMING_SPEC_MIN_SAMPLES: u64 = 20;
+/// Default hit-rate threshold below which speculation is recommended disabled.
+pub const STREAMING_SPEC_HIT_RATE_FLOOR: f64 = 0.10;
+
 /// The main auto-tuning engine.
 pub struct AutoTuningEngine {
     /// Evolution rules.
@@ -645,6 +682,8 @@ pub struct AutoTuningEngine {
     enabled: RwLock<bool>,
     /// Optional path for persisting aggregator state across restarts.
     storage_path: Option<PathBuf>,
+    /// Aggregate streaming-speculation stats reported by the host.
+    streaming_spec: RwLock<StreamingSpeculationStats>,
 }
 
 impl Default for AutoTuningEngine {
@@ -663,6 +702,7 @@ impl AutoTuningEngine {
             last_triggered: RwLock::new(HashMap::new()),
             enabled: RwLock::new(true),
             storage_path: None,
+            streaming_spec: RwLock::new(StreamingSpeculationStats::default()),
         }
     }
 
@@ -686,7 +726,52 @@ impl AutoTuningEngine {
             last_triggered: RwLock::new(HashMap::new()),
             enabled: RwLock::new(true),
             storage_path: Some(path),
+            streaming_spec: RwLock::new(StreamingSpeculationStats::default()),
         }
+    }
+
+    /// Record one batch of streaming-speculation metrics. Deltas are added
+    /// into a running aggregate accessible via [`Self::streaming_speculation_stats`].
+    ///
+    /// Callers typically pass per-batch snapshots (cumulative counters read
+    /// at the end of each tool batch). The engine does not care whether the
+    /// values are deltas or absolutes — it simply sums.
+    pub fn record_streaming_speculation(
+        &self,
+        started: u64,
+        hit: u64,
+        discarded: u64,
+        total_saved_ms: u64,
+    ) {
+        let mut stats = self.streaming_spec.write_or_recover();
+        stats.started = stats.started.saturating_add(started);
+        stats.hit = stats.hit.saturating_add(hit);
+        stats.discarded = stats.discarded.saturating_add(discarded);
+        stats.total_saved_ms = stats.total_saved_ms.saturating_add(total_saved_ms);
+        stats.reports = stats.reports.saturating_add(1);
+    }
+
+    /// Read a snapshot of the aggregated streaming-speculation stats.
+    pub fn streaming_speculation_stats(&self) -> StreamingSpeculationStats {
+        self.streaming_spec.read_or_recover().clone()
+    }
+
+    /// Reset aggregated streaming-speculation stats. Used at session boundaries.
+    pub fn reset_streaming_speculation_stats(&self) {
+        *self.streaming_spec.write_or_recover() = StreamingSpeculationStats::default();
+    }
+
+    /// Recommend whether speculation should be disabled based on accumulated
+    /// hit rate. Returns `true` only when at least
+    /// [`STREAMING_SPEC_MIN_SAMPLES`] speculations have been recorded AND the
+    /// hit rate is below [`STREAMING_SPEC_HIT_RATE_FLOOR`].
+    ///
+    /// Callers should gate the `ASTRA_STREAMING_TOOL_EXEC` runtime flag on
+    /// the inverse of this method (or expose it via a slash command / UI).
+    pub fn should_disable_streaming_speculation(&self) -> bool {
+        let stats = self.streaming_spec.read_or_recover();
+        stats.started >= STREAMING_SPEC_MIN_SAMPLES
+            && stats.hit_rate() < STREAMING_SPEC_HIT_RATE_FLOOR
     }
 
     /// Add an evolution rule.
@@ -2416,5 +2501,45 @@ mod tests {
         let stats = OutcomeStats::default();
         assert_eq!(stats.total(), 0);
         assert!((stats.success_rate() - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn streaming_speculation_aggregates_and_resets() {
+        let engine = AutoTuningEngine::new();
+        engine.record_streaming_speculation(10, 5, 1, 120);
+        engine.record_streaming_speculation(4, 2, 0, 30);
+
+        let stats = engine.streaming_speculation_stats();
+        assert_eq!(stats.started, 14);
+        assert_eq!(stats.hit, 7);
+        assert_eq!(stats.discarded, 1);
+        assert_eq!(stats.total_saved_ms, 150);
+        assert_eq!(stats.reports, 2);
+        assert!((stats.hit_rate() - 0.5).abs() < 1e-9);
+
+        engine.reset_streaming_speculation_stats();
+        assert_eq!(
+            engine.streaming_speculation_stats(),
+            StreamingSpeculationStats::default()
+        );
+    }
+
+    #[test]
+    fn streaming_speculation_disable_threshold() {
+        let engine = AutoTuningEngine::new();
+
+        // Below min-samples: never recommend disabling even if rate is 0.
+        engine.record_streaming_speculation(5, 0, 0, 0);
+        assert!(!engine.should_disable_streaming_speculation());
+
+        // Meets min-samples, above floor: keep enabled.
+        engine.reset_streaming_speculation_stats();
+        engine.record_streaming_speculation(25, 20, 0, 500);
+        assert!(!engine.should_disable_streaming_speculation());
+
+        // Meets min-samples, below floor: recommend disabling.
+        engine.reset_streaming_speculation_stats();
+        engine.record_streaming_speculation(25, 1, 0, 5);
+        assert!(engine.should_disable_streaming_speculation());
     }
 }

--- a/rust/crates/astra-pipeline/src/feedback_store.rs
+++ b/rust/crates/astra-pipeline/src/feedback_store.rs
@@ -5,6 +5,17 @@
 //! the feedback loop: detect → extract → store → inject.
 //!
 //! Rules are isolated per session_id — no cross-session leakage.
+//!
+//! # Why not persist across sessions?
+//!
+//! Feedback rules capture raw user corrections that may contain private or
+//! project-specific context (filenames, commands, identities). Persisting
+//! them would leak signal across unrelated sessions and risk re-injecting
+//! obsolete or private guidance into fresh conversations. Cross-session
+//! learning is expressed instead via aggregated, anonymised channels:
+//! `PatternLibrary`, `ProgressiveCalibrator`, `ToolHealthTracker`, and
+//! `ToolQualityTracker` — all of which are merged/sanitised before being
+//! written to the learning snapshot on disk.
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::Mutex;

--- a/rust/crates/astra-pipeline/src/pattern.rs
+++ b/rust/crates/astra-pipeline/src/pattern.rs
@@ -1,23 +1,20 @@
 //! Tool Chain Pattern Library — learns successful tool sequences for reuse.
 //!
 //! Records which tool combinations succeed or fail for each task type and domain,
-//! then suggests the best patterns for similar future queries.
+//! then ranks the best patterns for similar future queries.
 //!
-//! **Note**: The pattern recording and drift signals remain active, but the
-//! L3 adaptive suggestion/exploration layer is being deprecated in favor of
-//! `SelfModel` + LLM reasoning.
+//! **Note**: The L3 adaptive LLM-facing suggestion layer has been retired in favor
+//! of `SelfModel` + LLM reasoning. What remains (`top_patterns`, `boost_terms_for`,
+//! `blocked_tool_names`) are structural internal ranking helpers used by the
+//! TF-IDF router and learned-context prompt summaries — not model-facing
+//! suggestions.
 //!
 //! # Learning flow
 //!
 //! 1. User asks "show me PRs for matrixorigin" → routes to Fetch + GitHub
 //! 2. Agent uses [github_search, github_list_prs] → succeeds (quality 0.9)
 //! 3. Pattern recorded: signature="github_list_prs|github_search", task=Fetch, domain=GitHub
-//! 4. Next similar query → suggest() returns this pattern → boost these tools
-//!
-//! # Exploration
-//!
-//! To prevent pattern drift and discover new tools, `suggest_with_exploration()`
-//! uses epsilon-greedy: 10% chance to include a low-frequency or stale pattern.
+//! 4. Next similar query → `top_patterns()` returns this pattern → boost these tools
 //!
 //! # Integration
 //!
@@ -26,7 +23,7 @@
 //! library.record_outcome(&tools_used, TaskType::Fetch, Some(DomainHint::GitHub), true, 0.9, None);
 //!
 //! // At turn start (Plan):
-//! let suggestions = library.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 3);
+//! let top = library.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 3);
 //! let boost_terms = library.boost_terms_for(TaskType::Fetch, Some(DomainHint::GitHub));
 //! ```
 
@@ -47,8 +44,6 @@ pub enum PatternAction {
 const DECAY_GRACE_DAYS: u64 = 7;
 /// Half-life in days for exponential decay after grace period.
 const DECAY_HALF_LIFE_DAYS: f64 = 30.0;
-/// Probability of including an exploration pattern (epsilon-greedy).
-const EXPLORATION_EPSILON: f64 = 0.1;
 /// Window size for recent outcomes used in drift detection.
 const DRIFT_WINDOW_SIZE: usize = 10;
 /// Drift threshold: if recent success rate drops this much below historical, flag as drifting.
@@ -480,16 +475,17 @@ impl PatternLibrary {
         count
     }
 
-    /// Suggest best patterns for a task type + optional domain filter.
+    /// Top-ranked patterns for a task type + optional domain filter.
     ///
     /// Returns up to `limit` patterns sorted by time-decayed score (descending).
     /// If domain is Some, only returns patterns matching that domain.
     /// Stale patterns are ranked lower even if historically successful.
-    #[deprecated(
-        since = "0.9.0",
-        note = "Superseded by SelfModel + LLM reasoning. Keep pattern recording, but let the model reason over self-awareness instead of precomputed suggestions."
-    )]
-    pub fn suggest(
+    ///
+    /// This is an internal ranking helper used by TF-IDF boost terms,
+    /// learned-context prompt summaries, and task-level tool suggestions.
+    /// It is **not** a model-facing "suggestion" — the LLM reasons over
+    /// the `SelfModel` snapshot instead.
+    pub fn top_patterns(
         &self,
         task_type: TaskType,
         domain: Option<DomainHint>,
@@ -523,86 +519,19 @@ impl PatternLibrary {
         candidates
     }
 
-    /// Suggest patterns with epsilon-greedy exploration.
+    /// Top patterns with forced exploration (for testing).
     ///
-    /// With probability EXPLORATION_EPSILON (10%), includes a low-frequency or
-    /// stale pattern among the suggestions. This helps rediscover tools that
-    /// may have been deprecated due to time decay but are still valuable.
-    ///
-    /// Returns up to `limit` patterns, with the exploration slot (if triggered)
-    /// replacing the last regular suggestion.
-    #[deprecated(
-        since = "0.9.0",
-        note = "Superseded by SelfModel + LLM reasoning. Use self-awareness-driven exploration instead of epsilon-greedy pattern hints."
-    )]
-    pub fn suggest_with_exploration(
-        &self,
-        task_type: TaskType,
-        domain: Option<DomainHint>,
-        limit: usize,
-    ) -> Vec<&ToolChainPattern> {
-        let mut suggestions = self.suggest(task_type, domain, limit);
-
-        // Roll for exploration using timestamp-based pseudo-randomness
-        // Using nanos % 100 gives 0-99, so < 10 is ~10% probability
-        let roll = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.subsec_nanos() % 100)
-            .unwrap_or(50);
-        let should_explore = (roll as f64) < (EXPLORATION_EPSILON * 100.0);
-
-        if !should_explore || limit == 0 {
-            return suggestions;
-        }
-
-        // Find exploration candidates: patterns not in top suggestions, sorted by staleness
-        let top_sigs: std::collections::HashSet<_> =
-            suggestions.iter().map(|p| &p.signature).collect();
-
-        let keys = match self.type_index.get(&task_type) {
-            Some(keys) => keys,
-            None => return suggestions,
-        };
-
-        let mut exploration_candidates: Vec<&ToolChainPattern> = keys
-            .iter()
-            .filter_map(|k| self.patterns.get(k))
-            .filter(|p| !top_sigs.contains(&p.signature))
-            .filter(|p| match domain {
-                Some(d) => p.domain == Some(d) || p.domain.is_none(),
-                None => true,
-            })
-            .filter(|p| p.success_rate() >= 0.3) // Must have some success history
-            .collect();
-
-        if exploration_candidates.is_empty() {
-            return suggestions;
-        }
-
-        // Sort by staleness (oldest first) to prioritize rediscovery
-        exploration_candidates.sort_by_key(|a| a.last_used_at);
-
-        // Replace last suggestion with exploration pick
-        if suggestions.len() >= limit {
-            suggestions.pop();
-        }
-        suggestions.push(exploration_candidates[0]);
-
-        suggestions
-    }
-
-    /// Suggest patterns with forced exploration (for testing).
-    ///
-    /// Same as `suggest_with_exploration` but always triggers exploration
-    /// if exploration candidates exist.
+    /// Always triggers exploration if exploration candidates exist. Replaces
+    /// the epsilon-greedy `suggest_with_exploration` that was retired along
+    /// with the LLM-facing suggestion layer.
     #[cfg(test)]
-    pub fn suggest_with_forced_exploration(
+    pub fn top_patterns_with_forced_exploration(
         &self,
         task_type: TaskType,
         domain: Option<DomainHint>,
         limit: usize,
     ) -> Vec<&ToolChainPattern> {
-        let mut suggestions = self.suggest(task_type, domain, limit);
+        let mut suggestions = self.top_patterns(task_type, domain, limit);
 
         if limit == 0 {
             return suggestions;
@@ -646,7 +575,7 @@ impl PatternLibrary {
     /// Returns tool names from top patterns (success_rate > 0.5) for use as
     /// TF-IDF boost terms in routing.
     pub fn boost_terms_for(&self, task_type: TaskType, domain: Option<DomainHint>) -> Vec<String> {
-        let suggestions = self.suggest(task_type, domain, 3);
+        let suggestions = self.top_patterns(task_type, domain, 3);
         let mut terms: Vec<String> = Vec::new();
         let mut seen = std::collections::HashSet::new();
 
@@ -1268,7 +1197,7 @@ mod tests {
             lib.record_outcome(&tools(&["bash"]), TaskType::Code, None, true, 0.8, None);
         }
 
-        let fetch_suggestions = lib.suggest(TaskType::Fetch, None, 5);
+        let fetch_suggestions = lib.top_patterns(TaskType::Fetch, None, 5);
         assert_eq!(fetch_suggestions.len(), 1);
         assert!(
             fetch_suggestions[0]
@@ -1276,7 +1205,7 @@ mod tests {
                 .contains(&"github_search".to_string())
         );
 
-        let code_suggestions = lib.suggest(TaskType::Code, None, 5);
+        let code_suggestions = lib.top_patterns(TaskType::Code, None, 5);
         assert_eq!(code_suggestions.len(), 1);
         assert!(code_suggestions[0].tools.contains(&"bash".to_string()));
     }
@@ -1305,11 +1234,11 @@ mod tests {
             );
         }
 
-        let github = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+        let github = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
         assert_eq!(github.len(), 1);
         assert!(github[0].tools.contains(&"github_api".to_string()));
 
-        let system = lib.suggest(TaskType::Fetch, Some(DomainHint::System), 5);
+        let system = lib.top_patterns(TaskType::Fetch, Some(DomainHint::System), 5);
         assert_eq!(system.len(), 1);
         assert!(system[0].tools.contains(&"bash".to_string()));
     }
@@ -1319,7 +1248,7 @@ mod tests {
         let mut lib = PatternLibrary::new();
         lib.record_outcome(&tools(&["bash"]), TaskType::Code, None, true, 0.9, None);
         // Only 1 observation → not suggested
-        assert!(lib.suggest(TaskType::Code, None, 5).is_empty());
+        assert!(lib.top_patterns(TaskType::Code, None, 5).is_empty());
     }
 
     #[test]
@@ -1369,7 +1298,7 @@ mod tests {
             );
         }
 
-        let suggestions = lib.suggest(TaskType::Fetch, None, 3);
+        let suggestions = lib.top_patterns(TaskType::Fetch, None, 3);
         assert!(suggestions.len() >= 2);
         // First should be pattern_a (highest score)
         assert!(suggestions[0].score() >= suggestions[1].score());
@@ -1391,14 +1320,14 @@ mod tests {
                 );
             }
         }
-        let suggestions = lib.suggest(TaskType::Code, None, 2);
+        let suggestions = lib.top_patterns(TaskType::Code, None, 2);
         assert_eq!(suggestions.len(), 2);
     }
 
     #[test]
     fn suggest_empty_for_unknown_type() {
         let lib = PatternLibrary::new();
-        assert!(lib.suggest(TaskType::Memory, None, 5).is_empty());
+        assert!(lib.top_patterns(TaskType::Memory, None, 5).is_empty());
     }
 
     // ── Boost terms ──
@@ -1499,7 +1428,7 @@ mod tests {
         lib2.merge(&exported);
         assert_eq!(lib2.len(), 1);
 
-        let suggestions = lib2.suggest(TaskType::Code, None, 5);
+        let suggestions = lib2.top_patterns(TaskType::Code, None, 5);
         assert_eq!(suggestions.len(), 1);
         assert_eq!(suggestions[0].success_count, 5);
     }
@@ -1549,7 +1478,7 @@ mod tests {
 
         // Phase 1: No patterns → no suggestions
         assert!(
-            lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 3)
+            lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 3)
                 .is_empty()
         );
 
@@ -1566,7 +1495,7 @@ mod tests {
         }
 
         // Phase 3: Suggestions now available
-        let suggestions = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 3);
+        let suggestions = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 3);
         assert_eq!(suggestions.len(), 1);
         assert!(suggestions[0].score() > 0.8);
         assert_eq!(suggestions[0].tools.len(), 2);
@@ -1990,7 +1919,7 @@ mod tests {
             None,
         );
 
-        let suggestions = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 2);
+        let suggestions = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 2);
 
         // Recent pattern should rank higher due to time decay
         if suggestions.len() >= 2 {
@@ -2053,14 +1982,14 @@ mod tests {
         }
 
         // Normal suggest should not include old_tool (decayed score too low)
-        let normal = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 2);
+        let normal = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 2);
         let has_old_in_normal = normal
             .iter()
             .any(|p| p.tools.contains(&"old_tool".to_string()));
 
         // Forced exploration should include old_tool
         let explored =
-            lib.suggest_with_forced_exploration(TaskType::Fetch, Some(DomainHint::GitHub), 2);
+            lib.top_patterns_with_forced_exploration(TaskType::Fetch, Some(DomainHint::GitHub), 2);
         let has_old_in_explored = explored
             .iter()
             .any(|p| p.tools.contains(&"old_tool".to_string()));
@@ -2101,7 +2030,7 @@ mod tests {
         }
 
         // Exploration should pick the oldest (old_60)
-        let explored = lib.suggest_with_forced_exploration(TaskType::Fetch, None, 1);
+        let explored = lib.top_patterns_with_forced_exploration(TaskType::Fetch, None, 1);
         let picked = explored.iter().find(|p| {
             p.tools.contains(&"old_60".to_string()) || p.tools.contains(&"old_30".to_string())
         });
@@ -2153,11 +2082,11 @@ mod tests {
         }
 
         // Normal suggest returns top 2 by decayed_score (good_a and good_b)
-        let normal = lib.suggest(TaskType::Fetch, None, 2);
+        let normal = lib.top_patterns(TaskType::Fetch, None, 2);
         let has_bad_in_normal = normal.iter().any(|p| p.tools.contains(&"bad".to_string()));
 
         // Forced exploration: bad pattern excluded because success_rate < 0.3
-        let explored = lib.suggest_with_forced_exploration(TaskType::Fetch, None, 2);
+        let explored = lib.top_patterns_with_forced_exploration(TaskType::Fetch, None, 2);
         let has_bad_in_explored = explored
             .iter()
             .any(|p| p.tools.contains(&"bad".to_string()));
@@ -2181,8 +2110,8 @@ mod tests {
             lib.record_outcome(&tools(&["only"]), TaskType::Fetch, None, true, 0.9, None);
         }
 
-        let normal = lib.suggest(TaskType::Fetch, None, 2);
-        let explored = lib.suggest_with_forced_exploration(TaskType::Fetch, None, 2);
+        let normal = lib.top_patterns(TaskType::Fetch, None, 2);
+        let explored = lib.top_patterns_with_forced_exploration(TaskType::Fetch, None, 2);
 
         // With no exploration candidates, both should return the same
         assert_eq!(normal.len(), explored.len());

--- a/rust/crates/astra-pipeline/src/task_learning.rs
+++ b/rust/crates/astra-pipeline/src/task_learning.rs
@@ -313,7 +313,7 @@ impl TaskLearningBridge for PipelineTaskLearningBridge {
         // Pattern-based suggestions: find top patterns for this task type
         if let Some(pl) = &self.pattern_library {
             let lib = pl.lock().unwrap_or_else(|e| e.into_inner());
-            let patterns = lib.suggest(tt, domain, 3);
+            let patterns = lib.top_patterns(tt, domain, 3);
             for pattern in patterns {
                 suggestions.extend(pattern.tools.iter().cloned());
             }

--- a/rust/crates/astra-sync-adapters/src/lib.rs
+++ b/rust/crates/astra-sync-adapters/src/lib.rs
@@ -10,7 +10,9 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
-use astra_evolution::persistence::{self, LearningSnapshot, ToolHealthEntry};
+use astra_evolution::persistence::{
+    self, LearningSnapshot, ToolHealthEntry, ToolQualityPersistEntry,
+};
 use astra_pipeline::calibration::ProgressiveCalibrator;
 use astra_pipeline::entity::EntityGraph;
 use astra_pipeline::pattern::PatternLibrary;
@@ -70,6 +72,7 @@ impl LearningAdapter {
             + snapshot.patterns.len() as u32
             + if snapshot.calibration.is_some() { 1 } else { 0 }
             + snapshot.tool_health.len() as u32
+            + snapshot.tool_quality.len() as u32
     }
 }
 
@@ -250,6 +253,33 @@ impl DomainAdapter for LearningAdapter {
             }
         }
 
+        // Tool-quality entries are cumulative counters. Merging across devices
+        // should sum observations so neither side loses signal. If the same
+        // tool is present on both, pick the larger counters per field (max
+        // rather than sum) to avoid double-counting when both devices shared
+        // a common ancestor snapshot that was already merged previously.
+        let mut quality_map: std::collections::HashMap<String, ToolQualityPersistEntry> =
+            remote_snap
+                .tool_quality
+                .into_iter()
+                .map(|q| (q.name.clone(), q))
+                .collect();
+        for local_q in local_snap.tool_quality.drain(..) {
+            match quality_map.get_mut(&local_q.name) {
+                Some(existing) => {
+                    existing.entry.selections =
+                        existing.entry.selections.max(local_q.entry.selections);
+                    existing.entry.uses = existing.entry.uses.max(local_q.entry.uses);
+                    if local_q.entry.quality_sum > existing.entry.quality_sum {
+                        existing.entry.quality_sum = local_q.entry.quality_sum;
+                    }
+                }
+                None => {
+                    quality_map.insert(local_q.name.clone(), local_q);
+                }
+            }
+        }
+
         let merged = LearningSnapshot {
             version: 1,
             snapshot_epoch: std::time::SystemTime::now()
@@ -260,6 +290,7 @@ impl DomainAdapter for LearningAdapter {
             patterns: merged_patterns,
             calibration: remote_snap.calibration.or(local_snap.calibration),
             tool_health: health_map.into_values().collect(),
+            tool_quality: quality_map.into_values().collect(),
             // Active canaries are runtime-local rollback state. Keep them in the
             // local learning snapshot for restart recovery, but never merge or
             // sync them across devices.
@@ -1275,6 +1306,7 @@ mod tests {
                 last_updated_epoch: 200,
                 recent_outcomes: vec![],
             }],
+            tool_quality: Vec::new(),
             active_canary: None,
         };
         let data = serde_json::to_vec(&remote_snapshot).unwrap();

--- a/rust/crates/astra-turn-core/src/pipeline_learning.rs
+++ b/rust/crates/astra-turn-core/src/pipeline_learning.rs
@@ -867,7 +867,7 @@ mod tests {
         }
 
         let l = lib.lock().unwrap();
-        let suggestions = l.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+        let suggestions = l.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
         assert!(
             !suggestions.is_empty(),
             "pattern library should have learned the tool chain"

--- a/rust/crates/astra-turn-core/src/streaming_tool_exec.rs
+++ b/rust/crates/astra-turn-core/src/streaming_tool_exec.rs
@@ -20,6 +20,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinHandle;
@@ -63,6 +64,63 @@ pub fn should_speculate(tool_name: &str, perm_decision: Option<&PermissionDecisi
 /// Maximum speculative executions during streaming.
 const MAX_SPECULATIVE: usize = 5;
 
+/// Runtime counters describing how often speculative execution fired and
+/// how much wall-clock was saved. Exposed via [`StreamingToolExecutor::snapshot`].
+///
+/// Consumers (CLI session-end logger, ObservabilityHub) can aggregate across
+/// sessions or emit a single structured event per turn/session.
+///
+/// Fields are monotonic over the executor's lifetime unless [`StreamingToolExecutor::reset_metrics`]
+/// is called. `wasted` is derived, not stored: `wasted = started - hit - discarded - inflight`.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct StreamingSpeculationMetrics {
+    /// Number of `on_tool_block` invocations that actually spawned a speculative future.
+    pub started: u64,
+    /// Number of speculative results successfully merged back into a real tool_call batch.
+    pub hit: u64,
+    /// Number of speculative results dropped because Step 3 (skill/delegation) intercepted.
+    pub discarded: u64,
+    /// Number of speculative futures still in-flight at the time of this snapshot.
+    pub inflight: u64,
+    /// Sum of per-hit execution durations (ms). Approximates the wall-clock time
+    /// the tool's I/O overlapped with LLM streaming — an upper bound on savings.
+    pub total_saved_ms: u64,
+}
+
+impl StreamingSpeculationMetrics {
+    /// Estimate of "wasted" speculations: started but neither hit nor discarded
+    /// nor still in flight. Typically indicates a read-only tool whose call_id
+    /// never appeared in the post-stream batch (e.g., Step 3 replaced it with
+    /// a different tool call without calling `discard`).
+    pub fn wasted(&self) -> u64 {
+        self.started
+            .saturating_sub(self.hit)
+            .saturating_sub(self.discarded)
+            .saturating_sub(self.inflight)
+    }
+
+    /// Hit rate (0.0–1.0): fraction of started speculations that translated
+    /// into real wall-clock savings. Returns 0.0 if nothing has been started.
+    pub fn hit_rate(&self) -> f64 {
+        if self.started == 0 {
+            0.0
+        } else {
+            self.hit as f64 / self.started as f64
+        }
+    }
+}
+
+#[derive(Default)]
+struct InnerMetrics {
+    started: u64,
+    hit: u64,
+    discarded: u64,
+    total_saved_ms: u64,
+    /// call_id → (start_instant, duration on completion)
+    started_at: HashMap<String, Instant>,
+    completed_ms: HashMap<String, u64>,
+}
+
 /// Tracks in-flight speculative tool executions during SSE streaming.
 pub struct StreamingToolExecutor {
     executor: ToolExecutorFn,
@@ -71,6 +129,7 @@ pub struct StreamingToolExecutor {
     inflight: Arc<Mutex<HashMap<String, JoinHandle<ToolExecResult>>>>,
     /// call_id → completed results (ready for harvest)
     completed: Arc<Mutex<HashMap<String, ToolExecResult>>>,
+    metrics: Arc<Mutex<InnerMetrics>>,
 }
 
 impl StreamingToolExecutor {
@@ -80,6 +139,7 @@ impl StreamingToolExecutor {
             semaphore: Arc::new(Semaphore::new(MAX_SPECULATIVE)),
             inflight: Arc::new(Mutex::new(HashMap::new())),
             completed: Arc::new(Mutex::new(HashMap::new())),
+            metrics: Arc::new(Mutex::new(InnerMetrics::default())),
         }
     }
 
@@ -100,11 +160,13 @@ impl StreamingToolExecutor {
         let sem = self.semaphore.clone();
         let exec = self.executor.clone();
         let completed = self.completed.clone();
+        let metrics = self.metrics.clone();
         let cid = call_id.clone();
 
         // Insert a placeholder into inflight BEFORE spawning to avoid race
         // where the task completes before the handle is recorded.
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let started_at = Instant::now();
         let handle = tokio::spawn(async move {
             // Wait until handle is registered in inflight map
             let _ = rx.await;
@@ -132,10 +194,23 @@ impl StreamingToolExecutor {
                 success,
             };
 
+            // Record duration for metrics before moving result.
+            {
+                let mut m = metrics.lock().await;
+                let elapsed_ms = started_at.elapsed().as_millis().min(u64::MAX as u128) as u64;
+                m.completed_ms.insert(cid.clone(), elapsed_ms);
+            }
+
             // Move to completed map
             completed.lock().await.insert(cid, result.clone());
             result
         });
+
+        {
+            let mut m = self.metrics.lock().await;
+            m.started = m.started.saturating_add(1);
+            m.started_at.insert(call_id.clone(), started_at);
+        }
 
         self.inflight.lock().await.insert(call_id, handle);
         // Signal task to proceed now that handle is in the map
@@ -154,10 +229,20 @@ impl StreamingToolExecutor {
     /// Discard a speculative result (e.g., when Step 3 intercepts the tool call).
     /// Cancels the in-flight task if still running.
     pub async fn discard(&self, call_id: &str) {
+        let mut aborted = false;
         if let Some(handle) = self.inflight.lock().await.remove(call_id) {
             handle.abort();
+            aborted = true;
         }
-        self.completed.lock().await.remove(call_id);
+        if self.completed.lock().await.remove(call_id).is_some() {
+            aborted = true;
+        }
+        if aborted {
+            let mut m = self.metrics.lock().await;
+            m.discarded = m.discarded.saturating_add(1);
+            m.started_at.remove(call_id);
+            m.completed_ms.remove(call_id);
+        }
     }
 
     /// Wait for all in-flight speculative executions to complete.
@@ -203,6 +288,13 @@ impl StreamingToolExecutor {
         for cid in tool_call_ids {
             if let Some(result) = speculative.get(cid) {
                 done.push(result.clone());
+                // Account this call_id as a hit.
+                let mut m = self.metrics.lock().await;
+                m.hit = m.hit.saturating_add(1);
+                if let Some(ms) = m.completed_ms.remove(cid) {
+                    m.total_saved_ms = m.total_saved_ms.saturating_add(ms);
+                }
+                m.started_at.remove(cid);
             } else {
                 needed.push(cid.clone());
             }
@@ -214,6 +306,48 @@ impl StreamingToolExecutor {
     /// Number of currently in-flight speculative executions.
     pub async fn inflight_count(&self) -> usize {
         self.inflight.lock().await.len()
+    }
+
+    /// Take a metrics snapshot. Does not reset counters.
+    pub async fn snapshot(&self) -> StreamingSpeculationMetrics {
+        let inflight = self.inflight.lock().await.len() as u64;
+        let m = self.metrics.lock().await;
+        StreamingSpeculationMetrics {
+            started: m.started,
+            hit: m.hit,
+            discarded: m.discarded,
+            inflight,
+            total_saved_ms: m.total_saved_ms,
+        }
+    }
+
+    /// Reset all counters to zero. Used at session boundaries when per-session
+    /// aggregation is desired.
+    pub async fn reset_metrics(&self) {
+        let mut m = self.metrics.lock().await;
+        *m = InnerMetrics::default();
+    }
+
+    /// Emit the current metrics snapshot as a structured `tracing::info!`
+    /// event on target `astra::streaming_speculation::metrics`. Intended to
+    /// be called once at session/turn end by the host.
+    ///
+    /// The event fields are stable so downstream log aggregators and the
+    /// ObservabilityHub can pick them up without parsing prose.
+    pub async fn emit_metrics_log(&self, session_id: Option<&str>) {
+        let snap = self.snapshot().await;
+        tracing::info!(
+            target: "astra::streaming_speculation::metrics",
+            session_id = session_id.unwrap_or(""),
+            started = snap.started,
+            hit = snap.hit,
+            discarded = snap.discarded,
+            inflight = snap.inflight,
+            wasted = snap.wasted(),
+            total_saved_ms = snap.total_saved_ms,
+            hit_rate = snap.hit_rate(),
+            "streaming speculation metrics"
+        );
     }
 }
 
@@ -383,5 +517,92 @@ mod tests {
             "write_file",
             Some(&PermissionDecision::approve())
         ));
+    }
+
+    #[tokio::test]
+    async fn metrics_counts_hit_and_saved_ms() {
+        let exec = StreamingToolExecutor::new(make_slow_executor(80));
+
+        // Two read-only speculations.
+        exec.on_tool_block(
+            "c1".into(),
+            "read_file".into(),
+            tool_block("read_file", "c1"),
+            0,
+        )
+        .await;
+        exec.on_tool_block("c2".into(), "grep".into(), tool_block("grep", "c2"), 1)
+            .await;
+
+        let snap_before = exec.snapshot().await;
+        assert_eq!(snap_before.started, 2);
+        assert_eq!(snap_before.hit, 0);
+
+        // Merge: c1 becomes a hit, c2 is listed but we also claim c3 which has
+        // no speculation.
+        let (done, needed) = exec.merge_speculative(&["c1".into(), "c3".into()]).await;
+        assert_eq!(done.len(), 1);
+        assert_eq!(done[0].call_id, "c1");
+        assert_eq!(needed, vec!["c3"]);
+
+        let snap = exec.snapshot().await;
+        assert_eq!(snap.started, 2);
+        assert_eq!(snap.hit, 1);
+        assert_eq!(snap.discarded, 0);
+        assert_eq!(snap.inflight, 0);
+        // c2 was started but not merged and not discarded → wasted.
+        assert_eq!(snap.wasted(), 1);
+        // Saved ≥ tool duration (80ms) since the speculative future fully completed.
+        assert!(
+            snap.total_saved_ms >= 70,
+            "saved_ms={}",
+            snap.total_saved_ms
+        );
+        assert!((snap.hit_rate() - 0.5).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn metrics_counts_discard() {
+        let exec = StreamingToolExecutor::new(make_slow_executor(200));
+
+        exec.on_tool_block(
+            "c1".into(),
+            "read_file".into(),
+            tool_block("read_file", "c1"),
+            0,
+        )
+        .await;
+        exec.discard("c1").await;
+
+        // Discarding a second time with no entry must not double-count.
+        exec.discard("c1").await;
+
+        let snap = exec.snapshot().await;
+        assert_eq!(snap.started, 1);
+        assert_eq!(snap.hit, 0);
+        assert_eq!(snap.discarded, 1);
+        assert_eq!(snap.wasted(), 0);
+        assert_eq!(snap.total_saved_ms, 0);
+    }
+
+    #[tokio::test]
+    async fn metrics_reset_clears_counters() {
+        let exec = StreamingToolExecutor::new(make_fast_executor());
+
+        exec.on_tool_block(
+            "c1".into(),
+            "read_file".into(),
+            tool_block("read_file", "c1"),
+            0,
+        )
+        .await;
+        let (_done, _) = exec.merge_speculative(&["c1".into()]).await;
+
+        let before = exec.snapshot().await;
+        assert!(before.started >= 1 && before.hit >= 1);
+
+        exec.reset_metrics().await;
+        let after = exec.snapshot().await;
+        assert_eq!(after, StreamingSpeculationMetrics::default());
     }
 }

--- a/rust/crates/astra-turn-core/src/tool_registry_report.rs
+++ b/rust/crates/astra-turn-core/src/tool_registry_report.rs
@@ -73,6 +73,18 @@ pub struct ToolQualityEntry {
     pub quality_sum: f64,
 }
 
+/// Persistence-friendly view of a single tracker entry.
+///
+/// `ToolQualityTracker` stores entries in a `HashMap` (iteration order
+/// non-deterministic). For persisted snapshots we flatten into a stable
+/// sorted `Vec` so byte-for-byte comparisons and cloud-merge behave.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ToolQualityPersistEntry {
+    pub name: String,
+    #[serde(flatten)]
+    pub entry: ToolQualityEntry,
+}
+
 impl ToolQualityEntry {
     /// Effectiveness score: how often this tool is actually used when selected.
     /// Range: 0.0 to 1.0.
@@ -143,6 +155,40 @@ impl ToolQualityTracker {
     /// Get all tracked tool quality entries.
     pub fn all_entries(&self) -> &std::collections::HashMap<String, ToolQualityEntry> {
         &self.scores
+    }
+
+    /// Export all entries as a sorted list suitable for persistence.
+    ///
+    /// Sorted by tool name for deterministic byte output and stable diffs
+    /// when merging local/cloud snapshots.
+    pub fn export(&self) -> Vec<ToolQualityPersistEntry> {
+        let mut out: Vec<ToolQualityPersistEntry> = self
+            .scores
+            .iter()
+            .map(|(name, entry)| ToolQualityPersistEntry {
+                name: name.clone(),
+                entry: entry.clone(),
+            })
+            .collect();
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        out
+    }
+
+    /// Additive merge of persisted entries into this tracker.
+    ///
+    /// For each incoming `(name, entry)` pair, counters (`selections`, `uses`,
+    /// `quality_sum`) are summed into the existing entry, or inserted if
+    /// unseen. This matches `record_selection` / `record_feedback` semantics:
+    /// historical observations accumulate across sessions.
+    pub fn merge(&mut self, entries: &[ToolQualityPersistEntry]) {
+        for incoming in entries {
+            let existing = self.scores.entry(incoming.name.clone()).or_default();
+            existing.selections = existing
+                .selections
+                .saturating_add(incoming.entry.selections);
+            existing.uses = existing.uses.saturating_add(incoming.entry.uses);
+            existing.quality_sum += incoming.entry.quality_sum;
+        }
     }
 }
 
@@ -289,5 +335,47 @@ mod tests {
             high_boost > low_boost,
             "high quality {high_boost} should beat low quality {low_boost}"
         );
+    }
+
+    #[test]
+    fn export_sorts_by_name_and_round_trips_through_merge() {
+        let mut tracker = ToolQualityTracker::new();
+        tracker.record_selection(&["grep".into(), "bash".into(), "apply_patch".into()]);
+        tracker.record_feedback(&SelectionFeedback {
+            tools_used: vec!["grep".into()],
+            unused_count: 2,
+            precision: 1.0 / 3.0,
+            recall: 1.0,
+        });
+        tracker.record_quality("grep", 0.9);
+
+        let exported = tracker.export();
+        let names: Vec<_> = exported.iter().map(|e| e.name.clone()).collect();
+        assert_eq!(names, vec!["apply_patch", "bash", "grep"]);
+
+        let mut fresh = ToolQualityTracker::new();
+        fresh.merge(&exported);
+        let restored_grep = fresh.all_entries().get("grep").expect("grep entry");
+        assert_eq!(restored_grep.selections, 1);
+        assert_eq!(restored_grep.uses, 1);
+        assert!((restored_grep.quality_sum - 0.9).abs() < 1e-9);
+    }
+
+    #[test]
+    fn merge_is_additive_across_sessions() {
+        let mut session_one = ToolQualityTracker::new();
+        session_one.record_selection(&["bash".into()]);
+        session_one.record_selection(&["bash".into()]);
+        session_one.record_quality("bash", 0.8);
+
+        let mut session_two = ToolQualityTracker::new();
+        session_two.record_selection(&["bash".into()]);
+        session_two.record_quality("bash", 0.6);
+        // Rehydrate session_two from session_one's snapshot.
+        session_two.merge(&session_one.export());
+
+        let entry = session_two.all_entries().get("bash").expect("bash entry");
+        assert_eq!(entry.selections, 3);
+        assert!((entry.quality_sum - (0.8 + 0.6)).abs() < 1e-9);
     }
 }

--- a/rust/crates/runtime/src/observability_integration.rs
+++ b/rust/crates/runtime/src/observability_integration.rs
@@ -830,6 +830,39 @@ impl ObservabilityHub {
         self.tuning_engine.record_feedback(signal);
     }
 
+    /// Record a batch of streaming speculative tool execution metrics.
+    ///
+    /// Forwards the cumulative counters into the
+    /// [`astra_learning::auto_tuning::AutoTuningEngine`] so that speculation
+    /// hit rate can be tracked across a session and used to auto-gate
+    /// `ASTRA_STREAMING_TOOL_EXEC` via
+    /// [`AutoTuningEngine::should_disable_streaming_speculation`].
+    ///
+    /// Also emits a structured `tracing::info!` event on target
+    /// `astra::streaming_speculation::metrics` for downstream log consumers.
+    pub fn record_streaming_speculation_metrics(
+        &self,
+        metrics: &astra_turn_core::streaming_tool_exec::StreamingSpeculationMetrics,
+    ) {
+        self.tuning_engine.record_streaming_speculation(
+            metrics.started,
+            metrics.hit,
+            metrics.discarded,
+            metrics.total_saved_ms,
+        );
+        tracing::info!(
+            target: "astra::streaming_speculation::metrics",
+            started = metrics.started,
+            hit = metrics.hit,
+            discarded = metrics.discarded,
+            inflight = metrics.inflight,
+            wasted = metrics.wasted(),
+            total_saved_ms = metrics.total_saved_ms,
+            hit_rate = metrics.hit_rate(),
+            "hub.record_streaming_speculation_metrics"
+        );
+    }
+
     fn signal_with_session_context(
         &self,
         session_id: &str,
@@ -1673,5 +1706,27 @@ mod tests {
         assert_eq!(s.outcome_bias.get("bash"), Some(&0.25));
         s.set_outcome_bias(std::collections::BTreeMap::new());
         assert!(s.outcome_bias.is_empty());
+    }
+
+    #[test]
+    fn hub_forwards_streaming_speculation_metrics() {
+        use astra_turn_core::streaming_tool_exec::StreamingSpeculationMetrics;
+
+        let hub = ObservabilityHub::new();
+        let metrics = StreamingSpeculationMetrics {
+            started: 8,
+            hit: 4,
+            discarded: 1,
+            inflight: 0,
+            total_saved_ms: 240,
+        };
+        hub.record_streaming_speculation_metrics(&metrics);
+
+        let stats = hub.tuning().streaming_speculation_stats();
+        assert_eq!(stats.started, 8);
+        assert_eq!(stats.hit, 4);
+        assert_eq!(stats.discarded, 1);
+        assert_eq!(stats.total_saved_ms, 240);
+        assert!((stats.hit_rate() - 0.5).abs() < 1e-9);
     }
 }

--- a/rust/crates/runtime/src/tool_selector.rs
+++ b/rust/crates/runtime/src/tool_selector.rs
@@ -423,7 +423,7 @@ impl TfIdfSelector {
                 Ok(p) => p,
                 Err(e) => e.into_inner(),
             };
-            for pattern in patterns.suggest(routing.task_type, routing.domain_hint, 2) {
+            for pattern in patterns.top_patterns(routing.task_type, routing.domain_hint, 2) {
                 learned.pattern_hints.push(format!(
                     "Successful tool chain for {:?}/{:?}: {} (success {:.0}%, quality {:.2})",
                     pattern.task_type,
@@ -2941,7 +2941,7 @@ mod tests {
         // Verify PatternLibrary recorded the outcome
         {
             let l = lib.lock().unwrap();
-            let suggestions = l.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+            let suggestions = l.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
             assert!(
                 !suggestions.is_empty(),
                 "pattern library should have recorded the outcome"
@@ -3049,7 +3049,7 @@ mod tests {
         }
         {
             let l = lib.lock().unwrap();
-            let suggestions = l.suggest(TaskType::Fetch, None, 5);
+            let suggestions = l.top_patterns(TaskType::Fetch, None, 5);
             assert!(
                 !suggestions.is_empty(),
                 "pattern library should still record chains without domain"

--- a/rust/crates/runtime/tests/improvement_proofs.rs
+++ b/rust/crates/runtime/tests/improvement_proofs.rs
@@ -5558,6 +5558,7 @@ mod hardening_proofs {
                     recent_outcomes: vec![],
                 },
             ],
+            tool_quality: Vec::new(),
             active_canary: None,
         };
         save_snapshot_to(&path, &snapshot).unwrap();

--- a/rust/crates/runtime/tests/improvement_proofs.rs
+++ b/rust/crates/runtime/tests/improvement_proofs.rs
@@ -2409,8 +2409,8 @@ mod state_convergence {
         assert_eq!(graph.domain_for("mo_tables"), Some(DomainHint::Database));
 
         let lib = pl_a.lock().unwrap();
-        let github_suggestions = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
-        let db_suggestions = lib.suggest(TaskType::Mutate, Some(DomainHint::Database), 5);
+        let github_suggestions = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+        let db_suggestions = lib.top_patterns(TaskType::Mutate, Some(DomainHint::Database), 5);
         assert!(
             !github_suggestions.is_empty(),
             "should have GitHub patterns"
@@ -3662,7 +3662,7 @@ mod learning_improves_selection {
         merge_into_modules(&snapshot, &eg2, &pl2, &cal2);
 
         let lib = pl2.lock().unwrap();
-        let suggestions = lib.suggest(TaskType::Reasoning, Some(DomainHint::Git), 5);
+        let suggestions = lib.top_patterns(TaskType::Reasoning, Some(DomainHint::Git), 5);
         assert!(
             !suggestions.is_empty(),
             "session 2 should have pattern suggestions from session 1"
@@ -3743,7 +3743,7 @@ mod learning_improves_selection {
         );
 
         let lib = pl2.lock().unwrap();
-        let suggestions = lib.suggest(TaskType::Fetch, Some(DomainHint::GitHub), 5);
+        let suggestions = lib.top_patterns(TaskType::Fetch, Some(DomainHint::GitHub), 5);
         assert!(
             !suggestions.is_empty(),
             "pattern suggestions survived roundtrip"
@@ -4677,7 +4677,7 @@ mod security_safety_gaps {
         assert!(!pref_keys::LANGUAGE.is_empty());
     }
 
-    /// PROOF: PatternLibrary.suggest() returns relevant patterns.
+    /// PROOF: PatternLibrary.top_patterns() returns relevant patterns.
     ///
     /// OLD: suggest() was only tested, never called in production.
     /// NEW: boost_terms_for() (which calls suggest internally) IS wired
@@ -4694,7 +4694,7 @@ mod security_safety_gaps {
         lib.record_outcome(&tools, TaskType::Code, None, true, 0.9, None);
         lib.record_outcome(&tools, TaskType::Code, None, true, 0.7, None);
 
-        let suggestions = lib.suggest(TaskType::Code, None, 5);
+        let suggestions = lib.top_patterns(TaskType::Code, None, 5);
         assert!(
             !suggestions.is_empty(),
             "should return at least one pattern"


### PR DESCRIPTION
## Bundle

This PR combines three previously-separate self-evolution fixes into a single
reviewable unit, replacing #203, #204, and #205.

### ① Streaming speculation metrics → ObservabilityHub + AutoTuningEngine  *(was #203)*

Track per-turn speculation hit / discard / saved-ms counters in
`StreamingToolExecutor`, snapshot them at each batch boundary, feed them into
`ObservabilityHub::record_streaming_speculation_metrics`, and teach
`AutoTuningEngine` to disable speculation when the hit rate collapses.
`reset_metrics()` is called after each hub report so the engine sees deltas,
not cumulative snapshots.

### ② PatternLibrary::suggest → top_patterns  *(was #204)*

The `#[deprecated(since = "0.9.0")]` tag was misleading — production still
relies on the ranking helper. Intent was to retire the *LLM-facing* suggestion
surface, not the internal ranking. Renamed `suggest` → `top_patterns`,
removed the unused `suggest_with_exploration` variant and its now-dead
`EXPLORATION_EPSILON` constant, renamed the forced-exploration test helper,
and updated 4 production callers + 1 test caller. No behaviour change.

### ③ Persist ToolQualityTracker across sessions  *(was #205)*

`ToolQualityTracker` counters previously reset to neutral (boost = 1.0) on
every REPL launch. Added backward-compatible `tool_quality` field to
`LearningSnapshot` (serde-default, skip-empty), new
`save_learning_state_full` / `export_from_modules_full` variants, additive
`ToolQualityTracker::export/merge`, cloud-sync merge that takes max per
counter to avoid double-counting, and CLI load/save wiring. Also clarified in
doc comments that `FeedbackStore` is intentionally session-scoped for privacy
(not a persistence bug).

## Verification

- `make check` ✅ (fmt + clippy + compile)
- `make test-offline` ✅ (73 runtime + all crate-local tests green)
- New tests:
  - `tool_registry_report::export_sorts_by_name_and_round_trips_through_merge`
  - `tool_registry_report::merge_is_additive_across_sessions`
  - `persistence::tool_quality_roundtrip_in_snapshot`
  - `persistence::tool_quality_empty_not_serialized`
  - `persistence::tool_quality_backward_compatible_load`

## Supersedes

- Closes #203
- Closes #204
- Closes #205