### PR TITLE
feat(plan): add analytical plans and background execution

### DIFF
--- a/rust/crates/astra-cli/src/cli/plan_interaction.rs
+++ b/rust/crates/astra-cli/src/cli/plan_interaction.rs
@@ -1330,7 +1330,6 @@ pub async fn handle_plan_mode_input(
         }
         state.plan_handle = None;
         state.plan_mode = None;
-        state.plan_resume_pending = false;
         state.executing_plan = None;
         eprintln!(
             "  {} Plan abandoned. Sending as normal chat...",
@@ -1705,9 +1704,8 @@ async fn handle_plan_command(
                     "⚙".cyan()
                 );
                 eprintln!(
-                    "  {} Prompt shows {} while the run is active.",
+                    "  {} The run continues in background; approvals and status stay available on the normal prompt.",
                     "→".dim(),
-                    "plan*[…]>".yellow()
                 );
                 eprintln!();
             }
@@ -1812,6 +1810,15 @@ async fn handle_plan_command(
             state.plan_execution_rounds = 0;
             state.plan_execution_corrections.clear();
             state.executing_plan = Some(plan);
+            state.plan_mode = None;
+            state.chat_plan_only = false;
+            state.pending_plan_resume_digest = None;
+            PlanModeState::clear_saved_state();
+            eprintln!(
+                "  {} Left plan mode — execution is now running in background. Use {} to inspect it.",
+                "←".cyan(),
+                "/plan status".cyan()
+            );
         }
 
         PlanCommand::Resume => {
@@ -1825,8 +1832,11 @@ async fn handle_plan_command(
                 match handle.send_command(crate::plan_executor::PlanCommand::Resume { corrections })
                 {
                     Ok(()) => {
-                        eprintln!("  {} Resuming plan execution...", "▶".cyan());
-                        state.plan_resume_pending = true;
+                        eprintln!(
+                            "  {} Resuming plan execution in background. Use {} for progress.",
+                            "▶".cyan(),
+                            "/plan status".cyan()
+                        );
                     }
                     Err(e) => eprintln!("  {} {}", theme::icon_err(), e),
                 }
@@ -2928,6 +2938,37 @@ mod tests {
         assert!(
             state.plan_handle.is_none(),
             "plain chat should clear the paused executor handle"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_exits_plan_mode_and_leaves_background_state() {
+        let mut state = ReplState::default();
+        state.chat_plan_only = true;
+        let mut ps = plan::PlanModeState::new("goal".into(), plan::ProjectContext::default());
+        ps.plan.subtasks.push(SubtaskPlan {
+            id: "s1".into(),
+            title: "one".into(),
+            ..Default::default()
+        });
+        state.plan_mode = Some(ps);
+
+        let api = astra_thin_client::ThinClient::new("http://127.0.0.1:1", None).unwrap();
+
+        let result = handle_plan_mode_input("go".into(), None, &mut state, &api)
+            .await
+            .unwrap();
+
+        assert!(matches!(result, PlanInputResult::Handled));
+        assert!(state.plan_mode.is_none(), "execute should leave plan mode");
+        assert!(
+            state.executing_plan.is_some(),
+            "execute should preserve plan for background status"
+        );
+        assert_eq!(state.executing_plan_goal.as_deref(), Some("goal"));
+        assert!(
+            !state.chat_plan_only,
+            "execute should restore normal chat after leaving plan mode"
         );
     }
 

--- a/rust/crates/astra-cli/src/cli/plan_interaction.rs
+++ b/rust/crates/astra-cli/src/cli/plan_interaction.rs
@@ -845,6 +845,91 @@ fn abort_plan_mode_after_failure(state: &mut ReplState, stage: &'static str, rea
     let _ = astra_runtime::plan_decompose::PlanModeState::clear_saved_state_at(&path);
 }
 
+/// P2: Single-stage analytical-plan generation.
+///
+/// Runs one LLM call against `astra_plan::analytical::analytical_prompt`,
+/// renders the resulting `ResearchPlan`, and tears down plan_mode. Unlike
+/// the executable flow there is no outline/confirm/expand loop and no
+/// executor invocation — the deliverable is the rendered plan itself.
+async fn handle_analytical_goal(
+    goal: String,
+    tok: &str,
+    state: &mut ReplState,
+    api: &astra_thin_client::ThinClient,
+) -> Result<PlanInputResult, String> {
+    let context = state
+        .plan_mode
+        .as_ref()
+        .map(|ps| ps.context.clone())
+        .unwrap_or_default();
+
+    let prompt = astra_runtime::plan::analytical::analytical_prompt(&goal, &context);
+    let payload = serde_json::json!({
+        "messages": [{"role": "user", "content": prompt}],
+        "session_id": state.session_id.clone(),
+    });
+
+    eprintln!();
+    eprintln!("  {} Analyzing question…", "⋯".dim());
+
+    let result = plan_llm_call(api, tok, &payload).await;
+    maybe_init_session_from_plan(state, &result);
+    let text = match result {
+        PlanLlmOutcome::Ok { text, .. } => text,
+        PlanLlmOutcome::Cancelled => {
+            eprintln!("  {} Analytical plan cancelled.", theme::icon_warn());
+            abort_plan_mode_after_failure(state, "analytical", "cancelled");
+            return Ok(PlanInputResult::Handled);
+        }
+        PlanLlmOutcome::Error(e) => {
+            eprintln!("  {} {}", theme::icon_err(), e.clone().red());
+            abort_plan_mode_after_failure(state, "analytical", &e);
+            return Ok(PlanInputResult::Handled);
+        }
+    };
+
+    match astra_runtime::plan::analytical::parse_analytical_response(&text) {
+        Ok(plan) => {
+            eprintln!();
+            eprintln!(
+                "{}",
+                astra_runtime::plan::analytical::format_research_plan(&plan)
+            );
+            journal_plan_event(
+                &mut state.journal,
+                session_journal::JournalEventType::PlanLifecycle,
+                &format!(
+                    "Analytical plan delivered ({} questions)",
+                    plan.questions.len()
+                ),
+                Some(serde_json::json!({
+                    "stage": "analytical_delivered",
+                    "kind": "analytical",
+                    "question_count": plan.questions.len(),
+                    "outcome": "ok",
+                })),
+            );
+            // Analytical is one-shot: drop plan_mode so the user falls
+            // back into normal chat to discuss any of the sub-questions.
+            state.plan_mode = None;
+            state.chat_plan_only = false;
+            state.pending_plan_resume_digest = None;
+            let path = astra_runtime::plan_decompose::PlanModeState::state_path();
+            let _ = astra_runtime::plan_decompose::PlanModeState::clear_saved_state_at(&path);
+            Ok(PlanInputResult::Handled)
+        }
+        Err(e) => {
+            eprintln!(
+                "  {} Failed to parse analytical plan: {}",
+                theme::icon_err(),
+                e.clone().red()
+            );
+            abort_plan_mode_after_failure(state, "analytical", &e);
+            Ok(PlanInputResult::Handled)
+        }
+    }
+}
+
 pub(super) fn journal_goal_steering_event(
     journal: &mut Option<session_journal::JournalWriter>,
     turn: u32,
@@ -2084,6 +2169,18 @@ async fn handle_goal_submission(
         state.verbose_mode,
     )
     .await;
+
+    // P2: If the goal classifies as an analytical / evaluative question,
+    // route it through the single-stage research-plan generator instead of
+    // the outline → subtasks → executor pipeline. The research plan is a
+    // one-shot deliverable; we tear down plan_mode after rendering so the
+    // user falls back into normal chat to continue the discussion.
+    if matches!(
+        astra_runtime::plan_decompose::classify_plan_suggestion(&goal).map(|s| s.kind),
+        Some(astra_runtime::plan_decompose::PlanKind::Analytical)
+    ) {
+        return handle_analytical_goal(goal, tok, state, api).await;
+    }
 
     // ── Stage 1: Generate outline ───────────────────────────────────────
     eprintln!();

--- a/rust/crates/astra-cli/src/cli/plan_monitor.rs
+++ b/rust/crates/astra-cli/src/cli/plan_monitor.rs
@@ -279,6 +279,11 @@ fn display_plan_updates_live(
                 continue;
             }
             PlanUpdate::SubtaskStatusSync { id, status } => {
+                if let Some(ref mut plan) = state.executing_plan {
+                    if let Some(st) = plan.subtasks.iter_mut().find(|s| s.id == id) {
+                        st.status = status;
+                    }
+                }
                 if let Some(ref mut ps) = state.plan_mode {
                     if let Some(st) = ps.plan.subtasks.iter_mut().find(|s| s.id == id) {
                         st.status = status;
@@ -969,15 +974,60 @@ fn apply_trailing_update(update: plan_executor::PlanUpdate, state: &mut ReplStat
     }
 }
 
-/// Update the plan_mode's subtask status to keep it in sync with the executor.
+/// Update all in-memory plan copies so background execution stays observable
+/// after plan mode exits.
 fn sync_subtask_status(
     state: &mut ReplState,
     subtask_id: &str,
     status: astra_services::task_orchestrator::TaskStatus,
 ) {
+    if let Some(ref mut plan) = state.executing_plan {
+        if let Some(st) = plan.subtasks.iter_mut().find(|s| s.id == subtask_id) {
+            st.status = status;
+        }
+    }
     if let Some(ref mut ps) = state.plan_mode {
         if let Some(st) = ps.plan.subtasks.iter_mut().find(|s| s.id == subtask_id) {
             st.status = status;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astra_services::task_orchestrator::{SubtaskPlan, TaskPlan, TaskStatus};
+
+    #[test]
+    fn flush_plan_updates_syncs_status_into_executing_plan() {
+        let mut state = ReplState::default();
+        state.executing_plan = Some(TaskPlan {
+            subtasks: vec![SubtaskPlan {
+                id: "s1".into(),
+                title: "one".into(),
+                status: TaskStatus::Pending,
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+
+        let (handle, update_tx, _cmd_rx) = plan_executor::create_plan_channels();
+        state.plan_handle = Some(handle);
+        let _ = update_tx.send(plan_executor::PlanUpdate::SubtaskStatusSync {
+            id: "s1".into(),
+            status: TaskStatus::InProgress,
+        });
+
+        let terminal = flush_plan_updates_between_prompts(&mut state);
+        assert!(!terminal);
+        assert_eq!(
+            state
+                .executing_plan
+                .as_ref()
+                .expect("plan retained")
+                .subtasks[0]
+                .status,
+            TaskStatus::InProgress
+        );
     }
 }

--- a/rust/crates/astra-cli/src/cli/plan_runtime.rs
+++ b/rust/crates/astra-cli/src/cli/plan_runtime.rs
@@ -3,7 +3,6 @@
 use crate::durable_bridge;
 use crate::plan_executor;
 use crate::plan_interaction;
-use crate::plan_monitor::run_blocking_plan_monitor;
 use crate::repl_runtime::create_background_plan_selector;
 use crate::repl_state::ReplState;
 use crate::theme;
@@ -35,16 +34,16 @@ pub(crate) fn build_learning_bridge(
 
 /// Extract a [`BackgroundPlanContext`] from the current REPL state.
 ///
-/// Moves the active plan, durable task state, and corrections out of `state`
-/// (using `take()`), and clones the remaining fields needed by the background
-/// executor. On success `state.executing_plan` will be `None`.
+/// Clones the active plan for the background executor, moves durable task state
+/// and corrections out of `state`, and leaves an in-memory copy behind so
+/// `/plan status` can keep reporting progress after plan mode exits.
 fn take_plan_context(
     state: &mut ReplState,
     api: &astra_thin_client::ThinClient,
     current_token: Option<&str>,
     profile: Option<&str>,
 ) -> Result<plan_executor::BackgroundPlanContext, String> {
-    let plan = state.executing_plan.take().ok_or("No plan to execute")?;
+    let plan = state.executing_plan.clone().ok_or("No plan to execute")?;
     let token = current_token
         .ok_or("Not logged in — cannot start background plan")?
         .to_string();
@@ -102,12 +101,12 @@ fn create_background_selector(
     create_background_plan_selector(ctx)
 }
 
-/// Spawn a plan executor, then block until it finishes, pauses, or errors.
+/// Spawn a plan executor and return immediately to the normal REPL prompt.
 ///
-/// The executor runs as a `tokio` task; this function enters a monitoring
-/// loop that displays progress in real-time, handles Ctrl-C (→ pause), and
-/// resolves approval prompts inline. The REPL prompt is not shown until
-/// this function returns.
+/// The executor runs as a `tokio` task. Progress is rendered between prompts
+/// by [`crate::plan_monitor::flush_plan_updates_between_prompts`], while the
+/// in-memory `executing_plan` copy keeps `/plan status` useful from normal
+/// chat after plan mode exits.
 pub(crate) async fn start_and_monitor_plan(
     state: &mut ReplState,
     current_token: Option<&str>,
@@ -128,9 +127,11 @@ pub(crate) async fn start_and_monitor_plan(
     let handle = plan_executor::spawn_plan_executor(ctx, selector);
     state.plan_handle = Some(handle);
 
-    eprintln!("  {} {}", "▸".bold().cyan(), "Plan executing…".bold());
-
-    run_blocking_plan_monitor(state).await;
+    eprintln!(
+        "  {} {}",
+        "▸".bold().cyan(),
+        "Plan executing in background — use /plan status to inspect progress.".bold()
+    );
 
     Ok(())
 }

--- a/rust/crates/astra-cli/src/cli/repl_state.rs
+++ b/rust/crates/astra-cli/src/cli/repl_state.rs
@@ -221,10 +221,6 @@ pub(crate) struct ReplState {
     /// Set when the executor exits with [`PlanUpdate::PlanError`].
     pub plan_run_task_last_error: Option<String>,
 
-    /// Set by `handle_plan_command(Resume)` so the main loop re-enters
-    /// the blocking plan monitor after `handle_plan_mode_input` returns.
-    pub plan_resume_pending: bool,
-
     /// When Some, a plan-executor tool is waiting for user approval.
     /// In blocking mode this is handled inline; kept for edge-case fallback.
     pub pending_approval: Option<tokio::sync::oneshot::Sender<bool>>,
@@ -411,7 +407,6 @@ impl Default for ReplState {
             plan_run_task_id: None,
             plan_run_task_last_progress: None,
             plan_run_task_last_error: None,
-            plan_resume_pending: false,
             pending_approval: None,
             plan_in_token_stream: false,
             plan_md_renderer: None,

--- a/rust/crates/astra-cli/src/cli/slash_memory.rs
+++ b/rust/crates/astra-cli/src/cli/slash_memory.rs
@@ -2289,14 +2289,18 @@ fn handle_plan_status(state: &ReplState) {
 }
 
 fn handle_plan_pause(state: &mut ReplState) {
-    if state.executing_plan.is_some() {
-        // Signal the running plan to pause after current subtask
-        // Currently, plan execution is synchronous, so this just sets a flag
-        // that run_plan_execution checks between subtasks.
-        state.last_turn_interrupted = true;
+    if let Some(ref handle) = state.plan_handle {
+        match handle.send_command(crate::plan_executor::PlanCommand::Pause) {
+            Ok(()) => eprintln!(
+                "  {} Pause requested. The background run will stop after the current subtask.",
+                "⏸".yellow()
+            ),
+            Err(e) => eprintln!("  {} {}", theme::icon_err(), e),
+        }
+    } else if state.executing_plan.is_some() {
         eprintln!(
-            "  {} Pause requested. Plan will pause after current subtask completes.",
-            "⏸".yellow()
+            "  {} No live executor is attached right now. Use 'continue' to restart the plan run.",
+            theme::icon_warn()
         );
     } else {
         eprintln!("  {} No plan is currently executing.", theme::icon_warn());

--- a/rust/crates/astra-cli/src/cli/slash_session.rs
+++ b/rust/crates/astra-cli/src/cli/slash_session.rs
@@ -4431,7 +4431,6 @@ fn reset_state_for_session_restore(state: &mut ReplState) {
     state.last_turn_interrupted = false;
     state.last_turn_event = None;
     state.plan_execution_corrections.clear();
-    state.plan_resume_pending = false;
     state.pending_approval = None;
     state.plan_in_token_stream = false;
     state.plan_md_renderer = None;

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -275,7 +275,7 @@ pub(crate) use streaming_types::{PartialTurnData, StreamResult, TurnFailure, Ver
 use idle_agent_messages::drain_root_mailbox_into_idle_queue;
 use plan_monitor::{
     finalize_plan_run_task_after_executor, flush_plan_updates_between_prompts,
-    run_blocking_plan_monitor, sync_plan_run_task_progress,
+    sync_plan_run_task_progress,
 };
 pub(crate) use plan_monitor::{format_duration_short, format_plan_progress};
 pub(crate) use plan_runtime::build_learning_bridge;
@@ -557,12 +557,11 @@ async fn run_chat_repl(
                                 .await?;
                             }
                             Err(e) => {
-                                state.plan_resume_pending = false;
                                 return Err(e);
                             }
                         }
 
-                        // If plan execution was just triggered, start the executor (blocking).
+                        // If plan execution was just triggered, start the background executor.
                         if state.executing_plan.is_some() {
                             start_and_monitor_plan(
                                 &mut state,
@@ -571,10 +570,6 @@ async fn run_chat_repl(
                                 profile,
                             )
                             .await?;
-                        } else if state.plan_resume_pending {
-                            // Resume was sent to a paused executor — re-enter blocking monitor.
-                            state.plan_resume_pending = false;
-                            run_blocking_plan_monitor(&mut state).await;
                         }
                     } else if (state.executing_plan.is_some() || state.plan_handle.is_some())
                         && plan_decompose::is_resume_command(&line)
@@ -590,8 +585,6 @@ async fn run_chat_repl(
                                     Some(std::mem::take(&mut state.plan_execution_corrections))
                                 },
                             });
-                            // Re-enter blocking monitor until done/paused/error
-                            run_blocking_plan_monitor(&mut state).await;
                         } else {
                             start_and_monitor_plan(
                                 &mut state,

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -688,9 +688,17 @@ async fn run_chat_repl(
                         // Auto plan detection: suggest plan mode for complex tasks
                         let mut should_proceed_normal = true;
                         let line_for_plan = line.clone(); // Clone early to avoid borrow issues
-                        if let Some(reason) = plan_decompose::should_suggest_plan_mode(&line) {
+                        // P2: classify both kinds — analytical inputs now route
+                        // through the research-plan generator instead of being
+                        // suppressed.
+                        if let Some(suggestion) = plan_decompose::classify_plan_suggestion(&line) {
+                            let kind_label = match suggestion.kind {
+                                plan_decompose::PlanKind::Executable => "execution plan",
+                                plan_decompose::PlanKind::Analytical => "research plan",
+                            };
+                            let banner = format!("{} ({})", suggestion.reason, kind_label);
                             let decision = plan_auto_suggest::prompt_auto_suggest(
-                                reason,
+                                &banner,
                                 plan_auto_suggest::DEFAULT_TIMEOUT,
                             );
                             match decision {

--- a/rust/crates/astra-plan/src/analytical.rs
+++ b/rust/crates/astra-plan/src/analytical.rs
@@ -1,0 +1,235 @@
+//! Analytical plan generation — for evaluative / research questions.
+//!
+//! The executable plan flow (outline → subtasks → executor) is the wrong
+//! shape for inputs like "客观评价是正确的方向吗？" or "compare the two
+//! approaches and tell me which is better". For those, the user wants a
+//! structured breakdown of *what to investigate*, not a list of file
+//! mutations to apply.
+//!
+//! This module provides a parallel, single-stage pipeline:
+//! 1. Build an analytical prompt asking the LLM to decompose the question
+//!    into a `ResearchPlan` (a small set of focused sub-questions).
+//! 2. Parse the response (reusing `extract_json_robust` for resilience).
+//! 3. Render the plan for display in the REPL.
+//!
+//! No executor invocation. No persisted `PlanModeState`. The output is a
+//! one-shot deliverable — the user reads it, optionally pursues each
+//! sub-question via normal chat, and moves on.
+
+use serde::{Deserialize, Serialize};
+
+use crate::decompose::{ProjectContext, extract_json_robust};
+
+/// A research plan: a structured decomposition of an analytical question.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResearchPlan {
+    pub goal: String,
+    /// Two- to four-sentence summary of how the question will be approached.
+    #[serde(default)]
+    pub summary: String,
+    pub questions: Vec<ResearchQuestion>,
+}
+
+/// One sub-question inside a research plan.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResearchQuestion {
+    pub id: String,
+    pub title: String,
+    /// Why this sub-question matters to the parent goal — keeps the LLM
+    /// honest about each item's relevance.
+    #[serde(default)]
+    pub why_it_matters: String,
+    /// Concrete aspects the answer should cover (bullet list).
+    #[serde(default)]
+    pub key_aspects: Vec<String>,
+    /// Where to look (files, modules, docs, references) — optional.
+    #[serde(default)]
+    pub suggested_investigations: Vec<String>,
+}
+
+/// Build the LLM prompt that turns a goal into a `ResearchPlan`.
+pub fn analytical_prompt(goal: &str, context: &ProjectContext) -> String {
+    let mut p = String::with_capacity(1024);
+    p.push_str(
+        "You are a senior software architect helping the user think through an \
+         analytical / evaluative question. Decompose the question into a small \
+         set of focused sub-questions that, once answered, would let the user \
+         reach a confident conclusion.\n\n",
+    );
+
+    p.push_str("## Project context\n");
+    if !context.languages.is_empty() {
+        p.push_str(&format!("- Languages: {}\n", context.languages.join(", ")));
+    }
+    p.push_str(&format!("- Files: ~{}\n", context.source_file_count));
+    if let Some(ref branch) = context.git_branch {
+        p.push_str(&format!("- Branch: {branch}\n"));
+    }
+    if !context.key_modules.is_empty() {
+        let top: Vec<_> = context
+            .key_modules
+            .iter()
+            .take(5)
+            .map(|(path, lines)| format!("{path} ({lines}L)"))
+            .collect();
+        p.push_str(&format!("- Key files: {}\n", top.join(", ")));
+    }
+
+    p.push_str(&format!("\n## Question\n{goal}\n"));
+
+    p.push_str(
+        r#"
+## Instructions
+Return ONLY the following JSON (no markdown, no commentary):
+```json
+{
+  "goal": "<echo of the question>",
+  "summary": "2-4 sentences describing how you'll approach this question",
+  "questions": [
+    {
+      "id": "q1",
+      "title": "Concise sub-question",
+      "why_it_matters": "1 sentence on why answering this is necessary",
+      "key_aspects": ["aspect 1", "aspect 2"],
+      "suggested_investigations": ["src/relevant.rs", "the X interface in Y"]
+    }
+  ]
+}
+```
+
+Rules:
+- 3-6 sub-questions. Fewer if the goal is narrow; more only if the goal is broad.
+- Each sub-question must be answerable through code reading or reasoning,
+  not by running tests or mutating files.
+- Order sub-questions by dependency (foundational understanding first).
+- Do NOT propose subtasks, file edits, or executor steps — this is a
+  research/evaluation plan, not an executable plan.
+"#,
+    );
+
+    p
+}
+
+/// Parse an analytical-plan response from the LLM. Uses
+/// [`extract_json_robust`] so trailing-comma / smart-quote / Python-literal
+/// noise from the model is handled transparently.
+pub fn parse_analytical_response(text: &str) -> Result<ResearchPlan, String> {
+    let json_str = extract_json_robust(text);
+    let parsed: serde_json::Value = serde_json::from_str(&json_str)
+        .map_err(|e| format!("Invalid analytical-plan JSON: {e}"))?;
+    if !parsed.is_object() || !parsed.get("questions").is_some_and(|v| v.is_array()) {
+        return Err("Expected JSON object with 'questions' array".into());
+    }
+    let plan: ResearchPlan = serde_json::from_str(&json_str)
+        .map_err(|e| format!("Schema mismatch in analytical plan: {e}"))?;
+    if plan.questions.is_empty() {
+        return Err("Analytical plan must contain at least one sub-question".into());
+    }
+    Ok(plan)
+}
+
+/// Render a research plan for terminal display. The output is plain text
+/// (no ANSI codes) so callers can colorize as needed.
+pub fn format_research_plan(plan: &ResearchPlan) -> String {
+    let mut out = String::with_capacity(512);
+    out.push_str(&format!("Research plan for: {}\n", plan.goal));
+    if !plan.summary.is_empty() {
+        out.push('\n');
+        out.push_str(&plan.summary);
+        out.push('\n');
+    }
+    for (i, q) in plan.questions.iter().enumerate() {
+        out.push('\n');
+        out.push_str(&format!("  {}. [{}] {}\n", i + 1, q.id, q.title));
+        if !q.why_it_matters.is_empty() {
+            out.push_str(&format!("     why: {}\n", q.why_it_matters));
+        }
+        for aspect in &q.key_aspects {
+            out.push_str(&format!("       • {aspect}\n"));
+        }
+        if !q.suggested_investigations.is_empty() {
+            out.push_str(&format!(
+                "     look at: {}\n",
+                q.suggested_investigations.join(", ")
+            ));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ProjectContext {
+        ProjectContext {
+            languages: vec!["Rust".into()],
+            source_file_count: 100,
+            git_branch: Some("main".into()),
+            ..ProjectContext::default()
+        }
+    }
+
+    #[test]
+    fn analytical_prompt_includes_goal_and_context() {
+        let p = analytical_prompt("评估当前接口是否合理", &ctx());
+        assert!(p.contains("评估当前接口是否合理"));
+        assert!(p.contains("Rust"));
+        assert!(p.contains("research/evaluation plan"));
+    }
+
+    #[test]
+    fn parse_analytical_response_minimal_json() {
+        let raw = r#"{
+            "goal": "evaluate api X",
+            "summary": "we will look at X",
+            "questions": [
+                {"id": "q1", "title": "is X correct", "key_aspects": ["a", "b"]}
+            ]
+        }"#;
+        let plan = parse_analytical_response(raw).expect("valid analytical JSON");
+        assert_eq!(plan.questions.len(), 1);
+        assert_eq!(plan.questions[0].id, "q1");
+        assert_eq!(plan.questions[0].key_aspects, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn parse_analytical_response_rejects_empty_questions() {
+        let raw = r#"{"goal": "x", "questions": []}"#;
+        let err = parse_analytical_response(raw).expect_err("must reject empty");
+        assert!(err.contains("at least one"));
+    }
+
+    #[test]
+    fn parse_analytical_response_handles_robust_repair() {
+        // Smart quotes + trailing comma + markdown fence — same noise the
+        // real LLM emits. Should still parse via extract_json_robust.
+        let raw = "```json\n{\u{201C}goal\u{201D}: \u{201C}eval\u{201D}, \
+                   \u{201C}questions\u{201D}: [{\u{201C}id\u{201D}: \u{201C}q1\u{201D}, \
+                   \u{201C}title\u{201D}: \u{201C}t\u{201D},}],}\n```";
+        let plan = parse_analytical_response(raw).expect("robust repair must succeed");
+        assert_eq!(plan.questions.len(), 1);
+        assert_eq!(plan.questions[0].title, "t");
+    }
+
+    #[test]
+    fn format_research_plan_is_human_readable() {
+        let plan = ResearchPlan {
+            goal: "g".into(),
+            summary: "s".into(),
+            questions: vec![ResearchQuestion {
+                id: "q1".into(),
+                title: "title".into(),
+                why_it_matters: "why".into(),
+                key_aspects: vec!["a".into()],
+                suggested_investigations: vec!["src/x.rs".into()],
+            }],
+        };
+        let out = format_research_plan(&plan);
+        assert!(out.contains("Research plan for: g"));
+        assert!(out.contains("[q1] title"));
+        assert!(out.contains("why: why"));
+        assert!(out.contains("• a"));
+        assert!(out.contains("src/x.rs"));
+    }
+}

--- a/rust/crates/astra-plan/src/lib.rs
+++ b/rust/crates/astra-plan/src/lib.rs
@@ -1,5 +1,6 @@
 //! Astra Plan — goal decomposition engine for breaking complex tasks into subtasks.
 
+pub mod analytical;
 pub mod decompose;
 pub mod metrics;
 pub mod outline;

--- a/rust/crates/runtime/src/plan/mod.rs
+++ b/rust/crates/runtime/src/plan/mod.rs
@@ -1,3 +1,4 @@
+pub use astra_plan::analytical;
 pub use astra_plan::metrics;
 pub use astra_plan::outline;
 pub use astra_plan::performance;


### PR DESCRIPTION
## Summary
- add a dedicated analytical plan generator that produces research questions instead of executable subtasks
- route analytical goals through the new one-shot plan path in plan mode and expose the same path through auto-suggest classification
- switch execute/go to a cursor-style background run: leave plan mode immediately, keep execution observable from normal chat, and make /plan status plus /plan pause work against the background executor state

## Validation
- cargo build -p astra-cli
- cargo test -p astra-plan -p astra-cli
- cargo clippy -p astra-plan -p astra-cli --all-targets -- -D warnings
- make format
- make check
- make test-offline
- make format && cd rust && cargo test -p astra-cli && cargo clippy -p astra-cli --all-targets -- -D warnings
- make check && make test-offline

## Notes
- Stacked on top of #239 (base branch: plan-mode-v3)
- P3 JSON robustness stays in the stacked base: this PR reuses that path instead of re-implementing it
- After execute starts, progress is synchronized into executing_plan so /plan status still works after plan mode exits