### PR TITLE
chore(build): unify profiles, disable test incremental, fix sweep

### DIFF
--- a/.github/workflows/e2e-matrix-nightly.yml
+++ b/.github/workflows/e2e-matrix-nightly.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-          shared-key: ci-online
+          shared-key: ci-test
           save-if: false
       - name: Wait for dependencies
         run: make dev-deps-wait

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   check:
@@ -22,7 +23,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-          shared-key: ci-static
+          shared-key: ci-test
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run clippy
         run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   # ── Stage 1: compile once, cache for all downstream jobs ───────────

--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,6 @@ build: build-release
 build-release: sweep
 	@echo "Building Rust workspace (release)..."
 	@$(CARGO) build $(CARGO_MANIFEST_FLAG) --release
-	@touch $(RUST_TARGET_DIR)/.sweep-stamp
 	@echo "✅ Release artifacts: $(RUST_RELEASE_BIN_DIR)/"
 
 .PHONY: build-cli
@@ -449,28 +448,23 @@ clean-incremental:
 	@rm -rf $(RUST_TARGET_DIR)/debug/incremental
 	@echo "✅ Incremental cache removed"
 
-SWEEP_STAMP := $(RUST_TARGET_DIR)/.sweep-stamp
+# Maximum age (in hours) for build artifacts before sweep removes them.
+# Override: make sweep SWEEP_MAX_AGE_H=2
+SWEEP_MAX_AGE_H ?= 4
 
-.PHONY: sweep-stamp
-sweep-stamp:
-	@touch $(SWEEP_STAMP)
-
+# Time-based sweep: removes debug and release artifacts older than SWEEP_MAX_AGE_H.
+# Runs automatically before build-release and test-offline to keep disk usage bounded.
 .PHONY: sweep
 sweep:
-	@if [ -f $(SWEEP_STAMP) ]; then \
-		echo "Sweeping artifacts inactive since $$(stat -c '%y' $(SWEEP_STAMP) | cut -d. -f1)..."; \
-		find $(RUST_TARGET_DIR)/debug/incremental -maxdepth 1 -type d ! -newer $(SWEEP_STAMP) -exec rm -rf {} + 2>/dev/null || true; \
-		find $(RUST_TARGET_DIR)/debug/deps -type f ! -newer $(SWEEP_STAMP) -delete 2>/dev/null || true; \
-		find $(RUST_TARGET_DIR)/debug/.fingerprint -maxdepth 1 -type d ! -newer $(SWEEP_STAMP) -exec rm -rf {} + 2>/dev/null || true; \
-		find $(RUST_TARGET_DIR)/release/incremental -maxdepth 1 -type d ! -newer $(SWEEP_STAMP) -exec rm -rf {} + 2>/dev/null || true; \
-	else \
-		echo "No stamp found, sweeping artifacts older than 5 days..."; \
-		find $(RUST_TARGET_DIR)/debug/incremental -maxdepth 1 -type d -mtime +5 -exec rm -rf {} + 2>/dev/null || true; \
-		find $(RUST_TARGET_DIR)/debug/deps -type f -atime +5 -delete 2>/dev/null || true; \
-		find $(RUST_TARGET_DIR)/debug/.fingerprint -maxdepth 1 -type d -mtime +5 -exec rm -rf {} + 2>/dev/null || true; \
-		find $(RUST_TARGET_DIR)/release/incremental -maxdepth 1 -type d -mtime +5 -exec rm -rf {} + 2>/dev/null || true; \
-	fi
-	@echo "✅ Inactive artifacts removed"
+	@AGE_MIN=$$(( $(SWEEP_MAX_AGE_H) * 60 )); \
+	echo "Sweeping artifacts older than $(SWEEP_MAX_AGE_H)h..."; \
+	find $(RUST_TARGET_DIR)/debug/incremental -mindepth 1 -maxdepth 1 -type d -mmin +$$AGE_MIN -exec rm -rf {} + 2>/dev/null || true; \
+	find $(RUST_TARGET_DIR)/debug/deps -type f -mmin +$$AGE_MIN -delete 2>/dev/null || true; \
+	find $(RUST_TARGET_DIR)/debug/.fingerprint -mindepth 1 -maxdepth 1 -type d -mmin +$$AGE_MIN -exec rm -rf {} + 2>/dev/null || true; \
+	find $(RUST_TARGET_DIR)/release/incremental -mindepth 1 -maxdepth 1 -type d -mmin +$$AGE_MIN -exec rm -rf {} + 2>/dev/null || true; \
+	find $(RUST_TARGET_DIR)/release/deps -type f -mmin +$$AGE_MIN -delete 2>/dev/null || true; \
+	find $(RUST_TARGET_DIR)/release/.fingerprint -mindepth 1 -maxdepth 1 -type d -mmin +$$AGE_MIN -exec rm -rf {} + 2>/dev/null || true
+	@echo "✅ Stale artifacts removed"
 	@du -sh $(RUST_TARGET_DIR) 2>/dev/null || true
 
 # ============================================================================
@@ -481,14 +475,14 @@ sweep:
 test: test-offline test-online
 
 .PHONY: test-offline
-test-offline: test-workspace test-runtime-bridge-hooks test-sdk-offline
+test-offline: sweep test-workspace test-runtime-bridge-hooks test-sdk-offline
 
 .PHONY: test-workspace
 test-workspace:
 	@echo "Running Rust workspace tests (nextest profile=$(NEXTEST_OFFLINE_PROFILE))..."
-	@cargo nextest run $(CARGO_MANIFEST_FLAG) --workspace $(NEXTEST_OFFLINE_FLAGS)
+	@CARGO_INCREMENTAL=0 cargo nextest run $(CARGO_MANIFEST_FLAG) --workspace $(NEXTEST_OFFLINE_FLAGS)
 	@echo "Running workspace doctests (cargo test --doc; not covered by nextest)..."
-	@$(CARGO) test $(CARGO_MANIFEST_FLAG) --workspace --doc
+	@CARGO_INCREMENTAL=0 $(CARGO) test $(CARGO_MANIFEST_FLAG) --workspace --doc
 
 # Guard: server allowlist names ⊆ all_tool_schemas(), memory_* allowlist coverage,
 # DEFAULT_EXECUTOR_TOOL_NAMES ⊆ SERVER_EXECUTOR_TOOL_NAMES (manifest-path rust/Cargo.toml).
@@ -502,7 +496,7 @@ check-server-tool-schemas:
 .PHONY: test-runtime-bridge-hooks
 test-runtime-bridge-hooks:
 	@echo "Running astra-runtime tests with feature bridge-e2e-hooks (nextest profile=$(NEXTEST_OFFLINE_PROFILE))..."
-	@cargo nextest run $(CARGO_MANIFEST_FLAG) $(API_SHELL_PKG) \
+	@CARGO_INCREMENTAL=0 cargo nextest run $(CARGO_MANIFEST_FLAG) $(API_SHELL_PKG) \
 		--features bridge-e2e-hooks $(NEXTEST_OFFLINE_FLAGS)
 
 # Ignored tests: opt-in via env vars (see `make test-online`). Enable with:
@@ -528,7 +522,7 @@ test-ignored-integration:
 		else \
 			echo "Running online integration tests (ignored; live MatrixOne; bridge-e2e-hooks enabled for system_matrix_http_e2e)..."; \
 		fi; \
-		cargo nextest run $(CARGO_MANIFEST_FLAG) \
+		CARGO_INCREMENTAL=0 cargo nextest run $(CARGO_MANIFEST_FLAG) \
 			-p astra-runtime -p astra-services -p astra-plan \
 			--features astra-runtime/bridge-e2e-hooks \
 			--tests --run-ignored only \
@@ -557,7 +551,7 @@ test-online:
 	echo "Running astra-runtime ignored unit tests (live DB; nextest profile=$(NEXTEST_ONLINE_PROFILE); live-LLM suite gated by ASTRA_LIVE_LLM)..."; \
 	FAILED=""; \
 	ASTRA_DATABASE=$$TEST_DB ASTRA_DATABASE_PREFIX="" ASTRA_AUTO_CREATE_DATABASE=1 \
-		cargo nextest run $(CARGO_MANIFEST_FLAG) $(API_SHELL_PKG) \
+		CARGO_INCREMENTAL=0 cargo nextest run $(CARGO_MANIFEST_FLAG) $(API_SHELL_PKG) \
 			--run-ignored only $(NEXTEST_ONLINE_FLAGS) \
 			|| FAILED="$$FAILED astra-runtime-ignored"; \
 	ASTRA_DATABASE=$$TEST_DB ASTRA_DATABASE_PREFIX="" ASTRA_AUTO_CREATE_DATABASE=1 \
@@ -651,7 +645,7 @@ ci: check test
 .PHONY: lint
 lint:
 	@echo "Running clippy..."
-	@$(CARGO) clippy $(CARGO_MANIFEST_FLAG) --release --all-targets -- -D warnings
+	@$(CARGO) clippy $(CARGO_MANIFEST_FLAG) --all-targets -- -D warnings
 
 .PHONY: lint-fix
 lint-fix:
@@ -675,7 +669,7 @@ audit:
 .PHONY: type-check
 type-check:
 	@echo "Running compile checks..."
-	@$(CARGO) check $(CARGO_MANIFEST_FLAG) --release --all-targets
+	@$(CARGO) check $(CARGO_MANIFEST_FLAG) --all-targets
 
 # ============================================================================
 # Memoria (Memory Service)


### PR DESCRIPTION
## What type of PR is this?

- [x] Improvement
- [x] Code Refactoring

## What this PR does / why we need it:

Optimizes local and CI build times by eliminating redundant compilation and fixing disk bloat from stale artifacts.

### Problems solved

1. **lint + test compiled twice**: clippy used `--release`, tests used debug — no artifact sharing. Now both use debug profile → lint→test recompiles 0 crates.

2. **Incremental cache explosion**: `rust/target/debug/incremental` grew to 113GB (2253 dirs). Each nextest binary got its own incremental session with minimal reuse. Now `CARGO_INCREMENTAL=0` for all test targets eliminates this entirely.

3. **Sweep was broken**: only triggered by `make build-release`, used a stamp that was always older than debug artifacts (tests run after build), 5-day fallback was too generous (~40GB/day accumulation). Now time-based (4h default), covers debug+release, runs before both build and test.

4. **CI cache fragmentation**: static-checks had its own `ci-static` cache (release), e2e-matrix used `ci-online` (never saved). Now all workflows share `ci-test` cache.

### Changes

| File | Change |
|------|--------|
| Makefile | lint/type-check → debug; CARGO_INCREMENTAL=0 for tests; time-based sweep with -mindepth 1 fix; sweep as test-offline dep; remove dead stamp |
| static-checks.yml | shared-key ci-test; CARGO_INCREMENTAL=0 |
| test.yml | CARGO_INCREMENTAL=0 (global env) |
| e2e-matrix-nightly.yml | shared-key ci-test (was ci-online) |

### Verified locally

- `make lint` → clippy passes (debug profile, 0.26s cached)
- `cargo test --no-run` after lint → 0 recompiles (full artifact reuse)
- `make build` → release build passes
- `make test-offline` → 13715/13721 pass (6 failures from /tmp disk full, unrelated)