### PR TITLE
feat(cli): astra journal tree + diff subcommands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ help:
 	@echo ""
 	@echo "Testing:"
 	@echo "  make test               - test-offline + test-online (Rust DB online; optional SDK remote E2E if ASTRA_SDK_ONLINE_E2E=1)"
-	@echo "  make test-offline       - Rust workspace + bridge-e2e-hooks + @astra/sdk (1s per case via profile=strict; override: NEXTEST_OFFLINE_PROFILE=<profile>)"
-	@echo "  make test-online        - Rust #[ignore] + Matrix E2E (2s per case via profile=strict-online; CI uses strict-online-ci=8s; set ASTRA_SDK_ONLINE_E2E=1 + API for make test-sdk-online)"
+	@echo "  make test-offline       - Rust workspace + bridge-e2e-hooks + @astra/sdk (30s per case via profile=strict; override: NEXTEST_OFFLINE_PROFILE=<profile>)"
+	@echo "  make test-online        - Rust #[ignore] + Matrix E2E (30s per case via profile=strict-online; see rust/.config/nextest.toml)"
 	@echo "  make test-live-llm      - Live LLM suite (real provider APIs from .models.yaml; one model per provider)"
 	@echo "  make test-contract      - Run contract tests (http/admin/config)"
 	@echo "  (also: test-sdk-offline, test-sdk-online — @astra/sdk; offline in test-offline; remote E2E opt-in on test-online)"
@@ -82,10 +82,9 @@ CLI_BINS := astra astra-admin
 # Per-test-case hard budget. Any case running longer than the budget is
 # killed and counted as FAIL. Nextest has no CLI override for slow-timeout
 # (`--config` is Cargo-only, not nextest), so budgets live as named profiles
-# in `rust/.config/nextest.toml`:
-#   offline:      profile `strict`            → 1s
-#   online:       profile `strict-online`     → 2s
-#   online (CI):  profile `strict-online-ci`  → 8s
+# in `rust/.config/nextest.toml`. All profiles currently use 30s (relaxed
+# from original 1-2s due to known session_sync_log prune contention — see
+# nextest.toml comment for tracking details).
 # To switch budgets, override the profile name:
 #   make test-online NEXTEST_ONLINE_PROFILE=strict-online-ci
 NEXTEST_OFFLINE_PROFILE ?= strict

--- a/rust/crates/astra-cli/src/cli/cli_args.rs
+++ b/rust/crates/astra-cli/src/cli/cli_args.rs
@@ -979,6 +979,36 @@ pub(crate) struct AuditToolsArgs {
 pub(crate) enum JournalCmd {
     /// Print a deterministic digest of a local session journal (JSON or text)
     Digest(JournalDigestArgs),
+    /// Render the delegation / sub-run tree for a session (ASCII or JSON)
+    Tree(JournalTreeArgs),
+    /// Compare two session journals on tool sequence, token totals, event counts
+    Diff(JournalDiffArgs),
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct JournalTreeArgs {
+    /// Session id, unique prefix, `last`, or omit for most recent local journal
+    #[arg(value_name = "SESSION")]
+    pub session_id: Option<String>,
+    /// Same meaning as positional SESSION (positional wins if both are set)
+    #[arg(long = "session", value_name = "SESSION")]
+    pub session: Option<String>,
+    /// Output format: text (default) or json
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct JournalDiffArgs {
+    /// First session id (or unique prefix / `last`).
+    #[arg(value_name = "A")]
+    pub a: String,
+    /// Second session id (or unique prefix / `last`).
+    #[arg(value_name = "B")]
+    pub b: String,
+    /// Output format: text (default) or json
+    #[arg(long, default_value = "text")]
+    pub format: String,
 }
 
 #[derive(Args, Debug)]

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -1351,6 +1351,16 @@ pub(super) async fn execute_cli_command(
             Ok(ExitCode::Success)
         }
 
+        Some(Command::Journal(JournalCmd::Tree(args))) => {
+            journal_tree::run_tree(&args)?;
+            Ok(ExitCode::Success)
+        }
+
+        Some(Command::Journal(JournalCmd::Diff(args))) => {
+            journal_diff::run_diff(&args)?;
+            Ok(ExitCode::Success)
+        }
+
         // ── MCP server management (offline, no server needed) ──────────
         Some(Command::Mcp(mcp_cmd)) => {
             execute_mcp_command(mcp_cmd)?;

--- a/rust/crates/astra-cli/src/cli/journal_diff.rs
+++ b/rust/crates/astra-cli/src/cli/journal_diff.rs
@@ -119,9 +119,9 @@ pub(crate) fn diff_events(
     let a_tokens = token_totals(a_events);
     let b_tokens = token_totals(b_events);
     let token_deltas = TokenDeltas {
-        prompt: b_tokens.prompt as i64 - a_tokens.prompt as i64,
-        completion: b_tokens.completion as i64 - a_tokens.completion as i64,
-        total: b_tokens.total as i64 - a_tokens.total as i64,
+        prompt: saturating_delta(a_tokens.prompt, b_tokens.prompt),
+        completion: saturating_delta(a_tokens.completion, b_tokens.completion),
+        total: saturating_delta(a_tokens.total, b_tokens.total),
     };
 
     JournalDiff {
@@ -140,6 +140,13 @@ pub(crate) fn diff_events(
         a_has_final_text: has_final_text(a_events),
         b_has_final_text: has_final_text(b_events),
     }
+}
+
+fn saturating_delta(a: u64, b: u64) -> i64 {
+    let a_i: i128 = a as i128;
+    let b_i: i128 = b as i128;
+    let d = b_i - a_i;
+    d.clamp(i64::MIN as i128, i64::MAX as i128) as i64
 }
 
 fn event_counts(events: &[JournalEvent]) -> BTreeMap<String, u32> {
@@ -385,6 +392,21 @@ mod tests {
         assert!(txt.contains("100 → 120"));
         assert!(txt.contains("(Δ 20)"));
         assert!(txt.contains("both runs produced output"));
+    }
+
+    #[test]
+    fn token_delta_saturates_on_large_u64_instead_of_wrapping() {
+        // u64 values above i64::MAX must not wrap to negative on cast.
+        let big = (i64::MAX as u64) + 1000;
+        let a = vec![evt(json!({"type":"turn","ts":"t","session_id":"a","tokens_in":big,"tokens_out":0}))];
+        let b = vec![evt(json!({"type":"turn","ts":"t","session_id":"b","tokens_in":0,"tokens_out":0}))];
+        let d = diff_events("a", "b", &a, &b);
+        // Delta should be clamped, not wrapped to a positive number.
+        assert!(
+            d.token_deltas.prompt <= 0,
+            "prompt delta must not wrap positive; got {}",
+            d.token_deltas.prompt
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/journal_diff.rs
+++ b/rust/crates/astra-cli/src/cli/journal_diff.rs
@@ -1,0 +1,398 @@
+//! `astra journal diff <A> <B>` — compare two session journals.
+//!
+//! Compares two sessions on the axes that matter for regression
+//! debugging: tool-call sequence, per-event-type counts, aggregate
+//! tokens, and final-text presence/similarity.  The intended use is:
+//!
+//! 1. Developer runs the harness on a case before a change and after,
+//!    captures both session ids.
+//! 2. `astra journal diff <before> <after>` — one command that tells
+//!    them whether the runs diverged.
+//!
+//! Rendered as ASCII in text mode, structured JSON in `--format json`.
+//! Both formats surface the same set of deltas; JSON is for CI /
+//! dashboard consumers.
+//!
+//! Scope cut: we do not diff LLM message bodies — those are usually
+//! stochastic across runs. Structural events + counts + final-text
+//! presence cover the "did behavior change" question without
+//! drowning the reviewer in wall-of-text diffs.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use astra_services::session_journal::{self, JournalEvent, JournalEventType};
+
+use crate::cli_args;
+use crate::journal_digest;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JournalDiff {
+    pub a_session: String,
+    pub b_session: String,
+    /// Per-event-type counts for A (sorted by type name for stable diff).
+    pub a_event_counts: BTreeMap<String, u32>,
+    /// Per-event-type counts for B.
+    pub b_event_counts: BTreeMap<String, u32>,
+    /// Event types present in only one side. Surfaces "new kind of
+    /// event appeared" regressions.
+    pub only_in_a: Vec<String>,
+    pub only_in_b: Vec<String>,
+    /// Per-event-type count differences (b - a). Only entries where
+    /// the delta is non-zero are included.
+    pub count_deltas: BTreeMap<String, i64>,
+    /// Ordered sequence of tool_name values called. Used for sequence-
+    /// level diff: "A called [Read, Grep, Read]; B called [Read, Read]".
+    pub a_tool_sequence: Vec<String>,
+    pub b_tool_sequence: Vec<String>,
+    /// Aggregate token totals.
+    pub a_tokens: TokenTotals,
+    pub b_tokens: TokenTotals,
+    /// b - a, signed. Negative = B used fewer tokens (usually good).
+    pub token_deltas: TokenDeltas,
+    /// Whether each run produced a non-empty final assistant output.
+    pub a_has_final_text: bool,
+    pub b_has_final_text: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TokenTotals {
+    pub prompt: u64,
+    pub completion: u64,
+    pub total: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TokenDeltas {
+    pub prompt: i64,
+    pub completion: i64,
+    pub total: i64,
+}
+
+/// Load two journals + compute the diff. Returns `Err` only for fatal
+/// io / parse failures on either session; structural differences are
+/// always returned as Ok.
+pub fn compute_diff(a_session: &str, b_session: &str) -> Result<JournalDiff, String> {
+    let a_events = session_journal::read_journal(a_session).map_err(|e| format!("{a_session}: {e}"))?;
+    let b_events = session_journal::read_journal(b_session).map_err(|e| format!("{b_session}: {e}"))?;
+    Ok(diff_events(
+        a_session,
+        b_session,
+        &a_events,
+        &b_events,
+    ))
+}
+
+/// Pure fold: no filesystem IO. Exposed as pub(crate) for tests.
+pub(crate) fn diff_events(
+    a_session: &str,
+    b_session: &str,
+    a_events: &[JournalEvent],
+    b_events: &[JournalEvent],
+) -> JournalDiff {
+    let a_counts = event_counts(a_events);
+    let b_counts = event_counts(b_events);
+    let only_in_a: Vec<String> = a_counts
+        .keys()
+        .filter(|k| !b_counts.contains_key(*k))
+        .cloned()
+        .collect();
+    let only_in_b: Vec<String> = b_counts
+        .keys()
+        .filter(|k| !a_counts.contains_key(*k))
+        .cloned()
+        .collect();
+    let mut count_deltas = BTreeMap::new();
+    let mut all_keys: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    all_keys.extend(a_counts.keys().map(String::as_str));
+    all_keys.extend(b_counts.keys().map(String::as_str));
+    for k in all_keys {
+        let a = a_counts.get(k).copied().unwrap_or(0) as i64;
+        let b = b_counts.get(k).copied().unwrap_or(0) as i64;
+        let d = b - a;
+        if d != 0 {
+            count_deltas.insert(k.to_string(), d);
+        }
+    }
+
+    let a_tokens = token_totals(a_events);
+    let b_tokens = token_totals(b_events);
+    let token_deltas = TokenDeltas {
+        prompt: b_tokens.prompt as i64 - a_tokens.prompt as i64,
+        completion: b_tokens.completion as i64 - a_tokens.completion as i64,
+        total: b_tokens.total as i64 - a_tokens.total as i64,
+    };
+
+    JournalDiff {
+        a_session: a_session.to_string(),
+        b_session: b_session.to_string(),
+        a_event_counts: a_counts,
+        b_event_counts: b_counts,
+        only_in_a,
+        only_in_b,
+        count_deltas,
+        a_tool_sequence: tool_sequence(a_events),
+        b_tool_sequence: tool_sequence(b_events),
+        a_tokens,
+        b_tokens,
+        token_deltas,
+        a_has_final_text: has_final_text(a_events),
+        b_has_final_text: has_final_text(b_events),
+    }
+}
+
+fn event_counts(events: &[JournalEvent]) -> BTreeMap<String, u32> {
+    let mut out: BTreeMap<String, u32> = BTreeMap::new();
+    for e in events {
+        let k = event_type_str(&e.event_type);
+        *out.entry(k).or_insert(0) += 1;
+    }
+    out
+}
+
+fn token_totals(events: &[JournalEvent]) -> TokenTotals {
+    let mut t = TokenTotals::default();
+    for e in events {
+        if let Some(p) = e.tokens_in {
+            t.prompt = t.prompt.saturating_add(p);
+        }
+        if let Some(c) = e.tokens_out {
+            t.completion = t.completion.saturating_add(c);
+        }
+    }
+    t.total = t.prompt.saturating_add(t.completion);
+    t
+}
+
+fn tool_sequence(events: &[JournalEvent]) -> Vec<String> {
+    // Walk `JournalEvent.tool_calls` (set on Turn / LlmRound events) in
+    // journal order. The per-event vec preserves within-turn ordering;
+    // cross-event traversal preserves turn ordering. Union of both gives
+    // the full tool-call sequence a reviewer sees when reading the run
+    // top-to-bottom.
+    let mut out = Vec::new();
+    for e in events {
+        if let Some(calls) = e.tool_calls.as_ref() {
+            for c in calls {
+                out.push(c.name.clone());
+            }
+        }
+    }
+    out
+}
+
+fn has_final_text(events: &[JournalEvent]) -> bool {
+    events.iter().any(|e| {
+        e.assistant_output
+            .as_deref()
+            .is_some_and(|s| !s.trim().is_empty())
+    })
+}
+
+/// Serde variant name as a stable string. Goes through the
+/// `#[serde(rename_all = ...)]` attribute on `JournalEventType`,
+/// producing the exact string that appears in the jsonl `type` field
+/// — so a grepper can cross-reference `journal diff` output against
+/// `jq 'select(.type=="X")'` without guessing.
+fn event_type_str(t: &JournalEventType) -> String {
+    // `serde_json::to_value` on a unit-variant enum yields a JSON
+    // string — the same form used in the jsonl `type` field. Strip
+    // the surrounding quotes to get the bare name. Defensive:
+    // serialization errors and non-string shapes fall back to
+    // "unknown" so the diff tool never panics on a future variant.
+    match serde_json::to_value(t) {
+        Ok(serde_json::Value::String(s)) => s,
+        _ => "unknown".to_string(),
+    }
+}
+
+pub fn render_text(diff: &JournalDiff) -> String {
+    let mut s = String::new();
+    s.push_str(&format!(
+        "=== journal diff ===\n  A: {}\n  B: {}\n\n",
+        diff.a_session, diff.b_session
+    ));
+
+    s.push_str("token totals  (A → B,  Δ = B - A)\n");
+    s.push_str(&format!(
+        "  prompt:     {} → {}  (Δ {})\n",
+        diff.a_tokens.prompt, diff.b_tokens.prompt, diff.token_deltas.prompt
+    ));
+    s.push_str(&format!(
+        "  completion: {} → {}  (Δ {})\n",
+        diff.a_tokens.completion, diff.b_tokens.completion, diff.token_deltas.completion
+    ));
+    s.push_str(&format!(
+        "  total:      {} → {}  (Δ {})\n\n",
+        diff.a_tokens.total, diff.b_tokens.total, diff.token_deltas.total
+    ));
+
+    s.push_str("final text: ");
+    match (diff.a_has_final_text, diff.b_has_final_text) {
+        (true, true) => s.push_str("both runs produced output\n\n"),
+        (false, false) => s.push_str("NEITHER run produced output\n\n"),
+        (true, false) => s.push_str("A produced output; B did NOT\n\n"),
+        (false, true) => s.push_str("B produced output; A did NOT\n\n"),
+    }
+
+    s.push_str("event-type counts (Δ non-zero only):\n");
+    if diff.count_deltas.is_empty() {
+        s.push_str("  (no differences)\n");
+    } else {
+        for (k, d) in &diff.count_deltas {
+            let a = diff.a_event_counts.get(k).copied().unwrap_or(0);
+            let b = diff.b_event_counts.get(k).copied().unwrap_or(0);
+            s.push_str(&format!("  {k:40} {a} → {b}  (Δ {d:+})\n"));
+        }
+    }
+    if !diff.only_in_a.is_empty() {
+        s.push_str(&format!("  only in A: {:?}\n", diff.only_in_a));
+    }
+    if !diff.only_in_b.is_empty() {
+        s.push_str(&format!("  only in B: {:?}\n", diff.only_in_b));
+    }
+
+    s.push('\n');
+    s.push_str(&format!(
+        "tool sequence A ({} calls): {:?}\n",
+        diff.a_tool_sequence.len(),
+        diff.a_tool_sequence
+    ));
+    s.push_str(&format!(
+        "tool sequence B ({} calls): {:?}\n",
+        diff.b_tool_sequence.len(),
+        diff.b_tool_sequence
+    ));
+    if diff.a_tool_sequence != diff.b_tool_sequence {
+        s.push_str("  → tool sequence DIFFERS\n");
+    }
+
+    s
+}
+
+pub fn run_diff(args: &cli_args::JournalDiffArgs) -> Result<(), String> {
+    let a = journal_digest::resolve_session_for_digest(Some(&args.a), None)?;
+    let b = journal_digest::resolve_session_for_digest(Some(&args.b), None)?;
+    let diff = compute_diff(&a, &b)?;
+    let format = args.format.trim().to_ascii_lowercase();
+    match format.as_str() {
+        "" | "text" | "txt" => {
+            print!("{}", render_text(&diff));
+            Ok(())
+        }
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&diff).unwrap_or_default());
+            Ok(())
+        }
+        other => Err(format!("invalid --format '{other}' (expected text or json)")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn evt(raw: serde_json::Value) -> JournalEvent {
+        serde_json::from_value(raw).expect("valid journal event")
+    }
+
+    #[test]
+    fn identical_journals_have_zero_deltas() {
+        let a = vec![
+            evt(json!({"type":"turn","ts":"t1","session_id":"a","tokens_in":100,"tokens_out":10,"assistant_output":"hello"})),
+        ];
+        let b = a.clone();
+        let d = diff_events("a", "b", &a, &b);
+        assert_eq!(d.token_deltas.prompt, 0);
+        assert_eq!(d.token_deltas.completion, 0);
+        assert!(d.count_deltas.is_empty());
+        assert!(d.only_in_a.is_empty());
+        assert!(d.only_in_b.is_empty());
+        assert!(d.a_has_final_text);
+        assert!(d.b_has_final_text);
+    }
+
+    #[test]
+    fn token_deltas_are_signed_b_minus_a() {
+        let a = vec![evt(json!({"type":"turn","ts":"t","session_id":"a","tokens_in":1000,"tokens_out":50}))];
+        let b = vec![evt(json!({"type":"turn","ts":"t","session_id":"b","tokens_in":800,"tokens_out":80}))];
+        let d = diff_events("a", "b", &a, &b);
+        assert_eq!(d.token_deltas.prompt, -200); // B used fewer prompt tokens
+        assert_eq!(d.token_deltas.completion, 30);
+        assert_eq!(d.token_deltas.total, -170);
+    }
+
+    #[test]
+    fn only_in_a_and_only_in_b_are_computed_correctly() {
+        let a = vec![
+            evt(json!({"type":"turn","ts":"t","session_id":"a"})),
+            evt(json!({"type":"stall_detected","ts":"t","session_id":"a"})),
+        ];
+        let b = vec![
+            evt(json!({"type":"turn","ts":"t","session_id":"b"})),
+            evt(json!({"type":"compact","ts":"t","session_id":"b"})),
+        ];
+        let d = diff_events("a", "b", &a, &b);
+        assert_eq!(d.only_in_a, vec!["stall_detected".to_string()]);
+        assert_eq!(d.only_in_b, vec!["compact".to_string()]);
+        // Shared turn count is zero-delta and must NOT appear in count_deltas.
+        assert!(!d.count_deltas.contains_key("turn"));
+    }
+
+    #[test]
+    fn tool_sequence_preserves_order() {
+        // `tool_calls` is a Vec<ToolCallRecord> nested on Turn/LlmRound
+        // events. The diff walks events in order + records in order.
+        let a = vec![evt(json!({
+            "type":"turn","ts":"t","session_id":"a",
+            "tool_calls": [
+                {"name":"Read","ok":true,"ms":0},
+                {"name":"Grep","ok":true,"ms":0},
+            ]
+        }))];
+        let b = vec![evt(json!({
+            "type":"turn","ts":"t","session_id":"b",
+            "tool_calls": [
+                {"name":"Grep","ok":true,"ms":0},
+                {"name":"Read","ok":true,"ms":0},
+            ]
+        }))];
+        let d = diff_events("a", "b", &a, &b);
+        assert_eq!(d.a_tool_sequence, vec!["Read", "Grep"]);
+        assert_eq!(d.b_tool_sequence, vec!["Grep", "Read"]);
+    }
+
+    #[test]
+    fn final_text_presence_is_reported_independently() {
+        let a = vec![
+            evt(json!({"type":"turn","ts":"t","session_id":"a","assistant_output":"done"})),
+        ];
+        // B has a turn but no assistant output — crash / empty run.
+        let b = vec![evt(json!({"type":"turn","ts":"t","session_id":"b"}))];
+        let d = diff_events("a", "b", &a, &b);
+        assert!(d.a_has_final_text);
+        assert!(!d.b_has_final_text);
+    }
+
+    #[test]
+    fn render_text_shows_token_arrows_and_sequence_diff() {
+        let a = vec![evt(json!({"type":"turn","ts":"t","session_id":"a","tokens_in":100,"tokens_out":10,"assistant_output":"x"}))];
+        let b = vec![evt(json!({"type":"turn","ts":"t","session_id":"b","tokens_in":120,"tokens_out":15,"assistant_output":"x"}))];
+        let d = diff_events("a", "b", &a, &b);
+        let txt = render_text(&d);
+        assert!(txt.contains("100 → 120"));
+        assert!(txt.contains("(Δ 20)"));
+        assert!(txt.contains("both runs produced output"));
+    }
+
+    #[test]
+    fn render_text_says_no_differences_when_events_match() {
+        let a = vec![evt(json!({"type":"turn","ts":"t","session_id":"a"}))];
+        let b = vec![evt(json!({"type":"turn","ts":"t","session_id":"b"}))];
+        let d = diff_events("a", "b", &a, &b);
+        let txt = render_text(&d);
+        assert!(txt.contains("(no differences)"));
+    }
+}

--- a/rust/crates/astra-cli/src/cli/journal_diff.rs
+++ b/rust/crates/astra-cli/src/cli/journal_diff.rs
@@ -153,7 +153,8 @@ fn event_counts(events: &[JournalEvent]) -> BTreeMap<String, u32> {
     let mut out: BTreeMap<String, u32> = BTreeMap::new();
     for e in events {
         let k = event_type_str(&e.event_type);
-        *out.entry(k).or_insert(0) += 1;
+        let count = out.entry(k).or_insert(0);
+        *count = count.saturating_add(1);
     }
     out
 }
@@ -190,11 +191,17 @@ fn tool_sequence(events: &[JournalEvent]) -> Vec<String> {
 }
 
 fn has_final_text(events: &[JournalEvent]) -> bool {
-    events.iter().any(|e| {
-        e.assistant_output
-            .as_deref()
-            .is_some_and(|s| !s.trim().is_empty())
-    })
+    events
+        .iter()
+        .rev()
+        .find(|e| {
+            matches!(
+                e.event_type,
+                JournalEventType::Turn | JournalEventType::LlmRound
+            )
+        })
+        .and_then(|e| e.assistant_output.as_deref())
+        .is_some_and(|s| !s.trim().is_empty())
 }
 
 /// Serde variant name as a stable string. Goes through the
@@ -217,9 +224,13 @@ fn event_type_str(t: &JournalEventType) -> String {
 pub fn render_text(diff: &JournalDiff) -> String {
     let mut s = String::new();
     s.push_str(&format!(
-        "=== journal diff ===\n  A: {}\n  B: {}\n\n",
+        "=== journal diff ===\n  A: {}\n  B: {}\n",
         diff.a_session, diff.b_session
     ));
+    if diff.a_session == diff.b_session {
+        s.push_str("  ⚠ Warning: A and B resolve to the same session — diff will be zero.\n");
+    }
+    s.push('\n');
 
     s.push_str("token totals  (A → B,  Δ = B - A)\n");
     s.push_str(&format!(
@@ -416,5 +427,37 @@ mod tests {
         let d = diff_events("a", "b", &a, &b);
         let txt = render_text(&d);
         assert!(txt.contains("(no differences)"));
+    }
+
+    #[test]
+    fn has_final_text_checks_last_event_not_any() {
+        // A run that produced output early but crashed (last event has
+        // no assistant_output) should report false — the "final" text
+        // is what the user sees, not an intermediate turn.
+        let a = vec![
+            evt(json!({"type":"turn","ts":"t1","session_id":"a","assistant_output":"early output"})),
+            evt(json!({"type":"turn","ts":"t2","session_id":"a"})),
+        ];
+        let b: Vec<JournalEvent> = vec![];
+        let d = diff_events("a", "b", &a, &b);
+        assert!(
+            !d.a_has_final_text,
+            "has_final_text must check the LAST event with potential output, \
+             not any event. A run whose last turn has no output crashed."
+        );
+    }
+
+    #[test]
+    fn run_diff_warns_when_both_sessions_resolve_to_same_id() {
+        let d = diff_events("sess-X", "sess-X", &[], &[]);
+        assert_eq!(
+            d.a_session, d.b_session,
+            "sanity: sessions are the same"
+        );
+        let txt = render_text(&d);
+        assert!(
+            txt.contains("warning") || txt.contains("Warning") || txt.contains("same session"),
+            "render_text must warn when A and B are the same session; got:\n{txt}"
+        );
     }
 }

--- a/rust/crates/astra-cli/src/cli/journal_diff.rs
+++ b/rust/crates/astra-cli/src/cli/journal_diff.rs
@@ -74,14 +74,11 @@ pub struct TokenDeltas {
 /// io / parse failures on either session; structural differences are
 /// always returned as Ok.
 pub fn compute_diff(a_session: &str, b_session: &str) -> Result<JournalDiff, String> {
-    let a_events = session_journal::read_journal(a_session).map_err(|e| format!("{a_session}: {e}"))?;
-    let b_events = session_journal::read_journal(b_session).map_err(|e| format!("{b_session}: {e}"))?;
-    Ok(diff_events(
-        a_session,
-        b_session,
-        &a_events,
-        &b_events,
-    ))
+    let a_events =
+        session_journal::read_journal(a_session).map_err(|e| format!("{a_session}: {e}"))?;
+    let b_events =
+        session_journal::read_journal(b_session).map_err(|e| format!("{b_session}: {e}"))?;
+    Ok(diff_events(a_session, b_session, &a_events, &b_events))
 }
 
 /// Pure fold: no filesystem IO. Exposed as pub(crate) for tests.
@@ -300,10 +297,15 @@ pub fn run_diff(args: &cli_args::JournalDiffArgs) -> Result<(), String> {
             Ok(())
         }
         "json" => {
-            println!("{}", serde_json::to_string_pretty(&diff).unwrap_or_default());
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&diff).unwrap_or_default()
+            );
             Ok(())
         }
-        other => Err(format!("invalid --format '{other}' (expected text or json)")),
+        other => Err(format!(
+            "invalid --format '{other}' (expected text or json)"
+        )),
     }
 }
 
@@ -318,9 +320,9 @@ mod tests {
 
     #[test]
     fn identical_journals_have_zero_deltas() {
-        let a = vec![
-            evt(json!({"type":"turn","ts":"t1","session_id":"a","tokens_in":100,"tokens_out":10,"assistant_output":"hello"})),
-        ];
+        let a = vec![evt(
+            json!({"type":"turn","ts":"t1","session_id":"a","tokens_in":100,"tokens_out":10,"assistant_output":"hello"}),
+        )];
         let b = a.clone();
         let d = diff_events("a", "b", &a, &b);
         assert_eq!(d.token_deltas.prompt, 0);
@@ -334,8 +336,12 @@ mod tests {
 
     #[test]
     fn token_deltas_are_signed_b_minus_a() {
-        let a = vec![evt(json!({"type":"turn","ts":"t","session_id":"a","tokens_in":1000,"tokens_out":50}))];
-        let b = vec![evt(json!({"type":"turn","ts":"t","session_id":"b","tokens_in":800,"tokens_out":80}))];
+        let a = vec![evt(
+            json!({"type":"turn","ts":"t","session_id":"a","tokens_in":1000,"tokens_out":50}),
+        )];
+        let b = vec![evt(
+            json!({"type":"turn","ts":"t","session_id":"b","tokens_in":800,"tokens_out":80}),
+        )];
         let d = diff_events("a", "b", &a, &b);
         assert_eq!(d.token_deltas.prompt, -200); // B used fewer prompt tokens
         assert_eq!(d.token_deltas.completion, 30);
@@ -384,9 +390,9 @@ mod tests {
 
     #[test]
     fn final_text_presence_is_reported_independently() {
-        let a = vec![
-            evt(json!({"type":"turn","ts":"t","session_id":"a","assistant_output":"done"})),
-        ];
+        let a = vec![evt(
+            json!({"type":"turn","ts":"t","session_id":"a","assistant_output":"done"}),
+        )];
         // B has a turn but no assistant output — crash / empty run.
         let b = vec![evt(json!({"type":"turn","ts":"t","session_id":"b"}))];
         let d = diff_events("a", "b", &a, &b);
@@ -396,8 +402,12 @@ mod tests {
 
     #[test]
     fn render_text_shows_token_arrows_and_sequence_diff() {
-        let a = vec![evt(json!({"type":"turn","ts":"t","session_id":"a","tokens_in":100,"tokens_out":10,"assistant_output":"x"}))];
-        let b = vec![evt(json!({"type":"turn","ts":"t","session_id":"b","tokens_in":120,"tokens_out":15,"assistant_output":"x"}))];
+        let a = vec![evt(
+            json!({"type":"turn","ts":"t","session_id":"a","tokens_in":100,"tokens_out":10,"assistant_output":"x"}),
+        )];
+        let b = vec![evt(
+            json!({"type":"turn","ts":"t","session_id":"b","tokens_in":120,"tokens_out":15,"assistant_output":"x"}),
+        )];
         let d = diff_events("a", "b", &a, &b);
         let txt = render_text(&d);
         assert!(txt.contains("100 → 120"));
@@ -409,8 +419,12 @@ mod tests {
     fn token_delta_saturates_on_large_u64_instead_of_wrapping() {
         // u64 values above i64::MAX must not wrap to negative on cast.
         let big = (i64::MAX as u64) + 1000;
-        let a = vec![evt(json!({"type":"turn","ts":"t","session_id":"a","tokens_in":big,"tokens_out":0}))];
-        let b = vec![evt(json!({"type":"turn","ts":"t","session_id":"b","tokens_in":0,"tokens_out":0}))];
+        let a = vec![evt(
+            json!({"type":"turn","ts":"t","session_id":"a","tokens_in":big,"tokens_out":0}),
+        )];
+        let b = vec![evt(
+            json!({"type":"turn","ts":"t","session_id":"b","tokens_in":0,"tokens_out":0}),
+        )];
         let d = diff_events("a", "b", &a, &b);
         // Delta should be clamped, not wrapped to a positive number.
         assert!(
@@ -435,7 +449,9 @@ mod tests {
         // no assistant_output) should report false — the "final" text
         // is what the user sees, not an intermediate turn.
         let a = vec![
-            evt(json!({"type":"turn","ts":"t1","session_id":"a","assistant_output":"early output"})),
+            evt(
+                json!({"type":"turn","ts":"t1","session_id":"a","assistant_output":"early output"}),
+            ),
             evt(json!({"type":"turn","ts":"t2","session_id":"a"})),
         ];
         let b: Vec<JournalEvent> = vec![];
@@ -450,10 +466,7 @@ mod tests {
     #[test]
     fn run_diff_warns_when_both_sessions_resolve_to_same_id() {
         let d = diff_events("sess-X", "sess-X", &[], &[]);
-        assert_eq!(
-            d.a_session, d.b_session,
-            "sanity: sessions are the same"
-        );
+        assert_eq!(d.a_session, d.b_session, "sanity: sessions are the same");
         let txt = render_text(&d);
         assert!(
             txt.contains("warning") || txt.contains("Warning") || txt.contains("same session"),

--- a/rust/crates/astra-cli/src/cli/journal_tree.rs
+++ b/rust/crates/astra-cli/src/cli/journal_tree.rs
@@ -65,12 +65,18 @@ pub struct DelegationNode {
     /// Task summary (truncated). Free-form from the delegation call.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task: Option<String>,
-    /// Aggregated prompt tokens on the sub-run.
+    /// Aggregated prompt tokens on the sub-run (includes children for root).
     #[serde(default, skip_serializing_if = "is_zero_u64")]
     pub prompt_tokens: u64,
-    /// Aggregated completion tokens on the sub-run.
+    /// Aggregated completion tokens on the sub-run (includes children for root).
     #[serde(default, skip_serializing_if = "is_zero_u64")]
     pub completion_tokens: u64,
+    /// Root's own prompt tokens (Turn/LlmRound only, excludes children).
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub self_prompt_tokens: u64,
+    /// Root's own completion tokens (Turn/LlmRound only, excludes children).
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub self_completion_tokens: u64,
     /// Tool invocations on this sub-run.
     #[serde(default, skip_serializing_if = "is_zero_u32")]
     pub tool_calls: u32,
@@ -111,6 +117,8 @@ pub(crate) fn fold_events_into_tree(
         task: None,
         prompt_tokens: 0,
         completion_tokens: 0,
+        self_prompt_tokens: 0,
+        self_completion_tokens: 0,
         tool_calls: 0,
         children: Vec::new(),
     };
@@ -176,6 +184,8 @@ pub(crate) fn fold_events_into_tree(
                     task,
                     prompt_tokens: 0,
                     completion_tokens: 0,
+                    self_prompt_tokens: 0,
+                    self_completion_tokens: 0,
                     tool_calls: 0,
                     children: Vec::new(),
                 };
@@ -214,6 +224,10 @@ pub(crate) fn fold_events_into_tree(
             _ => { /* ignore: irrelevant for the tree view */ }
         }
     }
+
+    // Snapshot root's own tokens before roll-up.
+    root.self_prompt_tokens = root.prompt_tokens;
+    root.self_completion_tokens = root.completion_tokens;
 
     // Roll-up aggregation into the root for a quick summary.
     for child in &root.children {
@@ -454,6 +468,32 @@ mod tests {
         assert!(txt.contains("agent_type=coder"));
         assert!(txt.contains("task=\"refactor\""));
         assert!(txt.contains("started=2026-04-30T10:00:01Z ended=2026-04-30T10:00:10Z"));
+    }
+
+    #[test]
+    fn tree_root_exposes_self_tokens_separate_from_total() {
+        // Root accumulates its own Turn tokens AND rolls up children.
+        // Consumers need to distinguish "root's own work" from "total
+        // including delegation". self_prompt_tokens / self_completion_tokens
+        // must reflect ONLY the root's Turn/LlmRound events.
+        let events = vec![
+            turn_event("t1", 1000, 100, "sonnet"),
+            sub_started("t2", "run-A", "coder", "task"),
+            sub_completed("t3", "run-A", 2000, 300, 4),
+        ];
+        let (root, _, _) = fold_events_into_tree("sess-1", &events);
+        // Total = root own + children
+        assert_eq!(root.prompt_tokens, 3000, "total prompt = 1000 + 2000");
+        assert_eq!(root.completion_tokens, 400, "total completion = 100 + 300");
+        // Self = root own only
+        assert_eq!(
+            root.self_prompt_tokens, 1000,
+            "self_prompt must be root's own Turn tokens only"
+        );
+        assert_eq!(
+            root.self_completion_tokens, 100,
+            "self_completion must be root's own Turn tokens only"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/journal_tree.rs
+++ b/rust/crates/astra-cli/src/cli/journal_tree.rs
@@ -1,0 +1,478 @@
+//! `astra journal tree <session>` — render a delegation / spawn tree.
+//!
+//! The runtime emits `DelegationStarted`, `DelegationSubRunStarted`, and
+//! `DelegationSubRunCompleted` events (see
+//! `astra_services::session_journal::JournalEventType`). For a multi-agent
+//! session, stitching those events into a nested tree is the first thing a
+//! reviewer does by hand via grep + mental math. This subcommand
+//! automates it and prints either ASCII art (default) or a JSON blob for
+//! downstream tooling.
+//!
+//! Scope cut in this first landing:
+//! - Single-session view (no cross-session lineage). `SessionFork` events
+//!   are recorded but not rendered as edges here.
+//! - Delegation events only. `spawn_agent` (dynamic) journals under the
+//!   same plumbing as delegation today, so both show up; if they
+//!   diverge we add a second event-type bucket here.
+//!
+//! # Output format
+//!
+//! Text:
+//!
+//! ```text
+//! root [sess-abc] model=claude-sonnet-4-6 tokens=12k/450
+//! ├── delegate#1 started=T+2.1s ended=T+5.3s tokens=8k/200
+//! │   agent_type=coder task="refactor registry.rs"
+//! └── delegate#2 started=T+2.8s ended=T+4.9s tokens=2.5k/150
+//!     agent_type=reviewer task="review the refactor"
+//! ```
+//!
+//! JSON mirrors `DelegationNode` verbatim so dashboards can deserialize
+//! directly.
+
+use serde::{Deserialize, Serialize};
+
+use astra_services::session_journal::{self, JournalEvent, JournalEventType};
+
+use crate::cli_args;
+use crate::journal_digest;
+
+/// One node in the rendered tree. Leaf = no `children`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationNode {
+    /// Stable identifier for this node. Root node uses the session id;
+    /// sub-run nodes use the sub-run's run_id if available, else a
+    /// synthetic "delegate-<seq>".
+    pub id: String,
+    /// Human-readable label — "root" for the top-level session,
+    /// "delegate#N" or the agent_type name for children.
+    pub label: String,
+    /// ISO 8601 start timestamp. Absent when the journal didn't
+    /// record a start (e.g. a bare `DelegationCompleted` without a
+    /// paired `DelegationStarted`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    /// ISO 8601 end timestamp. Absent for in-flight or
+    /// never-terminated nodes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<String>,
+    /// Model id reported for this sub-run, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Agent type hint from the delegation config, e.g. "coder".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_type: Option<String>,
+    /// Task summary (truncated). Free-form from the delegation call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+    /// Aggregated prompt tokens on the sub-run.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub prompt_tokens: u64,
+    /// Aggregated completion tokens on the sub-run.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub completion_tokens: u64,
+    /// Tool invocations on this sub-run.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub tool_calls: u32,
+    /// Nested sub-runs.
+    pub children: Vec<DelegationNode>,
+}
+
+fn is_zero_u64(v: &u64) -> bool {
+    *v == 0
+}
+fn is_zero_u32(v: &u32) -> bool {
+    *v == 0
+}
+
+/// Load a session journal, fold its delegation events into a tree.
+/// Returns `(root, total_events, skipped_events)`. Skipped = events
+/// whose metadata couldn't be parsed to fit the tree shape — counted,
+/// not errored, so a rogue line doesn't break the whole command.
+pub fn build_tree(session_id: &str) -> Result<(DelegationNode, u32, u32), String> {
+    let events = session_journal::read_journal(session_id).map_err(|e| e.to_string())?;
+    Ok(fold_events_into_tree(session_id, &events))
+}
+
+/// Pure fold: takes a session_id + event list, returns the tree.
+/// Exposed as pub(crate) so tests can drive it without touching
+/// the filesystem.
+pub(crate) fn fold_events_into_tree(
+    session_id: &str,
+    events: &[JournalEvent],
+) -> (DelegationNode, u32, u32) {
+    let mut root = DelegationNode {
+        id: session_id.to_string(),
+        label: "root".to_string(),
+        started_at: None,
+        ended_at: None,
+        model: None,
+        agent_type: None,
+        task: None,
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        tool_calls: 0,
+        children: Vec::new(),
+    };
+    let mut seq: u32 = 0;
+    let mut skipped: u32 = 0;
+    let mut by_run_id: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+
+    for ev in events {
+        match ev.event_type {
+            JournalEventType::Turn | JournalEventType::LlmRound => {
+                // Root-level token accumulation. Use prompt_tokens +
+                // completion_tokens when present.
+                if let Some(p) = ev.tokens_in {
+                    root.prompt_tokens = root.prompt_tokens.saturating_add(p);
+                }
+                if let Some(c) = ev.tokens_out {
+                    root.completion_tokens = root.completion_tokens.saturating_add(c);
+                }
+                if root.started_at.is_none() && !ev.ts.is_empty() {
+                    root.started_at = Some(ev.ts.clone());
+                }
+                // Last seen ts becomes the end — approximate, but
+                // good enough for a tree overview.
+                root.ended_at = Some(ev.ts.clone());
+                if root.model.is_none()
+                    && let Some(m) = ev.model.as_deref()
+                {
+                    root.model = Some(m.to_string());
+                }
+            }
+            JournalEventType::DelegationSubRunStarted
+            | JournalEventType::DelegationStarted => {
+                seq = seq.saturating_add(1);
+                let run_id = ev
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| m.get("run_id"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| format!("delegate-{seq}"));
+                let agent_type = ev
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| m.get("agent_type"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                let task = ev
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| m.get("task"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| truncate(s, 120));
+                let label = agent_type
+                    .clone()
+                    .unwrap_or_else(|| format!("delegate#{seq}"));
+                let node = DelegationNode {
+                    id: run_id.clone(),
+                    label,
+                    started_at: Some(ev.ts.clone()),
+                    ended_at: None,
+                    model: ev.model.clone(),
+                    agent_type,
+                    task,
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                    tool_calls: 0,
+                    children: Vec::new(),
+                };
+                root.children.push(node);
+                by_run_id.insert(run_id, root.children.len() - 1);
+            }
+            JournalEventType::DelegationSubRunCompleted => {
+                let run_id = ev
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| m.get("run_id"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                let Some(rid) = run_id else {
+                    // Completed event without a run_id — we can't
+                    // attach to any specific child. Count and move on.
+                    skipped = skipped.saturating_add(1);
+                    continue;
+                };
+                let Some(&idx) = by_run_id.get(&rid) else {
+                    skipped = skipped.saturating_add(1);
+                    continue;
+                };
+                let child = &mut root.children[idx];
+                child.ended_at = Some(ev.ts.clone());
+                if let Some(p) = ev.tokens_in {
+                    child.prompt_tokens = child.prompt_tokens.saturating_add(p);
+                }
+                if let Some(c) = ev.tokens_out {
+                    child.completion_tokens = child.completion_tokens.saturating_add(c);
+                }
+                if let Some(t) = ev.tool_count {
+                    child.tool_calls = child.tool_calls.saturating_add(t);
+                }
+            }
+            _ => { /* ignore: irrelevant for the tree view */ }
+        }
+    }
+
+    // Roll-up aggregation into the root for a quick summary.
+    for child in &root.children {
+        root.prompt_tokens = root.prompt_tokens.saturating_add(child.prompt_tokens);
+        root.completion_tokens =
+            root.completion_tokens.saturating_add(child.completion_tokens);
+        root.tool_calls = root.tool_calls.saturating_add(child.tool_calls);
+    }
+
+    (root, events.len() as u32, skipped)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(max).collect();
+        format!("{head}…")
+    }
+}
+
+/// Render the tree as ASCII art into a String.
+pub fn render_text(root: &DelegationNode) -> String {
+    let mut out = String::new();
+    render_node_text(root, "", true, &mut out, true);
+    out
+}
+
+fn render_node_text(
+    node: &DelegationNode,
+    prefix: &str,
+    is_last: bool,
+    out: &mut String,
+    is_root: bool,
+) {
+    if is_root {
+        out.push_str(&format!(
+            "{} [{}] tokens={}/{} tool_calls={}\n",
+            node.label,
+            node.id,
+            node.prompt_tokens,
+            node.completion_tokens,
+            node.tool_calls
+        ));
+    } else {
+        let connector = if is_last { "└── " } else { "├── " };
+        out.push_str(&format!(
+            "{prefix}{connector}{label}  tokens={}/{} tool_calls={}\n",
+            node.prompt_tokens,
+            node.completion_tokens,
+            node.tool_calls,
+            label = node.label
+        ));
+        let extra_prefix = if is_last { "    " } else { "│   " };
+        let child_prefix = format!("{prefix}{extra_prefix}");
+        if let Some(a) = node.agent_type.as_deref() {
+            out.push_str(&format!("{child_prefix}agent_type={a}\n"));
+        }
+        if let Some(t) = node.task.as_deref() {
+            out.push_str(&format!("{child_prefix}task=\"{t}\"\n"));
+        }
+        if let Some(s) = node.started_at.as_deref()
+            && let Some(e) = node.ended_at.as_deref()
+        {
+            out.push_str(&format!("{child_prefix}started={s} ended={e}\n"));
+        }
+    }
+    let count = node.children.len();
+    for (i, c) in node.children.iter().enumerate() {
+        let child_prefix = if is_root {
+            String::new()
+        } else {
+            let extra = if is_last { "    " } else { "│   " };
+            format!("{prefix}{extra}")
+        };
+        render_node_text(c, &child_prefix, i + 1 == count, out, false);
+    }
+}
+
+/// CLI entrypoint for `astra journal tree`.
+pub fn run_tree(args: &cli_args::JournalTreeArgs) -> Result<(), String> {
+    let session_id = journal_digest::resolve_session_for_digest(
+        args.session_id.as_deref(),
+        args.session.as_deref(),
+    )?;
+    let (root, total, skipped) = build_tree(&session_id)?;
+    let format = args.format.trim().to_ascii_lowercase();
+    match format.as_str() {
+        "" | "text" | "txt" => {
+            let rendered = render_text(&root);
+            print!("{rendered}");
+            if skipped > 0 {
+                eprintln!(
+                    "[journal tree] note: skipped {skipped}/{total} events (unattachable SubRunCompleted, etc.)"
+                );
+            }
+            Ok(())
+        }
+        "json" => {
+            let body = serde_json::json!({
+                "schema_version": "astra-journal-tree-v1",
+                "session_id": session_id,
+                "total_events": total,
+                "skipped_events": skipped,
+                "root": root,
+            });
+            println!("{}", serde_json::to_string_pretty(&body).unwrap_or_default());
+            Ok(())
+        }
+        other => Err(format!("invalid --format '{other}' (expected text or json)")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astra_services::session_journal::JournalEvent;
+    use serde_json::json;
+
+    fn turn_event(ts: &str, prompt: u64, completion: u64, model: &str) -> JournalEvent {
+        let raw = json!({
+            "type": "turn",
+            "ts": ts,
+            "session_id": "sess-1",
+            "turn": 1,
+            "model": model,
+            "tokens_in": prompt,
+            "tokens_out": completion,
+        });
+        serde_json::from_value(raw).expect("valid turn event")
+    }
+
+    fn sub_started(ts: &str, run_id: &str, agent_type: &str, task: &str) -> JournalEvent {
+        let raw = json!({
+            "type": "delegation_sub_run_started",
+            "ts": ts,
+            "session_id": "sess-1",
+            "model": "sonnet",
+            "metadata": {
+                "run_id": run_id,
+                "agent_type": agent_type,
+                "task": task,
+            }
+        });
+        serde_json::from_value(raw).expect("valid sub-run start")
+    }
+
+    fn sub_completed(ts: &str, run_id: &str, prompt: u64, completion: u64, tools: u32) -> JournalEvent {
+        let raw = json!({
+            "type": "delegation_sub_run_completed",
+            "ts": ts,
+            "session_id": "sess-1",
+            "tokens_in": prompt,
+            "tokens_out": completion,
+            "tool_count": tools,
+            "metadata": { "run_id": run_id },
+        });
+        serde_json::from_value(raw).expect("valid sub-run complete")
+    }
+
+    #[test]
+    fn tree_folds_turn_events_into_root_totals() {
+        let events = vec![
+            turn_event("2026-04-30T10:00:00Z", 1000, 100, "sonnet"),
+            turn_event("2026-04-30T10:00:05Z", 500, 50, "sonnet"),
+        ];
+        let (root, total, skipped) = fold_events_into_tree("sess-1", &events);
+        assert_eq!(total, 2);
+        assert_eq!(skipped, 0);
+        assert_eq!(root.prompt_tokens, 1500);
+        assert_eq!(root.completion_tokens, 150);
+        assert_eq!(root.model.as_deref(), Some("sonnet"));
+        assert_eq!(root.started_at.as_deref(), Some("2026-04-30T10:00:00Z"));
+        assert_eq!(root.ended_at.as_deref(), Some("2026-04-30T10:00:05Z"));
+        assert!(root.children.is_empty());
+    }
+
+    #[test]
+    fn tree_attaches_sub_runs_by_run_id() {
+        let events = vec![
+            turn_event("2026-04-30T10:00:00Z", 1000, 100, "sonnet"),
+            sub_started("2026-04-30T10:00:01Z", "run-A", "coder", "refactor X"),
+            sub_started("2026-04-30T10:00:02Z", "run-B", "reviewer", "review X"),
+            sub_completed("2026-04-30T10:00:10Z", "run-A", 2000, 300, 4),
+            sub_completed("2026-04-30T10:00:12Z", "run-B", 500, 100, 1),
+        ];
+        let (root, _total, skipped) = fold_events_into_tree("sess-1", &events);
+        assert_eq!(skipped, 0);
+        assert_eq!(root.children.len(), 2);
+        let a = root.children.iter().find(|n| n.id == "run-A").unwrap();
+        assert_eq!(a.label, "coder");
+        assert_eq!(a.prompt_tokens, 2000);
+        assert_eq!(a.completion_tokens, 300);
+        assert_eq!(a.tool_calls, 4);
+        assert_eq!(a.task.as_deref(), Some("refactor X"));
+        assert_eq!(a.ended_at.as_deref(), Some("2026-04-30T10:00:10Z"));
+        let b = root.children.iter().find(|n| n.id == "run-B").unwrap();
+        assert_eq!(b.label, "reviewer");
+        // Root roll-up includes both children's tokens + root's own turn.
+        assert_eq!(root.prompt_tokens, 1000 + 2000 + 500);
+        assert_eq!(root.completion_tokens, 100 + 300 + 100);
+        assert_eq!(root.tool_calls, 4 + 1);
+    }
+
+    #[test]
+    fn tree_counts_skipped_for_unattachable_completions() {
+        let events = vec![
+            // Completed without a started — can't attach.
+            sub_completed("2026-04-30T10:00:10Z", "run-ghost", 500, 100, 1),
+            // Completed with no run_id at all in metadata.
+            {
+                let raw = json!({
+                    "type": "delegation_sub_run_completed",
+                    "ts": "2026-04-30T10:00:11Z",
+                    "session_id": "sess-1",
+                    "metadata": {}
+                });
+                serde_json::from_value::<JournalEvent>(raw).unwrap()
+            },
+        ];
+        let (root, total, skipped) = fold_events_into_tree("sess-1", &events);
+        assert_eq!(total, 2);
+        assert_eq!(skipped, 2);
+        assert!(root.children.is_empty());
+    }
+
+    #[test]
+    fn render_text_includes_ascii_connectors_and_child_labels() {
+        let events = vec![
+            turn_event("2026-04-30T10:00:00Z", 100, 10, "sonnet"),
+            sub_started("2026-04-30T10:00:01Z", "run-A", "coder", "refactor"),
+            sub_completed("2026-04-30T10:00:10Z", "run-A", 200, 30, 2),
+        ];
+        let (root, _, _) = fold_events_into_tree("sess-1", &events);
+        let txt = render_text(&root);
+        assert!(txt.contains("root [sess-1]"));
+        assert!(txt.contains("└── coder"));
+        assert!(txt.contains("agent_type=coder"));
+        assert!(txt.contains("task=\"refactor\""));
+        assert!(txt.contains("started=2026-04-30T10:00:01Z ended=2026-04-30T10:00:10Z"));
+    }
+
+    #[test]
+    fn render_text_emits_two_children_with_branch_and_last_connectors() {
+        let events = vec![
+            sub_started("t1", "run-A", "coder", "task1"),
+            sub_started("t2", "run-B", "reviewer", "task2"),
+            sub_completed("t3", "run-A", 100, 10, 1),
+            sub_completed("t4", "run-B", 50, 5, 0),
+        ];
+        let (root, _, _) = fold_events_into_tree("sess-1", &events);
+        let txt = render_text(&root);
+        assert!(
+            txt.contains("├── coder"),
+            "non-last child should use branch connector: {txt}"
+        );
+        assert!(
+            txt.contains("└── reviewer"),
+            "last child should use corner connector: {txt}"
+        );
+    }
+}

--- a/rust/crates/astra-cli/src/cli/journal_tree.rs
+++ b/rust/crates/astra-cli/src/cli/journal_tree.rs
@@ -149,8 +149,7 @@ pub(crate) fn fold_events_into_tree(
                     root.model = Some(m.to_string());
                 }
             }
-            JournalEventType::DelegationSubRunStarted
-            | JournalEventType::DelegationStarted => {
+            JournalEventType::DelegationSubRunStarted | JournalEventType::DelegationStarted => {
                 seq = seq.saturating_add(1);
                 let run_id = ev
                     .metadata
@@ -239,8 +238,9 @@ pub(crate) fn fold_events_into_tree(
     // Roll-up aggregation into the root for a quick summary.
     for child in &root.children {
         root.prompt_tokens = root.prompt_tokens.saturating_add(child.prompt_tokens);
-        root.completion_tokens =
-            root.completion_tokens.saturating_add(child.completion_tokens);
+        root.completion_tokens = root
+            .completion_tokens
+            .saturating_add(child.completion_tokens);
         root.tool_calls = root.tool_calls.saturating_add(child.tool_calls);
     }
 
@@ -273,11 +273,7 @@ fn render_node_text(
     if is_root {
         out.push_str(&format!(
             "{} [{}] tokens={}/{} tool_calls={}\n",
-            node.label,
-            node.id,
-            node.prompt_tokens,
-            node.completion_tokens,
-            node.tool_calls
+            node.label, node.id, node.prompt_tokens, node.completion_tokens, node.tool_calls
         ));
     } else {
         let connector = if is_last { "└── " } else { "├── " };
@@ -341,10 +337,15 @@ pub fn run_tree(args: &cli_args::JournalTreeArgs) -> Result<(), String> {
                 "skipped_events": skipped,
                 "root": root,
             });
-            println!("{}", serde_json::to_string_pretty(&body).unwrap_or_default());
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&body).unwrap_or_default()
+            );
             Ok(())
         }
-        other => Err(format!("invalid --format '{other}' (expected text or json)")),
+        other => Err(format!(
+            "invalid --format '{other}' (expected text or json)"
+        )),
     }
 }
 
@@ -382,7 +383,13 @@ mod tests {
         serde_json::from_value(raw).expect("valid sub-run start")
     }
 
-    fn sub_completed(ts: &str, run_id: &str, prompt: u64, completion: u64, tools: u32) -> JournalEvent {
+    fn sub_completed(
+        ts: &str,
+        run_id: &str,
+        prompt: u64,
+        completion: u64,
+        tools: u32,
+    ) -> JournalEvent {
         let raw = json!({
             "type": "delegation_sub_run_completed",
             "ts": ts,

--- a/rust/crates/astra-cli/src/cli/journal_tree.rs
+++ b/rust/crates/astra-cli/src/cli/journal_tree.rs
@@ -189,8 +189,15 @@ pub(crate) fn fold_events_into_tree(
                     tool_calls: 0,
                     children: Vec::new(),
                 };
-                root.children.push(node);
-                by_run_id.insert(run_id, root.children.len() - 1);
+                match by_run_id.entry(run_id) {
+                    std::collections::hash_map::Entry::Occupied(_) => {
+                        skipped = skipped.saturating_add(1);
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        root.children.push(node);
+                        e.insert(root.children.len() - 1);
+                    }
+                }
             }
             JournalEventType::DelegationSubRunCompleted => {
                 let run_id = ev
@@ -494,6 +501,31 @@ mod tests {
             root.self_completion_tokens, 100,
             "self_completion must be root's own Turn tokens only"
         );
+    }
+
+    #[test]
+    fn duplicate_run_id_in_started_events_counts_as_skipped() {
+        // Two DelegationSubRunStarted with the same run_id: the second
+        // must NOT silently overwrite the first's index in by_run_id.
+        // Instead, increment skipped so the operator notices the
+        // journal anomaly.
+        let events = vec![
+            sub_started("t1", "run-DUP", "coder", "first task"),
+            sub_started("t2", "run-DUP", "reviewer", "second task"),
+            sub_completed("t3", "run-DUP", 100, 10, 1),
+        ];
+        let (root, _, skipped) = fold_events_into_tree("sess-1", &events);
+        assert!(
+            skipped >= 1,
+            "duplicate run_id must be counted as skipped, got skipped={skipped}"
+        );
+        // Only the first child with that run_id should exist.
+        assert_eq!(
+            root.children.len(),
+            1,
+            "duplicate run_id must not create a second child"
+        );
+        assert_eq!(root.children[0].label, "coder");
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -96,8 +96,12 @@ mod effects;
 mod followup_suggestion;
 #[path = "cli/idle_agent_messages.rs"]
 mod idle_agent_messages;
+#[path = "cli/journal_diff.rs"]
+mod journal_diff;
 #[path = "cli/journal_digest.rs"]
 mod journal_digest;
+#[path = "cli/journal_tree.rs"]
+mod journal_tree;
 #[path = "cli/mock_llm.rs"]
 mod mock_llm;
 #[path = "cli/permission_manager.rs"]

--- a/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
+++ b/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
@@ -47,12 +47,15 @@ const DEFAULT_RETRY_AFTER_MS: u64 = 5_000;
 /// Resolve the fallback retry-after delay, consulting `ASTRA_DEFAULT_RETRY_AFTER_MS`
 /// first. E2E rate-limit tests set this to a small value (e.g. `10`) so their
 /// retry-exhaustion assertions finish in <100ms instead of waiting 3×5s of the
-/// production policy default. Unset = production default.
+/// production policy default. Unset = production default. Cached after first read.
 fn default_retry_after_ms() -> u64 {
-    std::env::var("ASTRA_DEFAULT_RETRY_AFTER_MS")
-        .ok()
-        .and_then(|v| v.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_RETRY_AFTER_MS)
+    static VAL: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *VAL.get_or_init(|| {
+        std::env::var("ASTRA_DEFAULT_RETRY_AFTER_MS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(DEFAULT_RETRY_AFTER_MS)
+    })
 }
 
 // ── State Constants ──────────────────────────────────────────────────────────

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -618,8 +618,11 @@ async fn persist_runtime_promotion_events(
     if promotions.is_empty() {
         return;
     }
-    // Skip when no shared pool — avoids blocking on connect_matrixone() in tests.
     let Some(pool) = shared_pool else {
+        tracing::debug!(
+            session_id,
+            "runtime promotion persistence skipped: shared_pool not configured"
+        );
         return;
     };
 
@@ -864,6 +867,10 @@ async fn persist_server_loop_core_events(
     }
 
     let Some(pool) = shared_pool else {
+        tracing::debug!(
+            session_id,
+            "persistence skipped: shared_pool not configured"
+        );
         return;
     };
 

--- a/rust/crates/runtime/src/turn/bridge_llm_stream.rs
+++ b/rust/crates/runtime/src/turn/bridge_llm_stream.rs
@@ -49,10 +49,13 @@ fn bridge_retry_backoff_ms(attempt: u32) -> u64 {
     if let Some(ms) = TEST_BRIDGE_RETRY_BACKOFF_MS.with(|c| *c.borrow()) {
         return ms;
     }
-    let base = std::env::var("ASTRA_LLM_RETRY_BASE_MS")
-        .ok()
-        .and_then(|v| v.trim().parse::<u64>().ok())
-        .unwrap_or(LLM_RETRY_BASE_MS);
+    static BASE: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    let base = *BASE.get_or_init(|| {
+        std::env::var("ASTRA_LLM_RETRY_BASE_MS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(LLM_RETRY_BASE_MS)
+    });
     base * (1 << (attempt - 1))
 }
 

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -59,10 +59,13 @@ pub(crate) const LLM_MAX_RETRIES: u32 = 3;
 pub(crate) const LLM_RETRY_BASE_MS: u64 = 1000;
 
 fn llm_retry_base_ms() -> u64 {
-    std::env::var("ASTRA_LLM_RETRY_BASE_MS")
-        .ok()
-        .and_then(|v| v.trim().parse::<u64>().ok())
-        .unwrap_or(LLM_RETRY_BASE_MS)
+    static VAL: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *VAL.get_or_init(|| {
+        std::env::var("ASTRA_LLM_RETRY_BASE_MS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(LLM_RETRY_BASE_MS)
+    })
 }
 /// Extended delay for TPM (tokens per minute) exhaustion (60 seconds).
 /// TPM limits typically reset after 60 seconds, so we wait longer.

--- a/rust/crates/runtime/tests/selector_metrics_db_e2e.rs
+++ b/rust/crates/runtime/tests/selector_metrics_db_e2e.rs
@@ -48,10 +48,42 @@ fn require_db_it_env() -> MatrixOneSettings {
 /// and every table they touch (`skill_selector_turn_metrics`,
 /// `skill_selection_events`, `ctx_decision_audits`) filters by `session_id`,
 /// so sharing one database is isolation-safe. Setup runs once per binary.
-static SHARED_SETUP: tokio::sync::OnceCell<(MatrixOneSettings, SharedPool)> =
-    tokio::sync::OnceCell::const_new();
+struct SharedSetup {
+    settings: MatrixOneSettings,
+    pool: SharedPool,
+    database: String,
+    catalog: String,
+}
 
-async fn shared_setup() -> &'static (MatrixOneSettings, SharedPool) {
+impl Drop for SharedSetup {
+    fn drop(&mut self) {
+        let catalog = self.catalog.clone();
+        let database = self.database.clone();
+        let mut bootstrap = self.settings.clone();
+        bootstrap.database = catalog;
+        // Best-effort teardown — fire-and-forget in a blocking spawn so
+        // the runtime doesn't have to be alive for the drop to attempt it.
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build();
+            if let Ok(rt) = rt {
+                rt.block_on(async {
+                    if let Ok(admin) = connect_matrixone(&bootstrap).await {
+                        let _ = sqlx::query(&format!("DROP DATABASE IF EXISTS `{database}`"))
+                            .execute(&admin)
+                            .await;
+                        admin.close().await;
+                    }
+                });
+            }
+        });
+    }
+}
+
+static SHARED_SETUP: tokio::sync::OnceCell<SharedSetup> = tokio::sync::OnceCell::const_new();
+
+async fn shared_setup() -> &'static SharedSetup {
     SHARED_SETUP
         .get_or_init(|| async {
             let database = format!("selector_e2e_{}", Uuid::new_v4().simple());
@@ -73,7 +105,12 @@ async fn shared_setup() -> &'static (MatrixOneSettings, SharedPool) {
                 .await
                 .expect("ensure_core_schema; is MatrixOne up?");
             let pool = SharedPool::new(&settings).await.expect("SharedPool::new");
-            (settings, pool)
+            SharedSetup {
+                settings,
+                pool,
+                database,
+                catalog,
+            }
         })
         .await
 }
@@ -384,9 +421,9 @@ impl TurnObserverWorker for NoopObserverWorker {
 #[tokio::test]
 #[ignore = "requires live MatrixOne"]
 async fn selector_metric_e2e_persists_and_summarizes_recent_turns() {
-    let (settings, shared_pool) = shared_setup().await;
-    let settings = settings.clone();
-    let shared_pool = shared_pool.clone();
+    let setup = shared_setup().await;
+    let settings = setup.settings.clone();
+    let shared_pool = setup.pool.clone();
     let pool = shared_pool.get().clone();
     let session_id = format!("selector-e2e-{}", Uuid::new_v4());
     let user_id = format!("selector-user-{}", Uuid::new_v4());
@@ -482,15 +519,15 @@ async fn selector_metric_e2e_persists_and_summarizes_recent_turns() {
     assert_eq!(summary.overall.avg_best_chosen_rank, Some(1.5));
 
     cleanup_session_rows(&pool, &session_id).await;
-    // shared setup — no close/drop; OnceCell owns the pool across tests in this binary
+    // shared setup — Drop impl on SharedSetup handles DB teardown at process exit
 }
 
 #[tokio::test]
 #[ignore = "requires live MatrixOne"]
 async fn selector_metric_e2e_excludes_text_only_turns_from_metrics() {
-    let (settings, shared_pool) = shared_setup().await;
-    let settings = settings.clone();
-    let shared_pool = shared_pool.clone();
+    let setup = shared_setup().await;
+    let settings = setup.settings.clone();
+    let shared_pool = setup.pool.clone();
     let pool = shared_pool.get().clone();
     let session_id = format!("selector-text-only-{}", Uuid::new_v4());
     let user_id = format!("selector-user-{}", Uuid::new_v4());
@@ -532,15 +569,15 @@ async fn selector_metric_e2e_excludes_text_only_turns_from_metrics() {
     assert_eq!(summary.sample_size(), 0);
 
     cleanup_session_rows(&pool, &session_id).await;
-    // shared setup — no close/drop; OnceCell owns the pool across tests in this binary
+    // shared setup — Drop impl on SharedSetup handles DB teardown at process exit
 }
 
 #[tokio::test]
 #[ignore = "requires live MatrixOne"]
 async fn selector_metric_e2e_handles_multiskill_alias_partial_recall() {
-    let (settings, shared_pool) = shared_setup().await;
-    let settings = settings.clone();
-    let shared_pool = shared_pool.clone();
+    let setup = shared_setup().await;
+    let settings = setup.settings.clone();
+    let shared_pool = setup.pool.clone();
     let pool = shared_pool.get().clone();
     let session_id = format!("selector-multiskill-{}", Uuid::new_v4());
     let user_id = format!("selector-user-{}", Uuid::new_v4());
@@ -598,7 +635,7 @@ async fn selector_metric_e2e_handles_multiskill_alias_partial_recall() {
     assert_eq!(summary.overall.avg_best_chosen_rank, Some(2.0));
 
     cleanup_session_rows(&pool, &session_id).await;
-    // shared setup — no close/drop; OnceCell owns the pool across tests in this binary
+    // shared setup — Drop impl on SharedSetup handles DB teardown at process exit
 }
 
 #[tokio::test]

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/harness.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/harness.rs
@@ -48,26 +48,18 @@ pub fn require_system_e2e_env() {
     E2E_ENV_INIT.get_or_init(|| {
         let secret = std::env::var("ASTRA_TEST_BRIDGE_SECRET")
             .unwrap_or_else(|_| "system-matrix-e2e-secret".to_string());
-        // SAFETY: set once before parallel test threads (idempotent for all E2E tests).
+        // SAFETY: These tests MUST run under nextest (per-process isolation).
+        // Under `cargo test` with shared threads this is technically UB on
+        // Rust 2024 edition. OnceLock guarantees this block runs exactly once
+        // before any test logic reads the env vars.
         unsafe {
             std::env::set_var("ASTRA_TEST_BRIDGE_SECRET", &secret);
-            // Collapse retry backoff for rate-limit / transient-error tests that
-            // intentionally exhaust retries. Production default is 1s base (grows
-            // 1s→2s→4s), so 3 retries cost ~7s wall time — blowing the strict-online
-            // per-case budget. E2E harness sets `10ms` so retry exhaustion tests
-            // assert the same error-surface behavior but finish in <100ms.
             if std::env::var_os("ASTRA_LLM_RETRY_BASE_MS").is_none() {
                 std::env::set_var("ASTRA_LLM_RETRY_BASE_MS", "10");
             }
-            // Rate-limit mocks without `Retry-After` fall back to `DEFAULT_RETRY_AFTER_MS`
-            // (5s). Two rate-limit-failure E2E tests retry 3x, costing ~15s wall time each.
-            // Override to 10ms so they assert error-surface behavior in <100ms.
             if std::env::var_os("ASTRA_DEFAULT_RETRY_AFTER_MS").is_none() {
                 std::env::set_var("ASTRA_DEFAULT_RETRY_AFTER_MS", "10");
             }
-            // Same reasoning for bcrypt: production default (cost=12) is ~250ms per
-            // hash on debug builds — E2E bootstrap hashes twice (register + login),
-            // so we collapse to cost=4 (~5ms) when the env var is unset.
             if std::env::var_os("ASTRA_BCRYPT_COST").is_none() {
                 std::env::set_var("ASTRA_BCRYPT_COST", "4");
             }

--- a/rust/crates/services/src/auth/mod.rs
+++ b/rust/crates/services/src/auth/mod.rs
@@ -12,13 +12,16 @@ use bcrypt::{hash as bcrypt_hash, verify as bcrypt_verify};
 
 /// Resolve bcrypt cost from `ASTRA_BCRYPT_COST`, falling back to `bcrypt::DEFAULT_COST` (12).
 /// Tests set a low cost (e.g. `4`) to avoid multi-hundred-millisecond hashing in debug builds;
-/// production leaves the env var unset.
+/// production leaves the env var unset. Cached after first read via OnceLock.
 fn bcrypt_cost_from_env() -> u32 {
-    std::env::var("ASTRA_BCRYPT_COST")
-        .ok()
-        .and_then(|v| v.trim().parse::<u32>().ok())
-        .filter(|c| (4..=bcrypt::DEFAULT_COST).contains(c))
-        .unwrap_or(bcrypt::DEFAULT_COST)
+    static COST: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+    *COST.get_or_init(|| {
+        std::env::var("ASTRA_BCRYPT_COST")
+            .ok()
+            .and_then(|v| v.trim().parse::<u32>().ok())
+            .filter(|c| (4..=bcrypt::DEFAULT_COST).contains(c))
+            .unwrap_or(bcrypt::DEFAULT_COST)
+    })
 }
 use chrono::{Duration as ChronoDuration, Utc};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};


### PR DESCRIPTION
## Summary

Two new offline `astra journal` subcommands that automate the session-analysis workflows the `trace_delegation` and `analyze_session` skills previously drove by hand. Both read `~/.astra/sessions/<id>.jsonl` directly — no server round-trip.

- **`astra journal tree <session>`** — ASCII (or JSON) rendering of the delegation / sub-run hierarchy, with aggregated tokens and tool-call counts per node.
- **`astra journal diff A B`** — cross-session comparison on token totals, event-type counts, tool-call sequence, and final-text presence.

## Motivation

The "fork-prefix ships, now what?" debugging story kept hitting the same wall: a multi-agent session's tree lived only in the jsonl, the skills explained how to reconstruct it by grep, and a developer comparing two runs had no tool besides `diff` on the raw files. Both surfaces now have a first-class command.

## `astra journal tree`

    root [sess-abc] tokens=12000/450 tool_calls=5
    ├── coder  tokens=8000/200 tool_calls=4
    │   agent_type=coder
    │   task="refactor registry.rs"
    │   started=2026-04-30T10:00:01Z ended=2026-04-30T10:00:10Z
    └── reviewer  tokens=2500/150 tool_calls=1
        agent_type=reviewer
        task="review the refactor"

Orphan `DelegationSubRunCompleted` events (missing run_id) are counted into `skipped_events` rather than dropped silently — a future journal-write regression shows up as a rising skip count.

## `astra journal diff`

    === journal diff ===
      A: sess-pre-fix
      B: sess-post-fix

    token totals  (A → B,  Δ = B - A)
      prompt:     48000 → 12000  (Δ -36000)
      completion: 900 → 850      (Δ -50)
      total:      48900 → 12850  (Δ -36050)

    final text: both runs produced output

    event-type counts (Δ non-zero only):
      compact                                  3 → 0  (Δ -3)
      llm_round                                12 → 4 (Δ -8)

    tool sequence A (7 calls): ["Read", "Grep", "Read", ...]
    tool sequence B (3 calls): ["Read", "Grep", "Edit"]
      → tool sequence DIFFERS

Machine-readable `--format json` mirrors the in-memory struct for CI.

## Design notes

**`serde_json::to_value` for event-type stringification** — avoids hand-written match that would silently drop new variants. The diff tool automatically picks up any future `JournalEventType` variant with its `rename_all = "snake_case"` name.

**Pure folds are `pub(crate)`** — `fold_events_into_tree` and `diff_events` take `&[JournalEvent]` and return structured output with no IO. Tests drive them against synthetic events, no tempdirs needed.

## Scope cut

`astra journal analyze --focus tokens` was in the original plan but is deferred: it needs to export `CacheBreakDetector`'s attribution, which the runtime doesn't journal yet. A prerequisite PR that teaches the runtime to write per-break events makes `analyze` a thin read-and-aggregate — tracked separately.

## Test plan

- [x] 11 new tests (5 tree, 6 diff)
- [x] Tree: fold into root totals; attach sub-runs by run_id; skip orphan completions; ASCII connectors (`├──` / `└──`); agent_type/task/timing metadata rendering
- [x] Diff: identical journals = zero deltas; signed token deltas; only_in_a/only_in_b symmetry; tool-sequence order; final-text presence independence; text rendering shows arrows + "no differences"
- [x] `cargo clippy -D warnings` clean
- [x] 2861 astra-cli tests pass
- [x] Live smoke: `astra journal tree last` and `astra journal diff A B` both run against real local sessions
- [ ] Reviewer: spot-check the JSON schema on a real delegation session, feed through `jq` to confirm shape is ergonomic