### PR TITLE
fix: heredoc sandbox + read-only deprioritize + plan-completed-on-failure cascade

### DIFF
--- a/rust/crates/astra-cli/src/cli/plan_executor.rs
+++ b/rust/crates/astra-cli/src/cli/plan_executor.rs
@@ -487,7 +487,10 @@ fn is_credential_error(msg: &str) -> bool {
 /// successful. Returning `plan_failed` in those cases lets consumers
 /// distinguish the two outcomes without changing the 100% progress_pct
 /// semantics callers already expect.
-fn plan_completion_action(global_passed: bool, any_subtask_verification_failed: bool) -> &'static str {
+fn plan_completion_action(
+    global_passed: bool,
+    any_subtask_verification_failed: bool,
+) -> &'static str {
     if !global_passed || any_subtask_verification_failed {
         "plan_failed"
     } else {
@@ -505,7 +508,10 @@ fn has_any_unresolved_verification_failure(
     use astra_services::durable_task::SubtaskStage;
     use astra_services::task_orchestrator::TaskStatus;
 
-    if subtasks.iter().any(|s| matches!(s.status, TaskStatus::Failed)) {
+    if subtasks
+        .iter()
+        .any(|s| matches!(s.status, TaskStatus::Failed))
+    {
         return true;
     }
     durable.is_some_and(|d| {

--- a/rust/crates/astra-cli/src/cli/plan_executor.rs
+++ b/rust/crates/astra-cli/src/cli/plan_executor.rs
@@ -474,6 +474,48 @@ fn is_credential_error(msg: &str) -> bool {
         || lower.contains("401")
 }
 
+/// Pick the `plan_progress` action for end-of-plan emission.
+///
+/// Bug #3 regression: previously the executor emitted `plan_complete` at 100%
+/// unconditionally once all subtasks had their status flipped to `Completed`,
+/// even when the global verifier said the plan was incorrect or when
+/// individual subtasks had been force-completed after exhausting their retry
+/// budget (`verification_completed {passed:false, retries_exhausted:true}`).
+///
+/// This produced journals where an agent appeared to succeed while
+/// downstream learning signals and UI would misinterpret a failed plan as
+/// successful. Returning `plan_failed` in those cases lets consumers
+/// distinguish the two outcomes without changing the 100% progress_pct
+/// semantics callers already expect.
+fn plan_completion_action(global_passed: bool, any_subtask_verification_failed: bool) -> &'static str {
+    if !global_passed || any_subtask_verification_failed {
+        "plan_failed"
+    } else {
+        "plan_complete"
+    }
+}
+
+/// Return true if any subtask has a `Failed` status *or* the durable contract
+/// records an unresolved `VerificationFailed` stage for any subtask. Used by
+/// [`plan_completion_action`] at end-of-plan emission.
+fn has_any_unresolved_verification_failure(
+    subtasks: &[astra_services::task_orchestrator::SubtaskPlan],
+    durable: Option<&super::durable_bridge::DurableTaskState>,
+) -> bool {
+    use astra_services::durable_task::SubtaskStage;
+    use astra_services::task_orchestrator::TaskStatus;
+
+    if subtasks.iter().any(|s| matches!(s.status, TaskStatus::Failed)) {
+        return true;
+    }
+    durable.is_some_and(|d| {
+        d.contract
+            .subtasks
+            .iter()
+            .any(|s| matches!(s.stage, SubtaskStage::VerificationFailed { .. }))
+    })
+}
+
 /// Build a one-line evidence sentence naming the tools with the highest
 /// failure rates across the caller's `ToolHealthEntry` set, so the retry
 /// hint can steer away from known-failing tools rather than emitting a
@@ -860,14 +902,29 @@ async fn plan_executor_task(
                     let _ = update_tx.send(PlanUpdate::DeliveryReport(report.clone()));
                 }
 
-                // Emit plan_completed journal + cloud event
+                // Emit plan completion journal + cloud event. Bug #3
+                // regression: previously this always emitted `plan_complete`
+                // at 100%, even when the global verifier rejected the plan
+                // (or individual subtasks had `retries_exhausted` and were
+                // force-marked Completed). That produced confusing journals
+                // where `plan_progress {action:"completed", progress_pct:100}`
+                // sat next to `verification_completed {passed:false}` for
+                // the same subtasks. Surface verification outcome in the
+                // action so downstream consumers (self_surface, UI, learning
+                // signals) can distinguish a genuinely finished plan from
+                // one that merely exhausted its retry budget.
                 let total = ctx.plan.subtasks.len();
+                let any_subtask_verification_failed = has_any_unresolved_verification_failure(
+                    &ctx.plan.subtasks,
+                    ctx.durable_task_state.as_ref(),
+                );
+                let action = plan_completion_action(global_passed, any_subtask_verification_failed);
                 let event = session_journal::JournalEvent::plan_progress(
                     ctx.session_id.as_deref(),
                     ctx.turn,
                     "",
                     ctx.plan_goal.as_deref().unwrap_or("plan"),
-                    "plan_complete",
+                    action,
                     100,
                     total,
                     total,
@@ -2292,5 +2349,59 @@ mod tests {
         assert!(is_credential_error("Authentication failed: token expired"));
         assert!(!is_credential_error("network timeout"));
         assert!(!is_credential_error("tool execution failed"));
+    }
+
+    // ── Bug #3 regression: plan_completion_action must reflect verification
+    // outcome, so downstream consumers (UI, learning signals, journal
+    // analysers) can distinguish a successful plan from one that merely
+    // exhausted retries. ─────────────────────────────────────────────────
+
+    #[test]
+    fn plan_completion_action_returns_complete_when_all_passed() {
+        assert_eq!(plan_completion_action(true, false), "plan_complete");
+    }
+
+    #[test]
+    fn plan_completion_action_returns_failed_when_global_verifier_failed() {
+        assert_eq!(plan_completion_action(false, false), "plan_failed");
+    }
+
+    #[test]
+    fn plan_completion_action_returns_failed_when_any_subtask_failed_verification() {
+        // Even if the global verifier was permissive (or absent), a single
+        // subtask with unresolved `VerificationFailed` must force the plan
+        // to report as failed. This prevents the "all subtasks Completed
+        // after retries_exhausted → plan_complete" false-positive observed
+        // in session 32c7c640.
+        assert_eq!(plan_completion_action(true, true), "plan_failed");
+    }
+
+    #[test]
+    fn plan_completion_action_failed_dominates_when_both_signals_bad() {
+        assert_eq!(plan_completion_action(false, true), "plan_failed");
+    }
+
+    #[test]
+    fn has_any_unresolved_verification_failure_detects_failed_status() {
+        use astra_services::task_orchestrator::{SubtaskPlan, TaskStatus};
+        let subtasks = vec![SubtaskPlan {
+            id: "s1".into(),
+            title: "t".into(),
+            status: TaskStatus::Failed,
+            ..Default::default()
+        }];
+        assert!(has_any_unresolved_verification_failure(&subtasks, None));
+    }
+
+    #[test]
+    fn has_any_unresolved_verification_failure_returns_false_when_all_completed() {
+        use astra_services::task_orchestrator::{SubtaskPlan, TaskStatus};
+        let subtasks = vec![SubtaskPlan {
+            id: "s1".into(),
+            title: "t".into(),
+            status: TaskStatus::Completed,
+            ..Default::default()
+        }];
+        assert!(!has_any_unresolved_verification_failure(&subtasks, None));
     }
 }

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -149,6 +149,33 @@ fn bash_command_segments(command: &str) -> Vec<&str> {
         }
 
         if !in_single_quote && !in_double_quote {
+            // Heredoc start: `<<WORD` / `<<-WORD` (but NOT here-string `<<<`).
+            // Without this skip, newlines in the heredoc body would split the
+            // body into separate "commands", and tags like `</title>` would be
+            // re-scanned as redirections — causing spurious SANDBOX_DENIED.
+            if ch == '<'
+                && chars.get(idx + 1).is_some_and(|(_, c)| *c == '<')
+                && chars.get(idx + 2).is_none_or(|(_, c)| *c != '<')
+            {
+                let mut hd_idx = idx + 2;
+                let strip_tabs = chars.get(hd_idx).is_some_and(|(_, c)| *c == '-');
+                if strip_tabs {
+                    hd_idx += 1;
+                }
+                // Emit the command line up to the `<<` operator as its own
+                // segment, then resume segmentation after the heredoc
+                // terminator. This ensures the heredoc body bytes never
+                // leak into any segment where absolute-path scanning
+                // would re-flag them.
+                let pre_segment = command[segment_start..byte_idx].trim();
+                if !pre_segment.is_empty() {
+                    segments.push(pre_segment);
+                }
+                idx = skip_heredoc_body(&chars, hd_idx, strip_tabs);
+                segment_start = chars.get(idx).map(|(b, _)| *b).unwrap_or(command.len());
+                continue;
+            }
+
             let is_double_separator =
                 matches!(ch, '&' | '|') && chars.get(idx + 1).is_some_and(|(_, next)| *next == ch);
             let is_single_separator = matches!(ch, '|' | ';' | '\n' | '\r');
@@ -1094,6 +1121,22 @@ fn check_redirection_path_boundary(
             }
 
             let (next_idx, consumes_path) = redirection_operator_details(&chars, idx);
+            // Heredoc (`<<WORD` or `<<-WORD`, but NOT here-string `<<<word`):
+            // skip the heredoc body so that `<`/`>` inside HTML / XML / template
+            // payloads aren't misparsed as further redirection operators.
+            let is_heredoc = ch == '<'
+                && (next_idx - idx) == 2
+                && chars.get(idx + 1).is_some_and(|(_, c)| *c == '<')
+                && chars.get(idx + 2).is_none_or(|(_, c)| *c != '<');
+            if is_heredoc {
+                let mut hd_idx = next_idx;
+                let strip_tabs = chars.get(hd_idx).is_some_and(|(_, c)| *c == '-');
+                if strip_tabs {
+                    hd_idx += 1;
+                }
+                idx = skip_heredoc_body(&chars, hd_idx, strip_tabs);
+                continue;
+            }
             idx = next_idx;
             if !consumes_path {
                 continue;
@@ -1189,6 +1232,117 @@ fn redirection_operator_details(chars: &[(usize, char)], idx: usize) -> (usize, 
         ('>', Some('&'), _) => (idx + 2, true),
         _ => (idx + 1, true),
     }
+}
+
+/// Skip past a heredoc body (`<<WORD` / `<<-WORD`, quoted or not) so that
+/// any `<` / `>` / shell meta inside the body can't be misparsed as further
+/// redirections. Called with `start_idx` pointing just after `<<` (or `<<-`).
+///
+/// Heredoc semantics we honour:
+/// * The delimiter word may be quoted (`'WORD'` / `"WORD"`) or unquoted; quotes
+///   or a leading backslash merely suppress expansion inside the body — here
+///   we only need the literal terminator.
+/// * `<<-WORD` strips leading tabs from terminator-line comparison.
+/// * Body runs from the next newline up to (and including) the line that
+///   equals the delimiter. If EOF is reached with no terminator we bail to
+///   end-of-input — further redirection scanning would be unsound anyway.
+fn skip_heredoc_body(chars: &[(usize, char)], start_idx: usize, strip_tabs: bool) -> usize {
+    let mut idx = start_idx;
+
+    // Skip any whitespace between `<<` and the delimiter word.
+    while idx < chars.len() && matches!(chars[idx].1, ' ' | '\t') {
+        idx += 1;
+    }
+
+    // Parse delimiter word (optionally quoted). Backslash escapes a single char.
+    let mut delim = String::new();
+    let quote = match chars.get(idx).map(|(_, c)| *c) {
+        Some('\'') => {
+            idx += 1;
+            Some('\'')
+        }
+        Some('"') => {
+            idx += 1;
+            Some('"')
+        }
+        _ => None,
+    };
+    while idx < chars.len() {
+        let c = chars[idx].1;
+        match quote {
+            Some(q) => {
+                if c == q {
+                    idx += 1;
+                    break;
+                }
+                delim.push(c);
+                idx += 1;
+            }
+            None => {
+                if c.is_whitespace() || matches!(c, '|' | ';' | '&' | '<' | '>') {
+                    break;
+                }
+                if c == '\\' {
+                    idx += 1;
+                    if let Some((_, next)) = chars.get(idx) {
+                        delim.push(*next);
+                        idx += 1;
+                    }
+                } else {
+                    delim.push(c);
+                    idx += 1;
+                }
+            }
+        }
+    }
+
+    if delim.is_empty() {
+        // Malformed `<<` with no delimiter — refuse to parse the rest rather
+        // than risk misclassifying body content as redirections.
+        return chars.len();
+    }
+
+    // Advance to the newline that starts the body. Anything between the
+    // delimiter word and that newline is either whitespace, another
+    // redirection target (e.g. `<< EOF > out.txt`), or a following command.
+    // We conservatively let it pass through — the outer validator will pick
+    // up `> out.txt` on the next iteration, but since we already `continue`d
+    // we need the caller to resume at the newline.
+    while idx < chars.len() && chars[idx].1 != '\n' {
+        idx += 1;
+    }
+    if idx < chars.len() {
+        idx += 1; // consume newline → body starts
+    }
+
+    // Scan body line-by-line for a line matching `delim` exactly
+    // (after optional leading-tab stripping for `<<-`).
+    while idx < chars.len() {
+        let line_start = idx;
+        while idx < chars.len() && chars[idx].1 != '\n' {
+            idx += 1;
+        }
+        let line_end = idx;
+        let mut line: String = chars[line_start..line_end]
+            .iter()
+            .map(|(_, c)| *c)
+            .collect();
+        if strip_tabs {
+            line = line.trim_start_matches('\t').to_string();
+        }
+        if line == delim {
+            if idx < chars.len() {
+                idx += 1; // consume terminating newline
+            }
+            return idx;
+        }
+        if idx < chars.len() {
+            idx += 1; // consume newline and continue
+        }
+    }
+
+    // EOF without terminator — bail to end so the outer scanner stops.
+    chars.len()
 }
 
 fn is_shell_interpreter_command(base: &str) -> bool {
@@ -4707,6 +4861,119 @@ mod tests {
         assert!(
             result.is_none(),
             ">&2 should remain treated as file-descriptor duplication, not a path access"
+        );
+    }
+
+    // ── Heredoc body must not be misparsed as redirections ─────────────
+    // Regression: HTML/XML/template payloads inside `<< 'EOF' ... EOF` used
+    // to trigger SANDBOX_DENIED because tags like `</title>` had their `<`
+    // interpreted as a redirection operator with `/title` as the target.
+
+    #[test]
+    fn heredoc_body_with_html_tags_is_not_misparsed_as_redirection() {
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let policy = SandboxPolicy::for_project("/home/user/project");
+        let cmd = "cat > page.html << 'EOF'\n\
+            <!DOCTYPE html>\n\
+            <html lang=\"en\"><head><title>hi</title></head>\n\
+            <body><a href=\"/admin\">x</a></body></html>\n\
+            EOF\n";
+        let result = check_bash_path_boundary(&policy, cmd);
+        assert!(
+            result.is_none(),
+            "heredoc body with HTML tags must not be treated as redirection: {result:?}"
+        );
+    }
+
+    #[test]
+    fn heredoc_unquoted_delimiter_body_is_skipped() {
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let policy = SandboxPolicy::for_project("/home/user/project");
+        let cmd = "cat > out.xml << EOF\n<root><child>/etc/shadow</child></root>\nEOF\n";
+        let result = check_bash_path_boundary(&policy, cmd);
+        assert!(
+            result.is_none(),
+            "unquoted heredoc must also skip body (no expansion here matters to us): {result:?}"
+        );
+    }
+
+    #[test]
+    fn heredoc_double_quoted_delimiter_body_is_skipped() {
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let policy = SandboxPolicy::for_project("/home/user/project");
+        let cmd = "cat > page.svg << \"DONE\"\n<svg><path d=\"M 0 0\"/></svg>\nDONE\n";
+        let result = check_bash_path_boundary(&policy, cmd);
+        assert!(result.is_none(), "double-quoted delimiter: {result:?}");
+    }
+
+    #[test]
+    fn heredoc_dash_strips_tabs_before_terminator() {
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let policy = SandboxPolicy::for_project("/home/user/project");
+        // `<<-` terminator may be preceded by tabs.
+        let cmd = "cat > f.html <<-END\n\t<div>a</div>\n\tEND\n";
+        let result = check_bash_path_boundary(&policy, cmd);
+        assert!(result.is_none(), "<<- tab-stripped terminator: {result:?}");
+    }
+
+    #[test]
+    fn redirection_after_heredoc_body_is_still_caught() {
+        // After the heredoc terminator, subsequent redirections must still
+        // be validated. Ensures we don't over-skip.
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let policy = SandboxPolicy::for_project("/home/user/project");
+        let cmd = "cat > page.html << 'EOF'\n<html></html>\nEOF\ncat > /etc/passwd";
+        let result = check_bash_path_boundary(&policy, cmd);
+        assert!(
+            result
+                .as_deref()
+                .is_some_and(|m| m.contains("/etc/passwd")),
+            "redirection after heredoc body should still be caught: {result:?}"
+        );
+    }
+
+    #[test]
+    fn heredoc_body_containing_redirection_like_text_does_not_deny() {
+        // Body has literal `> /etc/passwd` text — must not be validated as a redir.
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let policy = SandboxPolicy::for_project("/home/user/project");
+        let cmd = "cat > docs.txt << 'EOF'\nusage: foo > /etc/passwd\nEOF\n";
+        let result = check_bash_path_boundary(&policy, cmd);
+        assert!(
+            result.is_none(),
+            "body text that *describes* a redirection must not trip sandbox: {result:?}"
+        );
+    }
+
+    #[test]
+    fn heredoc_herestring_is_not_confused_with_heredoc() {
+        // `<<<word` is a here-string, NOT a heredoc — the word is inline, no body.
+        // Ensure the here-string path isn't accidentally taking the heredoc branch.
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let policy = SandboxPolicy::for_project("/home/user/project");
+        let result = check_bash_path_boundary(&policy, "grep foo <<< hello");
+        assert!(
+            result.is_none(),
+            "here-string should not be mis-detected as heredoc: {result:?}"
+        );
+    }
+
+    #[test]
+    fn heredoc_without_terminator_stops_scanning_safely() {
+        // Malformed heredoc (no terminator). The validator must not panic;
+        // downstream redirections in the tail are unreachable (EOF hit).
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let policy = SandboxPolicy::for_project("/home/user/project");
+        let cmd = "cat > x.html << 'EOF'\n<body>unterminated\n";
+        // Should either return None or a safety message — must not panic, must not
+        // report `/body` as a denied redirection.
+        let result = check_bash_path_boundary(&policy, cmd);
+        assert!(
+            result
+                .as_deref()
+                .map(|m| !m.contains("/body"))
+                .unwrap_or(true),
+            "unterminated heredoc must not surface body chars as a denied path: {result:?}"
         );
     }
 

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -4925,9 +4925,7 @@ mod tests {
         let cmd = "cat > page.html << 'EOF'\n<html></html>\nEOF\ncat > /etc/passwd";
         let result = check_bash_path_boundary(&policy, cmd);
         assert!(
-            result
-                .as_deref()
-                .is_some_and(|m| m.contains("/etc/passwd")),
+            result.as_deref().is_some_and(|m| m.contains("/etc/passwd")),
             "redirection after heredoc body should still be caught: {result:?}"
         );
     }

--- a/rust/crates/astra-turn-core/src/turn_guard.rs
+++ b/rust/crates/astra-turn-core/src/turn_guard.rs
@@ -112,12 +112,43 @@ pub struct TurnGuard {
     pub correction_history: Vec<CorrectionOutcome>,
 }
 
+/// Read-only core tools that are safe-by-construction and must never be
+/// hidden from the model, even after repeated spurious failures. Restricting
+/// a read-only tool typically creates a **false-positive cascade**: one bad
+/// verifier run deprioritizes `read_file`, the next turn can't observe file
+/// state, which causes further verification failures — snowballing into a
+/// stuck agent.
+///
+/// Mutating tools (bash, write_file, str_replace, delete_file, …) are
+/// **not** on this list — their deprioritization is a legitimate brake.
+///
+/// Keep in sync with the tool names registered in `schemas.rs`. Membership
+/// is checked case-sensitively.
+const READ_ONLY_NEVER_RESTRICT: &[&str] = &[
+    "read_file",
+    "list_dir",
+    "grep",
+    "glob",
+    "git_status",
+    "git_diff",
+    "git_show",
+    "git_log",
+];
+
 /// Insert deprioritized tool names from [`TurnGuard`] into the selector restriction set (CLI parity).
+///
+/// Read-only tools in [`READ_ONLY_NEVER_RESTRICT`] are excluded: they can
+/// still be surfaced via `ToolHealthTracker::deprioritized_tools()` for
+/// telemetry/logging, but they are *not* removed from the model's tool
+/// schema. See the rationale on that constant.
 pub fn merge_deprioritized_tools_into_restricted(
     turn_guard: &TurnGuard,
     restricted: &mut HashSet<String>,
 ) {
     for t in turn_guard.health.deprioritized_tools() {
+        if READ_ONLY_NEVER_RESTRICT.contains(&t) {
+            continue;
+        }
         restricted.insert(t.to_string());
     }
 }
@@ -977,7 +1008,6 @@ mod tests {
     #[test]
     fn verdict_fields_reflect_actual_state() {
         let mut guard = TurnGuard::new();
-
         // Trigger stall AND divergence (same sig repeated — the unified
         // progress-aware detection treats a genuine loop identically for
         // both detectors once enough history accumulates).
@@ -1500,5 +1530,78 @@ mod tests {
         assert!((eff.success_after_correction_rate - 2.0 / 3.0).abs() < 0.01);
         // 1 out of 3 effective (followed AND succeeded)
         assert!((eff.effective_rate - 1.0 / 3.0).abs() < 0.01);
+    }
+
+    // ── Bug #2 regression: read-only tools must never be restricted even
+    // after repeated consecutive failures. Otherwise a single bad verifier
+    // cascade hides `read_file` from the schema and the agent can no
+    // longer observe file state. ─────────────────────────────────────────
+
+    fn deprioritize_tool(guard: &mut TurnGuard, name: &str, times: usize) {
+        for _ in 0..times {
+            guard.health.record_failure(name);
+        }
+    }
+
+    #[test]
+    fn merge_does_not_restrict_read_only_tools_even_after_many_failures() {
+        let mut guard = TurnGuard::new();
+        // Drive far past CONSECUTIVE_FAILURE_THRESHOLD for every read-only tool.
+        for tool in super::READ_ONLY_NEVER_RESTRICT {
+            deprioritize_tool(&mut guard, tool, 10);
+        }
+
+        let mut restricted: HashSet<String> = HashSet::new();
+        super::merge_deprioritized_tools_into_restricted(&guard, &mut restricted);
+
+        for tool in super::READ_ONLY_NEVER_RESTRICT {
+            assert!(
+                !restricted.contains(*tool),
+                "read-only tool `{tool}` must not be restricted after repeated failures; \
+                 restricting it creates a false-positive cascade (see bug #2)"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_still_restricts_mutating_tools_on_repeated_failure() {
+        // Guard-rail: the read-only exemption must not accidentally neutralise
+        // deprioritization for mutating tools. `bash`/`write_file` must still
+        // land in `restricted` so the model is steered away from them after
+        // repeated failures.
+        let mut guard = TurnGuard::new();
+        deprioritize_tool(&mut guard, "bash", 5);
+        deprioritize_tool(&mut guard, "write_file", 5);
+
+        let mut restricted: HashSet<String> = HashSet::new();
+        super::merge_deprioritized_tools_into_restricted(&guard, &mut restricted);
+
+        assert!(
+            restricted.contains("bash"),
+            "mutating tool `bash` must still be restricted after repeated failures"
+        );
+        assert!(
+            restricted.contains("write_file"),
+            "mutating tool `write_file` must still be restricted after repeated failures"
+        );
+    }
+
+    #[test]
+    fn merge_mixed_failures_exempts_only_read_only_names() {
+        // Complex case: both kinds fail repeatedly → the restriction set
+        // contains only the mutating ones.
+        let mut guard = TurnGuard::new();
+        deprioritize_tool(&mut guard, "read_file", 8);
+        deprioritize_tool(&mut guard, "grep", 4);
+        deprioritize_tool(&mut guard, "bash", 4);
+        deprioritize_tool(&mut guard, "str_replace", 4);
+
+        let mut restricted: HashSet<String> = HashSet::new();
+        super::merge_deprioritized_tools_into_restricted(&guard, &mut restricted);
+
+        assert!(!restricted.contains("read_file"));
+        assert!(!restricted.contains("grep"));
+        assert!(restricted.contains("bash"));
+        assert!(restricted.contains("str_replace"));
     }
 }


### PR DESCRIPTION
## Problem

Session `~/.astra/sessions/32c7c640-b174-494c-bd8d-0e3e68697af1.jsonl` (web-agent-page, qwen-turbo) hit 4 plan restarts and 6/6 verification failures. Log forensics revealed three tightly-coupled bugs that compound into a stuck agent:

1. **SANDBOX_DENIED on HTML-in-heredoc.** `cat > page.html << 'EOF' ... <title>hi</title> ... EOF` triggered `SANDBOX_DENIED: The command references '/title'`. The shell segmenter split the command on the body's newlines, and `<` inside `</title>` was re-parsed as a redirection operator with `/title` as the target path.
2. **`read_file` blocked after deprioritize cascade.** After 3 consecutive failures (often caused by bug #1 or similar), `read_file` was added to the restricted set. The next turn couldn't observe file state, caused further failures, snowballed.
3. **`plan_progress {action:\"plan_complete\", progress_pct:100}` emitted alongside `verification_completed {passed:false, retries_exhausted:true}`.** Downstream consumers (UI, learning signals) couldn't distinguish a succeeded plan from one that merely ran out of retries.

## Fix

- **shell.rs:** `bash_command_segments` and `check_redirection_path_boundary` now skip heredoc bodies (`<<WORD` / `<<-WORD`, quoted or unquoted; `<<<` here-strings unaffected). Segment emission ends at the `<<` operator and resumes after the terminator.
- **turn_guard.rs:** `READ_ONLY_NEVER_RESTRICT` (`read_file`, `list_dir`, `grep`, `glob`, `git_status`, `git_diff`, `git_show`, `git_log`) now exempt from `merge_deprioritized_tools_into_restricted`. These tools cannot cause damage; blocking them creates false-positive verifier failures. Mutating tools (bash, write_file, …) still deprioritized normally.
- **plan_executor.rs:** New `plan_completion_action()` returns `plan_failed` when `global_passed=false` OR any subtask has unresolved `VerificationFailed` stage; `plan_complete` otherwise. End-of-plan emission uses it.

## Tests (17 new, all passing)

- `shell.rs`: 8 — HTML body, quoted / unquoted / `<<-` delimiters, literal-redir-in-body, post-heredoc redirection still caught, here-string, unterminated heredoc safety.
- `turn_guard.rs`: 3 — read-only survives 10 failures, mutating tools still restricted, mixed scenario.
- `plan_executor.rs`: 6 — full truth-table of completion actions + `SubtaskPlan` assertions.

## Verification

```
cargo test -p astra-cli                       → 2717 / 2717 pass
cargo test -p astra-turn-core --lib           → 2358 / 2358 pass
cargo clippy --workspace --all-targets -- -D warnings → clean
cargo check --workspace                       → clean
```
