### PR TITLE
fix(observability): LLM error + journal + tool content redaction

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "serial_test",
  "sha2",
  "sqlx",
  "tempfile",

--- a/rust/crates/astra-cli/src/edge_tools/schemas.rs
+++ b/rust/crates/astra-cli/src/edge_tools/schemas.rs
@@ -1557,10 +1557,6 @@ pub fn all_tool_schemas() -> Vec<Value> {
                         "pattern": {
                             "type": "string",
                             "description": "Regex pattern for search (case-insensitive)"
-                        },
-                        "show_values": {
-                            "type": "boolean",
-                            "description": "Show full values in list/search (default: false, shows char count instead)"
                         }
                     },
                     "required": ["operation"]

--- a/rust/crates/astra-tools/src/env_tools.rs
+++ b/rust/crates/astra-tools/src/env_tools.rs
@@ -89,11 +89,11 @@ pub fn env_tool(args: &Value) -> String {
 
 /// List all environment variables (values masked by default for security).
 fn env_list(args: &Value) -> String {
-    let show_values = args
-        .get("show_values")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-
+    // The `show_values` parameter is intentionally not honored on the LLM
+    // tool path: a malicious / drifted model must not be able to exfiltrate
+    // env values by passing show_values=true. Direct CLI callers should use
+    // the CLI surface (which can still print raw values when appropriate).
+    let _ = args;
     let vars = overlay_all();
 
     let entries: Vec<Value> = vars
@@ -101,8 +101,6 @@ fn env_list(args: &Value) -> String {
         .map(|(name, value)| {
             let display_value = if is_sensitive_var(&name) {
                 format!("***MASKED*** ({} chars)", value.len())
-            } else if show_values {
-                value
             } else {
                 format!("({} chars)", value.len())
             };
@@ -221,10 +219,7 @@ fn env_search(args: &Value) -> String {
         Some(p) => p,
         None => return json!({ "error": "Missing required parameter: pattern" }).to_string(),
     };
-    let show_values = args
-        .get("show_values")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    // `show_values` intentionally not honored — see env_list().
 
     // ReDoS protection: limit pattern length
     if pattern.len() > 500 {
@@ -243,8 +238,6 @@ fn env_search(args: &Value) -> String {
         if regex.is_match(&name) || regex.is_match(&value) {
             let display_value = if is_sensitive_var(&name) {
                 format!("***MASKED*** ({} chars)", value.len())
-            } else if show_values {
-                value
             } else {
                 format!("({} chars)", value.len())
             };
@@ -309,4 +302,40 @@ pub fn is_sensitive_var(name: &str) -> bool {
         || upper.starts_with("STRIPE_")
         || upper.starts_with("SENDGRID")
         || upper.starts_with("TWILIO")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn env_list_ignores_show_values_arg_from_llm() {
+        overlay_set("R5_TEST_NONSENSITIVE", "abcdefgh");
+        let out = env_list(&json!({ "show_values": true }));
+        assert!(
+            !out.contains("\"abcdefgh\""),
+            "env_list leaked raw value despite show_values=true: {out}"
+        );
+        assert!(
+            out.contains("(8 chars)"),
+            "expected char-count format in output: {out}"
+        );
+        overlay_remove("R5_TEST_NONSENSITIVE");
+    }
+
+    #[test]
+    fn env_search_ignores_show_values_arg_from_llm() {
+        overlay_set("R5_TEST_SEARCHABLE", "matchvalue");
+        let out = env_search(&json!({
+            "pattern": "R5_TEST_SEARCHABLE",
+            "show_values": true,
+        }));
+        assert!(
+            !out.contains("\"matchvalue\""),
+            "env_search leaked raw value despite show_values=true: {out}"
+        );
+        assert!(out.contains("(10 chars)"));
+        overlay_remove("R5_TEST_SEARCHABLE");
+    }
 }

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -1764,10 +1764,6 @@ pub fn all_tool_schemas() -> Vec<Value> {
                         "pattern": {
                             "type": "string",
                             "description": "Regex pattern for search (case-insensitive)"
-                        },
-                        "show_values": {
-                            "type": "boolean",
-                            "description": "Show full values in list/search (default: false, shows char count instead)"
                         }
                     },
                     "required": ["operation"]
@@ -2034,6 +2030,28 @@ mod tests {
                 "`{name}` is in DEFAULT_EXECUTOR_TOOL_NAMES but missing from SERVER_EXECUTOR_TOOL_NAMES"
             );
         }
+    }
+
+    #[test]
+    fn env_tool_schema_does_not_advertise_show_values() {
+        let schemas = all_tool_schemas();
+        let env_schema = schemas
+            .iter()
+            .find(|s| {
+                s.get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(Value::as_str)
+                    == Some("env")
+            })
+            .expect("env tool schema present");
+        let props = env_schema
+            .pointer("/function/parameters/properties")
+            .and_then(Value::as_object)
+            .expect("env parameters.properties");
+        assert!(
+            !props.contains_key("show_values"),
+            "env tool schema must not expose show_values to the LLM"
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/bridge_llm_stream.rs
+++ b/rust/crates/runtime/src/turn/bridge_llm_stream.rs
@@ -506,7 +506,10 @@ pub(crate) async fn call_llm_stream(
             .and_then(|v| v.to_str().ok())
             .and_then(parse_retry_after_ms);
 
-        let text = response.text().await.unwrap_or_default();
+        let text = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("<body read error: {e}>"));
         last_err = format!("LLM error {status}: {text}");
 
         // Record rate-limit errors to cooldown tracker

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -43,10 +43,10 @@ pub(crate) fn redact_provider_secrets(s: &str) -> String {
     while !rest.is_empty() {
         let mut best: Option<(usize, &str)> = None;
         for p in &prefixes {
-            if let Some(idx) = rest.find(p) {
-                if best.map(|(b, _)| idx < b).unwrap_or(true) {
-                    best = Some((idx, p));
-                }
+            if let Some(idx) = rest.find(p)
+                && best.map(|(b, _)| idx < b).unwrap_or(true)
+            {
+                best = Some((idx, p));
             }
         }
         match best {

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -27,6 +27,46 @@ use crate::bridge::rate_limit_cooldown::{
 use crate::output_style::current_output_style;
 use crate::prompts;
 
+/// Redact common provider secret patterns from a string before logging.
+///
+/// Replaces the value following well-known prefixes (`sk-`, `Bearer `, `key-`)
+/// with `[REDACTED]`. The scan stops at the first whitespace, quote, or comma,
+/// which is sufficient for the JSON / plaintext error bodies that providers
+/// commonly echo authorization material into.
+pub(crate) fn redact_provider_secrets(s: &str) -> String {
+    fn boundary(c: char) -> bool {
+        c.is_whitespace() || c == '"' || c == '\'' || c == ',' || c == ')' || c == '}'
+    }
+    let prefixes = ["sk-", "Bearer ", "key-"];
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while !rest.is_empty() {
+        let mut best: Option<(usize, &str)> = None;
+        for p in &prefixes {
+            if let Some(idx) = rest.find(p) {
+                if best.map(|(b, _)| idx < b).unwrap_or(true) {
+                    best = Some((idx, p));
+                }
+            }
+        }
+        match best {
+            Some((idx, p)) => {
+                out.push_str(&rest[..idx]);
+                out.push_str(p);
+                out.push_str("[REDACTED]");
+                let tail = &rest[idx + p.len()..];
+                let cut = tail.find(boundary).unwrap_or(tail.len());
+                rest = &tail[cut..];
+            }
+            None => {
+                out.push_str(rest);
+                break;
+            }
+        }
+    }
+    out
+}
+
 /// Maximum retries for transient LLM errors (429, 5xx, network).
 pub(crate) const LLM_MAX_RETRIES: u32 = 3;
 /// Base delay between retries (doubles each attempt: 1s, 2s, 4s).
@@ -813,8 +853,35 @@ pub(crate) async fn call_llm_and_collect_with_request_overrides(
             .and_then(|v| v.to_str().ok())
             .and_then(parse_retry_after_ms);
 
-        let text = response.text().await.unwrap_or_default();
-        last_err = format!("LLM error {status}: {text}");
+        let text = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("<body read error: {e}>"));
+
+        // Auth errors: redact the body in logs and return a generic message
+        // so provider-echoed secrets cannot leak through error propagation.
+        if status == 401 || status == 403 {
+            let truncated = &text[..text.len().min(80)];
+            let redacted = redact_provider_secrets(truncated);
+            tracing::warn!(
+                target: "astra_runtime::llm_client",
+                "LLM auth error ({status}) on {model_key}: {redacted}",
+            );
+            return Err(astra_core::ClassifiedError::new(
+                astra_core::ErrorKind::Auth,
+                "LLM provider authentication failed".to_string(),
+            ));
+        }
+
+        // For other 4xx errors, suppress the raw response body to avoid
+        // leaking secrets that providers may echo back. Retain body for 5xx
+        // (helpful for diagnosing transient backend failures) and the 400
+        // context-window check below (which still needs to inspect text).
+        last_err = if (400..500).contains(&status) {
+            format!("LLM request rejected: {status}")
+        } else {
+            format!("LLM error {status}: {text}")
+        };
 
         // Record rate-limit errors to cooldown tracker
         if is_rate_limit_status(status) {
@@ -875,15 +942,7 @@ pub(crate) async fn call_llm_and_collect_with_request_overrides(
         if status == 400 && is_context_window_error(&text.to_lowercase()) {
             return Err(astra_core::ClassifiedError::new(
                 astra_core::ErrorKind::ContextWindow,
-                last_err,
-            ));
-        }
-
-        // Auth errors
-        if status == 401 || status == 403 {
-            return Err(astra_core::ClassifiedError::new(
-                astra_core::ErrorKind::Auth,
-                last_err,
+                format!("LLM error {status}: {text}"),
             ));
         }
 
@@ -2768,6 +2827,12 @@ mod tests {
         .await
         .expect_err("should fail with auth");
         assert_eq!(err.kind, astra_core::ErrorKind::Auth);
+        assert!(
+            !err.message.contains("Unauthorized"),
+            "auth error message must not echo provider body, got: {}",
+            err.message
+        );
+        assert!(err.message.contains("authentication failed"));
         unsafe { std::env::remove_var("MO_STREAM_IDLE_TIMEOUT_MS") };
     }
 
@@ -3196,5 +3261,43 @@ mod tests {
         let (r, c) = extract_think_tags(text).unwrap();
         assert_eq!(r, "step 1");
         assert_eq!(c, "answer");
+    }
+
+    #[test]
+    fn redact_provider_secrets_strips_known_prefixes() {
+        let input = "sk-abc12345 and Bearer tok_xyz plus key-deadbeef end";
+        let out = redact_provider_secrets(input);
+        assert!(out.contains("[REDACTED]"), "missing redacted marker: {out}");
+        assert!(!out.contains("abc12345"), "leaked sk- secret: {out}");
+        assert!(!out.contains("tok_xyz"), "leaked bearer secret: {out}");
+        assert!(!out.contains("deadbeef"), "leaked key- secret: {out}");
+        assert!(out.contains("end"), "trailing text dropped: {out}");
+    }
+
+    #[test]
+    fn redact_provider_secrets_leaves_clean_text() {
+        let input = "Internal server error: upstream timeout";
+        assert_eq!(redact_provider_secrets(input), input);
+    }
+
+    #[test]
+    fn redact_provider_secrets_handles_quoted_json() {
+        let input = r#"{"error":"invalid api key sk-abcXYZ"}"#;
+        let out = redact_provider_secrets(input);
+        assert!(!out.contains("abcXYZ"), "leaked sk- secret in JSON: {out}");
+        assert!(out.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_provider_secrets_simulates_auth_log_path() {
+        // Simulate what the auth-error path logs: a truncated body containing a key.
+        let body = r#"{"error":{"message":"Incorrect API key sk-abc12345 provided"}}"#;
+        let truncated = &body[..body.len().min(80)];
+        let log_line = format!(
+            "LLM auth error (401): {}",
+            redact_provider_secrets(truncated)
+        );
+        assert!(!log_line.contains("sk-abc12345"));
+        assert!(log_line.contains("[REDACTED]"));
     }
 }

--- a/rust/crates/services/Cargo.toml
+++ b/rust/crates/services/Cargo.toml
@@ -32,6 +32,7 @@ dotenvy.workspace = true
 astra-core.workspace = true
 filetime = "0.2"
 serde_json.workspace = true
+serial_test = "3"
 sqlx.workspace = true
 tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }

--- a/rust/crates/services/src/durable_task.rs
+++ b/rust/crates/services/src/durable_task.rs
@@ -269,6 +269,17 @@ impl CloudLlmJudge {
             let bytes = resp.bytes().await.unwrap_or_default();
             // Truncate upstream error body before it reaches logs.
             let text = String::from_utf8_lossy(&bytes[..bytes.len().min(4096)]);
+            // 401/403: redact provider secrets from logs and return a generic
+            // error message instead of echoing the upstream body.
+            if status.as_u16() == 401 || status.as_u16() == 403 {
+                let truncated = &text[..text.len().min(80)];
+                tracing::debug!(
+                    target: "astra_services::durable_task",
+                    "LLM judge auth error ({status}): {}",
+                    redact_judge_secrets(truncated)
+                );
+                return Err("LLM judge unavailable (auth error)".to_string());
+            }
             return Err(format!(
                 "Cloud LLM API error {status}: {}",
                 &text[..text.len().min(200)]
@@ -1074,11 +1085,24 @@ impl VerificationRunner {
                                 format!("LLM evaluation: {}", truncate(prompt, 200)),
                             ))
                         }
-                        Err(e) => Ok((
-                            false,
-                            format!("LLM judge error: {e}"),
-                            format!("LLM evaluation: {}", truncate(prompt, 200)),
-                        )),
+                        Err(e) => {
+                            // call_cloud_llm already maps 401/403 to a
+                            // redacted "LLM judge unavailable (auth error)"
+                            // message; pass it through cleanly. Other errors
+                            // get the legacy 'LLM judge error:' prefix.
+                            let reason = if e.contains("auth error")
+                                || e.starts_with("LLM judge unavailable")
+                            {
+                                e.clone()
+                            } else {
+                                format!("LLM judge error: {e}")
+                            };
+                            Ok((
+                                false,
+                                reason,
+                                format!("LLM evaluation: {}", truncate(prompt, 200)),
+                            ))
+                        }
                     }
                 } else {
                     // No LLM judge available — skip with informative message
@@ -1314,6 +1338,45 @@ fn truncate(s: &str, max: usize) -> String {
     } else {
         format!("{}…[truncated]", &s[..max])
     }
+}
+
+/// Local copy of `astra_runtime::turn::llm_client::redact_provider_secrets`.
+///
+/// Duplicated here because `services` cannot depend on `runtime`. The two
+/// implementations are intentionally identical and will be consolidated in
+/// a follow-up alongside `feat/secret-hardening`.
+fn redact_judge_secrets(s: &str) -> String {
+    fn boundary(c: char) -> bool {
+        c.is_whitespace() || c == '"' || c == '\'' || c == ',' || c == ')' || c == '}'
+    }
+    let prefixes = ["sk-", "Bearer ", "key-"];
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while !rest.is_empty() {
+        let mut best: Option<(usize, &str)> = None;
+        for p in &prefixes {
+            if let Some(idx) = rest.find(p)
+                && best.map(|(b, _)| idx < b).unwrap_or(true)
+            {
+                best = Some((idx, p));
+            }
+        }
+        match best {
+            Some((idx, p)) => {
+                out.push_str(&rest[..idx]);
+                out.push_str(p);
+                out.push_str("[REDACTED]");
+                let tail = &rest[idx + p.len()..];
+                let cut = tail.find(boundary).unwrap_or(tail.len());
+                rest = &tail[cut..];
+            }
+            None => {
+                out.push_str(rest);
+                break;
+            }
+        }
+    }
+    out
 }
 
 /// Search for a file by its basename (or path suffix) under `root`.
@@ -4033,6 +4096,53 @@ mod tests {
     #[test]
     fn verification_history_row_cap_is_positive() {
         const _: () = assert!(MAX_VERIFICATION_HISTORY_ROWS >= 1000);
+    }
+
+    #[test]
+    fn redact_judge_secrets_replaces_known_prefixes() {
+        let s = "auth failed: sk-abc12345 used Bearer tok_xyz key-pqrs9";
+        let out = redact_judge_secrets(s);
+        assert!(!out.contains("abc12345"));
+        assert!(!out.contains("tok_xyz"));
+        assert!(!out.contains("pqrs9"));
+        assert!(out.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_judge_secrets_passthrough_for_clean_text() {
+        let s = "internal error: timeout";
+        assert_eq!(redact_judge_secrets(s), s);
+    }
+
+    #[test]
+    fn judge_error_reason_drops_auth_prefix_and_secret() {
+        // Simulate the mapping at the judge call site: call_cloud_llm
+        // returns "LLM judge unavailable (auth error)" for 401/403.
+        let upstream_err = "LLM judge unavailable (auth error)".to_string();
+        let reason = if upstream_err.contains("auth error")
+            || upstream_err.starts_with("LLM judge unavailable")
+        {
+            upstream_err.clone()
+        } else {
+            format!("LLM judge error: {upstream_err}")
+        };
+        assert!(!reason.contains("sk-"));
+        assert!(reason.contains("LLM judge unavailable"));
+        assert!(!reason.starts_with("LLM judge error:"));
+    }
+
+    #[test]
+    fn judge_error_reason_keeps_prefix_for_non_auth_errors() {
+        let upstream_err = "Cloud LLM API error 503: backend down".to_string();
+        let reason = if upstream_err.contains("auth error")
+            || upstream_err.starts_with("LLM judge unavailable")
+        {
+            upstream_err.clone()
+        } else {
+            format!("LLM judge error: {upstream_err}")
+        };
+        assert!(reason.starts_with("LLM judge error:"));
+        assert!(reason.contains("503"));
     }
 
     #[test]

--- a/rust/crates/services/src/event_ingestion.rs
+++ b/rust/crates/services/src/event_ingestion.rs
@@ -36,6 +36,11 @@ pub struct IngestionConfig {
     pub channel_capacity: usize,
     /// Max retries per batch on transient errors.
     pub max_retries: u32,
+    /// When true, replace user-content fields (`content`) on outgoing
+    /// IngestionEvents with a privacy marker (`<redacted: len=N sha=...>`)
+    /// instead of the raw text. Default: `false` for backward compat;
+    /// callers that need PII-free cloud ingestion should opt in.
+    pub redact_content: bool,
 }
 
 impl Default for IngestionConfig {
@@ -45,8 +50,24 @@ impl Default for IngestionConfig {
             flush_interval_secs: 5,
             channel_capacity: 200,
             max_retries: 3,
+            redact_content: false,
         }
     }
+}
+
+/// Replace raw user content with a deterministic privacy marker.
+///
+/// The marker has the form `<redacted: len=N sha=HHHHHHHHHHHHHHHH>` where
+/// the suffix is a non-cryptographic 64-bit hash. It is used only for
+/// dedup/debugging when `IngestionConfig.redact_content` is enabled — not as
+/// a security primitive — so [`std::collections::hash_map::DefaultHasher`]
+/// is acceptable.
+pub fn redacted_content_marker(raw: &str) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    raw.hash(&mut h);
+    format!("<redacted: len={} sha={:016x}>", raw.len(), h.finish())
 }
 
 /// A journal event prepared for cloud ingestion.
@@ -119,6 +140,16 @@ impl IngestionEvent {
     /// - `user_id`: the authenticated user (not stored in journal events)
     /// - Generates a unique event_id from session_id + turn + event_type
     pub fn from_journal_event(event: &crate::session_journal::JournalEvent, user_id: &str) -> Self {
+        Self::from_journal_event_with_redact(event, user_id, false)
+    }
+
+    /// Like [`from_journal_event`] but optionally replaces the `content` field
+    /// with a deterministic privacy marker when `redact_content == true`.
+    pub fn from_journal_event_with_redact(
+        event: &crate::session_journal::JournalEvent,
+        user_id: &str,
+        redact_content: bool,
+    ) -> Self {
         let session_id = event
             .session_id
             .clone()
@@ -156,6 +187,11 @@ impl IngestionEvent {
             .clone()
             .or_else(|| event.error.clone())
             .or_else(|| event.stall_type.clone());
+        let content = if redact_content {
+            content.as_deref().map(redacted_content_marker)
+        } else {
+            content
+        };
 
         // Token usage as JSON
         let token_usage = match (event.tokens_in, event.tokens_out) {
@@ -207,7 +243,17 @@ impl IngestionEvent {
         event: &crate::session_journal::JournalEvent,
         user_id: &str,
     ) -> Vec<Self> {
-        let main_event = Self::from_journal_event(event, user_id);
+        Self::expand_journal_event_with_redact(event, user_id, false)
+    }
+
+    /// Like [`expand_journal_event`] but applies privacy redaction to both the
+    /// main event and any tool_call expansion content when enabled.
+    pub fn expand_journal_event_with_redact(
+        event: &crate::session_journal::JournalEvent,
+        user_id: &str,
+        redact_content: bool,
+    ) -> Vec<Self> {
+        let main_event = Self::from_journal_event_with_redact(event, user_id, redact_content);
         let session_id = main_event.session_id.clone();
         let uid = main_event.user_id.clone();
         let main_event_id = main_event.event_id.clone();
@@ -230,7 +276,7 @@ impl IngestionEvent {
                     format!("evt-{:016x}", hasher.finish())
                 };
 
-                let content = if tc.ok {
+                let raw_content = if tc.ok {
                     format!("{} completed in {}ms", tc.name, tc.ms)
                 } else {
                     format!(
@@ -239,6 +285,11 @@ impl IngestionEvent {
                         tc.ms,
                         tc.error.as_deref().unwrap_or("unknown error")
                     )
+                };
+                let content = if redact_content {
+                    redacted_content_marker(&raw_content)
+                } else {
+                    raw_content
                 };
 
                 let metadata = serde_json::json!({
@@ -710,6 +761,95 @@ mod tests {
         assert_eq!(config.flush_interval_secs, 5);
         assert_eq!(config.channel_capacity, 200);
         assert_eq!(config.max_retries, 3);
+        assert!(
+            !config.redact_content,
+            "redact_content default must be false for backward compat"
+        );
+    }
+
+    #[test]
+    fn redacted_content_marker_is_deterministic() {
+        let a = redacted_content_marker("hello world");
+        let b = redacted_content_marker("hello world");
+        assert_eq!(a, b);
+        assert!(a.contains("len=11"));
+        assert!(a.starts_with("<redacted: len=11 sha="));
+        assert!(a.ends_with('>'));
+        assert!(!a.contains("hello"));
+    }
+
+    #[test]
+    fn from_journal_event_with_redact_off_keeps_raw_content() {
+        let event = crate::session_journal::JournalEvent::turn(
+            Some("sess-r"),
+            1,
+            Some("gpt-4"),
+            "hello world",
+            "ok",
+            0,
+            10,
+            5,
+            100,
+        );
+        let ingestion = IngestionEvent::from_journal_event_with_redact(&event, "u1", false);
+        assert_eq!(ingestion.content.as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn from_journal_event_with_redact_on_replaces_content_with_marker() {
+        let event = crate::session_journal::JournalEvent::turn(
+            Some("sess-r"),
+            1,
+            Some("gpt-4"),
+            "hello world",
+            "ok",
+            0,
+            10,
+            5,
+            100,
+        );
+        let ingestion = IngestionEvent::from_journal_event_with_redact(&event, "u1", true);
+        let content = ingestion.content.expect("content present");
+        assert!(!content.contains("hello world"));
+        assert!(content.starts_with("<redacted: len=11 sha="));
+    }
+
+    #[test]
+    fn expand_journal_event_with_redact_redacts_tool_call_content() {
+        use crate::session_journal::{JournalEvent, ToolCallRecord};
+        let mut event = JournalEvent::turn(
+            Some("sess-tc"),
+            1,
+            Some("gpt-4"),
+            "list files",
+            "done",
+            1,
+            10,
+            5,
+            100,
+        );
+        event.tool_calls = Some(vec![ToolCallRecord {
+            name: "shell".into(),
+            ok: true,
+            ms: 12,
+            ..Default::default()
+        }]);
+        let evs = IngestionEvent::expand_journal_event_with_redact(&event, "u1", true);
+        assert_eq!(evs.len(), 2);
+        let main = &evs[0];
+        assert!(
+            main.content
+                .as_deref()
+                .unwrap_or("")
+                .starts_with("<redacted:")
+        );
+        let tc = &evs[1];
+        assert!(
+            tc.content
+                .as_deref()
+                .unwrap_or("")
+                .starts_with("<redacted:")
+        );
     }
 
     #[test]

--- a/rust/crates/services/src/session_journal.rs
+++ b/rust/crates/services/src/session_journal.rs
@@ -2284,8 +2284,13 @@ impl JournalEvent {
         let mut evt = Self::base(JournalEventType::Turn, session_id);
         evt.turn = Some(turn);
         evt.model = model.map(|s| s.to_string());
-        evt.user_input = Some(truncate(user_input, 500));
-        evt.assistant_output = Some(truncate(assistant_output, 10000));
+        if journal_content_redact_enabled() {
+            evt.user_input = Some(journal_content_marker(user_input));
+            evt.assistant_output = Some(journal_content_marker(assistant_output));
+        } else {
+            evt.user_input = Some(truncate(user_input, 500));
+            evt.assistant_output = Some(truncate(assistant_output, 10000));
+        }
         evt.tool_count = Some(tool_count);
         evt.tokens_in = Some(tokens_in);
         evt.tokens_out = Some(tokens_out);
@@ -2316,7 +2321,11 @@ impl JournalEvent {
         let mut evt = Self::base(JournalEventType::TurnError, session_id);
         evt.turn = Some(turn);
         evt.model = model.map(|s| s.to_string());
-        evt.user_input = Some(truncate(user_input, 500));
+        if journal_content_redact_enabled() {
+            evt.user_input = Some(journal_content_marker(user_input));
+        } else {
+            evt.user_input = Some(truncate(user_input, 500));
+        }
         evt.error = Some(truncate(error, 500));
         evt.duration_ms = Some(duration_ms);
         evt
@@ -3158,6 +3167,29 @@ fn truncate(s: &str, max: usize) -> String {
         t.push('…');
         t
     }
+}
+
+/// Returns true when `ASTRA_JOURNAL_CONTENT_REDACT=1` is set in the
+/// environment. When enabled, the on-disk JSONL journal stores a privacy
+/// marker (`<redacted: len=N sha=...>`) in place of `user_input` and
+/// `assistant_output` fields.
+///
+/// TODO: a `--no-journal-content` CLI flag should map onto this env var
+/// in `stream_render.rs` so operators can toggle it without touching env.
+pub fn journal_content_redact_enabled() -> bool {
+    std::env::var("ASTRA_JOURNAL_CONTENT_REDACT").as_deref() == Ok("1")
+}
+
+/// Replace raw user content with a deterministic privacy marker.
+///
+/// Uses a non-cryptographic 64-bit hash for dedup/debugging only — not as
+/// a security primitive.
+pub fn journal_content_marker(raw: &str) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    raw.hash(&mut h);
+    format!("<redacted: len={} sha={:016x}>", raw.len(), h.finish())
 }
 
 // ═══════════════════════════ Session Lifecycle ════════════════════════════
@@ -5547,6 +5579,97 @@ mod tests {
             rec.is_synthetic_placeholder(),
             "surgically_removed=true must classify as synthetic regardless of name"
         );
+    }
+
+    #[test]
+    fn journal_content_marker_is_deterministic() {
+        let a = journal_content_marker("hello world");
+        let b = journal_content_marker("hello world");
+        assert_eq!(a, b);
+        assert!(a.starts_with("<redacted: len=11 sha="));
+        assert!(a.ends_with('>'));
+        assert!(!a.contains("hello"));
+    }
+
+    #[test]
+    fn journal_content_marker_differs_for_different_input() {
+        assert_ne!(
+            journal_content_marker("hello"),
+            journal_content_marker("world")
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(astra_journal_content_redact_env)]
+    fn journal_content_redact_enabled_reads_env_var() {
+        // SAFETY: serialized via #[serial] above.
+        unsafe { std::env::remove_var("ASTRA_JOURNAL_CONTENT_REDACT") };
+        assert!(!journal_content_redact_enabled());
+        unsafe { std::env::set_var("ASTRA_JOURNAL_CONTENT_REDACT", "1") };
+        assert!(journal_content_redact_enabled());
+        unsafe { std::env::set_var("ASTRA_JOURNAL_CONTENT_REDACT", "0") };
+        assert!(!journal_content_redact_enabled());
+        unsafe { std::env::remove_var("ASTRA_JOURNAL_CONTENT_REDACT") };
+    }
+
+    #[test]
+    #[serial_test::serial(astra_journal_content_redact_env)]
+    fn turn_event_redacts_content_when_env_set() {
+        unsafe { std::env::set_var("ASTRA_JOURNAL_CONTENT_REDACT", "1") };
+        let evt = JournalEvent::turn(
+            Some("s1"),
+            1,
+            Some("gpt-4"),
+            "secret query",
+            "secret answer",
+            0,
+            10,
+            5,
+            100,
+        );
+        let user = evt.user_input.as_deref().unwrap_or("");
+        let asst = evt.assistant_output.as_deref().unwrap_or("");
+        assert!(!user.contains("secret query"), "user_input leaked: {user}");
+        assert!(
+            !asst.contains("secret answer"),
+            "assistant_output leaked: {asst}"
+        );
+        assert!(user.starts_with("<redacted:"));
+        assert!(asst.starts_with("<redacted:"));
+        unsafe { std::env::remove_var("ASTRA_JOURNAL_CONTENT_REDACT") };
+    }
+
+    #[test]
+    #[serial_test::serial(astra_journal_content_redact_env)]
+    fn turn_event_keeps_content_when_env_unset() {
+        unsafe { std::env::remove_var("ASTRA_JOURNAL_CONTENT_REDACT") };
+        let evt = JournalEvent::turn(
+            Some("s1"),
+            1,
+            Some("gpt-4"),
+            "hello",
+            "world",
+            0,
+            10,
+            5,
+            100,
+        );
+        assert_eq!(evt.user_input.as_deref(), Some("hello"));
+        assert_eq!(evt.assistant_output.as_deref(), Some("world"));
+    }
+
+    #[test]
+    #[serial_test::serial(astra_journal_content_redact_env)]
+    fn turn_error_event_redacts_user_input_when_env_set() {
+        unsafe { std::env::set_var("ASTRA_JOURNAL_CONTENT_REDACT", "1") };
+        let evt =
+            JournalEvent::turn_error(Some("s1"), 1, Some("gpt-4"), "secret query", "boom", 50);
+        let user = evt.user_input.as_deref().unwrap_or("");
+        assert!(!user.contains("secret query"));
+        assert!(user.starts_with("<redacted:"));
+        // Error message itself is system-generated, kept as-is.
+        assert_eq!(evt.error.as_deref(), Some("boom"));
+        unsafe { std::env::remove_var("ASTRA_JOURNAL_CONTENT_REDACT") };
     }
 }
 


### PR DESCRIPTION
## Summary

Five-item privacy / secret-leak hardening sweep, written test-first.

### R1 — LLM provider error redaction (HIGH)

`runtime/turn/llm_client.rs` previously spliced the raw upstream HTTP body
into propagated error messages and into 401/403 `ClassifiedError` payloads
that travel out to WS clients and logs. Providers routinely echo the
offending Authorization header / api key into their error JSON, so this was
a passive secret-disclosure path.

- New `redact_provider_secrets()` helper masks values after `sk-`,
  `Bearer `, `key-` with `[REDACTED]`.
- 401/403 path now logs a redacted, truncated body and returns a generic
  `"LLM provider authentication failed"` message (kind `Auth`).
- Other 4xx paths (excluding 429 and the existing 400 context-window
  classifier) replace the raw body with `"LLM request rejected: {status}"`.
- `response.text()` errors render as `<body read error: …>` instead of an
  empty string for clearer diagnostics.
- Same `unwrap_or_default` → `unwrap_or_else` fix applied to
  `bridge_llm_stream.rs`.

### R2 — Cloud IngestionEvent content redaction (MED)

- `IngestionConfig` gains `redact_content: bool` (default `false` for
  backward compat).
- New `from_journal_event_with_redact` /
  `expand_journal_event_with_redact` apply a deterministic
  `<redacted: len=N sha=HHHH>` marker (non-crypto 64-bit hash, used only
  for dedup/debugging) to the outgoing `content` field, including
  tool_call expansions.

### R3 — On-disk journal content redaction (MED)

- New `ASTRA_JOURNAL_CONTENT_REDACT=1` env switch.
- When set, `JournalEvent::turn()` and `turn_error()` write the
  privacy marker in place of `user_input` / `assistant_output` instead
  of the truncated raw text.
- Default behavior is unchanged.

### R4 — LLM judge auth error redaction (MED)

`durable_task::DurableTaskService::chat_completion` (used by the cloud
LLM judge) now special-cases 401/403: log a redacted body via a local
mirror of the runtime helper, return a fixed
`"LLM judge unavailable (auth error)"` message. Verifier callsite maps
the marker onto the criterion reason cleanly (no `LLM judge error:`
prefix for the auth case).

### R5 — env tool `show_values` removal (MED)

The `env` LLM-visible tool schema (both
`astra-tools/src/schemas.rs` and `astra-cli/src/edge_tools/schemas.rs`)
no longer advertises `show_values`. `env_list` / `env_search` ignore
the parameter on the dispatch path; non-sensitive variables always render
as `(N chars)` for the model. A drifted/malicious LLM can no longer
exfiltrate env values by passing `show_values=true`.

## Behavior changes

- **Auth errors via WebSocket / API**: clients now see
  `"LLM provider authentication failed"` instead of the raw provider
  body. (Logs still contain the redacted, truncated body for ops triage.)
- **Other 4xx LLM errors**: error message becomes
  `"LLM request rejected: {status}"` (status-only) — the upstream body
  is kept out of propagation paths. 429 / 5xx retry semantics unchanged.
  The 400 context-window classifier is unaffected.
- **`ASTRA_JOURNAL_CONTENT_REDACT=1`**: opt-in env switch. When set,
  on-disk JSONL journal stores
  `<redacted: len=N sha=HHHHHHHHHHHHHHHH>` instead of raw
  `user_input` / `assistant_output`.
- **`IngestionConfig.redact_content`**: new field, default `false`
  (backward compat). Cloud-ingestion callers can now opt in to the
  same marker. matrix_cloud_runtime callsite still uses the
  non-redacting wrapper — flipping it on is a follow-up.
- **`env` tool schema**: no longer exposes `show_values` to the model.
  Existing CLI / direct invokers are unaffected (the parameter was
  already advisory-only on those surfaces).

## Test delta

- `runtime/turn/llm_client.rs`: 4 new unit tests for
  `redact_provider_secrets` (basic, no-op, JSON, auth log path) +
  tightened existing 401 mock test to assert the propagated message no
  longer leaks the upstream body.
- `services/event_ingestion.rs`: 4 new tests covering
  `IngestionConfig` default, marker determinism, redact-on/off paths,
  and tool_call expansion redaction.
- `services/session_journal.rs`: 5 new tests covering
  `journal_content_marker` determinism + uniqueness, env-var toggle
  (serialized via `serial_test`), and `turn` / `turn_error` redaction
  behavior with and without the env var. `serial_test` added to
  services dev-deps.
- `services/durable_task.rs`: 4 new tests for `redact_judge_secrets`
  + the auth/non-auth reason mapping.
- `astra-tools/env_tools.rs`: 2 new tests asserting
  `show_values=true` no longer leaks values via `env_list` /
  `env_search`.
- `astra-tools/schemas.rs`: schema test asserts `env` tool `properties`
  has no `show_values` key.

## Follow-ups

- `--no-journal-content` CLI flag in `stream_render.rs` mapping onto
  `ASTRA_JOURNAL_CONTENT_REDACT=1` (skipped here — that file is 9k+
  lines and the env-var mechanism already covers operator needs).
- Flip `IngestionConfig.redact_content` default to `true` once
  downstream consumers can read the marker format.
- Consolidate `redact_provider_secrets` (runtime) /
  `redact_judge_secrets` (services) into a shared crate, alongside
  any related helpers from `feat/secret-hardening`.
- Thread `IngestionConfig.redact_content` through
  `matrix_cloud_runtime` so cloud ingestion can opt in declaratively.
- One-time session-start warning when journal content redaction is
  off — wired in `session_journal.rs` as a TODO; needs a clearly
  scoped call site.

## Verification

- `make format && make check`: ✅
- `make test-workspace`: ✅ (no failures)