### PR TITLE
fix(harness): two independent fixes from MiniMax-M2.7 smoke (Class A + C)

### DIFF
--- a/rust/crates/astra-test-harness/cases/crash_robustness_journal_parseable.yaml
+++ b/rust/crates/astra-test-harness/cases/crash_robustness_journal_parseable.yaml
@@ -21,10 +21,15 @@ criteria:
   # The harness's SessionCapture exposes `skipped_lines` in its
   # debug string but not as a direct criterion. We proxy by asking
   # for a strictly positive event count — if the journal were
-  # unparseable we'd see 0 events. `llm_round` is universal in
-  # `~/.astra/sessions/<id>.jsonl` (every turn records one);
-  # `ToolCallCompleted` only fires in the step-events layout and is
-  # absent on many run types.
+  # unparseable we'd see 0 events.
+  #
+  # Layout note: real `astra chat --json` runs on this deployment
+  # write ONLY the step-events layout (`<id>/step_events.jsonl`).
+  # The legacy layout (`<id>.jsonl` with `llm_round`) is gated
+  # behind `full_llm_capture` / `astra session trace on` and is
+  # NOT produced by a plain chat invocation. Count `StepCompleted`
+  # — the step-events analogue of `llm_round` that fires exactly
+  # once per completed turn.
   - type: session_event_count
-    event_type: llm_round
+    event_type: StepCompleted
     min: 1

--- a/rust/crates/astra-test-harness/cases/journal_vs_envelope_tool_list_consistency.yaml
+++ b/rust/crates/astra-test-harness/cases/journal_vs_envelope_tool_list_consistency.yaml
@@ -12,8 +12,12 @@ description: |
   `llm_round.tool_calls[]` as well as step-events
   `ToolCallCompleted`). Both must agree on the same tool name.
 prompt: |
-  Use the list_dir tool to list the current directory. Then briefly
+  Use ONLY the `list_dir` tool (not `bash`, not any other tool) to
+  list the current directory. After you see the output, briefly
   describe what you saw in one sentence.
+
+  Constraint: you must call `list_dir` exactly once. Do not use bash,
+  read_file, grep, or any other tool for this task.
 debug_log: true
 timeout_seconds: 120
 criteria:
@@ -23,10 +27,12 @@ criteria:
     name: list_dir
   - type: journal_tool_called
     name: list_dir
-  # `llm_round` is universal in the legacy jsonl; `ToolCallCompleted`
-  # only appears when the step-events layout is enabled. Assert on
-  # the universal event type so this case runs cleanly against any
-  # session.
+  # Layout note: real `astra chat --json` runs on this deployment
+  # write ONLY the step-events layout (`<id>/step_events.jsonl`).
+  # The legacy layout (`<id>.jsonl` with `llm_round`) is gated
+  # behind `full_llm_capture` / `astra session trace on` and is
+  # NOT produced by a plain chat invocation. `StepCompleted` is
+  # the step-events analogue: exactly one per completed turn.
   - type: session_event_count
-    event_type: llm_round
+    event_type: StepCompleted
     min: 1

--- a/rust/crates/astra-test-harness/tests/real_journal_wire_shape.rs
+++ b/rust/crates/astra-test-harness/tests/real_journal_wire_shape.rs
@@ -221,6 +221,132 @@ fn step_events_fixture_counts_and_tool_match() {
     );
 }
 
+// ── Universal "a turn completed" event across layouts ──
+//
+// The two shipped cases `crash_robustness_journal_parseable` and
+// `journal_vs_envelope_tool_list_consistency` asserted
+// `session_event_count { event_type: llm_round, min: 1 }`, but real
+// `astra chat --json` runs write ONLY the step-events layout
+// (`<id>/step_events.jsonl` — no `<id>.jsonl`), so `llm_round` count
+// is always 0 and the criterion falsely fails.
+//
+// `StepCompleted` is the step-events analogue: every turn that reaches
+// the end writes exactly one. These tests pin that contract so a
+// future runtime change to step-events cannot silently break the
+// criterion again.
+
+#[test]
+fn step_completed_is_present_in_step_events_fixture() {
+    // The step-events fixture has one complete turn → exactly one
+    // `StepCompleted`. This is what the two shipped cases should
+    // actually count.
+    let cap = load_session_from_path(
+        "fixture-sess-step",
+        &fixture_path("fixture_realistic_step_events.jsonl"),
+    )
+    .expect("fixture should load");
+    assert_eq!(
+        cap.count_events("StepCompleted"),
+        1,
+        "StepCompleted must be present on the step-events layout so \
+         shipped criteria can count it. Events: {:?}",
+        cap.events.iter().map(|e| &e.event_type).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn session_event_count_step_completed_passes_on_step_events_layout() {
+    // The substantive TDD assertion: with the YAMLs updated to count
+    // `StepCompleted` (per the fix below), the criterion PASSES on a
+    // step-events-only session that previously counted 0 `llm_round`.
+    let cap = load_session_from_path(
+        "fixture-sess-step",
+        &fixture_path("fixture_realistic_step_events.jsonl"),
+    )
+    .expect("fixture should load");
+    let outcome = RunOutcome::new("fixture-model").with_session_id("fixture-sess-step");
+
+    let pass = evaluate_deterministic_with_session(
+        &[Criterion::SessionEventCount {
+            event_type: "StepCompleted".into(),
+            min: 1,
+            optional: false,
+        }],
+        &outcome,
+        Some(&cap),
+    );
+    assert!(
+        pass[0].passed,
+        "StepCompleted count >= 1 must PASS on step-events layout: {}",
+        pass[0].detail
+    );
+}
+
+#[test]
+fn session_event_count_llm_round_still_fails_on_step_events_only() {
+    // Negative assertion: the old criterion (`llm_round`) correctly
+    // reports 0 on a step-events-only session. This test both
+    // documents the bug we fixed in the YAMLs AND guards against a
+    // regression where someone adds an alias that would make the
+    // wrong criterion silently succeed.
+    let cap = load_session_from_path(
+        "fixture-sess-step",
+        &fixture_path("fixture_realistic_step_events.jsonl"),
+    )
+    .expect("fixture should load");
+    let outcome = RunOutcome::new("fixture-model").with_session_id("fixture-sess-step");
+
+    let res = evaluate_deterministic_with_session(
+        &[Criterion::SessionEventCount {
+            event_type: "llm_round".into(),
+            min: 1,
+            optional: false,
+        }],
+        &outcome,
+        Some(&cap),
+    );
+    assert!(
+        !res[0].passed,
+        "llm_round count on step-events-only session must FAIL (proves \
+         step_events and legacy layouts have disjoint event_type values): {}",
+        res[0].detail
+    );
+    assert!(
+        res[0].detail.contains("count=0"),
+        "detail should report count=0 to make the diagnosis obvious: {}",
+        res[0].detail
+    );
+}
+
+// ── Shipped-case contract: the two formerly-broken cases must now
+// reference `StepCompleted`, not `llm_round`. A grep-based check is
+// cheap, deterministic, and catches a regression where someone
+// reintroduces the old criterion.
+
+#[test]
+fn shipped_cases_no_longer_count_llm_round() {
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let cases = [
+        "crash_robustness_journal_parseable.yaml",
+        "journal_vs_envelope_tool_list_consistency.yaml",
+    ];
+    for name in cases {
+        let body = std::fs::read_to_string(crate_root.join("cases").join(name))
+            .unwrap_or_else(|e| panic!("read {name}: {e}"));
+        assert!(
+            !body.contains("event_type: llm_round"),
+            "{name} must not count `llm_round` — real `astra chat` runs \
+             produce only the step-events layout. Use `StepCompleted` \
+             instead. Body:\n{body}"
+        );
+        assert!(
+            body.contains("event_type: StepCompleted"),
+            "{name} must count `StepCompleted` so the criterion works \
+             against the step-events layout real runs produce. Body:\n{body}"
+        );
+    }
+}
+
 // ── Cross-layout merge: both legacy + step_events for the same session ──
 
 #[test]

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -206,6 +206,121 @@ fn build_resolved_active_llm_from_row(
     })
 }
 
+/// Resolve a short / partial model name against the full list of
+/// active model names.
+///
+/// The LLM, when prompted to call `spawn_agent`, frequently produces
+/// the short family name (`claude-sonnet`, `qwen-flash`) rather than
+/// the fully-qualified registered name (`us.anthropic.claude-sonnet-4-6`).
+/// Rejecting those calls outright forces the case author to retrain
+/// the prompt. Instead, we do a **deterministic, unambiguous** alias
+/// lookup:
+///
+/// 1. **Exact match** — name equal (case-sensitive) → that name.
+/// 2. **Case-insensitive exact match** — unique match → that name.
+/// 3. **Substring match** — unique active row whose name contains the
+///    requested string (case-insensitive) → that name.
+/// 4. Otherwise → `Err` with the candidate list so the caller can
+///    surface a useful error. Ambiguity (2+ candidates) is also
+///    `Err` — picking arbitrarily would be worse than failing.
+///
+/// Pure function; the DB query path uses it by passing the names
+/// from `SELECT model_name FROM infra_llm_models WHERE is_active = 1`.
+/// Keeping it pure means the behavior is fully unit-testable without
+/// spinning up a pool.
+pub fn resolve_model_alias<'a>(
+    requested: &str,
+    active_names: &'a [String],
+) -> Result<&'a str, ModelAliasResolutionError> {
+    let trimmed = requested.trim();
+    if trimmed.is_empty() {
+        return Err(ModelAliasResolutionError::Empty);
+    }
+    // Level 1: exact match wins.
+    if let Some(hit) = active_names.iter().find(|n| n.as_str() == trimmed) {
+        return Ok(hit.as_str());
+    }
+    // Level 2: case-insensitive exact. Narrower than substring — a
+    // user typing "CLAUDE-HAIKU-4-5-20251001" should still resolve
+    // without needing to match case.
+    let requested_lower = trimmed.to_ascii_lowercase();
+    let ci_hits: Vec<&String> = active_names
+        .iter()
+        .filter(|n| n.to_ascii_lowercase() == requested_lower)
+        .collect();
+    match ci_hits.len() {
+        0 => {}
+        1 => return Ok(ci_hits[0].as_str()),
+        _ => {
+            return Err(ModelAliasResolutionError::Ambiguous {
+                requested: trimmed.into(),
+                candidates: ci_hits.iter().map(|s| s.to_string()).collect(),
+            });
+        }
+    }
+    // Level 3: substring (case-insensitive). Unique match only.
+    let sub_hits: Vec<&String> = active_names
+        .iter()
+        .filter(|n| n.to_ascii_lowercase().contains(&requested_lower))
+        .collect();
+    match sub_hits.len() {
+        0 => Err(ModelAliasResolutionError::NotFound {
+            requested: trimmed.into(),
+            candidates: active_names.iter().map(|s| s.to_string()).collect(),
+        }),
+        1 => Ok(sub_hits[0].as_str()),
+        _ => Err(ModelAliasResolutionError::Ambiguous {
+            requested: trimmed.into(),
+            candidates: sub_hits.iter().map(|s| s.to_string()).collect(),
+        }),
+    }
+}
+
+/// Error surface for [`resolve_model_alias`]. Preserved so the
+/// DB-layer caller can distinguish "no such model" from "ambiguous"
+/// and render a helpful message to the LLM / user.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelAliasResolutionError {
+    Empty,
+    NotFound {
+        requested: String,
+        candidates: Vec<String>,
+    },
+    Ambiguous {
+        requested: String,
+        candidates: Vec<String>,
+    },
+}
+
+impl std::fmt::Display for ModelAliasResolutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "empty model name"),
+            Self::NotFound {
+                requested,
+                candidates,
+            } => write!(
+                f,
+                "Model '{requested}' is not configured on this server \
+                 (no exact or substring match in infra_llm_models). \
+                 Registered active models: {candidates:?}. Omit the \
+                 model override or choose one of the registered names."
+            ),
+            Self::Ambiguous {
+                requested,
+                candidates,
+            } => write!(
+                f,
+                "Model '{requested}' is ambiguous — matches multiple \
+                 registered models: {candidates:?}. Use a more specific \
+                 name."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ModelAliasResolutionError {}
+
 /// Resolve the active LLM model from the database for in-process / server-side callers.
 ///
 /// When `preferred` is `Some(name)`, the row **must** exist and be active — otherwise this
@@ -241,6 +356,8 @@ pub async fn resolve_active_llm_model(
     let pref = preferred.map(str::trim).filter(|s| !s.is_empty());
 
     if let Some(name) = pref {
+        // Try exact match first — the fast path. If the LLM supplied
+        // the fully-qualified name it resolves in one query.
         let row = sqlx::query(
             "SELECT model_name, api_key_encrypted, base_url, provider, \
                     IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, is_active \
@@ -251,12 +368,42 @@ pub async fn resolve_active_llm_model(
         .await
         .map_err(|e| format!("DB query: {e}"))?;
 
-        let row = row.ok_or_else(|| {
-            format!(
-                "Model '{name}' is not configured on this server (no infra_llm_models row). \
-                 Omit the model override or choose a configured active model."
-            )
-        })?;
+        // Class C fix: fall through to the alias resolver when exact
+        // match fails. The LLM often produces short names like
+        // `claude-sonnet` for `spawn_agent`'s `model_override`; doing
+        // a deterministic substring / case-insensitive match against
+        // active rows lets those calls succeed without forcing every
+        // case author to retrain the prompt. Ambiguity still errors.
+        let row = match row {
+            Some(r) => r,
+            None => {
+                let active_names: Vec<String> = sqlx::query_scalar::<_, String>(
+                    "SELECT model_name FROM infra_llm_models WHERE is_active = 1",
+                )
+                .fetch_all(pool)
+                .await
+                .map_err(|e| format!("DB query: {e}"))?;
+
+                match resolve_model_alias(name, &active_names) {
+                    Ok(canonical) => sqlx::query(
+                        "SELECT model_name, api_key_encrypted, base_url, provider, \
+                                IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, is_active \
+                         FROM infra_llm_models WHERE model_name = ? LIMIT 1",
+                    )
+                    .bind(canonical)
+                    .fetch_optional(pool)
+                    .await
+                    .map_err(|e| format!("DB query: {e}"))?
+                    .ok_or_else(|| {
+                        format!(
+                            "alias resolver returned '{canonical}' but no row exists \
+                             — concurrent delete?"
+                        )
+                    })?,
+                    Err(e) => return Err(e.to_string()),
+                }
+            }
+        };
 
         let is_active_int: i16 = row.try_get("is_active").unwrap_or(0);
         if is_active_int == 0 {
@@ -1259,6 +1406,141 @@ impl From<ModelListItem> for ModelListItemResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── resolve_model_alias ──
+    //
+    // Class C regression: LLMs frequently produce short family names
+    // like `claude-sonnet` when calling `spawn_agent`, but the DB
+    // registers fully-qualified names like
+    // `us.anthropic.claude-sonnet-4-6`. Pre-alias behavior rejected
+    // these outright, breaking the three shipped fork-prefix /
+    // spawn-agent cases. The alias resolver deterministically maps
+    // short names to their unique registered form.
+
+    fn names(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn alias_exact_match_wins() {
+        let active = names(&[
+            "us.anthropic.claude-sonnet-4-6",
+            "us.anthropic.claude-haiku-4-5-20251001",
+        ]);
+        let hit = resolve_model_alias("us.anthropic.claude-sonnet-4-6", &active).unwrap();
+        assert_eq!(hit, "us.anthropic.claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn alias_short_name_resolves_to_unique_substring_match() {
+        // The primary motivating case: model emits `claude-sonnet`,
+        // registered name is `us.anthropic.claude-sonnet-4-6`. No
+        // other active model contains that substring.
+        let active = names(&[
+            "us.anthropic.claude-sonnet-4-6",
+            "us.anthropic.claude-haiku-4-5-20251001",
+            "MiniMax-M2.7",
+            "qwen3.6-plus",
+        ]);
+        let hit = resolve_model_alias("claude-sonnet", &active).unwrap();
+        assert_eq!(hit, "us.anthropic.claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn alias_short_name_qwen_flash_resolves() {
+        let active = names(&[
+            "qwen-flash",
+            "qwen3.6-plus",
+            "us.anthropic.claude-sonnet-4-6",
+        ]);
+        // Level 1 exact match.
+        let hit = resolve_model_alias("qwen-flash", &active).unwrap();
+        assert_eq!(hit, "qwen-flash");
+    }
+
+    #[test]
+    fn alias_case_insensitive_exact_match() {
+        let active = names(&["MiniMax-M2.7", "qwen-flash"]);
+        // `minimax-m2.7` (lowercased) should resolve to the
+        // mixed-case registered form.
+        let hit = resolve_model_alias("minimax-m2.7", &active).unwrap();
+        assert_eq!(hit, "MiniMax-M2.7");
+    }
+
+    #[test]
+    fn alias_unknown_name_reports_not_found_with_candidates() {
+        let active = names(&["qwen-flash", "MiniMax-M2.7"]);
+        let err = resolve_model_alias("gpt-5", &active).unwrap_err();
+        match err {
+            ModelAliasResolutionError::NotFound {
+                requested,
+                candidates,
+            } => {
+                assert_eq!(requested, "gpt-5");
+                assert!(candidates.contains(&"qwen-flash".into()));
+                assert!(candidates.contains(&"MiniMax-M2.7".into()));
+            }
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn alias_ambiguous_substring_fails_loudly_not_silently() {
+        // Both `claude-haiku-4-5` and `claude-haiku-4-5-20251001` are
+        // registered. A bare `claude-haiku` matches both — picking
+        // one arbitrarily would be worse than failing, because the
+        // caller's intent is unclear.
+        let active = names(&[
+            "us.anthropic.claude-haiku-4-5",
+            "us.anthropic.claude-haiku-4-5-20251001",
+            "MiniMax-M2.7",
+        ]);
+        let err = resolve_model_alias("claude-haiku", &active).unwrap_err();
+        match err {
+            ModelAliasResolutionError::Ambiguous {
+                requested,
+                candidates,
+            } => {
+                assert_eq!(requested, "claude-haiku");
+                assert_eq!(
+                    candidates.len(),
+                    2,
+                    "expected exactly two ambiguous candidates"
+                );
+            }
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn alias_empty_string_is_error_not_first_model() {
+        // Guard: an empty preferred-name coming from a caller should
+        // NOT fall through to first-match. The upstream DB query
+        // handles `preferred = None` separately; an explicit empty
+        // string is a bug the caller should see.
+        let active = names(&["qwen-flash", "MiniMax-M2.7"]);
+        assert!(matches!(
+            resolve_model_alias("", &active),
+            Err(ModelAliasResolutionError::Empty)
+        ));
+        assert!(matches!(
+            resolve_model_alias("   ", &active),
+            Err(ModelAliasResolutionError::Empty)
+        ));
+    }
+
+    #[test]
+    fn alias_exact_wins_even_when_substring_would_match_something_else() {
+        // Scenario: registered names `qwen-flash` and `qwen-flash-preview`.
+        // Requested = `qwen-flash`. Must pick exact match, not fail
+        // on substring ambiguity.
+        let active = names(&["qwen-flash", "qwen-flash-preview"]);
+        let hit = resolve_model_alias("qwen-flash", &active).unwrap();
+        assert_eq!(
+            hit, "qwen-flash",
+            "exact match must win over substring ambiguity"
+        );
+    }
 
     // -- rank_cheapest_index --
 

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -279,6 +279,12 @@ pub fn resolve_model_alias<'a>(
 /// Error surface for [`resolve_model_alias`]. Preserved so the
 /// DB-layer caller can distinguish "no such model" from "ambiguous"
 /// and render a helpful message to the LLM / user.
+///
+/// The `candidates` vector always carries the FULL list a caller
+/// might want to process programmatically. The `Display` impl
+/// truncates to [`MODEL_ALIAS_ERROR_CANDIDATE_CAP`] for readability
+/// — rendering 200 model names in a stderr line is a debugging
+/// anti-feature.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ModelAliasResolutionError {
     Empty,
@@ -292,6 +298,26 @@ pub enum ModelAliasResolutionError {
     },
 }
 
+/// Max number of candidate names the `Display` impl will render
+/// inline. Beyond this, the rendered string shows the first
+/// `MODEL_ALIAS_ERROR_CANDIDATE_CAP` entries and suffixes
+/// `... and N more`. Chosen to keep a single-line log readable
+/// while still being useful (20 model names ≈ 400-600 chars,
+/// within most log collectors' line limits).
+pub const MODEL_ALIAS_ERROR_CANDIDATE_CAP: usize = 20;
+
+fn render_truncated_candidates(
+    candidates: &[String],
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    if candidates.len() <= MODEL_ALIAS_ERROR_CANDIDATE_CAP {
+        return write!(f, "{candidates:?}");
+    }
+    let head = &candidates[..MODEL_ALIAS_ERROR_CANDIDATE_CAP];
+    let remaining = candidates.len() - MODEL_ALIAS_ERROR_CANDIDATE_CAP;
+    write!(f, "{head:?} ... and {remaining} more")
+}
+
 impl std::fmt::Display for ModelAliasResolutionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -299,27 +325,62 @@ impl std::fmt::Display for ModelAliasResolutionError {
             Self::NotFound {
                 requested,
                 candidates,
-            } => write!(
-                f,
-                "Model '{requested}' is not configured on this server \
-                 (no exact or substring match in infra_llm_models). \
-                 Registered active models: {candidates:?}. Omit the \
-                 model override or choose one of the registered names."
-            ),
+            } => {
+                write!(
+                    f,
+                    "Model '{requested}' is not configured on this server \
+                     (no exact or substring match in infra_llm_models). \
+                     Registered active models: "
+                )?;
+                render_truncated_candidates(candidates, f)?;
+                write!(
+                    f,
+                    ". Omit the model override or choose one of the registered names."
+                )
+            }
             Self::Ambiguous {
                 requested,
                 candidates,
-            } => write!(
-                f,
-                "Model '{requested}' is ambiguous — matches multiple \
-                 registered models: {candidates:?}. Use a more specific \
-                 name."
-            ),
+            } => {
+                write!(
+                    f,
+                    "Model '{requested}' is ambiguous — matches multiple \
+                     registered models: "
+                )?;
+                render_truncated_candidates(candidates, f)?;
+                write!(f, ". Use a more specific name.")
+            }
         }
     }
 }
 
 impl std::error::Error for ModelAliasResolutionError {}
+
+/// Format the error message for a requested model that was found
+/// (via exact or alias match) but has `is_active = 0`. If the alias
+/// resolver canonicalized the name, both forms are surfaced so the
+/// reader can see what happened; otherwise only one mention appears.
+///
+/// Extracted from [`resolve_active_llm_model`] so the message can
+/// be unit-tested without the DB path. The pre-alias behavior used
+/// the original requested name in the error even when the DB row
+/// was keyed on the resolved canonical form — misleading when the
+/// two disagree.
+pub fn format_inactive_model_error(requested: &str, canonical: &str) -> String {
+    if requested == canonical {
+        format!(
+            "Model '{canonical}' is inactive (connectivity failed or disabled). \
+             Run `astra-admin model check {canonical}` or pick an active model; \
+             the server will not substitute another model."
+        )
+    } else {
+        format!(
+            "Model '{requested}' (resolved to canonical '{canonical}') is inactive \
+             (connectivity failed or disabled). Run `astra-admin model check {canonical}` \
+             or pick an active model; the server will not substitute another model."
+        )
+    }
+}
 
 /// Resolve the active LLM model from the database for in-process / server-side callers.
 ///
@@ -358,7 +419,7 @@ pub async fn resolve_active_llm_model(
     if let Some(name) = pref {
         // Try exact match first — the fast path. If the LLM supplied
         // the fully-qualified name it resolves in one query.
-        let row = sqlx::query(
+        let exact_row = sqlx::query(
             "SELECT model_name, api_key_encrypted, base_url, provider, \
                     IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, is_active \
              FROM infra_llm_models WHERE model_name = ? LIMIT 1",
@@ -374,8 +435,14 @@ pub async fn resolve_active_llm_model(
         // a deterministic substring / case-insensitive match against
         // active rows lets those calls succeed without forcing every
         // case author to retrain the prompt. Ambiguity still errors.
-        let row = match row {
-            Some(r) => r,
+        //
+        // Track canonical name separately so the `is_active` error
+        // message below can name BOTH the requested alias and the
+        // resolved form when they differ — without this, a reader
+        // would see "Model 'claude-sonnet' is inactive" even though
+        // the DB row is keyed on the full bedrock name.
+        let (row, canonical) = match exact_row {
+            Some(r) => (r, name.to_string()),
             None => {
                 let active_names: Vec<String> = sqlx::query_scalar::<_, String>(
                     "SELECT model_name FROM infra_llm_models WHERE is_active = 1",
@@ -385,21 +452,25 @@ pub async fn resolve_active_llm_model(
                 .map_err(|e| format!("DB query: {e}"))?;
 
                 match resolve_model_alias(name, &active_names) {
-                    Ok(canonical) => sqlx::query(
-                        "SELECT model_name, api_key_encrypted, base_url, provider, \
-                                IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, is_active \
-                         FROM infra_llm_models WHERE model_name = ? LIMIT 1",
-                    )
-                    .bind(canonical)
-                    .fetch_optional(pool)
-                    .await
-                    .map_err(|e| format!("DB query: {e}"))?
-                    .ok_or_else(|| {
-                        format!(
-                            "alias resolver returned '{canonical}' but no row exists \
-                             — concurrent delete?"
+                    Ok(canonical_ref) => {
+                        let canonical = canonical_ref.to_string();
+                        let r = sqlx::query(
+                            "SELECT model_name, api_key_encrypted, base_url, provider, \
+                                    IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, is_active \
+                             FROM infra_llm_models WHERE model_name = ? LIMIT 1",
                         )
-                    })?,
+                        .bind(&canonical)
+                        .fetch_optional(pool)
+                        .await
+                        .map_err(|e| format!("DB query: {e}"))?
+                        .ok_or_else(|| {
+                            format!(
+                                "alias resolver returned '{canonical}' but no row exists \
+                                 — concurrent delete?"
+                            )
+                        })?;
+                        (r, canonical)
+                    }
                     Err(e) => return Err(e.to_string()),
                 }
             }
@@ -407,10 +478,7 @@ pub async fn resolve_active_llm_model(
 
         let is_active_int: i16 = row.try_get("is_active").unwrap_or(0);
         if is_active_int == 0 {
-            return Err(format!(
-                "Model '{name}' is inactive (connectivity failed or disabled). \
-                 Run `astra-admin model check {name}` or pick an active model; the server will not substitute another model."
-            ));
+            return Err(format_inactive_model_error(name, &canonical));
         }
 
         return build_resolved_active_llm_from_row(&row, encryptor);
@@ -1540,6 +1608,128 @@ mod tests {
             hit, "qwen-flash",
             "exact match must win over substring ambiguity"
         );
+    }
+
+    #[test]
+    fn alias_not_found_truncates_large_candidate_lists() {
+        // Review nit: an error string listing 200 model names is a
+        // debugging nightmare. Cap at MODEL_ALIAS_ERROR_CANDIDATE_CAP
+        // with a "... N more" suffix in the Display form, so logs stay
+        // scannable but nothing is lost (the full list is still on
+        // the variant for programmatic callers).
+        let active: Vec<String> = (0..50).map(|i| format!("model-{i}")).collect();
+        let err = resolve_model_alias("nonexistent-xyz", &active).unwrap_err();
+        match &err {
+            ModelAliasResolutionError::NotFound { candidates, .. } => {
+                // The variant itself MUST carry every candidate —
+                // programmatic callers might want them all. Truncation
+                // is a rendering concern.
+                assert_eq!(
+                    candidates.len(),
+                    50,
+                    "variant preserves full list; truncation is Display-only"
+                );
+            }
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+        let rendered = err.to_string();
+        // Render should cap the visible list and indicate truncation.
+        // Pick a threshold the caller can grep: \"...\" followed by a
+        // count. We don't pin the exact cap value here — that belongs
+        // in a separate assertion below — only that truncation happens
+        // and is disclosed.
+        assert!(
+            rendered.contains("...") && rendered.contains("more"),
+            "rendered NotFound with 50 candidates must disclose truncation: {rendered}"
+        );
+        // The rendered string must NOT contain `model-49` when the cap
+        // fires. `model-0`..`model-{CAP-1}` should be visible.
+        assert!(
+            !rendered.contains("model-49"),
+            "last entry must be truncated when exceeding cap: {rendered}"
+        );
+        assert!(
+            rendered.contains("model-0"),
+            "head of list must remain visible: {rendered}"
+        );
+    }
+
+    #[test]
+    fn inactive_error_names_both_requested_and_resolved_when_different() {
+        // Review nit: when alias resolution maps `claude-sonnet` →
+        // `us.anthropic.claude-sonnet-4-6` and the resolved row is
+        // later found inactive (e.g. admin deactivated between the
+        // alias query and the row refetch — a narrow TOCTOU window),
+        // the error message should name BOTH the requested alias and
+        // the canonical name so a reviewer can see what actually
+        // happened. The earlier message claimed the short form was
+        // inactive, which is misleading because the short form isn't
+        // what the DB row is keyed on.
+        let msg = format_inactive_model_error("claude-sonnet", "us.anthropic.claude-sonnet-4-6");
+        assert!(
+            msg.contains("claude-sonnet"),
+            "msg names the requested alias: {msg}"
+        );
+        assert!(
+            msg.contains("us.anthropic.claude-sonnet-4-6"),
+            "msg names the canonical: {msg}"
+        );
+        assert!(
+            msg.contains("inactive"),
+            "msg explains the failure mode: {msg}"
+        );
+        assert!(
+            msg.contains("astra-admin model check"),
+            "msg points at the diagnostic command: {msg}"
+        );
+    }
+
+    #[test]
+    fn inactive_error_does_not_duplicate_when_requested_equals_canonical() {
+        // When no alias resolution happened (exact-match path) the
+        // `requested` and `canonical` arguments are equal. Don't
+        // pollute the message with "resolved to the same name".
+        let name = "us.anthropic.claude-sonnet-4-6";
+        let msg = format_inactive_model_error(name, name);
+        // Count occurrences — exactly one mention of the name.
+        let n = msg.matches(name).count();
+        assert_eq!(
+            n, 2,
+            "expected name twice (in the 'Model X' and 'astra-admin model check X' parts), \
+             got {n}: {msg}"
+        );
+        assert!(
+            !msg.contains("resolved to"),
+            "no alias resolution happened, message must not claim one: {msg}"
+        );
+    }
+
+    #[test]
+    fn alias_not_found_below_cap_renders_full_list() {
+        // Inverse guard: if the candidate list fits under the cap, the
+        // render must not pretend truncation happened (that would be
+        // misleading).
+        let active = names(&[
+            "qwen-flash",
+            "MiniMax-M2.7",
+            "us.anthropic.claude-sonnet-4-6",
+        ]);
+        let err = resolve_model_alias("gpt-5", &active).unwrap_err();
+        let rendered = err.to_string();
+        assert!(
+            !rendered.contains("more"),
+            "under-cap list must not imply truncation: {rendered}"
+        );
+        for n in [
+            "qwen-flash",
+            "MiniMax-M2.7",
+            "us.anthropic.claude-sonnet-4-6",
+        ] {
+            assert!(
+                rendered.contains(n),
+                "under-cap list must include {n}: {rendered}"
+            );
+        }
     }
 
     // -- rank_cheapest_index --


### PR DESCRIPTION
## Summary

Two independent fixes surfaced by a full MiniMax-M2.7 harness smoke run. Packaged together per request; the two commits can be cleanly split if reviewers prefer.

### Commit 1 — Class A: `session_event_count` counts `StepCompleted`, not `llm_round`
Two shipped cases (`crash_robustness_journal_parseable`, `journal_vs_envelope_tool_list_consistency`) asserted `session_event_count { event_type: llm_round, min: 1 }`, but real `astra chat --json` runs on this deployment write ONLY the step-events layout (`<id>/step_events.jsonl`) — the legacy `<id>.jsonl` with `llm_round` events is gated behind `full_llm_capture` (per-session, enabled by `astra session trace on`). `StepCompleted` is the step-events analogue: exactly one per completed turn.

4 new wire-shape tests pin the contract (including a negative assertion that `llm_round` correctly counts 0 on step-events-only sessions, and a grep-based regression fence against future re-introduction of the bad criterion). Prompt in `journal_vs_envelope` tightened to force `list_dir` over `bash`.

### Commit 2 — Class C: model alias resolver for `spawn_agent` short names
When the LLM emits a short family name like `claude-sonnet` for `spawn_agent`'s `model_override`, `resolve_active_llm_model` threw \"Model 'claude-sonnet' is not configured on this server\" because the DB registers only the fully-qualified name `us.anthropic.claude-sonnet-4-6`. Every spawn_agent case that didn't pin the exact registered name failed.

New pure function `resolve_model_alias` with 3 deterministic levels (exact → CI-exact → substring), all unique-or-error. Ambiguity fails loudly with the candidate list. Never silently picks an arbitrary match. Wired into `resolve_active_llm_model` as an additive fallback after exact DB match misses.

8 unit tests cover every branch.

## Scope rationale
Bundled because:
- both came out of the same MiniMax smoke triage
- both are additive (new tests + new criteria values / new resolver path); neither changes existing behavior outside the broken cases
- cumulative diff is modest (436 LOC, mostly tests + error-message strings)

## TDD

### Class A (harness wire-shape)
1. Added 4 failing tests. `shipped_cases_no_longer_count_llm_round` (grep-based guard) failed red — both YAMLs still asserted `llm_round`.
2. Updated both YAMLs to count `StepCompleted` with inline layout-note comments so future readers know why.
3. Tightened `journal_vs_envelope` prompt to force `list_dir` (MiniMax-M2.7 was choosing `bash` without the constraint).
4. Live re-run on MiniMax-M2.7: both cases **PASS**.

### Class C (services alias)
1. Wrote 8 unit tests pinning every branch of the new resolver (exact, CI-exact, substring unique, ambiguous = Err, not-found = Err, empty = Err, exact wins over substring).
2. Implemented resolver + wired into `resolve_active_llm_model` with an additive fallback path.
3. Live verify: MiniMax-M2.7 `spawn_agent_hello` went from FAIL (model not configured) → PASS.

## Not in this PR

- **Class B**: `[fork-cache]` stderr still doesn't appear even after Class C unlocks spawn resolution. Root cause is not the CLI/server wiring I initially diagnosed — it's a spawn-lifecycle issue where the child's `step_events.jsonl` only contains `StepCreated` (child turn never completes, so `on_turn_completed` never fires and the probe never emits). Parent's follow-up `send_message` fails with \"agent not found\". Needs a focused runtime-debug session with live traces of the spawner background-task lifecycle; deferred to a separate PR.
- **Class D**: model-behavior failures (e.g. MiniMax choosing `bash` over `list_dir` when both are allowed) — not infra scope.

## Test plan

- [x] `cargo test -p astra-test-harness -p astra-services` — 117 lib + 11 wire-shape + 3 shipped-smoke + 1 doctest + 1294 services lib, all green
- [x] `cargo clippy -p astra-test-harness -p astra-services --all-targets -- -D warnings` clean
- [x] `make check` clean
- [x] Live MiniMax-M2.7 rerun — `crash_robustness_journal_parseable` PASS, `journal_vs_envelope_tool_list_consistency` PASS, `spawn_agent_hello` PASS

## Supersedes

Closes #293, closes #294. Both branches are the same two commits as this PR, packaged as one bundle.