### PR TITLE
fix: behavioral audit round 7 — resource governance, API contracts, data integrity

### DIFF
--- a/rust/crates/runtime/src/app_state.rs
+++ b/rust/crates/runtime/src/app_state.rs
@@ -218,10 +218,7 @@ impl AppState {
         self.memoria_forwarder = if key.is_empty() {
             Arc::new(NoopMemoriaForwarder)
         } else {
-            Arc::new(ReqwestMemoriaForwarder {
-                base_url: base_url.clone(),
-                master_key: key,
-            })
+            Arc::new(ReqwestMemoriaForwarder::new(base_url.clone(), key))
         };
         self.memoria_base_url = base_url;
         self.memoria_master_key = master_key;
@@ -652,6 +649,23 @@ impl Default for ServiceInfo {
 pub struct ReqwestMemoriaForwarder {
     pub base_url: String,
     pub master_key: String,
+    client: reqwest::Client,
+}
+
+impl ReqwestMemoriaForwarder {
+    pub fn new(base_url: String, master_key: String) -> Self {
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build Memoria HTTP client");
+        Self {
+            base_url,
+            master_key,
+            client,
+        }
+    }
 }
 
 #[async_trait]
@@ -662,13 +676,8 @@ impl MemoriaForwarder for ReqwestMemoriaForwarder {
         body: serde_json::Value,
     ) -> Result<serde_json::Value, String> {
         let url = format!("{}{}", self.base_url, endpoint);
-        let client = reqwest::Client::builder()
-            .no_proxy()
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .map_err(|e| format!("Memoria client build error: {e}"))?;
-        let resp = client
+        let resp = self
+            .client
             .post(&url)
             .header("Authorization", format!("Bearer {}", self.master_key))
             .json(&body)
@@ -789,10 +798,8 @@ mod tests {
             }
         });
 
-        let forwarder = ReqwestMemoriaForwarder {
-            base_url: format!("http://{addr}"),
-            master_key: "test-key".to_string(),
-        };
+        let forwarder =
+            ReqwestMemoriaForwarder::new(format!("http://{addr}"), "test-key".to_string());
 
         let start = std::time::Instant::now();
         let result = forwarder
@@ -807,6 +814,29 @@ mod tests {
         assert!(
             elapsed < std::time::Duration::from_secs(60),
             "should time out well before 60s, took {elapsed:?}"
+        );
+    }
+
+    /// P1-B: ReqwestMemoriaForwarder must NOT create a per-request client.
+    /// The `forward` method must reuse `self.client`.
+    #[test]
+    fn memoria_forwarder_reuses_client() {
+        let source = include_str!("app_state.rs");
+        let impl_start = source
+            .find("impl MemoriaForwarder for ReqwestMemoriaForwarder")
+            .expect("impl block must exist");
+        let impl_end = source[impl_start..]
+            .find("\n/// ")
+            .map(|p| impl_start + p)
+            .unwrap_or(source.len());
+        let impl_body = &source[impl_start..impl_end];
+        assert!(
+            !impl_body.contains("Client::builder"),
+            "forward() must not create a per-request client — use self.client"
+        );
+        assert!(
+            impl_body.contains("self.client") || impl_body.contains("self\n            .client"),
+            "forward() must use the shared self.client"
         );
     }
 }

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -2853,6 +2853,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         limit: u32,
         offset: u32,
     ) -> Result<RunListRecord, (StatusCode, Json<ErrorResponse>)> {
+        let (limit, offset) = astra_services::pagination::clamp_api_list_pagination(limit, offset);
         if let Some(engine) = &self.run_engine {
             let (durable_runs, total) = engine
                 .list_user_runs(&user_id, limit, offset)
@@ -4184,6 +4185,38 @@ mod tests {
         assert_eq!(page2.runs.len(), 2);
         let page3 = ok(svc.list_runs("user-1".into(), 2, 4).await);
         assert_eq!(page3.runs.len(), 1);
+    }
+
+    /// P2-B: list_runs must clamp pagination params like other list endpoints.
+    #[tokio::test]
+    async fn list_runs_clamps_pagination() {
+        let svc = test_service();
+        // Absurdly large limit/offset must not panic or produce unbounded queries
+        let result = ok(svc.list_runs("user-clamp".into(), u32::MAX, u32::MAX).await);
+        assert_eq!(result.runs.len(), 0);
+        // Verify the returned limit/offset are clamped
+        assert!(
+            result.limit <= astra_services::pagination::MAX_API_LIST_LIMIT,
+            "limit must be clamped to MAX_API_LIST_LIMIT"
+        );
+    }
+
+    /// P2-B source guard: list_runs must call clamp_api_list_pagination.
+    #[test]
+    fn list_runs_uses_pagination_clamping() {
+        let source = include_str!("run_lifecycle.rs");
+        let fn_start = source
+            .find("async fn list_runs(")
+            .expect("list_runs must exist");
+        let fn_end = source[fn_start..]
+            .find("\n    async fn ")
+            .map(|p| fn_start + p)
+            .unwrap_or(source.len());
+        let fn_body = &source[fn_start..fn_end];
+        assert!(
+            fn_body.contains("clamp_api_list_pagination"),
+            "list_runs must clamp pagination params"
+        );
     }
 
     #[test]

--- a/rust/crates/services/src/events.rs
+++ b/rust/crates/services/src/events.rs
@@ -442,7 +442,10 @@ impl EventService for DatabaseEventService {
         Self::hydrate_parent_event_ids(&pool, &mut records).await?;
         let record = records.pop().expect("single event record");
         if record.user_id != user_id {
-            return Err(error_response(StatusCode::FORBIDDEN, "Permission denied"));
+            return Err(error_response(
+                StatusCode::NOT_FOUND,
+                format!("Event {} not found", event_id),
+            ));
         }
         Ok(record)
     }
@@ -496,7 +499,10 @@ impl EventService for DatabaseEventService {
         })?;
         let owner: String = session_row.try_get("user_id").map_err(internal_error)?;
         if owner != user_id {
-            return Err(error_response(StatusCode::FORBIDDEN, "Permission denied"));
+            return Err(error_response(
+                StatusCode::NOT_FOUND,
+                format!("Session {} not found", session_id),
+            ));
         }
 
         let count_row =
@@ -556,7 +562,10 @@ impl EventService for DatabaseEventService {
         })?;
         let record = Self::event_record_from_row(row)?;
         if record.user_id != user_id {
-            return Err(error_response(StatusCode::FORBIDDEN, "Permission denied"));
+            return Err(error_response(
+                StatusCode::NOT_FOUND,
+                format!("Event {} not found", event_id),
+            ));
         }
 
         let mut tx = pool.begin().await.map_err(internal_error)?;
@@ -569,6 +578,13 @@ impl EventService for DatabaseEventService {
         query("DELETE FROM agent_events WHERE event_id = ?")
             .bind(&event_id)
             .execute(&mut *tx)
+            .await
+            .map_err(internal_error)?;
+        // Reconcile session event_count after deletion to prevent permanent drift.
+        let event_count = load_agent_event_count(&mut *tx, &record.session_id)
+            .await
+            .map_err(internal_error)?;
+        upsert_agent_session_event_count(&mut *tx, &record.session_id, &user_id, event_count)
             .await
             .map_err(internal_error)?;
         tx.commit().await.map_err(internal_error)?;
@@ -644,7 +660,7 @@ pub struct EventCreateRequest {
     pub metadata: Option<serde_json::Value>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize)]
 pub struct EventListQuery {
     pub session_id: Option<String>,
     pub event_type: Option<String>,
@@ -656,16 +672,38 @@ pub struct EventListQuery {
     pub offset: u32,
 }
 
+impl Default for EventListQuery {
+    fn default() -> Self {
+        Self {
+            session_id: None,
+            event_type: None,
+            agent_id: None,
+            causal_chain_id: None,
+            limit: default_event_limit(),
+            offset: 0,
+        }
+    }
+}
+
 pub fn default_event_limit() -> u32 {
     50
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize)]
 pub struct SessionEventQuery {
     #[serde(default = "default_session_event_limit")]
     pub limit: u32,
     #[serde(default)]
     pub offset: u32,
+}
+
+impl Default for SessionEventQuery {
+    fn default() -> Self {
+        Self {
+            limit: default_session_event_limit(),
+            offset: 0,
+        }
+    }
 }
 
 pub fn default_session_event_limit() -> u32 {
@@ -895,6 +933,103 @@ mod tests {
         assert_eq!(
             request.parent_event_ids.expect("parent_event_ids"),
             vec!["p0".to_string(), "p1".to_string()]
+        );
+    }
+
+    /// P1-C: delete_event must reconcile session event_count after deletion.
+    #[test]
+    fn delete_event_reconciles_event_count() {
+        let source = include_str!("events.rs");
+        // Find the DatabaseEventService impl of delete_event (contains actual SQL)
+        let impl_start = source
+            .find("impl EventService for DatabaseEventService")
+            .expect("DatabaseEventService impl must exist");
+        let impl_source = &source[impl_start..];
+        let fn_start = impl_source
+            .find("async fn delete_event")
+            .expect("delete_event must exist in DatabaseEventService");
+        let fn_end = impl_source[fn_start..]
+            .find("\n    async fn ")
+            .map(|p| fn_start + p)
+            .unwrap_or(impl_source.len());
+        let fn_body = &impl_source[fn_start..fn_end];
+        assert!(
+            fn_body.contains("load_agent_event_count"),
+            "delete_event must recount events after deletion"
+        );
+        assert!(
+            fn_body.contains("upsert_agent_session_event_count"),
+            "delete_event must update session event_count"
+        );
+    }
+
+    /// P2-A: get_event and delete_event must return 404 (not 403) for
+    /// non-owner access to prevent IDOR information leakage.
+    #[test]
+    fn event_access_returns_not_found_for_non_owner() {
+        let source = include_str!("events.rs");
+        let impl_start = source
+            .find("impl EventService for DatabaseEventService")
+            .expect("impl must exist");
+        let impl_source = &source[impl_start..];
+        // Check get_event
+        let get_start = impl_source
+            .find("async fn get_event")
+            .expect("get_event must exist");
+        let get_end = impl_source[get_start..]
+            .find("\n    async fn ")
+            .map(|p| get_start + p)
+            .unwrap_or(impl_source.len());
+        let get_body = &impl_source[get_start..get_end];
+        assert!(
+            !get_body.contains("StatusCode::FORBIDDEN"),
+            "get_event must return NOT_FOUND (not FORBIDDEN) for non-owner"
+        );
+        // Check delete_event
+        let del_start = impl_source
+            .find("async fn delete_event")
+            .expect("delete_event must exist");
+        let del_end = impl_source[del_start..]
+            .find("\n    async fn ")
+            .map(|p| del_start + p)
+            .unwrap_or(impl_source.len());
+        let del_body = &impl_source[del_start..del_end];
+        assert!(
+            !del_body.contains("StatusCode::FORBIDDEN"),
+            "delete_event must return NOT_FOUND (not FORBIDDEN) for non-owner"
+        );
+        // Check get_session_events
+        let ses_start = impl_source
+            .find("async fn get_session_events")
+            .expect("get_session_events must exist");
+        let ses_end = impl_source[ses_start..]
+            .find("\n    async fn ")
+            .map(|p| ses_start + p)
+            .unwrap_or(impl_source.len());
+        let ses_body = &impl_source[ses_start..ses_end];
+        assert!(
+            !ses_body.contains("StatusCode::FORBIDDEN"),
+            "get_session_events must return NOT_FOUND (not FORBIDDEN) for non-owner"
+        );
+    }
+
+    /// P2-E: EventListQuery::default() must use the same limit as serde deserialization.
+    #[test]
+    fn event_list_query_default_matches_serde() {
+        let q = EventListQuery::default();
+        assert_eq!(
+            q.limit, 50,
+            "EventListQuery::default().limit must be 50 (matching serde default)"
+        );
+    }
+
+    /// P2-E: SessionEventQuery::default() must use the same limit as serde deserialization.
+    #[test]
+    fn session_event_query_default_matches_serde() {
+        let q = SessionEventQuery::default();
+        assert_eq!(
+            q.limit, 100,
+            "SessionEventQuery::default().limit must be 100 (matching serde default)"
         );
     }
 }

--- a/rust/crates/services/src/protocol.rs
+++ b/rust/crates/services/src/protocol.rs
@@ -149,7 +149,8 @@ pub struct DeltaBatch {
 }
 
 impl DeltaBatch {
-    /// Create a new empty delta batch.
+    /// Create a new empty delta batch. The batch is not valid until at least one
+    /// operation is added via [`push`](Self::push), which auto-adjusts `target_version`.
     pub fn new(source_version: i64, checkpoint_id: impl Into<String>) -> Self {
         Self {
             source_version,
@@ -197,7 +198,11 @@ impl DeltaBatch {
             ));
         }
         if self.operations.len() as i64 != self.target_version - self.source_version {
-            // This is a warning condition, not necessarily an error
+            return Err(DeltaError::ValidationFailed(format!(
+                "operation count ({}) does not match version delta ({})",
+                self.operations.len(),
+                self.target_version - self.source_version,
+            )));
         }
         if self.checkpoint_id.is_empty() {
             return Err(DeltaError::InvalidCheckpoint(
@@ -540,7 +545,7 @@ impl DeltaError {
         match self {
             Self::InvalidVersion(_) | Self::InvalidCheckpoint(_) | Self::ValidationFailed(_) => 400,
             Self::VersionConflict { .. } => 409,
-            Self::DeltaTooLarge { .. } => 409,
+            Self::DeltaTooLarge { .. } => 413,
             Self::VersionExpired { .. } => 410,
             Self::CheckpointNotFound(_) => 404,
             Self::OperationNotAllowed(_) => 403,
@@ -552,11 +557,11 @@ impl DeltaError {
         matches!(self, Self::VersionConflict { .. })
     }
 
-    /// Convert to error response JSON.
+    /// Convert to error response JSON (matches standard `ErrorResponse` envelope).
     pub fn to_error_response(&self) -> serde_json::Value {
         serde_json::json!({
-            "error": self.error_code(),
-            "message": self.to_string(),
+            "detail": self.to_string(),
+            "error_code": self.error_code(),
         })
     }
 
@@ -1249,7 +1254,7 @@ mod tests {
             size: 100,
             threshold: 50,
         };
-        assert_eq!(err.status_code(), 409);
+        assert_eq!(err.status_code(), 413);
         assert!(!err.is_retryable());
         assert_eq!(err.error_code(), "delta_too_large");
 
@@ -1295,7 +1300,7 @@ mod tests {
                 threshold: 50
             }
             .status_code(),
-            409
+            413
         );
         assert_eq!(
             DeltaError::VersionExpired {
@@ -1342,8 +1347,8 @@ mod tests {
             actual: 2,
         };
         let resp = err.to_error_response();
-        assert_eq!(resp["error"], "version_conflict");
-        assert!(resp["message"].as_str().unwrap().contains("expected 1"));
+        assert_eq!(resp["error_code"], "version_conflict");
+        assert!(resp["detail"].as_str().unwrap().contains("expected 1"));
     }
 
     #[test]
@@ -1365,5 +1370,58 @@ mod tests {
         let mut batch2 = DeltaBatch::new(1, "cp1");
         batch2.push(DeltaOp::add("/a", serde_json::json!("x")));
         assert!(batch2.approx_size() > initial);
+    }
+
+    /// P1-D: validate() must reject batches where op count doesn't match version delta.
+    #[test]
+    fn validate_rejects_op_count_version_mismatch() {
+        // DeltaBatch::new(1, "cp") creates source=1, target=2, 0 ops → mismatch
+        let batch = DeltaBatch::new(1, "cp1");
+        assert!(
+            batch.validate().is_err(),
+            "0 ops for version delta 1 must fail"
+        );
+
+        // Correct: 1 op for version delta 1
+        let mut batch = DeltaBatch::new(0, "cp1");
+        batch.push(DeltaOp::add("/a", serde_json::json!("x")));
+        assert!(
+            batch.validate().is_ok(),
+            "1 op for version delta 1 must pass"
+        );
+    }
+
+    /// P2-C: to_error_response must use standard ErrorResponse field names.
+    #[test]
+    fn error_response_uses_standard_envelope() {
+        let err = DeltaError::InvalidVersion("bad".into());
+        let json = err.to_error_response();
+        assert!(json.get("detail").is_some(), "must use 'detail' field");
+        assert!(
+            json.get("error_code").is_some(),
+            "must use 'error_code' field"
+        );
+        assert!(
+            json.get("error").is_none(),
+            "must not use legacy 'error' field"
+        );
+        assert!(
+            json.get("message").is_none(),
+            "must not use legacy 'message' field"
+        );
+    }
+
+    /// P2-D: DeltaTooLarge must return 413, not 409.
+    #[test]
+    fn delta_too_large_returns_413() {
+        let err = DeltaError::DeltaTooLarge {
+            size: 100,
+            threshold: 50,
+        };
+        assert_eq!(
+            err.status_code(),
+            413,
+            "DeltaTooLarge must be 413 Payload Too Large"
+        );
     }
 }

--- a/rust/crates/services/src/resource_governor.rs
+++ b/rust/crates/services/src/resource_governor.rs
@@ -53,6 +53,13 @@ pub struct ResourceUsage {
     pub active_sessions: u32,
 }
 
+/// Per-user usage with the date it was last reset.
+#[derive(Debug, Clone)]
+struct DatedUsage {
+    date: chrono::NaiveDate,
+    usage: ResourceUsage,
+}
+
 /// Result of a pre-execution limit check.
 #[derive(Debug, Clone, PartialEq)]
 pub enum LimitCheck {
@@ -371,7 +378,7 @@ impl ResourceGovernor for DatabaseResourceGovernor {
 
 pub struct InMemoryResourceGovernor {
     limits: Mutex<HashMap<String, ResourceLimits>>,
-    usage: Mutex<HashMap<String, ResourceUsage>>,
+    usage: Mutex<HashMap<String, DatedUsage>>,
 }
 
 impl InMemoryResourceGovernor {
@@ -380,6 +387,26 @@ impl InMemoryResourceGovernor {
             limits: Mutex::new(HashMap::new()),
             usage: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Get or create usage for today, resetting daily counters if the date changed.
+    /// `active_sessions` is preserved across resets (it tracks live state, not daily aggregate).
+    fn get_or_reset(entry: &mut DatedUsage, today: chrono::NaiveDate) -> &mut ResourceUsage {
+        if entry.date != today {
+            let active = entry.usage.active_sessions;
+            entry.date = today;
+            entry.usage = ResourceUsage {
+                active_sessions: active,
+                ..Default::default()
+            };
+        }
+        &mut entry.usage
+    }
+
+    /// Evict stale entries: users with no active sessions whose usage is from a previous day.
+    /// Called lazily during reads to bound memory growth in multi-tenant deployments.
+    fn evict_stale(map: &mut HashMap<String, DatedUsage>, today: chrono::NaiveDate) {
+        map.retain(|_, entry| entry.date == today || entry.usage.active_sessions > 0);
     }
 }
 
@@ -408,12 +435,13 @@ impl ResourceGovernor for InMemoryResourceGovernor {
     }
 
     async fn get_usage(&self, user_id: &str) -> ResourceUsage {
-        self.usage
-            .lock()
-            .unwrap()
-            .get(user_id)
-            .cloned()
-            .unwrap_or_default()
+        let today = chrono::Utc::now().date_naive();
+        let mut map = self.usage.lock().unwrap();
+        Self::evict_stale(&mut map, today);
+        match map.get_mut(user_id) {
+            Some(entry) => Self::get_or_reset(entry, today).clone(),
+            None => ResourceUsage::default(),
+        }
     }
 
     async fn check_session_create(&self, user_id: &str) -> LimitCheck {
@@ -451,22 +479,41 @@ impl ResourceGovernor for InMemoryResourceGovernor {
     }
 
     async fn record_session_created(&self, user_id: &str) {
+        let today = chrono::Utc::now().date_naive();
         let mut map = self.usage.lock().unwrap();
-        let usage = map.entry(user_id.to_string()).or_default();
+        let entry = map
+            .entry(user_id.to_string())
+            .or_insert_with(|| DatedUsage {
+                date: today,
+                usage: ResourceUsage::default(),
+            });
+        let usage = Self::get_or_reset(entry, today);
         usage.sessions_created += 1;
         usage.active_sessions += 1;
     }
 
     async fn record_tool_calls(&self, user_id: &str, count: u64) {
+        let today = chrono::Utc::now().date_naive();
         let mut map = self.usage.lock().unwrap();
-        let usage = map.entry(user_id.to_string()).or_default();
-        usage.tool_calls += count;
+        let entry = map
+            .entry(user_id.to_string())
+            .or_insert_with(|| DatedUsage {
+                date: today,
+                usage: ResourceUsage::default(),
+            });
+        Self::get_or_reset(entry, today).tool_calls += count;
     }
 
     async fn record_tokens(&self, user_id: &str, tokens: u64) {
+        let today = chrono::Utc::now().date_naive();
         let mut map = self.usage.lock().unwrap();
-        let usage = map.entry(user_id.to_string()).or_default();
-        usage.tokens_consumed += tokens;
+        let entry = map
+            .entry(user_id.to_string())
+            .or_insert_with(|| DatedUsage {
+                date: today,
+                usage: ResourceUsage::default(),
+            });
+        Self::get_or_reset(entry, today).tokens_consumed += tokens;
     }
 }
 
@@ -489,9 +536,12 @@ mod tests {
             let mut map = gov.usage.lock().unwrap();
             map.insert(
                 "u1".into(),
-                ResourceUsage {
-                    active_sessions: 5,
-                    ..Default::default()
+                DatedUsage {
+                    date: chrono::Utc::now().date_naive(),
+                    usage: ResourceUsage {
+                        active_sessions: 5,
+                        ..Default::default()
+                    },
                 },
             );
         }
@@ -508,9 +558,12 @@ mod tests {
             let mut map = gov.usage.lock().unwrap();
             map.insert(
                 "u1".into(),
-                ResourceUsage {
-                    sessions_created: 50,
-                    ..Default::default()
+                DatedUsage {
+                    date: chrono::Utc::now().date_naive(),
+                    usage: ResourceUsage {
+                        sessions_created: 50,
+                        ..Default::default()
+                    },
                 },
             );
         }
@@ -527,9 +580,12 @@ mod tests {
             let mut map = gov.usage.lock().unwrap();
             map.insert(
                 "u1".into(),
-                ResourceUsage {
-                    tokens_consumed: 2_000_000,
-                    ..Default::default()
+                DatedUsage {
+                    date: chrono::Utc::now().date_naive(),
+                    usage: ResourceUsage {
+                        tokens_consumed: 2_000_000,
+                        ..Default::default()
+                    },
                 },
             );
         }
@@ -546,9 +602,12 @@ mod tests {
             let mut map = gov.usage.lock().unwrap();
             map.insert(
                 "u1".into(),
-                ResourceUsage {
-                    tokens_consumed: 1_999_999,
-                    ..Default::default()
+                DatedUsage {
+                    date: chrono::Utc::now().date_naive(),
+                    usage: ResourceUsage {
+                        tokens_consumed: 1_999_999,
+                        ..Default::default()
+                    },
                 },
             );
         }
@@ -570,9 +629,12 @@ mod tests {
             let mut map = gov.usage.lock().unwrap();
             map.insert(
                 "admin".into(),
-                ResourceUsage {
-                    tokens_consumed: 999_999_999,
-                    ..Default::default()
+                DatedUsage {
+                    date: chrono::Utc::now().date_naive(),
+                    usage: ResourceUsage {
+                        tokens_consumed: 999_999_999,
+                        ..Default::default()
+                    },
                 },
             );
         }
@@ -758,6 +820,98 @@ mod tests {
         assert!(
             record_pos.is_some(),
             "record_tokens must be called after persist_usage in run_lifecycle"
+        );
+    }
+
+    /// P1-A: Daily counters must reset when the date changes.
+    /// A user denied yesterday must be allowed today.
+    /// active_sessions must survive the reset (it tracks live state).
+    #[tokio::test]
+    async fn daily_counters_reset_on_date_change() {
+        let gov = InMemoryResourceGovernor::new();
+        let user = "u-daily-reset";
+        let yesterday = chrono::Utc::now().date_naive() - chrono::Duration::days(1);
+
+        // Simulate yesterday's usage: at the daily cap
+        {
+            let mut map = gov.usage.lock().unwrap();
+            map.insert(
+                user.into(),
+                DatedUsage {
+                    date: yesterday,
+                    usage: ResourceUsage {
+                        sessions_created: 50,
+                        tokens_consumed: 2_000_000,
+                        tool_calls: 999,
+                        active_sessions: 2, // live sessions survive reset
+                    },
+                },
+            );
+        }
+
+        // Today: daily counters must have reset, so session create is allowed
+        assert_eq!(
+            gov.check_session_create(user).await,
+            LimitCheck::Allowed,
+            "daily counters must reset — yesterday's usage must not block today"
+        );
+
+        // Verify counters actually reset
+        let usage = gov.get_usage(user).await;
+        assert_eq!(usage.sessions_created, 0, "sessions_created must reset");
+        assert_eq!(usage.tokens_consumed, 0, "tokens_consumed must reset");
+        assert_eq!(usage.tool_calls, 0, "tool_calls must reset");
+        assert_eq!(
+            usage.active_sessions, 2,
+            "active_sessions must survive daily reset (live state)"
+        );
+    }
+
+    /// Stale entries (previous day, no active sessions) must be evicted
+    /// to prevent unbounded memory growth in multi-tenant deployments.
+    #[tokio::test]
+    async fn stale_entries_evicted_on_read() {
+        let gov = InMemoryResourceGovernor::new();
+        let yesterday = chrono::Utc::now().date_naive() - chrono::Duration::days(1);
+
+        {
+            let mut map = gov.usage.lock().unwrap();
+            // Stale user: yesterday, no active sessions → should be evicted
+            map.insert(
+                "stale".into(),
+                DatedUsage {
+                    date: yesterday,
+                    usage: ResourceUsage {
+                        sessions_created: 10,
+                        active_sessions: 0,
+                        ..Default::default()
+                    },
+                },
+            );
+            // Active user: yesterday but has active sessions → should survive
+            map.insert(
+                "active".into(),
+                DatedUsage {
+                    date: yesterday,
+                    usage: ResourceUsage {
+                        active_sessions: 1,
+                        ..Default::default()
+                    },
+                },
+            );
+        }
+
+        // Trigger eviction via get_usage
+        let _ = gov.get_usage("anyone").await;
+
+        let map = gov.usage.lock().unwrap();
+        assert!(
+            !map.contains_key("stale"),
+            "stale entry (yesterday, 0 active) must be evicted"
+        );
+        assert!(
+            map.contains_key("active"),
+            "entry with active sessions must survive eviction"
         );
     }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Improvement

## What this PR does / why we need it

Behavioral audit round 7: 4 P1 + 5 P2 fixes across resource governance, API contracts, and data integrity.

### P1 fixes

| ID | Finding | Fix |
|----|---------|-----|
| P1-A | `InMemoryResourceGovernor` daily limits never reset — counters grow monotonically | Added date-based reset: counters reset when date changes, `active_sessions` preserved |
| P1-B | `ReqwestMemoriaForwarder` creates new HTTP client per request | Shared client stored in struct, reused across all `forward()` calls |
| P1-C | `delete_event` doesn't reconcile session `event_count` | Added `load_agent_event_count` + `upsert_agent_session_event_count` inside transaction |
| P1-D | `DeltaBatch::validate()` silently accepts op count / version mismatch | Now returns `ValidationFailed` error |

### P2 fixes

| ID | Finding | Fix |
|----|---------|-----|
| P2-A | `get_event`/`delete_event` return 403 for non-owner (IDOR info leak) | Changed to 404 NOT_FOUND |
| P2-B | `list_runs` doesn't clamp pagination params | Added `clamp_api_list_pagination` |
| P2-C | `DeltaError::to_error_response()` wrong JSON shape | Aligned with standard `ErrorResponse` envelope (`detail`/`error_code`) |
| P2-D | `DeltaTooLarge` returns 409 instead of 413 | Changed to 413 Payload Too Large |
| P2-E | `EventListQuery`/`SessionEventQuery` Default gives limit=0 | Manual Default impl matching serde defaults (50/100) |

### Testing

- 11 new behavioral tests + source guard tests
- All existing tests updated for breaking changes (status codes, JSON shape)
- `make format && make check && make test-offline` — all pass (1306 tests, 0 failures)

### Files changed (5)

- `resource_governor.rs` — P1-A: daily reset with `DatedUsage` wrapper
- `app_state.rs` — P1-B: shared client in `ReqwestMemoriaForwarder`
- `events.rs` — P1-C: delete reconciliation + P2-A: 403→404 + P2-E: Default impl
- `protocol.rs` — P1-D: validate reject + P2-C: JSON shape + P2-D: 413
- `run_lifecycle.rs` — P2-B: list_runs pagination clamping