### PR TITLE
fix(secrets): fail-closed defaults + Debug redaction + masking layer

### DIFF
--- a/fixtures/contracts/settings_contract.json
+++ b/fixtures/contracts/settings_contract.json
@@ -21,6 +21,7 @@
     "APP_ENV": "production",
     "LOG_LEVEL": "INFO",
     "SECRET_KEY": "prod-secret",
+    "JWT_SECRET_KEY": "override-jwt-secret-key-123456",
     "GITHUB_TOKEN": "ghp_example",
     "CHAT_TURN_BRIDGE_URL": "http://bridge.internal:9001/internal/chat/turn",
     "CHAT_TURN_BRIDGE_SECRET": "bridge-secret-prod"

--- a/rust/crates/astra-cli/src/cli/durable_bridge.rs
+++ b/rust/crates/astra-cli/src/cli/durable_bridge.rs
@@ -1202,6 +1202,16 @@ pub struct HttpLlmJudge {
     model: String,
 }
 
+impl std::fmt::Debug for HttpLlmJudge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpLlmJudge")
+            .field("api_key", &"[REDACTED]")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .finish()
+    }
+}
+
 impl HttpLlmJudge {
     pub fn new(api_key: String, base_url: String, model: String) -> Self {
         let client = build_client_for_url(&base_url);

--- a/rust/crates/astra-cli/src/cli/repl_startup.rs
+++ b/rust/crates/astra-cli/src/cli/repl_startup.rs
@@ -234,9 +234,7 @@ pub(crate) async fn complete_repl_startup(
     }
 
     if let Ok(settings) = astra_runtime::matrix_settings_from_env().map_err(|e| {
-        eprintln!(
-            "[startup] cloud sync disabled: {e}. Set MATRIXONE_PASSWORD to enable."
-        );
+        eprintln!("[startup] cloud sync disabled: {e}. Set MATRIXONE_PASSWORD to enable.");
         state.matrix_runtime = None;
     }) {
         state.matrix_runtime = match SharedPool::new(&settings).await {

--- a/rust/crates/astra-cli/src/cli/repl_startup.rs
+++ b/rust/crates/astra-cli/src/cli/repl_startup.rs
@@ -233,8 +233,12 @@ pub(crate) async fn complete_repl_startup(
         state.synced_tool_health_entries = cross_session_health_entries;
     }
 
-    {
-        let settings = astra_runtime::matrix_settings_from_env();
+    if let Ok(settings) = astra_runtime::matrix_settings_from_env().map_err(|e| {
+        eprintln!(
+            "[startup] cloud sync disabled: {e}. Set MATRIXONE_PASSWORD to enable."
+        );
+        state.matrix_runtime = None;
+    }) {
         state.matrix_runtime = match SharedPool::new(&settings).await {
             Ok(pool) => {
                 let user_id = std::env::var("MO_USER_ID").unwrap_or_else(|_| "local".to_string());

--- a/rust/crates/astra-cli/src/edge_tools/mo_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools/mo_tools.rs
@@ -31,8 +31,8 @@ fn mo_current_account() -> &'static str {
     use std::sync::OnceLock;
     static ACCOUNT: OnceLock<String> = OnceLock::new();
     ACCOUNT.get_or_init(|| {
-        let out = mo_execute_sql("SELECT current_account_name() AS name", None)
-            .unwrap_or_else(|e| e);
+        let out =
+            mo_execute_sql("SELECT current_account_name() AS name", None).unwrap_or_else(|e| e);
         // Parse the value from mysql --table output.
         out.lines()
             .filter(|l| !l.starts_with('+') && !l.contains("name"))
@@ -464,8 +464,9 @@ impl ToolExecutor {
         let mut tool_result_fields = None;
         if mo_query_requires_pre_state_snapshot(sql, allow_destructive) {
             let snapshot_id = mo_pre_state_snapshot_name();
-            let snapshot_output = mo_execute_sql(&mo_create_snapshot_sql(&snapshot_id, database), None)
-                .unwrap_or_else(|e| e);
+            let snapshot_output =
+                mo_execute_sql(&mo_create_snapshot_sql(&snapshot_id, database), None)
+                    .unwrap_or_else(|e| e);
             if is_mo_error(&snapshot_output) {
                 return ToolExecutionOutcome::text(format!(
                     "Error: failed to capture pre-state snapshot `{snapshot_id}` before executing query.\n{snapshot_output}"

--- a/rust/crates/astra-cli/src/edge_tools/mo_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools/mo_tools.rs
@@ -31,7 +31,8 @@ fn mo_current_account() -> &'static str {
     use std::sync::OnceLock;
     static ACCOUNT: OnceLock<String> = OnceLock::new();
     ACCOUNT.get_or_init(|| {
-        let out = mo_execute_sql("SELECT current_account_name() AS name", None);
+        let out = mo_execute_sql("SELECT current_account_name() AS name", None)
+            .unwrap_or_else(|e| e);
         // Parse the value from mysql --table output.
         out.lines()
             .filter(|l| !l.starts_with('+') && !l.contains("name"))
@@ -182,13 +183,18 @@ fn is_mo_error(output: &str) -> bool {
 }
 
 /// Build a mysql Command with connection parameters from environment.
-fn mo_mysql_cmd(database: Option<&str>) -> Command {
-    astra_core::warn_default_credentials_once();
+///
+/// Requires `MATRIXONE_PASSWORD` to be set — returns an error message string
+/// when missing rather than falling back to a hardcoded development password.
+fn mo_mysql_cmd(database: Option<&str>) -> Result<Command, String> {
     let host = std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".to_string());
     let port = std::env::var("MATRIXONE_PORT").unwrap_or_else(|_| "6001".to_string());
     let user = std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".to_string());
-    let password = std::env::var("MATRIXONE_PASSWORD")
-        .unwrap_or_else(|_| astra_core::DEV_MATRIXONE_PASSWORD.to_string());
+    let password = std::env::var("MATRIXONE_PASSWORD").map_err(|_| {
+        "Error: MATRIXONE_PASSWORD environment variable is required. \
+         Set it before using MatrixOne tools."
+            .to_string()
+    })?;
     let db = database
         .map(String::from)
         .unwrap_or_else(|| astra_core::resolve_database_name(&|k| std::env::var(k).ok()));
@@ -201,12 +207,15 @@ fn mo_mysql_cmd(database: Option<&str>) -> Command {
         .arg(&db)
         .arg(format!("--connect-timeout={MO_CONNECT_TIMEOUT_SECS}"))
         .arg("--table"); // Pretty-print results
-    cmd
+    Ok(cmd)
 }
 
 /// Execute a SQL statement against MatrixOne via the mysql CLI.
-fn mo_execute_sql(sql: &str, database: Option<&str>) -> String {
-    let mut cmd = mo_mysql_cmd(database);
+///
+/// Returns `Err` with an explanatory message when `MATRIXONE_PASSWORD` is unset.
+/// Tool callers that need a `String` output should use `.unwrap_or_else(|e| e)`.
+fn mo_execute_sql(sql: &str, database: Option<&str>) -> Result<String, String> {
+    let mut cmd = mo_mysql_cmd(database)?;
     cmd.arg("-e").arg(sql);
 
     match cmd.output() {
@@ -228,9 +237,9 @@ fn mo_execute_sql(sql: &str, database: Option<&str>) -> String {
                     msg.push_str("\n--- auto-fetched schema ---\n");
                     msg.push_str(&hint);
                 }
-                msg
+                Ok(msg)
             } else if stdout.is_empty() {
-                "OK (no results)".to_string()
+                Ok("OK (no results)".to_string())
             } else {
                 let result = stdout.to_string();
                 if result.len() > 20_000 {
@@ -241,17 +250,17 @@ fn mo_execute_sql(sql: &str, database: Option<&str>) -> String {
                         "\n[truncated at 20KB: showing ~{} of {} rows. Use LIMIT to narrow results.]",
                         rows_shown, total_rows
                     ));
-                    t
+                    Ok(t)
                 } else {
-                    result
+                    Ok(result)
                 }
             }
         }
         Err(e) => {
             if e.kind() == std::io::ErrorKind::NotFound {
-                "Error: mysql client not found. Install mysql-client or mariadb-client to use MatrixOne tools.\nHint: apt install mariadb-client OR brew install mysql-client".to_string()
+                Ok("Error: mysql client not found. Install mysql-client or mariadb-client to use MatrixOne tools.\nHint: apt install mariadb-client OR brew install mysql-client".to_string())
             } else {
-                format!("Error: failed to execute mysql: {e}")
+                Ok(format!("Error: failed to execute mysql: {e}"))
             }
         }
     }
@@ -282,10 +291,9 @@ fn schema_hint_for_error(lower_err: &str, sql: &str, database: Option<&str>) -> 
     if lower_err.contains("column") && lower_err.contains("does not exist") {
         // Column not found → DESCRIBE the table
         if let Some(table) = extract_table_from_sql(sql) {
-            let desc = mo_execute_sql(&format!("DESCRIBE {table}"), database);
-            if !desc.starts_with("Error:") {
-                return Some(desc);
-            }
+            return mo_execute_sql(&format!("DESCRIBE {table}"), database)
+                .ok()
+                .filter(|desc| !desc.starts_with("Error:"));
         }
     } else if lower_err.contains("table") && lower_err.contains("does not exist") {
         // Table not found → SHOW TABLES in the database
@@ -293,10 +301,9 @@ fn schema_hint_for_error(lower_err: &str, sql: &str, database: Option<&str>) -> 
             .map(String::from)
             .unwrap_or_else(|| astra_core::resolve_database_name(&|k| std::env::var(k).ok()));
         if !db.is_empty() {
-            let tables = mo_execute_sql(&format!("SHOW TABLES IN `{db}`"), None);
-            if !tables.starts_with("Error:") {
-                return Some(tables);
-            }
+            return mo_execute_sql(&format!("SHOW TABLES IN `{db}`"), None)
+                .ok()
+                .filter(|t| !t.starts_with("Error:"));
         }
     }
     None
@@ -411,7 +418,8 @@ impl ToolExecutor {
         let restore_output = mo_execute_sql(
             &mo_restore_snapshot_sql(&entry.snapshot_id, entry.database.as_deref()),
             None,
-        );
+        )
+        .unwrap_or_else(|e| e);
         if is_mo_error(&restore_output) {
             Err(restore_output)
         } else {
@@ -456,8 +464,8 @@ impl ToolExecutor {
         let mut tool_result_fields = None;
         if mo_query_requires_pre_state_snapshot(sql, allow_destructive) {
             let snapshot_id = mo_pre_state_snapshot_name();
-            let snapshot_output =
-                mo_execute_sql(&mo_create_snapshot_sql(&snapshot_id, database), None);
+            let snapshot_output = mo_execute_sql(&mo_create_snapshot_sql(&snapshot_id, database), None)
+                .unwrap_or_else(|e| e);
             if is_mo_error(&snapshot_output) {
                 return ToolExecutionOutcome::text(format!(
                     "Error: failed to capture pre-state snapshot `{snapshot_id}` before executing query.\n{snapshot_output}"
@@ -480,7 +488,7 @@ impl ToolExecutor {
         }
 
         ToolExecutionOutcome {
-            output: mo_execute_sql(sql, database),
+            output: mo_execute_sql(sql, database).unwrap_or_else(|e| e),
             tool_result_fields,
         }
     }
@@ -689,9 +697,9 @@ impl ToolExecutor {
                 };
                 // MatrixOne database-level snapshot
                 let sql = mo_create_snapshot_sql(name, database);
-                mo_execute_sql(&sql, None)
+                mo_execute_sql(&sql, None).unwrap_or_else(|e| e)
             }
-            "list" => mo_execute_sql("SHOW SNAPSHOTS", None),
+            "list" => mo_execute_sql("SHOW SNAPSHOTS", None).unwrap_or_else(|e| e),
             "drop" | "delete" => {
                 let name = match args.get("name").and_then(Value::as_str) {
                     Some(n) if is_valid_snapshot_name(n) => n,
@@ -704,7 +712,7 @@ impl ToolExecutor {
                     None => return "Error: missing 'name' for snapshot deletion".to_string(),
                 };
                 let sql = format!("DROP SNAPSHOT IF EXISTS `{}`", name);
-                mo_execute_sql(&sql, None)
+                mo_execute_sql(&sql, None).unwrap_or_else(|e| e)
             }
             "restore" => {
                 let name = match args.get("name").and_then(Value::as_str) {
@@ -718,7 +726,7 @@ impl ToolExecutor {
                     None => return "Error: missing 'name' for snapshot restore".to_string(),
                 };
                 let sql = mo_restore_snapshot_sql(name, database);
-                mo_execute_sql(&sql, None)
+                mo_execute_sql(&sql, None).unwrap_or_else(|e| e)
             }
             other => format!(
                 "Error: unknown action '{}'. Supported: create, list, drop, restore",
@@ -744,7 +752,7 @@ impl ToolExecutor {
                 }
 
                 // MatrixOne snapshots (serve as data branches)
-                let snapshots = mo_execute_sql("SHOW SNAPSHOTS", None);
+                let snapshots = mo_execute_sql("SHOW SNAPSHOTS", None).unwrap_or_else(|e| e);
                 result.push_str("## MatrixOne Snapshots (Data Branches)\n");
                 result.push_str(&snapshots);
 
@@ -781,12 +789,12 @@ impl ToolExecutor {
                             "Creating data branch '{}' aligned with git branch '{}'\n\n{}",
                             auto_name,
                             branch,
-                            mo_execute_sql(&sql, None)
+                            mo_execute_sql(&sql, None).unwrap_or_else(|e| e)
                         );
                     }
                 };
                 let sql = mo_create_snapshot_sql(name, None);
-                mo_execute_sql(&sql, None)
+                mo_execute_sql(&sql, None).unwrap_or_else(|e| e)
             }
             "sync" => {
                 // Show the relationship between git state and MO state
@@ -796,7 +804,7 @@ impl ToolExecutor {
                 let git_head = super::git_gix::head_short(&self.project_root);
                 result.push_str(&format!("Git: branch={}, head={}\n", git_branch, git_head));
 
-                let snapshots = mo_execute_sql("SHOW SNAPSHOTS", None);
+                let snapshots = mo_execute_sql("SHOW SNAPSHOTS", None).unwrap_or_else(|e| e);
                 result.push_str(&format!("MatrixOne snapshots:\n{}\n", snapshots));
 
                 // Check if there's a matching snapshot for current branch
@@ -1021,8 +1029,9 @@ mod tests {
         unsafe {
             std::env::set_var("MATRIXONE_HOST", "nonexistent-host-12345");
             std::env::set_var("MATRIXONE_PORT", "6001");
+            std::env::set_var("MATRIXONE_PASSWORD", "test-pw");
         }
-        let result = mo_execute_sql("SELECT 1", None);
+        let result = mo_execute_sql("SELECT 1", None).expect("password set, should be Ok");
         assert!(
             result.contains("Error") || result.contains("error") || result.contains("not found"),
             "should handle missing mysql gracefully: {result}"
@@ -1030,7 +1039,40 @@ mod tests {
         unsafe {
             std::env::remove_var("MATRIXONE_HOST");
             std::env::remove_var("MATRIXONE_PORT");
+            std::env::remove_var("MATRIXONE_PASSWORD");
         }
+    }
+
+    #[test]
+    fn mo_execute_sql_requires_matrixone_password() {
+        let _guard = env_guard();
+        unsafe {
+            std::env::remove_var("MATRIXONE_PASSWORD");
+        }
+        let result = mo_execute_sql("SELECT 1", None);
+        assert!(
+            result.is_err(),
+            "should error when MATRIXONE_PASSWORD is unset"
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("MATRIXONE_PASSWORD"),
+            "error should mention the missing var: {msg}"
+        );
+        assert!(
+            !msg.contains("111"),
+            "should not fall back to hardcoded password: {msg}"
+        );
+    }
+
+    #[test]
+    fn mo_mysql_cmd_requires_matrixone_password() {
+        let _guard = env_guard();
+        unsafe {
+            std::env::remove_var("MATRIXONE_PASSWORD");
+        }
+        let result = mo_mysql_cmd(None);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1039,8 +1081,9 @@ mod tests {
         unsafe {
             std::env::set_var("MATRIXONE_HOST", "testhost");
             std::env::set_var("MATRIXONE_PORT", "7001");
+            std::env::set_var("MATRIXONE_PASSWORD", "test-pw");
         }
-        let cmd = mo_mysql_cmd(Some("testdb"));
+        let cmd = mo_mysql_cmd(Some("testdb")).expect("password set, should be Ok");
         let args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().to_string())
@@ -1071,6 +1114,7 @@ mod tests {
         unsafe {
             std::env::remove_var("MATRIXONE_HOST");
             std::env::remove_var("MATRIXONE_PORT");
+            std::env::remove_var("MATRIXONE_PASSWORD");
         }
     }
 
@@ -1080,8 +1124,9 @@ mod tests {
         unsafe {
             std::env::remove_var("ASTRA_DATABASE");
             std::env::remove_var("ASTRA_DATABASE_PREFIX");
+            std::env::set_var("MATRIXONE_PASSWORD", "test-pw");
         }
-        let cmd = mo_mysql_cmd(None);
+        let cmd = mo_mysql_cmd(None).expect("password set, should be Ok");
         let args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().to_string())
@@ -1091,6 +1136,9 @@ mod tests {
             "should default to astra_runtime: {:?}",
             args
         );
+        unsafe {
+            std::env::remove_var("MATRIXONE_PASSWORD");
+        }
     }
 
     #[test]
@@ -1100,8 +1148,9 @@ mod tests {
             std::env::remove_var("ASTRA_DATABASE_PREFIX");
             std::env::set_var("ASTRA_DATABASE_PREFIX", "it_");
             std::env::set_var("ASTRA_DATABASE", "astra_runtime");
+            std::env::set_var("MATRIXONE_PASSWORD", "test-pw");
         }
-        let cmd = mo_mysql_cmd(None);
+        let cmd = mo_mysql_cmd(None).expect("password set, should be Ok");
         let args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().to_string())
@@ -1114,6 +1163,7 @@ mod tests {
         unsafe {
             std::env::remove_var("ASTRA_DATABASE_PREFIX");
             std::env::remove_var("ASTRA_DATABASE");
+            std::env::remove_var("MATRIXONE_PASSWORD");
         }
     }
 

--- a/rust/crates/astra-logging/src/lib.rs
+++ b/rust/crates/astra-logging/src/lib.rs
@@ -164,3 +164,95 @@ pub fn init_from_env_or_ignores_duplicate(config: LogInitConfig<'_>) {
         eprintln!("[astra-logging] logging init failed: {e}");
     }
 }
+
+// ─── Secret<T> newtype (S5 stub) ─────────────────────────────────────────────
+
+/// A wrapper that redacts the inner value in `Debug` and `Display` output.
+///
+/// Use this to store secret values (API keys, passwords, tokens) in structs
+/// where you want to derive `Debug` without leaking the secret in logs or
+/// panic messages.
+///
+/// A full `tracing` subscriber layer for field-level scrubbing is deferred to
+/// a follow-up; this stub only provides the newtype wrapper.
+///
+/// # Example
+/// ```
+/// use astra_logging::Secret;
+/// let s = Secret::new("my-api-key".to_string());
+/// assert_eq!(format!("{s:?}"), "[REDACTED]");
+/// assert_eq!(format!("{s}"), "[REDACTED]");
+/// assert_eq!(s.expose(), "my-api-key");
+/// ```
+#[derive(Clone, PartialEq, Eq)]
+pub struct Secret<T: AsRef<str>>(T);
+
+impl<T: AsRef<str>> Secret<T> {
+    pub fn new(value: T) -> Self {
+        Self(value)
+    }
+
+    /// Returns the inner secret value. Avoid logging the result.
+    pub fn expose(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl<T: AsRef<str>> std::fmt::Debug for Secret<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+impl<T: AsRef<str>> std::fmt::Display for Secret<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+impl From<String> for Secret<String> {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for Secret<String> {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+#[cfg(test)]
+mod secret_tests {
+    use super::Secret;
+
+    #[test]
+    fn secret_debug_is_redacted() {
+        let s = Secret::new("my-api-key-abc123".to_string());
+        let debug = format!("{s:?}");
+        assert_eq!(debug, "[REDACTED]");
+        assert!(!debug.contains("my-api-key-abc123"));
+    }
+
+    #[test]
+    fn secret_display_is_redacted() {
+        let s = Secret::new("super-secret".to_string());
+        let display = format!("{s}");
+        assert_eq!(display, "[REDACTED]");
+    }
+
+    #[test]
+    fn secret_expose_returns_value() {
+        let s = Secret::new("actual-value".to_string());
+        assert_eq!(s.expose(), "actual-value");
+    }
+
+    #[test]
+    fn secret_from_str_and_string() {
+        let a: Secret<String> = "hello".into();
+        let b: Secret<String> = String::from("hello").into();
+        assert_eq!(a.expose(), "hello");
+        assert_eq!(b.expose(), "hello");
+        assert_eq!(format!("{a:?}"), "[REDACTED]");
+    }
+}

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -14,3 +14,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[features]
+dev-defaults = []

--- a/rust/crates/core/src/config.rs
+++ b/rust/crates/core/src/config.rs
@@ -68,11 +68,7 @@ impl AppSettings {
                 host: value_or_default(&lookup, "MATRIXONE_HOST", "localhost"),
                 port: parse_or_default(&lookup, "MATRIXONE_PORT", 6001)?,
                 user: value_or_default(&lookup, "MATRIXONE_USER", "root"),
-                password: value_or_default(
-                    &lookup,
-                    "MATRIXONE_PASSWORD",
-                    super::runtime_limits::DEV_MATRIXONE_PASSWORD,
-                ),
+                password: value_or_default(&lookup, "MATRIXONE_PASSWORD", "111"),
                 database: resolve_database_name(&lookup),
             },
             application: ApplicationSettings {

--- a/rust/crates/core/src/config.rs
+++ b/rust/crates/core/src/config.rs
@@ -68,28 +68,28 @@ impl AppSettings {
                 host: value_or_default(&lookup, "MATRIXONE_HOST", "localhost"),
                 port: parse_or_default(&lookup, "MATRIXONE_PORT", 6001)?,
                 user: value_or_default(&lookup, "MATRIXONE_USER", "root"),
-                password: value_or_default(&lookup, "MATRIXONE_PASSWORD", "111"),
+                password: required_value(&lookup, "MATRIXONE_PASSWORD", "111")?,
                 database: resolve_database_name(&lookup),
             },
             application: ApplicationSettings {
                 app_env: value_or_default(&lookup, "APP_ENV", "development"),
                 log_level: value_or_default(&lookup, "LOG_LEVEL", "DEBUG"),
-                secret_key: value_or_default(
+                secret_key: required_value(
                     &lookup,
                     "SECRET_KEY",
                     "dev-secret-key-change-in-production",
-                ),
+                )?,
             },
             jwt: JwtSettings::from_lookup(&lookup)?,
             github_token: optional_value(&lookup, "GITHUB_TOKEN"),
             memoria_base_url: value_or_default(&lookup, "MEMORIA_BASE_URL", DEFAULT_MEMORIA_URL),
             memoria_master_key: optional_value(&lookup, "MEMORIA_MASTER_KEY"),
             chat_turn_bridge_url: optional_value(&lookup, "CHAT_TURN_BRIDGE_URL"),
-            chat_turn_bridge_secret: value_or_default(
+            chat_turn_bridge_secret: required_value(
                 &lookup,
                 "CHAT_TURN_BRIDGE_SECRET",
                 "dev-bridge-secret-change-me",
-            ),
+            )?,
         })
     }
 }
@@ -142,7 +142,7 @@ impl JwtSettings {
     where
         F: Fn(&str) -> Option<String>,
     {
-        let secret = value_or_default(lookup, "JWT_SECRET_KEY", "change-me-in-production");
+        let secret = required_value(lookup, "JWT_SECRET_KEY", "change-me-in-production")?;
         Ok(Self {
             secret_key: normalize_jwt_secret(&secret),
             algorithm: value_or_default(lookup, "JWT_ALGORITHM", "HS256"),
@@ -163,6 +163,7 @@ impl JwtSettings {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ConfigError {
     InvalidInteger { key: &'static str, value: String },
+    MissingRequiredKey { name: &'static str },
 }
 
 impl fmt::Display for ConfigError {
@@ -170,6 +171,14 @@ impl fmt::Display for ConfigError {
         match self {
             Self::InvalidInteger { key, value } => {
                 write!(f, "invalid integer for {key}: {value}")
+            }
+            Self::MissingRequiredKey { name } => {
+                write!(
+                    f,
+                    "required configuration key `{name}` is unset; set the env var or \
+                     opt into bundled insecure defaults with ASTRA_ALLOW_INSECURE_DEFAULTS=1 \
+                     (NOT for production)"
+                )
             }
         }
     }
@@ -209,6 +218,40 @@ where
     F: Fn(&str) -> Option<String>,
 {
     lookup(key).unwrap_or_else(|| default.to_string())
+}
+
+/// Returns the value from the lookup, or an insecure default if
+/// `ASTRA_ALLOW_INSECURE_DEFAULTS=1` is set in the same lookup.
+///
+/// In production (no opt-in), missing required keys return
+/// `Err(ConfigError::MissingRequiredKey)`.
+///
+/// # Dev escape hatch
+/// Set `ASTRA_ALLOW_INSECURE_DEFAULTS=1` to permit the bundled defaults.
+/// This emits a `tracing::error!` warning once and MUST NOT be used in production.
+fn required_value<F>(
+    lookup: &F,
+    key: &'static str,
+    insecure_default: &str,
+) -> Result<String, ConfigError>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    if let Some(val) = lookup(key) {
+        return Ok(val);
+    }
+    if lookup("ASTRA_ALLOW_INSECURE_DEFAULTS")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        tracing::error!(
+            key = key,
+            "INSECURE DEFAULTS — DO NOT USE IN PRODUCTION: {} is using bundled default",
+            key
+        );
+        return Ok(insecure_default.to_string());
+    }
+    Err(ConfigError::MissingRequiredKey { name: key })
 }
 
 fn optional_value<F>(lookup: &F, key: &'static str) -> Option<String>
@@ -303,7 +346,9 @@ mod tests {
 
     #[test]
     fn jwt_settings_match_runtime_defaults_and_padding() {
-        let settings = AppSettings::from_map(&HashMap::new()).expect("defaults should parse");
+        let mut m = HashMap::new();
+        m.insert("ASTRA_ALLOW_INSECURE_DEFAULTS".into(), "1".into());
+        let settings = AppSettings::from_map(&m).expect("defaults should parse");
 
         assert_eq!(settings.jwt.algorithm, "HS256");
         assert_eq!(settings.jwt.access_token_expire_minutes, 60);
@@ -318,8 +363,53 @@ mod tests {
     }
 
     #[test]
+    fn from_lookup_missing_required_keys_returns_error() {
+        let m = HashMap::new(); // no ASTRA_ALLOW_INSECURE_DEFAULTS
+        let result = AppSettings::from_map(&m);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ConfigError::MissingRequiredKey { .. } => {}
+            other => panic!("expected MissingRequiredKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_lookup_explicit_required_values_work() {
+        let mut m = HashMap::new();
+        m.insert("MATRIXONE_PASSWORD".into(), "testpw".into());
+        m.insert("SECRET_KEY".into(), "test-secret".into());
+        m.insert("JWT_SECRET_KEY".into(), "my-test-jwt-secret-key-123".into());
+        m.insert("CHAT_TURN_BRIDGE_SECRET".into(), "bridge-secret".into());
+        let result = AppSettings::from_map(&m);
+        assert!(result.is_ok(), "explicit values should parse: {:?}", result);
+        let settings = result.unwrap();
+        assert!(
+            settings
+                .jwt
+                .secret_key
+                .starts_with("my-test-jwt-secret-key-123")
+        );
+        assert_eq!(settings.matrixone.password, "testpw");
+        assert_eq!(settings.application.secret_key, "test-secret");
+        assert_eq!(settings.chat_turn_bridge_secret, "bridge-secret");
+    }
+
+    #[test]
+    fn from_lookup_insecure_defaults_allowed_with_opt_in() {
+        let mut m = HashMap::new();
+        m.insert("ASTRA_ALLOW_INSECURE_DEFAULTS".into(), "1".into());
+        let result = AppSettings::from_map(&m);
+        assert!(
+            result.is_ok(),
+            "insecure defaults should parse with opt-in: {:?}",
+            result
+        );
+    }
+
+    #[test]
     fn app_settings_database_includes_prefix() {
         let mut m = HashMap::new();
+        m.insert("ASTRA_ALLOW_INSECURE_DEFAULTS".into(), "1".into());
         m.insert("ASTRA_DATABASE".into(), "agent_db".into());
         m.insert("ASTRA_DATABASE_PREFIX".into(), "ci_".into());
         let settings = AppSettings::from_map(&m).expect("parse");
@@ -385,7 +475,9 @@ mod settings_contract_tests {
     #[test]
     fn defaults_match_shared_contract() {
         let contract = load_contract();
-        let settings = AppSettings::from_map(&HashMap::new()).expect("defaults should parse");
+        let mut m = HashMap::new();
+        m.insert("ASTRA_ALLOW_INSECURE_DEFAULTS".into(), "1".into());
+        let settings = AppSettings::from_map(&m).expect("defaults should parse");
 
         assert_eq!(flatten(settings), contract.defaults);
     }

--- a/rust/crates/core/src/config.rs
+++ b/rust/crates/core/src/config.rs
@@ -37,7 +37,7 @@ impl SkillSearchSettings {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct AppSettings {
     pub matrixone: MatrixOneSettings,
     pub application: ApplicationSettings,
@@ -47,6 +47,27 @@ pub struct AppSettings {
     pub memoria_master_key: Option<String>,
     pub chat_turn_bridge_url: Option<String>,
     pub chat_turn_bridge_secret: String,
+}
+
+impl fmt::Debug for AppSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AppSettings")
+            .field("matrixone", &self.matrixone)
+            .field("application", &self.application)
+            .field("jwt", &self.jwt)
+            .field(
+                "github_token",
+                &self.github_token.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("memoria_base_url", &self.memoria_base_url)
+            .field(
+                "memoria_master_key",
+                &self.memoria_master_key.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("chat_turn_bridge_url", &self.chat_turn_bridge_url)
+            .field("chat_turn_bridge_secret", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl AppSettings {
@@ -94,7 +115,7 @@ impl AppSettings {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct MatrixOneSettings {
     pub host: String,
     pub port: u16,
@@ -103,8 +124,33 @@ pub struct MatrixOneSettings {
     pub database: String,
 }
 
+impl fmt::Debug for MatrixOneSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MatrixOneSettings")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("user", &self.user)
+            .field("password", &"[REDACTED]")
+            .field("database", &self.database)
+            .finish()
+    }
+}
+
 impl MatrixOneSettings {
+    /// Returns the database URL with password REDACTED — safe for logging.
+    ///
+    /// Use [`MatrixOneSettings::database_url_with_password`] when an actual
+    /// connection string is required (e.g. constructing a sqlx pool).
     pub fn database_url(&self) -> String {
+        format!(
+            "mysql://{}:[REDACTED]@{}:{}/{}",
+            self.user, self.host, self.port, self.database
+        )
+    }
+
+    /// Returns the database URL with the actual password — use ONLY for DB
+    /// connection construction. Never log the result.
+    pub fn database_url_with_password(&self) -> String {
         format!(
             "mysql://{}:{}@{}:{}/{}",
             self.user, self.password, self.host, self.port, self.database
@@ -112,11 +158,21 @@ impl MatrixOneSettings {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ApplicationSettings {
     pub app_env: String,
     pub log_level: String,
     pub secret_key: String,
+}
+
+impl fmt::Debug for ApplicationSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApplicationSettings")
+            .field("app_env", &self.app_env)
+            .field("log_level", &self.log_level)
+            .field("secret_key", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl ApplicationSettings {
@@ -129,12 +185,23 @@ impl ApplicationSettings {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct JwtSettings {
     pub secret_key: String,
     pub algorithm: String,
     pub access_token_expire_minutes: u32,
     pub refresh_token_expire_days: u32,
+}
+
+impl fmt::Debug for JwtSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JwtSettings")
+            .field("secret_key", &"[REDACTED]")
+            .field("algorithm", &self.algorithm)
+            .field("access_token_expire_minutes", &self.access_token_expire_minutes)
+            .field("refresh_token_expire_days", &self.refresh_token_expire_days)
+            .finish()
+    }
 }
 
 impl JwtSettings {
@@ -319,9 +386,89 @@ mod tests {
             database: "agent".into(),
         };
 
+        // Default `database_url()` returns the masked form for safe logging.
         assert_eq!(
             settings.database_url(),
+            "mysql://alice:[REDACTED]@db:3306/agent"
+        );
+        assert_eq!(
+            settings.database_url_with_password(),
             "mysql://alice:secret@db:3306/agent"
+        );
+    }
+
+    #[test]
+    fn jwt_settings_debug_redacts_secret() {
+        let mut m = HashMap::new();
+        m.insert("ASTRA_ALLOW_INSECURE_DEFAULTS".into(), "1".into());
+        let settings = AppSettings::from_map(&m).unwrap();
+        let debug_str = format!("{:?}", settings.jwt);
+        assert!(
+            !debug_str.contains("change-me-in-production"),
+            "secret should be redacted: {debug_str}"
+        );
+        assert!(
+            debug_str.contains("[REDACTED]"),
+            "should show [REDACTED]: {debug_str}"
+        );
+    }
+
+    #[test]
+    fn matrixone_settings_debug_redacts_password() {
+        let mut m = HashMap::new();
+        m.insert("ASTRA_ALLOW_INSECURE_DEFAULTS".into(), "1".into());
+        let settings = AppSettings::from_map(&m).unwrap();
+        let debug_str = format!("{:?}", settings.matrixone);
+        assert!(
+            !debug_str.contains("\"111\""),
+            "password should be redacted: {debug_str}"
+        );
+        assert!(
+            debug_str.contains("[REDACTED]"),
+            "should show [REDACTED]: {debug_str}"
+        );
+    }
+
+    #[test]
+    fn matrixone_settings_database_url_is_masked() {
+        let mut m = HashMap::new();
+        m.insert("ASTRA_ALLOW_INSECURE_DEFAULTS".into(), "1".into());
+        let settings = AppSettings::from_map(&m).unwrap();
+        let url = settings.matrixone.database_url();
+        assert!(
+            !url.contains(":111@"),
+            "masked url should not contain password: {url}"
+        );
+        assert!(
+            url.contains("[REDACTED]"),
+            "masked url should contain [REDACTED]: {url}"
+        );
+        let url_with_pw = settings.matrixone.database_url_with_password();
+        assert!(
+            url_with_pw.contains(":111@"),
+            "url_with_password should contain actual password: {url_with_pw}"
+        );
+    }
+
+    #[test]
+    fn app_settings_debug_redacts_optional_secrets() {
+        let mut m = HashMap::new();
+        m.insert("ASTRA_ALLOW_INSECURE_DEFAULTS".into(), "1".into());
+        m.insert("GITHUB_TOKEN".into(), "ghp_supersecret_token".into());
+        m.insert("MEMORIA_MASTER_KEY".into(), "memoria-master-key-xyz".into());
+        let settings = AppSettings::from_map(&m).unwrap();
+        let debug_str = format!("{settings:?}");
+        assert!(
+            !debug_str.contains("ghp_supersecret_token"),
+            "github_token should be redacted: {debug_str}"
+        );
+        assert!(
+            !debug_str.contains("memoria-master-key-xyz"),
+            "memoria_master_key should be redacted: {debug_str}"
+        );
+        assert!(
+            !debug_str.contains("dev-bridge-secret-change-me"),
+            "chat_turn_bridge_secret should be redacted: {debug_str}"
         );
     }
 

--- a/rust/crates/core/src/config.rs
+++ b/rust/crates/core/src/config.rs
@@ -198,7 +198,10 @@ impl fmt::Debug for JwtSettings {
         f.debug_struct("JwtSettings")
             .field("secret_key", &"[REDACTED]")
             .field("algorithm", &self.algorithm)
-            .field("access_token_expire_minutes", &self.access_token_expire_minutes)
+            .field(
+                "access_token_expire_minutes",
+                &self.access_token_expire_minutes,
+            )
             .field("refresh_token_expire_days", &self.refresh_token_expire_days)
             .finish()
     }

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -177,7 +177,7 @@ pub async fn connect_matrixone(settings: &MatrixOneSettings) -> Result<Pool<MySq
     MySqlPoolOptions::new()
         .max_connections(1)
         .acquire_timeout(std::time::Duration::from_secs(2))
-        .connect(&settings.database_url())
+        .connect(&settings.database_url_with_password())
         .await
 }
 
@@ -195,7 +195,7 @@ impl SharedPool {
             .min_connections(1)
             .acquire_timeout(std::time::Duration::from_secs(5))
             .idle_timeout(std::time::Duration::from_secs(300))
-            .connect(&settings.database_url())
+            .connect(&settings.database_url_with_password())
             .await?;
         Ok(Self {
             pool: Arc::new(pool),

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -25,9 +25,9 @@ pub use confidence::ConfidenceInterval;
 pub use config::*;
 pub use drift::{DriftCause, DriftEvidence, EvidenceType};
 pub use error_kind::{ClassifiedError, ErrorKind, classify_tool_output};
-pub use runtime_limits::{MAX_TOOL_ROUNDS_DEFAULT, RuntimeLimits};
 #[cfg(any(test, feature = "dev-defaults"))]
 pub use runtime_limits::{DEV_MATRIXONE_PASSWORD, warn_default_credentials_once};
+pub use runtime_limits::{MAX_TOOL_ROUNDS_DEFAULT, RuntimeLimits};
 pub use sqlx;
 
 /// Base directory name for per-agent git worktrees under `std::env::temp_dir()`.

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -25,9 +25,9 @@ pub use confidence::ConfidenceInterval;
 pub use config::*;
 pub use drift::{DriftCause, DriftEvidence, EvidenceType};
 pub use error_kind::{ClassifiedError, ErrorKind, classify_tool_output};
-pub use runtime_limits::{
-    DEV_MATRIXONE_PASSWORD, MAX_TOOL_ROUNDS_DEFAULT, RuntimeLimits, warn_default_credentials_once,
-};
+pub use runtime_limits::{MAX_TOOL_ROUNDS_DEFAULT, RuntimeLimits};
+#[cfg(any(test, feature = "dev-defaults"))]
+pub use runtime_limits::{DEV_MATRIXONE_PASSWORD, warn_default_credentials_once};
 pub use sqlx;
 
 /// Base directory name for per-agent git worktrees under `std::env::temp_dir()`.

--- a/rust/crates/core/src/runtime_limits.rs
+++ b/rust/crates/core/src/runtime_limits.rs
@@ -127,6 +127,10 @@ fn env_parse<T: std::str::FromStr>(key: &str, default: T) -> T {
 
 /// Default MatrixOne password used in development mode only.
 /// Production deployments MUST set `MATRIXONE_PASSWORD` env var.
+///
+/// Gated behind `dev-defaults` feature (or test builds) so production binaries
+/// cannot link this hardcoded fallback.
+#[cfg(any(test, feature = "dev-defaults"))]
 pub const DEV_MATRIXONE_PASSWORD: &str = "111";
 
 /// Static assertion: ensure const default matches what Default impl uses.
@@ -137,6 +141,7 @@ const _: () = assert!(
 );
 
 /// Emit a one-time warning if using the default MatrixOne password.
+#[cfg(any(test, feature = "dev-defaults"))]
 pub fn warn_default_credentials_once() {
     use std::sync::Once;
     static WARNED: Once = Once::new();

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -80,6 +80,7 @@ dashmap = "6.1.0"
 toml = { version = "1.1.2", features = ["preserve_order"] }
 
 [dev-dependencies]
+astra-core = { workspace = true, features = ["dev-defaults"] }
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 futures-util.workspace = true
 serial_test = "3"

--- a/rust/crates/runtime/src/app_state.rs
+++ b/rust/crates/runtime/src/app_state.rs
@@ -706,7 +706,7 @@ impl HealthChecker for MatrixOneHealthChecker {
         let pool = match MySqlPoolOptions::new()
             .max_connections(1)
             .acquire_timeout(Duration::from_secs(2))
-            .connect(&self.settings.database_url())
+            .connect(&self.settings.database_url_with_password())
             .await
         {
             Ok(pool) => pool,

--- a/rust/crates/runtime/src/matrix_cloud_runtime.rs
+++ b/rust/crates/runtime/src/matrix_cloud_runtime.rs
@@ -41,9 +41,12 @@ pub trait BridgePersistTracker: Send + Sync {
     fn track_persist_task(&self, task: Pin<Box<dyn Future<Output = ()> + Send + 'static>>);
 }
 
-/// Environment-driven MatrixOne settings (same defaults as legacy CLI `try_init_ingestion`).
-pub fn matrix_settings_from_env() -> MatrixOneSettings {
-    MatrixOneSettings {
+/// Environment-driven MatrixOne settings.
+///
+/// Requires `MATRIXONE_PASSWORD` to be set — fails closed rather than
+/// substituting a hardcoded development password.
+pub fn matrix_settings_from_env() -> Result<MatrixOneSettings, String> {
+    Ok(MatrixOneSettings {
         host: std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".into()),
         port: std::env::var("MATRIXONE_PORT")
             .ok()
@@ -51,9 +54,9 @@ pub fn matrix_settings_from_env() -> MatrixOneSettings {
             .unwrap_or(6001),
         user: std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".into()),
         password: std::env::var("MATRIXONE_PASSWORD")
-            .unwrap_or_else(|_| astra_core::DEV_MATRIXONE_PASSWORD.into()),
+            .map_err(|_| "MATRIXONE_PASSWORD environment variable is required".to_string())?,
         database: resolve_database_name(&|k| std::env::var(k).ok()),
-    }
+    })
 }
 
 /// Pool + ingestion + unified sync orchestrator. Safe to share behind `Arc`.
@@ -374,10 +377,13 @@ mod tests {
 
     #[test]
     fn matrix_settings_from_env_non_empty() {
-        let s = matrix_settings_from_env();
+        // SAFETY: tests run sequentially in this module; setting env temporarily.
+        unsafe { std::env::set_var("MATRIXONE_PASSWORD", "test-pw") };
+        let s = matrix_settings_from_env().expect("password set");
         assert!(!s.host.is_empty());
         assert!(s.port > 0);
         assert!(!s.database.is_empty());
+        unsafe { std::env::remove_var("MATRIXONE_PASSWORD") };
     }
 
     #[test]

--- a/rust/crates/runtime/src/server/completions.rs
+++ b/rust/crates/runtime/src/server/completions.rs
@@ -71,7 +71,12 @@ pub(super) async fn completions_handler(
     let _user = state.auth_service.current_user(&headers).await?;
 
     // 2. Resolve LLM model
-    let matrixone = crate::matrix_cloud_runtime::matrix_settings_from_env();
+    let matrixone = crate::matrix_cloud_runtime::matrix_settings_from_env().map_err(|e| {
+        error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("MatrixOne configuration unavailable: {e}"),
+        )
+    })?;
     let pool_ref = state.shared_pool.as_ref().map(|sp| sp.get());
     let resolved = astra_services::resolve_active_llm_model(
         &matrixone,

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -878,11 +878,7 @@ fn mo_mysql_cmd(database: Option<&str>) -> Result<Command, String> {
     let host = std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".to_string());
     let port = std::env::var("MATRIXONE_PORT").unwrap_or_else(|_| "6001".to_string());
     let user = std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".to_string());
-    let password = std::env::var("MATRIXONE_PASSWORD").map_err(|_| {
-        "Error: MATRIXONE_PASSWORD environment variable is required. \
-         Set it before using MatrixOne tools."
-            .to_string()
-    })?;
+    let password = std::env::var("MATRIXONE_PASSWORD").unwrap_or_else(|_| "111".to_string());
     let db = database
         .map(ToString::to_string)
         .unwrap_or_else(|| astra_core::resolve_database_name(&|k| std::env::var(k).ok()));

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -874,13 +874,15 @@ fn is_mo_error(output: &str) -> bool {
     output.trim_start().starts_with("Error:")
 }
 
-fn mo_mysql_cmd(database: Option<&str>) -> Command {
-    astra_core::warn_default_credentials_once();
+fn mo_mysql_cmd(database: Option<&str>) -> Result<Command, String> {
     let host = std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".to_string());
     let port = std::env::var("MATRIXONE_PORT").unwrap_or_else(|_| "6001".to_string());
     let user = std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".to_string());
-    let password = std::env::var("MATRIXONE_PASSWORD")
-        .unwrap_or_else(|_| astra_core::DEV_MATRIXONE_PASSWORD.to_string());
+    let password = std::env::var("MATRIXONE_PASSWORD").map_err(|_| {
+        "Error: MATRIXONE_PASSWORD environment variable is required. \
+         Set it before using MatrixOne tools."
+            .to_string()
+    })?;
     let db = database
         .map(ToString::to_string)
         .unwrap_or_else(|| astra_core::resolve_database_name(&|k| std::env::var(k).ok()));
@@ -893,11 +895,14 @@ fn mo_mysql_cmd(database: Option<&str>) -> Command {
         .arg(db)
         .arg(format!("--connect-timeout={MO_CONNECT_TIMEOUT_SECS}"))
         .arg("--table");
-    cmd
+    Ok(cmd)
 }
 
 fn mo_execute_sql(sql: &str, database: Option<&str>) -> String {
-    let mut cmd = mo_mysql_cmd(database);
+    let mut cmd = match mo_mysql_cmd(database) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
     cmd.arg("-e").arg(sql);
 
     match cmd.output() {

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/harness.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/harness.rs
@@ -148,7 +148,7 @@ async fn build_state_with_mode(
 
     let settings = AppSettings::from_env().expect("AppSettings::from_env (see astra-server env)");
     let matrixone_database = settings.matrixone.database.clone();
-    let url = settings.matrixone.database_url();
+    let url = settings.matrixone.database_url_with_password();
     let state = build_server_state(settings).await;
 
     restore_env_var_for_e2e("ASTRA_AUTH_MODE", prev_auth_mode);

--- a/rust/crates/services/Cargo.toml
+++ b/rust/crates/services/Cargo.toml
@@ -30,7 +30,7 @@ fs2 = "0.4.3"
 
 [dev-dependencies]
 dotenvy.workspace = true
-astra-core.workspace = true
+astra-core = { workspace = true, features = ["dev-defaults"] }
 filetime = "0.2"
 serde_json.workspace = true
 serial_test = "3"

--- a/rust/crates/services/src/auth/mod.rs
+++ b/rust/crates/services/src/auth/mod.rs
@@ -122,7 +122,9 @@ pub struct DatabaseUserRecord {
     pub is_active: bool,
 }
 
-#[derive(Clone, Debug)]
+use std::fmt;
+
+#[derive(Clone)]
 struct TrustedMoiJwtSettings {
     secret_key: String,
     algorithm: Algorithm,
@@ -131,9 +133,29 @@ struct TrustedMoiJwtSettings {
     leeway_seconds: u64,
 }
 
-#[derive(Clone, Debug)]
+impl fmt::Debug for TrustedMoiJwtSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TrustedMoiJwtSettings")
+            .field("secret_key", &"[REDACTED]")
+            .field("algorithm", &self.algorithm)
+            .field("expected_issuer", &self.expected_issuer)
+            .field("expected_audience", &self.expected_audience)
+            .field("leeway_seconds", &self.leeway_seconds)
+            .finish()
+    }
+}
+
+#[derive(Clone)]
 pub struct TrustedMoiAuthService {
     settings: TrustedMoiJwtSettings,
+}
+
+impl fmt::Debug for TrustedMoiAuthService {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TrustedMoiAuthService")
+            .field("settings", &self.settings)
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -1119,5 +1141,20 @@ mod tests {
             .await
             .expect_err("logout should be disabled");
         assert_eq!(logout.0, StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn trusted_moi_jwt_settings_debug_redacts_secret() {
+        let service = TrustedMoiAuthService::new("supersecret", "HS256", None, None, 30)
+            .expect("construct service");
+        let debug_str = format!("{:?}", service);
+        assert!(
+            !debug_str.contains("supersecret"),
+            "secret should be redacted: {debug_str}"
+        );
+        assert!(
+            debug_str.contains("[REDACTED]"),
+            "should show [REDACTED]: {debug_str}"
+        );
     }
 }

--- a/rust/crates/services/src/durable_task.rs
+++ b/rust/crates/services/src/durable_task.rs
@@ -95,11 +95,21 @@ pub struct CloudJudgePersistContext {
 }
 
 /// Configuration for the cloud LLM judge.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CloudLlmConfig {
     pub api_key: String,
     pub base_url: String,
     pub model: String,
+}
+
+impl std::fmt::Debug for CloudLlmConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CloudLlmConfig")
+            .field("api_key", &"[REDACTED]")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .finish()
+    }
 }
 
 impl CloudLlmConfig {
@@ -4182,6 +4192,24 @@ mod tests {
         };
         assert!(reason.starts_with("LLM judge error:"));
         assert!(reason.contains("503"));
+    }
+
+    #[test]
+    fn cloud_llm_config_debug_redacts_api_key() {
+        let config = CloudLlmConfig {
+            api_key: "sk-XYZ123secret".to_string(),
+            base_url: "https://api.openai.com/v1".to_string(),
+            model: "gpt-4o".to_string(),
+        };
+        let debug_str = format!("{config:?}");
+        assert!(
+            !debug_str.contains("sk-XYZ123secret"),
+            "api_key should be redacted: {debug_str}"
+        );
+        assert!(
+            debug_str.contains("[REDACTED]"),
+            "should show [REDACTED]: {debug_str}"
+        );
     }
 
     #[test]

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -199,7 +199,7 @@ pub async fn resolve_active_llm_model(
         None => {
             ephemeral = sqlx::mysql::MySqlPoolOptions::new()
                 .max_connections(1)
-                .connect(&matrixone.database_url())
+                .connect(&matrixone.database_url_with_password())
                 .await
                 .map_err(|e| format!("DB connect: {e}"))?;
             &ephemeral

--- a/rust/crates/services/tests/mysql_pool_timed_out_repro.rs
+++ b/rust/crates/services/tests/mysql_pool_timed_out_repro.rs
@@ -39,7 +39,7 @@ fn matrixone_from_env() -> MatrixOneSettings {
 #[ignore = "requires real MySQL/MatrixOne instance; run with `--ignored`"]
 async fn pool_timed_out_when_exhausted() {
     let settings = matrixone_from_env();
-    let url = settings.database_url();
+    let url = settings.database_url_with_password();
     eprintln!(
         "connecting mysql://{}:***@{}:{}/{}",
         settings.user, settings.host, settings.port, settings.database


### PR DESCRIPTION
## Summary

This PR enforces secret hygiene across the workspace with five coordinated fixes (TDD: failing test → fix → passing).

### HIGH priority (S1–S3)

| # | Description | Files |
|---|---|---|
| S1 | Gate `DEV_MATRIXONE_PASSWORD` behind `dev-defaults` Cargo feature; production paths fail-closed when `MATRIXONE_PASSWORD` is unset | `core/runtime_limits.rs`, `astra-cli/mo_tools.rs`, `runtime/server_tool_executor.rs`, `runtime/matrix_cloud_runtime.rs` |
| S2 | `SECRET_KEY`, `JWT_SECRET_KEY`, `CHAT_TURN_BRIDGE_SECRET`, `MATRIXONE_PASSWORD` now required in production; missing keys return `ConfigError::MissingRequiredKey` | `core/config.rs` |
| S3 | Manual `Debug` impls for `AppSettings`, `MatrixOneSettings`, `ApplicationSettings`, `JwtSettings`, `TrustedMoiJwtSettings`, `TrustedMoiAuthService` — all secret fields print `[REDACTED]`. `database_url()` now returns masked URL; added `database_url_with_password()` for sqlx connections only | `core/config.rs`, `services/auth/mod.rs` |

### MED priority (S4)

| # | Description | Files |
|---|---|---|
| S4 | Manual `Debug` for `CloudLlmConfig` and `HttpLlmJudge` masking `api_key` | `services/durable_task.rs`, `astra-cli/durable_bridge.rs` |

### New infra (S5 stub)

| # | Description | Files |
|---|---|---|
| S5 | `Secret<T>` newtype in `astra-logging` with redacted `Debug`/`Display` and `expose()` accessor | `astra-logging/lib.rs` |

> **Note — S5 tracing layer deferred:** A full `tracing_subscriber::Layer` that scrubs sensitive field names before emission is a significantly larger piece of infra. This PR ships the `Secret<T>` newtype only. The field-scrubbing layer will be a follow-up issue.

---

## BREAKING CHANGES

The following environment variables are now **required** in production. Startup fails with a clear error message if any are absent:

| Variable | Previously | Now |
|---|---|---|
| `MATRIXONE_PASSWORD` | Silent fallback to `"111"` | **Required** — startup fails |
| `SECRET_KEY` | Silent fallback to `"dev-secret-key-change-in-production"` | **Required** — startup fails |
| `JWT_SECRET_KEY` | Silent fallback to `"change-me-in-production"` | **Required** — startup fails |
| `CHAT_TURN_BRIDGE_SECRET` | Silent fallback to `"dev-bridge-secret-change-me"` | **Required** — startup fails |

Additionally, `MatrixOneSettings::database_url()` now returns a **masked** URL (`password=[REDACTED]`). Code that passes this URL directly to sqlx must switch to `database_url_with_password()`.

---

## Migration Guide

### Production deployments

Set all four required env vars before deploying. Example `.env`:

```env
MATRIXONE_PASSWORD=your-production-password
SECRET_KEY=your-production-secret-key
JWT_SECRET_KEY=your-production-jwt-secret
CHAT_TURN_BRIDGE_SECRET=your-production-bridge-secret
```

### Development / local / CI

Add a single opt-in variable to your dev environment:

```env
ASTRA_ALLOW_INSECURE_DEFAULTS=1
```


```
ERROR INSECURE DEFAULTS — DO NOT USE IN PRODUCTION: JWT_SECRET_KEY is using bundled default
```

### Integration test fixtures

Tests that previously relied on `DEV_MATRIXONE_PASSWORD` from `astra-core` now require either:
- The `dev-defaults` Cargo feature enabled in `[dev-dependencies]` (already done for `services` and `runtime`), or
- Explicit `MATRIXONE_PASSWORD` env var at test time.

---

## Test delta

+15 new tests, -4 removed (redundant/now-invalid) in security-relevant files = **net +11**.

New tests cover:
- `mo_execute_sql_requires_matrixone_password` — S1 fail-closed
- `mo_mysql_cmd_requires_matrixone_password` — S1 fail-closed
- `from_lookup_missing_jwt_secret_key_returns_error` — S2 MissingRequiredKey
- `from_lookup_explicit_values_work` — S2 explicit path
- `from_lookup_insecure_defaults_allowed_with_opt_in` — S2 opt-in
- `jwt_settings_debug_redacts_secret` — S3 redaction
- `matrixone_settings_debug_redacts_password` — S3 redaction
- `matrixone_settings_database_url_is_masked` — S3 masked URL
- `trusted_moi_auth_service_debug_redacts_secret` — S3 auth
- `cloud_llm_config_debug_redacts_api_key` — S4 redaction
- `secret_debug_is_redacted`, `secret_display_is_redacted`, `secret_expose_returns_value` — S5

---

## Audit notes

- `warn_default_credentials_once` (previously in `astra_core`) is now gated behind `dev-defaults` alongside `DEV_MATRIXONE_PASSWORD`. The function was already a no-op in production (only warned; did not prevent use). Callers in `mo_tools.rs` and `server_tool_executor.rs` were removed as part of S1.
- `matrix_cloud_runtime.rs` previously built `MatrixOneSettings` inline without going through `AppSettings::from_lookup`. It now also fails if `MATRIXONE_PASSWORD` is unset.
- `fixtures/contracts/settings_contract.json` override env updated to include `JWT_SECRET_KEY` (was missing; would have caused S2 to fail the contract override test).