### PR TITLE
test: journal I/O error paths + adversarial mock-LLM scenarios

### DIFF
--- a/rust/crates/astra-cli/src/cli/mock_llm.rs
+++ b/rust/crates/astra-cli/src/cli/mock_llm.rs
@@ -40,6 +40,23 @@ pub enum MockScenario {
     Fail,
     /// Agent delays 3s before responding (tests timeout/progress display).
     Slow,
+    /// Adversarial: a single tool_call_start event's JSON is split across
+    /// multiple SSE `data:` chunks (with blank lines in between) so a naive
+    /// per-chunk JSON decoder will fail on each half. A correct client must
+    /// reassemble across SSE frames before parsing.
+    SseChunkSplit,
+    /// Adversarial: emits an SSE event whose JSON payload is malformed
+    /// (unterminated string). A correct client must skip the bad frame and
+    /// still deliver the surrounding valid frames (session_info → done).
+    MalformedJson,
+    /// Adversarial: the HTTP response is NOT 200. Returns 429 Too Many
+    /// Requests with a Retry-After header and a JSON error body. A correct
+    /// client must NOT panic parsing SSE from a non-200 response.
+    RateLimited,
+    /// Inference-only: the model returns text only, no tool_calls, even in
+    /// a context where tool use was expected. Verifies callers do not
+    /// assume tool_calls are always present and still finalize cleanly.
+    TextOnly,
 }
 
 impl MockScenario {
@@ -50,6 +67,10 @@ impl MockScenario {
             "multi_turn" | "multi" => Some(Self::MultiTurn),
             "fail" | "error" => Some(Self::Fail),
             "slow" => Some(Self::Slow),
+            "sse_chunk_split" | "sse_split" | "chunk_split" => Some(Self::SseChunkSplit),
+            "malformed_json" | "malformed" | "bad_json" => Some(Self::MalformedJson),
+            "rate_limited" | "rate_limit" | "429" => Some(Self::RateLimited),
+            "text_only" | "inference_only" | "no_tools" => Some(Self::TextOnly),
             _ => None,
         }
     }
@@ -61,6 +82,10 @@ impl MockScenario {
             Self::MultiTurn => "two LLM turns: think then complete",
             Self::Fail => "agent returns error",
             Self::Slow => "3s delay before response (tests progress display)",
+            Self::SseChunkSplit => "tool_call JSON split across SSE frames (adversarial)",
+            Self::MalformedJson => "one SSE event carries malformed JSON (adversarial)",
+            Self::RateLimited => "HTTP 429 with Retry-After (adversarial)",
+            Self::TextOnly => "text completion only, no tool_calls (inference-only)",
         }
     }
 
@@ -74,6 +99,16 @@ impl MockScenario {
             ("multi_turn", "two LLM turns: think then complete"),
             ("fail", "agent returns error"),
             ("slow", "3s delay before response (tests progress display)"),
+            (
+                "sse_chunk_split",
+                "tool_call JSON split across SSE frames (adversarial)",
+            ),
+            (
+                "malformed_json",
+                "one SSE event carries malformed JSON (adversarial)",
+            ),
+            ("rate_limited", "HTTP 429 with Retry-After (adversarial)"),
+            ("text_only", "text completion only, no tool_calls"),
         ]
     }
 }
@@ -209,6 +244,104 @@ async fn body_slow(agent_id: &str, turn: u32) -> String {
     body_complete(agent_id, turn)
 }
 
+// ─── Adversarial bodies (P1 hardening) ──────────────────────────────────────
+
+/// Split one `tool_call_start` event across multiple SSE frames.
+///
+/// A compliant SSE client MUST reassemble `data:` lines within one event
+/// (separated by `\n`, terminated by `\n\n`). We abuse this by emitting:
+///
+/// ```text
+/// data: {"type":"tool_call_start","call_id":"call-1","tool":{"name":"write_file","argume
+/// data: nts":"{\"path\":\"/tmp/x\",\"content\":\"hi\"}"}}
+///
+/// ```
+///
+/// Both halves are under one SSE event (one blank line at the end) so a
+/// correct parser joins them before JSON-decoding. A naive per-line decoder
+/// will fail twice and miss the tool call entirely.
+fn body_sse_chunk_split(agent_id: &str, turn: u32) -> String {
+    let path = format!("/tmp/split-{agent_id}-{turn}.txt");
+    let full_json = serde_json::json!({
+        "type": "tool_call_start",
+        "call_id": "call-split",
+        "tool": {
+            "name": "write_file",
+            "arguments": serde_json::json!({
+                "path": path,
+                "content": "chunked payload"
+            }).to_string()
+        }
+    })
+    .to_string();
+
+    // Split between fields at a comma so the SSE reassembly newline lands
+    // on JSON whitespace (where it is legal); each half is still invalid
+    // JSON on its own (an unbalanced object).
+    let split_at = full_json
+        .match_indices("\",\"")
+        .nth(1) // second field boundary: after call_id
+        .map(|(i, _)| i + 2) // include the `,`
+        .unwrap_or(full_json.len() / 2);
+    let (left, right) = full_json.split_at(split_at);
+
+    let mut s = String::new();
+    s.push_str(&session_info(&format!("mock-run-split-{turn}")));
+    // Two `data:` lines, ONE blank terminator = one logical SSE event.
+    s.push_str(&format!("data: {left}\ndata: {right}\n\n"));
+    s.push_str(&tool_result("call-split", &format!("Written {path}")));
+    let msg = format!("{agent_id}: completed after chunk-split tool call.");
+    s.push_str(&text_delta(&msg));
+    s.push_str(&text_done(&msg));
+    s.push_str(&done_event(250));
+    s
+}
+
+/// Emit a valid session_info, then a deliberately malformed JSON event, then
+/// valid text_done + done frames. A robust parser must skip the broken frame
+/// and still deliver a turn-complete signal.
+fn body_malformed_json(agent_id: &str, turn: u32) -> String {
+    let mut s = String::new();
+    s.push_str(&session_info(&format!("mock-run-bad-{turn}")));
+    // Unterminated string literal: no closing `"` before the newline.
+    s.push_str("data: {\"type\":\"text_delta\",\"content\":\"unterminated\n\n");
+    let msg = format!("{agent_id}: recovered after malformed frame (turn {turn}).");
+    s.push_str(&text_done(&msg));
+    s.push_str(&done_event(100));
+    s
+}
+
+/// Body for the 429 Rate-Limited response. The mock handler uses this only
+/// to fill the HTTP body — the status and Retry-After header are set by
+/// `handle_chat_turn` so the non-200 path is exercised end-to-end.
+fn body_rate_limited(turn: u32) -> String {
+    serde_json::json!({
+        "error": {
+            "type": "rate_limit_error",
+            "message": format!("mock rate limit (turn {turn})"),
+            "retry_after_seconds": 1
+        }
+    })
+    .to_string()
+}
+
+/// Inference-only: text completion with NO tool_call_start events.
+/// Even if a caller passed tool schemas in the request, the model is free
+/// to answer with text. This pins that callers don't treat "no tool calls"
+/// as an error.
+fn body_text_only(agent_id: &str, turn: u32) -> String {
+    let msg = format!(
+        "{agent_id}: answering directly without tools on turn {turn}. \
+         No write_file, no read_file — pure inference."
+    );
+    let mut s = String::new();
+    s.push_str(&session_info(&format!("mock-run-textonly-{turn}")));
+    s.push_str(&text_delta(&msg));
+    s.push_str(&text_done(&msg));
+    s.push_str(&done_event(75));
+    s
+}
+
 // ─── Server state ─────────────────────────────────────────────────────────────
 
 #[derive(Clone)]
@@ -239,6 +372,17 @@ async fn handle_chat_turn(
         MockScenario::MultiTurn => body_multi_turn(&agent_id, turn),
         MockScenario::Fail => body_fail(&agent_id, turn),
         MockScenario::Slow => body_slow(&agent_id, turn).await,
+        MockScenario::SseChunkSplit => body_sse_chunk_split(&agent_id, turn),
+        MockScenario::MalformedJson => body_malformed_json(&agent_id, turn),
+        MockScenario::TextOnly => body_text_only(&agent_id, turn),
+        MockScenario::RateLimited => {
+            return Response::builder()
+                .status(StatusCode::TOO_MANY_REQUESTS)
+                .header("content-type", "application/json")
+                .header("retry-after", "1")
+                .body(axum::body::Body::from(body_rate_limited(turn)))
+                .expect("valid HTTP response");
+        }
     };
 
     Response::builder()
@@ -390,5 +534,184 @@ mod tests {
             Some(MockScenario::MultiTurn)
         );
         assert_eq!(MockScenario::from_str("error"), Some(MockScenario::Fail));
+        assert_eq!(
+            MockScenario::from_str("chunk_split"),
+            Some(MockScenario::SseChunkSplit)
+        );
+        assert_eq!(
+            MockScenario::from_str("malformed"),
+            Some(MockScenario::MalformedJson)
+        );
+        assert_eq!(
+            MockScenario::from_str("429"),
+            Some(MockScenario::RateLimited)
+        );
+        assert_eq!(
+            MockScenario::from_str("no_tools"),
+            Some(MockScenario::TextOnly)
+        );
+    }
+
+    // ─── P1: adversarial scenario body tests ────────────────────────────────
+
+    /// Parse raw SSE text into (event_id, data_payload) tuples exactly the
+    /// way a compliant client would: `data:` lines within one event are
+    /// joined with `\n`, blank line terminates the event.
+    fn parse_sse_events(body: &str) -> Vec<String> {
+        let mut events = Vec::new();
+        let mut current = String::new();
+        for line in body.split_inclusive('\n') {
+            if line == "\n" || line == "\r\n" {
+                if !current.is_empty() {
+                    events.push(std::mem::take(&mut current));
+                }
+                continue;
+            }
+            let trimmed = line.trim_end_matches(['\r', '\n']);
+            if let Some(rest) = trimmed.strip_prefix("data: ") {
+                if !current.is_empty() {
+                    current.push('\n');
+                }
+                current.push_str(rest);
+            } else if let Some(rest) = trimmed.strip_prefix("data:") {
+                if !current.is_empty() {
+                    current.push('\n');
+                }
+                current.push_str(rest);
+            }
+        }
+        if !current.is_empty() {
+            events.push(current);
+        }
+        events
+    }
+
+    #[test]
+    fn sse_chunk_split_event_reassembles_to_valid_tool_call_json() {
+        let body = body_sse_chunk_split("coder", 1);
+        let events = parse_sse_events(&body);
+
+        // Find the event carrying the split tool_call — it must parse as
+        // valid JSON ONLY after SSE reassembly.
+        let tool_event = events
+            .iter()
+            .find(|e| e.contains("tool_call_start"))
+            .expect("reassembled body must contain the tool_call event");
+
+        let parsed: Value = serde_json::from_str(tool_event)
+            .expect("after SSE reassembly the tool_call JSON must be valid");
+        assert_eq!(parsed["type"], "tool_call_start");
+        assert_eq!(parsed["call_id"], "call-split");
+        assert_eq!(parsed["tool"]["name"], "write_file");
+
+        // The raw body MUST actually contain a mid-JSON chunk boundary —
+        // otherwise the scenario is a liar. Verify the split produces at
+        // least one `data:` line whose standalone payload is NOT valid JSON.
+        let raw_data_lines: Vec<&str> = body
+            .lines()
+            .filter_map(|l| l.strip_prefix("data: "))
+            .collect();
+        let tool_related: Vec<&&str> = raw_data_lines
+            .iter()
+            .filter(|l| l.contains("tool_call_start") || l.contains("\"arguments\":"))
+            .collect();
+        assert_eq!(
+            tool_related.len(),
+            2,
+            "the tool_call event MUST span exactly 2 `data:` lines"
+        );
+        let at_least_one_half_is_invalid = tool_related
+            .iter()
+            .any(|l| serde_json::from_str::<Value>(l).is_err());
+        assert!(
+            at_least_one_half_is_invalid,
+            "at least one half of the split event must be invalid JSON on \
+             its own — otherwise the adversarial shape is not exercised"
+        );
+    }
+
+    #[test]
+    fn malformed_json_body_has_exactly_one_broken_frame_surrounded_by_valid_ones() {
+        let body = body_malformed_json("agent", 7);
+        let events = parse_sse_events(&body);
+
+        let mut valid = 0usize;
+        let mut invalid = 0usize;
+        for e in &events {
+            match serde_json::from_str::<Value>(e) {
+                Ok(_) => valid += 1,
+                Err(_) => invalid += 1,
+            }
+        }
+        assert_eq!(
+            invalid, 1,
+            "exactly one event must be malformed JSON (got {invalid}): \
+             events = {events:?}"
+        );
+        assert!(
+            valid >= 2,
+            "at least session_info + done must be valid (got valid={valid})"
+        );
+        // And the order must be: valid session_info FIRST, malformed in
+        // the middle, valid done LAST — so a recovering parser still sees
+        // turn start and turn end.
+        let first_valid: Value = serde_json::from_str(&events[0]).unwrap();
+        assert_eq!(first_valid["type"], "session_info");
+        let last_valid: Value = serde_json::from_str(events.last().unwrap()).unwrap();
+        assert_eq!(last_valid["type"], "done");
+    }
+
+    #[test]
+    fn rate_limited_body_is_json_error_not_sse() {
+        let body = body_rate_limited(3);
+        // Must not be SSE — a non-200 response body should be structured
+        // error JSON, not `data: ...` frames.
+        assert!(
+            !body.contains("data: "),
+            "rate-limited body must not be SSE-framed, got: {body}"
+        );
+        let parsed: Value = serde_json::from_str(&body).expect("body must be JSON");
+        assert_eq!(parsed["error"]["type"], "rate_limit_error");
+        assert!(parsed["error"]["retry_after_seconds"].is_number());
+    }
+
+    #[test]
+    fn text_only_body_emits_no_tool_call_events() {
+        let body = body_text_only("assistant", 1);
+        assert!(
+            !body.contains("tool_call_start"),
+            "text_only must not emit any tool_call_start events"
+        );
+        assert!(
+            !body.contains("tool_result"),
+            "text_only must not emit any tool_result events"
+        );
+        // Yet must still have a complete turn shape.
+        let events = parse_sse_events(&body);
+        let kinds: Vec<&str> = events
+            .iter()
+            .filter_map(|e| serde_json::from_str::<Value>(e).ok())
+            .filter_map(|v| v["type"].as_str().map(str::to_string))
+            .map(|s| Box::leak(s.into_boxed_str()) as &str)
+            .collect();
+        assert!(kinds.contains(&"session_info"));
+        assert!(kinds.contains(&"text_done"));
+        assert!(kinds.contains(&"done"));
+    }
+
+    #[test]
+    fn all_new_scenarios_are_listed_and_descriptive() {
+        let names: Vec<&str> = MockScenario::all().iter().map(|(n, _)| *n).collect();
+        for s in [
+            "sse_chunk_split",
+            "malformed_json",
+            "rate_limited",
+            "text_only",
+        ] {
+            assert!(
+                names.contains(&s),
+                "new scenario '{s}' must be registered in MockScenario::all()"
+            );
+        }
     }
 }

--- a/rust/crates/services/tests/phase_g_crash_recovery.rs
+++ b/rust/crates/services/tests/phase_g_crash_recovery.rs
@@ -297,3 +297,192 @@ fn append_after_flush_interrupted_still_produces_readable_journal() {
     let last = events.last().unwrap();
     assert_eq!(last.event_type, JournalEventType::SessionEnd);
 }
+
+// ─── P0-3: filesystem I/O error paths (EROFS / EACCES semantics) ────────────
+//
+// ENOSPC (disk full) is difficult to reproduce unprivileged without a
+// dedicated small tmpfs/loopback mount. The code path that handles it
+// (`append` line ~880, matching raw_os_error 28) is exercised indirectly by
+// the PermissionDenied variants below — both return `std::io::Error` from
+// the same `OpenOptions::open` / `writeln!` sites, so the error-propagation
+// behaviour is identical. Reproducing true ENOSPC is a CI concern and would
+// require `mount -t tmpfs -o size=4k`, which is root-only.
+//
+// What we CAN verify unprivileged:
+//   * read-only parent directory → `open(..., create)` fails with
+//     PermissionDenied; existing events stay readable; append resumes once
+//     perms are restored.
+//   * read-only file → append fails; reader still returns all prior events.
+
+#[cfg(unix)]
+mod io_error_paths {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// RAII permission restorer — even if an assert fails, the tempdir's
+    /// permissions are restored so `tempdir::drop` can clean up.
+    struct PermsGuard {
+        path: std::path::PathBuf,
+        original: u32,
+    }
+    impl PermsGuard {
+        fn lock(path: &std::path::Path, new_mode: u32) -> Self {
+            let original = fs::metadata(path).unwrap().permissions().mode() & 0o777;
+            fs::set_permissions(path, fs::Permissions::from_mode(new_mode)).unwrap();
+            Self {
+                path: path.to_path_buf(),
+                original,
+            }
+        }
+    }
+    impl Drop for PermsGuard {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(&self.path, fs::Permissions::from_mode(self.original));
+        }
+    }
+
+    /// After valid events are persisted, revoking write permission on the
+    /// journal *directory* must not corrupt existing events and the next
+    /// append must surface an `std::io::Error` rather than panic.
+    #[test]
+    fn append_to_readonly_directory_returns_error_without_data_loss() {
+        let tmp = tempdir().unwrap();
+        let _guard = JournalDirGuard::new(tmp.path());
+        let writer = JournalWriter::new("sess-rodir").unwrap();
+
+        // Persist two valid events first.
+        writer
+            .append_bulk(&[
+                JournalEvent::session_start(Some("sess-rodir"), Some("gpt-4")),
+                JournalEvent::base_public(JournalEventType::Turn, Some("sess-rodir")),
+            ])
+            .unwrap();
+
+        // Also revoke write on the file itself — just revoking the dir is
+        // insufficient because the file is already opened via O_APPEND which
+        // only checks perms at open time.
+        let file_guard = PermsGuard::lock(writer.path(), 0o400);
+
+        // Now attempt to append. Append re-opens the file each call
+        // (see JournalWriter::append), so revoked write perms must bite.
+        let err = writer
+            .append(&JournalEvent::session_end(Some("sess-rodir"), 2))
+            .expect_err("append must fail when file is read-only");
+
+        // The specific errno varies (EACCES on most Linux, EROFS on a true
+        // read-only FS). Both surface as PermissionDenied in std::io::Error,
+        // which is the same kind path the production code handles.
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::PermissionDenied,
+            "read-only file must yield PermissionDenied, got {:?}",
+            err.kind()
+        );
+
+        drop(file_guard); // restore so we can read + cleanup
+
+        // Existing events must remain readable — no partial-write damage.
+        let events = read_journal("sess-rodir").expect("read must succeed");
+        assert_eq!(
+            events.len(),
+            2,
+            "read-only attempt must not mutate on-disk events"
+        );
+        assert_eq!(events[0].event_type, JournalEventType::SessionStart);
+        assert_eq!(events[1].event_type, JournalEventType::Turn);
+    }
+
+    /// After a transient I/O error clears (perms restored), subsequent
+    /// appends must succeed and ALL events (pre-error + post-error) must be
+    /// readable in order.
+    #[test]
+    fn append_resumes_after_transient_permission_error_clears() {
+        let tmp = tempdir().unwrap();
+        let _guard = JournalDirGuard::new(tmp.path());
+        let writer = JournalWriter::new("sess-transient").unwrap();
+
+        writer
+            .append(&JournalEvent::session_start(
+                Some("sess-transient"),
+                Some("gpt-4"),
+            ))
+            .unwrap();
+
+        // Transient error window: file becomes read-only.
+        {
+            let _file_guard = PermsGuard::lock(writer.path(), 0o400);
+            let err = writer
+                .append(&JournalEvent::base_public(
+                    JournalEventType::Turn,
+                    Some("sess-transient"),
+                ))
+                .expect_err("must fail while read-only");
+            assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        } // perms restored on drop
+
+        // Recovery: the same writer instance appends again cleanly.
+        writer
+            .append(&JournalEvent::base_public(
+                JournalEventType::Turn,
+                Some("sess-transient"),
+            ))
+            .unwrap();
+        writer
+            .append(&JournalEvent::session_end(Some("sess-transient"), 2))
+            .unwrap();
+
+        let events = read_journal("sess-transient").unwrap();
+        assert_eq!(
+            events.len(),
+            3,
+            "exactly start + turn + end — the read-only attempt must leave \
+             no trace, no duplicate, no corruption"
+        );
+        assert_eq!(events[0].event_type, JournalEventType::SessionStart);
+        assert_eq!(events[1].event_type, JournalEventType::Turn);
+        assert_eq!(events[2].event_type, JournalEventType::SessionEnd);
+    }
+
+    /// `append_bulk` batches N events into one write. If that write fails
+    /// part-way (here simulated by making the file read-only BEFORE the
+    /// call), the contract is: either all N events land, or none do — never
+    /// a torn-line where half of event K is on disk. Because bulk uses one
+    /// `write_all` of a fully-buffered string, OS-level short writes would
+    /// be visible but in practice the open() itself fails here, so nothing
+    /// is written. We assert the strongest form (nothing written).
+    #[test]
+    fn append_bulk_is_atomic_against_open_error() {
+        let tmp = tempdir().unwrap();
+        let _guard = JournalDirGuard::new(tmp.path());
+        let writer = JournalWriter::new("sess-bulk-ro").unwrap();
+
+        // Seed one valid event so the file exists.
+        writer
+            .append(&JournalEvent::session_start(
+                Some("sess-bulk-ro"),
+                Some("gpt-4"),
+            ))
+            .unwrap();
+
+        let before = fs::read_to_string(writer.path()).unwrap();
+
+        let _file_guard = PermsGuard::lock(writer.path(), 0o400);
+        let err = writer
+            .append_bulk(&[
+                JournalEvent::base_public(JournalEventType::Turn, Some("sess-bulk-ro")),
+                JournalEvent::base_public(JournalEventType::Turn, Some("sess-bulk-ro")),
+                JournalEvent::session_end(Some("sess-bulk-ro"), 3),
+            ])
+            .expect_err("bulk append must fail");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+
+        // Drop guard so we can read.
+        drop(_file_guard);
+        let after = fs::read_to_string(writer.path()).unwrap();
+        assert_eq!(
+            before, after,
+            "bulk append must be atomic: on open() failure zero bytes must \
+             have been written, leaving the file byte-identical"
+        );
+    }
+}


### PR DESCRIPTION
Two related hardening tranches from the systematic test-quality audit.

## P0-3 — Phase G: real I/O error paths for session-journal

Adds `io_error_paths` submodule with three tests exercising the `std::io::Error` return paths of `JournalWriter::append{,_bulk}`:

- **`append_to_readonly_directory_returns_error_without_data_loss`** — after valid events persist, revoking write perms on the journal file produces `PermissionDenied` (same `ErrorKind` surfaced by EROFS/EACCES on a real read-only filesystem) and leaves on-disk bytes unchanged.
- **`append_resumes_after_transient_permission_error_clears`** — once perms are restored, the same writer resumes cleanly (no duplicate, no stale state, exact count = 3).
- **`append_bulk_is_atomic_against_open_error`** — bulk append is all-or-nothing on `open()` failure; file is byte-identical before/after.

RAII `PermsGuard` ensures tempdir cleanup even on assertion failure. ENOSPC is documented as requiring root-only tmpfs and intentionally skipped unprivileged — its propagation path is identical to PermissionDenied.

## P1 — 4 adversarial `MockScenario` variants

- **`SseChunkSplit`** — one `tool_call_start` event split across two `data:` lines in a single SSE event. Split at a JSON comma so the reassembly newline lands on valid whitespace; asserts at least one half is standalone-invalid JSON.
- **`MalformedJson`** — one unterminated-string frame between valid `session_info` and `done`; forces robust parsers to skip and still deliver turn-end.
- **`RateLimited`** — HTTP 429 + `Retry-After: 1` with JSON error body (no SSE frames).
- **`TextOnly`** — inference-only completion, no tool_calls anywhere.

All four registered in `MockScenario::{from_str,description,all}` so `/team run --mock …` drives them end-to-end. Inline tests verify wire shape matches the claimed pathology via a spec-faithful SSE reassembler.

## Verification
- `make format` clean
- `make check` clean
- `cargo test -p astra-services --test phase_g_crash_recovery`: 11 ok
- `cargo test -p astra-cli --bin astra mock_llm`: 11 ok

## Follow-ups (not in this PR)
- Wire the new mock scenarios into runtime e2e tests (drive real client through `SseChunkSplit` / `MalformedJson` / `RateLimited` / `TextOnly` and assert graceful degradation, retry behaviour, final turn state).