### PR TITLE
fix(cli): align parent run_id so fork-cache prefix capture works

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -154,6 +154,14 @@ pub(crate) async fn stream_chat_sse(
 ) -> Result<StreamResult, crate::TurnFailure> {
     let start = Instant::now();
     let root_agent_id = p.root_agent_id.unwrap_or("main");
+    // Stable run_id for this turn — shared by:
+    //   1. state.current_run_id (so on_turn_completed captures the
+    //      parent prefix keyed on this id)
+    //   2. SpawnAgentContext.run_id (so the spawner's resolver looks
+    //      up the same key)
+    // Pre-fix these were different ("ephemeral" vs None), so the
+    // parent capture never happened and fork-cache probes were dead.
+    let parent_turn_run_id = format!("run-{}", uuid::Uuid::new_v4());
     let term_width = terminal_width_usize();
     // Capture the model id up front for later `resolve_for_model` calls —
     // `p.model` (Option<&str>) gets consumed into `host.model` below.
@@ -235,10 +243,18 @@ pub(crate) async fn stream_chat_sse(
         } else {
             ex
         };
-        // Wire spawn_agent tool context when spawner is available
+        // Wire spawn_agent tool context when spawner is available.
+        // The run_id MUST match what state.current_run_id uses so that
+        // on_turn_completed captures the parent prefix under the same
+        // key the spawner resolves against. Previously this was
+        // p.session_id.unwrap_or("ephemeral") — a mismatch that made
+        // on_turn_completed early-return (current_run_id = None) and
+        // the spawner look up "ephemeral" in the prefix store, finding
+        // nothing. Generating a stable UUID here and threading it into
+        // both sites closes the gap.
         if let Some(ref spawner) = p.agent_spawner {
             let spawn_ctx = edge_tools::agent_spawning::SpawnAgentContext {
-                run_id: p.session_id.unwrap_or("ephemeral").to_string(),
+                run_id: parent_turn_run_id.clone(),
                 agent_id: root_agent_id.to_string(),
                 recursion_depth: 0,
                 working_dir: project_root.clone(),
@@ -537,7 +553,7 @@ pub(crate) async fn stream_chat_sse(
         messages,
         tool_results: Vec::new(),
         current_session_id,
-        current_run_id: None,
+        current_run_id: Some(parent_turn_run_id.clone()),
         recursion_depth: 0,
         final_text: String::new(),
         final_text_streamed: false,


### PR DESCRIPTION
## Summary

Class B of the MiniMax harness triage: `[fork-cache]` stderr events never appeared because the parent prefix was never captured.

**Root cause**: run_id mismatch between prefix capture and spawn resolver.
- `SpawnAgentContext.run_id` = `p.session_id.unwrap_or("ephemeral")` (literal string)
- `state.current_run_id` = `None`
- `on_turn_completed` reads `state.current_run_id` → `None` → early return → **no prefix captured**
- Spawner resolver looks up `"ephemeral"` in prefix store → `NotFound` → `inherited_prefix = None` → probe skipped

**Fix**: generate a stable `parent_turn_run_id` (UUID) early in the SSE loop setup. Thread it into both `state.current_run_id` and `SpawnAgentContext.run_id`. Now capture and resolve use the same key.

## Diagnosis

Instrumented `maybe_emit_fork_cache_probe` and `resolve_inherit_prefix` with temporary debug `eprintln!`s. Output confirmed:
```
resolve_inherit_prefix: spec=true caller_run=ephemeral outcome=Fallback(NotFound { run_id: "ephemeral" })
SubRunHost::on_turn_completed fired. sink=true inherited_prefix=false cache_read=0
probe skipped: inherited_prefix is None
```

## Live verification

MiniMax-M2.7 full harness suite (17 runs):

| | Before | After |
|---|---|---|
| PASS | 6 | **11** |
| FAIL | 11 | **6** |

Newly passing: `selector_spawn_agent_visible_across_matrix` (all 3 rows), `crash_robustness_journal_parseable`, `journal_vs_envelope_tool_list_consistency`.

Remaining 6 failures are model-behavior (LLM not passing `inherit_prefix: {}`), Bedrock 400 errors, or model choosing wrong tools — not infrastructure.

## Test plan

- [x] `make check` clean
- [x] Live MiniMax-M2.7 full suite: 11/17 pass (was 6/17)
- [x] 1 file, 19 insertions, 3 deletions — minimal change

## Context

Part of the 4-class MiniMax harness triage. PR #295 fixed Class A + C. This PR fixes Class B.