### PR TITLE
refactor: Strengthen deterministic e2e coverage

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -52,5 +52,5 @@ jobs:
         run: |
           npm ci
           npm run typecheck
-          npm run test:coverage
+          ASTRA_SDK_E2E=1 npm run test:coverage
           npm run build

--- a/packages/sdk/src/__tests__/integration/local-e2e-server.ts
+++ b/packages/sdk/src/__tests__/integration/local-e2e-server.ts
@@ -5,7 +5,17 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { text as streamText } from 'node:stream/consumers';
 
-import { PATH_AUTH_LOGIN, PATH_AUTH_ME, PATH_AUTH_REFRESH, PATH_SESSIONS } from '../../paths';
+import {
+  PATH_AUTH_LOGIN,
+  PATH_AUTH_ME,
+  PATH_AUTH_REFRESH,
+  PATH_CHAT_STREAM,
+  PATH_MEMORY_PURGE,
+  PATH_MEMORY_RETRIEVE,
+  PATH_MEMORY_SEARCH,
+  PATH_MEMORY_STORE,
+  PATH_SESSIONS,
+} from '../../paths';
 
 export type LocalE2eServer = {
   baseUrl: string;
@@ -21,9 +31,44 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.end(JSON.stringify(body));
 }
 
+function sendSse(res: ServerResponse, events: unknown[]): void {
+  res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+  res.end(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(''));
+}
+
 function readBody(req: IncomingMessage): Promise<string> {
   return streamText(req);
 }
+
+type HarnessSession = {
+  session_id: string;
+  user_id: string;
+  agent_id: string | null;
+  title: string | null;
+  status: string;
+  event_count: number;
+  created_at: string;
+  updated_at: string | null;
+  ended_at: string | null;
+  metadata: Record<string, unknown>;
+};
+
+type HarnessRun = {
+  run_id: string;
+  session_id: string;
+  status: string;
+  waiting_for: string | null;
+  events: Array<Record<string, unknown>>;
+};
+
+type HarnessMemory = {
+  id: string;
+  content: string;
+  memory_type?: string;
+  session_id?: string;
+  trust_tier?: string;
+  created_at: string;
+};
 
 /**
  * @param pathPrefix - `''` or `'/api'`. API routes live under this prefix. `/health` is always on the server root (no prefix).
@@ -34,6 +79,14 @@ export async function startLocalE2eServer(pathPrefix = ''): Promise<LocalE2eServ
   const testPassword = 'e2e_pass';
   const staticAccessToken = 'harness-access-token';
   const staticRefreshToken = 'harness-refresh-token';
+  const sessions = new Map<string, HarnessSession>();
+  const runs = new Map<string, HarnessRun>();
+  const memories: HarnessMemory[] = [];
+  const delegations = new Map<string, string[]>();
+  let sessionSeq = 1;
+  let runSeq = 1;
+  let memorySeq = 1;
+  let activitySeq = 1;
 
   function apiPathname(reqPath: string): string {
     const u = new URL(reqPath, 'http://e2e/');
@@ -67,6 +120,13 @@ export async function startLocalE2eServer(pathPrefix = ''): Promise<LocalE2eServ
 
         const pathname = apiPathname(req.url);
         const method = req.method ?? 'GET';
+        const bearerOk = (h: string | undefined) =>
+          h === `Bearer ${staticAccessToken}` || h === `Bearer ${staticAccessToken}-refreshed`;
+
+        if (pathname !== PATH_AUTH_LOGIN && pathname !== PATH_AUTH_REFRESH && !bearerOk(req.headers.authorization)) {
+          sendJson(res, 401, { detail: 'unauthorized' });
+          return;
+        }
 
         if (method === 'POST' && pathname === PATH_AUTH_LOGIN) {
           const body = await readBody(req);
@@ -100,14 +160,7 @@ export async function startLocalE2eServer(pathPrefix = ''): Promise<LocalE2eServ
           return;
         }
 
-        const bearerOk = (h: string | undefined) =>
-          h === `Bearer ${staticAccessToken}` || h === `Bearer ${staticAccessToken}-refreshed`;
-
         if (method === 'GET' && pathname === PATH_AUTH_ME) {
-          if (!bearerOk(req.headers.authorization)) {
-            sendJson(res, 401, { detail: 'unauthorized' });
-            return;
-          }
           sendJson(res, 200, {
             user_id: 'harness-uid-1',
             username: testUsername,
@@ -117,50 +170,300 @@ export async function startLocalE2eServer(pathPrefix = ''): Promise<LocalE2eServ
           return;
         }
 
+        if (method === 'POST' && pathname === PATH_SESSIONS) {
+          const raw = await readBody(req);
+          const body = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+          const sessionId = `sess-${sessionSeq++}`;
+          const now = new Date().toISOString();
+          const session: HarnessSession = {
+            session_id: sessionId,
+            user_id: 'harness-uid-1',
+            agent_id: typeof body.agent_id === 'string' ? body.agent_id : null,
+            title: typeof body.title === 'string' ? body.title : null,
+            status: 'active',
+            event_count: 0,
+            created_at: now,
+            updated_at: now,
+            ended_at: null,
+            metadata:
+              body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
+                ? (body.metadata as Record<string, unknown>)
+                : {},
+          };
+          sessions.set(sessionId, session);
+          sendJson(res, 200, session);
+          return;
+        }
+
         if (method === 'GET' && pathname === PATH_SESSIONS) {
-          if (!bearerOk(req.headers.authorization)) {
-            sendJson(res, 401, { detail: 'unauthorized' });
-            return;
-          }
           sendJson(res, 200, {
-            sessions: [],
-            total: 0,
+            sessions: [...sessions.values()],
+            total: sessions.size,
             limit: 50,
             offset: 0,
           });
           return;
         }
 
-        const streamRun = /^\/chat\/runs\/([^/]+)\/stream$/.exec(pathname);
-        if (method === 'GET' && streamRun) {
-          if (!bearerOk(req.headers.authorization)) {
-            sendJson(res, 401, { detail: 'unauthorized' });
+        const sessionRoute = /^\/sessions\/([^/]+)(?:\/([^/]+)(?:\/([^/]+))?)?$/.exec(pathname);
+        if (sessionRoute) {
+          const sessionId = decodeURIComponent(sessionRoute[1]!);
+          const action = sessionRoute[2];
+          const subAction = sessionRoute[3];
+          const session = sessions.get(sessionId);
+          if (!session) {
+            sendJson(res, 404, { detail: 'session not found' });
             return;
           }
+
+          if (method === 'GET' && !action) {
+            sendJson(res, 200, session);
+            return;
+          }
+
+          if (method === 'POST' && action === 'close') {
+            session.status = 'closed';
+            session.ended_at = new Date().toISOString();
+            session.updated_at = session.ended_at;
+            sendJson(res, 200, session);
+            return;
+          }
+
+          if (method === 'GET' && action === 'activity') {
+            sendJson(res, 200, {
+              session_id: sessionId,
+              activities: [...runs.values()]
+                .filter((run) => run.session_id === sessionId)
+                .flatMap((run) =>
+                  run.events.map((event) => ({
+                    log_id: `log-${activitySeq++}`,
+                    action: event.type,
+                    details: event,
+                    created_at: new Date().toISOString(),
+                  })),
+                ),
+              total: session.event_count,
+            });
+            return;
+          }
+
+          if (method === 'GET' && action === 'audit' && subAction === 'summary') {
+            const sessionRuns = [...runs.values()].filter((run) => run.session_id === sessionId);
+            sendJson(res, 200, {
+              session_id: sessionId,
+              status: session.status,
+              turn_count: sessionRuns.length,
+              tokens_in: sessionRuns.length * 10,
+              tokens_out: sessionRuns.length * 20,
+              tool_calls_total: sessionRuns
+                .flatMap((run) => run.events)
+                .filter((event) => event.type === 'tool_call_start').length,
+              tool_calls_failed: 0,
+              error_count: 0,
+              stall_count: 0,
+              checkpoint_count: 0,
+              compact_count: 0,
+              execution_boundary_opened_count: 0,
+              execution_boundary_committed_count: 0,
+              execution_boundary_aborted_count: 0,
+              approval_required_count: 0,
+              approval_decision_count: 0,
+              approval_timeout_count: 0,
+              models_used: ['harness-model'],
+              duration_secs: 0,
+              created_at: session.created_at,
+              ended_at: session.ended_at,
+            });
+            return;
+          }
+        }
+
+        if (method === 'POST' && pathname === PATH_CHAT_STREAM) {
+          const raw = await readBody(req);
+          const body = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+          const requestedSession =
+            typeof body.session_id === 'string' ? sessions.get(body.session_id) : undefined;
+          if (body.session_id && !requestedSession) {
+            sendJson(res, 404, { detail: 'session not found' });
+            return;
+          }
+          if (requestedSession?.status === 'closed') {
+            sendJson(res, 409, { detail: 'session is closed' });
+            return;
+          }
+
+          const session =
+            requestedSession ??
+            (() => {
+              const sessionId = `sess-${sessionSeq++}`;
+              const now = new Date().toISOString();
+              const created: HarnessSession = {
+                session_id: sessionId,
+                user_id: 'harness-uid-1',
+                agent_id: typeof body.agent_id === 'string' ? body.agent_id : null,
+                title: null,
+                status: 'active',
+                event_count: 0,
+                created_at: now,
+                updated_at: now,
+                ended_at: null,
+                metadata: {},
+              };
+              sessions.set(sessionId, created);
+              return created;
+            })();
+
+          const runId = `run-${runSeq++}`;
+          const turn = [...runs.values()].filter((run) => run.session_id === session.session_id).length + 1;
+          const context = body.context && typeof body.context === 'object' ? body.context : {};
+          const events = [
+            { type: 'session_info', session_id: session.session_id, run_id: runId },
+            { type: 'run_started', run_id: runId, session_id: session.session_id },
+            {
+              type: 'text_delta',
+              content: `turn=${turn};message=${body.message};context=${JSON.stringify(context)}`,
+            },
+            { type: 'usage', prompt_tokens: 10, completion_tokens: 20, cache_read_tokens: turn > 1 ? 100 : 0 },
+            { type: 'turn_complete' },
+          ];
+          runs.set(runId, {
+            run_id: runId,
+            session_id: session.session_id,
+            status: 'completed',
+            waiting_for: null,
+            events,
+          });
+          session.event_count += events.length;
+          session.updated_at = new Date().toISOString();
+          sendSse(res, events);
+          return;
+        }
+
+        if (method === 'POST' && pathname === PATH_MEMORY_STORE) {
+          const body = JSON.parse(await readBody(req)) as Partial<HarnessMemory>;
+          const memory: HarnessMemory = {
+            id: `mem-${memorySeq++}`,
+            content: String(body.content ?? ''),
+            memory_type: body.memory_type,
+            session_id: body.session_id,
+            trust_tier: body.trust_tier,
+            created_at: new Date().toISOString(),
+          };
+          memories.push(memory);
+          sendJson(res, 200, { id: memory.id });
+          return;
+        }
+
+        if (method === 'POST' && (pathname === PATH_MEMORY_SEARCH || pathname === PATH_MEMORY_RETRIEVE)) {
+          const body = JSON.parse(await readBody(req)) as { query?: string; top_k?: number };
+          const terms = String(body.query ?? '')
+            .toLowerCase()
+            .split(/\s+/)
+            .filter(Boolean);
+          const topK = body.top_k ?? (pathname === PATH_MEMORY_RETRIEVE ? 5 : 10);
+          const results = memories
+            .map((memory) => {
+              const text = memory.content.toLowerCase();
+              const hits = terms.filter((term) => text.includes(term)).length;
+              return {
+                id: memory.id,
+                content: memory.content,
+                score: hits / Math.max(terms.length, 1),
+                memory_type: memory.memory_type,
+                created_at: memory.created_at,
+              };
+            })
+            .filter((memory) => memory.score > 0)
+            .sort((a, b) => b.score - a.score)
+            .slice(0, topK);
+          sendJson(res, 200, results);
+          return;
+        }
+
+        if (method === 'POST' && pathname === PATH_MEMORY_PURGE) {
+          const body = JSON.parse(await readBody(req)) as { topic?: string };
+          const topic = String(body.topic ?? '').toLowerCase();
+          if (!topic) {
+            sendJson(res, 400, { detail: 'topic required' });
+            return;
+          }
+          for (let i = memories.length - 1; i >= 0; i--) {
+            if (memories[i].content.toLowerCase().includes(topic)) {
+              memories.splice(i, 1);
+            }
+          }
+          sendJson(res, 200, {});
+          return;
+        }
+
+        const streamRun = /^\/chat\/runs\/([^/]+)\/stream$/.exec(pathname);
+        if (method === 'GET' && streamRun) {
           const u = new URL(req.url, 'http://e2e/');
           if (u.searchParams.get('last_index') === null) {
             res.writeHead(400);
             res.end();
             return;
           }
-          res.writeHead(200, { 'Content-Type': 'text/event-stream' });
-          res.end('data: {"type":"text_delta","content":"e2e"}\n\ndata: {"type":"turn_complete"}\n\n');
+          const runId = decodeURIComponent(streamRun[1]!);
+          const run = runs.get(runId);
+          const start = Number(u.searchParams.get('last_index') ?? '0');
+          sendSse(
+            res,
+            run
+              ? run.events.slice(start)
+              : [{ type: 'text_delta', content: 'e2e' }, { type: 'turn_complete' }],
+          );
           return;
+        }
+
+        const delegateMatch = /^\/chat\/runs\/([^/]+)\/delegate$/.exec(pathname);
+        if (method === 'POST' && delegateMatch) {
+          const runId = decodeURIComponent(delegateMatch[1]!);
+          const body = JSON.parse(await readBody(req)) as { delegation_id?: string; pattern?: unknown };
+          const agentIds = extractAgentIds(body.pattern);
+          const childRuns = agentIds.map((agentId) => `${runId}-${agentId}-child`);
+          delegations.set(runId, childRuns);
+          sendJson(res, 200, {
+            delegation_id: body.delegation_id ?? `delegation-${runId}`,
+            status: 'completed',
+            agent_results: agentIds.map((agentId) => ({
+              agent_id: agentId,
+              status: 'completed',
+              output: `ok:${agentId}`,
+              error: null,
+            })),
+            aggregated_output: childRuns.join(','),
+            total_prompt_tokens: agentIds.length * 10,
+            total_completion_tokens: agentIds.length * 20,
+            total_tool_calls: agentIds.length,
+          });
+          return;
+        }
+
+        const delegationsMatch = /^\/chat\/runs\/([^/]+)\/delegations(?:\/(pause|resume))?$/.exec(pathname);
+        if (delegationsMatch) {
+          const runId = decodeURIComponent(delegationsMatch[1]!);
+          const subRunIds = delegations.get(runId) ?? [];
+          if (method === 'GET' && !delegationsMatch[2]) {
+            sendJson(res, 200, { parent_run_id: runId, sub_run_ids: subRunIds });
+            return;
+          }
+          if (method === 'POST' && delegationsMatch[2]) {
+            sendJson(res, 200, { parent_run_id: runId, affected: subRunIds.length });
+            return;
+          }
         }
 
         const runIdMatch = /^\/chat\/runs\/([^/]+)$/.exec(pathname);
         if (method === 'GET' && runIdMatch) {
-          if (!bearerOk(req.headers.authorization)) {
-            sendJson(res, 401, { detail: 'unauthorized' });
-            return;
-          }
           const runId = runIdMatch[1]!;
+          const run = runs.get(runId);
           sendJson(res, 200, {
             run_id: runId,
-            session_id: 'sess-1',
-            status: 'completed',
-            events_count: 2,
-            waiting_for: null,
+            session_id: run?.session_id ?? 'sess-1',
+            status: run?.status ?? 'completed',
+            events_count: run?.events.length ?? 2,
+            waiting_for: run?.waiting_for ?? null,
           });
           return;
         }
@@ -197,4 +500,27 @@ export async function startLocalE2eServer(pathPrefix = ''): Promise<LocalE2eServ
     });
     server.on('error', reject);
   });
+}
+
+function extractAgentIds(pattern: unknown): string[] {
+  const out = new Set<string>();
+  function visit(value: unknown, key?: string): void {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, key);
+      return;
+    }
+    if (value && typeof value === 'object') {
+      for (const [childKey, childValue] of Object.entries(value)) visit(childValue, childKey);
+      return;
+    }
+    if (
+      typeof value === 'string' &&
+      value.includes('agent') &&
+      (key === 'agent_id' || key === 'agent_ids' || key === 'agents')
+    ) {
+      out.add(value);
+    }
+  }
+  visit(pattern);
+  return out.size > 0 ? [...out] : ['agent-a'];
 }

--- a/packages/sdk/src/__tests__/integration/online-smoke.test.ts
+++ b/packages/sdk/src/__tests__/integration/online-smoke.test.ts
@@ -8,7 +8,8 @@
  * - `ASTRA_SDK_USERNAME` + `ASTRA_SDK_PASSWORD`
  * for authenticated tests (`getMe`, `listSessions`, …). Optional: `ASTRA_SDK_PATH_PREFIX`, `ASTRA_SDK_TEST_RUN_ID`.
  */
-import { AstraClient } from '../../client';
+import { AstraApiError, AstraClient } from '../../client';
+import type { StreamEvent } from '../../types';
 import { startLocalE2eServer, type LocalE2eServer } from './local-e2e-server';
 
 const e2e = process.env.ASTRA_SDK_E2E === '1';
@@ -17,6 +18,16 @@ const describeReal = e2e && Boolean(process.env.ASTRA_SDK_BASE_URL) ? describe :
 
 function healthUrlFromBaseUrl(base: string): string {
   return `${base.replace(/\/$/, '')}/health`;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error('timed out waiting for local e2e condition');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
 }
 
 describeLocal('integration / online (Mode A: local HTTP harness)', () => {
@@ -80,6 +91,174 @@ describeLocal('integration / online (Mode A: local HTTP harness)', () => {
     });
     const evs = await client.getRunEvents('run-h2', 4);
     expect(evs.map((e) => e.type)).toEqual(['text_delta', 'turn_complete']);
+  });
+
+  test('multi-turn streamChat preserves session context and replays persisted run events', async () => {
+    const client = new AstraClient({
+      baseUrl: harness.baseUrl,
+      accessToken: harness.staticAccessToken,
+    });
+    const session = await client.createSession({
+      title: 'local multi-turn',
+      metadata: { scenario: 'context-regression' },
+    });
+
+    const firstEvents: StreamEvent[] = [];
+    const first = client.streamChat(
+      {
+        sessionId: session.sessionId,
+        message: 'turn one',
+        context: { memory: ['prefer PKCE'], turn: 1 },
+        model: 'harness-model',
+      },
+      { onEvent: (event) => firstEvents.push(event) },
+    );
+    await waitFor(() => firstEvents.some((event) => event.type === 'turn_complete'));
+    first.close();
+
+    const firstRunId = firstEvents.find((event) => event.type === 'session_info')?.run_id;
+    expect(firstRunId).toBeDefined();
+    const replay = await client.getRunEvents(firstRunId!, 2);
+    expect(replay.map((event) => event.type)).toEqual(['text_delta', 'usage', 'turn_complete']);
+    expect(replay[0]).toMatchObject({
+      type: 'text_delta',
+      content: expect.stringContaining('"prefer PKCE"'),
+    });
+
+    const secondEvents: StreamEvent[] = [];
+    const second = client.streamChat(
+      {
+        sessionId: session.sessionId,
+        message: 'turn two',
+        context: { memory: ['prefer PKCE', 'schema changed'], turn: 2 },
+      },
+      { onEvent: (event) => secondEvents.push(event) },
+    );
+    await waitFor(() => secondEvents.some((event) => event.type === 'turn_complete'));
+    second.close();
+
+    expect(secondEvents.find((event) => event.type === 'text_delta')).toMatchObject({
+      type: 'text_delta',
+      content: expect.stringContaining('turn=2'),
+    });
+    expect(secondEvents.find((event) => event.type === 'usage')).toMatchObject({
+      type: 'usage',
+      cache_read_tokens: 100,
+    });
+
+    const audit = await client.getSessionAudit(session.sessionId);
+    expect(audit.turn_count).toBe(2);
+    expect(audit.status).toBe('active');
+    const activity = await client.getSessionActivity(session.sessionId);
+    expect(activity.total).toBeGreaterThanOrEqual(10);
+  });
+
+  test('closed session rejects a follow-up stream with a surfaced error event', async () => {
+    const client = new AstraClient({
+      baseUrl: harness.baseUrl,
+      accessToken: harness.staticAccessToken,
+    });
+    const session = await client.createSession({ title: 'close guard' });
+    await client.closeSession(session.sessionId);
+
+    const events: StreamEvent[] = [];
+    const sse = client.streamChat(
+      { sessionId: session.sessionId, message: 'should fail' },
+      { onEvent: (event) => events.push(event) },
+    );
+    await waitFor(() => events.some((event) => event.type === 'error'));
+    sse.close();
+
+    expect(events[0]).toMatchObject({
+      type: 'error',
+      message: expect.stringContaining('session is closed'),
+      retryable: false,
+    });
+  });
+
+  test('memory store/search/retrieve/purge runs through local HTTP state', async () => {
+    const client = new AstraClient({
+      baseUrl: harness.baseUrl,
+      accessToken: harness.staticAccessToken,
+    });
+    const semantic = await client.memoryStore({
+      content: 'OAuth migration prefers PKCE and preserves sessions',
+      memory_type: 'semantic',
+      session_id: 'sess-memory-http',
+      trust_tier: 'T2',
+    });
+    await client.memoryStore({
+      content: 'Cloud-edge callbacks are idempotent by request id',
+      memory_type: 'procedural',
+      session_id: 'sess-memory-http',
+    });
+
+    expect(semantic.id).toMatch(/^mem-/);
+    const search = await client.memorySearch('OAuth PKCE', 1);
+    expect(search).toHaveLength(1);
+    expect(search[0]).toMatchObject({ id: semantic.id, score: 1 });
+
+    const retrieved = await client.memoryRetrieve('callbacks request id', 5);
+    expect(retrieved.map((memory) => memory.content)).toContain(
+      'Cloud-edge callbacks are idempotent by request id',
+    );
+
+    await client.memoryPurge('OAuth');
+    const afterPurge = await client.memorySearch('OAuth PKCE', 5);
+    expect(afterPurge).toEqual([]);
+  });
+
+  test('memory purge rejects an empty topic without deleting unrelated memories', async () => {
+    const client = new AstraClient({
+      baseUrl: harness.baseUrl,
+      accessToken: harness.staticAccessToken,
+    });
+    await client.memoryStore({
+      content: 'Do not delete this unrelated memory',
+      memory_type: 'semantic',
+    });
+
+    await expect(client.memoryPurge('')).rejects.toBeInstanceOf(AstraApiError);
+    const stillThere = await client.memorySearch('unrelated memory', 5);
+    expect(stillThere.map((memory) => memory.content)).toContain(
+      'Do not delete this unrelated memory',
+    );
+  });
+
+  test('delegation lifecycle persists child runs across delegate/list/pause/resume', async () => {
+    const client = new AstraClient({
+      baseUrl: harness.baseUrl,
+      accessToken: harness.staticAccessToken,
+    });
+
+    const result = await client.delegateRun('run-parent-http', {
+      delegation_id: 'del-http',
+      parent_run_id: 'run-parent-http',
+      task: 'fan out to cloud and edge agents',
+      pattern: { fan_out: { agent_ids: ['agent-cloud', 'agent-edge'] } },
+      user_id: 'harness-uid-1',
+      depth: 1,
+      context: { session_id: 'sess-delegation-http' },
+    });
+    expect(result.status).toBe('completed');
+    expect(result.agent_results.map((agent) => agent.agent_id)).toEqual([
+      'agent-cloud',
+      'agent-edge',
+    ]);
+
+    const listed = await client.listDelegations('run-parent-http');
+    expect(listed.sub_run_ids).toEqual([
+      'run-parent-http-agent-cloud-child',
+      'run-parent-http-agent-edge-child',
+    ]);
+    await expect(client.pauseDelegations('run-parent-http')).resolves.toEqual({
+      parent_run_id: 'run-parent-http',
+      affected: 2,
+    });
+    await expect(client.resumeDelegations('run-parent-http')).resolves.toEqual({
+      parent_run_id: 'run-parent-http',
+      affected: 2,
+    });
   });
 
   test('pathPrefix: same routes under /api + client.pathPrefix', async () => {

--- a/packages/sdk/src/__tests__/scenarios/memory-workflows.test.ts
+++ b/packages/sdk/src/__tests__/scenarios/memory-workflows.test.ts
@@ -1,0 +1,101 @@
+import { AstraClient } from '../../client';
+import type { MemoryEntry, MemorySearchResult } from '../../types';
+
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+describe('scenarios / memory workflows', () => {
+  it('stores session-scoped memories, searches by score order, retrieves topK, and purges by topic', async () => {
+    const stored: Array<MemoryEntry & { id: string }> = [];
+    const fetchImpl = jest.fn().mockImplementation((url: string, init?: RequestInit) => {
+      const path = new URL(url).pathname;
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+
+      if (path === '/memory/store') {
+        const id = `mem-${stored.length + 1}`;
+        stored.push({ id, ...(body as MemoryEntry) });
+        return Promise.resolve(jsonResponse({ id }));
+      }
+
+      if (path === '/memory/search') {
+        expect(body.top_k).toBe(3);
+        const results: MemorySearchResult[] = stored
+          .filter((m) => m.content.includes('PKCE') || m.content.includes('OAuth'))
+          .map((m) => ({
+            id: m.id,
+            content: m.content,
+            score: m.content.includes('PKCE') ? 0.96 : 0.72,
+            memory_type: m.memory_type,
+          }))
+          .sort((a, b) => b.score - a.score)
+          .slice(0, body.top_k);
+        return Promise.resolve(jsonResponse(results));
+      }
+
+      if (path === '/memory/retrieve') {
+        expect(body.top_k).toBe(1);
+        const results: MemorySearchResult[] = stored
+          .filter((m) => m.session_id === 'sess-memory-1')
+          .map((m) => ({ id: m.id, content: m.content, score: 0.9, memory_type: m.memory_type }))
+          .slice(0, body.top_k);
+        return Promise.resolve(jsonResponse(results));
+      }
+
+      if (path === '/memory/purge') {
+        expect(body.topic).toBe('OAuth');
+        for (let i = stored.length - 1; i >= 0; i--) {
+          if (stored[i].content.includes('OAuth') || stored[i].content.includes('PKCE')) {
+            stored.splice(i, 1);
+          }
+        }
+        return Promise.resolve(jsonResponse({}));
+      }
+
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    globalThis.fetch = fetchImpl;
+
+    const client = new AstraClient({ baseUrl: 'http://localhost:8000', accessToken: 'token' });
+
+    await expect(
+      client.memoryStore({
+        content: 'OAuth migration must use PKCE and keep sessions intact',
+        memory_type: 'semantic',
+        session_id: 'sess-memory-1',
+        trust_tier: 'T2',
+      }),
+    ).resolves.toEqual({ id: 'mem-1' });
+    await client.memoryStore({
+      content: 'Cloud-edge regression suite covers duplicate tool callbacks',
+      memory_type: 'procedural',
+      session_id: 'sess-memory-2',
+    });
+
+    const search = await client.memorySearch('OAuth PKCE', 3);
+    expect(search.map((m) => m.id)).toEqual(['mem-1']);
+    expect(search[0].score).toBeGreaterThan(0.9);
+
+    const retrieved = await client.memoryRetrieve('session scoped OAuth facts', 1);
+    expect(retrieved).toHaveLength(1);
+    expect(retrieved[0].content).toContain('PKCE');
+
+    await client.memoryPurge('OAuth');
+    const afterPurge = await client.memorySearch('OAuth PKCE', 3);
+    expect(afterPurge).toEqual([]);
+  });
+});

--- a/packages/sdk/src/__tests__/scenarios/multi-agent-delegation.test.ts
+++ b/packages/sdk/src/__tests__/scenarios/multi-agent-delegation.test.ts
@@ -1,0 +1,167 @@
+import { AstraClient } from '../../client';
+import { chatRunDelegatePath, chatRunDelegationsPath } from '../../paths';
+import type { StreamEvent } from '../../types';
+
+function streamFrom(chunks: string[]) {
+  const enc = new TextEncoder();
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(enc.encode(chunks[i]));
+        i++;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+async function nextTick(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('scenarios / multi-agent delegation', () => {
+  it('streams nested delegation lifecycle events in causal order', async () => {
+    const chunks = [
+      'data: {"type":"agent_delegated","agent_id":"researcher","task":"map context"}\n\n',
+      'data: {"type":"agent_spawned","agent_id":"researcher","run_id":"run-child-1","parent_run_id":"run-parent","agent_type":"explore","description":"Map context"}\n\n',
+      'data: {"type":"agent_progress","agent_id":"researcher","status":"running","description":"reading files","turn":1,"max_turns":3}\n\n',
+      'data: {"type":"agent_delegated","agent_id":"tester","task":"verify regression"}\n\n',
+      'data: {"type":"agent_spawned","agent_id":"tester","run_id":"run-child-2","parent_run_id":"run-child-1","agent_type":"task","description":"Verify regression"}\n\n',
+      'data: {"type":"agent_completed","agent_id":"tester","status":"completed","result_summary":"tests passed","total_tool_calls":2}\n\n',
+      'data: {"type":"agent_completed","agent_id":"researcher","status":"completed","result_summary":"context mapped","total_tool_calls":5}\n\n',
+      'data: {"type":"turn_complete"}\n\n',
+    ];
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: streamFrom(chunks),
+      headers: new Headers(),
+    } as unknown as Response);
+
+    const client = new AstraClient({ baseUrl: 'http://localhost:8000', accessToken: 'token' });
+    const events: StreamEvent[] = [];
+    const sse = client.streamChat({ message: 'coordinate agents', sessionId: 'sess-agents' }, {
+      onEvent: (event) => events.push(event),
+    });
+    await nextTick();
+    sse.close();
+
+    expect(events.map((event) => event.type)).toEqual([
+      'agent_delegated',
+      'agent_spawned',
+      'agent_progress',
+      'agent_delegated',
+      'agent_spawned',
+      'agent_completed',
+      'agent_completed',
+      'turn_complete',
+    ]);
+    expect(events[1]).toMatchObject({
+      type: 'agent_spawned',
+      agent_id: 'researcher',
+      run_id: 'run-child-1',
+      parent_run_id: 'run-parent',
+    });
+    expect(events[4]).toMatchObject({
+      type: 'agent_spawned',
+      agent_id: 'tester',
+      run_id: 'run-child-2',
+      parent_run_id: 'run-child-1',
+    });
+    expect(events[6]).toMatchObject({
+      type: 'agent_completed',
+      agent_id: 'researcher',
+      status: 'completed',
+      total_tool_calls: 5,
+    });
+  });
+
+  it('delegates, lists, pauses, and resumes a parent run with stable paths and bodies', async () => {
+    const fetchImpl = jest.fn().mockImplementation((url: string, init?: RequestInit) => {
+      const path = new URL(url).pathname;
+      if (path === chatRunDelegatePath('run-parent')) {
+        expect(init?.method).toBe('POST');
+        expect(JSON.parse(String(init?.body))).toEqual({
+          delegation_id: 'del-1',
+          parent_run_id: 'run-parent',
+          task: 'validate cloud-edge rollback',
+          pattern: { type: 'fan_out', agents: ['agent-edge', 'agent-tester'] },
+          user_id: 'user-1',
+          depth: 1,
+          context: { session_id: 'sess-agents', priority: 'high' },
+        });
+        return Promise.resolve(jsonResponse({
+          delegation_id: 'del-1',
+          status: 'running',
+          agent_results: [],
+          aggregated_output: null,
+          total_prompt_tokens: 0,
+          total_completion_tokens: 0,
+          total_tool_calls: 0,
+        }));
+      }
+      if (path === chatRunDelegationsPath('run-parent')) {
+        return Promise.resolve(jsonResponse({
+          parent_run_id: 'run-parent',
+          sub_run_ids: ['run-child-a', 'run-child-b'],
+        }));
+      }
+      if (path === '/chat/runs/run-parent/delegations/pause') {
+        return Promise.resolve(jsonResponse({ parent_run_id: 'run-parent', affected: 2 }));
+      }
+      if (path === '/chat/runs/run-parent/delegations/resume') {
+        return Promise.resolve(jsonResponse({ parent_run_id: 'run-parent', affected: 2 }));
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    globalThis.fetch = fetchImpl;
+
+    const client = new AstraClient({ baseUrl: 'http://localhost:8000', accessToken: 'token' });
+
+    await expect(client.delegateRun('run-parent', {
+      delegation_id: 'del-1',
+      parent_run_id: 'run-parent',
+      task: 'validate cloud-edge rollback',
+      pattern: { type: 'fan_out', agents: ['agent-edge', 'agent-tester'] },
+      user_id: 'user-1',
+      depth: 1,
+      context: { session_id: 'sess-agents', priority: 'high' },
+    })).resolves.toMatchObject({
+      delegation_id: 'del-1',
+      status: 'running',
+    });
+
+    const delegations = await client.listDelegations('run-parent');
+    expect(delegations.parent_run_id).toBe('run-parent');
+    expect(delegations.sub_run_ids).toEqual(['run-child-a', 'run-child-b']);
+
+    await expect(client.pauseDelegations('run-parent')).resolves.toEqual({
+      parent_run_id: 'run-parent',
+      affected: 2,
+    });
+    await expect(client.resumeDelegations('run-parent')).resolves.toEqual({
+      parent_run_id: 'run-parent',
+      affected: 2,
+    });
+  });
+});

--- a/packages/sdk/src/__tests__/scenarios/multi-turn-context.test.ts
+++ b/packages/sdk/src/__tests__/scenarios/multi-turn-context.test.ts
@@ -1,0 +1,144 @@
+import { AstraClient, chatRequestToWire } from '../../client';
+import type { StreamEvent } from '../../types';
+
+function streamFrom(chunks: string[]) {
+  const enc = new TextEncoder();
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(enc.encode(chunks[i]));
+        i++;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function okSseResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    body: streamFrom(['data: {"type":"turn_complete"}\n\n']),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+async function nextTick(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('scenarios / multi-turn context wire contract', () => {
+  it('preserves session, context, planning, budget, model, tools, skills, and edge routing fields', () => {
+    const wire = chatRequestToWire({
+      message: 'continue from the last failed migration',
+      sessionId: 'sess-multi-1',
+      agentId: 'agent-planner',
+      model: 'claude-sonnet-4.6',
+      context: {
+        previousTurns: [
+          { role: 'user', content: 'migrate auth table' },
+          { role: 'assistant', content: 'migration failed at step 3' },
+        ],
+        memoryHints: ['use PKCE', 'do not drop sessions'],
+      },
+      explain: true,
+      planSubtaskId: 'subtask-db-3',
+      isPlanSubtask: true,
+      edgeExecutorId: 'edge-shanghai-1',
+      capabilities: ['shell', 'filesystem', 'edge-tools'],
+      allowSkills: ['db-migration', 'regression-tests'],
+      allowTools: ['read_file', 'grep', 'bash'],
+      executionBudget: { initialTurns: 2, hardTurnLimit: 6 },
+      skillSearch: { dynamicSurface: true, minCatalogSize: 8, surfaceCap: 12 },
+    });
+
+    expect(wire).toEqual({
+      message: 'continue from the last failed migration',
+      session_id: 'sess-multi-1',
+      agent_id: 'agent-planner',
+      model: 'claude-sonnet-4.6',
+      context: {
+        previousTurns: [
+          { role: 'user', content: 'migrate auth table' },
+          { role: 'assistant', content: 'migration failed at step 3' },
+        ],
+        memoryHints: ['use PKCE', 'do not drop sessions'],
+      },
+      explain: true,
+      plan_subtask_id: 'subtask-db-3',
+      is_plan_subtask: true,
+      edge_executor_id: 'edge-shanghai-1',
+      capabilities: ['shell', 'filesystem', 'edge-tools'],
+      allow_skills: ['db-migration', 'regression-tests'],
+      allow_tools: ['read_file', 'grep', 'bash'],
+      execution_budget: { initial_turns: 2, hard_turn_limit: 6 },
+      skill_search: { dynamic_surface: true, min_catalog_size: 8, surface_cap: 12 },
+    });
+  });
+
+  it('streamChat sends consecutive turns with the same session id and updated context', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(okSseResponse());
+    globalThis.fetch = fetchImpl;
+
+    const client = new AstraClient({
+      baseUrl: 'http://localhost:8000',
+      accessToken: 'token',
+    });
+    const events: StreamEvent[] = [];
+
+    const first = client.streamChat(
+      {
+        message: 'turn 1: inspect the cache regression',
+        sessionId: 'sess-ctx',
+        context: { turn: 1, facts: ['cache_read_tokens unexpectedly zero'] },
+        executionBudget: { initialTurns: 1, hardTurnLimit: 4 },
+      },
+      { onEvent: (e) => events.push(e) },
+    );
+    await nextTick();
+    first.close();
+
+    const second = client.streamChat(
+      {
+        message: 'turn 2: apply the fix',
+        sessionId: 'sess-ctx',
+        context: {
+          turn: 2,
+          facts: ['cache_read_tokens unexpectedly zero', 'tool schema changed mid-session'],
+          priorRunId: 'run-1',
+        },
+        executionBudget: { initialTurns: 2, hardTurnLimit: 4 },
+      },
+      { onEvent: (e) => events.push(e) },
+    );
+    await nextTick();
+    second.close();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    const secondBody = JSON.parse(fetchImpl.mock.calls[1][1].body);
+
+    expect(firstBody.session_id).toBe('sess-ctx');
+    expect(secondBody.session_id).toBe('sess-ctx');
+    expect(firstBody.context).toEqual({
+      turn: 1,
+      facts: ['cache_read_tokens unexpectedly zero'],
+    });
+    expect(secondBody.context).toEqual({
+      turn: 2,
+      facts: ['cache_read_tokens unexpectedly zero', 'tool schema changed mid-session'],
+      priorRunId: 'run-1',
+    });
+    expect(secondBody.execution_budget).toEqual({ initial_turns: 2, hard_turn_limit: 4 });
+  });
+});

--- a/packages/sdk/src/__tests__/scenarios/streaming-resilience.test.ts
+++ b/packages/sdk/src/__tests__/scenarios/streaming-resilience.test.ts
@@ -1,0 +1,168 @@
+import { SSEClient, parseSseDataEvents } from '../../sse-client';
+import type { ConnectionState, StreamEvent } from '../../types';
+
+function byteStream(chunks: Uint8Array[]) {
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(chunks[i]);
+        i++;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function streamFromText(chunks: string[]) {
+  const enc = new TextEncoder();
+  return byteStream(chunks.map((chunk) => enc.encode(chunk)));
+}
+
+function streamResponse(body: ReadableStream<Uint8Array>, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    body,
+    headers: new Headers(),
+    text: () => Promise.resolve(status === 200 ? '' : 'unavailable'),
+  } as unknown as Response;
+}
+
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('scenarios / streaming resilience', () => {
+  it('buffered SSE skips malformed blocks while preserving valid events before and after them', () => {
+    const raw = [
+      'data: {"type":"text_delta","content":"before"}',
+      '',
+      'data: {"type":"text_delta","content":',
+      '',
+      'data: {"type":"tool_call_start","call_id":"c1","tool":"grep","arguments":"{}"}',
+      '',
+      'data: {"type":"error","message":"tool failed","retryable":true,"retry_after_ms":25}',
+      '',
+      'data: {"type":"turn_complete"}',
+      '',
+    ].join('\n');
+
+    const parsed = parseSseDataEvents(raw);
+    expect(parsed.map((event) => event.type)).toEqual([
+      'text_delta',
+      'tool_call_start',
+      'error',
+      'turn_complete',
+    ]);
+    expect(parsed[2]).toMatchObject({
+      type: 'error',
+      message: 'tool failed',
+      retryable: true,
+      retry_after_ms: 25,
+    });
+  });
+
+  it('stream reader reconstructs split UTF-8 and large text_delta payloads', async () => {
+    const enc = new TextEncoder();
+    const payload = `prefix-${'x'.repeat(128 * 1024)}-边云协同-🚀`;
+    const frame = `data: ${JSON.stringify({ type: 'text_delta', content: payload })}\n\n`;
+    const bytes = enc.encode(frame);
+    const chunks = [
+      bytes.slice(0, 17),
+      bytes.slice(17, bytes.length - 11),
+      bytes.slice(bytes.length - 11),
+    ];
+    globalThis.fetch = jest.fn().mockResolvedValue(streamResponse(byteStream(chunks)));
+
+    const events: StreamEvent[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: (event) => events.push(event),
+    });
+    await client.connect();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'text_delta', content: payload });
+  });
+
+  it('emits an error for a stream that ends after tool_call_start without tool_call_end', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue(streamResponse(streamFromText([
+      'data: {"type":"tool_call_start","call_id":"c1","tool":"bash","arguments":"{}"}\n\n',
+      'data: {"type":"error","message":"edge executor disconnected","retryable":true}\n\n',
+    ])));
+
+    const events: StreamEvent[] = [];
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      onEvent: (event) => events.push(event),
+    });
+    await client.connect();
+
+    expect(events.map((event) => event.type)).toEqual(['tool_call_start', 'error']);
+    expect(events[1]).toMatchObject({
+      type: 'error',
+      message: 'edge executor disconnected',
+      retryable: true,
+    });
+  });
+
+  it('retries one transient HTTP failure and then streams successfully', async () => {
+    const states: ConnectionState[] = [];
+    const events: StreamEvent[] = [];
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(streamResponse(streamFromText([]), 503))
+      .mockResolvedValueOnce(streamResponse(streamFromText([
+        'data: {"type":"text_delta","content":"recovered"}\n\n',
+        'data: {"type":"turn_complete"}\n\n',
+      ])));
+
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      retryDelayMs: 1,
+      maxRetries: 1,
+      onStateChange: (state) => states.push(state),
+      onEvent: (event) => events.push(event),
+    });
+    await client.connect();
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(states).toContain('error');
+    expect(events[0]).toMatchObject({
+      type: 'error',
+      message: 'Connection error: unavailable',
+      retryable: true,
+    });
+    expect(events.slice(1).map((event) => event.type)).toEqual(['text_delta', 'turn_complete']);
+  });
+
+  it('stops after maxRetries instead of resetting retry count on every reconnect', async () => {
+    const events: StreamEvent[] = [];
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue(streamResponse(streamFromText([]), 503));
+
+    const client = new SSEClient({
+      url: 'http://localhost/stream',
+      retryDelayMs: 1,
+      maxRetries: 2,
+      onEvent: (event) => events.push(event),
+    });
+    await client.connect();
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    expect(events.map((event) => event.type)).toEqual(['error', 'error', 'error']);
+    expect(events.map((event) => (event.type === 'error' ? event.retryable : undefined))).toEqual([
+      true,
+      true,
+      false,
+    ]);
+  });
+});

--- a/packages/sdk/src/sse-client.ts
+++ b/packages/sdk/src/sse-client.ts
@@ -72,8 +72,12 @@ export class SSEClient {
   }
 
   async connect(): Promise<void> {
-    this.closed = false;
     this.retryCount = 0;
+    await this.connectAttempt();
+  }
+
+  private async connectAttempt(): Promise<void> {
+    this.closed = false;
     this.options.onStateChange?.('connecting');
 
     this.controller = new AbortController();
@@ -195,7 +199,7 @@ export class SSEClient {
     await new Promise((r) => setTimeout(r, delay));
 
     if (!this.closed) {
-      await this.connect();
+      await this.connectAttempt();
     }
   }
 }

--- a/rust/crates/astra-turn-core/src/cloud_tool_delivery.rs
+++ b/rust/crates/astra-turn-core/src/cloud_tool_delivery.rs
@@ -1101,6 +1101,94 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tool_result_wait_is_user_scoped_and_does_not_consume_wrong_user_entry() {
+        let ledger = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let tc = read_tool("shared-call");
+        ledger.lock().await.insert(
+            tool_callback_key("user-b", "shared-call"),
+            json!({"body": {"request_id": "shared-call", "status": "ok", "output": "wrong-user"}}),
+        );
+
+        let user_a_delivery =
+            wait_tool_result_ledger_for_tool(&ledger, "user-a", &tc, Duration::from_millis(60))
+                .await;
+
+        assert_eq!(user_a_delivery.tool_results.len(), 1);
+        assert_eq!(user_a_delivery.tool_results[0].status, "timed_out");
+        assert!(
+            user_a_delivery.tool_results[0]
+                .tool_result_fields
+                .as_ref()
+                .and_then(|fields| fields.get("output"))
+                .and_then(Value::as_str)
+                .is_some_and(|output| output.contains(MSG_TOOL_LEDGER_TIMEOUT)),
+            "wrong user's ledger entry must not satisfy user-a wait"
+        );
+        assert!(
+            ledger
+                .lock()
+                .await
+                .contains_key(&tool_callback_key("user-b", "shared-call")),
+            "wrong user's callback should remain available for that user"
+        );
+
+        let user_b_delivery =
+            wait_tool_result_ledger_for_tool(&ledger, "user-b", &tc, Duration::from_millis(60))
+                .await;
+        assert_eq!(user_b_delivery.tool_results[0].status, "ok");
+        assert_eq!(
+            user_b_delivery.tool_results[0]
+                .tool_result_fields
+                .as_ref()
+                .and_then(|fields| fields.get("output"))
+                .and_then(Value::as_str),
+            Some("wrong-user")
+        );
+        assert!(ledger.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn approval_wait_is_user_and_namespace_scoped() {
+        let ledger = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let tc = write_tool("shared-approval");
+        {
+            let mut guard = ledger.lock().await;
+            guard.insert(
+                tool_callback_key("user-a", "shared-approval"),
+                json!({"body": {"request_id": "shared-approval", "status": "ok", "output": "tool-result-not-approval"}}),
+            );
+            guard.insert(
+                approval_callback_key("user-b", "shared-approval"),
+                json!({"kind": "approval_respond", "body": {"request_id": "shared-approval", "decision": "allow"}}),
+            );
+        }
+
+        let user_a_result =
+            wait_approval_ledger_for_tool(&ledger, "user-a", &tc, Duration::from_millis(60), None)
+                .await;
+
+        let user_a_delivery = user_a_result.expect_err(
+            "user-a must time out instead of consuming a tool-result namespace or user-b approval",
+        );
+        assert_eq!(
+            user_a_delivery.persist_tool_results[0]["result"],
+            MSG_APPROVAL_LEDGER_TIMEOUT
+        );
+        {
+            let guard = ledger.lock().await;
+            assert!(guard.contains_key(&tool_callback_key("user-a", "shared-approval")));
+            assert!(guard.contains_key(&approval_callback_key("user-b", "shared-approval")));
+        }
+
+        wait_approval_ledger_for_tool(&ledger, "user-b", &tc, Duration::from_millis(60), None)
+            .await
+            .expect("user-b should consume its own approval");
+        let guard = ledger.lock().await;
+        assert!(guard.contains_key(&tool_callback_key("user-a", "shared-approval")));
+        assert!(!guard.contains_key(&approval_callback_key("user-b", "shared-approval")));
+    }
+
+    #[tokio::test]
     async fn write_file_waits_approval_then_tool() {
         let ledger = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
         let uid = "u2";

--- a/rust/crates/astra-turn-core/src/edge_ledger.rs
+++ b/rust/crates/astra-turn-core/src/edge_ledger.rs
@@ -350,6 +350,34 @@ mod tests {
     }
 
     #[test]
+    fn callback_keys_partition_user_and_callback_namespaces() {
+        let request_id = "same-request";
+        let user_a_tool = tool_callback_key("user-a", request_id);
+        let user_b_tool = tool_callback_key("user-b", request_id);
+        let user_a_approval = approval_callback_key("user-a", request_id);
+        let user_a_prompt = user_prompt_callback_key("user-a", request_id);
+
+        let keys: std::collections::HashSet<_> = [
+            user_a_tool.as_str(),
+            user_b_tool.as_str(),
+            user_a_approval.as_str(),
+            user_a_prompt.as_str(),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(
+            keys.len(),
+            4,
+            "same request_id must never collide across users or callback namespaces"
+        );
+        assert_eq!(user_a_tool, "user-a:tool:same-request");
+        assert_eq!(user_b_tool, "user-b:tool:same-request");
+        assert_eq!(user_a_approval, "user-a:approval:same-request");
+        assert_eq!(user_a_prompt, "user-a:user_prompt:same-request");
+    }
+
+    #[test]
     fn ensure_tool_call_ids_fills_empty_and_skips_nonempty() {
         let mut calls = vec![
             json!({"id": "", "function": {"name": "x", "arguments": "{}"}}),
@@ -1077,6 +1105,30 @@ mod tests {
         assert!(ledger.contains_key("fresh"));
         assert_eq!(ts.get("fresh"), Some(&now));
         assert!(!ts.contains_key("stale"));
+    }
+
+    #[test]
+    fn sweep_expired_entries_inner_preserves_unexpired_observed_keys() {
+        let mut ledger: HashMap<String, Value> = HashMap::new();
+        let mut ts: HashMap<String, Instant> = HashMap::new();
+        let now = Instant::now();
+        let max_age = Duration::from_secs(60);
+
+        ledger.insert("old-but-valid".into(), json!({"v": 1}));
+        ledger.insert("brand-new".into(), json!({"v": 2}));
+        ts.insert("old-but-valid".into(), now - Duration::from_secs(59));
+
+        let removed = sweep_expired_entries_inner(&mut ledger, &mut ts, now, max_age);
+
+        assert_eq!(removed, 0);
+        assert_eq!(ledger.len(), 2);
+        assert!(ledger.contains_key("old-but-valid"));
+        assert!(ledger.contains_key("brand-new"));
+        assert_eq!(
+            ts.get("old-but-valid"),
+            Some(&(now - Duration::from_secs(59)))
+        );
+        assert_eq!(ts.get("brand-new"), Some(&now));
     }
 
     /// audit-#6: the timestamps side-table must not retain entries for keys

--- a/rust/crates/astra-turn-core/src/tool_result_compression.rs
+++ b/rust/crates/astra-turn-core/src/tool_result_compression.rs
@@ -133,7 +133,10 @@ fn compress_json_object(v: &Value, _budget: usize) -> String {
     let elided = obj.len() - JSON_OBJECT_KEY_LIMIT;
     kept.insert(
         "__compressed__".into(),
-        Value::String(format!("{elided} more keys elided")),
+        Value::String(format!(
+            "{}{elided} more keys elided …]",
+            COMPRESSION_MARKER.trim_start()
+        )),
     );
     Value::Object(kept).to_string()
 }

--- a/rust/crates/astra-turn-core/tests/context_pipeline_integration.rs
+++ b/rust/crates/astra-turn-core/tests/context_pipeline_integration.rs
@@ -82,6 +82,46 @@ fn fallback_head_tail_for_opaque_blob() {
     assert!(out.contains(COMPRESSION_MARKER), "fallback missing marker");
 }
 
+#[test]
+fn json_object_compression_carries_marker_and_preserves_stable_keys() {
+    let mut obj = serde_json::Map::new();
+    for i in 0..80 {
+        obj.insert(
+            format!("key_{i:02}"),
+            json!({"idx": i, "pad": "x".repeat(300)}),
+        );
+    }
+    let content = Value::Object(obj).to_string();
+    assert!(content.len() > DEFAULT_COMPRESSION_BUDGET_CHARS);
+
+    let out = compress_with_default_budget("tool_search", &content);
+    assert!(
+        out.contains(COMPRESSION_MARKER.trim_start()),
+        "object compression must carry marker: {out}"
+    );
+    assert!(out.contains("key_00"), "first stable key should survive");
+    assert!(out.contains("key_11"), "key budget boundary should survive");
+    assert!(
+        !out.contains("key_79"),
+        "tail keys should be summarized, not leaked"
+    );
+}
+
+#[test]
+fn fallback_compression_preserves_utf8_boundaries() {
+    let content = format!("{}{}{}", "头".repeat(3_000), "MIDDLE", "🚀".repeat(3_000));
+    assert!(content.len() > DEFAULT_COMPRESSION_BUDGET_CHARS);
+
+    let out = compress_with_default_budget("read_file", &content);
+    assert!(out.contains(COMPRESSION_MARKER));
+    assert!(out.starts_with('头'), "head unicode content should survive");
+    assert!(out.ends_with('🚀'), "tail unicode content should survive");
+    assert!(
+        !out.contains("MIDDLE"),
+        "middle sentinel should be elided by fallback compression"
+    );
+}
+
 // ─── cp-oversized-single-message ──────────────────────────────────────────
 
 #[test]
@@ -129,6 +169,25 @@ fn canonical_arg_form_means_key_order_does_not_break_cache_key() {
     assert_eq!(
         a.input_hash, b.input_hash,
         "canonicalised args must produce identical hash regardless of key order"
+    );
+}
+
+#[test]
+fn context_hash_isolates_identical_reads_across_sessions() {
+    let mut cache = ResultCache::new(8, None);
+    let args = json!({"path": "/workspace/README.md"});
+    let session_a = CallSignature::from_args("read_file", &args).with_ctx_hash(0xA57A);
+    let session_b = CallSignature::from_args("read_file", &args).with_ctx_hash(0xBEEF);
+
+    cache.record(session_a.clone(), "session A contents".into());
+
+    assert_eq!(
+        cache.lookup(&session_a).as_deref(),
+        Some("session A contents")
+    );
+    assert!(
+        cache.lookup(&session_b).is_none(),
+        "same tool args in a different context/session must not reuse stale output"
     );
 }
 

--- a/rust/crates/astra-turn-core/tests/parallel_tool_exec_cap_test.rs
+++ b/rust/crates/astra-turn-core/tests/parallel_tool_exec_cap_test.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use astra_turn_core::parallel_tool_exec::{
     MAX_CONCURRENT_READ_ONLY, MAX_CONCURRENT_TOOL_EXECUTIONS, ToolExecutorFn,
-    execute_parallel_round,
+    execute_parallel_round, parse_tool_args, partition_tool_calls,
 };
 use serde_json::{Value, json};
 
@@ -18,6 +18,14 @@ fn tool_call(name: &str, id: &str) -> Value {
         "id": id,
         "type": "function",
         "function": { "name": name, "arguments": "{}" }
+    })
+}
+
+fn tool_call_with_arguments(name: &str, id: &str, arguments: Value) -> Value {
+    json!({
+        "id": id,
+        "type": "function",
+        "function": { "name": name, "arguments": arguments }
     })
 }
 
@@ -304,6 +312,47 @@ fn shared_tool_semaphore_returns_same_instance() {
     );
 }
 
+#[test]
+fn tool_arg_parser_handles_nested_quotes_unicode_and_malformed_fail_closed() {
+    let nested = tool_call_with_arguments(
+        "bash",
+        "q1",
+        Value::String(
+            json!({
+                "command": "printf '%s' \"hello \\\"astra\\\" 边云\"",
+                "env": {"GREETING": "hello \"quoted\""},
+                "flags": ["--json", "emoji-🚀"]
+            })
+            .to_string(),
+        ),
+    );
+    let parsed = parse_tool_args(&nested).expect("nested JSON string args should parse");
+    assert_eq!(
+        parsed["command"], "printf '%s' \"hello \\\"astra\\\" 边云\"",
+        "escaped quotes and unicode must survive parsing"
+    );
+    assert_eq!(parsed["env"]["GREETING"], "hello \"quoted\"");
+
+    let malformed = tool_call_with_arguments(
+        "bash",
+        "bad",
+        Value::String("{\"command\":\"git status\"".into()),
+    );
+    assert!(parse_tool_args(&malformed).is_none());
+
+    let calls = vec![malformed];
+    let (read_only, mutating) = partition_tool_calls(&calls);
+    assert!(
+        read_only.is_empty(),
+        "malformed bash args must not be classified as read-only"
+    );
+    assert_eq!(
+        mutating.len(),
+        1,
+        "malformed bash args must fail closed into the mutating lane"
+    );
+}
+
 // ── Sibling-abort coverage for non-bash mutating tools ──
 //
 // Previously, the sibling-abort guard only fired when the failing tool was
@@ -359,4 +408,60 @@ async fn unhappy_any_failing_mutating_tool_aborts_siblings() {
             r.content
         );
     }
+}
+
+#[tokio::test]
+async fn complex_mixed_failures_abort_only_queued_mutations_after_trigger() {
+    let mut calls: Vec<Value> = (0..10)
+        .map(|i| tool_call("read_file", &format!("r{i:02}")))
+        .collect();
+    for i in 0..5 {
+        calls.push(tool_call("write_file", &format!("w{i:02}")));
+    }
+
+    let invocations = Arc::new(AtomicUsize::new(0));
+    let writes_seen = Arc::new(AtomicUsize::new(0));
+    let invocations_c = invocations.clone();
+    let writes_seen_c = writes_seen.clone();
+    let exec: ToolExecutorFn = Arc::new(move |tc: Value| {
+        let invocations = invocations_c.clone();
+        let writes_seen = writes_seen_c.clone();
+        Box::pin(async move {
+            invocations.fetch_add(1, Ordering::SeqCst);
+            let call_id = tc["id"].as_str().unwrap_or("").to_string();
+            let name = tc["function"]["name"].as_str().unwrap_or("").to_string();
+            if name == "write_file" {
+                let write_index = writes_seen.fetch_add(1, Ordering::SeqCst);
+                if write_index == 2 {
+                    return (call_id, name, "simulated disk full".into(), false);
+                }
+            }
+            (call_id, name, "ok".into(), true)
+        })
+    });
+
+    let outcome = execute_parallel_round(&calls, exec).await;
+
+    assert_eq!(outcome.parallel_count, 10);
+    assert_eq!(outcome.sequential_count, 5);
+    assert!(outcome.sibling_aborted);
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        13,
+        "10 reads + first 3 writes should run; 2 queued writes should abort"
+    );
+    assert_eq!(outcome.results.len(), 15);
+    assert!(outcome.results[12].content.contains("disk full"));
+    assert!(
+        outcome.results[13]
+            .content
+            .to_lowercase()
+            .contains("aborted")
+    );
+    assert!(
+        outcome.results[14]
+            .content
+            .to_lowercase()
+            .contains("aborted")
+    );
 }

--- a/rust/crates/runtime/tests/session_memory_offline.rs
+++ b/rust/crates/runtime/tests/session_memory_offline.rs
@@ -474,3 +474,81 @@ async fn compaction_degrades_gracefully_when_retrieve_errors() {
         "failed retrieve should skip memory_context injection"
     );
 }
+
+#[tokio::test]
+async fn concurrent_l1_persistence_keeps_session_scopes_separate() {
+    let fake = std::sync::Arc::new(RecordingFake::new());
+    let messages_a = vec![
+        user_msg("remember project A prefers PKCE"),
+        assistant_msg("project A PKCE preference recorded"),
+    ];
+    let messages_b = vec![
+        user_msg("remember project B prefers device-code auth"),
+        assistant_msg("project B device-code preference recorded"),
+    ];
+    let l1_a = build_l1_from_messages(&messages_a, 2, 2_000);
+    let l1_b = build_l1_from_messages(&messages_b, 2, 2_000);
+
+    let (ra, rb) = tokio::join!(
+        persist_l1(fake.as_ref(), &l1_a, "sess-a"),
+        persist_l1(fake.as_ref(), &l1_b, "sess-b"),
+    );
+    ra.expect("session A persist should succeed");
+    rb.expect("session B persist should succeed");
+
+    let ops = fake.ops();
+    let purge_sessions: std::collections::BTreeSet<String> = ops
+        .iter()
+        .filter_map(|op| match op {
+            Op::Purge { session_id } => Some(session_id.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        purge_sessions,
+        ["sess-a".to_string(), "sess-b".to_string()]
+            .into_iter()
+            .collect()
+    );
+
+    let stores: Vec<_> = ops
+        .iter()
+        .filter_map(|op| match op {
+            Op::Store {
+                content,
+                memory_type,
+                session_id: Some(session_id),
+                trust_tier,
+            } => Some((
+                session_id.as_str(),
+                memory_type.as_str(),
+                trust_tier.as_deref(),
+                content,
+            )),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        stores.len(),
+        2,
+        "one working-memory store per session: {ops:?}"
+    );
+    assert!(
+        stores.iter().any(|(session, memory_type, trust, content)| {
+            *session == "sess-a"
+                && *memory_type == "working"
+                && *trust == Some("T2")
+                && content.contains("project A")
+        }),
+        "session A store should keep session A content only: {stores:?}"
+    );
+    assert!(
+        stores.iter().any(|(session, memory_type, trust, content)| {
+            *session == "sess-b"
+                && *memory_type == "working"
+                && *trust == Some("T2")
+                && content.contains("project B")
+        }),
+        "session B store should keep session B content only: {stores:?}"
+    );
+}

--- a/rust/crates/runtime/tests/team_delegation_integration.rs
+++ b/rust/crates/runtime/tests/team_delegation_integration.rs
@@ -881,6 +881,69 @@ async fn concurrent_team_executions_isolated() {
     assert!(log.iter().any(|e| e.contains("coder-b")));
 }
 
+#[tokio::test]
+async fn concurrent_same_team_executions_have_distinct_runs_and_history_records() {
+    let store = Arc::new(InMemoryTeamStore::new());
+    let team = test_team(
+        "same-team",
+        TeamCoordination::Pipeline,
+        vec![("worker", Some("Handle one request"))],
+    );
+    let team_id = team.team_id.clone();
+    store.save_team(&team).await.unwrap();
+
+    struct EchoExecutor;
+    #[async_trait]
+    impl SubRunExecutor for EchoExecutor {
+        async fn execute(&self, config: SubRunConfig) -> Result<AgentResult, String> {
+            Ok(AgentResult {
+                agent_id: config.agent_profile.agent_id.clone(),
+                run_id: config.run_id,
+                status: "completed".to_string(),
+                output: Some(format!("done by {}", config.agent_profile.agent_id)),
+                error: None,
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                tool_calls: 1,
+            })
+        }
+    }
+
+    let (orch, run_engine, _) =
+        setup_orchestrator_with_executor(store.clone(), Arc::new(EchoExecutor)).await;
+    let (report_a, report_b) = tokio::join!(
+        orch.execute_team("same-team", "task A", None),
+        orch.execute_team("same-team", "task B", None),
+    );
+
+    assert_eq!(report_a.status, TeamExecutionStatus::Completed);
+    assert_eq!(report_b.status, TeamExecutionStatus::Completed);
+    assert_ne!(report_a.parent_run_id, report_b.parent_run_id);
+    assert_ne!(report_a.delegation_id, report_b.delegation_id);
+
+    let run_a = run_engine
+        .load_run(&report_a.parent_run_id)
+        .await
+        .unwrap()
+        .expect("run A should be persisted");
+    let run_b = run_engine
+        .load_run(&report_b.parent_run_id)
+        .await
+        .unwrap()
+        .expect("run B should be persisted");
+    assert_eq!(run_a.status, "completed");
+    assert_eq!(run_b.status, "completed");
+
+    let history = store.list_executions(&team_id, 10).await.unwrap();
+    assert_eq!(
+        history.len(),
+        2,
+        "concurrent same-team executions must both be recorded"
+    );
+    let tasks: std::collections::BTreeSet<_> = history.iter().map(|e| e.task.as_str()).collect();
+    assert_eq!(tasks, ["task A", "task B"].into_iter().collect());
+}
+
 /// Tests that sequential coordination with stop_on_success stops after first success.
 #[tokio::test]
 async fn sequential_stop_on_success_stops_early() {

--- a/rust/crates/runtime/tests/web_agent_e2e.rs
+++ b/rust/crates/runtime/tests/web_agent_e2e.rs
@@ -1115,7 +1115,7 @@ async fn edge_tool_delivery_emits_tool_request_and_waits_for_result() {
     assert_eq!(status, StatusCode::OK);
 
     // Wait for the stream to complete.
-    let events = tokio::time::timeout(std::time::Duration::from_secs(10), reader)
+    let _events = tokio::time::timeout(std::time::Duration::from_secs(10), reader)
         .await
         .expect("stream timed out")
         .expect("reader task failed");


### PR DESCRIPTION
## Summary
- add deterministic SDK scenario coverage for multi-turn context, memory workflows, multi-agent delegation, and streaming resilience
- expand the SDK local E2E harness into a stateful HTTP server covering sessions, runs, memory, delegation, and closed-session error paths
- harden Rust regression coverage for compression markers, parallel tool scheduling, edge ledger isolation, cloud-edge delivery scoping, session memory isolation, and team delegation concurrency
- fix SDK SSE retry accounting so persistent failures stop at maxRetries
- fix JSON object compression summaries to preserve the compression marker
- enable SDK local E2E coverage in static checks with `ASTRA_SDK_E2E=1`

## Validation
- `npm run typecheck -- --pretty false` in `packages/sdk`
- `ASTRA_SDK_E2E=1 npm run test:coverage` in `packages/sdk`
- `npm run build` in `packages/sdk`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo test -p astra-turn-core`
- `cargo test -p astra-runtime --test session_memory_offline --test team_delegation_integration`
