### PR TITLE
fix: at-most-once idempotency audit — 4 sites (WS approval, skills register/publish, learning sync)

### DIFF
--- a/rust/crates/runtime/src/server/ws_handler.rs
+++ b/rust/crates/runtime/src/server/ws_handler.rs
@@ -782,6 +782,54 @@ async fn handle_resume_run(
     }
 }
 
+/// Outcome of a dedup-insert into the edge-callback ledger.
+#[derive(Debug, PartialEq)]
+pub(crate) enum WsLedgerOutcome {
+    /// Key was absent; value has been inserted.
+    Inserted,
+    /// Key was present with an identical JSON value; no-op idempotent replay.
+    IdempotentReplay,
+    /// Key was present with a DIFFERENT value; the original decision is preserved.
+    ConflictIgnored,
+}
+
+/// Insert `value` under `key` in the ledger with at-most-once idempotency semantics.
+///
+/// - Key absent → insert, return `Inserted`.
+/// - Key present + same JSON value → no-op, return `IdempotentReplay`.
+/// - Key present + different JSON value → do NOT overwrite; emit a warning;
+///   return `ConflictIgnored`.
+pub(crate) fn ws_ledger_dedup_insert(
+    ledger: &mut std::collections::HashMap<String, serde_json::Value>,
+    key: String,
+    value: serde_json::Value,
+) -> WsLedgerOutcome {
+    use std::collections::hash_map::Entry;
+    match ledger.entry(key.clone()) {
+        Entry::Vacant(e) => {
+            e.insert(value);
+            WsLedgerOutcome::Inserted
+        }
+        Entry::Occupied(e) => {
+            let existing = e.get();
+            if existing == &value {
+                WsLedgerOutcome::IdempotentReplay
+            } else {
+                let existing_repr = existing.to_string().chars().take(80).collect::<String>();
+                let new_repr = value.to_string().chars().take(80).collect::<String>();
+                tracing::warn!(
+                    target: "astra_runtime::ws_callback",
+                    key = %key,
+                    existing = %existing_repr,
+                    incoming = %new_repr,
+                    "WS ledger dedup: incoming value conflicts with stored decision; original preserved"
+                );
+                WsLedgerOutcome::ConflictIgnored
+            }
+        }
+    }
+}
+
 /// Store a tool approval response in the edge callback ledger.
 async fn handle_tool_approval(
     state: &AppState,
@@ -799,7 +847,7 @@ async fn handle_tool_approval(
     });
     let ledger = state.edge_callback_ledger.clone();
     let mut guard = ledger.lock().await;
-    guard.insert(key, value);
+    ws_ledger_dedup_insert(&mut guard, key, value);
 }
 
 /// Store an ask_user response in the edge callback ledger.
@@ -819,7 +867,7 @@ async fn handle_user_prompt_response(
     });
     let ledger = state.edge_callback_ledger.clone();
     let mut guard = ledger.lock().await;
-    guard.insert(key, value);
+    ws_ledger_dedup_insert(&mut guard, key, value);
 }
 
 #[cfg(test)]
@@ -4036,5 +4084,50 @@ mod tests {
 
         let json = r#"{"type":"user_prompt","request_id":"req-1"}"#;
         assert!(serde_json::from_str::<WsClientMessage>(json).is_err());
+    }
+
+    // ── ws_ledger_dedup_insert unit tests ──────────────────────────────────
+
+    #[test]
+    fn ws_ledger_dedup_insert_absent_key_inserts_and_returns_inserted() {
+        let mut ledger = std::collections::HashMap::new();
+        let outcome = ws_ledger_dedup_insert(
+            &mut ledger,
+            "user:req-1".to_string(),
+            serde_json::json!({"approved": true, "reason": null}),
+        );
+        assert_eq!(outcome, WsLedgerOutcome::Inserted);
+        assert_eq!(
+            ledger["user:req-1"],
+            serde_json::json!({"approved": true, "reason": null})
+        );
+    }
+
+    #[test]
+    fn ws_ledger_dedup_insert_identical_value_is_idempotent_replay() {
+        let mut ledger = std::collections::HashMap::new();
+        let value = serde_json::json!({"approved": true, "reason": null});
+        ledger.insert("user:req-1".to_string(), value.clone());
+
+        let outcome = ws_ledger_dedup_insert(&mut ledger, "user:req-1".to_string(), value.clone());
+        assert_eq!(outcome, WsLedgerOutcome::IdempotentReplay);
+        // original value unchanged
+        assert_eq!(ledger["user:req-1"], value);
+    }
+
+    #[test]
+    fn ws_ledger_dedup_insert_different_value_is_conflict_ignored_and_preserves_original() {
+        let mut ledger = std::collections::HashMap::new();
+        let original = serde_json::json!({"approved": true, "reason": null});
+        let conflicting = serde_json::json!({"approved": false, "reason": "changed mind"});
+        ledger.insert("user:req-1".to_string(), original.clone());
+
+        let outcome = ws_ledger_dedup_insert(&mut ledger, "user:req-1".to_string(), conflicting);
+        assert_eq!(outcome, WsLedgerOutcome::ConflictIgnored);
+        // original MUST NOT be overwritten
+        assert_eq!(
+            ledger["user:req-1"], original,
+            "conflicting update must not overwrite the first decision"
+        );
     }
 }

--- a/rust/crates/services/src/lib.rs
+++ b/rust/crates/services/src/lib.rs
@@ -193,7 +193,10 @@ pub use session_fork::{
 pub use skill_config::{
     DatabaseSkillConfigService, SkillConfigService, UnconfiguredSkillConfigService,
 };
-pub use skills::{DatabaseSkillService, SkillRecord, SkillService, UnconfiguredSkillService};
+pub use skills::{
+    DatabaseSkillService, SkillPublishRequestData, SkillRecord, SkillRegisterRequestData,
+    SkillService, UnconfiguredSkillService,
+};
 pub use state_sync::{
     LocalOnlySyncService, MatrixOneSyncService, PlanTemplateSyncRow, StateSyncService,
     SyncDirection, SyncResult, SyncStatus,

--- a/rust/crates/services/src/skills.rs
+++ b/rust/crates/services/src/skills.rs
@@ -161,6 +161,102 @@ const SKILL_REGISTRY_LIST_SELECT: &str = "\
     status, source, category, \
     DATE_FORMAT(created_at, '%Y-%m-%dT%H:%i:%s') AS created_at";
 
+// ── Idempotency classifiers ───────────────────────────────────────────────────
+
+/// Row fetched from `skills_registry` when checking for a duplicate before register.
+pub(crate) struct ExistingRegisterRow {
+    pub skill_name: String,
+    pub version: String,
+    pub description: Option<String>,
+    pub skill_definition: String,
+    pub code_hash: String,
+    pub created_at: Option<String>,
+}
+
+/// Decision returned by [`classify_register_duplicate`].
+#[derive(Debug, PartialEq)]
+pub(crate) enum RegisterDuplicateDecision {
+    /// No existing row; proceed with INSERT.
+    Insert,
+    /// Existing row is identical to the incoming request; return it as idempotent success.
+    IdempotentReplay(SkillRecord),
+    /// Existing row differs; return 409 Conflict.
+    Conflict,
+}
+
+/// Classify whether a duplicate `register_skill` call is an idempotent retry or a real conflict.
+///
+/// Compares `skill_definition` JSON and `code_hash` of the stored row against the values
+/// that would be produced by the incoming request.  Identical → idempotent success; different → 409.
+pub(crate) fn classify_register_duplicate(
+    existing: Option<ExistingRegisterRow>,
+    skill_id: &str,
+    new_definition_json: &str,
+    new_code_hash: &str,
+) -> RegisterDuplicateDecision {
+    let Some(row) = existing else {
+        return RegisterDuplicateDecision::Insert;
+    };
+    let same_def = row.skill_definition == new_definition_json;
+    let same_hash = row.code_hash == new_code_hash;
+    if same_def && same_hash {
+        let metadata: Option<serde_json::Value> = serde_json::from_str(&row.skill_definition).ok();
+        RegisterDuplicateDecision::IdempotentReplay(SkillRecord {
+            skill_id: skill_id.to_string(),
+            skill_name: row.skill_name,
+            version: row.version,
+            description: row.description,
+            metadata,
+            created_at: row.created_at,
+        })
+    } else {
+        RegisterDuplicateDecision::Conflict
+    }
+}
+
+/// Row fetched from `skills_registry` when a duplicate key fires during publish.
+pub(crate) struct ExistingPublishRow {
+    pub skill_name: String,
+    pub version: String,
+    pub skill_definition: String,
+    pub manifest: String,
+}
+
+/// Decision returned by [`classify_publish_duplicate`].
+#[derive(Debug, PartialEq)]
+pub(crate) enum PublishDuplicateDecision {
+    /// Existing row is identical; return 200 success with original payload.
+    IdempotentReplay(serde_json::Value),
+    /// Existing row differs; return 409 Conflict.
+    Conflict,
+}
+
+/// Classify whether a duplicate `publish_skill` call is an idempotent retry or a real conflict.
+///
+/// Compares `skill_definition` and `manifest` of the stored row against what was being inserted.
+pub(crate) fn classify_publish_duplicate(
+    existing: Option<ExistingPublishRow>,
+    skill_id: &str,
+    new_definition_json: &str,
+    new_manifest_json: &str,
+) -> PublishDuplicateDecision {
+    let Some(row) = existing else {
+        return PublishDuplicateDecision::Conflict;
+    };
+    let same_def = row.skill_definition == new_definition_json;
+    let same_manifest = row.manifest == new_manifest_json;
+    if same_def && same_manifest {
+        PublishDuplicateDecision::IdempotentReplay(serde_json::json!({
+            "skill_id": skill_id,
+            "skill_name": row.skill_name,
+            "version": row.version,
+            "status": "published",
+        }))
+    } else {
+        PublishDuplicateDecision::Conflict
+    }
+}
+
 // ── Trait ─────────────────────────────────────────────────────────────────────
 
 #[async_trait]
@@ -304,18 +400,8 @@ impl SkillService for DatabaseSkillService {
             request.skill_id.clone()
         };
 
-        let existing = query("SELECT skill_id FROM skills_registry WHERE skill_id = ?")
-            .bind(&skill_id)
-            .fetch_optional(&pool)
-            .await
-            .map_err(internal_error)?;
-        if existing.is_some() {
-            return Err(error_response(
-                StatusCode::CONFLICT,
-                format!("Skill '{}' already exists", skill_id),
-            ));
-        }
-
+        // Build skill_definition and code_hash before the duplicate-check SELECT so the
+        // classifier can compare them against the stored row.
         let mut skill_definition = match request.metadata.clone() {
             Some(serde_json::Value::Object(mut map)) => {
                 strip_reserved_skill_definition_keys(&mut map);
@@ -345,6 +431,44 @@ impl SkillService for DatabaseSkillService {
         let definition_json =
             serde_json::to_string(&definition_value).unwrap_or_else(|_| "{}".to_string());
         let code_hash = format!("{:x}", sha2::Sha256::digest(request.skill_code.as_bytes()));
+
+        // Idempotency check: fetch existing row to compare definition + code_hash.
+        let existing_row = query(
+            "SELECT skill_name, version, description, \
+             IFNULL(CAST(skill_definition AS CHAR), '') AS skill_definition, \
+             IFNULL(code_hash, '') AS code_hash, \
+             DATE_FORMAT(created_at, '%Y-%m-%dT%H:%i:%s') AS created_at \
+             FROM skills_registry WHERE skill_id = ?",
+        )
+        .bind(&skill_id)
+        .fetch_optional(&pool)
+        .await
+        .map_err(internal_error)?
+        .map(|row| ExistingRegisterRow {
+            skill_name: row.try_get::<String, _>("skill_name").unwrap_or_default(),
+            version: row.try_get::<String, _>("version").unwrap_or_default(),
+            description: row.try_get::<String, _>("description").ok(),
+            skill_definition: row
+                .try_get::<String, _>("skill_definition")
+                .unwrap_or_default(),
+            code_hash: row.try_get::<String, _>("code_hash").unwrap_or_default(),
+            created_at: row.try_get::<String, _>("created_at").ok(),
+        });
+
+        match classify_register_duplicate(existing_row, &skill_id, &definition_json, &code_hash) {
+            RegisterDuplicateDecision::Insert => {
+                // Proceed to INSERT below.
+            }
+            RegisterDuplicateDecision::IdempotentReplay(record) => {
+                return Ok(record);
+            }
+            RegisterDuplicateDecision::Conflict => {
+                return Err(error_response(
+                    StatusCode::CONFLICT,
+                    format!("Skill '{}' already exists", skill_id),
+                ));
+            }
+        }
 
         query(
             "INSERT INTO skills_registry \
@@ -754,10 +878,43 @@ impl SkillService for DatabaseSkillService {
 
         if let Err(error) = insert_result {
             if is_duplicate_key_error(&error) {
-                return Err(error_response(
-                    StatusCode::CONFLICT,
-                    format!("Skill '{}' already exists", skill_id),
-                ));
+                // Re-query to determine whether this is an idempotent retry or a real conflict.
+                let dup_row = query(
+                    "SELECT skill_name, version, \
+                     IFNULL(CAST(skill_definition AS CHAR), '') AS skill_definition, \
+                     IFNULL(CAST(manifest AS CHAR), '') AS manifest \
+                     FROM skills_registry WHERE skill_id = ?",
+                )
+                .bind(&skill_id)
+                .fetch_optional(&pool)
+                .await
+                .ok()
+                .flatten()
+                .map(|row| ExistingPublishRow {
+                    skill_name: row.try_get::<String, _>("skill_name").unwrap_or_default(),
+                    version: row.try_get::<String, _>("version").unwrap_or_default(),
+                    skill_definition: row
+                        .try_get::<String, _>("skill_definition")
+                        .unwrap_or_default(),
+                    manifest: row.try_get::<String, _>("manifest").unwrap_or_default(),
+                });
+
+                match classify_publish_duplicate(
+                    dup_row,
+                    &skill_id,
+                    &skill_definition_json,
+                    &manifest_json,
+                ) {
+                    PublishDuplicateDecision::IdempotentReplay(value) => {
+                        return Ok(value);
+                    }
+                    PublishDuplicateDecision::Conflict => {
+                        return Err(error_response(
+                            StatusCode::CONFLICT,
+                            format!("Skill '{}' already exists", skill_id),
+                        ));
+                    }
+                }
             }
             return Err(internal_error(error));
         }
@@ -1096,5 +1253,115 @@ mod tests {
             !SKILL_REGISTRY_LIST_SELECT.contains("skill_definition"),
             "list_skills must not read skill_definition (use get_skill for full record)"
         );
+    }
+
+    // ── classify_register_duplicate unit tests ────────────────────────────────
+
+    fn make_existing_register_row(def: &str, hash: &str) -> ExistingRegisterRow {
+        ExistingRegisterRow {
+            skill_name: "my-skill".to_string(),
+            version: "1.0.0".to_string(),
+            description: Some("desc".to_string()),
+            skill_definition: def.to_string(),
+            code_hash: hash.to_string(),
+            created_at: Some("2024-01-01T00:00:00".to_string()),
+        }
+    }
+
+    #[test]
+    fn classify_register_duplicate_none_returns_insert() {
+        let decision =
+            classify_register_duplicate(None, "my-skill@1.0.0", r#"{"skill_type":"local"}"#, "abc");
+        assert_eq!(decision, RegisterDuplicateDecision::Insert);
+    }
+
+    #[test]
+    fn classify_register_duplicate_identical_returns_idempotent_replay() {
+        let def = r#"{"skill_type":"local","instructions":"fn run() {}"}"#;
+        let hash = "deadbeef";
+        let row = make_existing_register_row(def, hash);
+        let decision = classify_register_duplicate(Some(row), "my-skill@1.0.0", def, hash);
+        assert!(
+            matches!(decision, RegisterDuplicateDecision::IdempotentReplay(_)),
+            "identical payload must return IdempotentReplay, got {decision:?}"
+        );
+        if let RegisterDuplicateDecision::IdempotentReplay(record) = decision {
+            assert_eq!(record.skill_id, "my-skill@1.0.0");
+            assert_eq!(record.skill_name, "my-skill");
+        }
+    }
+
+    #[test]
+    fn classify_register_duplicate_different_definition_returns_conflict() {
+        let stored_def = r#"{"skill_type":"local","instructions":"fn run() {}"}"#;
+        let new_def = r#"{"skill_type":"local","instructions":"fn run() { panic!() }"}"#;
+        let row = make_existing_register_row(stored_def, "abc");
+        let decision = classify_register_duplicate(Some(row), "my-skill@1.0.0", new_def, "abc");
+        assert_eq!(decision, RegisterDuplicateDecision::Conflict);
+    }
+
+    #[test]
+    fn classify_register_duplicate_different_hash_returns_conflict() {
+        let def = r#"{"skill_type":"local","instructions":"fn run() {}"}"#;
+        let row = make_existing_register_row(def, "old-hash");
+        let decision = classify_register_duplicate(Some(row), "my-skill@1.0.0", def, "new-hash");
+        assert_eq!(decision, RegisterDuplicateDecision::Conflict);
+    }
+
+    // ── classify_publish_duplicate unit tests ─────────────────────────────────
+
+    fn make_existing_publish_row(def: &str, manifest: &str) -> ExistingPublishRow {
+        ExistingPublishRow {
+            skill_name: "pub-skill".to_string(),
+            version: "2.0.0".to_string(),
+            skill_definition: def.to_string(),
+            manifest: manifest.to_string(),
+        }
+    }
+
+    #[test]
+    fn classify_publish_duplicate_none_returns_conflict() {
+        let decision = classify_publish_duplicate(None, "pub-skill@2.0.0", r#"{}"#, r#"{}"#);
+        assert_eq!(decision, PublishDuplicateDecision::Conflict);
+    }
+
+    #[test]
+    fn classify_publish_duplicate_identical_returns_idempotent_replay() {
+        let def = r#"{"skill_type":"local","priority":5}"#;
+        let manifest = r#"{"skill_type":"local","priority":5}"#;
+        let row = make_existing_publish_row(def, manifest);
+        let decision = classify_publish_duplicate(Some(row), "pub-skill@2.0.0", def, manifest);
+        assert!(
+            matches!(decision, PublishDuplicateDecision::IdempotentReplay(_)),
+            "identical payload must return IdempotentReplay, got {decision:?}"
+        );
+        if let PublishDuplicateDecision::IdempotentReplay(value) = decision {
+            assert_eq!(value["skill_id"], "pub-skill@2.0.0");
+            assert_eq!(value["status"], "published");
+        }
+    }
+
+    #[test]
+    fn classify_publish_duplicate_different_definition_returns_conflict() {
+        let row = make_existing_publish_row(r#"{"priority":5}"#, r#"{"priority":5}"#);
+        let decision = classify_publish_duplicate(
+            Some(row),
+            "pub-skill@2.0.0",
+            r#"{"priority":10}"#,
+            r#"{"priority":5}"#,
+        );
+        assert_eq!(decision, PublishDuplicateDecision::Conflict);
+    }
+
+    #[test]
+    fn classify_publish_duplicate_different_manifest_returns_conflict() {
+        let row = make_existing_publish_row(r#"{"priority":5}"#, r#"{"priority":5}"#);
+        let decision = classify_publish_duplicate(
+            Some(row),
+            "pub-skill@2.0.0",
+            r#"{"priority":5}"#,
+            r#"{"priority":10}"#,
+        );
+        assert_eq!(decision, PublishDuplicateDecision::Conflict);
     }
 }

--- a/rust/crates/services/src/state_sync.rs
+++ b/rust/crates/services/src/state_sync.rs
@@ -29,6 +29,8 @@ use async_trait::async_trait;
 use base64::Engine;
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use serde::{Deserialize, Serialize};
+use sha2::Digest;
+use sqlx::Row;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::time::Duration;
@@ -45,6 +47,37 @@ const MAX_BACKOFF_MS: u64 = 2000;
 const SYNC_LOG_SUCCESS_RETAIN: usize = 200;
 /// Retain a smaller bounded tail of error rows per user.
 const SYNC_LOG_ERROR_RETAIN: usize = 50;
+
+// ─── Learning snapshot idempotency classifier ───────────────────────────────
+
+/// Decision returned by [`classify_learning_insert_duplicate`].
+#[derive(Debug, PartialEq)]
+pub(crate) enum LearningDuplicateDecision {
+    /// The stored snapshot is identical to what was inserted; return success.
+    Idempotent,
+    /// The stored snapshot differs; treat as a real conflict.
+    Conflict,
+}
+
+/// Classify a duplicate-key hit during a new-snapshot INSERT.
+///
+/// Compares SHA-256 hashes of the original (uncompressed) snapshot JSON.
+/// If the stored hash matches what we computed before insertion the request
+/// was a retryable-insert retry and should succeed; otherwise it is a real conflict.
+pub(crate) fn classify_learning_insert_duplicate(
+    existing_hash: Option<&[u8]>,
+    new_hash: &[u8],
+) -> LearningDuplicateDecision {
+    match existing_hash {
+        Some(h) if h == new_hash => LearningDuplicateDecision::Idempotent,
+        _ => LearningDuplicateDecision::Conflict,
+    }
+}
+
+/// Compute the SHA-256 digest of a string slice as a fixed-size byte array.
+fn sha256_bytes(input: &str) -> [u8; 32] {
+    sha2::Sha256::digest(input.as_bytes()).into()
+}
 
 /// Check if an error is likely transient and worth retrying.
 fn is_retryable_error(err: &sqlx::Error) -> bool {
@@ -580,6 +613,8 @@ impl StateSyncService for MatrixOneSyncService {
             Ok(value) => value,
             Err(e) => return SyncResult::err(SyncDirection::Push, "learning", e),
         };
+        // Pre-compute hash of the original JSON for idempotency comparison on dup-key retry.
+        let new_snapshot_hash = sha256_bytes(snapshot_json);
 
         // Retry loop with exponential backoff for transient network errors
         let mut backoff_ms = INITIAL_BACKOFF_MS;
@@ -726,6 +761,51 @@ impl StateSyncService for MatrixOneSyncService {
                         Err(e) => {
                             let msg = format!("push_learning_versioned (new): {e}");
                             if is_duplicate_key_error(&e) {
+                                // Re-query the stored snapshot to determine if this is an
+                                // idempotent retry (connection dropped after first INSERT committed)
+                                // or a genuine conflict (different payload under same key).
+                                let stored_row = sqlx::query(
+                                    "SELECT snapshot_json FROM learning_snapshots \
+                                     WHERE user_id = ? AND profile_name = ?",
+                                )
+                                .bind(user_id)
+                                .bind(profile)
+                                .fetch_optional(&self.pool)
+                                .await;
+
+                                let decision = if let Ok(Some(row)) = stored_row {
+                                    let stored_compressed: String =
+                                        row.try_get("snapshot_json").unwrap_or_default();
+                                    let existing_hash = decompress_json_payload(&stored_compressed)
+                                        .ok()
+                                        .map(|json| sha256_bytes(&json));
+                                    classify_learning_insert_duplicate(
+                                        existing_hash.as_ref().map(|h| h.as_slice()),
+                                        &new_snapshot_hash,
+                                    )
+                                } else {
+                                    LearningDuplicateDecision::Conflict
+                                };
+
+                                if decision == LearningDuplicateDecision::Idempotent {
+                                    self.log_sync(
+                                        user_id,
+                                        "",
+                                        "learning_versioned",
+                                        SyncDirection::Push,
+                                        compressed_snapshot.len(),
+                                        "success",
+                                        None,
+                                    )
+                                    .await;
+                                    return SyncResult::ok_with_version(
+                                        SyncDirection::Push,
+                                        "learning",
+                                        1,
+                                        1,
+                                    );
+                                }
+
                                 self.log_sync(
                                     user_id,
                                     "",
@@ -1834,5 +1914,51 @@ mod tests {
         assert!((1000..=5000).contains(&max_backoff_ms));
         // Ensure max backoff is greater than initial
         assert!(max_backoff_ms > initial_backoff_ms);
+    }
+
+    // ── classify_learning_insert_duplicate unit tests ────────────────────────
+
+    #[test]
+    fn classify_learning_insert_dup_matching_hash_is_idempotent() {
+        let hash = sha256_bytes(r#"{"entities":[]}"#);
+        let decision = classify_learning_insert_duplicate(Some(hash.as_slice()), hash.as_slice());
+        assert_eq!(
+            decision,
+            LearningDuplicateDecision::Idempotent,
+            "same hash must be idempotent"
+        );
+    }
+
+    #[test]
+    fn classify_learning_insert_dup_different_hash_is_conflict() {
+        let hash_a = sha256_bytes(r#"{"entities":[]}"#);
+        let hash_b = sha256_bytes(r#"{"entities":[{"id":"x"}]}"#);
+        let decision =
+            classify_learning_insert_duplicate(Some(hash_a.as_slice()), hash_b.as_slice());
+        assert_eq!(
+            decision,
+            LearningDuplicateDecision::Conflict,
+            "different hashes must be a conflict"
+        );
+    }
+
+    #[test]
+    fn classify_learning_insert_dup_no_stored_row_is_conflict() {
+        let hash = sha256_bytes(r#"{"entities":[]}"#);
+        let decision = classify_learning_insert_duplicate(None, hash.as_slice());
+        assert_eq!(
+            decision,
+            LearningDuplicateDecision::Conflict,
+            "missing stored row must be treated as conflict"
+        );
+    }
+
+    #[test]
+    fn sha256_bytes_is_deterministic() {
+        let h1 = sha256_bytes("hello");
+        let h2 = sha256_bytes("hello");
+        assert_eq!(h1, h2);
+        let h3 = sha256_bytes("world");
+        assert_ne!(h1, h3);
     }
 }

--- a/rust/crates/services/tests/services_db_integration.rs
+++ b/rust/crates/services/tests/services_db_integration.rs
@@ -33,8 +33,8 @@ use astra_services::{
     DatabaseSkillService, DecisionListFilter, DecisionService, DurableTaskLifecycle,
     EventCreateRequestData, EventListFilter, EventService, MAX_API_LIST_LIMIT, MAX_API_LIST_OFFSET,
     MAX_MARKETPLACE_SEARCH_OFFSET, MarketplaceStatsService, MatrixOneDurableTaskLifecycle,
-    SessionListFilter, SessionService, SkillSearchQuery, SkillService, StagedMutationState,
-    ensure_core_schema,
+    MatrixOneSyncService, SessionListFilter, SessionService, SkillSearchQuery, SkillService,
+    StagedMutationState, StateSyncService, ensure_core_schema,
 };
 use sqlx::Row;
 use std::collections::HashSet;
@@ -2742,4 +2742,171 @@ async fn event_write_paths_reconcile_event_count_on_live_matrixone() {
         &[],
     )
     .await;
+}
+
+// ── At-most-once idempotency integration tests ───────────────────────────────
+// Gated by ASTRA_SERVICES_DB_IT=1. Document the end-to-end compare-before-reject
+// contract introduced by the idempotency audit (PR: fix/at-most-once-idempotency-audit).
+
+#[tokio::test]
+#[ignore]
+async fn it_register_skill_idempotent_retry_returns_200() {
+    let (shared_pool, settings) = setup_pool_and_settings().await;
+    let raw_pool = shared_pool.get().clone();
+    let svc = DatabaseSkillService::new(settings).with_pool(shared_pool);
+    let skill_id = format!("it-idem-reg-{}", Uuid::new_v4().simple());
+    let request = astra_services::SkillRegisterRequestData {
+        skill_id: skill_id.clone(),
+        skill_name: skill_id.clone(),
+        skill_version: "1.0.0".to_string(),
+        skill_code: "fn run() {}".to_string(),
+        skill_type: "local".to_string(),
+        remote_url: None,
+        description: Some("idempotency test".to_string()),
+        metadata: None,
+    };
+
+    // First call — should insert.
+    let first = svc
+        .register_skill("it-user".to_string(), request.clone())
+        .await
+        .expect("first register_skill should succeed");
+    assert_eq!(first.skill_id, skill_id);
+
+    // Second call with identical payload — should return 200, not 409.
+    let second = svc
+        .register_skill("it-user".to_string(), request)
+        .await
+        .expect("idempotent retry of register_skill must return 200");
+    assert_eq!(
+        second.skill_id, skill_id,
+        "idempotent reply must return same skill_id"
+    );
+
+    // Cleanup.
+    sqlx::query("DELETE FROM skills_registry WHERE skill_id = ?")
+        .bind(&skill_id)
+        .execute(&raw_pool)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+#[ignore]
+async fn it_register_skill_conflict_different_code_returns_409() {
+    let (shared_pool, settings) = setup_pool_and_settings().await;
+    let raw_pool = shared_pool.get().clone();
+    let svc = DatabaseSkillService::new(settings).with_pool(shared_pool);
+    let skill_id = format!("it-conflict-reg-{}", Uuid::new_v4().simple());
+    let base = astra_services::SkillRegisterRequestData {
+        skill_id: skill_id.clone(),
+        skill_name: skill_id.clone(),
+        skill_version: "1.0.0".to_string(),
+        skill_code: "fn run() {}".to_string(),
+        skill_type: "local".to_string(),
+        remote_url: None,
+        description: Some("conflict test".to_string()),
+        metadata: None,
+    };
+    svc.register_skill("it-user".to_string(), base.clone())
+        .await
+        .expect("first register_skill should succeed");
+
+    let different = astra_services::SkillRegisterRequestData {
+        skill_code: "fn run() { panic!() }".to_string(),
+        ..base
+    };
+    let err = svc
+        .register_skill("it-user".to_string(), different)
+        .await
+        .expect_err("different code for same skill_id must return 409");
+    assert_eq!(err.0, axum::http::StatusCode::CONFLICT);
+
+    // Cleanup.
+    sqlx::query("DELETE FROM skills_registry WHERE skill_id = ?")
+        .bind(&skill_id)
+        .execute(&raw_pool)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+#[ignore]
+async fn it_publish_skill_idempotent_retry_returns_200() {
+    let (shared_pool, settings) = setup_pool_and_settings().await;
+    let raw_pool = shared_pool.get().clone();
+    let svc = DatabaseSkillService::new(settings).with_pool(shared_pool);
+    let name = format!("it-idem-pub-{}", Uuid::new_v4().simple());
+    let request = astra_services::SkillPublishRequestData {
+        name: name.clone(),
+        version: "1.0.0".to_string(),
+        description: "idempotency test".to_string(),
+        triggers: None,
+        dependencies: None,
+        manifest: None,
+        skill_type: "local".to_string(),
+        remote_url: None,
+        category: "user".to_string(),
+        priority: 5,
+        publisher_id: None,
+        trust_tier: None,
+    };
+
+    let first = svc
+        .publish_skill("it-user".to_string(), request.clone())
+        .await
+        .expect("first publish_skill should succeed");
+    assert_eq!(first["status"], "published");
+
+    // Retry with identical payload — must return 200.
+    let second = svc
+        .publish_skill("it-user".to_string(), request)
+        .await
+        .expect("idempotent retry of publish_skill must return 200");
+    assert_eq!(second["status"], "published");
+
+    let skill_id = format!("{}@1.0.0", name);
+    sqlx::query("DELETE FROM skills_registry WHERE skill_id = ?")
+        .bind(&skill_id)
+        .execute(&raw_pool)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+#[ignore]
+async fn it_push_learning_versioned_idempotent_insert_returns_ok() {
+    let (shared_pool, settings) = setup_pool_and_settings().await;
+    let raw_pool = shared_pool.get().clone();
+    let _ = settings; // used for pool setup; MatrixOneSyncService takes a raw pool
+    let svc = MatrixOneSyncService::new(raw_pool.clone());
+    let user_id = format!("it-sync-user-{}", Uuid::new_v4().simple());
+    let profile = "default";
+    let snapshot = r#"{"entities":[],"patterns":[]}"#;
+
+    let first = svc
+        .push_learning_versioned(&user_id, profile, snapshot, 0, 0, false, None)
+        .await;
+    assert!(first.success, "first insert must succeed: {first:?}");
+
+    // Retry with same snapshot — must succeed (idempotent), not conflict.
+    // (Simulates: INSERT committed, TCP reset, client retries → gets dup-key.)
+    let second = svc
+        .push_learning_versioned(&user_id, profile, snapshot, 0, 0, false, None)
+        .await;
+    assert!(
+        second.success,
+        "idempotent retry of push_learning_versioned must return success, got: {second:?}"
+    );
+    assert!(
+        !second.is_conflict,
+        "idempotent retry must not be a conflict"
+    );
+
+    // Cleanup.
+    sqlx::query("DELETE FROM learning_snapshots WHERE user_id = ?")
+        .bind(&user_id)
+        .execute(&raw_pool)
+        .await
+        .ok();
 }


### PR DESCRIPTION
## Summary

Fixes 4 "at-most-once" idempotency bugs discovered by a cross-cutting audit. Each fix uses the same **compare-before-reject** pattern: on a duplicate hit, re-read the stored value and compare with the incoming request — identical → idempotent 200; different → 409.

PR #233 (`feat/adversarial-infra-sweep`) ships the same pattern for the HTTP edge-callback handlers (`edge_callback_handlers.rs`) and `chat_turn_sse_dispatch.rs`. This PR covers the remaining sites and stands independent; trivial rebase after #233 lands.

---

## Bug #1 (HIGH) — WS handler silent-overwrite
**File:** `rust/crates/runtime/src/server/ws_handler.rs`  
**Functions:** `handle_tool_approval`, `handle_user_prompt_response`

**Problem:** `guard.insert(key, value)` silently overwrites a prior approval decision if a WS reconnect delivers a second `tool_approval` with a different `approved` value — security bug.

**Fix:** Extracted `ws_ledger_dedup_insert(ledger, key, value) -> WsLedgerOutcome` (`pub(crate)`):
- Key absent → insert → `Inserted`
- Key present + identical JSON → no-op → `IdempotentReplay`

**Tests added:** 3 unit tests (insert, idempotent replay, conflict-ignored + original preserved)

---

## Bug #2 (HIGH) — `register_skill` returns 409 on identical retry
**File:** `rust/crates/services/src/skills.rs` (lines `307–317`)

**Problem:** `SELECT skill_id ... → if existing.is_some() → 409`. An identical retry after a dropped HTTP response fails with conflict.

**Fix:** Pure classifier `classify_register_duplicate(existing: Option<ExistingRegisterRow>, skill_id, new_definition_json, new_code_hash) -> RegisterDuplicateDecision { Insert | IdempotentReplay(SkillRecord) | Conflict }`. Changed SELECT to fetch `skill_definition` + `code_hash`. Moved definition/hash computation before the SELECT so the classifier can compare.

**Tests added:** 4 unit tests (None→Insert, identical→IdempotentReplay, diff-def→Conflict, diff-hash→Conflict)

---

## Bug #3 (MED) — `publish_skill` 409 on SQL unique-violation without payload compare
**File:** `rust/crates/services/src/skills.rs` (lines `750–762`)

**Problem:** On `is_duplicate_key_error`, always returns 409 without checking whether the manifest is identical.

**Fix:** On dup-key, re-queries `skill_definition` + `manifest`. Pure classifier `classify_publish_duplicate(existing: Option<ExistingPublishRow>, skill_id, new_definition_json, new_manifest_json) -> PublishDuplicateDecision { IdempotentReplay(Value) | Conflict }`.

**Tests added:** 4 unit tests (None→Conflict, identical→IdempotentReplay, diff-def→Conflict, diff-manifest→Conflict)

---

## Bug #4 (MED) — `push_learning_versioned` false-conflict on retryable-insert-dup
**File:** `rust/crates/services/src/state_sync.rs` (lines `688–772`, `None` expected\_version branch)

**Problem:** INSERT commits, connection drops (`is_retryable_error`), retry fires, gets `is_duplicate_key_error` → returns `SyncResult::conflict` — even though the first attempt succeeded.

**Fix:** On dup-key, re-queries stored `snapshot_json`, decompresses, SHA-256 hashes and compares with pre-computed hash of the incoming `snapshot_json`. Pure classifier `classify_learning_insert_duplicate(existing_hash: Option<&[u8]>, new_hash: &[u8]) -> LearningDuplicateDecision { Idempotent | Conflict }`.

**Tests added:** 4 unit tests (matching hash→Idempotent, different hash→Conflict, missing row→Conflict, sha256 determinism)

---

## Integration tests (live-DB, `--ignored`)

Added 4 `#[ignore]` integration tests in `services_db_integration.rs`, gated by `ASTRA_SERVICES_DB_IT=1`:
- `it_register_skill_idempotent_retry_returns_200`
- `it_register_skill_conflict_different_code_returns_409`
- `it_publish_skill_idempotent_retry_returns_200`
- `it_push_learning_versioned_idempotent_insert_returns_ok`

These exercise the full DB path and can be run with:
```
ASTRA_SERVICES_DB_IT=1 cargo test -p astra-services --test services_db_integration -- --ignored
```

---

## TDD evidence

All classifiers were extracted as pure functions first, verified via unit tests:
- `make format` — ✅ clean
- `make check` — ✅ clean  
- `cargo test -p astra-runtime --lib server::ws_handler` — ✅ 99 passed
- `cargo test -p astra-services --lib skills` — ✅ 22 passed (+8 new)
- `cargo test -p astra-services --lib state_sync` — ✅ 44 passed (+4 new)

**Total new tests: 19** (3 ws_ledger + 8 skills classifiers + 4 state_sync classifiers + 4 live-DB integration)