### PR TITLE
feat(cli): add per-batch tracing for speculation reconciliation + tool batching

### DIFF
--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -1472,9 +1472,35 @@ impl CliSseStreamHost<'_> {
             .collect();
         let (done, _needed) = exec.merge_speculative(&ids).await;
         let mut out = std::collections::HashMap::new();
+        let mut reusable = 0usize;
+        let mut rejected_failure = 0usize;
         for r in done {
+            if r.success {
+                reusable += 1;
+            } else {
+                // Speculation completed but failed — the reconciler will fall
+                // back to real execution (see `reusable_speculative_output`).
+                // Track this separately from `snapshot().wasted` so operators
+                // can distinguish "speculation errored" from "speculation
+                // never started" when diagnosing hit-rate drops.
+                rejected_failure += 1;
+            }
             out.insert(r.call_id.clone(), (r.content.clone(), r.success));
         }
+        // Per-batch reconciliation breakdown: complements the cumulative
+        // `astra::streaming_speculation::metrics` with this-batch counts so
+        // operators can correlate a specific turn's LLM-emitted batch against
+        // what actually came back from speculation. Target:
+        // `astra::streaming_speculation::batch`.
+        tracing::info!(
+            target: "astra::streaming_speculation::batch",
+            batch_size = conc_reqs.len(),
+            reusable = reusable,
+            rejected_failure = rejected_failure,
+            not_speculated = conc_reqs.len().saturating_sub(reusable + rejected_failure),
+            session_id = self.executor.active_session_id().as_deref().unwrap_or(""),
+            "speculation reconciliation for batch"
+        );
         // Emit a structured metrics event once per batch merge so log
         // aggregators / ObservabilityHub can track speculation effectiveness
         // over time. Target: `astra::streaming_speculation::metrics`.
@@ -2475,6 +2501,21 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                         .await,
                 );
             }
+        }
+        // Batch-size observation: correlates the read-only batching prompt
+        // (`prompts/system.rs`) with actual LLM emission patterns. When >=2
+        // concurrent tools arrive together the model followed the guidance;
+        // when conc_reqs is empty or has a single entry, batching didn't
+        // happen this turn. Target: `astra::tool_batching::batch_size`.
+        if !conc_reqs.is_empty() {
+            tracing::info!(
+                target: "astra::tool_batching::batch_size",
+                parallel_count = conc_reqs.len(),
+                sequential_count = seq_total,
+                tool_names = ?conc_reqs.iter().map(|(_, r)| r.tool.as_str()).collect::<Vec<_>>(),
+                session_id = self.executor.active_session_id().as_deref().unwrap_or(""),
+                "LLM emitted parallel tool batch"
+            );
         }
 
         // Pre-check: can all concurrent tools auto-proceed?


### PR DESCRIPTION
## Problem

Two observability gaps identified during PR #201 review:

1. **Speculation reconciliation is opaque per-batch.** The existing
   `astra::streaming_speculation::metrics` event reports cumulative counters
   across the session. No way to correlate a *specific* LLM-emitted batch
   against what came back from speculation — e.g., was this turn's `[grep,
   glob, read_file]` batch fully reused, half-reused, or all-refreshed?
2. **Read-only batching prompt has no feedback signal.** PR #201 added
   prompt guidance instructing the model to batch read-only tool_calls.
   If a weaker model regresses to serialized calls, there's no trace to
   detect it.

## Fix

Two targeted `tracing::info!` events:

### `astra::streaming_speculation::batch`
Logged once per `harvest_speculation_for_batch`:
- `batch_size` — how many concurrent requests this batch had
- `reusable` — speculated with `success=true` (reused)
- `rejected_failure` — speculated with `success=false` (falls through to real exec via `reusable_speculative_output`; separated from "never started" so operators can diagnose hit-rate drops correctly)
- `not_speculated` — had no speculative result at all

### `astra::tool_batching::batch_size`
Logged when `execute_tools_batch` sees a non-empty concurrent set:
- `parallel_count`, `sequential_count`, `tool_names` — correlates the prompt guidance with actual LLM behavior

Both use dedicated `target:` strings so they can be filtered/routed
independently from cumulative metrics.

## Verification

- `make check` ✅
- Zero behavior change; pure observability additions.

## Context

Part 3/3 of the follow-up on PR #201:
- Part 1 — PR #222 (speculative success-flag discarded) ✅
- Part 2 — PR #224 (shared process-wide semaphore) ✅
- Part 3 — this PR
