### PR TITLE
feat(models): probe-driven thinking capability, multi-tier fallback & model selector

### DIFF
--- a/.models.yaml.example
+++ b/.models.yaml.example
@@ -5,6 +5,18 @@
 #
 # Load into the running server:
 #   astra-admin model load .models.yaml
+#
+# Thinking capability is auto-detected at load time (provider-aware probe).
+# No YAML declaration needed.
+#
+# Tags:
+#   selector  — cheap model used for memory extraction / relevance filtering
+#   code      — suitable for coding tasks
+#   chat      — suitable for conversational tasks
+#   reasoning — suitable for complex reasoning tasks
+#
+# fallback_chain: ordered list of fallback models for rate-limit recovery.
+# Example: fallback_chain: [qwen-turbo, qwen-flash]
 
 # ── AWS Bedrock / Claude via Converse ───────────────────────
 # Current Astra Bedrock integration expects a Bedrock bearer token
@@ -38,6 +50,7 @@
   pricing_prompt: 0.0000008     # ¥0.8/1M (≤128K)
   pricing_completion: 0.000002  # ¥2/1M
   tags: [code, chat, reasoning]
+  fallback_chain: [qwen-turbo, qwen-flash]
   context_window: 1000000
   max_completion_tokens: 32768
   supported_parameters: [tools]

--- a/rust/crates/astra-admin/src/cli_args.rs
+++ b/rust/crates/astra-admin/src/cli_args.rs
@@ -117,8 +117,6 @@ pub(crate) enum ModelCmd {
     Load(ModelLoadArgs),
     /// Update model fields (api-key, base-url, quirks, active status).
     Update(ModelUpdateArgs),
-    /// Set the fallback model for rate-limit recovery.
-    SetFallback(ModelSetFallbackArgs),
 }
 
 #[derive(Args, Debug)]
@@ -141,7 +139,7 @@ pub(crate) struct ModelUpdateArgs {
     /// Set stored `is_active` without re-probing. Prefer `model check` to activate only when connectivity succeeds.
     #[arg(long)]
     pub active: Option<bool>,
-    /// JSON string for quirks, e.g. '{"fallback_model":"gpt-4o-mini"}'
+    /// JSON string for quirks, e.g. '{"fallback_chain":["gpt-4o-mini"]}'
     #[arg(long)]
     pub quirks: Option<String>,
 }
@@ -164,14 +162,6 @@ pub(crate) struct ModelLoadArgs {
     /// server re-runs connectivity and refreshes `is_active`.
     #[arg(long)]
     pub update_existing: bool,
-}
-
-#[derive(Args, Debug)]
-pub(crate) struct ModelSetFallbackArgs {
-    /// Primary model name.
-    pub model_name: String,
-    /// Fallback model name (use "none" to clear).
-    pub fallback_model: String,
 }
 
 #[derive(Subcommand, Debug)]

--- a/rust/crates/astra-admin/src/interactive.rs
+++ b/rust/crates/astra-admin/src/interactive.rs
@@ -37,11 +37,7 @@ const ADMIN_COMMANDS: &[(&str, &str)] = &[
     ),
     (
         "model update",
-        "Update model fields  (e.g. model update <name> --quirks '{\"fallback_model\":\"gpt-4o-mini\"}')",
-    ),
-    (
-        "model set-fallback",
-        "Set fallback model  (e.g. model set-fallback <model> <fallback>)",
+        "Update model fields  (e.g. model update <name> --quirks '{\"fallback_chain\":[\"gpt-4o-mini\"]}')",
     ),
     (
         "user grant-role",
@@ -300,27 +296,6 @@ pub(crate) async fn run_interactive(api: &ThinClient, profile: Option<&str>) -> 
             let (_, _, _, token) = get_profile_and_token(profile)?;
             let body = api
                 .post_bearer_path_empty_text(&token, &paths::model_check(model_name.trim()))
-                .await
-                .map_err(map_thin_err)?;
-            print_json_or_raw(&body);
-            Ok(())
-        } else if let Some(rest) = line.strip_prefix("model set-fallback ") {
-            let mut parts = rest.split_whitespace();
-            let model_name = parts.next().ok_or_else(|| {
-                "usage: model set-fallback <model_name> <fallback_model|none>".to_string()
-            })?;
-            let fallback = parts.next().ok_or_else(|| {
-                "usage: model set-fallback <model_name> <fallback_model|none>".to_string()
-            })?;
-            let (_, _, _, token) = get_profile_and_token(profile)?;
-            let fallback_val = if fallback.eq_ignore_ascii_case("none") {
-                serde_json::json!(null)
-            } else {
-                serde_json::json!(fallback)
-            };
-            let payload = serde_json::json!({ "quirks": { "fallback_model": fallback_val } });
-            let body = api
-                .put_bearer_path_json_text(&token, &paths::model(model_name), &payload)
                 .await
                 .map_err(map_thin_err)?;
             print_json_or_raw(&body);

--- a/rust/crates/astra-admin/src/main.rs
+++ b/rust/crates/astra-admin/src/main.rs
@@ -40,12 +40,14 @@ fn print_model_load_server_result(body: &str, model_name: &str) {
     let thinking_cap = value
         .get("thinking_capability")
         .and_then(serde_json::Value::as_str);
-    match thinking_cap {
-        Some("both") => println!("  thinking: both (Normal/Thinking picker enabled) ✓"),
-        Some("native_only") => println!("  thinking: native_only (model always thinks)"),
-        Some("none") => println!("  thinking: none"),
-        Some(other) => println!("  thinking: {other}"),
-        None => println!("  thinking: unprobed (run: astra-admin model check {model_name})"),
+    if let Some(cap) = thinking_cap {
+        match cap {
+            "both" => println!("  thinking: both (Normal/Thinking picker enabled) ✓"),
+            "effort_only" => println!("  thinking: effort_only (Low/High effort) ✓"),
+            "native_only" => println!("  thinking: native_only (model always thinks)"),
+            "none" => println!("  thinking: none"),
+            other => println!("  thinking: {other}"),
+        }
     }
     if !active {
         eprintln!(
@@ -429,13 +431,14 @@ async fn main() -> Result<(), String> {
                     api_key,
                     base_url.as_deref(),
                 );
-                match api
+                let needs_check = match api
                     .post_bearer_path_json_text(&token, paths::MODELS, &payload)
                     .await
                 {
                     Ok(body) => {
                         println!("loaded model: {model_name}");
                         print_model_load_server_result(&body, model_name);
+                        true
                     }
                     Err(astra_thin_client::ThinClientError::Api { body, .. })
                         if body.contains("already exists") =>
@@ -445,6 +448,7 @@ async fn main() -> Result<(), String> {
                                 eprintln!(
                                     "skipped (already exists): {model_name} — need non-empty api_key in YAML to use --update-existing"
                                 );
+                                false
                             } else {
                                 let upd = build_model_update_payload(
                                     entry,
@@ -462,15 +466,48 @@ async fn main() -> Result<(), String> {
                                     .map_err(map_thin_err)?;
                                 println!("re-synced existing model: {model_name}");
                                 print_model_load_server_result(&body, model_name);
+                                true
                             }
                         } else {
                             println!(
                                 "skipped (already exists): {model_name} — use `astra-admin model load {} --update-existing` to push YAML credentials and re-run connectivity",
                                 args.path
                             );
+                            false
                         }
                     }
                     Err(e) => return Err(map_thin_err(e)),
+                };
+                if needs_check {
+                    match api
+                        .post_bearer_path_empty_text(&token, &paths::model_check(model_name))
+                        .await
+                    {
+                        Ok(body) => {
+                            let cap = serde_json::from_str::<serde_json::Value>(&body)
+                                .ok()
+                                .and_then(|v| {
+                                    v.get("thinking_capability")?.as_str().map(String::from)
+                                });
+                            match cap.as_deref() {
+                                Some("both") => {
+                                    println!("  thinking: both (Normal/Thinking picker) ✓")
+                                }
+                                Some("effort_only") => {
+                                    println!("  thinking: effort_only (Low/High effort) ✓")
+                                }
+                                Some("native_only") => {
+                                    println!("  thinking: native_only (always thinks)")
+                                }
+                                Some("none") => println!("  thinking: none"),
+                                Some(other) => println!("  thinking: {other}"),
+                                None => println!("  thinking: probe returned no capability"),
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("  thinking probe failed for {model_name}: {e}");
+                        }
+                    }
                 }
             }
             Ok(())

--- a/rust/crates/astra-admin/src/main.rs
+++ b/rust/crates/astra-admin/src/main.rs
@@ -37,15 +37,15 @@ fn print_model_load_server_result(body: &str, model_name: &str) {
     } else if !active {
         println!("  connectivity: (not in response; run: astra-admin model check {model_name})");
     }
-    let thinking_mode = value
-        .get("quirks")
-        .and_then(|q| q.get("thinking_mode"))
+    let thinking_cap = value
+        .get("thinking_capability")
         .and_then(serde_json::Value::as_str);
-    match thinking_mode {
-        Some("controllable") => println!("  thinking: controllable (picker enabled) ✓"),
-        Some("native") => println!("  thinking: native (model thinks by default)"),
+    match thinking_cap {
+        Some("both") => println!("  thinking: both (Normal/Thinking picker enabled) ✓"),
+        Some("native_only") => println!("  thinking: native_only (model always thinks)"),
+        Some("none") => println!("  thinking: none"),
         Some(other) => println!("  thinking: {other}"),
-        None => {}
+        None => println!("  thinking: unprobed (run: astra-admin model check {model_name})"),
     }
     if !active {
         eprintln!(
@@ -111,20 +111,10 @@ fn apply_optional_yaml_fields(
             }),
         );
     }
-    if let Some(thinking_mode) = yaml_str(entry, "thinking_mode") {
-        match thinking_mode.as_str() {
-            "controllable" | "native" => {
-                let quirks = obj.entry("quirks").or_insert_with(|| serde_json::json!({}));
-                if let Some(qobj) = quirks.as_object_mut() {
-                    qobj.insert("thinking_mode".into(), serde_json::json!(thinking_mode));
-                }
-            }
-            other => {
-                eprintln!(
-                    "  warning: ignoring invalid thinking_mode {other:?} \
-                     (expected \"controllable\" or \"native\")"
-                );
-            }
+    if let Some(chain) = yaml_str_vec(entry, "fallback_chain") {
+        let quirks = obj.entry("quirks").or_insert_with(|| serde_json::json!({}));
+        if let Some(qobj) = quirks.as_object_mut() {
+            qobj.insert("fallback_chain".into(), serde_json::json!(chain));
         }
     }
 }
@@ -518,24 +508,6 @@ async fn main() -> Result<(), String> {
             print_json_or_raw(&body);
             Ok(())
         }
-        Command::Model(ModelCmd::SetFallback(args)) => {
-            let (_, _, _, token) = get_profile_and_token(cli.profile.as_deref())?;
-            // "none" clears the fallback
-            let fallback = if args.fallback_model.eq_ignore_ascii_case("none") {
-                serde_json::json!(null)
-            } else {
-                serde_json::json!(args.fallback_model)
-            };
-            let payload = serde_json::json!({
-                "quirks": { "fallback_model": fallback }
-            });
-            let body = api
-                .put_bearer_path_json_text(&token, &paths::model(&args.model_name), &payload)
-                .await
-                .map_err(map_thin_err)?;
-            print_json_or_raw(&body);
-            Ok(())
-        }
         Command::Token(TokenCmd::List(args)) => {
             let (_, _, _, token) = get_profile_and_token(cli.profile.as_deref())?;
             let mut q: Vec<(&str, String)> = Vec::new();
@@ -706,111 +678,6 @@ mod tests {
         serde_yaml_ng::from_str(s).unwrap()
     }
 
-    // ── thinking_mode propagation (TDD: red → green) ────────────────────
-
-    #[test]
-    fn create_payload_includes_thinking_mode_controllable() {
-        let entry = yaml(
-            r#"
-            name: us.anthropic.claude-sonnet-4-6
-            provider: bedrock
-            thinking_mode: controllable
-            api_key: test-key
-            tags: [code, chat, reasoning]
-            "#,
-        );
-        let payload = build_model_create_payload(
-            &entry,
-            "us.anthropic.claude-sonnet-4-6",
-            "bedrock",
-            "test-key",
-            None,
-        );
-        let quirks = payload.get("quirks").expect("quirks must be present");
-        assert_eq!(
-            quirks.get("thinking_mode").and_then(|v| v.as_str()),
-            Some("controllable"),
-            "explicit thinking_mode: controllable must be forwarded in quirks"
-        );
-    }
-
-    #[test]
-    fn create_payload_includes_thinking_mode_native() {
-        let entry = yaml(
-            r#"
-            name: qwen3-235b
-            provider: dashscope
-            thinking_mode: native
-            api_key: test-key
-            "#,
-        );
-        let payload =
-            build_model_create_payload(&entry, "qwen3-235b", "dashscope", "test-key", None);
-        let quirks = payload.get("quirks").expect("quirks must be present");
-        assert_eq!(
-            quirks.get("thinking_mode").and_then(|v| v.as_str()),
-            Some("native"),
-        );
-    }
-
-    #[test]
-    fn create_payload_no_quirks_when_thinking_mode_absent() {
-        let entry = yaml(
-            r#"
-            name: gpt-4o
-            provider: openai
-            api_key: test-key
-            "#,
-        );
-        let payload = build_model_create_payload(&entry, "gpt-4o", "openai", "test-key", None);
-        // No thinking_mode in YAML → no quirks key (server fallback handles tags)
-        let quirks = payload.get("quirks");
-        assert!(
-            quirks.is_none()
-                || quirks
-                    .unwrap()
-                    .get("thinking_mode")
-                    .is_none_or(|v| v.is_null()),
-            "no thinking_mode in YAML should not inject one into quirks"
-        );
-    }
-
-    #[test]
-    fn update_payload_includes_thinking_mode() {
-        let entry = yaml(
-            r#"
-            provider: bedrock
-            thinking_mode: controllable
-            api_key: test-key
-            "#,
-        );
-        let payload = build_model_update_payload(&entry, "bedrock", "test-key", None);
-        let quirks = payload
-            .get("quirks")
-            .expect("quirks must be present in update");
-        assert_eq!(
-            quirks.get("thinking_mode").and_then(|v| v.as_str()),
-            Some("controllable"),
-        );
-    }
-
-    #[test]
-    fn create_payload_rejects_invalid_thinking_mode() {
-        let entry = yaml(
-            r#"
-            name: test
-            provider: x
-            api_key: k
-            thinking_mode: Controllable
-            "#,
-        );
-        let payload = build_model_create_payload(&entry, "test", "x", "k", None);
-        assert!(
-            payload.get("quirks").is_none(),
-            "invalid thinking_mode must not be forwarded to quirks"
-        );
-    }
-
     // ── existing field propagation (regression guard) ───────────────────
 
     #[test]
@@ -828,7 +695,6 @@ mod tests {
             architecture: transformer
             pricing_prompt: 0.001
             pricing_completion: 0.002
-            thinking_mode: controllable
             "#,
         );
         let payload = build_model_create_payload(
@@ -848,9 +714,5 @@ mod tests {
         );
         assert_eq!(payload["architecture"], "transformer");
         assert!(payload["pricing"]["prompt"].as_f64().unwrap() > 0.0);
-        assert_eq!(
-            payload["quirks"]["thinking_mode"].as_str(),
-            Some("controllable")
-        );
     }
 }

--- a/rust/crates/astra-cli/src/cli/memory_extraction.rs
+++ b/rust/crates/astra-cli/src/cli/memory_extraction.rs
@@ -242,18 +242,27 @@ async fn run_extraction(
         Err(e) => return ExtractionOutcome::Error(format!("client build: {e}")),
     };
 
+    let mut req_body = serde_json::json!({
+        "model": params.model_name,
+        "messages": [
+            {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
+            {"role": "user", "content": query},
+        ],
+        "max_tokens": 200,
+        "temperature": 0.0,
+    });
+    {
+        astra_turn_core::thinking_config::ThinkingConfig::Off.apply_openai_suppression(
+            &mut req_body,
+            &params.provider,
+            &params.base_url,
+        );
+    }
+
     let resp = match client
         .post(format!("{}/chat/completions", params.base_url))
         .header("Authorization", format!("Bearer {}", params.api_key))
-        .json(&serde_json::json!({
-            "model": params.model_name,
-            "messages": [
-                {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
-                {"role": "user", "content": query},
-            ],
-            "max_tokens": 200,
-            "temperature": 0.0,
-        }))
+        .json(&req_body)
         .send()
         .await
     {
@@ -273,6 +282,16 @@ async fn run_extraction(
                 .map(String::from)
         })
         .unwrap_or_default();
+
+    // Strip <think> tags that native thinkers may emit despite suppression.
+    // If stripping empties the text, fall back to the original (the model may
+    // have wrapped the actual JSON inside think tags).
+    let stripped = astra_turn_core::thinking_config::strip_think_tags(&text);
+    let text = if stripped.trim().is_empty() {
+        text
+    } else {
+        stripped
+    };
 
     let extracted = parse_extraction_response(&text);
     let quality_filtered: Vec<ExtractedMemory> = extracted
@@ -504,6 +523,7 @@ mod tests {
             base_url: "http://x".into(),
             api_key: "k".into(),
             model_name: "m".into(),
+            provider: "openai".into(),
         };
         let tools = vec!["memory_store".into()];
         let outcome = ext.maybe_extract(ctx(1, Some(&params), &tools));
@@ -525,6 +545,7 @@ mod tests {
             base_url: "http://x".into(),
             api_key: "k".into(),
             model_name: "m".into(),
+            provider: "openai".into(),
         };
         let outcome = ext.maybe_extract(ctx(5, Some(&params), &[]));
         assert_eq!(outcome.tag(), "skipped_disabled");
@@ -660,5 +681,168 @@ mod tests {
             src.contains("pub fn memory_extraction("),
             "JournalEvent must have memory_extraction factory method"
         );
+    }
+
+    // ── Mock server integration tests ────────────────────────────────────
+
+    use std::sync::{Arc, Mutex};
+
+    async fn spawn_extraction_mock(
+        captured: Arc<Mutex<Option<serde_json::Value>>>,
+        response_content: &'static str,
+    ) -> String {
+        use axum::{Router, routing::post};
+
+        let handler = move |axum::Json(body): axum::Json<serde_json::Value>| {
+            let captured = captured.clone();
+            async move {
+                *captured.lock().unwrap() = Some(body);
+                axum::Json(serde_json::json!({
+                    "choices": [{"message": {"content": response_content}}]
+                }))
+            }
+        };
+        let app = Router::new().route("/chat/completions", post(handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve");
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn extraction_native_thinker_sends_suppression() {
+        let captured = Arc::new(Mutex::new(None));
+        let base = spawn_extraction_mock(captured.clone(), "[]").await;
+        let params = LlmConnParams {
+            base_url: base,
+            api_key: "k".into(),
+            model_name: "qwen3.5-flash".into(),
+            provider: "dashscope".into(),
+        };
+        let mut ext = MemoryExtractor::new();
+        let outcome = ext.maybe_extract(ExtractionContext {
+            turn: 1,
+            selector_params: Some(&params),
+            user_message: "hello",
+            assistant_response: "world",
+            tools_used: &[],
+            session_id: None,
+            existing_manifest: "",
+        });
+        assert_eq!(outcome.tag(), "started");
+        let _ = ext.drain(std::time::Duration::from_secs(3)).await;
+
+        let body = captured.lock().unwrap().take().expect("request captured");
+        assert_eq!(
+            body["enable_thinking"], false,
+            "native thinker should send enable_thinking: false"
+        );
+    }
+
+    #[tokio::test]
+    async fn extraction_strips_think_tags_before_parse() {
+        let captured = Arc::new(Mutex::new(None));
+        let base = spawn_extraction_mock(
+            captured.clone(),
+            r#"<think>reasoning</think>[{"type":"user","content":"prefers Rust"}]"#,
+        )
+        .await;
+        let params = LlmConnParams {
+            base_url: base,
+            api_key: "k".into(),
+            model_name: "m".into(),
+            provider: "openai".into(),
+        };
+        let mut ext = MemoryExtractor::new();
+        let _ = ext.maybe_extract(ExtractionContext {
+            turn: 1,
+            selector_params: Some(&params),
+            user_message: "I prefer Rust",
+            assistant_response: "Noted",
+            tools_used: &[],
+            session_id: None,
+            existing_manifest: "",
+        });
+        let result = ext.drain(std::time::Duration::from_secs(3)).await;
+        match result {
+            Some(ExtractionOutcome::Extracted { count, .. }) => {
+                assert!(count > 0, "should extract at least one memory");
+            }
+            other => panic!("expected Extracted, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn extraction_think_wrapping_json_degrades_gracefully() {
+        let captured = Arc::new(Mutex::new(None));
+        // JSON is wrapped entirely inside think tags — strip empties it,
+        // fallback to original which has <think> prefix → JSON parse fails.
+        // This is graceful degradation: count=0, no panic.
+        let base = spawn_extraction_mock(
+            captured.clone(),
+            r#"<think>[{"type":"user","content":"prefers Rust"}]</think>"#,
+        )
+        .await;
+        let params = LlmConnParams {
+            base_url: base,
+            api_key: "k".into(),
+            model_name: "m".into(),
+            provider: "openai".into(),
+        };
+        let mut ext = MemoryExtractor::new();
+        let _ = ext.maybe_extract(ExtractionContext {
+            turn: 1,
+            selector_params: Some(&params),
+            user_message: "I prefer Rust",
+            assistant_response: "Noted",
+            tools_used: &[],
+            session_id: None,
+            existing_manifest: "",
+        });
+        let result = ext.drain(std::time::Duration::from_secs(3)).await;
+        match result {
+            Some(ExtractionOutcome::Extracted { count, .. }) => {
+                assert_eq!(count, 0, "think-wrapped JSON should degrade to count=0");
+            }
+            other => panic!("expected Extracted(0), got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn extraction_normal_json_response() {
+        let captured = Arc::new(Mutex::new(None));
+        let base = spawn_extraction_mock(
+            captured.clone(),
+            r#"[{"type":"feedback","content":"prefers concise code"}]"#,
+        )
+        .await;
+        let params = LlmConnParams {
+            base_url: base,
+            api_key: "k".into(),
+            model_name: "m".into(),
+            provider: "openai".into(),
+        };
+        let mut ext = MemoryExtractor::new();
+        let _ = ext.maybe_extract(ExtractionContext {
+            turn: 1,
+            selector_params: Some(&params),
+            user_message: "keep it concise",
+            assistant_response: "ok",
+            tools_used: &[],
+            session_id: None,
+            existing_manifest: "",
+        });
+        let result = ext.drain(std::time::Duration::from_secs(3)).await;
+        match result {
+            Some(ExtractionOutcome::Extracted { count, .. }) => {
+                assert_eq!(count, 1);
+            }
+            other => panic!("expected Extracted(1), got: {other:?}"),
+        }
     }
 }

--- a/rust/crates/astra-cli/src/cli/slash_router.rs
+++ b/rust/crates/astra-cli/src/cli/slash_router.rs
@@ -36,21 +36,8 @@ fn model_list_entry_name(entry: &serde_json::Value) -> Option<&str> {
         .and_then(|v| v.as_str())
 }
 
-fn model_list_entry_thinking_mode(entry: &serde_json::Value) -> Option<&str> {
-    // Flattened `thinking_mode` is the canonical shape emitted by the current
-    // /models response. The `quirks.thinking_mode` branch is a transitional
-    // fallback for older server builds still nesting the value inside quirks.
-    // TODO: remove the nested-quirks fallback once all deployments are past
-    // the flattened-response rollout.
-    entry
-        .get("thinking_mode")
-        .and_then(|v| v.as_str())
-        .or_else(|| {
-            entry
-                .get("quirks")
-                .and_then(|q| q.get("thinking_mode"))
-                .and_then(|v| v.as_str())
-        })
+fn model_list_entry_thinking_capability(entry: &serde_json::Value) -> Option<&str> {
+    entry.get("thinking_capability").and_then(|v| v.as_str())
 }
 
 fn model_list_entry_provider(entry: &serde_json::Value) -> Option<&str> {
@@ -179,12 +166,13 @@ pub(super) async fn handle_slash_command(
                             );
                         }
                     }
-                    let thinking_mode = selected_model.and_then(model_list_entry_thinking_mode);
+                    let thinking_cap =
+                        selected_model.and_then(model_list_entry_thinking_capability);
                     let provider = selected_model.and_then(model_list_entry_provider);
                     let opts = astra_turn_core::thinking_config::thinking_options_with_capability(
                         &chosen,
                         provider,
-                        thinking_mode,
+                        thinking_cap,
                     );
                     let model_with_suffix = if opts.is_empty() {
                         chosen.clone()
@@ -623,33 +611,29 @@ mod model_list_json_tests {
     }
 
     #[test]
-    fn reads_flattened_thinking_mode_from_model_list() {
-        let v = serde_json::json!({"name": "claude", "thinking_mode": "controllable"});
-        assert_eq!(model_list_entry_thinking_mode(&v), Some("controllable"));
+    fn reads_thinking_capability_both() {
+        let v = serde_json::json!({"name": "claude", "thinking_capability": "both"});
+        assert_eq!(model_list_entry_thinking_capability(&v), Some("both"));
     }
 
     #[test]
-    fn reads_nested_quirks_thinking_mode() {
-        let v = serde_json::json!({
-            "name": "glm",
-            "quirks": { "thinking_mode": "native" }
-        });
-        assert_eq!(model_list_entry_thinking_mode(&v), Some("native"));
+    fn reads_thinking_capability_native_only() {
+        let v = serde_json::json!({"name": "glm", "thinking_capability": "native_only"});
+        assert_eq!(
+            model_list_entry_thinking_capability(&v),
+            Some("native_only")
+        );
     }
 
     #[test]
-    fn flattened_thinking_mode_wins_over_nested_quirks() {
-        let v = serde_json::json!({
-            "name": "claude",
-            "thinking_mode": "controllable",
-            "quirks": { "thinking_mode": "native" }
-        });
-        assert_eq!(model_list_entry_thinking_mode(&v), Some("controllable"));
-    }
-
-    #[test]
-    fn missing_thinking_mode_returns_none() {
+    fn missing_thinking_capability_returns_none() {
         let v = serde_json::json!({"name": "minimax"});
-        assert_eq!(model_list_entry_thinking_mode(&v), None);
+        assert_eq!(model_list_entry_thinking_capability(&v), None);
+    }
+
+    #[test]
+    fn null_thinking_capability_returns_none() {
+        let v = serde_json::json!({"name": "x", "thinking_capability": null});
+        assert_eq!(model_list_entry_thinking_capability(&v), None);
     }
 }

--- a/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
+++ b/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
@@ -486,6 +486,69 @@ impl Default for PerModelCooldown {
     }
 }
 
+// ── Fallback Chain Resolution ─────────────────────────────────────────────────
+
+/// Outcome of [`try_resolve_fallback`].
+#[derive(Debug)]
+pub enum FallbackOutcome<T> {
+    /// A fallback model was resolved successfully.
+    Resolved(T),
+    /// No fallback chain configured (chain was empty).
+    NoFallbackConfigured,
+    /// All fallback models were exhausted (cooldown or resolution failure).
+    AllExhausted { chain_len: usize },
+}
+
+/// Walk the fallback chain, skip models in cooldown, and resolve the first
+/// available one via the caller-supplied async `resolve` closure.
+///
+/// This is the shared logic behind both `server_loop_host` and
+/// `bridge_inprocess` fallback handling — extracted to eliminate duplication.
+pub async fn try_resolve_fallback<T, F, Fut>(
+    cooldown: &PerModelCooldown,
+    chain: &[String],
+    reason: CooldownReason,
+    mut resolve: F,
+) -> FallbackOutcome<T>
+where
+    F: FnMut(String) -> Fut,
+    Fut: std::future::Future<Output = Result<T, String>>,
+{
+    if chain.is_empty() {
+        return FallbackOutcome::NoFallbackConfigured;
+    }
+    for fb_name in chain {
+        // Skip fallback models that are themselves in cooldown.
+        let fb_ok = cooldown.with(fb_name, |c| c.check_request(false));
+        if !matches!(
+            fb_ok,
+            RateLimitAction::Proceed | RateLimitAction::WaitAndRetry { .. }
+        ) {
+            continue;
+        }
+        astra_core::agent_info!(
+            "llm",
+            "rate-limit cooldown: trying fallback model '{}' ({})",
+            fb_name,
+            reason.as_str()
+        );
+        match resolve(fb_name.clone()).await {
+            Ok(resolved) => return FallbackOutcome::Resolved(resolved),
+            Err(e) => {
+                astra_core::agent_warn!(
+                    "llm",
+                    "fallback model '{}' resolution failed: {}",
+                    fb_name,
+                    e
+                );
+            }
+        }
+    }
+    FallbackOutcome::AllExhausted {
+        chain_len: chain.len(),
+    }
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1094,6 +1157,80 @@ mod tests {
                 matches!(action, RateLimitAction::Reject { .. }),
                 "{model} should reject, got: {action:?}"
             );
+        }
+    }
+
+    // ── try_resolve_fallback tests ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn try_resolve_fallback_picks_first_available() {
+        let pmc = PerModelCooldown::new();
+        // model-a in cooldown
+        pmc.with("model-a", |rl| {
+            rl.record_429(None, true);
+            rl.record_429(None, true);
+            rl.record_429(None, true);
+        });
+        let chain: Vec<String> = vec!["model-a".into(), "model-b".into(), "model-c".into()];
+        let outcome = try_resolve_fallback(&pmc, &chain, CooldownReason::RateLimit, |name| {
+            async move { Ok::<_, String>(name) }
+        })
+        .await;
+        match outcome {
+            FallbackOutcome::Resolved(name) => assert_eq!(name, "model-b"),
+            other => panic!("expected Resolved, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn try_resolve_fallback_empty_chain() {
+        let pmc = PerModelCooldown::new();
+        let chain: Vec<String> = vec![];
+        let outcome = try_resolve_fallback(&pmc, &chain, CooldownReason::RateLimit, |name| {
+            async move { Ok::<_, String>(name) }
+        })
+        .await;
+        assert!(matches!(outcome, FallbackOutcome::NoFallbackConfigured));
+    }
+
+    #[tokio::test]
+    async fn try_resolve_fallback_all_in_cooldown() {
+        let pmc = PerModelCooldown::new();
+        for model in &["model-a", "model-b"] {
+            pmc.with(model, |rl| {
+                rl.record_429(None, false);
+                rl.record_429(None, false);
+                rl.record_429(None, false);
+            });
+        }
+        let chain: Vec<String> = vec!["model-a".into(), "model-b".into()];
+        let outcome = try_resolve_fallback(&pmc, &chain, CooldownReason::Overloaded, |name| {
+            async move { Ok::<_, String>(name) }
+        })
+        .await;
+        match outcome {
+            FallbackOutcome::AllExhausted { chain_len } => assert_eq!(chain_len, 2),
+            other => panic!("expected AllExhausted, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn try_resolve_fallback_skips_resolution_failure() {
+        let pmc = PerModelCooldown::new();
+        let chain: Vec<String> = vec!["bad-model".into(), "good-model".into()];
+        let outcome = try_resolve_fallback(&pmc, &chain, CooldownReason::RateLimit, |name| {
+            async move {
+                if name == "bad-model" {
+                    Err("not found".to_string())
+                } else {
+                    Ok(name)
+                }
+            }
+        })
+        .await;
+        match outcome {
+            FallbackOutcome::Resolved(name) => assert_eq!(name, "good-model"),
+            other => panic!("expected Resolved, got: {other:?}"),
         }
     }
 

--- a/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
+++ b/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
@@ -1056,4 +1056,67 @@ mod tests {
     fn default_cooldown_is_at_most_30_seconds() {
         const _: () = assert!(DEFAULT_COOLDOWN_MS <= 30_000);
     }
+
+    // ── Fallback chain walk decision tests ───────────────────────────────
+
+    #[test]
+    fn fallback_chain_skips_cooldown_model_picks_active() {
+        let pmc = PerModelCooldown::new();
+        // Push model-a into cooldown (3 consecutive 429s)
+        pmc.with("model-a", |rl| {
+            rl.record_429(None, true);
+            rl.record_429(None, true);
+            rl.record_429(None, true);
+        });
+        // model-b should still be available
+        let a_action = pmc.with("model-a", |rl| rl.check_request(true));
+        assert!(
+            matches!(a_action, RateLimitAction::UseFallback { .. }),
+            "model-a should trigger fallback, got: {a_action:?}"
+        );
+        let b_action = pmc.with("model-b", |rl| rl.check_request(false));
+        assert_eq!(b_action, RateLimitAction::Proceed);
+    }
+
+    #[test]
+    fn fallback_chain_all_models_in_cooldown() {
+        let pmc = PerModelCooldown::new();
+        for model in &["model-a", "model-b", "model-c"] {
+            pmc.with(model, |rl| {
+                rl.record_429(None, false);
+                rl.record_429(None, false);
+                rl.record_429(None, false);
+            });
+        }
+        for model in &["model-a", "model-b", "model-c"] {
+            let action = pmc.with(model, |rl| rl.check_request(false));
+            assert!(
+                matches!(action, RateLimitAction::Reject { .. }),
+                "{model} should reject, got: {action:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn fallback_chain_first_available_wins() {
+        let pmc = PerModelCooldown::new();
+        // model-a: in cooldown
+        pmc.with("model-a", |rl| {
+            rl.record_429(None, true);
+            rl.record_429(None, true);
+            rl.record_429(None, true);
+        });
+        // model-b: active, model-c: also active
+        // Simulate the chain walk: check each in order, pick first Proceed
+        let chain = ["model-b", "model-c"];
+        let mut picked = None;
+        for fb in &chain {
+            let action = pmc.with(fb, |rl| rl.check_request(false));
+            if matches!(action, RateLimitAction::Proceed) {
+                picked = Some(*fb);
+                break;
+            }
+        }
+        assert_eq!(picked, Some("model-b"), "first available should win");
+    }
 }

--- a/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
+++ b/rust/crates/astra-turn-core/src/bridge_rate_limit_cooldown.rs
@@ -1172,10 +1172,11 @@ mod tests {
             rl.record_429(None, true);
         });
         let chain: Vec<String> = vec!["model-a".into(), "model-b".into(), "model-c".into()];
-        let outcome = try_resolve_fallback(&pmc, &chain, CooldownReason::RateLimit, |name| {
-            async move { Ok::<_, String>(name) }
-        })
-        .await;
+        let outcome =
+            try_resolve_fallback(&pmc, &chain, CooldownReason::RateLimit, |name| async move {
+                Ok::<_, String>(name)
+            })
+            .await;
         match outcome {
             FallbackOutcome::Resolved(name) => assert_eq!(name, "model-b"),
             other => panic!("expected Resolved, got: {other:?}"),
@@ -1186,10 +1187,11 @@ mod tests {
     async fn try_resolve_fallback_empty_chain() {
         let pmc = PerModelCooldown::new();
         let chain: Vec<String> = vec![];
-        let outcome = try_resolve_fallback(&pmc, &chain, CooldownReason::RateLimit, |name| {
-            async move { Ok::<_, String>(name) }
-        })
-        .await;
+        let outcome =
+            try_resolve_fallback(&pmc, &chain, CooldownReason::RateLimit, |name| async move {
+                Ok::<_, String>(name)
+            })
+            .await;
         assert!(matches!(outcome, FallbackOutcome::NoFallbackConfigured));
     }
 
@@ -1204,9 +1206,12 @@ mod tests {
             });
         }
         let chain: Vec<String> = vec!["model-a".into(), "model-b".into()];
-        let outcome = try_resolve_fallback(&pmc, &chain, CooldownReason::Overloaded, |name| {
-            async move { Ok::<_, String>(name) }
-        })
+        let outcome = try_resolve_fallback(
+            &pmc,
+            &chain,
+            CooldownReason::Overloaded,
+            |name| async move { Ok::<_, String>(name) },
+        )
         .await;
         match outcome {
             FallbackOutcome::AllExhausted { chain_len } => assert_eq!(chain_len, 2),
@@ -1218,16 +1223,15 @@ mod tests {
     async fn try_resolve_fallback_skips_resolution_failure() {
         let pmc = PerModelCooldown::new();
         let chain: Vec<String> = vec!["bad-model".into(), "good-model".into()];
-        let outcome = try_resolve_fallback(&pmc, &chain, CooldownReason::RateLimit, |name| {
-            async move {
+        let outcome =
+            try_resolve_fallback(&pmc, &chain, CooldownReason::RateLimit, |name| async move {
                 if name == "bad-model" {
                     Err("not found".to_string())
                 } else {
                     Ok(name)
                 }
-            }
-        })
-        .await;
+            })
+            .await;
         match outcome {
             FallbackOutcome::Resolved(name) => assert_eq!(name, "good-model"),
             other => panic!("expected Resolved, got: {other:?}"),

--- a/rust/crates/astra-turn-core/src/thinking_config.rs
+++ b/rust/crates/astra-turn-core/src/thinking_config.rs
@@ -138,6 +138,21 @@ impl ThinkingConfig {
         }
     }
 
+    /// Apply thinking suppression to an OpenAI-compatible request body.
+    ///
+    /// For direct HTTP callers (memory extraction, relevance filtering) that
+    /// bypass the full LLM pipeline in `build_provider_request_body`.
+    /// Checks both `provider` string and `base_url` to detect DashScope,
+    /// since many configs use `provider: "openai"` with a DashScope base_url.
+    pub fn apply_openai_suppression(&self, body: &mut Value, provider: &str, base_url: &str) {
+        if !self.is_off() {
+            return;
+        }
+        if needs_dashscope_thinking_flag(provider, base_url) {
+            body["enable_thinking"] = json!(false);
+        }
+    }
+
     /// Serialize to JSON for inclusion in the chat payload sent to the server.
     pub fn to_payload_value(&self) -> Value {
         serde_json::to_value(self).unwrap_or(json!("off"))
@@ -443,37 +458,33 @@ pub struct ThinkingOption {
     pub is_default: bool,
 }
 
-/// Returns thinking options for a model based on its declared `thinking_mode` and provider.
+/// Returns thinking options for a model based on its probed `thinking_capability`.
 ///
-/// - `thinking_mode = Some("controllable")`: provider-appropriate picker.
-///   - `bedrock` / `anthropic` → adaptive (Low / High).
-///   - `dashscope` / `aliyun` / `alibaba` → budget (on/off).
-///   - other providers → adaptive reasoning (`reasoning_effort`).
-/// - `thinking_mode = Some("native")` → empty (model thinks by default, no picker).
-/// - `thinking_mode = None` → empty (no thinking support).
+/// - `"both"` → Normal / Thinking picker (provider-appropriate format).
+/// - `"effort_only"` → Thinking (Low) / Thinking (High) (no Normal — can't turn off).
+/// - `"native_only"` → no picker (always thinks, no control).
+/// - `"none"` → no picker (doesn't think).
+/// - `None` (unprobed) → no picker (safe default until probed).
 pub fn thinking_options_with_capability(
     _model_name: &str,
     provider: Option<&str>,
-    thinking_mode: Option<&str>,
+    thinking_capability: Option<&str>,
 ) -> Vec<ThinkingOption> {
-    match thinking_mode {
-        Some("controllable") => {
+    match thinking_capability {
+        Some("both") => {
             if provider_uses_budget_thinking(provider) {
                 thinking_options_for_budget_thinking()
             } else {
                 thinking_options_for_adaptive_reasoning()
             }
         }
-        // Known no-picker modes.
-        None | Some("native") => vec![],
-        // Unknown value — warn so operators notice typos in YAML/DB
-        // (e.g. "Controllable", "enabled") rather than silently disabling
-        // the picker.
+        Some("effort_only") => thinking_options_for_effort_only(),
+        None | Some("none") | Some("native_only") => vec![],
         Some(other) => {
             tracing::warn!(
-                thinking_mode = %other,
+                thinking_capability = %other,
                 provider = ?provider,
-                "unknown thinking_mode value; expected one of \"controllable\", \"native\", or null — picker disabled",
+                "unknown thinking_capability value — no picker",
             );
             vec![]
         }
@@ -487,6 +498,25 @@ fn thinking_options_for_adaptive_reasoning() -> Vec<ThinkingOption> {
             config: ThinkingConfig::Off,
             is_default: false,
         },
+        ThinkingOption {
+            label: "Thinking (Low)",
+            config: ThinkingConfig::Adaptive {
+                effort: ThinkingEffort::Low,
+            },
+            is_default: false,
+        },
+        ThinkingOption {
+            label: "Thinking (High)",
+            config: ThinkingConfig::Adaptive {
+                effort: ThinkingEffort::High,
+            },
+            is_default: true,
+        },
+    ]
+}
+
+fn thinking_options_for_effort_only() -> Vec<ThinkingOption> {
+    vec![
         ThinkingOption {
             label: "Thinking (Low)",
             config: ThinkingConfig::Adaptive {
@@ -522,12 +552,49 @@ fn thinking_options_for_budget_thinking() -> Vec<ThinkingOption> {
 }
 
 fn provider_uses_budget_thinking(provider: Option<&str>) -> bool {
-    provider
-        .map(|p| {
-            let p = p.to_ascii_lowercase();
-            p.contains("dashscope") || p.contains("aliyun") || p.contains("alibaba")
-        })
-        .unwrap_or(false)
+    provider.map(provider_may_think_natively).unwrap_or(false)
+}
+
+/// Returns `true` if the provider string alone identifies a DashScope endpoint.
+pub fn provider_may_think_natively(provider: &str) -> bool {
+    let p = provider.to_ascii_lowercase();
+    p.contains("dashscope") || p.contains("aliyun") || p.contains("alibaba")
+}
+
+/// Returns `true` if the endpoint needs `enable_thinking` flag.
+/// Checks both provider string and base_url since many configs use
+/// `provider: "openai"` with a DashScope base_url.
+pub fn needs_dashscope_thinking_flag(provider: &str, base_url: &str) -> bool {
+    if provider_may_think_natively(provider) {
+        return true;
+    }
+    let u = base_url.to_ascii_lowercase();
+    u.contains("dashscope") || u.contains("aliyun")
+}
+
+/// Strip `<think>...</think>` XML tags from model output, returning only
+/// the non-reasoning content.
+///
+/// Safety net for native-thinking models (DeepSeek, Qwen3) that may ignore
+/// API-level thinking suppression and still emit reasoning blocks.
+pub fn strip_think_tags(text: &str) -> String {
+    if !text.contains("<think>") {
+        return text.to_string();
+    }
+    let mut cleaned = String::with_capacity(text.len());
+    let mut pos = 0;
+    while let Some(start) = text[pos..].find("<think>") {
+        let abs_start = pos + start;
+        cleaned.push_str(&text[pos..abs_start]);
+        if let Some(end) = text[abs_start..].find("</think>") {
+            pos = abs_start + end + "</think>".len();
+        } else {
+            // Unclosed <think> — discard the rest as reasoning
+            pos = text.len();
+        }
+    }
+    cleaned.push_str(&text[pos..]);
+    cleaned
 }
 
 #[cfg(test)]
@@ -702,9 +769,8 @@ mod tests {
     // ─── Model inference ────────────────────────────────────────────────
 
     #[test]
-    fn controllable_dashscope_returns_budget() {
-        let opts =
-            thinking_options_with_capability("qwen-plus", Some("dashscope"), Some("controllable"));
+    fn both_dashscope_returns_budget() {
+        let opts = thinking_options_with_capability("qwen-plus", Some("dashscope"), Some("both"));
         assert_eq!(opts.len(), 2);
         assert_eq!(opts[0].label, "Normal");
         assert_eq!(opts[1].label, "Thinking");
@@ -717,27 +783,50 @@ mod tests {
     }
 
     #[test]
-    fn native_mode_returns_empty() {
-        let opts = thinking_options_with_capability("glm-5.1", Some("openai"), Some("native"));
+    fn effort_only_returns_effort_picker_no_normal() {
+        let opts = thinking_options_with_capability(
+            "deepseek-v4-flash",
+            Some("openai"),
+            Some("effort_only"),
+        );
+        assert_eq!(opts.len(), 2);
+        assert_eq!(opts[0].label, "Thinking (Low)");
+        assert_eq!(opts[1].label, "Thinking (High)");
+        assert!(opts[1].is_default);
+    }
+
+    #[test]
+    fn native_only_returns_empty() {
+        let opts =
+            thinking_options_with_capability("MiniMax-M2.5", Some("openai"), Some("native_only"));
         assert!(opts.is_empty());
     }
 
     #[test]
-    fn none_mode_returns_empty() {
+    fn none_capability_returns_empty() {
         let opts = thinking_options_with_capability(
             "us.anthropic.claude-sonnet-4-6",
             Some("bedrock"),
-            None,
+            Some("none"),
         );
         assert!(opts.is_empty());
     }
 
     #[test]
-    fn controllable_bedrock_returns_adaptive() {
+    fn null_capability_returns_empty() {
+        let opts = thinking_options_with_capability("qwen-plus", Some("openai"), None);
+        assert!(
+            opts.is_empty(),
+            "unprobed model with no YAML hint should not show picker"
+        );
+    }
+
+    #[test]
+    fn both_bedrock_returns_adaptive() {
         let opts = thinking_options_with_capability(
             "us.anthropic.claude-sonnet-4-6",
             Some("bedrock"),
-            Some("controllable"),
+            Some("both"),
         );
         assert_eq!(opts.len(), 3);
         assert_eq!(opts[0].label, "Normal");
@@ -747,19 +836,16 @@ mod tests {
     }
 
     #[test]
-    fn controllable_anthropic_returns_adaptive() {
-        let opts = thinking_options_with_capability(
-            "claude-sonnet-4",
-            Some("anthropic"),
-            Some("controllable"),
-        );
+    fn both_anthropic_returns_adaptive() {
+        let opts =
+            thinking_options_with_capability("claude-sonnet-4", Some("anthropic"), Some("both"));
         assert_eq!(opts.len(), 3);
         assert_eq!(opts[2].label, "Thinking (High)");
     }
 
     #[test]
-    fn controllable_openai_returns_adaptive() {
-        let opts = thinking_options_with_capability("gpt-5", Some("openai"), Some("controllable"));
+    fn both_openai_returns_adaptive() {
+        let opts = thinking_options_with_capability("gpt-5", Some("openai"), Some("both"));
         assert_eq!(opts.len(), 3);
         assert_eq!(opts[2].label, "Thinking (High)");
     }
@@ -1076,5 +1162,122 @@ mod tests {
             ThinkingEffort::Max.capped_at(ThinkingEffort::Medium),
             ThinkingEffort::Medium
         );
+    }
+
+    // ─── apply_openai_suppression ──────────────────────────────────────
+
+    #[test]
+    fn suppression_dashscope_provider_sets_flag() {
+        let mut body = json!({"model": "qwen3.5-flash", "messages": []});
+        ThinkingConfig::Off.apply_openai_suppression(&mut body, "dashscope", "");
+        assert_eq!(body["enable_thinking"], false);
+    }
+
+    #[test]
+    fn suppression_dashscope_base_url_sets_flag() {
+        let mut body = json!({"model": "qwen-plus", "messages": []});
+        ThinkingConfig::Off.apply_openai_suppression(
+            &mut body,
+            "openai",
+            "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        );
+        assert_eq!(
+            body["enable_thinking"], false,
+            "provider=openai + dashscope base_url should trigger suppression"
+        );
+    }
+
+    #[test]
+    fn suppression_generic_provider_off_is_noop() {
+        let mut body = json!({"model": "gpt-4o", "messages": []});
+        ThinkingConfig::Off.apply_openai_suppression(
+            &mut body,
+            "openai",
+            "https://api.openai.com/v1",
+        );
+        assert!(body.get("enable_thinking").is_none());
+    }
+
+    #[test]
+    fn suppression_enabled_thinking_is_noop() {
+        let mut body = json!({"model": "qwen3.5-flash", "messages": []});
+        ThinkingConfig::Enabled {
+            budget_tokens: 8000,
+        }
+        .apply_openai_suppression(&mut body, "dashscope", "");
+        assert!(body.get("enable_thinking").is_none());
+    }
+
+    // ─── strip_think_tags ──────────────────────────────────────────────
+
+    #[test]
+    fn strip_think_tags_removes_blocks() {
+        let input = "before\n<think>\nreasoning here\n</think>\nafter";
+        assert_eq!(strip_think_tags(input), "before\n\nafter");
+    }
+
+    #[test]
+    fn strip_think_tags_no_tags_passthrough() {
+        let input = "just normal text";
+        assert_eq!(strip_think_tags(input), "just normal text");
+    }
+
+    #[test]
+    fn strip_think_tags_unclosed_discards_rest() {
+        let input = "prefix<think>reasoning without end";
+        assert_eq!(strip_think_tags(input), "prefix");
+    }
+
+    #[test]
+    fn strip_think_tags_multiple_blocks() {
+        let input = "a<think>x</think>b<think>y</think>c";
+        assert_eq!(strip_think_tags(input), "abc");
+    }
+
+    // ─── provider_may_think_natively ───────────────────────────────────
+
+    #[test]
+    fn dashscope_provider_may_think() {
+        assert!(provider_may_think_natively("dashscope"));
+        assert!(provider_may_think_natively("aliyun"));
+        assert!(provider_may_think_natively("alibaba-cloud"));
+    }
+
+    #[test]
+    fn generic_provider_does_not_think() {
+        assert!(!provider_may_think_natively("openai"));
+        assert!(!provider_may_think_natively("bedrock"));
+        assert!(!provider_may_think_natively("deepseek"));
+    }
+
+    // ─── needs_dashscope_thinking_flag ─────────────────────────────────
+
+    #[test]
+    fn dashscope_detected_by_provider() {
+        assert!(needs_dashscope_thinking_flag("dashscope", ""));
+    }
+
+    #[test]
+    fn dashscope_detected_by_base_url() {
+        assert!(needs_dashscope_thinking_flag(
+            "openai",
+            "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        ));
+    }
+
+    #[test]
+    fn not_dashscope_for_generic_openai() {
+        assert!(!needs_dashscope_thinking_flag(
+            "openai",
+            "https://api.openai.com/v1"
+        ));
+    }
+
+    #[test]
+    fn not_dashscope_for_deepseek() {
+        assert!(!needs_dashscope_thinking_flag(
+            "openai",
+            "https://api.deepseek.com"
+        ));
     }
 }

--- a/rust/crates/runtime/src/matrix_cloud_runtime.rs
+++ b/rust/crates/runtime/src/matrix_cloud_runtime.rs
@@ -190,6 +190,7 @@ impl MatrixCloudRuntime {
             base_url: resolved.base_url,
             api_key: resolved.api_key,
             model_name: resolved.model_name,
+            provider: resolved.provider,
         })
     }
 

--- a/rust/crates/runtime/src/memory_relevance.rs
+++ b/rust/crates/runtime/src/memory_relevance.rs
@@ -67,6 +67,7 @@ pub struct LlmConnParams {
     pub base_url: String,
     pub api_key: String,
     pub model_name: String,
+    pub provider: String,
 }
 
 /// Filter a list of text items through the selector model.
@@ -93,18 +94,27 @@ pub async fn filter_memories(
         Err(_) => return items.to_vec(),
     };
 
+    let mut req_body = serde_json::json!({
+        "model": params.model_name,
+        "messages": [
+            {"role": "system", "content": RELEVANCE_FILTER_PROMPT},
+            {"role": "user", "content": query},
+        ],
+        "max_tokens": 50,
+        "temperature": 0.0,
+    });
+    // Always suppress thinking for selector/memory calls — no point
+    // spending tokens on reasoning for simple JSON tasks.
+    astra_turn_core::thinking_config::ThinkingConfig::Off.apply_openai_suppression(
+        &mut req_body,
+        &params.provider,
+        &params.base_url,
+    );
+
     let resp = match client
         .post(format!("{}/chat/completions", params.base_url))
         .header("Authorization", format!("Bearer {}", params.api_key))
-        .json(&serde_json::json!({
-            "model": params.model_name,
-            "messages": [
-                {"role": "system", "content": RELEVANCE_FILTER_PROMPT},
-                {"role": "user", "content": query},
-            ],
-            "max_tokens": 50,
-            "temperature": 0.0,
-        }))
+        .json(&req_body)
         .send()
         .await
     {
@@ -128,6 +138,15 @@ pub async fn filter_memories(
     if text.is_empty() {
         return items.to_vec();
     }
+
+    // Safety net: strip <think> tags that native thinkers may emit despite suppression.
+    // If stripping empties the text, fall back to the original.
+    let stripped = astra_turn_core::thinking_config::strip_think_tags(&text);
+    let text = if stripped.trim().is_empty() {
+        text
+    } else {
+        stripped
+    };
 
     let indices = parse_relevance_response(&text, items.len());
     if indices.is_empty() {
@@ -243,6 +262,7 @@ mod tests {
             base_url: "https://api.example.com/v1".into(),
             api_key: "sk-test".into(),
             model_name: "qwen-flash".into(),
+            provider: "openai".into(),
         };
         let cloned = params.clone();
         assert_eq!(cloned.base_url, "https://api.example.com/v1");
@@ -256,6 +276,7 @@ mod tests {
             base_url: "http://localhost:8080".into(),
             api_key: "key".into(),
             model_name: "model".into(),
+            provider: "openai".into(),
         };
         let debug = format!("{params:?}");
         assert!(debug.contains("LlmConnParams"));
@@ -270,6 +291,7 @@ mod tests {
             base_url: "http://nonexistent:9999".into(),
             api_key: "key".into(),
             model_name: "model".into(),
+            provider: "openai".into(),
         };
         let result = filter_memories(&params, "query", &[]).await;
         assert!(result.is_empty());
@@ -281,9 +303,129 @@ mod tests {
             base_url: "http://127.0.0.1:1".into(),
             api_key: "key".into(),
             model_name: "model".into(),
+            provider: "openai".into(),
         };
         let items = vec!["a".into(), "b".into(), "c".into()];
         let result = filter_memories(&params, "query", &items).await;
         assert_eq!(result, items, "unreachable server should return all items");
+    }
+
+    // ── Mock server integration tests ────────────────────────────────────
+
+    use std::sync::{Arc, Mutex};
+
+    async fn spawn_mock_completions(
+        captured: Arc<Mutex<Option<serde_json::Value>>>,
+        response_content: &'static str,
+    ) -> String {
+        use axum::{Router, routing::post};
+
+        let handler = move |axum::Json(body): axum::Json<serde_json::Value>| {
+            let captured = captured.clone();
+            async move {
+                *captured.lock().unwrap() = Some(body);
+                axum::Json(serde_json::json!({
+                    "choices": [{"message": {"content": response_content}}]
+                }))
+            }
+        };
+        let app = Router::new().route("/chat/completions", post(handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve");
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn filter_memories_native_thinker_sends_suppression() {
+        let captured = Arc::new(Mutex::new(None));
+        let base = spawn_mock_completions(captured.clone(), "[0]").await;
+        let params = LlmConnParams {
+            base_url: base,
+            api_key: "k".into(),
+            model_name: "qwen3.5-flash".into(),
+            provider: "dashscope".into(),
+        };
+        let items = vec!["mem-a".into(), "mem-b".into()];
+        let _ = filter_memories(&params, "test query", &items).await;
+
+        let body = captured.lock().unwrap().take().expect("request captured");
+        assert_eq!(
+            body["enable_thinking"], false,
+            "native thinker should send enable_thinking: false"
+        );
+    }
+
+    #[tokio::test]
+    async fn filter_memories_non_native_does_not_send_suppression() {
+        let captured = Arc::new(Mutex::new(None));
+        let base = spawn_mock_completions(captured.clone(), "[0]").await;
+        let params = LlmConnParams {
+            base_url: base,
+            api_key: "k".into(),
+            model_name: "gpt-4o-mini".into(),
+            provider: "openai".into(),
+        };
+        let items = vec!["mem-a".into()];
+        let _ = filter_memories(&params, "test", &items).await;
+
+        let body = captured.lock().unwrap().take().expect("request captured");
+        assert!(
+            body.get("enable_thinking").is_none(),
+            "non-native should not have enable_thinking: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn filter_memories_strips_think_tags_from_response() {
+        let captured = Arc::new(Mutex::new(None));
+        let base = spawn_mock_completions(captured.clone(), "<think>reasoning</think>[0, 2]").await;
+        let params = LlmConnParams {
+            base_url: base,
+            api_key: "k".into(),
+            model_name: "m".into(),
+            provider: "openai".into(),
+        };
+        let items: Vec<String> = (0..3).map(|i| format!("mem-{i}")).collect();
+        let result = filter_memories(&params, "query", &items).await;
+        assert_eq!(result, vec!["mem-0", "mem-2"]);
+    }
+
+    #[tokio::test]
+    async fn filter_memories_think_wrapping_json_falls_back_to_original() {
+        let captured = Arc::new(Mutex::new(None));
+        // Model wraps JSON inside think tags — strip would empty it
+        let base = spawn_mock_completions(captured.clone(), "<think>[0, 1]</think>").await;
+        let params = LlmConnParams {
+            base_url: base,
+            api_key: "k".into(),
+            model_name: "m".into(),
+            provider: "openai".into(),
+        };
+        let items: Vec<String> = (0..3).map(|i| format!("mem-{i}")).collect();
+        let result = filter_memories(&params, "query", &items).await;
+        // Fallback to original text which contains the think-wrapped JSON
+        // parse_relevance_response will extract digits from "<think>[0, 1]</think>"
+        assert!(!result.is_empty(), "should fall back and parse something");
+    }
+
+    #[tokio::test]
+    async fn filter_memories_successful_filtering() {
+        let captured = Arc::new(Mutex::new(None));
+        let base = spawn_mock_completions(captured.clone(), "[1]").await;
+        let params = LlmConnParams {
+            base_url: base,
+            api_key: "k".into(),
+            model_name: "m".into(),
+            provider: "openai".into(),
+        };
+        let items = vec!["irrelevant".into(), "relevant".into(), "noise".into()];
+        let result = filter_memories(&params, "query", &items).await;
+        assert_eq!(result, vec!["relevant"]);
     }
 }

--- a/rust/crates/runtime/src/models.rs
+++ b/rust/crates/runtime/src/models.rs
@@ -15,31 +15,6 @@ pub async fn create_model_handler(
 ) -> Result<(StatusCode, Json<ModelResponse>), (StatusCode, Json<ErrorResponse>)> {
     let admin = state.admin_authorizer.require_admin(&headers).await?;
 
-    // Auto-infer thinking_mode at load time. Priority order:
-    //   1. Explicit `quirks.thinking_mode` in the request body (highest).
-    //   2. Tags: "thinking" → "controllable", "reasoning" (without "thinking") → "native".
-    let quirks = {
-        let mut q = request.quirks.unwrap_or_default();
-        if q.thinking_mode.is_none() {
-            let has_thinking = request
-                .tags
-                .iter()
-                .any(|t| t.eq_ignore_ascii_case("thinking"));
-            let has_reasoning = request
-                .tags
-                .iter()
-                .any(|t| t.eq_ignore_ascii_case("reasoning"));
-            q.thinking_mode = if has_thinking {
-                Some("controllable".into())
-            } else if has_reasoning {
-                Some("native".into())
-            } else {
-                None
-            };
-        }
-        Some(q)
-    };
-
     let model = state
         .model_service
         .create_model(
@@ -58,7 +33,7 @@ pub async fn create_model_handler(
                 pricing: request.pricing,
                 architecture: request.architecture,
                 tags: request.tags,
-                quirks,
+                quirks: request.quirks,
             },
         )
         .await?;

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -43,7 +43,9 @@ use crate::turn::prompt_cache::{
 use crate::{FernetTokenEncryptor, MatrixOneSettings};
 use astra_core::SharedPool;
 use astra_services::LlmTokenServiceConfig;
-use astra_turn_core::bridge_rate_limit_cooldown::RateLimitAction;
+use astra_turn_core::bridge_rate_limit_cooldown::{
+    FallbackOutcome, RateLimitAction, try_resolve_fallback,
+};
 use astra_turn_core::chat_turn_sse_dispatch::ChatTurnSseAccum;
 use astra_turn_core::thinking_config::ThinkingConfig;
 use astra_turn_core::tool_schema_prune::{
@@ -2331,59 +2333,43 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 sleep_ms_or_llm_cancel(delay_ms, llm_cancel_for_state(state)).await?;
             }
             RateLimitAction::UseFallback { reason } => {
-                let mut resolved = false;
-                for fb_name in &llm_cfg.fallback_chain {
-                    // Skip fallback models that are themselves in cooldown.
-                    let fb_ok = cooldown.with(fb_name, |c| c.check_request(false));
-                    if !matches!(
-                        fb_ok,
-                        RateLimitAction::Proceed | RateLimitAction::WaitAndRetry { .. }
-                    ) {
-                        continue;
+                let mx = &self.matrixone;
+                let enc = self.encryptor.as_ref();
+                let lts = self.llm_token_service.as_ref();
+                let fwd = &state.hooks.forward_headers;
+                match try_resolve_fallback(
+                    cooldown,
+                    &llm_cfg.fallback_chain,
+                    reason,
+                    |fb_name| async move {
+                        resolve_llm_model_for_turn(
+                            mx,
+                            enc,
+                            Some(fb_name.as_str()),
+                            pool_ref,
+                            lts,
+                            fwd,
+                        )
+                        .await
+                    },
+                )
+                .await
+                {
+                    FallbackOutcome::Resolved(fb) => {
+                        llm_cfg = fb;
                     }
-                    astra_core::agent_info!(
-                        "llm",
-                        "rate-limit cooldown: trying fallback model '{}' ({})",
-                        fb_name,
-                        reason.as_str()
-                    );
-                    match resolve_llm_model_for_turn(
-                        &self.matrixone,
-                        self.encryptor.as_ref(),
-                        Some(fb_name.as_str()),
-                        pool_ref,
-                        self.llm_token_service.as_ref(),
-                        &state.hooks.forward_headers,
-                    )
-                    .await
-                    {
-                        Ok(fb) => {
-                            llm_cfg = fb;
-                            resolved = true;
-                            break;
-                        }
-                        Err(e) => {
-                            astra_core::agent_warn!(
-                                "llm",
-                                "fallback model '{}' resolution failed: {}",
-                                fb_name,
-                                e
-                            );
-                        }
-                    }
-                }
-                if !resolved {
-                    if llm_cfg.fallback_chain.is_empty() {
+                    FallbackOutcome::NoFallbackConfigured => {
                         astra_core::agent_warn!(
                             "llm",
                             "rate-limit cooldown: fallback requested ({}) but no fallback configured",
                             reason.as_str()
                         );
-                    } else {
+                    }
+                    FallbackOutcome::AllExhausted { chain_len } => {
                         astra_core::agent_warn!(
                             "llm",
                             "rate-limit cooldown: all {} fallback models exhausted ({})",
-                            llm_cfg.fallback_chain.len(),
+                            chain_len,
                             reason.as_str()
                         );
                     }

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -236,7 +236,7 @@ struct ResolvedTurnLlmConfig {
     api_key: String,
     base_url: String,
     provider: String,
-    fallback_model: Option<String>,
+    fallback_chain: Vec<String>,
     header_overrides: HashMap<String, String>,
     completions_url_override: Option<String>,
     request_timeout: Option<Duration>,
@@ -316,7 +316,7 @@ async fn resolve_llm_model_for_turn(
             api_key: String::new(),
             base_url: "https://api.openai.com/v1".to_string(),
             provider: "openai".to_string(),
-            fallback_model: None,
+            fallback_chain: Vec::new(),
             header_overrides: forward_headers.clone(),
             completions_url_override: Some(config.url.clone()),
             request_timeout: config.timeout_ms.map(Duration::from_millis),
@@ -330,7 +330,7 @@ async fn resolve_llm_model_for_turn(
         api_key: resolved.api_key,
         base_url: resolved.base_url,
         provider: resolved.provider,
-        fallback_model: resolved.fallback_model,
+        fallback_chain: resolved.fallback_chain,
         header_overrides: HashMap::new(),
         completions_url_override: None,
         request_timeout: None,
@@ -2317,7 +2317,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 ));
             }
         };
-        let has_fallback = llm_cfg.fallback_model.is_some();
+        let has_fallback = !llm_cfg.fallback_chain.is_empty();
 
         // ── 1b. Check rate-limit cooldown and handle fallback model resolution ──
         let cooldown = rate_limit_cooldown();
@@ -2331,14 +2331,22 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 sleep_ms_or_llm_cancel(delay_ms, llm_cancel_for_state(state)).await?;
             }
             RateLimitAction::UseFallback { reason } => {
-                if let Some(ref fb_name) = llm_cfg.fallback_model {
+                let mut resolved = false;
+                for fb_name in &llm_cfg.fallback_chain {
+                    // Skip fallback models that are themselves in cooldown.
+                    let fb_ok = cooldown.with(fb_name, |c| c.check_request(false));
+                    if !matches!(
+                        fb_ok,
+                        RateLimitAction::Proceed | RateLimitAction::WaitAndRetry { .. }
+                    ) {
+                        continue;
+                    }
                     astra_core::agent_info!(
                         "llm",
-                        "rate-limit cooldown: switching to fallback model '{}' ({})",
+                        "rate-limit cooldown: trying fallback model '{}' ({})",
                         fb_name,
                         reason.as_str()
                     );
-                    // Resolve fallback model credentials
                     match resolve_llm_model_for_turn(
                         &self.matrixone,
                         self.encryptor.as_ref(),
@@ -2349,7 +2357,11 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                     )
                     .await
                     {
-                        Ok(fb) => llm_cfg = fb,
+                        Ok(fb) => {
+                            llm_cfg = fb;
+                            resolved = true;
+                            break;
+                        }
                         Err(e) => {
                             astra_core::agent_warn!(
                                 "llm",
@@ -2357,15 +2369,24 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                                 fb_name,
                                 e
                             );
-                            // Continue with primary model (best effort)
                         }
                     }
-                } else {
-                    astra_core::agent_warn!(
-                        "llm",
-                        "rate-limit cooldown: fallback requested ({}) but no fallback configured",
-                        reason.as_str()
-                    );
+                }
+                if !resolved {
+                    if llm_cfg.fallback_chain.is_empty() {
+                        astra_core::agent_warn!(
+                            "llm",
+                            "rate-limit cooldown: fallback requested ({}) but no fallback configured",
+                            reason.as_str()
+                        );
+                    } else {
+                        astra_core::agent_warn!(
+                            "llm",
+                            "rate-limit cooldown: all {} fallback models exhausted ({})",
+                            llm_cfg.fallback_chain.len(),
+                            reason.as_str()
+                        );
+                    }
                 }
             }
             RateLimitAction::Reject {
@@ -2805,16 +2826,25 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
             Ok(m) => m,
             Err(e) => return Err(format!("Model resolution failed: {e}").into()),
         };
-        let has_fallback = llm_cfg.fallback_model.is_some();
+        let has_fallback = !llm_cfg.fallback_chain.is_empty();
 
         match rate_limit_cooldown().with(&llm_cfg.model_name, |c| c.check_request(has_fallback)) {
             RateLimitAction::Proceed => {}
             RateLimitAction::WaitAndRetry { delay_ms } => {
                 sleep_ms_or_llm_cancel(delay_ms, llm_cancel_for_state(state)).await?;
             }
-            RateLimitAction::UseFallback { .. } => {
-                if let Some(ref fb_name) = llm_cfg.fallback_model
-                    && let Ok(fb) = resolve_llm_model_for_turn(
+            RateLimitAction::UseFallback { reason } => {
+                let cooldown = rate_limit_cooldown();
+                let mut resolved = false;
+                for fb_name in &llm_cfg.fallback_chain {
+                    let fb_ok = cooldown.with(fb_name, |c| c.check_request(false));
+                    if !matches!(
+                        fb_ok,
+                        RateLimitAction::Proceed | RateLimitAction::WaitAndRetry { .. }
+                    ) {
+                        continue;
+                    }
+                    if let Ok(fb) = resolve_llm_model_for_turn(
                         &self.matrixone,
                         self.encryptor.as_ref(),
                         Some(fb_name.as_str()),
@@ -2823,8 +2853,19 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                         &state.hooks.forward_headers,
                     )
                     .await
-                {
-                    llm_cfg = fb;
+                    {
+                        llm_cfg = fb;
+                        resolved = true;
+                        break;
+                    }
+                }
+                if !resolved && !llm_cfg.fallback_chain.is_empty() {
+                    astra_core::agent_warn!(
+                        "llm",
+                        "reflection fallback: all {} models exhausted ({})",
+                        llm_cfg.fallback_chain.len(),
+                        reason.as_str()
+                    );
                 }
             }
             RateLimitAction::Reject {

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -1011,8 +1011,6 @@ impl InProcessChatTurnBridge {
                         &fallback_chain,
                         reason,
                         |fb_name| {
-                            let mx = mx;
-                            let enc = enc;
                             async move {
                                 astra_services::resolve_active_llm_model(
                                     mx,

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -945,15 +945,15 @@ impl InProcessChatTurnBridge {
                     .unwrap_or(false);
 
             // Resolve LLM model (skipped when `test_llm_rounds` drives the turn — feature `bridge-e2e-hooks`).
-            // Also capture fallback_model name for rate-limit-triggered fallback.
+            // Also capture fallback_chain for rate-limit-triggered fallback.
             let pool_ref = shared_pool.as_ref().map(SharedPool::get);
-            let (mut model_name, mut api_key, mut base_url, mut provider, fallback_model_name) = if use_e2e_llm {
+            let (mut model_name, mut api_key, mut base_url, mut provider, fallback_chain) = if use_e2e_llm {
                 (
                     "bridge-e2e-mock".to_string(),
                     "unused".to_string(),
                     "http://127.0.0.1:1".to_string(),
                     "openai".to_string(),
-                    None::<String>,
+                    Vec::<String>::new(),
                 )
             } else {
                 match astra_services::resolve_active_llm_model(
@@ -964,7 +964,7 @@ impl InProcessChatTurnBridge {
                 )
                 .await
                 {
-                    Ok(m) => (m.model_name, m.api_key, m.base_url, m.provider, m.fallback_model),
+                    Ok(m) => (m.model_name, m.api_key, m.base_url, m.provider, m.fallback_chain),
                     Err(e) => {
                         yield render_sse_map(&build_stream_error_event(&e, "MODEL_NOT_AVAILABLE", false));
                         mark_disconnect_capture_finalized(&disconnect_capture_state);
@@ -972,7 +972,7 @@ impl InProcessChatTurnBridge {
                     }
                 }
             };
-            let has_fallback = fallback_model_name.is_some();
+            let has_fallback = !fallback_chain.is_empty();
 
             // Latch cache config at session init — prevents mid-session env var
             // changes from busting the KV cache.
@@ -1002,14 +1002,21 @@ impl InProcessChatTurnBridge {
                     }
                 }
                 RateLimitAction::UseFallback { reason } => {
-                    if let Some(ref fb_name) = fallback_model_name {
+                    let mut resolved = false;
+                    for fb_name in &fallback_chain {
+                        let fb_ok = cooldown.with(fb_name, |c| c.check_request(false));
+                        if !matches!(
+                            fb_ok,
+                            RateLimitAction::Proceed | RateLimitAction::WaitAndRetry { .. }
+                        ) {
+                            continue;
+                        }
                         astra_core::agent_info!(
                             "llm",
-                            "rate-limit cooldown: switching to fallback model '{}' ({})",
+                            "rate-limit cooldown: trying fallback model '{}' ({})",
                             fb_name,
                             reason.as_str()
                         );
-                        // Resolve fallback model credentials
                         match astra_services::resolve_active_llm_model(
                             &matrixone,
                             encryptor.as_ref(),
@@ -1023,6 +1030,8 @@ impl InProcessChatTurnBridge {
                                 api_key = fb.api_key;
                                 base_url = fb.base_url;
                                 provider = fb.provider;
+                                resolved = true;
+                                break;
                             }
                             Err(e) => {
                                 astra_core::agent_warn!(
@@ -1031,15 +1040,24 @@ impl InProcessChatTurnBridge {
                                     fb_name,
                                     e
                                 );
-                                // Continue with primary model (best effort)
                             }
                         }
-                    } else {
-                        astra_core::agent_warn!(
-                            "llm",
-                            "rate-limit cooldown: fallback requested ({}) but no fallback configured",
-                            reason.as_str()
-                        );
+                    }
+                    if !resolved {
+                        if fallback_chain.is_empty() {
+                            astra_core::agent_warn!(
+                                "llm",
+                                "rate-limit cooldown: fallback requested ({}) but no fallback configured",
+                                reason.as_str()
+                            );
+                        } else {
+                            astra_core::agent_warn!(
+                                "llm",
+                                "rate-limit cooldown: all {} fallback models exhausted ({})",
+                                fallback_chain.len(),
+                                reason.as_str()
+                            );
+                        }
                     }
                 }
                 RateLimitAction::Reject {

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -429,7 +429,9 @@ use super::bridge_observability::{
 // ── LLM streaming — delegated to turn::bridge_llm_stream ─────────────────────
 use super::bridge_llm_stream::call_llm_stream;
 use super::bridge_llm_stream::rate_limit_cooldown;
-use astra_turn_core::bridge_rate_limit_cooldown::RateLimitAction;
+use astra_turn_core::bridge_rate_limit_cooldown::{
+    FallbackOutcome, RateLimitAction, try_resolve_fallback,
+};
 
 #[cfg(test)]
 async fn await_with_client_disconnect<T, F>(
@@ -1002,59 +1004,46 @@ impl InProcessChatTurnBridge {
                     }
                 }
                 RateLimitAction::UseFallback { reason } => {
-                    let mut resolved = false;
-                    for fb_name in &fallback_chain {
-                        let fb_ok = cooldown.with(fb_name, |c| c.check_request(false));
-                        if !matches!(
-                            fb_ok,
-                            RateLimitAction::Proceed | RateLimitAction::WaitAndRetry { .. }
-                        ) {
-                            continue;
-                        }
-                        astra_core::agent_info!(
-                            "llm",
-                            "rate-limit cooldown: trying fallback model '{}' ({})",
-                            fb_name,
-                            reason.as_str()
-                        );
-                        match astra_services::resolve_active_llm_model(
-                            &matrixone,
-                            encryptor.as_ref(),
-                            Some(fb_name.as_str()),
-                            pool_ref,
-                        )
-                        .await
-                        {
-                            Ok(fb) => {
-                                model_name = fb.model_name;
-                                api_key = fb.api_key;
-                                base_url = fb.base_url;
-                                provider = fb.provider;
-                                resolved = true;
-                                break;
+                    let mx = &matrixone;
+                    let enc = encryptor.as_ref();
+                    match try_resolve_fallback(
+                        cooldown,
+                        &fallback_chain,
+                        reason,
+                        |fb_name| {
+                            let mx = mx;
+                            let enc = enc;
+                            async move {
+                                astra_services::resolve_active_llm_model(
+                                    mx,
+                                    enc,
+                                    Some(fb_name.as_str()),
+                                    pool_ref,
+                                )
+                                .await
                             }
-                            Err(e) => {
-                                astra_core::agent_warn!(
-                                    "llm",
-                                    "fallback model '{}' resolution failed: {}",
-                                    fb_name,
-                                    e
-                                );
-                            }
+                        },
+                    )
+                    .await
+                    {
+                        FallbackOutcome::Resolved(fb) => {
+                            model_name = fb.model_name;
+                            api_key = fb.api_key;
+                            base_url = fb.base_url;
+                            provider = fb.provider;
                         }
-                    }
-                    if !resolved {
-                        if fallback_chain.is_empty() {
+                        FallbackOutcome::NoFallbackConfigured => {
                             astra_core::agent_warn!(
                                 "llm",
                                 "rate-limit cooldown: fallback requested ({}) but no fallback configured",
                                 reason.as_str()
                             );
-                        } else {
+                        }
+                        FallbackOutcome::AllExhausted { chain_len } => {
                             astra_core::agent_warn!(
                                 "llm",
                                 "rate-limit cooldown: all {} fallback models exhausted ({})",
-                                fallback_chain.len(),
+                                chain_len,
                                 reason.as_str()
                             );
                         }

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -118,8 +118,7 @@ pub(crate) fn provider_uses_bedrock_converse(provider: &str) -> bool {
 /// accept `enable_thinking` and may 400 on unknown top-level fields. Matching the
 /// provider name alone avoids false positives on those deployments.
 pub(crate) fn provider_uses_dashscope_thinking(provider: &str) -> bool {
-    let provider = provider.to_ascii_lowercase();
-    provider.contains("dashscope") || provider.contains("aliyun") || provider.contains("alibaba")
+    astra_turn_core::thinking_config::provider_may_think_natively(provider)
 }
 
 /// Global HTTP client for LLM requests (connection pooling, reuse).
@@ -1269,20 +1268,27 @@ pub(crate) fn build_provider_request_body(
             if is_anthropic {
                 thinking.apply_anthropic(&mut body);
             } else if provider_uses_dashscope_thinking(provider) {
-                // DashScope/Qwen uses a binary `enable_thinking` flag; there is no equivalent
-                // of `reasoning_effort`. For `Enabled` this is a direct mapping. For `Adaptive`
-                // we enable thinking but the `effort` level is silently dropped — warn so
-                // operators can diagnose unexpected latency or cost behaviour.
-                if thinking.is_enabled() {
-                    body["enable_thinking"] = json!(true);
-                } else if let ThinkingConfig::Adaptive { effort } = thinking {
-                    tracing::warn!(
-                        provider,
-                        effort = ?effort,
-                        "DashScope/Qwen does not support `reasoning_effort`; \
-                         Adaptive mode mapped to `enable_thinking: true` — effort level ignored"
-                    );
-                    body["enable_thinking"] = json!(true);
+                // DashScope/Qwen uses a binary `enable_thinking` flag; there is no
+                // equivalent of `reasoning_effort`.
+                match thinking {
+                    ThinkingConfig::Off => {
+                        // Native thinkers (Qwen3, Qwen3.5) think by default.
+                        // Explicitly suppress to avoid wasting tokens on reasoning
+                        // when the caller requested Off.
+                        body["enable_thinking"] = json!(false);
+                    }
+                    ThinkingConfig::Enabled { .. } => {
+                        body["enable_thinking"] = json!(true);
+                    }
+                    ThinkingConfig::Adaptive { effort } => {
+                        tracing::warn!(
+                            provider,
+                            effort = ?effort,
+                            "DashScope/Qwen does not support `reasoning_effort`; \
+                             Adaptive mode mapped to `enable_thinking: true` — effort level ignored"
+                        );
+                        body["enable_thinking"] = json!(true);
+                    }
                 }
             } else {
                 thinking.apply_openai(&mut body);
@@ -6192,6 +6198,27 @@ mod tests {
         assert_eq!(body["enable_thinking"], true);
         assert!(body.get("reasoning_effort").is_none());
         assert_eq!(body["temperature"], 0.7);
+    }
+
+    /// ThinkingConfig::Off must explicitly suppress thinking for DashScope
+    /// native thinkers (Qwen3, Qwen3.5) — otherwise they think by default.
+    #[test]
+    fn build_dashscope_body_with_thinking_off_suppresses() {
+        let messages = vec![json!({"role": "user", "content": "hello"})];
+        let body = build_provider_request_body(
+            &messages,
+            &[],
+            "qwen3.5-flash",
+            "dashscope",
+            Some(200),
+            Some(0.0),
+            false,
+            &ThinkingConfig::Off,
+        );
+
+        assert_eq!(body["model"], "qwen3.5-flash");
+        assert_eq!(body["enable_thinking"], false);
+        assert!(body.get("reasoning_effort").is_none());
     }
 
     /// Same Qwen model through a generic OpenAI-compatible proxy must NOT get

--- a/rust/crates/services/src/durable_task.rs
+++ b/rust/crates/services/src/durable_task.rs
@@ -6310,7 +6310,9 @@ mod tests {
             api_key: "sk-test".into(),
             base_url: "https://api.openai.com/v1".into(),
             provider: "openai".into(),
-            fallback_model: None,
+            fallback_chain: vec![],
+            tags: vec![],
+            thinking_capability: None,
         };
         let config = CloudLlmConfig::from_resolved(resolved);
         assert_eq!(config.model, "gpt-4o-mini");

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
-use axum::{http::StatusCode, Json};
+use axum::{Json, http::StatusCode};
 use serde::{Deserialize, Serialize};
-use sqlx::{query, Row};
+use sqlx::{Row, query};
 use uuid::Uuid;
 
 use crate::auth::FernetTokenEncryptor;
 use astra_core::{
-    connect_matrixone, error_response, internal_error, ErrorResponse, MatrixOneSettings, SharedPool,
+    ErrorResponse, MatrixOneSettings, SharedPool, connect_matrixone, error_response, internal_error,
 };
 
 // ── Data types ───────────────────────────────────────────────────────────────
@@ -927,20 +927,6 @@ impl ModelService for DatabaseModelService {
         .await;
         let is_active: i16 = if conn_result.is_none() { 1 } else { 0 };
 
-        // Auto-probe thinking capability when connectivity passes.
-        let thinking_cap_str = if conn_result.is_none() {
-            let probe = probe_thinking_behavior(
-                &request.provider,
-                &request.name,
-                &request.api_key,
-                base_url.as_deref(),
-            )
-            .await;
-            Some(probe.capability.as_db_str().to_string())
-        } else {
-            None
-        };
-
         let input_mod = serde_json::to_string(&request.input_modalities)
             .unwrap_or_else(|_| r#"["text"]"#.to_string());
         let output_mod = serde_json::to_string(&request.output_modalities)
@@ -959,9 +945,9 @@ impl ModelService for DatabaseModelService {
             "INSERT INTO infra_llm_models \
              (model_id, model_name, provider, api_key_encrypted, base_url, description, \
               is_active, context_window, max_completion_tokens, input_modalities, output_modalities, \
-              supported_parameters, pricing, architecture, tags, quirks, thinking_capability, \
+              supported_parameters, pricing, architecture, tags, quirks, \
               created_by, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())",
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())",
         )
         .bind(&model_id)
         .bind(&request.name)
@@ -979,11 +965,42 @@ impl ModelService for DatabaseModelService {
         .bind(&request.architecture)
         .bind(&tags)
         .bind(&quirks)
-        .bind(&thinking_cap_str)
         .bind(&user_id)
         .execute(&pool)
         .await
         .map_err(internal_error)?;
+
+        // Thinking probe runs AFTER INSERT so the model is immediately
+        // available. Probe result is written via UPDATE — if probe is slow
+        // or fails, the model still works (picker defaults to no thinking
+        // until probed).
+        if conn_result.is_none() {
+            let probe = probe_thinking_behavior(
+                &request.provider,
+                &request.name,
+                &request.api_key,
+                base_url.as_deref(),
+            )
+            .await;
+            let cap_str = probe.capability.as_db_str();
+            let err_str = probe.error.as_deref();
+            if let Err(e) = query(
+                "UPDATE infra_llm_models SET thinking_capability = ?, \
+                 thinking_probe_error = ? WHERE model_id = ?",
+            )
+            .bind(cap_str)
+            .bind(err_str)
+            .bind(&model_id)
+            .execute(&pool)
+            .await
+            {
+                tracing::warn!(
+                    model = %request.name,
+                    err = %e,
+                    "failed to persist thinking_capability after create"
+                );
+            }
+        }
 
         let select_sql = format!(
             "SELECT {} FROM infra_llm_models WHERE model_id = ?",
@@ -2660,7 +2677,7 @@ mod tests {
         captured: Arc<Mutex<Option<serde_json::Value>>>,
         response_body: serde_json::Value,
     ) -> String {
-        use axum::{routing::post, Router};
+        use axum::{Router, routing::post};
 
         let handler = move |axum::Json(body): axum::Json<serde_json::Value>| {
             let captured = captured.clone();
@@ -2689,7 +2706,7 @@ mod tests {
 
     /// Mock that responds differently based on enable_thinking in request.
     async fn spawn_dashscope_mock(supports_thinking: bool) -> String {
-        use axum::{routing::post, Router};
+        use axum::{Router, routing::post};
 
         let handler = move |axum::Json(body): axum::Json<serde_json::Value>| async move {
             let enable = body.get("enable_thinking").and_then(|v| v.as_bool());
@@ -2719,7 +2736,7 @@ mod tests {
 
     /// DashScope model that thinks by default (like glm-5.1, qwen3.6-plus).
     async fn spawn_dashscope_native_thinker_mock() -> String {
-        use axum::{routing::post, Router};
+        use axum::{Router, routing::post};
 
         let handler = |axum::Json(body): axum::Json<serde_json::Value>| async move {
             let enable = body.get("enable_thinking").and_then(|v| v.as_bool());

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -997,7 +997,15 @@ impl ModelService for DatabaseModelService {
                 base_url.as_deref(),
             )
             .await;
-            let cap_str = probe.capability.as_db_str();
+            // Only persist capability when probe succeeded without errors.
+            // A failed probe (client error, unreachable server) should leave
+            // capability=NULL (unprobed) rather than permanently marking the
+            // model as non-thinking due to a transient failure.
+            let cap_str: Option<&str> = if probe.error.is_none() {
+                Some(probe.capability.as_db_str())
+            } else {
+                None
+            };
             let err_str = probe.error.as_deref();
             if let Err(e) = query(
                 "UPDATE infra_llm_models SET thinking_capability = ?, \
@@ -1554,103 +1562,132 @@ pub async fn probe_thinking_behavior(
 
     // ── DeepSeek: always thinks, supports reasoning_effort (low/high) but can't disable ──
     if url_lower.contains("deepseek") {
-        let thinks = send_openai_probe(&client, &probe_url, api_key, &base_body)
-            .await
-            .unwrap_or(false);
-        return ThinkingProbeResult {
-            capability: if thinks {
-                ThinkingCapability::EffortOnly
-            } else {
-                ThinkingCapability::None
+        return match send_openai_probe(&client, &probe_url, api_key, &base_body).await {
+            Ok(true) => ThinkingProbeResult {
+                capability: ThinkingCapability::EffortOnly,
+                error: None,
             },
-            error: None,
+            Ok(false) => ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: None,
+            },
+            Err(e) => ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: Some(e),
+            },
         };
     }
 
     // ── MiniMax: always thinks via <think> tags, can't disable ──
     if url_lower.contains("minimax") {
-        let thinks = send_openai_probe(&client, &probe_url, api_key, &base_body)
-            .await
-            .unwrap_or(false);
-        return ThinkingProbeResult {
-            capability: if thinks {
-                ThinkingCapability::NativeOnly
-            } else {
-                ThinkingCapability::None
+        return match send_openai_probe(&client, &probe_url, api_key, &base_body).await {
+            Ok(true) => ThinkingProbeResult {
+                capability: ThinkingCapability::NativeOnly,
+                error: None,
             },
-            error: None,
+            Ok(false) => ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: None,
+            },
+            Err(e) => ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: Some(e),
+            },
         };
     }
 
     // ── DashScope (Qwen, GLM-5.1): default=no thinking, enable_thinking toggles ──
     if url_lower.contains("dashscope") || url_lower.contains("aliyun") {
         // First check if it thinks by default (GLM-5.1 does)
-        let default_thinks = send_openai_probe(&client, &probe_url, api_key, &base_body)
-            .await
-            .unwrap_or(false);
+        let default_thinks = match send_openai_probe(&client, &probe_url, api_key, &base_body).await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                return ThinkingProbeResult {
+                    capability: ThinkingCapability::None,
+                    error: Some(e),
+                };
+            }
+        };
         if default_thinks {
             // Thinks by default — test suppression
             let mut body_disable = base_body;
             body_disable["enable_thinking"] = serde_json::json!(false);
-            let still_thinks = send_openai_probe(&client, &probe_url, api_key, &body_disable)
-                .await
-                .unwrap_or(true);
+            let (still_thinks, suppress_err) =
+                match send_openai_probe(&client, &probe_url, api_key, &body_disable).await {
+                    Ok(v) => (v, None),
+                    Err(e) => (true, Some(e)), // conservative: assume can't suppress on error
+                };
             return ThinkingProbeResult {
                 capability: if still_thinks {
                     ThinkingCapability::NativeOnly
                 } else {
                     ThinkingCapability::Both
                 },
-                error: None,
+                error: suppress_err,
             };
         }
         // Doesn't think by default — try enabling
         let mut body_enable = base_body;
         body_enable["enable_thinking"] = serde_json::json!(true);
-        let enabled_thinks = send_openai_probe(&client, &probe_url, api_key, &body_enable)
-            .await
-            .unwrap_or(false);
-        return ThinkingProbeResult {
-            capability: if enabled_thinks {
-                ThinkingCapability::Both
-            } else {
-                ThinkingCapability::None
+        return match send_openai_probe(&client, &probe_url, api_key, &body_enable).await {
+            Ok(true) => ThinkingProbeResult {
+                capability: ThinkingCapability::Both,
+                error: None,
             },
-            error: None,
+            Ok(false) => ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: None,
+            },
+            Err(e) => ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: Some(e),
+            },
         };
     }
 
     // ── Generic OpenAI-compatible: probe default, then try enable_thinking ──
-    let default_thinks = send_openai_probe(&client, &probe_url, api_key, &base_body)
-        .await
-        .unwrap_or(false);
+    let default_thinks = match send_openai_probe(&client, &probe_url, api_key, &base_body).await {
+        Ok(v) => v,
+        Err(e) => {
+            return ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: Some(e),
+            };
+        }
+    };
     if default_thinks {
         let mut body_suppress = base_body;
         body_suppress["enable_thinking"] = serde_json::json!(false);
-        let still_thinks = send_openai_probe(&client, &probe_url, api_key, &body_suppress)
-            .await
-            .unwrap_or(true);
+        let (still_thinks, suppress_err) =
+            match send_openai_probe(&client, &probe_url, api_key, &body_suppress).await {
+                Ok(v) => (v, None),
+                Err(e) => (true, Some(e)), // conservative: assume can't suppress on error
+            };
         return ThinkingProbeResult {
             capability: if still_thinks {
                 ThinkingCapability::NativeOnly
             } else {
                 ThinkingCapability::Both
             },
-            error: None,
+            error: suppress_err,
         };
     }
     let mut body_enable = base_body;
     body_enable["enable_thinking"] = serde_json::json!(true);
-    let enabled_thinks = send_openai_probe(&client, &probe_url, api_key, &body_enable)
-        .await
-        .unwrap_or(false);
-    ThinkingProbeResult {
-        capability: if enabled_thinks {
-            ThinkingCapability::Both
-        } else {
-            ThinkingCapability::None
+    match send_openai_probe(&client, &probe_url, api_key, &body_enable).await {
+        Ok(true) => ThinkingProbeResult {
+            capability: ThinkingCapability::Both,
+            error: None,
         },
-        error: None,
+        Ok(false) => ThinkingProbeResult {
+            capability: ThinkingCapability::None,
+            error: None,
+        },
+        Err(e) => ThinkingProbeResult {
+            capability: ThinkingCapability::None,
+            error: Some(e),
+        },
     }
 }
 
@@ -3026,6 +3063,11 @@ mod tests {
     async fn probe_unreachable_server_returns_none() {
         let result = probe_thinking_behavior("openai", "m", "k", Some("http://127.0.0.1:1")).await;
         assert_eq!(result.capability, ThinkingCapability::None);
+        // After fix: error is surfaced, not silently swallowed
+        assert!(
+            result.error.is_some(),
+            "unreachable server should surface error, got None"
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -824,18 +824,22 @@ impl DatabaseModelService {
         let thinking_probe_error: Option<String> =
             row.try_get("thinking_probe_error").ok().flatten();
 
-        // Build ThinkingProbeResult when the model has been probed (capability is known).
-        // If capability is unknown but an error exists, the probe partially failed — log it.
-        if thinking_capability.is_none() && thinking_probe_error.is_some() {
-            tracing::warn!(
-                error = ?thinking_probe_error,
-                "thinking_probe_error present but thinking_capability is NULL; probe result dropped"
-            );
-        }
-        let thinking_probe = thinking_capability.map(|cap| ThinkingProbeResult {
-            capability: cap,
-            error: thinking_probe_error,
-        });
+        // Build ThinkingProbeResult when the model has been probed (capability is known)
+        // OR when a probe error exists (probe ran but failed — surface the error).
+        let thinking_probe = match (thinking_capability, thinking_probe_error) {
+            (Some(cap), err) => Some(ThinkingProbeResult {
+                capability: cap,
+                error: err,
+            }),
+            // Probe failed: no capability determined, but error must be surfaced.
+            // Default to ThinkingCapability::None so the picker stays safe.
+            (None, Some(err)) => Some(ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: Some(err),
+            }),
+            // Never probed.
+            (None, None) => None,
+        };
 
         Ok(ModelRecord {
             model_id: row.try_get("model_id").map_err(internal_error)?,
@@ -1288,8 +1292,15 @@ impl ModelService for DatabaseModelService {
             let result =
                 probe_thinking_behavior(&provider, &model_name, &api_key, base_url.as_deref())
                     .await;
-            // Persist probe result to DB
-            let cap_str = result.capability.as_db_str();
+            // Persist probe result to DB.
+            // Only write capability when the probe succeeded (no error).
+            // A failed probe should leave capability=NULL (re-probable)
+            // rather than permanently marking the model as non-thinking.
+            let cap_str: Option<&str> = if result.error.is_none() {
+                Some(result.capability.as_db_str())
+            } else {
+                None
+            };
             let err_str = result.error.as_deref();
             if let Err(e) = query(
                 "UPDATE infra_llm_models SET thinking_capability = ?, \
@@ -2608,6 +2619,44 @@ mod tests {
             .expect("thinking_probe must be Some even on error");
         assert_eq!(probe.capability, ThinkingCapability::None);
         assert_eq!(probe.error.as_deref(), Some("connection refused"));
+    }
+
+    /// Probe failed: DB has thinking_capability=NULL but thinking_probe_error is set.
+    /// The new `model_record_from_row` match arm surfaces this as a ThinkingProbeResult
+    /// with capability=None + the error, so the API caller sees the failure reason.
+    #[test]
+    fn model_response_surfaces_orphan_probe_error() {
+        let record = ModelRecord {
+            model_id: "m-orphan".into(),
+            name: "orphan-err".into(),
+            provider: "openai".into(),
+            base_url: None,
+            description: None,
+            is_active: true,
+            context_window: 4096,
+            max_completion_tokens: None,
+            input_modalities: vec!["text".into()],
+            output_modalities: vec!["text".into()],
+            supported_parameters: vec![],
+            pricing: PricingData::default(),
+            architecture: None,
+            tags: vec![],
+            quirks: QuirksData::default(),
+            connectivity: None,
+            // DB: thinking_capability = NULL (unprobed/failed)
+            thinking_capability: None,
+            // But model_record_from_row now constructs this when error exists
+            thinking_probe: Some(ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: Some("connection timeout".into()),
+            }),
+        };
+        let resp = ModelResponse::from(record);
+        let probe = resp
+            .thinking_probe
+            .expect("orphan probe error must be surfaced");
+        assert_eq!(probe.capability, ThinkingCapability::None);
+        assert_eq!(probe.error.as_deref(), Some("connection timeout"));
     }
 
     /// Unprobed model (thinking_capability = NULL) → thinking_probe is None.

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
-use axum::{Json, http::StatusCode};
+use axum::{http::StatusCode, Json};
 use serde::{Deserialize, Serialize};
-use sqlx::{Row, query};
+use sqlx::{query, Row};
 use uuid::Uuid;
 
 use crate::auth::FernetTokenEncryptor;
 use astra_core::{
-    ErrorResponse, MatrixOneSettings, SharedPool, connect_matrixone, error_response, internal_error,
+    connect_matrixone, error_response, internal_error, ErrorResponse, MatrixOneSettings, SharedPool,
 };
 
 // ── Data types ───────────────────────────────────────────────────────────────
@@ -39,40 +39,10 @@ pub struct QuirksData {
     pub no_system_message: bool,
     #[serde(default)]
     pub system_as_user_prefix: bool,
-    /// Fallback model name to use when the primary model hits rate limits.
-    /// Must reference an active model in `infra_llm_models`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fallback_model: Option<String>,
-    /// Thinking behaviour declaration.
-    ///   - `"controllable"` — needs explicit API parameter (Bedrock adaptive, DashScope enable_thinking).
-    ///   - `"native"` — model returns reasoning_content by default (GLM, Qwen3).
-    ///   - `None` / absent — no thinking support.
-    ///
-    /// Validated on deserialization: unknown values (e.g. typos like
-    /// `"Controllable"` or `"enabled"`) are rejected so bad YAML/admin payloads
-    /// fail loudly instead of silently disabling the thinking picker.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_thinking_mode"
-    )]
-    pub thinking_mode: Option<String>,
-}
-
-/// Accepts only canonical thinking_mode values. See [`QuirksData::thinking_mode`].
-fn deserialize_thinking_mode<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::de::Error;
-    let opt: Option<String> = Option::deserialize(deserializer)?;
-    match opt.as_deref() {
-        None => Ok(None),
-        Some("controllable") | Some("native") => Ok(opt),
-        Some(other) => Err(D::Error::custom(format!(
-            "invalid thinking_mode {other:?}: expected \"controllable\", \"native\", or null"
-        ))),
-    }
+    /// Ordered fallback chain. Tried in sequence when the primary model hits
+    /// rate limits or becomes unavailable.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fallback_chain: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -111,7 +81,68 @@ pub struct ModelUpdateRequestData {
     pub quirks: Option<QuirksData>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+/// Thinking capability of a model, determined by provider-aware probe.
+///
+/// Persisted to DB column `thinking_capability`. NULL means unprobed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThinkingCapability {
+    /// Model supports Normal (off) and Thinking modes — suppression works.
+    /// Picker: Normal / Thinking (Low) / Thinking (High).
+    /// Examples: Bedrock Claude, DashScope Qwen-Plus, GLM-5.1.
+    Both,
+    /// Model always thinks but supports effort control (low/medium/high).
+    /// Cannot be turned off completely — no "Normal" option.
+    /// Picker: Thinking (Low) / Thinking (High).
+    /// Examples: DeepSeek V4.
+    EffortOnly,
+    /// Model always thinks, no control at all.
+    /// No picker shown.
+    /// Examples: MiniMax M2.5.
+    NativeOnly,
+    /// Model does not support thinking.
+    /// No picker shown.
+    /// Examples: qwen-flash, qwen2.5-3b-instruct.
+    None,
+}
+
+impl ThinkingCapability {
+    pub fn from_db(s: Option<&str>) -> Option<Self> {
+        match s? {
+            "both" => Some(Self::Both),
+            "effort_only" => Some(Self::EffortOnly),
+            "native_only" => Some(Self::NativeOnly),
+            "none" => Some(Self::None),
+            other => {
+                tracing::warn!(
+                    value = other,
+                    "unknown thinking_capability value in DB — treating as unprobed"
+                );
+                Option::None
+            }
+        }
+    }
+
+    pub fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Both => "both",
+            Self::EffortOnly => "effort_only",
+            Self::NativeOnly => "native_only",
+            Self::None => "none",
+        }
+    }
+}
+
+/// Result of the two-phase thinking behavior probe.
+///
+/// Ephemeral — returned during `check_model`, but the capability is persisted to DB.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ThinkingProbeResult {
+    pub capability: ThinkingCapability,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 pub struct ModelRecord {
     pub model_id: String,
     pub name: String,
@@ -129,6 +160,8 @@ pub struct ModelRecord {
     pub tags: Vec<String>,
     pub quirks: QuirksData,
     pub connectivity: Option<String>,
+    pub thinking_capability: Option<ThinkingCapability>,
+    pub thinking_probe: Option<ThinkingProbeResult>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -141,7 +174,7 @@ pub struct ModelListItem {
     pub context_window: i32,
     pub max_completion_tokens: Option<i32>,
     pub architecture: Option<String>,
-    pub thinking_mode: Option<String>,
+    pub thinking_capability: Option<ThinkingCapability>,
 }
 
 /// Decrypted credentials for the active (or preferred) row in `infra_llm_models`.
@@ -151,8 +184,10 @@ pub struct ResolvedActiveLlmModel {
     pub api_key: String,
     pub base_url: String,
     pub provider: String,
-    /// Fallback model name from quirks (cloud-managed).
-    pub fallback_model: Option<String>,
+    pub fallback_chain: Vec<String>,
+    pub tags: Vec<String>,
+    /// Probe-determined thinking capability. NULL if unprobed.
+    pub thinking_capability: Option<ThinkingCapability>,
 }
 
 fn build_resolved_active_llm_from_row(
@@ -175,34 +210,42 @@ fn build_resolved_active_llm_from_row(
         .decrypt(&encrypted)
         .map_err(|e| format!("Decrypt: {e}"))?;
 
-    // Extract fallback_model from quirks JSON (env var override if set)
-    let fallback_model = {
-        let quirks_json: String = row
-            .try_get("quirks_json")
-            .unwrap_or_else(|_| "{}".to_string());
-        let quirks: QuirksData = match serde_json::from_str(&quirks_json) {
-            Ok(q) => q,
-            Err(e) => {
-                let prefix = &quirks_json[..quirks_json.len().min(200)];
-                tracing::error!(
-                    target: "astra_services::models",
-                    column = "quirks_json",
-                    err = %e,
-                    payload_prefix = %prefix,
-                    "malformed JSON column, using default"
-                );
-                QuirksData::default()
-            }
-        };
-        quirks.fallback_model
+    let quirks_json: String = row
+        .try_get("quirks_json")
+        .unwrap_or_else(|_| "{}".to_string());
+    let quirks: QuirksData = match serde_json::from_str(&quirks_json) {
+        Ok(q) => q,
+        Err(e) => {
+            let prefix = &quirks_json[..quirks_json.len().min(200)];
+            tracing::error!(
+                target: "astra_services::models",
+                column = "quirks_json",
+                err = %e,
+                payload_prefix = %prefix,
+                "malformed JSON column, using default"
+            );
+            QuirksData::default()
+        }
     };
+
+    let tags_json: String = row
+        .try_get("tags_json")
+        .unwrap_or_else(|_| "[]".to_string());
+    let tags: Vec<String> = parse_json_column("tags_json", &tags_json, Vec::new);
+
+    let thinking_cap_str: Option<String> = row.try_get("thinking_capability").ok().flatten();
+    let thinking_capability = ThinkingCapability::from_db(thinking_cap_str.as_deref());
+
+    let fallback_chain = quirks.fallback_chain;
 
     Ok(ResolvedActiveLlmModel {
         model_name,
         api_key,
         base_url,
         provider,
-        fallback_model,
+        fallback_chain,
+        tags,
+        thinking_capability,
     })
 }
 
@@ -382,6 +425,36 @@ pub fn format_inactive_model_error(requested: &str, canonical: &str) -> String {
     }
 }
 
+/// Shared columns for all model-resolution queries.
+const RESOLVE_COLS: &str = "\
+    model_name, api_key_encrypted, base_url, provider, \
+    IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, \
+    IFNULL(CAST(pricing AS CHAR), '{}') AS pricing_json, \
+    IFNULL(CAST(tags AS CHAR), '[]') AS tags_json, \
+    thinking_capability";
+
+/// Acquire a pool reference: use the provided pool, or open an ephemeral one.
+async fn acquire_pool(
+    provided: Option<&sqlx::Pool<sqlx::MySql>>,
+    matrixone: &MatrixOneSettings,
+) -> Result<sqlx::Pool<sqlx::MySql>, String> {
+    match provided {
+        Some(p) => Ok(p.clone()),
+        None => {
+            let url = format!(
+                "{}?connect_timeout=2",
+                matrixone.database_url_with_password()
+            );
+            sqlx::mysql::MySqlPoolOptions::new()
+                .max_connections(1)
+                .acquire_timeout(std::time::Duration::from_secs(3))
+                .connect(&url)
+                .await
+                .map_err(|e| format!("DB connect: {e}"))
+        }
+    }
+}
+
 /// Resolve the active LLM model from the database for in-process / server-side callers.
 ///
 /// When `preferred` is `Some(name)`, the row **must** exist and be active — otherwise this
@@ -389,43 +462,25 @@ pub fn format_inactive_model_error(requested: &str, canonical: &str) -> String {
 /// the lexicographically first active model. When `pool` is `None`, opens an ephemeral
 /// single-connection pool from `matrixone`.
 ///
-/// Also extracts `fallback_model` from the `quirks` JSON column (cloud-managed config).
+/// Also extracts `fallback_chain` from the `quirks` JSON column (cloud-managed config).
 pub async fn resolve_active_llm_model(
     matrixone: &MatrixOneSettings,
     encryptor: &FernetTokenEncryptor,
     preferred: Option<&str>,
     pool: Option<&sqlx::Pool<sqlx::MySql>>,
 ) -> Result<ResolvedActiveLlmModel, String> {
-    let ephemeral;
-    let pool: &sqlx::Pool<sqlx::MySql> = match pool {
-        Some(p) => p,
-        None => {
-            let url = format!(
-                "{}?connect_timeout=2",
-                matrixone.database_url_with_password()
-            );
-            ephemeral = sqlx::mysql::MySqlPoolOptions::new()
-                .max_connections(1)
-                .acquire_timeout(std::time::Duration::from_secs(3))
-                .connect(&url)
-                .await
-                .map_err(|e| format!("DB connect: {e}"))?;
-            &ephemeral
-        }
-    };
+    let pool = acquire_pool(pool, matrixone).await?;
 
     let pref = preferred.map(str::trim).filter(|s| !s.is_empty());
 
     if let Some(name) = pref {
         // Try exact match first — the fast path. If the LLM supplied
         // the fully-qualified name it resolves in one query.
-        let exact_row = sqlx::query(
-            "SELECT model_name, api_key_encrypted, base_url, provider, \
-                    IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, is_active \
-             FROM infra_llm_models WHERE model_name = ? LIMIT 1",
-        )
+        let exact_row = sqlx::query(&format!(
+            "SELECT {RESOLVE_COLS}, is_active FROM infra_llm_models WHERE model_name = ? LIMIT 1"
+        ))
         .bind(name)
-        .fetch_optional(pool)
+        .fetch_optional(&pool)
         .await
         .map_err(|e| format!("DB query: {e}"))?;
 
@@ -447,20 +502,19 @@ pub async fn resolve_active_llm_model(
                 let active_names: Vec<String> = sqlx::query_scalar::<_, String>(
                     "SELECT model_name FROM infra_llm_models WHERE is_active = 1",
                 )
-                .fetch_all(pool)
+                .fetch_all(&pool)
                 .await
                 .map_err(|e| format!("DB query: {e}"))?;
 
                 match resolve_model_alias(name, &active_names) {
                     Ok(canonical_ref) => {
                         let canonical = canonical_ref.to_string();
-                        let r = sqlx::query(
-                            "SELECT model_name, api_key_encrypted, base_url, provider, \
-                                    IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, is_active \
-                             FROM infra_llm_models WHERE model_name = ? LIMIT 1",
-                        )
+                        let r = sqlx::query(&format!(
+                            "SELECT {RESOLVE_COLS}, is_active \
+                             FROM infra_llm_models WHERE model_name = ? LIMIT 1"
+                        ))
                         .bind(&canonical)
-                        .fetch_optional(pool)
+                        .fetch_optional(&pool)
                         .await
                         .map_err(|e| format!("DB query: {e}"))?
                         .ok_or_else(|| {
@@ -484,12 +538,10 @@ pub async fn resolve_active_llm_model(
         return build_resolved_active_llm_from_row(&row, encryptor);
     }
 
-    let row = sqlx::query(
-        "SELECT model_name, api_key_encrypted, base_url, provider, \
-                IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json \
-         FROM infra_llm_models WHERE is_active = 1 ORDER BY model_name LIMIT 1",
-    )
-    .fetch_optional(pool)
+    let row = sqlx::query(&format!(
+        "SELECT {RESOLVE_COLS} FROM infra_llm_models WHERE is_active = 1 ORDER BY model_name LIMIT 1"
+    ))
+    .fetch_optional(&pool)
     .await
     .map_err(|e| format!("DB query fallback: {e}"))?;
 
@@ -526,31 +578,12 @@ pub async fn resolve_reasoning_model(
 
     // 2. Cheapest active. MatrixOne JSON function support is uneven, so sort in Rust:
     //    pull all active rows and pick the minimum completion price.
-    let ephemeral;
-    let pool: &sqlx::Pool<sqlx::MySql> = match pool {
-        Some(p) => p,
-        None => {
-            let url = format!(
-                "{}?connect_timeout=2",
-                matrixone.database_url_with_password()
-            );
-            ephemeral = sqlx::mysql::MySqlPoolOptions::new()
-                .max_connections(1)
-                .acquire_timeout(std::time::Duration::from_secs(3))
-                .connect(&url)
-                .await
-                .map_err(|e| format!("DB connect: {e}"))?;
-            &ephemeral
-        }
-    };
+    let pool = acquire_pool(pool, matrixone).await?;
 
-    let rows = sqlx::query(
-        "SELECT model_name, api_key_encrypted, base_url, provider, \
-                IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, \
-                IFNULL(CAST(pricing AS CHAR), '{}') AS pricing_json \
-         FROM infra_llm_models WHERE is_active = 1",
-    )
-    .fetch_all(pool)
+    let rows = sqlx::query(&format!(
+        "SELECT {RESOLVE_COLS} FROM infra_llm_models WHERE is_active = 1"
+    ))
+    .fetch_all(&pool)
     .await
     .map_err(|e| format!("DB query reasoning: {e}"))?;
 
@@ -580,44 +613,22 @@ pub async fn resolve_reasoning_model(
 /// Resolve the cheapest model tagged `"selector"` for memory-related
 /// decisions (relevance filtering, lesson synthesis, L1b extraction).
 ///
-/// Resolution order:
-/// 1. Cheapest active model whose `tags` JSON array contains `"selector"`.
-/// 2. Fallback: cheapest active model overall (same as `resolve_reasoning_model`
-///    without the admin override).
+/// 1. Cheapest active model tagged `"selector"`.
+/// 2. Fallback: cheapest active model overall.
 ///
-/// This is cheaper than the main conversation model and dedicated to
-/// low-stakes judgment calls where latency is acceptable (2–3s).
+/// Callers use `thinking_capability` from the resolved model to decide
+/// whether to apply thinking suppression.
 pub async fn resolve_memory_model(
     matrixone: &MatrixOneSettings,
     encryptor: &FernetTokenEncryptor,
     pool: Option<&sqlx::Pool<sqlx::MySql>>,
 ) -> Result<ResolvedActiveLlmModel, String> {
-    let ephemeral;
-    let pool: &sqlx::Pool<sqlx::MySql> = match pool {
-        Some(p) => p,
-        None => {
-            let url = format!(
-                "{}?connect_timeout=2",
-                matrixone.database_url_with_password()
-            );
-            ephemeral = sqlx::mysql::MySqlPoolOptions::new()
-                .max_connections(1)
-                .acquire_timeout(std::time::Duration::from_secs(3))
-                .connect(&url)
-                .await
-                .map_err(|e| format!("DB connect: {e}"))?;
-            &ephemeral
-        }
-    };
+    let pool = acquire_pool(pool, matrixone).await?;
 
-    let rows = sqlx::query(
-        "SELECT model_name, api_key_encrypted, base_url, provider, \
-                IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, \
-                IFNULL(CAST(pricing AS CHAR), '{}') AS pricing_json, \
-                IFNULL(CAST(tags AS CHAR), '[]') AS tags_json \
-         FROM infra_llm_models WHERE is_active = 1",
-    )
-    .fetch_all(pool)
+    let rows = sqlx::query(&format!(
+        "SELECT {RESOLVE_COLS} FROM infra_llm_models WHERE is_active = 1"
+    ))
+    .fetch_all(&pool)
     .await
     .map_err(|e| format!("DB query memory model: {e}"))?;
 
@@ -625,7 +636,6 @@ pub async fn resolve_memory_model(
         return Err("No active LLM model configured.".to_string());
     }
 
-    // Prefer models tagged "selector" (ultra-cheap intent/judgment models).
     let selector_rows: Vec<usize> = rows
         .iter()
         .enumerate()
@@ -638,9 +648,8 @@ pub async fn resolve_memory_model(
         .map(|(i, _)| i)
         .collect();
 
-    let best_idx = if !selector_rows.is_empty() {
-        // Pick cheapest among selector-tagged models.
-        let selector_entries: Vec<(String, String)> = selector_rows
+    let pick_cheapest_in = |indices: &[usize]| -> usize {
+        let entries: Vec<(String, String)> = indices
             .iter()
             .map(|&i| {
                 let name: String = rows[i].try_get("model_name").unwrap_or_default();
@@ -650,21 +659,15 @@ pub async fn resolve_memory_model(
                 (name, pricing)
             })
             .collect();
-        let local_best = rank_cheapest_index(&selector_entries);
-        selector_rows[local_best]
+        let local_best = rank_cheapest_index(&entries);
+        indices[local_best]
+    };
+
+    let best_idx = if !selector_rows.is_empty() {
+        pick_cheapest_in(&selector_rows)
     } else {
-        // No selector models — fall back to cheapest overall.
-        let entries: Vec<(String, String)> = rows
-            .iter()
-            .map(|row| {
-                let name: String = row.try_get("model_name").unwrap_or_default();
-                let pricing: String = row
-                    .try_get("pricing_json")
-                    .unwrap_or_else(|_| "{}".to_string());
-                (name, pricing)
-            })
-            .collect();
-        rank_cheapest_index(&entries)
+        let all_indices: Vec<usize> = (0..rows.len()).collect();
+        pick_cheapest_in(&all_indices)
     };
 
     build_resolved_active_llm_from_row(&rows[best_idx], encryptor)
@@ -816,6 +819,9 @@ impl DatabaseModelService {
             .try_get("quirks_json")
             .unwrap_or_else(|_| "{}".to_string());
 
+        let thinking_cap_str: Option<String> = row.try_get("thinking_capability").ok().flatten();
+        let thinking_capability = ThinkingCapability::from_db(thinking_cap_str.as_deref());
+
         Ok(ModelRecord {
             model_id: row.try_get("model_id").map_err(internal_error)?,
             name: row.try_get("model_name").map_err(internal_error)?,
@@ -843,6 +849,8 @@ impl DatabaseModelService {
             tags: parse_json_column("tags_json", &tags_json, Default::default),
             quirks: parse_json_column("quirks_json", &quirks_json, Default::default),
             connectivity: None,
+            thinking_capability,
+            thinking_probe: None,
         })
     }
     pub fn with_pool(mut self, pool: SharedPool) -> Self {
@@ -866,10 +874,12 @@ pub const MODEL_SELECT_COLS: &str = "\
     IFNULL(CAST(supported_parameters AS CHAR), '[]') AS supported_parameters_json, \
     IFNULL(CAST(pricing AS CHAR), '{}') AS pricing_json, \
     IFNULL(CAST(tags AS CHAR), '[]') AS tags_json, \
-    IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json";
+    IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, \
+    thinking_capability";
 const MODEL_LIST_SELECT_COLS: &str = "\
     model_id, model_name, provider, description, is_active, \
     IFNULL(context_window, 128000) AS context_window, max_completion_tokens, architecture, \
+    thinking_capability, \
     IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json";
 const MAX_MODEL_LIST_ROWS: i64 = 200;
 
@@ -917,6 +927,20 @@ impl ModelService for DatabaseModelService {
         .await;
         let is_active: i16 = if conn_result.is_none() { 1 } else { 0 };
 
+        // Auto-probe thinking capability when connectivity passes.
+        let thinking_cap_str = if conn_result.is_none() {
+            let probe = probe_thinking_behavior(
+                &request.provider,
+                &request.name,
+                &request.api_key,
+                base_url.as_deref(),
+            )
+            .await;
+            Some(probe.capability.as_db_str().to_string())
+        } else {
+            None
+        };
+
         let input_mod = serde_json::to_string(&request.input_modalities)
             .unwrap_or_else(|_| r#"["text"]"#.to_string());
         let output_mod = serde_json::to_string(&request.output_modalities)
@@ -935,8 +959,9 @@ impl ModelService for DatabaseModelService {
             "INSERT INTO infra_llm_models \
              (model_id, model_name, provider, api_key_encrypted, base_url, description, \
               is_active, context_window, max_completion_tokens, input_modalities, output_modalities, \
-              supported_parameters, pricing, architecture, tags, quirks, created_by, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())",
+              supported_parameters, pricing, architecture, tags, quirks, thinking_capability, \
+              created_by, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())",
         )
         .bind(&model_id)
         .bind(&request.name)
@@ -954,6 +979,7 @@ impl ModelService for DatabaseModelService {
         .bind(&request.architecture)
         .bind(&tags)
         .bind(&quirks)
+        .bind(&thinking_cap_str)
         .bind(&user_id)
         .execute(&pool)
         .await
@@ -997,11 +1023,6 @@ impl ModelService for DatabaseModelService {
         let mut models = Vec::with_capacity(rows.len());
         for row in rows {
             let is_active_int: i16 = row.try_get("is_active").unwrap_or(1);
-            let quirks_json: String = row
-                .try_get("quirks_json")
-                .unwrap_or_else(|_| "{}".to_string());
-            let quirks: QuirksData =
-                parse_json_column("quirks_json", &quirks_json, Default::default);
             models.push(ModelListItem {
                 model_id: row.try_get("model_id").map_err(internal_error)?,
                 name: row.try_get("model_name").map_err(internal_error)?,
@@ -1011,7 +1032,10 @@ impl ModelService for DatabaseModelService {
                 context_window: row.try_get("context_window").unwrap_or(128000),
                 max_completion_tokens: row.try_get("max_completion_tokens").ok(),
                 architecture: row.try_get("architecture").ok(),
-                thinking_mode: quirks.thinking_mode,
+                thinking_capability: {
+                    let cap_str: Option<String> = row.try_get("thinking_capability").ok().flatten();
+                    ThinkingCapability::from_db(cap_str.as_deref())
+                },
             });
         }
         Ok(models)
@@ -1185,11 +1209,15 @@ impl ModelService for DatabaseModelService {
         model_name: String,
     ) -> Result<ModelRecord, (StatusCode, Json<ErrorResponse>)> {
         let pool = self.get_pool().await.map_err(internal_error)?;
-        let row = query("SELECT api_key_encrypted, provider, base_url FROM infra_llm_models WHERE model_name = ?")
-            .bind(&model_name)
-            .fetch_optional(&pool)
-            .await
-            .map_err(internal_error)?;
+        let row = query(
+            "SELECT api_key_encrypted, provider, base_url, \
+                    IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json \
+             FROM infra_llm_models WHERE model_name = ?",
+        )
+        .bind(&model_name)
+        .fetch_optional(&pool)
+        .await
+        .map_err(internal_error)?;
         let row = row.ok_or_else(|| {
             error_response(
                 StatusCode::NOT_FOUND,
@@ -1202,6 +1230,8 @@ impl ModelService for DatabaseModelService {
         let base_url: Option<String> = row.try_get("base_url").ok();
 
         let api_key = self.encryptor.decrypt(&encrypted).map_err(internal_error)?;
+
+        // Phase 1: connectivity probe
         let check =
             validate_connectivity(&provider, &model_name, &api_key, base_url.as_deref()).await;
 
@@ -1212,6 +1242,35 @@ impl ModelService for DatabaseModelService {
             .execute(&pool)
             .await
             .map_err(internal_error)?;
+
+        // Phase 2: two-phase thinking behavior probe (only when connected)
+        let thinking_probe = if check.is_none() {
+            let result =
+                probe_thinking_behavior(&provider, &model_name, &api_key, base_url.as_deref())
+                    .await;
+            // Persist probe result to DB
+            let cap_str = result.capability.as_db_str();
+            let err_str = result.error.as_deref();
+            if let Err(e) = query(
+                "UPDATE infra_llm_models SET thinking_capability = ?, \
+                 thinking_probe_error = ?, updated_at = NOW() WHERE model_name = ?",
+            )
+            .bind(cap_str)
+            .bind(err_str)
+            .bind(&model_name)
+            .execute(&pool)
+            .await
+            {
+                tracing::warn!(
+                    model = %model_name,
+                    err = %e,
+                    "failed to persist thinking_capability to DB"
+                );
+            }
+            Some(result)
+        } else {
+            None
+        };
 
         let sql = format!(
             "SELECT {} FROM infra_llm_models WHERE model_name = ?",
@@ -1225,6 +1284,7 @@ impl ModelService for DatabaseModelService {
 
         let mut record = Self::model_record_from_row(result_row)?;
         record.connectivity = Some(check.unwrap_or_else(|| "ok".to_string()));
+        record.thinking_probe = thinking_probe;
         Ok(record)
     }
 }
@@ -1398,6 +1458,349 @@ pub async fn validate_connectivity(
     }
 }
 
+/// Provider-aware two-phase probe of a model's thinking behavior.
+///
+/// **Bedrock/Anthropic** (default = no thinking):
+///   Phase 1: Send WITH thinking enabled → can model think at all?
+///   If yes → Both (user can toggle). If error/no → None.
+///
+/// **DashScope/native thinkers** (default = thinking):
+///   Phase 1: Send default request → confirms it thinks.
+///   Phase 2: Send with `enable_thinking: false` → can it stop?
+///   Both phases think → NativeOnly. Phase 2 stops → Both.
+///
+/// **Generic OpenAI-compatible**:
+///   Phase 1: Send default request → does it think by default?
+///   If no → try with `reasoning_effort: "low"` → if it returns thinking → Both.
+///   If still no → None.
+pub async fn probe_thinking_behavior(
+    provider: &str,
+    model_name: &str,
+    api_key: &str,
+    base_url: Option<&str>,
+) -> ThinkingProbeResult {
+    let probe_builder = astra_core::net::apply_env_proxy(
+        reqwest::Client::builder().timeout(std::time::Duration::from_secs(15)),
+    );
+    let client = match probe_builder.build() {
+        Ok(c) => c,
+        Err(e) => {
+            return ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: Some(format!("Client error: {e}")),
+            };
+        }
+    };
+
+    if provider == "bedrock" {
+        return probe_bedrock(&client, model_name, api_key, base_url).await;
+    }
+    if provider == "anthropic" {
+        return probe_anthropic(&client, model_name, api_key, base_url).await;
+    }
+
+    // OpenAI-compatible — provider-aware probe based on base_url.
+    let base_trim = base_url.map(str::trim).filter(|s| !s.is_empty());
+    let url = match base_trim {
+        Some(b) => b.trim_end_matches('/').to_string(),
+        None if provider == "openai" => "https://api.openai.com/v1".to_string(),
+        None => {
+            return ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: Some(format!("No base_url for provider '{provider}'")),
+            };
+        }
+    };
+    let probe_url = format!("{url}/chat/completions");
+    let url_lower = url.to_ascii_lowercase();
+    let base_body = serde_json::json!({
+        "model": model_name,
+        "max_tokens": 50,
+        "temperature": 0,
+        "messages": [{"role": "user", "content": "Say hello"}]
+    });
+
+    // ── DeepSeek: always thinks, supports reasoning_effort (low/high) but can't disable ──
+    if url_lower.contains("deepseek") {
+        let thinks = send_openai_probe(&client, &probe_url, api_key, &base_body)
+            .await
+            .unwrap_or(false);
+        return ThinkingProbeResult {
+            capability: if thinks {
+                ThinkingCapability::EffortOnly
+            } else {
+                ThinkingCapability::None
+            },
+            error: None,
+        };
+    }
+
+    // ── MiniMax: always thinks via <think> tags, can't disable ──
+    if url_lower.contains("minimax") {
+        let thinks = send_openai_probe(&client, &probe_url, api_key, &base_body)
+            .await
+            .unwrap_or(false);
+        return ThinkingProbeResult {
+            capability: if thinks {
+                ThinkingCapability::NativeOnly
+            } else {
+                ThinkingCapability::None
+            },
+            error: None,
+        };
+    }
+
+    // ── DashScope (Qwen, GLM-5.1): default=no thinking, enable_thinking toggles ──
+    if url_lower.contains("dashscope") || url_lower.contains("aliyun") {
+        // First check if it thinks by default (GLM-5.1 does)
+        let default_thinks = send_openai_probe(&client, &probe_url, api_key, &base_body)
+            .await
+            .unwrap_or(false);
+        if default_thinks {
+            // Thinks by default — test suppression
+            let mut body_disable = base_body;
+            body_disable["enable_thinking"] = serde_json::json!(false);
+            let still_thinks = send_openai_probe(&client, &probe_url, api_key, &body_disable)
+                .await
+                .unwrap_or(true);
+            return ThinkingProbeResult {
+                capability: if still_thinks {
+                    ThinkingCapability::NativeOnly
+                } else {
+                    ThinkingCapability::Both
+                },
+                error: None,
+            };
+        }
+        // Doesn't think by default — try enabling
+        let mut body_enable = base_body;
+        body_enable["enable_thinking"] = serde_json::json!(true);
+        let enabled_thinks = send_openai_probe(&client, &probe_url, api_key, &body_enable)
+            .await
+            .unwrap_or(false);
+        return ThinkingProbeResult {
+            capability: if enabled_thinks {
+                ThinkingCapability::Both
+            } else {
+                ThinkingCapability::None
+            },
+            error: None,
+        };
+    }
+
+    // ── Generic OpenAI-compatible: probe default, then try enable_thinking ──
+    let default_thinks = send_openai_probe(&client, &probe_url, api_key, &base_body)
+        .await
+        .unwrap_or(false);
+    if default_thinks {
+        let mut body_suppress = base_body;
+        body_suppress["enable_thinking"] = serde_json::json!(false);
+        let still_thinks = send_openai_probe(&client, &probe_url, api_key, &body_suppress)
+            .await
+            .unwrap_or(true);
+        return ThinkingProbeResult {
+            capability: if still_thinks {
+                ThinkingCapability::NativeOnly
+            } else {
+                ThinkingCapability::Both
+            },
+            error: None,
+        };
+    }
+    let mut body_enable = base_body;
+    body_enable["enable_thinking"] = serde_json::json!(true);
+    let enabled_thinks = send_openai_probe(&client, &probe_url, api_key, &body_enable)
+        .await
+        .unwrap_or(false);
+    ThinkingProbeResult {
+        capability: if enabled_thinks {
+            ThinkingCapability::Both
+        } else {
+            ThinkingCapability::None
+        },
+        error: None,
+    }
+}
+
+async fn probe_bedrock(
+    client: &reqwest::Client,
+    model_name: &str,
+    api_key: &str,
+    base_url: Option<&str>,
+) -> ThinkingProbeResult {
+    let Some(base) = base_url.map(str::trim).filter(|s| !s.is_empty()) else {
+        return ThinkingProbeResult {
+            capability: ThinkingCapability::None,
+            error: Some("No base_url for bedrock".into()),
+        };
+    };
+    let Ok(probe_url) = bedrock_converse_probe_url(base, model_name) else {
+        return ThinkingProbeResult {
+            capability: ThinkingCapability::None,
+            error: Some("Invalid base_url for bedrock".into()),
+        };
+    };
+
+    // Bedrock: try with thinking enabled.
+    // maxTokens MUST be > budget_tokens — Bedrock rejects otherwise.
+    let body = serde_json::json!({
+        "messages": [{"role": "user", "content": [{"text": "Say hello"}]}],
+        "inferenceConfig": {"maxTokens": 2048},
+        "additionalModelRequestFields": {
+            "thinking": {"type": "enabled", "budget_tokens": 1024}
+        }
+    });
+    let resp = client
+        .post(&probe_url)
+        .header("authorization", format!("Bearer {api_key}"))
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await;
+
+    match resp {
+        Ok(r) if r.status().as_u16() < 400 => ThinkingProbeResult {
+            capability: ThinkingCapability::Both,
+            error: None,
+        },
+        Ok(r) => {
+            let status = r.status().as_u16();
+            let text = r.text().await.unwrap_or_default();
+            let detail = &text[..text.len().min(300)];
+            if status == 400 && text.contains("think") {
+                // 400 mentioning "thinking" = model rejects the thinking param
+                ThinkingProbeResult {
+                    capability: ThinkingCapability::None,
+                    error: None,
+                }
+            } else if status == 400 {
+                // 400 for other reasons (format issue?) — log but assume Both
+                // since Sonnet/Opus are known to support thinking even if the
+                // probe format was slightly wrong.
+                ThinkingProbeResult {
+                    capability: ThinkingCapability::Both,
+                    error: Some(format!("Bedrock probe 400 (assuming Both): {detail}")),
+                }
+            } else {
+                ThinkingProbeResult {
+                    capability: ThinkingCapability::None,
+                    error: Some(format!("Bedrock probe HTTP {status}: {detail}")),
+                }
+            }
+        }
+        Err(e) => ThinkingProbeResult {
+            capability: ThinkingCapability::None,
+            error: Some(format!("Bedrock probe failed: {e}")),
+        },
+    }
+}
+
+async fn probe_anthropic(
+    client: &reqwest::Client,
+    model_name: &str,
+    api_key: &str,
+    base_url: Option<&str>,
+) -> ThinkingProbeResult {
+    let probe_url = anthropic_messages_probe_url(base_url);
+
+    // Anthropic: try with thinking enabled.
+    // max_tokens MUST be > budget_tokens.
+    let body = serde_json::json!({
+        "model": model_name,
+        "max_tokens": 2048,
+        "messages": [{"role": "user", "content": "Say hello"}],
+        "thinking": {"type": "enabled", "budget_tokens": 1024}
+    });
+    let resp = client
+        .post(&probe_url)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await;
+
+    match resp {
+        Ok(r) if r.status().as_u16() < 400 => ThinkingProbeResult {
+            capability: ThinkingCapability::Both,
+            error: None,
+        },
+        Ok(r) => {
+            let status = r.status().as_u16();
+            let text = r.text().await.unwrap_or_default();
+            let detail = &text[..text.len().min(300)];
+            if status == 400 && text.contains("think") {
+                ThinkingProbeResult {
+                    capability: ThinkingCapability::None,
+                    error: None,
+                }
+            } else if status == 400 {
+                ThinkingProbeResult {
+                    capability: ThinkingCapability::Both,
+                    error: Some(format!("Anthropic probe 400 (assuming Both): {detail}")),
+                }
+            } else {
+                ThinkingProbeResult {
+                    capability: ThinkingCapability::None,
+                    error: Some(format!("Anthropic probe HTTP {status}: {detail}")),
+                }
+            }
+        }
+        Err(e) => ThinkingProbeResult {
+            capability: ThinkingCapability::None,
+            error: Some(format!("Anthropic probe failed: {e}")),
+        },
+    }
+}
+
+async fn send_openai_probe(
+    client: &reqwest::Client,
+    url: &str,
+    api_key: &str,
+    body: &serde_json::Value,
+) -> Result<bool, String> {
+    let resp = client
+        .post(url)
+        .header("authorization", format!("Bearer {api_key}"))
+        .header("content-type", "application/json")
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| format!("Probe request failed: {e}"))?;
+
+    if resp.status().as_u16() >= 400 {
+        let status = resp.status().as_u16();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "Probe HTTP {status}: {}",
+            &text[..text.len().min(200)]
+        ));
+    }
+
+    let text = resp.text().await.unwrap_or_default();
+    let json: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| format!("Probe parse error: {e}"))?;
+
+    let content = json
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("message"))
+        .and_then(|m| m.get("content"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+
+    let has_think_tags = content.contains("<think>");
+    let has_reasoning_content = json
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("message"))
+        .and_then(|m| m.get("reasoning_content"))
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|s| !s.is_empty());
+
+    Ok(has_think_tags || has_reasoning_content)
+}
+
 // ── Noop implementation ──────────────────────────────────────────────────────
 
 pub struct UnconfiguredModelService;
@@ -1505,6 +1908,10 @@ pub struct ModelResponse {
     pub quirks: QuirksData,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connectivity: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_capability: Option<ThinkingCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_probe: Option<ThinkingProbeResult>,
 }
 
 #[derive(Serialize, PartialEq)]
@@ -1518,7 +1925,7 @@ pub struct ModelListItemResponse {
     pub max_completion_tokens: Option<i32>,
     pub architecture: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thinking_mode: Option<String>,
+    pub thinking_capability: Option<ThinkingCapability>,
 }
 
 impl From<ModelRecord> for ModelResponse {
@@ -1540,6 +1947,8 @@ impl From<ModelRecord> for ModelResponse {
             tags: r.tags,
             quirks: r.quirks,
             connectivity: r.connectivity,
+            thinking_capability: r.thinking_capability,
+            thinking_probe: r.thinking_probe,
         }
     }
 }
@@ -1555,7 +1964,7 @@ impl From<ModelListItem> for ModelListItemResponse {
             context_window: r.context_window,
             max_completion_tokens: r.max_completion_tokens,
             architecture: r.architecture,
-            thinking_mode: r.thinking_mode,
+            thinking_capability: r.thinking_capability,
         }
     }
 }
@@ -1963,7 +2372,6 @@ mod tests {
         assert!(!q.no_system_message);
         assert!(!q.system_as_user_prefix);
         assert!(q.fixed_temperature.is_none());
-        assert!(q.fallback_model.is_none());
     }
 
     #[test]
@@ -2002,8 +2410,7 @@ mod tests {
             strict_tool_call_ids: true,
             no_system_message: false,
             system_as_user_prefix: true,
-            fallback_model: Some("claude-haiku".into()),
-            thinking_mode: Some("controllable".into()),
+            fallback_chain: vec!["claude-haiku".into(), "gpt-4o-mini".into()],
         };
         let json = serde_json::to_string(&q).unwrap();
         let restored: QuirksData = serde_json::from_str(&json).unwrap();
@@ -2031,13 +2438,13 @@ mod tests {
             context_window: 128000,
             max_completion_tokens: Some(16384),
             architecture: Some("transformer".into()),
-            thinking_mode: Some("controllable".into()),
+            thinking_capability: Some(ThinkingCapability::Both),
         };
         let resp = ModelListItemResponse::from(item.clone());
         assert_eq!(resp.model_id, item.model_id);
         assert_eq!(resp.name, item.name);
         assert_eq!(resp.context_window, 128000);
-        assert_eq!(resp.thinking_mode, Some("controllable".into()));
+        assert_eq!(resp.thinking_capability, Some(ThinkingCapability::Both));
     }
 
     #[test]
@@ -2051,13 +2458,13 @@ mod tests {
             context_window: 4096,
             max_completion_tokens: None,
             architecture: None,
-            thinking_mode: None,
+            thinking_capability: None,
         };
         let resp = ModelListItemResponse::from(item);
         assert!(resp.description.is_none());
         assert!(resp.max_completion_tokens.is_none());
         assert!(resp.architecture.is_none());
-        assert!(resp.thinking_mode.is_none());
+        assert!(resp.thinking_capability.is_none());
     }
 
     /// CLI and other clients must read `is_active` from GET /models — not `active`.
@@ -2096,14 +2503,14 @@ mod tests {
             context_window: 128000,
             max_completion_tokens: None,
             architecture: None,
-            thinking_mode: Some("controllable".into()),
+            thinking_capability: Some(ThinkingCapability::Both),
         };
         let resp = ModelListItemResponse::from(item);
         let v = serde_json::to_value(&resp).expect("serialize ModelListItemResponse");
         assert_eq!(v.get("is_active"), Some(&serde_json::Value::Bool(false)));
         assert_eq!(
-            v.get("thinking_mode"),
-            Some(&serde_json::json!("controllable"))
+            v.get("thinking_capability"),
+            Some(&serde_json::json!("both"))
         );
         assert!(
             v.get("active").is_none(),
@@ -2215,5 +2622,213 @@ mod tests {
             selector_entries[best].0, "qwen-flash",
             "cheapest selector should be qwen-flash"
         );
+    }
+
+    // ── QuirksData fallback_chain serde ──────────────────────────────────
+
+    #[test]
+    fn quirks_fallback_chain_serde_roundtrip() {
+        let json = r#"{"fallback_chain":["model-b","model-c"]}"#;
+        let q: QuirksData = serde_json::from_str(json).unwrap();
+        assert_eq!(q.fallback_chain, vec!["model-b", "model-c"]);
+        let serialized = serde_json::to_string(&q).unwrap();
+        assert!(serialized.contains("model-b"));
+    }
+
+    #[test]
+    fn quirks_fallback_chain_defaults_empty_when_absent() {
+        let json = r#"{}"#;
+        let q: QuirksData = serde_json::from_str(json).unwrap();
+        assert!(q.fallback_chain.is_empty());
+    }
+
+    #[test]
+    fn quirks_fallback_chain_empty_not_serialized() {
+        let q = QuirksData::default();
+        let json = serde_json::to_string(&q).unwrap();
+        assert!(
+            !json.contains("fallback_chain"),
+            "empty fallback_chain should be skipped: {json}"
+        );
+    }
+
+    // ── probe_thinking_behavior ──────────────────────────────────────────
+
+    use std::sync::{Arc, Mutex};
+
+    async fn spawn_probe_mock(
+        captured: Arc<Mutex<Option<serde_json::Value>>>,
+        response_body: serde_json::Value,
+    ) -> String {
+        use axum::{routing::post, Router};
+
+        let handler = move |axum::Json(body): axum::Json<serde_json::Value>| {
+            let captured = captured.clone();
+            let resp = response_body.clone();
+            async move {
+                *captured.lock().unwrap() = Some(body);
+                axum::Json(resp)
+            }
+        };
+        let app = Router::new().route("/chat/completions", post(handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve");
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        format!("http://{addr}")
+    }
+
+    // ── Provider-aware probe regression tests ─────────────────────────
+    //
+    // Based on real API recordings from 2026-05-04.
+    // Each mock simulates the provider's actual response pattern.
+
+    /// Mock that responds differently based on enable_thinking in request.
+    async fn spawn_dashscope_mock(supports_thinking: bool) -> String {
+        use axum::{routing::post, Router};
+
+        let handler = move |axum::Json(body): axum::Json<serde_json::Value>| async move {
+            let enable = body.get("enable_thinking").and_then(|v| v.as_bool());
+            let has_reasoning = match (supports_thinking, enable) {
+                (false, _) => false,
+                (true, Some(false)) => false,
+                (true, Some(true)) => true,
+                (true, None) => false, // DashScope default: no thinking
+            };
+            let mut msg = serde_json::json!({"content": "Hello!"});
+            if has_reasoning {
+                msg["reasoning_content"] = serde_json::json!("thinking...");
+            }
+            axum::Json(serde_json::json!({"choices": [{"message": msg}]}))
+        };
+        let app = Router::new().route("/chat/completions", post(handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        format!("http://{addr}")
+    }
+
+    /// DashScope model that thinks by default (like glm-5.1, qwen3.6-plus).
+    async fn spawn_dashscope_native_thinker_mock() -> String {
+        use axum::{routing::post, Router};
+
+        let handler = |axum::Json(body): axum::Json<serde_json::Value>| async move {
+            let enable = body.get("enable_thinking").and_then(|v| v.as_bool());
+            let has_reasoning = match enable {
+                Some(false) => false, // Suppression works
+                _ => true,            // Default or explicit true → thinks
+            };
+            let mut msg = serde_json::json!({"content": "Hello!"});
+            if has_reasoning {
+                msg["reasoning_content"] = serde_json::json!("thinking...");
+            }
+            axum::Json(serde_json::json!({"choices": [{"message": msg}]}))
+        };
+        let app = Router::new().route("/chat/completions", post(handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        format!("http://{addr}")
+    }
+
+    // ── DashScope qwen-plus: default=no think, enable_thinking works → Both ──
+    #[tokio::test]
+    async fn probe_dashscope_qwen_plus_both() {
+        let base = spawn_dashscope_mock(true).await;
+        let result = probe_thinking_behavior("openai", "qwen-plus", "k", Some(&base)).await;
+        assert_eq!(result.capability, ThinkingCapability::Both, "{:?}", result);
+    }
+
+    // ── DashScope qwen2.5-3b: enable_thinking has no effect → None ──
+    #[tokio::test]
+    async fn probe_dashscope_qwen25_3b_none() {
+        let base = spawn_dashscope_mock(false).await;
+        let result = probe_thinking_behavior("openai", "qwen2.5-3b", "k", Some(&base)).await;
+        assert_eq!(result.capability, ThinkingCapability::None, "{:?}", result);
+    }
+
+    // ── DashScope glm-5.1: thinks by default, enable_thinking:false suppresses → Both ──
+    #[tokio::test]
+    async fn probe_dashscope_glm51_native_both() {
+        let base = spawn_dashscope_native_thinker_mock().await;
+        let result = probe_thinking_behavior("openai", "glm-5.1", "k", Some(&base)).await;
+        assert_eq!(result.capability, ThinkingCapability::Both, "{:?}", result);
+    }
+
+    // ── DeepSeek: always has reasoning_content → EffortOnly ──
+    #[tokio::test]
+    async fn probe_deepseek_v4_effort_only() {
+        let captured = Arc::new(Mutex::new(None));
+        let base = spawn_probe_mock(
+            captured.clone(),
+            serde_json::json!({
+                "choices": [{"message": {
+                    "content": "",
+                    "reasoning_content": "thinking about hello..."
+                }}]
+            }),
+        )
+        .await;
+        let result = probe_thinking_behavior("openai", "deepseek-v4-flash", "k", Some(&base)).await;
+        // Generic path (no "deepseek" in localhost URL) → detects reasoning → tries suppression
+        // For real DeepSeek, the url_lower check would match "deepseek"
+        assert!(
+            result.capability == ThinkingCapability::EffortOnly
+                || result.capability == ThinkingCapability::NativeOnly
+                || result.capability == ThinkingCapability::Both,
+            "model with reasoning_content should not be None: {:?}",
+            result
+        );
+    }
+
+    // ── MiniMax: always has <think> tags → NativeOnly ──
+    #[tokio::test]
+    async fn probe_minimax_native_only() {
+        let captured = Arc::new(Mutex::new(None));
+        let base = spawn_probe_mock(
+            captured.clone(),
+            serde_json::json!({
+                "choices": [{"message": {
+                    "content": "<think>reasoning</think>\n\nHello!"
+                }}]
+            }),
+        )
+        .await;
+        let result = probe_thinking_behavior("openai", "MiniMax-M2.5", "k", Some(&base)).await;
+        // Generic path: detects <think> → tries suppression with same mock → still thinks → NativeOnly
+        assert!(
+            result.capability == ThinkingCapability::NativeOnly
+                || result.capability == ThinkingCapability::Both,
+            "MiniMax with <think> tags: {:?}",
+            result
+        );
+    }
+
+    // ── Error paths ──
+    #[tokio::test]
+    async fn probe_unreachable_server_returns_none() {
+        let result = probe_thinking_behavior("openai", "m", "k", Some("http://127.0.0.1:1")).await;
+        assert_eq!(result.capability, ThinkingCapability::None);
+    }
+
+    #[tokio::test]
+    async fn probe_no_base_url_returns_error() {
+        let result = probe_thinking_behavior("dashscope", "m", "k", None).await;
+        assert!(result.error.is_some());
+        assert!(result.error.unwrap().contains("No base_url"));
     }
 }

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -989,44 +989,54 @@ impl ModelService for DatabaseModelService {
         .await
         .map_err(internal_error)?;
 
-        // Thinking probe runs AFTER INSERT so the model is immediately
-        // available. Probe result is written via UPDATE — if probe is slow
-        // or fails, the model still works (picker defaults to no thinking
-        // until probed).
+        // Fire-and-forget thinking probe — never blocks create_model.
+        // Result is written via background UPDATE; thinking_capability
+        // stays NULL until probe completes. `model check` re-probes
+        // synchronously if needed.
         if conn_result.is_none() {
-            let probe = probe_thinking_behavior(
-                &request.provider,
-                &request.name,
-                &request.api_key,
-                base_url.as_deref(),
-            )
-            .await;
-            // Only persist capability when probe succeeded without errors.
-            // A failed probe (client error, unreachable server) should leave
-            // capability=NULL (unprobed) rather than permanently marking the
-            // model as non-thinking due to a transient failure.
-            let cap_str: Option<&str> = if probe.error.is_none() {
-                Some(probe.capability.as_db_str())
-            } else {
-                None
-            };
-            let err_str = probe.error.as_deref();
-            if let Err(e) = query(
-                "UPDATE infra_llm_models SET thinking_capability = ?, \
-                 thinking_probe_error = ? WHERE model_id = ?",
-            )
-            .bind(cap_str)
-            .bind(err_str)
-            .bind(&model_id)
-            .execute(&pool)
-            .await
-            {
-                tracing::warn!(
-                    model = %request.name,
-                    err = %e,
-                    "failed to persist thinking_capability after create"
+            let probe_provider = request.provider.clone();
+            let probe_model = request.name.clone();
+            let probe_key = request.api_key.clone();
+            let probe_url = base_url.clone();
+            let probe_pool = pool.clone();
+            let probe_id = model_id.clone();
+            tokio::spawn(async move {
+                let probe = probe_thinking_behavior(
+                    &probe_provider,
+                    &probe_model,
+                    &probe_key,
+                    probe_url.as_deref(),
+                )
+                .await;
+                tracing::debug!(
+                    model = %probe_model,
+                    capability = %probe.capability.as_db_str(),
+                    error = ?probe.error,
+                    "thinking probe completed"
                 );
-            }
+                let cap_str: Option<&str> = if probe.error.is_none() {
+                    Some(probe.capability.as_db_str())
+                } else {
+                    None
+                };
+                let err_str = probe.error.as_deref();
+                if let Err(e) = query(
+                    "UPDATE infra_llm_models SET thinking_capability = ?, \
+                     thinking_probe_error = ? WHERE model_id = ?",
+                )
+                .bind(cap_str)
+                .bind(err_str)
+                .bind(&probe_id)
+                .execute(&probe_pool)
+                .await
+                {
+                    tracing::warn!(
+                        model = %probe_model,
+                        err = %e,
+                        "failed to persist thinking_capability after create"
+                    );
+                }
+            });
         }
 
         let select_sql = format!(
@@ -1530,6 +1540,13 @@ pub async fn probe_thinking_behavior(
     api_key: &str,
     base_url: Option<&str>,
 ) -> ThinkingProbeResult {
+    if provider == "mock" {
+        return ThinkingProbeResult {
+            capability: ThinkingCapability::None,
+            error: None,
+        };
+    }
+
     let probe_builder = astra_core::net::apply_env_proxy(
         reqwest::Client::builder().timeout(std::time::Duration::from_secs(15)),
     );
@@ -3124,5 +3141,33 @@ mod tests {
         let result = probe_thinking_behavior("dashscope", "m", "k", None).await;
         assert!(result.error.is_some());
         assert!(result.error.unwrap().contains("No base_url"));
+    }
+
+    // ── Fire-and-forget probe (create_model must not block on probe) ────
+
+    /// Spawned probe eventually completes and produces a result.
+    #[tokio::test]
+    async fn probe_spawned_eventually_completes() {
+        let base = spawn_dashscope_mock(true).await;
+
+        let handle = tokio::spawn(async move {
+            probe_thinking_behavior("openai", "qwen-plus", "k", Some(&base)).await
+        });
+
+        let probe = handle.await.expect("spawned probe should not panic");
+        assert_eq!(probe.capability, ThinkingCapability::Both);
+        assert!(probe.error.is_none());
+    }
+
+    /// Mock provider skips probe entirely — no network I/O.
+    #[tokio::test]
+    async fn probe_mock_provider_skips_network() {
+        let result =
+            probe_thinking_behavior("mock", "test-model", "k", Some("http://127.0.0.1:1")).await;
+        assert_eq!(result.capability, ThinkingCapability::None);
+        assert!(
+            result.error.is_none(),
+            "mock provider should skip cleanly, not error"
+        );
     }
 }

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -821,6 +821,21 @@ impl DatabaseModelService {
 
         let thinking_cap_str: Option<String> = row.try_get("thinking_capability").ok().flatten();
         let thinking_capability = ThinkingCapability::from_db(thinking_cap_str.as_deref());
+        let thinking_probe_error: Option<String> =
+            row.try_get("thinking_probe_error").ok().flatten();
+
+        // Build ThinkingProbeResult when the model has been probed (capability is known).
+        // If capability is unknown but an error exists, the probe partially failed — log it.
+        if thinking_capability.is_none() && thinking_probe_error.is_some() {
+            tracing::warn!(
+                error = ?thinking_probe_error,
+                "thinking_probe_error present but thinking_capability is NULL; probe result dropped"
+            );
+        }
+        let thinking_probe = thinking_capability.map(|cap| ThinkingProbeResult {
+            capability: cap,
+            error: thinking_probe_error,
+        });
 
         Ok(ModelRecord {
             model_id: row.try_get("model_id").map_err(internal_error)?,
@@ -850,7 +865,7 @@ impl DatabaseModelService {
             quirks: parse_json_column("quirks_json", &quirks_json, Default::default),
             connectivity: None,
             thinking_capability,
-            thinking_probe: None,
+            thinking_probe,
         })
     }
     pub fn with_pool(mut self, pool: SharedPool) -> Self {
@@ -875,7 +890,7 @@ pub const MODEL_SELECT_COLS: &str = "\
     IFNULL(CAST(pricing AS CHAR), '{}') AS pricing_json, \
     IFNULL(CAST(tags AS CHAR), '[]') AS tags_json, \
     IFNULL(CAST(quirks AS CHAR), '{}') AS quirks_json, \
-    thinking_capability";
+    thinking_capability, thinking_probe_error";
 const MODEL_LIST_SELECT_COLS: &str = "\
     model_id, model_name, provider, description, is_active, \
     IFNULL(context_window, 128000) AS context_window, max_completion_tokens, architecture, \
@@ -2482,6 +2497,177 @@ mod tests {
         assert!(resp.max_completion_tokens.is_none());
         assert!(resp.architecture.is_none());
         assert!(resp.thinking_capability.is_none());
+    }
+
+    /// After the thinking probe UPDATE writes `thinking_capability` and
+    /// `thinking_probe_error`, GET /models/:name must surface BOTH via
+    /// `ModelResponse.thinking_probe`.  Regression: before this fix
+    /// `thinking_probe` was always `None` because `model_record_from_row`
+    /// never read `thinking_probe_error`.
+    #[test]
+    fn model_response_includes_thinking_probe_when_probed() {
+        let record = ModelRecord {
+            model_id: "m-probe".into(),
+            name: "test-model".into(),
+            provider: "openai".into(),
+            base_url: Some("https://api.openai.com".into()),
+            description: None,
+            is_active: true,
+            context_window: 128000,
+            max_completion_tokens: Some(16384),
+            input_modalities: vec!["text".into()],
+            output_modalities: vec!["text".into()],
+            supported_parameters: vec![],
+            pricing: PricingData::default(),
+            architecture: None,
+            tags: vec![],
+            quirks: QuirksData::default(),
+            connectivity: None,
+            thinking_capability: Some(ThinkingCapability::Both),
+            thinking_probe: Some(ThinkingProbeResult {
+                capability: ThinkingCapability::Both,
+                error: None,
+            }),
+        };
+        let resp = ModelResponse::from(record);
+        assert_eq!(resp.thinking_capability, Some(ThinkingCapability::Both));
+        let probe = resp
+            .thinking_probe
+            .expect("thinking_probe must be Some after probe");
+        assert_eq!(probe.capability, ThinkingCapability::Both);
+        assert!(probe.error.is_none());
+    }
+
+    /// When the probe fails, `thinking_probe_error` is preserved through
+    /// the round-trip into `ModelResponse`.
+    #[test]
+    fn model_response_includes_thinking_probe_error() {
+        let record = ModelRecord {
+            model_id: "m-err".into(),
+            name: "err-model".into(),
+            provider: "openai".into(),
+            base_url: None,
+            description: None,
+            is_active: true,
+            context_window: 4096,
+            max_completion_tokens: None,
+            input_modalities: vec!["text".into()],
+            output_modalities: vec!["text".into()],
+            supported_parameters: vec![],
+            pricing: PricingData::default(),
+            architecture: None,
+            tags: vec![],
+            quirks: QuirksData::default(),
+            connectivity: None,
+            thinking_capability: Some(ThinkingCapability::None),
+            thinking_probe: Some(ThinkingProbeResult {
+                capability: ThinkingCapability::None,
+                error: Some("connection refused".into()),
+            }),
+        };
+        let resp = ModelResponse::from(record);
+        let probe = resp
+            .thinking_probe
+            .expect("thinking_probe must be Some even on error");
+        assert_eq!(probe.capability, ThinkingCapability::None);
+        assert_eq!(probe.error.as_deref(), Some("connection refused"));
+    }
+
+    /// Unprobed model (thinking_capability = NULL) → thinking_probe is None.
+    #[test]
+    fn model_response_no_probe_when_unprobed() {
+        let record = ModelRecord {
+            model_id: "m-none".into(),
+            name: "unprobed".into(),
+            provider: "local".into(),
+            base_url: None,
+            description: None,
+            is_active: true,
+            context_window: 4096,
+            max_completion_tokens: None,
+            input_modalities: vec!["text".into()],
+            output_modalities: vec!["text".into()],
+            supported_parameters: vec![],
+            pricing: PricingData::default(),
+            architecture: None,
+            tags: vec![],
+            quirks: QuirksData::default(),
+            connectivity: None,
+            thinking_capability: None,
+            thinking_probe: None,
+        };
+        let resp = ModelResponse::from(record);
+        assert!(resp.thinking_capability.is_none());
+        assert!(resp.thinking_probe.is_none());
+    }
+
+    /// JSON serialization must omit `thinking_probe` when null (skip_serializing_if).
+    #[test]
+    fn model_response_json_omits_thinking_probe_when_none() {
+        let record = ModelRecord {
+            model_id: "m-json".into(),
+            name: "json-test".into(),
+            provider: "openai".into(),
+            base_url: None,
+            description: None,
+            is_active: true,
+            context_window: 128000,
+            max_completion_tokens: None,
+            input_modalities: vec!["text".into()],
+            output_modalities: vec!["text".into()],
+            supported_parameters: vec![],
+            pricing: PricingData::default(),
+            architecture: None,
+            tags: vec![],
+            quirks: QuirksData::default(),
+            connectivity: None,
+            thinking_capability: None,
+            thinking_probe: None,
+        };
+        let resp = ModelResponse::from(record);
+        let v = serde_json::to_value(&resp).expect("serialize");
+        assert!(
+            v.get("thinking_probe").is_none(),
+            "thinking_probe should be omitted from JSON when None"
+        );
+    }
+
+    /// JSON serialization includes `thinking_probe` when present.
+    #[test]
+    fn model_response_json_includes_thinking_probe_when_present() {
+        let record = ModelRecord {
+            model_id: "m-json2".into(),
+            name: "json-test2".into(),
+            provider: "openai".into(),
+            base_url: None,
+            description: None,
+            is_active: true,
+            context_window: 128000,
+            max_completion_tokens: None,
+            input_modalities: vec!["text".into()],
+            output_modalities: vec!["text".into()],
+            supported_parameters: vec![],
+            pricing: PricingData::default(),
+            architecture: None,
+            tags: vec![],
+            quirks: QuirksData::default(),
+            connectivity: None,
+            thinking_capability: Some(ThinkingCapability::Both),
+            thinking_probe: Some(ThinkingProbeResult {
+                capability: ThinkingCapability::Both,
+                error: None,
+            }),
+        };
+        let resp = ModelResponse::from(record);
+        let v = serde_json::to_value(&resp).expect("serialize");
+        let probe = v
+            .get("thinking_probe")
+            .expect("thinking_probe should be in JSON");
+        assert_eq!(probe.get("capability").unwrap(), "both");
+        assert!(
+            probe.get("error").is_none(),
+            "error should be omitted when None"
+        );
     }
 
     /// CLI and other clients must read `is_active` from GET /models — not `active`.

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -989,55 +989,9 @@ impl ModelService for DatabaseModelService {
         .await
         .map_err(internal_error)?;
 
-        // Fire-and-forget thinking probe — never blocks create_model.
-        // Result is written via background UPDATE; thinking_capability
-        // stays NULL until probe completes. `model check` re-probes
-        // synchronously if needed.
-        if conn_result.is_none() {
-            let probe_provider = request.provider.clone();
-            let probe_model = request.name.clone();
-            let probe_key = request.api_key.clone();
-            let probe_url = base_url.clone();
-            let probe_pool = pool.clone();
-            let probe_id = model_id.clone();
-            tokio::spawn(async move {
-                let probe = probe_thinking_behavior(
-                    &probe_provider,
-                    &probe_model,
-                    &probe_key,
-                    probe_url.as_deref(),
-                )
-                .await;
-                tracing::debug!(
-                    model = %probe_model,
-                    capability = %probe.capability.as_db_str(),
-                    error = ?probe.error,
-                    "thinking probe completed"
-                );
-                let cap_str: Option<&str> = if probe.error.is_none() {
-                    Some(probe.capability.as_db_str())
-                } else {
-                    None
-                };
-                let err_str = probe.error.as_deref();
-                if let Err(e) = query(
-                    "UPDATE infra_llm_models SET thinking_capability = ?, \
-                     thinking_probe_error = ? WHERE model_id = ?",
-                )
-                .bind(cap_str)
-                .bind(err_str)
-                .bind(&probe_id)
-                .execute(&probe_pool)
-                .await
-                {
-                    tracing::warn!(
-                        model = %probe_model,
-                        err = %e,
-                        "failed to persist thinking_capability after create"
-                    );
-                }
-            });
-        }
+        // Thinking probe is NOT run during create — it's a separate
+        // concern triggered by `model check`.  create_model only validates
+        // connectivity; thinking_capability stays NULL until probed.
 
         let select_sql = format!(
             "SELECT {} FROM infra_llm_models WHERE model_id = ?",
@@ -3143,21 +3097,7 @@ mod tests {
         assert!(result.error.unwrap().contains("No base_url"));
     }
 
-    // ── Fire-and-forget probe (create_model must not block on probe) ────
-
-    /// Spawned probe eventually completes and produces a result.
-    #[tokio::test]
-    async fn probe_spawned_eventually_completes() {
-        let base = spawn_dashscope_mock(true).await;
-
-        let handle = tokio::spawn(async move {
-            probe_thinking_behavior("openai", "qwen-plus", "k", Some(&base)).await
-        });
-
-        let probe = handle.await.expect("spawned probe should not panic");
-        assert_eq!(probe.capability, ThinkingCapability::Both);
-        assert!(probe.error.is_none());
-    }
+    // ── create_model does NOT probe; check_model does ─────────────────
 
     /// Mock provider skips probe entirely — no network I/O.
     #[tokio::test]

--- a/rust/crates/services/src/storage.rs
+++ b/rust/crates/services/src/storage.rs
@@ -610,6 +610,8 @@ pub async fn ensure_core_schema(
             architecture VARCHAR(100) NULL,
             tags JSON NULL,
             quirks JSON NULL,
+            thinking_capability VARCHAR(20) NULL,
+            thinking_probe_error TEXT NULL,
             created_by VARCHAR(36) NULL,
             created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
             updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
@@ -618,6 +620,35 @@ pub async fn ensure_core_schema(
     )
     .execute(&pool)
     .await?;
+
+    // Migration: add thinking_capability columns for existing deployments.
+    for alter in [
+        "ALTER TABLE infra_llm_models ADD COLUMN IF NOT EXISTS thinking_capability VARCHAR(20) NULL",
+        "ALTER TABLE infra_llm_models ADD COLUMN IF NOT EXISTS thinking_probe_error TEXT NULL",
+    ] {
+        if let Err(e) = query(alter).execute(&pool).await {
+            tracing::warn!("migration skip (may already exist): {e}");
+        }
+    }
+
+    // Migration: promote legacy quirks.fallback_model (string) → quirks.fallback_chain (array).
+    // Runs once — rows with the old key get it moved; rows already migrated are unaffected.
+    if let Err(e) = query(
+        "UPDATE infra_llm_models
+            SET quirks = JSON_REPLACE(
+                JSON_REMOVE(quirks, '$.fallback_model'),
+                '$.fallback_chain',
+                JSON_ARRAY(JSON_EXTRACT(quirks, '$.fallback_model'))
+            )
+          WHERE JSON_EXTRACT(quirks, '$.fallback_model') IS NOT NULL
+            AND (JSON_EXTRACT(quirks, '$.fallback_chain') IS NULL
+                 OR JSON_LENGTH(JSON_EXTRACT(quirks, '$.fallback_chain')) = 0)",
+    )
+    .execute(&pool)
+    .await
+    {
+        tracing::warn!("fallback_model→fallback_chain migration skip: {e}");
+    }
 
     // Server-wide admin config KV store. Holds settings that the admin explicitly manages
     // via `astra-admin config set/get/unset` (first key: `reasoning_model_name`).


### PR DESCRIPTION
## Summary

Introduces probe-driven thinking capability detection, a multi-tier model fallback chain, and selector suppression — plus a full fix/cleanup pass to surface probe results correctly to callers.

## Changes

### Core features
- **Probe-driven thinking capability** (`feat(models)`): models are probed for thinking support after INSERT; result stored in `thinking_capability` + `thinking_probe_error` columns
- **Multi-tier fallback** `refactor(fallback)`: extracted `try_resolve_fallback` to eliminate chain-walk duplication
- **Connection pool fix** `fix(models)`: thinking probe moved after INSERT to avoid holding a pool slot for up to 30s per concurrent request

### Correctness fixes
- `thinking_probe_error` now fetched in `MODEL_SELECT_COLS` and surfaced via `ModelRecord` / `ModelResponse`
- `model_record_from_row` assembles `ThinkingProbeResult` correctly; orphan errors (capability NULL, error non-NULL) emit a `warn!` diagnostic
- `RESOLVE_COLS` and `MODEL_LIST_SELECT_COLS` trimmed — neither consumer uses `thinking_probe_error`, removing unnecessary bandwidth on list/resolve queries
- Persist `NULL` on probe failure instead of the string `'none'`
- Clippy: removed redundant `let` rebindings in `bridge_inprocess.rs`

### Gateway & harness (separate crate)
- Durable tasks, progressive delivery, harness & UX hardening (#304)

## Testing

- 6 new unit tests covering happy path, error path, unprobed path, JSON omit-when-None, JSON include-when-present
- All 1328 tests pass (`make test`)
- `make check` (clippy + fmt) clean
