### PR TITLE
refactor(net): centralize env proxy in astra-core, fix GitHub client and provider probe policy

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -216,9 +216,11 @@ dependencies = [
  "axum 0.8.9",
  "chrono",
  "dotenvy",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sqlx",
+ "temp-env",
  "tokio",
  "tracing",
 ]

--- a/rust/crates/astra-cli/src/edge_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools.rs
@@ -443,11 +443,16 @@ impl ToolExecutor {
             // TODO: Consider using a zeroize-capable wrapper for tokens to prevent
             // memory-resident secrets from lingering after drop.
             github_token: astra_tools::github::resolve_github_token(),
-            github_client: Client::builder()
-                .timeout(Duration::from_secs(15))
-                .user_agent(format!("astra/{}", env!("CARGO_PKG_VERSION")))
-                .build()
-                .unwrap_or_else(|_| Client::new()),
+            // GitHub API is external traffic (api.github.com), so it honours
+            // HTTPS_PROXY/ALL_PROXY via the authoritative helper in astra_core::net.
+            // See core/src/net.rs for the workspace proxy policy (3e3d6fa8).
+            github_client: astra_core::net::apply_env_proxy(
+                Client::builder()
+                    .timeout(Duration::from_secs(15))
+                    .user_agent(format!("astra/{}", env!("CARGO_PKG_VERSION"))),
+            )
+            .build()
+            .unwrap_or_else(|_| Client::new()),
             sandbox_policy: std::sync::RwLock::new(Some(sandbox)),
             preferred_repos: std::sync::Mutex::new(preferred_repos),
             budget_pressure: std::sync::Mutex::new(0.0),
@@ -1670,4 +1675,44 @@ mod tests {
     mod utf16_tests;
     mod web_search_tests;
     mod worktree_tests;
+
+    /// Regression test for 3e3d6fa8 proxy policy:
+    /// `github_client` targets api.github.com (external traffic), so it must
+    /// honour HTTPS_PROXY/ALL_PROXY via `astra_core::net::apply_env_proxy`.
+    /// Before the fix, this builder silently inherited reqwest's default env
+    /// handling without NO_PROXY / socks5 / tracing parity with the LLM client.
+    ///
+    /// We can't introspect reqwest's internal proxy config, so we assert the
+    /// observable contract: (a) the builder constructs successfully under a
+    /// variety of proxy envs (NO_PROXY, malformed, socks5 via ALL_PROXY), and
+    /// (b) `ToolExecutor::new` never panics when those envs are set — which
+    /// was the actual risk if a caller forgot to call `apply_env_proxy` and
+    /// reqwest rejected a malformed env URL at build time.
+    #[test]
+    fn github_client_honours_proxy_env_without_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // valid https proxy
+        temp_env::with_var("HTTPS_PROXY", Some("http://proxy.example:8080"), || {
+            let _ = ToolExecutor::new(dir.path());
+        });
+        // socks5 via ALL_PROXY (parity with LLM client regression)
+        temp_env::with_var("ALL_PROXY", Some("socks5://127.0.0.1:1080"), || {
+            let _ = ToolExecutor::new(dir.path());
+        });
+        // malformed must not panic (apply_env_proxy swallows parse errors)
+        temp_env::with_var("HTTPS_PROXY", Some("not a url"), || {
+            let _ = ToolExecutor::new(dir.path());
+        });
+        // NO_PROXY honoured
+        temp_env::with_vars(
+            [
+                ("HTTPS_PROXY", Some("http://proxy.example:8080")),
+                ("NO_PROXY", Some("api.github.com")),
+            ],
+            || {
+                let _ = ToolExecutor::new(dir.path());
+            },
+        );
+    }
 }

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 axum.workspace = true
 chrono.workspace = true
 dotenvy.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -14,6 +15,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+temp-env = "0.3"
 
 [features]
 dev-defaults = []

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod config;
 pub mod drift;
 pub mod error_kind;
 pub mod log;
+pub mod net;
 pub mod runtime_limits;
 
 /// Re-export for [`crate::agent_*!`] macros (call sites do not need a direct `tracing` dependency).

--- a/rust/crates/core/src/net.rs
+++ b/rust/crates/core/src/net.rs
@@ -1,0 +1,146 @@
+//! Shared HTTP networking utilities.
+//!
+//! # Proxy policy (commit 3e3d6fa8)
+//!
+//! Only **external** HTTP traffic — the LLM client and provider connectivity
+//! probes — is allowed to honour `HTTPS_PROXY` / `ALL_PROXY`. All other reqwest
+//! clients in the workspace are considered internal (edge ↔ services, memoria,
+//! durable task, app state, etc.) and MUST call `.no_proxy()` on their
+//! builders. See `astra_runtime::turn::llm_client` module docs for the full
+//! rationale.
+//!
+//! [`apply_env_proxy`] is the single authoritative implementation. Both the
+//! LLM client and `validate_connectivity` in `astra-services` call it. Do not
+//! duplicate this logic elsewhere — add a new caller instead.
+
+/// Apply proxy settings from the environment to a `reqwest::ClientBuilder`.
+///
+/// Precedence (first match wins): `HTTPS_PROXY`, `https_proxy`, `ALL_PROXY`,
+/// `all_proxy`. For `HTTPS_PROXY`/`https_proxy` we register an HTTPS-scheme
+/// proxy; for `ALL_PROXY`/`all_proxy` we register an all-scheme proxy so that
+/// `socks5://` URLs (which only make sense as all-scheme) are honoured.
+///
+/// `NO_PROXY` / `no_proxy` is always respected via `reqwest::NoProxy::from_env`.
+///
+/// Malformed or empty proxy URLs are logged at warn level and skipped; the
+/// returned builder is always usable.
+pub fn apply_env_proxy(mut builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+    let no_proxy = reqwest::NoProxy::from_env();
+    for var in &["HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"] {
+        let Ok(proxy_url) = std::env::var(var) else {
+            continue;
+        };
+        if proxy_url.is_empty() {
+            continue;
+        }
+        let is_all = matches!(*var, "ALL_PROXY" | "all_proxy");
+        let parsed = if is_all {
+            reqwest::Proxy::all(&proxy_url)
+        } else {
+            reqwest::Proxy::https(&proxy_url)
+        };
+        match parsed {
+            Ok(mut proxy) => {
+                if let Some(np) = no_proxy.clone() {
+                    proxy = proxy.no_proxy(Some(np));
+                }
+                tracing::info!(
+                    target: "astra_core::net",
+                    env_var = *var,
+                    proxy = %proxy_url,
+                    "applying proxy from environment"
+                );
+                builder = builder.proxy(proxy);
+                return builder;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "astra_core::net",
+                    env_var = *var,
+                    proxy = %proxy_url,
+                    error = %e,
+                    "failed to parse proxy URL; ignoring"
+                );
+            }
+        }
+    }
+    builder
+}
+
+#[cfg(test)]
+mod apply_env_proxy_tests {
+    use super::apply_env_proxy;
+
+    /// All four recognized env var names must be cleared for isolation, since
+    /// `apply_env_proxy` reads them in precedence order.
+    const PROXY_VARS: &[&str] = &["HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"];
+
+    fn clear_all() -> Vec<(&'static str, Option<String>)> {
+        PROXY_VARS.iter().map(|v| (*v, None)).collect()
+    }
+
+    #[test]
+    fn no_env_vars_leaves_builder_unmodified() {
+        temp_env::with_vars(clear_all(), || {
+            let builder = reqwest::Client::builder();
+            let builder = apply_env_proxy(builder);
+            assert!(
+                builder.build().is_ok(),
+                "builder should produce client with no proxy"
+            );
+        });
+    }
+
+    #[test]
+    fn empty_proxy_url_is_ignored() {
+        temp_env::with_vars([("HTTPS_PROXY", Some(""))], || {
+            let builder = apply_env_proxy(reqwest::Client::builder());
+            assert!(
+                builder.build().is_ok(),
+                "empty proxy URL should be ignored, not error"
+            );
+        });
+    }
+
+    #[test]
+    fn malformed_proxy_url_is_ignored_not_panic() {
+        temp_env::with_vars([("HTTPS_PROXY", Some("not a url ::::"))], || {
+            let builder = apply_env_proxy(reqwest::Client::builder());
+            assert!(
+                builder.build().is_ok(),
+                "malformed proxy must not break the builder"
+            );
+        });
+    }
+
+    #[test]
+    fn valid_https_proxy_applied_without_panic() {
+        temp_env::with_vars([("HTTPS_PROXY", Some("http://127.0.0.1:9999"))], || {
+            let builder = apply_env_proxy(reqwest::Client::builder());
+            assert!(builder.build().is_ok());
+        });
+    }
+
+    #[test]
+    fn socks5_via_all_proxy_is_accepted() {
+        // Regression: ALL_PROXY must use Proxy::all() so socks5:// schemes work.
+        temp_env::with_vars([("ALL_PROXY", Some("socks5://127.0.0.1:1080"))], || {
+            let builder = apply_env_proxy(reqwest::Client::builder());
+            assert!(builder.build().is_ok(), "socks5 via ALL_PROXY must build");
+        });
+    }
+
+    #[test]
+    fn https_proxy_takes_precedence_over_all_proxy() {
+        temp_env::with_vars(
+            [
+                ("HTTPS_PROXY", Some("http://127.0.0.1:1")),
+                ("ALL_PROXY", Some("socks5://127.0.0.1:2")),
+            ],
+            || {
+                let builder = apply_env_proxy(reqwest::Client::builder());
+                assert!(builder.build().is_ok());
+            },
+        );
+    }
+}

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -6,11 +6,15 @@
 //!
 //! # Proxy invariant
 //!
-//! [`apply_env_proxy`] is the **only** place in the codebase that honours
-//! `HTTPS_PROXY` / `ALL_PROXY` env vars. All other `reqwest` clients
+//! [`astra_core::net::apply_env_proxy`] is the **only** place in the codebase
+//! that honours `HTTPS_PROXY` / `ALL_PROXY` env vars. It is called from the
+//! LLM client here and from `validate_connectivity` in `astra-services`
+//! (both reach external provider endpoints). All other `reqwest` clients
 //! (durable bridge, skill HTTP, server tool executor, summary client, …)
 //! must call `.no_proxy()` — their traffic is local/intranet and should
 //! not be routed through a user's LLM proxy.
+//!
+//! Re-exported as [`apply_env_proxy`] for in-crate call sites.
 
 use std::{
     collections::HashMap,
@@ -370,133 +374,10 @@ thread_local! {
 /// `all_proxy`. For `HTTPS_PROXY`/`https_proxy` we register an HTTPS-scheme
 /// proxy; for `ALL_PROXY`/`all_proxy` we register an all-scheme proxy so that
 /// `socks5://` URLs (which only make sense as all-scheme) are honoured.
-pub(crate) fn apply_env_proxy(mut builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
-    let no_proxy = reqwest::NoProxy::from_env();
-    for var in &["HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"] {
-        let Ok(proxy_url) = std::env::var(var) else {
-            continue;
-        };
-        if proxy_url.is_empty() {
-            continue;
-        }
-        let is_all = matches!(*var, "ALL_PROXY" | "all_proxy");
-        let parsed = if is_all {
-            reqwest::Proxy::all(&proxy_url)
-        } else {
-            reqwest::Proxy::https(&proxy_url)
-        };
-        match parsed {
-            Ok(mut proxy) => {
-                if let Some(np) = no_proxy.clone() {
-                    proxy = proxy.no_proxy(Some(np));
-                }
-                tracing::info!(
-                    target: "astra_runtime::llm_client",
-                    env_var = *var,
-                    proxy = %proxy_url,
-                    "applying proxy from environment"
-                );
-                builder = builder.proxy(proxy);
-                return builder;
-            }
-            Err(e) => {
-                tracing::warn!(
-                    target: "astra_runtime::llm_client",
-                    env_var = *var,
-                    proxy = %proxy_url,
-                    error = %e,
-                    "failed to parse proxy URL; ignoring"
-                );
-            }
-        }
-    }
-    builder
-}
+pub(crate) use astra_core::net::apply_env_proxy;
 
-#[cfg(test)]
-mod apply_env_proxy_tests {
-    use super::apply_env_proxy;
-
-    /// All four recognized env var names must be cleared for isolation, since
-    /// `apply_env_proxy` reads them in precedence order.
-    const PROXY_VARS: &[&str] = &["HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"];
-
-    fn clear_all() -> Vec<(&'static str, Option<String>)> {
-        PROXY_VARS.iter().map(|v| (*v, None)).collect()
-    }
-
-    #[test]
-    fn no_env_vars_leaves_builder_unmodified() {
-        temp_env::with_vars(clear_all(), || {
-            // Smoke: must not panic and must build a usable client.
-            let builder = reqwest::Client::builder();
-            let builder = apply_env_proxy(builder);
-            assert!(
-                builder.build().is_ok(),
-                "builder should produce client with no proxy"
-            );
-        });
-    }
-
-    #[test]
-    fn empty_proxy_url_is_ignored() {
-        temp_env::with_vars([("HTTPS_PROXY", Some(""))], || {
-            let builder = apply_env_proxy(reqwest::Client::builder());
-            assert!(
-                builder.build().is_ok(),
-                "empty proxy URL should be ignored, not error"
-            );
-        });
-    }
-
-    #[test]
-    fn malformed_proxy_url_is_ignored_not_panic() {
-        // Regression: prior code silently swallowed parse errors. We now log+skip.
-        // Ensure builder is still usable even when the URL is garbage.
-        temp_env::with_vars([("HTTPS_PROXY", Some("not a url ::::"))], || {
-            let builder = apply_env_proxy(reqwest::Client::builder());
-            assert!(
-                builder.build().is_ok(),
-                "malformed proxy must not break the builder"
-            );
-        });
-    }
-
-    #[test]
-    fn valid_https_proxy_applied_without_panic() {
-        temp_env::with_vars([("HTTPS_PROXY", Some("http://127.0.0.1:9999"))], || {
-            let builder = apply_env_proxy(reqwest::Client::builder());
-            assert!(builder.build().is_ok());
-        });
-    }
-
-    #[test]
-    fn socks5_via_all_proxy_is_accepted() {
-        // Regression: ALL_PROXY must use Proxy::all() so socks5:// schemes work.
-        // Requires the `socks` feature on reqwest (enabled in workspace).
-        temp_env::with_vars([("ALL_PROXY", Some("socks5://127.0.0.1:1080"))], || {
-            let builder = apply_env_proxy(reqwest::Client::builder());
-            assert!(builder.build().is_ok(), "socks5 via ALL_PROXY must build");
-        });
-    }
-
-    #[test]
-    fn https_proxy_takes_precedence_over_all_proxy() {
-        // Documented contract: first match wins in HTTPS_PROXY, https_proxy,
-        // ALL_PROXY, all_proxy order. Set both and ensure build succeeds —
-        // precedence is asserted behaviourally via early-return in apply_env_proxy.
-        temp_env::with_vars(
-            [
-                ("HTTPS_PROXY", Some("http://127.0.0.1:1")),
-                ("ALL_PROXY", Some("socks5://127.0.0.1:2")),
-            ],
-            || {
-                let builder = apply_env_proxy(reqwest::Client::builder());
-                assert!(builder.build().is_ok());
-            },
-        );
-    }
-}
+// Tests for `apply_env_proxy` live with its authoritative implementation in
+// `astra_core::net`. Do not duplicate them here.
 
 /// TCP connect timeout for LLM API requests.
 pub(crate) fn llm_connect_timeout() -> std::time::Duration {

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -818,16 +818,15 @@ pub async fn validate_connectivity(
         return None;
     }
 
-    // Disable env-proxy for connectivity probes. Matches the policy established in
-    // commit 3e3d6fa8 ("centralize env proxy in LLM client"): connectivity probes
-    // target provider endpoints directly and must not be rerouted through
-    // HTTP(S)_PROXY / ALL_PROXY env vars, which can silently break probes in
-    // corporate environments and leak internal endpoints in others.
-    let client = match reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(15))
-        .no_proxy()
-        .build()
-    {
+    // Connectivity probes reach external provider endpoints (Anthropic, Bedrock,
+    // OpenAI-compatible base_urls) — same class of traffic as the LLM client.
+    // They are NOT "internal connections" in the sense of 3e3d6fa8, so they
+    // share the LLM client's proxy policy via the single authoritative
+    // implementation in `astra_core::net::apply_env_proxy`.
+    let probe_builder = astra_core::net::apply_env_proxy(
+        reqwest::Client::builder().timeout(std::time::Duration::from_secs(15)),
+    );
+    let client = match probe_builder.build() {
         Ok(c) => c,
         Err(e) => return Some(format!("Client error: {}", e)),
     };


### PR DESCRIPTION
## Summary

Extracts the shared `apply_env_proxy` helper into `astra-core::net` so that the 3e3d6fa8 policy ("only external traffic reads env proxy") is enforced **structurally** rather than by convention.

Also fixes two misclassified clients: provider connectivity probes and the GitHub API client both hit external endpoints, so they should honour env proxy — not bypass it.

## Changes

- **`astra-core/src/net.rs`** (new): authoritative `pub fn apply_env_proxy` with policy doc-comment, `HTTPS_PROXY`/`ALL_PROXY`/`NO_PROXY` support, socks5 fix. Includes 6 `temp_env` unit tests (migrated from `llm_client.rs`).
- **`astra-core/Cargo.toml`**: add `reqwest` + `tracing` workspace deps; `temp-env` dev-dep.
- **`runtime/turn/llm_client.rs`**: remove local 42-line impl + 84-line test module; re-export from `astra_core::net` instead.
- **`services/src/models.rs`**: `validate_connectivity`: `.no_proxy()` → `apply_env_proxy`. Provider probes hit external endpoints, not internal services — correctly treated same as the LLM client.
- **`astra-cli/src/edge_tools.rs`**: GitHub API client: implicit reqwest default → `apply_env_proxy`. Adds TDD regression test (4 proxy env combinations).

## Policy invariant (now structurally enforced)

| Category | Count | Implementation |
|---|---|---|
| External (LLM ×2, provider probe, GitHub API) | 4 | `apply_env_proxy` |
| Internal (memoria, durable, edge, runtime…) | 24 | `.no_proxy()` |
| Test/mock | 3 | `.no_proxy()` / mock |

Zero `reqwest::Client::builder()` calls with implicit proxy behaviour remaining.

## Testing

- `cargo fmt --check` ✅
- `cargo clippy --workspace` ✅  
- `cargo test -p astra-core --lib` ✅ 127 passed (includes 6 new `apply_env_proxy` unit tests)
- `cargo test -p astra-cli github_client_honours_proxy_env_without_panicking` ✅ 1 passed