### PR TITLE
obs/sibling abort signals 2026 04 23

### DIFF
--- a/rust/crates/astra-turn-core/src/parallel_tool_exec.rs
+++ b/rust/crates/astra-turn-core/src/parallel_tool_exec.rs
@@ -12,7 +12,6 @@
 //! `execute_tool` function is supplied by the caller (CLI's stream_render.rs
 //! or any other host).
 
-use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
@@ -259,12 +258,12 @@ pub async fn execute_parallel_round(
         }
     }
 
-    // Phase 2: Execute mutating tools sequentially
+    // Phase 2: Execute mutating tools sequentially.
+    // Sibling-abort fires on ANY mutating-tool failure (not just bash): a
+    // batched sequence of mutations is typically a coherent plan (write →
+    // commit → push) where later steps become meaningless once an earlier
+    // one fails, and continuing can partially apply destructive state.
     let sequential_count = mutating.len();
-    let bash_names: HashSet<&str> = ["bash", "BashTool", "shell", "execute_command"]
-        .iter()
-        .copied()
-        .collect();
 
     for (idx, tc) in mutating {
         if sibling_aborted {
@@ -292,8 +291,8 @@ pub async fn execute_parallel_round(
 
         let (call_id, tool_name, content, success) = executor(tc.clone()).await;
 
-        // Sibling abort: if a bash tool fails, skip remaining mutating tools
-        if !success && bash_names.contains(tool_name.as_str()) {
+        // Sibling abort: any mutating-tool failure aborts remaining siblings.
+        if !success {
             sibling_aborted = true;
         }
 

--- a/rust/crates/astra-turn-core/src/parallel_tool_exec.rs
+++ b/rust/crates/astra-turn-core/src/parallel_tool_exec.rs
@@ -264,8 +264,12 @@ pub async fn execute_parallel_round(
     // commit → push) where later steps become meaningless once an earlier
     // one fails, and continuing can partially apply destructive state.
     let sequential_count = mutating.len();
+    let mut mutating_executed: usize = 0;
+    let mut aborted_count: usize = 0;
+    let mut trigger_tool: Option<String> = None;
+    let mut trigger_position: Option<usize> = None;
 
-    for (idx, tc) in mutating {
+    for (mut_pos, (idx, tc)) in mutating.into_iter().enumerate() {
         if sibling_aborted {
             let call_id = tc
                 .get("id")
@@ -279,6 +283,7 @@ pub async fn execute_parallel_round(
                 .or_else(|| tc.get("name").and_then(|n| n.as_str()))
                 .unwrap_or("")
                 .to_string();
+            aborted_count += 1;
             results[idx] = Some(ToolExecResult {
                 original_index: idx,
                 call_id,
@@ -290,10 +295,13 @@ pub async fn execute_parallel_round(
         }
 
         let (call_id, tool_name, content, success) = executor(tc.clone()).await;
+        mutating_executed += 1;
 
         // Sibling abort: any mutating-tool failure aborts remaining siblings.
         if !success {
             sibling_aborted = true;
+            trigger_tool = Some(tool_name.clone());
+            trigger_position = Some(mut_pos);
         }
 
         results[idx] = Some(ToolExecResult {
@@ -304,6 +312,25 @@ pub async fn execute_parallel_round(
             success,
         });
     }
+
+    // Structured signal for the "signals to watch" section of
+    // docs/design/sibling-abort-policy.md. One event per round lets log
+    // aggregation answer: how often are mutating batches ≥ 2? which tool
+    // triggers aborts? at what position (early vs late) does the trigger
+    // sit in the queue?
+    tracing::info!(
+        target: "astra::parallel_tool_exec::round",
+        parallel_count,
+        sequential_count,
+        mutating_executed,
+        aborted_count,
+        sibling_aborted,
+        trigger_tool = trigger_tool.as_deref().unwrap_or(""),
+        trigger_position = trigger_position
+            .map(|p| p as i64)
+            .unwrap_or(-1),
+        "parallel_tool_exec round completed"
+    );
 
     ParallelRoundOutcome {
         results: results.into_iter().flatten().collect(),

--- a/rust/crates/astra-turn-core/tests/parallel_tool_exec_cap_test.rs
+++ b/rust/crates/astra-turn-core/tests/parallel_tool_exec_cap_test.rs
@@ -113,6 +113,27 @@ fn failing_bash_executor() -> (ToolExecutorFn, Arc<AtomicUsize>) {
     (exec, invocations)
 }
 
+/// Executor that makes the first `write_file` call fail; everything else succeeds.
+/// Used to verify sibling-abort triggers on non-bash mutating failures too.
+fn failing_write_executor() -> (ToolExecutorFn, Arc<AtomicUsize>) {
+    let invocations = Arc::new(AtomicUsize::new(0));
+    let invocations_c = invocations.clone();
+    let exec: ToolExecutorFn = Arc::new(move |tc: Value| {
+        let invocations = invocations_c.clone();
+        Box::pin(async move {
+            invocations.fetch_add(1, Ordering::SeqCst);
+            let call_id = tc["id"].as_str().unwrap_or("").to_string();
+            let name = tc["function"]["name"].as_str().unwrap_or("").to_string();
+            if name == "write_file" {
+                (call_id, name, "boom: permission denied".into(), false)
+            } else {
+                (call_id, name, "ok".into(), true)
+            }
+        })
+    });
+    (exec, invocations)
+}
+
 /// Unhappy path: a failing `bash` call must abort queued mutating siblings.
 /// Mix: [read (parallel), bash-failing, write_file, str_replace].
 #[tokio::test]
@@ -281,4 +302,61 @@ fn shared_tool_semaphore_returns_same_instance() {
         Arc::ptr_eq(&a, &b),
         "shared_tool_semaphore must return the same Arc on repeat calls"
     );
+}
+
+// ── Sibling-abort coverage for non-bash mutating tools ──
+//
+// Previously, the sibling-abort guard only fired when the failing tool was
+// in `["bash", "BashTool", "shell", "execute_command"]`. A failing
+// `write_file`, `git_commit`, `str_replace`, etc. did **not** abort queued
+// mutating siblings — even though mutations are typically part of a
+// coherent sequence (write → commit → push; the next step is meaningless
+// once an earlier one fails) and continuing can partially apply state.
+//
+// The guard now fires on any mutating-tool failure.
+
+#[tokio::test]
+async fn unhappy_any_failing_mutating_tool_aborts_siblings() {
+    // write_file fails first; subsequent mutating tools (str_replace, bash)
+    // must be skipped, not dispatched.
+    let calls = vec![
+        tool_call("read_file", "r0"),
+        tool_call("write_file", "w1"),
+        tool_call("str_replace", "s2"),
+        tool_call("bash", "b3"),
+    ];
+    let (exec, invocations) = failing_write_executor();
+
+    let outcome = execute_parallel_round(&calls, exec).await;
+
+    assert_eq!(outcome.parallel_count, 1, "one read-only call");
+    assert_eq!(outcome.sequential_count, 3, "three mutating calls queued");
+    assert!(
+        outcome.sibling_aborted,
+        "write_file failure must flip the sibling-abort flag too"
+    );
+
+    // Executor should have been called for r0 + w1 only — 2 calls total.
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        2,
+        "mutating siblings after a failing write_file must be skipped"
+    );
+
+    let ordered: Vec<_> = outcome
+        .results
+        .iter()
+        .map(|r| (r.tool_name.as_str(), r.success))
+        .collect();
+    assert_eq!(ordered[0], ("read_file", true));
+    assert_eq!(ordered[1], ("write_file", false));
+    assert!(!ordered[2].1, "str_replace should be aborted");
+    assert!(!ordered[3].1, "bash should be aborted");
+    for r in &outcome.results[2..] {
+        assert!(
+            r.content.to_lowercase().contains("aborted"),
+            "aborted sibling must carry 'aborted' reason: {}",
+            r.content
+        );
+    }
 }


### PR DESCRIPTION
- **fix(parallel-tool-exec): abort siblings on any mutating-tool failure**
- **obs(parallel-tool-exec): emit per-round signal for sibling-abort policy telemetry**
