### PR TITLE
fix(test-harness): count StepCompleted, not llm_round (2 shipped cases)

### DIFF
--- a/rust/crates/astra-test-harness/cases/crash_robustness_journal_parseable.yaml
+++ b/rust/crates/astra-test-harness/cases/crash_robustness_journal_parseable.yaml
@@ -21,10 +21,15 @@ criteria:
   # The harness's SessionCapture exposes `skipped_lines` in its
   # debug string but not as a direct criterion. We proxy by asking
   # for a strictly positive event count — if the journal were
-  # unparseable we'd see 0 events. `llm_round` is universal in
-  # `~/.astra/sessions/<id>.jsonl` (every turn records one);
-  # `ToolCallCompleted` only fires in the step-events layout and is
-  # absent on many run types.
+  # unparseable we'd see 0 events.
+  #
+  # Layout note: real `astra chat --json` runs on this deployment
+  # write ONLY the step-events layout (`<id>/step_events.jsonl`).
+  # The legacy layout (`<id>.jsonl` with `llm_round`) is gated
+  # behind `full_llm_capture` / `astra session trace on` and is
+  # NOT produced by a plain chat invocation. Count `StepCompleted`
+  # — the step-events analogue of `llm_round` that fires exactly
+  # once per completed turn.
   - type: session_event_count
-    event_type: llm_round
+    event_type: StepCompleted
     min: 1

--- a/rust/crates/astra-test-harness/cases/journal_vs_envelope_tool_list_consistency.yaml
+++ b/rust/crates/astra-test-harness/cases/journal_vs_envelope_tool_list_consistency.yaml
@@ -12,8 +12,12 @@ description: |
   `llm_round.tool_calls[]` as well as step-events
   `ToolCallCompleted`). Both must agree on the same tool name.
 prompt: |
-  Use the list_dir tool to list the current directory. Then briefly
+  Use ONLY the `list_dir` tool (not `bash`, not any other tool) to
+  list the current directory. After you see the output, briefly
   describe what you saw in one sentence.
+
+  Constraint: you must call `list_dir` exactly once. Do not use bash,
+  read_file, grep, or any other tool for this task.
 debug_log: true
 timeout_seconds: 120
 criteria:
@@ -23,10 +27,12 @@ criteria:
     name: list_dir
   - type: journal_tool_called
     name: list_dir
-  # `llm_round` is universal in the legacy jsonl; `ToolCallCompleted`
-  # only appears when the step-events layout is enabled. Assert on
-  # the universal event type so this case runs cleanly against any
-  # session.
+  # Layout note: real `astra chat --json` runs on this deployment
+  # write ONLY the step-events layout (`<id>/step_events.jsonl`).
+  # The legacy layout (`<id>.jsonl` with `llm_round`) is gated
+  # behind `full_llm_capture` / `astra session trace on` and is
+  # NOT produced by a plain chat invocation. `StepCompleted` is
+  # the step-events analogue: exactly one per completed turn.
   - type: session_event_count
-    event_type: llm_round
+    event_type: StepCompleted
     min: 1

--- a/rust/crates/astra-test-harness/tests/real_journal_wire_shape.rs
+++ b/rust/crates/astra-test-harness/tests/real_journal_wire_shape.rs
@@ -221,6 +221,132 @@ fn step_events_fixture_counts_and_tool_match() {
     );
 }
 
+// ── Universal "a turn completed" event across layouts ──
+//
+// The two shipped cases `crash_robustness_journal_parseable` and
+// `journal_vs_envelope_tool_list_consistency` asserted
+// `session_event_count { event_type: llm_round, min: 1 }`, but real
+// `astra chat --json` runs write ONLY the step-events layout
+// (`<id>/step_events.jsonl` — no `<id>.jsonl`), so `llm_round` count
+// is always 0 and the criterion falsely fails.
+//
+// `StepCompleted` is the step-events analogue: every turn that reaches
+// the end writes exactly one. These tests pin that contract so a
+// future runtime change to step-events cannot silently break the
+// criterion again.
+
+#[test]
+fn step_completed_is_present_in_step_events_fixture() {
+    // The step-events fixture has one complete turn → exactly one
+    // `StepCompleted`. This is what the two shipped cases should
+    // actually count.
+    let cap = load_session_from_path(
+        "fixture-sess-step",
+        &fixture_path("fixture_realistic_step_events.jsonl"),
+    )
+    .expect("fixture should load");
+    assert_eq!(
+        cap.count_events("StepCompleted"),
+        1,
+        "StepCompleted must be present on the step-events layout so \
+         shipped criteria can count it. Events: {:?}",
+        cap.events.iter().map(|e| &e.event_type).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn session_event_count_step_completed_passes_on_step_events_layout() {
+    // The substantive TDD assertion: with the YAMLs updated to count
+    // `StepCompleted` (per the fix below), the criterion PASSES on a
+    // step-events-only session that previously counted 0 `llm_round`.
+    let cap = load_session_from_path(
+        "fixture-sess-step",
+        &fixture_path("fixture_realistic_step_events.jsonl"),
+    )
+    .expect("fixture should load");
+    let outcome = RunOutcome::new("fixture-model").with_session_id("fixture-sess-step");
+
+    let pass = evaluate_deterministic_with_session(
+        &[Criterion::SessionEventCount {
+            event_type: "StepCompleted".into(),
+            min: 1,
+            optional: false,
+        }],
+        &outcome,
+        Some(&cap),
+    );
+    assert!(
+        pass[0].passed,
+        "StepCompleted count >= 1 must PASS on step-events layout: {}",
+        pass[0].detail
+    );
+}
+
+#[test]
+fn session_event_count_llm_round_still_fails_on_step_events_only() {
+    // Negative assertion: the old criterion (`llm_round`) correctly
+    // reports 0 on a step-events-only session. This test both
+    // documents the bug we fixed in the YAMLs AND guards against a
+    // regression where someone adds an alias that would make the
+    // wrong criterion silently succeed.
+    let cap = load_session_from_path(
+        "fixture-sess-step",
+        &fixture_path("fixture_realistic_step_events.jsonl"),
+    )
+    .expect("fixture should load");
+    let outcome = RunOutcome::new("fixture-model").with_session_id("fixture-sess-step");
+
+    let res = evaluate_deterministic_with_session(
+        &[Criterion::SessionEventCount {
+            event_type: "llm_round".into(),
+            min: 1,
+            optional: false,
+        }],
+        &outcome,
+        Some(&cap),
+    );
+    assert!(
+        !res[0].passed,
+        "llm_round count on step-events-only session must FAIL (proves \
+         step_events and legacy layouts have disjoint event_type values): {}",
+        res[0].detail
+    );
+    assert!(
+        res[0].detail.contains("count=0"),
+        "detail should report count=0 to make the diagnosis obvious: {}",
+        res[0].detail
+    );
+}
+
+// ── Shipped-case contract: the two formerly-broken cases must now
+// reference `StepCompleted`, not `llm_round`. A grep-based check is
+// cheap, deterministic, and catches a regression where someone
+// reintroduces the old criterion.
+
+#[test]
+fn shipped_cases_no_longer_count_llm_round() {
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let cases = [
+        "crash_robustness_journal_parseable.yaml",
+        "journal_vs_envelope_tool_list_consistency.yaml",
+    ];
+    for name in cases {
+        let body = std::fs::read_to_string(crate_root.join("cases").join(name))
+            .unwrap_or_else(|e| panic!("read {name}: {e}"));
+        assert!(
+            !body.contains("event_type: llm_round"),
+            "{name} must not count `llm_round` — real `astra chat` runs \
+             produce only the step-events layout. Use `StepCompleted` \
+             instead. Body:\n{body}"
+        );
+        assert!(
+            body.contains("event_type: StepCompleted"),
+            "{name} must count `StepCompleted` so the criterion works \
+             against the step-events layout real runs produce. Body:\n{body}"
+        );
+    }
+}
+
 // ── Cross-layout merge: both legacy + step_events for the same session ──
 
 #[test]


### PR DESCRIPTION
## Summary

Two shipped cases asserted `session_event_count { event_type: llm_round, min: 1 }`, but real `astra chat --json` runs on this deployment write ONLY the step-events layout (`~/.astra/sessions/<id>/step_events.jsonl`) — the legacy `<id>.jsonl` with `llm_round` events is gated behind `full_llm_capture` (per-session, enabled by `astra session trace on`). So on a plain chat invocation, `llm_round` count is always 0 and the criterion falsely fails.

Ground truth verified against 5 harness-produced sessions from a MiniMax-M2.7 smoke — every session had `<id>/step_events.jsonl` but no `<id>.jsonl`. `StepCompleted` is the step-events analogue: exactly one per completed turn.

## TDD

1. Added 4 wire-shape tests that pin the contract:
   - `step_completed_is_present_in_step_events_fixture`
   - `session_event_count_step_completed_passes_on_step_events_layout`
   - `session_event_count_llm_round_still_fails_on_step_events_only` — negative guard against a future alias hack that would silently accept the wrong criterion.
   - `shipped_cases_no_longer_count_llm_round` — grep-based regression fence.
2. Guard failed red, proving the bug.
3. Updated two YAMLs to count `StepCompleted` with inline layout notes.
4. Tightened `journal_vs_envelope` prompt to force `list_dir` (MiniMax-M2.7 was choosing `bash` without the constraint).
5. Live re-run on MiniMax-M2.7 — both cases PASS cleanly.

## Scope

Part of a 4-class diagnosis surfaced by a full MiniMax-M2.7 harness smoke run:

- **Class A (this PR)**: `session_event_count` assumed legacy journal format — fixed.
- Class B: `[fork-cache]` stderr never appears because `set_fork_inherit_prefix_enabled` is only wired in the CLI path, not in `astra-server`. Requires a new PR on the server bootstrap.
- Class C: child-model names in some cases (`claude-sonnet`, `qwen-flash`) aren't in the dev seed's `infra_llm_models`.
- Class D: model-behavior failures unrelated to infrastructure.

## Test plan

- [x] `cargo test -p astra-test-harness` — 117 lib + 11 wire-shape + 3 shipped-smoke + 1 doctest
- [x] `cargo clippy -p astra-test-harness --all-targets -- -D warnings` clean
- [x] `make check` clean
- [x] Live MiniMax-M2.7 rerun on both cases — PASS/PASS