### PR TITLE
fix(mock-llm): emit canonical tool_call_start shape [REAL BUG CAUGHT]

### DIFF
--- a/rust/crates/astra-cli/src/cli/mock_llm.rs
+++ b/rust/crates/astra-cli/src/cli/mock_llm.rs
@@ -107,10 +107,18 @@ fn text_done(full: &str) -> String {
 }
 
 fn tool_call_start(call_id: &str, tool: &str, args: Value) -> String {
+    // Canonical tool_call_start shape: flat `tool` (name string) + top-level
+    // `arguments` (JSON-stringified). See
+    // `chat_turn_sse_dispatch::normalize_tool_call_for_accum` — a nested
+    // `tool: {name, arguments}` would be silently dropped because that
+    // normalizer reads `tool` with `as_str()` and falls back to "" on a
+    // non-string, returning None. The regression anchor is
+    // `phase_r2_mock_dispatch_contract::mock_llm_tool_call_start_shape_is_captured_by_dispatch`.
     sse_line(&serde_json::json!({
         "type": "tool_call_start",
         "call_id": call_id,
-        "tool": { "name": tool, "arguments": args.to_string() },
+        "tool": tool,
+        "arguments": args.to_string(),
     }))
 }
 

--- a/rust/crates/astra-turn-core/tests/phase_r2_mock_dispatch_contract.rs
+++ b/rust/crates/astra-turn-core/tests/phase_r2_mock_dispatch_contract.rs
@@ -1,0 +1,167 @@
+//! Phase R2 — cross-contract hunt between mock-LLM emit shape and
+//! [`astra_turn_core::chat_turn_sse_dispatch`] normalizer.
+//!
+//! ## Hypothesis
+//!
+//! The mock LLM (`astra_cli::cli::mock_llm`) emits `tool_call_start` events
+//! with the tool nested under `tool`:
+//!
+//! ```json
+//! {"type":"tool_call_start",
+//!  "call_id":"call-1",
+//!  "tool":{"name":"write_file","arguments":"{...}"}}
+//! ```
+//!
+//! But `normalize_tool_call_for_accum` in `chat_turn_sse_dispatch.rs` expects
+//! `tool` to be a string (`as_str()` on line ~106). An object there fails
+//! the `as_str()` and the name falls back to `""`, which causes the function
+//! to return `None` → the tool call is **silently dropped**.
+//!
+//! If that's true, every test that runs a mock-LLM scenario through the
+//! real dispatch pipeline and claims a tool was called has been lying.
+//!
+//! These tests drive the mock-LLM body directly through the dispatch
+//! pipeline and assert tool_calls are observed. If they fail, one of:
+//!   1. the mock emit shape is wrong (should be `{"name":..., "arguments":...}`
+//!      flat, or `{"function":{...}}` OpenAI-style)
+//!   2. the dispatch normalizer needs to handle nested `tool:{name,args}`
+//!
+//! Either way it's a real bug that would break `/team run --mock
+//! tool_then_complete` in any harness that actually reads tool_calls.
+
+use astra_turn_core::chat_turn_sse_dispatch::{
+    ChatTurnEdgePending, ChatTurnSseAccum, dispatch_chat_turn_sse_event_block,
+};
+use serde_json::{Value, json};
+
+fn sse_block(event: &Value) -> String {
+    format!("data: {}\n\n", event)
+}
+
+/// Dispatch the EXACT shape the mock-LLM emits (post-fix) and assert the
+/// tool call arrives in `accum.tool_calls`.
+///
+/// **Regression story:** prior to this test the mock-LLM emitted a
+/// non-canonical nested shape `{"tool":{"name":...,"arguments":...}}`.
+/// `normalize_tool_call_for_accum` reads `tool` with `as_str()`, got
+/// `None` on the object, fell through the `name == ""` guard, and
+/// returned `None` — silently dropping the tool call. Every mock-driven
+/// test that checked tool_call capture via dispatch was a false pass.
+/// Mock now emits canonical `{"tool":"name","arguments":"{...}"}`.
+#[test]
+fn mock_llm_tool_call_start_shape_is_captured_by_dispatch() {
+    // This block is byte-identical to what mock_llm.rs::tool_call_start
+    // now emits. Changing either side must fail this test.
+    let event = json!({
+        "type": "tool_call_start",
+        "call_id": "call-1",
+        "tool": "write_file",
+        "arguments": r#"{"path":"/tmp/x","content":"hi"}"#
+    });
+    let block = sse_block(&event);
+
+    let mut accum = ChatTurnSseAccum::default();
+    let mut edge: Vec<ChatTurnEdgePending> = Vec::new();
+    let _effects = dispatch_chat_turn_sse_event_block(&block, &mut accum, &mut edge);
+
+    assert_eq!(
+        accum.tool_calls.len(),
+        1,
+        "mock-LLM tool_call_start must be captured by dispatch — got \
+         tool_calls={:?}. If this is 0, the emit shape and the normalizer \
+         disagree and every mock-LLM tool test is silently broken.",
+        accum.tool_calls
+    );
+    let tc = &accum.tool_calls[0];
+    assert_eq!(tc.get("id").and_then(Value::as_str), Some("call-1"));
+    assert_eq!(
+        tc.pointer("/function/name").and_then(Value::as_str),
+        Some("write_file")
+    );
+}
+
+/// Flat shape (`name` + `arguments` at top level) — this is what the
+/// normalizer can actually parse today. If the mock were emitting this,
+/// tool_calls would show up.
+#[test]
+fn flat_tool_call_start_shape_is_captured_by_dispatch() {
+    let event = json!({
+        "type": "tool_call_start",
+        "call_id": "call-2",
+        "name": "write_file",
+        "arguments": r#"{"path":"/tmp/x"}"#
+    });
+    let block = sse_block(&event);
+
+    let mut accum = ChatTurnSseAccum::default();
+    let mut edge: Vec<ChatTurnEdgePending> = Vec::new();
+    let _ = dispatch_chat_turn_sse_event_block(&block, &mut accum, &mut edge);
+
+    assert_eq!(accum.tool_calls.len(), 1);
+    assert_eq!(
+        accum.tool_calls[0]
+            .pointer("/function/name")
+            .and_then(Value::as_str),
+        Some("write_file")
+    );
+}
+
+/// OpenAI style (`function: {name, arguments}`) — should also be captured.
+#[test]
+fn openai_function_tool_call_shape_is_captured_by_dispatch() {
+    let event = json!({
+        "type": "tool_call_start",
+        "id": "call-3",
+        "function": {
+            "name": "write_file",
+            "arguments": r#"{"path":"/tmp/x"}"#
+        }
+    });
+    let block = sse_block(&event);
+
+    let mut accum = ChatTurnSseAccum::default();
+    let mut edge: Vec<ChatTurnEdgePending> = Vec::new();
+    let _ = dispatch_chat_turn_sse_event_block(&block, &mut accum, &mut edge);
+
+    assert_eq!(accum.tool_calls.len(), 1);
+    assert_eq!(
+        accum.tool_calls[0]
+            .pointer("/function/name")
+            .and_then(Value::as_str),
+        Some("write_file")
+    );
+}
+
+/// Regression anchor: a nested `{"tool":{"name":..., "arguments":...}}`
+/// shape is NOT canonical. The normalizer treats `tool` as a string and
+/// silently drops events whose `tool` is an object. This is the exact
+/// misshape the pre-fix mock-LLM emitted.
+///
+/// We pin the CURRENT (silent-drop) behaviour as a contract: if dispatch
+/// is ever made lenient to accept this nested shape, this assertion will
+/// fail and both sides should be reviewed together.
+#[test]
+fn nested_tool_object_shape_is_silently_dropped_regression_anchor() {
+    let event = json!({
+        "type": "tool_call_start",
+        "call_id": "call-nested",
+        "tool": {
+            "name": "write_file",
+            "arguments": r#"{"path":"/tmp/x"}"#
+        }
+    });
+    let block = sse_block(&event);
+
+    let mut accum = ChatTurnSseAccum::default();
+    let mut edge: Vec<ChatTurnEdgePending> = Vec::new();
+    let _ = dispatch_chat_turn_sse_event_block(&block, &mut accum, &mut edge);
+
+    assert_eq!(
+        accum.tool_calls.len(),
+        0,
+        "nested-tool-object shape is non-canonical; normalizer silently \
+         drops it. If this suddenly captures 1, the normalizer has become \
+         lenient — audit the mock-LLM emit side and any other producers \
+         at the same time."
+    );
+}

--- a/rust/crates/astra-turn-core/tests/phase_r_sse_contract_and_tripwires.rs
+++ b/rust/crates/astra-turn-core/tests/phase_r_sse_contract_and_tripwires.rs
@@ -1,0 +1,191 @@
+//! Phase R — SSE parser contract pins + spec-deviation tripwires.
+//!
+//! ## What the hunt found
+//!
+//! The current parser in [`astra_turn_core::sse_data_lines`] intentionally
+//! treats every `data:` line inside a single SSE event-block as its own JSON
+//! payload. That is **not** what WHATWG Server-Sent Events § 9.2 specifies:
+//!
+//! > If the data buffer is not the empty string, then: set lastEventId …
+//! > then … dispatch one event whose data is the data buffer with its last
+//! > trailing U+000A stripped, and whose internal lines have been joined.
+//!
+//! Strict spec compliance would join `data:` lines with `\n` and parse the
+//! joined buffer **once** per block. The current implementation is liberal:
+//! per-line parse, skip on error.
+//!
+//! ## Is it a bug?
+//!
+//! In practice: **no, not today.** OpenAI and Anthropic both emit exactly
+//! one `data:` line per blank-line-terminated event, so
+//! [`drain_complete_sse_event_blocks`] returns blocks that happen to contain
+//! only a single data line. The permissive per-line policy never
+//! disagrees with spec compliance on real-provider bytes.
+//!
+//! It is a **latent risk** because:
+//!  * a proxy that strips blank-line separators collapses multiple events
+//!    into one block → strict parser yields zero events (two adjacent
+//!    objects are invalid JSON), current parser still works.
+//!  * a provider that ever ships a multi-line `data:` payload (valid SSE)
+//!    → strict parser joins and decodes correctly, current parser silently
+//!    drops both halves.
+//!
+//! So direction matters: the current code is **too permissive** in one
+//! scenario and **too strict** in the other.
+//!
+//! ## What these tests do
+//!
+//! 1. **Contract pins** — lock in today's permissive behaviour so nobody
+//!    tightens the parser without noticing the multi-data-in-one-block
+//!    tests in `sse_data_lines.rs` (line 175, 221, 239) that rely on it.
+//! 2. **Spec-deviation tripwires** (`#[ignore]`d) — if a maintainer ever
+//!    moves the parser to strict spec compliance, removing `#[ignore]` on
+//!    these turns them into the new contract. Ready-made target tests for
+//!    a future refactor.
+//! 3. **Real bug-hunt results** captured inline so future readers see
+//!    *why* these tests exist, not just *what* they assert.
+
+use astra_turn_core::sse_data_lines::{
+    json_events_from_sse_event_block, parse_sse_data_json_events, validate_sse_event_block_json,
+};
+use serde_json::{Value, json};
+
+// ─── Contract pins for current (permissive) behaviour ────────────────────────
+
+/// Multiple `data:` lines inside one blank-line-terminated block are parsed
+/// AS SEPARATE EVENTS by the current parser. This matches real-provider
+/// streams where each event is its own blank-line-terminated block and the
+/// "multiple data in one block" case only happens if an upstream proxy
+/// collapsed separators — in which case per-line parsing is a forgiving
+/// recovery.
+#[test]
+fn pin_current_behaviour_multiple_data_lines_in_one_block_are_separate_events() {
+    let block = "data: {\"a\":1}\ndata: {\"b\":2}\n";
+    let out = json_events_from_sse_event_block(block);
+    assert_eq!(
+        out.events,
+        vec![json!({"a": 1}), json!({"b": 2})],
+        "permissive-by-design: two data lines → two events; see module doc"
+    );
+}
+
+/// A `data:` line whose payload cannot be parsed as JSON is silently
+/// dropped — NOT an error, NOT a panic. This is the "skip on error"
+/// policy that Anthropic's heartbeat-style events depend on.
+#[test]
+fn pin_current_behaviour_bad_json_data_line_is_silently_skipped() {
+    let block = "data: not-json\ndata: {\"ok\":true}\n";
+    let out = json_events_from_sse_event_block(block);
+    assert_eq!(out.events, vec![json!({"ok": true})]);
+}
+
+/// Non-`data:` lines (comments, `event:` tags, `id:` tags) are dropped.
+/// No state from them influences subsequent parsing.
+#[test]
+fn pin_current_behaviour_non_data_lines_are_dropped_without_side_effects() {
+    let block = "event: ping\nid: 42\n: a comment\ndata: {\"x\":9}\n";
+    let out = json_events_from_sse_event_block(block);
+    assert_eq!(out.events, vec![json!({"x": 9})]);
+    assert!(!out.stream_finished);
+}
+
+/// `data: [DONE]` terminates the stream regardless of what follows —
+/// subsequent `data:` lines in the same block are ignored.
+#[test]
+fn pin_current_behaviour_done_short_circuits_rest_of_block() {
+    let block = "data: {\"before\":true}\ndata: [DONE]\ndata: {\"after\":\"should be ignored\"}\n";
+    let out = json_events_from_sse_event_block(block);
+    assert_eq!(out.events, vec![json!({"before": true})]);
+    assert!(out.stream_finished);
+}
+
+/// The one-shot body parser is equivalent to streaming-then-flush for
+/// bodies without a terminal newline — the trailing incomplete line is
+/// still attempted.
+#[test]
+fn pin_current_behaviour_body_without_terminal_newline_still_parses_tail() {
+    let body = "data: {\"x\":1}\ndata: {\"y\":2}";
+    let v = parse_sse_data_json_events(body);
+    assert_eq!(v, vec![json!({"x": 1}), json!({"y": 2})]);
+}
+
+// ─── Spec-deviation tripwires (ignored until a future spec-compliance pass) ──
+
+/// SSE § 9.2: two `data:` lines in one event should be joined with `\n`
+/// before dispatch, yielding ONE event.
+///
+/// Current parser yields two (or, for split-mid-JSON, zero). This test
+/// is the contract target for a future spec-compliance refactor —
+/// remove `#[ignore]` to enable.
+#[test]
+#[ignore = "spec-compliance tripwire — see module doc; current parser is intentionally permissive"]
+fn tripwire_spec_joins_data_lines_before_json_parse_multi_field_object() {
+    // Split at a JSON comma so the inserted `\n` lands on JSON whitespace.
+    let block = "data: {\"split\":\"ok\",\ndata: \"second\":42}\n";
+    let out = json_events_from_sse_event_block(block);
+    assert_eq!(out.events, vec![json!({"split": "ok", "second": 42})]);
+}
+
+/// SSE § 9.2 strict: multiple top-level objects on consecutive `data:`
+/// lines within one block means ONE event whose joined payload is
+/// invalid JSON (two adjacent objects) → zero events, not two.
+///
+/// Under current (permissive) rules this is a false-positive: we get two
+/// events. The tripwire pins the compliant behaviour.
+#[test]
+#[ignore = "spec-compliance tripwire — pairs with the multi-field test above"]
+fn tripwire_spec_adjacent_objects_on_data_lines_yield_zero_events() {
+    let block = "data: {\"a\":1}\ndata: {\"b\":2}\n";
+    let out = json_events_from_sse_event_block(block);
+    assert_eq!(out.events, Vec::<Value>::new());
+}
+
+/// `validate_sse_event_block_json` should, under spec rules, accept a
+/// multi-line event whose join is valid JSON. Today it rejects because
+/// it validates each line independently.
+#[test]
+#[ignore = "spec-compliance tripwire — validator variant"]
+fn tripwire_spec_validator_accepts_multiline_data_whose_join_is_valid_json() {
+    let block = "data: {\"a\":1,\ndata: \"b\":2}\n";
+    let res = validate_sse_event_block_json(block);
+    assert!(res.is_ok(), "got: {res:?}");
+}
+
+// ─── Defensive contract — hostile payloads produce no panic ─────────────────
+
+/// Adversarial fuzz-like cases. These should all return a well-formed
+/// `SseJsonDrain` (possibly empty) without panicking. If any of these
+/// panic, that IS a bug — add a row.
+#[test]
+fn hostile_payloads_never_panic() {
+    let cases: &[&str] = &[
+        "",
+        "\n",
+        "\r\n",
+        "data:",
+        "data: ",
+        "data: \n",
+        "data: {\n",
+        "data: {",
+        "data: \"unterminated\n",
+        "data: \u{0000}\n",
+        "data: [DONE]",
+        "data: [DONE]\n",
+        "data: [DONE] \n", // trailing space
+        "\0data: {\"x\":1}\n",
+        &"data: {\"x\":1}\n".repeat(100), // large
+        "data: null\n",
+        "data: 42\n",
+        "data: \"just-a-string\"\n",
+        "data: [1,2,3]\n",
+    ];
+    for c in cases {
+        let out = json_events_from_sse_event_block(c);
+        // Invariant: events is a Vec and stream_finished is a bool —
+        // no panic means we pass. Assert a weak but real property: if
+        // any event was parsed, it must round-trip through serde_json.
+        for e in &out.events {
+            let _ = serde_json::to_string(e).expect("parsed events must serialize");
+        }
+    }
+}


### PR DESCRIPTION
## TL;DR

Hunting the SSE pipeline with adversarial intent caught a **real, silent bug** in the mock-LLM harness: every test that drove the mock through the real `chat_turn_sse_dispatch` and checked for tool-call capture was lying — the tool call never landed in `accum.tool_calls`.

## The bug

`mock_llm::tool_call_start` was emitting a NESTED shape:

```json
{"type":"tool_call_start",
 "call_id":"call-1",
 "tool":{"name":"write_file","arguments":"..."}}
```

But `normalize_tool_call_for_accum` in `chat_turn_sse_dispatch.rs` reads `tool` with `as_str()` (per the canonical flat shape pinned by the existing `tool_call_start_collected_in_canonical_shape` unit test). On an Object it returns `None` → `name = ""` → the whole normalizer returns `None` → **the event is silently dropped** by `apply_one_event`.

The existing mock_llm unit tests (`tool_body_contains_tool_call_and_result` etc.) only grep the raw response body for the string `tool_call_start`, so they never exercised the dispatch side and never caught this mismatch.

## Fix

`mock_llm::tool_call_start` now emits the canonical shape:

```json
{"type":"tool_call_start",
 "call_id":"call-1",
 "tool":"write_file",
 "arguments":"<json-stringified>"}
```

with a doc comment pointing at the regression anchor so future mock authors know *why*.

## New tests (all green on main+fix)

- **`phase_r_sse_contract_and_tripwires.rs`** — 5 pins of the *permissive* `json_events_from_sse_event_block` behaviour (real providers always blank-line-separate events, so the per-`data:`-line parse policy is a forgiving recovery for proxies that strip separators), 3 `#[ignore]`d spec-compliance tripwires for a future strict-SSE refactor, and a 19-case hostile-payloads-never-panic guard.
- **`phase_r2_mock_dispatch_contract.rs`** — 4 cross-contract tests between mock emit shape and dispatch normalizer. Includes a regression anchor `nested_tool_object_shape_is_silently_dropped_regression_anchor` that pins the silent-drop as an explicit contract: if someone makes the normalizer lenient to nested tool objects, that test flips and both sides should be re-audited.

## Verification
- `make format` clean
- `make check` clean
- `cargo test -p astra-turn-core --test phase_r_sse_contract_and_tripwires`: 6 pass / 3 ignored
- `cargo test -p astra-turn-core --test phase_r2_mock_dispatch_contract`: 4 pass
- `cargo test -p astra-cli --bin astra mock_llm`: 6 pass

## Meta
This answers the prior "added so many tests, caught a single real bug?" challenge. Before this: 1 real bug (control-chars-in-JSON from Phase N proptest, fixed in #219). With this: 2. Approach: drive adversarial mocks through the production parser/dispatch pipeline AND cross-check emit shapes against consumer assumptions — every mock↔consumer contract surface has this failure mode and deserves a dedicated test.