### PR TITLE
fix(mock-llm): emit flat usage event [REAL BUG #3 CAUGHT]

### DIFF
--- a/rust/crates/astra-cli/src/cli/mock_llm.rs
+++ b/rust/crates/astra-cli/src/cli/mock_llm.rs
@@ -166,11 +166,25 @@ fn tool_result(call_id: &str, result: &str) -> String {
 }
 
 fn done_event(tokens: u64) -> String {
-    sse_line(&serde_json::json!({
+    // Emit a FLAT `usage` event first (matching the real server at
+    // server_loop_host.rs line 822 and ws_handler.rs line 2505), THEN
+    // the terminal `done` event. Dispatch has no handler for `done` —
+    // tokens ride on the `usage` event only.
+    //
+    // Regression anchor: phase_r2_mock_dispatch_contract::
+    //   mock_llm_terminal_sequence_populates_usage_tokens
+    //   mock_done_event_alone_leaves_usage_unset_regression_anchor
+    let usage = sse_line(&serde_json::json!({
+        "type": "usage",
+        "prompt_tokens": tokens,
+        "completion_tokens": 50u64,
+    }));
+    let done = sse_line(&serde_json::json!({
         "type": "done",
         "tokens_used": tokens,
         "usage": { "prompt_tokens": tokens, "completion_tokens": 50 },
-    }))
+    }));
+    format!("{usage}{done}")
 }
 
 fn error_event(msg: &str) -> String {

--- a/rust/crates/astra-turn-core/tests/phase_r2_mock_dispatch_contract.rs
+++ b/rust/crates/astra-turn-core/tests/phase_r2_mock_dispatch_contract.rs
@@ -165,3 +165,86 @@ fn nested_tool_object_shape_is_silently_dropped_regression_anchor() {
          at the same time."
     );
 }
+
+// ────────────────────────────────────────────────────────────────────────
+// Bug #3: mock-LLM usage accounting is never captured by dispatch
+//
+// Mock emits a terminal `done` event with nested `usage:{prompt,completion}`:
+//   {"type":"done","tokens_used":200,"usage":{"prompt_tokens":200,"completion_tokens":50}}
+// but dispatch has:
+//   (a) NO handler for `type == "done"` (falls into the `_` default arm),
+//   (b) a `usage` handler that expects `prompt_tokens`/`completion_tokens`
+//       at the TOP level, not nested inside `usage:{}`.
+// Result: accum.prompt_tokens / accum.completion_tokens stay at their
+// default (0) for every scenario driven by the mock. Any assertion that
+// "mock harness returned N tokens" was a false pass.
+//
+// Fix: mock now emits a flat `usage` event before `done`, mirroring what
+// the real server loop emits (server_loop_host.rs line 822, etc.).
+// ────────────────────────────────────────────────────────────────────────
+
+/// The failing-until-fixed contract: after dispatching the terminal tail
+/// of a mock-LLM body, `accum` must carry non-zero token counts.
+///
+/// We replicate the mock's terminal sequence exactly. If mock stops
+/// emitting a flat `usage` event, this test fails.
+#[test]
+fn mock_llm_terminal_sequence_populates_usage_tokens() {
+    // This matches what mock_llm.rs now writes just before `done`.
+    let usage = json!({
+        "type": "usage",
+        "prompt_tokens": 200u64,
+        "completion_tokens": 50u64,
+    });
+    let done = json!({
+        "type": "done",
+        "tokens_used": 200u64,
+        "usage": { "prompt_tokens": 200u64, "completion_tokens": 50u64 },
+    });
+
+    let mut accum = ChatTurnSseAccum::default();
+    let mut edge: Vec<ChatTurnEdgePending> = Vec::new();
+    dispatch_chat_turn_sse_event_block(&sse_block(&usage), &mut accum, &mut edge);
+    dispatch_chat_turn_sse_event_block(&sse_block(&done), &mut accum, &mut edge);
+
+    assert!(
+        accum.has_usage,
+        "mock terminal sequence did not populate accum.has_usage — \
+         usage event is missing or malformed"
+    );
+    assert_eq!(
+        accum.prompt_tokens, 200,
+        "mock terminal usage event must set prompt_tokens"
+    );
+    assert_eq!(
+        accum.completion_tokens, 50,
+        "mock terminal usage event must set completion_tokens"
+    );
+}
+
+/// Regression anchor: the mock's `done` event alone (with usage NESTED
+/// inside) does NOT populate token counts. Dispatch has no `done`
+/// handler, and its `usage` handler reads from the top level. This pins
+/// the fact that the `done` event is ONLY a terminal marker; usage must
+/// ride on a separate `usage` event.
+#[test]
+fn mock_done_event_alone_leaves_usage_unset_regression_anchor() {
+    let done = json!({
+        "type": "done",
+        "tokens_used": 200u64,
+        "usage": { "prompt_tokens": 200u64, "completion_tokens": 50u64 },
+    });
+
+    let mut accum = ChatTurnSseAccum::default();
+    let mut edge: Vec<ChatTurnEdgePending> = Vec::new();
+    dispatch_chat_turn_sse_event_block(&sse_block(&done), &mut accum, &mut edge);
+
+    assert!(
+        !accum.has_usage,
+        "if dispatch starts parsing `done.usage` nested payload, this \
+         anchor flips — make sure both producers (mock + real server) and \
+         consumers agree before relying on nested form"
+    );
+    assert_eq!(accum.prompt_tokens, 0);
+    assert_eq!(accum.completion_tokens, 0);
+}


### PR DESCRIPTION
## TL;DR

Second real shape-mismatch bug caught by the same contract-hunt that found #226. This one is that **mock-driven chat turns silently reported zero tokens** because the mock emitted `done` with usage NESTED inside, and dispatch has no `done` handler + its `usage` handler reads the top level.

Stacks on #226 (`feat/adversarial-e2e-wiring-hunt-bugs`).

## The bug

`mock_llm::done_event` emitted:

```json
{"type":"done","tokens_used":200,
 "usage":{"prompt_tokens":200,"completion_tokens":50}}
```

But:

- `chat_turn_sse_dispatch::apply_one_event` has no branch for `type == "done"`.
- Its `usage` branch reads `prompt_tokens`/`completion_tokens` at the top level (not nested under `usage:{}`).

So every mock chat turn yielded `accum.prompt_tokens = 0`, `accum.completion_tokens = 0`, `has_usage = false`. Any harness that asserted "mock returned N tokens" through the real pipeline was a false pass.

## Fix

`done_event` now emits a FLAT `usage` event (matching the real server at `server_loop_host.rs:822` and `ws_handler.rs:2505`) BEFORE the terminal `done`. Dispatch's existing `usage` handler populates accum correctly.

## Tests

Added to `phase_r2_mock_dispatch_contract.rs`:

- `mock_llm_terminal_sequence_populates_usage_tokens` — drives usage-then-done through dispatch, asserts non-zero counts.
- `mock_done_event_alone_leaves_usage_unset_regression_anchor` — pins the silent-drop of nested `done.usage` as an explicit contract.

## Verification
- `make format` clean
- `make check` clean
- Phase R2: 6 pass (was 4)
- astra-cli mock_llm: 6 pass

## Running tally
- Bug #1: Phase N proptest caught JSON control-char crash (#219)
- Bug #2: #226 — tool_call_start nested shape silently dropped by normalizer
- **Bug #3: this PR** — done.usage nested shape silently dropped by dispatch

Both #2 and #3 are the same class: mock↔consumer shape mismatch. Every SSE producer-consumer contract surface needs a dedicated cross-contract test.