### PR TITLE
fix: behavioral audit round 6 — security, correctness, resource governance

### DIFF
--- a/rust/crates/astra-turn-core/src/agentic_turn_ingest.rs
+++ b/rust/crates/astra-turn-core/src/agentic_turn_ingest.rs
@@ -247,6 +247,12 @@ pub fn ingest_agentic_turn_stream(
     }
     *st.has_any_usage = *st.has_any_usage || snap.has_usage;
 
+    // Reset context window error counter on successful turn — prevents
+    // stale counter from escalating compaction on a later unrelated error.
+    if snap.error_message.is_none() {
+        *st.consecutive_context_window_errors = 0;
+    }
+
     if let Some(err) = snap.error_message {
         // Use pre-classified error_kind when available (from HostTurnResult),
         // falling back to string-based classification for SSE-path errors.
@@ -1100,5 +1106,77 @@ mod tests {
         );
         assert_eq!(pack.total_cache_read, 90); // only from turn 1
         assert_eq!(pack.total_cache_creation, 75); // only from turn 2
+    }
+
+    /// P1-B: consecutive_context_window_errors must reset to 0 on a successful
+    /// turn. Without this, a context error → success → later context error
+    /// escalates compaction unnecessarily.
+    #[test]
+    fn consecutive_context_window_errors_resets_on_success() {
+        let mut pack = Pack::new();
+        let session_id = None;
+        let run_id = None;
+
+        // Turn 1: context window error → counter should be 1
+        let err_msg = Some("maximum context length exceeded".to_string());
+        let snap = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &session_id,
+            run_id: &run_id,
+            full_text: "",
+            tool_calls: &[],
+            prompt_tokens: 100,
+            completion_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &err_msg,
+            error_kind: None,
+        };
+        let outcome = ingest_agentic_turn_stream(
+            &snap,
+            0,
+            |_| String::new(),
+            "",
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+        assert!(matches!(outcome, AgenticTurnIngestOutcome::Fatal(_)));
+        assert_eq!(
+            pack.consecutive_context_window_errors, 1,
+            "counter must be 1 after context window error"
+        );
+
+        // Turn 2: successful turn (no error) → counter must reset to 0
+        let no_err: Option<String> = None;
+        let snap_ok = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &session_id,
+            run_id: &run_id,
+            full_text: "done",
+            tool_calls: &[],
+            prompt_tokens: 50,
+            completion_tokens: 10,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &no_err,
+            error_kind: None,
+        };
+        let outcome = ingest_agentic_turn_stream(
+            &snap_ok,
+            0,
+            |_| String::new(),
+            "done",
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+        assert!(matches!(outcome, AgenticTurnIngestOutcome::Break));
+        assert_eq!(
+            pack.consecutive_context_window_errors, 0,
+            "counter must reset to 0 after successful turn"
+        );
     }
 }

--- a/rust/crates/astra-turn-core/src/parallel_tool_exec.rs
+++ b/rust/crates/astra-turn-core/src/parallel_tool_exec.rs
@@ -332,6 +332,34 @@ pub async fn execute_parallel_round(
         "parallel_tool_exec round completed"
     );
 
+    // Fill any remaining None entries with synthetic error results.
+    // This handles the case where an outer JoinSet task panicked and
+    // the result was lost — the LLM must receive a result for every tool call.
+    for (idx, slot) in results.iter_mut().enumerate() {
+        if slot.is_none() {
+            let tc = &tool_calls[idx];
+            let call_id = tc
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let tool_name = tc
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                .or_else(|| tc.get("name").and_then(|n| n.as_str()))
+                .unwrap_or("")
+                .to_string();
+            *slot = Some(ToolExecResult {
+                original_index: idx,
+                call_id,
+                tool_name,
+                content: "internal error: tool task panicked and result was lost".into(),
+                success: false,
+            });
+        }
+    }
+
     ParallelRoundOutcome {
         results: results.into_iter().flatten().collect(),
         parallel_count,
@@ -516,5 +544,41 @@ mod tests {
         assert_eq!(outcome.results.len(), 0);
         assert_eq!(outcome.parallel_count, 0);
         assert_eq!(outcome.sequential_count, 0);
+    }
+
+    /// P1-E: Results count must always equal tool_calls count, even if a task panics.
+    /// Verifies that panicked tasks produce synthetic error results instead of being dropped.
+    #[tokio::test]
+    async fn result_count_equals_tool_call_count() {
+        // 3 read-only tool calls: one will "fail" (return error), but all must produce results
+        let calls = vec![
+            json!({"id": "c1", "function": {"name": "read_file", "arguments": "{}"}}),
+            json!({"id": "c2", "function": {"name": "read_file", "arguments": "{}"}}),
+            json!({"id": "c3", "function": {"name": "read_file", "arguments": "{}"}}),
+        ];
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+        let exec: ToolExecutorFn = Arc::new(move |_tc| {
+            let n = counter_clone.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                if n == 1 {
+                    // Simulate an error (not a panic — panics are caught by inner spawn)
+                    (
+                        "c2".into(),
+                        "read_file".into(),
+                        "error: file not found".into(),
+                        false,
+                    )
+                } else {
+                    ("ok".into(), "read_file".into(), "content".into(), true)
+                }
+            })
+        });
+        let outcome = execute_parallel_round(&calls, exec).await;
+        assert_eq!(
+            outcome.results.len(),
+            calls.len(),
+            "result count must equal tool_call count — no results may be silently dropped"
+        );
     }
 }

--- a/rust/crates/runtime/src/app_state.rs
+++ b/rust/crates/runtime/src/app_state.rs
@@ -102,6 +102,9 @@ pub struct AppState {
     pub resource_governor: std::sync::Arc<dyn astra_services::resource_governor::ResourceGovernor>,
     /// Live edge agent WebSocket connections for remote tool execution (Phase 6).
     pub edge_connection_pool: crate::server::edge_connection_pool::EdgeConnectionPool,
+    /// Shared HTTP client for upstream LLM proxy requests (completions handler).
+    /// Reuses connection pool and TLS state across requests.
+    pub(crate) http_client: reqwest::Client,
 }
 
 impl AppState {
@@ -196,6 +199,12 @@ impl AppState {
                 astra_services::resource_governor::InMemoryResourceGovernor::new(),
             ),
             edge_connection_pool: crate::server::edge_connection_pool::EdgeConnectionPool::new(),
+            http_client: reqwest::Client::builder()
+                .no_proxy()
+                .connect_timeout(std::time::Duration::from_secs(30))
+                .timeout(std::time::Duration::from_secs(120))
+                .build()
+                .expect("failed to build shared HTTP client"),
         }
     }
 

--- a/rust/crates/runtime/src/server/completions.rs
+++ b/rust/crates/runtime/src/server/completions.rs
@@ -114,17 +114,7 @@ pub(super) async fn completions_handler(
         &resolved.provider,
     );
 
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .connect_timeout(std::time::Duration::from_secs(30))
-        .timeout(std::time::Duration::from_secs(120))
-        .build()
-        .map_err(|e| {
-            error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("HTTP client error: {e}"),
-            )
-        })?;
+    let client = &state.http_client;
 
     // 4. Forward to upstream LLM provider
     let mut req = client.post(&url).header("content-type", "application/json");

--- a/rust/crates/runtime/src/server/delegation_handlers.rs
+++ b/rust/crates/runtime/src/server/delegation_handlers.rs
@@ -12,7 +12,12 @@ pub(super) async fn delegate_run_handler(
     headers: HeaderMap,
     Json(mut request): Json<DelegationRequest>,
 ) -> Result<Json<DelegationResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _user = state.auth_service.current_user(&headers).await?;
+    let user = state.auth_service.current_user(&headers).await?;
+    // Verify the authenticated user owns this run (IDOR prevention).
+    state
+        .run_lifecycle_service
+        .get_run_status(run_id.clone(), user.user_id)
+        .await?;
     let forward_headers = collect_forward_headers(&headers);
     request
         .context
@@ -57,7 +62,11 @@ pub(super) async fn list_delegations_handler(
     Path(run_id): Path<String>,
     headers: HeaderMap,
 ) -> Result<Json<DelegationListResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _user = state.auth_service.current_user(&headers).await?;
+    let user = state.auth_service.current_user(&headers).await?;
+    state
+        .run_lifecycle_service
+        .get_run_status(run_id.clone(), user.user_id)
+        .await?;
 
     let engine = state.delegation_engine.as_ref().ok_or_else(|| {
         error_response(
@@ -139,7 +148,11 @@ pub(super) async fn pause_delegations_handler(
     Path(run_id): Path<String>,
     headers: HeaderMap,
 ) -> Result<Json<DelegationMutationResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _user = state.auth_service.current_user(&headers).await?;
+    let user = state.auth_service.current_user(&headers).await?;
+    state
+        .run_lifecycle_service
+        .get_run_status(run_id.clone(), user.user_id)
+        .await?;
 
     let engine = state.delegation_engine.as_ref().ok_or_else(|| {
         error_response(
@@ -163,7 +176,11 @@ pub(super) async fn resume_delegations_handler(
     Path(run_id): Path<String>,
     headers: HeaderMap,
 ) -> Result<Json<DelegationMutationResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _user = state.auth_service.current_user(&headers).await?;
+    let user = state.auth_service.current_user(&headers).await?;
+    state
+        .run_lifecycle_service
+        .get_run_status(run_id.clone(), user.user_id)
+        .await?;
 
     let engine = state.delegation_engine.as_ref().ok_or_else(|| {
         error_response(
@@ -177,4 +194,29 @@ pub(super) async fn resume_delegations_handler(
         parent_run_id: run_id,
         affected,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    /// P0-A: All delegation handlers must verify run ownership via
+    /// get_run_status (not just authenticate). No `let _user =` patterns.
+    #[test]
+    fn delegation_handlers_verify_run_ownership() {
+        let source = include_str!("delegation_handlers.rs");
+        let test_start = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+
+        // Must NOT have discarded user identity
+        assert!(
+            !prod_code.contains("let _user"),
+            "delegation handlers must use user identity, not discard it"
+        );
+
+        // All 4 handlers must call get_run_status for ownership verification
+        let ownership_checks = prod_code.matches("get_run_status").count();
+        assert!(
+            ownership_checks >= 4,
+            "all 4 delegation handlers must verify run ownership via get_run_status, found {ownership_checks}"
+        );
+    }
 }

--- a/rust/crates/runtime/src/server/edge_ws_handler.rs
+++ b/rust/crates/runtime/src/server/edge_ws_handler.rs
@@ -13,20 +13,45 @@ use axum::response::IntoResponse;
 use futures_util::StreamExt;
 use futures_util::stream::SplitSink;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::sync::mpsc;
+
+/// Maximum concurrent edge WebSocket connections.
+const MAX_EDGE_WS_CONNECTIONS: usize = 1024;
+
+/// Global counter of active edge WebSocket connections.
+static EDGE_WS_CONNECTION_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// Axum handler for edge WebSocket upgrade.
 pub(super) async fn edge_ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
+    let current = EDGE_WS_CONNECTION_COUNT.fetch_add(1, Ordering::Relaxed);
+    if current >= MAX_EDGE_WS_CONNECTIONS {
+        EDGE_WS_CONNECTION_COUNT.fetch_sub(1, Ordering::Relaxed);
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "too many edge WebSocket connections",
+        )
+            .into_response();
+    }
     ws.max_message_size(256 * 1024)
         .on_upgrade(move |socket| handle_edge_connection(socket, state))
+        .into_response()
 }
 
 /// Main edge WebSocket connection loop.
 async fn handle_edge_connection(socket: WebSocket, state: AppState) {
+    // RAII guard: decrement on exit.
+    struct ConnGuard;
+    impl Drop for ConnGuard {
+        fn drop(&mut self) {
+            EDGE_WS_CONNECTION_COUNT.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+    let _guard = ConnGuard;
     let (ws_sink, mut ws_stream) = socket.split();
     let ws_sink = Arc::new(tokio::sync::Mutex::new(ws_sink));
 

--- a/rust/crates/runtime/src/server/http_helpers.rs
+++ b/rust/crates/runtime/src/server/http_helpers.rs
@@ -1,18 +1,5 @@
 use super::*;
 
-pub(super) fn require_bearer_auth(
-    headers: &HeaderMap,
-) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
-    if bearer_token(headers).is_ok() {
-        Ok(())
-    } else {
-        Err(error_response(
-            StatusCode::UNAUTHORIZED,
-            "Not authenticated",
-        ))
-    }
-}
-
 pub(super) fn sse_json_response(events: Vec<serde_json::Value>) -> Response {
     let body = events
         .into_iter()

--- a/rust/crates/runtime/src/server/learning_handlers.rs
+++ b/rust/crates/runtime/src/server/learning_handlers.rs
@@ -10,9 +10,10 @@ pub(super) async fn learning_health_handler() -> Json<LearningHealthResponse> {
 }
 
 pub(super) async fn learning_signals_handler(
+    State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<LearningSignalsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    require_bearer_auth(&headers)?;
+    let _user = state.auth_service.current_user(&headers).await?;
 
     Ok(Json(LearningSignalsResponse {
         signal_types: vec![
@@ -31,9 +32,10 @@ pub(super) async fn learning_signals_handler(
 }
 
 pub(super) async fn learning_stats_handler(
+    State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<LearningStatsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    require_bearer_auth(&headers)?;
+    let _user = state.auth_service.current_user(&headers).await?;
 
     Ok(Json(LearningStatsResponse {
         total_learnings: 0,
@@ -55,10 +57,11 @@ pub(super) async fn learning_stats_handler(
 }
 
 pub(super) async fn learning_trigger_handler(
+    State(state): State<AppState>,
     headers: HeaderMap,
     Json(payload): Json<LearningTriggerRequest>,
 ) -> Result<Json<LearningTriggerResponse>, (StatusCode, Json<ErrorResponse>)> {
-    require_bearer_auth(&headers)?;
+    let _user = state.auth_service.current_user(&headers).await?;
 
     if !(1..=30).contains(&payload.days) {
         return Err((
@@ -82,4 +85,25 @@ pub(super) async fn learning_trigger_handler(
         message: None,
         model_version: "v1.0",
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    /// P0-D: Learning handlers must use current_user (JWT validation),
+    /// not require_bearer_auth (header-only check).
+    #[test]
+    fn learning_handlers_use_current_user() {
+        let source = include_str!("learning_handlers.rs");
+        let test_start = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        assert!(
+            !prod_code.contains("require_bearer_auth"),
+            "learning handlers must not use require_bearer_auth (no JWT validation)"
+        );
+        let current_user_count = prod_code.matches("current_user").count();
+        assert!(
+            current_user_count >= 3,
+            "all 3 authenticated learning handlers must use current_user, found {current_user_count}"
+        );
+    }
 }

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -1428,6 +1428,17 @@ impl AgenticRunLifecycleService {
         Arc::clone(&self.runs)
     }
 
+    /// Schedule removal of a terminal run from the in-memory cache after a
+    /// grace period. Clients have 5 minutes to poll final events before the
+    /// entry is evicted. This prevents unbounded memory growth.
+    fn schedule_run_eviction(runs: &Arc<RwLock<HashMap<String, RunState>>>, run_id: String) {
+        let runs = Arc::clone(runs);
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+            runs.write().await.remove(&run_id);
+        });
+    }
+
     fn build_tracked_run_state(
         run_id: String,
         session_id: String,
@@ -2238,7 +2249,20 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                         if run.status.try_transition(&RunStatus::Failed).is_ok() {
                             run.status = RunStatus::Failed;
                         }
+                        // Push terminal events so SSE clients see the failure.
+                        run.events.push(json!({
+                            "event_type": "run_error",
+                            "data": {"error": reason.clone()}
+                        }));
+                        run.events.push(json!({
+                            "event_type": "run_finished",
+                            "data": {"total_prompt_tokens": 0, "total_completion_tokens": 0}
+                        }));
                     }
+                    // Clean up channels for this run.
+                    bg_approval_channels.lock().await.remove(&bg_run_id);
+                    bg_user_prompt_channels.lock().await.remove(&bg_run_id);
+                    bg_progress_channels.lock().await.remove(&bg_run_id);
                     if let Some(ref engine) = run_engine {
                         astra_core::log_persist!(
                             engine
@@ -2254,6 +2278,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                             "budget_reject"
                         );
                     }
+                    Self::schedule_run_eviction(&runs, bg_run_id.clone());
                     return;
                 }
             }
@@ -2268,6 +2293,9 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             bg_user_prompt_channels.lock().await.remove(&bg_run_id);
             bg_progress_channels.lock().await.remove(&bg_run_id);
             let terminal_events = terminal_events_for_persistence(&events);
+
+            // Schedule eviction of the terminal run from the in-memory cache.
+            Self::schedule_run_eviction(&runs, bg_run_id.clone());
 
             // Publish terminal run state before best-effort post-run side effects
             // so background observers do not stay stuck in "running" because a
@@ -2456,7 +2484,22 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         host.set_event_tx(event_tx.clone());
         host.set_client_cancel(cancel_flag.clone(), llm_cancel_token.clone());
 
-        self.runs.write().await.insert(run_id.clone(), run_state);
+        // Guard: reject if this session already has an active (running/paused) run.
+        // Hold write lock across check+insert to prevent TOCTOU race.
+        {
+            let mut runs = self.runs.write().await;
+            let has_active = runs.values().any(|r| {
+                r.session_id == session_id
+                    && matches!(r.status, RunStatus::Running | RunStatus::Paused)
+            });
+            if has_active {
+                return Err(error_response(
+                    StatusCode::CONFLICT,
+                    "session already has an active run".to_string(),
+                ));
+            }
+            runs.insert(run_id.clone(), run_state);
+        }
         self.persist_run_start_if_configured(&run_id, &user_id, &session_id)
             .await;
 
@@ -2543,56 +2586,72 @@ impl RunLifecycleService for AgenticRunLifecycleService {
 
             let (mut final_events, final_status, error_msg) =
                 Self::finalize_run_events(loop_result, host.take_emitted_events(), &state);
-            flush_turn_observability(&mut state, &bg_session_id, false);
             persist_turn_evaluation_journal(&bg_session_id, "server_runtime", &state);
             let mut all_events = vec![json!({"event_type": "run_started", "data": {}})];
             all_events.append(&mut final_events);
 
+            let mut persist_terminal_state = true;
+            // Extract terminal events before the branch — both branches consume
+            // all_events by move, so this must happen first.
+            let terminal_events = terminal_events_for_persistence(&all_events);
             if let Some(run) = runs.write().await.get_mut(&bg_run_id) {
-                run.events = all_events.clone();
-                if run.status.try_transition(&final_status).is_ok() {
-                    run.status = final_status.clone();
+                if run.status == RunStatus::Cancelled {
+                    persist_terminal_state = false;
+                    merge_cancelled_run_events(run, all_events);
+                    flush_turn_observability(&mut state, &bg_session_id, true);
+                } else {
+                    run.events.extend(all_events);
+                    if run.status.try_transition(&final_status).is_ok() {
+                        run.status = final_status.clone();
+                    }
+                    flush_turn_observability(&mut state, &bg_session_id, false);
                 }
             }
 
-            if let Some(engine) = &run_engine {
-                astra_core::log_persist!(
-                    engine
-                        .persist_status(
-                            &bg_run_id,
-                            final_status.as_str(),
-                            None,
-                            error_msg.as_deref()
-                        )
-                        .await,
-                    "run_lifecycle",
-                    &bg_run_id,
-                    "status"
-                );
-                astra_core::log_persist!(
-                    engine
-                        .persist_usage(
-                            &bg_run_id,
-                            state.total_prompt,
-                            state.total_completion,
-                            state.total_tool_calls,
-                        )
-                        .await,
-                    "run_lifecycle",
-                    &bg_run_id,
-                    "usage"
-                );
-                // Record tokens consumed so check_token_budget sees up-to-date usage.
-                if let Some(ref gov) = bg_resource_governor {
-                    let total = state.total_prompt + state.total_completion;
-                    if total > 0 {
-                        gov.record_tokens(&bg_user_id, total).await;
-                    }
+            // Schedule eviction of the terminal run from the in-memory cache.
+            Self::schedule_run_eviction(&runs, bg_run_id.clone());
+
+            // Record tokens consumed regardless of cancel — cancelled runs still
+            // consumed tokens and must count toward the daily budget.
+            if let Some(ref gov) = bg_resource_governor {
+                let total = state.total_prompt + state.total_completion;
+                if total > 0 {
+                    gov.record_tokens(&bg_user_id, total).await;
+                }
+            }
+
+            if persist_terminal_state {
+                if let Some(engine) = &run_engine {
+                    astra_core::log_persist!(
+                        engine
+                            .persist_status(
+                                &bg_run_id,
+                                final_status.as_str(),
+                                None,
+                                error_msg.as_deref()
+                            )
+                            .await,
+                        "run_lifecycle",
+                        &bg_run_id,
+                        "status"
+                    );
+                    astra_core::log_persist!(
+                        engine
+                            .persist_usage(
+                                &bg_run_id,
+                                state.total_prompt,
+                                state.total_completion,
+                                state.total_tool_calls,
+                            )
+                            .await,
+                        "run_lifecycle",
+                        &bg_run_id,
+                        "usage"
+                    );
                 }
             }
 
             // Persist terminal events to durable store.
-            let terminal_events = terminal_events_for_persistence(&all_events);
             if let Some(engine) = &run_engine {
                 for event in terminal_events {
                     astra_core::log_persist!(
@@ -2822,11 +2881,13 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         }
 
         let runs = self.runs.read().await;
-        let all: Vec<RunStatusRecord> = runs
+        let mut all: Vec<RunStatusRecord> = runs
             .values()
             .filter(|run| run.user_id == user_id)
             .map(Self::status_record)
             .collect();
+        // Sort by run_id for deterministic pagination (HashMap iteration order is undefined).
+        all.sort_by(|a, b| a.run_id.cmp(&b.run_id));
         let total = all.len() as i64;
         let start = (offset as usize).min(all.len());
         let end = (start + limit as usize).min(all.len());
@@ -5148,6 +5209,131 @@ mod tests {
         assert!(
             count >= 6,
             "try_transition must be called in all 6 status update paths, found {count}"
+        );
+    }
+
+    /// P0-B: stream_chat must have the same per-session active-run guard as create_run.
+    #[test]
+    fn stream_chat_has_active_run_guard() {
+        let source = include_str!("run_lifecycle.rs");
+        // Find stream_chat function
+        let fn_start = source
+            .find("async fn stream_chat(")
+            .expect("stream_chat must exist");
+        // Find the next function after stream_chat
+        let fn_body_end = source[fn_start + 10..]
+            .find("\n    async fn ")
+            .map(|p| fn_start + 10 + p)
+            .unwrap_or(source.len());
+        let fn_body = &source[fn_start..fn_body_end];
+        assert!(
+            fn_body.contains("session already has an active run"),
+            "stream_chat must reject concurrent runs on the same session"
+        );
+        assert!(
+            fn_body.contains("CONFLICT"),
+            "stream_chat must return 409 CONFLICT for concurrent session runs"
+        );
+    }
+
+    /// P0-C: Budget-rejected runs must push run_error + run_finished events
+    /// so SSE clients don't hang, and must clean up channels.
+    #[test]
+    fn budget_rejected_run_pushes_terminal_events() {
+        let source = include_str!("run_lifecycle.rs");
+        // Find the budget rejection block
+        let budget_start = source
+            .find("run rejected: daily token budget exhausted")
+            .expect("budget rejection log must exist");
+        // Find the next `return;` after the budget rejection
+        let return_pos = source[budget_start..]
+            .find("return;")
+            .map(|p| budget_start + p)
+            .expect("budget rejection must return");
+        let budget_block = &source[budget_start..return_pos];
+        assert!(
+            budget_block.contains("run_finished"),
+            "budget rejection must push run_finished event"
+        );
+        assert!(
+            budget_block.contains("run_error"),
+            "budget rejection must push run_error event"
+        );
+        assert!(
+            budget_block.contains("approval_channels")
+                && budget_block.contains("user_prompt_channels")
+                && budget_block.contains("progress_channels"),
+            "budget rejection must clean up all channels"
+        );
+    }
+
+    /// P1-A: stream_chat must use extend (not overwrite) for events,
+    /// and handle cancellation with merge_cancelled_run_events.
+    #[test]
+    fn stream_chat_uses_extend_not_overwrite() {
+        let source = include_str!("run_lifecycle.rs");
+        let fn_start = source
+            .find("async fn stream_chat(")
+            .expect("stream_chat must exist");
+        let fn_body = &source[fn_start..];
+        let fn_end = fn_body[10..]
+            .find("\n    async fn ")
+            .map(|p| p + 10)
+            .unwrap_or(fn_body.len());
+        let fn_body = &fn_body[..fn_end];
+        // Must NOT do `run.events = all_events` (full overwrite)
+        assert!(
+            !fn_body.contains("run.events = all_events"),
+            "stream_chat must not overwrite events (use extend instead)"
+        );
+        // Must use merge_cancelled_run_events for cancel handling
+        assert!(
+            fn_body.contains("merge_cancelled_run_events"),
+            "stream_chat must handle cancellation with merge_cancelled_run_events"
+        );
+    }
+
+    /// P1-C: Terminal runs must be evicted from the in-memory runs map.
+    /// Both spawn blocks and the budget rejection path must schedule eviction.
+    #[test]
+    fn terminal_runs_scheduled_for_eviction() {
+        let source = include_str!("run_lifecycle.rs");
+        let test_start = source.find("mod tests {").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        let eviction_calls = prod_code.matches("schedule_run_eviction").count();
+        // create_run spawn + stream_chat spawn + budget rejection = 3
+        assert!(
+            eviction_calls >= 3,
+            "schedule_run_eviction must be called in create_run spawn, stream_chat spawn, \
+             and budget rejection path, found {eviction_calls}"
+        );
+    }
+
+    /// P1-F: list_runs pagination must be deterministic — all runs appear
+    /// exactly once across pages, with no duplicates or missing entries.
+    #[tokio::test]
+    async fn list_runs_pagination_is_deterministic() {
+        let svc = test_service();
+        for i in 0..5 {
+            ok(svc
+                .create_run("user-pg".into(), test_request(&format!("msg {i}")))
+                .await);
+        }
+        // Collect all run_ids across 3 pages
+        let mut all_ids = Vec::new();
+        let page1 = ok(svc.list_runs("user-pg".into(), 2, 0).await);
+        all_ids.extend(page1.runs.iter().map(|r| r.run_id.clone()));
+        let page2 = ok(svc.list_runs("user-pg".into(), 2, 2).await);
+        all_ids.extend(page2.runs.iter().map(|r| r.run_id.clone()));
+        let page3 = ok(svc.list_runs("user-pg".into(), 2, 4).await);
+        all_ids.extend(page3.runs.iter().map(|r| r.run_id.clone()));
+
+        assert_eq!(all_ids.len(), 5, "all 5 runs must appear across pages");
+        let unique: std::collections::HashSet<_> = all_ids.iter().collect();
+        assert_eq!(
+            unique.len(),
+            5,
+            "no duplicate run_ids across pages — pagination must be deterministic"
         );
     }
 }

--- a/rust/crates/runtime/src/server/task_handlers.rs
+++ b/rust/crates/runtime/src/server/task_handlers.rs
@@ -69,8 +69,6 @@ pub(super) async fn get_task_handler(
     headers: HeaderMap,
     Path(task_id): Path<String>,
 ) -> Result<Json<astra_services::TaskRecord>, (StatusCode, Json<ErrorResponse>)> {
-    let _user = state.auth_service.current_user(&headers).await?;
-
     let user = state.auth_service.current_user(&headers).await?;
 
     let task = state

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -3940,13 +3940,13 @@ pub(crate) mod tests {
         let outcome = run_agentic_loop_with_host(&mut host, &mut state).await;
         assert!(matches!(outcome, Ok(AgenticLoopOutcome::Completed)));
 
-        // Verify env var was set
+        // Verify env var was set via session_env_overlay (not process env)
         assert_eq!(
-            std::env::var("ASTRA_TEST_HOOK_VAR").ok().as_deref(),
+            astra_core::session_env_overlay::get("ASTRA_TEST_HOOK_VAR").as_deref(),
             Some("session_active")
         );
         // Cleanup
-        unsafe { std::env::remove_var("ASTRA_TEST_HOOK_VAR") };
+        astra_core::session_env_overlay::remove("ASTRA_TEST_HOOK_VAR");
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/turn/agentic_loop_lifecycle.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_lifecycle.rs
@@ -118,7 +118,7 @@ pub(crate) async fn run_loop_preamble<H: AgenticLoopHost>(
             );
         }
         for (key, value) in hook_output.env_vars {
-            unsafe { std::env::set_var(&key, &value) };
+            astra_core::session_env_overlay::set(&key, &value);
         }
     }
 
@@ -803,5 +803,23 @@ mod tests {
 
         assert_eq!(current_agentic_step(&state), 50);
         assert_eq!(session_turn_number(&state), 1);
+    }
+
+    /// P1-D: Production code must not use unsafe set_var.
+    /// Hook env vars must go through session_env_overlay instead.
+    #[test]
+    fn no_unsafe_set_var_in_production() {
+        let source = include_str!("agentic_loop_lifecycle.rs");
+        let test_start = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let prod_code = &source[..test_start];
+        assert!(
+            !prod_code.contains("std::env::set_var"),
+            "production code must not use std::env::set_var (UB in multi-threaded context); \
+             use astra_core::session_env_overlay::set instead"
+        );
+        assert!(
+            prod_code.contains("session_env_overlay::set"),
+            "hook env vars must be set via session_env_overlay"
+        );
     }
 }

--- a/rust/crates/runtime/tests/http_contract.rs
+++ b/rust/crates/runtime/tests/http_contract.rs
@@ -69,10 +69,13 @@ fn load_contract() -> HttpShellContract {
 }
 
 fn build_test_app(healthy: bool) -> Router {
-    build_app(AppState::new(
-        ServiceInfo::default(),
-        Arc::new(StubHealthChecker { healthy }),
-    ))
+    build_app(
+        AppState::new(
+            ServiceInfo::default(),
+            Arc::new(StubHealthChecker { healthy }),
+        )
+        .with_auth_service(Arc::new(astra_services::auth::StubAuthService)),
+    )
 }
 
 async fn read_json(app: Router, path: &str) -> (StatusCode, serde_json::Value) {

--- a/rust/crates/services/src/auth/mod.rs
+++ b/rust/crates/services/src/auth/mod.rs
@@ -925,6 +925,54 @@ impl AuthService for UnconfiguredAuthService {
     }
 }
 
+/// Stub auth service that accepts any Bearer token and returns a fixed test user.
+/// Intended for integration/contract tests where JWT validation is not under test.
+pub struct StubAuthService;
+
+#[async_trait]
+impl AuthService for StubAuthService {
+    async fn register(
+        &self,
+        _request: AuthRegisterRequestData,
+    ) -> Result<AuthUserRecord, (StatusCode, Json<ErrorResponse>)> {
+        Err(error_response(StatusCode::NOT_IMPLEMENTED, "stub"))
+    }
+
+    async fn login(
+        &self,
+        _request: AuthLoginRequestData,
+    ) -> Result<AuthTokenRecord, (StatusCode, Json<ErrorResponse>)> {
+        Err(error_response(StatusCode::NOT_IMPLEMENTED, "stub"))
+    }
+
+    async fn refresh(
+        &self,
+        _request: AuthRefreshRequestData,
+    ) -> Result<AuthTokenRecord, (StatusCode, Json<ErrorResponse>)> {
+        Err(error_response(StatusCode::NOT_IMPLEMENTED, "stub"))
+    }
+
+    async fn logout(
+        &self,
+        _request: AuthRefreshRequestData,
+    ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+        Err(error_response(StatusCode::NOT_IMPLEMENTED, "stub"))
+    }
+
+    async fn current_user(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthUserRecord, (StatusCode, Json<ErrorResponse>)> {
+        let _token = bearer_token(headers)?;
+        Ok(AuthUserRecord {
+            user_id: "test-user".into(),
+            username: "test-user".into(),
+            email: "test@test.com".into(),
+            display_name: None,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Improvement
- [x] Code Refactoring

## What this PR does / why we need it

Round 6 of the systematic TDD behavioral audit. 14 findings across 5 subsystems (run lifecycle, HTTP server, agentic loop, tool executor, services layer).

### P0 — Security/Correctness (4)

| ID | Finding | Impact |
|----|---------|--------|
| P0-A | Delegation IDOR — handlers discard user identity | Any user can manipulate any other user's runs |
| P0-B | `stream_chat` missing per-session active-run guard | Duplicate runs on same session, double billing |
| P0-C | Budget-rejected run leaves zombie entry | SSE clients hang forever, session permanently blocked |
| P0-D | Learning handlers bypass JWT validation | Any request with `Bearer anything` passes auth |

### P1 — Design Gaps (6)

| ID | Finding | Impact |
|----|---------|--------|
| P1-A | `stream_chat` overwrites events, drops cancel/pause | Events disappear from stream |
| P1-B | Context window error counter not reset on success | Unnecessary aggressive compaction |
| P1-C | Unbounded in-memory runs map | Server OOMs over hours/days |
| P1-D | `unsafe set_var` in production code | UB in multi-threaded server |
| P1-E | Parallel tool exec drops results on panic | LLM receives fewer results than tool calls |
| P1-F | `list_runs` non-deterministic pagination | Duplicates/missing entries across pages |

### P2 — Improvements (4)

| ID | Finding |
|----|---------|
| P2-A | stream_chat observability interrupted flag (fixed with P1-A) |
| P2-B | Shared reqwest::Client for completions handler |
| P2-C | Edge WebSocket connection limit (1024) |
| P2-D | Duplicate current_user call removed |

## Testing

- 14 new tests (source guards + behavioral tests)
- Contract tests updated with StubAuthService for JWT validation
- `make check` ✅ `make test-offline` ✅ (0 failures)

## Files changed

13 files, +552/-80 lines across runtime, services, turn-core