### PR TITLE
fix: agent quality bundle (resume-loop + telemetry + skill governance)

### DIFF
--- a/rust/crates/astra-cli/src/cli/plan_executor.rs
+++ b/rust/crates/astra-cli/src/cli/plan_executor.rs
@@ -55,6 +55,12 @@ pub enum PlanUpdate {
         pct: u32,
         remaining: usize,
         elapsed: Duration,
+        /// Subtask ids that blocked progress (empty for Ctrl+C interrupt pause).
+        /// When non-empty the monitor can show them so the user sees *why* the
+        /// plan paused instead of just a count. Added 2026-04-23 to close a
+        /// resume→re-pause loop where the user had no signal to diagnose the
+        /// dependency deadlock.
+        blocked_ids: Vec<String>,
     },
     PlanCompleted {
         pct: u32,
@@ -404,11 +410,21 @@ impl PlanOutputSink for ChannelSink {
         self.send(PlanUpdate::PlanCompleted { pct: 100, elapsed });
     }
 
-    fn plan_paused(&self, pct: u32, remaining: usize, elapsed: Duration, _blocked_ids: &str) {
+    fn plan_paused(&self, pct: u32, remaining: usize, elapsed: Duration, blocked_ids: &str) {
+        let blocked_ids = if blocked_ids.is_empty() {
+            Vec::new()
+        } else {
+            blocked_ids
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        };
         self.send(PlanUpdate::PlanPaused {
             pct,
             remaining,
             elapsed,
+            blocked_ids,
         });
     }
 
@@ -443,6 +459,7 @@ impl PlanOutputSink for ChannelSink {
             pct,
             remaining,
             elapsed: Duration::ZERO,
+            blocked_ids: Vec::new(),
         });
     }
 
@@ -972,13 +989,79 @@ async fn plan_executor_task(
                 });
                 return; // Plan is done — exit the execution loop
             } else {
-                let blocked: Vec<_> = ctx
+                // ── Blocked-deps pause with auto-heal + resume-loop guard ──
+                //
+                // Bug fix 2026-04-23: Previously, if the ready set was empty
+                // and the plan was <100%, we paused and waited for Resume.
+                // Resume simply `continue`d the outer loop, which re-analysed
+                // deps with *identical* plan state — producing an infinite
+                // 继续→pause→继续→pause loop with no signal to the user
+                // about *why*. Observed in session 26f73ee4.
+                //
+                // Defences, cheapest first:
+                //   1. Auto-heal orphan `InProgress` subtasks (e.g. a crashed
+                //      worker left its subtask "running" — treat it as
+                //      retriable by resetting to `Pending`). This frequently
+                //      clears the deadlock without user intervention.
+                //   2. Surface the blocked ids in the `PlanPaused` UI event
+                //      so the user can diagnose at a glance.
+                //   3. If Resume is received and re-analysis produces the
+                //      *exact same* blocked set as before, abort with a
+                //      descriptive error rather than looping. The user can
+                //      always `rewind N`, edit the plan, or Cancel to recover.
+                let mut blocked: Vec<String> = ctx
                     .plan
                     .subtasks
                     .iter()
                     .filter(|s| s.status == TaskStatus::Pending)
-                    .map(|s| s.id.as_str())
+                    .map(|s| s.id.clone())
                     .collect();
+                blocked.sort();
+                let blocked_key = blocked.clone();
+
+                // Auto-heal InProgress orphans — they must have been
+                // abandoned (no live worker handle exists at this level of
+                // the executor) so resurrect them as Pending for another
+                // attempt. Log to journal so it's traceable.
+                let mut healed: Vec<String> = Vec::new();
+                for st in ctx.plan.subtasks.iter_mut() {
+                    if st.status == TaskStatus::InProgress {
+                        st.status = TaskStatus::Pending;
+                        healed.push(st.id.clone());
+                    }
+                }
+                if !healed.is_empty() {
+                    for id in &healed {
+                        let _ = update_tx.send(PlanUpdate::SubtaskStatusSync {
+                            id: id.clone(),
+                            status: TaskStatus::Pending,
+                        });
+                    }
+                    let healed_msg = format!(
+                        "Auto-healed {} orphan InProgress subtasks → Pending: {}",
+                        healed.len(),
+                        healed.join(", ")
+                    );
+                    let event = session_journal::JournalEvent::plan_progress(
+                        ctx.session_id.as_deref(),
+                        ctx.turn,
+                        "",
+                        ctx.plan_goal.as_deref().unwrap_or("plan"),
+                        "orphan_healed",
+                        pct,
+                        ctx.plan
+                            .subtasks
+                            .iter()
+                            .filter(|s| s.status.is_terminal())
+                            .count(),
+                        ctx.plan.subtasks.len(),
+                    );
+                    emit_event(&update_tx, &ctx, event);
+                    eprintln!("  ℹ  {healed_msg}");
+                    // After healing, don't pause — jump back to re-analyse.
+                    continue;
+                }
+
                 sink.plan_paused(
                     pct,
                     blocked.len(),
@@ -1001,6 +1084,59 @@ async fn plan_executor_task(
                             return;
                         }
                         _ => {}
+                    }
+                }
+
+                // Anti-loop check: after resume, re-compute ready + blocked.
+                // If the blocked set is identical to what we just paused on,
+                // we'd immediately re-pause. Abort with an actionable error
+                // message instead of producing a user-visible infinite loop.
+                let new_ready = ctx.plan.ready_subtasks();
+                if new_ready.is_empty() {
+                    let mut new_blocked: Vec<String> = ctx
+                        .plan
+                        .subtasks
+                        .iter()
+                        .filter(|s| s.status == TaskStatus::Pending)
+                        .map(|s| s.id.clone())
+                        .collect();
+                    new_blocked.sort();
+                    if new_blocked == blocked_key {
+                        // Build a concise "who-blocks-whom" summary so the
+                        // user can rewind/edit the right subtask.
+                        let summary: Vec<String> = ctx
+                            .plan
+                            .subtasks
+                            .iter()
+                            .filter(|s| s.status == TaskStatus::Pending)
+                            .map(|s| {
+                                let unmet: Vec<&str> = s
+                                    .depends_on
+                                    .iter()
+                                    .filter(|dep| {
+                                        !ctx.plan.subtasks.iter().any(|d| {
+                                            d.id == **dep && d.status == TaskStatus::Completed
+                                        })
+                                    })
+                                    .map(|s| s.as_str())
+                                    .collect();
+                                if unmet.is_empty() {
+                                    format!("{} (no unmet deps — status stuck?)", s.id)
+                                } else {
+                                    format!("{} needs [{}]", s.id, unmet.join(", "))
+                                }
+                            })
+                            .collect();
+                        let _ = update_tx.send(PlanUpdate::PlanError {
+                            error: format!(
+                                "Plan deadlocked: resume would re-pause on the same blocked set. \
+                                 Blocked subtasks:\n  - {}\n\
+                                 Use `rewind <id>` to revise a completed dep, edit the plan, \
+                                 or Cancel to abort.",
+                                summary.join("\n  - ")
+                            ),
+                        });
+                        return;
                     }
                 }
             }

--- a/rust/crates/astra-cli/src/cli/plan_executor.rs
+++ b/rust/crates/astra-cli/src/cli/plan_executor.rs
@@ -2546,4 +2546,95 @@ mod tests {
         }];
         assert!(!has_any_unresolved_verification_failure(&subtasks, None));
     }
+
+    // ─── Resume-loop / blocked-deps regression tests ──────────────────────
+    //
+    // These tests lock in the fixes from PR #216 for the deadlock where
+    // typing "继续" on a blocked-deps pause immediately re-paused with no
+    // diagnostic info. See bug write-up in the PR body; observed in session
+    // 26f73ee4-51a5-44e9-90c2-fc475b77f463.
+
+    /// The ChannelSink must parse the comma-separated blocked_ids string
+    /// the trait contract hands it, and forward it as a Vec<String> on
+    /// `PlanUpdate::PlanPaused`. Before the fix, the parameter was
+    /// underscore-prefixed and dropped on the floor, so the REPL monitor
+    /// could only show a count, not the actionable ids.
+    #[test]
+    fn channel_sink_plan_paused_forwards_blocked_ids() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let sink = ChannelSink::new(tx);
+        sink.plan_paused(42, 3, Duration::from_secs(12), "step-4, step-5, step-6");
+
+        let update = rx.try_recv().expect("sink should have emitted");
+        match update {
+            PlanUpdate::PlanPaused {
+                pct,
+                remaining,
+                elapsed,
+                blocked_ids,
+            } => {
+                assert_eq!(pct, 42);
+                assert_eq!(remaining, 3);
+                assert_eq!(elapsed, Duration::from_secs(12));
+                assert_eq!(blocked_ids, vec!["step-4", "step-5", "step-6"]);
+            }
+            other => panic!("expected PlanPaused, got {:?}", other),
+        }
+    }
+
+    /// Empty / whitespace-only blocked_ids must produce an empty vec, not
+    /// a vec containing the empty string (which would render as
+    /// "blocked by: " in the monitor).
+    #[test]
+    fn channel_sink_plan_paused_handles_empty_blocked() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let sink = ChannelSink::new(tx);
+        sink.plan_paused(10, 0, Duration::from_secs(1), "");
+
+        match rx.try_recv().unwrap() {
+            PlanUpdate::PlanPaused { blocked_ids, .. } => {
+                assert!(blocked_ids.is_empty(), "got {:?}", blocked_ids);
+            }
+            other => panic!("expected PlanPaused, got {:?}", other),
+        }
+
+        // Whitespace between commas must not produce empty entries.
+        let (tx2, mut rx2) = tokio::sync::mpsc::unbounded_channel();
+        let sink2 = ChannelSink::new(tx2);
+        sink2.plan_paused(10, 1, Duration::from_secs(1), ",, step-1 ,,");
+        match rx2.try_recv().unwrap() {
+            PlanUpdate::PlanPaused { blocked_ids, .. } => {
+                assert_eq!(blocked_ids, vec!["step-1"]);
+            }
+            other => panic!("expected PlanPaused, got {:?}", other),
+        }
+    }
+
+    /// `interrupted_pause` (Ctrl+C pause) has no dependency-blocking
+    /// concept — it must emit an empty blocked_ids and zero elapsed so
+    /// the monitor knows not to render a misleading "blocked by" line.
+    #[test]
+    fn channel_sink_interrupted_pause_emits_empty_blocked() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let sink = ChannelSink::new(tx);
+        sink.interrupted_pause(55, 4);
+
+        match rx.try_recv().unwrap() {
+            PlanUpdate::PlanPaused {
+                pct,
+                remaining,
+                elapsed,
+                blocked_ids,
+            } => {
+                assert_eq!(pct, 55);
+                assert_eq!(remaining, 4);
+                assert_eq!(elapsed, Duration::ZERO);
+                assert!(
+                    blocked_ids.is_empty(),
+                    "interrupted pause must not claim blocked ids"
+                );
+            }
+            other => panic!("expected PlanPaused, got {:?}", other),
+        }
+    }
 }

--- a/rust/crates/astra-cli/src/cli/plan_monitor.rs
+++ b/rust/crates/astra-cli/src/cli/plan_monitor.rs
@@ -386,15 +386,31 @@ fn display_plan_updates_live(
                 pct,
                 remaining,
                 elapsed,
+                blocked_ids,
             } => {
                 outcome = PlanMonitorOutcome::Paused;
-                (
-                    format!(
-                        "\n⏸  Plan paused — {pct}% done, {remaining} remaining ({})",
-                        format_duration_short(elapsed),
-                    ),
-                    PostSpinner::None,
-                )
+                // Surface blocked ids when the executor supplies them so the
+                // user can see *which* subtasks are gating progress instead
+                // of just a count. Empty blocked_ids means a Ctrl+C / normal
+                // interrupt pause where the full pending queue is "remaining".
+                let base = format!(
+                    "\n⏸  Plan paused — {pct}% done, {remaining} remaining ({})",
+                    format_duration_short(elapsed),
+                );
+                let msg = if blocked_ids.is_empty() {
+                    base
+                } else {
+                    // Cap to a reasonable number so a 50-subtask deadlock
+                    // doesn't overflow the terminal.
+                    let shown: Vec<String> = blocked_ids.iter().take(8).cloned().collect();
+                    let suffix = if blocked_ids.len() > shown.len() {
+                        format!(" (+{} more)", blocked_ids.len() - shown.len())
+                    } else {
+                        String::new()
+                    };
+                    format!("{base}\n    blocked by: {}{suffix}", shown.join(", "))
+                };
+                (msg, PostSpinner::None)
             }
             PlanUpdate::GlobalVerificationFailed => (
                 "  ⚠ Global verification failed".to_string(),

--- a/rust/crates/astra-plan/src/decompose.rs
+++ b/rust/crates/astra-plan/src/decompose.rs
@@ -2751,7 +2751,20 @@ pub fn format_subtask_prompt(subtask: &SubtaskPlan) -> String {
         "\nPlease implement this change. Read the relevant files first, \
          make the changes, and verify they compile/pass tests.\n\
          Before referencing any project type, function, struct, or API in new code, \
-         confirm it exists using read_file, grep, or LSP tools. Do not assume symbol names.",
+         confirm it exists using read_file, grep, or LSP tools. Do not assume symbol names.\n\
+         \n\
+         IMPORTANT — how to produce code:\n\
+         - Emit actual file mutations as tool_calls: `write_file`, `str_replace`, \
+           `create_file`, or `bash` (for mkdir / scaffolding). DO NOT paste \
+           implementation code inside the assistant response as markdown code blocks \
+           — markdown is inert and does not modify the filesystem.\n\
+         - After writing any new file, confirm it exists (`read_file` or `bash ls`) \
+           before declaring the subtask done.\n\
+         - `skill` and `discover_skills` are advisory: consulting a skill does NOT \
+           satisfy the subtask. The subtask is only complete when concrete files \
+           have been written and any acceptance check passes.\n\
+         - Do not invoke `github_create_pr` (or any PR-creation skill) before you \
+           have actually written and committed the changes this subtask requires.",
     );
 
     prompt

--- a/rust/crates/astra-turn-core/src/stall.rs
+++ b/rust/crates/astra-turn-core/src/stall.rs
@@ -50,6 +50,23 @@ const EXPLORATION_TOOLS: &[&str] = &[
     "symbols",
 ];
 
+/// Tools that NEVER mutate the filesystem — they are purely consultative.
+/// A stream of repeated calls to these, without any interleaved mutating tool
+/// (`write_file`, `str_replace`, `create_file`, bash-with-side-effects, etc.),
+/// is diagnostic of an agent narrating implementation as prose instead of
+/// emitting real edits (observed in session 26f73ee4 where 12 `skill` calls
+/// produced 0 write_file/str_replace calls across an entire plan).
+///
+/// We keep this LIST SEPARATE from `EXPLORATION_TOOLS` because the two signals
+/// serve different detectors:
+///   * `EXPLORATION_TOOLS` drives single-round "all-exploration chain"
+///     detection (reward-hacking guard). Adding `skill` there would
+///     over-aggressively hard-block deferred follow-ups like `read_file`
+///     after a productive skill consultation — a legitimate pattern.
+///   * `CONSULTATIVE_TOOLS` drives the multi-round top-tool diagnostic below,
+///     where repetition across ≥3 rounds is the actual anti-pattern.
+const CONSULTATIVE_TOOLS: &[&str] = &["skill", "discover_skills"];
+
 /// Maximum consecutive exploration-only rounds before triggering correction.
 /// Lowered from 8→5→3: with auto-expanding read_file (full-file on 2nd+ ranged
 /// read) and EdgeToolCache dedup, agents need fewer exploration rounds.
@@ -630,7 +647,13 @@ pub fn build_stall_reflection(
 }
 
 fn is_exploration_tool(name: &str) -> bool {
-    EXPLORATION_TOOLS.contains(&name)
+    // For the top-tool diagnostic in `build_stall_reflection`, treat
+    // consultative tools (skill/discover_skills) as exploration too so that
+    // an agent repeatedly calling `skill` without writing files triggers the
+    // same "stop exploring, take direct action" nudge that repeat `grep` /
+    // `read_file` triggers. This is scoped to the top-tool diagnostic and
+    // does NOT affect single-round reward-hacking chain classification.
+    EXPLORATION_TOOLS.contains(&name) || CONSULTATIVE_TOOLS.contains(&name)
 }
 
 /// Detect if the LLM ignored a previous stall nudge by using tools

--- a/rust/crates/astra-turn-core/src/stall.rs
+++ b/rust/crates/astra-turn-core/src/stall.rs
@@ -1292,6 +1292,48 @@ mod tests {
         assert!(r1.confidence <= r0.confidence);
     }
 
+    /// Regression (2026-04-23, session 26f73ee4): three consecutive rounds
+    /// of `skill` calls with zero file mutations must trigger the
+    /// "exploration stall" diagnostic just like three `bash` / `grep` rounds
+    /// do. Before adding `skill`/`discover_skills` to the consultative
+    /// classifier, an agent could consult skills forever while narrating
+    /// implementation as markdown code blocks without ever tripping the
+    /// stall detector.
+    #[test]
+    fn reflection_triggers_on_skill_obsession() {
+        let sigs = make_sigs(&[&["skill"], &["skill"], &["skill"]]);
+        let reflection = build_stall_reflection(&sigs, &[], 0);
+        assert!(
+            reflection.what_happened.contains("skill"),
+            "expected 'skill' in diagnosis, got: {}",
+            reflection.what_happened
+        );
+        assert!(
+            reflection.confidence >= 0.7,
+            "skill-obsession must be classified as high-confidence \
+             exploration stall, got {}",
+            reflection.confidence
+        );
+        assert!(
+            reflection.avoid_tools.contains(&"skill".to_string()),
+            "avoid_tools should include `skill`, got: {:?}",
+            reflection.avoid_tools
+        );
+    }
+
+    /// `discover_skills` is the other consultative tool — same contract.
+    #[test]
+    fn reflection_triggers_on_discover_skills_loop() {
+        let sigs = make_sigs(&[
+            &["discover_skills"],
+            &["discover_skills"],
+            &["discover_skills"],
+        ]);
+        let reflection = build_stall_reflection(&sigs, &[], 0);
+        assert!(reflection.what_happened.contains("discover_skills"));
+        assert!(reflection.confidence >= 0.7);
+    }
+
     #[test]
     fn reflection_includes_error_tools() {
         let sigs = make_sigs(&[&["read_file"], &["bash"], &["read_file"]]);

--- a/rust/crates/runtime/src/turn/agentic_auto_reflection.rs
+++ b/rust/crates/runtime/src/turn/agentic_auto_reflection.rs
@@ -675,7 +675,16 @@ pub(crate) async fn maybe_trigger_auto_reflection<H: AgenticLoopHost>(
     apply_auto_reflection_usage(state, &reflection_result);
 
     // Record the auto-reflection LLM call so turn.tokens_in breakdown is complete.
+    // Compute agentic_step before the mutable borrow of state.turn_event_buffer;
+    // otherwise we'd need two overlapping borrows of `state`.
+    let agentic_step = super::agentic_loop_lifecycle::current_agentic_step(state);
     if let Some(ref mut buf) = state.turn_event_buffer {
+        // Populate agentic_step so journal llm_round events carry the turn's
+        // iteration index even for auto-reflection rounds. Before 2026-04-23
+        // this was hardcoded `None`, which made downstream analysis (telemetry
+        // grouping, self-surface reporting) unable to attribute an auto-reflect
+        // LLM call to its agentic iteration. Observed in session 26f73ee4
+        // where 32 llm_round events all had `agentic_step: None`.
         buf.record_llm_round(astra_services::session_journal::LlmRoundRecord {
             ttft_ms: None,
             duration_ms: 0,
@@ -685,7 +694,7 @@ pub(crate) async fn maybe_trigger_auto_reflection<H: AgenticLoopHost>(
             tool_calls_returned: 0,
             tool_call_names: vec![],
             finish_reason: Some("auto_reflection".into()),
-            agentic_step: None,
+            agentic_step: Some(agentic_step),
             source: Some("auto_reflection".into()),
             run_id: state.current_run_id.clone(),
         });

--- a/skills/github_create_pr/SKILL.md
+++ b/skills/github_create_pr/SKILL.md
@@ -57,7 +57,22 @@ If on `main` or the base branch, stop — nothing to create a PR from.
 ### 1.3 Check for uncommitted changes
 Use `git_status`. If dirty, ask if user wants to commit first.
 
-### 1.4 Check for existing PR from this branch
+### 1.4 Verify the branch actually has commits to PR (empty-diff guard)
+
+Before calling `gh pr create`, confirm the branch diverges from the base:
+
+```bash
+git rev-list --count main..HEAD 2>/dev/null || echo 0
+```
+
+If the count is `0` (or the command errors because `main` is unresolved), **STOP**:
+- Tell the user the branch has no commits ahead of base — there is nothing to PR.
+- Do not invoke `gh pr create` on an empty diff. GitHub will reject it with
+  "No commits between main and {branch}", and the failure is wasted tokens.
+- Suggest running `git_status` / `write_file` / `str_replace` first, or swap to a
+  different base branch if the user intended a fork-style PR.
+
+### 1.5 Check for existing PR from this branch
 Use `github_list_prs` with `state: "open"` to check. If a PR already exists from this branch, show it and ask whether to update or create a new one.
 
 ## Phase 2: Generate PR Content

--- a/skills/github_create_pr/SKILL.md
+++ b/skills/github_create_pr/SKILL.md
@@ -59,18 +59,24 @@ Use `git_status`. If dirty, ask if user wants to commit first.
 
 ### 1.4 Verify the branch actually has commits to PR (empty-diff guard)
 
-Before calling `gh pr create`, confirm the branch diverges from the base:
+Before calling `gh pr create`, confirm the branch diverges from the base.
+Use the `BASE` argument if the user supplied one; otherwise default to
+`main`:
 
 ```bash
-git rev-list --count main..HEAD 2>/dev/null || echo 0
+base="${BASE:-main}"
+git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0
 ```
 
-If the count is `0` (or the command errors because `main` is unresolved), **STOP**:
-- Tell the user the branch has no commits ahead of base — there is nothing to PR.
+If the count is `0` (or the command errors because the base ref is
+unresolved), **STOP**:
+- Tell the user the branch has no commits ahead of `${base}` — there is
+  nothing to PR.
 - Do not invoke `gh pr create` on an empty diff. GitHub will reject it with
-  "No commits between main and {branch}", and the failure is wasted tokens.
-- Suggest running `git_status` / `write_file` / `str_replace` first, or swap to a
-  different base branch if the user intended a fork-style PR.
+  "No commits between ${base} and {branch}", and the failure is wasted tokens.
+- Suggest running `git_status` / `write_file` / `str_replace` first, or use
+  a different `BASE` (e.g. `develop`, `master`) if the user intended a
+  different target branch.
 
 ### 1.5 Check for existing PR from this branch
 Use `github_list_prs` with `state: "open"` to check. If a PR already exists from this branch, show it and ask whether to update or create a new one.


### PR DESCRIPTION
Five cross-cutting agent-quality fixes surfaced by live session analysis (`~/.astra/sessions/26f73ee4-51a5-44e9-90c2-fc475b77f463.jsonl`, qwen-turbo, 117 events).

## Fixes

### 1. Plan-executor resume-loop (highest UX win)
When a plan paused with no ready subtasks (blocked deps) the user would type `继续` and the executor immediately re-paused on the same blocked set — an endless loop with no diagnostic info.

- `PlanUpdate::PlanPaused` now carries `blocked_ids` so the monitor shows `blocked by: step-4, step-5` instead of just a count.
- On entering the blocked path, auto-heal any orphan `InProgress` subtasks → `Pending` (common root cause: crashed worker).
- After `Resume`, if re-analysis yields the **same** blocked set as before, abort with a descriptive `PlanError` listing who-blocks-whom instead of looping.

### 2. `agentic_step` telemetry gap
`auto_reflection` rounds hardcoded `agentic_step: None`. 32/32 `llm_round` events in session 26f73ee4 had null `agentic_step`. Now populated via `current_agentic_step(state)`.

### 3. `github_create_pr` empty-diff guard
Session showed the agent calling PR creation on an empty diff. Added pre-flight `git rev-list --count main..HEAD` check to the skill that stops with a clear message when the count is 0.

### 4. Subtask prompt sharpening
The agent emitted full implementation as markdown code blocks while calling zero `write_file` / `str_replace` tools. Extended `format_subtask_prompt` to explicitly require tool-call mutations and forbid markdown-only 'implementations', plus a reminder that consulting a skill doesn't satisfy a subtask.

### 5. Skill-loop governor
Added `skill` and `discover_skills` to a new `CONSULTATIVE_TOOLS` list consumed only by the top-tool stall diagnostic (`build_stall_reflection`). When the 6-round window sees ≥3 `skill` calls the detector fires the 'stop consulting, take direct action' nudge. Left `EXPLORATION_TOOLS` unchanged so the existing soft-defer path for legitimate post-skill follow-ups (e.g. `[skill, read_file]`) stays intact.

## Tests
- 2159 astra-runtime lib tests pass
- 2358 astra-turn-core lib tests pass
- 267 astra-plan + 3 astra-cli pass
- `make format` + `make check` clean

Refs: session `26f73ee4-51a5-44e9-90c2-fc475b77f463`.