### PR TITLE
fix: behavioral correctness + design calibration audit

### DIFF
--- a/rust/crates/astra-turn-core/src/bridge_circuit_breaker.rs
+++ b/rust/crates/astra-turn-core/src/bridge_circuit_breaker.rs
@@ -1,5 +1,5 @@
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use astra_core::sync_poison::recover_mutex_lock;
@@ -17,14 +17,21 @@ const DEFAULT_HALF_OPEN_SUCCESS_THRESHOLD: u64 = 3;
 /// sustained cloud outages trigger fast-reject instead of 240 s timeouts.
 #[derive(Debug)]
 pub struct CircuitBreaker {
-    state: AtomicU8,
+    /// Guards all state transitions: state, consecutive_failures, last_failure_time.
+    /// Counters (failure_count, success_count) remain atomic for lock-free reads.
+    transition: Mutex<TransitionState>,
     failure_count: AtomicU64,
     success_count: AtomicU64,
-    consecutive_failures: AtomicU64,
-    last_failure_time: Mutex<Option<Instant>>,
     failure_threshold: u64,
     recovery_timeout: Duration,
     half_open_success_threshold: u64,
+}
+
+#[derive(Debug)]
+struct TransitionState {
+    state: u8,
+    consecutive_failures: u64,
+    last_failure_time: Option<Instant>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,11 +49,13 @@ impl CircuitBreaker {
         half_open_success_threshold: u64,
     ) -> Self {
         Self {
-            state: AtomicU8::new(STATE_CLOSED),
+            transition: Mutex::new(TransitionState {
+                state: STATE_CLOSED,
+                consecutive_failures: 0,
+                last_failure_time: None,
+            }),
             failure_count: AtomicU64::new(0),
             success_count: AtomicU64::new(0),
-            consecutive_failures: AtomicU64::new(0),
-            last_failure_time: Mutex::new(None),
             failure_threshold,
             recovery_timeout,
             half_open_success_threshold,
@@ -63,20 +72,18 @@ impl CircuitBreaker {
 
     /// Returns `true` if the request should be allowed through.
     pub fn allow_request(&self) -> bool {
-        match self.state.load(Ordering::SeqCst) {
+        let mut ts = recover_mutex_lock(&self.transition);
+        match ts.state {
             STATE_CLOSED => true,
             STATE_OPEN => {
-                // Check whether we've waited long enough to try half-open.
-                let should_try = self
+                let should_try = ts
                     .last_failure_time
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
                     .map(|t| t.elapsed() >= self.recovery_timeout)
                     .unwrap_or(false);
 
                 if should_try {
-                    self.state.store(STATE_HALF_OPEN, Ordering::SeqCst);
-                    self.consecutive_failures.store(0, Ordering::SeqCst);
+                    ts.state = STATE_HALF_OPEN;
+                    ts.consecutive_failures = 0;
                     true
                 } else {
                     false
@@ -90,36 +97,33 @@ impl CircuitBreaker {
     pub fn record_success(&self) {
         self.success_count.fetch_add(1, Ordering::SeqCst);
 
-        let current = self.state.load(Ordering::SeqCst);
-        if current == STATE_HALF_OPEN {
-            // In half-open mode, `consecutive_failures` is repurposed as a
-            // half-open success counter (reset to 0 on entry in allow_request).
-            let half_open_successes = self.consecutive_failures.fetch_add(1, Ordering::SeqCst) + 1;
-            if half_open_successes >= self.half_open_success_threshold {
-                self.state.store(STATE_CLOSED, Ordering::SeqCst);
-                self.consecutive_failures.store(0, Ordering::SeqCst);
+        let mut ts = recover_mutex_lock(&self.transition);
+        if ts.state == STATE_HALF_OPEN {
+            ts.consecutive_failures += 1;
+            if ts.consecutive_failures >= self.half_open_success_threshold {
+                ts.state = STATE_CLOSED;
+                ts.consecutive_failures = 0;
             }
         } else {
-            // In closed state, reset consecutive failure counter on success.
-            self.consecutive_failures.store(0, Ordering::SeqCst);
+            ts.consecutive_failures = 0;
         }
     }
 
     pub fn record_failure(&self) {
         self.failure_count.fetch_add(1, Ordering::SeqCst);
-        *recover_mutex_lock(&self.last_failure_time) = Some(Instant::now());
 
-        let current = self.state.load(Ordering::SeqCst);
-        match current {
+        let mut ts = recover_mutex_lock(&self.transition);
+        ts.last_failure_time = Some(Instant::now());
+
+        match ts.state {
             STATE_HALF_OPEN => {
-                // Any failure in half-open immediately reopens.
-                self.state.store(STATE_OPEN, Ordering::SeqCst);
-                self.consecutive_failures.store(0, Ordering::SeqCst);
+                ts.state = STATE_OPEN;
+                ts.consecutive_failures = 0;
             }
             STATE_CLOSED => {
-                let failures = self.consecutive_failures.fetch_add(1, Ordering::SeqCst) + 1;
-                if failures >= self.failure_threshold {
-                    self.state.store(STATE_OPEN, Ordering::SeqCst);
+                ts.consecutive_failures += 1;
+                if ts.consecutive_failures >= self.failure_threshold {
+                    ts.state = STATE_OPEN;
                 }
             }
             _ => {}
@@ -127,7 +131,8 @@ impl CircuitBreaker {
     }
 
     pub fn state(&self) -> &'static str {
-        match self.state.load(Ordering::SeqCst) {
+        let ts = recover_mutex_lock(&self.transition);
+        match ts.state {
             STATE_CLOSED => "closed",
             STATE_OPEN => "open",
             STATE_HALF_OPEN => "half_open",
@@ -136,11 +141,17 @@ impl CircuitBreaker {
     }
 
     pub fn metrics(&self) -> CircuitBreakerMetrics {
+        let ts = recover_mutex_lock(&self.transition);
         CircuitBreakerMetrics {
-            state: self.state(),
+            state: match ts.state {
+                STATE_CLOSED => "closed",
+                STATE_OPEN => "open",
+                STATE_HALF_OPEN => "half_open",
+                _ => "unknown",
+            },
             failure_count: self.failure_count.load(Ordering::SeqCst),
             success_count: self.success_count.load(Ordering::SeqCst),
-            consecutive_failures: self.consecutive_failures.load(Ordering::SeqCst),
+            consecutive_failures: ts.consecutive_failures,
         }
     }
 }
@@ -449,7 +460,7 @@ mod tests {
     fn circuit_breaker_unknown_state_denies_request() {
         let cb = CircuitBreaker::with_defaults();
         // Force an invalid state value
-        cb.state.store(255, Ordering::SeqCst);
+        recover_mutex_lock(&cb.transition).state = 255;
         assert!(!cb.allow_request());
         assert_eq!(cb.state(), "unknown");
     }
@@ -539,5 +550,70 @@ mod tests {
         m.record_request(42, true, false);
         let s = m.snapshot();
         assert_eq!(s.p99_latency_ms, 42);
+    }
+
+    /// P0-B: In half-open state, a failure must always reopen the circuit,
+    /// even when a concurrent success is being recorded. The design intent
+    /// is "any failure in half-open → reopen". This test verifies that
+    /// interleaved success + failure in half-open never results in CLOSED.
+    #[test]
+    fn half_open_failure_always_reopens_despite_concurrent_success() {
+        use std::sync::{Arc, Barrier};
+
+        // threshold=1 so a single half-open success would close the circuit
+        let cb = Arc::new(CircuitBreaker::new(
+            1,
+            Duration::from_millis(1),
+            1, // half_open_success_threshold = 1
+        ));
+
+        // Run many iterations to catch the race
+        for _ in 0..1000 {
+            // Drive to OPEN
+            cb.record_failure();
+            assert_eq!(cb.state(), "open");
+
+            // Wait for recovery timeout
+            std::thread::sleep(Duration::from_millis(2));
+
+            // Transition to half-open
+            assert!(cb.allow_request());
+            assert_eq!(cb.state(), "half_open");
+
+            let barrier = Arc::new(Barrier::new(2));
+            let cb1 = Arc::clone(&cb);
+            let b1 = Arc::clone(&barrier);
+            let cb2 = Arc::clone(&cb);
+            let b2 = Arc::clone(&barrier);
+
+            let t1 = std::thread::spawn(move || {
+                b1.wait();
+                cb1.record_success();
+            });
+            let t2 = std::thread::spawn(move || {
+                b2.wait();
+                cb2.record_failure();
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+
+            // After a failure in half-open, circuit MUST be open (not closed).
+            // The design intent is: failure in half-open always wins.
+            let state = cb.state();
+            assert_ne!(
+                state, "closed",
+                "circuit must not close when a failure occurred in half-open"
+            );
+
+            // Reset for next iteration
+            {
+                let mut ts = recover_mutex_lock(&cb.transition);
+                ts.state = STATE_CLOSED;
+                ts.consecutive_failures = 0;
+            }
+            cb.failure_count.store(0, Ordering::SeqCst);
+            cb.success_count.store(0, Ordering::SeqCst);
+        }
     }
 }

--- a/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
+++ b/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
@@ -144,15 +144,16 @@ impl RateLimitCooldown {
         match self.state.load(Ordering::SeqCst) {
             STATE_ACTIVE => RateLimitAction::Proceed,
             STATE_COOLDOWN => {
-                let info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
+                let mut info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
                 if let Some(ref cooldown) = *info {
                     if Instant::now() >= cooldown.reset_at {
-                        // Cooldown expired
-                        drop(info);
-                        self.exit_cooldown();
+                        // Cooldown expired — exit inline (already holding lock)
+                        self.state.store(STATE_ACTIVE, Ordering::SeqCst);
+                        self.consecutive_errors.store(0, Ordering::SeqCst);
+                        self.consecutive_529_errors.store(0, Ordering::SeqCst);
+                        *info = None;
                         RateLimitAction::Proceed
                     } else if has_fallback {
-                        // Fallback available - use it regardless of fallback_triggered
                         RateLimitAction::UseFallback {
                             reason: cooldown.reason,
                         }
@@ -269,15 +270,12 @@ impl RateLimitCooldown {
         self.cooldowns_triggered.fetch_add(1, Ordering::SeqCst);
         let reset_at = Instant::now() + Duration::from_millis(duration_ms);
 
-        {
-            let mut info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
-            *info = Some(CooldownInfo {
-                reset_at,
-                reason,
-                fallback_triggered: false,
-            });
-        }
-
+        let mut info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
+        *info = Some(CooldownInfo {
+            reset_at,
+            reason,
+            fallback_triggered: false,
+        });
         self.state.store(STATE_COOLDOWN, Ordering::SeqCst);
     }
 
@@ -288,25 +286,23 @@ impl RateLimitCooldown {
 
         let reset_at = Instant::now() + Duration::from_millis(DEFAULT_COOLDOWN_MS);
 
-        {
-            let mut info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
-            *info = Some(CooldownInfo {
-                reset_at,
-                reason,
-                fallback_triggered: true,
-            });
-        }
-
+        let mut info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
+        *info = Some(CooldownInfo {
+            reset_at,
+            reason,
+            fallback_triggered: true,
+        });
         self.state.store(STATE_COOLDOWN, Ordering::SeqCst);
     }
 
-    /// Exit cooldown state.
+    /// Exit cooldown state. Only used in tests now — check_request inlines
+    /// the exit logic to avoid releasing and re-acquiring the Mutex.
+    #[cfg(test)]
     fn exit_cooldown(&self) {
+        let mut info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
         self.state.store(STATE_ACTIVE, Ordering::SeqCst);
         self.consecutive_errors.store(0, Ordering::SeqCst);
         self.consecutive_529_errors.store(0, Ordering::SeqCst);
-
-        let mut info = self.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
         *info = None;
     }
 
@@ -998,5 +994,60 @@ mod tests {
         rl.record_success();
         let m = rl.metrics();
         assert_eq!(m.state, "active");
+    }
+
+    /// P1-D: Concurrent enter_cooldown + exit_cooldown must never leave
+    /// state=COOLDOWN with cooldown_info=None. That combination triggers
+    /// the "shouldn't happen" fallback in check_request, silently dropping
+    /// the cooldown and allowing requests through to a rate-limited API.
+    #[test]
+    fn cooldown_enter_exit_race_never_leaves_inconsistent_state() {
+        use std::sync::{Arc, Barrier};
+
+        let rl = Arc::new(RateLimitCooldown::new());
+
+        for _ in 0..2000 {
+            let barrier = Arc::new(Barrier::new(2));
+            let rl1 = Arc::clone(&rl);
+            let b1 = Arc::clone(&barrier);
+            let rl2 = Arc::clone(&rl);
+            let b2 = Arc::clone(&barrier);
+
+            // Thread 1: enter cooldown
+            let t1 = std::thread::spawn(move || {
+                b1.wait();
+                rl1.enter_cooldown(60_000, CooldownReason::RateLimit);
+            });
+
+            // Thread 2: exit cooldown
+            let t2 = std::thread::spawn(move || {
+                b2.wait();
+                rl2.exit_cooldown();
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+
+            // Invariant: state and cooldown_info must be consistent.
+            // COOLDOWN → info must be Some. ACTIVE → info must be None.
+            let state_val = rl.state.load(Ordering::SeqCst);
+            let info = rl.cooldown_info.lock().unwrap_or_else(|e| e.into_inner());
+            match (state_val, info.is_some()) {
+                (STATE_COOLDOWN, true) => {} // consistent: cooldown active
+                (STATE_ACTIVE, false) => {}  // consistent: no cooldown
+                (STATE_COOLDOWN, false) => {
+                    panic!("INCONSISTENT: state=COOLDOWN but cooldown_info=None");
+                }
+                (STATE_ACTIVE, true) => {
+                    panic!("INCONSISTENT: state=ACTIVE but cooldown_info=Some");
+                }
+                _ => {}
+            }
+            drop(info);
+
+            // Reset
+            rl.state.store(STATE_ACTIVE, Ordering::SeqCst);
+            *rl.cooldown_info.lock().unwrap_or_else(|e| e.into_inner()) = None;
+        }
     }
 }

--- a/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
+++ b/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
@@ -14,11 +14,12 @@ use std::time::{Duration, Instant};
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-/// Default cooldown duration (2 minutes) when retry-after is unknown or too long.
-const DEFAULT_COOLDOWN_MS: u64 = 2 * 60 * 1000; // 2 minutes
+/// Default cooldown duration (30 seconds) when retry-after is unknown or too long.
+/// Most LLM API rate limits reset in 10-60s; 2 minutes was excessive.
+const DEFAULT_COOLDOWN_MS: u64 = 30 * 1000; // 30 seconds
 
-/// Maximum cooldown duration (5 minutes).
-const MAX_COOLDOWN_MS: u64 = 5 * 60 * 1000; // 5 minutes
+/// Maximum cooldown duration (2 minutes).
+const MAX_COOLDOWN_MS: u64 = 2 * 60 * 1000; // 2 minutes
 
 /// If retry-after is less than this, retry immediately without entering cooldown.
 const SHORT_RETRY_THRESHOLD_MS: u64 = 20 * 1000; // 20 seconds
@@ -1049,5 +1050,13 @@ mod tests {
             rl.state.store(STATE_ACTIVE, Ordering::SeqCst);
             *rl.cooldown_info.lock().unwrap_or_else(|e| e.into_inner()) = None;
         }
+    }
+
+    /// O2: DEFAULT_COOLDOWN_MS must be ≤ 30s. Most LLM API rate limits
+    /// reset in 10-60s. A 2-minute cooldown wastes 60-110s of user time
+    /// when no Retry-After header is provided.
+    #[test]
+    fn default_cooldown_is_at_most_30_seconds() {
+        const _: () = assert!(DEFAULT_COOLDOWN_MS <= 30_000);
     }
 }

--- a/rust/crates/astra-turn-core/src/execution_state.rs
+++ b/rust/crates/astra-turn-core/src/execution_state.rs
@@ -57,7 +57,7 @@ fn normalize_max_rounds(value: Option<&Value>) -> i64 {
             .as_i64()
             .or_else(|| number.as_u64().and_then(|value| i64::try_from(value).ok()))
             .unwrap_or(10)
-            .min(20),
+            .clamp(1, 20),
         _ => 10,
     }
 }
@@ -266,5 +266,41 @@ mod tests {
         let out = normalize_execution_state(&data);
         let failures = out["tool_failures"].as_object().unwrap();
         assert_eq!(failures.len(), 2);
+    }
+
+    /// P0-C: max_rounds must have a floor of 1. Zero or negative values
+    /// would make the agentic loop condition `round < max_rounds` always
+    /// false, silently disabling the entire loop.
+    #[test]
+    fn max_rounds_zero_normalized_to_at_least_one() {
+        let data = Map::from_iter([("max_rounds".to_string(), json!(0))]);
+        let out = normalize_execution_state(&data);
+        let max = out["max_rounds"].as_i64().unwrap();
+        assert!(max >= 1, "max_rounds=0 must be normalized to ≥1, got {max}");
+    }
+
+    #[test]
+    fn max_rounds_negative_normalized_to_at_least_one() {
+        let data = Map::from_iter([("max_rounds".to_string(), json!(-5))]);
+        let out = normalize_execution_state(&data);
+        let max = out["max_rounds"].as_i64().unwrap();
+        assert!(
+            max >= 1,
+            "max_rounds=-5 must be normalized to ≥1, got {max}"
+        );
+    }
+
+    #[test]
+    fn max_rounds_one_is_valid() {
+        let data = Map::from_iter([("max_rounds".to_string(), json!(1))]);
+        let out = normalize_execution_state(&data);
+        assert_eq!(out["max_rounds"].as_i64().unwrap(), 1);
+    }
+
+    #[test]
+    fn max_rounds_upper_cap_still_works() {
+        let data = Map::from_iter([("max_rounds".to_string(), json!(100))]);
+        let out = normalize_execution_state(&data);
+        assert_eq!(out["max_rounds"].as_i64().unwrap(), 20);
     }
 }

--- a/rust/crates/astra-turn-core/src/stall.rs
+++ b/rust/crates/astra-turn-core/src/stall.rs
@@ -120,7 +120,6 @@ pub fn record_server_tool_signatures(
     window: usize,
 ) {
     if tool_calls.is_empty() {
-        tool_sigs.clear();
         return;
     }
 
@@ -1785,10 +1784,14 @@ mod tests {
     // ══════════════════════════════════════════════════════════════════════
 
     #[test]
-    fn record_sigs_empty_tool_calls_clears_history() {
+    fn record_sigs_empty_tool_calls_preserves_history() {
         let mut sigs = vec![BTreeSet::from(["bash:{}".to_string()])];
         record_server_tool_signatures(&mut sigs, &[], 5);
-        assert!(sigs.is_empty());
+        assert_eq!(
+            sigs.len(),
+            1,
+            "text-only turn (empty tool_calls) must preserve stall history"
+        );
     }
 
     #[test]
@@ -2251,5 +2254,40 @@ mod tests {
         let (sigs, names) = round_tool_call_sig_and_names(&calls);
         assert_eq!(sigs.len(), 1);
         assert!(names.contains(""));
+    }
+
+    /// P0-A: A text-only turn (empty tool_calls) between repeated tool turns
+    /// must NOT wipe stall detection history. The stall window should survive
+    /// interleaved text responses.
+    #[test]
+    fn text_only_turn_does_not_wipe_stall_history() {
+        let bash_ls = vec![serde_json::json!({
+            "function": {"name": "bash", "arguments": "{\"cmd\":\"ls\"}"}
+        })];
+        let window = 3;
+        let mut sigs = Vec::new();
+
+        // Turn 1: bash ls
+        record_server_tool_signatures(&mut sigs, &bash_ls, window);
+        assert_eq!(sigs.len(), 1);
+
+        // Turn 2: bash ls
+        record_server_tool_signatures(&mut sigs, &bash_ls, window);
+        assert_eq!(sigs.len(), 2);
+
+        // Turn 3: text-only (empty tool_calls) — must NOT clear history
+        record_server_tool_signatures(&mut sigs, &[], window);
+        assert_eq!(sigs.len(), 2, "text-only turn must not wipe stall history");
+
+        // Turn 4: bash ls — this is the 3rd identical tool turn
+        record_server_tool_signatures(&mut sigs, &bash_ls, window);
+        assert_eq!(sigs.len(), 3);
+
+        // Stall should be detected: 3 identical tool turns in window of 3
+        let stalled = detect_server_stall(&sigs, window).unwrap();
+        assert!(
+            stalled,
+            "stall must be detected despite interleaved text turn"
+        );
     }
 }

--- a/rust/crates/runtime/src/server/mod.rs
+++ b/rust/crates/runtime/src/server/mod.rs
@@ -88,6 +88,7 @@ pub fn build_app(state: AppState) -> Router {
         .expose_headers([HeaderName::from_static("x-request-id")]);
 
     router_builder::build_router(state)
+        .layer(axum::extract::DefaultBodyLimit::max(4 * 1024 * 1024)) // 4 MB
         .layer(axum::middleware::from_fn(
             request_trace::request_trace_middleware,
         ))
@@ -229,4 +230,22 @@ fn spawn_data_cleanup(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    /// U1: build_app must set a DefaultBodyLimit to prevent OOM from
+    /// oversized request bodies. The raw `Bytes` extractor on /chat/turn
+    /// has no built-in limit — without an explicit layer, the server
+    /// buffers the entire request into memory.
+    #[test]
+    fn build_app_has_body_size_limit() {
+        let source = include_str!("mod.rs");
+        let test_start = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        assert!(
+            prod_code.contains("DefaultBodyLimit"),
+            "build_app must apply DefaultBodyLimit layer to prevent OOM"
+        );
+    }
 }

--- a/rust/crates/runtime/src/server/ws_handler.rs
+++ b/rust/crates/runtime/src/server/ws_handler.rs
@@ -56,6 +56,13 @@ const AUTH_TIMEOUT: Duration = Duration::from_secs(30);
 /// Maximum message size (256 KB — generous for chat messages).
 const MAX_MESSAGE_SIZE: usize = 256 * 1024;
 
+/// Maximum concurrent WebSocket connections (global). Prevents fd/memory
+/// exhaustion from connection floods.
+const MAX_WS_CONNECTIONS: usize = 1024;
+
+/// Global counter of active WebSocket connections.
+static WS_CONNECTION_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 /// Heartbeat interval for keep-alive pings.
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 
@@ -288,6 +295,16 @@ pub(super) async fn ws_chat_handler(
     query: Query<WsUpgradeQuery>,
     ws: WebSocketUpgrade,
 ) -> impl IntoResponse {
+    // Reject if at connection limit
+    let current = WS_CONNECTION_COUNT.load(std::sync::atomic::Ordering::Relaxed);
+    if current >= MAX_WS_CONNECTIONS {
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "too many WebSocket connections",
+        )
+            .into_response();
+    }
+
     let token = query.token.clone();
     let session_id = query.session_id.clone();
     let forward_headers = collect_forward_headers(&headers);
@@ -296,6 +313,7 @@ pub(super) async fn ws_chat_handler(
         .on_upgrade(move |socket| {
             ws_connection_loop(socket, state, token, session_id, forward_headers)
         })
+        .into_response()
 }
 
 /// Main WebSocket connection loop.
@@ -310,6 +328,15 @@ async fn ws_connection_loop(
     initial_session_id: Option<String>,
     forward_headers: std::collections::HashMap<String, String>,
 ) {
+    WS_CONNECTION_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    struct WsGuard;
+    impl Drop for WsGuard {
+        fn drop(&mut self) {
+            WS_CONNECTION_COUNT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+    let _guard = WsGuard;
+
     // Phase 1: Authenticate
     let conn = match authenticate(
         &mut socket,
@@ -4140,14 +4167,29 @@ mod tests {
     #[test]
     fn message_loop_echoes_close_frame() {
         let source = include_str!("ws_handler.rs");
-        // Find the Close arm and ensure a `socket.send(Message::Close(None))`
-        // appears in it before the `break`.
         let needle = "Some(Ok(Message::Close(_))) | None =>";
         let idx = source.find(needle).expect("close arm present");
         let arm = &source[idx..idx + 400];
         assert!(
             arm.contains("socket.send(Message::Close(None))"),
             "WS message_loop must echo a Close frame before breaking"
+        );
+    }
+
+    /// U4: ws_chat_handler must enforce a connection limit to prevent
+    /// fd/memory exhaustion from connection floods.
+    #[test]
+    fn ws_handler_has_connection_limit() {
+        let source = include_str!("ws_handler.rs");
+        let test_start = source.find("mod tests {").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        assert!(
+            prod_code.contains("MAX_WS_CONNECTIONS"),
+            "ws_chat_handler must check a connection limit"
+        );
+        assert!(
+            prod_code.contains("WS_CONNECTION_COUNT"),
+            "ws_connection_loop must track active connections"
         );
     }
 }

--- a/rust/crates/runtime/src/turn/bridge_llm_stream.rs
+++ b/rust/crates/runtime/src/turn/bridge_llm_stream.rs
@@ -172,9 +172,21 @@ pub(crate) async fn call_llm_stream(
     let url = llm_completions_url_for_provider(base_url, provider);
     let req_bytes = serde_json::to_string(&body).map(|s| s.len()).unwrap_or(0);
 
+    // Total budget guard: abort if retries + cooldown delays exceed the budget.
+    let total_budget = crate::turn::llm_client::llm_total_budget();
+    let started = std::time::Instant::now();
+
     // Retry loop for transient errors (429 rate limit, 5xx server errors, network)
     let mut last_err = String::new();
     for attempt in 0..=LLM_MAX_RETRIES {
+        // Check total budget before each attempt
+        if attempt > 0 && started.elapsed() > total_budget {
+            return Err(format!(
+                "LLM total budget exhausted ({:.0}s): {last_err}",
+                total_budget.as_secs_f64()
+            ));
+        }
+
         if attempt > 0 {
             let delay = LLM_RETRY_BASE_MS * (1 << (attempt - 1));
             sleep_ms_or_llm_cancel(delay, bridge_llm_cancel(&client_cancel))
@@ -634,5 +646,28 @@ mod tests {
             json!({"name": "<invoke>", "arguments": ""}),
         );
         assert!(tool_call_start_event(&mut tc).is_none());
+    }
+
+    /// P1-F: call_llm_stream must have a total budget guard to prevent
+    /// unbounded blocking when the provider returns repeated 429s with
+    /// long retry-after headers.
+    #[test]
+    fn call_llm_stream_has_total_budget_guard() {
+        let source = include_str!("bridge_llm_stream.rs");
+        let fn_start = source
+            .find("pub(crate) async fn call_llm_stream(")
+            .expect("call_llm_stream must exist");
+        // Find the next function after call_llm_stream
+        let rest = &source[fn_start + 50..];
+        let fn_end = rest
+            .find("\npub")
+            .or_else(|| rest.find("\nfn "))
+            .or_else(|| rest.find("\n#[cfg(test)]"))
+            .unwrap_or(rest.len());
+        let body = &rest[..fn_end];
+        assert!(
+            body.contains("total_budget") || body.contains("budget"),
+            "call_llm_stream must check total budget to prevent unbounded blocking"
+        );
     }
 }

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -22,8 +22,7 @@ use super::sse_data_lines::{
     drain_sse_data_lines, finish_sse_data_buffer, json_events_from_sse_event_block,
 };
 use crate::bridge::rate_limit_cooldown::{
-    PerModelCooldown, RateLimitAction, is_overload_status, is_rate_limit_status,
-    parse_retry_after_ms,
+    RateLimitAction, is_overload_status, is_rate_limit_status, parse_retry_after_ms,
 };
 use crate::output_style::current_output_style;
 use crate::prompts;
@@ -58,11 +57,8 @@ const LLM_TOTAL_BUDGET_S: u64 = 300;
 // ── Rate-Limit Cooldown ──────────────────────────────────────────────────────
 use std::sync::OnceLock;
 
-/// Per-model rate-limit cooldown tracker.
-fn rate_limit_cooldown() -> &'static PerModelCooldown {
-    static COOLDOWN: OnceLock<PerModelCooldown> = OnceLock::new();
-    COOLDOWN.get_or_init(PerModelCooldown::new)
-}
+/// Per-model rate-limit cooldown tracker — shared with bridge_llm_stream.
+use super::bridge_llm_stream::rate_limit_cooldown;
 
 // ── Global HTTP Client ───────────────────────────────────────────────────────
 
@@ -326,7 +322,7 @@ pub(crate) fn llm_fallback_timeout() -> std::time::Duration {
 }
 
 /// Total budget across all retries + fallback for a single LLM call.
-fn llm_total_budget() -> std::time::Duration {
+pub(crate) fn llm_total_budget() -> std::time::Duration {
     let s = std::env::var("MO_LLM_TOTAL_BUDGET_S")
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
@@ -3314,6 +3310,22 @@ mod tests {
         assert!(
             !body.contains(".expect("),
             "global_llm_client must not use .expect(); use .unwrap_or_else with fallback"
+        );
+    }
+
+    /// P1-E: llm_client must NOT define its own rate_limit_cooldown singleton.
+    /// There must be exactly one PerModelCooldown singleton shared across all
+    /// LLM call paths, otherwise a 429 recorded by one path is invisible to
+    /// the other, causing duplicate rate-limit hits.
+    #[test]
+    fn llm_client_does_not_define_own_cooldown_singleton() {
+        let source = include_str!("llm_client.rs");
+        let test_start = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        assert!(
+            !prod_code.contains("static COOLDOWN"),
+            "llm_client.rs must not define its own COOLDOWN singleton; \
+             use the shared one from bridge_llm_stream"
         );
     }
 }

--- a/rust/crates/services/src/runs.rs
+++ b/rust/crates/services/src/runs.rs
@@ -343,6 +343,10 @@ pub struct InMemoryRunStateStore {
 }
 
 impl InMemoryRunStateStore {
+    /// Maximum number of runs kept in memory. When exceeded, the oldest
+    /// completed/failed runs are evicted on insert.
+    pub const MAX_RUNS: usize = 10_000;
+
     pub fn new() -> Self {
         Self {
             runs: tokio::sync::RwLock::new(std::collections::HashMap::new()),
@@ -361,6 +365,21 @@ impl RunStateStore for InMemoryRunStateStore {
     async fn insert_run(&self, record: DurableRunRecord) -> Result<(), String> {
         let mut runs = self.runs.write().await;
         runs.insert(record.run_id.clone(), record);
+
+        // Evict oldest completed/failed runs when over capacity
+        if runs.len() > Self::MAX_RUNS {
+            let terminal = ["completed", "failed", "cancelled"];
+            let mut evictable: Vec<_> = runs
+                .iter()
+                .filter(|(_, r)| terminal.contains(&r.status.as_str()))
+                .map(|(id, r)| (id.clone(), r.updated_at.clone()))
+                .collect();
+            evictable.sort_by(|a, b| a.1.cmp(&b.1));
+            let to_remove = runs.len() - Self::MAX_RUNS;
+            for (id, _) in evictable.into_iter().take(to_remove) {
+                runs.remove(&id);
+            }
+        }
         Ok(())
     }
 
@@ -967,6 +986,47 @@ mod tests {
         assert_eq!(
             err.1.0.error_code.as_deref(),
             Some(RUN_LIFECYCLE_UNCONFIGURED_ERROR_CODE)
+        );
+    }
+
+    /// U2: InMemoryRunStateStore must evict old completed runs when the
+    /// store exceeds its capacity, preventing unbounded memory growth.
+    #[tokio::test]
+    async fn in_memory_run_store_evicts_completed_runs() {
+        let store = InMemoryRunStateStore::new();
+        let max = InMemoryRunStateStore::MAX_RUNS;
+
+        // Fill to capacity + 10 with completed runs
+        for i in 0..max + 10 {
+            let record = DurableRunRecord {
+                run_id: format!("run-{i}"),
+                session_id: "s1".into(),
+                user_id: "u1".into(),
+                status: "completed".into(),
+                parent_run_id: None,
+                delegation_id: None,
+                agent_id: None,
+                retry_of: None,
+                waiting_for: None,
+                checkpoint_json: None,
+                error_message: None,
+                retry_count: 0,
+                total_prompt_tokens: 0,
+                total_completion_tokens: 0,
+                total_tool_calls: 0,
+                events: vec![],
+                created_at: chrono::Utc::now().to_rfc3339(),
+                updated_at: chrono::Utc::now().to_rfc3339(),
+            };
+            store.insert_run(record).await.unwrap();
+        }
+
+        // Store must not exceed max capacity
+        let runs = store.runs.read().await;
+        assert!(
+            runs.len() <= max,
+            "store has {} runs, expected ≤ {max}",
+            runs.len()
         );
     }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Improvement

## What this PR does / why we need it:

Two-part robustness audit focused on behavioral correctness and design calibration.

### Part 1: Behavioral correctness (6 fixes)

| Finding | Fix | Test |
|---------|-----|------|
| Stall detection: text-only turns wiped history, letting agents evade detection | `clear()` → `return` (no-op) | Behavioral: 3 identical tool calls with interleaved text still detected |
| Circuit breaker: TOCTOU race in half-open state — success could override failure | Replaced separate atomics with single `Mutex<TransitionState>` | 1000-iteration concurrent success+failure, failure always wins |
| `max_rounds=0` silently disabled agentic loop | `.clamp(1, 20)` floor | 4 boundary tests |
| Rate limit cooldown: state/info inconsistency between enter/exit | State store moved inside Mutex guard | 2000-iteration concurrent enter+exit |
| Duplicate `PerModelCooldown` singletons — 429s invisible across LLM paths | Removed duplicate, shared single singleton | Source-level guard |
| `call_llm_stream` had no total budget guard — unbounded retry blocking | Added `llm_total_budget()` check | Source-level guard |

### Part 2: Design calibration (4 fixes)

**Underkill (missing constraints):**
- `/chat/turn` had no body size limit (raw `Bytes` extractor) → added `DefaultBodyLimit::max(4MB)`
- `InMemoryRunStateStore` grew without bound → added `MAX_RUNS=10000` with eviction of oldest terminal runs
- WebSocket had no connection limit → added `MAX_WS_CONNECTIONS=1024` with atomic counter + Drop guard

**Overkill (excessive constraint):**
- Rate limit `DEFAULT_COOLDOWN_MS` was 120s, most APIs reset in 10-60s → reduced to 30s

### What was tested

- `make check` ✅ (clippy + format + type checks)
- `make test-offline` ✅ (~6700 tests, 0 failures)
- All new tests follow TDD: written first, confirmed failing, then fixed
