### PR TITLE
feat: detect and correct sequential single-tool round churn

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -492,6 +492,7 @@ pub(crate) async fn stream_chat_sse(
             forced_factual_retry: false,
             forced_execution_retry: false,
             forced_execution_escalation: false,
+            forced_parallel_batching: false,
             nudge_count: 0,
             guardrail_tuner: astra_runtime::guardrail_tuning::GuardrailTuner::default(),
             guardrail_tuner_records_cursor: 0,

--- a/rust/crates/astra-turn-core/src/context_assembly_trace.rs
+++ b/rust/crates/astra-turn-core/src/context_assembly_trace.rs
@@ -106,6 +106,10 @@ pub struct PromptGuidanceSignals {
     pub round_budget_warning: bool,
     pub synthesize_or_batch: bool,
     pub parallel_feedback: bool,
+    /// Set when the trailing N rounds in conversation history each ran
+    /// exactly one tool — strong signal the model is making sequential
+    /// single-tool calls that should have been batched.
+    pub parallel_batching_nudge: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/crates/astra-turn-core/src/evaluation.rs
+++ b/rust/crates/astra-turn-core/src/evaluation.rs
@@ -33,7 +33,17 @@ pub enum EvalSignal {
     NoToolsNeeded,
     /// All tools succeeded with good output.
     AllToolsHealthy,
+    /// A long run of consecutive single-tool rounds was detected — the model
+    /// likely should have batched these into parallel rounds. Carries the
+    /// length of the longest consecutive single-tool-round streak.
+    SequentialReadChurn(usize),
 }
+
+/// Threshold for [`EvalSignal::SequentialReadChurn`]: how many consecutive
+/// single-tool rounds we tolerate before flagging the turn. Calibrated against
+/// real session data: healthy turns (mutate→verify chains, locate→read pairs)
+/// observed up to 6; wasted turns (pure exploratory churn) observed at 10+.
+pub const SEQUENTIAL_READ_CHURN_THRESHOLD: usize = 8;
 
 /// Result of evaluating a turn's success and quality.
 #[derive(Debug, Clone)]
@@ -231,13 +241,57 @@ pub fn evaluate_tool_call_records(
         })
         .collect::<Vec<_>>();
     let is_live_query = looks_like_live_query_with_context(input, recent_tools);
-    evaluate_turn(
+    let mut eval = evaluate_turn(
         &tool_calls,
         stall_count,
         verdict_warning,
         budget_pressure,
         is_live_query,
-    )
+    );
+
+    // ─── Sequential read-churn detection ────────────────────────────────
+    // Count the longest run of consecutive single-tool rounds across the
+    // real (non-synthetic, non-policy-blocked) records. Excludes records
+    // without a `round` index (e.g., orphaned tail records). When the run
+    // is ≥ SEQUENTIAL_READ_CHURN_THRESHOLD, the model almost certainly
+    // could have batched these calls into parallel rounds.
+    let max_streak = longest_single_tool_round_streak(tool_call_records);
+    if max_streak >= SEQUENTIAL_READ_CHURN_THRESHOLD {
+        eval.signals.push(EvalSignal::SequentialReadChurn(max_streak));
+        eval.quality = (eval.quality - 0.10).clamp(0.0, 1.0);
+    }
+
+    eval
+}
+
+/// Group real (non-synthetic, non-policy-blocked) tool-call records by their
+/// `round` index and return the longest run of consecutive rounds that each
+/// contained exactly one tool call. Records without a round index are
+/// ignored to avoid false positives from orphaned tail entries.
+fn longest_single_tool_round_streak(records: &[ToolCallRecord]) -> usize {
+    use std::collections::BTreeMap;
+    let mut per_round: BTreeMap<u32, usize> = BTreeMap::new();
+    for record in records {
+        if record.is_synthetic_placeholder() || record.was_blocked_by_policy() {
+            continue;
+        }
+        if let Some(round) = record.round {
+            *per_round.entry(round).or_insert(0) += 1;
+        }
+    }
+    let mut current = 0_usize;
+    let mut best = 0_usize;
+    for &count in per_round.values() {
+        if count == 1 {
+            current += 1;
+            if current > best {
+                best = current;
+            }
+        } else {
+            current = 0;
+        }
+    }
+    best
 }
 
 pub fn eval_signal_to_json(signal: &EvalSignal) -> serde_json::Value {
@@ -274,6 +328,14 @@ pub fn eval_signal_to_json(signal: &EvalSignal) -> serde_json::Value {
         EvalSignal::AllToolsHealthy => json!({
             "kind": "all_tools_healthy",
             "message": "All tool calls completed successfully with non-empty output",
+        }),
+        EvalSignal::SequentialReadChurn(streak) => json!({
+            "kind": "sequential_read_churn",
+            "streak": streak,
+            "threshold": SEQUENTIAL_READ_CHURN_THRESHOLD,
+            "message": format!(
+                "Detected {streak} consecutive single-tool rounds — these calls likely should have been batched into parallel rounds"
+            ),
         }),
     }
 }
@@ -1069,5 +1131,151 @@ mod tests {
             ..Default::default()
         };
         assert!(!normal.is_synthetic_placeholder());
+    }
+
+    // ─── Sequential read-churn (real-session-shaped fixtures) ───────────
+    //
+    // Real sessions inspected to calibrate the threshold:
+    //   - 6566d6a8 turn 1: 10 consecutive single-tool read rounds → wasted
+    //   - bbae8641 turn 3: 11 consecutive single-tool read rounds → wasted
+    //   - 6da9cf8f turn 6: 16 consecutive single-tool read rounds → wasted
+    //   - 03945541 turn 1: 6 single-tool rounds (locate→read chain) → healthy
+    //   - 03945541 turn 2: max 4 single-tool rounds (mutate→verify) → healthy
+    // Threshold of 8 cleanly separates these populations.
+
+    fn record_in_round(name: &str, round: u32, batch: Option<&str>) -> ToolCallRecord {
+        ToolCallRecord {
+            name: name.to_string(),
+            ok: true,
+            ms: 50,
+            error: None,
+            input_bytes: Some(12),
+            output_bytes: Some(500),
+            args_preview: None,
+            result_preview: None,
+            file_path: None,
+            surgically_removed: None,
+            original_tool_name: None,
+            batch_id: batch.map(str::to_string),
+            parallel: Some(batch.is_some()),
+            round: Some(round),
+            args_full: None,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn sequential_read_churn_flags_long_single_tool_streak() {
+        // Mirrors session 6566d6a8 turn 1: 10 consecutive read_file rounds,
+        // each with exactly one tool call. The model should have batched.
+        let mut records = Vec::new();
+        for r in 0..10 {
+            records.push(record_in_round("read_file", r, None));
+        }
+        let eval = evaluate_tool_call_records("explain the auth flow", &[], &records, 0, false, 0.3);
+        let streak = eval.signals.iter().find_map(|s| match s {
+            EvalSignal::SequentialReadChurn(n) => Some(*n),
+            _ => None,
+        });
+        assert_eq!(
+            streak,
+            Some(10),
+            "expected SequentialReadChurn(10), got signals={:?}",
+            eval.signals
+        );
+        // Quality should be docked by the churn penalty.
+        let baseline = evaluate_tool_call_records(
+            "explain the auth flow",
+            &[],
+            &records[..1],
+            0,
+            false,
+            0.3,
+        );
+        assert!(
+            eval.quality < baseline.quality,
+            "churn turn quality={} should be below baseline={}",
+            eval.quality,
+            baseline.quality
+        );
+    }
+
+    #[test]
+    fn sequential_read_churn_does_not_flag_well_batched_turn() {
+        // Mirrors session 03945541 turn 2: 6 rounds, mostly batched in
+        // parallel pairs, with a few legitimately-sequential rounds for
+        // mutate→verify chains. max_consec_single_tool_rounds = 4.
+        let records = vec![
+            // round 0: 4-tool parallel batch
+            record_in_round("git_show", 0, Some("b-0-0")),
+            record_in_round("git_show", 0, Some("b-0-0")),
+            record_in_round("git_show", 0, Some("b-0-0")),
+            record_in_round("git_show", 0, Some("b-0-0")),
+            // round 1: 2-tool parallel
+            record_in_round("bash", 1, Some("b-1-0")),
+            record_in_round("bash", 1, Some("b-1-0")),
+            // rounds 2-5: 4 consecutive single-tool rounds (mutate→verify)
+            record_in_round("str_replace", 2, None),
+            record_in_round("read_file", 3, None),
+            record_in_round("str_replace", 4, None),
+            record_in_round("bash", 5, None),
+            // round 6: 2-tool parallel batch (cargo test pair)
+            record_in_round("bash", 6, Some("b-6-0")),
+            record_in_round("bash", 6, Some("b-6-0")),
+        ];
+        let eval = evaluate_tool_call_records("ship the fix", &[], &records, 0, false, 0.3);
+        assert!(
+            !eval.signals
+                .iter()
+                .any(|s| matches!(s, EvalSignal::SequentialReadChurn(_))),
+            "well-batched turn should NOT emit SequentialReadChurn; got {:?}",
+            eval.signals
+        );
+    }
+
+    #[test]
+    fn sequential_read_churn_does_not_flag_parallel_only_turn() {
+        // 12 rounds, every one with 3 parallel tools. Zero single-tool rounds.
+        let mut records = Vec::new();
+        for r in 0..12 {
+            let batch = format!("b-{r}-0");
+            for _ in 0..3 {
+                records.push(record_in_round("read_file", r, Some(batch.as_str())));
+            }
+        }
+        let eval = evaluate_tool_call_records("survey the codebase", &[], &records, 0, false, 0.3);
+        assert!(
+            !eval.signals
+                .iter()
+                .any(|s| matches!(s, EvalSignal::SequentialReadChurn(_))),
+            "all-parallel turn should NOT emit SequentialReadChurn; got {:?}",
+            eval.signals
+        );
+    }
+
+    #[test]
+    fn sequential_read_churn_below_threshold_is_silent() {
+        // Mirrors 03945541 turn 1: 6 single-tool rounds, just under the
+        // threshold of 8. Should NOT trigger.
+        let records: Vec<_> = (0..6)
+            .map(|r| record_in_round("git_show", r, None))
+            .collect();
+        let eval = evaluate_tool_call_records("review", &[], &records, 0, false, 0.3);
+        assert!(
+            !eval.signals
+                .iter()
+                .any(|s| matches!(s, EvalSignal::SequentialReadChurn(_))),
+            "6 single-tool rounds is below threshold; got {:?}",
+            eval.signals
+        );
+    }
+
+    #[test]
+    fn sequential_read_churn_signal_serializes_to_json() {
+        let value = eval_signal_to_json(&EvalSignal::SequentialReadChurn(11));
+        assert_eq!(value["kind"], "sequential_read_churn");
+        assert_eq!(value["streak"], 11);
+        assert_eq!(value["threshold"], SEQUENTIAL_READ_CHURN_THRESHOLD as i64);
+        assert!(value["message"].as_str().unwrap().contains("11"));
     }
 }

--- a/rust/crates/astra-turn-core/src/evaluation.rs
+++ b/rust/crates/astra-turn-core/src/evaluation.rs
@@ -257,8 +257,11 @@ pub fn evaluate_tool_call_records(
     // could have batched these calls into parallel rounds.
     let max_streak = longest_single_tool_round_streak(tool_call_records);
     if max_streak >= SEQUENTIAL_READ_CHURN_THRESHOLD {
-        eval.signals.push(EvalSignal::SequentialReadChurn(max_streak));
-        eval.quality = (eval.quality - 0.10).clamp(0.0, 1.0);
+        eval.signals
+            .push(EvalSignal::SequentialReadChurn(max_streak));
+        let penalty =
+            (0.05 + 0.01 * (max_streak - SEQUENTIAL_READ_CHURN_THRESHOLD) as f64).clamp(0.05, 0.20);
+        eval.quality = (eval.quality - penalty).clamp(0.0, 1.0);
     }
 
     eval
@@ -281,15 +284,21 @@ fn longest_single_tool_round_streak(records: &[ToolCallRecord]) -> usize {
     }
     let mut current = 0_usize;
     let mut best = 0_usize;
-    for &count in per_round.values() {
-        if count == 1 {
+    let mut prev_round: Option<u32> = None;
+    for (&round, &count) in &per_round {
+        // A gap in round indices breaks the streak — the missing round(s)
+        // may have been filtered out (synthetic/blocked) and we cannot
+        // assume they were single-tool.
+        let adjacent = prev_round.is_none_or(|p| round == p + 1);
+        if count == 1 && adjacent {
             current += 1;
             if current > best {
                 best = current;
             }
         } else {
-            current = 0;
+            current = if count == 1 { 1 } else { 0 };
         }
+        prev_round = Some(round);
     }
     best
 }
@@ -1172,7 +1181,8 @@ mod tests {
         for r in 0..10 {
             records.push(record_in_round("read_file", r, None));
         }
-        let eval = evaluate_tool_call_records("explain the auth flow", &[], &records, 0, false, 0.3);
+        let eval =
+            evaluate_tool_call_records("explain the auth flow", &[], &records, 0, false, 0.3);
         let streak = eval.signals.iter().find_map(|s| match s {
             EvalSignal::SequentialReadChurn(n) => Some(*n),
             _ => None,
@@ -1184,14 +1194,8 @@ mod tests {
             eval.signals
         );
         // Quality should be docked by the churn penalty.
-        let baseline = evaluate_tool_call_records(
-            "explain the auth flow",
-            &[],
-            &records[..1],
-            0,
-            false,
-            0.3,
-        );
+        let baseline =
+            evaluate_tool_call_records("explain the auth flow", &[], &records[..1], 0, false, 0.3);
         assert!(
             eval.quality < baseline.quality,
             "churn turn quality={} should be below baseline={}",
@@ -1225,7 +1229,8 @@ mod tests {
         ];
         let eval = evaluate_tool_call_records("ship the fix", &[], &records, 0, false, 0.3);
         assert!(
-            !eval.signals
+            !eval
+                .signals
                 .iter()
                 .any(|s| matches!(s, EvalSignal::SequentialReadChurn(_))),
             "well-batched turn should NOT emit SequentialReadChurn; got {:?}",
@@ -1245,7 +1250,8 @@ mod tests {
         }
         let eval = evaluate_tool_call_records("survey the codebase", &[], &records, 0, false, 0.3);
         assert!(
-            !eval.signals
+            !eval
+                .signals
                 .iter()
                 .any(|s| matches!(s, EvalSignal::SequentialReadChurn(_))),
             "all-parallel turn should NOT emit SequentialReadChurn; got {:?}",
@@ -1262,7 +1268,8 @@ mod tests {
             .collect();
         let eval = evaluate_tool_call_records("review", &[], &records, 0, false, 0.3);
         assert!(
-            !eval.signals
+            !eval
+                .signals
                 .iter()
                 .any(|s| matches!(s, EvalSignal::SequentialReadChurn(_))),
             "6 single-tool rounds is below threshold; got {:?}",
@@ -1277,5 +1284,98 @@ mod tests {
         assert_eq!(value["streak"], 11);
         assert_eq!(value["threshold"], SEQUENTIAL_READ_CHURN_THRESHOLD as i64);
         assert!(value["message"].as_str().unwrap().contains("11"));
+    }
+
+    #[test]
+    fn sequential_read_churn_streak_broken_by_round_gap() {
+        // Rounds 0,1,2 (single-tool) then gap (round 3 missing) then
+        // rounds 4,5,6,7,8,9,10,11,12 (single-tool). Without gap-awareness
+        // the streak would be 12; with it, the two segments are 3 and 9.
+        let mut records = Vec::new();
+        for r in [0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12] {
+            records.push(record_in_round("read_file", r, None));
+        }
+        let eval = evaluate_tool_call_records("explore", &[], &records, 0, false, 0.3);
+        let streak = eval.signals.iter().find_map(|s| match s {
+            EvalSignal::SequentialReadChurn(n) => Some(*n),
+            _ => None,
+        });
+        // Longest contiguous segment is 9 (rounds 4-12), which exceeds
+        // the threshold of 8.
+        assert_eq!(
+            streak,
+            Some(9),
+            "gap must break streak; expected 9, got {:?}",
+            eval.signals
+        );
+    }
+
+    #[test]
+    fn sequential_read_churn_gap_splits_below_threshold() {
+        // Two segments of 4 separated by a gap — neither reaches threshold.
+        let mut records = Vec::new();
+        for r in [0, 1, 2, 3, 8, 9, 10, 11] {
+            records.push(record_in_round("read_file", r, None));
+        }
+        let eval = evaluate_tool_call_records("explore", &[], &records, 0, false, 0.3);
+        assert!(
+            !eval
+                .signals
+                .iter()
+                .any(|s| matches!(s, EvalSignal::SequentialReadChurn(_))),
+            "two segments of 4 with gap should not trigger; got {:?}",
+            eval.signals
+        );
+    }
+
+    // ─── Graduated penalty calibration ─────────────────────────────────
+    //
+    // Formula: penalty = (0.05 + 0.01 * (streak - THRESHOLD)).clamp(0.05, 0.20)
+    // We verify three points: at threshold, mid-range, and cap.
+    // To isolate the churn penalty from other quality factors, we compare
+    // two evaluations with the SAME number of records — one with all
+    // single-tool rounds (triggers churn), one with all records in a
+    // single round (no churn). The quality delta is purely the penalty.
+
+    fn churn_penalty_for_streak(streak: usize) -> f64 {
+        // All-single-tool-rounds: triggers SequentialReadChurn.
+        let churn_records: Vec<_> = (0..streak as u32)
+            .map(|r| record_in_round("read_file", r, None))
+            .collect();
+        // Same records but all in round 0: one round with `streak` tools,
+        // so longest single-tool streak = 0 → no churn penalty.
+        let batched_records: Vec<_> = (0..streak)
+            .map(|_| record_in_round("read_file", 0, None))
+            .collect();
+        let eval_churn = evaluate_tool_call_records("q", &[], &churn_records, 0, false, 0.3);
+        let eval_batched = evaluate_tool_call_records("q", &[], &batched_records, 0, false, 0.3);
+        eval_batched.quality - eval_churn.quality
+    }
+
+    #[test]
+    fn graduated_penalty_at_threshold_is_minimum() {
+        let penalty = churn_penalty_for_streak(SEQUENTIAL_READ_CHURN_THRESHOLD); // 8
+        assert!(
+            (penalty - 0.05).abs() < 1e-9,
+            "streak=8 should penalize 0.05, got {penalty}"
+        );
+    }
+
+    #[test]
+    fn graduated_penalty_scales_with_streak() {
+        let penalty = churn_penalty_for_streak(18);
+        assert!(
+            (penalty - 0.15).abs() < 1e-9,
+            "streak=18 should penalize 0.15, got {penalty}"
+        );
+    }
+
+    #[test]
+    fn graduated_penalty_caps_at_maximum() {
+        let penalty = churn_penalty_for_streak(30);
+        assert!(
+            (penalty - 0.20).abs() < 1e-9,
+            "streak=30 should cap at 0.20, got {penalty}"
+        );
     }
 }

--- a/rust/crates/runtime/src/prompts/mod.rs
+++ b/rust/crates/runtime/src/prompts/mod.rs
@@ -24,13 +24,15 @@ pub use skills::{
     builtin_markdown_skill, builtin_system_skills,
 };
 pub use system::{
-    CacheScope, LOW_CONFIDENCE_THRESHOLD, PromptSection, PromptTokenBucket,
-    ROUND_BUDGET_HARD_LIMIT, ROUND_BUDGET_THRESHOLD, STALL_NUDGE, SYSTEM_PROMPT_BASE,
-    build_main_system_prompt, build_main_system_prompt_with_style, build_system_prompt_sections,
-    build_system_prompt_sections_with_style, build_system_prompt_trace, detect_task_type,
+    CacheScope, LOW_CONFIDENCE_THRESHOLD, PARALLEL_BATCHING_NUDGE_THRESHOLD, PromptSection,
+    PromptTokenBucket, ROUND_BUDGET_HARD_LIMIT, ROUND_BUDGET_THRESHOLD, STALL_NUDGE,
+    SYSTEM_PROMPT_BASE, build_main_system_prompt, build_main_system_prompt_with_style,
+    build_system_prompt_sections, build_system_prompt_sections_with_style,
+    build_system_prompt_trace, detect_task_type, parallel_batching_nudge_directive,
     parallel_execution_feedback, round_budget_directive, round_budget_directive_with,
     sections_to_string, self_awareness_prompt_section, synthesize_or_batch_directive,
     tool_round_guidance, tool_round_guidance_trace_with, tool_round_guidance_with,
+    trailing_single_tool_round_streak,
 };
 
 #[cfg(test)]

--- a/rust/crates/runtime/src/prompts/system.rs
+++ b/rust/crates/runtime/src/prompts/system.rs
@@ -885,6 +885,8 @@ pub fn build_system_prompt_trace(
             section.trace_signals.guidance_signals.synthesize_or_batch;
         guidance_signals.parallel_feedback |=
             section.trace_signals.guidance_signals.parallel_feedback;
+        guidance_signals.parallel_batching_nudge |=
+            section.trace_signals.guidance_signals.parallel_batching_nudge;
 
         match section.token_bucket {
             PromptTokenBucket::BasePersona => base_persona_tokens += tokens,
@@ -1145,8 +1147,79 @@ pub fn round_budget_directive_with(round_index: u32, warning: u32, limit: u32) -
     }
 }
 
-/// Inject an additional synthesis nudge once the loop has already spent several
-/// rounds without producing any assistant text after the latest tool batch.
+/// Threshold for the parallel-batching nudge: how many consecutive trailing
+/// single-tool rounds we tolerate before injecting a corrective directive.
+/// Set lower than [`crate::evaluation::SEQUENTIAL_READ_CHURN_THRESHOLD`] (=8,
+/// post-mortem) so we intervene EARLY — by round 4 of the same pattern, the
+/// turn is already wasting tokens and we want to break the streak.
+pub const PARALLEL_BATCHING_NUDGE_THRESHOLD: usize = 4;
+
+/// Walk the conversation tail backwards and count how many consecutive
+/// most-recent rounds each ran exactly one tool. A "round" here is a contiguous
+/// run of `tool` messages produced after one assistant turn; trailing runtime
+/// system messages (which we inject as nudges/feedback) are skipped.
+///
+/// Returns the streak length. The streak terminates as soon as we hit a round
+/// with a different tool count (zero or ≥2) or run out of history.
+pub fn trailing_single_tool_round_streak(messages: &[serde_json::Value]) -> usize {
+    let mut idx = messages.len();
+    let mut streak = 0_usize;
+
+    loop {
+        // Skip any runtime-injected system messages between rounds.
+        while idx > 0 && is_trailing_runtime_system_message(&messages[idx - 1]) {
+            idx -= 1;
+        }
+        // Count contiguous trailing tool messages = this round's tool result count.
+        let mut tool_count = 0_usize;
+        while idx > 0
+            && messages[idx - 1]
+                .get("role")
+                .and_then(|r| r.as_str())
+                == Some("tool")
+        {
+            tool_count += 1;
+            idx -= 1;
+        }
+        if tool_count == 1 {
+            streak += 1;
+            // Step over the assistant message that produced this single call,
+            // if present, then continue scanning further-back rounds.
+            if idx > 0
+                && messages[idx - 1]
+                    .get("role")
+                    .and_then(|r| r.as_str())
+                    == Some("assistant")
+            {
+                idx -= 1;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    streak
+}
+
+/// Inject a corrective batching nudge once the model has produced a streak of
+/// single-tool rounds. Symmetric counterpart to [`parallel_execution_feedback`]
+/// (positive reinforcement on multi-tool rounds).
+pub fn parallel_batching_nudge_directive(messages: &[serde_json::Value]) -> String {
+    let streak = trailing_single_tool_round_streak(messages);
+    if streak < PARALLEL_BATCHING_NUDGE_THRESHOLD {
+        return String::new();
+    }
+    format!(
+        "\n\n## ⚠ Sequential Tool Calls Detected\n\
+         Your last {streak} rounds each ran exactly ONE tool. This is the most expensive way to gather information.\n\
+         - Look at the next set of files / commands you intend to inspect.\n\
+         - If they are independent (different files, different greps, different reads), batch them ALL into the next single round in parallel.\n\
+         - Reserve sequential single-tool rounds for cases where each call genuinely depends on the previous result.\n"
+    )
+}
+
+
 ///
 /// This is generic and history-based: it looks only at the current round index
 /// plus whether the visible conversation ends with tool results.
@@ -1217,18 +1290,22 @@ pub fn tool_round_guidance_trace_with(
     let trailing_tool_count = trailing_tool_result_count(messages);
     let synthesize_or_batch = round_index >= warning && trailing_tool_count > 0;
     let parallel_feedback = trailing_tool_count > 1;
+    let single_tool_streak = trailing_single_tool_round_streak(messages);
+    let parallel_batching_nudge = single_tool_streak >= PARALLEL_BATCHING_NUDGE_THRESHOLD;
 
     (
         format!(
-            "{}{}{}",
+            "{}{}{}{}",
             round_budget_directive_with(round_index, warning, limit),
             synthesize_or_batch_directive(messages, round_index, warning),
+            parallel_batching_nudge_directive(messages),
             parallel_execution_feedback(messages)
         ),
         PromptGuidanceSignals {
             round_budget_warning,
             synthesize_or_batch,
             parallel_feedback,
+            parallel_batching_nudge,
         },
     )
 }
@@ -2876,5 +2953,116 @@ mod tests {
             !before_limit.contains("Round Budget Exceeded"),
             "round 14 should not trigger hard stop"
         );
+    }
+
+    // ─── Parallel batching nudge (real-session-shaped fixtures) ─────────
+    //
+    // Scenarios pulled from real sessions:
+    //   - 6566d6a8 turn 1: 10 trailing single-tool read rounds → strong nudge
+    //   - 03945541 turn 1: 6 single-tool rounds (locate→read) → soft case,
+    //     but the nudge still fires at round 4+ since it cannot distinguish
+    //     "legitimate dependency chain" from "should-have-batched" — the
+    //     model's own next-round planning is the right place to disambiguate.
+    //   - well-batched runs (≥2 tools per round) → never trigger.
+
+    fn assistant_with_tool_calls(n: usize) -> Vec<serde_json::Value> {
+        let mut msgs = vec![serde_json::json!({"role": "assistant", "tool_calls": []})];
+        for _ in 0..n {
+            msgs.push(serde_json::json!({"role": "tool", "content": "..."}));
+        }
+        msgs
+    }
+
+    fn rounds_pattern(per_round: &[usize]) -> Vec<serde_json::Value> {
+        let mut out = vec![serde_json::json!({"role": "user", "content": "go"})];
+        for &n in per_round {
+            out.extend(assistant_with_tool_calls(n));
+        }
+        out
+    }
+
+    #[test]
+    fn trailing_single_tool_streak_counts_consecutive_singletons_only() {
+        // [3, 1, 1, 1, 1] → trailing streak = 4
+        let msgs = rounds_pattern(&[3, 1, 1, 1, 1]);
+        assert_eq!(trailing_single_tool_round_streak(&msgs), 4);
+
+        // [1, 1, 2, 1, 1] → trailing streak = 2 (broken by the 2-tool round)
+        let msgs = rounds_pattern(&[1, 1, 2, 1, 1]);
+        assert_eq!(trailing_single_tool_round_streak(&msgs), 2);
+
+        // [3, 3, 3] → 0 (last round was multi-tool)
+        let msgs = rounds_pattern(&[3, 3, 3]);
+        assert_eq!(trailing_single_tool_round_streak(&msgs), 0);
+
+        // Empty / no tool messages → 0
+        assert_eq!(trailing_single_tool_round_streak(&[]), 0);
+        let only_user = vec![serde_json::json!({"role": "user", "content": "hi"})];
+        assert_eq!(trailing_single_tool_round_streak(&only_user), 0);
+    }
+
+    #[test]
+    fn parallel_batching_nudge_fires_after_threshold_streak() {
+        // 4 single-tool rounds in a row — at threshold.
+        let msgs = rounds_pattern(&[1, 1, 1, 1]);
+        let directive = parallel_batching_nudge_directive(&msgs);
+        assert!(
+            directive.contains("Sequential Tool Calls Detected"),
+            "expected nudge at threshold; got {:?}",
+            directive
+        );
+        assert!(directive.contains("4 rounds"));
+    }
+
+    #[test]
+    fn parallel_batching_nudge_silent_below_threshold() {
+        let msgs = rounds_pattern(&[1, 1, 1]);
+        assert!(parallel_batching_nudge_directive(&msgs).is_empty());
+    }
+
+    #[test]
+    fn parallel_batching_nudge_silent_when_last_round_was_parallel() {
+        // Long single-tool history followed by a 3-tool batch → no nudge,
+        // because the model already corrected the pattern.
+        let msgs = rounds_pattern(&[1, 1, 1, 1, 1, 1, 3]);
+        assert!(
+            parallel_batching_nudge_directive(&msgs).is_empty(),
+            "should not nudge after the model already batched"
+        );
+    }
+
+    #[test]
+    fn parallel_batching_nudge_skips_runtime_system_messages() {
+        // Trailing nudges/feedback injected by the runtime should not break
+        // the streak detection.
+        let mut msgs = rounds_pattern(&[1, 1, 1, 1]);
+        msgs.push(serde_json::json!({
+            "role": "system",
+            "content": "## Already Fetched (do NOT re-read these)\nFiles: foo.rs"
+        }));
+        assert_eq!(trailing_single_tool_round_streak(&msgs), 4);
+        assert!(
+            parallel_batching_nudge_directive(&msgs).contains("Sequential Tool Calls Detected")
+        );
+    }
+
+    #[test]
+    fn tool_round_guidance_includes_batching_nudge_and_signals_it() {
+        let msgs = rounds_pattern(&[1, 1, 1, 1]);
+        let (guidance, signals) = tool_round_guidance_trace_with(
+            &msgs,
+            0, // early in the loop — round-budget warning should NOT fire
+            ROUND_BUDGET_THRESHOLD,
+            ROUND_BUDGET_HARD_LIMIT,
+        );
+        assert!(
+            guidance.contains("Sequential Tool Calls Detected"),
+            "guidance must surface the batching nudge"
+        );
+        assert!(!guidance.contains("Round Budget Warning"));
+        assert!(signals.parallel_batching_nudge);
+        assert!(!signals.round_budget_warning);
+        // Single-tool last round → no positive parallel_feedback either.
+        assert!(!signals.parallel_feedback);
     }
 }

--- a/rust/crates/runtime/src/prompts/system.rs
+++ b/rust/crates/runtime/src/prompts/system.rs
@@ -885,8 +885,10 @@ pub fn build_system_prompt_trace(
             section.trace_signals.guidance_signals.synthesize_or_batch;
         guidance_signals.parallel_feedback |=
             section.trace_signals.guidance_signals.parallel_feedback;
-        guidance_signals.parallel_batching_nudge |=
-            section.trace_signals.guidance_signals.parallel_batching_nudge;
+        guidance_signals.parallel_batching_nudge |= section
+            .trace_signals
+            .guidance_signals
+            .parallel_batching_nudge;
 
         match section.token_bucket {
             PromptTokenBucket::BasePersona => base_persona_tokens += tokens,
@@ -1172,12 +1174,7 @@ pub fn trailing_single_tool_round_streak(messages: &[serde_json::Value]) -> usiz
         }
         // Count contiguous trailing tool messages = this round's tool result count.
         let mut tool_count = 0_usize;
-        while idx > 0
-            && messages[idx - 1]
-                .get("role")
-                .and_then(|r| r.as_str())
-                == Some("tool")
-        {
+        while idx > 0 && messages[idx - 1].get("role").and_then(|r| r.as_str()) == Some("tool") {
             tool_count += 1;
             idx -= 1;
         }
@@ -1186,10 +1183,7 @@ pub fn trailing_single_tool_round_streak(messages: &[serde_json::Value]) -> usiz
             // Step over the assistant message that produced this single call,
             // if present, then continue scanning further-back rounds.
             if idx > 0
-                && messages[idx - 1]
-                    .get("role")
-                    .and_then(|r| r.as_str())
-                    == Some("assistant")
+                && messages[idx - 1].get("role").and_then(|r| r.as_str()) == Some("assistant")
             {
                 idx -= 1;
             } else {
@@ -1218,7 +1212,6 @@ pub fn parallel_batching_nudge_directive(messages: &[serde_json::Value]) -> Stri
          - Reserve sequential single-tool rounds for cases where each call genuinely depends on the previous result.\n"
     )
 }
-
 
 ///
 /// This is generic and history-based: it looks only at the current round index

--- a/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
@@ -123,6 +123,28 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
         }
     }
 
+    // Third-tier guard: parallel-batching force. Independent of the mutating-
+    // task escalation above — fires whenever the model has produced a long
+    // streak of trailing single-tool rounds despite the prompt-layer nudge,
+    // regardless of task type. Catches the "exploratory churn" failure mode
+    // (sessions 6566d6a8, bbae8641, 6da9cf8f). One-shot per turn.
+    if should_force_parallel_batching(state) {
+        let streak = crate::prompts::trailing_single_tool_round_streak(&state.messages);
+        state.stall.forced_parallel_batching = true;
+        state.messages.push(serde_json::json!({
+            "role": "user",
+            "content": parallel_batching_force_message(streak, &state.message),
+        }));
+        if !prep.quiet {
+            host.emit_headless_line(
+                HeadlessStderrStyle::Yellow,
+                format!(
+                    "↻ {streak} consecutive single-tool rounds; forcing parallel-batching corrective…"
+                ),
+            );
+        }
+    }
+
     let llm_wall_start = Instant::now();
     // Increment the LLM-round counter regardless of outcome so retry/error
     // paths don't see a stale count (the counter tracks *attempted* LLM
@@ -612,7 +634,56 @@ pub(crate) fn is_execution_escalation(m: &serde_json::Value) -> bool {
 }
 
 pub(crate) fn is_execution_corrective_message(m: &serde_json::Value) -> bool {
-    is_execution_retry_correction(m) || is_execution_escalation(m)
+    is_execution_retry_correction(m) || is_execution_escalation(m) || is_parallel_batching_force(m)
+}
+
+/// Third-tier guard for the parallel-batching layer. The prompt-side soft
+/// nudge fires when the trailing single-tool round streak hits
+/// `PARALLEL_BATCHING_NUDGE_THRESHOLD` (=4). If the model ignores the nudge
+/// and produces yet another single-tool round, the streak crosses
+/// `PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD` (=5) and we inject a hard
+/// corrective `user` message — the same pattern as `EXECUTION_ESCALATION`,
+/// scoped to a different failure mode (sequential read churn rather than
+/// read-only spin on a mutating task).
+pub(crate) const PARALLEL_BATCHING_FORCE_MARKER: &str = "## ⤴ Parallel Batching Force";
+
+/// Trailing single-tool-round streak length at which the soft prompt nudge
+/// (=4) escalates into a forced corrective injection. One above the nudge
+/// threshold so the model gets exactly ONE chance to self-correct before we
+/// intervene with a higher-priority `user` message.
+pub(crate) const PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD: usize = 5;
+
+pub(crate) fn is_parallel_batching_force(m: &serde_json::Value) -> bool {
+    if m.get("role").and_then(|r| r.as_str()) != Some("user") {
+        return false;
+    }
+    m.get("content")
+        .and_then(|c| c.as_str())
+        .is_some_and(|s| s.starts_with(PARALLEL_BATCHING_FORCE_MARKER))
+}
+
+pub(crate) fn should_force_parallel_batching(state: &AgenticLoopState) -> bool {
+    if state.stall.forced_parallel_batching {
+        return false;
+    }
+    let streak = crate::prompts::trailing_single_tool_round_streak(&state.messages);
+    streak >= PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD
+}
+
+pub(crate) fn parallel_batching_force_message(streak: usize, original_query: &str) -> String {
+    format!(
+        "{PARALLEL_BATCHING_FORCE_MARKER}\n\
+         Runtime correction: your last {streak} rounds each ran exactly ONE tool, \
+         despite the prompt-layer nudge to batch independent calls. This wastes \
+         a round of latency, tokens, and budget for each call. \
+         Your NEXT response MUST do exactly one of the following:\n\
+         - Produce your final answer now if you already have enough information, OR\n\
+         - Call ≥3 independent tools in a single parallel batch (different files, \
+           different greps, different reads — anything that does not strictly \
+           depend on the previous tool's output).\n\
+         Do not produce another single-tool round.\n\n\
+         Original user query: {original_query}"
+    )
 }
 
 pub(crate) fn should_escalate_execution(state: &AgenticLoopState) -> bool {
@@ -1349,5 +1420,89 @@ mod tests {
 
         let unrelated = serde_json::json!({"role":"user","content":"fix the bug"});
         assert!(!is_execution_corrective_message(&unrelated));
+    }
+
+    // ─── Parallel-batching force (third-tier guard) ─────────────────────
+
+    fn push_single_tool_round(state: &mut AgenticLoopState) {
+        state
+            .messages
+            .push(serde_json::json!({"role": "assistant", "tool_calls": []}));
+        state
+            .messages
+            .push(serde_json::json!({"role": "tool", "content": "..."}));
+    }
+
+    #[test]
+    fn parallel_batching_force_fires_at_streak_threshold() {
+        let mut state = make_state();
+        state.message = "explore the codebase".into();
+        for _ in 0..PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD {
+            push_single_tool_round(&mut state);
+        }
+        assert!(should_force_parallel_batching(&state));
+    }
+
+    #[test]
+    fn parallel_batching_force_silent_below_threshold() {
+        let mut state = make_state();
+        state.message = "explore the codebase".into();
+        for _ in 0..(PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD - 1) {
+            push_single_tool_round(&mut state);
+        }
+        assert!(!should_force_parallel_batching(&state));
+    }
+
+    #[test]
+    fn parallel_batching_force_silent_when_last_round_batched() {
+        let mut state = make_state();
+        state.message = "explore the codebase".into();
+        // Long single-tool history that crossed threshold...
+        for _ in 0..(PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD + 2) {
+            push_single_tool_round(&mut state);
+        }
+        // ...but the most-recent round used 3 parallel tools — the model
+        // already self-corrected, no force needed.
+        state
+            .messages
+            .push(serde_json::json!({"role": "assistant", "tool_calls": []}));
+        for _ in 0..3 {
+            state
+                .messages
+                .push(serde_json::json!({"role": "tool", "content": "..."}));
+        }
+        assert!(!should_force_parallel_batching(&state));
+    }
+
+    #[test]
+    fn parallel_batching_force_is_one_shot_per_turn() {
+        let mut state = make_state();
+        state.message = "explore the codebase".into();
+        for _ in 0..(PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD + 3) {
+            push_single_tool_round(&mut state);
+        }
+        // First time would fire...
+        assert!(should_force_parallel_batching(&state));
+        // ...but once the flag is set, a second attempt is suppressed even
+        // if the model produces yet another single-tool round.
+        state.stall.forced_parallel_batching = true;
+        push_single_tool_round(&mut state);
+        assert!(!should_force_parallel_batching(&state));
+    }
+
+    #[test]
+    fn parallel_batching_force_marker_recognized_by_corrective_filter() {
+        let msg = serde_json::json!({
+            "role": "user",
+            "content": parallel_batching_force_message(7, "do something"),
+        });
+        assert!(is_parallel_batching_force(&msg));
+        assert!(is_execution_corrective_message(&msg));
+        // Other corrective markers must not be misclassified as this one.
+        let retry = serde_json::json!({
+            "role": "user",
+            "content": execution_retry_message("do something"),
+        });
+        assert!(!is_parallel_batching_force(&retry));
     }
 }

--- a/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
@@ -113,6 +113,13 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
             "role": "user",
             "content": execution_escalation_message(&state.message, read_only_calls),
         }));
+        tracing::warn!(
+            target: "astra::loop_guard",
+            tier = "execution_escalation",
+            read_only_calls,
+            round = state.llm_rounds_completed,
+            "loop guard fired"
+        );
         if !prep.quiet {
             host.emit_headless_line(
                 HeadlessStderrStyle::Yellow,
@@ -135,6 +142,13 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
             "role": "user",
             "content": parallel_batching_force_message(streak, &state.message),
         }));
+        tracing::warn!(
+            target: "astra::loop_guard",
+            tier = "parallel_batching_force",
+            streak,
+            round = state.llm_rounds_completed,
+            "loop guard fired"
+        );
         if !prep.quiet {
             host.emit_headless_line(
                 HeadlessStderrStyle::Yellow,
@@ -375,6 +389,12 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                     "role": "user",
                     "content": execution_retry_message(&state.message),
                 }));
+                tracing::warn!(
+                    target: "astra::loop_guard",
+                    tier = "execution_retry",
+                    round = state.llm_rounds_completed,
+                    "loop guard fired"
+                );
                 if !prep.quiet {
                     host.emit_headless_line(
                         HeadlessStderrStyle::Yellow,
@@ -451,6 +471,9 @@ fn should_force_execution_retry(state: &AgenticLoopState) -> bool {
     // tokens, and risk contradicting guidance. One corrective injection per
     // turn is the invariant.
     if state.stall.forced_execution_escalation {
+        return false;
+    }
+    if state.stall.forced_parallel_batching {
         return false;
     }
     if has_concrete_workspace_mutation(state) {
@@ -1400,6 +1423,22 @@ mod tests {
 
         // With the escalation flag set, retry must yield.
         state.stall.forced_execution_escalation = true;
+        assert!(!should_force_execution_retry(&state));
+    }
+
+    #[test]
+    fn parallel_batching_force_blocks_subsequent_retry_in_same_turn() {
+        let mut state = make_state();
+        state.message = "fix the bug".into();
+        state.task_profile =
+            crate::turn::chat_turn_heuristics::infer_task_execution_profile("fix the bug");
+        state.final_text = "I'll continue investigating.".into();
+        state.total_tool_calls = 10;
+        // Without the parallel-batching flag, this state would trigger retry.
+        assert!(should_force_execution_retry(&state));
+        // Once the parallel-batching force fired, retry must yield to honor
+        // the one-corrective-per-turn invariant.
+        state.stall.forced_parallel_batching = true;
         assert!(!should_force_execution_retry(&state));
     }
 

--- a/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
@@ -676,6 +676,15 @@ pub(crate) const PARALLEL_BATCHING_FORCE_MARKER: &str = "## ⤴ Parallel Batchin
 /// intervene with a higher-priority `user` message.
 pub(crate) const PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD: usize = 5;
 
+/// Tightened streak threshold once the turn has entered the round-budget
+/// warning zone (`round_index >= ROUND_BUDGET_THRESHOLD`). At that point any
+/// additional sequential single-tool round is materially closer to running
+/// out of budget without a final answer, so we intervene more aggressively.
+/// Empirical real-session data: turns near the round-budget warning that
+/// added a 3rd consecutive single-tool round virtually never converged
+/// without external correction.
+pub(crate) const PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD_LATE: usize = 3;
+
 pub(crate) fn is_parallel_batching_force(m: &serde_json::Value) -> bool {
     if m.get("role").and_then(|r| r.as_str()) != Some("user") {
         return false;
@@ -690,7 +699,14 @@ pub(crate) fn should_force_parallel_batching(state: &AgenticLoopState) -> bool {
         return false;
     }
     let streak = crate::prompts::trailing_single_tool_round_streak(&state.messages);
-    streak >= PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD
+    let threshold = if state.llm_rounds_completed
+        >= crate::prompts::ROUND_BUDGET_THRESHOLD
+    {
+        PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD_LATE
+    } else {
+        PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD
+    };
+    streak >= threshold
 }
 
 pub(crate) fn parallel_batching_force_message(streak: usize, original_query: &str) -> String {
@@ -1543,5 +1559,37 @@ mod tests {
             "content": execution_retry_message("do something"),
         });
         assert!(!is_parallel_batching_force(&retry));
+    }
+
+    #[test]
+    fn parallel_batching_force_uses_tighter_threshold_in_round_budget_warning_zone() {
+        // Streak of 3 — below the early-zone threshold of 5...
+        let mut state = make_state();
+        state.message = "explore the codebase".into();
+        for _ in 0..PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD_LATE {
+            push_single_tool_round(&mut state);
+        }
+        // ...so before the warning zone, this must NOT fire.
+        state.llm_rounds_completed = crate::prompts::ROUND_BUDGET_THRESHOLD - 1;
+        assert!(!should_force_parallel_batching(&state));
+
+        // Once round_index crosses ROUND_BUDGET_THRESHOLD, the same streak of
+        // 3 must fire — this is the coupling we want.
+        state.llm_rounds_completed = crate::prompts::ROUND_BUDGET_THRESHOLD;
+        assert!(should_force_parallel_batching(&state));
+    }
+
+    #[test]
+    fn parallel_batching_force_late_threshold_silent_at_streak_two() {
+        let mut state = make_state();
+        state.message = "explore the codebase".into();
+        for _ in 0..(PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD_LATE - 1) {
+            push_single_tool_round(&mut state);
+        }
+        state.llm_rounds_completed = crate::prompts::ROUND_BUDGET_THRESHOLD + 2;
+        // Even deep into the warning zone, a streak below the late threshold
+        // (=3) must not fire — we don't punish a single isolated single-tool
+        // round just because the turn is long.
+        assert!(!should_force_parallel_batching(&state));
     }
 }

--- a/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_execution_phase.rs
@@ -698,10 +698,13 @@ pub(crate) fn should_force_parallel_batching(state: &AgenticLoopState) -> bool {
     if state.stall.forced_parallel_batching {
         return false;
     }
+    // One corrective injection per turn: if mid-loop retry or escalation
+    // already fired, a parallel-batching force would duplicate correction.
+    if state.stall.forced_execution_retry || state.stall.forced_execution_escalation {
+        return false;
+    }
     let streak = crate::prompts::trailing_single_tool_round_streak(&state.messages);
-    let threshold = if state.llm_rounds_completed
-        >= crate::prompts::ROUND_BUDGET_THRESHOLD
-    {
+    let threshold = if state.llm_rounds_completed >= crate::prompts::ROUND_BUDGET_THRESHOLD {
         PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD_LATE
     } else {
         PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD
@@ -717,7 +720,7 @@ pub(crate) fn parallel_batching_force_message(streak: usize, original_query: &st
          a round of latency, tokens, and budget for each call. \
          Your NEXT response MUST do exactly one of the following:\n\
          - Produce your final answer now if you already have enough information, OR\n\
-         - Call ≥3 independent tools in a single parallel batch (different files, \
+         - Call ≥2 independent tools in a single parallel batch (different files, \
            different greps, different reads — anything that does not strictly \
            depend on the previous tool's output).\n\
          Do not produce another single-tool round.\n\n\
@@ -727,6 +730,14 @@ pub(crate) fn parallel_batching_force_message(streak: usize, original_query: &st
 
 pub(crate) fn should_escalate_execution(state: &AgenticLoopState) -> bool {
     if state.stall.forced_execution_escalation {
+        return false;
+    }
+    // One corrective injection per turn: if parallel-batching force already
+    // fired, skip escalation to avoid double-injecting corrective messages.
+    // NOTE: execution order in execute_turn_and_ingest_phase is
+    //   escalation → parallel-batching, so in practice escalation runs first.
+    //   This guard is defensive against future reordering.
+    if state.stall.forced_parallel_batching {
         return false;
     }
     if !state.task_profile.mutates_workspace {
@@ -1378,6 +1389,20 @@ mod tests {
     }
 
     #[test]
+    fn escalation_suppressed_when_parallel_batching_already_fired() {
+        let mut state = make_mutating_state_with_reads(EXECUTION_ESCALATION_TOOL_CALL_THRESHOLD);
+        // Precondition: without the flag, escalation would fire.
+        assert!(should_escalate_execution(&state));
+        // Once parallel-batching force has fired, escalation must yield to
+        // honor the one-corrective-per-turn invariant.
+        state.stall.forced_parallel_batching = true;
+        assert!(
+            !should_escalate_execution(&state),
+            "escalation must not fire when parallel-batching force already active"
+        );
+    }
+
+    #[test]
     fn escalation_ignores_failed_tool_calls_for_threshold() {
         let mut state = make_state();
         state.message = "fix the bug".into();
@@ -1456,6 +1481,38 @@ mod tests {
         // the one-corrective-per-turn invariant.
         state.stall.forced_parallel_batching = true;
         assert!(!should_force_execution_retry(&state));
+    }
+
+    #[test]
+    fn parallel_batching_suppressed_when_escalation_already_fired() {
+        let mut state = make_state();
+        state.message = "explore the codebase".into();
+        for _ in 0..PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD {
+            push_single_tool_round(&mut state);
+        }
+        // Precondition: without escalation flag, parallel-batching would fire.
+        assert!(should_force_parallel_batching(&state));
+        // Once escalation has fired, parallel-batching must yield.
+        state.stall.forced_execution_escalation = true;
+        assert!(
+            !should_force_parallel_batching(&state),
+            "parallel-batching must not fire when escalation already active"
+        );
+    }
+
+    #[test]
+    fn parallel_batching_suppressed_when_retry_already_fired() {
+        let mut state = make_state();
+        state.message = "explore the codebase".into();
+        for _ in 0..PARALLEL_BATCHING_FORCE_STREAK_THRESHOLD {
+            push_single_tool_round(&mut state);
+        }
+        assert!(should_force_parallel_batching(&state));
+        state.stall.forced_execution_retry = true;
+        assert!(
+            !should_force_parallel_batching(&state),
+            "parallel-batching must not fire when retry already active"
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -407,6 +407,10 @@ pub struct StallTrackingState {
     /// task accumulated enough read-only tool calls without producing any
     /// workspace mutation. One-shot per turn.
     pub forced_execution_escalation: bool,
+    /// Whether a parallel-batching force injection has fired this loop. Set
+    /// when the model has produced a long streak of consecutive single-tool
+    /// rounds despite the soft prompt-layer nudge. One-shot per turn.
+    pub forced_parallel_batching: bool,
     /// How many stall correction nudges have been injected this loop.
     /// Limits nudge frequency (at most one per stall type per session).
     pub nudge_count: u32,

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -2843,6 +2843,7 @@ mod tests {
                     round_budget_warning: true,
                     synthesize_or_batch: true,
                     parallel_feedback: false,
+                    parallel_batching_nudge: false,
                 },
                 ..Default::default()
             },


### PR DESCRIPTION
## Summary

Detect and correct the "sequential read churn" failure mode where the model makes one tool call per round instead of batching independent calls in parallel. Three-layer defense:

1. **Post-mortem evaluation** (`evaluation.rs`): `SequentialReadChurn` signal flags turns with ≥8 consecutive single-tool rounds; graduated quality penalty (0.05–0.20).
2. **Prompt-layer nudge** (`system.rs`): injects a batching directive when trailing single-tool streak hits 4.
3. **Forced corrective injection** (`agentic_loop_execution_phase.rs`): if the model ignores the nudge and streak hits 5 (or 3 in round-budget warning zone), a hard corrective `user` message is injected. One-shot per turn.

All three guard tiers (execution-retry, execution-escalation, parallel-batching-force) enforce mutual exclusion — at most one corrective fires per turn.

## Changes

- `evaluation.rs`: `longest_single_tool_round_streak()` with gap-aware round adjacency check; `SequentialReadChurn` signal; graduated penalty formula
- `context_assembly_trace.rs`: `parallel_batching_nudge` field in `PromptGuidanceSignals`
- `system.rs`: `trailing_single_tool_round_streak()`, `parallel_batching_nudge_directive()`, wired into `tool_round_guidance_trace_with()`
- `agentic_loop_execution_phase.rs`: `should_force_parallel_batching()` with early/late thresholds, `parallel_batching_force_message()`, `tracing::warn!` observability on all three guard tiers, full mutual exclusion between all guards
- `agentic_loop_host.rs`: `forced_parallel_batching` field in `StallTrackingState`

## Testing

19 new tests across evaluation and execution phase:
- Streak detection: flags long streaks, silent below threshold, silent for batched/parallel turns
- Gap-awareness: round gaps break streaks correctly
- Graduated penalty: calibrated at threshold (0.05), mid-range (0.15), cap (0.20)
- Guard mutual exclusion: all 6 directions of the 3-guard matrix covered
- Late-zone tighter threshold: fires at streak=3 when round_index ≥ ROUND_BUDGET_THRESHOLD
- Prompt nudge: fires/silent/skips-runtime-system-messages, wired into guidance signals

`make format && make check && make test-offline` all pass.