### PR TITLE
fix: unhappy-path hardening (timeouts, poison locks, observability)

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -158,11 +158,24 @@ impl AgenticLoopHost for CliAgenticLoopHost<'_> {
 
         // Propagate skill sandbox policy to the tool executor for this turn.
         // Saved/restored so it doesn't persist after the skill deactivates.
-        let prev_sandbox = self.executor.sandbox_policy.write().unwrap().take();
+        let prev_sandbox = self
+            .executor
+            .sandbox_policy
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
         if let Some(ref policy) = state.skills.sandbox_policy {
-            *self.executor.sandbox_policy.write().unwrap() = Some(policy.clone());
+            *self
+                .executor
+                .sandbox_policy
+                .write()
+                .unwrap_or_else(|e| e.into_inner()) = Some(policy.clone());
         } else {
-            *self.executor.sandbox_policy.write().unwrap() = prev_sandbox.clone();
+            *self
+                .executor
+                .sandbox_policy
+                .write()
+                .unwrap_or_else(|e| e.into_inner()) = prev_sandbox.clone();
         }
         self.executor.set_send_message_context(
             state
@@ -254,7 +267,11 @@ impl AgenticLoopHost for CliAgenticLoopHost<'_> {
         }
 
         // Restore previous sandbox policy after the turn.
-        *self.executor.sandbox_policy.write().unwrap() = prev_sandbox;
+        *self
+            .executor
+            .sandbox_policy
+            .write()
+            .unwrap_or_else(|e| e.into_inner()) = prev_sandbox;
 
         // Sync latest approval overrides into state for checkpoint persistence.
         state.approval_overrides = self.perm_manager.export_session_overrides();

--- a/rust/crates/astra-cli/src/cli/durable_bridge.rs
+++ b/rust/crates/astra-cli/src/cli/durable_bridge.rs
@@ -31,7 +31,11 @@ fn build_client_for_url(url: &str) -> reqwest::Client {
     if is_local {
         builder = builder.no_proxy();
     }
-    builder.build().unwrap_or_else(|_| reqwest::Client::new())
+    builder
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
 }
 
 // ─── Active contract state held by the REPL ──────────────────────────────────
@@ -2747,6 +2751,25 @@ mod tests {
         assert!(
             err.contains("Server proxy judge error"),
             "error should mention proxy: {err}"
+        );
+    }
+
+    /// audit-A6: build_client_for_url must set connect_timeout and timeout so a
+    /// hung durable task server cannot block the CLI indefinitely.
+    #[test]
+    fn durable_bridge_client_has_timeout() {
+        let source = include_str!("durable_bridge.rs");
+        let fn_start = source
+            .find("fn build_client_for_url(")
+            .expect("build_client_for_url must exist");
+        let body = &source[fn_start..fn_start + 500];
+        assert!(
+            body.contains("connect_timeout("),
+            "durable bridge client must set connect_timeout"
+        );
+        assert!(
+            body.contains(".timeout("),
+            "durable bridge client must set request timeout"
         );
     }
 }

--- a/rust/crates/astra-cli/src/cli/repl_runtime.rs
+++ b/rust/crates/astra-cli/src/cli/repl_runtime.rs
@@ -350,7 +350,13 @@ pub(super) async fn try_silent_auth(api: &astra_thin_client::ThinClient, profile
         // If refresh_token is truly expired, the next refresh will also fail and
         // user will be prompted to re-login then.
     }
-    let _ = save_credentials(&creds);
+    if let Err(e) = save_credentials(&creds) {
+        tracing::warn!(
+            target: "astra_cli::repl_runtime",
+            error = %e,
+            "failed to save credentials after token refresh"
+        );
+    }
 }
 
 fn should_keep_credentials_on_refresh_error(err: &astra_thin_client::ThinClientError) -> bool {

--- a/rust/crates/astra-cli/src/edge_tools/code_analysis.rs
+++ b/rust/crates/astra-cli/src/edge_tools/code_analysis.rs
@@ -33,7 +33,10 @@ impl ToolExecutor {
 
         // Sandbox check
         {
-            let sp_guard = self.sandbox_policy.read().unwrap();
+            let sp_guard = self
+                .sandbox_policy
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(ref policy) = *sp_guard
                 && let Err(e) = validate_path(policy, path_str)
             {

--- a/rust/crates/astra-cli/src/edge_tools/diagnose.rs
+++ b/rust/crates/astra-cli/src/edge_tools/diagnose.rs
@@ -279,7 +279,10 @@ impl ToolExecutor {
 
             // Sandbox policy
             {
-                let sp_guard = self.sandbox_policy.read().unwrap();
+                let sp_guard = self
+                    .sandbox_policy
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner());
                 if let Some(ref policy) = *sp_guard {
                     session_info.insert(
                         "sandbox_mode".to_string(),

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -138,7 +138,10 @@ impl ToolExecutor {
         }
 
         {
-            let sp_guard = self.sandbox_policy.read().unwrap();
+            let sp_guard = self
+                .sandbox_policy
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(ref policy) = *sp_guard
                 && !matches!(policy.mode, SandboxMode::Permissive)
             {

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -2993,7 +2993,10 @@ impl ToolExecutor {
         harden_command: bool,
     ) -> Result<std::process::Output, String> {
         let effective_command = if harden_command {
-            let sp_guard = self.sandbox_policy.read().unwrap();
+            let sp_guard = self
+                .sandbox_policy
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(ref policy) = *sp_guard {
                 if !matches!(policy.mode, SandboxMode::Permissive) {
                     wrap_command_with_limits(policy, command)
@@ -3028,7 +3031,10 @@ impl ToolExecutor {
 
         // Apply sandbox environment filtering
         {
-            let sp_guard = self.sandbox_policy.read().unwrap();
+            let sp_guard = self
+                .sandbox_policy
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(ref policy) = *sp_guard
                 && !matches!(policy.mode, SandboxMode::Permissive)
                 && let Err(e) = sandbox_command(policy, &mut child_cmd)
@@ -3273,7 +3279,10 @@ impl ToolExecutor {
         // This closes the loophole where read_file is blocked by the sandbox
         // but `cat /outside/path` bypasses it.
         {
-            let sp_guard = self.sandbox_policy.read().unwrap();
+            let sp_guard = self
+                .sandbox_policy
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(ref policy) = *sp_guard
                 && !matches!(policy.mode, SandboxMode::Permissive)
             {
@@ -3412,7 +3421,10 @@ impl ToolExecutor {
         let timeout_secs = args.get("timeout").and_then(Value::as_f64).unwrap_or(30.0);
 
         {
-            let sp_guard = self.sandbox_policy.read().unwrap();
+            let sp_guard = self
+                .sandbox_policy
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(ref policy) = *sp_guard
                 && !matches!(policy.mode, SandboxMode::Permissive)
             {
@@ -3771,7 +3783,10 @@ impl ToolExecutor {
 
         // Apply sandbox environment filtering (same as bash)
         {
-            let sp_guard = self.sandbox_policy.read().unwrap();
+            let sp_guard = self
+                .sandbox_policy
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(ref policy) = *sp_guard
                 && !matches!(policy.mode, SandboxMode::Permissive)
                 && let Err(e) = sandbox_command(policy, &mut cmd)

--- a/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
+++ b/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
@@ -144,7 +144,7 @@ impl RateLimitCooldown {
         match self.state.load(Ordering::SeqCst) {
             STATE_ACTIVE => RateLimitAction::Proceed,
             STATE_COOLDOWN => {
-                let info = self.cooldown_info.lock().expect("cooldown mutex");
+                let info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
                 if let Some(ref cooldown) = *info {
                     if Instant::now() >= cooldown.reset_at {
                         // Cooldown expired
@@ -270,7 +270,7 @@ impl RateLimitCooldown {
         let reset_at = Instant::now() + Duration::from_millis(duration_ms);
 
         {
-            let mut info = self.cooldown_info.lock().expect("cooldown mutex");
+            let mut info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
             *info = Some(CooldownInfo {
                 reset_at,
                 reason,
@@ -289,7 +289,7 @@ impl RateLimitCooldown {
         let reset_at = Instant::now() + Duration::from_millis(DEFAULT_COOLDOWN_MS);
 
         {
-            let mut info = self.cooldown_info.lock().expect("cooldown mutex");
+            let mut info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
             *info = Some(CooldownInfo {
                 reset_at,
                 reason,
@@ -306,7 +306,7 @@ impl RateLimitCooldown {
         self.consecutive_errors.store(0, Ordering::SeqCst);
         self.consecutive_529_errors.store(0, Ordering::SeqCst);
 
-        let mut info = self.cooldown_info.lock().expect("cooldown mutex");
+        let mut info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
         *info = None;
     }
 
@@ -315,7 +315,7 @@ impl RateLimitCooldown {
         match self.state.load(Ordering::SeqCst) {
             STATE_ACTIVE => RateLimitState::Active,
             STATE_COOLDOWN => {
-                let info = self.cooldown_info.lock().expect("cooldown mutex");
+                let info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
                 if let Some(ref cooldown) = *info {
                     // Convert Instant to epoch ms for external use
                     let now = Instant::now();
@@ -368,7 +368,7 @@ impl RateLimitCooldown {
             return 0;
         }
 
-        let info = self.cooldown_info.lock().expect("cooldown mutex");
+        let info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(ref cooldown) = *info {
             cooldown
                 .reset_at
@@ -384,7 +384,7 @@ impl RateLimitCooldown {
         self.state.store(STATE_ACTIVE, Ordering::SeqCst);
         self.consecutive_errors.store(0, Ordering::SeqCst);
         self.consecutive_529_errors.store(0, Ordering::SeqCst);
-        let mut info = self.cooldown_info.lock().expect("cooldown mutex");
+        let mut info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
         *info = None;
     }
 }
@@ -974,5 +974,29 @@ mod tests {
         rl.state.store(255, Ordering::SeqCst);
         let m = rl.metrics();
         assert_eq!(m.state, "unknown");
+    }
+
+    /// audit-B1: cooldown_info mutex must recover from poison instead of
+    /// cascading panics. This test poisons the mutex by panicking inside a
+    /// lock scope, then verifies subsequent operations still work.
+    #[test]
+    fn cooldown_mutex_recovers_from_poison() {
+        let rl = std::sync::Arc::new(RateLimitCooldown::new());
+        let rl2 = rl.clone();
+
+        // Poison the mutex by panicking while holding the lock.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = rl2.cooldown_info.lock().unwrap();
+            panic!("intentional poison");
+        }));
+        assert!(result.is_err(), "should have panicked");
+        assert!(rl.cooldown_info.lock().is_err(), "mutex should be poisoned");
+
+        // Despite the poison, all operations must still work.
+        assert!(matches!(rl.check_request(false), RateLimitAction::Proceed));
+        rl.record_429(None, false);
+        rl.record_success();
+        let m = rl.metrics();
+        assert_eq!(m.state, "active");
     }
 }

--- a/rust/crates/astra-turn-core/src/concurrency_safety.rs
+++ b/rust/crates/astra-turn-core/src/concurrency_safety.rs
@@ -182,7 +182,7 @@ fn global_cell() -> &'static RwLock<ConcurrencySafetyRegistry> {
 pub fn global_classify(tool_name: &str) -> ConcurrencySafety {
     global_cell()
         .read()
-        .expect("concurrency_safety global poisoned")
+        .unwrap_or_else(|e| e.into_inner())
         .classify(tool_name)
 }
 
@@ -190,7 +190,7 @@ pub fn global_classify(tool_name: &str) -> ConcurrencySafety {
 pub fn global_register(tool_name: &str, level: ConcurrencySafety) {
     global_cell()
         .write()
-        .expect("concurrency_safety global poisoned")
+        .unwrap_or_else(|e| e.into_inner())
         .register(tool_name, level);
 }
 
@@ -349,5 +349,18 @@ mod tests {
         // Post-registration: seen as read-only by both APIs.
         assert_eq!(global_classify(name), ConcurrencySafety::ReadOnly);
         assert!(super::super::parallel_tool_exec::is_read_only_tool(name));
+    }
+
+    /// audit-B2: the global concurrency_safety RwLock must not cascade panics
+    /// if poisoned. Source-level guard: do not reintroduce expect on the global lock.
+    #[test]
+    fn concurrency_safety_does_not_expect_on_poison() {
+        let source = include_str!("concurrency_safety.rs");
+        let test_start = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        assert!(
+            !prod_code.contains(".expect(\"concurrency_safety global poisoned\")"),
+            "concurrency_safety production code must not use .expect on poisoned global lock"
+        );
     }
 }

--- a/rust/crates/astra-turn-core/src/tool_result_dedup.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_dedup.rs
@@ -199,14 +199,14 @@ where
     Fut: std::future::Future<Output = String>,
 {
     {
-        let mut guard = cache.lock().expect("result cache poisoned");
+        let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(hit) = guard.lookup(sig) {
             return (hit, true);
         }
     }
     let fresh = f().await;
     {
-        let mut guard = cache.lock().expect("result cache poisoned");
+        let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
         guard.record(sig.clone(), fresh.clone());
     }
     (fresh, false)
@@ -223,14 +223,14 @@ where
     F: FnOnce() -> String,
 {
     {
-        let mut guard = cache.lock().expect("result cache poisoned");
+        let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(hit) = guard.lookup(sig) {
             return (hit, true);
         }
     }
     let fresh = f();
     {
-        let mut guard = cache.lock().expect("result cache poisoned");
+        let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
         guard.record(sig.clone(), fresh.clone());
     }
     (fresh, false)
@@ -484,5 +484,27 @@ mod tests {
         let (out2, hit) = lookup_or_compute_sync(&cache, &sig2, || "miss".into());
         assert!(hit);
         assert_eq!(out2, "hello");
+    }
+
+    /// audit-B3: result cache mutex must recover from poison instead of
+    /// cascading panics across all tool dedup operations.
+    #[test]
+    fn result_cache_recovers_from_poison() {
+        let cache = new_shared_cache(10, None);
+        let cache2 = cache.clone();
+
+        // Poison the mutex.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = cache2.lock().unwrap();
+            panic!("intentional poison");
+        }));
+        assert!(result.is_err());
+        assert!(cache.lock().is_err(), "mutex should be poisoned");
+
+        // Despite the poison, lookup_or_compute_sync must still work.
+        let sig = CallSignature::from_args("tool", &json!({"key": "val"}));
+        let (out, hit) = lookup_or_compute_sync(&cache, &sig, || "recovered".to_string());
+        assert!(!hit);
+        assert_eq!(out, "recovered");
     }
 }

--- a/rust/crates/runtime/src/app_state.rs
+++ b/rust/crates/runtime/src/app_state.rs
@@ -655,6 +655,8 @@ impl MemoriaForwarder for ReqwestMemoriaForwarder {
         let url = format!("{}{}", self.base_url, endpoint);
         let client = reqwest::Client::builder()
             .no_proxy()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
             .build()
             .map_err(|e| format!("Memoria client build error: {e}"))?;
         let resp = client
@@ -756,5 +758,46 @@ mod tests {
         async fn database_healthy(&self) -> bool {
             true
         }
+    }
+
+    /// audit-A1: ReqwestMemoriaForwarder must set connect_timeout and timeout
+    /// so a hung Memoria server cannot block the Axum handler indefinitely.
+    /// This test starts a real TCP listener that accepts but never responds,
+    /// proving the client times out instead of hanging forever.
+    #[tokio::test]
+    async fn memoria_forwarder_times_out_on_unresponsive_server() {
+        // Black-hole server: accepts connections, never sends a response.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            loop {
+                let (sock, _) = listener.accept().await.unwrap();
+                // Hold the connection open, never respond.
+                tokio::spawn(async move {
+                    let _ = tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+                    drop(sock);
+                });
+            }
+        });
+
+        let forwarder = ReqwestMemoriaForwarder {
+            base_url: format!("http://{addr}"),
+            master_key: "test-key".to_string(),
+        };
+
+        let start = std::time::Instant::now();
+        let result = forwarder
+            .forward(
+                "/v1/memories/retrieve",
+                serde_json::json!({"query": "test"}),
+            )
+            .await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "should fail with timeout, got: {result:?}");
+        assert!(
+            elapsed < std::time::Duration::from_secs(60),
+            "should time out well before 60s, took {elapsed:?}"
+        );
     }
 }

--- a/rust/crates/runtime/src/server/completions.rs
+++ b/rust/crates/runtime/src/server/completions.rs
@@ -103,9 +103,9 @@ pub(super) async fn completions_handler(
 
     // Anthropic uses max_tokens; OpenAI prefers max_completion_tokens
     if resolved.provider != "anthropic" && !resolved.model_name.contains("claude") {
-        body.as_object_mut()
-            .expect("json object")
-            .remove("max_tokens");
+        if let Some(obj) = body.as_object_mut() {
+            obj.remove("max_tokens");
+        }
         body["max_completion_tokens"] = serde_json::json!(request.max_tokens);
     }
 
@@ -237,6 +237,19 @@ mod tests {
         assert_eq!(
             json["choices"][0]["message"]["content"],
             r#"{"score": 0.85}"#
+        );
+    }
+
+    /// audit-C2: completions handler must not use .expect("json object") —
+    /// panicking in a request handler crashes the connection.
+    #[test]
+    fn completions_handler_does_not_expect_json_object() {
+        let source = include_str!("completions.rs");
+        let test_start = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        assert!(
+            !prod_code.contains(".expect(\"json object\")"),
+            "completions handler must not panic on json object access"
         );
     }
 }

--- a/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
+++ b/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
@@ -312,6 +312,8 @@ impl HttpMemoriaClient {
             api_key,
             http: reqwest::Client::builder()
                 .no_proxy()
+                .connect_timeout(std::time::Duration::from_secs(10))
+                .timeout(std::time::Duration::from_secs(60))
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new()),
         }
@@ -2612,6 +2614,25 @@ mod tests {
             semantic_entries.is_empty(),
             "should not store semantic entries when disabled, got {}",
             semantic_entries.len()
+        );
+    }
+
+    /// audit-A3: HttpMemoriaClient must have connect_timeout and timeout so a
+    /// hung Memoria server cannot block the compaction pipeline indefinitely.
+    #[test]
+    fn memoria_compact_client_has_timeout() {
+        let source = include_str!("memoria_compact.rs");
+        let fn_start = source
+            .find("pub fn new(base_url: String, api_key: String)")
+            .expect("HttpMemoriaClient::new must exist");
+        let body = &source[fn_start..fn_start + 400];
+        assert!(
+            body.contains("connect_timeout("),
+            "HttpMemoriaClient must set connect_timeout"
+        );
+        assert!(
+            body.contains(".timeout("),
+            "HttpMemoriaClient must set request timeout"
         );
     }
 }

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -70,14 +70,44 @@ fn rate_limit_cooldown() -> &'static PerModelCooldown {
 fn global_llm_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
+        let connect = llm_connect_timeout();
+        let total = std::time::Duration::from_secs(LLM_TOTAL_BUDGET_S + 60);
+        match reqwest::Client::builder()
             .no_proxy()
-            .connect_timeout(llm_connect_timeout())
+            .connect_timeout(connect)
             // Use a generous timeout; per-request timeout handled via tokio::time::timeout
-            .timeout(std::time::Duration::from_secs(LLM_TOTAL_BUDGET_S + 60))
+            .timeout(total)
             .pool_max_idle_per_host(4)
             .build()
-            .expect("failed to build global LLM HTTP client")
+        {
+            Ok(client) => client,
+            Err(e) => {
+                // audit-C1: TLS / HTTP stack init failure should not crash the process.
+                // Retry with the same timeouts but without pool tuning so we still bound
+                // hung-upstream risk if this tier succeeds.
+                tracing::error!(
+                    target: "astra_runtime::llm_client",
+                    error = %e,
+                    "failed to build global LLM HTTP client; retrying without pool_max_idle_per_host"
+                );
+                match reqwest::Client::builder()
+                    .no_proxy()
+                    .connect_timeout(connect)
+                    .timeout(total)
+                    .build()
+                {
+                    Ok(client) => client,
+                    Err(e2) => {
+                        tracing::error!(
+                            target: "astra_runtime::llm_client",
+                            error = %e2,
+                            "failed to build minimal global LLM HTTP client; using reqwest::Client::new() without explicit timeouts"
+                        );
+                        reqwest::Client::new()
+                    }
+                }
+            }
+        }
     })
 }
 
@@ -3270,5 +3300,20 @@ mod tests {
         );
         assert!(!log_line.contains("sk-abc12345"));
         assert!(log_line.contains("[REDACTED]"));
+    }
+
+    /// audit-C1: global_llm_client must not use .expect() — a TLS backend
+    /// failure should not crash the entire process.
+    #[test]
+    fn global_llm_client_does_not_panic_on_build() {
+        let source = include_str!("llm_client.rs");
+        let fn_start = source
+            .find("fn global_llm_client()")
+            .expect("global_llm_client must exist");
+        let body = &source[fn_start..(fn_start + 600).min(source.len())];
+        assert!(
+            !body.contains(".expect("),
+            "global_llm_client must not use .expect(); use .unwrap_or_else with fallback"
+        );
     }
 }

--- a/rust/crates/runtime/src/turn/memory_prefetch.rs
+++ b/rust/crates/runtime/src/turn/memory_prefetch.rs
@@ -116,6 +116,8 @@ async fn fetch_memories(
 ) -> String {
     let client = reqwest::Client::builder()
         .no_proxy()
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .timeout(std::time::Duration::from_secs(10))
         .build()
         .unwrap_or_else(|_| reqwest::Client::new());
     let mut payload = serde_json::json!({"query": query, "top_k": top_k});
@@ -303,5 +305,41 @@ mod tests {
         assert_eq!(r.items, 0);
         assert!(r.preview.is_empty());
         assert_eq!(r.fetch_ms, 0);
+    }
+
+    /// audit-A2: fetch_memories must time out on an unresponsive Memoria server
+    /// instead of blocking the turn pipeline indefinitely.
+    #[tokio::test]
+    async fn fetch_memories_times_out_on_unresponsive_server() {
+        // Black-hole server: accepts connections, never responds.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            loop {
+                let (sock, _) = listener.accept().await.unwrap();
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+                    drop(sock);
+                });
+            }
+        });
+
+        let start = std::time::Instant::now();
+        let result = fetch_memories(
+            &format!("http://{addr}"),
+            "test-key",
+            "test query",
+            "user1",
+            5,
+        )
+        .await;
+        let elapsed = start.elapsed();
+
+        // fetch_memories returns empty string on error, not Err
+        assert!(result.is_empty(), "should return empty on timeout");
+        assert!(
+            elapsed < std::time::Duration::from_secs(30),
+            "should time out well before 30s, took {elapsed:?}"
+        );
     }
 }

--- a/rust/crates/runtime/src/turn/services.rs
+++ b/rust/crates/runtime/src/turn/services.rs
@@ -317,6 +317,8 @@ impl TurnObserverWorker for DatabaseTurnObserverWorker {
         });
         let response = reqwest::Client::builder()
             .no_proxy()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
             .build()
             .map_err(|error| error.to_string())?
             .post(format!(
@@ -354,6 +356,8 @@ impl TurnReflectionLessonWriter for DatabaseTurnReflectionLessonWriter {
         });
         let response = reqwest::Client::builder()
             .no_proxy()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
             .build()
             .map_err(|error| error.to_string())?
             .post(format!(

--- a/rust/crates/runtime/src/turn/skill_tool.rs
+++ b/rust/crates/runtime/src/turn/skill_tool.rs
@@ -1353,7 +1353,13 @@ fn remote_skill_http_client() -> &'static reqwest::Client {
         if cfg!(test) {
             builder = builder.no_proxy();
         }
-        builder.build().unwrap_or_else(|_| reqwest::Client::new())
+        // audit-A4: remote skill URLs are attacker-controllable (via skill manifest).
+        // Without a timeout, a malicious skill server can hang the agent loop forever.
+        builder
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new())
     })
 }
 
@@ -5572,5 +5578,38 @@ Normal.
         let (manifest, _body) = crate::skills::loader::parse_skill_md(skill_md).unwrap();
         let comp = manifest.composition.unwrap();
         assert_eq!(comp.max_depth, None);
+    }
+
+    /// audit-A4: remote_skill_http_client must have connect_timeout and timeout.
+    /// Remote skill URLs are attacker-controllable via skill manifests — without
+    /// a timeout, a malicious skill server hangs the agent loop forever.
+    /// This test proves the timeout fires against a real black-hole server.
+    #[tokio::test]
+    async fn remote_skill_client_times_out_on_unresponsive_server() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            loop {
+                let (sock, _) = listener.accept().await.unwrap();
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+                    drop(sock);
+                });
+            }
+        });
+
+        let client = remote_skill_http_client();
+        let start = std::time::Instant::now();
+        let result = client
+            .get(format!("http://{addr}/v1/skill/invoke"))
+            .send()
+            .await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "should fail with timeout, got: {result:?}");
+        assert!(
+            elapsed < std::time::Duration::from_secs(60),
+            "should time out well before 60s, took {elapsed:?}"
+        );
     }
 }

--- a/rust/crates/services/src/durable_task.rs
+++ b/rust/crates/services/src/durable_task.rs
@@ -198,7 +198,7 @@ impl CloudLlmJudge {
         };
 
         let evidence_with_score = format!("score={score:.2}; {evidence}");
-        let _ = sqlx::query(
+        if let Err(e) = sqlx::query(
             "INSERT INTO task_verification_results \
              (result_id, contract_id, task_id, subtask_id, criterion_id, \
               session_id, passed, evidence, expected, duration_ms, error_message) \
@@ -216,7 +216,16 @@ impl CloudLlmJudge {
         .bind(duration_ms as i64)
         .bind(error)
         .execute(pool)
-        .await;
+        .await
+        {
+            tracing::warn!(
+                target: "astra_services::durable_task",
+                contract_id = %contract_id,
+                result_id = %result_id,
+                error = %e,
+                "failed to persist verification result"
+            );
+        }
     }
 
     /// Generic chat-completion helper shared by the judge scoring path and
@@ -1527,8 +1536,16 @@ impl TaskBranchOps for TaskBranchService {
         // subtask may race. This is acceptable because subtasks are typically
         // executed sequentially per task_id; concurrent execution is rare.
         let drop_sql = format!("DROP SNAPSHOT IF EXISTS `{name}`");
-        // Drop failure is expected when snapshot doesn't exist; ignore error
-        let _ = sqlx::query(&drop_sql).execute(&self.pool).await;
+        // Drop failure is expected when snapshot doesn't exist, but log
+        // unexpected errors (permissions, connection) at debug level.
+        if let Err(e) = sqlx::query(&drop_sql).execute(&self.pool).await {
+            tracing::debug!(
+                target: "astra_services::durable_task",
+                snapshot = %name,
+                error = %e,
+                "failed to drop snapshot before recreate"
+            );
+        }
 
         let sql = crate::snapshot_sql::create_snapshot_for_db_sql(&name, &self.database);
         sqlx::query(&sql)

--- a/rust/crates/services/src/evaluation/database.rs
+++ b/rust/crates/services/src/evaluation/database.rs
@@ -982,6 +982,8 @@ impl DatabaseEvaluationService {
 
         let client = reqwest::Client::builder()
             .no_proxy()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
             .default_headers(headers)
             .build()
             .map_err(internal_error)?;
@@ -2834,5 +2836,25 @@ mod tests {
         use super::super::utils::not_implemented;
         let (status, _) = not_implemented("test");
         assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+    }
+
+    /// audit-A5: the Memoria evaluation client must have a timeout so a hung
+    /// Memoria server cannot block the Axum handler indefinitely.
+    #[test]
+    fn evaluation_memoria_client_has_timeout() {
+        let source = include_str!("database.rs");
+        let fn_start = source
+            .find("async fn retrieve_from_memoria")
+            .expect("retrieve_from_memoria must exist");
+        let end = (fn_start + 800).min(source.len());
+        let body = &source[fn_start..end];
+        assert!(
+            body.contains("connect_timeout("),
+            "evaluation Memoria client must set connect_timeout"
+        );
+        assert!(
+            body.contains(".timeout("),
+            "evaluation Memoria client must set request timeout"
+        );
     }
 }

--- a/rust/crates/services/src/event_ingestion.rs
+++ b/rust/crates/services/src/event_ingestion.rs
@@ -362,7 +362,13 @@ impl IngestionSender {
 
     /// Enqueue with backpressure (waits if channel full).
     pub async fn enqueue_async(&self, event: IngestionEvent) {
-        let _ = self.tx.send(event).await;
+        if self.tx.send(event).await.is_err() {
+            self.overflow_count.fetch_add(1, Ordering::Relaxed);
+            tracing::warn!(
+                target: "astra_services::event_ingestion",
+                "ingestion channel closed; event dropped"
+            );
+        }
     }
 
     /// Signal the worker to flush remaining events and shut down.

--- a/rust/crates/services/src/multi_agent.rs
+++ b/rust/crates/services/src/multi_agent.rs
@@ -583,14 +583,23 @@ impl TaskLeaseService for DatabaseTaskLeaseService {
         .rows_affected();
 
         if n > 0 {
-            let _ = sqlx::query(
+            if let Err(e) = sqlx::query(
                 "UPDATE agent_tasks SET agent_id = NULL WHERE task_id = ? AND user_id = ? AND agent_id = ?",
             )
             .bind(task_id)
             .bind(user_id)
             .bind(agent_id)
             .execute(&self.pool)
-            .await;
+            .await
+            {
+                tracing::warn!(
+                    target: "astra_services::multi_agent",
+                    task_id = %task_id,
+                    agent_id = %agent_id,
+                    error = %e,
+                    "failed to clear agent_id after lease release"
+                );
+            }
             self.hold_cache.release_hold(agent_id, task_id);
             Ok(true)
         } else {
@@ -741,5 +750,18 @@ mod unit_tests {
     async fn unconfigured_task_lease_errors() {
         let s = UnconfiguredTaskLeaseService;
         assert!(s.try_claim_lease("u", "t", "a", "e", 60).await.is_err());
+    }
+
+    /// audit-D9: multi_agent must not silently drop DB write errors.
+    #[test]
+    fn multi_agent_db_writes_are_not_silently_dropped() {
+        let source = include_str!("multi_agent.rs");
+        let test_start = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        let count = prod_code.matches("let _ = sqlx::query").count();
+        assert_eq!(
+            count, 0,
+            "multi_agent has {count} silently-dropped DB writes"
+        );
     }
 }

--- a/rust/crates/services/src/resource_governor.rs
+++ b/rust/crates/services/src/resource_governor.rs
@@ -180,7 +180,7 @@ impl ResourceGovernor for DatabaseResourceGovernor {
     }
 
     async fn set_limits(&self, user_id: &str, limits: ResourceLimits) {
-        let _ = sqlx::query(
+        if let Err(e) = sqlx::query(
             "INSERT INTO resource_limits \
                 (user_id, max_concurrent_sessions, max_tokens_per_day, max_disk_bytes, \
                  max_concurrent_bash, max_sessions_per_day) \
@@ -200,7 +200,15 @@ impl ResourceGovernor for DatabaseResourceGovernor {
         .bind(limits.max_concurrent_bash as i32)
         .bind(limits.max_sessions_per_day as i32)
         .execute(self.pool.get())
-        .await;
+        .await
+        {
+            tracing::warn!(
+                target: "astra_services::resource_governor",
+                user_id = %user_id,
+                error = %e,
+                "failed to persist resource limits"
+            );
+        }
     }
 
     async fn get_usage(&self, user_id: &str) -> ResourceUsage {
@@ -270,7 +278,7 @@ impl ResourceGovernor for DatabaseResourceGovernor {
 
     async fn record_session_created(&self, user_id: &str) {
         let today = Self::today();
-        let _ = sqlx::query(
+        if let Err(e) = sqlx::query(
             "INSERT INTO resource_usage (user_id, usage_date, sessions_created) \
              VALUES (?, ?, 1) \
              ON DUPLICATE KEY UPDATE sessions_created = sessions_created + 1",
@@ -278,12 +286,20 @@ impl ResourceGovernor for DatabaseResourceGovernor {
         .bind(user_id)
         .bind(&today)
         .execute(self.pool.get())
-        .await;
+        .await
+        {
+            tracing::warn!(
+                target: "astra_services::resource_governor",
+                user_id = %user_id,
+                error = %e,
+                "failed to record session creation"
+            );
+        }
     }
 
     async fn record_tool_calls(&self, user_id: &str, count: u64) {
         let today = Self::today();
-        let _ = sqlx::query(
+        if let Err(e) = sqlx::query(
             "INSERT INTO resource_usage (user_id, usage_date, tool_calls) \
              VALUES (?, ?, ?) \
              ON DUPLICATE KEY UPDATE tool_calls = tool_calls + VALUES(tool_calls)",
@@ -292,12 +308,20 @@ impl ResourceGovernor for DatabaseResourceGovernor {
         .bind(&today)
         .bind(count as i64)
         .execute(self.pool.get())
-        .await;
+        .await
+        {
+            tracing::warn!(
+                target: "astra_services::resource_governor",
+                user_id = %user_id,
+                error = %e,
+                "failed to record tool calls"
+            );
+        }
     }
 
     async fn record_tokens(&self, user_id: &str, tokens: u64) {
         let today = Self::today();
-        let _ = sqlx::query(
+        if let Err(e) = sqlx::query(
             "INSERT INTO resource_usage (user_id, usage_date, tokens_consumed) \
              VALUES (?, ?, ?) \
              ON DUPLICATE KEY UPDATE tokens_consumed = tokens_consumed + VALUES(tokens_consumed)",
@@ -306,7 +330,15 @@ impl ResourceGovernor for DatabaseResourceGovernor {
         .bind(&today)
         .bind(tokens as i64)
         .execute(self.pool.get())
-        .await;
+        .await
+        {
+            tracing::warn!(
+                target: "astra_services::resource_governor",
+                user_id = %user_id,
+                error = %e,
+                "failed to record token usage"
+            );
+        }
     }
 }
 
@@ -565,5 +597,21 @@ mod tests {
         gov.record_tool_calls("b", 20).await;
         assert_eq!(gov.get_usage("a").await.tool_calls, 10);
         assert_eq!(gov.get_usage("b").await.tool_calls, 20);
+    }
+
+    /// audit-D1/D2: DatabaseResourceGovernor must not silently drop DB write
+    /// errors. Every `sqlx::query(...).execute(...)` in production code must
+    /// be wrapped in error handling, not `let _ =`.
+    #[test]
+    fn resource_governor_db_writes_are_not_silently_dropped() {
+        let source = include_str!("resource_governor.rs");
+        let test_start = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        let silent_count = prod_code.matches("let _ = sqlx::query").count();
+        assert_eq!(
+            silent_count, 0,
+            "resource governor has {silent_count} silently-dropped DB writes; \
+             use `if let Err(e) = ... {{ tracing::warn!(...) }}` instead"
+        );
     }
 }

--- a/rust/crates/services/src/session_restore.rs
+++ b/rust/crates/services/src/session_restore.rs
@@ -1240,8 +1240,7 @@ async fn log_session_sync(
     // This prevents unbounded sync_log growth for long-running sessions.
     if inserted.rows_affected() > 0
         && let Some(retain) = crate::state_sync::sync_log_retain_limit(status)
-    {
-        let _ = sqlx::query(crate::state_sync::build_sync_log_prune_query())
+        && let Err(e) = sqlx::query(crate::state_sync::build_sync_log_prune_query())
             .bind(user_id)
             .bind(status)
             .bind(sync_type)
@@ -1250,7 +1249,15 @@ async fn log_session_sync(
             .bind(sync_type)
             .bind(retain as i64)
             .execute(pool)
-            .await;
+            .await
+    {
+        tracing::warn!(
+            target: "astra_services::session_restore",
+            user_id = %user_id,
+            sync_type = %sync_type,
+            error = %e,
+            "failed to prune sync logs"
+        );
     }
 
     Ok(())
@@ -2885,6 +2892,19 @@ mod tests {
         assert!(
             snippet.contains("cloud_step_checkpoint_number(checkpoint_number)?"),
             "step checkpoint cloud writes should use a disjoint number namespace"
+        );
+    }
+
+    /// audit-D10: session_restore must not silently drop DB write errors.
+    #[test]
+    fn session_restore_db_writes_are_not_silently_dropped() {
+        let source = include_str!("session_restore.rs");
+        let test_start = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        let count = prod_code.matches("let _ = sqlx::query").count();
+        assert_eq!(
+            count, 0,
+            "session_restore has {count} silently-dropped DB writes"
         );
     }
 }

--- a/rust/crates/services/src/state_sync.rs
+++ b/rust/crates/services/src/state_sync.rs
@@ -582,7 +582,7 @@ impl MatrixOneSyncService {
     }
 
     async fn prune_sync_logs(&self, user_id: &str, sync_type: &str, status: &str, retain: usize) {
-        let _ = sqlx::query(build_sync_log_prune_query())
+        if let Err(e) = sqlx::query(build_sync_log_prune_query())
             .bind(user_id)
             .bind(status)
             .bind(sync_type)
@@ -591,7 +591,16 @@ impl MatrixOneSyncService {
             .bind(sync_type)
             .bind(retain as i64)
             .execute(&self.pool)
-            .await;
+            .await
+        {
+            tracing::warn!(
+                target: "astra_services::state_sync",
+                user_id = %user_id,
+                sync_type = %sync_type,
+                error = %e,
+                "failed to prune sync logs"
+            );
+        }
     }
 }
 
@@ -1013,7 +1022,7 @@ impl StateSyncService for MatrixOneSyncService {
         // Write audit trail (best-effort, don't fail the push)
         if result.is_ok() {
             let history_id = uuid::Uuid::new_v4().to_string();
-            let _ = sqlx::query(
+            if let Err(e) = sqlx::query(
                 "INSERT INTO user_preference_history \
                  (history_id, user_id, pref_key, old_value, new_value, old_version, new_version, source) \
                  VALUES (?, ?, ?, ?, ?, ?, ?, 'edge')",
@@ -1026,7 +1035,16 @@ impl StateSyncService for MatrixOneSyncService {
             .bind(old_version)
             .bind(new_version)
             .execute(&self.pool)
-            .await;
+            .await
+            {
+                tracing::warn!(
+                    target: "astra_services::state_sync",
+                    user_id = %user_id,
+                    pref_key = %key,
+                    error = %e,
+                    "failed to write preference history audit trail"
+                );
+            }
         }
 
         match result {
@@ -1960,5 +1978,18 @@ mod tests {
         assert_eq!(h1, h2);
         let h3 = sha256_bytes("world");
         assert_ne!(h1, h3);
+    }
+
+    /// audit-D7/D8: state_sync must not silently drop DB write errors.
+    #[test]
+    fn state_sync_db_writes_are_not_silently_dropped() {
+        let source = include_str!("state_sync.rs");
+        let test_start = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        let count = prod_code.matches("let _ = sqlx::query").count();
+        assert_eq!(
+            count, 0,
+            "state_sync has {count} silently-dropped DB writes"
+        );
     }
 }

--- a/rust/crates/services/src/storage.rs
+++ b/rust/crates/services/src/storage.rs
@@ -1401,7 +1401,7 @@ pub async fn log_session_audit(
     session_id: &str,
     details: serde_json::Value,
 ) {
-    let _ = query(
+    if let Err(e) = query(
         "INSERT INTO auth_audit_logs \
          (log_id, user_id, action, resource_type, resource_id, details, created_at) \
          VALUES (?, ?, ?, 'session', ?, ?, NOW())",
@@ -1412,7 +1412,17 @@ pub async fn log_session_audit(
     .bind(session_id)
     .bind(details.to_string())
     .execute(pool)
-    .await;
+    .await
+    {
+        tracing::warn!(
+            target: "astra_services::storage",
+            user_id = %user_id,
+            action = %action,
+            session_id = %session_id,
+            error = %e,
+            "failed to write auth audit log"
+        );
+    }
 }
 
 pub async fn update_turn_skill_selection_version(


### PR DESCRIPTION
## Summary

Hardens edge/runtime/services paths against hung upstreams, lock poisoning panics, and silently dropped errors identified in the audit review.

## Changes

- **HTTP**: `connect_timeout` + `timeout` on Memoria clients (forwarder, compaction, evaluation, prefetch), durable-bridge and remote-skill reqwest builders, and turn observer/reflection outbound posts.
- **LLM client**: Tiered `global_llm_client` build — on failure, retry with the same timeouts without `pool_max_idle_per_host`; only then fall back to `Client::new()`.
- **Locks**: Use poison recovery (`unwrap_or_else(|e| e.into_inner())`) for rate-limit cooldown, tool-result dedup cache, concurrency_safety globals, and CLI sandbox `RwLock`.
- **Observability**: Replace `let _ = sqlx::...` / similar drops with `tracing::warn` in resource governor, durable verification insert, multi-agent lease release, plus related service paths (session restore, state sync, storage, event ingestion overflow).
- **Handler safety**: Avoid `.expect("json object")` in completions proxy; tighten evaluation Memoria timeout source test; narrow concurrency_safety guard to the prior poison expect string.
- **Tests**: Black-hole TCP timeout tests where appropriate; poison-recovery and source-scan regression tests.

## Testing

- `make format-check`
- `make lint`
- `make build`
- Targeted `cargo test` for touched units (llm_client, evaluation, turn-core) during development

Made with [Cursor](https://cursor.com)