### PR TITLE
fix(journal): synthesise finish_reason for tool-call rounds

### DIFF
--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -852,6 +852,104 @@ pub(crate) async fn run_agentic_loop_impl<H: AgenticLoopHost>(
 
 // ─── CTX_ helpers ────────────────────────────────────────────────────────────
 
+/// Derive a sensible OpenAI-protocol `finish_reason` when upstream didn't
+/// supply one. Observed in the wild: qwen-turbo frequently omits
+/// `finish_reason` on tool-call rounds (72/92 rounds null in a production
+/// session), which tripped up journal analysers and learning signals that
+/// used the field to distinguish tool-call rounds from stops.
+///
+/// Rule follows the OpenAI Chat Completions spec:
+/// * upstream value wins when present (we don't lie about "length"-truncated
+///   responses — that would suppress the output-token escalation at
+///   `server_loop_host.rs:1715`);
+/// * absent + tool_calls present → `"tool_calls"`;
+/// * absent + no tool_calls → `"stop"`.
+///
+/// This is a pure function to keep it trivially testable. Callers that need
+/// to record a journal event can use it without mutating the upstream
+/// `LlmCallResult`.
+pub(crate) fn synthesise_finish_reason(
+    upstream: Option<&str>,
+    has_tool_calls: bool,
+) -> &'static str {
+    match upstream {
+        Some("stop") => "stop",
+        Some("length") => "length",
+        Some("tool_calls") => "tool_calls",
+        Some("content_filter") => "content_filter",
+        Some("function_call") => "function_call",
+        // Unknown / other upstream string: we can't return it borrowed as
+        // `&'static`, but at the journal layer callers already have the
+        // original String when needed. Any caller that feeds a non-None
+        // upstream here is using this helper *as a default* — so fall
+        // through to the rules below for deterministic output.
+        Some(_) => {
+            if has_tool_calls {
+                "tool_calls"
+            } else {
+                "stop"
+            }
+        }
+        None => {
+            if has_tool_calls {
+                "tool_calls"
+            } else {
+                "stop"
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod synthesise_finish_reason_tests {
+    use super::synthesise_finish_reason;
+
+    #[test]
+    fn none_plus_tool_calls_becomes_tool_calls() {
+        assert_eq!(synthesise_finish_reason(None, true), "tool_calls");
+    }
+
+    #[test]
+    fn none_without_tool_calls_becomes_stop() {
+        assert_eq!(synthesise_finish_reason(None, false), "stop");
+    }
+
+    #[test]
+    fn upstream_length_is_preserved() {
+        // Critical: "length" is the signal that triggers max_output_tokens
+        // escalation in server_loop_host. We must never clobber it.
+        assert_eq!(synthesise_finish_reason(Some("length"), false), "length");
+        assert_eq!(synthesise_finish_reason(Some("length"), true), "length");
+    }
+
+    #[test]
+    fn upstream_known_values_are_preserved() {
+        assert_eq!(synthesise_finish_reason(Some("stop"), true), "stop");
+        assert_eq!(
+            synthesise_finish_reason(Some("tool_calls"), false),
+            "tool_calls"
+        );
+        assert_eq!(
+            synthesise_finish_reason(Some("content_filter"), false),
+            "content_filter"
+        );
+    }
+
+    #[test]
+    fn unknown_upstream_falls_back_to_rule() {
+        // Unknown reasons (forward-compatibility): treat as if absent so
+        // downstream consumers see consistent semantics.
+        assert_eq!(
+            synthesise_finish_reason(Some("something_new"), true),
+            "tool_calls"
+        );
+        assert_eq!(
+            synthesise_finish_reason(Some("something_new"), false),
+            "stop"
+        );
+    }
+}
+
 /// Extract repository name from a git remote URL.
 #[cfg(test)]
 pub(crate) mod tests {

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
@@ -859,7 +859,20 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
             cache_read_tokens: turn_result.accum.cache_read_tokens,
             tool_calls_returned: turn_result.accum.tool_calls.len() as u32,
             tool_call_names: tool_names,
-            finish_reason: None,
+            // Synthesise per OpenAI protocol when upstream leaves the field
+            // null (observed in the wild with qwen-turbo: 72/92 llm_rounds
+            // had no finish_reason in session 32c7c640). Reaching this code
+            // path means we *did* receive tool_calls, so `tool_calls` is the
+            // semantically correct value. Journal consumers (slash_debug,
+            // journal_digest, learning signals) can then distinguish genuine
+            // early-exit stops from tool-call rounds without heuristics.
+            finish_reason: Some(
+                super::agentic_loop_host::synthesise_finish_reason(
+                    None,
+                    !turn_result.accum.tool_calls.is_empty(),
+                )
+                .into(),
+            ),
             agentic_step: Some(agentic_step),
             source: Some("agentic_loop".into()),
             run_id,


### PR DESCRIPTION
## Problem

In production session `32c7c640-b174-494c-bd8d-0e3e68697af1`, **72 of 92** `llm_round` journal events have `metadata.finish_reason == null`. Perfect correlation: every null is a round with tool_calls; every "stop" is a round without. qwen-turbo (and other OpenAI-compatible providers) often omits `finish_reason` on tool-call rounds, so downstream consumers blindly record null.

Impact:
- `slash_debug` / `journal_digest` show `-` for 78% of rounds, hurting debuggability.
- Learning signals and future analysers can't distinguish tool-call rounds from early-exit stops without heuristics on `tool_calls_returned`.
- Cannot trigger max_output_tokens escalation for models that don't mark `length` explicitly (side benefit — this PR preserves upstream `length` when present).

## Root cause

`rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs` hardcoded `finish_reason: None` when writing the `LlmRoundRecord`, even when the round produced tool_calls. The upstream `turn_result` does not currently thread `finish_reason` through `ChatTurnSseAccum`, so that `None` was the only value available.

## Fix

Introduce a pure helper `synthesise_finish_reason(upstream: Option<&str>, has_tool_calls: bool) -> &'static str` in `agentic_loop_host.rs`, following the OpenAI Chat Completions protocol:

| upstream | has_tool_calls | result |
|---|---|---|
| `Some("length")` | any | `"length"` (critical — drives max_output_tokens retry at `server_loop_host.rs:1715`) |
| `Some("stop" / "tool_calls" / "content_filter" / "function_call")` | any | passthrough |
| `Some(unknown)` | true → `"tool_calls"` | false → `"stop"` |
| `None` | true → `"tool_calls"` | false → `"stop"` |

The tool-phase journal emitter now calls this helper from the accum rather than writing `None`.

Note: bridge_inprocess.rs already uses the same pattern (line 1703) — this PR brings the main agentic-loop emitter in line.

## Tests

5 new unit tests on the pure helper covering each branch of the match. All 2159 runtime lib tests pass; clippy clean.

## Files

- `rust/crates/runtime/src/turn/agentic_loop_host.rs` (+96): helper + tests.
- `rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs` (+16, -1): consume helper.

Evidence session: `32c7c640-b174-494c-bd8d-0e3e68697af1` (all 72 null finish_reasons were tool-call rounds).

Co-authored-by: Copilot