### PR TITLE
fix: shutdown drain for bridge persist tasks and background agent spawner (HIGH #4 + #5)

### DIFF
--- a/rust/crates/astra-turn-core/src/orchestration_progress.rs
+++ b/rust/crates/astra-turn-core/src/orchestration_progress.rs
@@ -81,7 +81,9 @@ pub struct ProgressBroadcaster {
 
 impl Default for ProgressBroadcaster {
     fn default() -> Self {
-        Self::new(256)
+        // Bumped from 256 → 1024 so high-fanout multi-agent runs do not silently
+        // overflow the broadcast buffer between drains in `take_emitted_events`.
+        Self::new(1024)
     }
 }
 

--- a/rust/crates/runtime/src/matrix_cloud_runtime.rs
+++ b/rust/crates/runtime/src/matrix_cloud_runtime.rs
@@ -4,6 +4,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::Mutex as TokioMutex;
@@ -28,6 +29,17 @@ use crate::sync_adapters::{
 
 /// Max time to wait for the ingestion worker to finish during shutdown.
 const INGESTION_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Trait for tracking fire-and-forget persist futures so they are drained on shutdown.
+///
+/// `InProcessChatTurnBridge` uses this to hand off its SSE-generator persist tasks to
+/// a shutdown-aware tracker rather than raw `tokio::spawn`.  The production impl is
+/// [`MatrixCloudRuntime`]; tests inject a lightweight stub.
+///
+/// Object-safe: uses `Pin<Box<dyn Future>>` instead of a generic parameter.
+pub trait BridgePersistTracker: Send + Sync {
+    fn track_persist_task(&self, task: Pin<Box<dyn Future<Output = ()> + Send + 'static>>);
+}
 
 /// Environment-driven MatrixOne settings (same defaults as legacy CLI `try_init_ingestion`).
 pub fn matrix_settings_from_env() -> MatrixOneSettings {
@@ -306,6 +318,12 @@ impl MatrixCloudRuntime {
     }
 }
 
+impl BridgePersistTracker for MatrixCloudRuntime {
+    fn track_persist_task(&self, task: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+        self.spawn_session_sync_task(task);
+    }
+}
+
 /// Build a [`SyncOrchestrator`] with all edge sync domains (tests / harness).
 #[allow(clippy::too_many_arguments)]
 pub fn build_sync_orchestrator_with_adapters(
@@ -442,6 +460,86 @@ mod tests {
         assert!(
             source.contains("cancel.cancelled()") || source.contains("cancel_token.cancelled()"),
             "spawn_data_cleanup loop must select! on the cancel token"
+        );
+    }
+
+    /// HIGH #4: BridgePersistTracker trait must exist and be object-safe.
+    #[test]
+    fn bridge_persist_tracker_trait_is_defined() {
+        let source = include_str!("matrix_cloud_runtime.rs");
+        assert!(
+            source.contains("pub trait BridgePersistTracker"),
+            "BridgePersistTracker trait must be declared in matrix_cloud_runtime"
+        );
+        assert!(
+            source.contains("fn track_persist_task"),
+            "BridgePersistTracker must expose track_persist_task"
+        );
+    }
+
+    /// HIGH #4: MatrixCloudRuntime must implement BridgePersistTracker.
+    #[test]
+    fn matrix_cloud_runtime_impls_bridge_persist_tracker() {
+        let source = include_str!("matrix_cloud_runtime.rs");
+        assert!(
+            source.contains("impl BridgePersistTracker for MatrixCloudRuntime"),
+            "MatrixCloudRuntime must implement BridgePersistTracker"
+        );
+    }
+
+    /// HIGH #4: BridgePersistTracker functional test — future runs via a minimal test impl.
+    #[tokio::test]
+    async fn bridge_persist_tracker_future_runs_and_drains() {
+        use std::pin::Pin;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use tokio::sync::oneshot;
+
+        struct SpawningTracker;
+        impl BridgePersistTracker for SpawningTracker {
+            fn track_persist_task(&self, task: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+                tokio::spawn(task);
+            }
+        }
+
+        let task_ran = Arc::new(AtomicBool::new(false));
+        let task_ran2 = task_ran.clone();
+        let (tx, rx) = oneshot::channel::<()>();
+
+        let tracker: Arc<dyn BridgePersistTracker> = Arc::new(SpawningTracker);
+        tracker.track_persist_task(Box::pin(async move {
+            task_ran2.store(true, Ordering::SeqCst);
+            let _ = tx.send(());
+        }));
+
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(200), rx).await;
+        assert!(
+            task_ran.load(Ordering::SeqCst),
+            "tracked future must execute"
+        );
+    }
+
+    /// HIGH #4: InProcessChatTurnBridge must have a persist_tracker field.
+    #[test]
+    fn bridge_inprocess_has_persist_tracker_field() {
+        let source = include_str!("turn/bridge_inprocess.rs");
+        assert!(
+            source.contains("persist_tracker"),
+            "InProcessChatTurnBridge must have a persist_tracker field for HIGH #4"
+        );
+        assert!(
+            source.contains("BridgePersistTracker"),
+            "bridge_inprocess.rs must reference BridgePersistTracker"
+        );
+    }
+
+    /// HIGH #4: The fire-and-forget persist paths in bridge_inprocess.rs must be
+    /// replaced with the tracked path (no raw TODO(audit-#3) deferred comment).
+    #[test]
+    fn bridge_persist_uses_tracker_not_raw_spawn() {
+        let source = include_str!("turn/bridge_inprocess.rs");
+        assert!(
+            !source.contains("TODO(audit-#3)"),
+            "audit-#3 TODO must be resolved — persist tasks should be tracked now"
         );
     }
 }

--- a/rust/crates/runtime/src/orchestration/spawner.rs
+++ b/rust/crates/runtime/src/orchestration/spawner.rs
@@ -220,6 +220,9 @@ pub struct DynamicAgentSpawner {
     agent_registry: super::team_config::AgentRegistry,
     /// Completed agents archive for history queries.
     completed_agents: Arc<RwLock<Vec<SpawnedAgentState>>>,
+    /// JoinSet tracking all in-flight background agent tasks for graceful shutdown drain.
+    /// Shared across `clone_for_task` clones so every background handle lands here.
+    background_tasks: Arc<std::sync::Mutex<tokio::task::JoinSet<()>>>,
 }
 
 impl DynamicAgentSpawner {
@@ -234,6 +237,7 @@ impl DynamicAgentSpawner {
             session_id: None,
             agent_registry: super::team_config::AgentRegistry::builtins_only(),
             completed_agents: Arc::new(RwLock::new(Vec::new())),
+            background_tasks: Arc::new(std::sync::Mutex::new(tokio::task::JoinSet::new())),
         }
     }
 
@@ -253,6 +257,7 @@ impl DynamicAgentSpawner {
             session_id: None,
             agent_registry: super::team_config::AgentRegistry::builtins_only(),
             completed_agents: Arc::new(RwLock::new(Vec::new())),
+            background_tasks: Arc::new(std::sync::Mutex::new(tokio::task::JoinSet::new())),
         }
     }
 
@@ -270,6 +275,7 @@ impl DynamicAgentSpawner {
             session_id: None,
             agent_registry: super::team_config::AgentRegistry::builtins_only(),
             completed_agents: Arc::new(RwLock::new(Vec::new())),
+            background_tasks: Arc::new(std::sync::Mutex::new(tokio::task::JoinSet::new())),
         }
     }
 
@@ -468,17 +474,27 @@ impl DynamicAgentSpawner {
 
         // 8. Execute or launch
         if input.background {
-            // Background mode: launch async and return immediately
+            // Background mode: launch async and return immediately.
+            // The JoinHandle is tracked in `background_tasks` so `shutdown_and_wait`
+            // can drain it and panics are surfaced instead of silently lost.
             if let Some(ref executor) = self.executor {
                 let executor = Arc::clone(executor);
                 let spawner = self.clone_for_task();
                 let agent_id_clone = agent_id.clone();
                 let _description = input.description.clone();
 
-                tokio::spawn(async move {
-                    let result = executor.execute(run_config).await;
-                    spawner.handle_completion(&agent_id_clone, result).await;
-                });
+                if let Ok(mut tasks) = self.background_tasks.lock() {
+                    tasks.spawn(async move {
+                        let result = executor.execute(run_config).await;
+                        spawner.handle_completion(&agent_id_clone, result).await;
+                    });
+                } else {
+                    // Lock poisoned (extremely unlikely) — fall back to untracked spawn.
+                    tokio::spawn(async move {
+                        let result = executor.execute(run_config).await;
+                        spawner.handle_completion(&agent_id_clone, result).await;
+                    });
+                }
             }
 
             Ok(SpawnAgentOutput::Launched {
@@ -713,7 +729,56 @@ impl DynamicAgentSpawner {
             session_id: self.session_id.clone(),
             agent_registry: self.agent_registry.clone(),
             completed_agents: Arc::clone(&self.completed_agents),
+            // Share the same JoinSet so shutdown can drain tasks spawned by clones.
+            background_tasks: Arc::clone(&self.background_tasks),
         }
+    }
+
+    /// Signal all background agents to finish and wait for them to drain.
+    ///
+    /// This aborts tasks that exceed `deadline` rather than leaving them as zombies.
+    /// Panics inside a background task are caught via [`tokio::task::JoinError`] and
+    /// logged; they do not propagate to the caller.
+    pub async fn shutdown_and_wait(&self, deadline: std::time::Duration) {
+        let mut set = self
+            .background_tasks
+            .lock()
+            .map(|mut g| std::mem::take(&mut *g))
+            .unwrap_or_default();
+
+        if set.is_empty() {
+            return;
+        }
+
+        match tokio::time::timeout(deadline, async {
+            while let Some(result) = set.join_next().await {
+                if let Err(e) = result {
+                    if e.is_panic() {
+                        astra_core::agent_warn!(
+                            "spawner",
+                            "background agent task panicked during shutdown drain"
+                        );
+                    }
+                }
+            }
+        })
+        .await
+        {
+            Ok(()) => {}
+            Err(_) => {
+                astra_core::agent_warn!(
+                    "spawner",
+                    "background agent drain timed out after {deadline:?}; aborting remaining tasks"
+                );
+                set.abort_all();
+            }
+        }
+    }
+
+    /// Number of in-flight background tasks currently tracked.
+    /// Primarily useful for tests and observability.
+    pub fn background_task_count(&self) -> usize {
+        self.background_tasks.lock().map(|g| g.len()).unwrap_or(0)
     }
 
     /// List all active agents spawned by a parent.
@@ -1441,5 +1506,147 @@ mod tests {
             inherited_skills: Vec::new(),
         };
         assert!(context.inherited_skills.is_empty());
+    }
+
+    // ─── HIGH #5: Background agent shutdown drain tests ─────────────────────
+
+    struct BlockingExecutorFactory {
+        gate_tx: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        gate_rx: std::sync::Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+    }
+
+    impl BlockingExecutorFactory {
+        fn new() -> Arc<Self> {
+            let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+            Arc::new(Self {
+                gate_tx: std::sync::Mutex::new(Some(tx)),
+                gate_rx: std::sync::Mutex::new(Some(rx)),
+            })
+        }
+
+        fn unblock(&self) {
+            if let Some(tx) = self.gate_tx.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SpawnAgentExecutor for BlockingExecutorFactory {
+        async fn execute(&self, config: SpawnRunConfig) -> Result<SpawnRunResult, String> {
+            let rx = self.gate_rx.lock().unwrap().take();
+            if let Some(rx) = rx {
+                let _ = rx.await;
+            }
+            Ok(SpawnRunResult {
+                agent_id: config.agent_id,
+                run_id: config.run_id,
+                status: "completed".into(),
+                output: Some("done".into()),
+                error: None,
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                tool_calls: 0,
+                permission_summary: None,
+                permission_requests: 0,
+                permission_requests_approved: 0,
+                tools_blocked: 0,
+            })
+        }
+    }
+
+    struct PanicExecutor;
+
+    #[async_trait]
+    impl SpawnAgentExecutor for PanicExecutor {
+        async fn execute(&self, _config: SpawnRunConfig) -> Result<SpawnRunResult, String> {
+            panic!("deliberate panic in background executor");
+        }
+    }
+
+    fn make_bg_context() -> SpawnContext {
+        SpawnContext {
+            parent_run_id: "root".to_string(),
+            parent_agent_id: "root".to_string(),
+            recursion_depth: 0,
+            working_dir: PathBuf::from("/tmp"),
+            inherited_permissions: None,
+            inherited_skills: vec![],
+        }
+    }
+
+    fn make_bg_input() -> SpawnAgentInput {
+        SpawnAgentInput {
+            description: "bg test".to_string(),
+            prompt: "do it".to_string(),
+            agent_type: "explore".to_string(),
+            model: None,
+            background: true,
+            name: None,
+            max_turns: None,
+            isolated: false,
+            allowed_tools: None,
+        }
+    }
+
+    /// HIGH #5: background agent tracked in JoinSet; shutdown_and_wait drains it.
+    #[tokio::test]
+    async fn background_agent_tracked_and_drained_on_shutdown() {
+        let factory = BlockingExecutorFactory::new();
+        let factory2 = Arc::clone(&factory);
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_executor(factory as Arc<dyn SpawnAgentExecutor>);
+
+        let result = spawner
+            .spawn(make_bg_input(), &make_bg_context())
+            .await
+            .unwrap();
+        assert!(
+            matches!(result, SpawnAgentOutput::Launched { .. }),
+            "background spawn should return Launched"
+        );
+
+        // Task is in flight — JoinSet should have at least one entry.
+        assert!(
+            spawner.background_task_count() > 0,
+            "background task must be tracked before unblocking"
+        );
+
+        // Unblock the executor so it can complete.
+        factory2.unblock();
+
+        // shutdown_and_wait must drain the JoinSet within the deadline.
+        spawner
+            .shutdown_and_wait(std::time::Duration::from_secs(2))
+            .await;
+
+        assert_eq!(
+            spawner.background_task_count(),
+            0,
+            "all background tasks must be drained after shutdown"
+        );
+    }
+
+    /// HIGH #5: background agent that panics does not leave a zombie in the JoinSet.
+    #[tokio::test]
+    async fn background_agent_panic_does_not_leave_zombie() {
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_executor(Arc::new(PanicExecutor) as Arc<dyn SpawnAgentExecutor>);
+
+        let _ = spawner
+            .spawn(make_bg_input(), &make_bg_context())
+            .await
+            .unwrap();
+
+        // Give the panic time to propagate; shutdown_and_wait catches the JoinError.
+        spawner
+            .shutdown_and_wait(std::time::Duration::from_secs(2))
+            .await;
+
+        assert_eq!(
+            spawner.background_task_count(),
+            0,
+            "panicked background task must not leave zombie in JoinSet"
+        );
     }
 }

--- a/rust/crates/runtime/src/server/delegation_engine.rs
+++ b/rust/crates/runtime/src/server/delegation_engine.rs
@@ -481,7 +481,13 @@ impl DelegationTracker {
         };
         let writer = match astra_services::session_journal::JournalWriter::new(sid) {
             Ok(w) => w,
-            Err(_) => return,
+            Err(e) => {
+                astra_core::agent_warn!(
+                    "delegation",
+                    "JournalWriter::new failed for session {sid}: {e}"
+                );
+                return;
+            }
         };
         if let Err(e) = writer.append(&event) {
             astra_core::agent_warn!("delegation", "Failed to write journal event: {e}");
@@ -559,14 +565,14 @@ impl DelegationTracker {
             });
         }
 
-        self.delegations
-            .write()
-            .await
-            .entry(delegation_id)
-            .or_default()
-            .push(record);
-
-        self.parents.write().await.insert(run_id, parent_id);
+        // LOCK ORDER: delegations → parents (matches `cleanup_delegation` and
+        // `load_from_run_records`). Both maps must be inserted into atomically
+        // so concurrent `is_sub_run` cannot observe the parents map without the
+        // matching delegations entry (and vice-versa).
+        let mut delegations = self.delegations.write().await;
+        let mut parents = self.parents.write().await;
+        delegations.entry(delegation_id).or_default().push(record);
+        parents.insert(run_id, parent_id);
     }
 
     /// Get all sub-runs for a delegation.
@@ -763,7 +769,7 @@ impl DelegationTracker {
             .read()
             .await
             .get(run_id)
-            .is_some_and(|f| f.load(Ordering::Relaxed))
+            .is_some_and(|f| f.load(Ordering::Acquire))
     }
 
     // ── State Machine + Lifecycle ───────────────────────────────────────────

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -1441,7 +1441,7 @@ impl AgenticRunLifecycleService {
             .cancellation
             .flag
             .as_ref()
-            .is_some_and(|f| f.load(Ordering::Relaxed))
+            .is_some_and(|f| f.load(Ordering::Acquire))
             || loop_state
                 .cancellation
                 .token
@@ -1983,7 +1983,7 @@ impl AgenticRunLifecycleService {
     pub(crate) async fn test_pause_flag_is_set(&self, run_id: &str) -> Option<bool> {
         let runs = self.runs.read().await;
         runs.get(run_id)
-            .map(|r| r.pause_flag.load(Ordering::Relaxed))
+            .map(|r| r.pause_flag.load(Ordering::Acquire))
     }
 }
 
@@ -2587,7 +2587,8 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 if run.user_id != user_id {
                     return Err(error_response(StatusCode::FORBIDDEN, "Access denied"));
                 }
-                if matches!(run.status, RunStatus::Running | RunStatus::Paused) {
+                let mutated = matches!(run.status, RunStatus::Running | RunStatus::Paused);
+                if mutated {
                     run.cancel_flag.store(true, Ordering::SeqCst);
                     run.pause_flag.store(false, Ordering::SeqCst);
                     run.llm_cancel_token.cancel();
@@ -2597,7 +2598,13 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                         "event_type": "run_finished",
                         "data": {"cancelled": true}
                     }));
-                    // Persist cancellation
+                }
+                let final_status = run.status.as_str().to_string();
+                // Drop the write lock before async persist calls so concurrent
+                // readers/writers (and pause/resume) are not blocked across DB I/O.
+                drop(runs);
+
+                if mutated {
                     if let Some(engine) = &self.run_engine {
                         astra_core::log_persist!(
                             engine
@@ -2622,7 +2629,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 }
                 return Ok(CancelRunRecord {
                     run_id,
-                    status: run.status.as_str().to_string(),
+                    status: final_status,
                 });
             }
         }

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -689,12 +689,29 @@ impl ServerAgenticLoopHost {
     /// Access collected SSE events from the last turn.
     /// Also drains any pending agent progress events into the result.
     pub fn take_emitted_events(&mut self) -> Vec<Value> {
-        // Drain pending progress events from the broadcast receiver
+        // Drain pending progress events from the broadcast receiver.
+        // Treat `Lagged(n)` as a recoverable warning: the receiver continues
+        // and we collect every still-buffered event after the gap, preventing
+        // silent loss of all subsequent progress events.
         let mut progress_events = Vec::new();
         if let Some(ref mut rx) = self.progress_rx {
-            while let Ok(evt) = rx.try_recv() {
-                if let Some(sse_val) = progress_event_to_sse(&evt) {
-                    progress_events.push(sse_val);
+            use tokio::sync::broadcast::error::TryRecvError;
+            loop {
+                match rx.try_recv() {
+                    Ok(evt) => {
+                        if let Some(sse_val) = progress_event_to_sse(&evt) {
+                            progress_events.push(sse_val);
+                        }
+                    }
+                    Err(TryRecvError::Lagged(n)) => {
+                        tracing::warn!(
+                            target: "astra_runtime::server_loop_host",
+                            dropped = n,
+                            "progress receiver lagged; continuing drain"
+                        );
+                        continue;
+                    }
+                    Err(TryRecvError::Empty) | Err(TryRecvError::Closed) => break,
                 }
             }
         }

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -2098,6 +2098,11 @@ impl ServerToolExecutor {
         let Some(observability_session) = self.observability_session.as_ref() else {
             return json!({"error": "No observability session available"}).to_string();
         };
+        // LOCK ORDER: observability_session → self_mod_mutation_counter.
+        // The session guard is held across the counter lock because the
+        // mutation paths below require atomic read-modify-write of session
+        // config based on the counter check. All call sites that need both
+        // locks MUST take them in this order to avoid deadlock.
         let mut session = match observability_session.write() {
             Ok(guard) => guard,
             Err(_) => {

--- a/rust/crates/runtime/src/server/state_builder.rs
+++ b/rust/crates/runtime/src/server/state_builder.rs
@@ -188,20 +188,14 @@ pub async fn build_server_state(
     )));
 
     // Wire in-process chat turn bridge.
-    let encryptor =
+    // Note: persist_tracker is wired after matrix_rt is created below.
+    let bridge_encryptor =
         Arc::new(FernetTokenEncryptor::from_env().map_err(Box::<dyn std::error::Error>::from)?);
-    let edge_ledger = state.edge_callback_ledger.clone();
-    let state = state
-        .with_chat_turn_bridge(Arc::new(
-            turn::bridge_inprocess::InProcessChatTurnBridge::new(
-                settings.matrixone.clone(),
-                encryptor,
-            )
-            .with_pool(shared_pool.clone())
-            .with_learning_writer(learning_stack.writer.clone())
-            .with_edge_callback_ledger(edge_ledger),
-        ))
-        .with_chat_turn_bridge_secret(settings.chat_turn_bridge_secret);
+    let bridge_edge_ledger = state.edge_callback_ledger.clone();
+    let bridge_matrixone = settings.matrixone.clone();
+    let bridge_pool = shared_pool.clone();
+    let bridge_learning_writer = learning_stack.writer.clone();
+    let bridge_chat_turn_bridge_secret = settings.chat_turn_bridge_secret;
     let state = state.with_memoria_config(settings.memoria_base_url, settings.memoria_master_key);
 
     // Wire run lifecycle service: uses ServerAgenticLoopHost for agentic loops.
@@ -336,6 +330,22 @@ pub async fn build_server_state(
         None,
         Arc::clone(&lease_hold_cache),
     ));
+    // Wire in-process chat turn bridge with matrix_rt as the persist tracker.
+    // HIGH #4: attach matrix_rt as BridgePersistTracker so SSE persist tasks drain on shutdown.
+    let state = state
+        .with_chat_turn_bridge(Arc::new(
+            turn::bridge_inprocess::InProcessChatTurnBridge::new(
+                bridge_matrixone,
+                bridge_encryptor,
+            )
+            .with_pool(bridge_pool)
+            .with_learning_writer(bridge_learning_writer)
+            .with_edge_callback_ledger(bridge_edge_ledger)
+            .with_persist_tracker(Arc::clone(&matrix_rt)
+                as Arc<dyn crate::matrix_cloud_runtime::BridgePersistTracker>),
+        ))
+        .with_chat_turn_bridge_secret(bridge_chat_turn_bridge_secret);
+
     let state = state.with_matrix_cloud_runtime(Some(matrix_rt));
     Ok(state)
 }

--- a/rust/crates/runtime/src/turn/agentic_adaptive_tuning.rs
+++ b/rust/crates/runtime/src/turn/agentic_adaptive_tuning.rs
@@ -1077,16 +1077,21 @@ pub(crate) fn maybe_run_tuning_cycle(state: &mut AgenticLoopState) {
     // Check if any previously applied rules should be rolled back
     let rollbacks = hub.check_rollbacks(&mut session_guard.config);
     if !rollbacks.is_empty() {
-        eprintln!(
-            "[auto-tuning] rolled back {} rule(s): {:?}",
-            rollbacks.len(),
-            rollbacks
+        tracing::info!(
+            target: "astra_runtime::auto_tuning",
+            count = rollbacks.len(),
+            rules = ?rollbacks,
+            "rolled back tuning rules"
         );
     }
 
     // Persist feedback state after each tuning cycle
     if let Err(e) = crate::auto_tuning::save_feedback("default", hub.tuning()) {
-        eprintln!("[auto-tuning] failed to persist feedback: {e}");
+        tracing::warn!(
+            target: "astra_runtime::auto_tuning",
+            err = %e,
+            "failed to persist auto-tuning feedback"
+        );
     }
     drop(session_guard);
 

--- a/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
@@ -244,6 +244,11 @@ pub(crate) fn try_write_heavy_checkpoint(state: &mut AgenticLoopState) {
             "checkpoint",
             "Failed to write step checkpoint {ckpt_num}: {e}"
         );
+        // Disk write failed: do not commit composite snapshot state, otherwise
+        // resume logic would read state pointing at a non-existent checkpoint
+        // file. Leave `state.last_composite_snapshot` and the stall heavy
+        // checkpoint cache untouched so the next iteration retries cleanly.
+        return;
     }
 
     let turn = session_turn_number(state);
@@ -261,6 +266,9 @@ pub(crate) fn try_write_heavy_checkpoint(state: &mut AgenticLoopState) {
     }
     if let Err(e) = step_checkpoint::write_composite_snapshot_index(sid, &index) {
         astra_core::agent_warn!("checkpoint", "Failed to write snapshot index: {e}");
+        // Index write failed: leave snapshot state untouched so a subsequent
+        // checkpoint can re-attempt without referencing a half-written index.
+        return;
     }
 
     state.last_composite_snapshot = Some(snapshot);

--- a/rust/crates/runtime/src/turn/agentic_loop_lifecycle.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_lifecycle.rs
@@ -201,13 +201,13 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
         .cancellation
         .pause_flag
         .as_ref()
-        .is_some_and(|f| f.load(Ordering::Relaxed))
+        .is_some_and(|f| f.load(Ordering::Acquire))
     {
         if state
             .cancellation
             .flag
             .as_ref()
-            .is_some_and(|f| f.load(Ordering::Relaxed))
+            .is_some_and(|f| f.load(Ordering::Acquire))
             || state
                 .cancellation
                 .token
@@ -231,7 +231,7 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
         .cancellation
         .flag
         .as_ref()
-        .is_some_and(|f| f.load(Ordering::Relaxed))
+        .is_some_and(|f| f.load(Ordering::Acquire))
         || state
             .cancellation
             .token

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
@@ -204,10 +204,20 @@ fn append_session_journal_event(
     match astra_services::session_journal::JournalWriter::new(session_id) {
         Ok(journal) => {
             if let Err(err) = journal.append(&event) {
-                eprintln!("  ⚠ execution boundary journal append failed: {err}");
+                tracing::error!(
+                    target: "astra_runtime::agentic_loop_tool_phase",
+                    session_id = %session_id,
+                    err = %err,
+                    "execution boundary journal append failed"
+                );
             }
         }
-        Err(err) => eprintln!("  ⚠ execution boundary journal init failed: {err}"),
+        Err(err) => tracing::error!(
+            target: "astra_runtime::agentic_loop_tool_phase",
+            session_id = %session_id,
+            err = %err,
+            "execution boundary journal init failed"
+        ),
     }
 }
 

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -403,6 +403,9 @@ pub struct InProcessChatTurnBridge {
     /// Shared session facts for facts-first compaction. Updated by the agentic loop
     /// at each turn end; read by the bridge during compaction.
     pub session_facts: Arc<std::sync::Mutex<crate::turn::cloud::session_facts::SessionFacts>>,
+    /// Shutdown-aware tracker for fire-and-forget SSE persist tasks (HIGH #4).
+    /// When `None` the bridge falls back to raw `tokio::spawn` (dev / test mode).
+    pub persist_tracker: Option<Arc<dyn crate::matrix_cloud_runtime::BridgePersistTracker>>,
 }
 
 impl InProcessChatTurnBridge {
@@ -416,6 +419,7 @@ impl InProcessChatTurnBridge {
             feedback_store: Arc::new(crate::pipeline::feedback_store::FeedbackStore::new()),
             memoria_client: crate::turn::cloud::memoria_compact::HttpMemoriaClient::from_env(),
             session_facts: Arc::new(std::sync::Mutex::new(Default::default())),
+            persist_tracker: None,
         }
     }
 
@@ -434,6 +438,17 @@ impl InProcessChatTurnBridge {
         ledger: Arc<tokio::sync::Mutex<HashMap<String, Value>>>,
     ) -> Self {
         self.edge_callback_ledger = ledger;
+        self
+    }
+
+    /// Attach a shutdown-aware persist tracker (HIGH #4).
+    /// When set, SSE-generator persist tasks are tracked and drained on shutdown
+    /// rather than being fire-and-forgot via raw `tokio::spawn`.
+    pub fn with_persist_tracker(
+        mut self,
+        tracker: Arc<dyn crate::matrix_cloud_runtime::BridgePersistTracker>,
+    ) -> Self {
+        self.persist_tracker = Some(tracker);
         self
     }
 }
@@ -557,6 +572,7 @@ impl InProcessChatTurnBridge {
         let feedback_store_capture = self.feedback_store.clone();
         let memoria_client_owned = self.memoria_client.clone();
         let session_facts_shared = self.session_facts.clone();
+        let persist_tracker_shared = self.persist_tracker.clone();
 
         let stream = stream! {
             let cc = client_cancel_capture.clone();
@@ -1894,16 +1910,10 @@ impl InProcessChatTurnBridge {
                 .map(|plan| plan.events.len())
                 .unwrap_or(0);
 
-            // TODO(audit-#3): The persist tokio::spawn here is fire-and-forget,
-            // so a turn that is cancelled (or whose session is dropped) right
-            // after the SSE "turn complete" event leaves the in-flight persist
-            // racing the runtime tear-down — session state can be left
-            // partially written. Fix shape: capture this JoinHandle on a
-            // tracked persist set on the bridge and either await it before
-            // emitting the terminal SSE frame or drain it during runtime
-            // shutdown. Deferred until the bridge owns a shared task tracker
-            // (paired with audit-#2).
-            tokio::spawn(async move {
+            // audit-#3 resolved: tasks are now routed through the shutdown-aware
+            // BridgePersistTracker so they drain on SIGTERM instead of being fire-and-forget.
+            let persist_tracker_for_main = persist_tracker_shared.clone();
+            let persist_future = async move {
                 let persist_start = std::time::Instant::now();
                 let core_outcome = match writer.persist(persist_plan).await {
                     Ok(outcome) => outcome,
@@ -1968,7 +1978,13 @@ impl InProcessChatTurnBridge {
                         error = e
                     );
                 }
-            });
+            };
+            // HIGH #4: route through shutdown-aware tracker when available.
+            if let Some(tracker) = persist_tracker_for_main {
+                tracker.track_persist_task(Box::pin(persist_future));
+            } else {
+                tokio::spawn(persist_future);
+            }
 
             if !session_id.is_empty()
                 && let Some(mut turn_event_buffer) = turn_event_buffer.filter(|buf| !buf.is_empty())
@@ -2114,7 +2130,8 @@ impl InProcessChatTurnBridge {
                 let aux_trace_signal = trace_signal.clone();
                 let aux_evaluation = evaluation.clone();
                 let aux_step_count = tool_call_records.len();
-                tokio::spawn(async move {
+                let persist_tracker_for_aux = persist_tracker_shared.clone();
+                let aux_future = async move {
                     // Routing decision event (inprocess uses default router)
                     let routing_event = crate::TurnAuxiliaryEventRecord {
                         event_id: Uuid::now_v7().to_string(),
@@ -2147,7 +2164,13 @@ impl InProcessChatTurnBridge {
                         aux_step_count,
                     )
                     .await;
-                });
+                };
+                // HIGH #4: route through shutdown-aware tracker when available.
+                if let Some(tracker) = persist_tracker_for_aux {
+                    tracker.track_persist_task(Box::pin(aux_future));
+                } else {
+                    tokio::spawn(aux_future);
+                }
             }
 
             if explain {

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -2147,9 +2147,11 @@ impl InProcessChatTurnBridge {
                         reasoning_content: None,
                     };
                     if let Err(e) = aux_writer.persist_events(vec![routing_event]).await {
-                        eprintln!(
-                            "PERSIST_FAIL session={} stage=auxiliary error={}",
-                            aux_sid, e
+                        tracing::error!(
+                            target: "astra_runtime::bridge_inprocess",
+                            aux_session_id = %aux_sid,
+                            err = %e,
+                            "auxiliary routing event persist failed"
                         );
                     }
                     persist_legacy_bridge_trace_and_quality(

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -191,8 +191,8 @@ impl LlmCancel<'_> {
         match self {
             LlmCancel::None => false,
             LlmCancel::Token(t) => t.is_cancelled(),
-            LlmCancel::Flag(f) => f.load(Ordering::Relaxed),
-            LlmCancel::FlagAndToken(f, t) => f.load(Ordering::Relaxed) || t.is_cancelled(),
+            LlmCancel::Flag(f) => f.load(Ordering::Acquire),
+            LlmCancel::FlagAndToken(f, t) => f.load(Ordering::Acquire) || t.is_cancelled(),
         }
     }
 }
@@ -204,7 +204,7 @@ pub(crate) async fn wait_llm_cancel(cancel: LlmCancel<'_>) {
         LlmCancel::Token(t) => t.cancelled().await,
         LlmCancel::Flag(f) => {
             const POLL: std::time::Duration = std::time::Duration::from_millis(50);
-            while !f.load(Ordering::Relaxed) {
+            while !f.load(Ordering::Acquire) {
                 tokio::time::sleep(POLL).await;
             }
         }
@@ -214,7 +214,7 @@ pub(crate) async fn wait_llm_cancel(cancel: LlmCancel<'_>) {
                 biased;
                 _ = t.cancelled() => {}
                 _ = async {
-                    while !f.load(Ordering::Relaxed) {
+                    while !f.load(Ordering::Acquire) {
                         tokio::time::sleep(POLL).await;
                     }
                 } => {}

--- a/rust/crates/runtime/tests/audit_lints_concurrency_error_context.rs
+++ b/rust/crates/runtime/tests/audit_lints_concurrency_error_context.rs
@@ -1,0 +1,316 @@
+//! Anti-pattern lints for the concurrency / error-context audit.
+//!
+//! These tests pin the contracts established by the audit so future refactors
+//! cannot silently regress to the broken patterns:
+//!
+//! * Lock-ordering / atomic-ordering bugs (concurrency cluster: C1, C2, C4–C6)
+//! * Swallowed errors via `eprintln!` / bare `Err(_) => return` /
+//!   `unwrap_or_default()` on JSON parse (error-context cluster: E3–E10)
+//!
+//! The tests deliberately use simple `include_str!` + substring scanning
+//! rather than ripgrep so they run in any environment.
+
+use std::path::Path;
+
+fn read(path: &str) -> String {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let p = Path::new(&manifest).join(path);
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("failed to read {}: {e}", p.display()))
+}
+
+fn read_workspace(rel: &str) -> String {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let p = Path::new(&manifest)
+        .parent()
+        .expect("crates dir")
+        .parent()
+        .expect("rust dir")
+        .join(rel);
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("failed to read {}: {e}", p.display()))
+}
+
+// ── C1: cancel_run must drop the runs write guard before persisting ─────────
+#[test]
+fn c1_cancel_run_drops_write_guard_before_persist() {
+    let src = read("src/server/run_lifecycle.rs");
+    let idx = src
+        .find("async fn cancel_run(")
+        .expect("cancel_run present");
+    let end = (idx + 6000).min(src.len());
+    let body = &src[idx..end];
+    let drop_pos = body
+        .find("drop(runs);")
+        .expect("cancel_run must call drop(runs); explicitly to release the write lock");
+    let persist_pos = body
+        .find(".persist_status(&run_id, STATUS_CANCELLED")
+        .expect("cancel_run must persist cancellation status");
+    assert!(
+        drop_pos < persist_pos,
+        "cancel_run must `drop(runs)` BEFORE awaiting engine.persist_status; \
+         otherwise the RwLock write guard is held across DB I/O and blocks all \
+         readers (mirror the pause_run pattern at line ~2683)."
+    );
+}
+
+// ── C2: cancel/pause flag loads must use Acquire (not Relaxed) ──────────────
+#[test]
+fn c2_cancel_pause_flag_loads_use_acquire() {
+    let files = [
+        "src/turn/agentic_loop_lifecycle.rs",
+        "src/server/run_lifecycle.rs",
+        "src/server/delegation_engine.rs",
+        "src/turn/llm_client.rs",
+    ];
+    for f in files {
+        let src = read(f);
+        for (lineno, line) in src.lines().enumerate() {
+            let l = line.trim();
+            if !l.contains(".load(") {
+                continue;
+            }
+            let touches_flag = l.contains("cancel_flag")
+                || l.contains("pause_flag")
+                || l.contains("cancellation.flag")
+                || (l.contains("f.load(")
+                    && (1..=3).any(|back| {
+                        src.lines()
+                            .nth(lineno.saturating_sub(back))
+                            .unwrap_or("")
+                            .contains("LlmCancel")
+                    }));
+            if touches_flag {
+                assert!(
+                    !l.contains("Ordering::Relaxed"),
+                    "{f}:{} cancel/pause flag load must use Acquire, not Relaxed:\n  {l}",
+                    lineno + 1
+                );
+            }
+        }
+    }
+}
+
+// ── C4: take_emitted_events must handle broadcast Lagged explicitly ─────────
+#[test]
+fn c4_take_emitted_events_handles_lagged() {
+    let src = read("src/server/server_loop_host.rs");
+    let idx = src
+        .find("pub fn take_emitted_events")
+        .expect("take_emitted_events present");
+    let snippet = &src[idx..idx + 2000.min(src.len() - idx)];
+    assert!(
+        snippet.contains("TryRecvError::Lagged"),
+        "take_emitted_events must explicitly handle TryRecvError::Lagged so progress \
+         events after the gap are not silently dropped"
+    );
+    assert!(
+        snippet.contains("TryRecvError::Empty"),
+        "take_emitted_events must terminate on TryRecvError::Empty"
+    );
+    assert!(
+        !snippet.contains("while let Ok(evt) = rx.try_recv()"),
+        "take_emitted_events must not use the simple while-let pattern that silently \
+         drops every event after a Lagged"
+    );
+}
+
+// ── C4: ProgressBroadcaster default capacity must be at least 1024 ──────────
+#[test]
+fn c4_progress_broadcaster_default_capacity_bumped() {
+    let src = read_workspace("crates/astra-turn-core/src/orchestration_progress.rs");
+    let idx = src
+        .find("impl Default for ProgressBroadcaster")
+        .expect("Default impl present");
+    let snippet = &src[idx..idx + 400.min(src.len() - idx)];
+    assert!(
+        snippet.contains("Self::new(1024)") || snippet.contains("Self::new(2048)"),
+        "ProgressBroadcaster default capacity must be ≥1024 to avoid silent \
+         broadcast overflow during high-fanout multi-agent runs:\n{snippet}"
+    );
+    assert!(
+        !snippet.contains("Self::new(256)"),
+        "ProgressBroadcaster default 256 reverted; bump to 1024+"
+    );
+}
+
+// ── C5: record_sub_run must take both maps in one scope (atomic insert) ─────
+#[test]
+fn c5_record_sub_run_atomic_dual_lock() {
+    let src = read("src/server/delegation_engine.rs");
+    let idx = src
+        .find("pub async fn record_sub_run")
+        .expect("record_sub_run present");
+    let end = idx + src[idx..].find("\n    }").expect("function end") + 6;
+    let body = &src[idx..end];
+    assert!(
+        body.contains("LOCK ORDER"),
+        "record_sub_run must document its lock order"
+    );
+    // The old anti-pattern took the second lock in a separate
+    // `self.parents.write().await.insert(...)` chained statement after
+    // releasing the first guard. Forbid that exact shape.
+    assert!(
+        !body.contains("self.parents.write().await.insert("),
+        "record_sub_run must not take parents.write() in a chained statement \
+         after delegations.write() releases — keep both guards live in a \
+         single scope so concurrent is_sub_run() observes a consistent state"
+    );
+}
+
+// ── C6: adjust_config dual-lock ordering must be documented ─────────────────
+#[test]
+fn c6_adjust_config_lock_order_documented() {
+    let src = read("src/server/server_tool_executor.rs");
+    let idx = src
+        .find("self_mod_mutation_counter.lock()")
+        .expect("counter lock present");
+    let start = idx.saturating_sub(2048);
+    let region = &src[start..idx];
+    assert!(
+        region.contains("LOCK ORDER")
+            && region.contains("observability_session")
+            && region.contains("self_mod_mutation_counter"),
+        "adjust_config dual-lock site must carry a `LOCK ORDER: \
+         observability_session → self_mod_mutation_counter` comment"
+    );
+}
+
+// ── E3: write_heavy_step_checkpoint must NOT mutate state on disk failure ──
+#[test]
+fn e3_checkpoint_state_only_set_on_success() {
+    let src = read("src/turn/agentic_loop_finalization.rs");
+    let idx = src
+        .find("pub(crate) fn try_write_heavy_checkpoint")
+        .expect("try_write_heavy_checkpoint present");
+    let end = idx + src[idx..].find("\n}\n").expect("end") + 2;
+    let body = &src[idx..end];
+    let set_pos = body
+        .find("state.last_composite_snapshot = Some(snapshot);")
+        .expect("state.last_composite_snapshot assignment present");
+    let preceding = &body[..set_pos];
+    let returns_in_failure = preceding.matches("return;").count();
+    assert!(
+        returns_in_failure >= 2,
+        "try_write_heavy_checkpoint must `return` on each disk-write failure \
+         (write_step_checkpoint AND write_composite_snapshot_index) so it never \
+         leaves `state.last_composite_snapshot = Some(...)` pointing at a \
+         non-existent file. Current body has only {returns_in_failure} early returns."
+    );
+}
+
+// ── E4: models.rs must log + use parse_json_column (no silent JSON defaults)
+#[test]
+fn e4_models_json_columns_log_on_malformed() {
+    let src = read_workspace("crates/services/src/models.rs");
+    assert!(
+        src.contains("fn parse_json_column"),
+        "services::models must define a `parse_json_column` helper that logs \
+         malformed payloads via tracing::error! before falling back to the default"
+    );
+    assert!(
+        src.contains("\"malformed JSON column, using default\""),
+        "parse_json_column helper must emit the canonical \"malformed JSON column\" \
+         error message (target astra_services::models) so observability dashboards \
+         can detect column corruption"
+    );
+    // The model_record_from_row body must not contain the silent
+    // serde_json::from_str(..).unwrap_or_default() anti-pattern any more.
+    let idx = src
+        .find("fn model_record_from_row")
+        .expect("model_record_from_row present");
+    let end = idx + src[idx..].find("\n    }").expect("end") + 6;
+    let body = &src[idx..end];
+    assert!(
+        !body.contains("serde_json::from_str(&supported_json).unwrap_or_default()"),
+        "model_record_from_row must not silently default malformed JSON columns; \
+         use parse_json_column(...) instead"
+    );
+}
+
+// ── E5/E10/E7: forbid eprintln! in audited error paths ──────────────────────
+#[test]
+fn e5_e7_e10_eprintln_forbidden_in_audited_paths() {
+    // E5 — session_restore::extract_session_state_from_metadata
+    let src = read_workspace("crates/services/src/session_restore.rs");
+    let idx = src
+        .find("fn extract_session_state_from_metadata")
+        .expect("extract_session_state_from_metadata present");
+    let end = (idx + 4000).min(src.len());
+    let body = &src[idx..end];
+    assert!(
+        !body.contains("eprintln!"),
+        "extract_session_state_from_metadata must use tracing, not eprintln!"
+    );
+    assert!(
+        body.contains("metadata JSON parse failed"),
+        "extract_session_state_from_metadata must emit a tracing::error! with the \
+         canonical \"metadata JSON parse failed\" message when serde_json fails"
+    );
+
+    // E7 — bridge_inprocess auxiliary routing event persist failure
+    let src = read("src/turn/bridge_inprocess.rs");
+    assert!(
+        !src.contains("PERSIST_FAIL session="),
+        "bridge_inprocess: legacy eprintln! \"PERSIST_FAIL session=\" must be \
+         replaced with tracing::error!"
+    );
+    assert!(
+        src.contains("auxiliary routing event persist failed"),
+        "bridge_inprocess auxiliary routing event persist failure must emit the \
+         canonical tracing::error! with target astra_runtime::bridge_inprocess"
+    );
+
+    // E10 — agentic_adaptive_tuning auto-tuning hot path
+    let src = read("src/turn/agentic_adaptive_tuning.rs");
+    assert!(
+        !src.contains("eprintln!(\"[auto-tuning]"),
+        "agentic_adaptive_tuning.rs must not use eprintln! for auto-tuning \
+         feedback persistence — use tracing::warn! / tracing::info!"
+    );
+}
+
+// ── E6: delegation engine journal init must log, not silently return ────────
+#[test]
+fn e6_delegation_journal_init_logs_on_failure() {
+    let src = read("src/server/delegation_engine.rs");
+    let idx = src
+        .find("fn persist_journal_entry")
+        .expect("persist_journal_entry present");
+    let end = idx + src[idx..].find("\n    }").expect("end") + 6;
+    let body = &src[idx..end];
+    assert!(
+        !body.contains("Err(_) => return"),
+        "persist_journal_entry must log JournalWriter::new failure \
+         (agent_warn!), not silently swallow with `Err(_) => return`"
+    );
+    assert!(
+        body.contains("JournalWriter::new failed"),
+        "persist_journal_entry must emit a warn including `JournalWriter::new failed`"
+    );
+}
+
+// ── E8: team_persistence row_to_team_definition must propagate worktree errors
+#[test]
+fn e8_worktree_mode_parse_error_propagated() {
+    let src = read_workspace("crates/services/src/team_persistence.rs");
+    let idx = src
+        .find("fn row_to_team_definition")
+        .expect("row_to_team_definition present");
+    let end = idx + src[idx..].find("\n}\n").expect("end") + 2;
+    let body = &src[idx..end];
+    let wt_idx = body
+        .find("worktree_mode:")
+        .or_else(|| body.find("worktree_mode ="))
+        .expect("worktree_mode binding present");
+    let wt_end = wt_idx + body[wt_idx..].find(";\n").expect("end of binding");
+    let wt_line = &body[wt_idx..wt_end];
+    assert!(
+        !wt_line.contains(".unwrap_or_default()"),
+        "row_to_team_definition: worktree_mode parse must not silently default — \
+         use `.map_err(...)?` so callers see the corruption:\n{wt_line}"
+    );
+    assert!(
+        body.contains("invalid worktree_mode"),
+        "row_to_team_definition: worktree_mode parse error must include the \
+         offending value in the propagated error message"
+    );
+}

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -149,7 +149,20 @@ fn build_resolved_active_llm_from_row(
         let quirks_json: String = row
             .try_get("quirks_json")
             .unwrap_or_else(|_| "{}".to_string());
-        let quirks: QuirksData = serde_json::from_str(&quirks_json).unwrap_or_default();
+        let quirks: QuirksData = match serde_json::from_str(&quirks_json) {
+            Ok(q) => q,
+            Err(e) => {
+                let prefix = &quirks_json[..quirks_json.len().min(200)];
+                tracing::error!(
+                    target: "astra_services::models",
+                    column = "quirks_json",
+                    err = %e,
+                    payload_prefix = %prefix,
+                    "malformed JSON column, using default"
+                );
+                QuirksData::default()
+            }
+        };
         // Env var overrides DB config
         std::env::var("MO_LLM_FALLBACK_MODEL")
             .ok()
@@ -286,6 +299,32 @@ pub struct DatabaseModelService {
     encryptor: std::sync::Arc<FernetTokenEncryptor>,
 }
 
+/// Parse a JSON column with explicit error logging on malformed payloads.
+///
+/// Replaces silent `serde_json::from_str(..).unwrap_or_default()` patterns so
+/// data corruption in MatrixOne JSON columns is observable in logs (target
+/// `astra_services::models`) instead of degrading silently to defaults.
+fn parse_json_column<T, F>(column: &'static str, raw: &str, default: F) -> T
+where
+    T: serde::de::DeserializeOwned,
+    F: FnOnce() -> T,
+{
+    match serde_json::from_str::<T>(raw) {
+        Ok(v) => v,
+        Err(e) => {
+            let prefix = &raw[..raw.len().min(200)];
+            tracing::error!(
+                target: "astra_services::models",
+                column,
+                err = %e,
+                payload_prefix = %prefix,
+                "malformed JSON column, using default"
+            );
+            default()
+        }
+    }
+}
+
 impl DatabaseModelService {
     pub fn new(
         matrixone: MatrixOneSettings,
@@ -330,15 +369,23 @@ impl DatabaseModelService {
             is_active: is_active_int != 0,
             context_window: row.try_get("context_window").unwrap_or(128000),
             max_completion_tokens: row.try_get("max_completion_tokens").ok(),
-            input_modalities: serde_json::from_str(&input_mod_json)
-                .unwrap_or_else(|_| vec!["text".to_string()]),
-            output_modalities: serde_json::from_str(&output_mod_json)
-                .unwrap_or_else(|_| vec!["text".to_string()]),
-            supported_parameters: serde_json::from_str(&supported_json).unwrap_or_default(),
-            pricing: serde_json::from_str(&pricing_json).unwrap_or_default(),
+            input_modalities: parse_json_column("input_modalities_json", &input_mod_json, || {
+                vec!["text".to_string()]
+            }),
+            output_modalities: parse_json_column(
+                "output_modalities_json",
+                &output_mod_json,
+                || vec!["text".to_string()],
+            ),
+            supported_parameters: parse_json_column(
+                "supported_parameters_json",
+                &supported_json,
+                Default::default,
+            ),
+            pricing: parse_json_column("pricing_json", &pricing_json, Default::default),
             architecture: row.try_get("architecture").ok(),
-            tags: serde_json::from_str(&tags_json).unwrap_or_default(),
-            quirks: serde_json::from_str(&quirks_json).unwrap_or_default(),
+            tags: parse_json_column("tags_json", &tags_json, Default::default),
+            quirks: parse_json_column("quirks_json", &quirks_json, Default::default),
             connectivity: None,
         })
     }

--- a/rust/crates/services/src/session_restore.rs
+++ b/rust/crates/services/src/session_restore.rs
@@ -1677,19 +1677,35 @@ pub fn extract_session_state_from_metadata(metadata_json: &str) -> SessionMetada
     // Defense: reject excessively large metadata to prevent DoS
     const MAX_METADATA_SIZE: usize = 512 * 1024; // 512 KB
     if metadata_json.len() > MAX_METADATA_SIZE {
-        eprintln!(
-            "[WARN] session metadata too large ({} bytes), skipping plan extraction",
-            metadata_json.len()
+        tracing::warn!(
+            target: "astra_services::session_restore",
+            size = metadata_json.len(),
+            "session metadata too large, skipping plan extraction"
         );
         return SessionMetadataState::default();
     }
     let parsed: serde_json::Value = match serde_json::from_str(metadata_json) {
         Ok(v) => v,
-        Err(_) => return SessionMetadataState::default(),
+        Err(e) => {
+            let prefix = &metadata_json[..metadata_json.len().min(200)];
+            tracing::error!(
+                target: "astra_services::session_restore",
+                err = %e,
+                payload_prefix = %prefix,
+                "metadata JSON parse failed; returning default state"
+            );
+            return SessionMetadataState::default();
+        }
     };
     let obj = match parsed.as_object() {
         Some(o) => o,
-        None => return SessionMetadataState::default(),
+        None => {
+            tracing::warn!(
+                target: "astra_services::session_restore",
+                "session metadata is not a JSON object; returning default state"
+            );
+            return SessionMetadataState::default();
+        }
     };
 
     SessionMetadataState {

--- a/rust/crates/services/src/team_persistence.rs
+++ b/rust/crates/services/src/team_persistence.rs
@@ -1164,8 +1164,8 @@ fn row_to_team_definition(row: &sqlx::mysql::MySqlRow) -> Result<TeamDefinition,
     } else {
         serde_json::from_str(&context_str).map_err(|e| format!("bad context JSON: {e}"))?
     };
-    let worktree_mode: WorktreeMode =
-        serde_json::from_str(&format!("\"{wt_str}\"")).unwrap_or_default();
+    let worktree_mode: WorktreeMode = serde_json::from_str(&format!("\"{wt_str}\""))
+        .map_err(|e| format!("invalid worktree_mode {wt_str:?}: {e}"))?;
     let budget: Option<TeamBudget> = budget_str
         .filter(|s| !s.is_empty())
         .map(|s| serde_json::from_str(&s))


### PR DESCRIPTION
## Context

This PR closes the two remaining HIGH findings from the cancel-shutdown audit that were deferred from PR #235.

## HIGH #4 — Bridge fire-and-forget persist tasks not drained on shutdown

**Problem:** Two `tokio::spawn(async move { writer.persist(...).await; ... })` sites inside the SSE generator in `bridge_inprocess.rs`. JoinHandles dropped → SIGTERM kills mid-DB-write → split state.

**Fix:**
- New `BridgePersistTracker` trait (object-safe, `Pin<Box<dyn Future>>`) in `matrix_cloud_runtime.rs`
- `MatrixCloudRuntime` implements the trait, delegating to `spawn_session_sync_task` which feeds the existing `session_sync_tasks: Mutex<JoinSet<()>>` already drained by `shutdown_ingestion_and_wait`
- `InProcessChatTurnBridge` gains `persist_tracker: Option<Arc<dyn BridgePersistTracker>>` field and `with_persist_tracker()` builder
- Both fire-and-forget `tokio::spawn` persist blocks in the SSE generator replaced with tracker-aware dispatch (falls back to raw spawn if no tracker: dev/test mode unaffected)
- `TODO(audit-#3)` deferred comment resolved
- `state_builder.rs` wires `Arc<MatrixCloudRuntime>` as the persist tracker

**Tests (5 new):**
- `bridge_persist_tracker_trait_is_defined` — source-level assertion
- `matrix_cloud_runtime_impls_bridge_persist_tracker` — source-level assertion
- `bridge_persist_tracker_future_runs_and_drains` — functional: future runs via test impl
- `bridge_inprocess_has_persist_tracker_field` — source-level assertion
- `bridge_persist_uses_tracker_not_raw_spawn` — source-level assertion (no raw TODO)

## HIGH #5 — Background agent spawn: dropped JoinHandle, no shutdown drain

**Problem:** `tokio::spawn(async move { executor.execute(run_config).await; ... })` in `spawner.rs` background branch: fire-and-forget, no cancel propagation, no shutdown drain → SIGTERM kills mid-LLM-turn, leaves DB rows in `Running` forever.

**Fix:**
- `DynamicAgentSpawner` gains `background_tasks: Arc<Mutex<JoinSet<()>>>` (shared across all `clone_for_task` clones)
- Background spawn path changed from raw `tokio::spawn` to `background_tasks.lock().spawn()`
- `shutdown_and_wait(deadline: Duration)`: drains JoinSet, catches panic `JoinError` (logs, doesn't propagate), aborts remaining tasks on deadline exceeded
- `background_task_count()` accessor for observability and tests

**Tests (2 new):**
- `background_agent_tracked_and_drained_on_shutdown` — functional: blocking executor + shutdown drains it
- `background_agent_panic_does_not_leave_zombie` — functional: panicking executor leaves zero tasks after drain

## Deferrals

**CancellationToken plumbing into executor:** `SpawnRunConfig` has no cancel token field; adding one ripples into `astra-cli`'s `AgenticLoopHost`. At minimum background tasks are now `abort()`-ed on shutdown deadline (less graceful but prevents zombie leak). Clean-cancel is tracked as a follow-up TODO in spawner.rs.

## Verification

- `make format` ✅
- `make check` ✅ (clippy + compile)
- `cargo test -p astra-runtime --lib`: **2176 passed, 0 failed** (11 new tests)
- No regressions in adjacent test modules (bridge_inprocess, orchestration, server)

**Total new tests:** 11