### PR TITLE
fix(turn-core): make tool concurrency cap truly process-wide via OnceLock semaphore

### DIFF
--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -2583,9 +2583,11 @@ impl SseStreamHost for CliSseStreamHost<'_> {
         // Each future is wrapped with `catch_unwind` so a panicking tool is surfaced as
         // a tool failure instead of aborting the whole batch/turn.
         let executor: &crate::edge_tools::ToolExecutor = &self.executor;
-        let sem = Arc::new(tokio::sync::Semaphore::new(
-            astra_runtime::turn::parallel_tool_exec::MAX_CONCURRENT_TOOL_EXECUTIONS,
-        ));
+        // Use the process-wide shared semaphore so the concurrency cap
+        // genuinely spans every batch and every concurrent session in this
+        // process — previously each batch constructed its own `Semaphore::new(10)`,
+        // which allowed 10·N concurrent tools when N batches overlapped.
+        let sem = astra_runtime::turn::parallel_tool_exec::shared_tool_semaphore();
         // D-9: harvest speculative results from mid-stream execution.
         // Matching request_ids skip the normal dispatch and reuse the
         // speculative output. Journal/observability still fire exactly

--- a/rust/crates/astra-turn-core/src/parallel_tool_exec.rs
+++ b/rust/crates/astra-turn-core/src/parallel_tool_exec.rs
@@ -15,7 +15,7 @@
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use serde_json::Value;
 use tokio::sync::Semaphore;
@@ -27,6 +27,31 @@ pub const MAX_CONCURRENT_READ_ONLY: usize = 10;
 /// Kept equal to [`MAX_CONCURRENT_READ_ONLY`] so the in-turn cap matches
 /// claude-code semantics (10) across both speculative and batched paths.
 pub const MAX_CONCURRENT_TOOL_EXECUTIONS: usize = MAX_CONCURRENT_READ_ONLY;
+
+/// Process-wide semaphore shared across every tool-execution batch.
+///
+/// Previously, each call to `execute_parallel_round` and each CLI batch in
+/// `stream_render::execute_tools_batch` allocated its own `Semaphore::new(10)`.
+/// That made the 10-concurrent cap **per batch**, not shared — N overlapping
+/// batches allowed 10·N concurrent tools, contradicting the "shared semaphore"
+/// contract stated in prompts and code comments. On large sessions or when
+/// the runtime server multiplexes turns, this could saturate edge I/O or
+/// exhaust file descriptors.
+///
+/// The single process-wide instance below enforces the true cap across all
+/// batches, turns, and concurrent sessions sharing the same process.
+///
+/// Intended usage:
+///
+/// ```ignore
+/// let permit = shared_tool_semaphore().acquire_owned().await?;
+/// // run the tool, holding the permit
+/// ```
+pub fn shared_tool_semaphore() -> Arc<Semaphore> {
+    static CELL: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    CELL.get_or_init(|| Arc::new(Semaphore::new(MAX_CONCURRENT_TOOL_EXECUTIONS)))
+        .clone()
+}
 
 // ───────────────────────────── Tool Classification ──────────────────────
 
@@ -172,7 +197,7 @@ pub async fn execute_parallel_round(
     // Phase 1: Execute read-only tools in parallel
     let parallel_count = read_only.len();
     if !read_only.is_empty() {
-        let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_READ_ONLY));
+        let semaphore = shared_tool_semaphore();
         let mut join_set = tokio::task::JoinSet::new();
 
         for (idx, tc) in read_only {

--- a/rust/crates/astra-turn-core/tests/parallel_tool_exec_cap_test.rs
+++ b/rust/crates/astra-turn-core/tests/parallel_tool_exec_cap_test.rs
@@ -205,3 +205,80 @@ async fn complex_mixed_20_tools_respect_cap_and_ordering() {
         assert_eq!(r.call_id, format!("c{i:02}"));
     }
 }
+
+// ─────────── Process-wide shared-semaphore regression ───────────
+//
+// Previously `execute_parallel_round` allocated a fresh
+// `Semaphore::new(MAX_CONCURRENT_READ_ONLY)` on every call. Two concurrent
+// batches could therefore run up to 2·10 = 20 tools simultaneously, breaking
+// the "shared semaphore" contract stated in comments and prompts.
+//
+// With the process-wide semaphore, two (or more) concurrent batches must
+// collectively respect `MAX_CONCURRENT_TOOL_EXECUTIONS`.
+
+#[tokio::test]
+async fn two_concurrent_batches_share_process_wide_semaphore_cap() {
+    // Each batch fires 15 read-only tools. If the cap were per-batch, peak
+    // across both batches could reach 2·10 = 20. With the shared cap, peak
+    // must stay <= MAX_CONCURRENT_TOOL_EXECUTIONS.
+    let delay = 120u64;
+
+    let calls_a: Vec<Value> = (0..15)
+        .map(|i| tool_call("read_file", &format!("a{i:02}")))
+        .collect();
+    let calls_b: Vec<Value> = (0..15)
+        .map(|i| tool_call("grep", &format!("b{i:02}")))
+        .collect();
+
+    // Use a shared inflight/peak counter across BOTH executors so we observe
+    // the true cross-batch peak, not per-batch.
+    let inflight = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+
+    let make_exec = || -> ToolExecutorFn {
+        let inflight = inflight.clone();
+        let peak = peak.clone();
+        Arc::new(move |tc: Value| {
+            let inflight = inflight.clone();
+            let peak = peak.clone();
+            Box::pin(async move {
+                let cur = inflight.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(cur, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+                inflight.fetch_sub(1, Ordering::SeqCst);
+                let call_id = tc["id"].as_str().unwrap_or("").to_string();
+                let name = tc["function"]["name"].as_str().unwrap_or("").to_string();
+                (call_id, name, "ok".into(), true)
+            })
+        })
+    };
+
+    let (oa, ob) = tokio::join!(
+        execute_parallel_round(&calls_a, make_exec()),
+        execute_parallel_round(&calls_b, make_exec()),
+    );
+
+    assert_eq!(oa.results.len(), 15);
+    assert_eq!(ob.results.len(), 15);
+
+    let observed_peak = peak.load(Ordering::SeqCst);
+    assert!(
+        observed_peak <= MAX_CONCURRENT_TOOL_EXECUTIONS,
+        "cross-batch peak {observed_peak} must not exceed shared cap {MAX_CONCURRENT_TOOL_EXECUTIONS}"
+    );
+    assert!(
+        observed_peak > 0,
+        "sanity: at least one tool should have run concurrently",
+    );
+}
+
+#[test]
+fn shared_tool_semaphore_returns_same_instance() {
+    use astra_turn_core::parallel_tool_exec::shared_tool_semaphore;
+    let a = shared_tool_semaphore();
+    let b = shared_tool_semaphore();
+    assert!(
+        Arc::ptr_eq(&a, &b),
+        "shared_tool_semaphore must return the same Arc on repeat calls"
+    );
+}


### PR DESCRIPTION
## Problem

`execute_parallel_round` and `stream_render::execute_tools_batch` each
allocated a fresh `Arc::new(Semaphore::new(10))` on every call.

**Consequence**: the "shared semaphore" contract stated in prompts and code
comments was false. Two overlapping batches allowed up to 2·10 = 20
concurrent tools; under server-side session multiplexing this scales as N·10,
risking edge I/O saturation and file-descriptor exhaustion.

## Fix

- Add `shared_tool_semaphore() -> Arc<Semaphore>` backed by a process-wide
  `OnceLock<Arc<Semaphore>>` with capacity `MAX_CONCURRENT_TOOL_EXECUTIONS`.
- Both the turn-core parallel round orchestrator and the CLI batch dispatcher
  now pull from this single instance.

## Regression tests

1. `two_concurrent_batches_share_process_wide_semaphore_cap` — fires two
   15-tool batches via `tokio::join!` against a **shared inflight/peak
   counter** across both executors; asserts observed cross-batch peak ≤
   global cap. Before the fix this test fails (peak reaches ~20); after, it
   stays ≤10.
2. `shared_tool_semaphore_returns_same_instance` — Arc::ptr_eq guarantees
   repeated calls return the same Arc (not a fresh semaphore).

## Verification

- `make check` ✅ (lint + format + type-check)
- `cargo test -p astra-turn-core --test parallel_tool_exec_cap_test` → 6/6 ✅

## Context

Part 2/3 of the follow-up on PR #201. Part 1 (PR #222) fixed the speculative
`success`-flag-discarded bug. Part 3 (upcoming) adds tracing for
speculation hit/miss metrics.
