### PR TITLE
fix(services): async audit flusher for session_sync_log — eliminate prune hot-path

### DIFF
--- a/plans/session-sync-log-async-audit-redesign-2026-05-01.md
+++ b/plans/session-sync-log-async-audit-redesign-2026-05-01.md
@@ -1,0 +1,194 @@
+# session_sync_log: async audit with DB-level retention
+
+Status: design
+Date: 2026-05-01
+Supersedes: `session-sync-log-prune-hotpath-2026-05-01.md` (Option A probabilistic prune)
+
+## Root Cause
+
+Audit writes (INSERT) and retention maintenance (DELETE) are synchronous in the push critical path. This is a design flaw — audit is observability, not business logic. It must never block or contend with the operation it observes.
+
+## Design Principles
+
+1. **Audit writes are fire-and-forget** — losing an audit row is acceptable; blocking a push is not.
+2. **Retention is the DB's job** — application-level prune queries are unnecessary complexity.
+3. **Zero prune queries in application code** — remove `build_sync_log_prune_query` entirely.
+
+## Architecture
+
+```
+push_session_state_to_cloud()
+  ├── INSERT session state (business) ← sync, must succeed
+  └── tx.send(AuditEntry)            ← non-blocking, bounded channel
+
+Background:
+  AuditFlusher (tokio task)
+    └── batch INSERT every 1s or 64 entries (whichever first)
+    └── no prune — DB handles retention via TTL or scheduled cleanup
+
+DB-level:
+  storage::run_cleanup() already does time-based DELETE (sync_log_days policy)
+  → that's the only retention mechanism needed
+```
+
+## Detailed Design
+
+### 1. `AuditEntry` struct
+
+```rust
+pub(crate) struct SyncAuditEntry {
+    pub user_id: String,
+    pub session_id: String,
+    pub sync_type: String,
+    pub direction: SyncDirection,
+    pub payload_size: usize,
+    pub status: String,
+    pub error_message: Option<String>,
+}
+```
+
+### 2. `SyncAuditWriter`
+
+```rust
+pub(crate) struct SyncAuditWriter {
+    tx: tokio::sync::mpsc::Sender<SyncAuditEntry>,
+}
+
+impl SyncAuditWriter {
+    /// Non-blocking send. If channel is full, drop the entry (log a counter).
+    pub fn log(&self, entry: SyncAuditEntry) {
+        if self.tx.try_send(entry).is_err() {
+            // Metric: audit_entries_dropped += 1
+            tracing::debug!(target: "astra_services::audit", "sync audit channel full, entry dropped");
+        }
+    }
+}
+```
+
+### 3. `SyncAuditFlusher` (background task)
+
+```rust
+pub(crate) async fn run_audit_flusher(
+    mut rx: tokio::sync::mpsc::Receiver<SyncAuditEntry>,
+    pool: sqlx::Pool<sqlx::MySql>,
+) {
+    let mut buf = Vec::with_capacity(64);
+    loop {
+        // Drain up to 64 entries or wait 1s timeout
+        let deadline = tokio::time::sleep(Duration::from_secs(1));
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                entry = rx.recv() => {
+                    match entry {
+                        Some(e) => {
+                            buf.push(e);
+                            if buf.len() >= 64 { break; }
+                        }
+                        None => {
+                            // Channel closed, flush remaining and exit
+                            flush_batch(&pool, &mut buf).await;
+                            return;
+                        }
+                    }
+                }
+                _ = &mut deadline => { break; }
+            }
+        }
+        flush_batch(&pool, &mut buf).await;
+    }
+}
+
+async fn flush_batch(pool: &sqlx::Pool<sqlx::MySql>, buf: &mut Vec<SyncAuditEntry>) {
+    if buf.is_empty() { return; }
+    // Single multi-row INSERT for the batch
+    // INSERT INTO session_sync_log (...) VALUES (?, ...), (?, ...), ...
+    // On error: log warning, discard batch (audit is best-effort)
+    buf.clear();
+}
+```
+
+### 4. Integration into `MatrixOneSyncService`
+
+```rust
+pub struct MatrixOneSyncService {
+    pool: sqlx::Pool<sqlx::MySql>,
+    audit: SyncAuditWriter,
+}
+
+impl MatrixOneSyncService {
+    pub fn new(pool: sqlx::Pool<sqlx::MySql>) -> (Self, tokio::task::JoinHandle<()>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(256);
+        let handle = tokio::spawn(run_audit_flusher(rx, pool.clone()));
+        (Self { pool, audit: SyncAuditWriter { tx } }, handle)
+    }
+
+    // log_sync becomes:
+    fn log_sync(&self, ...) {
+        self.audit.log(SyncAuditEntry { ... });
+    }
+}
+```
+
+### 5. Integration into `session_restore.rs`
+
+`log_session_sync` becomes a method on a shared `SyncAuditWriter` passed into the push functions, instead of a standalone async fn that takes a pool.
+
+```rust
+// Before: await log_session_sync(pool, ...).await
+// After:  audit.log(SyncAuditEntry { ... })
+```
+
+No await. No error handling needed at call site. No Result return.
+
+### 6. Remove all prune code
+
+Delete entirely:
+- `build_sync_log_prune_query()`
+- `sync_log_retain_limit()`
+- `should_prune_sync_log()`
+- `SYNC_LOG_PRUNE_INVERSE_PROBABILITY`
+- `SYNC_LOG_SUCCESS_RETAIN` / `SYNC_LOG_ERROR_RETAIN`
+- `prune_sync_logs()` method
+
+Retention is handled solely by `storage::run_cleanup()` which already does:
+```sql
+DELETE FROM session_sync_log WHERE created_at < DATE_SUB(NOW(6), INTERVAL ? DAY) LIMIT ?
+```
+This is the correct mechanism — time-based, batched, runs on a schedule (not per-write).
+
+### 7. Graceful shutdown
+
+The API server's shutdown sequence must:
+1. Drop all `SyncAuditWriter` clones (closes channel sender)
+2. Await the flusher `JoinHandle` (drains remaining buffer)
+
+This ensures no audit entries are lost on clean shutdown.
+
+## Changes Summary
+
+| File | Change |
+|------|--------|
+| `state_sync.rs` | Add `SyncAuditEntry`, `SyncAuditWriter`, `run_audit_flusher`. Remove `build_sync_log_prune_query`, `sync_log_retain_limit`, `prune_sync_logs`, retain constants. Change `MatrixOneSyncService::new` signature. |
+| `session_restore.rs` | Replace `log_session_sync` / `log_checkpoint_sync` async fns with `audit.log(...)` calls. Remove prune logic. |
+| `storage.rs` | No change — `run_cleanup` already handles time-based retention. |
+| `Cargo.toml` | Remove `fastrand` (no longer needed). |
+| Tests | Update `session_sync_log_prune_partitions_by_sync_type_on_live_matrixone` — rewrite as a test of `run_audit_flusher` batch behavior. Remove prune-specific unit tests. |
+
+## Performance Impact
+
+| Metric | Before (current main) | After |
+|--------|----------------------|-------|
+| push_session_state latency | business INSERT + audit INSERT + prune DELETE | business INSERT only |
+| Concurrent test contention | 22× DELETE on same partition | zero — audit is buffered |
+| Audit write I/O | 1 INSERT per push (sync) | 1 batch INSERT per 64 pushes or 1s |
+| Worst-case audit loss | none (sync) | up to 256 entries on crash (acceptable) |
+
+## Testing Strategy
+
+1. Unit test: `SyncAuditWriter::log` is non-blocking even when channel full
+2. Unit test: `run_audit_flusher` flushes on batch-size threshold
+3. Unit test: `run_audit_flusher` flushes on timeout (1s)
+4. Unit test: graceful shutdown drains buffer
+5. Integration test: after N push operations + flush, DB has N audit rows
+6. Existing `run_cleanup` test covers time-based retention (unchanged)

--- a/plans/session-sync-log-async-audit-redesign-2026-05-01.md
+++ b/plans/session-sync-log-async-audit-redesign-2026-05-01.md
@@ -151,17 +151,26 @@ Delete entirely:
 - `SYNC_LOG_SUCCESS_RETAIN` / `SYNC_LOG_ERROR_RETAIN`
 - `prune_sync_logs()` method
 
-Retention is handled solely by `storage::run_cleanup()` which already does:
+Retention is handled solely by `storage::cleanup_expired_data()` which does:
 ```sql
 DELETE FROM session_sync_log WHERE created_at < DATE_SUB(NOW(6), INTERVAL ? DAY) LIMIT ?
 ```
-This is the correct mechanism — time-based, batched, runs on a schedule (not per-write).
+This runs on a periodic schedule (default policy: `sync_log_days = 30`), batched
+with `LIMIT 1000` to avoid long-running locks. Not a DB-level TTL — it is an
+application-level cleanup task invoked by the runtime's maintenance loop.
 
 ### 7. Graceful shutdown
 
-The API server's shutdown sequence must:
-1. Drop all `SyncAuditWriter` clones (closes channel sender)
-2. Await the flusher `JoinHandle` (drains remaining buffer)
+Runtime (`MatrixCloudRuntime`):
+1. Drain `session_sync_tasks` (drops CLI-spawned audit writer clones)
+2. Cancel `CancellationToken` (level-triggered — the flusher sees it immediately)
+3. Await the flusher `JoinHandle` (drains remaining buffer via `try_recv`)
+
+CLI ephemeral paths (`cloud_sync.rs`):
+1. Drop `MatrixOneSyncService` (drops its writer clone)
+2. Drop the `AuditFlusherHandle.writer` (drops the spawn-time clone)
+3. Cancel the `CancellationToken`
+4. Await the `JoinHandle` with 5s timeout
 
 This ensures no audit entries are lost on clean shutdown.
 

--- a/rust/crates/astra-cli/src/cli/cloud_sync.rs
+++ b/rust/crates/astra-cli/src/cli/cloud_sync.rs
@@ -109,11 +109,13 @@ pub(super) async fn try_cloud_pull(
         operation = "pull_learning",
         "starting MatrixOne learning pull"
     );
-    let svc = MatrixOneSyncService::new(pool);
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool, flusher.writer.clone());
     let user_id = std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
-    match StateSyncService::pull_learning_versioned(&svc, &user_id, profile_name).await {
+    let out = StateSyncService::pull_learning_versioned(&svc, &user_id, profile_name).await;
+    drain_ephemeral_audit(svc, flusher).await;
+    match out {
         Ok(Some(versioned)) => {
-            // Parse snapshot to extract tool health before merging entities/patterns
             let cloud_health = serde_json::from_str::<LearningSnapshot>(&versioned.json)
                 .map(|s| s.tool_health)
                 .unwrap_or_default();
@@ -144,6 +146,18 @@ pub(super) async fn try_cloud_pull(
     }
 }
 
+/// Shut down an ephemeral audit flusher: drop all senders, cancel the token,
+/// and await the flusher task so the final batch is flushed to DB.
+async fn drain_ephemeral_audit(
+    svc: MatrixOneSyncService,
+    flusher: astra_services::state_sync::AuditFlusherHandle,
+) {
+    drop(svc);
+    drop(flusher.writer);
+    flusher.shutdown.cancel();
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), flusher.join_handle).await;
+}
+
 /// Push learning state to cloud with optimistic locking.
 /// Returns the new cloud version if successful, or None on conflict/failure.
 /// On conflict, the caller should pull fresh data and retry.
@@ -165,7 +179,8 @@ pub(super) async fn try_cloud_push_versioned(
         Ok(j) => j,
         Err(_) => return None,
     };
-    let svc = MatrixOneSyncService::new(pool);
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool, flusher.writer.clone());
     let user_id = std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
     let result = StateSyncService::push_learning_versioned(
         &svc,
@@ -178,6 +193,7 @@ pub(super) async fn try_cloud_push_versioned(
         expected_version,
     )
     .await;
+    drain_ephemeral_audit(svc, flusher).await;
 
     if result.is_conflict {
         eprintln!(
@@ -252,12 +268,14 @@ pub(super) async fn try_cloud_push_delta(
         None => return None,
     };
 
-    let svc = MatrixOneSyncService::new(pool);
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool, flusher.writer.clone());
     let user_id = std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
 
     let result =
         StateSyncService::push_delta(&svc, &user_id, profile_name, &delta_json, expected_version)
             .await;
+    drain_ephemeral_audit(svc, flusher).await;
 
     if result.is_conflict {
         eprintln!(
@@ -311,9 +329,12 @@ pub(super) async fn try_cloud_pull_preferences(state: &mut ReplState) -> Vec<Str
         Some(p) => p,
         None => return Vec::new(),
     };
-    let svc = MatrixOneSyncService::new(pool);
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool, flusher.writer.clone());
     let user_id = std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
-    match StateSyncService::pull_all_preferences(&svc, &user_id).await {
+    let out = StateSyncService::pull_all_preferences(&svc, &user_id).await;
+    drain_ephemeral_audit(svc, flusher).await;
+    match out {
         Ok(prefs) if !prefs.is_empty() => {
             let keys: Vec<String> = prefs.iter().map(|(k, _)| k.clone()).collect();
             for (key, value) in &prefs {
@@ -326,7 +347,6 @@ pub(super) async fn try_cloud_pull_preferences(state: &mut ReplState) -> Vec<Str
                         };
                     }
                     pref_keys::BLOCKED_TOOLS => {
-                        // Merge cloud-persisted blocked tools into tool_health_entries
                         if let Ok(tools) = serde_json::from_str::<Vec<String>>(value) {
                             let existing: std::collections::HashSet<String> = state
                                 .tool_health_entries
@@ -356,7 +376,7 @@ pub(super) async fn try_cloud_pull_preferences(state: &mut ReplState) -> Vec<Str
             );
             keys
         }
-        Ok(_) => Vec::new(), // no cloud prefs yet
+        Ok(_) => Vec::new(),
         Err(e) => {
             eprintln!("{}", format!("  ⚠ Preference pull skipped: {e}").dim());
             Vec::new()
@@ -370,10 +390,10 @@ pub(super) async fn try_cloud_push_preferences(state: &ReplState) {
         Some(p) => p,
         None => return,
     };
-    let svc = MatrixOneSyncService::new(pool);
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool, flusher.writer.clone());
     let user_id = std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
 
-    // Collect blocked/deprioritized tools from health entries
     let blocked: Vec<String> = state
         .tool_health_entries
         .iter()
@@ -389,7 +409,7 @@ pub(super) async fn try_cloud_push_preferences(state: &ReplState) {
     for (key, value) in &prefs {
         let _ = svc.push_preference(&user_id, key, value).await;
     }
-    // Silently succeed — only warn on failure
+    drain_ephemeral_audit(svc, flusher).await;
 }
 
 // ═══════════════════════════════════════════ Journal Helpers ═══════════════════════

--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -1118,6 +1118,7 @@ fn commit_turn_journal_workspace_and_sidecars(
                 if let Some(ref mc) = state.matrix_runtime {
                     let user_id = state.ingestion_user_id.as_deref().unwrap_or("anonymous");
                     let pool = mc.shared_pool().get().clone();
+                    let audit = mc.audit_writer().clone();
                     let sid_owned = sid.to_string();
                     let user_id_owned = user_id.to_string();
                     let cp_clone = cp.clone();
@@ -1128,6 +1129,7 @@ fn commit_turn_journal_workspace_and_sidecars(
                             &sid_owned,
                             &user_id_owned,
                             &cp_clone,
+                            &audit,
                         )
                         .await
                         {
@@ -1156,6 +1158,7 @@ fn commit_turn_journal_workspace_and_sidecars(
             {
                 let user_id = state.ingestion_user_id.as_deref().unwrap_or("anonymous");
                 let pool = mc.shared_pool().get().clone();
+                let audit = mc.audit_writer().clone();
                 let sid_owned = sid.to_string();
                 let user_id_owned = user_id.to_string();
                 let cp_number = result
@@ -1163,7 +1166,6 @@ fn commit_turn_journal_workspace_and_sidecars(
                     .as_ref()
                     .map(|s| s.checkpoints)
                     .unwrap_or(0);
-                // Extract metadata from the checkpoint for column storage
                 let (tier, turn, title, tools_json): (String, u32, String, String) = match step_cp {
                     astra_pipeline::step_protocol::StepCheckpoint::Light(l) => (
                         "light".to_string(),
@@ -1193,6 +1195,7 @@ fn commit_turn_journal_workspace_and_sidecars(
                         &title,
                         &tools_json,
                         &state_json,
+                        &audit,
                     )
                     .await
                     {
@@ -1209,6 +1212,7 @@ fn commit_turn_journal_workspace_and_sidecars(
             {
                 let user_id = state.ingestion_user_id.as_deref().unwrap_or("anonymous");
                 let pool = mc.shared_pool().get().clone();
+                let audit = mc.audit_writer().clone();
                 let sid_owned = sid.to_string();
                 let user_id_owned = user_id.to_string();
                 let trace_signal = trace_signal.clone();
@@ -1219,6 +1223,7 @@ fn commit_turn_journal_workspace_and_sidecars(
                             &sid_owned,
                             &user_id_owned,
                             &trace_signal,
+                            &audit,
                         )
                         .await
                     {
@@ -1238,6 +1243,7 @@ fn commit_turn_journal_workspace_and_sidecars(
                 )
             {
                 let pool = mc.shared_pool().get().clone();
+                let audit = mc.audit_writer().clone();
                 let sid_owned = sid.to_string();
                 let user_id = state
                     .ingestion_user_id
@@ -1265,6 +1271,7 @@ fn commit_turn_journal_workspace_and_sidecars(
                         rounds,
                         git_branch.as_deref(),
                         model.as_deref(),
+                        &audit,
                     )
                     .await
                     {
@@ -2858,11 +2865,13 @@ fn spawn_manual_checkpoint_cloud_uploads(
         .to_string();
     let user_id_step = user_id.clone();
     let pool = mc.shared_pool().get().clone();
+    let audit = mc.audit_writer().clone();
+    let audit2 = audit.clone();
     let sid_owned = sid.to_string();
     let cp_clone = session_cp.clone();
     mc.spawn_session_sync_task(async move {
         if let Err(e) = astra_services::session_restore::push_checkpoint_to_cloud(
-            &pool, &sid_owned, &user_id, &cp_clone,
+            &pool, &sid_owned, &user_id, &cp_clone, &audit,
         )
         .await
         {
@@ -2887,6 +2896,7 @@ fn spawn_manual_checkpoint_cloud_uploads(
             &title_owned,
             &tools_json,
             &state_json,
+            &audit2,
         )
         .await
         {

--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -1117,19 +1117,16 @@ fn commit_turn_journal_workspace_and_sidecars(
                 // Push checkpoint to MatrixOne for cross-device availability
                 if let Some(ref mc) = state.matrix_runtime {
                     let user_id = state.ingestion_user_id.as_deref().unwrap_or("anonymous");
-                    let pool = mc.shared_pool().get().clone();
-                    let audit = mc.audit_writer().clone();
+                    let svc = std::sync::Arc::clone(mc.sync_service());
                     let sid_owned = sid.to_string();
                     let user_id_owned = user_id.to_string();
                     let cp_clone = cp.clone();
                     let cp_number = cp.number;
                     mc.spawn_session_sync_task(async move {
-                        if let Err(e) = astra_services::session_restore::push_checkpoint_to_cloud(
-                            &pool,
+                        if let Err(e) = svc.push_checkpoint(
                             &sid_owned,
                             &user_id_owned,
                             &cp_clone,
-                            &audit,
                         )
                         .await
                         {
@@ -1157,8 +1154,7 @@ fn commit_turn_journal_workspace_and_sidecars(
                 && let Ok(state_json) = serde_json::to_string(step_cp)
             {
                 let user_id = state.ingestion_user_id.as_deref().unwrap_or("anonymous");
-                let pool = mc.shared_pool().get().clone();
-                let audit = mc.audit_writer().clone();
+                let svc = std::sync::Arc::clone(mc.sync_service());
                 let sid_owned = sid.to_string();
                 let user_id_owned = user_id.to_string();
                 let cp_number = result
@@ -1185,8 +1181,7 @@ fn commit_turn_journal_workspace_and_sidecars(
                     }
                 };
                 mc.spawn_session_sync_task(async move {
-                    if let Err(e) = astra_services::session_restore::push_step_checkpoint_to_cloud(
-                        &pool,
+                    if let Err(e) = svc.push_step_checkpoint(
                         &sid_owned,
                         &user_id_owned,
                         cp_number,
@@ -1195,7 +1190,6 @@ fn commit_turn_journal_workspace_and_sidecars(
                         &title,
                         &tools_json,
                         &state_json,
-                        &audit,
                     )
                     .await
                     {
@@ -1211,21 +1205,17 @@ fn commit_turn_journal_workspace_and_sidecars(
                 && let Some(ref trace_signal) = ws.last_context_trace
             {
                 let user_id = state.ingestion_user_id.as_deref().unwrap_or("anonymous");
-                let pool = mc.shared_pool().get().clone();
-                let audit = mc.audit_writer().clone();
+                let svc = std::sync::Arc::clone(mc.sync_service());
                 let sid_owned = sid.to_string();
                 let user_id_owned = user_id.to_string();
                 let trace_signal = trace_signal.clone();
                 mc.spawn_session_sync_task(async move {
-                    if let Err(e) =
-                        astra_services::session_restore::push_context_trace_signal_to_cloud(
-                            &pool,
-                            &sid_owned,
-                            &user_id_owned,
-                            &trace_signal,
-                            &audit,
-                        )
-                        .await
+                    if let Err(e) = svc.push_context_trace_signal(
+                        &sid_owned,
+                        &user_id_owned,
+                        &trace_signal,
+                    )
+                    .await
                     {
                         astra_core::agent_warn!(
                             "context_trace_sync",
@@ -1242,8 +1232,7 @@ fn commit_turn_journal_workspace_and_sidecars(
                     astra_services::session_checkpoint::CHECKPOINT_INTERVAL,
                 )
             {
-                let pool = mc.shared_pool().get().clone();
-                let audit = mc.audit_writer().clone();
+                let svc = std::sync::Arc::clone(mc.sync_service());
                 let sid_owned = sid.to_string();
                 let user_id = state
                     .ingestion_user_id
@@ -1261,19 +1250,18 @@ fn commit_turn_journal_workspace_and_sidecars(
                     Some(ws.model.clone())
                 };
                 mc.spawn_session_sync_task(async move {
-                    if let Err(e) = astra_services::session_restore::push_session_state_to_cloud(
-                        &pool,
-                        &sid_owned,
-                        &user_id,
-                        plan_json.as_deref(),
-                        goal.as_deref(),
-                        config.as_deref(),
-                        rounds,
-                        git_branch.as_deref(),
-                        model.as_deref(),
-                        &audit,
-                    )
-                    .await
+                    if let Err(e) = svc
+                        .push_session_state(
+                            &sid_owned,
+                            &user_id,
+                            plan_json.as_deref(),
+                            goal.as_deref(),
+                            config.as_deref(),
+                            rounds,
+                            git_branch.as_deref(),
+                            model.as_deref(),
+                        )
+                        .await
                     {
                         astra_core::agent_warn!(
                             "session_state_sync",
@@ -2864,41 +2852,34 @@ fn spawn_manual_checkpoint_cloud_uploads(
         .unwrap_or("anonymous")
         .to_string();
     let user_id_step = user_id.clone();
-    let pool = mc.shared_pool().get().clone();
-    let audit = mc.audit_writer().clone();
-    let audit2 = audit.clone();
+    let svc = std::sync::Arc::clone(mc.sync_service());
+    let svc2 = std::sync::Arc::clone(&svc);
     let sid_owned = sid.to_string();
     let cp_clone = session_cp.clone();
     mc.spawn_session_sync_task(async move {
-        if let Err(e) = astra_services::session_restore::push_checkpoint_to_cloud(
-            &pool, &sid_owned, &user_id, &cp_clone, &audit,
-        )
-        .await
-        {
+        if let Err(e) = svc.push_checkpoint(&sid_owned, &user_id, &cp_clone).await {
             astra_core::agent_warn!("checkpoint", "cloud push session checkpoint: {e}");
         }
     });
 
-    let pool2 = mc.shared_pool().get().clone();
     let sid_step = sid.to_string();
     let title_owned = title.to_string();
     let state_json = serde_json::to_string(step_cp).unwrap_or_default();
     let tools_json =
         serde_json::to_string(&state.recent_tools).unwrap_or_else(|_| "[]".to_string());
     mc.spawn_session_sync_task(async move {
-        if let Err(e) = astra_services::session_restore::push_step_checkpoint_to_cloud(
-            &pool2,
-            &sid_step,
-            &user_id_step,
-            next_step,
-            turn,
-            "heavy",
-            &title_owned,
-            &tools_json,
-            &state_json,
-            &audit2,
-        )
-        .await
+        if let Err(e) = svc2
+            .push_step_checkpoint(
+                &sid_step,
+                &user_id_step,
+                next_step,
+                turn,
+                "heavy",
+                &title_owned,
+                &tools_json,
+                &state_json,
+            )
+            .await
         {
             astra_core::agent_warn!("checkpoint", "cloud push step checkpoint: {e}");
         }

--- a/rust/crates/astra-cli/src/cli/slash_health.rs
+++ b/rust/crates/astra-cli/src/cli/slash_health.rs
@@ -151,11 +151,9 @@ pub(super) async fn handle_health_command(arg: &str, state: &ReplState) {
             eprintln!("  {}", "Set MATRIXONE_HOST to enable cloud sync.".dim());
         }
         Some(mc) => {
-            let svc = astra_services::state_sync::MatrixOneSyncService::new(
-                mc.shared_pool().get().clone(),
-                mc.audit_writer().clone(),
-            );
-            let sync_status = astra_services::state_sync::StateSyncService::status(&svc).await;
+            let sync_status =
+                astra_services::state_sync::StateSyncService::status(mc.sync_service().as_ref())
+                    .await;
             display_sync_status(&sync_status);
         }
     }

--- a/rust/crates/astra-cli/src/cli/slash_health.rs
+++ b/rust/crates/astra-cli/src/cli/slash_health.rs
@@ -153,6 +153,7 @@ pub(super) async fn handle_health_command(arg: &str, state: &ReplState) {
         Some(mc) => {
             let svc = astra_services::state_sync::MatrixOneSyncService::new(
                 mc.shared_pool().get().clone(),
+                mc.audit_writer().clone(),
             );
             let sync_status = astra_services::state_sync::StateSyncService::status(&svc).await;
             display_sync_status(&sync_status);

--- a/rust/crates/runtime/src/matrix_cloud_runtime.rs
+++ b/rust/crates/runtime/src/matrix_cloud_runtime.rs
@@ -15,7 +15,7 @@ use astra_services::{
     CloudTransport, SyncOrchestrator, SyncPolicy, TaskLeaseHoldCache, TaskRecord,
     event_ingestion::{self, IngestionConfig, IngestionEvent},
     session_journal::JournalEvent,
-    state_sync::{MatrixOneSyncService, PlanTemplateSyncRow},
+    state_sync::{MatrixOneSyncService, PlanTemplateSyncRow, StateSyncService},
 };
 
 use crate::sync_adapters::{
@@ -86,7 +86,7 @@ pub struct MatrixCloudRuntime {
     /// Phase 3: dirty task IDs pending sync, shared with [`TaskAdapter`].
     pub task_dirty: Arc<Mutex<HashSet<String>>>,
     edge_agent_id: Arc<str>,
-    audit_writer: astra_services::state_sync::SyncAuditWriter,
+    sync_service: Arc<MatrixOneSyncService>,
     audit_flusher_shutdown: tokio_util::sync::CancellationToken,
     audit_flusher_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
@@ -120,7 +120,7 @@ impl MatrixCloudRuntime {
             audit_flusher.writer.clone(),
         ));
         let transport: Arc<dyn CloudTransport> = Arc::new(MatrixOneTransport::new(
-            sync_svc,
+            sync_svc.clone() as Arc<dyn StateSyncService>,
             profile.to_string(),
             edge_agent_id.as_ref(),
         ));
@@ -172,7 +172,7 @@ impl MatrixCloudRuntime {
             task_mirror,
             task_dirty,
             edge_agent_id,
-            audit_writer: audit_flusher.writer,
+            sync_service: sync_svc,
             audit_flusher_shutdown: audit_flusher.shutdown,
             audit_flusher_handle: Mutex::new(Some(audit_flusher.join_handle)),
         }
@@ -193,8 +193,14 @@ impl MatrixCloudRuntime {
         &self.shared_pool
     }
 
-    pub fn audit_writer(&self) -> &astra_services::state_sync::SyncAuditWriter {
-        &self.audit_writer
+    /// Shared sync service for push operations (checkpoints, session state, context traces).
+    ///
+    /// Callers that spawn background tasks holding an `Arc` clone **must** use
+    /// [`spawn_session_sync_task`] so the runtime can drain them before shutting
+    /// down the audit flusher. Tasks spawned outside that mechanism may lose
+    /// audit entries on shutdown.
+    pub fn sync_service(&self) -> &Arc<MatrixOneSyncService> {
+        &self.sync_service
     }
 
     /// Snapshot of ingestion stats (events received/flushed/errors + overflow).

--- a/rust/crates/runtime/src/matrix_cloud_runtime.rs
+++ b/rust/crates/runtime/src/matrix_cloud_runtime.rs
@@ -86,6 +86,9 @@ pub struct MatrixCloudRuntime {
     /// Phase 3: dirty task IDs pending sync, shared with [`TaskAdapter`].
     pub task_dirty: Arc<Mutex<HashSet<String>>>,
     edge_agent_id: Arc<str>,
+    audit_writer: astra_services::state_sync::SyncAuditWriter,
+    audit_flusher_shutdown: tokio_util::sync::CancellationToken,
+    audit_flusher_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl MatrixCloudRuntime {
@@ -111,7 +114,11 @@ impl MatrixCloudRuntime {
         let pool = shared_pool.get().clone();
         let (sender, ingestion_shutdown, ingestion_stats, ingestion_jh) =
             event_ingestion::EventIngestionWorker::spawn(pool.clone(), IngestionConfig::default());
-        let sync_svc = Arc::new(MatrixOneSyncService::new(pool));
+        let audit_flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+        let sync_svc = Arc::new(MatrixOneSyncService::new(
+            pool,
+            audit_flusher.writer.clone(),
+        ));
         let transport: Arc<dyn CloudTransport> = Arc::new(MatrixOneTransport::new(
             sync_svc,
             profile.to_string(),
@@ -165,6 +172,9 @@ impl MatrixCloudRuntime {
             task_mirror,
             task_dirty,
             edge_agent_id,
+            audit_writer: audit_flusher.writer,
+            audit_flusher_shutdown: audit_flusher.shutdown,
+            audit_flusher_handle: Mutex::new(Some(audit_flusher.join_handle)),
         }
     }
 
@@ -181,6 +191,10 @@ impl MatrixCloudRuntime {
     }
     pub fn shared_pool(&self) -> &SharedPool {
         &self.shared_pool
+    }
+
+    pub fn audit_writer(&self) -> &astra_services::state_sync::SyncAuditWriter {
+        &self.audit_writer
     }
 
     /// Snapshot of ingestion stats (events received/flushed/errors + overflow).
@@ -265,6 +279,8 @@ impl MatrixCloudRuntime {
             }
         }
 
+        // Drain session sync tasks FIRST — they hold audit writer clones that
+        // must be dropped before we can close the audit channel.
         let mut session_sync_tasks = self
             .session_sync_tasks
             .lock()
@@ -289,6 +305,31 @@ impl MatrixCloudRuntime {
                     astra_core::agent_warn!(
                         "session_sync",
                         "session sync drain timed out after {INGESTION_SHUTDOWN_TIMEOUT:?}, some sync sidecars may be lost"
+                    );
+                }
+            }
+        }
+
+        // Signal the audit flusher to drain and exit. CancellationToken is
+        // level-triggered — stays cancelled once cancelled, so the flusher sees
+        // it regardless of poll timing. Works even though SyncAuditWriter clones
+        // inside Arc<MatrixOneSyncService> keep the channel open.
+        self.audit_flusher_shutdown.cancel();
+        let audit_handle = self
+            .audit_flusher_handle
+            .lock()
+            .ok()
+            .and_then(|mut g| g.take());
+        if let Some(jh) = audit_handle {
+            match tokio::time::timeout(INGESTION_SHUTDOWN_TIMEOUT, jh).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    astra_core::agent_warn!("audit_flusher", "audit flusher join failed: {e}");
+                }
+                Err(_) => {
+                    astra_core::agent_warn!(
+                        "audit_flusher",
+                        "audit flusher drain timed out after {INGESTION_SHUTDOWN_TIMEOUT:?}"
                     );
                 }
             }

--- a/rust/crates/services/src/session_restore.rs
+++ b/rust/crates/services/src/session_restore.rs
@@ -1358,12 +1358,12 @@ pub async fn push_checkpoint_to_cloud(
     session_id: &str,
     user_id: &str,
     checkpoint: &super::session_checkpoint::Checkpoint,
+    audit: &crate::state_sync::SyncAuditWriter,
 ) -> Result<(), String> {
     let checkpoint_id = uuid::Uuid::new_v4().to_string();
     let tools_json =
         serde_json::to_string(&checkpoint.tools_used).unwrap_or_else(|_| "[]".to_string());
 
-    // Calculate payload_size for sync log (estimate based on serialized fields)
     let payload_size = checkpoint.title.len()
         + checkpoint.summary.len()
         + tools_json.len()
@@ -1372,14 +1372,13 @@ pub async fn push_checkpoint_to_cloud(
             .as_ref()
             .map_or(0, |s| s.len());
 
-    // Helper: log sync result (success or failure) and propagate result
-    let log_and_return = |result: Result<(), String>, size: usize| async move {
-        let (status, error_msg) = match &result {
+    let log_result = |result: &Result<(), String>, size: usize| {
+        let (status, error_msg) = match result {
             Ok(()) => ("success", None),
             Err(e) => ("error", Some(e.as_str())),
         };
-        let _ = log_checkpoint_sync(
-            pool,
+        log_checkpoint_sync(
+            audit,
             user_id,
             session_id,
             "checkpoint",
@@ -1387,9 +1386,7 @@ pub async fn push_checkpoint_to_cloud(
             size,
             status,
             error_msg,
-        )
-        .await;
-        result
+        );
     };
 
     let updated = match sqlx::query(
@@ -1413,8 +1410,9 @@ pub async fn push_checkpoint_to_cloud(
     {
         Ok(u) => u,
         Err(e) => {
-            let err = format!("push_checkpoint update: {e}");
-            return log_and_return(Err(err), payload_size).await;
+            let err = Err(format!("push_checkpoint update: {e}"));
+            log_result(&err, payload_size);
+            return err;
         }
     };
 
@@ -1461,79 +1459,45 @@ pub async fn push_checkpoint_to_cloud(
                 .execute(pool)
                 .await
                 {
-                    let err = format!("push_checkpoint retry update: {e}");
-                    return log_and_return(Err(err), payload_size).await;
+                    let err = Err(format!("push_checkpoint retry update: {e}"));
+                    log_result(&err, payload_size);
+                    return err;
                 }
             } else {
-                let err = format!("push_checkpoint insert: {e}");
-                return log_and_return(Err(err), payload_size).await;
+                let err = Err(format!("push_checkpoint insert: {e}"));
+                log_result(&err, payload_size);
+                return err;
             }
         }
     }
 
-    log_and_return(Ok(()), payload_size).await
+    log_result(&Ok(()), payload_size);
+    Ok(())
 }
 
-/// Log session sync activity to session_sync_log for audit trail.
-/// This helps diagnose sync issues like Session 7875e355 where cloud work reached
-/// MatrixOne through some paths but left no sync-log breadcrumb.
-async fn log_session_sync(
-    pool: &sqlx::Pool<sqlx::MySql>,
+fn log_session_sync(
+    audit: &crate::state_sync::SyncAuditWriter,
     user_id: &str,
     session_id: &str,
     sync_type: &str,
     payload_size: usize,
     status: &str,
     error_msg: Option<&str>,
-) -> Result<(), String> {
-    let inserted = sqlx::query(
-        "INSERT INTO session_sync_log \
-         (sync_id, user_id, session_id, sync_type, sync_direction, payload_size, status, error_message, created_at) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW())",
-    )
-    .bind(uuid::Uuid::new_v4().to_string())
-    .bind(user_id)
-    .bind(session_id)
-    .bind(sync_type)
-    .bind("push")
-    .bind(payload_size as i64)
-    .bind(status)
-    .bind(error_msg)
-    .execute(pool)
-    .await
-    .map_err(|e| format!("log_session_sync: {e}"))?;
-
-    // Apply retention pruning using the same policy as state_sync.
-    // This prevents unbounded sync_log growth for long-running sessions.
-    if inserted.rows_affected() > 0
-        && let Some(retain) = crate::state_sync::sync_log_retain_limit(status)
-        && let Err(e) = sqlx::query(crate::state_sync::build_sync_log_prune_query())
-            .bind(user_id)
-            .bind(status)
-            .bind(sync_type)
-            .bind(user_id)
-            .bind(status)
-            .bind(sync_type)
-            .bind(retain as i64)
-            .execute(pool)
-            .await
-    {
-        tracing::warn!(
-            target: "astra_services::session_restore",
-            user_id = %user_id,
-            sync_type = %sync_type,
-            error = %e,
-            "failed to prune sync logs"
-        );
-    }
-
-    Ok(())
+) {
+    audit.log(crate::state_sync::SyncAuditEntry {
+        user_id: user_id.to_string(),
+        session_id: session_id.to_string(),
+        sync_type: sync_type.to_string(),
+        direction: crate::state_sync::SyncDirection::Push,
+        payload_size,
+        status: status.to_string(),
+        error_message: error_msg.map(|s| s.to_string()),
+    });
 }
 
-/// Log checkpoint sync with checkpoint-number context preserved in the error field.
 #[allow(clippy::too_many_arguments)]
-async fn log_checkpoint_sync(
-    pool: &sqlx::Pool<sqlx::MySql>,
+fn log_checkpoint_sync(
+    audit: &crate::state_sync::SyncAuditWriter,
     user_id: &str,
     session_id: &str,
     sync_type: &str,
@@ -1541,18 +1505,17 @@ async fn log_checkpoint_sync(
     payload_size: usize,
     status: &str,
     error_msg: Option<&str>,
-) -> Result<(), String> {
+) {
     let error_with_number = error_msg.map(|e| format!("[checkpoint #{}] {}", checkpoint_number, e));
     log_session_sync(
-        pool,
+        audit,
         user_id,
         session_id,
         sync_type,
         payload_size,
         status,
         error_with_number.as_deref().or(error_msg),
-    )
-    .await
+    );
 }
 
 /// Push a Step Protocol checkpoint to MatrixOne with full state_json.
@@ -1569,17 +1532,19 @@ pub async fn push_step_checkpoint_to_cloud(
     title: &str,
     tools_json: &str,
     state_json: &str,
+    audit: &crate::state_sync::SyncAuditWriter,
 ) -> Result<(), String> {
     let checkpoint_id = uuid::Uuid::new_v4().to_string();
     let cloud_number = cloud_step_checkpoint_number(checkpoint_number)?;
     let payload_size = title.len() + tier.len() + tools_json.len() + state_json.len();
-    let log_and_return = |result: Result<(), String>, size: usize| async move {
-        let (status, error_msg) = match &result {
+
+    let log_result = |result: &Result<(), String>, size: usize| {
+        let (status, error_msg) = match result {
             Ok(()) => ("success", None),
             Err(e) => ("error", Some(e.as_str())),
         };
-        let _ = log_checkpoint_sync(
-            pool,
+        log_checkpoint_sync(
+            audit,
             user_id,
             session_id,
             "step_checkpoint",
@@ -1587,9 +1552,7 @@ pub async fn push_step_checkpoint_to_cloud(
             size,
             status,
             error_msg,
-        )
-        .await;
-        result
+        );
     };
 
     let updated = match sqlx::query(
@@ -1609,8 +1572,9 @@ pub async fn push_step_checkpoint_to_cloud(
     {
         Ok(updated) => updated,
         Err(e) => {
-            let err = format!("push_step_checkpoint update: {e}");
-            return log_and_return(Err(err), payload_size).await;
+            let err = Err(format!("push_step_checkpoint update: {e}"));
+            log_result(&err, payload_size);
+            return err;
         }
     };
 
@@ -1650,17 +1614,20 @@ pub async fn push_step_checkpoint_to_cloud(
                 .execute(pool)
                 .await
                 {
-                    let err = format!("push_step_checkpoint retry update: {err}");
-                    return log_and_return(Err(err), payload_size).await;
+                    let err = Err(format!("push_step_checkpoint retry update: {err}"));
+                    log_result(&err, payload_size);
+                    return err;
                 }
             } else {
-                let err = format!("push_step_checkpoint insert: {e}");
-                return log_and_return(Err(err), payload_size).await;
+                let err = Err(format!("push_step_checkpoint insert: {e}"));
+                log_result(&err, payload_size);
+                return err;
             }
         }
     }
 
-    log_and_return(Ok(()), payload_size).await
+    log_result(&Ok(()), payload_size);
+    Ok(())
 }
 
 /// Pull the latest Heavy step checkpoint JSON from MatrixOne for session recovery.
@@ -1707,6 +1674,7 @@ pub async fn push_session_state_to_cloud(
     plan_execution_rounds: usize,
     git_branch: Option<&str>,
     model: Option<&str>,
+    audit: &crate::state_sync::SyncAuditWriter,
 ) -> Result<(), String> {
     use sqlx::Row;
 
@@ -1734,25 +1702,8 @@ pub async fn push_session_state_to_cloud(
         model,
     );
     let payload_size = metadata_json.len();
-    let log_and_return = |result: Result<(), String>, size: usize| async move {
-        let (status, error_msg) = match &result {
-            Ok(()) => ("success", None),
-            Err(e) => ("error", Some(e.as_str())),
-        };
-        let _ = log_session_sync(
-            pool,
-            user_id,
-            session_id,
-            "session_state",
-            size,
-            status,
-            error_msg,
-        )
-        .await;
-        result
-    };
 
-    match sqlx::query(
+    let result = match sqlx::query(
         "INSERT INTO agent_sessions \
          (session_id, user_id, status, metadata, created_at, updated_at, last_active_at) \
          VALUES (?, ?, 'active', ?, NOW(), NOW(), NOW()) \
@@ -1765,12 +1716,23 @@ pub async fn push_session_state_to_cloud(
     .execute(pool)
     .await
     {
-        Ok(_) => log_and_return(Ok(()), payload_size).await,
-        Err(e) => {
-            let err = format!("push_session_state: {e}");
-            log_and_return(Err(err), payload_size).await
-        }
-    }
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!("push_session_state: {e}")),
+    };
+    let (status, error_msg) = match &result {
+        Ok(()) => ("success", None),
+        Err(e) => ("error", Some(e.as_str())),
+    };
+    log_session_sync(
+        audit,
+        user_id,
+        session_id,
+        "session_state",
+        payload_size,
+        status,
+        error_msg,
+    );
+    result
 }
 
 /// Push a structured context-trace signal as a first-class cloud event.
@@ -1779,6 +1741,7 @@ pub async fn push_context_trace_signal_to_cloud(
     session_id: &str,
     user_id: &str,
     signal: &super::session_workspace::ContextTraceSignal,
+    audit: &crate::state_sync::SyncAuditWriter,
 ) -> Result<(), String> {
     let metadata_json = serde_json::to_string(signal)
         .map_err(|e| format!("serialize context_trace_signal: {e}"))?;
@@ -1795,22 +1758,21 @@ pub async fn push_context_trace_signal_to_cloud(
         }
     };
     let payload_size = metadata_json.len() + content.len();
-    let log_and_return = |result: Result<(), String>, size: usize| async move {
-        let (status, error_msg) = match &result {
+
+    let log_result = |result: &Result<(), String>| {
+        let (status, error_msg) = match result {
             Ok(()) => ("success", None),
             Err(e) => ("error", Some(e.as_str())),
         };
-        let _ = log_session_sync(
-            pool,
+        log_session_sync(
+            audit,
             user_id,
             session_id,
             "context_trace",
-            size,
+            payload_size,
             status,
             error_msg,
-        )
-        .await;
-        result
+        );
     };
 
     if let Err(e) = sqlx::query(
@@ -1841,15 +1803,19 @@ pub async fn push_context_trace_signal_to_cloud(
     .execute(pool)
     .await
     {
-        let err = format!("push_context_trace_signal: {e}");
-        return log_and_return(Err(err), payload_size).await;
+        let err = Err(format!("push_context_trace_signal: {e}"));
+        log_result(&err);
+        return err;
     }
 
     if let Err(e) = reconcile_session_event_count(pool, session_id, user_id).await {
-        return log_and_return(Err(e), payload_size).await;
+        let err = Err(e);
+        log_result(&err);
+        return err;
     }
 
-    log_and_return(Ok(()), payload_size).await
+    log_result(&Ok(()));
+    Ok(())
 }
 
 async fn reconcile_session_event_count(

--- a/rust/crates/services/src/session_restore.rs
+++ b/rust/crates/services/src/session_restore.rs
@@ -1351,82 +1351,47 @@ impl SessionRestoreService for HybridRestoreService {
     }
 }
 
-/// Push a checkpoint to MatrixOne for cross-device availability.
-/// Also logs to session_sync_log for audit trail.
-pub async fn push_checkpoint_to_cloud(
-    pool: &sqlx::Pool<sqlx::MySql>,
-    session_id: &str,
-    user_id: &str,
-    checkpoint: &super::session_checkpoint::Checkpoint,
-    audit: &crate::state_sync::SyncAuditWriter,
-) -> Result<(), String> {
-    let checkpoint_id = uuid::Uuid::new_v4().to_string();
-    let tools_json =
-        serde_json::to_string(&checkpoint.tools_used).unwrap_or_else(|_| "[]".to_string());
+// ─── MatrixOneSyncService push methods ─────────────────────────────────────
 
-    let payload_size = checkpoint.title.len()
-        + checkpoint.summary.len()
-        + tools_json.len()
-        + checkpoint
-            .contract_state_json
-            .as_ref()
-            .map_or(0, |s| s.len());
+impl crate::state_sync::MatrixOneSyncService {
+    /// Push a checkpoint to MatrixOne for cross-device availability.
+    pub async fn push_checkpoint(
+        &self,
+        session_id: &str,
+        user_id: &str,
+        checkpoint: &super::session_checkpoint::Checkpoint,
+    ) -> Result<(), String> {
+        let checkpoint_id = uuid::Uuid::new_v4().to_string();
+        let tools_json =
+            serde_json::to_string(&checkpoint.tools_used).unwrap_or_else(|_| "[]".to_string());
 
-    let log_result = |result: &Result<(), String>, size: usize| {
-        let (status, error_msg) = match result {
-            Ok(()) => ("success", None),
-            Err(e) => ("error", Some(e.as_str())),
+        let payload_size = checkpoint.title.len()
+            + checkpoint.summary.len()
+            + tools_json.len()
+            + checkpoint
+                .contract_state_json
+                .as_ref()
+                .map_or(0, |s| s.len());
+
+        let log_result = |status: &str, error_msg: Option<&str>| {
+            log_checkpoint_sync(
+                &self.audit,
+                user_id,
+                session_id,
+                "checkpoint",
+                checkpoint.number,
+                payload_size,
+                status,
+                error_msg,
+            );
         };
-        log_checkpoint_sync(
-            audit,
-            user_id,
-            session_id,
-            "checkpoint",
-            checkpoint.number,
-            size,
-            status,
-            error_msg,
-        );
-    };
 
-    let updated = match sqlx::query(
-        "UPDATE session_checkpoints SET \
-            turn = ?, title = ?, summary = ?, tools_json = ?, total_tokens = ?, \
-            had_stalls = ?, error_count = ?, contract_state_json = ? \
-         WHERE session_id = ? AND number = ?",
-    )
-    .bind(checkpoint.turn as i32)
-    .bind(&checkpoint.title)
-    .bind(&checkpoint.summary)
-    .bind(&tools_json)
-    .bind(checkpoint.total_tokens as i64)
-    .bind(if checkpoint.had_stalls { 1i32 } else { 0 })
-    .bind(checkpoint.error_count as i32)
-    .bind(&checkpoint.contract_state_json)
-    .bind(session_id)
-    .bind(checkpoint.number as i32)
-    .execute(pool)
-    .await
-    {
-        Ok(u) => u,
-        Err(e) => {
-            let err = Err(format!("push_checkpoint update: {e}"));
-            log_result(&err, payload_size);
-            return err;
-        }
-    };
-
-    if updated.rows_affected() == 0 {
-        let inserted = sqlx::query(
-            "INSERT INTO session_checkpoints \
-             (checkpoint_id, session_id, user_id, number, turn, title, summary, \
-              tools_json, total_tokens, had_stalls, error_count, contract_state_json, created_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())",
+        let updated = match sqlx::query(
+            "UPDATE session_checkpoints SET \
+                turn = ?, title = ?, summary = ?, tools_json = ?, total_tokens = ?, \
+                had_stalls = ?, error_count = ?, contract_state_json = ? \
+             WHERE session_id = ? AND number = ?",
         )
-        .bind(&checkpoint_id)
-        .bind(session_id)
-        .bind(user_id)
-        .bind(checkpoint.number as i32)
         .bind(checkpoint.turn as i32)
         .bind(&checkpoint.title)
         .bind(&checkpoint.summary)
@@ -1435,44 +1400,331 @@ pub async fn push_checkpoint_to_cloud(
         .bind(if checkpoint.had_stalls { 1i32 } else { 0 })
         .bind(checkpoint.error_count as i32)
         .bind(&checkpoint.contract_state_json)
-        .execute(pool)
-        .await;
+        .bind(session_id)
+        .bind(checkpoint.number as i32)
+        .execute(&self.pool)
+        .await
+        {
+            Ok(u) => u,
+            Err(e) => {
+                let err = format!("push_checkpoint update: {e}");
+                log_result("error", Some(&err));
+                return Err(err);
+            }
+        };
 
-        if let Err(e) = inserted {
-            if is_duplicate_key_error(&e) {
-                if let Err(e) = sqlx::query(
-                    "UPDATE session_checkpoints SET \
-                        turn = ?, title = ?, summary = ?, tools_json = ?, total_tokens = ?, \
-                        had_stalls = ?, error_count = ?, contract_state_json = ? \
-                     WHERE session_id = ? AND number = ?",
-                )
-                .bind(checkpoint.turn as i32)
-                .bind(&checkpoint.title)
-                .bind(&checkpoint.summary)
-                .bind(&tools_json)
-                .bind(checkpoint.total_tokens as i64)
-                .bind(if checkpoint.had_stalls { 1i32 } else { 0 })
-                .bind(checkpoint.error_count as i32)
-                .bind(&checkpoint.contract_state_json)
-                .bind(session_id)
-                .bind(checkpoint.number as i32)
-                .execute(pool)
-                .await
-                {
-                    let err = Err(format!("push_checkpoint retry update: {e}"));
-                    log_result(&err, payload_size);
-                    return err;
+        if updated.rows_affected() == 0 {
+            let inserted = sqlx::query(
+                "INSERT INTO session_checkpoints \
+                 (checkpoint_id, session_id, user_id, number, turn, title, summary, \
+                  tools_json, total_tokens, had_stalls, error_count, contract_state_json, created_at) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())",
+            )
+            .bind(&checkpoint_id)
+            .bind(session_id)
+            .bind(user_id)
+            .bind(checkpoint.number as i32)
+            .bind(checkpoint.turn as i32)
+            .bind(&checkpoint.title)
+            .bind(&checkpoint.summary)
+            .bind(&tools_json)
+            .bind(checkpoint.total_tokens as i64)
+            .bind(if checkpoint.had_stalls { 1i32 } else { 0 })
+            .bind(checkpoint.error_count as i32)
+            .bind(&checkpoint.contract_state_json)
+            .execute(&self.pool)
+            .await;
+
+            if let Err(e) = inserted {
+                if is_duplicate_key_error(&e) {
+                    if let Err(e) = sqlx::query(
+                        "UPDATE session_checkpoints SET \
+                            turn = ?, title = ?, summary = ?, tools_json = ?, total_tokens = ?, \
+                            had_stalls = ?, error_count = ?, contract_state_json = ? \
+                         WHERE session_id = ? AND number = ?",
+                    )
+                    .bind(checkpoint.turn as i32)
+                    .bind(&checkpoint.title)
+                    .bind(&checkpoint.summary)
+                    .bind(&tools_json)
+                    .bind(checkpoint.total_tokens as i64)
+                    .bind(if checkpoint.had_stalls { 1i32 } else { 0 })
+                    .bind(checkpoint.error_count as i32)
+                    .bind(&checkpoint.contract_state_json)
+                    .bind(session_id)
+                    .bind(checkpoint.number as i32)
+                    .execute(&self.pool)
+                    .await
+                    {
+                        let err = format!("push_checkpoint retry update: {e}");
+                        log_result("error", Some(&err));
+                        return Err(err);
+                    }
+                } else {
+                    let err = format!("push_checkpoint insert: {e}");
+                    log_result("error", Some(&err));
+                    return Err(err);
                 }
-            } else {
-                let err = Err(format!("push_checkpoint insert: {e}"));
-                log_result(&err, payload_size);
-                return err;
             }
         }
+
+        log_result("success", None);
+        Ok(())
     }
 
-    log_result(&Ok(()), payload_size);
-    Ok(())
+    /// Push a Step Protocol checkpoint to MatrixOne with full state_json.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn push_step_checkpoint(
+        &self,
+        session_id: &str,
+        user_id: &str,
+        checkpoint_number: u32,
+        turn: u32,
+        tier: &str,
+        title: &str,
+        tools_json: &str,
+        state_json: &str,
+    ) -> Result<(), String> {
+        let checkpoint_id = uuid::Uuid::new_v4().to_string();
+        let cloud_number = cloud_step_checkpoint_number(checkpoint_number)?;
+        let payload_size = title.len() + tier.len() + tools_json.len() + state_json.len();
+
+        let log_result = |status: &str, error_msg: Option<&str>| {
+            log_checkpoint_sync(
+                &self.audit,
+                user_id,
+                session_id,
+                "step_checkpoint",
+                checkpoint_number,
+                payload_size,
+                status,
+                error_msg,
+            );
+        };
+
+        let updated = match sqlx::query(
+            "UPDATE session_checkpoints SET \
+                turn = ?, title = ?, summary = ?, tools_json = ?, state_json = ? \
+             WHERE session_id = ? AND number = ?",
+        )
+        .bind(turn as i32)
+        .bind(title)
+        .bind(tier)
+        .bind(tools_json)
+        .bind(state_json)
+        .bind(session_id)
+        .bind(cloud_number)
+        .execute(&self.pool)
+        .await
+        {
+            Ok(updated) => updated,
+            Err(e) => {
+                let err = format!("push_step_checkpoint update: {e}");
+                log_result("error", Some(&err));
+                return Err(err);
+            }
+        };
+
+        if updated.rows_affected() == 0 {
+            let inserted = sqlx::query(
+                "INSERT INTO session_checkpoints \
+                 (checkpoint_id, session_id, user_id, number, turn, title, summary, \
+                  tools_json, state_json, total_tokens, had_stalls, error_count, created_at) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, NOW())",
+            )
+            .bind(&checkpoint_id)
+            .bind(session_id)
+            .bind(user_id)
+            .bind(cloud_number)
+            .bind(turn as i32)
+            .bind(title)
+            .bind(tier)
+            .bind(tools_json)
+            .bind(state_json)
+            .execute(&self.pool)
+            .await;
+
+            if let Err(e) = inserted {
+                if is_duplicate_key_error(&e) {
+                    if let Err(err) = sqlx::query(
+                        "UPDATE session_checkpoints SET \
+                            turn = ?, title = ?, summary = ?, tools_json = ?, state_json = ? \
+                         WHERE session_id = ? AND number = ?",
+                    )
+                    .bind(turn as i32)
+                    .bind(title)
+                    .bind(tier)
+                    .bind(tools_json)
+                    .bind(state_json)
+                    .bind(session_id)
+                    .bind(cloud_number)
+                    .execute(&self.pool)
+                    .await
+                    {
+                        let err = format!("push_step_checkpoint retry update: {err}");
+                        log_result("error", Some(&err));
+                        return Err(err);
+                    }
+                } else {
+                    let err = format!("push_step_checkpoint insert: {e}");
+                    log_result("error", Some(&err));
+                    return Err(err);
+                }
+            }
+        }
+
+        log_result("success", None);
+        Ok(())
+    }
+
+    /// Push resumable session state to cloud via the agent_sessions.metadata JSON column.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn push_session_state(
+        &self,
+        session_id: &str,
+        user_id: &str,
+        executing_plan_json: Option<&str>,
+        plan_goal: Option<&str>,
+        plan_config_json: Option<&str>,
+        plan_execution_rounds: usize,
+        git_branch: Option<&str>,
+        model: Option<&str>,
+    ) -> Result<(), String> {
+        use sqlx::Row;
+
+        let existing_metadata_json = sqlx::query(
+            "SELECT CAST(metadata AS CHAR) AS metadata_json \
+             FROM agent_sessions WHERE session_id = ? LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| format!("load session metadata: {e}"))?
+        .and_then(|row| {
+            row.try_get::<Option<String>, _>("metadata_json")
+                .ok()
+                .flatten()
+        });
+
+        let metadata_json = merge_session_state_metadata(
+            existing_metadata_json.as_deref(),
+            executing_plan_json,
+            plan_goal,
+            plan_config_json,
+            plan_execution_rounds,
+            git_branch,
+            model,
+        );
+        let payload_size = metadata_json.len();
+
+        let result = sqlx::query(
+            "INSERT INTO agent_sessions \
+             (session_id, user_id, status, metadata, created_at, updated_at, last_active_at) \
+             VALUES (?, ?, 'active', ?, NOW(), NOW(), NOW()) \
+             ON DUPLICATE KEY UPDATE metadata = ?, updated_at = NOW(), last_active_at = NOW()",
+        )
+        .bind(session_id)
+        .bind(user_id)
+        .bind(&metadata_json)
+        .bind(&metadata_json)
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("push_session_state: {e}"));
+
+        let (status, error_msg) = match &result {
+            Ok(()) => ("success", None),
+            Err(e) => ("error", Some(e.as_str())),
+        };
+        log_session_sync(
+            &self.audit,
+            user_id,
+            session_id,
+            "session_state",
+            payload_size,
+            status,
+            error_msg,
+        );
+
+        result
+    }
+
+    /// Push a structured context-trace signal as a first-class cloud event.
+    pub async fn push_context_trace_signal(
+        &self,
+        session_id: &str,
+        user_id: &str,
+        signal: &super::session_workspace::ContextTraceSignal,
+    ) -> Result<(), String> {
+        let metadata_json = serde_json::to_string(signal)
+            .map_err(|e| format!("serialize context_trace_signal: {e}"))?;
+        let duration_ms = signal
+            .timing
+            .as_ref()
+            .map(|timing| timing.total_ms.min(i32::MAX as u64) as i32);
+        let content = {
+            let preview = signal.preview();
+            if preview.is_empty() {
+                "context trace signal".to_string()
+            } else {
+                preview
+            }
+        };
+        let payload_size = metadata_json.len() + content.len();
+
+        let log_result = |status: &str, error_msg: Option<&str>| {
+            log_session_sync(
+                &self.audit,
+                user_id,
+                session_id,
+                "context_trace",
+                payload_size,
+                status,
+                error_msg,
+            );
+        };
+
+        if let Err(e) = sqlx::query(
+            "INSERT INTO agent_events \
+             (event_id, session_id, user_id, agent_id, agent_version, event_type, content, \
+              parent_event_id, causal_chain_id, metadata, reasoning_content, meta_tool_name, \
+              meta_duration_ms, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())",
+        )
+        .bind(uuid::Uuid::now_v7().to_string())
+        .bind(session_id)
+        .bind(user_id)
+        .bind("astra-cli")
+        .bind(env!("CARGO_PKG_VERSION"))
+        .bind("context_trace_signal")
+        .bind(content)
+        .bind(None::<String>)
+        .bind(&signal.turn_id)
+        .bind(metadata_json)
+        .bind(None::<String>)
+        .bind(
+            signal
+                .tool_selection
+                .as_ref()
+                .and_then(|selection| selection.selected_tools.first().cloned()),
+        )
+        .bind(duration_ms)
+        .execute(&self.pool)
+        .await
+        {
+            let err = format!("push_context_trace_signal: {e}");
+            log_result("error", Some(&err));
+            return Err(err);
+        }
+
+        if let Err(e) = reconcile_session_event_count(&self.pool, session_id, user_id).await {
+            log_result("error", Some(&e));
+            return Err(e);
+        }
+
+        log_result("success", None);
+        Ok(())
+    }
 }
 
 fn log_session_sync(
@@ -1518,118 +1770,6 @@ fn log_checkpoint_sync(
     );
 }
 
-/// Push a Step Protocol checkpoint to MatrixOne with full state_json.
-/// Accepts pre-serialized JSON to avoid coupling services crate to runtime types.
-/// The caller serializes the StepCheckpoint; this function stores it.
-#[allow(clippy::too_many_arguments)]
-pub async fn push_step_checkpoint_to_cloud(
-    pool: &sqlx::Pool<sqlx::MySql>,
-    session_id: &str,
-    user_id: &str,
-    checkpoint_number: u32,
-    turn: u32,
-    tier: &str,
-    title: &str,
-    tools_json: &str,
-    state_json: &str,
-    audit: &crate::state_sync::SyncAuditWriter,
-) -> Result<(), String> {
-    let checkpoint_id = uuid::Uuid::new_v4().to_string();
-    let cloud_number = cloud_step_checkpoint_number(checkpoint_number)?;
-    let payload_size = title.len() + tier.len() + tools_json.len() + state_json.len();
-
-    let log_result = |result: &Result<(), String>, size: usize| {
-        let (status, error_msg) = match result {
-            Ok(()) => ("success", None),
-            Err(e) => ("error", Some(e.as_str())),
-        };
-        log_checkpoint_sync(
-            audit,
-            user_id,
-            session_id,
-            "step_checkpoint",
-            checkpoint_number,
-            size,
-            status,
-            error_msg,
-        );
-    };
-
-    let updated = match sqlx::query(
-        "UPDATE session_checkpoints SET \
-            turn = ?, title = ?, summary = ?, tools_json = ?, state_json = ? \
-         WHERE session_id = ? AND number = ?",
-    )
-    .bind(turn as i32)
-    .bind(title)
-    .bind(tier)
-    .bind(tools_json)
-    .bind(state_json)
-    .bind(session_id)
-    .bind(cloud_number)
-    .execute(pool)
-    .await
-    {
-        Ok(updated) => updated,
-        Err(e) => {
-            let err = Err(format!("push_step_checkpoint update: {e}"));
-            log_result(&err, payload_size);
-            return err;
-        }
-    };
-
-    if updated.rows_affected() == 0 {
-        let inserted = sqlx::query(
-            "INSERT INTO session_checkpoints \
-             (checkpoint_id, session_id, user_id, number, turn, title, summary, \
-              tools_json, state_json, total_tokens, had_stalls, error_count, created_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, NOW())",
-        )
-        .bind(&checkpoint_id)
-        .bind(session_id)
-        .bind(user_id)
-        .bind(cloud_number)
-        .bind(turn as i32)
-        .bind(title)
-        .bind(tier)
-        .bind(tools_json)
-        .bind(state_json)
-        .execute(pool)
-        .await;
-
-        if let Err(e) = inserted {
-            if is_duplicate_key_error(&e) {
-                if let Err(err) = sqlx::query(
-                    "UPDATE session_checkpoints SET \
-                        turn = ?, title = ?, summary = ?, tools_json = ?, state_json = ? \
-                     WHERE session_id = ? AND number = ?",
-                )
-                .bind(turn as i32)
-                .bind(title)
-                .bind(tier)
-                .bind(tools_json)
-                .bind(state_json)
-                .bind(session_id)
-                .bind(cloud_number)
-                .execute(pool)
-                .await
-                {
-                    let err = Err(format!("push_step_checkpoint retry update: {err}"));
-                    log_result(&err, payload_size);
-                    return err;
-                }
-            } else {
-                let err = Err(format!("push_step_checkpoint insert: {e}"));
-                log_result(&err, payload_size);
-                return err;
-            }
-        }
-    }
-
-    log_result(&Ok(()), payload_size);
-    Ok(())
-}
-
 /// Pull the latest Heavy step checkpoint JSON from MatrixOne for session recovery.
 /// Returns the raw state_json string — caller deserializes to StepCheckpoint.
 pub async fn pull_step_checkpoint_from_cloud(
@@ -1660,163 +1800,6 @@ pub async fn pull_step_checkpoint_from_cloud(
 }
 
 // ─── Plan State Cloud Sync ──────────────────────────────────────────────────
-
-/// Push resumable session state to cloud via the agent_sessions.metadata JSON column.
-/// Called at checkpoint boundaries and session end to enable cross-device restore.
-#[allow(clippy::too_many_arguments)]
-pub async fn push_session_state_to_cloud(
-    pool: &sqlx::Pool<sqlx::MySql>,
-    session_id: &str,
-    user_id: &str,
-    executing_plan_json: Option<&str>,
-    plan_goal: Option<&str>,
-    plan_config_json: Option<&str>,
-    plan_execution_rounds: usize,
-    git_branch: Option<&str>,
-    model: Option<&str>,
-    audit: &crate::state_sync::SyncAuditWriter,
-) -> Result<(), String> {
-    use sqlx::Row;
-
-    let existing_metadata_json = sqlx::query(
-        "SELECT CAST(metadata AS CHAR) AS metadata_json \
-         FROM agent_sessions WHERE session_id = ? LIMIT 1",
-    )
-    .bind(session_id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| format!("load session metadata: {e}"))?
-    .and_then(|row| {
-        row.try_get::<Option<String>, _>("metadata_json")
-            .ok()
-            .flatten()
-    });
-
-    let metadata_json = merge_session_state_metadata(
-        existing_metadata_json.as_deref(),
-        executing_plan_json,
-        plan_goal,
-        plan_config_json,
-        plan_execution_rounds,
-        git_branch,
-        model,
-    );
-    let payload_size = metadata_json.len();
-
-    let result = match sqlx::query(
-        "INSERT INTO agent_sessions \
-         (session_id, user_id, status, metadata, created_at, updated_at, last_active_at) \
-         VALUES (?, ?, 'active', ?, NOW(), NOW(), NOW()) \
-         ON DUPLICATE KEY UPDATE metadata = ?, updated_at = NOW(), last_active_at = NOW()",
-    )
-    .bind(session_id)
-    .bind(user_id)
-    .bind(&metadata_json)
-    .bind(&metadata_json)
-    .execute(pool)
-    .await
-    {
-        Ok(_) => Ok(()),
-        Err(e) => Err(format!("push_session_state: {e}")),
-    };
-    let (status, error_msg) = match &result {
-        Ok(()) => ("success", None),
-        Err(e) => ("error", Some(e.as_str())),
-    };
-    log_session_sync(
-        audit,
-        user_id,
-        session_id,
-        "session_state",
-        payload_size,
-        status,
-        error_msg,
-    );
-    result
-}
-
-/// Push a structured context-trace signal as a first-class cloud event.
-pub async fn push_context_trace_signal_to_cloud(
-    pool: &sqlx::Pool<sqlx::MySql>,
-    session_id: &str,
-    user_id: &str,
-    signal: &super::session_workspace::ContextTraceSignal,
-    audit: &crate::state_sync::SyncAuditWriter,
-) -> Result<(), String> {
-    let metadata_json = serde_json::to_string(signal)
-        .map_err(|e| format!("serialize context_trace_signal: {e}"))?;
-    let duration_ms = signal
-        .timing
-        .as_ref()
-        .map(|timing| timing.total_ms.min(i32::MAX as u64) as i32);
-    let content = {
-        let preview = signal.preview();
-        if preview.is_empty() {
-            "context trace signal".to_string()
-        } else {
-            preview
-        }
-    };
-    let payload_size = metadata_json.len() + content.len();
-
-    let log_result = |result: &Result<(), String>| {
-        let (status, error_msg) = match result {
-            Ok(()) => ("success", None),
-            Err(e) => ("error", Some(e.as_str())),
-        };
-        log_session_sync(
-            audit,
-            user_id,
-            session_id,
-            "context_trace",
-            payload_size,
-            status,
-            error_msg,
-        );
-    };
-
-    if let Err(e) = sqlx::query(
-        "INSERT INTO agent_events \
-         (event_id, session_id, user_id, agent_id, agent_version, event_type, content, \
-          parent_event_id, causal_chain_id, metadata, reasoning_content, meta_tool_name, \
-          meta_duration_ms, created_at) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())",
-    )
-    .bind(uuid::Uuid::now_v7().to_string())
-    .bind(session_id)
-    .bind(user_id)
-    .bind("astra-cli")
-    .bind(env!("CARGO_PKG_VERSION"))
-    .bind("context_trace_signal")
-    .bind(content)
-    .bind(None::<String>)
-    .bind(&signal.turn_id)
-    .bind(metadata_json)
-    .bind(None::<String>)
-    .bind(
-        signal
-            .tool_selection
-            .as_ref()
-            .and_then(|selection| selection.selected_tools.first().cloned()),
-    )
-    .bind(duration_ms)
-    .execute(pool)
-    .await
-    {
-        let err = Err(format!("push_context_trace_signal: {e}"));
-        log_result(&err);
-        return err;
-    }
-
-    if let Err(e) = reconcile_session_event_count(pool, session_id, user_id).await {
-        let err = Err(e);
-        log_result(&err);
-        return err;
-    }
-
-    log_result(&Ok(()));
-    Ok(())
-}
 
 async fn reconcile_session_event_count(
     pool: &sqlx::Pool<sqlx::MySql>,
@@ -2363,7 +2346,7 @@ mod tests {
 
     #[test]
     fn checkpoint_fields_for_cloud_push() {
-        // Verify Checkpoint struct has all fields needed by push_checkpoint_to_cloud
+        // Verify Checkpoint struct has all fields needed by MatrixOneSyncService::push_checkpoint
         let ckpt = crate::session_checkpoint::Checkpoint {
             number: 3,
             turn: 15,

--- a/rust/crates/services/src/state_sync.rs
+++ b/rust/crates/services/src/state_sync.rs
@@ -43,10 +43,13 @@ const MAX_RETRIES: u32 = 3;
 const INITIAL_BACKOFF_MS: u64 = 100;
 /// Maximum backoff delay (exponential backoff caps at this value).
 const MAX_BACKOFF_MS: u64 = 2000;
-/// Retain only a bounded tail of successful sync audit rows per user.
-const SYNC_LOG_SUCCESS_RETAIN: usize = 200;
-/// Retain a smaller bounded tail of error rows per user.
-const SYNC_LOG_ERROR_RETAIN: usize = 50;
+/// Bounded channel capacity for the async audit writer. If the channel is full,
+/// audit entries are dropped (acceptable — audit is observability, not business logic).
+const AUDIT_CHANNEL_CAPACITY: usize = 256;
+/// Flush audit entries after this many accumulate.
+const AUDIT_FLUSH_BATCH_SIZE: usize = 64;
+/// Flush audit entries after this duration even if batch is not full.
+const AUDIT_FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 
 // ─── Learning snapshot idempotency classifier ───────────────────────────────
 
@@ -135,29 +138,149 @@ fn decompress_json_payload(encoded: &str) -> Result<String, String> {
     Ok(json)
 }
 
-/// Returns the retention limit for sync logs based on status.
-/// Exposed for checkpoint sync to reuse the same pruning policy.
-pub(crate) fn sync_log_retain_limit(status: &str) -> Option<usize> {
-    match status {
-        "success" => Some(SYNC_LOG_SUCCESS_RETAIN),
-        "error" => Some(SYNC_LOG_ERROR_RETAIN),
-        _ => None,
+// ─── Async Audit Writer ────────────────────────────────────────────────────
+
+/// A single audit row destined for `session_sync_log`. Fire-and-forget.
+pub struct SyncAuditEntry {
+    pub user_id: String,
+    pub session_id: String,
+    pub sync_type: String,
+    pub direction: SyncDirection,
+    pub payload_size: usize,
+    pub status: String,
+    pub error_message: Option<String>,
+}
+
+/// Non-blocking handle for emitting audit entries into a bounded channel.
+/// If the channel is full the entry is silently dropped — audit is best-effort.
+#[derive(Clone)]
+pub struct SyncAuditWriter {
+    tx: tokio::sync::mpsc::Sender<SyncAuditEntry>,
+}
+
+impl SyncAuditWriter {
+    pub fn log(&self, entry: SyncAuditEntry) {
+        match self.tx.try_send(entry) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(dropped)) => {
+                tracing::warn!(
+                    target: "astra_services::audit",
+                    session_id = %dropped.session_id,
+                    sync_type = %dropped.sync_type,
+                    "sync audit channel full, entry dropped"
+                );
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(dropped)) => {
+                tracing::error!(
+                    target: "astra_services::audit",
+                    session_id = %dropped.session_id,
+                    sync_type = %dropped.sync_type,
+                    "sync audit channel closed (flusher dead?), entry dropped"
+                );
+            }
+        }
     }
 }
 
-/// SQL query to prune old sync logs keeping the most recent N entries.
-/// Exposed for checkpoint sync to reuse the same pruning policy.
-pub(crate) fn build_sync_log_prune_query() -> &'static str {
-    "DELETE FROM session_sync_log \
-     WHERE user_id = ? AND status = ? AND sync_type = ? \
-       AND sync_id NOT IN ( \
-            SELECT sync_id FROM ( \
-                SELECT sync_id FROM session_sync_log \
-                WHERE user_id = ? AND status = ? AND sync_type = ? \
-                ORDER BY created_at DESC \
-                LIMIT ? \
-            ) AS keepers \
-        )"
+/// Handle returned by [`spawn_audit_flusher`]. Groups the writer, shutdown
+/// token, and background task join handle.
+pub struct AuditFlusherHandle {
+    pub writer: SyncAuditWriter,
+    pub shutdown: tokio_util::sync::CancellationToken,
+    pub join_handle: tokio::task::JoinHandle<()>,
+}
+
+/// Spawn the audit flusher background task.
+///
+/// Clean shutdown: call `handle.shutdown.cancel()`, then `.await handle.join_handle`.
+pub fn spawn_audit_flusher(pool: sqlx::Pool<sqlx::MySql>) -> AuditFlusherHandle {
+    let (tx, rx) = tokio::sync::mpsc::channel(AUDIT_CHANNEL_CAPACITY);
+    let token = tokio_util::sync::CancellationToken::new();
+    let join_handle = tokio::spawn(run_audit_flusher(rx, pool, token.clone()));
+    AuditFlusherHandle {
+        writer: SyncAuditWriter { tx },
+        shutdown: token,
+        join_handle,
+    }
+}
+
+async fn run_audit_flusher(
+    mut rx: tokio::sync::mpsc::Receiver<SyncAuditEntry>,
+    pool: sqlx::Pool<sqlx::MySql>,
+    shutdown: tokio_util::sync::CancellationToken,
+) {
+    let mut buf: Vec<SyncAuditEntry> = Vec::with_capacity(AUDIT_FLUSH_BATCH_SIZE);
+    loop {
+        let deadline = tokio::time::sleep(AUDIT_FLUSH_INTERVAL);
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                entry = rx.recv() => {
+                    match entry {
+                        Some(e) => {
+                            buf.push(e);
+                            if buf.len() >= AUDIT_FLUSH_BATCH_SIZE { break; }
+                        }
+                        None => {
+                            flush_audit_batch(&pool, &mut buf).await;
+                            return;
+                        }
+                    }
+                }
+                _ = &mut deadline => { break; }
+                _ = shutdown.cancelled() => {
+                    while let Ok(e) = rx.try_recv() {
+                        buf.push(e);
+                    }
+                    flush_audit_batch(&pool, &mut buf).await;
+                    return;
+                }
+            }
+        }
+        flush_audit_batch(&pool, &mut buf).await;
+    }
+}
+
+async fn flush_audit_batch(pool: &sqlx::Pool<sqlx::MySql>, buf: &mut Vec<SyncAuditEntry>) {
+    if buf.is_empty() {
+        return;
+    }
+    let mut sql = String::from(
+        "INSERT INTO session_sync_log \
+         (sync_id, user_id, session_id, sync_type, sync_direction, \
+          payload_size, status, error_message, created_at) VALUES ",
+    );
+    for (i, _) in buf.iter().enumerate() {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        sql.push_str("(?, ?, ?, ?, ?, ?, ?, ?, NOW())");
+    }
+    let mut q = sqlx::query(&sql);
+    for entry in buf.iter() {
+        let dir_str = match entry.direction {
+            SyncDirection::Push => "push",
+            SyncDirection::Pull => "pull",
+        };
+        q = q
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&entry.user_id)
+            .bind(&entry.session_id)
+            .bind(&entry.sync_type)
+            .bind(dir_str)
+            .bind(entry.payload_size as i64)
+            .bind(&entry.status)
+            .bind(entry.error_message.as_deref());
+    }
+    if let Err(e) = q.execute(pool).await {
+        tracing::warn!(
+            target: "astra_services::audit",
+            batch_size = buf.len(),
+            error = %e,
+            "failed to flush sync audit batch"
+        );
+    }
+    buf.clear();
 }
 
 // ─── Sync Types ─────────────────────────────────────────────────────────────
@@ -658,20 +781,20 @@ impl StateSyncService for LocalOnlySyncService {
 /// Tables used:
 /// - `learning_snapshots` — cross-session learning state
 /// - `user_preferences` — user settings
-/// - `session_sync_log` — audit trail
+/// - `session_sync_log` — audit trail (written via async `SyncAuditWriter`)
 pub struct MatrixOneSyncService {
     pool: sqlx::Pool<sqlx::MySql>,
+    audit: SyncAuditWriter,
 }
 
 impl MatrixOneSyncService {
-    /// Create from an existing connection pool.
-    pub fn new(pool: sqlx::Pool<sqlx::MySql>) -> Self {
-        Self { pool }
+    /// Create from an existing connection pool and shared audit writer.
+    pub fn new(pool: sqlx::Pool<sqlx::MySql>, audit: SyncAuditWriter) -> Self {
+        Self { pool, audit }
     }
 
-    /// Log a sync operation to the audit table.
     #[allow(clippy::too_many_arguments)]
-    async fn log_sync(
+    fn log_sync(
         &self,
         user_id: &str,
         session_id: &str,
@@ -681,54 +804,15 @@ impl MatrixOneSyncService {
         status: &str,
         error_msg: Option<&str>,
     ) {
-        let dir_str = match direction {
-            SyncDirection::Push => "push",
-            SyncDirection::Pull => "pull",
-        };
-        let inserted = sqlx::query(
-            "INSERT INTO session_sync_log \
-             (sync_id, user_id, session_id, sync_type, sync_direction, payload_size, status, error_message, created_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW())",
-        )
-        .bind(uuid::Uuid::new_v4().to_string())
-        .bind(user_id)
-        .bind(session_id)
-        .bind(sync_type)
-        .bind(dir_str)
-        .bind(payload_size as i64)
-        .bind(status)
-        .bind(error_msg)
-        .execute(&self.pool)
-        .await;
-
-        if inserted.is_ok()
-            && let Some(retain) = sync_log_retain_limit(status)
-        {
-            self.prune_sync_logs(user_id, sync_type, status, retain)
-                .await;
-        }
-    }
-
-    async fn prune_sync_logs(&self, user_id: &str, sync_type: &str, status: &str, retain: usize) {
-        if let Err(e) = sqlx::query(build_sync_log_prune_query())
-            .bind(user_id)
-            .bind(status)
-            .bind(sync_type)
-            .bind(user_id)
-            .bind(status)
-            .bind(sync_type)
-            .bind(retain as i64)
-            .execute(&self.pool)
-            .await
-        {
-            tracing::warn!(
-                target: "astra_services::state_sync",
-                user_id = %user_id,
-                sync_type = %sync_type,
-                error = %e,
-                "failed to prune sync logs"
-            );
-        }
+        self.audit.log(SyncAuditEntry {
+            user_id: user_id.to_string(),
+            session_id: session_id.to_string(),
+            sync_type: sync_type.to_string(),
+            direction,
+            payload_size,
+            status: status.to_string(),
+            error_message: error_msg.map(|s| s.to_string()),
+        });
     }
 }
 
@@ -791,8 +875,7 @@ impl StateSyncService for MatrixOneSyncService {
                                 compressed_snapshot.len(),
                                 "success",
                                 None,
-                            )
-                            .await;
+                            );
                             return SyncResult::ok_with_version(
                                 SyncDirection::Push,
                                 "learning",
@@ -811,8 +894,7 @@ impl StateSyncService for MatrixOneSyncService {
                                 0,
                                 "conflict",
                                 Some(&format!("expected version {ver}")),
-                            )
-                            .await;
+                            );
                             return SyncResult::conflict(
                                 SyncDirection::Push,
                                 "learning",
@@ -844,8 +926,7 @@ impl StateSyncService for MatrixOneSyncService {
                                 0,
                                 "error",
                                 Some(&msg),
-                            )
-                            .await;
+                            );
                             return SyncResult::err(SyncDirection::Push, "learning", msg);
                         }
                     }
@@ -886,8 +967,7 @@ impl StateSyncService for MatrixOneSyncService {
                                 compressed_snapshot.len(),
                                 "success",
                                 None,
-                            )
-                            .await;
+                            );
                             return SyncResult::ok_with_version(
                                 SyncDirection::Push,
                                 "learning",
@@ -933,8 +1013,7 @@ impl StateSyncService for MatrixOneSyncService {
                                         compressed_snapshot.len(),
                                         "success",
                                         None,
-                                    )
-                                    .await;
+                                    );
                                     return SyncResult::ok_with_version(
                                         SyncDirection::Push,
                                         "learning",
@@ -951,8 +1030,7 @@ impl StateSyncService for MatrixOneSyncService {
                                     0,
                                     "conflict",
                                     Some(&msg),
-                                )
-                                .await;
+                                );
                                 return SyncResult::conflict(
                                     SyncDirection::Push,
                                     "learning",
@@ -981,8 +1059,7 @@ impl StateSyncService for MatrixOneSyncService {
                                 0,
                                 "error",
                                 Some(&msg),
-                            )
-                            .await;
+                            );
                             return SyncResult::err(SyncDirection::Push, "learning", msg);
                         }
                     }
@@ -1036,8 +1113,7 @@ impl StateSyncService for MatrixOneSyncService {
                         json.len(),
                         "success",
                         None,
-                    )
-                    .await;
+                    );
                     return Ok(Some(VersionedSnapshot {
                         json: decompressed,
                         version,
@@ -2124,24 +2200,10 @@ mod tests {
     }
 
     #[test]
-    fn sync_log_retention_limits_are_bounded() {
-        assert_eq!(
-            sync_log_retain_limit("success"),
-            Some(SYNC_LOG_SUCCESS_RETAIN)
-        );
-        assert_eq!(sync_log_retain_limit("error"), Some(SYNC_LOG_ERROR_RETAIN));
-        assert_eq!(sync_log_retain_limit("pending"), None);
-    }
-
-    #[test]
-    fn prune_query_keeps_latest_rows_for_user_status_and_sync_type() {
-        let query = build_sync_log_prune_query();
-
-        assert!(query.contains("DELETE FROM session_sync_log"));
-        assert!(query.contains("WHERE user_id = ? AND status = ? AND sync_type = ?"));
-        assert!(query.contains("SELECT sync_id FROM session_sync_log"));
-        assert!(query.contains("ORDER BY created_at DESC"));
-        assert!(query.contains("LIMIT ?"));
+    fn audit_constants_are_reasonable() {
+        assert_eq!(AUDIT_CHANNEL_CAPACITY, 256);
+        assert_eq!(AUDIT_FLUSH_BATCH_SIZE, 64);
+        assert_eq!(AUDIT_FLUSH_INTERVAL, std::time::Duration::from_secs(1));
     }
 
     #[tokio::test]
@@ -2476,5 +2538,157 @@ mod tests {
         assert_eq!(h1, h2);
         let h3 = sha256_bytes("world");
         assert_ne!(h1, h3);
+    }
+
+    // ── SyncAuditWriter / flusher tests ──
+
+    fn make_entry(i: usize) -> SyncAuditEntry {
+        SyncAuditEntry {
+            user_id: format!("u{i}"),
+            session_id: "s1".into(),
+            sync_type: "test".into(),
+            direction: SyncDirection::Push,
+            payload_size: i,
+            status: "success".into(),
+            error_message: None,
+        }
+    }
+
+    fn dummy_pool() -> sqlx::Pool<sqlx::MySql> {
+        sqlx::pool::PoolOptions::<sqlx::MySql>::new()
+            .max_connections(1)
+            .acquire_timeout(std::time::Duration::from_millis(1))
+            .connect_lazy("mysql://invalid:x@127.0.0.1:1/none")
+            .expect("lazy pool")
+    }
+
+    #[test]
+    fn audit_writer_log_is_nonblocking_when_channel_full() {
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let writer = SyncAuditWriter { tx };
+        writer.log(make_entry(1));
+        writer.log(make_entry(2)); // channel full — must not block
+    }
+
+    #[test]
+    fn audit_writer_log_handles_closed_channel_without_panic() {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let writer = SyncAuditWriter { tx };
+        drop(rx);
+        writer.log(make_entry(1)); // Closed — error! log, no panic
+    }
+
+    #[tokio::test]
+    async fn flusher_exits_on_channel_close_with_1_entry() {
+        let pool = dummy_pool();
+        let token = tokio_util::sync::CancellationToken::new();
+        let (tx, rx) = tokio::sync::mpsc::channel(128);
+        tx.send(make_entry(0)).await.unwrap();
+        drop(tx);
+
+        let jh = tokio::spawn(run_audit_flusher(rx, pool, token));
+        tokio::time::timeout(std::time::Duration::from_secs(5), jh)
+            .await
+            .expect("flusher should exit within 5s")
+            .expect("flusher should not panic");
+    }
+
+    #[tokio::test]
+    async fn flusher_exits_on_channel_close_with_exact_batch() {
+        let pool = dummy_pool();
+        let token = tokio_util::sync::CancellationToken::new();
+        let (tx, rx) = tokio::sync::mpsc::channel(128);
+        for i in 0..AUDIT_FLUSH_BATCH_SIZE {
+            tx.send(make_entry(i)).await.unwrap();
+        }
+        drop(tx);
+
+        let jh = tokio::spawn(run_audit_flusher(rx, pool, token));
+        tokio::time::timeout(std::time::Duration::from_secs(5), jh)
+            .await
+            .expect("flusher should exit within 5s")
+            .expect("flusher should not panic");
+    }
+
+    #[tokio::test]
+    async fn flusher_exits_on_channel_close_with_batch_plus_one() {
+        let pool = dummy_pool();
+        let token = tokio_util::sync::CancellationToken::new();
+        let (tx, rx) = tokio::sync::mpsc::channel(128);
+        for i in 0..AUDIT_FLUSH_BATCH_SIZE + 1 {
+            tx.send(make_entry(i)).await.unwrap();
+        }
+        drop(tx);
+
+        let jh = tokio::spawn(run_audit_flusher(rx, pool, token));
+        tokio::time::timeout(std::time::Duration::from_secs(5), jh)
+            .await
+            .expect("flusher should exit within 5s")
+            .expect("flusher should not panic");
+    }
+
+    #[tokio::test]
+    async fn flusher_exits_on_cancel_with_senders_alive() {
+        let pool = dummy_pool();
+        let token = tokio_util::sync::CancellationToken::new();
+        let (tx, rx) = tokio::sync::mpsc::channel(128);
+        for i in 0..5 {
+            tx.send(make_entry(i)).await.unwrap();
+        }
+
+        let jh = tokio::spawn(run_audit_flusher(rx, pool, token.clone()));
+        token.cancel();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), jh)
+            .await
+            .expect("flusher should exit within 5s after cancel")
+            .expect("flusher should not panic");
+        // tx is still alive — exit was caused by cancellation, not channel close.
+        drop(tx);
+    }
+
+    #[tokio::test]
+    async fn flusher_flushes_partial_batch_on_timeout() {
+        let pool = dummy_pool();
+        let token = tokio_util::sync::CancellationToken::new();
+        let (tx, rx) = tokio::sync::mpsc::channel(128);
+        tx.send(make_entry(0)).await.unwrap();
+
+        let jh = tokio::spawn(run_audit_flusher(rx, pool, token));
+        // Wait past the flush interval, then close to let flusher exit.
+        tokio::time::sleep(AUDIT_FLUSH_INTERVAL + std::time::Duration::from_millis(100)).await;
+        drop(tx);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), jh)
+            .await
+            .expect("flusher should exit within 5s")
+            .expect("flusher should not panic");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn flusher_shutdown_drain_collects_buffered_entries() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<SyncAuditEntry>(128);
+        let token = tokio_util::sync::CancellationToken::new();
+        for i in 0..10 {
+            tx.send(make_entry(i)).await.unwrap();
+        }
+        // Read one via recv to prove entries are pending.
+        let first = rx.recv().await.unwrap();
+        token.cancel();
+        // Simulate the flusher's cancellation drain path.
+        let mut buf = vec![first];
+        while let Ok(e) = rx.try_recv() {
+            buf.push(e);
+        }
+        assert_eq!(buf.len(), 10, "all 10 entries must be collected");
+    }
+
+    #[test]
+    fn audit_flusher_handle_struct_fields_accessible() {
+        fn _assert_fields(h: AuditFlusherHandle) {
+            let _w: SyncAuditWriter = h.writer;
+            let _s: tokio_util::sync::CancellationToken = h.shutdown;
+            let _j: tokio::task::JoinHandle<()> = h.join_handle;
+        }
     }
 }

--- a/rust/crates/services/src/state_sync.rs
+++ b/rust/crates/services/src/state_sync.rs
@@ -163,12 +163,17 @@ impl SyncAuditWriter {
         match self.tx.try_send(entry) {
             Ok(()) => {}
             Err(tokio::sync::mpsc::error::TrySendError::Full(dropped)) => {
-                tracing::warn!(
-                    target: "astra_services::audit",
-                    session_id = %dropped.session_id,
-                    sync_type = %dropped.sync_type,
-                    "sync audit channel full, entry dropped"
-                );
+                static DROPPED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+                let n = DROPPED.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                if n.is_power_of_two() || n == 1 {
+                    tracing::warn!(
+                        target: "astra_services::audit",
+                        session_id = %dropped.session_id,
+                        sync_type = %dropped.sync_type,
+                        total_dropped = n,
+                        "sync audit channel full, entry dropped"
+                    );
+                }
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(dropped)) => {
                 tracing::error!(
@@ -783,8 +788,8 @@ impl StateSyncService for LocalOnlySyncService {
 /// - `user_preferences` — user settings
 /// - `session_sync_log` — audit trail (written via async `SyncAuditWriter`)
 pub struct MatrixOneSyncService {
-    pool: sqlx::Pool<sqlx::MySql>,
-    audit: SyncAuditWriter,
+    pub(crate) pool: sqlx::Pool<sqlx::MySql>,
+    pub(crate) audit: SyncAuditWriter,
 }
 
 impl MatrixOneSyncService {
@@ -794,7 +799,7 @@ impl MatrixOneSyncService {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn log_sync(
+    pub(crate) fn log_sync(
         &self,
         user_id: &str,
         session_id: &str,

--- a/rust/crates/services/tests/plan_sync_db_it.rs
+++ b/rust/crates/services/tests/plan_sync_db_it.rs
@@ -79,7 +79,8 @@ async fn scalar_i64(pool: &sqlx::Pool<sqlx::MySql>, sql: &str, bind: &str) -> i6
 #[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
 async fn push_plans_pack_upserts_plans_and_steps() {
     let pool = setup_pool().await;
-    let svc = MatrixOneSyncService::new(pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
     let user = format!("u-push-{}", Uuid::new_v4().simple());
     let plan_id = format!("psync-push-{}", Uuid::new_v4().simple());
     cleanup(&pool, &plan_id).await;
@@ -118,7 +119,8 @@ async fn push_plans_pack_upserts_plans_and_steps() {
 #[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
 async fn push_plans_pack_rejects_stale_version_optimistically() {
     let pool = setup_pool().await;
-    let svc = MatrixOneSyncService::new(pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
     let user = format!("u-stale-{}", Uuid::new_v4().simple());
     let plan_id = format!("psync-stale-{}", Uuid::new_v4().simple());
     cleanup(&pool, &plan_id).await;
@@ -194,7 +196,8 @@ async fn push_plans_pack_rejects_stale_version_optimistically() {
 #[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
 async fn push_plans_pack_drops_cross_user_plans() {
     let pool = setup_pool().await;
-    let svc = MatrixOneSyncService::new(pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
     let alice = format!("u-alice-{}", Uuid::new_v4().simple());
     let mallory = format!("u-mallory-{}", Uuid::new_v4().simple());
     let alice_plan = format!("psync-alice-{}", Uuid::new_v4().simple());
@@ -239,7 +242,8 @@ async fn push_plans_pack_drops_cross_user_plans() {
 #[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
 async fn push_plans_pack_step_runs_are_idempotent_on_replay() {
     let pool = setup_pool().await;
-    let svc = MatrixOneSyncService::new(pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
     let user = format!("u-idem-{}", Uuid::new_v4().simple());
     let plan_id = format!("psync-idem-{}", Uuid::new_v4().simple());
     // `run_id` is the PRIMARY KEY on `plan_step_runs` — it's the identity the
@@ -308,7 +312,8 @@ async fn push_plans_pack_step_runs_are_idempotent_on_replay() {
 #[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
 async fn push_plans_pack_rejects_orphan_step_runs() {
     let pool = setup_pool().await;
-    let svc = MatrixOneSyncService::new(pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
     let user = format!("u-orph-{}", Uuid::new_v4().simple());
     let ghost_plan = format!("psync-ghost-{}", Uuid::new_v4().simple());
     cleanup(&pool, &ghost_plan).await;
@@ -347,7 +352,8 @@ async fn push_plans_pack_scales_to_fifty_plans_without_n_plus_one() {
     // operation completes under a realistic LAN-latency budget, plus that all
     // the same correctness invariants still hold.
     let pool = setup_pool().await;
-    let svc = MatrixOneSyncService::new(pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
     let user = format!("u-perf-{}", Uuid::new_v4().simple());
     let prefix = format!("psync-perf-{}-", Uuid::new_v4().simple());
     cleanup(&pool, &prefix).await;
@@ -459,7 +465,8 @@ async fn push_plans_pack_preserves_edge_step_run_timestamps() {
     // Otherwise audit chains for offline work collapse to the moment of
     // reconnection.
     let pool = setup_pool().await;
-    let svc = MatrixOneSyncService::new(pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
     let user = format!("u-ts-{}", Uuid::new_v4().simple());
     let plan_id = format!("psync-ts-{}", Uuid::new_v4().simple());
     cleanup(&pool, &plan_id).await;
@@ -536,7 +543,8 @@ async fn push_plans_pack_preserves_edge_step_run_timestamps() {
 #[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
 async fn pull_plans_pack_returns_user_scoped_plans_and_runs() {
     let pool = setup_pool().await;
-    let svc = MatrixOneSyncService::new(pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
     let user = format!("u-pull-{}", Uuid::new_v4().simple());
     let other_user = format!("u-other-{}", Uuid::new_v4().simple());
     let plan_id = format!("psync-pull-{}", Uuid::new_v4().simple());
@@ -597,7 +605,8 @@ async fn pull_plans_pack_returns_user_scoped_plans_and_runs() {
 #[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
 async fn push_plans_pack_rejects_step_run_with_inverted_timestamps() {
     let pool = setup_pool().await;
-    let svc = MatrixOneSyncService::new(pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
     let user = format!("u-inv-{}", Uuid::new_v4().simple());
     let plan_id = format!("pit-inv-{}", Uuid::new_v4().simple());
     let session_id = format!("sit-inv-{}", Uuid::new_v4().simple());
@@ -643,7 +652,8 @@ async fn push_plans_pack_rejects_step_run_with_inverted_timestamps() {
 #[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
 async fn push_plans_pack_rejects_step_run_with_out_of_range_timestamps() {
     let pool = setup_pool().await;
-    let svc = MatrixOneSyncService::new(pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
     let user = format!("u-oor-{}", Uuid::new_v4().simple());
     let plan_id = format!("pit-oor-{}", Uuid::new_v4().simple());
     let session_id = format!("sit-oor-{}", Uuid::new_v4().simple());
@@ -837,7 +847,8 @@ async fn migration_dedupe_removes_duplicate_attempt_tuples() {
 #[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
 async fn push_plans_pack_rejects_step_run_with_oversized_error_string() {
     let pool = setup_pool().await;
-    let svc = MatrixOneSyncService::new(pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
     let user = format!("u-big-{}", Uuid::new_v4().simple());
     let plan_id = format!("pit-big-{}", Uuid::new_v4().simple());
     let session_id = format!("sit-big-{}", Uuid::new_v4().simple());

--- a/rust/crates/services/tests/services_db_integration.rs
+++ b/rust/crates/services/tests/services_db_integration.rs
@@ -1486,6 +1486,8 @@ async fn durable_task_resume_loads_verification_history_from_db() {
 async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
     let (shared, _settings) = setup_pool_and_settings().await;
     let pool = shared.get().clone();
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let audit = flusher.writer.clone();
 
     let user_id = Uuid::new_v4().to_string();
     let session_a = Uuid::new_v4().to_string();
@@ -1538,6 +1540,7 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
         3,
         Some("feature/cloud-sync"),
         Some("gpt-5.4"),
+        &audit,
     )
     .await
     .expect("push session state A");
@@ -1551,6 +1554,7 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
         2,
         Some("legacy-fallback"),
         None,
+        &audit,
     )
     .await
     .expect("push session state B");
@@ -1564,6 +1568,7 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
         0,
         Some("feature/cloud-sync"),
         Some("gpt-5.4"),
+        &audit,
     )
     .await
     .expect("clear session state A plan fields");
@@ -1724,10 +1729,10 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
         explanations: vec!["trace-b".into()],
     };
 
-    push_context_trace_signal_to_cloud(&pool, &session_a, &user_id, &trace_a)
+    push_context_trace_signal_to_cloud(&pool, &session_a, &user_id, &trace_a, &audit)
         .await
         .expect("push trace A");
-    push_context_trace_signal_to_cloud(&pool, &session_b, &user_id, &trace_b)
+    push_context_trace_signal_to_cloud(&pool, &session_b, &user_id, &trace_b, &audit)
         .await
         .expect("push trace B");
 
@@ -1844,6 +1849,11 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
     assert_eq!(listed_b.model.as_deref(), Some("claude-sonnet-4.5"));
     assert_eq!(listed_b.git_branch.as_deref(), Some("legacy-fallback"));
 
+    // Flush audit entries before checking sync_log counts.
+    drop(audit);
+    flusher.shutdown.cancel();
+    let _ = flusher.join_handle.await;
+
     let session_a_state_syncs: i64 = sqlx::query(
         "SELECT COUNT(*) AS c FROM session_sync_log \
          WHERE session_id = ? AND sync_type = 'session_state' AND status = 'success'",
@@ -1883,9 +1893,11 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
 
 #[tokio::test]
 #[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
-async fn session_sync_log_prune_partitions_by_sync_type_on_live_matrixone() {
+async fn session_sync_log_async_audit_flusher_writes_per_type_on_live_matrixone() {
     let (shared, _settings) = setup_pool_and_settings().await;
     let pool = shared.get().clone();
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let audit = flusher.writer.clone();
 
     let user_id = Uuid::new_v4().to_string();
     let session_id = Uuid::new_v4().to_string();
@@ -1902,6 +1914,7 @@ async fn session_sync_log_prune_partitions_by_sync_type_on_live_matrixone() {
         0,
         Some("feature/prune"),
         Some("gpt-5.4"),
+        &audit,
     )
     .await
     .expect("push session state");
@@ -1920,17 +1933,15 @@ async fn session_sync_log_prune_partitions_by_sync_type_on_live_matrixone() {
             error_count: 0,
             contract_state_json: None,
         },
+        &audit,
     )
     .await
     .expect("push checkpoint");
 
     // Bulk-seed 199 rows directly into `session_sync_log` (matching the
-    // schema that `push_context_trace_signal_to_cloud` would write) — each
-    // call through the production path is 2 DB round-trips + a prune DELETE,
-    // so 205 sequential pushes cost ~3.7s and contending parallel pushes are
-    // even worse (they collide on the same `(user_id, status, sync_type)`
-    // prune lock). The final 6 pushes still go through the production API so
-    // the prune path gets exercised end-to-end under known conditions.
+    // schema that `push_context_trace_signal_to_cloud` would write).
+    // The final 6 pushes go through the production API so the async audit
+    // flusher batches and writes audit entries alongside the seeded rows.
     let seed_count = 199_i64;
     let mut bulk_sql = String::from(
         "INSERT INTO session_sync_log \
@@ -1973,10 +1984,15 @@ async fn session_sync_log_prune_partitions_by_sync_type_on_live_matrixone() {
             timing: None,
             explanations: vec![format!("trace-{idx}")],
         };
-        push_context_trace_signal_to_cloud(&pool, &session_id, &user_id, &trace)
+        push_context_trace_signal_to_cloud(&pool, &session_id, &user_id, &trace, &audit)
             .await
             .expect("push context trace");
     }
+
+    // Flush audit entries before checking sync_log counts.
+    drop(audit);
+    flusher.shutdown.cancel();
+    let _ = flusher.join_handle.await;
 
     let session_state_count: i64 = sqlx::query(
         "SELECT COUNT(*) AS c FROM session_sync_log \
@@ -2019,15 +2035,17 @@ async fn session_sync_log_prune_partitions_by_sync_type_on_live_matrixone() {
     .try_get("c")
     .expect("total success sync count");
 
-    assert_eq!(session_state_count, 1);
-    assert_eq!(checkpoint_count, 1);
+    assert_eq!(session_state_count, 1, "1 push_session_state = 1 audit row");
+    assert_eq!(checkpoint_count, 1, "1 push_checkpoint = 1 audit row");
+    // 199 bulk-seeded + 6 from push_context_trace_signal_to_cloud
     assert_eq!(
-        context_trace_count, 200,
-        "context_trace sync logs should prune to the success retain limit"
+        context_trace_count, 205,
+        "199 seeded + 6 pushed = 205 context_trace audit rows"
     );
+    // 1 session_state + 1 checkpoint + 205 context_trace
     assert_eq!(
-        total_success_count, 202,
-        "high-volume context_trace success logs must not evict rarer sync types"
+        total_success_count, 207,
+        "total success audit rows = 1 + 1 + 205"
     );
 
     cleanup_restore_fixture(&pool, &user_id, &[session_id]).await;
@@ -2129,6 +2147,8 @@ async fn remote_workspace_artifact_restores_without_local_workspace_on_live_matr
 async fn remote_composite_snapshot_index_restores_without_local_index_on_live_matrixone() {
     let (shared, settings) = setup_pool_and_settings().await;
     let pool = shared.get().clone();
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let audit = flusher.writer.clone();
 
     let user_id = Uuid::new_v4().to_string();
     let session_id = Uuid::new_v4().to_string();
@@ -2153,6 +2173,7 @@ async fn remote_composite_snapshot_index_restores_without_local_index_on_live_ma
         0,
         Some("feature/remote-composite"),
         Some("gpt-5.4"),
+        &audit,
     )
     .await
     .expect("push session state");
@@ -2171,6 +2192,7 @@ async fn remote_composite_snapshot_index_restores_without_local_index_on_live_ma
             error_count: 0,
             contract_state_json: Some(r#"{"mode":"remote-composite"}"#.into()),
         },
+        &audit,
     )
     .await
     .expect("push checkpoint");
@@ -2279,6 +2301,8 @@ async fn remote_composite_snapshot_index_restores_without_local_index_on_live_ma
 async fn restore_recent_tools_falls_back_to_legacy_turn_complete_metadata_on_live_matrixone() {
     let (shared, _settings) = setup_pool_and_settings().await;
     let pool = shared.get().clone();
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let audit = flusher.writer.clone();
 
     let user_id = Uuid::new_v4().to_string();
     let session_id = Uuid::new_v4().to_string();
@@ -2295,6 +2319,7 @@ async fn restore_recent_tools_falls_back_to_legacy_turn_complete_metadata_on_liv
         0,
         Some("feature/legacy-tools"),
         Some("gpt-5.4"),
+        &audit,
     )
     .await
     .expect("push session state");
@@ -2364,6 +2389,8 @@ async fn restore_recent_tools_falls_back_to_legacy_turn_complete_metadata_on_liv
 async fn context_trace_push_lazily_creates_session_row_on_live_matrixone() {
     let (shared, _settings) = setup_pool_and_settings().await;
     let pool = shared.get().clone();
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let audit = flusher.writer.clone();
 
     let user_id = Uuid::new_v4().to_string();
     let session_id = Uuid::new_v4().to_string();
@@ -2389,7 +2416,7 @@ async fn context_trace_push_lazily_creates_session_row_on_live_matrixone() {
         explanations: vec!["missing row".into()],
     };
 
-    push_context_trace_signal_to_cloud(&pool, &session_id, &user_id, &trace)
+    push_context_trace_signal_to_cloud(&pool, &session_id, &user_id, &trace, &audit)
         .await
         .expect("push context trace");
 
@@ -2434,6 +2461,11 @@ async fn context_trace_push_lazily_creates_session_row_on_live_matrixone() {
         Some("turn-missing-row")
     );
 
+    // Flush audit entries before checking sync_log counts.
+    drop(audit);
+    flusher.shutdown.cancel();
+    let _ = flusher.join_handle.await;
+
     let context_trace_syncs: i64 = sqlx::query(
         "SELECT COUNT(*) AS c FROM session_sync_log \
          WHERE session_id = ? AND sync_type = 'context_trace' AND status = 'success'",
@@ -2454,6 +2486,8 @@ async fn context_trace_push_lazily_creates_session_row_on_live_matrixone() {
 async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live_matrixone() {
     let (shared, _settings) = setup_pool_and_settings().await;
     let pool = shared.get().clone();
+    let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
+    let audit = flusher.writer.clone();
 
     let user_id = Uuid::new_v4().to_string();
     let session_id = Uuid::new_v4().to_string();
@@ -2592,6 +2626,7 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             error_count: 0,
             contract_state_json: None,
         },
+        &audit,
     )
     .await
     .expect("push ordinary checkpoint");
@@ -2613,6 +2648,7 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             serde_json::json!({"kind":"rate_limited","resumable":true}),
             serde_json::json!({"attempt_count":1,"cumulative_tokens_freed":50,"last_was_insufficient":false}),
         ),
+        &audit,
     )
     .await
     .expect("push first step checkpoint");
@@ -2646,6 +2682,7 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             serde_json::json!({"kind":"rate_limited","resumable":true}),
             serde_json::json!({"attempt_count":2,"cumulative_tokens_freed":120,"last_was_insufficient":false}),
         ),
+        &audit,
     )
     .await
     .expect("update step checkpoint");
@@ -2669,6 +2706,7 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             serde_json::json!({"kind":"context_window","resumable":true}),
             serde_json::json!({"attempt_count":1,"cumulative_tokens_freed":80,"last_was_insufficient":true}),
         ),
+        &audit,
     )
     .await
     .expect("push heavy-only step checkpoint");
@@ -2704,6 +2742,7 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             serde_json::json!({"kind":"legacy_resume","resumable":true}),
             serde_json::json!({"attempt_count":3,"cumulative_tokens_freed":64,"last_was_insufficient":false}),
         ),
+        &audit,
     )
     .await
     .expect("push legacy heavy step checkpoint");
@@ -2895,6 +2934,11 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             .and_then(serde_json::Value::as_u64),
         Some(3)
     );
+
+    // Flush audit entries before checking sync_log counts.
+    drop(audit);
+    flusher.shutdown.cancel();
+    let _ = flusher.join_handle.await;
 
     let sync_successes = sqlx::query(
         "SELECT COUNT(*) AS c FROM session_sync_log \
@@ -3235,7 +3279,8 @@ async fn it_push_learning_versioned_idempotent_insert_returns_ok() {
     let (shared_pool, settings) = setup_pool_and_settings().await;
     let raw_pool = shared_pool.get().clone();
     let _ = settings; // used for pool setup; MatrixOneSyncService takes a raw pool
-    let svc = MatrixOneSyncService::new(raw_pool.clone());
+    let flusher = astra_services::state_sync::spawn_audit_flusher(raw_pool.clone());
+    let svc = MatrixOneSyncService::new(raw_pool.clone(), flusher.writer.clone());
     let user_id = format!("it-sync-user-{}", Uuid::new_v4().simple());
     let profile = "default";
     let snapshot = r#"{"entities":[],"patterns":[]}"#;

--- a/rust/crates/services/tests/services_db_integration.rs
+++ b/rust/crates/services/tests/services_db_integration.rs
@@ -24,8 +24,6 @@ use astra_services::session_audit::{
 use astra_services::session_restore::{
     COMPOSITE_SNAPSHOT_INDEX_ARTIFACT_KIND, HybridRestoreService, SessionRestoreService,
     persist_remote_composite_snapshot_index, pull_step_checkpoint_from_cloud,
-    push_checkpoint_to_cloud, push_context_trace_signal_to_cloud, push_session_state_to_cloud,
-    push_step_checkpoint_to_cloud,
 };
 use astra_services::session_workspace::{
     ContextTraceSignal, ContextTraceToolSelection, WorkspaceMetadata, persist_remote_workspace,
@@ -1488,6 +1486,7 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
     let pool = shared.get().clone();
     let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
     let audit = flusher.writer.clone();
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
 
     let user_id = Uuid::new_v4().to_string();
     let session_a = Uuid::new_v4().to_string();
@@ -1530,8 +1529,7 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
     .await
     .expect("insert existing session A");
 
-    push_session_state_to_cloud(
-        &pool,
+    svc.push_session_state(
         &session_a,
         &user_id,
         Some(&plan_a_json),
@@ -1540,12 +1538,10 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
         3,
         Some("feature/cloud-sync"),
         Some("gpt-5.4"),
-        &audit,
     )
     .await
     .expect("push session state A");
-    push_session_state_to_cloud(
-        &pool,
+    svc.push_session_state(
         &session_b,
         &user_id,
         Some(&plan_b_json),
@@ -1554,12 +1550,10 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
         2,
         Some("legacy-fallback"),
         None,
-        &audit,
     )
     .await
     .expect("push session state B");
-    push_session_state_to_cloud(
-        &pool,
+    svc.push_session_state(
         &session_a,
         &user_id,
         None,
@@ -1568,7 +1562,6 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
         0,
         Some("feature/cloud-sync"),
         Some("gpt-5.4"),
-        &audit,
     )
     .await
     .expect("clear session state A plan fields");
@@ -1729,10 +1722,10 @@ async fn session_restore_cloud_roundtrip_restores_resume_and_picker_fields() {
         explanations: vec!["trace-b".into()],
     };
 
-    push_context_trace_signal_to_cloud(&pool, &session_a, &user_id, &trace_a, &audit)
+    svc.push_context_trace_signal(&session_a, &user_id, &trace_a)
         .await
         .expect("push trace A");
-    push_context_trace_signal_to_cloud(&pool, &session_b, &user_id, &trace_b, &audit)
+    svc.push_context_trace_signal(&session_b, &user_id, &trace_b)
         .await
         .expect("push trace B");
 
@@ -1898,14 +1891,14 @@ async fn session_sync_log_async_audit_flusher_writes_per_type_on_live_matrixone(
     let pool = shared.get().clone();
     let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
     let audit = flusher.writer.clone();
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
 
     let user_id = Uuid::new_v4().to_string();
     let session_id = Uuid::new_v4().to_string();
 
     cleanup_restore_fixture(&pool, &user_id, std::slice::from_ref(&session_id)).await;
 
-    push_session_state_to_cloud(
-        &pool,
+    svc.push_session_state(
         &session_id,
         &user_id,
         None,
@@ -1914,12 +1907,10 @@ async fn session_sync_log_async_audit_flusher_writes_per_type_on_live_matrixone(
         0,
         Some("feature/prune"),
         Some("gpt-5.4"),
-        &audit,
     )
     .await
     .expect("push session state");
-    push_checkpoint_to_cloud(
-        &pool,
+    svc.push_checkpoint(
         &session_id,
         &user_id,
         &astra_services::session_checkpoint::Checkpoint {
@@ -1933,13 +1924,12 @@ async fn session_sync_log_async_audit_flusher_writes_per_type_on_live_matrixone(
             error_count: 0,
             contract_state_json: None,
         },
-        &audit,
     )
     .await
     .expect("push checkpoint");
 
     // Bulk-seed 199 rows directly into `session_sync_log` (matching the
-    // schema that `push_context_trace_signal_to_cloud` would write).
+    // schema that `push_context_trace_signal` would write).
     // The final 6 pushes go through the production API so the async audit
     // flusher batches and writes audit entries alongside the seeded rows.
     let seed_count = 199_i64;
@@ -1984,7 +1974,7 @@ async fn session_sync_log_async_audit_flusher_writes_per_type_on_live_matrixone(
             timing: None,
             explanations: vec![format!("trace-{idx}")],
         };
-        push_context_trace_signal_to_cloud(&pool, &session_id, &user_id, &trace, &audit)
+        svc.push_context_trace_signal(&session_id, &user_id, &trace)
             .await
             .expect("push context trace");
     }
@@ -2037,7 +2027,7 @@ async fn session_sync_log_async_audit_flusher_writes_per_type_on_live_matrixone(
 
     assert_eq!(session_state_count, 1, "1 push_session_state = 1 audit row");
     assert_eq!(checkpoint_count, 1, "1 push_checkpoint = 1 audit row");
-    // 199 bulk-seeded + 6 from push_context_trace_signal_to_cloud
+    // 199 bulk-seeded + 6 from push_context_trace_signal
     assert_eq!(
         context_trace_count, 205,
         "199 seeded + 6 pushed = 205 context_trace audit rows"
@@ -2148,7 +2138,7 @@ async fn remote_composite_snapshot_index_restores_without_local_index_on_live_ma
     let (shared, settings) = setup_pool_and_settings().await;
     let pool = shared.get().clone();
     let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
-    let audit = flusher.writer.clone();
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
 
     let user_id = Uuid::new_v4().to_string();
     let session_id = Uuid::new_v4().to_string();
@@ -2163,8 +2153,7 @@ async fn remote_composite_snapshot_index_restores_without_local_index_on_live_ma
         "fixture should prove remote composite snapshot restore without local composite_snapshots.json"
     );
 
-    push_session_state_to_cloud(
-        &pool,
+    svc.push_session_state(
         &session_id,
         &user_id,
         None,
@@ -2173,12 +2162,10 @@ async fn remote_composite_snapshot_index_restores_without_local_index_on_live_ma
         0,
         Some("feature/remote-composite"),
         Some("gpt-5.4"),
-        &audit,
     )
     .await
     .expect("push session state");
-    push_checkpoint_to_cloud(
-        &pool,
+    svc.push_checkpoint(
         &session_id,
         &user_id,
         &astra_services::session_checkpoint::Checkpoint {
@@ -2192,7 +2179,6 @@ async fn remote_composite_snapshot_index_restores_without_local_index_on_live_ma
             error_count: 0,
             contract_state_json: Some(r#"{"mode":"remote-composite"}"#.into()),
         },
-        &audit,
     )
     .await
     .expect("push checkpoint");
@@ -2302,15 +2288,14 @@ async fn restore_recent_tools_falls_back_to_legacy_turn_complete_metadata_on_liv
     let (shared, _settings) = setup_pool_and_settings().await;
     let pool = shared.get().clone();
     let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
-    let audit = flusher.writer.clone();
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
 
     let user_id = Uuid::new_v4().to_string();
     let session_id = Uuid::new_v4().to_string();
 
     cleanup_restore_fixture(&pool, &user_id, std::slice::from_ref(&session_id)).await;
 
-    push_session_state_to_cloud(
-        &pool,
+    svc.push_session_state(
         &session_id,
         &user_id,
         None,
@@ -2319,7 +2304,6 @@ async fn restore_recent_tools_falls_back_to_legacy_turn_complete_metadata_on_liv
         0,
         Some("feature/legacy-tools"),
         Some("gpt-5.4"),
-        &audit,
     )
     .await
     .expect("push session state");
@@ -2391,6 +2375,7 @@ async fn context_trace_push_lazily_creates_session_row_on_live_matrixone() {
     let pool = shared.get().clone();
     let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
     let audit = flusher.writer.clone();
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
 
     let user_id = Uuid::new_v4().to_string();
     let session_id = Uuid::new_v4().to_string();
@@ -2416,7 +2401,7 @@ async fn context_trace_push_lazily_creates_session_row_on_live_matrixone() {
         explanations: vec!["missing row".into()],
     };
 
-    push_context_trace_signal_to_cloud(&pool, &session_id, &user_id, &trace, &audit)
+    svc.push_context_trace_signal(&session_id, &user_id, &trace)
         .await
         .expect("push context trace");
 
@@ -2488,6 +2473,7 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
     let pool = shared.get().clone();
     let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
     let audit = flusher.writer.clone();
+    let svc = MatrixOneSyncService::new(pool.clone(), flusher.writer.clone());
 
     let user_id = Uuid::new_v4().to_string();
     let session_id = Uuid::new_v4().to_string();
@@ -2611,8 +2597,7 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
     .await
     .expect("insert legacy-heavy user_query");
 
-    push_checkpoint_to_cloud(
-        &pool,
+    svc.push_checkpoint(
         &session_id,
         &user_id,
         &astra_services::session_checkpoint::Checkpoint {
@@ -2626,13 +2611,11 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             error_count: 0,
             contract_state_json: None,
         },
-        &audit,
     )
     .await
     .expect("push ordinary checkpoint");
 
-    push_step_checkpoint_to_cloud(
-        &pool,
+    svc.push_step_checkpoint(
         &session_id,
         &user_id,
         1,
@@ -2648,7 +2631,6 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             serde_json::json!({"kind":"rate_limited","resumable":true}),
             serde_json::json!({"attempt_count":1,"cumulative_tokens_freed":50,"last_was_insufficient":false}),
         ),
-        &audit,
     )
     .await
     .expect("push first step checkpoint");
@@ -2660,8 +2642,7 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             "side_effect": "execute"
         }, true]]
     });
-    push_step_checkpoint_to_cloud(
-        &pool,
+    svc.push_step_checkpoint(
         &session_id,
         &user_id,
         1,
@@ -2682,12 +2663,10 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             serde_json::json!({"kind":"rate_limited","resumable":true}),
             serde_json::json!({"attempt_count":2,"cumulative_tokens_freed":120,"last_was_insufficient":false}),
         ),
-        &audit,
     )
     .await
     .expect("update step checkpoint");
-    push_step_checkpoint_to_cloud(
-        &pool,
+    svc.push_step_checkpoint(
         &heavy_only_session,
         &user_id,
         1,
@@ -2706,7 +2685,6 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             serde_json::json!({"kind":"context_window","resumable":true}),
             serde_json::json!({"attempt_count":1,"cumulative_tokens_freed":80,"last_was_insufficient":true}),
         ),
-        &audit,
     )
     .await
     .expect("push heavy-only step checkpoint");
@@ -2722,8 +2700,7 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             true
         ]]
     });
-    push_step_checkpoint_to_cloud(
-        &pool,
+    svc.push_step_checkpoint(
         &legacy_heavy_session,
         &user_id,
         1,
@@ -2742,7 +2719,6 @@ async fn checkpoint_cloud_roundtrip_keeps_session_and_step_rows_separate_on_live
             serde_json::json!({"kind":"legacy_resume","resumable":true}),
             serde_json::json!({"attempt_count":3,"cumulative_tokens_freed":64,"last_was_insufficient":false}),
         ),
-        &audit,
     )
     .await
     .expect("push legacy heavy step checkpoint");


### PR DESCRIPTION
## Summary

- Replace synchronous per-push audit INSERT + probabilistic prune DELETE with a bounded-channel async batch flusher. Push hot-path drops from 3 DB round-trips to 1 (business INSERT only).
- Encapsulate audit writer inside `MatrixOneSyncService` — push functions become service methods, eliminating `pool`/`audit` parameter threading through all callers.
- Remove `fastrand` dependency, all prune code (`build_sync_log_prune_query`, `sync_log_retain_limit`, `should_prune_sync_log`, retain constants). Retention handled solely by `storage::cleanup_expired_data` (30-day policy).

## Key design

```
push_session_state()
  ├── INSERT session state (business) ← sync, must succeed
  └── self.audit.log(entry)           ← non-blocking channel send

Background AuditFlusher (tokio task)
  └── batch INSERT every 1s or 64 entries
  └── CancellationToken for clean shutdown
  └── DB retention via cleanup_expired_data (not per-write prune)
```

## Performance impact

| Metric | Before | After |
|--------|--------|-------|
| push latency | business INSERT + audit INSERT + prune DELETE | business INSERT only |
| Concurrent DELETE contention | 22× on same partition | zero |
| Audit I/O | 1 INSERT per push | 1 batch INSERT per 64 pushes or 1s |
| Worst-case audit loss on crash | none | up to 256 entries (acceptable for observability) |

## Test plan

- [x] `make format` — pass
- [x] `make check` (clippy + fmt + type checks) — pass
- [x] `make test-offline` — 0 failures
- [x] 1306 unit tests pass (`cargo test -p astra-services --lib`)
- [x] Flusher lifecycle tests: 1-entry, 64-entry batch boundary, 65-entry split, cancel-with-senders-alive, timeout partial flush, shutdown drain
- [ ] `make test-online` (requires live MatrixOne) — integration test verifies exact audit row counts (1+1+205=207)

🤖 Generated with [Claude Code](https://claude.com/claude-code)