### PR TITLE
refactor: env audit, edge dedup, config consolidation, agent self-knowledge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,34 +17,38 @@ ASTRA_AUTO_CREATE_DATABASE=1
 # Bootstrap catalog used while running CREATE DATABASE. Defaults to `mysql`.
 #ASTRA_DATABASE_BOOTSTRAP_CATALOG=mysql
 
+# Separate database for `make test-online` (default: astra_runtime_test).
+#ASTRA_TEST_DATABASE=astra_runtime_test
+
 # ── Application ────────────────────────────────────────────────────────────
-ASTRA_APP_ENV=development
-ASTRA_LOG_LEVEL=DEBUG
 # Development only: permits bundled insecure defaults for required keys.
 ASTRA_ALLOW_INSECURE_DEFAULTS=1
+# Logging is controlled by RUST_LOG (standard tracing ecosystem variable).
+# Example: RUST_LOG=warn,astra_runtime=debug
 
 # ── API server ─────────────────────────────────────────────────────────────
 ASTRA_API_HOST=0.0.0.0
 ASTRA_API_PORT=8000
-# ASTRA_CORS_ORIGINS is parsed but not yet wired (CORS currently allows any origin).
+# Comma-separated allowed origins (e.g. https://app.example.com,https://admin.example.com).
+# Unset or "*" allows any origin.
+#ASTRA_CORS_ORIGINS=
 
 # ── Auth: JWT & encryption (REQUIRED in production) ────────────────────────
 # Generate with: openssl rand -hex 32
 ASTRA_JWT_SECRET=your-jwt-secret-min-32-characters-long-change-me
 ASTRA_JWT_ALGORITHM=HS256
-ASTRA_JWT_ACCESS_TTL_MINUTES=60
+# Code default is 10080 (7 days) for dev convenience. Production should use a shorter TTL.
+#ASTRA_JWT_ACCESS_TTL_MINUTES=60
 ASTRA_JWT_REFRESH_TTL_DAYS=7
 # Fernet key — generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ASTRA_TOKEN_ENCRYPTION_KEY=
 
 # Chat-turn bridge secret — shared between astra-server and the in-process bridge callback.
 ASTRA_BRIDGE_SECRET=your-bridge-secret-min-32-characters-long-change-me
-# Optional: override in-process bridge HTTP URL.
-#ASTRA_BRIDGE_URL=http://bridge.internal:9001/internal/chat/turn
 
-# Auth mode: `local_jwt` (default) or `trusted_external` (validate JWTs issued by an external IdP).
+# Auth mode: `local_jwt` (default) or `trusted_moi` (validate JWTs from external IdP).
 ASTRA_AUTH_MODE=local_jwt
-# External JWT (only used when ASTRA_AUTH_MODE=trusted_external).
+# External JWT (only used when ASTRA_AUTH_MODE=trusted_moi).
 #ASTRA_EXTERNAL_JWT_SECRET=
 #ASTRA_EXTERNAL_JWT_ALGORITHM=HS256
 #ASTRA_EXTERNAL_JWT_ISSUER=
@@ -86,7 +90,7 @@ MEMORIA_EMBEDDING_BASE_URL=
 #ASTRA_EDGE_EXECUTOR_ID=
 #ASTRA_EDGE_AGENT_ID=
 
-# ── GitHub integration (optional) ──────────────────────────────────────────
+# ── GitHub integration (optional, read directly by CLI) ────────────────────
 #GITHUB_TOKEN=
 
 # ── CLI overrides (optional) ───────────────────────────────────────────────

--- a/.env.production.example
+++ b/.env.production.example
@@ -9,14 +9,14 @@ MATRIXONE_PASSWORD=your-secure-password
 ASTRA_DATABASE=astra_runtime
 #ASTRA_DATABASE_PREFIX=
 
-# ── Application ────────────────────────────────────────────────────────────
-ASTRA_APP_ENV=production
-ASTRA_LOG_LEVEL=INFO
-
 # ── API server ─────────────────────────────────────────────────────────────
 ASTRA_API_HOST=0.0.0.0
 ASTRA_API_PORT=8000
 ASTRA_CORS_ORIGINS=https://app.your-domain.com
+
+# ── Logging ────────────────────────────────────────────────────────────────
+# Standard RUST_LOG filter (e.g. warn,astra_runtime=info,astra.http.access=info).
+#RUST_LOG=warn,astra_runtime=info
 
 # ── Auth secrets (REQUIRED) ────────────────────────────────────────────────
 # All secrets below MUST be set (no defaults) or the server will refuse to start.

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-          shared-key: ci-test
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          shared-key: ci-test-${{ github.base_ref || github.ref_name }}
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Run clippy
         run: make lint
       - name: Server tool schema guards (astra-tools)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-          shared-key: ci-test
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          shared-key: ci-test-${{ github.base_ref || github.ref_name }}
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       # Compile all test binaries (default + bridge-e2e-hooks) without running
       - name: Compile test binaries
         run: |
@@ -39,8 +39,8 @@ jobs:
   # Shard balance (test counts):
   #   shard-a: astra-cli (split by edge_tools group) — shell tests need process isolation
   #   shard-b: astra-runtime (3151) + contracts (19) + trusted_moi (4)
-  #   shard-c: astra-turn-core (2167) + astra-services (1186)
-  #   shard-d: core crates ~2460 + bridge-e2e-hooks (3176, mostly overlaps runtime)
+  #   shard-c: astra-turn-core (2167) + astra-services (1186) + plan/prompts
+  #   shard-d: remaining core crates + bridge-e2e-hooks (3176, mostly overlaps runtime)
 
   shard-a:
     name: "Test: astra-cli (${{ matrix.segment }})"
@@ -74,7 +74,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-          shared-key: ci-test
+          shared-key: ci-test-${{ github.base_ref || github.ref_name }}
           save-if: false
       - name: "Test astra-cli (${{ matrix.segment }})"
         env:
@@ -99,7 +99,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-          shared-key: ci-test
+          shared-key: ci-test-${{ github.base_ref || github.ref_name }}
           save-if: false
       - name: Test astra-runtime
         run: >-
@@ -126,7 +126,7 @@ jobs:
             });
 
   shard-c:
-    name: "Test: turn-core + services"
+    name: "Test: turn-core + services + plan"
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -137,12 +137,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-          shared-key: ci-test
+          shared-key: ci-test-${{ github.base_ref || github.ref_name }}
           save-if: false
-      - name: Test astra-turn-core + astra-services
+      - name: Test astra-turn-core + astra-services + astra-plan
         run: >-
           cargo nextest run --manifest-path rust/Cargo.toml
           -p astra-turn-core -p astra-services
+          -p astra-plan -p astra-prompts
           --profile ci
 
   shard-d:
@@ -157,7 +158,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-          shared-key: ci-test
+          shared-key: ci-test-${{ github.base_ref || github.ref_name }}
           save-if: false
       - name: Test core crates
         run: >-
@@ -167,7 +168,6 @@ jobs:
           -p astra-skills -p astra-sandbox -p astra-server-types
           -p astra-messaging -p astra-text-utils
           -p astra-config -p astra-learning
-          -p astra-plan -p astra-prompts
           --profile ci
       - name: Test bridge-e2e-hooks
         run: >-
@@ -216,7 +216,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-          shared-key: ci-test
+          shared-key: ci-test-${{ github.base_ref || github.ref_name }}
           save-if: false
       - name: Wait for dependencies
         run: make dev-deps-wait

--- a/deployment/all-in-one/.env.example
+++ b/deployment/all-in-one/.env.example
@@ -12,14 +12,11 @@ ASTRA_DATABASE=astra_runtime
 #ASTRA_DATABASE_PREFIX=test_
 ASTRA_AUTO_CREATE_DATABASE=1
 
-# ─── Application ───────────────────────────────────────────────
-ASTRA_APP_ENV=development
-ASTRA_LOG_LEVEL=INFO
-
 # ─── API server ────────────────────────────────────────────────
 ASTRA_API_HOST=0.0.0.0
 ASTRA_API_PORT=8000
-ASTRA_CORS_ORIGINS=*
+# Comma-separated allowed origins. Unset or "*" allows any origin.
+#ASTRA_CORS_ORIGINS=*
 
 # ─── Auth secrets (REQUIRED) ───────────────────────────────────
 ASTRA_JWT_SECRET=

--- a/deployment/all-in-one/docker-compose.deps.yml
+++ b/deployment/all-in-one/docker-compose.deps.yml
@@ -59,6 +59,8 @@ services:
       - "${MEMORIA_PORT:-8100}:8100"
     volumes:
       - ${MEMORIA_LOG_DIR:-./data/logs/memoria}:/var/log/memoria
+    # Memoria container expects bare EMBEDDING_* / MASTER_KEY names internally.
+    # Host-side .env uses MEMORIA_EMBEDDING_* / MEMORIA_MASTER_KEY prefix.
     environment:
       - DATABASE_URL=mysql://root:111@matrixone:6001/${MEMORIA_DB_NAME:-memoria}
       - MASTER_KEY=${MEMORIA_MASTER_KEY:-}

--- a/deployment/all-in-one/docker-compose.deps.yml
+++ b/deployment/all-in-one/docker-compose.deps.yml
@@ -62,7 +62,7 @@ services:
     # Memoria container expects bare EMBEDDING_* / MASTER_KEY names internally.
     # Host-side .env uses MEMORIA_EMBEDDING_* / MEMORIA_MASTER_KEY prefix.
     environment:
-      - DATABASE_URL=mysql://root:111@matrixone:6001/${MEMORIA_DB_NAME:-memoria}
+      - DATABASE_URL=mysql://${MATRIXONE_USER:-root}:${MATRIXONE_PASSWORD:-111}@matrixone:6001/${MEMORIA_DB_NAME:-memoria}
       - MASTER_KEY=${MEMORIA_MASTER_KEY:-}
       - EMBEDDING_PROVIDER=${MEMORIA_EMBEDDING_PROVIDER:-openai}
       - EMBEDDING_MODEL=${MEMORIA_EMBEDDING_MODEL:-BAAI/bge-m3}

--- a/deployment/all-in-one/docker-compose.memoria.yml
+++ b/deployment/all-in-one/docker-compose.memoria.yml
@@ -39,7 +39,7 @@ services:
     ports:
       - "8100:8000"
     environment:
-      - DATABASE_URL=mysql://root:111@matrixone:6001/memoria
+      - DATABASE_URL=mysql://${MATRIXONE_USER:-root}:${MATRIXONE_PASSWORD:-111}@matrixone:6001/memoria
       - MASTER_KEY=${MEMORIA_MASTER_KEY:-dev-master-key-change-in-production}
       - EMBEDDING_PROVIDER=${MEMORIA_EMBEDDING_PROVIDER:-openai}
       - EMBEDDING_API_KEY=${MEMORIA_EMBEDDING_API_KEY}

--- a/deployment/all-in-one/docker-compose.memoria.yml
+++ b/deployment/all-in-one/docker-compose.memoria.yml
@@ -24,10 +24,10 @@ services:
     networks:
       - mo-net
     healthcheck:
-      test: ["CMD-SHELL", "mysql -h127.0.0.1 -P6001 -uroot -p111 -e 'SELECT 1' || exit 1"]
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:6060/debug/vars"]
       interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 12
       start_period: 30s
     restart: unless-stopped
 
@@ -91,7 +91,6 @@ services:
     environment:
       - ASTRA_API_HOST=0.0.0.0
       - ASTRA_API_PORT=8000
-      - ASTRA_APP_ENV=${ASTRA_APP_ENV:-production}
       - MATRIXONE_HOST=matrixone
       - MATRIXONE_PORT=6001
       - MATRIXONE_PASSWORD=${MATRIXONE_PASSWORD}

--- a/deployment/all-in-one/docker-compose.prod.yml
+++ b/deployment/all-in-one/docker-compose.prod.yml
@@ -30,10 +30,10 @@ services:
     networks:
       - mo-net
     healthcheck:
-      test: ["CMD-SHELL", "mysql -h127.0.0.1 -P6001 -uroot -p111 -e 'SELECT 1' || exit 1"]
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:6060/debug/vars"]
       interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 12
       start_period: 30s
     restart: always
     deploy:
@@ -84,8 +84,6 @@ services:
       # API
       - ASTRA_API_HOST=0.0.0.0
       - ASTRA_API_PORT=8000
-      - ASTRA_APP_ENV=${ASTRA_APP_ENV:-production}
-      - ASTRA_LOG_LEVEL=${ASTRA_LOG_LEVEL:-info}
       - ASTRA_CORS_ORIGINS=${ASTRA_CORS_ORIGINS:-*}
 
     ports:

--- a/deployment/all-in-one/docker-compose.yml
+++ b/deployment/all-in-one/docker-compose.yml
@@ -65,7 +65,6 @@ services:
     environment:
       - ASTRA_API_HOST=0.0.0.0
       - ASTRA_API_PORT=8000
-      - ASTRA_APP_ENV=${ASTRA_APP_ENV:-production}
       - MATRIXONE_HOST=matrixone
       - MATRIXONE_PORT=6001
       - ASTRA_DATABASE=${ASTRA_DATABASE:-astra_runtime}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -21,9 +21,8 @@ Use these files as the canonical configuration references:
 
 ### Application
 
-- `ASTRA_APP_ENV` — `development` | `staging` | `production`
-- `ASTRA_LOG_LEVEL`
 - `ASTRA_ALLOW_INSECURE_DEFAULTS` — dev-only opt-in for bundled defaults on required keys
+- `RUST_LOG` — standard tracing filter (e.g. `warn,astra_runtime=info`)
 
 ### API server
 
@@ -33,11 +32,11 @@ Use these files as the canonical configuration references:
 
 - `ASTRA_JWT_SECRET`
 - `ASTRA_JWT_ALGORITHM` (default `HS256`)
-- `ASTRA_JWT_ACCESS_TTL_MINUTES` (default `60`)
+- `ASTRA_JWT_ACCESS_TTL_MINUTES` (default `10080` in code; production should override)
 - `ASTRA_JWT_REFRESH_TTL_DAYS` (default `7`)
 - `ASTRA_TOKEN_ENCRYPTION_KEY` (Fernet key)
-- `ASTRA_BRIDGE_SECRET`, `ASTRA_BRIDGE_URL` (optional)
-- `ASTRA_AUTH_MODE` — `local_jwt` (default) or `trusted_external`
+- `ASTRA_BRIDGE_SECRET`
+- `ASTRA_AUTH_MODE` — `local_jwt` (default) or `trusted_moi`
 - External-IdP mode only: `ASTRA_EXTERNAL_JWT_SECRET`, `ASTRA_EXTERNAL_JWT_ALGORITHM`, `ASTRA_EXTERNAL_JWT_ISSUER`, `ASTRA_EXTERNAL_JWT_AUDIENCE`, `ASTRA_EXTERNAL_JWT_LEEWAY_SECS`
 
 ### LLM

--- a/fixtures/contracts/settings_contract.json
+++ b/fixtures/contracts/settings_contract.json
@@ -5,10 +5,6 @@
     "matrixone_user": "root",
     "matrixone_password": "111",
     "matrixone_database": "astra_runtime",
-    "app_env": "development",
-    "log_level": "DEBUG",
-    "github_token": null,
-    "bridge_url": null,
     "bridge_secret": "dev-bridge-secret-change-me"
   },
   "override_env": {
@@ -17,11 +13,7 @@
     "MATRIXONE_USER": "agent",
     "MATRIXONE_PASSWORD": "super-secret",
     "ASTRA_DATABASE": "agent_db",
-    "ASTRA_APP_ENV": "production",
-    "ASTRA_LOG_LEVEL": "INFO",
     "ASTRA_JWT_SECRET": "override-jwt-secret-key-123456",
-    "GITHUB_TOKEN": "ghp_example",
-    "ASTRA_BRIDGE_URL": "http://bridge.internal:9001/internal/chat/turn",
     "ASTRA_BRIDGE_SECRET": "bridge-secret-prod"
   },
   "expected_override_settings": {
@@ -30,10 +22,6 @@
     "matrixone_user": "agent",
     "matrixone_password": "super-secret",
     "matrixone_database": "agent_db",
-    "app_env": "production",
-    "log_level": "INFO",
-    "github_token": "ghp_example",
-    "bridge_url": "http://bridge.internal:9001/internal/chat/turn",
     "bridge_secret": "bridge-secret-prod"
   }
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -239,6 +239,7 @@ name = "astra-edge"
 version = "0.1.0"
 dependencies = [
  "astra-logging",
+ "astra-server-types",
  "astra-tools",
  "clap",
  "futures-util",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,7 +44,7 @@ astra-pipeline = { path = "crates/astra-pipeline" }
 astra-plan = { path = "crates/astra-plan" }
 astra-prompts = { path = "crates/astra-prompts" }
 astra-sandbox = { path = "crates/astra-sandbox" }
-astra-server-types = { path = "crates/astra-server-types" }
+astra-server-types = { path = "crates/astra-server-types", default-features = false }
 astra-turn-core = { path = "crates/astra-turn-core" }
 astra-turn-types = { path = "crates/astra-turn-types" }
 astra-skills = { path = "crates/astra-skills" }

--- a/rust/crates/astra-cli/src/cli/cloud_sync.rs
+++ b/rust/crates/astra-cli/src/cli/cloud_sync.rs
@@ -111,7 +111,7 @@ pub(super) async fn try_cloud_pull(
     );
     let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
     let svc = MatrixOneSyncService::new(pool, flusher.writer.clone());
-    let user_id = std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
+    let user_id = astra_core::cli_user_id();
     let out = StateSyncService::pull_learning_versioned(&svc, &user_id, profile_name).await;
     drain_ephemeral_audit(svc, flusher).await;
     match out {
@@ -187,7 +187,7 @@ pub(super) async fn try_cloud_push_versioned(
     };
     let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
     let svc = MatrixOneSyncService::new(pool, flusher.writer.clone());
-    let user_id = std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
+    let user_id = astra_core::cli_user_id();
     let result = StateSyncService::push_learning_versioned(
         &svc,
         &user_id,
@@ -276,7 +276,7 @@ pub(super) async fn try_cloud_push_delta(
 
     let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
     let svc = MatrixOneSyncService::new(pool, flusher.writer.clone());
-    let user_id = std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
+    let user_id = astra_core::cli_user_id();
 
     let result =
         StateSyncService::push_delta(&svc, &user_id, profile_name, &delta_json, expected_version)
@@ -337,7 +337,7 @@ pub(super) async fn try_cloud_pull_preferences(state: &mut ReplState) -> Vec<Str
     };
     let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
     let svc = MatrixOneSyncService::new(pool, flusher.writer.clone());
-    let user_id = std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
+    let user_id = astra_core::cli_user_id();
     let out = StateSyncService::pull_all_preferences(&svc, &user_id).await;
     drain_ephemeral_audit(svc, flusher).await;
     match out {
@@ -398,7 +398,7 @@ pub(super) async fn try_cloud_push_preferences(state: &ReplState) {
     };
     let flusher = astra_services::state_sync::spawn_audit_flusher(pool.clone());
     let svc = MatrixOneSyncService::new(pool, flusher.writer.clone());
-    let user_id = std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
+    let user_id = astra_core::cli_user_id();
 
     let blocked: Vec<String> = state
         .tool_health_entries

--- a/rust/crates/astra-cli/src/cli/memory_extraction.rs
+++ b/rust/crates/astra-cli/src/cli/memory_extraction.rs
@@ -307,9 +307,8 @@ async fn run_extraction(
         })
         .collect();
 
-    let base = std::env::var("MEMORIA_BASE_URL")
-        .unwrap_or_else(|_| astra_core::config::DEFAULT_MEMORIA_URL.to_string());
-    let key = match std::env::var("MEMORIA_MASTER_KEY").ok() {
+    let mem = astra_core::MemoriaSettings::from_env();
+    let key = match mem.master_key {
         Some(k) => k,
         None => {
             return ExtractionOutcome::Extracted {
@@ -321,7 +320,7 @@ async fn run_extraction(
     };
 
     match client
-        .post(format!("{base}/v1/memories/batch"))
+        .post(format!("{}/v1/memories/batch", mem.base_url))
         .header("Authorization", format!("Bearer {key}"))
         .json(&serde_json::json!({ "memories": memories }))
         .send()

--- a/rust/crates/astra-cli/src/cli/repl_startup.rs
+++ b/rust/crates/astra-cli/src/cli/repl_startup.rs
@@ -234,7 +234,7 @@ pub(crate) async fn complete_repl_startup(
         state.matrix_runtime = match SharedPool::new(&settings).await {
             Ok(pool) => {
                 let user_id =
-                    std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
+                    astra_core::cli_user_id();
                 let th =
                     std::sync::Arc::new(std::sync::Mutex::new(state.tool_health_entries.clone()));
                 let lease = std::sync::Arc::new(astra_services::TaskLeaseHoldCache::default());
@@ -271,7 +271,7 @@ pub(crate) async fn complete_repl_startup(
         if let Some(ref mc) = state.matrix_runtime {
             let pool = mc.shared_pool().get().clone();
             let user_id =
-                std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
+                astra_core::cli_user_id();
             let mo_team_store = astra_services::team_persistence::MatrixOneTeamStore::new(pool);
             if let Err(e) = mo_team_store.ensure_builtins(&user_id).await {
                 eprintln!("  {} team store builtins: {e}", theme::icon_warn());

--- a/rust/crates/astra-cli/src/cli/repl_startup.rs
+++ b/rust/crates/astra-cli/src/cli/repl_startup.rs
@@ -233,8 +233,7 @@ pub(crate) async fn complete_repl_startup(
     }) {
         state.matrix_runtime = match SharedPool::new(&settings).await {
             Ok(pool) => {
-                let user_id =
-                    astra_core::cli_user_id();
+                let user_id = astra_core::cli_user_id();
                 let th =
                     std::sync::Arc::new(std::sync::Mutex::new(state.tool_health_entries.clone()));
                 let lease = std::sync::Arc::new(astra_services::TaskLeaseHoldCache::default());
@@ -270,8 +269,7 @@ pub(crate) async fn complete_repl_startup(
         };
         if let Some(ref mc) = state.matrix_runtime {
             let pool = mc.shared_pool().get().clone();
-            let user_id =
-                astra_core::cli_user_id();
+            let user_id = astra_core::cli_user_id();
             let mo_team_store = astra_services::team_persistence::MatrixOneTeamStore::new(pool);
             if let Err(e) = mo_team_store.ensure_builtins(&user_id).await {
                 eprintln!("  {} team store builtins: {e}", theme::icon_warn());

--- a/rust/crates/astra-cli/src/cli/slash_info.rs
+++ b/rust/crates/astra-cli/src/cli/slash_info.rs
@@ -1442,10 +1442,9 @@ pub(super) async fn handle_info_command(
             }
 
             // Memoria
-            let memoria_key_set = std::env::var("MEMORIA_MASTER_KEY").is_ok();
-            if memoria_key_set {
-                let memoria_base = std::env::var("MEMORIA_BASE_URL")
-                    .unwrap_or_else(|_| astra_core::config::DEFAULT_MEMORIA_URL.to_string());
+            let mem = astra_core::MemoriaSettings::from_env();
+            if mem.is_configured() {
+                let memoria_base = mem.base_url;
                 let memoria_health = format!("{}/health", memoria_base.trim_end_matches('/'));
                 match api.get_url(&memoria_health).await {
                     Ok(r) if r.status().is_success() => {

--- a/rust/crates/astra-cli/src/cli/slash_memory.rs
+++ b/rust/crates/astra-cli/src/cli/slash_memory.rs
@@ -279,23 +279,19 @@ pub(super) async fn handle_memory_domain_command(
                                             .unwrap_or("?");
                                         let preview: String = content.chars().take(60).collect();
                                         // Send "irrelevant" feedback to lower retrieval score
+                                        let mem = astra_core::MemoriaSettings::from_env();
                                         let fb_url = format!(
                                             "{}/v1/memories/{mid}/feedback",
-                                            std::env::var("MEMORIA_BASE_URL").unwrap_or_else(
-                                                |_| astra_core::config::DEFAULT_MEMORIA_URL
-                                                    .to_string()
-                                            )
+                                            mem.base_url
                                         );
-                                        let key =
-                                            std::env::var("MEMORIA_MASTER_KEY").unwrap_or_default();
-                                        if let Ok(client) = reqwest::Client::builder()
+                                        if let (Ok(client), Some(token)) = (reqwest::Client::builder()
                                             .timeout(std::time::Duration::from_secs(3))
                                             .no_proxy()
-                                            .build()
+                                            .build(), mem.bearer_token())
                                         {
                                             let _ = client
                                                 .post(&fb_url)
-                                                .header("Authorization", format!("Bearer {key}"))
+                                                .header("Authorization", token)
                                                 .json(&serde_json::json!({"signal": "irrelevant", "context": "user /memory dismiss"}))
                                                 .send()
                                                 .await;

--- a/rust/crates/astra-cli/src/cli/slash_memory.rs
+++ b/rust/crates/astra-cli/src/cli/slash_memory.rs
@@ -280,15 +280,15 @@ pub(super) async fn handle_memory_domain_command(
                                         let preview: String = content.chars().take(60).collect();
                                         // Send "irrelevant" feedback to lower retrieval score
                                         let mem = astra_core::MemoriaSettings::from_env();
-                                        let fb_url = format!(
-                                            "{}/v1/memories/{mid}/feedback",
-                                            mem.base_url
-                                        );
-                                        if let (Ok(client), Some(token)) = (reqwest::Client::builder()
-                                            .timeout(std::time::Duration::from_secs(3))
-                                            .no_proxy()
-                                            .build(), mem.bearer_token())
-                                        {
+                                        let fb_url =
+                                            format!("{}/v1/memories/{mid}/feedback", mem.base_url);
+                                        if let (Ok(client), Some(token)) = (
+                                            reqwest::Client::builder()
+                                                .timeout(std::time::Duration::from_secs(3))
+                                                .no_proxy()
+                                                .build(),
+                                            mem.bearer_token(),
+                                        ) {
                                             let _ = client
                                                 .post(&fb_url)
                                                 .header("Authorization", token)

--- a/rust/crates/astra-cli/src/edge_tools/memoria.rs
+++ b/rust/crates/astra-cli/src/edge_tools/memoria.rs
@@ -99,11 +99,10 @@ impl ToolExecutor {
         {
             return vec![];
         }
-        let base = std::env::var("MEMORIA_BASE_URL")
-            .unwrap_or_else(|_| astra_core::config::DEFAULT_MEMORIA_URL.to_string());
-        let key = match std::env::var("MEMORIA_MASTER_KEY").ok() {
-            Some(k) => k,
-            None => return vec![], // No key = no Memoria
+        let mem = astra_core::MemoriaSettings::from_env();
+        let token = match mem.bearer_token() {
+            Some(t) => t,
+            None => return vec![],
         };
         let client = match reqwest::Client::builder()
             .timeout(Duration::from_millis(800))
@@ -114,8 +113,8 @@ impl ToolExecutor {
             Err(_) => return vec![],
         };
         match client
-            .post(format!("{base}/v1/memories/retrieve"))
-            .header("Authorization", format!("Bearer {key}"))
+            .post(format!("{}/v1/memories/retrieve", mem.base_url))
+            .header("Authorization", token)
             .json(&json!({
                 "query": query,
                 "top_k": top_k,
@@ -153,10 +152,9 @@ impl ToolExecutor {
         {
             return;
         }
-        let base = std::env::var("MEMORIA_BASE_URL")
-            .unwrap_or_else(|_| astra_core::config::DEFAULT_MEMORIA_URL.to_string());
-        let key = match std::env::var("MEMORIA_MASTER_KEY").ok() {
-            Some(k) => k,
+        let mem = astra_core::MemoriaSettings::from_env();
+        let token = match mem.bearer_token() {
+            Some(t) => t,
             None => return,
         };
         tokio::spawn(async move {
@@ -169,10 +167,10 @@ impl ToolExecutor {
                 Err(_) => return,
             };
             for mid in memory_ids {
-                let url = format!("{base}/v1/memories/{mid}/feedback");
+                let url = format!("{}/v1/memories/{mid}/feedback", mem.base_url);
                 if let Err(e) = client
                     .post(&url)
-                    .header("Authorization", format!("Bearer {key}"))
+                    .header("Authorization", &token)
                     .json(&json!({
                         "signal": "useful",
                         "context": "boost_search retrieval"

--- a/rust/crates/astra-cli/src/edge_tools/mo_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools/mo_tools.rs
@@ -181,11 +181,8 @@ fn is_mo_error(output: &str) -> bool {
 }
 
 fn mo_mysql_cmd(database: Option<&str>) -> Result<Command, String> {
-    let settings = astra_core::MatrixOneSettings::from_env_strict().map_err(|e| {
-        format!(
-            "Error: {e}. Set MATRIXONE_PASSWORD before using MatrixOne tools."
-        )
-    })?;
+    let settings = astra_core::MatrixOneSettings::from_env_strict()
+        .map_err(|e| format!("Error: {e}. Set MATRIXONE_PASSWORD before using MatrixOne tools."))?;
     Ok(settings.mysql_cmd(database))
 }
 

--- a/rust/crates/astra-cli/src/edge_tools/mo_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools/mo_tools.rs
@@ -24,8 +24,6 @@ use uuid::Uuid;
 
 // ─── MatrixOne connection helper ────────────────────────────────────────────
 
-const ASTRA_CONNECT_TIMEOUT_SECS: u32 = 5;
-
 /// Cached account name — queried once via `SELECT current_account_name()`.
 fn mo_current_account() -> &'static str {
     use std::sync::OnceLock;
@@ -182,32 +180,13 @@ fn is_mo_error(output: &str) -> bool {
     output.trim_start().starts_with("Error:")
 }
 
-/// Build a mysql Command with connection parameters from environment.
-///
-/// Requires `MATRIXONE_PASSWORD` to be set — returns an error message string
-/// when missing rather than falling back to a hardcoded development password.
 fn mo_mysql_cmd(database: Option<&str>) -> Result<Command, String> {
-    let host = std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".to_string());
-    let port = std::env::var("MATRIXONE_PORT").unwrap_or_else(|_| "6001".to_string());
-    let user = std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".to_string());
-    let password = std::env::var("MATRIXONE_PASSWORD").map_err(|_| {
-        "Error: MATRIXONE_PASSWORD environment variable is required. \
-         Set it before using MatrixOne tools."
-            .to_string()
+    let settings = astra_core::MatrixOneSettings::from_env_strict().map_err(|e| {
+        format!(
+            "Error: {e}. Set MATRIXONE_PASSWORD before using MatrixOne tools."
+        )
     })?;
-    let db = database
-        .map(String::from)
-        .unwrap_or_else(|| astra_core::resolve_database_name(&|k| std::env::var(k).ok()));
-
-    let mut cmd = Command::new("mysql");
-    cmd.arg(format!("-h{}", host))
-        .arg(format!("-P{}", port))
-        .arg(format!("-u{}", user))
-        .env("MYSQL_PWD", &password) // pass via env, not CLI (hidden from ps)
-        .arg(&db)
-        .arg(format!("--connect-timeout={ASTRA_CONNECT_TIMEOUT_SECS}"))
-        .arg("--table"); // Pretty-print results
-    Ok(cmd)
+    Ok(settings.mysql_cmd(database))
 }
 
 /// Execute a SQL statement against MatrixOne via the mysql CLI.

--- a/rust/crates/astra-edge/Cargo.toml
+++ b/rust/crates/astra-edge/Cargo.toml
@@ -25,3 +25,4 @@ uuid = { workspace = true }
 hostname = { workspace = true }
 reqwest = { workspace = true }
 astra-tools = { path = "../astra-tools" }
+astra-server-types.workspace = true

--- a/rust/crates/astra-edge/src/main.rs
+++ b/rust/crates/astra-edge/src/main.rs
@@ -9,9 +9,11 @@
 //! astra-edge --server-url wss://astra.example.com --token <jwt> --workspace-dir ~/projects/my-app
 //! ```
 
+use astra_server_types::edge_ws_protocol::{
+    EdgeClientMessage, EdgeServerMessage, EDGE_AUTH_TIMEOUT_SECS, EDGE_HEARTBEAT_INTERVAL_SECS,
+};
 use clap::Parser;
 use futures_util::{SinkExt, StreamExt};
-use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
@@ -50,54 +52,6 @@ fn default_edge_id() -> String {
     format!("edge-{hostname}-{}", &uuid::Uuid::new_v4().to_string()[..8])
 }
 
-// ─── Protocol types (mirroring server edge_ws_protocol.rs) ───────────────────
-
-#[derive(Serialize)]
-#[serde(tag = "type")]
-enum EdgeToServer {
-    #[serde(rename = "edge_auth")]
-    Auth {
-        token: String,
-        edge_agent_id: String,
-        hostname: Option<String>,
-        workspace_dir: Option<String>,
-    },
-    #[serde(rename = "edge_tool_result")]
-    ToolResult {
-        request_id: String,
-        output: String,
-        is_error: bool,
-        duration_ms: u64,
-    },
-    #[serde(rename = "edge_ping")]
-    Ping,
-}
-
-#[derive(Deserialize)]
-#[serde(tag = "type")]
-enum ServerToEdge {
-    #[serde(rename = "edge_auth_ok")]
-    AuthOk { user_id: String },
-    #[serde(rename = "edge_auth_error")]
-    AuthError { message: String },
-    #[serde(rename = "edge_tool_request")]
-    ToolRequest {
-        request_id: String,
-        tool: String,
-        args: serde_json::Value,
-        #[serde(rename = "timeout_secs", default = "default_timeout")]
-        _timeout_secs: u64,
-    },
-    #[serde(rename = "edge_pong")]
-    Pong,
-    #[serde(rename = "edge_closing")]
-    Closing { reason: String },
-}
-
-fn default_timeout() -> u64 {
-    300
-}
-
 // ─── Connection loop ─────────────────────────────────────────────────────────
 
 async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
@@ -125,7 +79,7 @@ async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Erro
 
     // Send auth
     let hostname = hostname::get().ok().and_then(|h| h.into_string().ok());
-    let auth_msg = EdgeToServer::Auth {
+    let auth_msg = EdgeClientMessage::Auth {
         token: args.token.clone(),
         edge_agent_id: args.edge_id.clone(),
         hostname,
@@ -136,21 +90,23 @@ async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Erro
                 .to_string_lossy()
                 .to_string(),
         ),
+        capabilities: None,
     };
     write
         .send(Message::Text(serde_json::to_string(&auth_msg)?.into()))
         .await?;
 
     // Wait for auth response
-    let auth_timeout = Duration::from_secs(30);
+    let auth_timeout = Duration::from_secs(EDGE_AUTH_TIMEOUT_SECS);
     let auth_response = tokio::time::timeout(auth_timeout, read.next()).await;
 
     match auth_response {
-        Ok(Some(Ok(Message::Text(text)))) => match serde_json::from_str::<ServerToEdge>(&text) {
-            Ok(ServerToEdge::AuthOk { user_id }) => {
+        Ok(Some(Ok(Message::Text(text)))) => match serde_json::from_str::<EdgeServerMessage>(&text)
+        {
+            Ok(EdgeServerMessage::AuthOk { user_id }) => {
                 tracing::info!(user_id = %user_id, "Authenticated successfully");
             }
-            Ok(ServerToEdge::AuthError { message }) => {
+            Ok(EdgeServerMessage::AuthError { message }) => {
                 tracing::error!(
                     target: "astra.edge",
                     edge_id = %args.edge_id,
@@ -211,7 +167,7 @@ async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Erro
     }
 
     // Heartbeat ticker
-    let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
+    let mut heartbeat = tokio::time::interval(Duration::from_secs(EDGE_HEARTBEAT_INTERVAL_SECS));
     heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     tracing::info!(
@@ -224,12 +180,12 @@ async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Erro
             msg = read.next() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
-                        match serde_json::from_str::<ServerToEdge>(&text) {
-                            Ok(ServerToEdge::ToolRequest {
+                        match serde_json::from_str::<EdgeServerMessage>(&text) {
+                            Ok(EdgeServerMessage::ToolRequest {
                                 request_id,
                                 tool,
                                 args: tool_args,
-                                _timeout_secs: _,
+                                timeout_secs: _,
                             }) => {
                                 tracing::info!(tool = %tool, request_id = %request_id, "Executing tool");
                                 let start = Instant::now();
@@ -245,22 +201,22 @@ async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Erro
                                     output_len = output.len(),
                                     "Tool execution complete"
                                 );
-                                let result_msg = EdgeToServer::ToolResult {
+                                let result_msg = EdgeClientMessage::ToolResult {
                                     request_id,
                                     output,
                                     is_error,
-                                    duration_ms,
+                                    duration_ms: Some(duration_ms),
                                 };
                                 write.send(Message::Text(serde_json::to_string(&result_msg)?.into())).await?;
                             }
-                            Ok(ServerToEdge::Pong) => {
+                            Ok(EdgeServerMessage::Pong) => {
                                 // heartbeat ack
                             }
-                            Ok(ServerToEdge::Closing { reason }) => {
+                            Ok(EdgeServerMessage::Closing { reason }) => {
                                 tracing::info!(reason = %reason, "Server closing connection");
                                 break;
                             }
-                            Ok(ServerToEdge::AuthOk { .. } | ServerToEdge::AuthError { .. }) => {
+                            Ok(EdgeServerMessage::AuthOk { .. } | EdgeServerMessage::AuthError { .. }) => {
                                 // ignore duplicate auth
                             }
                             Err(e) => {
@@ -279,7 +235,7 @@ async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Erro
                 }
             }
             _ = heartbeat.tick() => {
-                let ping = EdgeToServer::Ping;
+                let ping = EdgeClientMessage::Ping;
                 if write.send(Message::Text(serde_json::to_string(&ping)?.into())).await.is_err() {
                     tracing::warn!("Failed to send heartbeat");
                     break;

--- a/rust/crates/astra-edge/src/main.rs
+++ b/rust/crates/astra-edge/src/main.rs
@@ -10,7 +10,7 @@
 //! ```
 
 use astra_server_types::edge_ws_protocol::{
-    EdgeClientMessage, EdgeServerMessage, EDGE_AUTH_TIMEOUT_SECS, EDGE_HEARTBEAT_INTERVAL_SECS,
+    EDGE_AUTH_TIMEOUT_SECS, EDGE_HEARTBEAT_INTERVAL_SECS, EdgeClientMessage, EdgeServerMessage,
 };
 use clap::Parser;
 use futures_util::{SinkExt, StreamExt};

--- a/rust/crates/astra-edge/src/main.rs
+++ b/rust/crates/astra-edge/src/main.rs
@@ -139,32 +139,14 @@ async fn run_edge_connection(args: &Args) -> Result<(), Box<dyn std::error::Erro
         .canonicalize()
         .unwrap_or_else(|_| args.workspace_dir.clone());
 
-    // Build a production ToolContext (not test) with HTTP client for web_fetch/GitHub
-    let http_client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .user_agent("astra-edge/0.1")
-        .no_proxy()
-        .build()
-        .expect("Failed to create HTTP client");
-    let ctx = astra_tools::ToolContext {
-        project_root: workspace.clone(),
-        workspace_root: workspace.clone(),
-        user_id: args.edge_id.clone(),
-        session_id: format!("edge-{}", &uuid::Uuid::new_v4().to_string()[..8]),
-        sandbox: astra_tools::SandboxConfig::standard(&workspace),
-        http_client: Some(http_client.clone()),
-        logger: std::sync::Arc::new(astra_tools::TracingLogger),
-        cancel_token: None,
-    };
-
-    // Build executor with optional GitHub client (from GITHUB_TOKEN + gh auth token)
-    let mut executor = astra_tools::executor::DefaultToolExecutor::new(ctx);
-    let tokens = astra_tools::github::resolve_github_tokens();
-    if !tokens.is_empty() {
-        let github =
-            astra_tools::github::GitHubClient::from_tokens(http_client, tokens, Vec::new());
-        executor = executor.with_github_client(github);
-    }
+    let session_id = format!("edge-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+    let executor = astra_tools::executor::DefaultToolExecutor::for_workspace(
+        &workspace,
+        args.edge_id.clone(),
+        session_id,
+        "astra-edge/0.1",
+        Duration::from_secs(30),
+    );
 
     // Heartbeat ticker
     let mut heartbeat = tokio::time::interval(Duration::from_secs(EDGE_HEARTBEAT_INTERVAL_SECS));

--- a/rust/crates/astra-plan/tests/plan_repository_db_it.rs
+++ b/rust/crates/astra-plan/tests/plan_repository_db_it.rs
@@ -27,20 +27,10 @@ fn require_db_it_env() -> MatrixOneSettings {
     assert_eq!(
         std::env::var("ASTRA_TEST_DB_IT").as_deref(),
         Ok("1"),
-        "set ASTRA_TEST_DB_IT=1 for ignored plan_repository_db_it tests"
+        "set ASTRA_TEST_DB_IT=1 for ignored integration tests"
     );
-    dotenvy::dotenv().ok();
-    MatrixOneSettings {
-        host: std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "127.0.0.1".into()),
-        port: std::env::var("MATRIXONE_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6001),
-        user: std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".into()),
-        password: std::env::var("MATRIXONE_PASSWORD")
-            .unwrap_or_else(|_| DEV_MATRIXONE_PASSWORD.to_string()),
-        database: resolve_database_name(&|k| std::env::var(k).ok()),
-    }
+    MatrixOneSettings::from_env()
+}
 }
 
 /// Per-binary cached schema-bootstrap + pool. `ensure_core_schema` costs

--- a/rust/crates/astra-plan/tests/plan_repository_db_it.rs
+++ b/rust/crates/astra-plan/tests/plan_repository_db_it.rs
@@ -12,7 +12,7 @@
 //! as `services_db_integration.rs`). Tests are `#[ignore]` so the normal
 //! `cargo test` is unaffected.
 
-use astra_core::{DEV_MATRIXONE_PASSWORD, MatrixOneSettings, SharedPool, resolve_database_name};
+use astra_core::{MatrixOneSettings, SharedPool};
 use astra_plan::{
     CloudPlanRepository, NewStepRun, PlanListFilter, PlanLoadError, PlanModeState, PlanRepository,
     ProjectContext,
@@ -30,7 +30,6 @@ fn require_db_it_env() -> MatrixOneSettings {
         "set ASTRA_TEST_DB_IT=1 for ignored integration tests"
     );
     MatrixOneSettings::from_env()
-}
 }
 
 /// Per-binary cached schema-bootstrap + pool. `ensure_core_schema` costs

--- a/rust/crates/astra-server-types/Cargo.toml
+++ b/rust/crates/astra-server-types/Cargo.toml
@@ -4,20 +4,37 @@ version.workspace = true
 edition.workspace = true
 description = "Server request and response types for astra runtime"
 
+[features]
+default = ["server"]
+server = [
+    "dep:astra-core",
+    "dep:astra-services",
+    "dep:astra-tools",
+    "dep:async-trait",
+    "dep:chrono",
+    "dep:dashmap",
+    "dep:regex",
+    "dep:serde_yaml_ng",
+    "dep:tokio",
+    "dep:tokio-util",
+    "dep:uuid",
+]
+
 [dependencies]
-astra-core.workspace = true
-astra-services.workspace = true
-astra-tools.workspace = true
-async-trait.workspace = true
-chrono.workspace = true
-dashmap = "6.1.0"
-regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-serde_yaml_ng.workspace = true
-tokio.workspace = true
-tokio-util.workspace = true
-uuid.workspace = true
+
+astra-core = { workspace = true, optional = true }
+astra-services = { workspace = true, optional = true }
+astra-tools = { workspace = true, optional = true }
+async-trait = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
+dashmap = { version = "6.1.0", optional = true }
+regex = { workspace = true, optional = true }
+serde_yaml_ng = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/crates/astra-server-types/src/edge_ws_protocol.rs
+++ b/rust/crates/astra-server-types/src/edge_ws_protocol.rs
@@ -258,7 +258,9 @@ mod tests {
         }))
         .unwrap();
         match msg {
-            EdgeServerMessage::ToolRequest { tool, timeout_secs, .. } => {
+            EdgeServerMessage::ToolRequest {
+                tool, timeout_secs, ..
+            } => {
                 assert_eq!(tool, "bash");
                 assert_eq!(timeout_secs, 120);
             }
@@ -292,8 +294,7 @@ mod tests {
 
     #[test]
     fn edge_server_pong_deserializes() {
-        let msg: EdgeServerMessage =
-            serde_json::from_value(json!({"type": "edge_pong"})).unwrap();
+        let msg: EdgeServerMessage = serde_json::from_value(json!({"type": "edge_pong"})).unwrap();
         assert!(matches!(msg, EdgeServerMessage::Pong));
     }
 

--- a/rust/crates/astra-server-types/src/edge_ws_protocol.rs
+++ b/rust/crates/astra-server-types/src/edge_ws_protocol.rs
@@ -225,6 +225,23 @@ mod tests {
     }
 
     #[test]
+    fn edge_client_tool_result_none_duration_serializes_as_null() {
+        let msg = EdgeClientMessage::ToolResult {
+            request_id: "r1".into(),
+            output: "ok".into(),
+            is_error: false,
+            duration_ms: None,
+        };
+        let v = serde_json::to_value(&msg).unwrap();
+        assert!(v["duration_ms"].is_null());
+        let rt: EdgeClientMessage = serde_json::from_value(v).unwrap();
+        match rt {
+            EdgeClientMessage::ToolResult { duration_ms, .. } => assert_eq!(duration_ms, None),
+            _ => panic!("expected ToolResult"),
+        }
+    }
+
+    #[test]
     fn edge_client_ping_serializes() {
         let v = serde_json::to_value(&EdgeClientMessage::Ping).unwrap();
         assert_eq!(v["type"], "edge_ping");

--- a/rust/crates/astra-server-types/src/edge_ws_protocol.rs
+++ b/rust/crates/astra-server-types/src/edge_ws_protocol.rs
@@ -35,7 +35,7 @@ pub const EDGE_AUTH_TIMEOUT_SECS: u64 = 30;
 pub const EDGE_HEARTBEAT_INTERVAL_SECS: u64 = 30;
 
 /// Messages sent from edge agent to server.
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type")]
 pub enum EdgeClientMessage {
     /// Authenticate the edge agent (must be first message).
@@ -68,7 +68,7 @@ pub enum EdgeClientMessage {
 }
 
 /// Messages sent from server to edge agent.
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type")]
 pub enum EdgeServerMessage {
     /// Authentication succeeded.
@@ -86,6 +86,7 @@ pub enum EdgeServerMessage {
         tool: String,
         args: Value,
         /// Maximum execution time in seconds.
+        #[serde(default = "default_tool_timeout_secs")]
         timeout_secs: u64,
     },
 
@@ -96,6 +97,10 @@ pub enum EdgeServerMessage {
     /// Server is closing the connection.
     #[serde(rename = "edge_closing")]
     Closing { reason: String },
+}
+
+fn default_tool_timeout_secs() -> u64 {
+    EDGE_TOOL_TIMEOUT_SECS
 }
 
 #[cfg(test)]
@@ -189,6 +194,97 @@ mod tests {
         let v = serde_json::to_value(&msg).unwrap();
         assert_eq!(v["type"], "edge_auth_ok");
         assert_eq!(v["user_id"], "u-123");
+    }
+
+    #[test]
+    fn edge_client_auth_serializes() {
+        let msg = EdgeClientMessage::Auth {
+            token: "Bearer tok".into(),
+            edge_agent_id: "e1".into(),
+            hostname: Some("h".into()),
+            workspace_dir: None,
+            capabilities: None,
+        };
+        let v = serde_json::to_value(&msg).unwrap();
+        assert_eq!(v["type"], "edge_auth");
+        assert_eq!(v["token"], "Bearer tok");
+        assert_eq!(v["edge_agent_id"], "e1");
+    }
+
+    #[test]
+    fn edge_client_tool_result_serializes() {
+        let msg = EdgeClientMessage::ToolResult {
+            request_id: "r1".into(),
+            output: "ok".into(),
+            is_error: false,
+            duration_ms: Some(42),
+        };
+        let v = serde_json::to_value(&msg).unwrap();
+        assert_eq!(v["type"], "edge_tool_result");
+        assert_eq!(v["duration_ms"], 42);
+    }
+
+    #[test]
+    fn edge_client_ping_serializes() {
+        let v = serde_json::to_value(&EdgeClientMessage::Ping).unwrap();
+        assert_eq!(v["type"], "edge_ping");
+    }
+
+    #[test]
+    fn edge_server_tool_request_deserializes() {
+        let msg: EdgeServerMessage = serde_json::from_value(json!({
+            "type": "edge_tool_request",
+            "request_id": "r1",
+            "tool": "bash",
+            "args": {"command": "ls"},
+            "timeout_secs": 120
+        }))
+        .unwrap();
+        match msg {
+            EdgeServerMessage::ToolRequest { tool, timeout_secs, .. } => {
+                assert_eq!(tool, "bash");
+                assert_eq!(timeout_secs, 120);
+            }
+            _ => panic!("expected ToolRequest"),
+        }
+    }
+
+    #[test]
+    fn edge_server_tool_request_default_timeout() {
+        let msg: EdgeServerMessage = serde_json::from_value(json!({
+            "type": "edge_tool_request",
+            "request_id": "r1",
+            "tool": "bash",
+            "args": {}
+        }))
+        .unwrap();
+        match msg {
+            EdgeServerMessage::ToolRequest { timeout_secs, .. } => {
+                assert_eq!(timeout_secs, EDGE_TOOL_TIMEOUT_SECS);
+            }
+            _ => panic!("expected ToolRequest"),
+        }
+    }
+
+    #[test]
+    fn edge_server_auth_ok_deserializes() {
+        let msg: EdgeServerMessage =
+            serde_json::from_value(json!({"type": "edge_auth_ok", "user_id": "u1"})).unwrap();
+        assert!(matches!(msg, EdgeServerMessage::AuthOk { .. }));
+    }
+
+    #[test]
+    fn edge_server_pong_deserializes() {
+        let msg: EdgeServerMessage =
+            serde_json::from_value(json!({"type": "edge_pong"})).unwrap();
+        assert!(matches!(msg, EdgeServerMessage::Pong));
+    }
+
+    #[test]
+    fn edge_server_closing_deserializes() {
+        let msg: EdgeServerMessage =
+            serde_json::from_value(json!({"type": "edge_closing", "reason": "shutdown"})).unwrap();
+        assert!(matches!(msg, EdgeServerMessage::Closing { .. }));
     }
 
     const _: () = {

--- a/rust/crates/astra-server-types/src/lib.rs
+++ b/rust/crates/astra-server-types/src/lib.rs
@@ -1,29 +1,43 @@
+#[cfg(feature = "server")]
 pub mod agent_mailbox;
+#[cfg(feature = "server")]
 pub mod agent_mcp;
+#[cfg(feature = "server")]
 mod chat_route;
+#[cfg(feature = "server")]
 pub mod conflict_resolver;
+#[cfg(feature = "server")]
 pub mod edge_connection_pool;
 pub mod edge_ws_protocol;
+#[cfg(feature = "server")]
 pub mod team_orchestrator_traits;
+#[cfg(feature = "server")]
 pub mod team_orchestrator_types;
+#[cfg(feature = "server")]
 pub mod worktree_isolation;
+#[cfg(feature = "server")]
 pub mod ws_progress_callback;
 
+#[cfg(feature = "server")]
 use astra_services::auth::SessionActivityRecord;
+#[cfg(feature = "server")]
 use astra_services::{
     AdminAuditRecord, AdminFeedbackStatsRecord, AdminInitRecord, AdminTokenRecord,
     AdminUserRoleRecord, AuthTokenRecord, AuthUserRecord, CancelRunRecord, ChatRequestData,
     ChatRunRecord, RunListRecord, RunMutationRecord, RunStatusRecord, SessionListRecord,
     SessionRecord,
 };
+#[cfg(feature = "server")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "server")]
 pub use chat_route::{ChatRouteResponse, classify_chat_route};
 pub use edge_ws_protocol::{
     EDGE_AUTH_TIMEOUT_SECS, EDGE_HEARTBEAT_INTERVAL_SECS, EDGE_TOOL_TIMEOUT_SECS,
     EdgeClientMessage, EdgeServerMessage,
 };
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct RootResponse {
     pub name: String,
@@ -31,6 +45,7 @@ pub struct RootResponse {
     pub docs: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct AuthRegisterRequest {
     pub username: String,
@@ -39,23 +54,27 @@ pub struct AuthRegisterRequest {
     pub display_name: Option<String>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct AuthLoginRequest {
     pub username: String,
     pub password: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct AuthRefreshRequest {
     pub refresh_token: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize, Default)]
 pub struct ChatRouteRequest {
     #[serde(default)]
     pub query: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct ChatRequest {
     pub message: String,
@@ -82,12 +101,14 @@ pub struct ChatRequest {
     pub is_plan_subtask: Option<bool>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize, Default)]
 pub struct RunStreamQuery {
     #[serde(default)]
     pub last_index: u32,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct SessionCreateRequest {
     pub agent_id: Option<String>,
@@ -95,6 +116,7 @@ pub struct SessionCreateRequest {
     pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct SessionUpdateRequest {
     pub title: Option<String>,
@@ -102,6 +124,7 @@ pub struct SessionUpdateRequest {
     pub status: Option<String>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize, Default)]
 pub struct SessionListQuery {
     pub agent_id: Option<String>,
@@ -112,6 +135,7 @@ pub struct SessionListQuery {
     pub offset: u32,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize, Default)]
 pub struct SessionActivityQuery {
     #[serde(default = "default_session_activity_limit")]
@@ -120,6 +144,7 @@ pub struct SessionActivityQuery {
     pub offset: u32,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct SessionActivityEntry {
     pub log_id: String,
@@ -128,6 +153,7 @@ pub struct SessionActivityEntry {
     pub created_at: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct SessionActivityResponse {
     pub session_id: String,
@@ -135,6 +161,7 @@ pub struct SessionActivityResponse {
     pub total: i64,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize, Default)]
 pub struct SessionArtifactListQuery {
     pub artifact_kind: Option<String>,
@@ -142,6 +169,7 @@ pub struct SessionArtifactListQuery {
     pub limit: u32,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq)]
 pub struct SessionArtifactResponse {
     pub artifact_id: String,
@@ -156,6 +184,7 @@ pub struct SessionArtifactResponse {
     pub created_at: Option<String>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq)]
 pub struct SessionArtifactListResponse {
     pub session_id: String,
@@ -163,6 +192,7 @@ pub struct SessionArtifactListResponse {
     pub limit: u32,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct AuthUserResponse {
     pub user_id: String,
@@ -173,6 +203,7 @@ pub struct AuthUserResponse {
 
 /// Returned by POST /auth/register — includes the user record plus ready-to-use tokens
 /// so callers don't need a separate login round-trip.
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct AuthRegisterResponse {
     pub user_id: String,
@@ -185,6 +216,7 @@ pub struct AuthRegisterResponse {
     pub expires_in: u32,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct AuthTokenResponse {
     pub access_token: String,
@@ -193,11 +225,13 @@ pub struct AuthTokenResponse {
     pub expires_in: u32,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct AuthLogoutResponse {
     pub message: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq)]
 pub struct SessionResponse {
     pub session_id: String,
@@ -212,6 +246,7 @@ pub struct SessionResponse {
     pub ended_at: Option<String>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq)]
 pub struct SessionListResponse {
     pub sessions: Vec<SessionResponse>,
@@ -220,6 +255,7 @@ pub struct SessionListResponse {
     pub offset: u32,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq)]
 pub struct ChatResponse {
     pub session_id: String,
@@ -228,6 +264,7 @@ pub struct ChatResponse {
     pub explain: Option<serde_json::Value>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct RunStatusResponse {
     pub run_id: String,
@@ -237,12 +274,14 @@ pub struct RunStatusResponse {
     pub events_count: i64,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct CancelRunResponse {
     pub run_id: String,
     pub status: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct RunMutationResponse {
     pub run_id: String,
@@ -250,6 +289,7 @@ pub struct RunMutationResponse {
     pub previous_status: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize, Default)]
 pub struct RunListQuery {
     #[serde(default = "default_run_list_limit")]
@@ -258,6 +298,7 @@ pub struct RunListQuery {
     pub offset: u32,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct RunListResponse {
     pub runs: Vec<RunStatusResponse>,
@@ -266,6 +307,7 @@ pub struct RunListResponse {
     pub offset: u32,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct HealthResponse {
     pub status: String,
@@ -274,6 +316,7 @@ pub struct HealthResponse {
     pub persist_fail: u64,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct LearningHealthResponse {
     pub status: String,
@@ -286,12 +329,14 @@ pub struct LearningHealthResponse {
     pub retired_count: Option<u64>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct LearningSignalsResponse {
     pub signal_types: Vec<&'static str>,
     pub descriptions: LearningSignalDescriptions,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct LearningSignalDescriptions {
     pub wrong_skill: &'static str,
@@ -300,6 +345,7 @@ pub struct LearningSignalDescriptions {
     pub low_satisfaction: &'static str,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq)]
 pub struct LearningStatsResponse {
     pub total_learnings: i32,
@@ -319,6 +365,7 @@ pub struct LearningStatsResponse {
     pub last_learning_time: Option<String>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct LearningTriggerRequest {
     #[serde(default = "default_days")]
@@ -331,6 +378,7 @@ pub struct LearningTriggerRequest {
     pub weights: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq)]
 pub struct LearningTriggerResponse {
     pub status: &'static str,
@@ -344,12 +392,14 @@ pub struct LearningTriggerResponse {
     pub model_version: &'static str,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize, Default)]
 pub struct AdminTokenListQuery {
     pub token_type: Option<String>,
     pub scope: Option<String>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct AdminTokenCreateRequest {
     pub token_type: String,
@@ -360,6 +410,7 @@ pub struct AdminTokenCreateRequest {
     pub token_value: Option<String>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct PromptOptimizeRequest {
     pub agent_id: String,
@@ -367,6 +418,7 @@ pub struct PromptOptimizeRequest {
     pub optimization_type: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct PromptOptimizeResponse {
     pub job_id: String,
@@ -374,6 +426,7 @@ pub struct PromptOptimizeResponse {
     pub message: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct FeedbackExportRequest {
     pub agent_id: Option<String>,
@@ -381,6 +434,7 @@ pub struct FeedbackExportRequest {
     pub format: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct FeedbackExportResponse {
     pub job_id: String,
@@ -388,12 +442,14 @@ pub struct FeedbackExportResponse {
     pub download_url: Option<String>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct AdminFeedbackStatsQuery {
     pub agent_id: Option<String>,
     pub since: Option<String>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct AdminAuditListQuery {
     pub user_id: Option<String>,
@@ -402,6 +458,7 @@ pub struct AdminAuditListQuery {
     pub limit: u32,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct AdminTokenResponse {
     pub token_id: String,
@@ -412,6 +469,7 @@ pub struct AdminTokenResponse {
     pub created_at: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq)]
 pub struct AdminAuditResponse {
     pub log_id: String,
@@ -423,6 +481,7 @@ pub struct AdminAuditResponse {
     pub details: Option<serde_json::Value>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq)]
 pub struct AdminFeedbackStatsResponse {
     pub total_feedback: i64,
@@ -432,18 +491,21 @@ pub struct AdminFeedbackStatsResponse {
     pub feedback_by_type: serde_json::Map<String, serde_json::Value>,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct AdminInitResponse {
     pub message: String,
     pub tables_created: i64,
 }
 
+#[cfg(feature = "server")]
 #[derive(Deserialize)]
 pub struct AdminUserRoleRequest {
     pub username: String,
     pub role_name: String,
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize, PartialEq, Eq)]
 pub struct AdminUserRoleResponse {
     pub username: String,
@@ -452,6 +514,7 @@ pub struct AdminUserRoleResponse {
 }
 
 /// Messages sent from browser client to server.
+#[cfg(feature = "server")]
 #[derive(Deserialize, Debug, Clone)]
 #[serde(tag = "type")]
 pub enum WsClientMessage {
@@ -510,6 +573,7 @@ pub enum WsClientMessage {
 }
 
 /// Messages sent from server to browser client.
+#[cfg(feature = "server")]
 #[derive(Serialize, Debug, Clone)]
 #[serde(tag = "type")]
 pub enum WsServerMessage {
@@ -597,6 +661,7 @@ pub enum WsServerMessage {
 }
 
 /// Query params for WebSocket upgrade — allows token in URL for browser compat.
+#[cfg(feature = "server")]
 #[derive(Deserialize, Default)]
 pub struct WsUpgradeQuery {
     /// Optional Bearer token (alternative to sending auth message).
@@ -605,6 +670,7 @@ pub struct WsUpgradeQuery {
     pub session_id: Option<String>,
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn merge_plan_subtask_context(
     mut context: Option<serde_json::Map<String, serde_json::Value>>,
@@ -628,56 +694,67 @@ pub fn merge_plan_subtask_context(
     context
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn default_days() -> i32 {
     7
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn default_admin_scope() -> String {
     "global".to_string()
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn default_session_limit() -> u32 {
     50
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn default_run_list_limit() -> u32 {
     50
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn default_session_activity_limit() -> u32 {
     100
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn default_session_artifact_limit() -> u32 {
     20
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn default_prompt_optimization_type() -> String {
     "compression".to_string()
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn default_feedback_export_format() -> String {
     "jsonl".to_string()
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn default_admin_audit_limit() -> u32 {
     100
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn default_signal_types() -> Vec<String> {
     vec!["wrong_skill".to_string()]
 }
 
+#[cfg(feature = "server")]
 pub fn sse_error_code_for_status(status: u16) -> &'static str {
     match status {
         401 | 403 => "AUTH_ERROR",
@@ -687,10 +764,12 @@ pub fn sse_error_code_for_status(status: u16) -> &'static str {
     }
 }
 
+#[cfg(feature = "server")]
 pub fn sse_retryable_for_status(status: u16) -> bool {
     status >= 500 || status == 429
 }
 
+#[cfg(feature = "server")]
 pub fn build_sse_error_event_payload(status: u16, message: impl Into<String>) -> serde_json::Value {
     serde_json::json!({
         "type": "error",
@@ -700,6 +779,7 @@ pub fn build_sse_error_event_payload(status: u16, message: impl Into<String>) ->
     })
 }
 
+#[cfg(feature = "server")]
 impl From<AdminTokenRecord> for AdminTokenResponse {
     fn from(value: AdminTokenRecord) -> Self {
         Self {
@@ -713,6 +793,7 @@ impl From<AdminTokenRecord> for AdminTokenResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<AdminAuditRecord> for AdminAuditResponse {
     fn from(value: AdminAuditRecord) -> Self {
         Self {
@@ -727,6 +808,7 @@ impl From<AdminAuditRecord> for AdminAuditResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<AdminFeedbackStatsRecord> for AdminFeedbackStatsResponse {
     fn from(value: AdminFeedbackStatsRecord) -> Self {
         Self {
@@ -739,6 +821,7 @@ impl From<AdminFeedbackStatsRecord> for AdminFeedbackStatsResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<AdminInitRecord> for AdminInitResponse {
     fn from(value: AdminInitRecord) -> Self {
         Self {
@@ -748,6 +831,7 @@ impl From<AdminInitRecord> for AdminInitResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<AdminUserRoleRecord> for AdminUserRoleResponse {
     fn from(value: AdminUserRoleRecord) -> Self {
         Self {
@@ -758,6 +842,7 @@ impl From<AdminUserRoleRecord> for AdminUserRoleResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<SessionRecord> for SessionResponse {
     fn from(value: SessionRecord) -> Self {
         Self {
@@ -775,6 +860,7 @@ impl From<SessionRecord> for SessionResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<SessionListRecord> for SessionListResponse {
     fn from(value: SessionListRecord) -> Self {
         Self {
@@ -790,6 +876,7 @@ impl From<SessionListRecord> for SessionListResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<SessionActivityRecord> for SessionActivityResponse {
     fn from(value: SessionActivityRecord) -> Self {
         Self {
@@ -809,6 +896,7 @@ impl From<SessionActivityRecord> for SessionActivityResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<ChatRunRecord> for ChatResponse {
     fn from(value: ChatRunRecord) -> Self {
         Self {
@@ -820,6 +908,7 @@ impl From<ChatRunRecord> for ChatResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<RunStatusRecord> for RunStatusResponse {
     fn from(value: RunStatusRecord) -> Self {
         Self {
@@ -832,6 +921,7 @@ impl From<RunStatusRecord> for RunStatusResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<CancelRunRecord> for CancelRunResponse {
     fn from(value: CancelRunRecord) -> Self {
         Self {
@@ -841,6 +931,7 @@ impl From<CancelRunRecord> for CancelRunResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<RunMutationRecord> for RunMutationResponse {
     fn from(value: RunMutationRecord) -> Self {
         Self {
@@ -851,6 +942,7 @@ impl From<RunMutationRecord> for RunMutationResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<RunListRecord> for RunListResponse {
     fn from(value: RunListRecord) -> Self {
         Self {
@@ -866,6 +958,7 @@ impl From<RunListRecord> for RunListResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<AuthUserRecord> for AuthUserResponse {
     fn from(value: AuthUserRecord) -> Self {
         Self {
@@ -877,6 +970,7 @@ impl From<AuthUserRecord> for AuthUserResponse {
     }
 }
 
+#[cfg(feature = "server")]
 impl From<AuthTokenRecord> for AuthTokenResponse {
     fn from(value: AuthTokenRecord) -> Self {
         Self {
@@ -888,6 +982,7 @@ impl From<AuthTokenRecord> for AuthTokenResponse {
     }
 }
 
+#[cfg(feature = "server")]
 #[doc(hidden)]
 pub fn chat_request_into_data(mut request: ChatRequest) -> ChatRequestData {
     let context = merge_plan_subtask_context(
@@ -913,7 +1008,7 @@ pub fn chat_request_into_data(mut request: ChatRequest) -> ChatRequestData {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "server"))]
 mod sse_error_payload_tests {
     use super::*;
 
@@ -935,5 +1030,5 @@ mod sse_error_payload_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "server"))]
 mod http_type_tests;

--- a/rust/crates/astra-tools/src/executor.rs
+++ b/rust/crates/astra-tools/src/executor.rs
@@ -70,6 +70,45 @@ impl DefaultToolExecutor {
             task_manager: Arc::new(TaskManager::new()),
         }
     }
+
+    /// Build a ready-to-use executor from workspace parameters.
+    ///
+    /// Handles the full setup recipe shared by edge and cloud:
+    /// HTTP client, `ToolContext`, sandbox, and optional GitHub integration.
+    pub fn for_workspace(
+        workspace: &Path,
+        user_id: impl Into<String>,
+        session_id: impl Into<String>,
+        user_agent: &str,
+        timeout: std::time::Duration,
+    ) -> Self {
+        let http_client = reqwest::Client::builder()
+            .timeout(timeout)
+            .user_agent(user_agent.to_string())
+            .no_proxy()
+            .build()
+            .expect("failed to build HTTP client for tool executor");
+
+        let ctx = crate::ToolContext {
+            project_root: workspace.to_path_buf(),
+            workspace_root: workspace.to_path_buf(),
+            user_id: user_id.into(),
+            session_id: session_id.into(),
+            sandbox: crate::SandboxConfig::standard(workspace),
+            http_client: Some(http_client.clone()),
+            logger: Arc::new(crate::TracingLogger),
+            cancel_token: None,
+        };
+
+        let mut executor = Self::new(ctx);
+        let tokens = crate::github::resolve_github_tokens();
+        if !tokens.is_empty() {
+            let github = GitHubClient::from_tokens(http_client, tokens, Vec::new());
+            executor = executor.with_github_client(github);
+        }
+        executor
+    }
+
     pub fn with_github_client(mut self, client: GitHubClient) -> Self {
         self.github_client = Some(client);
         self

--- a/rust/crates/astra-tools/src/memoria.rs
+++ b/rust/crates/astra-tools/src/memoria.rs
@@ -181,9 +181,8 @@ impl MemoriaClient {
                 HttpMethod::Post,
             )
         } else {
-            let base = std::env::var("MEMORIA_BASE_URL")
-                .unwrap_or_else(|_| astra_core::config::DEFAULT_MEMORIA_URL.to_string());
-            let key = match std::env::var("MEMORIA_MASTER_KEY").ok() {
+            let mem = astra_core::MemoriaSettings::from_env();
+            let key = match mem.master_key {
                 Some(k) => k,
                 None => {
                     return json!({
@@ -193,7 +192,7 @@ impl MemoriaClient {
                         .to_string();
                 }
             };
-            let (ep, pl, m) = Self::build_direct_request(&base, op, args);
+            let (ep, pl, m) = Self::build_direct_request(&mem.base_url, op, args);
             if ep.is_empty() {
                 return pl.to_string();
             }
@@ -242,10 +241,9 @@ impl MemoriaClient {
         if query.trim().is_empty() || self.is_circuit_open() {
             return vec![];
         }
-        let base = std::env::var("MEMORIA_BASE_URL")
-            .unwrap_or_else(|_| astra_core::config::DEFAULT_MEMORIA_URL.to_string());
-        let key = match std::env::var("MEMORIA_MASTER_KEY").ok() {
-            Some(k) => k,
+        let mem = astra_core::MemoriaSettings::from_env();
+        let token = match mem.bearer_token() {
+            Some(t) => t,
             None => return vec![],
         };
         let client = match reqwest::Client::builder()
@@ -257,8 +255,8 @@ impl MemoriaClient {
             Err(_) => return vec![],
         };
         match client
-            .post(format!("{base}/v1/memories/retrieve"))
-            .header("Authorization", format!("Bearer {key}"))
+            .post(format!("{}/v1/memories/retrieve", mem.base_url))
+            .header("Authorization", token)
             .json(&json!({
                 "query": query,
                 "top_k": top_k,
@@ -424,15 +422,14 @@ impl MemoriaClient {
 
 /// Build a one-shot Memoria HTTP client + auth header.
 pub fn memoria_oneshot_client(timeout_secs: u64) -> Option<(reqwest::Client, String, String)> {
-    let base = std::env::var("MEMORIA_BASE_URL")
-        .unwrap_or_else(|_| astra_core::config::DEFAULT_MEMORIA_URL.to_string());
-    let key = std::env::var("MEMORIA_MASTER_KEY").ok()?;
+    let mem = astra_core::MemoriaSettings::from_env();
+    let key = mem.master_key?;
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(timeout_secs))
         .no_proxy()
         .build()
         .ok()?;
-    Some((client, base, key))
+    Some((client, mem.base_url, key))
 }
 
 /// Fire-and-forget: trigger Memoria governance.

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -1929,23 +1929,6 @@ pub fn all_tool_schemas() -> Vec<Value> {
                 }
             }
         }),
-        json!({
-            "type": "function",
-            "function": {
-                "name": "get_agent_info",
-                "description": "Retrieve the agent's runtime identity and capabilities. Returns structured JSON with name, version, runtime mode, user/session IDs, workspace path, and available tools. Use this when you need to reflect on your own identity, verify your configuration, or report your runtime context to the user.",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "dimension": {
-                            "type": "string",
-                            "enum": ["identity", "capability", "all"],
-                            "description": "What to return: 'identity' (name, version, user, session, workspace), 'capability' (tools), or 'all' (both). Default: all."
-                        }
-                    }
-                }
-            }
-        }),
     ]
 }
 

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -82,6 +82,7 @@ pub const SERVER_EXECUTOR_TOOL_NAMES: &[&str] = &[
     "memory_profile",
     "enter_plan_mode",
     "exit_plan_mode",
+    "get_agent_info",
 ];
 
 fn filter_tool_schemas_by_name(allowed_names: &[&str]) -> Vec<Value> {
@@ -1923,6 +1924,23 @@ pub fn all_tool_schemas() -> Vec<Value> {
                         "approved": {
                             "type": "boolean",
                             "description": "Whether the plan is approved for execution. Default true."
+                        }
+                    }
+                }
+            }
+        }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "get_agent_info",
+                "description": "Retrieve the agent's runtime identity and capabilities. Returns structured JSON with name, version, runtime mode, user/session IDs, workspace path, and available tools. Use this when you need to reflect on your own identity, verify your configuration, or report your runtime context to the user.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "dimension": {
+                            "type": "string",
+                            "enum": ["identity", "capability", "all"],
+                            "description": "What to return: 'identity' (name, version, user, session, workspace), 'capability' (tools), or 'all' (both). Default: all."
                         }
                     }
                 }

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -142,7 +142,7 @@ pub fn all_tool_schemas() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "read_file",
-                "description": "Read file contents with optional line range. Output includes line numbers (tab-separated). IMPORTANT: If you are NOT certain the file exists, use list_dir or glob FIRST to verify the path — do NOT guess paths. Large files (over ~80KB) will return an error when read without a range — use start_line/end_line or outline=true. For files over 500 lines, prefer targeted reads. Set outline=true to get only function/class/struct/trait signatures (saves tokens). Common image types return a data URI; known binary formats are refused and should be inspected via bash instead. When using str_replace, provide old_str WITHOUT line numbers — only the actual file content.",
+                "description": "Read file contents with optional line range. Verify uncertain paths with list_dir/glob first. Large files (>80KB) require start_line/end_line or outline=true for signatures only. Output includes line numbers; pass content without line numbers to str_replace. Common images return a data URI; binary files are refused.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -1539,7 +1539,7 @@ pub fn all_tool_schemas() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "spawn_agent",
-                "description": "Launch a specialized sub-agent to perform a task. Agents run autonomously and return results. Use for parallel work, independent research, code review, or any task that benefits from dedicated focus. Agent types: 'explore' (fast codebase research), 'code-review' (analyze changes), 'task' (run commands), 'general-purpose' (full capabilities).",
+                "description": "Launch a sub-agent for independent work. Types: explore, code-review, task, general-purpose.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -1554,7 +1554,7 @@ pub fn all_tool_schemas() -> Vec<Value> {
                         "agent_type": {
                             "type": "string",
                             "enum": ["explore", "code-review", "task", "general-purpose"],
-                            "description": "Type of specialized agent. 'explore' for research, 'code-review' for reviewing changes, 'task' for running commands, 'general-purpose' for complex multi-step tasks.",
+                            "description": "Agent type: explore, code-review, task, or general-purpose.",
                             "default": "general-purpose"
                         },
                         "model": {

--- a/rust/crates/astra-turn-core/src/chat_turn_edge_profile.rs
+++ b/rust/crates/astra-turn-core/src/chat_turn_edge_profile.rs
@@ -15,10 +15,8 @@ pub fn read_git_branch_abbrev() -> Option<String> {
 
 /// Memoria URL + API key from environment (same semantics as CLI `chat_stream`).
 pub fn memoria_env_for_edge_profile() -> (String, String) {
-    let memoria_url = std::env::var("MEMORIA_BASE_URL")
-        .unwrap_or_else(|_| astra_core::config::DEFAULT_MEMORIA_URL.to_string());
-    let memoria_key = std::env::var("MEMORIA_MASTER_KEY").unwrap_or_default();
-    (memoria_url, memoria_key)
+    let mem = astra_core::MemoriaSettings::from_env();
+    (mem.base_url, mem.master_key.unwrap_or_default())
 }
 
 /// Retrieval top_k from environment (same semantics as RuntimeConfig).

--- a/rust/crates/astra-turn-core/src/conversation_log/db_store.rs
+++ b/rust/crates/astra-turn-core/src/conversation_log/db_store.rs
@@ -326,16 +326,7 @@ mod tests {
     // The DB must have the `conversation_log` table created (via ensure_core_schema).
 
     async fn test_store() -> DbCslStore {
-        let settings = MatrixOneSettings {
-            host: std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "127.0.0.1".into()),
-            port: std::env::var("MATRIXONE_PORT")
-                .ok()
-                .and_then(|p| p.parse().ok())
-                .unwrap_or(6001),
-            user: std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".into()),
-            password: std::env::var("MATRIXONE_PASSWORD").unwrap_or_else(|_| "111".into()),
-            database: std::env::var("MATRIXONE_DATABASE").unwrap_or_else(|_| "astra_test".into()),
-        };
+        let settings = MatrixOneSettings::from_env_with_database("astra_test");
         let store = DbCslStore::new(settings);
 
         // Ensure table exists for tests.

--- a/rust/crates/astra-turn-core/src/orchestration_spawn_tool.rs
+++ b/rust/crates/astra-turn-core/src/orchestration_spawn_tool.rs
@@ -231,7 +231,7 @@ pub fn spawn_agent_schema() -> serde_json::Value {
         "type": "function",
         "function": {
             "name": "spawn_agent",
-            "description": "Launch a specialized sub-agent to perform a task. Agents run autonomously and return results. Use for parallel work, independent research, code review, or any task that benefits from dedicated focus. Agent types: 'explore' (fast codebase research), 'code-review' (analyze changes), 'task' (run commands), 'general-purpose' (full capabilities). When the child task builds on the current conversation (summarize, follow-up, drill-down), pass `inherit_prefix: {}` to reuse the parent's prompt cache — cuts child input cost and latency substantially on every supported provider.",
+            "description": "Launch a sub-agent for independent work. Types: explore, code-review, task, general-purpose. Use `inherit_prefix: {}` when the child builds on current context.",
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -246,16 +246,16 @@ pub fn spawn_agent_schema() -> serde_json::Value {
                     "agent_type": {
                         "type": "string",
                         "enum": ["explore", "code-review", "task", "general-purpose"],
-                        "description": "Type of specialized agent. 'explore' for research, 'code-review' for reviewing changes, 'task' for running commands, 'general-purpose' for complex multi-step tasks.",
+                        "description": "Agent type: explore (research), code-review, task, or general-purpose.",
                         "default": "general-purpose"
                     },
                     "model": {
                         "type": "string",
-                        "description": "Optional model override (e.g., 'claude-sonnet', 'claude-opus', 'claude-haiku')."
+                        "description": "Optional model override."
                     },
                     "background": {
                         "type": "boolean",
-                        "description": "Run in background (async). If true, returns immediately with agent_id; use send_message to get results later. Default: false (synchronous — waits for child to complete and returns result directly).",
+                        "description": "If true, return immediately with agent_id. Default false waits for the result.",
                         "default": false
                     },
                     "name": {
@@ -280,20 +280,20 @@ pub fn spawn_agent_schema() -> serde_json::Value {
                     },
                     "max_output_tokens": {
                         "type": "integer",
-                        "description": "Max output tokens for the child's first API call. Interacts with prefix inheritance — see inherit_prefix.",
+                        "description": "Max output tokens for the child's first API call.",
                         "minimum": 1
                     },
                     "inherit_prefix": {
                         "type": "object",
-                        "description": "RECOMMENDED when the child task builds on what you just analyzed: inherit the parent's cacheable prompt prefix so the child's first API call hits the provider's prompt cache. Cuts child's first-turn input tokens and latency substantially (typical 70-95% token reuse on Anthropic, Kimi, DeepSeek, OpenAI). Must be a JSON OBJECT (not a string!): pass the object `{}` with no properties to opt in with defaults — the runtime infers the parent run id and soft-falls-back if the prefix isn't available. Pass `{\"required\": true}` when correctness depends on the child seeing the parent's context. Safe to OMIT this field entirely when the child task is truly independent of the parent's conversation.",
+                        "description": "RECOMMENDED when the child builds on current context: pass `{}` to inherit the parent's prompt-cache prefix, cutting first-turn input tokens and latency (often 70-95% reuse). Omit for independent tasks. Use {\"required\": true} only when missing inherited context should fail the spawn.",
                         "properties": {
                             "from_run_id": {
                                 "type": "string",
-                                "description": "Parent run id to inherit from. Omit to inherit from the caller's own run (the common case)."
+                                "description": "Parent run id. Omit to use the caller's run."
                             },
                             "required": {
                                 "type": "boolean",
-                                "description": "If true, spawn fails when the prefix is missing or incompatible (use when the child needs parent context to be correct). Default false: spawn proceeds without cache reuse on failure — recommended for opportunistic reuse.",
+                                "description": "If true, fail when the prefix is missing or incompatible. Default false.",
                                 "default": false
                             }
                         }

--- a/rust/crates/core/src/config.rs
+++ b/rust/crates/core/src/config.rs
@@ -204,6 +204,18 @@ impl MatrixOneSettings {
         s
     }
 
+    /// Fake settings for unit tests that never open a real DB connection.
+    #[cfg(any(test, feature = "dev-defaults"))]
+    pub fn mock() -> Self {
+        Self {
+            host: "127.0.0.1".into(),
+            port: 6001,
+            user: "test".into(),
+            password: "test".into(),
+            database: "test".into(),
+        }
+    }
+
     /// Returns the database URL with password REDACTED — safe for logging.
     ///
     /// Use [`MatrixOneSettings::database_url_with_password`] when an actual

--- a/rust/crates/core/src/config.rs
+++ b/rust/crates/core/src/config.rs
@@ -302,6 +302,19 @@ impl MemoriaSettings {
             master_key: env::var("MEMORIA_MASTER_KEY").ok(),
         }
     }
+
+    /// Returns `true` when a master key is configured (Memoria is usable).
+    pub fn is_configured(&self) -> bool {
+        self.master_key.as_ref().is_some_and(|k| !k.is_empty())
+    }
+
+    /// `Authorization: Bearer <key>` header value, or `None` if unconfigured.
+    pub fn bearer_token(&self) -> Option<String> {
+        self.master_key
+            .as_ref()
+            .filter(|k| !k.is_empty())
+            .map(|k| format!("Bearer {k}"))
+    }
 }
 
 impl fmt::Debug for MemoriaSettings {

--- a/rust/crates/core/src/config.rs
+++ b/rust/crates/core/src/config.rs
@@ -46,12 +46,9 @@ impl SkillSearchSettings {
 #[derive(Clone, PartialEq, Eq)]
 pub struct AppSettings {
     pub matrixone: MatrixOneSettings,
-    pub application: ApplicationSettings,
     pub jwt: JwtSettings,
     pub api: ApiSettings,
     pub memoria: MemoriaSettings,
-    pub github_token: Option<String>,
-    pub bridge_url: Option<String>,
     pub bridge_secret: String,
     pub token_encryption_key: Option<String>,
     pub database_bootstrap_catalog: String,
@@ -61,15 +58,9 @@ impl fmt::Debug for AppSettings {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AppSettings")
             .field("matrixone", &self.matrixone)
-            .field("application", &self.application)
             .field("jwt", &self.jwt)
             .field("api", &self.api)
             .field("memoria", &self.memoria)
-            .field(
-                "github_token",
-                &self.github_token.as_ref().map(|_| "[REDACTED]"),
-            )
-            .field("bridge_url", &self.bridge_url)
             .field("bridge_secret", &"[REDACTED]")
             .field(
                 "token_encryption_key",
@@ -106,10 +97,6 @@ impl AppSettings {
                 "ASTRA_DATABASE_BOOTSTRAP_CATALOG",
                 "mysql",
             ),
-            application: ApplicationSettings {
-                app_env: value_or_default(&lookup, "ASTRA_APP_ENV", "development"),
-                log_level: value_or_default(&lookup, "ASTRA_LOG_LEVEL", "DEBUG"),
-            },
             jwt: JwtSettings::from_lookup(&lookup)?,
             api: ApiSettings {
                 host: value_or_default(&lookup, "ASTRA_API_HOST", "0.0.0.0"),
@@ -120,8 +107,6 @@ impl AppSettings {
                 base_url: value_or_default(&lookup, "MEMORIA_BASE_URL", DEFAULT_MEMORIA_URL),
                 master_key: optional_value(&lookup, "MEMORIA_MASTER_KEY"),
             },
-            github_token: optional_value(&lookup, "GITHUB_TOKEN"),
-            bridge_url: optional_value(&lookup, "ASTRA_BRIDGE_URL"),
             bridge_secret: required_value(
                 &lookup,
                 "ASTRA_BRIDGE_SECRET",
@@ -172,31 +157,6 @@ impl MatrixOneSettings {
             "mysql://{}:{}@{}:{}/{}",
             self.user, self.password, self.host, self.port, self.database
         )
-    }
-}
-
-#[derive(Clone, PartialEq, Eq)]
-pub struct ApplicationSettings {
-    pub app_env: String,
-    pub log_level: String,
-}
-
-impl fmt::Debug for ApplicationSettings {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ApplicationSettings")
-            .field("app_env", &self.app_env)
-            .field("log_level", &self.log_level)
-            .finish()
-    }
-}
-
-impl ApplicationSettings {
-    pub fn is_development(&self) -> bool {
-        self.app_env == "development"
-    }
-
-    pub fn is_production(&self) -> bool {
-        self.app_env == "production"
     }
 }
 
@@ -411,23 +371,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn application_mode_helpers_match_runtime_modes() {
-        let development = ApplicationSettings {
-            app_env: "development".into(),
-            log_level: "DEBUG".into(),
-        };
-        let production = ApplicationSettings {
-            app_env: "production".into(),
-            log_level: "INFO".into(),
-        };
-
-        assert!(development.is_development());
-        assert!(!development.is_production());
-        assert!(production.is_production());
-        assert!(!production.is_development());
-    }
-
-    #[test]
     fn matrixone_settings_build_mysql_url() {
         let settings = MatrixOneSettings {
             host: "db".into(),
@@ -504,14 +447,9 @@ mod tests {
     fn app_settings_debug_redacts_optional_secrets() {
         let mut m = HashMap::new();
         m.insert("ASTRA_ALLOW_INSECURE_DEFAULTS".into(), "1".into());
-        m.insert("GITHUB_TOKEN".into(), "ghp_supersecret_token".into());
         m.insert("MEMORIA_MASTER_KEY".into(), "memoria-master-key-xyz".into());
         let settings = AppSettings::from_map(&m).unwrap();
         let debug_str = format!("{settings:?}");
-        assert!(
-            !debug_str.contains("ghp_supersecret_token"),
-            "github_token should be redacted: {debug_str}"
-        );
         assert!(
             !debug_str.contains("memoria-master-key-xyz"),
             "memoria master_key should be redacted: {debug_str}"
@@ -638,10 +576,6 @@ mod settings_contract_tests {
         matrixone_user: String,
         matrixone_password: String,
         matrixone_database: String,
-        app_env: String,
-        log_level: String,
-        github_token: Option<String>,
-        bridge_url: Option<String>,
         bridge_secret: String,
     }
 
@@ -660,10 +594,6 @@ mod settings_contract_tests {
             matrixone_user: settings.matrixone.user,
             matrixone_password: settings.matrixone.password,
             matrixone_database: settings.matrixone.database,
-            app_env: settings.application.app_env,
-            log_level: settings.application.log_level,
-            github_token: settings.github_token,
-            bridge_url: settings.bridge_url,
             bridge_secret: settings.bridge_secret,
         }
     }

--- a/rust/crates/core/src/config.rs
+++ b/rust/crates/core/src/config.rs
@@ -138,7 +138,72 @@ impl fmt::Debug for MatrixOneSettings {
     }
 }
 
+/// MySQL CLI connect timeout (seconds) — shared between server and edge tool execution.
+pub const MO_CLI_CONNECT_TIMEOUT_SECS: u32 = 5;
+
 impl MatrixOneSettings {
+    /// Build a `mysql` CLI [`Command`](std::process::Command) pre-configured
+    /// with this settings' host/port/user/password.
+    ///
+    /// Password is passed via `MYSQL_PWD` env var (hidden from `ps`).
+    pub fn mysql_cmd(&self, database: Option<&str>) -> std::process::Command {
+        let db = database.unwrap_or(&self.database);
+        let mut cmd = std::process::Command::new("mysql");
+        cmd.arg(format!("-h{}", self.host))
+            .arg(format!("-P{}", self.port))
+            .arg(format!("-u{}", self.user))
+            .env("MYSQL_PWD", &self.password)
+            .arg(db)
+            .arg(format!("--connect-timeout={MO_CLI_CONNECT_TIMEOUT_SECS}"))
+            .arg("--table");
+        cmd
+    }
+
+    /// Build settings from environment with dev-safe defaults.
+    ///
+    /// Falls back to `localhost:6001`, `root`, and the bundled dev password.
+    /// Suitable for local dev and tests. Call `dotenvy::dotenv().ok()` first
+    /// if you need `.env` file loading (the server entry point already does this).
+    pub fn from_env() -> Self {
+        let lookup = |k: &str| env::var(k).ok();
+        Self {
+            host: env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".into()),
+            port: env::var("MATRIXONE_PORT")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(6001),
+            user: env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".into()),
+            password: env::var("MATRIXONE_PASSWORD").unwrap_or_else(|_| "111".into()),
+            database: resolve_database_name(&lookup),
+        }
+    }
+
+    /// Build settings from environment, **requiring** `MATRIXONE_PASSWORD`.
+    ///
+    /// Returns `Err` when the password is unset — suitable for production and
+    /// any code path that must not silently fall back to a dev password.
+    pub fn from_env_strict() -> Result<Self, String> {
+        let lookup = |k: &str| env::var(k).ok();
+        Ok(Self {
+            host: env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".into()),
+            port: env::var("MATRIXONE_PORT")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(6001),
+            user: env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".into()),
+            password: env::var("MATRIXONE_PASSWORD")
+                .map_err(|_| "MATRIXONE_PASSWORD environment variable is required".to_string())?,
+            database: resolve_database_name(&lookup),
+        })
+    }
+
+    /// Build settings with a specific database name (other values from env).
+    pub fn from_env_with_database(database: impl Into<String>) -> Self {
+        let mut s = Self::from_env();
+        s.database = database.into();
+        s
+    }
+
     /// Returns the database URL with password REDACTED — safe for logging.
     ///
     /// Use [`MatrixOneSettings::database_url_with_password`] when an actual
@@ -226,6 +291,17 @@ impl fmt::Debug for ApiSettings {
 pub struct MemoriaSettings {
     pub base_url: String,
     pub master_key: Option<String>,
+}
+
+impl MemoriaSettings {
+    /// Read Memoria connection config from environment.
+    pub fn from_env() -> Self {
+        Self {
+            base_url: env::var("MEMORIA_BASE_URL")
+                .unwrap_or_else(|_| DEFAULT_MEMORIA_URL.to_string()),
+            master_key: env::var("MEMORIA_MASTER_KEY").ok(),
+        }
+    }
 }
 
 impl fmt::Debug for MemoriaSettings {
@@ -352,6 +428,11 @@ where
             .map_err(|_| ConfigError::InvalidInteger { key, value }),
         None => Ok(default),
     }
+}
+
+/// Read `ASTRA_CLI_USER_ID` from environment, defaulting to `"local"`.
+pub fn cli_user_id() -> String {
+    env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string())
 }
 
 fn normalize_jwt_secret(secret: &str) -> String {

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -45,7 +45,7 @@ astra-pipeline.workspace = true
 astra-plan.workspace = true
 astra-prompts.workspace = true
 astra-sandbox.workspace = true
-astra-server-types.workspace = true
+astra-server-types = { workspace = true, features = ["server"] }
 astra-skills.workspace = true
 astra-sync-adapters.workspace = true
 astra-turn-core = { workspace = true, features = ["db-store"] }

--- a/rust/crates/runtime/src/app_state.rs
+++ b/rust/crates/runtime/src/app_state.rs
@@ -124,6 +124,7 @@ impl AppState {
     pub fn new(service_info: ServiceInfo, health_checker: Arc<dyn HealthChecker>) -> Self {
         let chat_turn_bridge_cache =
             Arc::new(tokio::sync::Mutex::new(SessionCache::new(1000, 86400.0)));
+        let default_memoria = astra_core::MemoriaSettings::from_env();
         Self {
             service_info,
             health_checker,
@@ -188,9 +189,8 @@ impl AppState {
             chat_turn_bridge_secret: "dev-bridge-secret-change-me".to_string(),
             chat_turn_bridge_cache,
             turn_learning_writer: None,
-            memoria_base_url: std::env::var("MEMORIA_BASE_URL")
-                .unwrap_or_else(|_| crate::config::DEFAULT_MEMORIA_URL.to_string()),
-            memoria_master_key: std::env::var("MEMORIA_MASTER_KEY").ok(),
+            memoria_base_url: default_memoria.base_url,
+            memoria_master_key: default_memoria.master_key,
             memoria_forwarder: Arc::new(NoopMemoriaForwarder),
             shared_pool: None,
             matrix_cloud_runtime: None,

--- a/rust/crates/runtime/src/app_state.rs
+++ b/rust/crates/runtime/src/app_state.rs
@@ -109,6 +109,7 @@ pub struct AppState {
     /// Defaults to [`astra_plan::LocalCachePlanRepository`]; production wires
     /// [`astra_plan::CloudPlanRepository`] backed by the MatrixOne pool.
     pub(crate) plan_repo: Arc<dyn astra_plan::PlanRepository>,
+    pub(crate) cors_origins: Option<String>,
 }
 
 impl AppState {
@@ -211,7 +212,13 @@ impl AppState {
                 .build()
                 .expect("failed to build shared HTTP client"),
             plan_repo: Arc::new(astra_plan::LocalCachePlanRepository::new()),
+            cors_origins: None,
         }
+    }
+
+    pub fn with_cors_origins(mut self, cors_origins: Option<String>) -> Self {
+        self.cors_origins = cors_origins;
+        self
     }
 
     /// Inject the plan repository — production wires

--- a/rust/crates/runtime/src/matrix_cloud_runtime.rs
+++ b/rust/crates/runtime/src/matrix_cloud_runtime.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use tokio::sync::Mutex as TokioMutex;
 use tokio::task::JoinSet;
 
-use astra_core::{MatrixOneSettings, SharedPool, resolve_database_name};
+use astra_core::{MatrixOneSettings, SharedPool};
 use astra_services::{
     CloudTransport, SyncOrchestrator, SyncPolicy, TaskLeaseHoldCache, TaskRecord,
     event_ingestion::{self, IngestionConfig, IngestionEvent},
@@ -46,17 +46,7 @@ pub trait BridgePersistTracker: Send + Sync {
 /// Requires `MATRIXONE_PASSWORD` to be set — fails closed rather than
 /// substituting a hardcoded development password.
 pub fn matrix_settings_from_env() -> Result<MatrixOneSettings, String> {
-    Ok(MatrixOneSettings {
-        host: std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".into()),
-        port: std::env::var("MATRIXONE_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6001),
-        user: std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".into()),
-        password: std::env::var("MATRIXONE_PASSWORD")
-            .map_err(|_| "MATRIXONE_PASSWORD environment variable is required".to_string())?,
-        database: resolve_database_name(&|k| std::env::var(k).ok()),
-    })
+    MatrixOneSettings::from_env_strict()
 }
 
 /// Pool + ingestion + unified sync orchestrator. Safe to share behind `Arc`.

--- a/rust/crates/runtime/src/prompts/mod.rs
+++ b/rust/crates/runtime/src/prompts/mod.rs
@@ -20,8 +20,9 @@ pub use context::{
     estimate_tokens, estimate_tokens_cache_aware, estimate_tokens_precise,
 };
 pub use system::{
-    CacheScope, LOW_CONFIDENCE_THRESHOLD, PARALLEL_BATCHING_NUDGE_THRESHOLD, PromptSection,
-    PromptTokenBucket, ROUND_BUDGET_HARD_LIMIT, ROUND_BUDGET_THRESHOLD, STALL_NUDGE,
+    AgentRuntimeContext, CacheScope, LOW_CONFIDENCE_THRESHOLD,
+    PARALLEL_BATCHING_NUDGE_THRESHOLD, PromptSection, PromptTokenBucket,
+    ROUND_BUDGET_HARD_LIMIT, ROUND_BUDGET_THRESHOLD, STALL_NUDGE,
     SYSTEM_PROMPT_BASE, build_main_system_prompt, build_main_system_prompt_with_style,
     build_system_prompt_sections, build_system_prompt_sections_with_style,
     build_system_prompt_trace, detect_task_type, parallel_batching_nudge_directive,

--- a/rust/crates/runtime/src/prompts/mod.rs
+++ b/rust/crates/runtime/src/prompts/mod.rs
@@ -20,9 +20,8 @@ pub use context::{
     estimate_tokens, estimate_tokens_cache_aware, estimate_tokens_precise,
 };
 pub use system::{
-    AgentRuntimeContext, CacheScope, LOW_CONFIDENCE_THRESHOLD,
-    PARALLEL_BATCHING_NUDGE_THRESHOLD, PromptSection, PromptTokenBucket,
-    ROUND_BUDGET_HARD_LIMIT, ROUND_BUDGET_THRESHOLD, STALL_NUDGE,
+    AgentRuntimeContext, CacheScope, LOW_CONFIDENCE_THRESHOLD, PARALLEL_BATCHING_NUDGE_THRESHOLD,
+    PromptSection, PromptTokenBucket, ROUND_BUDGET_HARD_LIMIT, ROUND_BUDGET_THRESHOLD, STALL_NUDGE,
     SYSTEM_PROMPT_BASE, build_main_system_prompt, build_main_system_prompt_with_style,
     build_system_prompt_sections, build_system_prompt_sections_with_style,
     build_system_prompt_trace, detect_task_type, parallel_batching_nudge_directive,

--- a/rust/crates/runtime/src/prompts/system.rs
+++ b/rust/crates/runtime/src/prompts/system.rs
@@ -1,7 +1,50 @@
 /// Agent persona / base identity.
 pub const SYSTEM_PROMPT_BASE: &str = "You are an expert software engineer. You write clean, correct code and use tools precisely to solve tasks.";
 
+use std::fmt::Write;
+
 use astra_text_utils::output_style::OutputStyle;
+
+/// Session-stable runtime context for the agent's self-knowledge.
+///
+/// Injected into the system prompt so the agent knows its identity,
+/// environment, and session context — enabling inquiry, reflection,
+/// and retrospection without hallucinating these details.
+#[derive(Debug, Clone, Default)]
+pub struct AgentRuntimeContext {
+    pub model_name: Option<String>,
+    pub workspace_cwd: Option<String>,
+    pub git_branch: Option<String>,
+    pub session_id: Option<String>,
+    pub user_id: Option<String>,
+    pub current_date: Option<String>,
+}
+
+impl AgentRuntimeContext {
+    pub fn to_prompt_section(&self) -> String {
+        let mut s = String::with_capacity(256);
+        s.push_str("\n## Runtime Identity\n");
+        if let Some(ref v) = self.model_name {
+            let _ = writeln!(s, "Model: {v}");
+        }
+        if let Some(ref v) = self.current_date {
+            let _ = writeln!(s, "Date: {v}");
+        }
+        if let Some(ref v) = self.workspace_cwd {
+            let _ = writeln!(s, "Workspace: {v}");
+        }
+        if let Some(ref v) = self.git_branch {
+            let _ = writeln!(s, "Git branch: {v}");
+        }
+        if let Some(ref v) = self.session_id {
+            let _ = writeln!(s, "Session: {v}");
+        }
+        if let Some(ref v) = self.user_id {
+            let _ = writeln!(s, "User: {v}");
+        }
+        s
+    }
+}
 
 /// Confidence threshold below which the system prompt includes an advisory
 /// telling the LLM to ask for clarification rather than guessing with wrong tools.
@@ -237,7 +280,11 @@ fn tool_error_recovery_section() -> &'static str {
 
 /// Self-model (tool list). Session-scoped — changes when tool set changes.
 fn self_model_section(tool_names: &[&str]) -> String {
-    format!("\n## Self-Model\nTools: {}\n", tool_names.join(", "))
+    format!(
+        "\n## Self-Model\nTools: {}\n\
+         Refer to 'Runtime Identity' below for model, session, and environment details.\n",
+        tool_names.join(", ")
+    )
 }
 
 type MemoryPromptMode = astra_prompts::memory_types::MemoryPromptMode;

--- a/rust/crates/runtime/src/server/mod.rs
+++ b/rust/crates/runtime/src/server/mod.rs
@@ -62,8 +62,19 @@ pub use request_trace::RequestTrace;
 pub use state_builder::build_server_state;
 
 pub fn build_app(state: AppState) -> Router {
+    let allow_origin = match state.cors_origins.as_deref() {
+        Some(origins) if !origins.is_empty() && origins != "*" => {
+            let parsed: Vec<HeaderValue> = origins
+                .split(',')
+                .filter_map(|o| o.trim().parse().ok())
+                .collect();
+            AllowOrigin::list(parsed)
+        }
+        _ => AllowOrigin::any(),
+    };
+
     let cors = CorsLayer::new()
-        .allow_origin(AllowOrigin::any())
+        .allow_origin(allow_origin)
         .allow_methods([
             Method::GET,
             Method::POST,

--- a/rust/crates/runtime/src/server/run_handlers.rs
+++ b/rust/crates/runtime/src/server/run_handlers.rs
@@ -296,13 +296,7 @@ mod tests {
     }
 
     fn test_matrixone() -> astra_core::MatrixOneSettings {
-        astra_core::MatrixOneSettings {
-            host: "127.0.0.1".into(),
-            port: 6001,
-            user: "root".into(),
-            password: "root".into(),
-            database: "astra_test".into(),
-        }
+        astra_core::MatrixOneSettings::mock()
     }
 
     #[test]

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -4186,18 +4186,7 @@ mod tests {
     }
 
     fn test_settings() -> MatrixOneSettings {
-        dotenvy::dotenv().ok();
-        let lookup = |k: &str| std::env::var(k).ok();
-        MatrixOneSettings {
-            host: std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".into()),
-            port: std::env::var("MATRIXONE_PORT")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(6001),
-            user: std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".into()),
-            password: std::env::var("MATRIXONE_PASSWORD").unwrap_or_else(|_| "111".into()),
-            database: astra_core::resolve_database_name_or(&lookup, "test_astra_runtime"),
-        }
+        MatrixOneSettings::from_env_with_database("test_astra_runtime")
     }
 
     fn test_encryptor() -> Arc<FernetTokenEncryptor> {
@@ -4213,18 +4202,7 @@ mod tests {
     }
 
     fn runtime_db_it_settings(database: &str) -> MatrixOneSettings {
-        dotenvy::dotenv().ok();
-        MatrixOneSettings {
-            host: std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".into()),
-            port: std::env::var("MATRIXONE_PORT")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(6001),
-            user: std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".into()),
-            password: std::env::var("MATRIXONE_PASSWORD")
-                .unwrap_or_else(|_| astra_core::DEV_MATRIXONE_PASSWORD.to_string()),
-            database: database.to_string(),
-        }
+        MatrixOneSettings::from_env_with_database(database)
     }
 
     async fn setup_runtime_db_pool(database: &str) -> (MatrixOneSettings, SharedPool) {

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -2564,7 +2564,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         // When no edge tools are provided (no CLI connected), use the
         // already-provisioned workspace for the ServerToolExecutor.
         if let Some(workspace) = server_workspace {
-            let memoria_base = std::env::var("MEMORIA_BASE_URL").ok();
+            let memoria_base = Some(astra_core::MemoriaSettings::from_env().base_url);
             let mut executor = super::server_tool_executor::ServerToolExecutor::new(
                 workspace,
                 user_id.clone(),
@@ -3012,7 +3012,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
 
         // Wire ServerToolExecutor when no edge agent is connected (web-agent mode).
         if let Some(workspace) = server_workspace {
-            let memoria_base = std::env::var("MEMORIA_BASE_URL").ok();
+            let memoria_base = Some(astra_core::MemoriaSettings::from_env().base_url);
             let mut executor = super::server_tool_executor::ServerToolExecutor::new(
                 workspace,
                 user_id.clone(),
@@ -3865,7 +3865,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
         // server-side and sub-agents would get edge-protocol errors.
         {
             let workspace = self.provision_subrun_workspace(&config.session_id, &config.run_id);
-            let memoria_base = std::env::var("MEMORIA_BASE_URL").ok();
+            let memoria_base = Some(astra_core::MemoriaSettings::from_env().base_url);
             let mut executor = super::server_tool_executor::ServerToolExecutor::new(
                 workspace,
                 config.user_id.clone(),

--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -4215,7 +4215,7 @@ mod tests {
     fn runtime_db_it_settings(database: &str) -> MatrixOneSettings {
         dotenvy::dotenv().ok();
         MatrixOneSettings {
-            host: std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "127.0.0.1".into()),
+            host: std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".into()),
             port: std::env::var("MATRIXONE_PORT")
                 .ok()
                 .and_then(|s| s.parse().ok())

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -3180,13 +3180,7 @@ mod tests {
     use astra_turn_core::sse_stream_host::EdgeToolExecResult;
 
     fn mock_matrixone() -> MatrixOneSettings {
-        MatrixOneSettings {
-            host: "127.0.0.1".to_string(),
-            port: 6001,
-            user: "test".to_string(),
-            password: "test".to_string(),
-            database: "test".to_string(),
-        }
+        MatrixOneSettings::mock()
     }
 
     fn mock_encryptor() -> Arc<FernetTokenEncryptor> {

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -519,6 +519,7 @@ pub struct ServerAgenticLoopHost {
     shared_pool: Option<SharedPool>,
     model_override: Option<String>,
     llm_token_service: Option<LlmTokenServiceConfig>,
+    resolved_model_name: Option<String>,
 
     // ── Context ──
     edge_tools: Vec<Value>,
@@ -832,6 +833,7 @@ impl ServerAgenticLoopHostBuilder {
             shared_pool: self.shared_pool,
             model_override: self.model_override,
             llm_token_service: self.llm_token_service,
+            resolved_model_name: None,
             edge_tools,
             edge_profile: self.edge_profile,
             valid_tools,
@@ -1058,7 +1060,10 @@ impl ServerAgenticLoopHost {
         // loop host level — including Anthropic cache_control blocks and the
         // OpenAI stable-prefix / dynamic split.
         let cache_cfg = match &self.mock_provider {
-            Some((provider, model)) => PromptCacheConfig::latch(provider, model),
+            Some((provider, model)) => {
+                self.resolved_model_name = Some(model.clone());
+                PromptCacheConfig::latch(provider, model)
+            }
             None => PromptCacheConfig::default(),
         };
 
@@ -1809,6 +1814,24 @@ impl ServerAgenticLoopHost {
                 ),
             );
         }
+        // Runtime identity: model, workspace, session, user, date.
+        let runtime_ctx = crate::prompts::AgentRuntimeContext {
+            model_name: self.resolved_model_name.clone(),
+            workspace_cwd: self.edge_profile.get("cwd").and_then(Value::as_str).map(String::from),
+            git_branch: self
+                .edge_profile
+                .get("git_branch")
+                .and_then(Value::as_str)
+                .map(String::from),
+            session_id: Some(self.session_id.clone()),
+            user_id: Some(self.user_id.clone()),
+            current_date: Some(chrono::Local::now().format("%Y-%m-%d").to_string()),
+        };
+        dynamic_sections.push(crate::prompts::PromptSection::dynamic(
+            runtime_ctx.to_prompt_section(),
+            crate::prompts::PromptTokenBucket::Environment,
+        ));
+
         let full_dynamic = crate::prompts::sections_to_string(&dynamic_sections);
 
         // Build structured system messages with Anthropic cache annotations.
@@ -2011,8 +2034,21 @@ impl ServerAgenticLoopHost {
             .ok()
             .and_then(|g| g.clone())
             .unwrap_or_default();
+        let runtime_ctx = crate::prompts::AgentRuntimeContext {
+            model_name: self.resolved_model_name.clone(),
+            workspace_cwd: self.edge_profile.get("cwd").and_then(Value::as_str).map(String::from),
+            git_branch: self
+                .edge_profile
+                .get("git_branch")
+                .and_then(Value::as_str)
+                .map(String::from),
+            session_id: Some(self.session_id.clone()),
+            user_id: Some(self.user_id.clone()),
+            current_date: Some(chrono::Local::now().format("%Y-%m-%d").to_string()),
+        };
+        let runtime_identity = runtime_ctx.to_prompt_section();
         let full_dynamic = format!(
-            "{profile_desc}{skill_hint}{learned_context_hint}{memory_signal_hint}{round_budget_hint}{plan_resume}"
+            "{profile_desc}{skill_hint}{learned_context_hint}{memory_signal_hint}{round_budget_hint}{plan_resume}{runtime_identity}"
         );
 
         cached_system_prompt(
@@ -2370,6 +2406,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
         // Latch prompt cache config from provider info (once per turn is fine;
         // provider doesn't change within a turn).
         let cache_cfg = PromptCacheConfig::latch(&llm_cfg.provider, &llm_cfg.model_name);
+        self.resolved_model_name = Some(llm_cfg.model_name.clone());
 
         let (system_messages, system_prompt_plain, system_prompt_breakdown) =
             self.build_system_messages_cached(&user_content, &visible_tools, state, &cache_cfg);

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -1817,7 +1817,11 @@ impl ServerAgenticLoopHost {
         // Runtime identity: model, workspace, session, user, date.
         let runtime_ctx = crate::prompts::AgentRuntimeContext {
             model_name: self.resolved_model_name.clone(),
-            workspace_cwd: self.edge_profile.get("cwd").and_then(Value::as_str).map(String::from),
+            workspace_cwd: self
+                .edge_profile
+                .get("cwd")
+                .and_then(Value::as_str)
+                .map(String::from),
             git_branch: self
                 .edge_profile
                 .get("git_branch")
@@ -2036,7 +2040,11 @@ impl ServerAgenticLoopHost {
             .unwrap_or_default();
         let runtime_ctx = crate::prompts::AgentRuntimeContext {
             model_name: self.resolved_model_name.clone(),
-            workspace_cwd: self.edge_profile.get("cwd").and_then(Value::as_str).map(String::from),
+            workspace_cwd: self
+                .edge_profile
+                .get("cwd")
+                .and_then(Value::as_str)
+                .map(String::from),
             git_branch: self
                 .edge_profile
                 .get("git_branch")

--- a/rust/crates/runtime/src/server/server_skill_subrun.rs
+++ b/rust/crates/runtime/src/server/server_skill_subrun.rs
@@ -432,7 +432,7 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
         // ── Wire ServerToolExecutor for skill sub-run tool execution ────
         {
             let workspace = self.provision_skill_workspace(skill_name, &subrun_session_id);
-            let memoria_base = std::env::var("MEMORIA_BASE_URL").ok();
+            let memoria_base = Some(astra_core::MemoriaSettings::from_env().base_url);
             let mut executor = super::server_tool_executor::ServerToolExecutor::new(
                 workspace,
                 String::new(), // skill sub-runs don't track user_id

--- a/rust/crates/runtime/src/server/server_skill_subrun.rs
+++ b/rust/crates/runtime/src/server/server_skill_subrun.rs
@@ -473,13 +473,7 @@ mod tests {
     use super::*;
 
     fn mock_matrixone() -> MatrixOneSettings {
-        MatrixOneSettings {
-            host: "127.0.0.1".to_string(),
-            port: 6001,
-            user: "test".to_string(),
-            password: "test".to_string(),
-            database: "test".to_string(),
-        }
+        MatrixOneSettings::mock()
     }
 
     fn mock_encryptor() -> Arc<FernetTokenEncryptor> {

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, SystemTime};
 use serde_json::{Value, json};
 
 use astra_tools::executor::DefaultToolExecutor;
-use astra_tools::{AskUserDecision, AskUserGate, ToolContext, ToolExecutor};
+use astra_tools::{AskUserDecision, AskUserGate, ToolExecutor};
 use async_trait::async_trait;
 
 use crate::tool_sandbox::{
@@ -1090,35 +1090,13 @@ impl ServerToolExecutor {
                 .map(|workspace| (workspace.pinned_tools, workspace.deprioritized_tools))
                 .unwrap_or_else(|_| (Vec::new(), Vec::new()));
 
-        let http_client = reqwest::Client::builder()
-            .no_proxy()
-            .timeout(Duration::from_secs(15))
-            .user_agent("astra-server/0.1.0")
-            .build()
-            .expect("Failed to build HTTP client");
-
-        let default_executor = DefaultToolExecutor::new(ToolContext {
-            project_root: workspace_root.clone(),
-            workspace_root: workspace_root.clone(),
-            user_id: user_id.clone(),
-            session_id: session_id.clone(),
-            sandbox: astra_tools::SandboxConfig::standard(workspace_root.clone()),
-            http_client: Some(http_client.clone()),
-            logger: std::sync::Arc::new(astra_tools::TracingLogger),
-            cancel_token: None,
-        });
-        // Wire GitHubClient into DefaultToolExecutor if any token is available
-        let github_tokens = astra_tools::github::resolve_github_tokens();
-        let default_executor = if !github_tokens.is_empty() {
-            let github = astra_tools::github::GitHubClient::from_tokens(
-                http_client.clone(),
-                github_tokens,
-                Vec::new(),
-            );
-            default_executor.with_github_client(github)
-        } else {
-            default_executor
-        };
+        let default_executor = DefaultToolExecutor::for_workspace(
+            &workspace_root,
+            user_id.clone(),
+            session_id.clone(),
+            "astra-server/0.1.0",
+            Duration::from_secs(15),
+        );
 
         Self {
             workspace_root,

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -1411,6 +1411,8 @@ impl ServerToolExecutor {
                     .execute("github_create_issue", args)
                     .await
             }
+            // ── Agent introspection ────────────────────────────────────
+            "get_agent_info" => tool_result_from_output(self.server_get_agent_info(args)),
             // ── Delegation placeholder ─────────────────────────────────
             "delegate" => astra_tools::ToolResult::text(
                 "Delegation request acknowledged. The delegation engine will execute \
@@ -1426,7 +1428,7 @@ impl ServerToolExecutor {
                      grep, glob, git_status, git_diff, git_log, git_file_history, git_contributors, git_log_search, \
                      git_show, git_blame, symbols, git_commit, git_stash, git_revert_commit, github_list_prs, github_get_pr, \
                      github_ci_status, github_list_issues, github_get_issue, github_repo_stats, github_create_issue, memory_*, web_fetch, \
-                     web_search, ask_user"
+                     web_search, ask_user, get_agent_info"
             )),
         };
 
@@ -2178,6 +2180,52 @@ impl ServerToolExecutor {
             );
         }
         output
+    }
+
+    fn server_get_agent_info(&self, args: &Value) -> String {
+        let dimension = args
+            .get("dimension")
+            .and_then(Value::as_str)
+            .unwrap_or("all");
+        let identity = || {
+            serde_json::json!({
+                "name": "astra",
+                "version": env!("CARGO_PKG_VERSION"),
+                "runtime": "cloud-server",
+                "user_id": self.user_id,
+                "session_id": self.session_id,
+                "workspace": self.workspace_root.display().to_string(),
+            })
+        };
+        let capability = || {
+            let schemas = astra_tools::schemas::server_executor_tool_schemas();
+            let tool_names: Vec<&str> = schemas
+                .iter()
+                .filter_map(|t| {
+                    t.get("function")
+                        .and_then(|f| f.get("name"))
+                        .and_then(Value::as_str)
+                })
+                .collect();
+            serde_json::json!({
+                "tool_count": tool_names.len(),
+                "tools": tool_names,
+            })
+        };
+        match dimension {
+            "identity" => identity().to_string(),
+            "capability" => capability().to_string(),
+            _ => {
+                let mut info = identity();
+                if let Value::Object(ref mut m) = info {
+                    let cap = capability();
+                    if let Value::Object(cap_m) = cap {
+                        m.extend(cap_m);
+                    }
+                }
+                info.to_string()
+            }
+        }
     }
 
     fn adjust_config(&self, args: &Value) -> String {

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -31,8 +31,6 @@ use crate::tool_sandbox::{
 };
 use astra_turn_core::file_edit_journal::{EditType, FileEditJournal};
 
-const ASTRA_CONNECT_TIMEOUT_SECS: u32 = 5;
-
 fn normalize_path(path: &Path) -> PathBuf {
     path.components()
         .fold(PathBuf::new(), |mut acc, component| {
@@ -938,23 +936,8 @@ fn is_mo_error(output: &str) -> bool {
 }
 
 fn mo_mysql_cmd(database: Option<&str>) -> Result<Command, String> {
-    let host = std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "localhost".to_string());
-    let port = std::env::var("MATRIXONE_PORT").unwrap_or_else(|_| "6001".to_string());
-    let user = std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".to_string());
-    let password = std::env::var("MATRIXONE_PASSWORD").unwrap_or_else(|_| "111".to_string());
-    let db = database
-        .map(ToString::to_string)
-        .unwrap_or_else(|| astra_core::resolve_database_name(&|k| std::env::var(k).ok()));
-
-    let mut cmd = Command::new("mysql");
-    cmd.arg(format!("-h{host}"))
-        .arg(format!("-P{port}"))
-        .arg(format!("-u{user}"))
-        .env("MYSQL_PWD", &password)
-        .arg(db)
-        .arg(format!("--connect-timeout={ASTRA_CONNECT_TIMEOUT_SECS}"))
-        .arg("--table");
-    Ok(cmd)
+    let settings = astra_core::MatrixOneSettings::from_env();
+    Ok(settings.mysql_cmd(database))
 }
 
 fn mo_execute_sql(sql: &str, database: Option<&str>) -> String {

--- a/rust/crates/runtime/src/server/state_builder.rs
+++ b/rust/crates/runtime/src/server/state_builder.rs
@@ -307,7 +307,7 @@ pub async fn build_server_state(
     // Wire team persistence store backed by MatrixOne.
     let team_store =
         astra_services::team_persistence::MatrixOneTeamStore::new(shared_pool.get().clone());
-    let user_id = std::env::var("ASTRA_CLI_USER_ID").unwrap_or_else(|_| "local".to_string());
+    let user_id = astra_core::cli_user_id();
     if let Err(e) = team_store.ensure_builtins(&user_id).await {
         tracing::warn!(
             target: "astra_runtime::state_builder",

--- a/rust/crates/runtime/src/server/state_builder.rs
+++ b/rust/crates/runtime/src/server/state_builder.rs
@@ -43,6 +43,7 @@ pub async fn build_server_state(
         ServiceInfo::default(),
         Arc::new(MatrixOneHealthChecker::new(settings.matrixone.clone())),
     )
+    .with_cors_origins(settings.api.cors_origins.clone())
     .with_shared_pool(shared_pool.clone())
     .with_plan_repository(Arc::new(astra_plan::CloudPlanRepository::new(
         shared_pool.get().clone(),

--- a/rust/crates/runtime/src/turn/agentic_loop_lifecycle.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_lifecycle.rs
@@ -298,8 +298,6 @@ pub(crate) async fn run_loop_preamble<H: AgenticLoopHost>(
                 );
             host.inject_tool_schema(crate::turn::skill_tool::skill_tool_schema(
                 &visible,
-                Some(&state.skills.quality_tracker),
-                Some(&state.skills.pinned),
                 open_skill_name,
             ));
             if open_skill_name {

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_phase.rs
@@ -1221,8 +1221,6 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
                     );
                 host.inject_tool_schema(crate::turn::skill_tool::skill_tool_schema(
                     &visible,
-                    Some(&state.skills.quality_tracker),
-                    Some(&state.skills.pinned),
                     open_skill_name,
                 ));
                 if open_skill_name {

--- a/rust/crates/runtime/src/turn/agentic_loop_tool_support.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_tool_support.rs
@@ -49,7 +49,7 @@ pub fn delegate_tool_schema() -> Value {
         "type": "function",
         "function": {
             "name": "delegate",
-            "description": "Delegate a task to one or more specialized sub-agents. Use this when a task benefits from parallel execution, pipeline processing, or adversarial review by specialized agents.",
+            "description": "Delegate a task to specialized sub-agents for parallel, sequential, pipeline, or review workflows.",
             "parameters": {
                 "type": "object",
                 "required": ["task", "agents"],
@@ -66,7 +66,7 @@ pub fn delegate_tool_schema() -> Value {
                     "pattern": {
                         "type": "string",
                         "enum": ["sequential", "fan_out", "pipeline", "adversarial"],
-                        "description": "Coordination pattern. 'sequential': agents run one by one. 'fan_out': agents run in parallel. 'pipeline': output of each feeds the next. 'adversarial': producer+reviewer iterate."
+                        "description": "Coordination pattern: sequential, fan_out, pipeline, or adversarial."
                     },
                     "max_rounds": {
                         "type": "integer",

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -3454,13 +3454,7 @@ mod tests {
 
     #[allow(dead_code)]
     fn bridge_test_matrixone() -> MatrixOneSettings {
-        MatrixOneSettings {
-            host: "127.0.0.1".to_string(),
-            port: 6001,
-            user: "test".to_string(),
-            password: "test".to_string(),
-            database: "test".to_string(),
-        }
+        MatrixOneSettings::mock()
     }
 
     #[allow(dead_code)]

--- a/rust/crates/runtime/src/turn/bridge_llm_stream.rs
+++ b/rust/crates/runtime/src/turn/bridge_llm_stream.rs
@@ -18,8 +18,9 @@ use uuid::Uuid;
 
 use crate::turn::bridge_sse_helpers::render_sse;
 use crate::turn::llm_client::{
-    LlmCancel, apply_provider_auth, build_provider_request_body, consolidate_system_messages,
-    llm_request_url_for_provider, provider_uses_bedrock_converse, sleep_ms_or_llm_cancel,
+    LLM_MAX_RETRIES, LlmCancel, apply_provider_auth, build_provider_request_body,
+    consolidate_system_messages, llm_request_url_for_provider, llm_retry_base_ms,
+    provider_uses_bedrock_converse, sleep_ms_or_llm_cancel,
 };
 use astra_turn_core::bridge_rate_limit_cooldown::{
     PerModelCooldown, RateLimitAction, is_overload_status, is_rate_limit_status,
@@ -29,17 +30,8 @@ use astra_turn_core::edge_ledger::ensure_tool_call_ids;
 use futures_util::StreamExt;
 use std::sync::OnceLock;
 
-/// Maximum retries for transient LLM errors (429, 5xx, network).
-const LLM_MAX_RETRIES: u32 = 3;
-/// Base delay between retries (doubles each attempt: 1s, 2s, 4s).
-const LLM_RETRY_BASE_MS: u64 = 1000;
-
 #[cfg(test)]
 thread_local! {
-    /// Test override for the between-retry backoff. Flat value in ms; when
-    /// `Some`, replaces the exponential `LLM_RETRY_BASE_MS * 2^(attempt-1)`.
-    /// See `set_test_retry_backoff_ms` in llm_client.rs for the matching
-    /// pattern used elsewhere in the runtime.
     static TEST_BRIDGE_RETRY_BACKOFF_MS: std::cell::RefCell<Option<u64>> =
         const { std::cell::RefCell::new(None) };
 }
@@ -49,14 +41,7 @@ fn bridge_retry_backoff_ms(attempt: u32) -> u64 {
     if let Some(ms) = TEST_BRIDGE_RETRY_BACKOFF_MS.with(|c| *c.borrow()) {
         return ms;
     }
-    static BASE: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
-    let base = *BASE.get_or_init(|| {
-        std::env::var("ASTRA_LLM_RETRY_BASE_MS")
-            .ok()
-            .and_then(|v| v.trim().parse::<u64>().ok())
-            .unwrap_or(LLM_RETRY_BASE_MS)
-    });
-    base * (1 << (attempt - 1))
+    llm_retry_base_ms() * (1 << (attempt - 1))
 }
 
 /// Returns `true` if `name` looks like a valid tool function name.

--- a/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
+++ b/rust/crates/runtime/src/turn/cloud/memoria_compact.rs
@@ -294,10 +294,8 @@ impl HttpMemoriaClient {
 
     /// Create from environment variables.
     pub fn from_env() -> Option<Self> {
-        let base_url = std::env::var("MEMORIA_BASE_URL")
-            .unwrap_or_else(|_| "http://127.0.0.1:8100".to_string());
-        let api_key = std::env::var("MEMORIA_MASTER_KEY").ok()?;
-        Some(Self::new(base_url, api_key))
+        let mem = astra_core::MemoriaSettings::from_env();
+        Some(Self::new(mem.base_url, mem.master_key?))
     }
 }
 

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -58,7 +58,7 @@ pub(crate) const LLM_MAX_RETRIES: u32 = 3;
 /// intentionally exhaust retries to assert error-surface behavior).
 pub(crate) const LLM_RETRY_BASE_MS: u64 = 1000;
 
-fn llm_retry_base_ms() -> u64 {
+pub(crate) fn llm_retry_base_ms() -> u64 {
     static VAL: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
     *VAL.get_or_init(|| {
         std::env::var("ASTRA_LLM_RETRY_BASE_MS")

--- a/rust/crates/runtime/src/turn/skill_tool.rs
+++ b/rust/crates/runtime/src/turn/skill_tool.rs
@@ -554,65 +554,53 @@ pub fn execute_discover_skills(
     )
 }
 
+fn skill_enum_names(skills: &[SkillToolInfo]) -> Vec<String> {
+    let mut seen: HashSet<&str> = skills.iter().map(|s| s.name.as_str()).collect();
+    let mut names: Vec<String> = skills.iter().map(|s| s.name.clone()).collect();
+    for skill in skills {
+        for alias in &skill.aliases {
+            if seen.insert(alias.as_str()) {
+                names.push(alias.clone());
+            }
+        }
+    }
+    names
+}
+
 /// Generate the OpenAI-compatible tool schema for the `skill` tool.
 ///
 /// When `open_skill_name` is true (dynamic surfacing), `skill_name` is a free string
 /// (no JSON `enum`) so the catalog can grow mid-session via `discover_skills` without
 /// re-injecting schemas. Otherwise an enum lists all callable aliases.
 ///
-/// Descriptions are budget-capped to avoid blowing up the context window.
-pub fn skill_tool_schema(
-    skills: &[SkillToolInfo],
-    quality_tracker: Option<&crate::skills::quality::SkillQualityTracker>,
-    pinned_skills: Option<&std::collections::HashSet<String>>,
-    open_skill_name: bool,
-) -> Value {
-    let (skill_entries, all_names) = format_skills_within_budget(
-        skills,
-        DEFAULT_SKILL_LISTING_BUDGET,
-        quality_tracker,
-        pinned_skills,
-    );
-
+/// The catalog itself is injected by `skill_listing_system_message`; keep this
+/// schema description short so we don't duplicate the same list in tool JSON.
+pub fn skill_tool_schema(skills: &[SkillToolInfo], open_skill_name: bool) -> Value {
     let mut skill_name_prop = serde_json::json!({
         "type": "string",
         "description": "The name of the skill to execute (canonical name or alias)."
     });
     if !open_skill_name {
-        let skill_names: Vec<Value> = all_names.into_iter().map(Value::String).collect();
+        let skill_names = skill_enum_names(skills)
+            .into_iter()
+            .map(Value::String)
+            .collect();
         if let Some(obj) = skill_name_prop.as_object_mut() {
             obj.insert("enum".to_string(), Value::Array(skill_names));
         }
     }
 
     let dynamic_note = if open_skill_name {
-        "\n\nOnly a subset of skills is listed below. If none apply, call `discover_skills` with a specific description of your next action before improvising."
+        " If no visible skill applies, call `discover_skills` before improvising."
     } else {
         ""
     };
 
     let description = format!(
-        "Execute a skill within the current conversation.\n\n\
-         When users ask you to perform tasks, check if any of the available skills \
-         below can help complete the task more effectively. Skills provide specialized \
-         capabilities and domain knowledge.\n\n\
-         How to invoke:\n\
-         - Use this tool with the skill name only (no arguments) for most skills\n\
-         - Optionally provide a task description for additional context\n\n\
-         Important:\n\
-         - When a skill is relevant to the user's request, invoke it IMMEDIATELY \
-         as your first action\n\
-         - When a skill matches the user's request, this is a BLOCKING REQUIREMENT: \
-         invoke the relevant skill tool BEFORE generating any other response about the task. \
-         Do NOT call any other tools in the same response as a skill invocation — the skill \
-         must be loaded first so you can follow its instructions\n\
-         - NEVER just mention a skill in your text response without actually calling this tool\n\
-         - If the user explicitly references a skill by name, invoke it\n\
-         - If you see a `<skill-loaded name=\"...\"/>` tag in a tool result, the skill \
-         has already executed. Follow those instructions directly — do NOT call any \
-         other tools or re-invoke the skill\n\n\
-         Available skills:\n{}{}",
-        skill_entries.join("\n"),
+        "Execute a specialized skill in the current conversation. Use a skill from the \
+         <available_skills> system listing or a skill returned by discover_skills. Invoke \
+         before other tools when the user's request matches a skill; optionally include \
+         task for extra context. Do not re-invoke after a <skill-loaded/> result.{}",
         dynamic_note
     );
 
@@ -639,7 +627,8 @@ pub fn skill_tool_schema(
 /// Build a system-reminder message listing available skills.
 ///
 /// Injected into the conversation so the LLM is aware skills exist even
-/// before inspecting tool schemas. Uses the same budget as the tool schema.
+/// before inspecting tool schemas. This is the single place where the visible
+/// skill catalog is listed; the `skill` tool schema only references it.
 pub fn skill_listing_system_message(
     skills: &[SkillToolInfo],
     quality_tracker: Option<&crate::skills::quality::SkillQualityTracker>,
@@ -2211,7 +2200,7 @@ mod tests {
     fn schema_has_correct_structure() {
         let resolver = stub_resolver();
         let skills = resolver.available_skills();
-        let schema = skill_tool_schema(&skills, None, None, false);
+        let schema = skill_tool_schema(&skills, false);
 
         assert_eq!(schema["function"]["name"], SKILL_TOOL_NAME);
         let params = &schema["function"]["parameters"];
@@ -2219,13 +2208,51 @@ mod tests {
 
         let skill_enum = &params["properties"]["skill_name"]["enum"];
         assert!(skill_enum.is_array());
-        let names: Vec<&str> = skill_enum
+        let names: Vec<String> = skill_enum
             .as_array()
             .unwrap()
             .iter()
-            .map(|v| v.as_str().unwrap())
+            .map(|v| v.as_str().unwrap().to_string())
             .collect();
-        assert_eq!(names, vec!["code-review", "test-writer"]);
+        let expected = skill_enum_names(&skills);
+        assert_eq!(names, expected);
+    }
+
+    #[test]
+    fn skill_enum_names_include_unique_aliases() {
+        let skills = vec![
+            SkillToolInfo {
+                name: "review".into(),
+                aliases: vec!["inspect".into(), "audit".into()],
+                ..Default::default()
+            },
+            SkillToolInfo {
+                name: "audit".into(),
+                aliases: vec!["inspect".into(), "check".into()],
+                ..Default::default()
+            },
+        ];
+
+        assert_eq!(
+            skill_enum_names(&skills),
+            vec!["review", "audit", "inspect", "check"]
+        );
+    }
+
+    #[test]
+    fn schema_description_does_not_duplicate_skill_listing() {
+        let resolver = stub_resolver();
+        let skills = resolver.available_skills();
+        let schema = skill_tool_schema(&skills, false);
+        let desc = schema["function"]["description"].as_str().unwrap();
+
+        assert!(!desc.contains("code-review"), "{desc}");
+        assert!(!desc.contains("Available skills:"), "{desc}");
+
+        let listing = skill_listing_system_message(&skills, None, None, false);
+        let content = listing["content"].as_str().unwrap();
+        assert!(content.contains("code-review"), "{content}");
+        assert!(content.contains("<available_skills>"), "{content}");
     }
 
     #[test]
@@ -2235,7 +2262,7 @@ mod tests {
             description: "test".into(),
             ..Default::default()
         }];
-        let schema = skill_tool_schema(&skills, None, None, true);
+        let schema = skill_tool_schema(&skills, true);
         assert!(
             schema["function"]["parameters"]["properties"]["skill_name"]
                 .get("enum")
@@ -2413,7 +2440,7 @@ mod tests {
 
     #[test]
     fn schema_empty_when_no_skills() {
-        let schema = skill_tool_schema(&[], None, None, false);
+        let schema = skill_tool_schema(&[], false);
         let skill_enum = &schema["function"]["parameters"]["properties"]["skill_name"]["enum"];
         assert_eq!(skill_enum.as_array().unwrap().len(), 0);
     }
@@ -3607,7 +3634,7 @@ mod tests {
     }
 
     #[test]
-    fn schema_includes_when_to_use() {
+    fn system_listing_includes_when_to_use() {
         let skills = vec![SkillToolInfo {
             name: "deployer".into(),
             description: "Deploy services".into(),
@@ -3618,9 +3645,9 @@ mod tests {
             tags: Vec::new(),
             triggers: Vec::new(),
         }];
-        let schema = skill_tool_schema(&skills, None, None, false);
-        let desc = schema["function"]["description"].as_str().unwrap();
-        assert!(desc.contains("when user asks to deploy"));
+        let listing = skill_listing_system_message(&skills, None, None, false);
+        let content = listing["content"].as_str().unwrap();
+        assert!(content.contains("when user asks to deploy"));
     }
 
     #[test]

--- a/rust/crates/runtime/tests/chat_turn_bridge_ledger_inject_e2e.rs
+++ b/rust/crates/runtime/tests/chat_turn_bridge_ledger_inject_e2e.rs
@@ -199,8 +199,8 @@ impl TurnToolEventWriter for CapturingTurnToolWriter {
 }
 
 fn matrixone_dummy() -> MatrixOneSettings {
-        MatrixOneSettings::mock()
-    }
+    MatrixOneSettings::mock()
+}
 
 fn ledger_inject_app(capture: ToolPersistCapture) -> Router {
     let encryptor =

--- a/rust/crates/runtime/tests/chat_turn_bridge_ledger_inject_e2e.rs
+++ b/rust/crates/runtime/tests/chat_turn_bridge_ledger_inject_e2e.rs
@@ -199,14 +199,8 @@ impl TurnToolEventWriter for CapturingTurnToolWriter {
 }
 
 fn matrixone_dummy() -> MatrixOneSettings {
-    MatrixOneSettings {
-        host: "127.0.0.1".into(),
-        port: 1,
-        user: "x".into(),
-        password: "x".into(),
-        database: "x".into(),
+        MatrixOneSettings::mock()
     }
-}
 
 fn ledger_inject_app(capture: ToolPersistCapture) -> Router {
     let encryptor =

--- a/rust/crates/runtime/tests/evaluation_contract.rs
+++ b/rust/crates/runtime/tests/evaluation_contract.rs
@@ -80,8 +80,8 @@ fn build_unconfigured_app() -> axum::Router {
 }
 
 fn dummy_matrixone() -> MatrixOneSettings {
-        MatrixOneSettings::mock()
-    }
+    MatrixOneSettings::mock()
+}
 
 async fn start_mock_memoria_health() -> String {
     let app = Router::new()

--- a/rust/crates/runtime/tests/evaluation_contract.rs
+++ b/rust/crates/runtime/tests/evaluation_contract.rs
@@ -80,16 +80,8 @@ fn build_unconfigured_app() -> axum::Router {
 }
 
 fn dummy_matrixone() -> MatrixOneSettings {
-    // Placeholder settings — the memory-health/memory-metrics routes only call
-    // Memoria over HTTP and never open a DB connection, so this is never dialed.
-    MatrixOneSettings {
-        host: "invalid.test".to_string(),
-        port: 1,
-        user: "x".to_string(),
-        password: "x".to_string(),
-        database: "x".to_string(),
+        MatrixOneSettings::mock()
     }
-}
 
 async fn start_mock_memoria_health() -> String {
     let app = Router::new()

--- a/rust/crates/runtime/tests/mock_llm_prompt_cache_e2e.rs
+++ b/rust/crates/runtime/tests/mock_llm_prompt_cache_e2e.rs
@@ -25,14 +25,8 @@ use serde_json::{Value, json};
 const VALID_FERNET_KEY: &str = "cJ8pxr3t6iJmSYqe6wD7vu2rN_C3ovGUxkC5H3NXFNY=";
 
 fn mock_matrixone() -> MatrixOneSettings {
-    MatrixOneSettings {
-        host: "127.0.0.1".to_string(),
-        port: 6001,
-        user: "test".to_string(),
-        password: "test".to_string(),
-        database: "test".to_string(),
+        MatrixOneSettings::mock()
     }
-}
 
 fn mock_encryptor() -> Arc<FernetTokenEncryptor> {
     Arc::new(FernetTokenEncryptor::new(VALID_FERNET_KEY).unwrap())

--- a/rust/crates/runtime/tests/mock_llm_prompt_cache_e2e.rs
+++ b/rust/crates/runtime/tests/mock_llm_prompt_cache_e2e.rs
@@ -25,8 +25,8 @@ use serde_json::{Value, json};
 const VALID_FERNET_KEY: &str = "cJ8pxr3t6iJmSYqe6wD7vu2rN_C3ovGUxkC5H3NXFNY=";
 
 fn mock_matrixone() -> MatrixOneSettings {
-        MatrixOneSettings::mock()
-    }
+    MatrixOneSettings::mock()
+}
 
 fn mock_encryptor() -> Arc<FernetTokenEncryptor> {
     Arc::new(FernetTokenEncryptor::new(VALID_FERNET_KEY).unwrap())

--- a/rust/crates/runtime/tests/phase_j_prompt_cache_gaps.rs
+++ b/rust/crates/runtime/tests/phase_j_prompt_cache_gaps.rs
@@ -24,8 +24,8 @@ use serde_json::{Value, json};
 const VALID_FERNET_KEY: &str = "cJ8pxr3t6iJmSYqe6wD7vu2rN_C3ovGUxkC5H3NXFNY=";
 
 fn mock_matrixone() -> MatrixOneSettings {
-        MatrixOneSettings::mock()
-    }
+    MatrixOneSettings::mock()
+}
 
 fn mock_encryptor() -> Arc<FernetTokenEncryptor> {
     Arc::new(FernetTokenEncryptor::new(VALID_FERNET_KEY).unwrap())

--- a/rust/crates/runtime/tests/phase_j_prompt_cache_gaps.rs
+++ b/rust/crates/runtime/tests/phase_j_prompt_cache_gaps.rs
@@ -24,14 +24,8 @@ use serde_json::{Value, json};
 const VALID_FERNET_KEY: &str = "cJ8pxr3t6iJmSYqe6wD7vu2rN_C3ovGUxkC5H3NXFNY=";
 
 fn mock_matrixone() -> MatrixOneSettings {
-    MatrixOneSettings {
-        host: "127.0.0.1".to_string(),
-        port: 6001,
-        user: "test".to_string(),
-        password: "test".to_string(),
-        database: "test".to_string(),
+        MatrixOneSettings::mock()
     }
-}
 
 fn mock_encryptor() -> Arc<FernetTokenEncryptor> {
     Arc::new(FernetTokenEncryptor::new(VALID_FERNET_KEY).unwrap())

--- a/rust/crates/runtime/tests/phase_r5_mock_lifecycle_e2e.rs
+++ b/rust/crates/runtime/tests/phase_r5_mock_lifecycle_e2e.rs
@@ -29,8 +29,8 @@ use serde_json::{Value, json};
 const VALID_FERNET_KEY: &str = "cJ8pxr3t6iJmSYqe6wD7vu2rN_C3ovGUxkC5H3NXFNY=";
 
 fn mock_matrixone() -> MatrixOneSettings {
-        MatrixOneSettings::mock()
-    }
+    MatrixOneSettings::mock()
+}
 
 fn mock_encryptor() -> Arc<FernetTokenEncryptor> {
     Arc::new(FernetTokenEncryptor::new(VALID_FERNET_KEY).unwrap())

--- a/rust/crates/runtime/tests/phase_r5_mock_lifecycle_e2e.rs
+++ b/rust/crates/runtime/tests/phase_r5_mock_lifecycle_e2e.rs
@@ -29,14 +29,8 @@ use serde_json::{Value, json};
 const VALID_FERNET_KEY: &str = "cJ8pxr3t6iJmSYqe6wD7vu2rN_C3ovGUxkC5H3NXFNY=";
 
 fn mock_matrixone() -> MatrixOneSettings {
-    MatrixOneSettings {
-        host: "127.0.0.1".to_string(),
-        port: 6001,
-        user: "t".to_string(),
-        password: "t".to_string(),
-        database: "t".to_string(),
+        MatrixOneSettings::mock()
     }
-}
 
 fn mock_encryptor() -> Arc<FernetTokenEncryptor> {
     Arc::new(FernetTokenEncryptor::new(VALID_FERNET_KEY).unwrap())

--- a/rust/crates/runtime/tests/phase_r6_unhappy_lifecycle.rs
+++ b/rust/crates/runtime/tests/phase_r6_unhappy_lifecycle.rs
@@ -19,8 +19,8 @@ use serde_json::{Value, json};
 const VALID_FERNET_KEY: &str = "cJ8pxr3t6iJmSYqe6wD7vu2rN_C3ovGUxkC5H3NXFNY=";
 
 fn mock_matrixone() -> MatrixOneSettings {
-        MatrixOneSettings::mock()
-    }
+    MatrixOneSettings::mock()
+}
 
 fn mock_encryptor() -> Arc<FernetTokenEncryptor> {
     Arc::new(FernetTokenEncryptor::new(VALID_FERNET_KEY).unwrap())

--- a/rust/crates/runtime/tests/phase_r6_unhappy_lifecycle.rs
+++ b/rust/crates/runtime/tests/phase_r6_unhappy_lifecycle.rs
@@ -19,14 +19,8 @@ use serde_json::{Value, json};
 const VALID_FERNET_KEY: &str = "cJ8pxr3t6iJmSYqe6wD7vu2rN_C3ovGUxkC5H3NXFNY=";
 
 fn mock_matrixone() -> MatrixOneSettings {
-    MatrixOneSettings {
-        host: "127.0.0.1".to_string(),
-        port: 6001,
-        user: "t".to_string(),
-        password: "t".to_string(),
-        database: "t".to_string(),
+        MatrixOneSettings::mock()
     }
-}
 
 fn mock_encryptor() -> Arc<FernetTokenEncryptor> {
     Arc::new(FernetTokenEncryptor::new(VALID_FERNET_KEY).unwrap())

--- a/rust/crates/runtime/tests/phase_r7_context_design_invariants.rs
+++ b/rust/crates/runtime/tests/phase_r7_context_design_invariants.rs
@@ -27,14 +27,8 @@ use serde_json::{Value, json};
 const VALID_FERNET_KEY: &str = "cJ8pxr3t6iJmSYqe6wD7vu2rN_C3ovGUxkC5H3NXFNY=";
 
 fn mock_matrixone() -> MatrixOneSettings {
-    MatrixOneSettings {
-        host: "127.0.0.1".to_string(),
-        port: 6001,
-        user: "t".to_string(),
-        password: "t".to_string(),
-        database: "t".to_string(),
+        MatrixOneSettings::mock()
     }
-}
 
 fn mock_encryptor() -> Arc<FernetTokenEncryptor> {
     Arc::new(FernetTokenEncryptor::new(VALID_FERNET_KEY).unwrap())

--- a/rust/crates/runtime/tests/phase_r7_context_design_invariants.rs
+++ b/rust/crates/runtime/tests/phase_r7_context_design_invariants.rs
@@ -27,8 +27,8 @@ use serde_json::{Value, json};
 const VALID_FERNET_KEY: &str = "cJ8pxr3t6iJmSYqe6wD7vu2rN_C3ovGUxkC5H3NXFNY=";
 
 fn mock_matrixone() -> MatrixOneSettings {
-        MatrixOneSettings::mock()
-    }
+    MatrixOneSettings::mock()
+}
 
 fn mock_encryptor() -> Arc<FernetTokenEncryptor> {
     Arc::new(FernetTokenEncryptor::new(VALID_FERNET_KEY).unwrap())

--- a/rust/crates/runtime/tests/plan_http_db_it.rs
+++ b/rust/crates/runtime/tests/plan_http_db_it.rs
@@ -52,18 +52,7 @@ fn require_db_it_env() -> Option<MatrixOneSettings> {
     if std::env::var("ASTRA_TEST_DB_IT").as_deref() != Ok("1") {
         return None;
     }
-    dotenvy::dotenv().ok();
-    Some(MatrixOneSettings {
-        host: std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "127.0.0.1".into()),
-        port: std::env::var("MATRIXONE_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6001),
-        user: std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".into()),
-        password: std::env::var("MATRIXONE_PASSWORD")
-            .unwrap_or_else(|_| DEV_MATRIXONE_PASSWORD.to_string()),
-        database: resolve_database_name(&|k| std::env::var(k).ok()),
-    })
+    Some(MatrixOneSettings::from_env())
 }
 
 /// Per-binary cached schema-bootstrap + pool. `ensure_core_schema` is

--- a/rust/crates/runtime/tests/plan_http_db_it.rs
+++ b/rust/crates/runtime/tests/plan_http_db_it.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use astra_core::{DEV_MATRIXONE_PASSWORD, MatrixOneSettings, SharedPool, resolve_database_name};
+use astra_core::{MatrixOneSettings, SharedPool};
 use astra_plan::CloudPlanRepository;
 use astra_runtime::{AppState, HealthChecker, ServiceInfo, build_app};
 use astra_services::ensure_core_schema;

--- a/rust/crates/runtime/tests/selector_metrics_db_e2e.rs
+++ b/rust/crates/runtime/tests/selector_metrics_db_e2e.rs
@@ -23,18 +23,13 @@ use sqlx::{MySql, Row};
 use uuid::Uuid;
 
 fn require_db_it_env() -> MatrixOneSettings {
-    dotenvy::dotenv().ok();
-    MatrixOneSettings {
-        host: std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "127.0.0.1".into()),
-        port: std::env::var("MATRIXONE_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6001),
-        user: std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".into()),
-        password: std::env::var("MATRIXONE_PASSWORD")
-            .unwrap_or_else(|_| DEV_MATRIXONE_PASSWORD.to_string()),
-        database: resolve_database_name(&|k| std::env::var(k).ok()),
-    }
+    assert_eq!(
+        std::env::var("ASTRA_TEST_DB_IT").as_deref(),
+        Ok("1"),
+        "set ASTRA_TEST_DB_IT=1 for ignored integration tests"
+    );
+    MatrixOneSettings::from_env()
+}
 }
 
 /// Shared test DB across the 4 selector-metric tests in this binary.

--- a/rust/crates/runtime/tests/selector_metrics_db_e2e.rs
+++ b/rust/crates/runtime/tests/selector_metrics_db_e2e.rs
@@ -6,9 +6,7 @@
 
 use std::time::Duration;
 
-use astra_core::{
-    DEV_MATRIXONE_PASSWORD, MatrixOneSettings, SharedPool, connect_matrixone, resolve_database_name,
-};
+use astra_core::{MatrixOneSettings, SharedPool, connect_matrixone};
 use astra_runtime::bridge::side_effects::run_bridge_hook_side_effects;
 use astra_runtime::{
     DatabaseTurnHookDbWriter, TurnHookDbPersistPlan, TurnHookDbWriter, TurnObserverRequest,
@@ -29,7 +27,6 @@ fn require_db_it_env() -> MatrixOneSettings {
         "set ASTRA_TEST_DB_IT=1 for ignored integration tests"
     );
     MatrixOneSettings::from_env()
-}
 }
 
 /// Shared test DB across the 4 selector-metric tests in this binary.

--- a/rust/crates/services/tests/common/mod.rs
+++ b/rust/crates/services/tests/common/mod.rs
@@ -31,18 +31,8 @@ pub fn require_db_it_env() -> MatrixOneSettings {
         Ok("1"),
         "set ASTRA_TEST_DB_IT=1 for ignored integration tests"
     );
-    dotenvy::dotenv().ok();
-    MatrixOneSettings {
-        host: std::env::var("MATRIXONE_HOST").unwrap_or_else(|_| "127.0.0.1".into()),
-        port: std::env::var("MATRIXONE_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(6001),
-        user: std::env::var("MATRIXONE_USER").unwrap_or_else(|_| "root".into()),
-        password: std::env::var("MATRIXONE_PASSWORD")
-            .unwrap_or_else(|_| DEV_MATRIXONE_PASSWORD.to_string()),
-        database: resolve_database_name(&|k| std::env::var(k).ok()),
-    }
+    MatrixOneSettings::from_env()
+}
 }
 
 /// Shared per-binary bootstrap. Runs `ensure_core_schema` + `SharedPool::new`

--- a/rust/crates/services/tests/common/mod.rs
+++ b/rust/crates/services/tests/common/mod.rs
@@ -21,7 +21,7 @@
 
 #![allow(dead_code)]
 
-use astra_core::{DEV_MATRIXONE_PASSWORD, MatrixOneSettings, SharedPool, resolve_database_name};
+use astra_core::{MatrixOneSettings, SharedPool};
 use astra_services::storage::ensure_core_schema;
 
 /// Asserts `ASTRA_TEST_DB_IT=1` is set, loads `.env`, returns MatrixOneSettings.
@@ -32,7 +32,6 @@ pub fn require_db_it_env() -> MatrixOneSettings {
         "set ASTRA_TEST_DB_IT=1 for ignored integration tests"
     );
     MatrixOneSettings::from_env()
-}
 }
 
 /// Shared per-binary bootstrap. Runs `ensure_core_schema` + `SharedPool::new`

--- a/scripts/dev/start-api.sh
+++ b/scripts/dev/start-api.sh
@@ -46,42 +46,6 @@ echo "Building release API binary..."
 cargo build -q --manifest-path rust/Cargo.toml -p astra-runtime --release --bin astra-server
 echo "✅ Using $BIN_PATH"
 
-# Best-effort bridge autodiscovery for local dev.
-# Keeps explicit ASTRA_BRIDGE_URL untouched when already configured.
-if [ -z "${ASTRA_BRIDGE_URL:-}" ]; then
-    echo "Detecting chat turn bridge endpoint..."
-    for candidate in \
-        "http://127.0.0.1:3001/internal/chat/turn" \
-        "http://127.0.0.1:3001/api/chat/turn" \
-        "http://127.0.0.1:18100/internal/chat/turn"; do
-        resp_file=$(mktemp)
-        header_file=$(mktemp)
-        code=$(curl -s --noproxy '*' -m 2 -D "$header_file" -o "$resp_file" -w '%{http_code}' \
-            -X POST "$candidate" \
-            -H 'content-type: application/json' \
-            -H "x-mo-bridge-secret: ${ASTRA_BRIDGE_SECRET:-}" \
-            -d '{"messages":[{"role":"user","content":"ping"}]}' || true)
-        ctype=$(grep -i '^content-type:' "$header_file" | head -1 | tr -d '\r' | cut -d' ' -f2- | tr '[:upper:]' '[:lower:]')
-        body=$(cat "$resp_file" 2>/dev/null)
-        rm -f "$header_file" "$resp_file"
-        # Reject HTML responses and non-bridge JSON services (e.g. Grafana returns messageId field)
-        if [[ "$ctype" == text/html* ]]; then
-            continue
-        fi
-        if echo "$body" | grep -q '"messageId"'; then
-            continue
-        fi
-        if [ "$code" = "200" ] || [ "$code" = "401" ] || [ "$code" = "403" ] || [ "$code" = "422" ]; then
-            export ASTRA_BRIDGE_URL="$candidate"
-            echo "✅ ASTRA_BRIDGE_URL auto-set to $ASTRA_BRIDGE_URL (probe status: $code, content-type: ${ctype:-unknown})"
-            break
-        fi
-    done
-    if [ -z "${ASTRA_BRIDGE_URL:-}" ]; then
-        echo "⚠️  No local chat-turn bridge detected; chat will return actionable bridge-disabled error."
-    fi
-fi
-
 start_detached() {
     if command -v setsid >/dev/null 2>&1; then
         setsid "$@" >> "$LOG_FILE" 2>&1 &


### PR DESCRIPTION
## Summary

Comprehensive cleanup across config, protocol, tools, and prompts:

- **Env var audit & cleanup**: removed 4 dead `AppSettings` fields (`app_env`, `log_level`, `bridge_url`, `github_token`), wired `ASTRA_CORS_ORIGINS` into CorsLayer, updated all `.env`/Docker/CI/docs
- **Edge protocol dedup**: deleted 47 lines of duplicated WebSocket types from `astra-edge`, imports canonical types from `astra-server-types` with feature-gating (`default = ["server"]`) to keep edge binary lightweight
- **Config consolidation**: `MatrixOneSettings::from_env()`/`from_env_strict()`/`mock()`, `MemoriaSettings::from_env()`, `cli_user_id()` — replaced ~30 scattered env reads across 15+ files
- **`DefaultToolExecutor::for_workspace()`**: extracted shared HTTP client + ToolContext + GitHub setup builder, used by both server and edge
- **Agent self-knowledge**: injected `## Runtime Identity` section (model, workspace, git branch, session, user, date) into system prompt as dynamic section; added `get_agent_info` tool in server mode
- **Tool schema trim**: shortened verbose descriptions (spawn_agent, delegate, read_file, skill), moved skill catalog out of tool schema into `skill_listing_system_message` (single source of truth)

## Commits (10)

1. `c145e22b` — env var audit & cleanup (4 dead fields, CORS, .env, Docker, docs)
2. `90344fa9` — edge WebSocket protocol dedup with feature-gating
3. `e7edc4eb` — dead ASTRA_BRIDGE_URL autodetection removal
4. `83ce7410` — stale docs, inconsistent defaults, duplicate LLM retry const
5. `ddbca849` — `DefaultToolExecutor::for_workspace()` builder
6. `c6283120` — MatrixOne/Memoria/CLI config consolidation
7. `e7431cb2` — Memoria env read migration (15 sites)
8. `e190acb8` — test helper dedup (15 mock/db helpers → `mock()`/`from_env()`)
9. `2eeacc12` — agent self-knowledge (Runtime Identity + `get_agent_info`)
10. `aaf0eb3d` — tool schema description trim, skill catalog dedup

## Impact

- 62 files changed, +827 / −681 lines
- Zero prompt-cache impact (Runtime Identity is `CacheScope::None`, injected after cache breakpoints)
- No backward compatibility shims — clean breaks throughout

## Test plan

- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo test -p astra-runtime --lib` — skill_tool, prompts, server_tool_executor tests pass
- [ ] `cargo test -p astra-turn-core --lib` — orchestration_spawn tests pass
- [ ] `cargo test -p astra-tools --lib` — schema validation tests pass
- [ ] `cargo test -p astra-server-types --lib` — 9 roundtrip protocol tests pass
- [ ] Verify agent responds correctly to "what model are you?", "what's your workspace?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)