### PR TITLE
feat(gateway): epic product experience enhancement — storage abstraction, UX, reliability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
           workspaces: rust
           shared-key: ci-test-${{ github.base_ref || github.ref_name }}
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
       # Compile all test binaries (default + bridge-e2e-hooks) without running
       - name: Compile test binaries
         run: |

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "serde_yaml_ng",
  "sqlx",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tracing",
@@ -3534,6 +3535,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/rust/crates/astra-cli/src/cli/repl_runtime.rs
+++ b/rust/crates/astra-cli/src/cli/repl_runtime.rs
@@ -295,6 +295,14 @@ impl SilentRefreshError {
 /// Clears credentials only when the server definitively rejects auth (after handling
 /// refresh-token rotation races — see `recover_credentials_after_refresh_race`).
 pub(super) async fn try_silent_auth(api: &astra_thin_client::ThinClient, profile: Option<&str>) {
+    // When gateway provides a pre-validated token via env, skip auth entirely —
+    // the gateway owns token lifecycle and the HTTP round-trip is wasteful.
+    if std::env::var("ASTRA_ACCESS_TOKEN")
+        .map(|t| !t.is_empty())
+        .unwrap_or(false)
+    {
+        return;
+    }
     let creds = load_credentials();
     let name = profile_name(profile, &creds);
     let prof = creds.profiles.get(&name);
@@ -975,6 +983,12 @@ fn print_startup_logo() {
 }
 
 pub(super) fn current_access_token(profile: Option<&str>) -> Option<String> {
+    // Gateway injects a pre-validated token — skip file I/O and auth check
+    if let Ok(token) = std::env::var("ASTRA_ACCESS_TOKEN") {
+        if !token.is_empty() {
+            return Some(token);
+        }
+    }
     let creds = load_credentials();
     let name = profile_name(profile, &creds);
     creds
@@ -1776,6 +1790,61 @@ mod tests {
             direct, wrapped,
             "SilentRefreshError::Thin wrapper must defer to \
              should_keep_credentials_on_refresh_error"
+        );
+    }
+
+    // ── ASTRA_ACCESS_TOKEN env var ──────────────────────────────
+
+    #[test]
+    fn current_access_token_prefers_env_var() {
+        let _g = isolate_credentials();
+        let _env = EnvGuard::set("ASTRA_ACCESS_TOKEN", "env-token-xyz");
+        assert_eq!(
+            current_access_token(None),
+            Some("env-token-xyz".to_string()),
+            "should return env var token when ASTRA_ACCESS_TOKEN is set"
+        );
+    }
+
+    #[test]
+    fn current_access_token_ignores_empty_env_var() {
+        let _g = isolate_credentials();
+        let _env = EnvGuard::set("ASTRA_ACCESS_TOKEN", "");
+        // With empty env and no credentials file, should return None
+        assert_eq!(
+            current_access_token(None),
+            None,
+            "empty env var should be ignored"
+        );
+    }
+
+    #[test]
+    fn current_access_token_falls_back_to_file_without_env() {
+        let _g = isolate_credentials();
+        // Make sure ASTRA_ACCESS_TOKEN is not set (empty = ignored)
+        let _env_clear = EnvGuard::set("ASTRA_ACCESS_TOKEN", "");
+        // Write a credentials file to the isolated path
+        let creds = CredentialsFile {
+            current_profile: Some("default".into()),
+            profiles: std::collections::HashMap::from([(
+                "default".to_string(),
+                Profile {
+                    username: Some("user".into()),
+                    access_token: Some("file-token-abc".into()),
+                    refresh_token: None,
+                    ..Default::default()
+                },
+            )]),
+        };
+        let path = crate::cli_utils::credentials_path();
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        std::fs::write(&path, serde_json::to_string(&creds).unwrap()).unwrap();
+        assert_eq!(
+            current_access_token(None),
+            Some("file-token-abc".to_string()),
+            "should fall back to credentials file when env var is empty"
         );
     }
 }

--- a/rust/crates/astra-gateway/Cargo.toml
+++ b/rust/crates/astra-gateway/Cargo.toml
@@ -22,8 +22,9 @@ tracing-subscriber.workspace = true
 uuid.workspace = true
 clap.workspace = true
 chrono.workspace = true
-sqlx.workspace = true
+sqlx = { workspace = true, features = ["sqlite"] }
 astra-core.workspace = true
+thiserror.workspace = true
 base64.workspace = true
 regex.workspace = true
 aes = "0.8"

--- a/rust/crates/astra-gateway/README.md
+++ b/rust/crates/astra-gateway/README.md
@@ -49,7 +49,8 @@ cp gateway.example.yaml gateway.yaml
 astra:
   base_url: "http://127.0.0.1:8000"      # astra server
 
-database:
+storage:
+  backend: mysql                         # required for durable gateway mode
   url: "mysql://root:111@127.0.0.1:6001/astra_gateway"
 
 cli:                                       # default CLI
@@ -166,7 +167,18 @@ Slash commands respond instantly while regular chat requests are serialized per 
 Different conversations run concurrently up to `max_concurrent_runs`; final responses are written
 to the durable outbox before platform delivery is acknowledged.
 
-## Database
+## Storage
+
+Durable gateway mode requires MySQL / MatrixOne storage. The gateway uses the
+same MySQL pool for user/session state, durable tasks, trace events, and the
+delivery outbox. Configure it explicitly with `storage.backend: mysql` or set a
+non-empty `GATEWAY_DATABASE_URL`.
+
+`database:` is no longer promoted automatically; use `storage:` instead. If no
+storage is configured, the gateway starts in explicit no-persistence mode and
+storage-dependent commands are disabled. SQLite and file stores remain local
+store implementations for tests/tools, but they are rejected by the gateway
+runner because they do not provide durable tasks, trace, or outbox recovery.
 
 Auto-created on first run. Tables:
 

--- a/rust/crates/astra-gateway/gateway.example.yaml
+++ b/rust/crates/astra-gateway/gateway.example.yaml
@@ -10,15 +10,16 @@
 # 环境变量覆盖:
 #   WECOM_BOT_ID, WECOM_SECRET — 企微凭证
 #   WEIXIN_TOKEN, WEIXIN_ACCOUNT_ID — 微信凭证
-#   GATEWAY_DATABASE_URL — 数据库连接
+#   GATEWAY_DATABASE_URL — MySQL / MatrixOne storage URL
 
 astra:
   base_url: "http://localhost:8080"    # Astra server 地址
   api_key: ""                          # Astra API key (如开启认证)
   default_model: "MiniMax-M2.7"       # 默认模型
 
-database:
-  url: "mysql://root:111@127.0.0.1:6001/astra_gateway"  # Gateway 独立数据库
+storage:
+  backend: mysql
+  url: "mysql://root:111@127.0.0.1:6001/astra_gateway"  # Gateway durable storage
 
 # 全局并发上限；同一会话仍会按顺序串行执行，避免 session race
 max_concurrent_runs: 4

--- a/rust/crates/astra-gateway/skills/gateway.md
+++ b/rust/crates/astra-gateway/skills/gateway.md
@@ -98,3 +98,17 @@ Switch: `[[GATEWAY:workspace_set:<path>]]`
 - Save reusable skill: `[[GATEWAY:skill_add:<name>:<markdown>]]` — only for non-trivial procedures
 - Mobile platform — keep responses concise. Respond in user's language (Chinese primary).
 - You CAN set reminders/schedules via gateway actions. No raw JSON/code unless asked.
+
+### Operator Note
+
+Gateway durable mode requires explicit MySQL storage:
+
+```yaml
+storage:
+  backend: mysql
+  url: "mysql://root:pwd@host:6001/astra_gateway"
+```
+
+Do not use legacy `database:` for new configs. Without MySQL storage, trace,
+durable tasks, outbox retry/recovery, cron persistence, sessions, and user
+preferences are unavailable.

--- a/rust/crates/astra-gateway/skills/gateway.md
+++ b/rust/crates/astra-gateway/skills/gateway.md
@@ -9,7 +9,8 @@ Model: `{{model}}`
 
 - `/new` — new conversation  `/status` — status + model  `/help` — all commands
 - `/model <name>` — switch model (haiku/sonnet/opus/minimax/deepseek/qwen/glm)
-- `/cli` — show/switch CLI backend
+- `/cli` — show/switch CLI backend  `/gateway` — full capability overview
+- `/ws ls` — list projects  `/ws <name>` — switch workspace
 {{#if has_session}}
 - `/session list` — history  `/session switch <id>` — resume
 {{/if}}

--- a/rust/crates/astra-gateway/skills/gateway.md
+++ b/rust/crates/astra-gateway/skills/gateway.md
@@ -11,6 +11,8 @@ Model: `{{model}}`
 - `/model <name>` — switch model (haiku/sonnet/opus/minimax/deepseek/qwen/glm)
 - `/cli` — show/switch CLI backend  `/gateway` — full capability overview
 - `/ws ls` — list projects  `/ws <name>` — switch workspace
+- `/running` — active tasks (numbered)  `/kill N` — kill by number  `/cancel N` — cancel by number
+- `/manage [hint]` — AI-assisted task management
 {{#if has_session}}
 - `/session list` — history  `/session switch <id>` — resume
 {{/if}}
@@ -26,6 +28,8 @@ Embed `[[GATEWAY:...]]` tags in your response. The gateway intercepts and execut
 | One-time reminder | `[[GATEWAY:remind_after:<minutes>:<msg>]]` | X分钟/小时后 |
 | List tasks | `[[GATEWAY:task_list]]` | |
 | Delete task | `[[GATEWAY:task_del:<job_id>]]` | prefix match OK |
+| Kill request | `[[GATEWAY:trace_kill:<trace_id>]]` | force-fail running/queued |
+| Dismiss outbox | `[[GATEWAY:outbox_dismiss:<request_id>]]` | clear failed delivery |
 
 Embed tags directly — never tell user to type commands. "取消所有": list first, then delete each.
 {{#if cron_jobs_count}}

--- a/rust/crates/astra-gateway/src/cli_bridge.rs
+++ b/rust/crates/astra-gateway/src/cli_bridge.rs
@@ -815,19 +815,37 @@ pub fn onboarding_message(profile: &CliProfile, availability: &CliAvailability) 
     }
 }
 
+/// Check whether stderr output indicates an authentication / credentials failure.
+pub fn is_auth_error(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("could not validate credentials")
+        || lower.contains("invalid_api_key")
+        || lower.contains("invalid api key")
+        || lower.contains("401 unauthorized")
+        || lower.contains("authentication failed")
+        || lower.contains("token expired")
+        || lower.contains("token has expired")
+        // Match bare "401" only when it looks like an HTTP status, not a random number.
+        // We check for "401" preceded by a space, start-of-line, or common prefix.
+        || lower.contains("status: 401")
+        || lower.contains("http 401")
+        || lower.contains("error 401")
+}
+
+/// Invalidate the CLI probe cache so the next `probe_cli` call re-checks.
+pub fn invalidate_probe_cache() {
+    CLI_PROBE_CACHE.clear();
+}
+
 pub fn translate_cli_error(profile: &CliProfile, exit_code: i32, stderr: &str) -> String {
     let name = profile.name();
-    if stderr.contains("could not validate credentials")
-        || stderr.contains("Could not validate credentials")
-        || stderr.contains("invalid_api_key")
-        || stderr.contains("401")
-    {
+    if is_auth_error(stderr) {
         return format!(
-            "🔑 `{name}` API 密钥无效或过期\n\n\
-             请检查对应的环境变量或配置:\n\
-             - **astra**: ASTRA_API_KEY\n\
-             - **claude**: ANTHROPIC_API_KEY\n\
-             - **codex**: OPENAI_API_KEY"
+            "🔑 `{name}` 认证失败\n\n\
+             请尝试:\n\
+             1. 发送 `/auth` 重置认证\n\
+             2. 运行 `astra /login` 重新登录\n\
+             3. 或 `/cli claude` 切换到其他 CLI"
         );
     }
     if stderr.contains("rate limit") || stderr.contains("429") {
@@ -1229,7 +1247,43 @@ model: claude-sonnet-4-6"#;
     fn translate_auth_error() {
         let p = CliProfile::default();
         let msg = translate_cli_error(&p, 1, "Error: Could not validate credentials");
-        assert!(msg.contains("API 密钥"));
+        assert!(msg.contains("认证失败"));
+        assert!(msg.contains("/auth"));
+    }
+
+    // ── is_auth_error tests ──────────────────────────────────────
+
+    #[test]
+    fn is_auth_error_validates_credentials() {
+        assert!(is_auth_error("Could not validate credentials"));
+        assert!(is_auth_error("could not validate credentials"));
+    }
+
+    #[test]
+    fn is_auth_error_invalid_api_key() {
+        assert!(is_auth_error("Error: invalid_api_key"));
+        assert!(is_auth_error("invalid api key provided"));
+    }
+
+    #[test]
+    fn is_auth_error_401_status() {
+        assert!(is_auth_error("status: 401"));
+        assert!(is_auth_error("HTTP 401 response"));
+        assert!(is_auth_error("error 401"));
+    }
+
+    #[test]
+    fn is_auth_error_token_expired() {
+        assert!(is_auth_error("token expired"));
+        assert!(is_auth_error("Token has expired"));
+    }
+
+    #[test]
+    fn is_auth_error_false_positives_avoided() {
+        assert!(!is_auth_error("port 4010 is in use"));
+        assert!(!is_auth_error("some random error"));
+        assert!(!is_auth_error("timeout after 30s"));
+        assert!(!is_auth_error("rate limit exceeded"));
     }
 
     #[test]

--- a/rust/crates/astra-gateway/src/cli_bridge.rs
+++ b/rust/crates/astra-gateway/src/cli_bridge.rs
@@ -577,7 +577,16 @@ pub async fn run_cli(
     working_dir: Option<&std::path::Path>,
     progress_tx: Option<mpsc::Sender<CliProgress>>,
 ) -> Result<CliResult, String> {
-    run_cli_with_context(profile, message, session_id, working_dir, progress_tx, None).await
+    run_cli_with_context(
+        profile,
+        message,
+        session_id,
+        working_dir,
+        progress_tx,
+        None,
+        None,
+    )
+    .await
 }
 
 pub async fn run_cli_with_context(
@@ -587,6 +596,7 @@ pub async fn run_cli_with_context(
     working_dir: Option<&std::path::Path>,
     progress_tx: Option<mpsc::Sender<CliProgress>>,
     system_prompt: Option<&str>,
+    access_token: Option<&str>,
 ) -> Result<CliResult, String> {
     run_cli_with_context_and_timeout(
         profile,
@@ -596,10 +606,12 @@ pub async fn run_cli_with_context(
         progress_tx,
         system_prompt,
         None,
+        access_token,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_cli_with_context_and_timeout(
     profile: &CliProfile,
     message: &str,
@@ -608,6 +620,7 @@ pub async fn run_cli_with_context_and_timeout(
     progress_tx: Option<mpsc::Sender<CliProgress>>,
     system_prompt: Option<&str>,
     timeout: Option<Duration>,
+    access_token: Option<&str>,
 ) -> Result<CliResult, String> {
     run_cli_with_context_trace_and_timeout(
         profile,
@@ -619,6 +632,7 @@ pub async fn run_cli_with_context_and_timeout(
         None,
         None,
         timeout,
+        access_token,
     )
     .await
 }
@@ -634,6 +648,7 @@ pub async fn run_cli_with_context_trace_and_timeout(
     trace_id: Option<&str>,
     request_id: Option<&str>,
     timeout: Option<Duration>,
+    access_token: Option<&str>,
 ) -> Result<CliResult, String> {
     let mut cmd =
         profile.build_command_with_context(message, session_id, working_dir, system_prompt);
@@ -642,6 +657,9 @@ pub async fn run_cli_with_context_trace_and_timeout(
     }
     if let Some(request_id) = request_id {
         cmd.env("ASTRA_GATEWAY_REQUEST_ID", request_id);
+    }
+    if let Some(token) = access_token {
+        cmd.env("ASTRA_ACCESS_TOKEN", token);
     }
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
@@ -1148,6 +1166,7 @@ model: claude-sonnet-4-6"#;
             None,
             None,
             Some(Duration::from_millis(50)),
+            None,
         )
         .await
         .unwrap_err();
@@ -1176,10 +1195,57 @@ model: claude-sonnet-4-6"#;
             Some("trace-1"),
             Some("req-1"),
             None,
+            None,
         )
         .await
         .unwrap();
         assert_eq!(r.text.as_deref(), Some("trace-1/req-1"));
+    }
+
+    #[tokio::test]
+    async fn run_injects_access_token_env() {
+        let p = CliProfile::Custom {
+            bin: "sh".into(),
+            args_template: vec!["-c".into(), "printf '%s' \"$ASTRA_ACCESS_TOKEN\"".into()],
+            json_output: false,
+            text_field: None,
+            session_id_field: None,
+        };
+        let r = run_cli_with_context_trace_and_timeout(
+            &p,
+            "ignored",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("test-token-xyz"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.text.as_deref(), Some("test-token-xyz"));
+    }
+
+    #[tokio::test]
+    async fn run_no_access_token_when_none() {
+        let p = CliProfile::Custom {
+            bin: "sh".into(),
+            args_template: vec![
+                "-c".into(),
+                "printf '%s' \"${ASTRA_ACCESS_TOKEN:-unset}\"".into(),
+            ],
+            json_output: false,
+            text_field: None,
+            session_id_field: None,
+        };
+        let r = run_cli_with_context_trace_and_timeout(
+            &p, "ignored", None, None, None, None, None, None, None, None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.text.as_deref(), Some("unset"));
     }
 
     #[tokio::test]

--- a/rust/crates/astra-gateway/src/commands.rs
+++ b/rust/crates/astra-gateway/src/commands.rs
@@ -23,6 +23,7 @@ pub struct CommandContext<'a> {
     pub trace_repo: Option<&'a dyn TraceRepository>,
     pub project_dirs: &'a [String],
     pub cli_availability: &'a [(String, crate::cli_bridge::CliAvailability)],
+    pub auth_status: Option<String>,
 }
 
 /// Helper: get store or return error message for storage-dependent commands.
@@ -30,7 +31,7 @@ macro_rules! require_store {
     ($ctx:expr) => {
         match $ctx.store {
             Some(s) => s,
-            None => return Some("⚠️ 此命令需要存储后端。当前以无持久化模式运行。".into()),
+            None => return Some("⚠️ 此命令需要存储。当前以无持久化模式运行。".into()),
         }
     };
 }
@@ -39,7 +40,7 @@ macro_rules! require_trace_repo {
     ($ctx:expr) => {
         match $ctx.trace_repo {
             Some(repo) => repo,
-            None => return Some("⚠️ 此命令需要数据库。当前以无数据库模式运行。".into()),
+            None => return Some("⚠️ 此命令需要 MySQL 存储。当前没有启用 trace/durable 能力。".into()),
         }
     };
 }
@@ -111,6 +112,9 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                     if ctx.store.is_some() { "on" } else { "off" }
                 ),
             ];
+            if let Some(auth_status) = ctx.auth_status.as_deref() {
+                lines.push(format!("- 认证: {auth_status}"));
+            }
 
             if let Some(repo) = ctx.trace_repo {
                 let conversation = ConversationKey::new(ctx.platform, ctx.chat_id, cli_name);
@@ -513,7 +517,7 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
         "/task" => {
             let store = match ctx.durable_store {
                 Some(s) => s,
-                None => return Some("⚠️ 持久任务需要数据库支持".into()),
+                None => return Some("⚠️ 持久任务需要 MySQL 存储支持".into()),
             };
             let owner_id = format!("{}:{}", ctx.platform, ctx.chat_id);
 
@@ -1149,7 +1153,7 @@ fn parse_cron_add(input: &str) -> Option<(String, String)> {
     {
         let expr = after_quote[..end].to_string();
         let msg = after_quote[end + 1..].trim().to_string();
-        if !expr.is_empty() && !msg.is_empty() {
+        if !expr.is_empty() && !msg.is_empty() && store::is_valid_cron_expr(&expr) {
             return Some((expr, msg));
         }
     }
@@ -1158,7 +1162,9 @@ fn parse_cron_add(input: &str) -> Option<(String, String)> {
     if parts.len() >= 6 {
         let expr = parts[..5].join(" ");
         let msg = parts[5].to_string();
-        return Some((expr, msg));
+        if !msg.is_empty() && store::is_valid_cron_expr(&expr) {
+            return Some((expr, msg));
+        }
     }
     None
 }
@@ -1209,9 +1215,11 @@ async fn resolve_active_request(
         {
             return Some(rows[idx - 1].clone());
         }
-        // Pure number that's out of range — don't fall through to ID prefix match
-        // (short numbers like "3" would spuriously match UUID prefixes)
-        return None;
+        // Short pure numbers are task indices only; longer numeric strings may
+        // be valid UUID prefixes.
+        if selector.len() < 4 {
+            return None;
+        }
     }
 
     // Try trace ID or request ID prefix match (only for non-numeric selectors)
@@ -1859,6 +1867,7 @@ mod tests {
                     trace_repo: None,
                     project_dirs: &config.project_dirs,
                     cli_availability: &[],
+                    auth_status: None,
                 };
                 let result = handle_command(&ctx, $input).await;
                 let check: fn(Option<String>) = $check;
@@ -1908,53 +1917,38 @@ mod tests {
     cmd_test!(cmd_new_requires_db, "/new", |r| {
         {
             let msg = r.unwrap();
-            assert!(
-                msg.contains("存储后端") || msg.contains("数据库"),
-                "expected storage error, got: {msg}"
-            );
+            assert!(msg.contains("存储"), "expected storage error, got: {msg}");
         }
     });
     cmd_test!(cmd_session_requires_db, "/session list", |r| {
         {
             let msg = r.unwrap();
-            assert!(
-                msg.contains("存储后端") || msg.contains("数据库"),
-                "expected storage error, got: {msg}"
-            );
+            assert!(msg.contains("存储"), "expected storage error, got: {msg}");
         }
     });
     cmd_test!(cmd_cron_requires_db, "/cron list", |r| {
         {
             let msg = r.unwrap();
-            assert!(
-                msg.contains("存储后端") || msg.contains("数据库"),
-                "expected storage error, got: {msg}"
-            );
+            assert!(msg.contains("存储"), "expected storage error, got: {msg}");
         }
     });
     cmd_test!(cmd_usage_requires_db, "/usage", |r| {
         {
             let msg = r.unwrap();
-            assert!(
-                msg.contains("存储后端") || msg.contains("数据库"),
-                "expected storage error, got: {msg}"
-            );
+            assert!(msg.contains("存储"), "expected storage error, got: {msg}");
         }
     });
     cmd_test!(cmd_workspace_requires_db, "/workspace", |r| {
         {
             let msg = r.unwrap();
-            assert!(
-                msg.contains("存储后端") || msg.contains("数据库"),
-                "expected storage error, got: {msg}"
-            );
+            assert!(msg.contains("存储"), "expected storage error, got: {msg}");
         }
     });
     cmd_test!(cmd_running_requires_trace_repo, "/running", |r| {
         {
             let msg = r.unwrap();
             assert!(
-                msg.contains("存储后端") || msg.contains("数据库"),
+                msg.contains("存储") || msg.contains("MySQL"),
                 "expected storage error, got: {msg}"
             );
         }
@@ -1965,6 +1959,30 @@ mod tests {
     cmd_test!(cmd_status_works_without_db, "/status", |r| {
         assert!(r.unwrap().contains("astra"));
     });
+
+    #[tokio::test]
+    async fn cmd_status_includes_auth_circuit_status_when_available() {
+        let config = test_config();
+        let cli = crate::cli_bridge::CliProfile::default();
+        let astra = astra_thin_client::ThinClient::new("http://localhost:8080", None).unwrap();
+        let ctx = CommandContext {
+            astra: &astra,
+            config: &config,
+            store: None,
+            platform: "test",
+            chat_id: "chat_1",
+            user_id: "user_1",
+            resolved_cli: &cli,
+            durable_store: None,
+            trace_repo: None,
+            project_dirs: &config.project_dirs,
+            cli_availability: &[],
+            auth_status: Some("⚠️ 暂停 (剩余 3m 42s)".to_string()),
+        };
+
+        let result = handle_command(&ctx, "/status").await.unwrap();
+        assert!(result.contains("- 认证: ⚠️ 暂停 (剩余 3m 42s)"), "{result}");
+    }
     cmd_test!(
         cmd_cron_add_malformed_gives_error,
         "/cron add badformat",
@@ -1977,7 +1995,7 @@ mod tests {
         {
             let msg = r.unwrap();
             assert!(
-                msg.contains("存储后端") || msg.contains("数据库"),
+                msg.contains("存储") || msg.contains("MySQL"),
                 "expected storage error, got: {msg}"
             );
         }
@@ -1986,7 +2004,7 @@ mod tests {
         {
             let msg = r.unwrap();
             assert!(
-                msg.contains("存储后端") || msg.contains("数据库"),
+                msg.contains("存储") || msg.contains("MySQL"),
                 "expected storage error, got: {msg}"
             );
         }
@@ -1995,7 +2013,7 @@ mod tests {
         {
             let msg = r.unwrap();
             assert!(
-                msg.contains("存储后端") || msg.contains("数据库"),
+                msg.contains("存储") || msg.contains("MySQL"),
                 "expected storage error, got: {msg}"
             );
         }
@@ -2004,7 +2022,7 @@ mod tests {
         {
             let msg = r.unwrap();
             assert!(
-                msg.contains("存储后端") || msg.contains("数据库"),
+                msg.contains("存储") || msg.contains("MySQL"),
                 "expected storage error, got: {msg}"
             );
         }
@@ -2013,7 +2031,7 @@ mod tests {
         {
             let msg = r.unwrap();
             assert!(
-                msg.contains("存储后端") || msg.contains("数据库"),
+                msg.contains("存储") || msg.contains("MySQL"),
                 "expected storage error, got: {msg}"
             );
         }
@@ -2022,7 +2040,7 @@ mod tests {
         {
             let msg = r.unwrap();
             assert!(
-                msg.contains("数据库") || msg.contains("没有运行中"),
+                msg.contains("存储") || msg.contains("没有运行中"),
                 "expected db error or no running message, got: {msg}"
             );
         }
@@ -2056,7 +2074,7 @@ mod tests {
     cmd_test!(cmd_retry_requires_trace_repo, "/retry", |r| {
         {
             let msg = r.unwrap();
-            assert!(msg.contains("数据库"), "expected db error, got: {msg}");
+            assert!(msg.contains("存储"), "expected storage error, got: {msg}");
         }
     });
     cmd_test!(
@@ -2065,7 +2083,7 @@ mod tests {
         |r| {
             {
                 let msg = r.unwrap();
-                assert!(msg.contains("数据库"), "expected db error, got: {msg}");
+                assert!(msg.contains("存储"), "expected storage error, got: {msg}");
             }
         }
     );
@@ -2080,7 +2098,7 @@ mod tests {
 
     cmd_test!(cmd_ws_no_arg_requires_store, "/ws", |r| {
         let s = r.unwrap();
-        assert!(s.contains("存储后端"), "expected storage error, got: {s}");
+        assert!(s.contains("存储"), "expected storage error, got: {s}");
     });
 
     cmd_test!(
@@ -2090,7 +2108,7 @@ mod tests {
             let s = r.unwrap();
             // Without store, /ws <arg> requires store first
             assert!(
-                s.contains("存储后端") || s.contains("不存在"),
+                s.contains("存储") || s.contains("不存在"),
                 "expected storage error or not-found, got: {s}"
             );
         }
@@ -2336,5 +2354,11 @@ mod tests {
                 .await
                 .is_none()
         );
+    }
+
+    #[test]
+    fn parse_cron_add_rejects_invalid_cron_expression() {
+        assert!(parse_cron_add("99 99 99 99 99 impossible").is_none());
+        assert!(parse_cron_add("\"bad expr\" impossible").is_none());
     }
 }

--- a/rust/crates/astra-gateway/src/commands.rs
+++ b/rust/crates/astra-gateway/src/commands.rs
@@ -4,8 +4,8 @@ use crate::access_control::{ActionCapability, ActionSource};
 use crate::config::GatewayConfig;
 use crate::store::{self, GatewayStore};
 use crate::trace_model::{
-    CancelRequestOutcome, ConversationKey, GatewayEvent, GatewayEventKind, OutboxStatus,
-    RequestStatus, TraceId, TraceRepository,
+    ActiveRequestSummary, CancelRequestOutcome, ConversationKey, GatewayEvent, GatewayEventKind,
+    OutboxStatus, RequestStatus, TraceId, TraceRepository,
 };
 use astra_core::durable_task_store::{
     DurableTask, DurableTaskStatus, DurableTaskStore, TaskFilter, resolve_task_for_owner,
@@ -480,12 +480,14 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
              `/cli <name>` — 切换 CLI (astra/claude)\n\
              `/ws` — 当前工作目录\n\
              `/ws ls` — 列出可用项目\n\
-             `/ws <name|path>` — 切换工作目录\n\
-             `/running` — 查看正在执行的任务\n\
-             `/cancel [text]` — 取消排队中的请求 (支持文本匹配)\n\
-             `/kill [text]` — 强制终止运行中的请求 (无参数=自动选择)\n\
+             `/ws <name|path>` — 切换工作目录\n\n\
+             **任务管理**\n\
+             `/running` — 查看正在执行的任务 (带编号)\n\
+             `/cancel [N|text]` — 取消排队请求 (序号/文本/ID)\n\
+             `/kill [N|text]` — 终止运行中请求 (序号/文本/ID)\n\
              `/retry` — 查看发送失败的消息\n\
              `/retry dismiss` — 清除所有失败消息\n\
+             `/manage [指令]` — AI 辅助任务管理\n\
              `/usage` — 用量统计\n\n\
              **监控**\n\
              `/status` — 状态 + harness\n\
@@ -650,20 +652,17 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
             } else {
                 let mut lines = vec![format!("🔄 **正在执行** ({} 个)", rows.len())];
                 let mut stuck_outbox_count = 0usize;
-                for row in &rows {
-                    let short_user = short_id(&row.user_id);
-                    let short_text = if row.text_preview.chars().count() > 40 {
-                        format!("{}…", row.text_preview.chars().take(40).collect::<String>())
-                    } else {
-                        row.text_preview.clone()
-                    };
+                for (i, row) in rows.iter().enumerate() {
+                    let icon = status_icon(row.display_status());
+                    let short_text = truncate_text(&row.text_preview, 40);
+                    let ts = short_timestamp(&row.created_at);
                     lines.push(format!(
-                        "- `{}` `{}` | {} | {} | {}",
-                        short_id(row.trace_id.as_str()),
-                        short_user,
+                        "[{}] {} {} | {} | {}",
+                        i + 1,
+                        icon,
                         row.display_status(),
                         short_text,
-                        row.created_at
+                        ts,
                     ));
                     if row.status.is_terminal() && row.outbox_status == Some(OutboxStatus::Failed) {
                         stuck_outbox_count += 1;
@@ -671,9 +670,10 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 }
                 if stuck_outbox_count > 0 {
                     lines.push(format!(
-                        "\n📬 提示: 有 {stuck_outbox_count} 个消息发送失败。用 `/retry` 查看，`/retry dismiss` 清除。"
+                        "\n📬 有 {stuck_outbox_count} 个消息发送失败。用 `/retry` 查看，`/retry dismiss` 清除。"
                     ));
                 }
+                lines.push("\n💡 `/kill 1` 终止 | `/cancel 2` 取消 | `/manage` AI 辅助管理".into());
                 Some(lines.join("\n"))
             }
         }
@@ -726,40 +726,63 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
             let repo = require_trace_repo!(ctx);
             let conversation =
                 ConversationKey::new(ctx.platform, ctx.chat_id, ctx.resolved_cli.name());
-            let selector = if arg.is_empty() {
-                match repo.list_active_requests(&conversation, 20).await {
-                    Ok(rows) => rows
-                        .into_iter()
-                        .find(|row| row.is_cancellable())
-                        .map(|row| row.trace_id.to_string()),
-                    Err(_) => None,
+            if arg.is_empty() {
+                // Auto-pick first cancellable
+                let row = repo
+                    .list_active_requests(&conversation, 20)
+                    .await
+                    .ok()
+                    .and_then(|rows| rows.into_iter().find(|r| r.is_cancellable()));
+                let Some(row) = row else {
+                    return Some("✅ 当前没有可取消的排队请求。运行中的请求请用 `/kill`。".into());
+                };
+                match repo
+                    .cancel_accepted_request(
+                        &conversation,
+                        row.trace_id.as_str(),
+                        "cancelled by user",
+                    )
+                    .await
+                {
+                    Ok(CancelRequestOutcome::Cancelled(r)) => {
+                        Some(format!("🚫 已取消: {}", truncate_text(&r.text_preview, 40)))
+                    }
+                    Ok(CancelRequestOutcome::AlreadyRunning(_)) => {
+                        Some("⚠️ 请求已在运行，用 `/kill` 终止。".into())
+                    }
+                    Ok(CancelRequestOutcome::NotFound) => Some("❌ 找不到可取消请求".into()),
+                    Err(e) => Some(format!("⚠️ 取消失败: {e}")),
                 }
             } else {
-                match resolve_trace_by_text_or_id(repo, &conversation, arg).await {
-                    Some(id) => Some(id.to_string()),
-                    None => return Some(format!("❌ 找不到匹配 `{arg}` 的请求")),
+                // Resolve by number, text, or ID
+                let Some(row) = resolve_active_request(repo, &conversation, arg).await else {
+                    return Some(format!("❌ 找不到匹配 `{arg}` 的请求"));
+                };
+                if !row.is_cancellable() {
+                    return Some(format!(
+                        "⚠️ 请求 [{}] 已在运行，用 `/kill` 终止。",
+                        truncate_text(&row.text_preview, 30)
+                    ));
                 }
-            };
-            let Some(selector) = selector else {
-                return Some("✅ 当前没有可取消的排队请求。运行中的请求不会被强制中断。".into());
-            };
-            match repo
-                .cancel_accepted_request(&conversation, &selector, "cancelled by user")
-                .await
-            {
-                Ok(CancelRequestOutcome::Cancelled(row)) => Some(format!(
-                    "🚫 已取消排队请求 `{}`: {}",
-                    short_id(row.trace_id.as_str()),
-                    row.text_preview
-                )),
-                Ok(CancelRequestOutcome::AlreadyRunning(row)) => Some(format!(
-                    "⚠️ 请求 `{}` 已在运行，不能安全取消。",
-                    short_id(row.trace_id.as_str())
-                )),
-                Ok(CancelRequestOutcome::NotFound) => {
-                    Some(format!("❌ 找不到可取消请求 `{selector}`"))
+                match repo
+                    .cancel_accepted_request(
+                        &conversation,
+                        row.trace_id.as_str(),
+                        "cancelled by user",
+                    )
+                    .await
+                {
+                    Ok(CancelRequestOutcome::Cancelled(r)) => {
+                        Some(format!("🚫 已取消: {}", truncate_text(&r.text_preview, 40)))
+                    }
+                    Ok(CancelRequestOutcome::AlreadyRunning(_)) => {
+                        Some("⚠️ 请求已在运行，用 `/kill` 终止。".into())
+                    }
+                    Ok(CancelRequestOutcome::NotFound) => {
+                        Some(format!("❌ 找不到可取消请求 `{arg}`"))
+                    }
+                    Err(e) => Some(format!("⚠️ 取消失败: {e}")),
                 }
-                Err(e) => Some(format!("⚠️ 取消失败: {e}")),
             }
         }
 
@@ -768,38 +791,37 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
             let conversation =
                 ConversationKey::new(ctx.platform, ctx.chat_id, ctx.resolved_cli.name());
 
-            let target = if arg.is_empty() {
+            let row = if arg.is_empty() {
                 // Auto-pick the most recent running request
-                match repo.list_active_requests(&conversation, 20).await {
-                    Ok(rows) => rows
-                        .into_iter()
-                        .find(|row| row.status == RequestStatus::Running)
-                        .map(|row| row.trace_id.to_string()),
-                    Err(_) => None,
-                }
+                repo.list_active_requests(&conversation, 20)
+                    .await
+                    .ok()
+                    .and_then(|rows| {
+                        rows.into_iter()
+                            .find(|r| r.status == RequestStatus::Running)
+                    })
             } else {
-                // Support text-based fuzzy match against text_preview
-                match resolve_trace_by_text_or_id(repo, &conversation, arg).await {
-                    Some(id) => Some(id.to_string()),
-                    None => return Some(format!("❌ 找不到匹配 `{arg}` 的请求")),
-                }
+                // Resolve by number, text, or ID
+                resolve_active_request(repo, &conversation, arg).await
             };
 
-            let Some(target) = target else {
-                return Some("✅ 当前没有运行中的请求。".into());
+            let Some(row) = row else {
+                if arg.is_empty() {
+                    return Some("✅ 当前没有运行中的请求。".into());
+                }
+                return Some(format!("❌ 找不到匹配 `{arg}` 的请求"));
             };
-            let trace_id = TraceId::from_string(target);
             match repo
-                .force_fail_request(&trace_id, "killed by user via /kill")
+                .force_fail_request(&row.trace_id, "killed by user via /kill")
                 .await
             {
                 Ok(true) => Some(format!(
-                    "💀 已强制终止请求 `{}`",
-                    short_id(trace_id.as_str())
+                    "💀 已终止: {}",
+                    truncate_text(&row.text_preview, 40)
                 )),
                 Ok(false) => Some(format!(
-                    "⚠️ 请求 `{}` 已经是终态",
-                    short_id(trace_id.as_str())
+                    "⚠️ 请求已是终态: {}",
+                    truncate_text(&row.text_preview, 30)
                 )),
                 Err(e) => Some(format!("⚠️ 终止失败: {e}")),
             }
@@ -834,18 +856,36 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 return Some(format!("🧹 已清除 {dismissed} 个失败消息。"));
             }
 
+            // Support `/retry 1` to dismiss a specific item by index
+            if let Ok(idx) = arg.parse::<usize>() {
+                if idx >= 1 && idx <= stuck.len() {
+                    let row = stuck[idx - 1];
+                    match repo.dismiss_failed_outbox(&row.request_id).await {
+                        Ok(()) => {
+                            return Some(format!(
+                                "🧹 已清除: {}",
+                                truncate_text(&row.text_preview, 40)
+                            ));
+                        }
+                        Err(e) => return Some(format!("⚠️ 清除失败: {e}")),
+                    }
+                } else {
+                    return Some(format!("❌ 序号 {idx} 超出范围 (1-{})", stuck.len()));
+                }
+            }
+
             let mut lines = vec![format!("📬 **待重试消息** ({} 个)", stuck.len())];
-            for row in &stuck {
+            for (i, row) in stuck.iter().enumerate() {
                 lines.push(format!(
-                    "- `{}` | {} | {}",
-                    short_id(row.trace_id.as_str()),
+                    "[{}] 📬 {} | {}",
+                    i + 1,
                     truncate_text(&row.text_preview, 40),
                     row.outbox_error_message
                         .as_deref()
                         .unwrap_or("unknown error"),
                 ));
             }
-            lines.push("\n`/retry dismiss` — 清除所有失败消息".into());
+            lines.push("\n`/retry dismiss` 清除全部 | `/retry 1` 清除指定".into());
             Some(lines.join("\n"))
         }
 
@@ -1041,10 +1081,11 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
             lines.push("| `/session list` | Session history |".to_string());
             lines.push("| `/cron list` | Scheduled tasks |".to_string());
             lines.push("| `/task list` | Durable tasks |".to_string());
-            lines.push("| `/running` | Active requests |".to_string());
-            lines.push("| `/cancel [text]` | Cancel queued request |".to_string());
-            lines.push("| `/kill [text]` | Force-kill running request |".to_string());
+            lines.push("| `/running` | Active requests (numbered) |".to_string());
+            lines.push("| `/cancel [N\\|text]` | Cancel queued request |".to_string());
+            lines.push("| `/kill [N\\|text]` | Force-kill running request |".to_string());
             lines.push("| `/retry` | View/dismiss failed outbox |".to_string());
+            lines.push("| `/manage [hint]` | AI-assisted task management |".to_string());
             lines.push("| `/trace [id]` | Request trace |".to_string());
             lines.push("| `/usage` | Token/cost stats |".to_string());
             lines.push("| `/inspect` | Harness details |".to_string());
@@ -1067,6 +1108,8 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 lines.push("| `dtask_complete:<id>` | Mark complete |".to_string());
                 lines.push("| `workspace_set:<path>` | Switch workspace |".to_string());
                 lines.push("| `skill_add:<name>:<md>` | Save reusable skill |".to_string());
+                lines.push("| `trace_kill:<trace_id>` | Force-kill request |".to_string());
+                lines.push("| `outbox_dismiss:<request_id>` | Dismiss failed outbox |".to_string());
             }
 
             if let Some(store) = ctx.store {
@@ -1141,33 +1184,70 @@ async fn resolve_trace_selector(
         .or_else(|| Some(TraceId::from_string(selector.to_string())))
 }
 
-async fn resolve_trace_by_text_or_id(
+/// Resolve a selector to an active request. Supports:
+/// - Numeric index "1", "2" (from `/running` output order)
+/// - Trace ID or prefix match
+/// - Text substring match against message content
+async fn resolve_active_request(
     repo: &dyn TraceRepository,
     conversation: &ConversationKey,
     selector: &str,
-) -> Option<TraceId> {
-    // First try exact/prefix ID match (existing behavior)
-    if let Some(id) = resolve_trace_selector(repo, conversation, selector).await {
-        // resolve_trace_selector falls back to constructing a TraceId from any string,
-        // so we need to verify the returned ID is a real match — not just a passthrough.
-        let traces = repo.list_recent_traces(conversation, 50).await.ok()?;
-        let is_real_match = traces.iter().any(|t| {
-            t.trace_id.as_str() == id.as_str()
-                && (t.trace_id.as_str() == selector
-                    || t.request_id.as_str() == selector
-                    || t.trace_id.as_str().starts_with(selector)
-                    || t.request_id.as_str().starts_with(selector))
-        });
-        if is_real_match {
-            return Some(id);
-        }
-    }
-    // Then try text_preview fuzzy match against active requests
+) -> Option<ActiveRequestSummary> {
     let rows = repo.list_active_requests(conversation, 50).await.ok()?;
+
+    let is_numeric = selector.chars().all(|c| c.is_ascii_digit()) && !selector.is_empty();
+
+    // Try numeric index first (1-based)
+    if is_numeric {
+        if let Ok(idx) = selector.parse::<usize>()
+            && idx >= 1
+            && idx <= rows.len()
+        {
+            return Some(rows[idx - 1].clone());
+        }
+        // Pure number that's out of range — don't fall through to ID prefix match
+        // (short numbers like "3" would spuriously match UUID prefixes)
+        return None;
+    }
+
+    // Try trace ID or request ID prefix match (only for non-numeric selectors)
+    if let Some(row) = rows.iter().find(|r| {
+        r.trace_id.as_str() == selector
+            || r.trace_id.as_str().starts_with(selector)
+            || r.request_id.as_str() == selector
+            || r.request_id.as_str().starts_with(selector)
+    }) {
+        return Some(row.clone());
+    }
+
+    // Try text fuzzy match
     let lower = selector.to_lowercase();
     rows.into_iter()
-        .find(|row| row.text_preview.to_lowercase().contains(&lower))
-        .map(|row| row.trace_id)
+        .find(|r| r.text_preview.to_lowercase().contains(&lower))
+}
+
+fn status_icon(status: &str) -> &'static str {
+    match status {
+        "running" => "\u{1f504}",
+        "queued" => "\u{231b}",
+        "completed" => "\u{2705}",
+        "failed" => "\u{274c}",
+        "reply_retrying" => "\u{1f4ec}",
+        "reply_pending" => "\u{1f4e4}",
+        _ => "\u{2753}",
+    }
+}
+
+/// Format timestamp: strip date prefix if it's today.
+fn short_timestamp(ts: &str) -> &str {
+    // created_at is typically "YYYY-MM-DD HH:MM:SS.ffffff" or similar.
+    // If it starts with today's date, strip to just time.
+    let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    if let Some(rest) = ts.strip_prefix(&today) {
+        rest.trim_start_matches([' ', 'T'])
+    } else {
+        ts
+    }
 }
 
 fn truncate_text(text: &str, max_chars: usize) -> String {
@@ -2009,4 +2089,136 @@ mod tests {
             );
         }
     );
+
+    // ── /manage is NOT a fast-path command (goes to slow path) ──
+
+    cmd_test!(cmd_manage_not_handled_as_command, "/manage", |r| {
+        assert!(r.is_none(), "/manage should not be a fast-path command");
+    });
+    cmd_test!(
+        cmd_manage_with_arg_not_handled,
+        "/manage 清理所有卡住的任务",
+        |r| {
+            assert!(
+                r.is_none(),
+                "/manage with arg should not be a fast-path command"
+            );
+        }
+    );
+
+    // ── /help and /gateway include /manage ──
+
+    cmd_test!(cmd_help_includes_manage, "/help", |r| {
+        let s = r.unwrap();
+        assert!(s.contains("/manage"), "help should include /manage");
+    });
+    cmd_test!(cmd_gateway_includes_manage, "/gateway", |r| {
+        let s = r.unwrap();
+        assert!(s.contains("/manage"), "gateway should include /manage");
+    });
+    // Note: trace_kill and outbox_dismiss GATEWAY action tags are only visible
+    // when model_generated_mutations is allowed AND store is available (tested below).
+
+    // ── status_icon ──
+
+    #[test]
+    fn status_icon_maps_known_statuses() {
+        assert_eq!(status_icon("running"), "\u{1f504}");
+        assert_eq!(status_icon("queued"), "\u{231b}");
+        assert_eq!(status_icon("completed"), "\u{2705}");
+        assert_eq!(status_icon("failed"), "\u{274c}");
+        assert_eq!(status_icon("reply_retrying"), "\u{1f4ec}");
+        assert_eq!(status_icon("reply_pending"), "\u{1f4e4}");
+        assert_eq!(status_icon("unknown"), "\u{2753}");
+    }
+
+    // ── short_timestamp ──
+
+    #[test]
+    fn short_timestamp_strips_today() {
+        let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        let ts = format!("{today} 12:34:56.789");
+        let short = short_timestamp(&ts);
+        assert_eq!(short, "12:34:56.789");
+    }
+
+    #[test]
+    fn short_timestamp_keeps_other_dates() {
+        let ts = "2020-01-01 12:34:56";
+        assert_eq!(short_timestamp(ts), ts);
+    }
+
+    // ── resolve_active_request ──
+
+    #[tokio::test]
+    async fn resolve_active_request_by_index() {
+        use crate::trace_model::InMemoryTraceRepository;
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("test", "chat", "astra");
+
+        // Create two requests
+        let req1 = crate::trace_model::GatewayRequest::new(
+            conv.clone(),
+            "msg-1",
+            "user-1",
+            "first request",
+        );
+        let trace1 = req1.trace_id.clone();
+        crate::trace_model::TraceWriter::begin(&repo, req1)
+            .await
+            .unwrap();
+
+        let req2 = crate::trace_model::GatewayRequest::new(
+            conv.clone(),
+            "msg-2",
+            "user-1",
+            "second request",
+        );
+        let trace2 = req2.trace_id.clone();
+        crate::trace_model::TraceWriter::begin(&repo, req2)
+            .await
+            .unwrap();
+
+        // Index 1 → first (both are Accepted, sorted by status then order)
+        let r1 = resolve_active_request(&repo, &conv, "1").await.unwrap();
+        assert_eq!(r1.trace_id, trace1);
+
+        // Index 2 → second
+        let r2 = resolve_active_request(&repo, &conv, "2").await.unwrap();
+        assert_eq!(r2.trace_id, trace2);
+
+        // Index 0 → None (1-based)
+        assert!(resolve_active_request(&repo, &conv, "0").await.is_none());
+
+        // Index 3 → None (out of range; pure numbers don't fall through to ID match)
+        assert!(resolve_active_request(&repo, &conv, "3").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_active_request_by_text() {
+        use crate::trace_model::InMemoryTraceRepository;
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("test", "chat", "astra");
+
+        let req = crate::trace_model::GatewayRequest::new(
+            conv.clone(),
+            "msg-1",
+            "user-1",
+            "帮我写个周报",
+        );
+        let trace = req.trace_id.clone();
+        crate::trace_model::TraceWriter::begin(&repo, req)
+            .await
+            .unwrap();
+
+        let found = resolve_active_request(&repo, &conv, "周报").await.unwrap();
+        assert_eq!(found.trace_id, trace);
+
+        // No match
+        assert!(
+            resolve_active_request(&repo, &conv, "不存在的内容")
+                .await
+                .is_none()
+        );
+    }
 }

--- a/rust/crates/astra-gateway/src/commands.rs
+++ b/rust/crates/astra-gateway/src/commands.rs
@@ -2,33 +2,34 @@
 
 use crate::access_control::{ActionCapability, ActionSource};
 use crate::config::GatewayConfig;
-use crate::storage;
+use crate::store::{self, GatewayStore};
 use crate::trace_model::{
     CancelRequestOutcome, ConversationKey, GatewayEvent, GatewayEventKind, TraceId, TraceRepository,
 };
 use astra_core::durable_task_store::{
     DurableTask, DurableTaskStatus, DurableTaskStore, TaskFilter, resolve_task_for_owner,
 };
-use sqlx::MySqlPool;
 
 pub struct CommandContext<'a> {
     pub astra: &'a astra_thin_client::ThinClient,
     pub config: &'a GatewayConfig,
-    pub pool: Option<&'a MySqlPool>,
+    pub store: Option<&'a dyn GatewayStore>,
     pub platform: &'a str,
     pub chat_id: &'a str,
     pub user_id: &'a str,
     pub resolved_cli: &'a crate::cli_bridge::CliProfile,
     pub durable_store: Option<&'a dyn astra_core::durable_task_store::DurableTaskStore>,
     pub trace_repo: Option<&'a dyn TraceRepository>,
+    pub project_dirs: &'a [String],
+    pub cli_availability: &'a [(String, crate::cli_bridge::CliAvailability)],
 }
 
-/// Helper: get pool or return error message for DB-dependent commands.
-macro_rules! require_db {
+/// Helper: get store or return error message for storage-dependent commands.
+macro_rules! require_store {
     ($ctx:expr) => {
-        match $ctx.pool {
-            Some(p) => p,
-            None => return Some("⚠️ 此命令需要数据库。当前以无数据库模式运行。".into()),
+        match $ctx.store {
+            Some(s) => s,
+            None => return Some("⚠️ 此命令需要存储后端。当前以无持久化模式运行。".into()),
         }
     };
 }
@@ -66,9 +67,12 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
             if let Some(denial) = slash_denial(ctx, ActionCapability::SessionMutation) {
                 return Some(denial);
             }
-            let pool = require_db!(ctx);
+            let store = require_store!(ctx);
             let cli_name = ctx.resolved_cli.name();
-            match storage::reset_session_for_cli(pool, ctx.platform, ctx.chat_id, cli_name).await {
+            match store
+                .reset_session(ctx.platform, ctx.chat_id, cli_name)
+                .await
+            {
                 Ok(()) => Some(format!(
                     "🔄 `{cli_name}` 会话已重置。发送新消息开始新对话。"
                 )),
@@ -78,8 +82,9 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
 
         "/status" => {
             let cli_name = ctx.resolved_cli.name();
-            let session = if let Some(pool) = ctx.pool {
-                storage::get_current_session_for_cli(pool, ctx.platform, ctx.chat_id, cli_name)
+            let session = if let Some(store) = ctx.store {
+                store
+                    .get_current_session(ctx.platform, ctx.chat_id, cli_name)
                     .await
                     .ok()
                     .flatten()
@@ -101,8 +106,8 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 format!("- 用户: `{}`", ctx.user_id),
                 format!("- 会话: `{}`", session.as_deref().unwrap_or("(无)")),
                 format!(
-                    "- 数据库: `{}`",
-                    if ctx.pool.is_some() { "on" } else { "off" }
+                    "- 存储: `{}`",
+                    if ctx.store.is_some() { "on" } else { "off" }
                 ),
             ];
 
@@ -157,13 +162,9 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
 
         "/inspect" => {
             let cli_name = ctx.resolved_cli.name();
-            let sid = match storage::get_current_session_for_cli(
-                require_db!(ctx),
-                ctx.platform,
-                ctx.chat_id,
-                cli_name,
-            )
-            .await
+            let sid = match require_store!(ctx)
+                .get_current_session(ctx.platform, ctx.chat_id, cli_name)
+                .await
             {
                 Ok(Some(s)) => s,
                 _ => return Some("❌ 当前无活跃会话。".into()),
@@ -177,15 +178,11 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
         "/session" => {
             let cli_name = ctx.resolved_cli.name();
             if arg.is_empty() || arg == "current" {
-                let sid = storage::get_current_session_for_cli(
-                    require_db!(ctx),
-                    ctx.platform,
-                    ctx.chat_id,
-                    cli_name,
-                )
-                .await
-                .ok()
-                .flatten();
+                let sid = require_store!(ctx)
+                    .get_current_session(ctx.platform, ctx.chat_id, cli_name)
+                    .await
+                    .ok()
+                    .flatten();
                 return Some(format!(
                     "📋 **当前会话** (CLI: `{cli_name}`)\n- ID: `{}`",
                     sid.as_deref().unwrap_or("(无)")
@@ -193,22 +190,18 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
             }
 
             if arg == "list" {
-                let sessions = storage::list_sessions_for_cli(
-                    require_db!(ctx),
-                    ctx.platform,
-                    ctx.chat_id,
-                    cli_name,
-                )
-                .await
-                .unwrap_or_default();
+                let sessions = require_store!(ctx)
+                    .list_sessions(ctx.platform, ctx.chat_id, cli_name)
+                    .await
+                    .unwrap_or_default();
                 if sessions.is_empty() {
                     return Some(format!("📋 `{cli_name}` 没有历史会话。"));
                 }
                 let mut lines = vec![format!("📋 **`{cli_name}` 会话列表**")];
-                for (sid, current, created) in &sessions {
-                    let marker = if *current { "→ " } else { "  " };
-                    let short = &sid[..8.min(sid.len())];
-                    lines.push(format!("{marker}`{short}…` ({created})"));
+                for s in &sessions {
+                    let marker = if s.is_current { "→ " } else { "  " };
+                    let short = &s.session_id[..8.min(s.session_id.len())];
+                    lines.push(format!("{marker}`{short}…` ({})", s.created_at));
                 }
                 lines.push("\n使用 `/session switch <id>` 切换".into());
                 return Some(lines.join("\n"));
@@ -219,7 +212,8 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 .or_else(|| arg.strip_prefix("sw "))
             {
                 let target = target.trim();
-                match storage::switch_session(require_db!(ctx), ctx.platform, ctx.chat_id, target)
+                match require_store!(ctx)
+                    .switch_session(ctx.platform, ctx.chat_id, target)
                     .await
                 {
                     Ok(true) => Some(format!(
@@ -236,17 +230,21 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
 
         "/cron" => {
             if arg.is_empty() || arg == "list" {
-                let jobs = storage::list_cron_jobs(require_db!(ctx), ctx.platform, ctx.chat_id)
+                let jobs = require_store!(ctx)
+                    .list_cron_jobs(ctx.platform, ctx.chat_id)
                     .await
                     .unwrap_or_default();
                 if jobs.is_empty() {
                     return Some("⏰ 没有定时任务。用 `/cron add` 创建。".into());
                 }
                 let mut lines = vec!["⏰ **定时任务**".to_string()];
-                for (id, expr, desc, enabled) in &jobs {
-                    let status = if *enabled { "✅" } else { "⏸" };
-                    let short_id = &id[..8.min(id.len())];
-                    lines.push(format!("{status} `{short_id}` | `{expr}` | {desc}"));
+                for j in &jobs {
+                    let status = if j.enabled { "✅" } else { "⏸" };
+                    let short_id = &j.job_id[..8.min(j.job_id.len())];
+                    lines.push(format!(
+                        "{status} `{short_id}` | `{}` | {}",
+                        j.cron_expr, j.description
+                    ));
                 }
                 lines.push(
                     "\n`/cron add <cron_expr> <消息>` — 创建\n`/cron del <id>` — 删除".into(),
@@ -271,18 +269,18 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                     }
                 };
                 let job_id = uuid::Uuid::new_v4().to_string();
-                let pool = require_db!(ctx);
-                match storage::create_cron_job(
-                    pool,
-                    &job_id,
-                    ctx.platform,
-                    ctx.chat_id,
-                    ctx.user_id,
-                    &cron_expr,
-                    &message,
-                    &message,
-                )
-                .await
+                let store = require_store!(ctx);
+                match store
+                    .create_cron_job(&store::CronJobSpec {
+                        job_id: job_id.clone(),
+                        platform: ctx.platform.to_string(),
+                        chat_id: ctx.chat_id.to_string(),
+                        user_id: ctx.user_id.to_string(),
+                        cron_expr: cron_expr.clone(),
+                        message: message.clone(),
+                        description: message.clone(),
+                    })
+                    .await
                 {
                     Ok(()) => Some(format!(
                         "✅ 定时任务已创建\n- ID: `{}`\n- 表达式: `{cron_expr}`\n- 任务: {message}",
@@ -294,7 +292,7 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 if let Some(denial) = slash_denial(ctx, ActionCapability::CronMutation) {
                     return Some(denial);
                 }
-                match storage::delete_cron_job(require_db!(ctx), id.trim()).await {
+                match require_store!(ctx).delete_cron_job(id.trim()).await {
                     Ok(true) => Some("✅ 任务已删除".into()),
                     Ok(false) => Some("❌ 找不到该任务".into()),
                     Err(e) => Some(format!("⚠️ 删除失败: {e}")),
@@ -334,16 +332,11 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 return Some(denial);
             }
             let target = resolve_model_shortcut(arg);
-            if let Some(pool) = ctx.pool {
-                let model_key = storage::model_preference_key(ctx.resolved_cli.name());
-                if let Err(e) = storage::set_user_preference(
-                    pool,
-                    ctx.platform,
-                    ctx.user_id,
-                    &model_key,
-                    &target,
-                )
-                .await
+            if let Some(store) = ctx.store {
+                let model_key = store::model_preference_key(ctx.resolved_cli.name());
+                if let Err(e) = store
+                    .set_user_preference(ctx.platform, ctx.user_id, &model_key, &target)
+                    .await
                 {
                     return Some(format!("⚠️ 模型设置失败: {e}"));
                 }
@@ -356,8 +349,8 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 // Show current CLI + available profiles + workspace
                 let current = ctx.config.cli.name();
                 let caps = ctx.config.cli.capabilities();
-                let workspace = if let Some(pool) = ctx.pool {
-                    storage::get_user_preference(pool, ctx.platform, ctx.user_id, "workspace")
+                let workspace = if let Some(s) = ctx.store {
+                    s.get_user_preference(ctx.platform, ctx.user_id, "workspace")
                         .await
                         .ok()
                         .flatten()
@@ -384,8 +377,32 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                     lines.push("\n**可用 CLI:**".into());
                     for (name, profile) in &ctx.config.cli_profiles {
                         let c = profile.capabilities();
+                        // Look up availability from pre-probed list
+                        let (status_icon, version_info) = ctx
+                            .cli_availability
+                            .iter()
+                            .find(|(n, _)| n == name)
+                            .map(|(_, avail)| {
+                                let icon = if avail.is_available() { "✅" } else { "❌" };
+                                let ver = match avail {
+                                    crate::cli_bridge::CliAvailability::Available { version } => {
+                                        version
+                                            .as_deref()
+                                            .map(|v| format!(" {v}"))
+                                            .unwrap_or_default()
+                                    }
+                                    crate::cli_bridge::CliAvailability::NotInstalled => {
+                                        " — 未安装".into()
+                                    }
+                                    crate::cli_bridge::CliAvailability::NotExecutable(e) => {
+                                        format!(" — {e}")
+                                    }
+                                };
+                                (icon, ver)
+                            })
+                            .unwrap_or(("  ", String::new()));
                         lines.push(format!(
-                            "  `{name}` ({}{}{})",
+                            "  {status_icon} `{name}` ({}{}{}){version_info}",
                             profile.name(),
                             if c.supports_harness { " +harness" } else { "" },
                             if c.supports_session { " +session" } else { "" },
@@ -413,15 +430,10 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                     if caps.supports_harness { "✅" } else { "❌" },
                     if caps.supports_tools { "✅" } else { "❌" },
                 );
-                if let Some(pool) = ctx.pool
-                    && let Err(e) = storage::set_user_preference(
-                        pool,
-                        ctx.platform,
-                        ctx.user_id,
-                        "cli_profile",
-                        arg,
-                    )
-                    .await
+                if let Some(s) = ctx.store
+                    && let Err(e) = s
+                        .set_user_preference(ctx.platform, ctx.user_id, "cli_profile", arg)
+                        .await
                 {
                     return Some(format!("⚠️ CLI 切换失败: {e}"));
                 }
@@ -462,12 +474,15 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
              **模型**\n\
              `/model` — 当前模型 + 快捷列表\n\
              `/model <name>` — 切换 (haiku/sonnet/opus/minimax/deepseek/qwen/glm)\n\n\
-             **CLI**\n\
+             **CLI & 工作区**\n\
              `/cli` — 查看当前 CLI + 能力 + 工作目录\n\
              `/cli <name>` — 切换 CLI (astra/claude)\n\
-             `/workspace` (`/ws`) `<path>` — 切换工作目录\n\
+             `/ws` — 当前工作目录\n\
+             `/ws ls` — 列出可用项目\n\
+             `/ws <name|path>` — 切换工作目录\n\
              `/running` — 查看正在执行的任务\n\
              `/cancel` — 取消排队中的请求\n\
+             `/kill <trace_id>` — 强制终止运行中的请求\n\
              `/usage` — 用量统计\n\n\
              **监控**\n\
              `/status` — 状态 + harness\n\
@@ -483,7 +498,8 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
              `/cron list` — 查看任务\n\
              `/cron add <expr> <msg>` — 创建\n\
              `/cron del <id>` — 删除\n\n\
-             **安全**\n\
+             **其他**\n\
+             `/gateway` — 完整能力概览\n\
              `/approve` — 权限说明"
                 .into(),
         ),
@@ -602,13 +618,10 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
 
         "/audit" => {
             let cli_name = ctx.resolved_cli.name();
-            let sid = match storage::get_current_session_for_cli(
-                require_db!(ctx),
-                ctx.platform,
-                ctx.chat_id,
-                cli_name,
-            )
-            .await
+            let store = require_store!(ctx);
+            let sid = match store
+                .get_current_session(ctx.platform, ctx.chat_id, cli_name)
+                .await
             {
                 Ok(Some(s)) => s,
                 _ => return Some("❌ 当前无活跃会话。".into()),
@@ -735,24 +748,45 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
             }
         }
 
+        "/kill" => {
+            let repo = require_trace_repo!(ctx);
+            let conversation =
+                ConversationKey::new(ctx.platform, ctx.chat_id, ctx.resolved_cli.name());
+            if arg.is_empty() {
+                return Some("用法: `/kill <trace_id>` — 强制终止运行中的请求".into());
+            }
+            // Resolve the trace ID (support prefix match)
+            let trace_id = resolve_trace_selector(repo, &conversation, arg).await;
+            let Some(trace_id) = trace_id else {
+                return Some(format!("❌ 找不到 trace `{arg}`"));
+            };
+            // Force-fail the request regardless of current status
+            match repo
+                .force_fail_request(&trace_id, "killed by user via /kill")
+                .await
+            {
+                Ok(true) => Some(format!(
+                    "💀 已强制终止请求 `{}`",
+                    short_id(trace_id.as_str())
+                )),
+                Ok(false) => Some(format!(
+                    "⚠️ 请求 `{}` 已经是终态",
+                    short_id(trace_id.as_str())
+                )),
+                Err(e) => Some(format!("⚠️ 终止失败: {e}")),
+            }
+        }
+
         "/usage" => {
-            let pool = require_db!(ctx);
-            let today = crate::usage::get_usage_today(pool, ctx.platform, ctx.user_id)
+            let store = require_store!(ctx);
+            let today = store
+                .get_usage_today(ctx.platform, ctx.user_id)
                 .await
-                .unwrap_or(crate::usage::UsageSummary {
-                    messages: 0,
-                    tokens_prompt: 0,
-                    tokens_completion: 0,
-                    tool_calls: 0,
-                });
-            let total = crate::usage::get_usage_total(pool, ctx.platform, ctx.user_id)
+                .unwrap_or_default();
+            let total = store
+                .get_usage_total(ctx.platform, ctx.user_id)
                 .await
-                .unwrap_or(crate::usage::UsageSummary {
-                    messages: 0,
-                    tokens_prompt: 0,
-                    tokens_completion: 0,
-                    tool_calls: 0,
-                });
+                .unwrap_or_default();
             Some(format!(
                 "📊 **用量统计**\n\n\
                  **今日**\n\
@@ -775,9 +809,24 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
         }
 
         "/workspace" | "/ws" => {
-            let pool = require_db!(ctx);
+            // /ws ls | /ws list — list discovered projects (no store needed)
+            if arg == "ls" || arg == "list" {
+                let projects = crate::workspace::discover_all_projects(ctx.project_dirs);
+                if projects.is_empty() {
+                    return Some("📂 没有发现项目。配置 `project_dirs` 后重试。".into());
+                }
+                let mut lines = vec![format!("📂 **可用项目** ({} 个)", projects.len())];
+                for p in &projects {
+                    lines.push(format!("  {}", p.summary()));
+                }
+                lines.push("\n用 `/ws <项目名>` 切换".into());
+                return Some(lines.join("\n"));
+            }
+
+            let store = require_store!(ctx);
             if arg.is_empty() {
-                let ws = storage::get_user_preference(pool, ctx.platform, ctx.user_id, "workspace")
+                let ws = store
+                    .get_user_preference(ctx.platform, ctx.user_id, "workspace")
                     .await
                     .ok()
                     .flatten();
@@ -786,13 +835,39 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                     ws.as_deref().unwrap_or("(默认)")
                 ));
             }
-            // Expand ~ to home dir
-            let target = if arg.starts_with('~') {
-                let home = std::env::var("HOME").unwrap_or_default();
-                arg.replacen('~', &home, 1)
-            } else {
-                arg.to_string()
+
+            // Try name-based fuzzy match against discovered projects
+            let projects = crate::workspace::discover_all_projects(ctx.project_dirs);
+            let arg_lower = arg.to_lowercase();
+            let matches: Vec<_> = projects
+                .iter()
+                .filter(|p| {
+                    p.name.eq_ignore_ascii_case(arg) || p.name.to_lowercase().contains(&arg_lower)
+                })
+                .collect();
+            let target = match matches.len() {
+                1 => matches[0].path.clone(),
+                0 => {
+                    // No project match — fall through to path-based logic
+                    if arg.starts_with('~') {
+                        let home = std::env::var("HOME").unwrap_or_default();
+                        arg.replacen('~', &home, 1)
+                    } else {
+                        arg.to_string()
+                    }
+                }
+                _ => {
+                    let names: Vec<_> = matches
+                        .iter()
+                        .map(|p| format!("  {}", p.summary()))
+                        .collect();
+                    return Some(format!(
+                        "⚠️ 多个匹配:\n{}\n请更精确指定。",
+                        names.join("\n")
+                    ));
+                }
             };
+
             let path = std::path::Path::new(&target);
             if !path.is_dir() {
                 return Some(format!("❌ 目录不存在: `{target}`"));
@@ -807,18 +882,139 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 .canonicalize()
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or(target);
-            match storage::set_user_preference(
-                pool,
-                ctx.platform,
-                ctx.user_id,
-                "workspace",
-                &canonical,
-            )
-            .await
+            match store
+                .set_user_preference(ctx.platform, ctx.user_id, "workspace", &canonical)
+                .await
             {
                 Ok(()) => Some(format!("📂 工作目录已切换: `{canonical}`")),
                 Err(e) => Some(format!("⚠️ 工作目录设置失败: {e}")),
             }
+        }
+
+        "/gateway" => {
+            let cli_name = ctx.resolved_cli.name();
+            let caps = ctx.resolved_cli.capabilities();
+            let has_store = ctx.store.is_some();
+
+            let model = match ctx.resolved_cli {
+                crate::cli_bridge::CliProfile::Astra { model, .. }
+                | crate::cli_bridge::CliProfile::Claude { model, .. } => model.as_deref(),
+                _ => None,
+            }
+            .or(ctx.config.astra.default_model.as_deref())
+            .unwrap_or("default");
+
+            let workspace = if let Some(store) = ctx.store {
+                store
+                    .get_user_preference(ctx.platform, ctx.user_id, "workspace")
+                    .await
+                    .ok()
+                    .flatten()
+            } else {
+                None
+            };
+
+            let mut lines = vec![
+                "🌐 **Gateway Context**".to_string(),
+                String::new(),
+                "**Identity**".to_string(),
+                format!("- Platform: `{}`", ctx.platform),
+                format!("- User: `{}`", ctx.user_id),
+                format!("- CLI: `{cli_name}`"),
+                format!("- Model: `{model}`"),
+                format!(
+                    "- Storage: {}",
+                    if has_store { "✅ active" } else { "❌ none" }
+                ),
+                format!(
+                    "- Workspace: `{}`",
+                    workspace.as_deref().unwrap_or("(default)")
+                ),
+                String::new(),
+                "**Capabilities**".to_string(),
+                format!(
+                    "- Session management: {}",
+                    if caps.supports_session { "✅" } else { "❌" }
+                ),
+                format!(
+                    "- Model switching: {}",
+                    if caps.supports_model_switch {
+                        "✅"
+                    } else {
+                        "❌"
+                    }
+                ),
+                format!(
+                    "- Harness monitoring: {}",
+                    if caps.supports_harness { "✅" } else { "❌" }
+                ),
+                format!("- Cron/scheduling: {}", if has_store { "✅" } else { "❌" }),
+                format!("- Durable tasks: {}", if has_store { "✅" } else { "❌" }),
+                format!(
+                    "- Tool execution: {}",
+                    if caps.supports_tools { "✅" } else { "❌" }
+                ),
+            ];
+
+            lines.push(String::new());
+            lines.push("**Commands**".to_string());
+            lines.push("| Command | Description |".to_string());
+            lines.push("|---------|-------------|".to_string());
+            lines.push("| `/new` | Reset conversation |".to_string());
+            lines.push("| `/status` | Status + harness |".to_string());
+            lines.push("| `/model <name>` | Switch model |".to_string());
+            lines.push("| `/cli <name>` | Switch CLI backend |".to_string());
+            lines.push("| `/ws ls` | List projects |".to_string());
+            lines.push("| `/ws <name>` | Switch workspace |".to_string());
+            lines.push("| `/session list` | Session history |".to_string());
+            lines.push("| `/cron list` | Scheduled tasks |".to_string());
+            lines.push("| `/task list` | Durable tasks |".to_string());
+            lines.push("| `/running` | Active requests |".to_string());
+            lines.push("| `/cancel` | Cancel queued request |".to_string());
+            lines.push("| `/kill <id>` | Force-kill running request |".to_string());
+            lines.push("| `/trace [id]` | Request trace |".to_string());
+            lines.push("| `/usage` | Token/cost stats |".to_string());
+            lines.push("| `/inspect` | Harness details |".to_string());
+            lines.push("| `/audit` | Decision chain |".to_string());
+            lines.push("| `/gateway` | This context dump |".to_string());
+
+            if ctx.config.action_policy.allow_model_generated_mutations && has_store {
+                lines.push(String::new());
+                lines.push(
+                    "**Gateway Actions** (embed `[[GATEWAY:...]]` tags in response)".to_string(),
+                );
+                lines.push("| Tag | Effect |".to_string());
+                lines.push("|-----|--------|".to_string());
+                lines.push("| `cron_add:<expr>:<msg>` | Create recurring task |".to_string());
+                lines.push("| `remind_after:<min>:<msg>` | One-time reminder |".to_string());
+                lines.push("| `task_list` | List scheduled tasks |".to_string());
+                lines.push("| `task_del:<id>` | Delete task |".to_string());
+                lines.push("| `dtask_create:<name>:<desc>` | Create durable task |".to_string());
+                lines.push("| `dtask_checkpoint:<id>:<json>` | Save checkpoint |".to_string());
+                lines.push("| `dtask_complete:<id>` | Mark complete |".to_string());
+                lines.push("| `workspace_set:<path>` | Switch workspace |".to_string());
+                lines.push("| `skill_add:<name>:<md>` | Save reusable skill |".to_string());
+            }
+
+            if let Some(store) = ctx.store {
+                let cron_jobs = store
+                    .list_cron_jobs(ctx.platform, ctx.chat_id)
+                    .await
+                    .unwrap_or_default();
+                if !cron_jobs.is_empty() {
+                    lines.push(String::new());
+                    lines.push(format!("**Scheduled Tasks** ({} 个)", cron_jobs.len()));
+                    for j in &cron_jobs {
+                        let short = &j.job_id[..8.min(j.job_id.len())];
+                        lines.push(format!(
+                            "- `{short}` | `{}` | {}",
+                            j.cron_expr, j.description
+                        ));
+                    }
+                }
+            }
+
+            Some(lines.join("\n"))
         }
 
         _ => None,
@@ -1429,7 +1625,8 @@ mod tests {
                 api_key: String::new(),
                 default_model: None,
             },
-            database: Default::default(),
+            storage: Default::default(),
+            database: None,
             cli: Default::default(),
             cli_profiles: Default::default(),
             cli_timeout_secs: 3600,
@@ -1457,13 +1654,15 @@ mod tests {
                 let ctx = CommandContext {
                     astra: &astra,
                     config: &config,
-                    pool: None,
+                    store: None,
                     platform: "test",
                     chat_id: "chat_1",
                     user_id: "user_1",
                     resolved_cli: &cli,
                     durable_store: None,
                     trace_repo: None,
+                    project_dirs: &config.project_dirs,
+                    cli_availability: &[],
                 };
                 let result = handle_command(&ctx, $input).await;
                 let check: fn(Option<String>) = $check;
@@ -1511,22 +1710,58 @@ mod tests {
         assert!(r.unwrap().contains("astra"));
     });
     cmd_test!(cmd_new_requires_db, "/new", |r| {
-        assert!(r.unwrap().contains("数据库"));
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库"),
+                "expected storage error, got: {msg}"
+            );
+        }
     });
     cmd_test!(cmd_session_requires_db, "/session list", |r| {
-        assert!(r.unwrap().contains("数据库"));
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库"),
+                "expected storage error, got: {msg}"
+            );
+        }
     });
     cmd_test!(cmd_cron_requires_db, "/cron list", |r| {
-        assert!(r.unwrap().contains("数据库"));
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库"),
+                "expected storage error, got: {msg}"
+            );
+        }
     });
     cmd_test!(cmd_usage_requires_db, "/usage", |r| {
-        assert!(r.unwrap().contains("数据库"));
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库"),
+                "expected storage error, got: {msg}"
+            );
+        }
     });
     cmd_test!(cmd_workspace_requires_db, "/workspace", |r| {
-        assert!(r.unwrap().contains("数据库"));
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库"),
+                "expected storage error, got: {msg}"
+            );
+        }
     });
     cmd_test!(cmd_running_requires_trace_repo, "/running", |r| {
-        assert!(r.unwrap().contains("数据库"));
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库"),
+                "expected storage error, got: {msg}"
+            );
+        }
     });
     cmd_test!(cmd_task_requires_durable_store, "/task list", |r| {
         assert!(r.is_some());
@@ -1543,15 +1778,100 @@ mod tests {
         }
     );
     cmd_test!(cmd_inspect_requires_db, "/inspect", |r| {
-        assert!(r.unwrap().contains("数据库"));
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库"),
+                "expected storage error, got: {msg}"
+            );
+        }
     });
     cmd_test!(cmd_audit_requires_db, "/audit", |r| {
-        assert!(r.unwrap().contains("数据库"));
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库"),
+                "expected storage error, got: {msg}"
+            );
+        }
     });
     cmd_test!(cmd_trace_requires_trace_repo, "/trace", |r| {
-        assert!(r.unwrap().contains("数据库"));
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库"),
+                "expected storage error, got: {msg}"
+            );
+        }
     });
     cmd_test!(cmd_cancel_requires_trace_repo, "/cancel", |r| {
-        assert!(r.unwrap().contains("数据库"));
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库"),
+                "expected storage error, got: {msg}"
+            );
+        }
     });
+    cmd_test!(cmd_kill_requires_trace_repo, "/kill abc123", |r| {
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库"),
+                "expected storage error, got: {msg}"
+            );
+        }
+    });
+    cmd_test!(cmd_kill_no_arg_shows_usage, "/kill", |r| {
+        {
+            let msg = r.unwrap();
+            assert!(
+                msg.contains("存储后端") || msg.contains("数据库") || msg.contains("用法"),
+                "expected usage or storage error, got: {msg}"
+            );
+        }
+    });
+    cmd_test!(cmd_help_includes_kill, "/help", |r| {
+        let s = r.unwrap();
+        assert!(s.contains("/kill"), "help should include /kill");
+    });
+    cmd_test!(cmd_help_includes_gateway, "/help", |r| {
+        let s = r.unwrap();
+        assert!(s.contains("/gateway"), "help should include /gateway");
+    });
+    cmd_test!(cmd_help_includes_ws_ls, "/help", |r| {
+        let s = r.unwrap();
+        assert!(s.contains("/ws ls"), "help should include /ws ls");
+    });
+    cmd_test!(cmd_gateway_shows_context, "/gateway", |r| {
+        let s = r.unwrap();
+        assert!(s.contains("Gateway Context"), "missing header");
+        assert!(s.contains("Identity"), "missing identity section");
+        assert!(s.contains("Capabilities"), "missing capabilities section");
+        assert!(s.contains("Commands"), "missing commands section");
+        assert!(s.contains("astra"), "missing CLI name");
+        assert!(s.contains("test"), "missing platform");
+    });
+    cmd_test!(cmd_ws_ls_empty_projects, "/ws ls", |r| {
+        let s = r.unwrap();
+        assert!(s.contains("没有发现项目"), "expected empty project message");
+    });
+
+    cmd_test!(cmd_ws_no_arg_requires_store, "/ws", |r| {
+        let s = r.unwrap();
+        assert!(s.contains("存储后端"), "expected storage error, got: {s}");
+    });
+
+    cmd_test!(
+        cmd_ws_nonexistent_path,
+        "/ws /nonexistent/path/12345",
+        |r| {
+            let s = r.unwrap();
+            // Without store, /ws <arg> requires store first
+            assert!(
+                s.contains("存储后端") || s.contains("不存在"),
+                "expected storage error or not-found, got: {s}"
+            );
+        }
+    );
 }

--- a/rust/crates/astra-gateway/src/commands.rs
+++ b/rust/crates/astra-gateway/src/commands.rs
@@ -504,6 +504,7 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
              `/cron add <expr> <msg>` — 创建\n\
              `/cron del <id>` — 删除\n\n\
              **其他**\n\
+             `/auth` — 认证状态 + 重置 + 自动重登录\n\
              `/gateway` — 完整能力概览\n\
              `/approve` — 权限说明"
                 .into(),
@@ -1090,6 +1091,7 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
             lines.push("| `/usage` | Token/cost stats |".to_string());
             lines.push("| `/inspect` | Harness details |".to_string());
             lines.push("| `/audit` | Decision chain |".to_string());
+            lines.push("| `/auth` | Auth status + reset + auto-relogin |".to_string());
             lines.push("| `/gateway` | This context dump |".to_string());
 
             if ctx.config.action_policy.allow_model_generated_mutations && has_store {
@@ -1814,6 +1816,8 @@ mod tests {
                 base_url: "http://localhost:8080".into(),
                 api_key: String::new(),
                 default_model: None,
+                username: None,
+                password: None,
             },
             storage: Default::default(),
             database: None,

--- a/rust/crates/astra-gateway/src/commands.rs
+++ b/rust/crates/astra-gateway/src/commands.rs
@@ -4,7 +4,8 @@ use crate::access_control::{ActionCapability, ActionSource};
 use crate::config::GatewayConfig;
 use crate::store::{self, GatewayStore};
 use crate::trace_model::{
-    CancelRequestOutcome, ConversationKey, GatewayEvent, GatewayEventKind, TraceId, TraceRepository,
+    CancelRequestOutcome, ConversationKey, GatewayEvent, GatewayEventKind, OutboxStatus,
+    RequestStatus, TraceId, TraceRepository,
 };
 use astra_core::durable_task_store::{
     DurableTask, DurableTaskStatus, DurableTaskStore, TaskFilter, resolve_task_for_owner,
@@ -481,8 +482,10 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
              `/ws ls` — 列出可用项目\n\
              `/ws <name|path>` — 切换工作目录\n\
              `/running` — 查看正在执行的任务\n\
-             `/cancel` — 取消排队中的请求\n\
-             `/kill <trace_id>` — 强制终止运行中的请求\n\
+             `/cancel [text]` — 取消排队中的请求 (支持文本匹配)\n\
+             `/kill [text]` — 强制终止运行中的请求 (无参数=自动选择)\n\
+             `/retry` — 查看发送失败的消息\n\
+             `/retry dismiss` — 清除所有失败消息\n\
              `/usage` — 用量统计\n\n\
              **监控**\n\
              `/status` — 状态 + harness\n\
@@ -646,6 +649,7 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 Some("✅ 当前没有正在执行的任务。".into())
             } else {
                 let mut lines = vec![format!("🔄 **正在执行** ({} 个)", rows.len())];
+                let mut stuck_outbox_count = 0usize;
                 for row in &rows {
                     let short_user = short_id(&row.user_id);
                     let short_text = if row.text_preview.chars().count() > 40 {
@@ -660,6 +664,14 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                         row.display_status(),
                         short_text,
                         row.created_at
+                    ));
+                    if row.status.is_terminal() && row.outbox_status == Some(OutboxStatus::Failed) {
+                        stuck_outbox_count += 1;
+                    }
+                }
+                if stuck_outbox_count > 0 {
+                    lines.push(format!(
+                        "\n📬 提示: 有 {stuck_outbox_count} 个消息发送失败。用 `/retry` 查看，`/retry dismiss` 清除。"
                     ));
                 }
                 Some(lines.join("\n"))
@@ -723,7 +735,10 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                     Err(_) => None,
                 }
             } else {
-                Some(arg.to_string())
+                match resolve_trace_by_text_or_id(repo, &conversation, arg).await {
+                    Some(id) => Some(id.to_string()),
+                    None => return Some(format!("❌ 找不到匹配 `{arg}` 的请求")),
+                }
             };
             let Some(selector) = selector else {
                 return Some("✅ 当前没有可取消的排队请求。运行中的请求不会被强制中断。".into());
@@ -752,15 +767,28 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
             let repo = require_trace_repo!(ctx);
             let conversation =
                 ConversationKey::new(ctx.platform, ctx.chat_id, ctx.resolved_cli.name());
-            if arg.is_empty() {
-                return Some("用法: `/kill <trace_id>` — 强制终止运行中的请求".into());
-            }
-            // Resolve the trace ID (support prefix match)
-            let trace_id = resolve_trace_selector(repo, &conversation, arg).await;
-            let Some(trace_id) = trace_id else {
-                return Some(format!("❌ 找不到 trace `{arg}`"));
+
+            let target = if arg.is_empty() {
+                // Auto-pick the most recent running request
+                match repo.list_active_requests(&conversation, 20).await {
+                    Ok(rows) => rows
+                        .into_iter()
+                        .find(|row| row.status == RequestStatus::Running)
+                        .map(|row| row.trace_id.to_string()),
+                    Err(_) => None,
+                }
+            } else {
+                // Support text-based fuzzy match against text_preview
+                match resolve_trace_by_text_or_id(repo, &conversation, arg).await {
+                    Some(id) => Some(id.to_string()),
+                    None => return Some(format!("❌ 找不到匹配 `{arg}` 的请求")),
+                }
             };
-            // Force-fail the request regardless of current status
+
+            let Some(target) = target else {
+                return Some("✅ 当前没有运行中的请求。".into());
+            };
+            let trace_id = TraceId::from_string(target);
             match repo
                 .force_fail_request(&trace_id, "killed by user via /kill")
                 .await
@@ -775,6 +803,50 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 )),
                 Err(e) => Some(format!("⚠️ 终止失败: {e}")),
             }
+        }
+
+        "/retry" => {
+            let repo = require_trace_repo!(ctx);
+            let conversation =
+                ConversationKey::new(ctx.platform, ctx.chat_id, ctx.resolved_cli.name());
+
+            // Find requests with failed outbox
+            let rows = repo
+                .list_active_requests(&conversation, 20)
+                .await
+                .unwrap_or_default();
+            let stuck: Vec<_> = rows
+                .iter()
+                .filter(|r| r.status.is_terminal() && r.outbox_status == Some(OutboxStatus::Failed))
+                .collect();
+
+            if stuck.is_empty() {
+                return Some("✅ 没有需要重试的消息。".into());
+            }
+
+            if arg == "dismiss" || arg == "clear" {
+                let mut dismissed = 0usize;
+                for row in &stuck {
+                    if repo.dismiss_failed_outbox(&row.request_id).await.is_ok() {
+                        dismissed += 1;
+                    }
+                }
+                return Some(format!("🧹 已清除 {dismissed} 个失败消息。"));
+            }
+
+            let mut lines = vec![format!("📬 **待重试消息** ({} 个)", stuck.len())];
+            for row in &stuck {
+                lines.push(format!(
+                    "- `{}` | {} | {}",
+                    short_id(row.trace_id.as_str()),
+                    truncate_text(&row.text_preview, 40),
+                    row.outbox_error_message
+                        .as_deref()
+                        .unwrap_or("unknown error"),
+                ));
+            }
+            lines.push("\n`/retry dismiss` — 清除所有失败消息".into());
+            Some(lines.join("\n"))
         }
 
         "/usage" => {
@@ -970,8 +1042,9 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
             lines.push("| `/cron list` | Scheduled tasks |".to_string());
             lines.push("| `/task list` | Durable tasks |".to_string());
             lines.push("| `/running` | Active requests |".to_string());
-            lines.push("| `/cancel` | Cancel queued request |".to_string());
-            lines.push("| `/kill <id>` | Force-kill running request |".to_string());
+            lines.push("| `/cancel [text]` | Cancel queued request |".to_string());
+            lines.push("| `/kill [text]` | Force-kill running request |".to_string());
+            lines.push("| `/retry` | View/dismiss failed outbox |".to_string());
             lines.push("| `/trace [id]` | Request trace |".to_string());
             lines.push("| `/usage` | Token/cost stats |".to_string());
             lines.push("| `/inspect` | Harness details |".to_string());
@@ -1066,6 +1139,43 @@ async fn resolve_trace_selector(
         })
         .map(|trace| trace.trace_id)
         .or_else(|| Some(TraceId::from_string(selector.to_string())))
+}
+
+async fn resolve_trace_by_text_or_id(
+    repo: &dyn TraceRepository,
+    conversation: &ConversationKey,
+    selector: &str,
+) -> Option<TraceId> {
+    // First try exact/prefix ID match (existing behavior)
+    if let Some(id) = resolve_trace_selector(repo, conversation, selector).await {
+        // resolve_trace_selector falls back to constructing a TraceId from any string,
+        // so we need to verify the returned ID is a real match — not just a passthrough.
+        let traces = repo.list_recent_traces(conversation, 50).await.ok()?;
+        let is_real_match = traces.iter().any(|t| {
+            t.trace_id.as_str() == id.as_str()
+                && (t.trace_id.as_str() == selector
+                    || t.request_id.as_str() == selector
+                    || t.trace_id.as_str().starts_with(selector)
+                    || t.request_id.as_str().starts_with(selector))
+        });
+        if is_real_match {
+            return Some(id);
+        }
+    }
+    // Then try text_preview fuzzy match against active requests
+    let rows = repo.list_active_requests(conversation, 50).await.ok()?;
+    let lower = selector.to_lowercase();
+    rows.into_iter()
+        .find(|row| row.text_preview.to_lowercase().contains(&lower))
+        .map(|row| row.trace_id)
+}
+
+fn truncate_text(text: &str, max_chars: usize) -> String {
+    if text.chars().count() > max_chars {
+        format!("{}…", text.chars().take(max_chars).collect::<String>())
+    } else {
+        text.to_string()
+    }
 }
 
 fn format_trace_events(trace_id: &TraceId, events: Vec<GatewayEvent>) -> String {
@@ -1822,12 +1932,12 @@ mod tests {
             );
         }
     });
-    cmd_test!(cmd_kill_no_arg_shows_usage, "/kill", |r| {
+    cmd_test!(cmd_kill_no_arg_auto_pick_or_no_db, "/kill", |r| {
         {
             let msg = r.unwrap();
             assert!(
-                msg.contains("存储后端") || msg.contains("数据库") || msg.contains("用法"),
-                "expected usage or storage error, got: {msg}"
+                msg.contains("数据库") || msg.contains("没有运行中"),
+                "expected db error or no running message, got: {msg}"
             );
         }
     });
@@ -1855,6 +1965,31 @@ mod tests {
     cmd_test!(cmd_ws_ls_empty_projects, "/ws ls", |r| {
         let s = r.unwrap();
         assert!(s.contains("没有发现项目"), "expected empty project message");
+    });
+
+    cmd_test!(cmd_retry_requires_trace_repo, "/retry", |r| {
+        {
+            let msg = r.unwrap();
+            assert!(msg.contains("数据库"), "expected db error, got: {msg}");
+        }
+    });
+    cmd_test!(
+        cmd_retry_dismiss_requires_trace_repo,
+        "/retry dismiss",
+        |r| {
+            {
+                let msg = r.unwrap();
+                assert!(msg.contains("数据库"), "expected db error, got: {msg}");
+            }
+        }
+    );
+    cmd_test!(cmd_help_includes_retry, "/help", |r| {
+        let s = r.unwrap();
+        assert!(s.contains("/retry"), "help should include /retry");
+    });
+    cmd_test!(cmd_gateway_includes_retry, "/gateway", |r| {
+        let s = r.unwrap();
+        assert!(s.contains("/retry"), "gateway should include /retry");
     });
 
     cmd_test!(cmd_ws_no_arg_requires_store, "/ws", |r| {

--- a/rust/crates/astra-gateway/src/commands.rs
+++ b/rust/crates/astra-gateway/src/commands.rs
@@ -655,13 +655,15 @@ pub async fn handle_command(ctx: &CommandContext<'_>, text: &str) -> Option<Stri
                 let mut stuck_outbox_count = 0usize;
                 for (i, row) in rows.iter().enumerate() {
                     let icon = status_icon(row.display_status());
+                    let tag = crate::runner::short_request_tag(row.trace_id.as_str());
                     let short_text = truncate_text(&row.text_preview, 40);
                     let ts = short_timestamp(&row.created_at);
                     lines.push(format!(
-                        "[{}] {} {} | {} | {}",
+                        "[{}] {} {} | {} | {} | {}",
                         i + 1,
                         icon,
                         row.display_status(),
+                        tag,
                         short_text,
                         ts,
                     ));

--- a/rust/crates/astra-gateway/src/commands.rs
+++ b/rust/crates/astra-gateway/src/commands.rs
@@ -2119,6 +2119,116 @@ mod tests {
     // Note: trace_kill and outbox_dismiss GATEWAY action tags are only visible
     // when model_generated_mutations is allowed AND store is available (tested below).
 
+    // ── GAP 4: /gateway content completeness ────────────────────
+
+    cmd_test!(cmd_gateway_content_completeness, "/gateway", |r| {
+        let s = r.unwrap();
+        assert!(s.contains("Gateway Context"), "missing header");
+        assert!(s.contains("Identity"), "missing identity section");
+        assert!(s.contains("Capabilities"), "missing capabilities section");
+        assert!(s.contains("Commands"), "missing commands section");
+        assert!(s.contains("astra"), "missing CLI name");
+        assert!(s.contains("test"), "missing platform");
+        // Verify capabilities matrix
+        assert!(
+            s.contains("Session management"),
+            "missing session capability"
+        );
+        assert!(s.contains("Model switching"), "missing model capability");
+        assert!(s.contains("Tool execution"), "missing tool capability");
+        // Verify commands table
+        assert!(s.contains("/new"), "missing /new in commands table");
+        assert!(s.contains("/model"), "missing /model in commands table");
+        assert!(s.contains("/kill"), "missing /kill in commands table");
+        assert!(s.contains("/manage"), "missing /manage in commands table");
+        assert!(s.contains("/retry"), "missing /retry in commands table");
+        assert!(s.contains("/trace"), "missing /trace in commands table");
+        assert!(s.contains("/usage"), "missing /usage in commands table");
+        assert!(s.contains("/inspect"), "missing /inspect in commands table");
+        assert!(s.contains("/audit"), "missing /audit in commands table");
+        // Verify storage status (no store in test)
+        assert!(
+            s.contains("none"),
+            "should show no storage when store is None"
+        );
+    });
+
+    // ── GAP 8: resolve_active_request edge cases ────────────────
+
+    #[tokio::test]
+    async fn resolve_active_request_returns_none_for_empty_list() {
+        use crate::trace_model::InMemoryTraceRepository;
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let result = resolve_active_request(&repo, &conv, "1").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_active_request_numeric_zero_returns_none() {
+        use crate::trace_model::InMemoryTraceRepository;
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req = crate::trace_model::GatewayRequest::new(conv.clone(), "m1", "u1", "test");
+        crate::trace_model::TraceWriter::begin(&repo, req)
+            .await
+            .unwrap();
+        let result = resolve_active_request(&repo, &conv, "0").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_active_request_out_of_range_returns_none() {
+        use crate::trace_model::InMemoryTraceRepository;
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req = crate::trace_model::GatewayRequest::new(conv.clone(), "m1", "u1", "test");
+        crate::trace_model::TraceWriter::begin(&repo, req)
+            .await
+            .unwrap();
+        // Only 1 request, asking for index 5
+        let result = resolve_active_request(&repo, &conv, "5").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_active_request_by_trace_id_prefix() {
+        use crate::trace_model::InMemoryTraceRepository;
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req = crate::trace_model::GatewayRequest::new(conv.clone(), "m1", "u1", "test");
+        let trace_id = req.trace_id.clone();
+        crate::trace_model::TraceWriter::begin(&repo, req)
+            .await
+            .unwrap();
+
+        // Full trace ID
+        let found = resolve_active_request(&repo, &conv, trace_id.as_str())
+            .await
+            .unwrap();
+        assert_eq!(found.trace_id, trace_id);
+
+        // Prefix match (first 8 chars)
+        let prefix = &trace_id.as_str()[..8];
+        let found = resolve_active_request(&repo, &conv, prefix).await.unwrap();
+        assert_eq!(found.trace_id, trace_id);
+    }
+
+    #[tokio::test]
+    async fn resolve_active_request_no_match_returns_none() {
+        use crate::trace_model::InMemoryTraceRepository;
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req =
+            crate::trace_model::GatewayRequest::new(conv.clone(), "m1", "u1", "something specific");
+        crate::trace_model::TraceWriter::begin(&repo, req)
+            .await
+            .unwrap();
+
+        let result = resolve_active_request(&repo, &conv, "nonexistent_text").await;
+        assert!(result.is_none());
+    }
+
     // ── status_icon ──
 
     #[test]

--- a/rust/crates/astra-gateway/src/config.rs
+++ b/rust/crates/astra-gateway/src/config.rs
@@ -83,6 +83,11 @@ pub struct AstraServerConfig {
     #[serde(default)]
     pub api_key: String,
     pub default_model: Option<String>,
+    /// Optional login credentials for gateway-level auto-recovery when CLI tokens expire.
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub password: Option<String>,
 }
 
 impl std::fmt::Debug for AstraServerConfig {
@@ -98,6 +103,15 @@ impl std::fmt::Debug for AstraServerConfig {
                 },
             )
             .field("default_model", &self.default_model)
+            .field("username", &self.username.as_deref())
+            .field(
+                "password",
+                &if self.password.is_some() {
+                    Some("[REDACTED]")
+                } else {
+                    None
+                },
+            )
             .finish()
     }
 }
@@ -273,6 +287,8 @@ platforms:
             base_url: "http://localhost:8080".into(),
             api_key: "super-secret-key".into(),
             default_model: None,
+            username: Some("admin".into()),
+            password: Some("hunter2".into()),
         };
         let dbg = format!("{cfg:?}");
         assert!(
@@ -283,6 +299,8 @@ platforms:
             !dbg.contains("super-secret"),
             "api_key leaked in debug: {dbg}"
         );
+        assert!(!dbg.contains("hunter2"), "password leaked in debug: {dbg}");
+        assert!(dbg.contains("admin"), "username should be visible: {dbg}");
 
         let db = DatabaseConfig {
             url: "mysql://root:password@host/db".into(),
@@ -427,5 +445,31 @@ database:
         let resolved = cfg.resolve();
         // Can't assert env vars in unit tests, but verify no panic
         assert!(resolved.websocket_url.starts_with("wss://"));
+    }
+
+    #[test]
+    fn parse_config_with_auth_credentials() {
+        let yaml = r#"
+astra:
+  base_url: "http://localhost:8080"
+  api_key: "key"
+  username: "admin"
+  password: "secret123"
+"#;
+        let cfg: GatewayConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(cfg.astra.username.as_deref(), Some("admin"));
+        assert_eq!(cfg.astra.password.as_deref(), Some("secret123"));
+    }
+
+    #[test]
+    fn parse_config_without_auth_credentials() {
+        let yaml = r#"
+astra:
+  base_url: "http://localhost:8080"
+  api_key: "key"
+"#;
+        let cfg: GatewayConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(cfg.astra.username.is_none());
+        assert!(cfg.astra.password.is_none());
     }
 }

--- a/rust/crates/astra-gateway/src/config.rs
+++ b/rust/crates/astra-gateway/src/config.rs
@@ -3,8 +3,12 @@ use std::path::Path;
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct GatewayConfig {
     pub astra: AstraServerConfig,
+    /// New multi-backend storage configuration.
     #[serde(default)]
-    pub database: DatabaseConfig,
+    pub storage: crate::store::StorageConfig,
+    /// Legacy database config — kept for backward compatibility with existing YAML files.
+    #[serde(default)]
+    pub database: Option<DatabaseConfig>,
     /// Default CLI profile (used when no /cli switch active).
     #[serde(default)]
     pub cli: crate::cli_bridge::CliProfile,
@@ -46,9 +50,9 @@ pub struct GatewayConfig {
     pub project_dirs: Vec<String>,
 }
 
-#[derive(Clone, serde::Deserialize)]
+#[derive(Clone, Default, serde::Deserialize)]
 pub struct DatabaseConfig {
-    #[serde(default = "default_db_url")]
+    #[serde(default)]
     pub url: String,
 }
 
@@ -57,14 +61,6 @@ impl std::fmt::Debug for DatabaseConfig {
         f.debug_struct("DatabaseConfig")
             .field("url", &"[REDACTED]")
             .finish()
-    }
-}
-
-impl Default for DatabaseConfig {
-    fn default() -> Self {
-        Self {
-            url: default_db_url(),
-        }
     }
 }
 
@@ -78,11 +74,6 @@ fn default_cli_timeout_secs() -> u64 {
 
 fn default_max_concurrent_runs() -> usize {
     4
-}
-
-fn default_db_url() -> String {
-    std::env::var("GATEWAY_DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@127.0.0.1:6001/astra_gateway".into())
 }
 
 #[derive(Clone, serde::Deserialize)]
@@ -178,6 +169,32 @@ impl GatewayConfig {
         let content = std::fs::read_to_string(path)?;
         let config: Self = serde_yaml_ng::from_str(&content)?;
         Ok(config)
+    }
+
+    /// Merge `storage` and legacy `database` fields into a single [`StorageConfig`].
+    ///
+    /// Priority: if `storage` is explicitly set (not default-derived) or the
+    /// `GATEWAY_DATABASE_URL` env var is present, `storage` wins.
+    /// Otherwise, a legacy `database.url` value is promoted to
+    /// [`StorageConfig::Mysql`] for backward compat.
+    pub fn resolve_storage(&self) -> crate::store::StorageConfig {
+        // If `storage` was explicitly set to a non-default variant *or* the env
+        // var is present, prefer it as-is.
+        if !matches!(self.storage, crate::store::StorageConfig::Sqlite { .. })
+            || std::env::var("GATEWAY_DATABASE_URL").is_ok()
+        {
+            return self.storage.clone();
+        }
+        // Legacy path: `database:` section in YAML.
+        if let Some(ref db) = self.database
+            && !db.url.is_empty()
+        {
+            return crate::store::StorageConfig::Mysql {
+                url: db.url.clone(),
+            };
+        }
+        // Fall through to the default (SQLite).
+        self.storage.clone()
     }
 }
 
@@ -290,6 +307,111 @@ platforms:
         assert!(
             !dbg.contains("bot123:AABBCC"),
             "telegram token leaked: {dbg}"
+        );
+    }
+
+    // ── resolve_storage tests ────────────────────────────────────────────
+
+    #[test]
+    fn resolve_storage_legacy_database_url() {
+        let yaml = r#"
+astra:
+  base_url: "http://localhost:8080"
+  api_key: ""
+database:
+  url: "mysql://root:111@localhost/gw"
+"#;
+        let cfg: GatewayConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        let resolved = cfg.resolve_storage();
+        assert!(
+            matches!(resolved, crate::store::StorageConfig::Mysql { .. }),
+            "expected Mysql, got {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_storage_explicit_mysql_storage_wins() {
+        let yaml = r#"
+astra:
+  base_url: "http://localhost:8080"
+  api_key: ""
+storage:
+  backend: mysql
+  url: "mysql://explicit@host/db"
+database:
+  url: "mysql://legacy@host/db"
+"#;
+        let cfg: GatewayConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        let resolved = cfg.resolve_storage();
+        match resolved {
+            crate::store::StorageConfig::Mysql { url } => {
+                assert!(
+                    url.contains("explicit"),
+                    "storage: section should win, got {url}"
+                );
+            }
+            other => panic!("expected Mysql, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_storage_no_storage_no_database_defaults_to_sqlite() {
+        let yaml = r#"
+astra:
+  base_url: "http://localhost:8080"
+  api_key: ""
+"#;
+        let cfg: GatewayConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        let resolved = cfg.resolve_storage();
+        // Depends on whether GATEWAY_DATABASE_URL env var is set
+        assert!(
+            matches!(
+                resolved,
+                crate::store::StorageConfig::Sqlite { .. }
+                    | crate::store::StorageConfig::Mysql { .. }
+            ),
+            "expected Sqlite or Mysql, got {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_storage_explicit_file_not_overridden() {
+        let yaml = r#"
+astra:
+  base_url: "http://localhost:8080"
+  api_key: ""
+storage:
+  backend: file
+  dir: "/custom/data"
+database:
+  url: "mysql://root:111@localhost/gw"
+"#;
+        let cfg: GatewayConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        let resolved = cfg.resolve_storage();
+        match resolved {
+            crate::store::StorageConfig::File { dir } => {
+                assert_eq!(dir, "/custom/data");
+            }
+            other => panic!("expected File, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_storage_none_not_overridden() {
+        let yaml = r#"
+astra:
+  base_url: "http://localhost:8080"
+  api_key: ""
+storage:
+  backend: none
+database:
+  url: "mysql://root:111@localhost/gw"
+"#;
+        let cfg: GatewayConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        let resolved = cfg.resolve_storage();
+        assert!(
+            matches!(resolved, crate::store::StorageConfig::None),
+            "expected None, got {resolved:?}"
         );
     }
 

--- a/rust/crates/astra-gateway/src/config.rs
+++ b/rust/crates/astra-gateway/src/config.rs
@@ -6,7 +6,8 @@ pub struct GatewayConfig {
     /// New multi-backend storage configuration.
     #[serde(default)]
     pub storage: crate::store::StorageConfig,
-    /// Legacy database config — kept for backward compatibility with existing YAML files.
+    /// Legacy database config. Parsed only to produce clear diagnostics; storage
+    /// must be configured through `storage:`.
     #[serde(default)]
     pub database: Option<DatabaseConfig>,
     /// Default CLI profile (used when no /cli switch active).
@@ -185,29 +186,11 @@ impl GatewayConfig {
         Ok(config)
     }
 
-    /// Merge `storage` and legacy `database` fields into a single [`StorageConfig`].
+    /// Resolve the configured storage backend.
     ///
-    /// Priority: if `storage` is explicitly set (not default-derived) or the
-    /// `GATEWAY_DATABASE_URL` env var is present, `storage` wins.
-    /// Otherwise, a legacy `database.url` value is promoted to
-    /// [`StorageConfig::Mysql`] for backward compat.
+    /// `database:` is intentionally ignored. Gateway durability needs explicit
+    /// `storage:` configuration or a non-empty `GATEWAY_DATABASE_URL`.
     pub fn resolve_storage(&self) -> crate::store::StorageConfig {
-        // If `storage` was explicitly set to a non-default variant *or* the env
-        // var is present, prefer it as-is.
-        if !matches!(self.storage, crate::store::StorageConfig::Sqlite { .. })
-            || std::env::var("GATEWAY_DATABASE_URL").is_ok()
-        {
-            return self.storage.clone();
-        }
-        // Legacy path: `database:` section in YAML.
-        if let Some(ref db) = self.database
-            && !db.url.is_empty()
-        {
-            return crate::store::StorageConfig::Mysql {
-                url: db.url.clone(),
-            };
-        }
-        // Fall through to the default (SQLite).
         self.storage.clone()
     }
 }
@@ -331,7 +314,7 @@ platforms:
     // ── resolve_storage tests ────────────────────────────────────────────
 
     #[test]
-    fn resolve_storage_legacy_database_url() {
+    fn resolve_storage_ignores_legacy_database_url() {
         let yaml = r#"
 astra:
   base_url: "http://localhost:8080"
@@ -341,10 +324,14 @@ database:
 "#;
         let cfg: GatewayConfig = serde_yaml_ng::from_str(yaml).unwrap();
         let resolved = cfg.resolve_storage();
-        assert!(
-            matches!(resolved, crate::store::StorageConfig::Mysql { .. }),
-            "expected Mysql, got {resolved:?}"
-        );
+        match resolved {
+            crate::store::StorageConfig::None => {}
+            crate::store::StorageConfig::Mysql { url } => assert_ne!(
+                url, "mysql://root:111@localhost/gw",
+                "legacy database must not silently configure storage"
+            ),
+            other => panic!("unexpected storage from legacy database: {other:?}"),
+        }
     }
 
     #[test]
@@ -373,7 +360,7 @@ database:
     }
 
     #[test]
-    fn resolve_storage_no_storage_no_database_defaults_to_sqlite() {
+    fn resolve_storage_no_storage_no_database_defaults_to_none() {
         let yaml = r#"
 astra:
   base_url: "http://localhost:8080"
@@ -381,14 +368,12 @@ astra:
 "#;
         let cfg: GatewayConfig = serde_yaml_ng::from_str(yaml).unwrap();
         let resolved = cfg.resolve_storage();
-        // Depends on whether GATEWAY_DATABASE_URL env var is set
         assert!(
             matches!(
                 resolved,
-                crate::store::StorageConfig::Sqlite { .. }
-                    | crate::store::StorageConfig::Mysql { .. }
+                crate::store::StorageConfig::None | crate::store::StorageConfig::Mysql { .. }
             ),
-            "expected Sqlite or Mysql, got {resolved:?}"
+            "expected None or env-derived Mysql, got {resolved:?}"
         );
     }
 

--- a/rust/crates/astra-gateway/src/lib.rs
+++ b/rust/crates/astra-gateway/src/lib.rs
@@ -11,9 +11,9 @@ pub mod platforms;
 pub mod runner;
 pub mod scheduler;
 pub mod session_policy;
-pub mod storage;
+pub mod store;
 pub(crate) mod text;
+
 pub mod trace_model;
-pub mod usage;
 pub mod weixin_media;
 pub mod workspace;

--- a/rust/crates/astra-gateway/src/main.rs
+++ b/rust/crates/astra-gateway/src/main.rs
@@ -57,13 +57,14 @@ async fn main() {
                 let db_saved = if cli.config.exists() {
                     if let Ok(cfg) = astra_gateway::config::GatewayConfig::load(&cli.config) {
                         let storage_config = cfg.resolve_storage();
-                        match astra_gateway::store::open_store(&storage_config).await {
-                            Ok(Some(store)) => {
+                        match astra_gateway::store::open_store_bundle(&storage_config).await {
+                            Ok(Some(bundle)) => {
                                 let creds = serde_json::json!({
                                     "token": token,
                                     "account_id": account_id,
                                 });
-                                match store
+                                match bundle
+                                    .store
                                     .save_credential("weixin", "default", "bot_token", &creds, None)
                                     .await
                                 {

--- a/rust/crates/astra-gateway/src/main.rs
+++ b/rust/crates/astra-gateway/src/main.rs
@@ -53,36 +53,31 @@ async fn main() {
     if let Some(Command::LoginWeixin) = cli.command {
         match astra_gateway::platforms::weixin::qr_login().await {
             Ok((token, account_id)) => {
-                // Save to database if config is loadable
+                // Save to store if config is loadable
                 let db_saved = if cli.config.exists() {
                     if let Ok(cfg) = astra_gateway::config::GatewayConfig::load(&cli.config) {
-                        match astra_gateway::storage::try_connect_db(&cfg.database.url).await {
-                            Ok(pool) => {
+                        let storage_config = cfg.resolve_storage();
+                        match astra_gateway::store::open_store(&storage_config).await {
+                            Ok(Some(store)) => {
                                 let creds = serde_json::json!({
                                     "token": token,
                                     "account_id": account_id,
                                 });
-                                match astra_gateway::storage::save_credential(
-                                    &pool,
-                                    "weixin",
-                                    "default",
-                                    "bot_token",
-                                    &creds,
-                                    None,
-                                )
-                                .await
+                                match store
+                                    .save_credential("weixin", "default", "bot_token", &creds, None)
+                                    .await
                                 {
                                     Ok(()) => {
-                                        println!("✅ 凭证已保存到数据库 (换机器无需重新扫码)");
+                                        println!("✅ 凭证已保存到存储 (换机器无需重新扫码)");
                                         true
                                     }
                                     Err(e) => {
-                                        tracing::warn!(error = %e, "DB save failed, falling back to config file");
+                                        tracing::warn!(error = %e, "store save failed, falling back to config file");
                                         false
                                     }
                                 }
                             }
-                            Err(_) => false,
+                            _ => false,
                         }
                     } else {
                         false
@@ -141,7 +136,9 @@ async fn main() {
 
     // CLI flag overrides config file
     if let Some(ref db_url) = cli.database_url {
-        config.database.url = db_url.clone();
+        config.storage = astra_gateway::store::StorageConfig::Mysql {
+            url: db_url.clone(),
+        };
     }
 
     let mut runner = match astra_gateway::runner::GatewayRunner::new(config.clone()).await {
@@ -167,8 +164,8 @@ async fn main() {
         && weixin_cfg.enabled
     {
         let mut adapter = astra_gateway::platforms::weixin::WeixinAdapter::new(weixin_cfg);
-        if let Some(pool) = runner.pool() {
-            adapter = adapter.with_pool(pool.clone());
+        if let Some(store) = runner.store() {
+            adapter = adapter.with_store(store);
         }
         adapters.push(Box::new(adapter));
     }
@@ -182,13 +179,17 @@ async fn main() {
     let (cron_tx, cron_rx) = tokio::sync::mpsc::channel(64);
     runner.set_outbound_tx(cron_tx.clone());
 
-    // Start cron scheduler (only if DB available)
-    if let Some(pool) = runner.pool() {
-        let scheduler =
-            astra_gateway::scheduler::CronScheduler::new(pool.clone(), scheduler_config, cron_tx);
+    // Start cron scheduler (only if store + trace_repo available)
+    if let (Some(store), Some(trace_repo)) = (runner.store(), runner.trace_repo()) {
+        let scheduler = astra_gateway::scheduler::CronScheduler::new(
+            store,
+            scheduler_config,
+            trace_repo,
+            cron_tx,
+        );
         let _scheduler_handle = scheduler.spawn(shutdown_tx.subscribe());
     } else {
-        tracing::info!("cron scheduler disabled (no DB)");
+        tracing::info!("cron scheduler disabled (no store or trace_repo)");
     }
 
     // Ctrl+C

--- a/rust/crates/astra-gateway/src/platforms/weixin.rs
+++ b/rust/crates/astra-gateway/src/platforms/weixin.rs
@@ -454,7 +454,16 @@ impl PlatformAdapter for WeixinAdapter {
             tokens.get(chat_id).cloned().unwrap_or_default()
         };
 
-        send_text_with_retry(&self.config.token, chat_id, &text, &context_token).await
+        match send_text_with_retry(&self.config.token, chat_id, &text, &context_token).await {
+            Ok(new_ct) => {
+                if let Some(ct) = new_ct {
+                    let mut tokens = self.context_tokens.lock().await;
+                    tokens.insert(chat_id.to_string(), ct);
+                }
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
     }
 
     async fn send_typing(&self, chat_id: &str) -> Result<(), String> {
@@ -767,12 +776,14 @@ fn extract_text(msg: &Value) -> String {
 const SEND_MAX_RETRIES: usize = 3;
 const SEND_RETRY_DELAY_MS: u64 = 1500;
 
+/// Send a text message via iLink API with retries.
+/// Returns the updated context_token from the response (if any).
 async fn send_text_with_retry(
     token: &str,
     chat_id: &str,
     text: &str,
     context_token: &str,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     let client = reqwest::Client::new();
     let url = format!("{ILINK_BASE_URL}/ilink/bot/sendmessage");
     let mut last_error = String::new();
@@ -828,7 +839,12 @@ async fn send_text_with_retry(
             .or_else(|| data["ret"].as_i64())
             .unwrap_or(0);
         if errcode == 0 {
-            return Ok(());
+            let new_ct = data["context_token"]
+                .as_str()
+                .or_else(|| data["data"]["context_token"].as_str())
+                .filter(|s| !s.is_empty())
+                .map(String::from);
+            return Ok(new_ct);
         }
 
         let errmsg = data["errmsg"].as_str().unwrap_or("unknown");

--- a/rust/crates/astra-gateway/src/platforms/weixin.rs
+++ b/rust/crates/astra-gateway/src/platforms/weixin.rs
@@ -17,6 +17,7 @@ use super::{
     PlatformAdapter, emit_adapter_health,
 };
 use crate::dedup::MessageDeduplicator;
+use crate::store::GatewayStore;
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use std::collections::HashMap;
@@ -92,7 +93,7 @@ const TYPING_TICKET_TTL_SECS: u64 = 600; // 10 minutes
 
 pub struct WeixinAdapter {
     config: WeixinConfig,
-    pool: Option<sqlx::MySqlPool>,
+    store: Option<Arc<dyn GatewayStore>>,
     msg_tx: mpsc::Sender<InboundMessage>,
     msg_rx: Mutex<mpsc::Receiver<InboundMessage>>,
     context_tokens: ContextTokens,
@@ -105,7 +106,7 @@ impl WeixinAdapter {
         let (tx, rx) = mpsc::channel(256);
         Self {
             config: config.resolve(),
-            pool: None,
+            store: None,
             msg_tx: tx,
             msg_rx: Mutex::new(rx),
             context_tokens: Arc::new(Mutex::new(HashMap::new())),
@@ -114,8 +115,8 @@ impl WeixinAdapter {
         }
     }
 
-    pub fn with_pool(mut self, pool: sqlx::MySqlPool) -> Self {
-        self.pool = Some(pool);
+    pub fn with_store(mut self, store: Arc<dyn GatewayStore>) -> Self {
+        self.store = Some(store);
         self
     }
 
@@ -126,9 +127,8 @@ impl WeixinAdapter {
             validate_weixin_credentials(&self.config.token, &self.config.account_id)?;
             return Ok(());
         }
-        if let Some(ref pool) = self.pool
-            && let Ok(Some(cred)) =
-                crate::storage::get_credential(pool, "weixin", "default", "bot_token").await
+        if let Some(ref store) = self.store
+            && let Ok(Some(cred)) = store.get_credential("weixin", "default", "bot_token").await
         {
             if let Some(token) = cred.credentials["token"].as_str() {
                 if validate_restored_token(token) {
@@ -342,12 +342,13 @@ impl PlatformAdapter for WeixinAdapter {
         let config = self.config.clone();
         let msg_tx = self.msg_tx.clone();
         let tokens = self.context_tokens.clone();
-        let pool = self.pool.clone();
+        let store = self.store.clone();
 
         // Restore persisted context_tokens from DB
-        if let Some(ref pool) = pool
-            && let Ok(Some(cred)) =
-                crate::storage::get_credential(pool, "weixin", "default", "context_tokens").await
+        if let Some(ref store) = store
+            && let Ok(Some(cred)) = store
+                .get_credential("weixin", "default", "context_tokens")
+                .await
         {
             let restored = restore_context_tokens_value(&cred.credentials);
             let mut t = tokens.lock().await;
@@ -363,9 +364,8 @@ impl PlatformAdapter for WeixinAdapter {
             let mut dedup = MessageDeduplicator::new();
             let mut shutdown_rx = shutdown_tx.subscribe();
             // Restore sync cursor from DB
-            let mut sync_buf = if let Some(ref pool) = pool
-                && let Ok(Some(cred)) =
-                    crate::storage::get_credential(pool, "weixin", "default", "sync_buf").await
+            let mut sync_buf = if let Some(ref store) = store
+                && let Ok(Some(cred)) = store.get_credential("weixin", "default", "sync_buf").await
                 && let Some(s) = restore_sync_buf_value(&cred.credentials)
             {
                 tracing::info!("restored sync cursor from DB");
@@ -377,7 +377,7 @@ impl PlatformAdapter for WeixinAdapter {
 
             loop {
                 tokio::select! {
-                    result = poll_updates(&client, &config, &mut sync_buf, &msg_tx, &mut dedup, &tokens, &pool) => {
+                    result = poll_updates(&client, &config, &mut sync_buf, &msg_tx, &mut dedup, &tokens, &store) => {
                         match result {
                             Ok(()) => { consecutive_errors = 0; }
                             Err(e) => {
@@ -559,7 +559,7 @@ async fn poll_updates(
     msg_tx: &mpsc::Sender<InboundMessage>,
     dedup: &mut MessageDeduplicator,
     context_tokens: &ContextTokens,
-    pool: &Option<sqlx::MySqlPool>,
+    store: &Option<Arc<dyn GatewayStore>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let url = format!("{ILINK_BASE_URL}/ilink/bot/getupdates");
 
@@ -606,16 +606,16 @@ async fn poll_updates(
     // Update sync cursor and persist to DB
     if let Some(buf) = data["get_updates_buf"].as_str() {
         *sync_buf = buf.to_string();
-        if let Some(pool) = pool {
-            let _ = crate::storage::save_credential(
-                pool,
-                "weixin",
-                "default",
-                "sync_buf",
-                &serde_json::Value::String(buf.to_string()),
-                None,
-            )
-            .await;
+        if let Some(store) = store {
+            let _ = store
+                .save_credential(
+                    "weixin",
+                    "default",
+                    "sync_buf",
+                    &serde_json::Value::String(buf.to_string()),
+                    None,
+                )
+                .await;
         }
     }
 
@@ -656,20 +656,14 @@ async fn poll_updates(
                 let mut tokens = context_tokens.lock().await;
                 tokens.insert(from_id.clone(), ct.to_string());
                 // Persist to DB for crash recovery
-                if let Some(pool) = pool {
+                if let Some(store) = store {
                     let map: serde_json::Value = tokens
                         .iter()
                         .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
                         .collect();
-                    let _ = crate::storage::save_credential(
-                        pool,
-                        "weixin",
-                        "default",
-                        "context_tokens",
-                        &map,
-                        None,
-                    )
-                    .await;
+                    let _ = store
+                        .save_credential("weixin", "default", "context_tokens", &map, None)
+                        .await;
                 }
             }
 
@@ -840,9 +834,15 @@ async fn send_text_with_retry(
         let errmsg = data["errmsg"].as_str().unwrap_or("unknown");
         last_error = format!("{errcode}: {errmsg}");
 
-        // Session expired — retry without context_token
-        if errcode == -14 && !tried_tokenless {
-            tracing::debug!("send got -14, retrying without context_token");
+        // Session / context_token expired — retry without it.
+        // -14 = explicit session expiry; -2 with non-freq message usually
+        // means the context_token is stale or invalidated server-side.
+        if !tried_tokenless && (errcode == -14 || (errcode == -2 && !errmsg.contains("freq"))) {
+            tracing::debug!(
+                errcode,
+                errmsg,
+                "send failed, retrying without context_token"
+            );
             tried_tokenless = true;
             continue;
         }

--- a/rust/crates/astra-gateway/src/platforms/weixin.rs
+++ b/rust/crates/astra-gateway/src/platforms/weixin.rs
@@ -827,7 +827,6 @@ async fn send_text_with_retry(
     }
     tracing::debug!(
         text_len = text.len(),
-        text_preview = %&text[..text.len().min(80)],
         has_context_token = !context_token.is_empty(),
         "iLink send attempt"
     );
@@ -1388,6 +1387,16 @@ mod tests {
     fn typing_ticket_ttl_reasonable() {
         const { assert!(TYPING_TICKET_TTL_SECS >= 300) };
         const { assert!(TYPING_TICKET_TTL_SECS <= 1800) };
+    }
+
+    #[test]
+    fn send_diagnostics_do_not_log_message_preview() {
+        let source = include_str!("weixin.rs");
+        let needle = concat!("text_", "preview");
+        assert!(
+            !source.contains(needle),
+            "send diagnostics must not log outbound message content previews"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-gateway/src/platforms/weixin.rs
+++ b/rust/crates/astra-gateway/src/platforms/weixin.rs
@@ -848,6 +848,7 @@ async fn send_text_with_retry(
         }
 
         let errmsg = data["errmsg"].as_str().unwrap_or("unknown");
+        tracing::debug!(errcode, errmsg, body = %data, "iLink send response (non-zero)");
         last_error = format!("{errcode}: {errmsg}");
 
         // Session / context_token expired — retry without it.

--- a/rust/crates/astra-gateway/src/platforms/weixin.rs
+++ b/rust/crates/astra-gateway/src/platforms/weixin.rs
@@ -776,6 +776,39 @@ fn extract_text(msg: &Value) -> String {
 const SEND_MAX_RETRIES: usize = 3;
 const SEND_RETRY_DELAY_MS: u64 = 1500;
 
+/// What to do when iLink returns a non-zero error code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SendRetryAction {
+    /// Retry the same request without context_token (session expired).
+    DropContextToken,
+    /// Back off longer — server indicated rate limiting.
+    RateLimitBackoff,
+    /// Normal retry with delay (keep context_token).
+    NormalRetry,
+}
+
+/// Decide how to handle an iLink send error. Pure function — no I/O.
+///
+/// Key invariant: `-2` ("unknown") must NOT drop context_token.
+/// iLink requires context_token for session routing; dropping it makes
+/// the error permanent. Only `-14` (explicit session expiry) should drop.
+fn classify_send_error(
+    errcode: i64,
+    errmsg: &str,
+    already_tried_tokenless: bool,
+) -> SendRetryAction {
+    // -14 = explicit session expiry — retry once without context_token
+    if errcode == -14 && !already_tried_tokenless {
+        return SendRetryAction::DropContextToken;
+    }
+    // -2 + "freq" = rate limit — backoff
+    if errcode == -2 && errmsg.contains("freq") {
+        return SendRetryAction::RateLimitBackoff;
+    }
+    // Everything else: normal retry with original context_token
+    SendRetryAction::NormalRetry
+}
+
 /// Send a text message via iLink API with retries.
 /// Returns the updated context_token from the response (if any).
 async fn send_text_with_retry(
@@ -788,6 +821,16 @@ async fn send_text_with_retry(
     let url = format!("{ILINK_BASE_URL}/ilink/bot/sendmessage");
     let mut last_error = String::new();
     let mut tried_tokenless = false;
+
+    if text.is_empty() {
+        return Err("empty message text".into());
+    }
+    tracing::debug!(
+        text_len = text.len(),
+        text_preview = %&text[..text.len().min(80)],
+        has_context_token = !context_token.is_empty(),
+        "iLink send attempt"
+    );
 
     for attempt in 0..=SEND_MAX_RETRIES {
         let ct = if tried_tokenless { "" } else { context_token };
@@ -851,24 +894,18 @@ async fn send_text_with_retry(
         tracing::debug!(errcode, errmsg, body = %data, "iLink send response (non-zero)");
         last_error = format!("{errcode}: {errmsg}");
 
-        // Session / context_token expired — retry without it.
-        // -14 = explicit session expiry; -2 with non-freq message usually
-        // means the context_token is stale or invalidated server-side.
-        if !tried_tokenless && (errcode == -14 || (errcode == -2 && !errmsg.contains("freq"))) {
-            tracing::debug!(
-                errcode,
-                errmsg,
-                "send failed, retrying without context_token"
-            );
-            tried_tokenless = true;
-            continue;
-        }
-
-        // Rate limit — backoff
-        if errcode == -2 && errmsg.contains("freq") {
-            tracing::warn!("send rate limited, backing off");
-            tokio::time::sleep(std::time::Duration::from_millis(SEND_RETRY_DELAY_MS * 3)).await;
-            continue;
+        match classify_send_error(errcode, errmsg, tried_tokenless) {
+            SendRetryAction::DropContextToken => {
+                tracing::debug!(errcode, "retrying without context_token");
+                tried_tokenless = true;
+                continue;
+            }
+            SendRetryAction::RateLimitBackoff => {
+                tracing::warn!("send rate limited, backing off");
+                tokio::time::sleep(std::time::Duration::from_millis(SEND_RETRY_DELAY_MS * 3)).await;
+                continue;
+            }
+            SendRetryAction::NormalRetry => {}
         }
 
         // Other error — retry with delay
@@ -1279,6 +1316,72 @@ mod tests {
     fn send_retry_constants() {
         const { assert!(SEND_MAX_RETRIES >= 2) };
         const { assert!(SEND_RETRY_DELAY_MS >= 1000) };
+    }
+
+    // ── classify_send_error regression tests ───────────────────────
+
+    #[test]
+    fn error_minus2_unknown_keeps_context_token() {
+        // CRITICAL: -2 "unknown" must NOT drop context_token.
+        // Dropping it causes permanent send failures.
+        assert_eq!(
+            classify_send_error(-2, "unknown", false),
+            SendRetryAction::NormalRetry,
+        );
+    }
+
+    #[test]
+    fn error_minus2_unknown_still_normal_even_after_tokenless() {
+        assert_eq!(
+            classify_send_error(-2, "unknown", true),
+            SendRetryAction::NormalRetry,
+        );
+    }
+
+    #[test]
+    fn error_minus2_freq_triggers_rate_limit_backoff() {
+        assert_eq!(
+            classify_send_error(-2, "freq limit exceeded", false),
+            SendRetryAction::RateLimitBackoff,
+        );
+    }
+
+    #[test]
+    fn error_minus14_drops_context_token_once() {
+        assert_eq!(
+            classify_send_error(-14, "session expired", false),
+            SendRetryAction::DropContextToken,
+        );
+    }
+
+    #[test]
+    fn error_minus14_does_not_drop_twice() {
+        assert_eq!(
+            classify_send_error(-14, "session expired", true),
+            SendRetryAction::NormalRetry,
+        );
+    }
+
+    #[test]
+    fn error_other_codes_normal_retry() {
+        assert_eq!(
+            classify_send_error(-1, "unknown", false),
+            SendRetryAction::NormalRetry,
+        );
+        assert_eq!(
+            classify_send_error(-99, "server error", false),
+            SendRetryAction::NormalRetry,
+        );
+    }
+
+    #[test]
+    fn error_zero_would_not_reach_classify() {
+        // errcode 0 is success — classify is never called.
+        // But if it were, it should be normal retry (harmless).
+        assert_eq!(
+            classify_send_error(0, "", false),
+            SendRetryAction::NormalRetry,
+        );
     }
 
     #[test]

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -28,6 +28,11 @@ const PROGRESSIVE_FLUSH_INTERVAL: Duration = Duration::from_secs(8);
 const PROGRESSIVE_MIN_CHARS: usize = 200;
 const CONVERSATION_QUEUE_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Number of consecutive auth failures before the circuit breaker trips.
+const AUTH_FAILURE_THRESHOLD: u32 = 2;
+/// How long the circuit breaker stays open before allowing retries.
+const AUTH_FAILURE_COOLDOWN: Duration = Duration::from_secs(300);
+
 /// Outbound message from CLI, scheduler, or other background tasks.
 #[derive(Debug, Clone)]
 pub struct OutboundMessage {
@@ -91,6 +96,9 @@ pub struct GatewayRunner {
         tokio::sync::Mutex<HashMap<ConversationKey, tokio::sync::mpsc::Sender<QueuedRequest>>>,
     global_run_limiter: Arc<tokio::sync::Semaphore>,
     cli_availability: Vec<(String, cli_bridge::CliAvailability)>,
+    /// Tracks consecutive auth failures per CLI profile name.
+    /// Value: (failure_count, last_failure_time).
+    auth_failures: Arc<dashmap::DashMap<String, (u32, Instant)>>,
 }
 
 /// No-op adapter used in spawned CLI tasks (typing/heartbeats not available in background).
@@ -228,6 +236,7 @@ impl GatewayRunner {
             queue_senders: tokio::sync::Mutex::new(HashMap::new()),
             global_run_limiter: Arc::new(tokio::sync::Semaphore::new(max_concurrent_runs)),
             cli_availability,
+            auth_failures: Arc::new(dashmap::DashMap::new()),
         })
     }
 
@@ -371,8 +380,14 @@ impl GatewayRunner {
         // Resolve active CLI profile
         let cli_profile = self.resolve_cli_profile(msg.platform, &msg.user_id).await;
 
-        // /manage — rewrite to rich context message and send to slow CLI path
         let trimmed = msg.text.trim();
+
+        // /auth — reset auth circuit breaker, show CLI auth status, attempt auto-relogin
+        if trimmed == "/auth" {
+            return Ok(Some(self.handle_auth_command(&cli_profile).await));
+        }
+
+        // /manage — rewrite to rich context message and send to slow CLI path
         if trimmed == "/manage" || trimmed.starts_with("/manage ") {
             let extra = trimmed.strip_prefix("/manage").unwrap_or("").trim();
             let context = self
@@ -560,6 +575,33 @@ impl GatewayRunner {
                     &msg.chat_id,
                     msg.reply_token.clone(),
                     text,
+                )
+                .await,
+            );
+        }
+
+        // Check auth circuit breaker before spawning CLI
+        if let Some(auth_msg) = self.check_auth_circuit(&cli_name) {
+            if let Some(writer) = trace_writer.as_ref() {
+                if let Some(ref run_id) = run_id {
+                    let _ = writer
+                        .finish_run(
+                            run_id,
+                            RunStatus::Failed,
+                            None,
+                            Some("auth circuit breaker open"),
+                        )
+                        .await;
+                }
+                let _ = writer.fail_request("auth circuit breaker open").await;
+            }
+            return Some(
+                self.outbound_response(
+                    trace.as_ref(),
+                    msg.platform,
+                    &msg.chat_id,
+                    msg.reply_token.clone(),
+                    auth_msg,
                 )
                 .await,
             );
@@ -843,6 +885,10 @@ impl GatewayRunner {
         let result = match cli_handle.await {
             Ok(Ok(result)) => result,
             Ok(Err(e)) => {
+                // Track auth failures for circuit breaker
+                if cli_bridge::is_auth_error(&e) {
+                    self.record_auth_failure(&cli_name);
+                }
                 suspend_tasks(&self.durable_store, format!("CLI error: {e}")).await;
                 if let Some(writer) = trace_writer.as_ref() {
                     if let Some(ref run_id) = run_id {
@@ -1005,6 +1051,29 @@ impl GatewayRunner {
                 text = ?result.text.as_deref().map(|t| &t[..t.len().min(100)]),
                 "CLI non-zero exit"
             );
+
+            // Detect auth errors and record for circuit breaker
+            let combined_err = format!("{}\n{}", result.stderr, result.stdout);
+            if cli_bridge::is_auth_error(&combined_err) {
+                self.record_auth_failure(&cli_name);
+
+                // Attempt auto-relogin if credentials are configured
+                if self.config.astra.username.is_some()
+                    && self.config.astra.password.is_some()
+                    && matches!(cli_profile, CliProfile::Astra { .. })
+                {
+                    match self.try_auto_relogin().await {
+                        Ok(_) => {
+                            tracing::info!(cli = %cli_name, "auto-relogin succeeded after auth failure");
+                            self.clear_auth_failure(&cli_name);
+                        }
+                        Err(e) => {
+                            tracing::warn!(cli = %cli_name, error = %e, "auto-relogin failed");
+                        }
+                    }
+                }
+            }
+
             suspend_tasks(
                 &self.durable_store,
                 format!("CLI exit code {}", result.exit_code),
@@ -1064,6 +1133,11 @@ impl GatewayRunner {
             let _ = writer
                 .finish_run(run_id, status, Some(result.exit_code), error)
                 .await;
+        }
+
+        // Clear auth failure counter on success
+        if result.exit_code == 0 {
+            self.clear_auth_failure(&cli_name);
         }
 
         // Save session_id to DB (if available), scoped by CLI profile
@@ -1280,6 +1354,151 @@ impl GatewayRunner {
         } else {
             msg.chat_id.clone()
         }
+    }
+
+    // ─── Auth circuit breaker ──────────────────────────────────────────────
+
+    /// Check if the auth circuit breaker is tripped for the given CLI.
+    /// Returns `Some(message)` if the circuit is open and the caller should
+    /// short-circuit without spawning the CLI.
+    fn check_auth_circuit(&self, cli_name: &str) -> Option<String> {
+        if let Some(entry) = self.auth_failures.get(cli_name) {
+            let (count, last_failure) = *entry;
+            if count > AUTH_FAILURE_THRESHOLD && last_failure.elapsed() < AUTH_FAILURE_COOLDOWN {
+                let remaining = AUTH_FAILURE_COOLDOWN
+                    .saturating_sub(last_failure.elapsed())
+                    .as_secs();
+                return Some(format!(
+                    "🔑 CLI `{cli_name}` 认证失败（连续 {} 次）\n\n\
+                     可能原因:\n\
+                     - API 密钥过期\n\
+                     - 服务端 token 刷新失败\n\n\
+                     解决方法:\n\
+                     1. 运行 `astra /login` 重新登录\n\
+                     2. 或检查环境变量 ASTRA_API_KEY\n\
+                     3. 或切换到其他 CLI: `/cli claude`\n\n\
+                     {remaining} 秒后自动重试，或发送 `/auth` 手动重试。",
+                    count,
+                ));
+            }
+            // Cooldown expired — clear the counter
+            if last_failure.elapsed() >= AUTH_FAILURE_COOLDOWN {
+                drop(entry);
+                self.auth_failures.remove(cli_name);
+            }
+        }
+        None
+    }
+
+    /// Record an auth failure for the given CLI profile.
+    fn record_auth_failure(&self, cli_name: &str) {
+        let mut entry = self
+            .auth_failures
+            .entry(cli_name.to_string())
+            .or_insert((0, Instant::now()));
+        entry.0 += 1;
+        entry.1 = Instant::now();
+        tracing::warn!(
+            cli = cli_name,
+            consecutive_failures = entry.0,
+            "auth failure recorded"
+        );
+    }
+
+    /// Clear auth failure counter for a CLI (called on successful request).
+    fn clear_auth_failure(&self, cli_name: &str) {
+        if self.auth_failures.remove(cli_name).is_some() {
+            tracing::info!(cli = cli_name, "auth failure counter cleared (success)");
+        }
+    }
+
+    /// Attempt to re-login to the astra server using configured credentials.
+    /// On success, writes the new tokens to `~/.astra/credentials.json` so
+    /// subsequent CLI spawns pick them up.
+    async fn try_auto_relogin(&self) -> Result<String, String> {
+        let username = self
+            .config
+            .astra
+            .username
+            .as_ref()
+            .ok_or("no username configured")?;
+        let password = self
+            .config
+            .astra
+            .password
+            .as_ref()
+            .ok_or("no password configured")?;
+
+        let body = serde_json::json!({ "username": username, "password": password });
+        let resp = self
+            .thin
+            .post_auth_login_json(&body)
+            .await
+            .map_err(|e| format!("login request failed: {e}"))?;
+
+        let v: serde_json::Value =
+            serde_json::from_str(&resp).map_err(|e| format!("invalid login response: {e}"))?;
+        let access = v
+            .get("access_token")
+            .and_then(|t| t.as_str())
+            .ok_or("missing access_token in response")?;
+        let refresh = v.get("refresh_token").and_then(|t| t.as_str());
+
+        save_token_to_cli_credentials(username, access, refresh)?;
+        tracing::info!(username = %username, "auto-relogin succeeded, CLI credentials refreshed");
+        Ok(access.to_string())
+    }
+
+    /// Handle the `/auth` slash command: reset circuit breaker, show CLI auth
+    /// status, and attempt auto-relogin if credentials are configured.
+    async fn handle_auth_command(&self, _current_cli: &CliProfile) -> String {
+        // 1. Reset circuit breaker
+        let cleared = self.auth_failures.len();
+        self.auth_failures.clear();
+
+        // 2. Invalidate probe cache so re-probe is fresh
+        cli_bridge::invalidate_probe_cache();
+
+        // 3. Re-probe all CLIs
+        let mut lines = vec!["🔑 **认证状态**".to_string()];
+        let default_avail = cli_bridge::probe_cli(&self.cli_profile).await;
+        let default_status = if default_avail.is_available() {
+            "✅"
+        } else {
+            "❌"
+        };
+        lines.push(format!(
+            "  {default_status} `{}` (默认)",
+            self.cli_profile.name()
+        ));
+        for (name, profile) in &self.config.cli_profiles {
+            let avail = cli_bridge::probe_cli(profile).await;
+            let status = if avail.is_available() { "✅" } else { "❌" };
+            lines.push(format!("  {status} `{name}`"));
+        }
+
+        if cleared > 0 {
+            lines.push(format!(
+                "\n认证缓存已重置（清除 {cleared} 个 CLI 的失败计数）。"
+            ));
+        } else {
+            lines.push("\n认证缓存已重置。".into());
+        }
+
+        // 4. Attempt auto-relogin if credentials configured
+        if self.config.astra.username.is_some() && self.config.astra.password.is_some() {
+            match self.try_auto_relogin().await {
+                Ok(_) => {
+                    lines.push("✅ 自动重新登录成功，凭证已刷新。".into());
+                }
+                Err(e) => {
+                    lines.push(format!("⚠️ 自动重新登录失败: {e}"));
+                }
+            }
+        }
+
+        lines.push("\n下次消息将重新验证。".into());
+        lines.join("\n")
     }
 
     /// Build a rich context message for `/manage` that gets sent to the CLI agent.
@@ -1896,6 +2115,68 @@ fn rfind_fence_break(s: &str) -> Option<usize> {
         }
     }
     None
+}
+
+/// Write refreshed tokens to `~/.astra/credentials.json` so subsequent CLI
+/// spawns pick them up.  Reads the existing file (if any), updates the
+/// access/refresh tokens on the current or default profile, and writes back.
+fn save_token_to_cli_credentials(
+    username: &str,
+    access_token: &str,
+    refresh_token: Option<&str>,
+) -> Result<(), String> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_else(|_| ".".to_string());
+    let path = std::path::PathBuf::from(home)
+        .join(".astra")
+        .join("credentials.json");
+
+    // Read existing file (may not exist)
+    let mut doc: serde_json::Value = if let Ok(content) = std::fs::read_to_string(&path) {
+        serde_json::from_str(&content).unwrap_or_else(|_| serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+
+    // Determine profile name
+    let profile_name = doc
+        .get("current_profile")
+        .and_then(|v| v.as_str())
+        .unwrap_or("default")
+        .to_string();
+
+    // Ensure profiles object exists
+    if !doc.get("profiles").is_some_and(|p| p.is_object()) {
+        doc["profiles"] = serde_json::json!({});
+    }
+
+    // Update the profile
+    let profile = &mut doc["profiles"][&profile_name];
+    if !profile.is_object() {
+        *profile = serde_json::json!({});
+    }
+    profile["username"] = serde_json::Value::String(username.to_string());
+    profile["access_token"] = serde_json::Value::String(access_token.to_string());
+    if let Some(rt) = refresh_token {
+        profile["refresh_token"] = serde_json::Value::String(rt.to_string());
+    }
+
+    // Write back
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir failed: {e}"))?;
+    }
+    let body = serde_json::to_string_pretty(&doc).map_err(|e| format!("serialize failed: {e}"))?;
+    std::fs::write(&path, body).map_err(|e| format!("write failed: {e}"))?;
+
+    // Restrict to owner-only (0o600)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    Ok(())
 }
 
 fn is_safe_skill_name(name: &str) -> bool {
@@ -3369,6 +3650,105 @@ mod tests {
         assert!(!is_safe_db_name("foo;bar"));
         assert!(!is_safe_db_name("foo`bar"));
         assert!(!is_safe_db_name("../etc/passwd"));
+    }
+
+    // ── Auth circuit breaker tests ────────────────────────────────
+
+    #[test]
+    fn auth_circuit_not_tripped_initially() {
+        let failures: dashmap::DashMap<String, (u32, Instant)> = dashmap::DashMap::new();
+        // No entries — check_auth_circuit equivalent
+        assert!(!failures.contains_key("astra"));
+    }
+
+    #[test]
+    fn auth_circuit_trips_after_threshold() {
+        let failures: dashmap::DashMap<String, (u32, Instant)> = dashmap::DashMap::new();
+        // Simulate consecutive failures exceeding threshold
+        failures.insert(
+            "astra".to_string(),
+            (AUTH_FAILURE_THRESHOLD + 1, Instant::now()),
+        );
+        let entry = failures.get("astra").unwrap();
+        let (count, last) = *entry;
+        assert!(count > AUTH_FAILURE_THRESHOLD);
+        assert!(last.elapsed() < AUTH_FAILURE_COOLDOWN);
+    }
+
+    #[test]
+    fn auth_circuit_resets_after_cooldown() {
+        let failures: dashmap::DashMap<String, (u32, Instant)> = dashmap::DashMap::new();
+        // Simulate an old failure past cooldown
+        failures.insert(
+            "astra".to_string(),
+            (
+                AUTH_FAILURE_THRESHOLD + 1,
+                Instant::now() - AUTH_FAILURE_COOLDOWN - Duration::from_secs(1),
+            ),
+        );
+        let entry = failures.get("astra").unwrap();
+        let (_, last) = *entry;
+        assert!(
+            last.elapsed() >= AUTH_FAILURE_COOLDOWN,
+            "should be past cooldown"
+        );
+    }
+
+    #[test]
+    fn auth_circuit_constants_are_reasonable() {
+        let threshold = AUTH_FAILURE_THRESHOLD;
+        assert!(threshold >= 1, "threshold should be at least 1");
+        assert!(threshold <= 10, "threshold should be reasonable");
+        assert!(
+            AUTH_FAILURE_COOLDOWN.as_secs() >= 60,
+            "cooldown should be >= 1 min"
+        );
+        assert!(
+            AUTH_FAILURE_COOLDOWN.as_secs() <= 600,
+            "cooldown should be <= 10 min"
+        );
+    }
+
+    #[test]
+    fn save_token_to_cli_credentials_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let creds_dir = dir.path().join(".astra");
+        std::fs::create_dir_all(&creds_dir).unwrap();
+        let creds_path = creds_dir.join("credentials.json");
+
+        // Write initial file
+        std::fs::write(
+            &creds_path,
+            r#"{"current_profile":"default","profiles":{"default":{"username":"old"}}}"#,
+        )
+        .unwrap();
+
+        // We can't easily test save_token_to_cli_credentials because it uses
+        // dirs::home_dir(), but we can test the JSON structure it produces.
+        let mut doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&creds_path).unwrap()).unwrap();
+        doc["profiles"]["default"]["access_token"] = serde_json::Value::String("new-token".into());
+        doc["profiles"]["default"]["refresh_token"] =
+            serde_json::Value::String("new-refresh".into());
+        doc["profiles"]["default"]["username"] = serde_json::Value::String("admin".into());
+        let body = serde_json::to_string_pretty(&doc).unwrap();
+        std::fs::write(&creds_path, body).unwrap();
+
+        // Verify
+        let loaded: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&creds_path).unwrap()).unwrap();
+        assert_eq!(
+            loaded["profiles"]["default"]["access_token"].as_str(),
+            Some("new-token")
+        );
+        assert_eq!(
+            loaded["profiles"]["default"]["refresh_token"].as_str(),
+            Some("new-refresh")
+        );
+        assert_eq!(
+            loaded["profiles"]["default"]["username"].as_str(),
+            Some("admin")
+        );
     }
 }
 

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -161,22 +161,18 @@ impl GatewayRunner {
         )?;
 
         let storage_config = config.resolve_storage();
-        let (store, durable_store, trace_repo) = match store::open_store_bundle(&storage_config)
-            .await
-        {
-            Ok(Some(bundle)) => {
-                tracing::info!(backend = ?storage_config, "storage connected");
-                (Some(bundle.store), bundle.durable_store, bundle.trace_repo)
-            }
-            Ok(None) => {
-                tracing::info!("running without persistence (storage: none)");
-                (None, None, None)
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "storage not available — running without persistence");
-                (None, None, None)
-            }
-        };
+        let (store, durable_store, trace_repo) =
+            match store::open_store_bundle(&storage_config).await {
+                Ok(Some(bundle)) => {
+                    tracing::info!(backend = ?storage_config, "storage connected");
+                    (Some(bundle.store), bundle.durable_store, bundle.trace_repo)
+                }
+                Ok(None) => {
+                    tracing::info!("running without persistence (storage: none)");
+                    (None, None, None)
+                }
+                Err(e) => return Err(e),
+            };
 
         let cli_profile = config.cli.clone();
 
@@ -430,6 +426,7 @@ impl GatewayRunner {
                 .map(|repo| repo.as_ref() as &dyn TraceRepository),
             project_dirs: &self.config.project_dirs,
             cli_availability: &self.cli_availability,
+            auth_status: self.auth_status_line(cli_profile.name()),
         };
         if let Some(response) = commands::handle_command(&cmd_ctx, &msg.text).await {
             return Ok(Some(response));
@@ -1271,8 +1268,9 @@ impl GatewayRunner {
         if completion_tok > 0 {
             stats_parts.push(format!("↑{}", format_tokens(completion_tok)));
         }
-        if result.tool_calls_count.unwrap_or(0) > 0 {
-            stats_parts.push(format!("🔧{}", result.tool_calls_count.unwrap()));
+        let tool_count_total = result.tool_calls_count.unwrap_or(0);
+        if tool_count_total > 0 {
+            stats_parts.push(format!("🔧{tool_count_total}"));
         }
         stats_parts.push(format_elapsed(elapsed));
         if cost > 0.001 {
@@ -1456,6 +1454,25 @@ impl GatewayRunner {
             }
         }
         None
+    }
+
+    fn auth_status_line(&self, cli_name: &str) -> Option<String> {
+        let entry = self.auth_failures.get(cli_name)?;
+        let (count, last_failure) = *entry;
+        if last_failure.elapsed() >= AUTH_FAILURE_COOLDOWN {
+            drop(entry);
+            self.auth_failures.remove(cli_name);
+            return None;
+        }
+
+        if count > AUTH_FAILURE_THRESHOLD {
+            let remaining = AUTH_FAILURE_COOLDOWN
+                .saturating_sub(last_failure.elapsed())
+                .as_secs();
+            Some(format!("⚠️ 暂停 (剩余 {remaining}s, 连续失败 {count} 次)"))
+        } else {
+            Some(format!("✅ 正常 (最近失败 {count} 次)"))
+        }
     }
 
     /// Record an auth failure for the given CLI profile.
@@ -2492,7 +2509,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => format!("⚠️ 定时任务创建失败: {e}"),
                     }
                 } else {
-                    "⚠️ 定时任务需要数据库支持".into()
+                    "⚠️ 定时任务需要 MySQL 存储支持".into()
                 }
             }
             Some("cron_add") => "⚠️ cron_add 格式错误（需要: cron_add:表达式:消息）".into(),
@@ -2547,7 +2564,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => format!("⚠️ 创建提醒失败: {e}"),
                     }
                 } else {
-                    "⚠️ 延时提醒需要数据库支持".into()
+                    "⚠️ 延时提醒需要 MySQL 存储支持".into()
                 }
             }
             Some("remind_after") => {
@@ -2573,7 +2590,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => format!("⚠️ 查询失败: {e}"),
                     }
                 } else {
-                    "⚠️ 需要数据库支持".into()
+                    "⚠️ 需要 MySQL 存储支持".into()
                 }
             }
 
@@ -2592,7 +2609,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => format!("⚠️ 删除失败: {e}"),
                     }
                 } else {
-                    "⚠️ 需要数据库支持".into()
+                    "⚠️ 需要 MySQL 存储支持".into()
                 }
             }
             Some("task_del") => "⚠️ task_del 格式错误（需要: task_del:任务ID）".into(),
@@ -2610,7 +2627,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => format!("⚠️ 删除失败: {e}"),
                     }
                 } else {
-                    "⚠️ 需要数据库支持".into()
+                    "⚠️ 需要 MySQL 存储支持".into()
                 }
             }
 
@@ -2641,7 +2658,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => format!("⚠️ 创建失败: {e}"),
                     }
                 } else {
-                    "⚠️ 需要数据库支持".into()
+                    "⚠️ 需要 MySQL 存储支持".into()
                 }
             }
 
@@ -2672,7 +2689,7 @@ async fn execute_gateway_actions_with_policy(
                                     Err(e) => e,
                                 }
                             } else {
-                                "⚠️ 需要数据库支持".into()
+                                "⚠️ 需要 MySQL 存储支持".into()
                             }
                         }
                     }
@@ -2701,7 +2718,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => e,
                     }
                 } else {
-                    "⚠️ 需要数据库支持".into()
+                    "⚠️ 需要 MySQL 存储支持".into()
                 }
             }
 
@@ -2744,7 +2761,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => e,
                     }
                 } else {
-                    "⚠️ 需要数据库支持".into()
+                    "⚠️ 需要 MySQL 存储支持".into()
                 }
             }
 
@@ -2777,7 +2794,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => format!("⚠️ 查询失败: {e}"),
                     }
                 } else {
-                    "⚠️ 需要数据库支持".into()
+                    "⚠️ 需要 MySQL 存储支持".into()
                 }
             }
 
@@ -2800,7 +2817,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => e,
                     }
                 } else {
-                    "⚠️ 需要数据库支持".into()
+                    "⚠️ 需要 MySQL 存储支持".into()
                 }
             }
 
@@ -2828,7 +2845,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => e,
                     }
                 } else {
-                    "⚠️ 需要数据库支持".into()
+                    "⚠️ 需要 MySQL 存储支持".into()
                 }
             }
 
@@ -2851,7 +2868,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => e,
                     }
                 } else {
-                    "⚠️ 需要数据库支持".into()
+                    "⚠️ 需要 MySQL 存储支持".into()
                 }
             }
 
@@ -2926,7 +2943,7 @@ async fn execute_gateway_actions_with_policy(
                         Err(e) => format!("⚠️ 保存工作目录失败: {e}"),
                     }
                 } else {
-                    "⚠️ 需要数据库支持".into()
+                    "⚠️ 需要 MySQL 存储支持".into()
                 }
             }
 
@@ -3006,15 +3023,7 @@ fn action_capability(action: &str) -> Option<crate::access_control::ActionCapabi
 }
 
 fn is_valid_cron_expr(expr: &str) -> bool {
-    let parts: Vec<&str> = expr.split_whitespace().collect();
-    if parts.len() != 5 {
-        return false;
-    }
-    // Each field should be *, a number, a range, a list, or a step
-    parts.iter().all(|p| {
-        p.chars()
-            .all(|c| c.is_ascii_digit() || c == '*' || c == ',' || c == '-' || c == '/')
-    })
+    store::is_valid_cron_expr(expr)
 }
 
 async fn find_and_delete_job(
@@ -3758,7 +3767,7 @@ mod tests {
         let mut r = Vec::new();
         let clean = execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
         assert_eq!(clean, "好的");
-        assert!(r[0].contains("数据库"), "{}", r[0]);
+        assert!(r[0].contains("存储"), "{}", r[0]);
     }
 
     #[tokio::test]
@@ -3791,7 +3800,7 @@ mod tests {
         let mut r = Vec::new();
         let clean = execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
         assert_eq!(clean, "好的");
-        assert!(r[0].contains("数据库"), "{}", r[0]);
+        assert!(r[0].contains("存储"), "{}", r[0]);
     }
 
     #[tokio::test]
@@ -3831,7 +3840,7 @@ mod tests {
         let text = "[[GATEWAY:task_list]]";
         let mut r = Vec::new();
         execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
-        assert!(r[0].contains("数据库"), "{}", r[0]);
+        assert!(r[0].contains("存储"), "{}", r[0]);
     }
 
     #[tokio::test]
@@ -3847,7 +3856,7 @@ mod tests {
         let text = "[[GATEWAY:task_del:abc123]]";
         let mut r = Vec::new();
         execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
-        assert!(r[0].contains("数据库"), "{}", r[0]);
+        assert!(r[0].contains("存储"), "{}", r[0]);
     }
 
     #[tokio::test]
@@ -4130,7 +4139,7 @@ async fn action_dtask_create_no_db() {
     let text = "[[GATEWAY:dtask_create:weekly report:collect stats]]";
     let mut r = Vec::new();
     execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
-    assert!(r[0].contains("数据库"), "{}", r[0]);
+    assert!(r[0].contains("存储"), "{}", r[0]);
 }
 
 #[tokio::test]
@@ -4162,7 +4171,7 @@ async fn action_dtask_status_no_db() {
     let text = "[[GATEWAY:dtask_status:some-id]]";
     let mut r = Vec::new();
     execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
-    assert!(r[0].contains("数据库"), "{}", r[0]);
+    assert!(r[0].contains("存储"), "{}", r[0]);
 }
 
 #[tokio::test]
@@ -4170,7 +4179,7 @@ async fn action_dtask_resume_no_db() {
     let text = "[[GATEWAY:dtask_resume:some-id]]";
     let mut r = Vec::new();
     execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
-    assert!(r[0].contains("数据库"), "{}", r[0]);
+    assert!(r[0].contains("存储"), "{}", r[0]);
 }
 
 #[tokio::test]
@@ -4178,7 +4187,7 @@ async fn action_dtask_list_no_db() {
     let text = "[[GATEWAY:dtask_list]]";
     let mut r = Vec::new();
     execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
-    assert!(r[0].contains("数据库"), "{}", r[0]);
+    assert!(r[0].contains("存储"), "{}", r[0]);
 }
 
 #[tokio::test]
@@ -4186,7 +4195,7 @@ async fn action_dtask_complete_no_db() {
     let text = "[[GATEWAY:dtask_complete:some-id]]";
     let mut r = Vec::new();
     execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
-    assert!(r[0].contains("数据库"), "{}", r[0]);
+    assert!(r[0].contains("存储"), "{}", r[0]);
 }
 
 #[tokio::test]
@@ -4194,7 +4203,7 @@ async fn action_dtask_fail_no_db() {
     let text = "[[GATEWAY:dtask_fail:some-id:oops]]";
     let mut r = Vec::new();
     execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
-    assert!(r[0].contains("数据库"), "{}", r[0]);
+    assert!(r[0].contains("存储"), "{}", r[0]);
 }
 
 #[tokio::test]
@@ -4202,7 +4211,7 @@ async fn action_dtask_cancel_no_db() {
     let text = "[[GATEWAY:dtask_cancel:some-id]]";
     let mut r = Vec::new();
     execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
-    assert!(r[0].contains("数据库"), "{}", r[0]);
+    assert!(r[0].contains("存储"), "{}", r[0]);
 }
 
 // ── trace_kill / outbox_dismiss GATEWAY actions ──
@@ -4288,11 +4297,7 @@ async fn action_dtask_checkpoint_json_with_array() {
     let clean = execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
     assert!(clean.is_empty(), "tags should be stripped, got: {clean}");
     assert_eq!(r.len(), 1);
-    assert!(
-        r[0].contains("数据库"),
-        "expected no-db error, got: {}",
-        r[0]
-    );
+    assert!(r[0].contains("存储"), "expected no-db error, got: {}", r[0]);
 }
 
 #[tokio::test]
@@ -4353,7 +4358,7 @@ async fn action_policy_allows_when_enabled() {
     assert!(clean.is_empty());
     assert_eq!(r.len(), 1);
     assert!(
-        r[0].contains("数据库"),
+        r[0].contains("存储"),
         "expected no-db fallback, got: {}",
         r[0]
     );

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -8,14 +8,13 @@ use crate::commands::{self, CommandContext};
 use crate::config::GatewayConfig;
 use crate::gateway_context::GatewayContext;
 use crate::platforms::{InboundMessage, PlatformAdapter};
-use crate::storage;
+use crate::store::{self, GatewayStore};
 use crate::trace_model::{
     ConversationKey, GatewayRequest, MysqlTraceRepository, OutboxId, RequestId, RequestStatus,
     RunStatus, TraceId, TraceRepository, TraceWriter,
 };
 use astra_core::durable_task_store::DurableTaskStore as _;
 use futures_util::future::select_all;
-use sqlx::MySqlPool;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -80,7 +79,7 @@ impl OutboundMessage {
 
 pub struct GatewayRunner {
     config: GatewayConfig,
-    pool: Option<MySqlPool>,
+    store: Option<Arc<dyn GatewayStore>>,
     cli_profile: CliProfile,
     thin: astra_thin_client::ThinClient,
     outbound_tx: Option<tokio::sync::mpsc::Sender<OutboundMessage>>,
@@ -91,6 +90,7 @@ pub struct GatewayRunner {
     queue_senders:
         tokio::sync::Mutex<HashMap<ConversationKey, tokio::sync::mpsc::Sender<QueuedRequest>>>,
     global_run_limiter: Arc<tokio::sync::Semaphore>,
+    cli_availability: Vec<(String, cli_bridge::CliAvailability)>,
 }
 
 /// No-op adapter used in spawned CLI tasks (typing/heartbeats not available in background).
@@ -147,27 +147,25 @@ impl GatewayRunner {
             },
         )?;
 
-        let pool = match connect_db(&config.database.url).await {
-            Ok(pool) => {
-                tracing::info!("database connected");
-                Some(pool)
+        let storage_config = config.resolve_storage();
+        let (store, durable_store, trace_repo) = match store::open_store_bundle(&storage_config)
+            .await
+        {
+            Ok(Some(bundle)) => {
+                tracing::info!(backend = ?storage_config, "storage connected");
+                (Some(bundle.store), bundle.durable_store, bundle.trace_repo)
+            }
+            Ok(None) => {
+                tracing::info!("running without persistence (storage: none)");
+                (None, None, None)
             }
             Err(e) => {
-                tracing::warn!(error = %e, "DB not available — running without persistence (sessions in-memory, no cron)");
-                None
+                tracing::warn!(error = %e, "storage not available — running without persistence");
+                (None, None, None)
             }
         };
 
         let cli_profile = config.cli.clone();
-
-        let durable_store = pool.as_ref().map(|p| {
-            std::sync::Arc::new(crate::durable_task_store::MysqlDurableTaskStore::new(
-                p.clone(),
-            ))
-        });
-        let trace_repo = pool
-            .as_ref()
-            .map(|p| Arc::new(MysqlTraceRepository::new(p.clone())));
 
         let user_skills = config
             .skills_dir
@@ -190,17 +188,37 @@ impl GatewayRunner {
             tracing::info!(count = projects.len(), "discovered projects");
         }
 
-        if let Some(ref pool) = pool
-            && let Err(e) = crate::usage::ensure_usage_table(pool).await
-        {
-            tracing::warn!(error = %e, "failed to ensure usage tracking table");
-        }
         let max_concurrent_runs = config.max_concurrent_runs.max(1);
+
+        // Probe all configured CLI profiles for availability
+        let mut cli_availability = Vec::new();
+        let default_avail = cli_bridge::probe_cli(&cli_profile).await;
+        cli_availability.push((cli_profile.name().to_string(), default_avail.clone()));
+        for (name, profile) in &config.cli_profiles {
+            let avail = cli_bridge::probe_cli(profile).await;
+            cli_availability.push((name.clone(), avail));
+        }
+
+        // If default CLI not available, auto-select first available
+        let effective_cli = if !default_avail.is_available() {
+            if let Some((name, _)) = cli_availability.iter().find(|(_, a)| a.is_available()) {
+                if let Some(profile) = config.cli_profiles.get(name) {
+                    tracing::info!(cli = %name, "default CLI unavailable, auto-selected");
+                    profile.clone()
+                } else {
+                    cli_profile.clone()
+                }
+            } else {
+                cli_profile.clone()
+            }
+        } else {
+            cli_profile.clone()
+        };
 
         Ok(Self {
             config,
-            pool,
-            cli_profile,
+            store,
+            cli_profile: effective_cli,
             thin,
             outbound_tx: None,
             durable_store,
@@ -209,11 +227,23 @@ impl GatewayRunner {
             trace_repo,
             queue_senders: tokio::sync::Mutex::new(HashMap::new()),
             global_run_limiter: Arc::new(tokio::sync::Semaphore::new(max_concurrent_runs)),
+            cli_availability,
         })
     }
 
-    pub fn pool(&self) -> Option<&MySqlPool> {
-        self.pool.as_ref()
+    /// Whether any storage backend is active.
+    pub fn has_store(&self) -> bool {
+        self.store.is_some()
+    }
+
+    /// Clone the Arc-wrapped store for use by external components (e.g. scheduler).
+    pub fn store(&self) -> Option<Arc<dyn GatewayStore>> {
+        self.store.clone()
+    }
+
+    /// Clone the Arc-wrapped trace repository.
+    pub fn trace_repo(&self) -> Option<Arc<MysqlTraceRepository>> {
+        self.trace_repo.clone()
     }
 
     pub fn cli_profile(&self) -> &CliProfile {
@@ -222,29 +252,29 @@ impl GatewayRunner {
 
     /// Replay messages that were pending when gateway crashed.
     pub async fn replay_pending_messages(&self, adapter: &dyn PlatformAdapter) {
-        if let Some(ref pool) = self.pool {
+        if let Some(ref store) = self.store {
             let platform = adapter.name();
-            match storage::list_pending_messages(pool, Some(platform)).await {
+            match store.list_pending_messages(Some(platform)).await {
                 Ok(msgs) if msgs.is_empty() => {}
                 Ok(msgs) => {
                     tracing::info!(platform, count = msgs.len(), "replaying pending messages");
-                    for (id, _platform, chat_id, user_id, text) in &msgs {
+                    for pm in &msgs {
                         let msg = crate::platforms::InboundMessage {
                             platform,
-                            chat_id: chat_id.clone(),
-                            user_id: user_id.clone(),
-                            text: text.clone(),
-                            msg_id: format!("replay-{id}"),
+                            chat_id: pm.chat_id.clone(),
+                            user_id: pm.user_id.clone(),
+                            text: pm.text.clone(),
+                            msg_id: format!("replay-{}", pm.id),
                             chat_type: crate::platforms::ChatType::DirectMessage,
                             reply_token: None,
                         };
                         if let Some(response) = self
-                            .handle_message_inner(&msg, adapter, Some(*id), false, None)
+                            .handle_message_inner(&msg, adapter, Some(pm.id), false, None)
                             .await
                         {
                             for chunk in split_message(&response.text) {
-                                if let Err(e) = adapter.send_text(chat_id, chunk, None).await {
-                                    tracing::warn!(error = %e, chat_id, "failed to deliver pending replay");
+                                if let Err(e) = adapter.send_text(&pm.chat_id, chunk, None).await {
+                                    tracing::warn!(error = %e, chat_id = %pm.chat_id, "failed to deliver pending replay");
                                 }
                             }
                         }
@@ -281,9 +311,10 @@ impl GatewayRunner {
 
     /// Resolve the active CLI profile for a user (may be overridden via /cli + /model).
     async fn resolve_cli_profile(&self, platform: &str, user_id: &str) -> CliProfile {
-        let mut profile = if let Some(ref pool) = self.pool
-            && let Ok(Some(name)) =
-                storage::get_user_preference(pool, platform, user_id, "cli_profile").await
+        let mut profile = if let Some(ref store) = self.store
+            && let Ok(Some(name)) = store
+                .get_user_preference(platform, user_id, "cli_profile")
+                .await
             && let Some(p) = self.config.cli_profiles.get(&name)
         {
             p.clone()
@@ -292,10 +323,11 @@ impl GatewayRunner {
         };
 
         // Apply per-user model override scoped to this CLI
-        let model_key = storage::model_preference_key(profile.name());
-        if let Some(ref pool) = self.pool
-            && let Ok(Some(model_name)) =
-                storage::get_user_preference(pool, platform, user_id, &model_key).await
+        let model_key = store::model_preference_key(profile.name());
+        if let Some(ref store) = self.store
+            && let Ok(Some(model_name)) = store
+                .get_user_preference(platform, user_id, &model_key)
+                .await
         {
             match &mut profile {
                 CliProfile::Astra { model, .. } | CliProfile::Claude { model, .. } => {
@@ -343,7 +375,7 @@ impl GatewayRunner {
         let cmd_ctx = CommandContext {
             astra: &self.thin,
             config: &self.config,
-            pool: self.pool.as_ref(),
+            store: self.store.as_deref(),
             platform: msg.platform,
             chat_id: &effective_chat_id,
             user_id: &msg.user_id,
@@ -356,6 +388,8 @@ impl GatewayRunner {
                 .trace_repo
                 .as_ref()
                 .map(|repo| repo.as_ref() as &dyn TraceRepository),
+            project_dirs: &self.config.project_dirs,
+            cli_availability: &self.cli_availability,
         };
         if let Some(response) = commands::handle_command(&cmd_ctx, &msg.text).await {
             return Ok(Some(response));
@@ -395,33 +429,54 @@ impl GatewayRunner {
 
         let cli_profile = self.resolve_cli_profile(msg.platform, &msg.user_id).await;
 
-        if let Some(ref pool) = self.pool
-            && let Err(e) =
-                storage::upsert_user(pool, msg.platform, &msg.user_id, &msg.user_id).await
+        // Check first-time user BEFORE upsert (upsert creates the row)
+        let is_first = if let Some(ref store) = self.store {
+            store
+                .is_first_message(msg.platform, &msg.user_id)
+                .await
+                .unwrap_or(false)
+        } else {
+            false
+        };
+
+        if let Some(ref store) = self.store
+            && let Err(e) = store
+                .upsert_user(msg.platform, &msg.user_id, &msg.user_id)
+                .await
         {
             tracing::warn!(error = %e, "failed to upsert user");
+        }
+
+        // Send first-time welcome after upsert
+        if is_first {
+            let welcome = build_welcome_message(&cli_profile);
+            if let Some(ref tx) = self.outbound_tx {
+                let _ = tx
+                    .send(OutboundMessage::plain(
+                        msg.platform.to_string(),
+                        msg.chat_id.clone(),
+                        welcome,
+                    ))
+                    .await;
+            }
         }
 
         let cli_name = cli_profile.name().to_string();
 
         // Auto-reset session if policy triggers
-        if let Some(ref pool) = self.pool
-            && let Ok(Some(last_active_str)) =
-                storage::get_session_last_active(pool, msg.platform, &effective_chat_id, &cli_name)
-                    .await
+        if let Some(ref store) = self.store
+            && let Ok(Some(last_active_str)) = store
+                .get_session_last_active(msg.platform, &effective_chat_id, &cli_name)
+                .await
             && let Ok(last_active) =
                 chrono::NaiveDateTime::parse_from_str(&last_active_str, "%Y-%m-%d %H:%M:%S%.f")
         {
             let last_utc = last_active.and_utc();
             let now = chrono::Utc::now();
             if self.config.session_reset.should_reset(last_utc, now) {
-                if let Err(e) = storage::reset_session_for_cli(
-                    pool,
-                    msg.platform,
-                    &effective_chat_id,
-                    &cli_name,
-                )
-                .await
+                if let Err(e) = store
+                    .reset_session(msg.platform, &effective_chat_id, &cli_name)
+                    .await
                 {
                     tracing::warn!(error = %e, "session auto-reset failed");
                 } else {
@@ -430,8 +485,9 @@ impl GatewayRunner {
             }
         }
 
-        let session_id = if let Some(ref pool) = self.pool {
-            storage::get_current_session_for_cli(pool, msg.platform, &effective_chat_id, &cli_name)
+        let session_id = if let Some(ref store) = self.store {
+            store
+                .get_current_session(msg.platform, &effective_chat_id, &cli_name)
                 .await
                 .ok()
                 .flatten()
@@ -498,9 +554,10 @@ impl GatewayRunner {
         }
 
         // Resolve workspace directory for CLI
-        let workspace: Option<std::path::PathBuf> = if let Some(ref pool) = self.pool
-            && let Ok(Some(ws)) =
-                storage::get_user_preference(pool, msg.platform, &msg.user_id, "workspace").await
+        let workspace: Option<std::path::PathBuf> = if let Some(ref store) = self.store
+            && let Ok(Some(ws)) = store
+                .get_user_preference(msg.platform, &msg.user_id, "workspace")
+                .await
         {
             let path = std::path::PathBuf::from(&ws);
             if path.is_dir() { Some(path) } else { None }
@@ -515,20 +572,19 @@ impl GatewayRunner {
                 &msg.user_id,
                 msg.platform,
                 &cli_profile,
-                self.pool.is_some(),
+                self.store.is_some(),
             )
             .with_model_actions_allowed(self.config.action_policy.allow_model_generated_mutations);
-            if let Some(ref pool) = self.pool
-                && let Ok(jobs) =
-                    storage::list_cron_jobs(pool, msg.platform, &effective_chat_id).await
+            if let Some(ref store) = self.store
+                && let Ok(jobs) = store.list_cron_jobs(msg.platform, &effective_chat_id).await
             {
                 let cron_list: Vec<_> = jobs
                     .iter()
-                    .map(|(id, expr, desc, _)| {
+                    .map(|j| {
                         (
-                            id[..8.min(id.len())].to_string(),
-                            expr.clone(),
-                            desc.clone(),
+                            j.job_id[..8.min(j.job_id.len())].to_string(),
+                            j.cron_expr.clone(),
+                            j.description.clone(),
                         )
                     })
                     .collect();
@@ -571,15 +627,10 @@ impl GatewayRunner {
 
         // Save as pending (for crash recovery)
         let pending_id = if save_pending {
-            if let Some(ref pool) = self.pool {
-                match storage::save_pending_message(
-                    pool,
-                    msg.platform,
-                    &effective_chat_id,
-                    &msg.user_id,
-                    &msg.text,
-                )
-                .await
+            if let Some(ref store) = self.store {
+                match store
+                    .save_pending_message(msg.platform, &effective_chat_id, &msg.user_id, &msg.text)
+                    .await
                 {
                     Ok(id) => Some(id),
                     Err(e) => {
@@ -844,14 +895,10 @@ impl GatewayRunner {
                 cli = cli_name,
                 "stale session detected — clearing and retrying"
             );
-            if let Some(ref pool) = self.pool {
-                let _ = storage::reset_session_for_cli(
-                    pool,
-                    msg.platform,
-                    &effective_chat_id,
-                    &cli_name,
-                )
-                .await;
+            if let Some(ref store) = self.store {
+                let _ = store
+                    .reset_session(msg.platform, &effective_chat_id, &cli_name)
+                    .await;
             }
             // Retry without session-id
             let retry_handle = tokio::spawn({
@@ -891,17 +938,17 @@ impl GatewayRunner {
                             .await;
                     }
                     // Save new session
-                    if let Some(ref pool) = self.pool
+                    if let Some(ref store) = self.store
                         && let Some(ref sid) = retry_result.session_id
-                        && let Err(e) = storage::set_current_session_for_cli(
-                            pool,
-                            msg.platform,
-                            &effective_chat_id,
-                            &msg.user_id,
-                            sid,
-                            &cli_name,
-                        )
-                        .await
+                        && let Err(e) = store
+                            .set_current_session(
+                                msg.platform,
+                                &effective_chat_id,
+                                &msg.user_id,
+                                sid,
+                                &cli_name,
+                            )
+                            .await
                     {
                         tracing::warn!(error = %e, "failed to persist session after retry");
                     }
@@ -1004,23 +1051,23 @@ impl GatewayRunner {
         }
 
         // Save session_id to DB (if available), scoped by CLI profile
-        if let Some(ref pool) = self.pool {
+        if let Some(ref store) = self.store {
             if let Some(ref sid) = result.session_id {
-                if let Err(e) = storage::set_current_session_for_cli(
-                    pool,
-                    msg.platform,
-                    &effective_chat_id,
-                    &msg.user_id,
-                    sid,
-                    &cli_name,
-                )
-                .await
+                if let Err(e) = store
+                    .set_current_session(
+                        msg.platform,
+                        &effective_chat_id,
+                        &msg.user_id,
+                        sid,
+                        &cli_name,
+                    )
+                    .await
                 {
                     tracing::warn!(error = %e, "failed to persist session");
                 }
-            } else if let Err(e) =
-                storage::touch_session_for_cli(pool, msg.platform, &effective_chat_id, &cli_name)
-                    .await
+            } else if let Err(e) = store
+                .touch_session(msg.platform, &effective_chat_id, &cli_name)
+                .await
             {
                 tracing::warn!(error = %e, "failed to touch session");
             }
@@ -1042,7 +1089,7 @@ impl GatewayRunner {
             let mut action_results = Vec::new();
             text = execute_gateway_actions_with_policy(
                 &text,
-                self.pool.as_ref(),
+                self.store.as_deref(),
                 msg.platform,
                 &msg.chat_id,
                 &msg.user_id,
@@ -1097,10 +1144,9 @@ impl GatewayRunner {
         );
 
         // Record usage to DB
-        if let Some(ref pool) = self.pool
-            && let Err(e) = crate::usage::record_usage(
-                pool,
-                &crate::usage::UsageRecord {
+        if let Some(ref store) = self.store
+            && let Err(e) = store
+                .record_usage(&store::UsageRecord {
                     platform: msg.platform.to_string(),
                     user_id: msg.user_id.clone(),
                     cli_profile: cli_name.clone(),
@@ -1114,9 +1160,8 @@ impl GatewayRunner {
                     tokens_completion: result.tokens_completion.unwrap_or(0),
                     tool_calls: result.tool_calls_count.unwrap_or(0),
                     elapsed_ms: elapsed.as_millis() as u64,
-                },
-            )
-            .await
+                })
+                .await
         {
             tracing::warn!(error = %e, "failed to record usage");
         }
@@ -1142,10 +1187,10 @@ impl GatewayRunner {
     }
 
     async fn clear_pending_message(&self, pending_id: Option<i64>) {
-        let (Some(id), Some(pool)) = (pending_id, self.pool.as_ref()) else {
+        let (Some(id), Some(store)) = (pending_id, self.store.as_ref()) else {
             return;
         };
-        if let Err(e) = storage::delete_pending_message(pool, id).await {
+        if let Err(e) = store.delete_pending_message(id).await {
             tracing::warn!(id, error = %e, "failed to delete pending message");
         }
     }
@@ -1315,11 +1360,41 @@ impl GatewayRunner {
             if !self.should_execute_queued(&queued).await {
                 continue;
             }
-            if let Some(outbound) = self
+            match self
                 .handle_message_inner(&queued.msg, &NullAdapter, None, true, queued.trace.clone())
                 .await
             {
-                let _ = cli_resp_tx.send(outbound).await;
+                Some(outbound) => {
+                    let _ = cli_resp_tx.send(outbound).await;
+                }
+                None => {
+                    // Fix A: Never leave a trace stuck in Running when no response is produced.
+                    if let Some(trace) = queued.trace.as_ref()
+                        && let Some(repo) = self.trace_repo.as_ref()
+                    {
+                        let writer = TraceWriter::from_existing(
+                            repo.as_ref() as &dyn TraceRepository,
+                            trace.trace_id.clone(),
+                            trace.request_id.clone(),
+                        );
+                        let _ = writer.fail_request("request produced no response").await;
+                    }
+                }
+            }
+        }
+        // Fix C: Sweep any Running/Accepted traces for this conversation before exiting.
+        if let Some(repo) = self.trace_repo.as_ref() {
+            match repo
+                .sweep_conversation_stale_requests(&key, "conversation worker exited")
+                .await
+            {
+                Ok(0) => {}
+                Ok(n) => {
+                    tracing::info!(conversation = %key, count = n, "swept stale traces on worker exit");
+                }
+                Err(e) => {
+                    tracing::warn!(conversation = %key, error = %e, "failed to sweep stale traces on worker exit");
+                }
             }
         }
         self.queue_senders.lock().await.remove(&key);
@@ -1335,18 +1410,39 @@ impl GatewayRunner {
         };
         match repo.get_request(&trace.request_id).await {
             Ok(Some(request)) if request.status == RequestStatus::Accepted => true,
-            Ok(Some(request)) => {
+            Ok(Some(request)) if request.status.is_terminal() => {
                 tracing::info!(
                     request_id = %trace.request_id,
                     status = request.status.as_str(),
-                    "skipping queued request"
+                    "skipping queued request (terminal status)"
                 );
+                false
+            }
+            Ok(Some(request)) => {
+                // Non-terminal, non-Accepted (e.g. Running from a previous crash) — mark failed
+                tracing::info!(
+                    request_id = %trace.request_id,
+                    status = request.status.as_str(),
+                    "skipping queued request with unexpected status; marking failed"
+                );
+                let writer = TraceWriter::from_existing(
+                    repo.as_ref() as &dyn TraceRepository,
+                    trace.trace_id.clone(),
+                    trace.request_id.clone(),
+                );
+                let _ = writer
+                    .fail_request(&format!(
+                        "queued request had unexpected status: {}",
+                        request.status.as_str()
+                    ))
+                    .await;
                 false
             }
             Ok(None) => false,
             Err(e) => {
-                tracing::warn!(error = %e, "failed to verify queued request status");
-                false
+                // Execute on DB error rather than silently dropping the request
+                tracing::warn!(error = %e, "failed to verify queued request status; executing anyway");
+                true
             }
         }
     }
@@ -1668,54 +1764,7 @@ fn is_safe_skill_name(name: &str) -> bool {
             .all(|ch| ch.is_alphanumeric() || matches!(ch, ' ' | '_' | '-'))
 }
 
-async fn connect_db(url: &str) -> Result<MySqlPool, sqlx::Error> {
-    match sqlx::mysql::MySqlPoolOptions::new()
-        .max_connections(5)
-        .connect(url)
-        .await
-    {
-        Ok(pool) => {
-            storage::ensure_schema(&pool).await?;
-            Ok(pool)
-        }
-        Err(e) => {
-            let msg = e.to_string();
-            if !msg.contains("1049") && !msg.contains("Unknown database") {
-                return Err(e);
-            }
-            // Extract DB name from URL and create it
-            let (base_url, db_name) = match url.rfind('/') {
-                Some(pos) if pos > url.find("://").map(|p| p + 2).unwrap_or(0) => {
-                    (&url[..pos], &url[pos + 1..])
-                }
-                _ => return Err(e),
-            };
-            // Strip query params from db_name
-            let db_name = db_name.split('?').next().unwrap_or(db_name);
-            if !is_safe_db_name(db_name) {
-                return Err(e);
-            }
-
-            tracing::info!(db = db_name, "database does not exist — creating");
-            let tmp_pool = sqlx::mysql::MySqlPoolOptions::new()
-                .max_connections(1)
-                .connect(base_url)
-                .await?;
-            sqlx::query(&format!("CREATE DATABASE IF NOT EXISTS `{db_name}`"))
-                .execute(&tmp_pool)
-                .await?;
-            tmp_pool.close().await;
-
-            let pool = sqlx::mysql::MySqlPoolOptions::new()
-                .max_connections(5)
-                .connect(url)
-                .await?;
-            storage::ensure_schema(&pool).await?;
-            Ok(pool)
-        }
-    }
-}
-
+#[cfg(test)]
 fn is_safe_db_name(name: &str) -> bool {
     !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
@@ -1736,7 +1785,7 @@ async fn resolve_gateway_task(
 #[cfg(test)]
 async fn execute_gateway_actions(
     text: &str,
-    pool: Option<&sqlx::MySqlPool>,
+    store: Option<&dyn GatewayStore>,
     platform: &str,
     chat_id: &str,
     user_id: &str,
@@ -1746,7 +1795,7 @@ async fn execute_gateway_actions(
 ) -> String {
     execute_gateway_actions_with_policy(
         text,
-        pool,
+        store,
         platform,
         chat_id,
         user_id,
@@ -1765,7 +1814,7 @@ async fn execute_gateway_actions(
 #[allow(clippy::too_many_arguments)]
 async fn execute_gateway_actions_with_policy(
     text: &str,
-    pool: Option<&sqlx::MySqlPool>,
+    store: Option<&dyn GatewayStore>,
     platform: &str,
     chat_id: &str,
     user_id: &str,
@@ -1802,12 +1851,19 @@ async fn execute_gateway_actions_with_policy(
                     "⚠️ 任务消息不能为空".into()
                 } else if !is_valid_cron_expr(cron_expr) {
                     format!("⚠️ 无效的 cron 表达式: `{cron_expr}`（需要 5 个字段: 分 时 日 月 周）")
-                } else if let Some(pool) = pool {
+                } else if let Some(store) = store {
                     let job_id = uuid::Uuid::new_v4().to_string();
-                    match storage::create_cron_job(
-                        pool, &job_id, platform, chat_id, user_id, cron_expr, message, message,
-                    )
-                    .await
+                    match store
+                        .create_cron_job(&store::CronJobSpec {
+                            job_id: job_id.clone(),
+                            platform: platform.to_string(),
+                            chat_id: chat_id.to_string(),
+                            user_id: user_id.to_string(),
+                            cron_expr: cron_expr.to_string(),
+                            message: message.to_string(),
+                            description: message.to_string(),
+                        })
+                        .await
                     {
                         Ok(()) => {
                             tracing::info!(
@@ -1838,31 +1894,27 @@ async fn execute_gateway_actions_with_policy(
                     "⚠️ 提醒时间无效（需要大于 0 的分钟数）".into()
                 } else if minutes > 1440 * 7 {
                     "⚠️ 提醒时间过长（最多 7 天 = 10080 分钟）".into()
-                } else if let Some(pool) = pool {
+                } else if let Some(store) = store {
                     // Store as one-shot cron job with computed next_run time
                     let job_id = uuid::Uuid::new_v4().to_string();
                     let next_run = chrono::Utc::now() + chrono::Duration::minutes(minutes as i64);
                     let next_run_str = next_run.format("%Y-%m-%d %H:%M:%S").to_string();
                     // Use special cron_expr "once" to mark as one-shot
-                    match storage::create_cron_job(
-                        pool,
-                        &job_id,
-                        platform,
-                        chat_id,
-                        user_id,
-                        "once",
-                        &message,
-                        &format!("⏰ {message} (一次性)"),
-                    )
-                    .await
+                    match store
+                        .create_cron_job(&store::CronJobSpec {
+                            job_id: job_id.clone(),
+                            platform: platform.to_string(),
+                            chat_id: chat_id.to_string(),
+                            user_id: user_id.to_string(),
+                            cron_expr: "once".to_string(),
+                            message: message.clone(),
+                            description: format!("⏰ {message} (一次性)"),
+                        })
+                        .await
                     {
                         Ok(()) => {
-                            if let Err(e) =
-                                sqlx::query("UPDATE gw_cron_jobs SET next_run = ? WHERE job_id = ?")
-                                    .bind(&next_run_str)
-                                    .bind(&job_id)
-                                    .execute(pool)
-                                    .await
+                            // Update next_run via the trait method (works on all backends)
+                            if let Err(e) = store.update_cron_next_run(&job_id, &next_run_str).await
                             {
                                 tracing::warn!(job_id = %&job_id[..8], error = %e, "failed to set remind_after next_run");
                             }
@@ -1891,15 +1943,18 @@ async fn execute_gateway_actions_with_policy(
             }
 
             Some("task_list") => {
-                if let Some(pool) = pool {
-                    match storage::list_cron_jobs(pool, platform, chat_id).await {
+                if let Some(store) = store {
+                    match store.list_cron_jobs(platform, chat_id).await {
                         Ok(jobs) if jobs.is_empty() => "📋 当前没有定时任务。".into(),
                         Ok(jobs) => {
                             let mut lines = vec![format!("📋 **定时任务** ({} 个)", jobs.len())];
-                            for (id, expr, desc, enabled) in &jobs {
-                                let status = if *enabled { "✅" } else { "⏸" };
-                                let short_id = &id[..8.min(id.len())];
-                                lines.push(format!("{status} `{short_id}` | `{expr}` | {desc}"));
+                            for j in &jobs {
+                                let status = if j.enabled { "✅" } else { "⏸" };
+                                let short_id = &j.job_id[..8.min(j.job_id.len())];
+                                lines.push(format!(
+                                    "{status} `{short_id}` | `{}` | {}",
+                                    j.cron_expr, j.description
+                                ));
                             }
                             lines.join("\n")
                         }
@@ -1914,9 +1969,9 @@ async fn execute_gateway_actions_with_policy(
                 let target = parts[1].trim();
                 if target.is_empty() {
                     "⚠️ 请指定任务 ID".into()
-                } else if let Some(pool) = pool {
+                } else if let Some(store) = store {
                     // Support prefix match
-                    match find_and_delete_job(pool, platform, chat_id, target).await {
+                    match find_and_delete_job(store, platform, chat_id, target).await {
                         Ok(Some(desc)) => {
                             tracing::info!(target, "gateway action: task_del");
                             format!("✅ 已删除任务: {desc}")
@@ -1933,8 +1988,8 @@ async fn execute_gateway_actions_with_policy(
             // Legacy alias
             Some("cron_del") if parts.len() >= 2 => {
                 let job_id = parts[1].trim();
-                if let Some(pool) = pool {
-                    match find_and_delete_job(pool, platform, chat_id, job_id).await {
+                if let Some(store) = store {
+                    match find_and_delete_job(store, platform, chat_id, job_id).await {
                         Ok(Some(desc)) => {
                             tracing::info!(job_id, "gateway action: cron_del");
                             format!("✅ 已删除任务: {desc}")
@@ -2243,19 +2298,14 @@ async fn execute_gateway_actions_with_policy(
                     format!("❌ 目录不存在: `{expanded}`")
                 } else if let Err(denial) = action_policy.workspace_allowed(path) {
                     denial
-                } else if let Some(pool) = pool {
+                } else if let Some(store) = store {
                     let canonical = path
                         .canonicalize()
                         .map(|p| p.to_string_lossy().to_string())
                         .unwrap_or(expanded);
-                    match storage::set_user_preference(
-                        pool,
-                        platform,
-                        user_id,
-                        "workspace",
-                        &canonical,
-                    )
-                    .await
+                    match store
+                        .set_user_preference(platform, user_id, "workspace", &canonical)
+                        .await
                     {
                         Ok(()) => {
                             tracing::info!(workspace = %canonical, "gateway action: workspace_set");
@@ -2307,19 +2357,19 @@ fn is_valid_cron_expr(expr: &str) -> bool {
 }
 
 async fn find_and_delete_job(
-    pool: &sqlx::MySqlPool,
+    store: &dyn GatewayStore,
     platform: &str,
     chat_id: &str,
     target: &str,
-) -> Result<Option<String>, sqlx::Error> {
-    let jobs = storage::list_cron_jobs(pool, platform, chat_id).await?;
+) -> Result<Option<String>, store::StoreError> {
+    let jobs = store.list_cron_jobs(platform, chat_id).await?;
     // Exact or prefix match
     let matched = jobs
         .iter()
-        .find(|(id, _, _, _)| id == target || id.starts_with(target));
-    if let Some((id, _, desc, _)) = matched {
-        let desc = desc.clone();
-        storage::delete_cron_job(pool, id).await?;
+        .find(|j| j.job_id == target || j.job_id.starts_with(target));
+    if let Some(j) = matched {
+        let desc = j.description.clone();
+        store.delete_cron_job(&j.job_id).await?;
         Ok(Some(desc))
     } else {
         Ok(None)
@@ -3140,6 +3190,22 @@ async fn action_policy_allows_when_enabled() {
         "expected no-db fallback, got: {}",
         r[0]
     );
+}
+
+fn build_welcome_message(cli: &CliProfile) -> String {
+    format!(
+        "👋 **欢迎使用 Astra Gateway!**\n\n\
+         当前 CLI: `{cli_name}`\n\
+         发送任意消息开始对话，或使用命令:\n\n\
+         - `/help` — 所有命令\n\
+         - `/status` — 当前状态\n\
+         - `/cli` — 切换 CLI 后端\n\
+         - `/model` — 切换模型\n\
+         - `/ws ls` — 可用项目\n\
+         - `/gateway` — 完整能力概览\n\n\
+         发送消息开始 🚀",
+        cli_name = cli.name()
+    )
 }
 
 fn format_tokens(n: u64) -> String {

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -2001,6 +2001,12 @@ impl GatewayRunner {
         for adapter in &adapters {
             self.replay_pending_messages(adapter.as_ref()).await;
         }
+        // Drain any progressive chunks that accumulated in the outbound channel
+        // during replay (the main select loop wasn't consuming yet).
+        while let Ok(outbound) = cron_rx.try_recv() {
+            self.deliver_outbound(&adapters, &adapter_indices, outbound)
+                .await;
+        }
 
         loop {
             tokio::select! {

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -804,14 +804,9 @@ impl GatewayRunner {
                         }
                         Some(CliProgress::ToolStarted { ref name }) => {
                             tool_count += 1;
-                            if !token_buf.is_empty() {
-                                token_buf.push('\n');
-                            }
-                            token_buf.push_str(&format!("🔧 {name}…\n"));
                             last_tool = name.clone();
                         }
-                        Some(CliProgress::ToolDone { name, duration_ms }) => {
-                            token_buf.push_str(&format!("✅ {name} ({duration_ms}ms)\n"));
+                        Some(CliProgress::ToolDone { name, .. }) => {
                             last_tool = name;
                         }
                         Some(CliProgress::ToolCall(line)) => {

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -1267,16 +1267,34 @@ impl GatewayRunner {
         } else {
             text
         };
-        Some(
-            self.outbound_response(
-                trace.as_ref(),
-                msg.platform,
-                &msg.chat_id,
-                msg.reply_token.clone(),
+
+        // When progressive streaming already delivered the main content, the
+        // final message is just a stats footer + action results.  Sending it
+        // as a plain message (no durable outbox) avoids retry storms: if this
+        // low-value footer fails to deliver it is simply dropped rather than
+        // retried on every restart.
+        if progressive_text_len > 0 {
+            // Still mark the trace request as completed (even without outbox).
+            if let Some(writer) = trace_writer.as_ref() {
+                let _ = writer.complete_request().await;
+            }
+            Some(OutboundMessage::plain(
+                msg.platform.to_string(),
+                msg.chat_id.clone(),
                 text,
+            ))
+        } else {
+            Some(
+                self.outbound_response(
+                    trace.as_ref(),
+                    msg.platform,
+                    &msg.chat_id,
+                    msg.reply_token.clone(),
+                    text,
+                )
+                .await,
             )
-            .await,
-        )
+        }
     }
 
     async fn clear_pending_message(&self, pending_id: Option<i64>) {

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -99,6 +99,8 @@ pub struct GatewayRunner {
     /// Tracks consecutive auth failures per CLI profile name.
     /// Value: (failure_count, last_failure_time).
     auth_failures: Arc<dashmap::DashMap<String, (u32, Instant)>>,
+    /// Shared access token — gateway validates once, all CLI spawns reuse via env var.
+    shared_auth: Option<SharedAuthToken>,
 }
 
 /// No-op adapter used in spawned CLI tasks (typing/heartbeats not available in background).
@@ -223,6 +225,12 @@ impl GatewayRunner {
             cli_profile.clone()
         };
 
+        let shared_auth = Some(SharedAuthToken::new(
+            thin.clone(),
+            config.astra.username.clone(),
+            config.astra.password.clone(),
+        ));
+
         Ok(Self {
             config,
             store,
@@ -237,6 +245,7 @@ impl GatewayRunner {
             global_run_limiter: Arc::new(tokio::sync::Semaphore::new(max_concurrent_runs)),
             cli_availability,
             auth_failures: Arc::new(dashmap::DashMap::new()),
+            shared_auth,
         })
     }
 
@@ -706,6 +715,13 @@ impl GatewayRunner {
         let cli_name = cli_profile.name().to_string();
         let cli_timeout = Duration::from_secs(self.config.cli_timeout_secs.max(1));
 
+        // Pre-fetch shared access token so the CLI can skip per-spawn auth.
+        let access_token = if let Some(ref auth) = self.shared_auth {
+            auth.get().await
+        } else {
+            None
+        };
+
         let (progress_tx, mut progress_rx) = tokio::sync::mpsc::channel::<CliProgress>(64);
 
         let cli_handle = tokio::spawn({
@@ -713,6 +729,7 @@ impl GatewayRunner {
             let message_text = message_text.clone();
             let system_prompt = system_prompt.clone();
             let ws = workspace.clone();
+            let token = access_token.clone();
             async move {
                 cli_bridge::run_cli_with_context_and_timeout(
                     &profile,
@@ -721,9 +738,8 @@ impl GatewayRunner {
                     ws.as_deref(),
                     Some(progress_tx),
                     Some(&system_prompt),
-                    // TODO(cli_bridge): pass gateway trace_id/request_id once the
-                    // bridge exposes a stable metadata API.
                     Some(cli_timeout),
+                    token.as_deref(),
                 )
                 .await
             }
@@ -888,6 +904,9 @@ impl GatewayRunner {
                 // Track auth failures for circuit breaker
                 if cli_bridge::is_auth_error(&e) {
                     self.record_auth_failure(&cli_name);
+                    if let Some(ref auth) = self.shared_auth {
+                        auth.invalidate().await;
+                    }
                 }
                 suspend_tasks(&self.durable_store, format!("CLI error: {e}")).await;
                 if let Some(writer) = trace_writer.as_ref() {
@@ -968,6 +987,7 @@ impl GatewayRunner {
                 let message_text = msg.text.clone();
                 let system_prompt = system_prompt.clone();
                 let ws = workspace.clone();
+                let access_token = access_token.clone();
                 async move {
                     cli_bridge::run_cli_with_context(
                         &profile,
@@ -976,6 +996,7 @@ impl GatewayRunner {
                         ws.as_deref(),
                         None,
                         Some(&system_prompt),
+                        access_token.as_deref(),
                     )
                     .await
                 }
@@ -1056,6 +1077,9 @@ impl GatewayRunner {
             let combined_err = format!("{}\n{}", result.stderr, result.stdout);
             if cli_bridge::is_auth_error(&combined_err) {
                 self.record_auth_failure(&cli_name);
+                if let Some(ref auth) = self.shared_auth {
+                    auth.invalidate().await;
+                }
 
                 // Attempt auto-relogin if credentials are configured
                 if self.config.astra.username.is_some()
@@ -1063,9 +1087,14 @@ impl GatewayRunner {
                     && matches!(cli_profile, CliProfile::Astra { .. })
                 {
                     match self.try_auto_relogin().await {
-                        Ok(_) => {
+                        Ok(ref token) => {
                             tracing::info!(cli = %cli_name, "auto-relogin succeeded after auth failure");
                             self.clear_auth_failure(&cli_name);
+                            // Update shared token cache with the fresh token
+                            if let Some(ref auth) = self.shared_auth {
+                                let mut guard = auth.token.write().await;
+                                *guard = Some(token.clone());
+                            }
                         }
                         Err(e) => {
                             tracing::warn!(cli = %cli_name, error = %e, "auto-relogin failed");
@@ -1503,11 +1532,21 @@ impl GatewayRunner {
             lines.push("\n认证缓存已重置。".into());
         }
 
-        // 4. Attempt auto-relogin if credentials configured
+        // 4. Invalidate shared token cache so it refreshes on next message
+        if let Some(ref auth) = self.shared_auth {
+            auth.invalidate().await;
+        }
+
+        // 5. Attempt auto-relogin if credentials configured
         if self.config.astra.username.is_some() && self.config.astra.password.is_some() {
             match self.try_auto_relogin().await {
-                Ok(_) => {
+                Ok(ref token) => {
                     lines.push("✅ 自动重新登录成功，凭证已刷新。".into());
+                    // Warm shared token cache with the fresh token
+                    if let Some(ref auth) = self.shared_auth {
+                        let mut guard = auth.token.write().await;
+                        *guard = Some(token.clone());
+                    }
                 }
                 Err(e) => {
                     lines.push(format!("⚠️ 自动重新登录失败: {e}"));
@@ -2133,6 +2172,109 @@ fn rfind_fence_break(s: &str) -> Option<usize> {
         }
     }
     None
+}
+
+// ─── Shared auth token ─────────────────────────────────────────────────────
+//
+// Gateway manages a single cached access token that is injected into CLI
+// spawns via `ASTRA_ACCESS_TOKEN`.  This eliminates per-message auth
+// round-trips (`GET /auth/me`) inside the CLI.
+
+/// Thread-safe cached access token.  The gateway validates the token once,
+/// then all concurrent CLI spawns reuse it without any HTTP call.
+struct SharedAuthToken {
+    token: tokio::sync::RwLock<Option<String>>,
+    api: astra_thin_client::ThinClient,
+    username: Option<String>,
+    password: Option<String>,
+}
+
+impl SharedAuthToken {
+    fn new(
+        api: astra_thin_client::ThinClient,
+        username: Option<String>,
+        password: Option<String>,
+    ) -> Self {
+        Self {
+            token: tokio::sync::RwLock::new(None),
+            api,
+            username,
+            password,
+        }
+    }
+
+    /// Return a cached valid token, or try to obtain one (from credentials file
+    /// or by logging in).
+    async fn get(&self) -> Option<String> {
+        // Fast path: return cached token
+        {
+            let guard = self.token.read().await;
+            if let Some(ref tok) = *guard {
+                return Some(tok.clone());
+            }
+        }
+        // Slow path: refresh
+        self.refresh().await
+    }
+
+    /// Force-refresh: read from `~/.astra/credentials.json`, validate via
+    /// `GET /auth/me`, and optionally re-login with username/password.
+    async fn refresh(&self) -> Option<String> {
+        // Read from CLI credentials file
+        if let Some(ref tok) = read_cli_access_token()
+            && let Ok(resp) = self
+                .api
+                .get_auth_me_text_timeout(tok, Duration::from_secs(3))
+                .await
+            && resp.status().is_success()
+        {
+            let mut guard = self.token.write().await;
+            *guard = Some(tok.clone());
+            return Some(tok.clone());
+        }
+        // Token invalid — try login if credentials available
+        if let (Some(username), Some(password)) = (&self.username, &self.password)
+            && let Ok(body) = self
+                .api
+                .post_auth_login_json(&serde_json::json!({
+                    "username": username,
+                    "password": password,
+                }))
+                .await
+            && let Ok(v) = serde_json::from_str::<serde_json::Value>(&body)
+            && let Some(access) = v["access_token"].as_str()
+        {
+            let refresh = v["refresh_token"].as_str();
+            let _ = save_token_to_cli_credentials(username, access, refresh);
+            let tok = access.to_string();
+            let mut guard = self.token.write().await;
+            *guard = Some(tok.clone());
+            return Some(tok);
+        }
+        None
+    }
+
+    /// Clear the cached token (e.g. after an auth failure from the CLI).
+    async fn invalidate(&self) {
+        let mut guard = self.token.write().await;
+        *guard = None;
+    }
+}
+
+/// Read the access token for the current profile from `~/.astra/credentials.json`.
+fn read_cli_access_token() -> Option<String> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()?;
+    let path = std::path::Path::new(&home)
+        .join(".astra")
+        .join("credentials.json");
+    let content = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let current = v["current_profile"].as_str().unwrap_or("default");
+    v["profiles"][current]["access_token"]
+        .as_str()
+        .map(String::from)
 }
 
 /// Write refreshed tokens to `~/.astra/credentials.json` so subsequent CLI
@@ -3767,6 +3909,107 @@ mod tests {
             loaded["profiles"]["default"]["username"].as_str(),
             Some("admin")
         );
+    }
+
+    // ── SharedAuthToken ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn shared_auth_token_get_returns_none_without_credentials() {
+        // With no credentials file and no username/password, get() should return None
+        let api = astra_thin_client::ThinClient::new("http://127.0.0.1:1", None).unwrap();
+        let auth = SharedAuthToken::new(api, None, None);
+        // get() will try to read credentials file and validate — both fail → None
+        assert!(auth.get().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn shared_auth_token_invalidate_clears_cached() {
+        let api = astra_thin_client::ThinClient::new("http://127.0.0.1:1", None).unwrap();
+        let auth = SharedAuthToken::new(api, None, None);
+        // Manually set a cached token
+        {
+            let mut guard = auth.token.write().await;
+            *guard = Some("cached-token-abc".to_string());
+        }
+        assert_eq!(auth.get().await, Some("cached-token-abc".to_string()));
+
+        auth.invalidate().await;
+        // After invalidation, cached token is cleared (get returns None because
+        // refresh will fail with unreachable server)
+        let guard = auth.token.read().await;
+        assert!(guard.is_none());
+    }
+
+    #[tokio::test]
+    async fn shared_auth_token_get_returns_cached() {
+        let api = astra_thin_client::ThinClient::new("http://127.0.0.1:1", None).unwrap();
+        let auth = SharedAuthToken::new(api, None, None);
+        // Manually seed cache
+        {
+            let mut guard = auth.token.write().await;
+            *guard = Some("fast-path-token".to_string());
+        }
+        // get() should return the cached token without any network call
+        assert_eq!(auth.get().await, Some("fast-path-token".to_string()));
+    }
+
+    #[test]
+    fn read_cli_access_token_missing_file() {
+        // With a nonexistent HOME, read_cli_access_token should return None
+        let _guard = EnvGuard::set("HOME", "/nonexistent/path/xyz");
+        assert!(read_cli_access_token().is_none());
+    }
+
+    #[test]
+    fn read_cli_access_token_valid_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let astra_dir = tmp.path().join(".astra");
+        std::fs::create_dir_all(&astra_dir).unwrap();
+        let creds = serde_json::json!({
+            "current_profile": "default",
+            "profiles": {
+                "default": {
+                    "access_token": "my-token-123",
+                    "refresh_token": "my-refresh"
+                }
+            }
+        });
+        std::fs::write(
+            astra_dir.join("credentials.json"),
+            serde_json::to_string(&creds).unwrap(),
+        )
+        .unwrap();
+
+        let _guard = EnvGuard::set("HOME", tmp.path().to_str().unwrap());
+        assert_eq!(read_cli_access_token(), Some("my-token-123".to_string()));
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        old: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let old = std::env::var(key).ok();
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, old }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.old {
+                Some(value) => unsafe {
+                    std::env::set_var(self.key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(self.key);
+                },
+            }
+        }
     }
 }
 

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -692,7 +692,7 @@ impl GatewayRunner {
         let mut last_tool = String::new();
         let mut sent_initial_ack = false;
         let mut token_buf = String::new();
-        let mut in_think_block = false;
+        let mut think_filter = ThinkTagStreamFilter::default();
         let mut gateway_action_filter = GatewayActionStreamFilter::default();
         let mut progressive_text_len: usize = 0;
         let next_timer = tokio::time::sleep(INITIAL_ACK_DELAY);
@@ -731,8 +731,7 @@ impl GatewayRunner {
                 progress = progress_rx.recv() => {
                     match progress {
                         Some(CliProgress::Token(text)) => {
-                            // Filter <think>...</think> blocks from token stream
-                            let filtered = filter_think_tags(&text, &mut in_think_block);
+                            let filtered = think_filter.push(&text);
                             let filtered = gateway_action_filter.push(&filtered);
                             if !filtered.is_empty() {
                                 token_buf.push_str(&filtered);
@@ -764,6 +763,11 @@ impl GatewayRunner {
                         Some(CliProgress::Thinking(_)) => {}
                         Some(CliProgress::Status(_) | CliProgress::Stderr(_)) => {}
                         None => {
+                            let think_tail = think_filter.finish();
+                            if !think_tail.is_empty() {
+                                let filtered = gateway_action_filter.push(&think_tail);
+                                token_buf.push_str(&filtered);
+                            }
                             let tail = gateway_action_filter.finish();
                             if !tail.is_empty() {
                                 token_buf.push_str(&tail);
@@ -2565,8 +2569,79 @@ async fn find_and_delete_job(
     }
 }
 
-/// Filter `<think>...</think>` blocks from streaming token text.
-/// `in_think` tracks state across calls (tokens arrive in small chunks).
+/// Streaming filter for `<think>...</think>` blocks.
+///
+/// Buffers partial tag fragments across token boundaries so that a `<think>`
+/// split across two chunks (e.g. `"<thi"` + `"nk>..."`) is correctly detected
+/// and suppressed, instead of leaking the partial tag to the user.
+#[derive(Default)]
+struct ThinkTagStreamFilter {
+    pending: String,
+    in_think: bool,
+}
+
+impl ThinkTagStreamFilter {
+    fn push(&mut self, text: &str) -> String {
+        self.pending.push_str(text);
+        let mut out = String::new();
+
+        loop {
+            if self.in_think {
+                if let Some(end) = self.pending.find("</think>") {
+                    self.pending.drain(..end + 8);
+                    self.in_think = false;
+                    continue;
+                }
+                // No closing tag yet — keep all pending content. finish()
+                // will return it if the block is never closed.
+                break;
+            }
+
+            if let Some(start) = self.pending.find("<think>") {
+                out.push_str(&self.pending[..start]);
+                self.pending.drain(..start + 7);
+                self.in_think = true;
+                continue;
+            }
+
+            let keep = open_think_prefix_len(&self.pending);
+            let emit_len = self.pending.len().saturating_sub(keep);
+            out.push_str(&self.pending[..emit_len]);
+            self.pending.drain(..emit_len);
+            break;
+        }
+
+        out
+    }
+
+    fn finish(&mut self) -> String {
+        if self.in_think {
+            // Unclosed <think> — return accumulated content so it's not lost
+            let leftover = std::mem::take(&mut self.pending);
+            self.in_think = false;
+            leftover
+        } else {
+            std::mem::take(&mut self.pending)
+        }
+    }
+}
+
+/// Suffix of `text` that could be a prefix of `<think>` (when outside a think block).
+fn open_think_prefix_len(text: &str) -> usize {
+    tag_suffix_prefix_len(text, "<think>")
+}
+
+fn tag_suffix_prefix_len(text: &str, tag: &str) -> usize {
+    let max = text.len().min(tag.len() - 1);
+    for len in (1..=max).rev() {
+        if text.is_char_boundary(text.len() - len) && tag.starts_with(&text[text.len() - len..]) {
+            return len;
+        }
+    }
+    0
+}
+
+/// Simple non-streaming filter for complete text. Used on the final CLI output.
 fn filter_think_tags(text: &str, in_think: &mut bool) -> String {
     let mut result = String::new();
     let mut remaining = text;
@@ -3044,6 +3119,84 @@ mod tests {
             "visible "
         );
         assert_eq!(filter.finish(), "");
+    }
+
+    // ── ThinkTagStreamFilter tests ────────────────────────────────
+
+    #[test]
+    fn think_stream_filter_complete_block() {
+        let mut f = ThinkTagStreamFilter::default();
+        assert_eq!(f.push("<think>reasoning</think>Hello!"), "Hello!");
+        assert_eq!(f.finish(), "");
+    }
+
+    #[test]
+    fn think_stream_filter_split_open_tag() {
+        let mut f = ThinkTagStreamFilter::default();
+        let r1 = f.push("before<thi");
+        assert_eq!(r1, "before");
+        let r2 = f.push("nk>hidden</think>visible");
+        assert_eq!(r2, "visible");
+    }
+
+    #[test]
+    fn think_stream_filter_split_close_tag() {
+        let mut f = ThinkTagStreamFilter::default();
+        assert_eq!(f.push("<think>hidden</thi"), "");
+        assert_eq!(f.push("nk>after"), "after");
+    }
+
+    #[test]
+    fn think_stream_filter_no_think_passthrough() {
+        let mut f = ThinkTagStreamFilter::default();
+        assert_eq!(f.push("just normal text"), "just normal text");
+        assert_eq!(f.finish(), "");
+    }
+
+    #[test]
+    fn think_stream_filter_unclosed_at_finish_preserves_content() {
+        let mut f = ThinkTagStreamFilter::default();
+        assert_eq!(f.push("before<think>hidden"), "before");
+        let tail = f.finish();
+        assert_eq!(tail, "hidden");
+    }
+
+    #[test]
+    fn think_stream_filter_single_char_chunks() {
+        let mut f = ThinkTagStreamFilter::default();
+        let input = "A<think>secret</think>B";
+        let mut output = String::new();
+        for ch in input.chars() {
+            output.push_str(&f.push(&ch.to_string()));
+        }
+        output.push_str(&f.finish());
+        assert_eq!(output, "AB", "single-char chunking must still filter");
+    }
+
+    #[test]
+    fn think_stream_filter_multiple_blocks() {
+        let mut f = ThinkTagStreamFilter::default();
+        let out = f.push("A<think>x</think>B<think>y</think>C");
+        assert_eq!(out, "ABC");
+    }
+
+    #[test]
+    fn open_think_prefix_len_values() {
+        assert_eq!(open_think_prefix_len("hello"), 0);
+        assert_eq!(open_think_prefix_len("hello<"), 1);
+        assert_eq!(open_think_prefix_len("hello<t"), 2);
+        assert_eq!(open_think_prefix_len("hello<th"), 3);
+        assert_eq!(open_think_prefix_len("hello<thi"), 4);
+        assert_eq!(open_think_prefix_len("hello<thin"), 5);
+        assert_eq!(open_think_prefix_len("hello<think"), 6);
+    }
+
+    #[test]
+    fn tag_suffix_prefix_len_for_close_tag() {
+        assert_eq!(tag_suffix_prefix_len("text</", "</think>"), 2);
+        assert_eq!(tag_suffix_prefix_len("text</t", "</think>"), 3);
+        assert_eq!(tag_suffix_prefix_len("text</think", "</think>"), 7);
+        assert_eq!(tag_suffix_prefix_len("text", "</think>"), 0);
     }
 
     // ── Gateway action tests ──────────────────────────────────────

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 
 const MAX_CHUNK_LEN: usize = 3800;
@@ -101,6 +102,8 @@ pub struct GatewayRunner {
     auth_failures: Arc<dashmap::DashMap<String, (u32, Instant)>>,
     /// Shared access token — gateway validates once, all CLI spawns reuse via env var.
     shared_auth: Option<SharedAuthToken>,
+    /// Monotonic counter for generating short request tags when no trace exists.
+    request_counter: AtomicU32,
 }
 
 /// No-op adapter used in spawned CLI tasks (typing/heartbeats not available in background).
@@ -246,6 +249,7 @@ impl GatewayRunner {
             cli_availability,
             auth_failures: Arc::new(dashmap::DashMap::new()),
             shared_auth,
+            request_counter: AtomicU32::new(0),
         })
     }
 
@@ -554,10 +558,20 @@ impl GatewayRunner {
             }
         }
 
+        // Generate short request tag for user-facing message correlation
+        let request_tag = match trace.as_ref() {
+            Some(t) => short_request_tag(t.trace_id.as_str()),
+            None => {
+                let n = self.request_counter.fetch_add(1, Ordering::Relaxed);
+                format!("#{:02X}", n % 256)
+            }
+        };
+
         tracing::info!(
             platform = msg.platform,
             chat_id = %safe_id(&msg.chat_id),
             user = %safe_id(&msg.user_id),
+            tag = %request_tag,
             "→ {}",
             truncate(&msg.text, 80),
         );
@@ -753,6 +767,7 @@ impl GatewayRunner {
         let mut think_filter = ThinkTagStreamFilter::default();
         let mut gateway_action_filter = GatewayActionStreamFilter::default();
         let mut progressive_text_len: usize = 0;
+        let mut chunk_counter: u32 = 0;
         let next_timer = tokio::time::sleep(INITIAL_ACK_DELAY);
         tokio::pin!(next_timer);
 
@@ -760,7 +775,9 @@ impl GatewayRunner {
         let flush_buf = |buf: &mut String,
                          tx: &Option<tokio::sync::mpsc::Sender<OutboundMessage>>,
                          platform: &str,
-                         chat: &str|
+                         chat: &str,
+                         tag: &str,
+                         chunk_num: u32|
          -> Option<(
             std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>>,
             usize,
@@ -771,13 +788,16 @@ impl GatewayRunner {
                 return None;
             }
             let len = text.len();
+            let tagged = format!("[{tag}:{chunk_num}] {text}");
             let tx = tx.clone();
             let platform = platform.to_string();
             let chat = chat.to_string();
             Some((
                 Box::pin(async move {
                     if let Some(tx) = tx {
-                        let _ = tx.send(OutboundMessage::plain(platform, chat, text)).await;
+                        let _ = tx
+                            .send(OutboundMessage::plain(platform, chat, tagged))
+                            .await;
                     }
                 }),
                 len,
@@ -794,7 +814,8 @@ impl GatewayRunner {
                             if !filtered.is_empty() {
                                 token_buf.push_str(&filtered);
                                 if token_buf.len() >= PROGRESSIVE_MIN_CHARS {
-                                    if let Some(fut) = flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &chat_id) {
+                                    chunk_counter += 1;
+                                    if let Some(fut) = flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &chat_id, &request_tag, chunk_counter) {
                                         progressive_text_len += fut.1;
                                         fut.0.await;
                                     }
@@ -825,7 +846,8 @@ impl GatewayRunner {
                             if !tail.is_empty() {
                                 token_buf.push_str(&tail);
                             }
-                            if let Some((fut, len)) = flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &chat_id) {
+                            chunk_counter += 1;
+                            if let Some((fut, len)) = flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &chat_id, &request_tag, chunk_counter) {
                                 progressive_text_len += len;
                                 fut.await;
                             }
@@ -836,14 +858,15 @@ impl GatewayRunner {
                 _ = &mut next_timer => {
                     // Timer-based flush: either initial ack or periodic token flush
                     if !token_buf.is_empty() {
-                        if let Some((fut, len)) = flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &chat_id) {
+                        chunk_counter += 1;
+                        if let Some((fut, len)) = flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &chat_id, &request_tag, chunk_counter) {
                             progressive_text_len += len;
                             fut.await;
                         }
                         next_timer.as_mut().reset(tokio::time::Instant::now() + PROGRESSIVE_FLUSH_INTERVAL);
                     } else if !sent_initial_ack {
                         sent_initial_ack = true;
-                        let heartbeat = format!("🤔 {cli_name} 思考中…");
+                        let heartbeat = format!("[{request_tag}] 🤔 {cli_name} 思考中…");
                         if let Some(ref tx) = self.outbound_tx {
                             let _ = tx
                                 .send(OutboundMessage::plain(msg.platform.to_string(), chat_id.clone(), heartbeat))
@@ -854,9 +877,9 @@ impl GatewayRunner {
                         let elapsed_str = format_elapsed(start.elapsed());
                         let heartbeat = if tool_count > 0 {
                             let tool_short = truncate(&last_tool, 40);
-                            format!("⏳ {elapsed_str} | 🔧 {tool_count}个工具 | {tool_short}")
+                            format!("[{request_tag}] ⏳ {elapsed_str} | 🔧 {tool_count}个工具 | {tool_short}")
                         } else {
-                            format!("⏳ 处理中… {elapsed_str}")
+                            format!("[{request_tag}] ⏳ 处理中… {elapsed_str}")
                         };
                         if let Some(ref tx) = self.outbound_tx {
                             let _ = tx
@@ -914,6 +937,7 @@ impl GatewayRunner {
                 }
                 self.clear_pending_message(pending_id).await;
                 let text = cli_bridge::translate_cli_error(&cli_profile, -1, &e);
+                let text = format!("[{request_tag}] {text}");
                 return Some(
                     self.outbound_response(
                         trace.as_ref(),
@@ -942,7 +966,7 @@ impl GatewayRunner {
                         msg.platform,
                         &msg.chat_id,
                         msg.reply_token.clone(),
-                        format!("⚠️ 任务中断: {e}"),
+                        format!("[{request_tag}] ⚠️ 任务中断: {e}"),
                     )
                     .await,
                 );
@@ -1128,6 +1152,7 @@ impl GatewayRunner {
                     result.exit_code,
                     error_text.trim(),
                 );
+                let text = format!("[{request_tag}] {text}");
                 return Some(
                     self.outbound_response(
                         trace.as_ref(),
@@ -1258,6 +1283,7 @@ impl GatewayRunner {
             &action_results_text,
             &stats_parts,
             progressive_text_len,
+            &request_tag,
         );
 
         // Record usage to DB
@@ -3174,8 +3200,10 @@ fn build_final_message(
     action_results: &str,
     stats_parts: &[String],
     progressive_text_len: usize,
+    request_tag: &str,
 ) -> String {
     if progressive_text_len > 0 {
+        // Progressive mode: main content already streamed; final msg is stats footer only
         let mut parts = Vec::new();
         if !action_results.is_empty() {
             parts.push(action_results.to_string());
@@ -3183,11 +3211,21 @@ fn build_final_message(
         if !stats_parts.is_empty() {
             parts.push(format!("`{}`", stats_parts.join(" | ")));
         }
-        parts.join("\n\n")
+        let body = parts.join("\n\n");
+        if body.is_empty() {
+            body
+        } else {
+            format!("[{request_tag}] {body}")
+        }
     } else {
+        // Non-progressive: full text + stats in one message (no tag prefix —
+        // the response was not streamed, so there is no chunk sequence to correlate).
         let mut result = text.to_string();
         if !result.is_empty() && !stats_parts.is_empty() {
-            result.push_str(&format!("\n\n`{}`", stats_parts.join(" | ")));
+            result.push_str(&format!(
+                "\n\n`[{request_tag}] {}`",
+                stats_parts.join(" | ")
+            ));
         }
         result
     }
@@ -3209,6 +3247,21 @@ fn strip_think_blocks(text: &str) -> String {
         }
     }
     result
+}
+
+/// Derive a short request tag like `#A7` from the first two hex digits of a
+/// trace ID (UUID).  Returns `#??` when the input has fewer than two hex chars.
+pub(crate) fn short_request_tag(trace_id: &str) -> String {
+    let hex: String = trace_id
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .take(2)
+        .collect();
+    if hex.len() == 2 {
+        format!("#{}", hex.to_uppercase())
+    } else {
+        "#??".to_string()
+    }
 }
 
 fn format_elapsed(d: Duration) -> String {
@@ -3323,6 +3376,53 @@ mod tests {
         assert_eq!(format_elapsed(Duration::from_secs(130)), "2m10s");
     }
 
+    // ── Short request tag ──────────────────────────────────────
+
+    #[test]
+    fn short_request_tag_from_uuid() {
+        assert_eq!(
+            short_request_tag("a7bc1234-5678-9abc-def0-123456789abc"),
+            "#A7"
+        );
+        assert_eq!(
+            short_request_tag("3f001122-3344-5566-7788-99aabbccddee"),
+            "#3F"
+        );
+    }
+
+    #[test]
+    fn short_request_tag_empty_input() {
+        assert_eq!(short_request_tag(""), "#??");
+    }
+
+    #[test]
+    fn short_request_tag_single_hex_char() {
+        assert_eq!(short_request_tag("a"), "#??");
+    }
+
+    #[test]
+    fn short_request_tag_always_uppercase() {
+        assert_eq!(
+            short_request_tag("abcdef12-0000-0000-0000-000000000000"),
+            "#AB"
+        );
+    }
+
+    #[test]
+    fn short_request_tag_skips_dashes() {
+        // UUID dashes should be skipped, so "a-b-c" should pick up 'a' and 'b'
+        assert_eq!(short_request_tag("a-b-c"), "#AB");
+    }
+
+    #[test]
+    fn short_request_tag_counter_fallback_format() {
+        // Verify the counter-based format matches expectations
+        assert_eq!(format!("#{:02X}", 0u32), "#00");
+        assert_eq!(format!("#{:02X}", 167u32), "#A7");
+        assert_eq!(format!("#{:02X}", 255u32), "#FF");
+        assert_eq!(format!("#{:02X}", 256u32 % 256), "#00"); // wraps
+    }
+
     #[test]
     fn initial_ack_delay_is_shorter_than_heartbeat() {
         assert!(INITIAL_ACK_DELAY < HEARTBEAT_INTERVAL);
@@ -3428,37 +3528,46 @@ mod tests {
     #[test]
     fn final_message_no_progressive_includes_full_text() {
         let stats = vec!["↓8.4k".into(), "↑95".into(), "8s".into()];
-        let msg = build_final_message("Hello world", "", &stats, 0);
+        let msg = build_final_message("Hello world", "", &stats, 0, "#A7");
         assert!(msg.contains("Hello world"));
         assert!(msg.contains("↓8.4k"));
+        assert!(msg.contains("[#A7]"), "stats footer should have tag: {msg}");
     }
 
     #[test]
     fn final_message_progressive_skips_body() {
         let stats = vec!["↓8.4k".into(), "↑95".into()];
-        let msg = build_final_message("Hello world (already sent)", "", &stats, 500);
+        let msg = build_final_message("Hello world (already sent)", "", &stats, 500, "#3F");
         assert!(
             !msg.contains("Hello world"),
             "body should not repeat: {msg}"
         );
         assert!(msg.contains("↓8.4k"), "stats should still appear: {msg}");
+        assert!(
+            msg.starts_with("[#3F]"),
+            "progressive footer should be tagged: {msg}"
+        );
     }
 
     #[test]
     fn final_message_progressive_with_actions() {
         let stats = vec!["8s".into()];
-        let msg = build_final_message("body", "⏰ 提醒已创建", &stats, 100);
+        let msg = build_final_message("body", "⏰ 提醒已创建", &stats, 100, "#B2");
         assert!(
             msg.contains("⏰ 提醒已创建"),
             "action results should appear"
         );
         assert!(msg.contains("8s"), "stats should appear");
         assert!(!msg.contains("body"), "body should not repeat");
+        assert!(
+            msg.starts_with("[#B2]"),
+            "progressive footer should be tagged: {msg}"
+        );
     }
 
     #[test]
     fn final_message_progressive_empty_stats() {
-        let msg = build_final_message("body", "", &[], 100);
+        let msg = build_final_message("body", "", &[], 100, "#C0");
         assert!(
             msg.is_empty(),
             "nothing to send if progressive + no actions + no stats"

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -371,6 +371,18 @@ impl GatewayRunner {
         // Resolve active CLI profile
         let cli_profile = self.resolve_cli_profile(msg.platform, &msg.user_id).await;
 
+        // /manage — rewrite to rich context message and send to slow CLI path
+        let trimmed = msg.text.trim();
+        if trimmed == "/manage" || trimmed.starts_with("/manage ") {
+            let extra = trimmed.strip_prefix("/manage").unwrap_or("").trim();
+            let context = self
+                .build_manage_context(msg, &effective_chat_id, &cli_profile, extra)
+                .await;
+            let mut managed_msg = msg.clone();
+            managed_msg.text = context;
+            return Err(managed_msg);
+        }
+
         // Slash commands — instant response, no CLI
         let cmd_ctx = CommandContext {
             astra: &self.thin,
@@ -1098,6 +1110,9 @@ impl GatewayRunner {
                     .map(|s| s.as_ref() as &dyn astra_core::durable_task_store::DurableTaskStore),
                 self.config.skills_dir.as_deref(),
                 &self.config.action_policy,
+                self.trace_repo
+                    .as_ref()
+                    .map(|r| r.as_ref() as &dyn TraceRepository),
                 &mut action_results,
             )
             .await;
@@ -1261,6 +1276,129 @@ impl GatewayRunner {
         } else {
             msg.chat_id.clone()
         }
+    }
+
+    /// Build a rich context message for `/manage` that gets sent to the CLI agent.
+    async fn build_manage_context(
+        &self,
+        msg: &InboundMessage,
+        effective_chat_id: &str,
+        cli_profile: &CliProfile,
+        extra: &str,
+    ) -> String {
+        let cli_name = cli_profile.name();
+        let mut sections = vec![
+            "# Gateway 任务管理模式".to_string(),
+            "你现在是 Gateway 任务管理助手。分析以下运行状态，帮助用户管理任务。".to_string(),
+            "你可以使用 [[GATEWAY:...]] 标签直接执行操作。".to_string(),
+        ];
+
+        // Active requests
+        if let Some(repo) = self.trace_repo.as_ref() {
+            let conversation = ConversationKey::new(msg.platform, effective_chat_id, cli_name);
+            let rows = repo
+                .list_active_requests(&conversation, 50)
+                .await
+                .unwrap_or_default();
+            if !rows.is_empty() {
+                sections.push("\n## 活跃请求".to_string());
+                for (i, row) in rows.iter().enumerate() {
+                    let icon = match row.display_status() {
+                        "running" => "\u{1f504}",
+                        "queued" => "\u{231b}",
+                        "reply_retrying" => "\u{1f4ec}",
+                        "reply_pending" => "\u{1f4e4}",
+                        _ => "\u{2753}",
+                    };
+                    let error_suffix = row
+                        .error_message
+                        .as_ref()
+                        .map(|e| format!(" | error: {e}"))
+                        .unwrap_or_default();
+                    sections.push(format!(
+                        "[{}] {} {} | {} | {}{}",
+                        i + 1,
+                        icon,
+                        row.display_status(),
+                        row.text_preview,
+                        row.created_at,
+                        error_suffix,
+                    ));
+                }
+                sections.push("\n可用操作:".to_string());
+                sections.push("- 终止运行中: [[GATEWAY:trace_kill:<trace_id>]]".to_string());
+                sections
+                    .push("- 清除失败投递: [[GATEWAY:outbox_dismiss:<request_id>]]".to_string());
+            } else {
+                sections.push("\n## 活跃请求\n无".to_string());
+            }
+        }
+
+        // Cron jobs
+        if let Some(ref store) = self.store {
+            let jobs = store
+                .list_cron_jobs(msg.platform, effective_chat_id)
+                .await
+                .unwrap_or_default();
+            if !jobs.is_empty() {
+                sections.push("\n## 定时任务".to_string());
+                for job in &jobs {
+                    let short = &job.job_id[..8.min(job.job_id.len())];
+                    let status = if job.enabled { "\u{2705}" } else { "\u{23f8}" };
+                    sections.push(format!(
+                        "- {status} `{short}` | `{}` | {}",
+                        job.cron_expr, job.description
+                    ));
+                }
+                sections.push("\n可用操作: [[GATEWAY:task_del:<job_id>]] 删除".to_string());
+            }
+        }
+
+        // Durable tasks
+        if let Some(ref durable) = self.durable_store {
+            let owner = format!("{}:{}", msg.platform, effective_chat_id);
+            let filter = astra_core::durable_task_store::TaskFilter {
+                owner_id: Some(owner),
+                ..Default::default()
+            };
+            if let Ok(tasks) = durable.list(filter).await {
+                let active: Vec<_> = tasks.iter().filter(|t| t.status.is_active()).collect();
+                if !active.is_empty() {
+                    sections.push("\n## 持久任务".to_string());
+                    for t in &active {
+                        let short = &t.id.0[..8.min(t.id.0.len())];
+                        let icon = match t.status {
+                            astra_core::durable_task_store::DurableTaskStatus::Running => {
+                                "\u{1f504}"
+                            }
+                            astra_core::durable_task_store::DurableTaskStatus::Suspended => {
+                                "\u{23f8}"
+                            }
+                            _ => "\u{1f4cb}",
+                        };
+                        let step = t
+                            .step_description
+                            .as_ref()
+                            .map(|s| format!(" | {s}"))
+                            .unwrap_or_default();
+                        sections.push(format!(
+                            "- {} `{short}` | {} | {}%{}",
+                            icon, t.name, t.progress_pct, step,
+                        ));
+                    }
+                }
+            }
+        }
+
+        if !extra.is_empty() {
+            sections.push(format!("\n## 用户指示\n{extra}"));
+        } else {
+            sections.push(
+                "\n## 请求\n请分析以上状态，报告异常，并建议操作。如果有明显的问题（如长时间 running、失败的投递），直接用 GATEWAY 标签处理。".to_string(),
+            );
+        }
+
+        sections.join("\n")
     }
 
     async fn build_queued_request(&self, msg: InboundMessage) -> QueuedRequest {
@@ -1806,6 +1944,7 @@ async fn execute_gateway_actions(
             allow_model_generated_mutations: true,
             workspace_roots: Vec::new(),
         },
+        None,
         action_results,
     )
     .await
@@ -1821,6 +1960,7 @@ async fn execute_gateway_actions_with_policy(
     durable_store: Option<&dyn astra_core::durable_task_store::DurableTaskStore>,
     skills_dir: Option<&str>,
     action_policy: &crate::access_control::ActionPolicy,
+    trace_repo: Option<&dyn TraceRepository>,
     action_results: &mut Vec<String>,
 ) -> String {
     static RE: std::sync::LazyLock<regex::Regex> =
@@ -2315,6 +2455,55 @@ async fn execute_gateway_actions_with_policy(
                     }
                 } else {
                     "⚠️ 需要数据库支持".into()
+                }
+            }
+
+            Some("trace_kill") if parts.len() >= 2 => {
+                let trace_id_str = parts[1].trim();
+                if trace_id_str.is_empty() {
+                    "⚠️ 请指定 trace ID".into()
+                } else if let Some(repo) = trace_repo {
+                    let tid = TraceId::from_string(trace_id_str.to_string());
+                    match repo.force_fail_request(&tid, "killed via manage").await {
+                        Ok(true) => {
+                            tracing::info!(trace_id = trace_id_str, "gateway action: trace_kill");
+                            format!(
+                                "💀 已终止请求 `{}`",
+                                &trace_id_str[..8.min(trace_id_str.len())]
+                            )
+                        }
+                        Ok(false) => format!(
+                            "⚠️ 请求 `{}` 已是终态",
+                            &trace_id_str[..8.min(trace_id_str.len())]
+                        ),
+                        Err(e) => format!("⚠️ 终止失败: {e}"),
+                    }
+                } else {
+                    "⚠️ 需要 trace 支持".into()
+                }
+            }
+
+            Some("outbox_dismiss") if parts.len() >= 2 => {
+                let request_id_str = parts[1].trim();
+                if request_id_str.is_empty() {
+                    "⚠️ 请指定 request ID".into()
+                } else if let Some(repo) = trace_repo {
+                    let rid = RequestId::from_string(request_id_str.to_string());
+                    match repo.dismiss_failed_outbox(&rid).await {
+                        Ok(()) => {
+                            tracing::info!(
+                                request_id = request_id_str,
+                                "gateway action: outbox_dismiss"
+                            );
+                            format!(
+                                "🧹 已清除失败消息 `{}`",
+                                &request_id_str[..8.min(request_id_str.len())]
+                            )
+                        }
+                        Err(e) => format!("⚠️ 清除失败: {e}"),
+                    }
+                } else {
+                    "⚠️ 需要 trace 支持".into()
                 }
             }
 
@@ -3112,6 +3301,80 @@ async fn action_dtask_cancel_no_db() {
     assert!(r[0].contains("数据库"), "{}", r[0]);
 }
 
+// ── trace_kill / outbox_dismiss GATEWAY actions ──
+
+#[tokio::test]
+async fn action_trace_kill_no_repo() {
+    let text = "[[GATEWAY:trace_kill:some-trace-id]]";
+    let mut r = Vec::new();
+    // execute_gateway_actions passes None for trace_repo
+    execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
+    assert!(r[0].contains("trace 支持"), "{}", r[0]);
+}
+
+#[tokio::test]
+async fn action_trace_kill_empty_id() {
+    let text = "[[GATEWAY:trace_kill:]]";
+    let mut r = Vec::new();
+    execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
+    assert!(r[0].contains("请指定"), "{}", r[0]);
+}
+
+#[tokio::test]
+async fn action_trace_kill_with_repo() {
+    use crate::trace_model::{InMemoryTraceRepository, TraceWriter};
+    let repo = InMemoryTraceRepository::default();
+    let conv = crate::trace_model::ConversationKey::new("wx", "c1", "astra");
+    let req = crate::trace_model::GatewayRequest::new(conv, "msg-1", "u1", "hello");
+    let trace_id = req.trace_id.clone();
+    let writer = TraceWriter::begin(&repo, req).await.unwrap();
+    let _ = writer.start_run("astra", None).await.unwrap();
+
+    let text = format!("[[GATEWAY:trace_kill:{}]]", trace_id);
+    let policy = crate::access_control::ActionPolicy {
+        allow_slash_mutations: true,
+        allow_model_generated_mutations: true,
+        workspace_roots: Vec::new(),
+    };
+    let mut r = Vec::new();
+    let repo_ref: &dyn crate::trace_model::TraceRepository = &repo;
+    execute_gateway_actions_with_policy(
+        &text,
+        None,
+        "wx",
+        "c1",
+        "u1",
+        None,
+        None,
+        &policy,
+        Some(repo_ref),
+        &mut r,
+    )
+    .await;
+    assert_eq!(r.len(), 1);
+    assert!(
+        r[0].contains("已终止"),
+        "expected kill confirmation, got: {}",
+        r[0]
+    );
+}
+
+#[tokio::test]
+async fn action_outbox_dismiss_no_repo() {
+    let text = "[[GATEWAY:outbox_dismiss:some-request-id]]";
+    let mut r = Vec::new();
+    execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
+    assert!(r[0].contains("trace 支持"), "{}", r[0]);
+}
+
+#[tokio::test]
+async fn action_outbox_dismiss_empty_id() {
+    let text = "[[GATEWAY:outbox_dismiss:]]";
+    let mut r = Vec::new();
+    execute_gateway_actions(text, None, "wx", "c1", "u1", None, None, &mut r).await;
+    assert!(r[0].contains("请指定"), "{}", r[0]);
+}
+
 // ── Fix #1: Regex handles JSON with `]` chars (arrays/nested) ──
 
 #[tokio::test]
@@ -3162,7 +3425,7 @@ async fn action_policy_blocks_model_mutations_when_disabled() {
     };
     let mut r = Vec::new();
     let clean = execute_gateway_actions_with_policy(
-        text, None, "wx", "c1", "u1", None, None, &policy, &mut r,
+        text, None, "wx", "c1", "u1", None, None, &policy, None, &mut r,
     )
     .await;
     assert!(clean.is_empty(), "tag should be stripped: {clean}");
@@ -3180,7 +3443,7 @@ async fn action_policy_allows_when_enabled() {
     };
     let mut r = Vec::new();
     let clean = execute_gateway_actions_with_policy(
-        text, None, "wx", "c1", "u1", None, None, &policy, &mut r,
+        text, None, "wx", "c1", "u1", None, None, &policy, None, &mut r,
     )
     .await;
     assert!(clean.is_empty());

--- a/rust/crates/astra-gateway/src/scheduler.rs
+++ b/rust/crates/astra-gateway/src/scheduler.rs
@@ -3,11 +3,11 @@
 use crate::cli_bridge::{self, CliProfile};
 use crate::config::GatewayConfig;
 use crate::runner::{OutboundMessage, OutboxDelivery};
-use crate::storage;
+use crate::store::{self, GatewayStore};
 use crate::trace_model::{
     ConversationKey, GatewayRequest, MysqlTraceRepository, RunStatus, TraceWriter,
 };
-use sqlx::MySqlPool;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -16,21 +16,21 @@ const POLL_INTERVAL: Duration = Duration::from_secs(60);
 const CLI_TIMEOUT: Duration = Duration::from_secs(300);
 
 pub struct CronScheduler {
-    pool: MySqlPool,
+    store: Arc<dyn GatewayStore>,
     config: GatewayConfig,
-    trace_repo: MysqlTraceRepository,
+    trace_repo: Arc<MysqlTraceRepository>,
     outbound_tx: mpsc::Sender<OutboundMessage>,
 }
 
 impl CronScheduler {
     pub fn new(
-        pool: MySqlPool,
+        store: Arc<dyn GatewayStore>,
         config: GatewayConfig,
+        trace_repo: Arc<MysqlTraceRepository>,
         outbound_tx: mpsc::Sender<OutboundMessage>,
     ) -> Self {
-        let trace_repo = MysqlTraceRepository::new(pool.clone());
         Self {
-            pool,
+            store,
             config,
             trace_repo,
             outbound_tx,
@@ -56,7 +56,7 @@ impl CronScheduler {
     }
 
     async fn tick(&self) {
-        let jobs = match storage::get_due_jobs(&self.pool).await {
+        let jobs = match self.store.get_due_jobs().await {
             Ok(j) => j,
             Err(e) => {
                 tracing::error!(error = %e, "cron: query failed");
@@ -64,16 +64,21 @@ impl CronScheduler {
             }
         };
 
-        for (job_id, platform, chat_id, message, cron_expr) in jobs {
+        for job in jobs {
+            let job_id = &job.job_id;
+            let platform = &job.platform;
+            let chat_id = &job.chat_id;
+            let message = &job.message;
+            let cron_expr = &job.cron_expr;
             tracing::info!(job_id = %job_id, expr = %cron_expr, "cron: executing");
 
-            let user_id = self.resolve_job_user_id(&job_id).await.unwrap_or_default();
+            let user_id = self.resolve_job_user_id(job_id).await.unwrap_or_default();
 
             if cron_expr == "once" {
                 let text = format!("⏰ 提醒: {message}");
                 let outbound = self
                     .enqueue_scheduler_outbox(
-                        &job_id, &platform, &chat_id, &user_id, "reminder", &text, None,
+                        job_id, platform, chat_id, &user_id, "reminder", &text, None,
                     )
                     .await
                     .unwrap_or_else(|_| {
@@ -82,22 +87,23 @@ impl CronScheduler {
                 if let Err(e) = self.outbound_tx.send(outbound).await {
                     tracing::warn!(job_id = %job_id, error = %e, "failed to send one-shot reminder");
                 }
-                if let Err(e) = storage::delete_cron_job(&self.pool, &job_id).await {
+                if let Err(e) = self.store.delete_cron_job(job_id).await {
                     tracing::error!(job_id = %job_id, error = %e, "failed to delete one-shot cron job — will re-fire next tick");
                 }
                 continue;
             }
 
-            let cli_profile = self.resolve_cli_profile(&platform, &user_id).await;
+            let cli_profile = self.resolve_cli_profile(platform, &user_id).await;
             let cli_name = cli_profile.name().to_string();
-            let workspace = self.resolve_workspace(&platform, &user_id).await;
-            let session_id =
-                storage::get_current_session_for_cli(&self.pool, &platform, &chat_id, &cli_name)
-                    .await
-                    .ok()
-                    .flatten();
+            let workspace = self.resolve_workspace(platform, &user_id).await;
+            let session_id = self
+                .store
+                .get_current_session(platform, chat_id, &cli_name)
+                .await
+                .ok()
+                .flatten();
             let trace = self
-                .begin_scheduler_trace(&job_id, &platform, &chat_id, &cli_name, &message)
+                .begin_scheduler_trace(job_id, platform, chat_id, &cli_name, message)
                 .await;
             let run_id = if let Some(writer) = trace.as_ref() {
                 writer.start_run(&cli_name, session_id.clone()).await.ok()
@@ -107,7 +113,7 @@ impl CronScheduler {
 
             let cli_future = cli_bridge::run_cli_with_context_and_timeout(
                 &cli_profile,
-                &message,
+                message,
                 session_id.as_deref(),
                 workspace.as_deref(),
                 None,
@@ -118,10 +124,10 @@ impl CronScheduler {
             let response = match cli_future.await {
                 Ok(r) => {
                     if let Some(ref sid) = r.session_id
-                        && let Err(e) = storage::set_current_session_for_cli(
-                            &self.pool, &platform, &chat_id, "", sid, &cli_name,
-                        )
-                        .await
+                        && let Err(e) = self
+                            .store
+                            .set_current_session(platform, chat_id, "", sid, &cli_name)
+                            .await
                     {
                         tracing::warn!(error = %e, "scheduler: failed to save session");
                     }
@@ -158,10 +164,7 @@ impl CronScheduler {
             let prefix = format!("⏰ **定时任务 `{}`**\n\n", &job_id[..8.min(job_id.len())]);
             let body = format!("{prefix}{response}");
             if let Some(writer) = trace.as_ref() {
-                match writer
-                    .enqueue_outbox(&platform, &chat_id, None, &body)
-                    .await
-                {
+                match writer.enqueue_outbox(platform, chat_id, None, &body).await {
                     Ok(outbox_id) => {
                         if let Err(e) = self
                             .outbound_tx
@@ -195,24 +198,28 @@ impl CronScheduler {
                 tracing::warn!(error = %e, "scheduler: outbound send failed");
             }
 
-            if let Err(e) = storage::mark_job_run(&self.pool, &job_id, &cron_expr).await {
+            if let Err(e) = self.store.mark_job_run(job_id, cron_expr).await {
                 tracing::warn!(job_id = %job_id, error = %e, "scheduler: failed to mark job run");
             }
         }
     }
 
     async fn resolve_cli_profile(&self, platform: &str, user_id: &str) -> CliProfile {
-        let mut profile = if let Ok(Some(name)) =
-            storage::get_user_preference(&self.pool, platform, user_id, "cli_profile").await
+        let mut profile = if let Ok(Some(name)) = self
+            .store
+            .get_user_preference(platform, user_id, "cli_profile")
+            .await
             && let Some(profile) = self.config.cli_profiles.get(&name)
         {
             profile.clone()
         } else {
             self.config.cli.clone()
         };
-        let model_key = storage::model_preference_key(profile.name());
-        if let Ok(Some(model_name)) =
-            storage::get_user_preference(&self.pool, platform, user_id, &model_key).await
+        let model_key = store::model_preference_key(profile.name());
+        if let Ok(Some(model_name)) = self
+            .store
+            .get_user_preference(platform, user_id, &model_key)
+            .await
         {
             match &mut profile {
                 CliProfile::Astra { model, .. } | CliProfile::Claude { model, .. } => {
@@ -225,7 +232,9 @@ impl CronScheduler {
     }
 
     async fn resolve_workspace(&self, platform: &str, user_id: &str) -> Option<std::path::PathBuf> {
-        let ws = storage::get_user_preference(&self.pool, platform, user_id, "workspace")
+        let ws = self
+            .store
+            .get_user_preference(platform, user_id, "workspace")
             .await
             .ok()
             .flatten()?;
@@ -233,14 +242,14 @@ impl CronScheduler {
         if path.is_dir() { Some(path) } else { None }
     }
 
-    async fn resolve_job_user_id(&self, job_id: &str) -> Option<String> {
-        let row: Option<(String,)> =
-            sqlx::query_as("SELECT user_id FROM gw_cron_jobs WHERE job_id = ?")
-                .bind(job_id)
-                .fetch_optional(&self.pool)
-                .await
-                .ok()?;
-        row.map(|(user_id,)| user_id)
+    /// Resolve the user_id who created the cron job.
+    ///
+    /// NOTE: This currently does a raw SQL query. Once the `GatewayStore` trait
+    /// exposes a `get_cron_job` method, this should migrate to that.
+    async fn resolve_job_user_id(&self, _job_id: &str) -> Option<String> {
+        // TODO: add a `get_cron_job_user` method to GatewayStore trait.
+        // For now return None — the caller falls back to empty string.
+        None
     }
 
     async fn begin_scheduler_trace(
@@ -257,7 +266,7 @@ impl CronScheduler {
             "",
             message,
         );
-        match TraceWriter::begin(&self.trace_repo, request).await {
+        match TraceWriter::begin(self.trace_repo.as_ref(), request).await {
             Ok(writer) => Some(writer),
             Err(e) => {
                 tracing::warn!(error = %e, "scheduler trace begin failed");

--- a/rust/crates/astra-gateway/src/scheduler.rs
+++ b/rust/crates/astra-gateway/src/scheduler.rs
@@ -119,6 +119,7 @@ impl CronScheduler {
                 None,
                 None,
                 Some(Duration::from_secs(self.config.cli_timeout_secs.max(1))),
+                None, // scheduler does not use shared auth token
             );
 
             let response = match cli_future.await {

--- a/rust/crates/astra-gateway/src/scheduler.rs
+++ b/rust/crates/astra-gateway/src/scheduler.rs
@@ -243,13 +243,8 @@ impl CronScheduler {
     }
 
     /// Resolve the user_id who created the cron job.
-    ///
-    /// NOTE: This currently does a raw SQL query. Once the `GatewayStore` trait
-    /// exposes a `get_cron_job` method, this should migrate to that.
-    async fn resolve_job_user_id(&self, _job_id: &str) -> Option<String> {
-        // TODO: add a `get_cron_job_user` method to GatewayStore trait.
-        // For now return None — the caller falls back to empty string.
-        None
+    async fn resolve_job_user_id(&self, job_id: &str) -> Option<String> {
+        self.store.get_cron_job_user_id(job_id).await.ok().flatten()
     }
 
     async fn begin_scheduler_trace(

--- a/rust/crates/astra-gateway/src/store/file.rs
+++ b/rust/crates/astra-gateway/src/store/file.rs
@@ -19,7 +19,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicI64, Ordering};
-use tokio::sync::RwLock;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::{Mutex, RwLock};
 
 pub struct FileGatewayStore {
     base_dir: PathBuf,
@@ -28,6 +29,7 @@ pub struct FileGatewayStore {
     cron_jobs: RwLock<HashMap<String, CronJobEntry>>,
     credentials: RwLock<HashMap<String, CredentialEntry>>,
     pending_counter: AtomicI64,
+    disk_write_lock: Mutex<()>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -121,7 +123,7 @@ impl FileGatewayStore {
         let cron_jobs = load_json_map(&base_dir.join("cron_jobs.json")).await?;
         let credentials = load_json_map(&base_dir.join("credentials.json")).await?;
 
-        let pending_counter = count_pending_files(&base_dir.join("pending")).await;
+        let pending_counter = load_pending_counter(&base_dir.join("pending")).await?;
 
         Ok(Self {
             base_dir,
@@ -130,27 +132,40 @@ impl FileGatewayStore {
             cron_jobs: RwLock::new(cron_jobs),
             credentials: RwLock::new(credentials),
             pending_counter: AtomicI64::new(pending_counter),
+            disk_write_lock: Mutex::new(()),
         })
     }
 
     async fn flush_users(&self) -> Result<(), StoreError> {
+        let _guard = self.disk_write_lock.lock().await;
         let data = self.users.read().await;
         save_json_map(&self.base_dir.join("users.json"), &*data).await
     }
 
     async fn flush_sessions(&self) -> Result<(), StoreError> {
+        let _guard = self.disk_write_lock.lock().await;
         let data = self.sessions.read().await;
         save_json_map(&self.base_dir.join("sessions.json"), &*data).await
     }
 
     async fn flush_cron_jobs(&self) -> Result<(), StoreError> {
+        let _guard = self.disk_write_lock.lock().await;
         let data = self.cron_jobs.read().await;
         save_json_map(&self.base_dir.join("cron_jobs.json"), &*data).await
     }
 
     async fn flush_credentials(&self) -> Result<(), StoreError> {
+        let _guard = self.disk_write_lock.lock().await;
         let data = self.credentials.read().await;
         save_json_map(&self.base_dir.join("credentials.json"), &*data).await
+    }
+
+    async fn persist_pending_counter_locked(&self, value: i64) -> Result<(), StoreError> {
+        atomic_write(
+            &self.base_dir.join("pending").join(".counter"),
+            value.to_string().as_bytes(),
+        )
+        .await
     }
 }
 
@@ -190,9 +205,12 @@ impl GatewayStore for FileGatewayStore {
     ) -> Result<(), StoreError> {
         let ukey = user_key(platform, user_id);
         let mut users = self.users.write().await;
-        if let Some(entry) = users.get_mut(&ukey) {
-            entry.preferences.insert(key.to_string(), value.to_string());
-        }
+        let Some(entry) = users.get_mut(&ukey) else {
+            return Err(StoreError::NotFound(format!(
+                "user not found: {platform}:{user_id}"
+            )));
+        };
+        entry.preferences.insert(key.to_string(), value.to_string());
         drop(users);
         self.flush_users().await
     }
@@ -385,7 +403,9 @@ impl GatewayStore for FileGatewayStore {
         user_id: &str,
         text: &str,
     ) -> Result<i64, StoreError> {
+        let _guard = self.disk_write_lock.lock().await;
         let id = self.pending_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        self.persist_pending_counter_locked(id).await?;
         let entry = serde_json::json!({
             "id": id,
             "platform": platform,
@@ -397,7 +417,7 @@ impl GatewayStore for FileGatewayStore {
         let path = self.base_dir.join("pending").join(format!("{id}.json"));
         let data = serde_json::to_string_pretty(&entry)
             .map_err(|e| StoreError::Serialization(e.to_string()))?;
-        tokio::fs::write(&path, data).await?;
+        atomic_write(&path, data.as_bytes()).await?;
         Ok(id)
     }
 
@@ -709,8 +729,43 @@ async fn save_json_map<T: serde::Serialize>(
 ) -> Result<(), StoreError> {
     let json =
         serde_json::to_string_pretty(data).map_err(|e| StoreError::Serialization(e.to_string()))?;
-    tokio::fs::write(path, json).await?;
+    atomic_write(path, json.as_bytes()).await?;
     Ok(())
+}
+
+async fn atomic_write(path: &Path, data: &[u8]) -> Result<(), StoreError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| StoreError::Io(std::io::Error::other("path has no parent directory")))?;
+    tokio::fs::create_dir_all(parent).await?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| StoreError::Io(std::io::Error::other("path has no valid file name")))?;
+    let tmp_path = parent.join(format!(
+        ".{file_name}.{}.tmp",
+        uuid::Uuid::new_v4().simple()
+    ));
+
+    let mut file = tokio::fs::File::create(&tmp_path).await?;
+    file.write_all(data).await?;
+    file.sync_all().await?;
+    drop(file);
+
+    tokio::fs::rename(&tmp_path, path).await?;
+    if let Ok(dir) = tokio::fs::File::open(parent).await {
+        let _ = dir.sync_all().await;
+    }
+    Ok(())
+}
+
+async fn load_pending_counter(dir: &Path) -> Result<i64, StoreError> {
+    let from_counter = match tokio::fs::read_to_string(dir.join(".counter")).await {
+        Ok(value) => value.trim().parse::<i64>().unwrap_or(0),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => 0,
+        Err(e) => return Err(e.into()),
+    };
+    Ok(from_counter.max(count_pending_files(dir).await))
 }
 
 async fn count_pending_files(dir: &Path) -> i64 {
@@ -796,6 +851,19 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(val.as_deref(), Some("dark"));
+    }
+
+    #[tokio::test]
+    async fn setting_preference_for_missing_user_fails() {
+        let (_dir, store) = test_store().await;
+        let err = store
+            .set_user_preference("wx", "missing", "theme", "dark")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("user not found"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]
@@ -995,6 +1063,35 @@ mod tests {
             assert_eq!(msgs[0].text, "persist me");
             assert_eq!(msgs[0].id, msg_id);
         }
+    }
+
+    #[tokio::test]
+    async fn pending_message_ids_remain_monotonic_after_reopen_and_delete() {
+        let dir = tempfile::tempdir().unwrap();
+        let second_id;
+        {
+            let store = FileGatewayStore::open(dir.path()).await.unwrap();
+            let first_id = store
+                .save_pending_message("wx", "c1", "u1", "first")
+                .await
+                .unwrap();
+            second_id = store
+                .save_pending_message("wx", "c1", "u1", "second")
+                .await
+                .unwrap();
+            assert!(second_id > first_id);
+            assert_eq!(store.delete_pending_message(second_id).await.unwrap(), 1);
+        }
+
+        let store = FileGatewayStore::open(dir.path()).await.unwrap();
+        let next_id = store
+            .save_pending_message("wx", "c1", "u1", "third")
+            .await
+            .unwrap();
+        assert!(
+            next_id > second_id,
+            "pending ids must be monotonic across restarts even after deleting the highest file"
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/astra-gateway/src/store/file.rs
+++ b/rust/crates/astra-gateway/src/store/file.rs
@@ -538,6 +538,11 @@ impl GatewayStore for FileGatewayStore {
         self.flush_cron_jobs().await
     }
 
+    async fn get_cron_job_user_id(&self, job_id: &str) -> Result<Option<String>, StoreError> {
+        let jobs = self.cron_jobs.read().await;
+        Ok(jobs.get(job_id).map(|j| j.user_id.clone()))
+    }
+
     // ─── Platform Credentials ─────────────────────────────────────────
     async fn save_credential(
         &self,

--- a/rust/crates/astra-gateway/src/store/file.rs
+++ b/rust/crates/astra-gateway/src/store/file.rs
@@ -892,6 +892,111 @@ mod tests {
         );
     }
 
+    // ── GAP 3: persistence roundtrip ──────────────────────────────
+
+    #[tokio::test]
+    async fn persistence_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Write
+        {
+            let store = FileGatewayStore::open(dir.path()).await.unwrap();
+            store.upsert_user("wx", "u1", "Alice").await.unwrap();
+            store
+                .set_user_preference("wx", "u1", "theme", "dark")
+                .await
+                .unwrap();
+            store
+                .set_current_session("wx", "c1", "u1", "s1", "astra")
+                .await
+                .unwrap();
+            store
+                .create_cron_job(&CronJobSpec {
+                    job_id: "j1".into(),
+                    platform: "wx".into(),
+                    chat_id: "c1".into(),
+                    user_id: "u1".into(),
+                    cron_expr: "0 9 * * *".into(),
+                    message: "hello".into(),
+                    description: "daily".into(),
+                })
+                .await
+                .unwrap();
+        }
+        // Store dropped -- all in-memory state gone
+
+        // Reopen
+        {
+            let store = FileGatewayStore::open(dir.path()).await.unwrap();
+            assert!(
+                !store.is_first_message("wx", "u1").await.unwrap(),
+                "user should persist"
+            );
+            assert_eq!(
+                store
+                    .get_user_preference("wx", "u1", "theme")
+                    .await
+                    .unwrap()
+                    .as_deref(),
+                Some("dark"),
+                "preference should persist"
+            );
+            assert_eq!(
+                store
+                    .get_current_session("wx", "c1", "astra")
+                    .await
+                    .unwrap()
+                    .as_deref(),
+                Some("s1"),
+                "session should persist"
+            );
+            let jobs = store.list_cron_jobs("wx", "c1").await.unwrap();
+            assert_eq!(jobs.len(), 1, "cron job should persist");
+            assert_eq!(jobs[0].job_id, "j1");
+        }
+    }
+
+    #[tokio::test]
+    async fn credentials_persist_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let store = FileGatewayStore::open(dir.path()).await.unwrap();
+            store
+                .save_credential("wx", "u1", "token", &serde_json::json!({"k": "v"}), None)
+                .await
+                .unwrap();
+        }
+        {
+            let store = FileGatewayStore::open(dir.path()).await.unwrap();
+            let cred = store
+                .get_credential("wx", "u1", "token")
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(cred.credentials["k"], "v");
+        }
+    }
+
+    #[tokio::test]
+    async fn pending_messages_persist_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let msg_id;
+        {
+            let store = FileGatewayStore::open(dir.path()).await.unwrap();
+            msg_id = store
+                .save_pending_message("wx", "c1", "u1", "persist me")
+                .await
+                .unwrap();
+        }
+        {
+            let store = FileGatewayStore::open(dir.path()).await.unwrap();
+            let msgs = store.list_pending_messages(Some("wx")).await.unwrap();
+            assert_eq!(msgs.len(), 1);
+            assert_eq!(msgs[0].text, "persist me");
+            assert_eq!(msgs[0].id, msg_id);
+        }
+    }
+
     #[tokio::test]
     async fn usage_recording() {
         let (_dir, store) = test_store().await;

--- a/rust/crates/astra-gateway/src/store/file.rs
+++ b/rust/crates/astra-gateway/src/store/file.rs
@@ -1,0 +1,910 @@
+//! File-based GatewayStore — JSON files in a local directory.
+//!
+//! Zero-dependency operation: no database required. Suitable for single-user
+//! setups or environments where installing MySQL/SQLite is impractical.
+//!
+//! Directory layout under `base_dir`:
+//!   users.json        — keyed by "platform:user_id"
+//!   sessions.json     — keyed by "platform:chat_id:cli_profile"
+//!   cron_jobs.json    — keyed by job_id
+//!   credentials.json  — keyed by "platform:user_id:type"
+//!   pending/          — numbered JSON files
+//!   usage/            — one YYYY-MM-DD.jsonl per day
+
+use super::{
+    CronJobRecord, CronJobSpec, DueJob, GatewayStore, PendingMessage, PlatformCredential,
+    SessionRecord, StoreError, UsageRecord, UsageSummary, next_cron_run_str,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicI64, Ordering};
+use tokio::sync::RwLock;
+
+pub struct FileGatewayStore {
+    base_dir: PathBuf,
+    users: RwLock<HashMap<String, UserEntry>>,
+    sessions: RwLock<HashMap<String, Vec<SessionEntry>>>,
+    cron_jobs: RwLock<HashMap<String, CronJobEntry>>,
+    credentials: RwLock<HashMap<String, CredentialEntry>>,
+    pending_counter: AtomicI64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UserEntry {
+    platform: String,
+    user_id: String,
+    display_name: String,
+    preferences: HashMap<String, String>,
+    created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SessionEntry {
+    session_id: String,
+    platform: String,
+    chat_id: String,
+    user_id: String,
+    cli_profile: String,
+    is_current: bool,
+    created_at: String,
+    last_active: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CronJobEntry {
+    job_id: String,
+    platform: String,
+    chat_id: String,
+    user_id: String,
+    cron_expr: String,
+    message: String,
+    description: String,
+    enabled: bool,
+    last_run: Option<String>,
+    next_run: Option<String>,
+    created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CredentialEntry {
+    platform: String,
+    user_id: String,
+    credential_type: String,
+    credentials: serde_json::Value,
+    expires_at: Option<String>,
+    updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UsageEntry {
+    platform: String,
+    user_id: String,
+    cli_profile: String,
+    model: Option<String>,
+    tokens_prompt: u64,
+    tokens_completion: u64,
+    tool_calls: u32,
+    elapsed_ms: u64,
+    created_at: String,
+}
+
+fn now_str() -> String {
+    chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+fn today_str() -> String {
+    chrono::Utc::now().format("%Y-%m-%d").to_string()
+}
+
+fn user_key(platform: &str, user_id: &str) -> String {
+    format!("{platform}:{user_id}")
+}
+
+fn session_key(platform: &str, chat_id: &str, cli_profile: &str) -> String {
+    format!("{platform}:{chat_id}:{cli_profile}")
+}
+
+fn cred_key(platform: &str, user_id: &str, credential_type: &str) -> String {
+    format!("{platform}:{user_id}:{credential_type}")
+}
+
+impl FileGatewayStore {
+    pub async fn open(base_dir: impl AsRef<Path>) -> Result<Self, StoreError> {
+        let base_dir = base_dir.as_ref().to_path_buf();
+        tokio::fs::create_dir_all(&base_dir).await?;
+        tokio::fs::create_dir_all(base_dir.join("pending")).await?;
+        tokio::fs::create_dir_all(base_dir.join("usage")).await?;
+
+        let users = load_json_map(&base_dir.join("users.json")).await?;
+        let sessions = load_json_map(&base_dir.join("sessions.json")).await?;
+        let cron_jobs = load_json_map(&base_dir.join("cron_jobs.json")).await?;
+        let credentials = load_json_map(&base_dir.join("credentials.json")).await?;
+
+        let pending_counter = count_pending_files(&base_dir.join("pending")).await;
+
+        Ok(Self {
+            base_dir,
+            users: RwLock::new(users),
+            sessions: RwLock::new(sessions),
+            cron_jobs: RwLock::new(cron_jobs),
+            credentials: RwLock::new(credentials),
+            pending_counter: AtomicI64::new(pending_counter),
+        })
+    }
+
+    async fn flush_users(&self) -> Result<(), StoreError> {
+        let data = self.users.read().await;
+        save_json_map(&self.base_dir.join("users.json"), &*data).await
+    }
+
+    async fn flush_sessions(&self) -> Result<(), StoreError> {
+        let data = self.sessions.read().await;
+        save_json_map(&self.base_dir.join("sessions.json"), &*data).await
+    }
+
+    async fn flush_cron_jobs(&self) -> Result<(), StoreError> {
+        let data = self.cron_jobs.read().await;
+        save_json_map(&self.base_dir.join("cron_jobs.json"), &*data).await
+    }
+
+    async fn flush_credentials(&self) -> Result<(), StoreError> {
+        let data = self.credentials.read().await;
+        save_json_map(&self.base_dir.join("credentials.json"), &*data).await
+    }
+}
+
+#[async_trait::async_trait]
+impl GatewayStore for FileGatewayStore {
+    async fn ensure_schema(&self) -> Result<(), StoreError> {
+        Ok(())
+    }
+
+    // ─── Users ────────────────────────────────────────────────────────
+    async fn upsert_user(
+        &self,
+        platform: &str,
+        user_id: &str,
+        display_name: &str,
+    ) -> Result<(), StoreError> {
+        let key = user_key(platform, user_id);
+        let mut users = self.users.write().await;
+        let entry = users.entry(key).or_insert_with(|| UserEntry {
+            platform: platform.to_string(),
+            user_id: user_id.to_string(),
+            display_name: String::new(),
+            preferences: HashMap::new(),
+            created_at: now_str(),
+        });
+        entry.display_name = display_name.to_string();
+        drop(users);
+        self.flush_users().await
+    }
+
+    async fn set_user_preference(
+        &self,
+        platform: &str,
+        user_id: &str,
+        key: &str,
+        value: &str,
+    ) -> Result<(), StoreError> {
+        let ukey = user_key(platform, user_id);
+        let mut users = self.users.write().await;
+        if let Some(entry) = users.get_mut(&ukey) {
+            entry.preferences.insert(key.to_string(), value.to_string());
+        }
+        drop(users);
+        self.flush_users().await
+    }
+
+    async fn get_user_preference(
+        &self,
+        platform: &str,
+        user_id: &str,
+        key: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let ukey = user_key(platform, user_id);
+        let users = self.users.read().await;
+        Ok(users
+            .get(&ukey)
+            .and_then(|e| e.preferences.get(key).cloned()))
+    }
+
+    async fn is_first_message(&self, platform: &str, user_id: &str) -> Result<bool, StoreError> {
+        let key = user_key(platform, user_id);
+        let users = self.users.read().await;
+        Ok(!users.contains_key(&key))
+    }
+
+    // ─── Sessions ─────────────────────────────────────────────────────
+    async fn get_current_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let key = session_key(platform, chat_id, cli_profile);
+        let sessions = self.sessions.read().await;
+        Ok(sessions.get(&key).and_then(|entries| {
+            entries
+                .iter()
+                .filter(|e| e.is_current)
+                .max_by(|a, b| a.last_active.cmp(&b.last_active))
+                .map(|e| e.session_id.clone())
+        }))
+    }
+
+    async fn get_session_last_active(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let key = session_key(platform, chat_id, cli_profile);
+        let sessions = self.sessions.read().await;
+        Ok(sessions.get(&key).and_then(|entries| {
+            entries
+                .iter()
+                .filter(|e| e.is_current)
+                .max_by(|a, b| a.last_active.cmp(&b.last_active))
+                .map(|e| e.last_active.clone())
+        }))
+    }
+
+    async fn set_current_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        user_id: &str,
+        session_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError> {
+        let key = session_key(platform, chat_id, cli_profile);
+        let mut sessions = self.sessions.write().await;
+        let entries = sessions.entry(key).or_insert_with(Vec::new);
+        for e in entries.iter_mut() {
+            e.is_current = false;
+        }
+        if let Some(existing) = entries.iter_mut().find(|e| e.session_id == session_id) {
+            existing.is_current = true;
+            existing.last_active = now_str();
+        } else {
+            entries.push(SessionEntry {
+                session_id: session_id.to_string(),
+                platform: platform.to_string(),
+                chat_id: chat_id.to_string(),
+                user_id: user_id.to_string(),
+                cli_profile: cli_profile.to_string(),
+                is_current: true,
+                created_at: now_str(),
+                last_active: now_str(),
+            });
+        }
+        drop(sessions);
+        self.flush_sessions().await
+    }
+
+    async fn touch_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError> {
+        let key = session_key(platform, chat_id, cli_profile);
+        let mut sessions = self.sessions.write().await;
+        if let Some(entries) = sessions.get_mut(&key) {
+            for e in entries.iter_mut().filter(|e| e.is_current) {
+                e.last_active = now_str();
+            }
+        }
+        drop(sessions);
+        self.flush_sessions().await
+    }
+
+    async fn list_sessions(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Vec<SessionRecord>, StoreError> {
+        let key = session_key(platform, chat_id, cli_profile);
+        let sessions = self.sessions.read().await;
+        Ok(sessions
+            .get(&key)
+            .map(|entries| {
+                let mut sorted: Vec<_> = entries.iter().collect();
+                sorted.sort_by(|a, b| b.last_active.cmp(&a.last_active));
+                sorted
+                    .into_iter()
+                    .take(20)
+                    .map(|e| SessionRecord {
+                        session_id: e.session_id.clone(),
+                        is_current: e.is_current,
+                        created_at: e.created_at.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
+    async fn switch_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        target_session_id: &str,
+    ) -> Result<bool, StoreError> {
+        let mut sessions = self.sessions.write().await;
+        let mut found = false;
+        for entries in sessions.values_mut() {
+            if entries
+                .iter()
+                .any(|e| e.platform == platform && e.chat_id == chat_id)
+            {
+                for e in entries.iter_mut() {
+                    if e.platform == platform && e.chat_id == chat_id {
+                        if e.session_id == target_session_id {
+                            e.is_current = true;
+                            e.last_active = now_str();
+                            found = true;
+                        } else {
+                            e.is_current = false;
+                        }
+                    }
+                }
+            }
+        }
+        drop(sessions);
+        if found {
+            self.flush_sessions().await?;
+        }
+        Ok(found)
+    }
+
+    async fn reset_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError> {
+        let key = session_key(platform, chat_id, cli_profile);
+        let mut sessions = self.sessions.write().await;
+        if let Some(entries) = sessions.get_mut(&key) {
+            for e in entries.iter_mut().filter(|e| e.is_current) {
+                e.is_current = false;
+            }
+        }
+        drop(sessions);
+        self.flush_sessions().await
+    }
+
+    // ─── Pending Messages ─────────────────────────────────────────────
+    async fn save_pending_message(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        user_id: &str,
+        text: &str,
+    ) -> Result<i64, StoreError> {
+        let id = self.pending_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        let entry = serde_json::json!({
+            "id": id,
+            "platform": platform,
+            "chat_id": chat_id,
+            "user_id": user_id,
+            "text": text,
+            "created_at": now_str(),
+        });
+        let path = self.base_dir.join("pending").join(format!("{id}.json"));
+        let data = serde_json::to_string_pretty(&entry)
+            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+        tokio::fs::write(&path, data).await?;
+        Ok(id)
+    }
+
+    async fn list_pending_messages(
+        &self,
+        platform: Option<&str>,
+    ) -> Result<Vec<PendingMessage>, StoreError> {
+        let dir = self.base_dir.join("pending");
+        let mut messages = Vec::new();
+        let mut entries = tokio::fs::read_dir(&dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let data = tokio::fs::read_to_string(&path).await?;
+            let v: serde_json::Value = serde_json::from_str(&data)
+                .map_err(|e| StoreError::Serialization(e.to_string()))?;
+            let msg_platform = v["platform"].as_str().unwrap_or_default();
+            if let Some(filter_platform) = platform
+                && msg_platform != filter_platform
+            {
+                continue;
+            }
+            messages.push(PendingMessage {
+                id: v["id"].as_i64().unwrap_or(0),
+                platform: msg_platform.to_string(),
+                chat_id: v["chat_id"].as_str().unwrap_or_default().to_string(),
+                user_id: v["user_id"].as_str().unwrap_or_default().to_string(),
+                text: v["text"].as_str().unwrap_or_default().to_string(),
+            });
+        }
+        messages.sort_by_key(|m| m.id);
+        if messages.len() > 50 {
+            messages.truncate(50);
+        }
+        Ok(messages)
+    }
+
+    async fn delete_pending_message(&self, id: i64) -> Result<u64, StoreError> {
+        let path = self.base_dir.join("pending").join(format!("{id}.json"));
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => Ok(1),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(0),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    // ─── Cron Jobs ────────────────────────────────────────────────────
+    async fn create_cron_job(&self, spec: &CronJobSpec) -> Result<(), StoreError> {
+        let next = next_cron_run_str(&spec.cron_expr);
+        let entry = CronJobEntry {
+            job_id: spec.job_id.to_string(),
+            platform: spec.platform.to_string(),
+            chat_id: spec.chat_id.to_string(),
+            user_id: spec.user_id.to_string(),
+            cron_expr: spec.cron_expr.to_string(),
+            message: spec.message.to_string(),
+            description: spec.description.to_string(),
+            enabled: true,
+            last_run: None,
+            next_run: Some(next),
+            created_at: now_str(),
+        };
+        let mut jobs = self.cron_jobs.write().await;
+        jobs.insert(spec.job_id.to_string(), entry);
+        drop(jobs);
+        self.flush_cron_jobs().await
+    }
+
+    async fn list_cron_jobs(
+        &self,
+        platform: &str,
+        chat_id: &str,
+    ) -> Result<Vec<CronJobRecord>, StoreError> {
+        let jobs = self.cron_jobs.read().await;
+        Ok(jobs
+            .values()
+            .filter(|j| j.platform == platform && j.chat_id == chat_id)
+            .map(|j| CronJobRecord {
+                job_id: j.job_id.clone(),
+                cron_expr: j.cron_expr.clone(),
+                description: j.description.clone(),
+                enabled: j.enabled,
+            })
+            .collect())
+    }
+
+    async fn delete_cron_job(&self, job_id: &str) -> Result<bool, StoreError> {
+        let mut jobs = self.cron_jobs.write().await;
+        let removed = jobs.remove(job_id).is_some();
+        drop(jobs);
+        if removed {
+            self.flush_cron_jobs().await?;
+        }
+        Ok(removed)
+    }
+
+    async fn get_due_jobs(&self) -> Result<Vec<DueJob>, StoreError> {
+        let now = now_str();
+        let jobs = self.cron_jobs.read().await;
+        Ok(jobs
+            .values()
+            .filter(|j| {
+                j.enabled
+                    && j.next_run
+                        .as_ref()
+                        .map(|nr| nr.as_str() <= now.as_str())
+                        .unwrap_or(true)
+            })
+            .map(|j| DueJob {
+                job_id: j.job_id.clone(),
+                platform: j.platform.clone(),
+                chat_id: j.chat_id.clone(),
+                message: j.message.clone(),
+                cron_expr: j.cron_expr.clone(),
+            })
+            .collect())
+    }
+
+    async fn mark_job_run(&self, job_id: &str, cron_expr: &str) -> Result<(), StoreError> {
+        let next = next_cron_run_str(cron_expr);
+        let mut jobs = self.cron_jobs.write().await;
+        if let Some(job) = jobs.get_mut(job_id) {
+            job.last_run = Some(now_str());
+            job.next_run = Some(next);
+        }
+        drop(jobs);
+        self.flush_cron_jobs().await
+    }
+
+    async fn update_cron_next_run(&self, job_id: &str, next_run: &str) -> Result<(), StoreError> {
+        let mut jobs = self.cron_jobs.write().await;
+        if let Some(job) = jobs.get_mut(job_id) {
+            job.next_run = Some(next_run.to_string());
+        }
+        drop(jobs);
+        self.flush_cron_jobs().await
+    }
+
+    // ─── Platform Credentials ─────────────────────────────────────────
+    async fn save_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+        credentials: &serde_json::Value,
+        expires_at: Option<&str>,
+    ) -> Result<(), StoreError> {
+        let key = cred_key(platform, user_id, credential_type);
+        let entry = CredentialEntry {
+            platform: platform.to_string(),
+            user_id: user_id.to_string(),
+            credential_type: credential_type.to_string(),
+            credentials: credentials.clone(),
+            expires_at: expires_at.map(String::from),
+            updated_at: now_str(),
+        };
+        let mut creds = self.credentials.write().await;
+        creds.insert(key, entry);
+        drop(creds);
+        self.flush_credentials().await
+    }
+
+    async fn get_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+    ) -> Result<Option<PlatformCredential>, StoreError> {
+        let key = cred_key(platform, user_id, credential_type);
+        let creds = self.credentials.read().await;
+        Ok(creds.get(&key).map(|e| PlatformCredential {
+            platform: e.platform.clone(),
+            user_id: e.user_id.clone(),
+            credential_type: e.credential_type.clone(),
+            credentials: e.credentials.clone(),
+            expires_at: e.expires_at.clone(),
+        }))
+    }
+
+    async fn list_credentials(
+        &self,
+        platform: &str,
+    ) -> Result<Vec<PlatformCredential>, StoreError> {
+        let creds = self.credentials.read().await;
+        Ok(creds
+            .values()
+            .filter(|e| e.platform == platform)
+            .map(|e| PlatformCredential {
+                platform: e.platform.clone(),
+                user_id: e.user_id.clone(),
+                credential_type: e.credential_type.clone(),
+                credentials: e.credentials.clone(),
+                expires_at: e.expires_at.clone(),
+            })
+            .collect())
+    }
+
+    async fn delete_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+    ) -> Result<bool, StoreError> {
+        let key = cred_key(platform, user_id, credential_type);
+        let mut creds = self.credentials.write().await;
+        let removed = creds.remove(&key).is_some();
+        drop(creds);
+        if removed {
+            self.flush_credentials().await?;
+        }
+        Ok(removed)
+    }
+
+    // ─── Usage ────────────────────────────────────────────────────────
+    async fn record_usage(&self, record: &UsageRecord) -> Result<(), StoreError> {
+        let day = today_str();
+        let path = self.base_dir.join("usage").join(format!("{day}.jsonl"));
+        let entry = UsageEntry {
+            platform: record.platform.clone(),
+            user_id: record.user_id.clone(),
+            cli_profile: record.cli_profile.clone(),
+            model: record.model.clone(),
+            tokens_prompt: record.tokens_prompt,
+            tokens_completion: record.tokens_completion,
+            tool_calls: record.tool_calls,
+            elapsed_ms: record.elapsed_ms,
+            created_at: now_str(),
+        };
+        let mut line =
+            serde_json::to_string(&entry).map_err(|e| StoreError::Serialization(e.to_string()))?;
+        line.push('\n');
+        use tokio::io::AsyncWriteExt;
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await?;
+        file.write_all(line.as_bytes()).await?;
+        Ok(())
+    }
+
+    async fn get_usage_today(
+        &self,
+        platform: &str,
+        user_id: &str,
+    ) -> Result<UsageSummary, StoreError> {
+        let day = today_str();
+        let path = self.base_dir.join("usage").join(format!("{day}.jsonl"));
+        load_usage_summary(&path, platform, user_id).await
+    }
+
+    async fn get_usage_total(
+        &self,
+        platform: &str,
+        user_id: &str,
+    ) -> Result<UsageSummary, StoreError> {
+        let dir = self.base_dir.join("usage");
+        let mut total = UsageSummary {
+            messages: 0,
+            tokens_prompt: 0,
+            tokens_completion: 0,
+            tool_calls: 0,
+        };
+        let mut entries = match tokio::fs::read_dir(&dir).await {
+            Ok(e) => e,
+            Err(_) => return Ok(total),
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                let day = load_usage_summary(&path, platform, user_id).await?;
+                total.messages += day.messages;
+                total.tokens_prompt += day.tokens_prompt;
+                total.tokens_completion += day.tokens_completion;
+                total.tool_calls += day.tool_calls;
+            }
+        }
+        Ok(total)
+    }
+}
+
+// ─── File I/O helpers ─────────────────────────────────────────────────────
+
+async fn load_json_map<T: serde::de::DeserializeOwned>(
+    path: &Path,
+) -> Result<HashMap<String, T>, StoreError> {
+    match tokio::fs::read_to_string(path).await {
+        Ok(data) => {
+            if data.trim().is_empty() {
+                return Ok(HashMap::new());
+            }
+            serde_json::from_str(&data).map_err(|e| StoreError::Serialization(e.to_string()))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(HashMap::new()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+async fn save_json_map<T: serde::Serialize>(
+    path: &Path,
+    data: &HashMap<String, T>,
+) -> Result<(), StoreError> {
+    let json =
+        serde_json::to_string_pretty(data).map_err(|e| StoreError::Serialization(e.to_string()))?;
+    tokio::fs::write(path, json).await?;
+    Ok(())
+}
+
+async fn count_pending_files(dir: &Path) -> i64 {
+    let mut max_id = 0i64;
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        if let Some(id) = entry
+            .path()
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .and_then(|s| s.parse::<i64>().ok())
+        {
+            max_id = max_id.max(id);
+        }
+    }
+    max_id
+}
+
+async fn load_usage_summary(
+    path: &Path,
+    platform: &str,
+    user_id: &str,
+) -> Result<UsageSummary, StoreError> {
+    let mut summary = UsageSummary {
+        messages: 0,
+        tokens_prompt: 0,
+        tokens_completion: 0,
+        tool_calls: 0,
+    };
+    let data = match tokio::fs::read_to_string(path).await {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(summary),
+        Err(e) => return Err(e.into()),
+    };
+    for line in data.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(entry) = serde_json::from_str::<UsageEntry>(line)
+            && entry.platform == platform
+            && entry.user_id == user_id
+        {
+            summary.messages += 1;
+            summary.tokens_prompt += entry.tokens_prompt;
+            summary.tokens_completion += entry.tokens_completion;
+            summary.tool_calls += entry.tool_calls as u64;
+        }
+    }
+    Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_store() -> (tempfile::TempDir, FileGatewayStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileGatewayStore::open(dir.path()).await.unwrap();
+        (dir, store)
+    }
+
+    #[tokio::test]
+    async fn user_roundtrip() {
+        let (_dir, store) = test_store().await;
+        assert!(store.is_first_message("wx", "u1").await.unwrap());
+        store.upsert_user("wx", "u1", "Test").await.unwrap();
+        assert!(!store.is_first_message("wx", "u1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn preference_roundtrip() {
+        let (_dir, store) = test_store().await;
+        store.upsert_user("wx", "u1", "Test").await.unwrap();
+        store
+            .set_user_preference("wx", "u1", "theme", "dark")
+            .await
+            .unwrap();
+        let val = store
+            .get_user_preference("wx", "u1", "theme")
+            .await
+            .unwrap();
+        assert_eq!(val.as_deref(), Some("dark"));
+    }
+
+    #[tokio::test]
+    async fn session_lifecycle() {
+        let (_dir, store) = test_store().await;
+        assert!(
+            store
+                .get_current_session("wx", "c1", "astra")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        store
+            .set_current_session("wx", "c1", "u1", "s1", "astra")
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .get_current_session("wx", "c1", "astra")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("s1")
+        );
+        store.reset_session("wx", "c1", "astra").await.unwrap();
+        assert!(
+            store
+                .get_current_session("wx", "c1", "astra")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn cron_job_lifecycle() {
+        let (_dir, store) = test_store().await;
+        let spec = CronJobSpec {
+            job_id: "j1".into(),
+            platform: "wx".into(),
+            chat_id: "c1".into(),
+            user_id: "u1".into(),
+            cron_expr: "0 9 * * *".into(),
+            message: "hello".into(),
+            description: "greeting".into(),
+        };
+        store.create_cron_job(&spec).await.unwrap();
+        let jobs = store.list_cron_jobs("wx", "c1").await.unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].job_id, "j1");
+        assert!(store.delete_cron_job("j1").await.unwrap());
+        assert!(store.list_cron_jobs("wx", "c1").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn pending_message_lifecycle() {
+        let (_dir, store) = test_store().await;
+        let id = store
+            .save_pending_message("wx", "c1", "u1", "hello")
+            .await
+            .unwrap();
+        let msgs = store.list_pending_messages(Some("wx")).await.unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].text, "hello");
+        assert_eq!(store.delete_pending_message(id).await.unwrap(), 1);
+        assert!(
+            store
+                .list_pending_messages(Some("wx"))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn credential_roundtrip() {
+        let (_dir, store) = test_store().await;
+        let creds = serde_json::json!({"token": "abc"});
+        store
+            .save_credential("wx", "u1", "bot_token", &creds, None)
+            .await
+            .unwrap();
+        let got = store
+            .get_credential("wx", "u1", "bot_token")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.credentials["token"], "abc");
+        assert!(
+            store
+                .delete_credential("wx", "u1", "bot_token")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn usage_recording() {
+        let (_dir, store) = test_store().await;
+        let record = UsageRecord {
+            platform: "wx".into(),
+            user_id: "u1".into(),
+            cli_profile: "astra".into(),
+            model: None,
+            tokens_prompt: 100,
+            tokens_completion: 50,
+            tool_calls: 2,
+            elapsed_ms: 3000,
+        };
+        store.record_usage(&record).await.unwrap();
+        let today = store.get_usage_today("wx", "u1").await.unwrap();
+        assert_eq!(today.messages, 1);
+        assert_eq!(today.tokens_prompt, 100);
+        let total = store.get_usage_total("wx", "u1").await.unwrap();
+        assert_eq!(total.messages, 1);
+    }
+}

--- a/rust/crates/astra-gateway/src/store/mod.rs
+++ b/rust/crates/astra-gateway/src/store/mod.rs
@@ -240,6 +240,9 @@ pub trait GatewayStore: Send + Sync + 'static {
     /// from a cron expression.
     async fn update_cron_next_run(&self, job_id: &str, next_run: &str) -> Result<(), StoreError>;
 
+    /// Return the `user_id` that created a cron job, or `None` if not found.
+    async fn get_cron_job_user_id(&self, job_id: &str) -> Result<Option<String>, StoreError>;
+
     // ── Platform credentials ────────────────────────────────────────────
     async fn save_credential(
         &self,
@@ -1074,6 +1077,23 @@ url: "mysql://root:111@localhost/gw""#;
             .update_cron_next_run("j-test", "2099-12-31 23:59:59")
             .await
             .unwrap();
+
+        // get_cron_job_user_id
+        assert_eq!(
+            store
+                .get_cron_job_user_id("j-test")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("u1")
+        );
+        assert!(
+            store
+                .get_cron_job_user_id("nonexistent")
+                .await
+                .unwrap()
+                .is_none()
+        );
 
         // Delete
         assert!(store.delete_cron_job("j-test").await.unwrap());

--- a/rust/crates/astra-gateway/src/store/mod.rs
+++ b/rust/crates/astra-gateway/src/store/mod.rs
@@ -1,0 +1,1266 @@
+//! Abstract gateway storage layer.
+//!
+//! Defines the [`GatewayStore`] trait and shared domain types. Backend
+//! implementations live in sub-modules:
+//! - [`mysql`] -- MySQL / MatrixOne (production)
+//! - [`sqlite`] -- SQLite (lightweight / single-node)
+//! - [`file`] -- JSON files on disk (zero-dependency, single-user)
+
+pub mod file;
+pub mod mysql;
+pub mod sqlite;
+
+use async_trait::async_trait;
+use chrono::Datelike;
+
+// ─── Error type ────────────────────────────────────────────────────────────
+
+/// Unified error type for storage backends.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    #[error("database error: {0}")]
+    Database(String),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("serialization error: {0}")]
+    Serialization(String),
+}
+
+impl From<sqlx::Error> for StoreError {
+    fn from(e: sqlx::Error) -> Self {
+        StoreError::Database(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for StoreError {
+    fn from(e: serde_json::Error) -> Self {
+        StoreError::Serialization(e.to_string())
+    }
+}
+
+// ─── Domain types ──────────────────────────────────────────────────────────
+
+/// A gateway session record mapping a platform chat to an astra session.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SessionRecord {
+    pub session_id: String,
+    pub is_current: bool,
+    pub created_at: String,
+}
+
+/// A message queued for async delivery (e.g. when the CLI is busy).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PendingMessage {
+    pub id: i64,
+    pub platform: String,
+    pub chat_id: String,
+    pub user_id: String,
+    pub text: String,
+}
+
+/// Parameters for creating a new cron job.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CronJobSpec {
+    pub job_id: String,
+    pub platform: String,
+    pub chat_id: String,
+    pub user_id: String,
+    pub cron_expr: String,
+    pub message: String,
+    pub description: String,
+}
+
+/// A cron job as returned by list operations (display-oriented subset).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CronJobRecord {
+    pub job_id: String,
+    pub cron_expr: String,
+    pub description: String,
+    pub enabled: bool,
+}
+
+/// A cron job that is due for execution.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DueJob {
+    pub job_id: String,
+    pub platform: String,
+    pub chat_id: String,
+    pub message: String,
+    pub cron_expr: String,
+}
+
+/// Stored credentials for a platform integration (e.g. bot tokens, API keys).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PlatformCredential {
+    pub platform: String,
+    pub user_id: String,
+    pub credential_type: String,
+    pub credentials: serde_json::Value,
+    pub expires_at: Option<String>,
+}
+
+/// A single usage event to be recorded.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UsageRecord {
+    pub platform: String,
+    pub user_id: String,
+    pub cli_profile: String,
+    pub model: Option<String>,
+    pub tokens_prompt: u64,
+    pub tokens_completion: u64,
+    pub tool_calls: u32,
+    pub elapsed_ms: u64,
+}
+
+/// Aggregated usage statistics over a time period.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct UsageSummary {
+    pub messages: u64,
+    pub tokens_prompt: u64,
+    pub tokens_completion: u64,
+    pub tool_calls: u64,
+}
+
+// ─── GatewayStore trait ────────────────────────────────────────────────────
+
+/// Unified persistence interface for gateway state.
+///
+/// Every method takes `&self` (implementations hold their own connection pool
+/// or directory handle) and returns `Result<T, StoreError>`.
+///
+/// Methods that operated on a specific CLI profile in the old `storage.rs` now
+/// take an explicit `cli_profile: &str` parameter instead of relying on
+/// `_for_cli` function name suffixes.
+#[async_trait]
+pub trait GatewayStore: Send + Sync + 'static {
+    // ── Schema / lifecycle ──────────────────────────────────────────────
+
+    /// Ensure all required tables / directories exist.
+    async fn ensure_schema(&self) -> Result<(), StoreError>;
+
+    // ── Users ───────────────────────────────────────────────────────────
+
+    /// Returns `true` if the user has never been seen before (no row exists).
+    async fn is_first_message(&self, platform: &str, user_id: &str) -> Result<bool, StoreError>;
+
+    async fn upsert_user(
+        &self,
+        platform: &str,
+        user_id: &str,
+        display_name: &str,
+    ) -> Result<(), StoreError>;
+
+    async fn set_user_preference(
+        &self,
+        platform: &str,
+        user_id: &str,
+        key: &str,
+        value: &str,
+    ) -> Result<(), StoreError>;
+
+    async fn get_user_preference(
+        &self,
+        platform: &str,
+        user_id: &str,
+        key: &str,
+    ) -> Result<Option<String>, StoreError>;
+
+    // ── Sessions ────────────────────────────────────────────────────────
+    async fn get_current_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Option<String>, StoreError>;
+
+    async fn get_session_last_active(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Option<String>, StoreError>;
+
+    async fn set_current_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        user_id: &str,
+        astra_session_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError>;
+
+    async fn touch_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError>;
+
+    async fn list_sessions(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Vec<SessionRecord>, StoreError>;
+
+    async fn switch_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        target_session_id: &str,
+    ) -> Result<bool, StoreError>;
+
+    async fn reset_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError>;
+
+    // ── Cron jobs ───────────────────────────────────────────────────────
+    async fn create_cron_job(&self, spec: &CronJobSpec) -> Result<(), StoreError>;
+
+    async fn list_cron_jobs(
+        &self,
+        platform: &str,
+        chat_id: &str,
+    ) -> Result<Vec<CronJobRecord>, StoreError>;
+
+    async fn delete_cron_job(&self, job_id: &str) -> Result<bool, StoreError>;
+
+    async fn get_due_jobs(&self) -> Result<Vec<DueJob>, StoreError>;
+
+    async fn mark_job_run(&self, job_id: &str, cron_expr: &str) -> Result<(), StoreError>;
+
+    /// Update the `next_run` timestamp for a specific cron job.
+    ///
+    /// Used by `remind_after` to set a one-shot fire time that doesn't come
+    /// from a cron expression.
+    async fn update_cron_next_run(&self, job_id: &str, next_run: &str) -> Result<(), StoreError>;
+
+    // ── Platform credentials ────────────────────────────────────────────
+    async fn save_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+        credentials: &serde_json::Value,
+        expires_at: Option<&str>,
+    ) -> Result<(), StoreError>;
+
+    async fn get_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+    ) -> Result<Option<PlatformCredential>, StoreError>;
+
+    async fn list_credentials(&self, platform: &str)
+    -> Result<Vec<PlatformCredential>, StoreError>;
+
+    async fn delete_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+    ) -> Result<bool, StoreError>;
+
+    // ── Pending messages ────────────────────────────────────────────────
+    async fn save_pending_message(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        user_id: &str,
+        text: &str,
+    ) -> Result<i64, StoreError>;
+
+    async fn list_pending_messages(
+        &self,
+        platform: Option<&str>,
+    ) -> Result<Vec<PendingMessage>, StoreError>;
+
+    async fn delete_pending_message(&self, id: i64) -> Result<u64, StoreError>;
+
+    // ── Usage ───────────────────────────────────────────────────────────
+    async fn record_usage(&self, record: &UsageRecord) -> Result<(), StoreError>;
+
+    async fn get_usage_today(
+        &self,
+        platform: &str,
+        user_id: &str,
+    ) -> Result<UsageSummary, StoreError>;
+
+    async fn get_usage_total(
+        &self,
+        platform: &str,
+        user_id: &str,
+    ) -> Result<UsageSummary, StoreError>;
+}
+
+// ─── Shared helpers ────────────────────────────────────────────────────────
+
+/// Compute the next run time from a cron expression as a datetime string
+/// (`YYYY-MM-DD HH:MM:SS`).
+///
+/// Supports: `M H * * *` (daily), `M H * * DOW` (weekday filter).
+/// Falls back to +24 h if parsing fails.
+pub fn next_cron_run_str(expr: &str) -> String {
+    let now = chrono::Utc::now();
+    let parts: Vec<&str> = expr.split_whitespace().collect();
+
+    if parts.len() != 5 {
+        let fallback = now + chrono::Duration::hours(24);
+        return fallback.format("%Y-%m-%d %H:%M:%S").to_string();
+    }
+
+    let minute: u32 = parts[0].parse().unwrap_or(0);
+    let hour: u32 = parts[1].parse().unwrap_or(9);
+
+    let tomorrow = now + chrono::Duration::days(1);
+    let mut candidate = tomorrow
+        .date_naive()
+        .and_hms_opt(hour, minute, 0)
+        .unwrap_or(tomorrow.naive_utc());
+
+    if parts[4] != "*" {
+        let target_days = parse_dow(parts[4]);
+        if !target_days.is_empty() {
+            for _ in 0..8 {
+                let weekday = candidate.weekday().num_days_from_monday();
+                if target_days.contains(&weekday) {
+                    break;
+                }
+                candidate += chrono::Duration::days(1);
+            }
+        }
+    }
+
+    candidate.format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+/// Parse cron DOW field and convert to chrono's Monday-based numbering.
+///
+/// Cron:  0 = Sunday, 1 = Monday, ..., 6 = Saturday.
+/// Chrono `num_days_from_monday`: 0 = Monday, ..., 6 = Sunday.
+pub fn parse_dow(s: &str) -> Vec<u32> {
+    let mut days = Vec::new();
+    for part in s.split(',') {
+        if let Some((start, end)) = part.split_once('-') {
+            if let (Ok(s), Ok(e)) = (start.parse::<u32>(), end.parse::<u32>()) {
+                for d in s..=e {
+                    days.push(cron_dow_to_chrono(d));
+                }
+            }
+        } else if let Ok(d) = part.parse::<u32>() {
+            days.push(cron_dow_to_chrono(d));
+        }
+    }
+    days
+}
+
+/// Convert cron day-of-week (0 = Sun) to chrono (0 = Mon).
+pub fn cron_dow_to_chrono(cron_day: u32) -> u32 {
+    (cron_day + 6) % 7
+}
+
+/// Build a JSON-path-safe preference key for per-CLI model overrides.
+pub fn model_preference_key(cli_name: &str) -> String {
+    let safe: String = cli_name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    format!("model_override_{safe}")
+}
+
+// ─── Storage configuration ────────────────────────────────────────────────
+
+/// Backend selection and connection parameters for gateway persistence.
+///
+/// Deserialized from the gateway config file via a `"backend"` tag:
+///
+/// ```yaml
+/// storage:
+///   backend: mysql
+///   url: "mysql://root:111@127.0.0.1:6001/astra_gateway"
+/// ```
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(tag = "backend", rename_all = "snake_case")]
+pub enum StorageConfig {
+    Mysql {
+        url: String,
+    },
+    Sqlite {
+        #[serde(default = "default_sqlite_path")]
+        path: String,
+    },
+    File {
+        #[serde(default = "default_file_dir")]
+        dir: String,
+    },
+    None,
+}
+
+fn default_sqlite_path() -> String {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    format!("{home}/.astra-gateway/gateway.db")
+}
+
+fn default_file_dir() -> String {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    format!("{home}/.astra-gateway/data")
+}
+
+impl Default for StorageConfig {
+    /// Auto-detect: if `GATEWAY_DATABASE_URL` is set, use MySQL; otherwise
+    /// fall back to SQLite at `~/.astra-gateway/gateway.db`.
+    fn default() -> Self {
+        match std::env::var("GATEWAY_DATABASE_URL") {
+            Ok(url) => Self::Mysql { url },
+            Err(_) => Self::Sqlite {
+                path: default_sqlite_path(),
+            },
+        }
+    }
+}
+
+/// Factory: create the right store from config.
+pub async fn open_store(
+    config: &StorageConfig,
+) -> Result<Option<Box<dyn GatewayStore>>, Box<dyn std::error::Error + Send + Sync>> {
+    match config {
+        StorageConfig::Mysql { url } => {
+            let store = mysql::MysqlGatewayStore::connect(url).await?;
+            store.ensure_schema().await?;
+            Ok(Some(Box::new(store)))
+        }
+        StorageConfig::Sqlite { path } => {
+            let store = sqlite::SqliteGatewayStore::connect(path).await?;
+            store.ensure_schema().await?;
+            Ok(Some(Box::new(store)))
+        }
+        StorageConfig::File { dir } => {
+            let store = file::FileGatewayStore::open(dir).await?;
+            Ok(Some(Box::new(store)))
+        }
+        StorageConfig::None => Ok(None),
+    }
+}
+
+// ─── Store bundle ─────────────────────────────────────────────────────────
+
+/// Everything the runner needs from the storage layer.
+///
+/// `durable_store` and `trace_repo` currently require a MySQL pool, so they
+/// are only available when the backend is MySQL. SQLite / file backends set
+/// them to `None`.
+pub struct StoreBundle {
+    pub store: std::sync::Arc<dyn GatewayStore>,
+    pub durable_store: Option<std::sync::Arc<crate::durable_task_store::MysqlDurableTaskStore>>,
+    pub trace_repo: Option<std::sync::Arc<crate::trace_model::MysqlTraceRepository>>,
+    /// The raw MySQL pool (if applicable). Exposed so callers that still need
+    /// low-level pool access (e.g. ad-hoc SQL in gateway actions, scheduler
+    /// `resolve_job_user_id`) can use it without down-casting.
+    pub mysql_pool: Option<sqlx::MySqlPool>,
+}
+
+/// Create a [`StoreBundle`] from config — or `None` for [`StorageConfig::None`].
+///
+/// For MySQL backends the bundle also provisions the durable-task store and
+/// trace repository backed by the same connection pool.
+pub async fn open_store_bundle(
+    config: &StorageConfig,
+) -> Result<Option<StoreBundle>, Box<dyn std::error::Error + Send + Sync>> {
+    match config {
+        StorageConfig::Mysql { url } => {
+            let store = mysql::MysqlGatewayStore::connect(url).await?;
+            store.ensure_schema().await?;
+            store.ensure_usage_table().await?;
+            let pool = store.pool().clone();
+
+            // Durable tasks
+            let durable = std::sync::Arc::new(
+                crate::durable_task_store::MysqlDurableTaskStore::new(pool.clone()),
+            );
+
+            // Trace repository
+            crate::trace_model::ensure_schema(&pool).await?;
+            let trace =
+                std::sync::Arc::new(crate::trace_model::MysqlTraceRepository::new(pool.clone()));
+
+            Ok(Some(StoreBundle {
+                store: std::sync::Arc::new(store),
+                durable_store: Some(durable),
+                trace_repo: Some(trace),
+                mysql_pool: Some(pool),
+            }))
+        }
+        StorageConfig::Sqlite { path } => {
+            let store = sqlite::SqliteGatewayStore::connect(path).await?;
+            store.ensure_schema().await?;
+            Ok(Some(StoreBundle {
+                store: std::sync::Arc::new(store),
+                durable_store: None,
+                trace_repo: None,
+                mysql_pool: None,
+            }))
+        }
+        StorageConfig::File { dir } => {
+            let store = file::FileGatewayStore::open(dir).await?;
+            Ok(Some(StoreBundle {
+                store: std::sync::Arc::new(store),
+                durable_store: None,
+                trace_repo: None,
+                mysql_pool: None,
+            }))
+        }
+        StorageConfig::None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Cron utilities ──────────────────────────────────────────────────
+
+    #[test]
+    fn next_cron_daily() {
+        let next = next_cron_run_str("30 9 * * *");
+        assert!(next.contains("09:30:00"), "expected 09:30, got {next}");
+    }
+
+    #[test]
+    fn next_cron_weekday() {
+        let next = next_cron_run_str("0 9 * * 1-5");
+        assert!(next.contains("09:00:00"));
+        assert!(next.len() >= 19);
+    }
+
+    #[test]
+    fn next_cron_invalid_fallback() {
+        let next = next_cron_run_str("garbage");
+        assert!(next.len() >= 19, "should return a valid datetime string");
+    }
+
+    #[test]
+    fn next_cron_midnight() {
+        let next = next_cron_run_str("0 0 * * *");
+        assert!(next.contains("00:00:00"));
+    }
+
+    #[test]
+    fn next_cron_step_value_fallback() {
+        let next = next_cron_run_str("*/5 * * * *");
+        assert!(next.len() >= 19, "should be a valid datetime: {next}");
+    }
+
+    #[test]
+    fn next_cron_is_in_future() {
+        let next = next_cron_run_str("0 9 * * *");
+        let now = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
+        assert!(next > now, "next_run {next} should be after now {now}");
+    }
+
+    #[test]
+    fn parse_dow_range() {
+        assert_eq!(parse_dow("1-5"), vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn parse_dow_sunday() {
+        assert_eq!(parse_dow("0"), vec![6]);
+    }
+
+    #[test]
+    fn parse_dow_comma() {
+        assert_eq!(parse_dow("1,3,5"), vec![0, 2, 4]);
+    }
+
+    #[test]
+    fn parse_dow_empty() {
+        assert!(parse_dow("").is_empty());
+    }
+
+    #[test]
+    fn parse_dow_star() {
+        assert!(parse_dow("*").is_empty());
+    }
+
+    #[test]
+    fn parse_dow_weekend() {
+        let days = parse_dow("0,6");
+        assert!(days.contains(&6));
+        assert!(days.contains(&5));
+    }
+
+    #[test]
+    fn cron_dow_conversion() {
+        assert_eq!(cron_dow_to_chrono(0), 6); // Sun
+        assert_eq!(cron_dow_to_chrono(1), 0); // Mon
+        assert_eq!(cron_dow_to_chrono(6), 5); // Sat
+    }
+
+    // ── model_preference_key ────────────────────────────────────────────
+
+    #[test]
+    fn model_override_key_basic() {
+        assert_eq!(model_preference_key("astra"), "model_override_astra");
+        assert_eq!(model_preference_key("claude"), "model_override_claude");
+        assert_eq!(model_preference_key("codex"), "model_override_codex");
+    }
+
+    #[test]
+    fn model_override_key_uses_underscore_separator() {
+        for cli_name in &["astra", "claude", "codex"] {
+            let key = model_preference_key(cli_name);
+            assert!(
+                key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
+                "key must be alphanumeric + underscore only: {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn model_override_key_sanitizes_special_chars() {
+        assert_eq!(
+            model_preference_key("/opt/my-cli.v2"),
+            "model_override__opt_my_cli_v2"
+        );
+        assert_eq!(
+            model_preference_key("some:tool"),
+            "model_override_some_tool"
+        );
+    }
+
+    // ── StorageConfig ───────────────────────────────────────────────────
+
+    #[test]
+    fn storage_config_default_without_env() {
+        let cfg = StorageConfig::default();
+        match &cfg {
+            StorageConfig::Mysql { url } => {
+                assert!(!url.is_empty(), "MySQL URL should not be empty");
+            }
+            StorageConfig::Sqlite { path } => {
+                assert!(
+                    path.ends_with("gateway.db"),
+                    "SQLite path should end with gateway.db, got: {path}"
+                );
+            }
+            other => panic!("expected Mysql or Sqlite default, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_config_deserialize_mysql() {
+        let json = r#"{"backend":"mysql","url":"mysql://root@localhost/gw"}"#;
+        let cfg: StorageConfig = serde_json::from_str(json).unwrap();
+        match cfg {
+            StorageConfig::Mysql { url } => {
+                assert_eq!(url, "mysql://root@localhost/gw");
+            }
+            other => panic!("expected Mysql, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_config_deserialize_mysql_yaml() {
+        let yaml = r#"backend: mysql
+url: "mysql://root:111@localhost/gw""#;
+        let cfg: StorageConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(matches!(cfg, StorageConfig::Mysql { .. }));
+    }
+
+    #[test]
+    fn storage_config_deserialize_sqlite() {
+        let json = r#"{"backend":"sqlite","path":"/tmp/test.db"}"#;
+        let cfg: StorageConfig = serde_json::from_str(json).unwrap();
+        match cfg {
+            StorageConfig::Sqlite { path } => {
+                assert_eq!(path, "/tmp/test.db");
+            }
+            other => panic!("expected Sqlite, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_config_deserialize_sqlite_default_path() {
+        let json = r#"{"backend":"sqlite"}"#;
+        let cfg: StorageConfig = serde_json::from_str(json).unwrap();
+        match cfg {
+            StorageConfig::Sqlite { path } => {
+                assert!(
+                    path.ends_with("gateway.db"),
+                    "default path should end with gateway.db, got: {path}"
+                );
+            }
+            other => panic!("expected Sqlite, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_config_deserialize_file() {
+        let json = r#"{"backend":"file","dir":"/var/data/gw"}"#;
+        let cfg: StorageConfig = serde_json::from_str(json).unwrap();
+        match cfg {
+            StorageConfig::File { dir } => {
+                assert_eq!(dir, "/var/data/gw");
+            }
+            other => panic!("expected File, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_config_deserialize_file_default_dir() {
+        let json = r#"{"backend":"file"}"#;
+        let cfg: StorageConfig = serde_json::from_str(json).unwrap();
+        match cfg {
+            StorageConfig::File { dir } => {
+                assert!(
+                    dir.ends_with("data"),
+                    "default dir should end with 'data', got: {dir}"
+                );
+            }
+            other => panic!("expected File, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_config_deserialize_none() {
+        let json = r#"{"backend":"none"}"#;
+        let cfg: StorageConfig = serde_json::from_str(json).unwrap();
+        assert!(matches!(cfg, StorageConfig::None));
+    }
+
+    #[test]
+    fn storage_config_deserialize_none_yaml() {
+        let yaml = "backend: none";
+        let cfg: StorageConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(matches!(cfg, StorageConfig::None));
+    }
+
+    // ── Domain type construction ────────────────────────────────────────
+
+    #[test]
+    fn session_record_fields() {
+        let r = SessionRecord {
+            session_id: "sess-001".into(),
+            is_current: true,
+            created_at: "2026-01-01 00:00:00".into(),
+        };
+        assert!(r.is_current);
+        assert_eq!(r.session_id, "sess-001");
+    }
+
+    #[test]
+    fn pending_message_fields() {
+        let m = PendingMessage {
+            id: 42,
+            platform: "weixin".into(),
+            chat_id: "chat-1".into(),
+            user_id: "u-1".into(),
+            text: "hello".into(),
+        };
+        assert_eq!(m.id, 42);
+        assert_eq!(m.text, "hello");
+    }
+
+    #[test]
+    fn cron_job_spec_fields() {
+        let spec = CronJobSpec {
+            job_id: "j-1".into(),
+            platform: "telegram".into(),
+            chat_id: "c-1".into(),
+            user_id: "u-1".into(),
+            cron_expr: "0 9 * * *".into(),
+            message: "/status".into(),
+            description: "daily check".into(),
+        };
+        assert_eq!(spec.cron_expr, "0 9 * * *");
+    }
+
+    #[test]
+    fn cron_job_record_fields() {
+        let rec = CronJobRecord {
+            job_id: "j-2".into(),
+            cron_expr: "0 0 * * 1".into(),
+            description: "weekly".into(),
+            enabled: false,
+        };
+        assert!(!rec.enabled);
+    }
+
+    #[test]
+    fn due_job_fields() {
+        let dj = DueJob {
+            job_id: "j-3".into(),
+            platform: "wecom".into(),
+            chat_id: "c-2".into(),
+            message: "run".into(),
+            cron_expr: "*/5 * * * *".into(),
+        };
+        assert_eq!(dj.platform, "wecom");
+    }
+
+    #[test]
+    fn platform_credential_roundtrip() {
+        let creds = serde_json::json!({
+            "token": "test-token-123",
+            "account_id": "wx_abc"
+        });
+        let pc = PlatformCredential {
+            platform: "weixin".into(),
+            user_id: "default".into(),
+            credential_type: "bot_token".into(),
+            credentials: creds,
+            expires_at: Some("2026-06-01 00:00:00".into()),
+        };
+        assert_eq!(pc.credentials["token"], "test-token-123");
+        assert_eq!(pc.credentials["account_id"], "wx_abc");
+        assert_eq!(pc.platform, "weixin");
+        assert!(pc.expires_at.is_some());
+    }
+
+    #[test]
+    fn platform_credential_no_expiry() {
+        let pc = PlatformCredential {
+            platform: "wecom".into(),
+            user_id: "bot-1".into(),
+            credential_type: "api_key".into(),
+            credentials: serde_json::json!({"secret": "s3cr3t"}),
+            expires_at: None,
+        };
+        assert!(pc.expires_at.is_none());
+        assert_eq!(pc.credentials["secret"], "s3cr3t");
+    }
+
+    #[test]
+    fn usage_record_fields() {
+        let r = UsageRecord {
+            platform: "weixin".into(),
+            user_id: "u1".into(),
+            cli_profile: "claude".into(),
+            model: Some("opus".into()),
+            tokens_prompt: 1000,
+            tokens_completion: 200,
+            tool_calls: 3,
+            elapsed_ms: 5000,
+        };
+        assert_eq!(r.tokens_prompt + r.tokens_completion, 1200);
+    }
+
+    #[test]
+    fn usage_summary_default() {
+        let s = UsageSummary::default();
+        assert_eq!(s.messages, 0);
+        assert_eq!(s.tokens_prompt, 0);
+        assert_eq!(s.tokens_completion, 0);
+        assert_eq!(s.tool_calls, 0);
+    }
+
+    // ── StoreError ──────────────────────────────────────────────────────
+
+    #[test]
+    fn store_error_display() {
+        let e = StoreError::Database("connection refused".into());
+        assert_eq!(e.to_string(), "database error: connection refused");
+
+        let e = StoreError::Serialization("invalid JSON".into());
+        assert_eq!(e.to_string(), "serialization error: invalid JSON");
+    }
+
+    #[test]
+    fn store_error_from_io() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
+        let e: StoreError = io_err.into();
+        assert!(matches!(e, StoreError::Io(_)));
+        assert!(e.to_string().contains("file missing"));
+    }
+
+    #[test]
+    fn store_error_from_serde_json() {
+        let json_err = serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
+        let e: StoreError = json_err.into();
+        assert!(matches!(e, StoreError::Serialization(_)));
+    }
+
+    // ── Serde round-trips (file backend compatibility) ──────────────────
+
+    #[test]
+    fn session_record_serde_roundtrip() {
+        let original = SessionRecord {
+            session_id: "s-1".into(),
+            is_current: true,
+            created_at: "2026-05-04 12:00:00".into(),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: SessionRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.session_id, original.session_id);
+        assert_eq!(decoded.is_current, original.is_current);
+    }
+
+    #[test]
+    fn pending_message_serde_roundtrip() {
+        let original = PendingMessage {
+            id: 7,
+            platform: "telegram".into(),
+            chat_id: "c".into(),
+            user_id: "u".into(),
+            text: "msg with \"quotes\"".into(),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: PendingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.text, original.text);
+    }
+
+    #[test]
+    fn credential_serde_roundtrip() {
+        let original = PlatformCredential {
+            platform: "weixin".into(),
+            user_id: "u".into(),
+            credential_type: "token".into(),
+            credentials: serde_json::json!({"k": "v"}),
+            expires_at: None,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: PlatformCredential = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.credentials["k"], "v");
+    }
+
+    #[test]
+    fn usage_record_serde_roundtrip() {
+        let original = UsageRecord {
+            platform: "wx".into(),
+            user_id: "u1".into(),
+            cli_profile: "astra".into(),
+            model: Some("opus".into()),
+            tokens_prompt: 500,
+            tokens_completion: 100,
+            tool_calls: 2,
+            elapsed_ms: 3000,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: UsageRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.tokens_prompt, 500);
+        assert_eq!(decoded.model.as_deref(), Some("opus"));
+    }
+
+    // ── Cross-backend compliance ────────────────────────────────────────
+
+    async fn compliance_test(store: &dyn GatewayStore) {
+        // Schema
+        store.ensure_schema().await.unwrap();
+
+        // User lifecycle
+        assert!(store.is_first_message("test", "u1").await.unwrap());
+        store.upsert_user("test", "u1", "Alice").await.unwrap();
+        assert!(!store.is_first_message("test", "u1").await.unwrap());
+
+        // Preferences
+        store
+            .set_user_preference("test", "u1", "theme", "dark")
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .get_user_preference("test", "u1", "theme")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("dark")
+        );
+        assert!(
+            store
+                .get_user_preference("test", "u1", "missing")
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Sessions
+        assert!(
+            store
+                .get_current_session("test", "c1", "astra")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        store
+            .set_current_session("test", "c1", "u1", "s1", "astra")
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .get_current_session("test", "c1", "astra")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("s1")
+        );
+        assert!(
+            store
+                .get_session_last_active("test", "c1", "astra")
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        // Session switch
+        store
+            .set_current_session("test", "c1", "u1", "s2", "astra")
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .get_current_session("test", "c1", "astra")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("s2")
+        );
+        let sessions = store.list_sessions("test", "c1", "astra").await.unwrap();
+        assert_eq!(sessions.len(), 2);
+
+        // Reset
+        store.reset_session("test", "c1", "astra").await.unwrap();
+        assert!(
+            store
+                .get_current_session("test", "c1", "astra")
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // CLI profile isolation
+        store
+            .set_current_session("test", "c1", "u1", "s3", "claude")
+            .await
+            .unwrap();
+        assert!(
+            store
+                .get_current_session("test", "c1", "astra")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            store
+                .get_current_session("test", "c1", "claude")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("s3")
+        );
+
+        // Cron jobs
+        let spec = CronJobSpec {
+            job_id: "j-test".into(),
+            platform: "test".into(),
+            chat_id: "c1".into(),
+            user_id: "u1".into(),
+            cron_expr: "0 9 * * *".into(),
+            message: "hello".into(),
+            description: "desc".into(),
+        };
+        store.create_cron_job(&spec).await.unwrap();
+        let jobs = store.list_cron_jobs("test", "c1").await.unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].job_id, "j-test");
+
+        // update_cron_next_run (new method!)
+        store
+            .update_cron_next_run("j-test", "2099-12-31 23:59:59")
+            .await
+            .unwrap();
+
+        // Delete
+        assert!(store.delete_cron_job("j-test").await.unwrap());
+        assert!(!store.delete_cron_job("j-test").await.unwrap());
+
+        // Pending messages
+        let id = store
+            .save_pending_message("test", "c1", "u1", "hello")
+            .await
+            .unwrap();
+        let msgs = store.list_pending_messages(Some("test")).await.unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].text, "hello");
+        store.delete_pending_message(id).await.unwrap();
+        assert!(
+            store
+                .list_pending_messages(Some("test"))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // Credentials
+        let creds = serde_json::json!({"key": "value"});
+        store
+            .save_credential("test", "u1", "token", &creds, None)
+            .await
+            .unwrap();
+        let got = store
+            .get_credential("test", "u1", "token")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.credentials["key"], "value");
+        let list = store.list_credentials("test").await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert!(
+            store
+                .delete_credential("test", "u1", "token")
+                .await
+                .unwrap()
+        );
+
+        // switch_session
+        store
+            .set_current_session("test", "c1", "u1", "s10", "astra")
+            .await
+            .unwrap();
+        store
+            .set_current_session("test", "c1", "u1", "s11", "astra")
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .get_current_session("test", "c1", "astra")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("s11")
+        );
+        assert!(store.switch_session("test", "c1", "s10").await.unwrap());
+        assert_eq!(
+            store
+                .get_current_session("test", "c1", "astra")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("s10")
+        );
+        assert!(
+            !store
+                .switch_session("test", "c1", "nonexistent")
+                .await
+                .unwrap()
+        );
+
+        // Pending messages
+        let id = store
+            .save_pending_message("test", "c1", "u1", "hello")
+            .await
+            .unwrap();
+        let msgs = store.list_pending_messages(Some("test")).await.unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].text, "hello");
+        store.delete_pending_message(id).await.unwrap();
+        assert!(
+            store
+                .list_pending_messages(Some("test"))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // list_pending_messages with None (all platforms)
+        let id_a = store
+            .save_pending_message("plat_a", "c1", "u1", "msg_a")
+            .await
+            .unwrap();
+        let id_b = store
+            .save_pending_message("plat_b", "c1", "u1", "msg_b")
+            .await
+            .unwrap();
+        let all = store.list_pending_messages(None).await.unwrap();
+        assert!(
+            all.len() >= 2,
+            "should list from all platforms, got {}",
+            all.len()
+        );
+        store.delete_pending_message(id_a).await.unwrap();
+        store.delete_pending_message(id_b).await.unwrap();
+
+        // Credentials
+        let creds = serde_json::json!({"key": "value"});
+        store
+            .save_credential("test", "u1", "token", &creds, None)
+            .await
+            .unwrap();
+        let got = store
+            .get_credential("test", "u1", "token")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.credentials["key"], "value");
+        let list = store.list_credentials("test").await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert!(
+            store
+                .delete_credential("test", "u1", "token")
+                .await
+                .unwrap()
+        );
+
+        // Usage
+        let record = UsageRecord {
+            platform: "test".into(),
+            user_id: "u1".into(),
+            cli_profile: "astra".into(),
+            model: Some("opus".into()),
+            tokens_prompt: 100,
+            tokens_completion: 50,
+            tool_calls: 2,
+            elapsed_ms: 3000,
+        };
+        store.record_usage(&record).await.unwrap();
+        let today = store.get_usage_today("test", "u1").await.unwrap();
+        assert_eq!(today.messages, 1);
+        assert_eq!(today.tokens_prompt, 100);
+
+        // Usage accumulation
+        store.record_usage(&record).await.unwrap();
+        let total = store.get_usage_total("test", "u1").await.unwrap();
+        assert_eq!(total.messages, 2);
+        assert_eq!(total.tokens_prompt, 200);
+    }
+
+    #[tokio::test]
+    async fn compliance_sqlite() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite");
+        let store = super::sqlite::SqliteGatewayStore::new(pool);
+        store.ensure_schema().await.expect("ensure_schema");
+        compliance_test(&store).await;
+    }
+
+    #[tokio::test]
+    async fn compliance_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = super::file::FileGatewayStore::open(dir.path())
+            .await
+            .unwrap();
+        compliance_test(&store).await;
+    }
+
+    #[test]
+    fn cron_job_spec_serde_roundtrip() {
+        let original = CronJobSpec {
+            job_id: "j-1".into(),
+            platform: "wx".into(),
+            chat_id: "c-1".into(),
+            user_id: "u-1".into(),
+            cron_expr: "0 9 * * *".into(),
+            message: "hi".into(),
+            description: "desc".into(),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: CronJobSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.job_id, "j-1");
+    }
+}

--- a/rust/crates/astra-gateway/src/store/mod.rs
+++ b/rust/crates/astra-gateway/src/store/mod.rs
@@ -26,6 +26,9 @@ pub enum StoreError {
 
     #[error("serialization error: {0}")]
     Serialization(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
 }
 
 impl From<sqlx::Error> for StoreError {
@@ -304,6 +307,55 @@ pub trait GatewayStore: Send + Sync + 'static {
 
 // ─── Shared helpers ────────────────────────────────────────────────────────
 
+/// Validate the gateway-supported 5-field cron subset.
+pub fn is_valid_cron_expr(expr: &str) -> bool {
+    let parts: Vec<&str> = expr.split_whitespace().collect();
+    if parts.len() != 5 {
+        return false;
+    }
+
+    validate_cron_field(parts[0], 0, 59)
+        && validate_cron_field(parts[1], 0, 23)
+        && validate_cron_field(parts[2], 1, 31)
+        && validate_cron_field(parts[3], 1, 12)
+        && validate_cron_field(parts[4], 0, 7)
+}
+
+fn validate_cron_field(field: &str, min: u32, max: u32) -> bool {
+    if field.is_empty() {
+        return false;
+    }
+    field
+        .split(',')
+        .all(|part| validate_cron_part(part, min, max))
+}
+
+fn validate_cron_part(part: &str, min: u32, max: u32) -> bool {
+    let (base, step) = part.split_once('/').unwrap_or((part, ""));
+    if !step.is_empty() {
+        match step.parse::<u32>() {
+            Ok(step) if step > 0 => {}
+            _ => return false,
+        }
+    }
+
+    if base == "*" {
+        return true;
+    }
+
+    if let Some((start, end)) = base.split_once('-') {
+        let (Ok(start), Ok(end)) = (start.parse::<u32>(), end.parse::<u32>()) else {
+            return false;
+        };
+        return start <= end && start >= min && end <= max;
+    }
+
+    match base.parse::<u32>() {
+        Ok(value) => value >= min && value <= max,
+        Err(_) => false,
+    }
+}
+
 /// Compute the next run time from a cron expression as a datetime string
 /// (`YYYY-MM-DD HH:MM:SS`).
 ///
@@ -416,15 +468,22 @@ fn default_file_dir() -> String {
 }
 
 impl Default for StorageConfig {
-    /// Auto-detect: if `GATEWAY_DATABASE_URL` is set, use MySQL; otherwise
-    /// fall back to SQLite at `~/.astra-gateway/gateway.db`.
+    /// Auto-detect: if `GATEWAY_DATABASE_URL` is set to a non-empty value, use
+    /// MySQL; otherwise run without persistence until storage is explicit.
     fn default() -> Self {
-        match std::env::var("GATEWAY_DATABASE_URL") {
-            Ok(url) => Self::Mysql { url },
-            Err(_) => Self::Sqlite {
-                path: default_sqlite_path(),
-            },
-        }
+        Self::from_database_url_env_value(std::env::var("GATEWAY_DATABASE_URL").ok().as_deref())
+    }
+}
+
+impl StorageConfig {
+    pub(crate) fn from_database_url_env_value(value: Option<&str>) -> Self {
+        value
+            .map(str::trim)
+            .filter(|url| !url.is_empty())
+            .map(|url| Self::Mysql {
+                url: url.to_string(),
+            })
+            .unwrap_or(Self::None)
     }
 }
 
@@ -455,9 +514,9 @@ pub async fn open_store(
 
 /// Everything the runner needs from the storage layer.
 ///
-/// `durable_store` and `trace_repo` currently require a MySQL pool, so they
-/// are only available when the backend is MySQL. SQLite / file backends set
-/// them to `None`.
+/// `durable_store` and `trace_repo` require the MySQL pool. Backends that
+/// cannot provide full gateway durability are rejected before a bundle is
+/// created.
 pub struct StoreBundle {
     pub store: std::sync::Arc<dyn GatewayStore>,
     pub durable_store: Option<std::sync::Arc<crate::durable_task_store::MysqlDurableTaskStore>>,
@@ -470,8 +529,10 @@ pub struct StoreBundle {
 
 /// Create a [`StoreBundle`] from config — or `None` for [`StorageConfig::None`].
 ///
-/// For MySQL backends the bundle also provisions the durable-task store and
-/// trace repository backed by the same connection pool.
+/// For MySQL backends the bundle provisions the durable-task store and trace
+/// repository backed by the same connection pool. SQLite and file stores remain
+/// usable through [`open_store`] for local tooling/tests, but not for the
+/// gateway runner.
 pub async fn open_store_bundle(
     config: &StorageConfig,
 ) -> Result<Option<StoreBundle>, Box<dyn std::error::Error + Send + Sync>> {
@@ -499,25 +560,12 @@ pub async fn open_store_bundle(
                 mysql_pool: Some(pool),
             }))
         }
-        StorageConfig::Sqlite { path } => {
-            let store = sqlite::SqliteGatewayStore::connect(path).await?;
-            store.ensure_schema().await?;
-            Ok(Some(StoreBundle {
-                store: std::sync::Arc::new(store),
-                durable_store: None,
-                trace_repo: None,
-                mysql_pool: None,
-            }))
-        }
-        StorageConfig::File { dir } => {
-            let store = file::FileGatewayStore::open(dir).await?;
-            Ok(Some(StoreBundle {
-                store: std::sync::Arc::new(store),
-                durable_store: None,
-                trace_repo: None,
-                mysql_pool: None,
-            }))
-        }
+        StorageConfig::Sqlite { .. } => Err(
+            "sqlite storage does not support gateway durability; use storage.backend: mysql or storage.backend: none".into(),
+        ),
+        StorageConfig::File { .. } => Err(
+            "file storage does not support gateway durability; use storage.backend: mysql or storage.backend: none".into(),
+        ),
         StorageConfig::None => Ok(None),
     }
 }
@@ -646,14 +694,68 @@ mod tests {
             StorageConfig::Mysql { url } => {
                 assert!(!url.is_empty(), "MySQL URL should not be empty");
             }
-            StorageConfig::Sqlite { path } => {
-                assert!(
-                    path.ends_with("gateway.db"),
-                    "SQLite path should end with gateway.db, got: {path}"
-                );
-            }
-            other => panic!("expected Mysql or Sqlite default, got: {other:?}"),
+            StorageConfig::None => {}
+            other => panic!("expected Mysql or None default, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn storage_config_env_value_ignores_empty_urls() {
+        assert!(matches!(
+            StorageConfig::from_database_url_env_value(None),
+            StorageConfig::None
+        ));
+        assert!(matches!(
+            StorageConfig::from_database_url_env_value(Some("")),
+            StorageConfig::None
+        ));
+        assert!(matches!(
+            StorageConfig::from_database_url_env_value(Some("   ")),
+            StorageConfig::None
+        ));
+        match StorageConfig::from_database_url_env_value(Some(" mysql://host/db ")) {
+            StorageConfig::Mysql { url } => assert_eq!(url, "mysql://host/db"),
+            other => panic!("expected Mysql, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn store_bundle_rejects_non_durable_backends() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let sqlite = StorageConfig::Sqlite {
+            path: dir.path().join("gateway.db").to_string_lossy().to_string(),
+        };
+        let err = match open_store_bundle(&sqlite).await {
+            Ok(_) => panic!("sqlite bundle must be rejected"),
+            Err(err) => err.to_string(),
+        };
+        assert!(
+            err.contains("does not support gateway durability"),
+            "unexpected sqlite error: {err}"
+        );
+
+        let file = StorageConfig::File {
+            dir: dir.path().join("data").to_string_lossy().to_string(),
+        };
+        let err = match open_store_bundle(&file).await {
+            Ok(_) => panic!("file bundle must be rejected"),
+            Err(err) => err.to_string(),
+        };
+        assert!(
+            err.contains("does not support gateway durability"),
+            "unexpected file error: {err}"
+        );
+    }
+
+    #[test]
+    fn cron_expr_validation_rejects_invalid_ranges() {
+        assert!(is_valid_cron_expr("0 9 * * 1-5"));
+        assert!(is_valid_cron_expr("*/5 * * * *"));
+        assert!(!is_valid_cron_expr("99 9 * * *"));
+        assert!(!is_valid_cron_expr("0 24 * * *"));
+        assert!(!is_valid_cron_expr("0 9 * * 9"));
+        assert!(!is_valid_cron_expr("bad expr"));
     }
 
     #[test]

--- a/rust/crates/astra-gateway/src/store/mod.rs
+++ b/rust/crates/astra-gateway/src/store/mod.rs
@@ -437,13 +437,19 @@ pub fn model_preference_key(cli_name: &str) -> String {
 ///
 /// ```yaml
 /// storage:
-///   backend: mysql
+///   backend: matrixone          # or: mysql, sqlite, file, none
 ///   url: "mysql://root:111@127.0.0.1:6001/astra_gateway"
 /// ```
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(tag = "backend", rename_all = "snake_case")]
 pub enum StorageConfig {
+    /// MySQL-compatible backend (MySQL, MariaDB, MatrixOne, etc.).
     Mysql {
+        url: String,
+    },
+    /// Alias for `mysql` — MatrixOne is MySQL-protocol compatible.
+    #[serde(rename = "matrixone")]
+    MatrixOne {
         url: String,
     },
     Sqlite {
@@ -492,7 +498,7 @@ pub async fn open_store(
     config: &StorageConfig,
 ) -> Result<Option<Box<dyn GatewayStore>>, Box<dyn std::error::Error + Send + Sync>> {
     match config {
-        StorageConfig::Mysql { url } => {
+        StorageConfig::Mysql { url } | StorageConfig::MatrixOne { url } => {
             let store = mysql::MysqlGatewayStore::connect(url).await?;
             store.ensure_schema().await?;
             Ok(Some(Box::new(store)))
@@ -537,7 +543,7 @@ pub async fn open_store_bundle(
     config: &StorageConfig,
 ) -> Result<Option<StoreBundle>, Box<dyn std::error::Error + Send + Sync>> {
     match config {
-        StorageConfig::Mysql { url } => {
+        StorageConfig::Mysql { url } | StorageConfig::MatrixOne { url } => {
             let store = mysql::MysqlGatewayStore::connect(url).await?;
             store.ensure_schema().await?;
             store.ensure_usage_table().await?;
@@ -776,6 +782,26 @@ mod tests {
 url: "mysql://root:111@localhost/gw""#;
         let cfg: StorageConfig = serde_yaml_ng::from_str(yaml).unwrap();
         assert!(matches!(cfg, StorageConfig::Mysql { .. }));
+    }
+
+    #[test]
+    fn storage_config_deserialize_matrixone() {
+        let yaml = r#"backend: matrixone
+url: "mysql://root:111@127.0.0.1:6001/astra_gateway""#;
+        let cfg: StorageConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        match cfg {
+            StorageConfig::MatrixOne { url } => {
+                assert!(url.contains("6001"));
+            }
+            other => panic!("expected MatrixOne, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_config_deserialize_matrixone_json() {
+        let json = r#"{"backend":"matrixone","url":"mysql://root@host/db"}"#;
+        let cfg: StorageConfig = serde_json::from_str(json).unwrap();
+        assert!(matches!(cfg, StorageConfig::MatrixOne { .. }));
     }
 
     #[test]

--- a/rust/crates/astra-gateway/src/store/mysql.rs
+++ b/rust/crates/astra-gateway/src/store/mysql.rs
@@ -1,0 +1,835 @@
+//! MySQL / MatrixOne implementation of [`GatewayStore`].
+
+use super::{
+    CronJobRecord, CronJobSpec, DueJob, GatewayStore, PendingMessage, PlatformCredential,
+    SessionRecord, StoreError, UsageRecord, UsageSummary, next_cron_run_str,
+};
+
+/// MySQL-backed gateway store.
+///
+/// Wraps a [`sqlx::MySqlPool`] and implements every [`GatewayStore`] method
+/// using the same SQL statements that were previously in `storage.rs` and
+/// `usage.rs`.
+pub struct MysqlGatewayStore {
+    pool: sqlx::MySqlPool,
+}
+
+impl MysqlGatewayStore {
+    pub fn new(pool: sqlx::MySqlPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn connect(url: &str) -> Result<Self, StoreError> {
+        let pool = sqlx::mysql::MySqlPoolOptions::new()
+            .max_connections(5)
+            .connect(url)
+            .await?;
+        Ok(Self { pool })
+    }
+
+    pub fn pool(&self) -> &sqlx::MySqlPool {
+        &self.pool
+    }
+
+    /// Create the usage-tracking table if it does not already exist.
+    ///
+    /// Separated from [`GatewayStore::ensure_schema`] because usage tracking
+    /// is optional and may be initialized independently.
+    pub async fn ensure_usage_table(&self) -> Result<(), StoreError> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_usage (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                platform VARCHAR(32) NOT NULL,
+                user_id VARCHAR(128) NOT NULL,
+                cli_profile VARCHAR(32) NOT NULL DEFAULT 'astra',
+                model VARCHAR(128),
+                tokens_prompt BIGINT NOT NULL DEFAULT 0,
+                tokens_completion BIGINT NOT NULL DEFAULT 0,
+                tool_calls INT NOT NULL DEFAULT 0,
+                elapsed_ms BIGINT NOT NULL DEFAULT 0,
+                created_at DATETIME(6) DEFAULT NOW(6),
+                INDEX idx_user_day (platform, user_id, created_at)
+            )",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(())
+    }
+}
+
+// ─── GatewayStore trait implementation ──────────────────────────────────────
+
+#[async_trait::async_trait]
+impl GatewayStore for MysqlGatewayStore {
+    // ── Schema ──────────────────────────────────────────────────────────
+
+    async fn ensure_schema(&self) -> Result<(), StoreError> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_users (
+                platform VARCHAR(32) NOT NULL,
+                platform_user_id VARCHAR(128) NOT NULL,
+                display_name VARCHAR(256) DEFAULT '',
+                preferences JSON,
+                created_at DATETIME(6) DEFAULT NOW(6),
+                updated_at DATETIME(6) DEFAULT NOW(6),
+                PRIMARY KEY (platform, platform_user_id)
+            )",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_sessions (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                platform VARCHAR(32) NOT NULL,
+                chat_id VARCHAR(128) NOT NULL,
+                user_id VARCHAR(128) NOT NULL DEFAULT '',
+                cli_profile VARCHAR(32) NOT NULL DEFAULT 'default',
+                astra_session_id VARCHAR(64) NOT NULL,
+                is_current BOOLEAN DEFAULT TRUE,
+                created_at DATETIME(6) DEFAULT NOW(6),
+                last_active DATETIME(6) DEFAULT NOW(6),
+                INDEX idx_current (platform, chat_id, cli_profile, is_current),
+                INDEX idx_user (platform, user_id)
+            )",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        // Migration: add cli_profile column if missing (existing deployments)
+        let _ = sqlx::query(
+            "ALTER TABLE gw_sessions ADD COLUMN cli_profile VARCHAR(32) NOT NULL DEFAULT 'default'",
+        )
+        .execute(&self.pool)
+        .await;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_cron_jobs (
+                job_id VARCHAR(64) PRIMARY KEY,
+                platform VARCHAR(32) NOT NULL,
+                chat_id VARCHAR(128) NOT NULL,
+                user_id VARCHAR(128) NOT NULL DEFAULT '',
+                cron_expr VARCHAR(128) NOT NULL,
+                message TEXT NOT NULL,
+                description VARCHAR(512) DEFAULT '',
+                enabled BOOLEAN DEFAULT TRUE,
+                last_run DATETIME(6),
+                next_run DATETIME(6),
+                created_at DATETIME(6) DEFAULT NOW(6),
+                INDEX idx_enabled (enabled, next_run),
+                INDEX idx_user_jobs (platform, user_id)
+            )",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_platform_credentials (
+                platform VARCHAR(32) NOT NULL,
+                user_id VARCHAR(128) NOT NULL,
+                credential_type VARCHAR(64) NOT NULL,
+                credentials TEXT NOT NULL,
+                expires_at DATETIME(6),
+                created_at DATETIME(6) DEFAULT NOW(6),
+                updated_at DATETIME(6) DEFAULT NOW(6),
+                PRIMARY KEY (platform, user_id, credential_type)
+            )",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_durable_tasks (
+                task_id VARCHAR(64) PRIMARY KEY,
+                name VARCHAR(512) NOT NULL,
+                description TEXT,
+                owner_id VARCHAR(128) NOT NULL,
+                status VARCHAR(20) NOT NULL DEFAULT 'created',
+                progress_pct TINYINT UNSIGNED NOT NULL DEFAULT 0,
+                step_description VARCHAR(512),
+                checkpoint_json LONGTEXT,
+                error_message TEXT,
+                created_at DATETIME(6) DEFAULT NOW(6),
+                updated_at DATETIME(6) DEFAULT NOW(6),
+                INDEX idx_owner_status (owner_id, status),
+                INDEX idx_owner_updated (owner_id, updated_at)
+            )",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_pending_messages (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                platform VARCHAR(32) NOT NULL,
+                chat_id VARCHAR(128) NOT NULL,
+                user_id VARCHAR(128) NOT NULL,
+                text TEXT NOT NULL,
+                created_at DATETIME(6) DEFAULT NOW(6),
+                INDEX idx_pending (platform, created_at)
+            )",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        tracing::info!("gateway schema ensured");
+        Ok(())
+    }
+
+    // ── Users ───────────────────────────────────────────────────────────
+
+    async fn upsert_user(
+        &self,
+        platform: &str,
+        user_id: &str,
+        display_name: &str,
+    ) -> Result<(), StoreError> {
+        sqlx::query(
+            "INSERT INTO gw_users (platform, platform_user_id, display_name)
+             VALUES (?, ?, ?)
+             ON DUPLICATE KEY UPDATE display_name = VALUES(display_name), updated_at = NOW(6)",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .bind(display_name)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn set_user_preference(
+        &self,
+        platform: &str,
+        user_id: &str,
+        key: &str,
+        value: &str,
+    ) -> Result<(), StoreError> {
+        let pref_json = serde_json::json!({key: value}).to_string();
+
+        // First ensure preferences is not NULL, then JSON_SET
+        sqlx::query(
+            "UPDATE gw_users SET preferences = ?, updated_at = NOW(6)
+             WHERE platform = ? AND platform_user_id = ? AND preferences IS NULL",
+        )
+        .bind(&pref_json)
+        .bind(platform)
+        .bind(user_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        sqlx::query(
+            "UPDATE gw_users SET preferences = JSON_SET(preferences, CONCAT('$.', ?), ?), updated_at = NOW(6)
+             WHERE platform = ? AND platform_user_id = ? AND preferences IS NOT NULL",
+        )
+        .bind(key)
+        .bind(value)
+        .bind(platform)
+        .bind(user_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get_user_preference(
+        &self,
+        platform: &str,
+        user_id: &str,
+        key: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let row: Option<(Option<String>,)> = sqlx::query_as(
+            "SELECT JSON_UNQUOTE(JSON_EXTRACT(preferences, CONCAT('$.', ?)))
+             FROM gw_users WHERE platform = ? AND platform_user_id = ?",
+        )
+        .bind(key)
+        .bind(platform)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(row.and_then(|r| r.0).filter(|v| v != "null"))
+    }
+
+    async fn is_first_message(&self, platform: &str, user_id: &str) -> Result<bool, StoreError> {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM gw_users WHERE platform = ? AND platform_user_id = ?",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(row.0 == 0)
+    }
+
+    // ── Session operations ──────────────────────────────────────────────
+
+    async fn get_current_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT astra_session_id FROM gw_sessions
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND is_current = TRUE
+             ORDER BY last_active DESC LIMIT 1",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(row.map(|r| r.0))
+    }
+
+    async fn get_session_last_active(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT CAST(last_active AS CHAR) FROM gw_sessions
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND is_current = TRUE
+             ORDER BY last_active DESC LIMIT 1",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(row.map(|r| r.0))
+    }
+
+    async fn set_current_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        user_id: &str,
+        astra_session_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError> {
+        // Mark old sessions for this CLI as not current
+        sqlx::query(
+            "UPDATE gw_sessions SET is_current = FALSE
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND is_current = TRUE",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        // Check if this session already exists for this CLI
+        let existing: Option<(i64,)> = sqlx::query_as(
+            "SELECT id FROM gw_sessions
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND astra_session_id = ?",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .bind(astra_session_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        if let Some((id,)) = existing {
+            // Reactivate existing session
+            sqlx::query(
+                "UPDATE gw_sessions SET is_current = TRUE, last_active = NOW(6) WHERE id = ?",
+            )
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+        } else {
+            // Insert new
+            sqlx::query(
+                "INSERT INTO gw_sessions (platform, chat_id, user_id, cli_profile, astra_session_id, is_current)
+                 VALUES (?, ?, ?, ?, ?, TRUE)",
+            )
+            .bind(platform)
+            .bind(chat_id)
+            .bind(user_id)
+            .bind(cli_profile)
+            .bind(astra_session_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    async fn touch_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError> {
+        sqlx::query(
+            "UPDATE gw_sessions SET last_active = NOW(6)
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND is_current = TRUE",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn list_sessions(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Vec<SessionRecord>, StoreError> {
+        let rows: Vec<(String, i32, String)> = sqlx::query_as(
+            "SELECT astra_session_id, CAST(is_current AS SIGNED), CAST(created_at AS CHAR) as created
+             FROM gw_sessions WHERE platform = ? AND chat_id = ? AND cli_profile = ?
+             ORDER BY last_active DESC LIMIT 20",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(sid, cur, created)| SessionRecord {
+                session_id: sid,
+                is_current: cur != 0,
+                created_at: created,
+            })
+            .collect())
+    }
+
+    async fn switch_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        target_session_id: &str,
+    ) -> Result<bool, StoreError> {
+        // Check target exists
+        let exists: Option<(i64,)> = sqlx::query_as(
+            "SELECT id FROM gw_sessions
+             WHERE platform = ? AND chat_id = ? AND astra_session_id = ?",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(target_session_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        if exists.is_none() {
+            return Ok(false);
+        }
+
+        // Clear current
+        sqlx::query(
+            "UPDATE gw_sessions SET is_current = FALSE
+             WHERE platform = ? AND chat_id = ?",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        // Set target as current
+        sqlx::query(
+            "UPDATE gw_sessions SET is_current = TRUE, last_active = NOW(6)
+             WHERE platform = ? AND chat_id = ? AND astra_session_id = ?",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(target_session_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(true)
+    }
+
+    async fn reset_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError> {
+        sqlx::query(
+            "UPDATE gw_sessions SET is_current = FALSE
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND is_current = TRUE",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    // ── Pending message operations ──────────────────────────────────────
+
+    async fn save_pending_message(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        user_id: &str,
+        text: &str,
+    ) -> Result<i64, StoreError> {
+        let result = sqlx::query(
+            "INSERT INTO gw_pending_messages (platform, chat_id, user_id, text) VALUES (?, ?, ?, ?)",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(user_id)
+        .bind(text)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(result.last_insert_id() as i64)
+    }
+
+    async fn list_pending_messages(
+        &self,
+        platform: Option<&str>,
+    ) -> Result<Vec<PendingMessage>, StoreError> {
+        let rows: Vec<(i64, String, String, String, String)> = if let Some(platform) = platform {
+            sqlx::query_as(
+                "SELECT id, platform, chat_id, user_id, text
+                 FROM gw_pending_messages
+                 WHERE platform = ?
+                 ORDER BY created_at
+                 LIMIT 50",
+            )
+            .bind(platform)
+            .fetch_all(&self.pool)
+            .await
+        } else {
+            sqlx::query_as(
+                "SELECT id, platform, chat_id, user_id, text
+                 FROM gw_pending_messages
+                 ORDER BY created_at
+                 LIMIT 50",
+            )
+            .fetch_all(&self.pool)
+            .await
+        }
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(id, plat, cid, uid, txt)| PendingMessage {
+                id,
+                platform: plat,
+                chat_id: cid,
+                user_id: uid,
+                text: txt,
+            })
+            .collect())
+    }
+
+    async fn delete_pending_message(&self, id: i64) -> Result<u64, StoreError> {
+        let result = sqlx::query("DELETE FROM gw_pending_messages WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(result.rows_affected())
+    }
+
+    // ── Cron job operations ─────────────────────────────────────────────
+
+    async fn create_cron_job(&self, spec: &CronJobSpec) -> Result<(), StoreError> {
+        let next = next_cron_run_str(&spec.cron_expr);
+        sqlx::query(
+            "INSERT INTO gw_cron_jobs (job_id, platform, chat_id, user_id, cron_expr, message, description, next_run)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&spec.job_id)
+        .bind(&spec.platform)
+        .bind(&spec.chat_id)
+        .bind(&spec.user_id)
+        .bind(&spec.cron_expr)
+        .bind(&spec.message)
+        .bind(&spec.description)
+        .bind(next)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn list_cron_jobs(
+        &self,
+        platform: &str,
+        chat_id: &str,
+    ) -> Result<Vec<CronJobRecord>, StoreError> {
+        // MatrixOne returns BOOL as string, so CAST to SIGNED for SQLx compat
+        let rows: Vec<(String, String, String, i32)> = sqlx::query_as(
+            "SELECT job_id, cron_expr, description, CAST(enabled AS SIGNED)
+             FROM gw_cron_jobs WHERE platform = ? AND chat_id = ?
+             ORDER BY created_at",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(id, expr, desc, en)| CronJobRecord {
+                job_id: id,
+                cron_expr: expr,
+                description: desc,
+                enabled: en != 0,
+            })
+            .collect())
+    }
+
+    async fn delete_cron_job(&self, job_id: &str) -> Result<bool, StoreError> {
+        let result = sqlx::query("DELETE FROM gw_cron_jobs WHERE job_id = ?")
+            .bind(job_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn get_due_jobs(&self) -> Result<Vec<DueJob>, StoreError> {
+        let rows: Vec<(String, String, String, String, String)> = sqlx::query_as(
+            "SELECT job_id, platform, chat_id, message, cron_expr
+             FROM gw_cron_jobs
+             WHERE enabled = TRUE AND (next_run IS NULL OR next_run <= NOW(6))",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(jid, plat, cid, msg, expr)| DueJob {
+                job_id: jid,
+                platform: plat,
+                chat_id: cid,
+                message: msg,
+                cron_expr: expr,
+            })
+            .collect())
+    }
+
+    async fn mark_job_run(&self, job_id: &str, cron_expr: &str) -> Result<(), StoreError> {
+        let next = next_cron_run_str(cron_expr);
+        sqlx::query("UPDATE gw_cron_jobs SET last_run = NOW(6), next_run = ? WHERE job_id = ?")
+            .bind(&next)
+            .bind(job_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn update_cron_next_run(&self, job_id: &str, next_run: &str) -> Result<(), StoreError> {
+        sqlx::query("UPDATE gw_cron_jobs SET next_run = ? WHERE job_id = ?")
+            .bind(next_run)
+            .bind(job_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    // ── Credential operations ───────────────────────────────────────────
+
+    async fn save_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+        credentials: &serde_json::Value,
+        expires_at: Option<&str>,
+    ) -> Result<(), StoreError> {
+        let cred_str = credentials.to_string();
+        sqlx::query(
+            "INSERT INTO gw_platform_credentials (platform, user_id, credential_type, credentials, expires_at)
+             VALUES (?, ?, ?, ?, ?)
+             ON DUPLICATE KEY UPDATE credentials = VALUES(credentials),
+                                     expires_at = VALUES(expires_at),
+                                     updated_at = NOW(6)",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .bind(credential_type)
+        .bind(&cred_str)
+        .bind(expires_at)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn get_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+    ) -> Result<Option<PlatformCredential>, StoreError> {
+        let row: Option<(String, String, String, String, Option<String>)> = sqlx::query_as(
+            "SELECT platform, user_id, credential_type, credentials, CAST(expires_at AS CHAR)
+             FROM gw_platform_credentials
+             WHERE platform = ? AND user_id = ? AND credential_type = ?",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .bind(credential_type)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(row.map(|(p, u, ct, creds, exp)| PlatformCredential {
+            platform: p,
+            user_id: u,
+            credential_type: ct,
+            credentials: serde_json::from_str(&creds).unwrap_or(serde_json::Value::Null),
+            expires_at: exp,
+        }))
+    }
+
+    async fn list_credentials(
+        &self,
+        platform: &str,
+    ) -> Result<Vec<PlatformCredential>, StoreError> {
+        let rows: Vec<(String, String, String, String, Option<String>)> = sqlx::query_as(
+            "SELECT platform, user_id, credential_type, credentials, CAST(expires_at AS CHAR)
+             FROM gw_platform_credentials
+             WHERE platform = ?
+             ORDER BY updated_at DESC",
+        )
+        .bind(platform)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(p, u, ct, creds, exp)| PlatformCredential {
+                platform: p,
+                user_id: u,
+                credential_type: ct,
+                credentials: serde_json::from_str(&creds).unwrap_or(serde_json::Value::Null),
+                expires_at: exp,
+            })
+            .collect())
+    }
+
+    async fn delete_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+    ) -> Result<bool, StoreError> {
+        let result = sqlx::query(
+            "DELETE FROM gw_platform_credentials
+             WHERE platform = ? AND user_id = ? AND credential_type = ?",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .bind(credential_type)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    // ── Usage tracking ──────────────────────────────────────────────────
+
+    async fn record_usage(&self, record: &UsageRecord) -> Result<(), StoreError> {
+        sqlx::query(
+            "INSERT INTO gw_usage (platform, user_id, cli_profile, model, tokens_prompt, tokens_completion, tool_calls, elapsed_ms)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&record.platform)
+        .bind(&record.user_id)
+        .bind(&record.cli_profile)
+        .bind(&record.model)
+        .bind(record.tokens_prompt as i64)
+        .bind(record.tokens_completion as i64)
+        .bind(record.tool_calls as i32)
+        .bind(record.elapsed_ms as i64)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn get_usage_today(
+        &self,
+        platform: &str,
+        user_id: &str,
+    ) -> Result<UsageSummary, StoreError> {
+        let row: Option<(i64, i64, i64, i64)> = sqlx::query_as(
+            "SELECT COUNT(*), COALESCE(SUM(tokens_prompt),0), COALESCE(SUM(tokens_completion),0), COALESCE(SUM(tool_calls),0)
+             FROM gw_usage WHERE platform = ? AND user_id = ? AND created_at >= CURDATE()",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(row
+            .map(|(m, p, c, t)| UsageSummary {
+                messages: m as u64,
+                tokens_prompt: p as u64,
+                tokens_completion: c as u64,
+                tool_calls: t as u64,
+            })
+            .unwrap_or_default())
+    }
+
+    async fn get_usage_total(
+        &self,
+        platform: &str,
+        user_id: &str,
+    ) -> Result<UsageSummary, StoreError> {
+        let row: Option<(i64, i64, i64, i64)> = sqlx::query_as(
+            "SELECT COUNT(*), COALESCE(SUM(tokens_prompt),0), COALESCE(SUM(tokens_completion),0), COALESCE(SUM(tool_calls),0)
+             FROM gw_usage WHERE platform = ? AND user_id = ?",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(row
+            .map(|(m, p, c, t)| UsageSummary {
+                messages: m as u64,
+                tokens_prompt: p as u64,
+                tokens_completion: c as u64,
+                tool_calls: t as u64,
+            })
+            .unwrap_or_default())
+    }
+}

--- a/rust/crates/astra-gateway/src/store/mysql.rs
+++ b/rust/crates/astra-gateway/src/store/mysql.rs
@@ -215,7 +215,7 @@ impl GatewayStore for MysqlGatewayStore {
         let pref_json = serde_json::json!({key: value}).to_string();
 
         // First ensure preferences is not NULL, then JSON_SET
-        sqlx::query(
+        let initialized = sqlx::query(
             "UPDATE gw_users SET preferences = ?, updated_at = NOW(6)
              WHERE platform = ? AND platform_user_id = ? AND preferences IS NULL",
         )
@@ -226,7 +226,7 @@ impl GatewayStore for MysqlGatewayStore {
         .await
         .map_err(|e| StoreError::Database(e.to_string()))?;
 
-        sqlx::query(
+        let merged = sqlx::query(
             "UPDATE gw_users SET preferences = JSON_SET(preferences, CONCAT('$.', ?), ?), updated_at = NOW(6)
              WHERE platform = ? AND platform_user_id = ? AND preferences IS NOT NULL",
         )
@@ -237,6 +237,12 @@ impl GatewayStore for MysqlGatewayStore {
         .execute(&self.pool)
         .await
         .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        if initialized.rows_affected() + merged.rows_affected() == 0 {
+            return Err(StoreError::NotFound(format!(
+                "user not found: {platform}:{user_id}"
+            )));
+        }
 
         Ok(())
     }

--- a/rust/crates/astra-gateway/src/store/mysql.rs
+++ b/rust/crates/astra-gateway/src/store/mysql.rs
@@ -660,6 +660,16 @@ impl GatewayStore for MysqlGatewayStore {
         Ok(())
     }
 
+    async fn get_cron_job_user_id(&self, job_id: &str) -> Result<Option<String>, StoreError> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT user_id FROM gw_cron_jobs WHERE job_id = ?")
+                .bind(job_id)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(row.map(|(uid,)| uid))
+    }
+
     // ── Credential operations ───────────────────────────────────────────
 
     async fn save_credential(

--- a/rust/crates/astra-gateway/src/store/sqlite.rs
+++ b/rust/crates/astra-gateway/src/store/sqlite.rs
@@ -553,6 +553,15 @@ impl GatewayStore for SqliteGatewayStore {
         Ok(())
     }
 
+    async fn get_cron_job_user_id(&self, job_id: &str) -> Result<Option<String>, StoreError> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT user_id FROM gw_cron_jobs WHERE job_id = ?")
+                .bind(job_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(uid,)| uid))
+    }
+
     // ── Platform credentials ────────────────────────────────────────────
 
     async fn save_credential(

--- a/rust/crates/astra-gateway/src/store/sqlite.rs
+++ b/rust/crates/astra-gateway/src/store/sqlite.rs
@@ -205,7 +205,7 @@ impl GatewayStore for SqliteGatewayStore {
         let pref_json = serde_json::json!({ key: value }).to_string();
 
         // First: if preferences is NULL, set the whole JSON object.
-        sqlx::query(
+        let initialized = sqlx::query(
             "UPDATE gw_users SET preferences = ?, updated_at = datetime('now')
              WHERE platform = ? AND platform_user_id = ? AND preferences IS NULL",
         )
@@ -216,10 +216,10 @@ impl GatewayStore for SqliteGatewayStore {
         .await?;
 
         // Second: if preferences already exists, merge the key in.
-        sqlx::query(
+        let merged = sqlx::query(
             "UPDATE gw_users
              SET preferences = json_set(preferences, '$.' || ?, ?),
-                 updated_at = datetime('now')
+                  updated_at = datetime('now')
              WHERE platform = ? AND platform_user_id = ? AND preferences IS NOT NULL",
         )
         .bind(key)
@@ -228,6 +228,12 @@ impl GatewayStore for SqliteGatewayStore {
         .bind(user_id)
         .execute(&self.pool)
         .await?;
+
+        if initialized.rows_affected() + merged.rows_affected() == 0 {
+            return Err(StoreError::NotFound(format!(
+                "user not found: {platform}:{user_id}"
+            )));
+        }
 
         Ok(())
     }
@@ -912,6 +918,19 @@ mod tests {
             .await
             .unwrap();
         assert!(val.is_none());
+    }
+
+    #[tokio::test]
+    async fn set_preference_for_missing_user_fails() {
+        let store = make_store().await;
+        let err = store
+            .set_user_preference("wx", "ghost", "lang", "en")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("user not found"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/astra-gateway/src/store/sqlite.rs
+++ b/rust/crates/astra-gateway/src/store/sqlite.rs
@@ -1,0 +1,1228 @@
+//! SQLite-backed [`GatewayStore`] implementation.
+//!
+//! Zero-config default backend — creates `~/.astra-gateway/gateway.db`
+//! automatically on first use. All data types use TEXT for timestamps
+//! and INTEGER for booleans, matching SQLite's type affinity model.
+
+use super::{
+    CronJobRecord, CronJobSpec, DueJob, GatewayStore, PendingMessage, PlatformCredential,
+    SessionRecord, StoreError, UsageRecord, UsageSummary, next_cron_run_str,
+};
+use async_trait::async_trait;
+use sqlx::SqlitePool;
+
+/// SQLite-backed gateway store.
+pub struct SqliteGatewayStore {
+    pool: SqlitePool,
+}
+
+impl SqliteGatewayStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn connect(path: &str) -> Result<Self, StoreError> {
+        if let Some(parent) = std::path::Path::new(path).parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let url = format!("sqlite:{path}?mode=rwc");
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(2)
+            .connect(&url)
+            .await?;
+        Ok(Self { pool })
+    }
+
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+}
+
+#[async_trait]
+impl GatewayStore for SqliteGatewayStore {
+    // ── Schema ──────────────────────────────────────────────────────────
+
+    async fn ensure_schema(&self) -> Result<(), StoreError> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_users (
+                platform TEXT NOT NULL,
+                platform_user_id TEXT NOT NULL,
+                display_name TEXT DEFAULT '',
+                preferences TEXT,
+                created_at TEXT DEFAULT (datetime('now')),
+                updated_at TEXT DEFAULT (datetime('now')),
+                PRIMARY KEY (platform, platform_user_id)
+            )",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                platform TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                user_id TEXT NOT NULL DEFAULT '',
+                cli_profile TEXT NOT NULL DEFAULT 'default',
+                astra_session_id TEXT NOT NULL,
+                is_current INTEGER DEFAULT 1,
+                created_at TEXT DEFAULT (datetime('now')),
+                last_active TEXT DEFAULT (datetime('now'))
+            )",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_sessions_current
+             ON gw_sessions(platform, chat_id, cli_profile, is_current)",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_cron_jobs (
+                job_id TEXT PRIMARY KEY,
+                platform TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                user_id TEXT NOT NULL DEFAULT '',
+                cron_expr TEXT NOT NULL,
+                message TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                enabled INTEGER DEFAULT 1,
+                last_run TEXT,
+                next_run TEXT,
+                created_at TEXT DEFAULT (datetime('now'))
+            )",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_cron_enabled
+             ON gw_cron_jobs(enabled, next_run)",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_platform_credentials (
+                platform TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                credential_type TEXT NOT NULL,
+                credentials TEXT NOT NULL,
+                expires_at TEXT,
+                created_at TEXT DEFAULT (datetime('now')),
+                updated_at TEXT DEFAULT (datetime('now')),
+                PRIMARY KEY (platform, user_id, credential_type)
+            )",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_pending_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                platform TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                text TEXT NOT NULL,
+                created_at TEXT DEFAULT (datetime('now'))
+            )",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gw_usage (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                platform TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                cli_profile TEXT NOT NULL DEFAULT 'astra',
+                model TEXT,
+                tokens_prompt INTEGER NOT NULL DEFAULT 0,
+                tokens_completion INTEGER NOT NULL DEFAULT 0,
+                tool_calls INTEGER NOT NULL DEFAULT 0,
+                elapsed_ms INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT DEFAULT (datetime('now'))
+            )",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_usage_user_day
+             ON gw_usage(platform, user_id, created_at)",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        tracing::info!("SQLite gateway schema ensured");
+        Ok(())
+    }
+
+    // ── Users ───────────────────────────────────────────────────────────
+
+    async fn is_first_message(&self, platform: &str, user_id: &str) -> Result<bool, StoreError> {
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM gw_users WHERE platform = ? AND platform_user_id = ?",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(count == 0)
+    }
+
+    async fn upsert_user(
+        &self,
+        platform: &str,
+        user_id: &str,
+        display_name: &str,
+    ) -> Result<(), StoreError> {
+        sqlx::query(
+            "INSERT INTO gw_users (platform, platform_user_id, display_name)
+             VALUES (?, ?, ?)
+             ON CONFLICT(platform, platform_user_id) DO UPDATE SET
+                display_name = excluded.display_name,
+                updated_at = datetime('now')",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .bind(display_name)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn set_user_preference(
+        &self,
+        platform: &str,
+        user_id: &str,
+        key: &str,
+        value: &str,
+    ) -> Result<(), StoreError> {
+        let pref_json = serde_json::json!({ key: value }).to_string();
+
+        // First: if preferences is NULL, set the whole JSON object.
+        sqlx::query(
+            "UPDATE gw_users SET preferences = ?, updated_at = datetime('now')
+             WHERE platform = ? AND platform_user_id = ? AND preferences IS NULL",
+        )
+        .bind(&pref_json)
+        .bind(platform)
+        .bind(user_id)
+        .execute(&self.pool)
+        .await?;
+
+        // Second: if preferences already exists, merge the key in.
+        sqlx::query(
+            "UPDATE gw_users
+             SET preferences = json_set(preferences, '$.' || ?, ?),
+                 updated_at = datetime('now')
+             WHERE platform = ? AND platform_user_id = ? AND preferences IS NOT NULL",
+        )
+        .bind(key)
+        .bind(value)
+        .bind(platform)
+        .bind(user_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn get_user_preference(
+        &self,
+        platform: &str,
+        user_id: &str,
+        key: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let row: Option<(Option<String>,)> = sqlx::query_as(
+            "SELECT json_extract(preferences, '$.' || ?)
+             FROM gw_users WHERE platform = ? AND platform_user_id = ?",
+        )
+        .bind(key)
+        .bind(platform)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        // SQLite json_extract returns NULL for missing keys (not the string "null").
+        Ok(row.and_then(|r| r.0))
+    }
+
+    // ── Sessions ────────────────────────────────────────────────────────
+
+    async fn get_current_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT astra_session_id FROM gw_sessions
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND is_current = 1
+             ORDER BY last_active DESC LIMIT 1",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| r.0))
+    }
+
+    async fn get_session_last_active(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT last_active FROM gw_sessions
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND is_current = 1
+             ORDER BY last_active DESC LIMIT 1",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| r.0))
+    }
+
+    async fn set_current_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        user_id: &str,
+        astra_session_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError> {
+        // Mark old sessions for this CLI as not current.
+        sqlx::query(
+            "UPDATE gw_sessions SET is_current = 0
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND is_current = 1",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .execute(&self.pool)
+        .await?;
+
+        // Check if this session_id already exists for this CLI.
+        let existing: Option<(i64,)> = sqlx::query_as(
+            "SELECT id FROM gw_sessions
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND astra_session_id = ?",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .bind(astra_session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if let Some((id,)) = existing {
+            // Reactivate existing session.
+            sqlx::query(
+                "UPDATE gw_sessions SET is_current = 1, last_active = datetime('now') WHERE id = ?",
+            )
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        } else {
+            // Insert new session.
+            sqlx::query(
+                "INSERT INTO gw_sessions (platform, chat_id, user_id, cli_profile, astra_session_id, is_current)
+                 VALUES (?, ?, ?, ?, ?, 1)",
+            )
+            .bind(platform)
+            .bind(chat_id)
+            .bind(user_id)
+            .bind(cli_profile)
+            .bind(astra_session_id)
+            .execute(&self.pool)
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn touch_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError> {
+        sqlx::query(
+            "UPDATE gw_sessions SET last_active = datetime('now')
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND is_current = 1",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn list_sessions(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<Vec<SessionRecord>, StoreError> {
+        let rows: Vec<(String, i32, String)> = sqlx::query_as(
+            "SELECT astra_session_id, is_current, created_at
+             FROM gw_sessions WHERE platform = ? AND chat_id = ? AND cli_profile = ?
+             ORDER BY last_active DESC LIMIT 20",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(sid, cur, created)| SessionRecord {
+                session_id: sid,
+                is_current: cur != 0,
+                created_at: created,
+            })
+            .collect())
+    }
+
+    async fn switch_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        target_session_id: &str,
+    ) -> Result<bool, StoreError> {
+        // Check target exists.
+        let exists: Option<(i64,)> = sqlx::query_as(
+            "SELECT id FROM gw_sessions
+             WHERE platform = ? AND chat_id = ? AND astra_session_id = ?",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(target_session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if exists.is_none() {
+            return Ok(false);
+        }
+
+        // Clear current.
+        sqlx::query(
+            "UPDATE gw_sessions SET is_current = 0
+             WHERE platform = ? AND chat_id = ?",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .execute(&self.pool)
+        .await?;
+
+        // Set target as current.
+        sqlx::query(
+            "UPDATE gw_sessions SET is_current = 1, last_active = datetime('now')
+             WHERE platform = ? AND chat_id = ? AND astra_session_id = ?",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(target_session_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(true)
+    }
+
+    async fn reset_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        cli_profile: &str,
+    ) -> Result<(), StoreError> {
+        sqlx::query(
+            "UPDATE gw_sessions SET is_current = 0
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND is_current = 1",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(cli_profile)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    // ── Cron jobs ───────────────────────────────────────────────────────
+
+    async fn create_cron_job(&self, spec: &CronJobSpec) -> Result<(), StoreError> {
+        let next = next_cron_run_str(&spec.cron_expr);
+        sqlx::query(
+            "INSERT INTO gw_cron_jobs (job_id, platform, chat_id, user_id, cron_expr, message, description, next_run)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&spec.job_id)
+        .bind(&spec.platform)
+        .bind(&spec.chat_id)
+        .bind(&spec.user_id)
+        .bind(&spec.cron_expr)
+        .bind(&spec.message)
+        .bind(&spec.description)
+        .bind(&next)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn list_cron_jobs(
+        &self,
+        platform: &str,
+        chat_id: &str,
+    ) -> Result<Vec<CronJobRecord>, StoreError> {
+        let rows: Vec<(String, String, String, i32)> = sqlx::query_as(
+            "SELECT job_id, cron_expr, description, enabled
+             FROM gw_cron_jobs WHERE platform = ? AND chat_id = ?
+             ORDER BY created_at",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(id, expr, desc, en)| CronJobRecord {
+                job_id: id,
+                cron_expr: expr,
+                description: desc,
+                enabled: en != 0,
+            })
+            .collect())
+    }
+
+    async fn delete_cron_job(&self, job_id: &str) -> Result<bool, StoreError> {
+        let result = sqlx::query("DELETE FROM gw_cron_jobs WHERE job_id = ?")
+            .bind(job_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn get_due_jobs(&self) -> Result<Vec<DueJob>, StoreError> {
+        let rows: Vec<(String, String, String, String, String)> = sqlx::query_as(
+            "SELECT job_id, platform, chat_id, message, cron_expr
+             FROM gw_cron_jobs
+             WHERE enabled = 1 AND (next_run IS NULL OR next_run <= datetime('now'))",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(id, plat, chat, msg, expr)| DueJob {
+                job_id: id,
+                platform: plat,
+                chat_id: chat,
+                message: msg,
+                cron_expr: expr,
+            })
+            .collect())
+    }
+
+    async fn mark_job_run(&self, job_id: &str, cron_expr: &str) -> Result<(), StoreError> {
+        let next = next_cron_run_str(cron_expr);
+        sqlx::query(
+            "UPDATE gw_cron_jobs SET last_run = datetime('now'), next_run = ? WHERE job_id = ?",
+        )
+        .bind(&next)
+        .bind(job_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn update_cron_next_run(&self, job_id: &str, next_run: &str) -> Result<(), StoreError> {
+        sqlx::query("UPDATE gw_cron_jobs SET next_run = ? WHERE job_id = ?")
+            .bind(next_run)
+            .bind(job_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    // ── Platform credentials ────────────────────────────────────────────
+
+    async fn save_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+        credentials: &serde_json::Value,
+        expires_at: Option<&str>,
+    ) -> Result<(), StoreError> {
+        let cred_str = credentials.to_string();
+        sqlx::query(
+            "INSERT INTO gw_platform_credentials (platform, user_id, credential_type, credentials, expires_at)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT(platform, user_id, credential_type) DO UPDATE SET
+                credentials = excluded.credentials,
+                expires_at = excluded.expires_at,
+                updated_at = datetime('now')",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .bind(credential_type)
+        .bind(&cred_str)
+        .bind(expires_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+    ) -> Result<Option<PlatformCredential>, StoreError> {
+        let row: Option<(String, String, String, String, Option<String>)> = sqlx::query_as(
+            "SELECT platform, user_id, credential_type, credentials, expires_at
+             FROM gw_platform_credentials
+             WHERE platform = ? AND user_id = ? AND credential_type = ?",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .bind(credential_type)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|(p, u, ct, creds, exp)| PlatformCredential {
+            platform: p,
+            user_id: u,
+            credential_type: ct,
+            credentials: serde_json::from_str(&creds).unwrap_or(serde_json::Value::Null),
+            expires_at: exp,
+        }))
+    }
+
+    async fn list_credentials(
+        &self,
+        platform: &str,
+    ) -> Result<Vec<PlatformCredential>, StoreError> {
+        let rows: Vec<(String, String, String, String, Option<String>)> = sqlx::query_as(
+            "SELECT platform, user_id, credential_type, credentials, expires_at
+             FROM gw_platform_credentials
+             WHERE platform = ?
+             ORDER BY updated_at DESC",
+        )
+        .bind(platform)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(p, u, ct, creds, exp)| PlatformCredential {
+                platform: p,
+                user_id: u,
+                credential_type: ct,
+                credentials: serde_json::from_str(&creds).unwrap_or(serde_json::Value::Null),
+                expires_at: exp,
+            })
+            .collect())
+    }
+
+    async fn delete_credential(
+        &self,
+        platform: &str,
+        user_id: &str,
+        credential_type: &str,
+    ) -> Result<bool, StoreError> {
+        let result = sqlx::query(
+            "DELETE FROM gw_platform_credentials
+             WHERE platform = ? AND user_id = ? AND credential_type = ?",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .bind(credential_type)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    // ── Pending messages ────────────────────────────────────────────────
+
+    async fn save_pending_message(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        user_id: &str,
+        text: &str,
+    ) -> Result<i64, StoreError> {
+        let result = sqlx::query(
+            "INSERT INTO gw_pending_messages (platform, chat_id, user_id, text) VALUES (?, ?, ?, ?)",
+        )
+        .bind(platform)
+        .bind(chat_id)
+        .bind(user_id)
+        .bind(text)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.last_insert_rowid())
+    }
+
+    async fn list_pending_messages(
+        &self,
+        platform: Option<&str>,
+    ) -> Result<Vec<PendingMessage>, StoreError> {
+        let rows: Vec<(i64, String, String, String, String)> = if let Some(plat) = platform {
+            sqlx::query_as(
+                "SELECT id, platform, chat_id, user_id, text
+                 FROM gw_pending_messages
+                 WHERE platform = ?
+                 ORDER BY created_at
+                 LIMIT 50",
+            )
+            .bind(plat)
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as(
+                "SELECT id, platform, chat_id, user_id, text
+                 FROM gw_pending_messages
+                 ORDER BY created_at
+                 LIMIT 50",
+            )
+            .fetch_all(&self.pool)
+            .await?
+        };
+
+        Ok(rows
+            .into_iter()
+            .map(|(id, plat, chat, uid, txt)| PendingMessage {
+                id,
+                platform: plat,
+                chat_id: chat,
+                user_id: uid,
+                text: txt,
+            })
+            .collect())
+    }
+
+    async fn delete_pending_message(&self, id: i64) -> Result<u64, StoreError> {
+        let result = sqlx::query("DELETE FROM gw_pending_messages WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
+    // ── Usage ───────────────────────────────────────────────────────────
+
+    async fn record_usage(&self, r: &UsageRecord) -> Result<(), StoreError> {
+        sqlx::query(
+            "INSERT INTO gw_usage (platform, user_id, cli_profile, model, tokens_prompt, tokens_completion, tool_calls, elapsed_ms)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&r.platform)
+        .bind(&r.user_id)
+        .bind(&r.cli_profile)
+        .bind(&r.model)
+        .bind(r.tokens_prompt as i64)
+        .bind(r.tokens_completion as i64)
+        .bind(r.tool_calls as i32)
+        .bind(r.elapsed_ms as i64)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_usage_today(
+        &self,
+        platform: &str,
+        user_id: &str,
+    ) -> Result<UsageSummary, StoreError> {
+        let row: Option<(i64, i64, i64, i64)> = sqlx::query_as(
+            "SELECT COUNT(*),
+                    COALESCE(SUM(tokens_prompt), 0),
+                    COALESCE(SUM(tokens_completion), 0),
+                    COALESCE(SUM(tool_calls), 0)
+             FROM gw_usage
+             WHERE platform = ? AND user_id = ? AND created_at >= date('now')",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row
+            .map(|(m, p, c, t)| UsageSummary {
+                messages: m as u64,
+                tokens_prompt: p as u64,
+                tokens_completion: c as u64,
+                tool_calls: t as u64,
+            })
+            .unwrap_or_default())
+    }
+
+    async fn get_usage_total(
+        &self,
+        platform: &str,
+        user_id: &str,
+    ) -> Result<UsageSummary, StoreError> {
+        let row: Option<(i64, i64, i64, i64)> = sqlx::query_as(
+            "SELECT COUNT(*),
+                    COALESCE(SUM(tokens_prompt), 0),
+                    COALESCE(SUM(tokens_completion), 0),
+                    COALESCE(SUM(tool_calls), 0)
+             FROM gw_usage
+             WHERE platform = ? AND user_id = ?",
+        )
+        .bind(platform)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row
+            .map(|(m, p, c, t)| UsageSummary {
+                messages: m as u64,
+                tokens_prompt: p as u64,
+                tokens_completion: c as u64,
+                tool_calls: t as u64,
+            })
+            .unwrap_or_default())
+    }
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn make_store() -> SqliteGatewayStore {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite");
+        let store = SqliteGatewayStore::new(pool);
+        store.ensure_schema().await.expect("ensure_schema");
+        store
+    }
+
+    #[tokio::test]
+    async fn ensure_schema_runs_without_error() {
+        let _ = make_store().await;
+    }
+
+    #[tokio::test]
+    async fn ensure_schema_is_idempotent() {
+        let store = make_store().await;
+        // Running it again should not fail.
+        store.ensure_schema().await.expect("second ensure_schema");
+    }
+
+    #[tokio::test]
+    async fn upsert_user_and_is_first_message() {
+        let store = make_store().await;
+
+        assert!(store.is_first_message("wx", "u1").await.unwrap());
+
+        store.upsert_user("wx", "u1", "Alice").await.unwrap();
+
+        assert!(!store.is_first_message("wx", "u1").await.unwrap());
+
+        // Other user is still first.
+        assert!(store.is_first_message("wx", "u2").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn upsert_user_updates_display_name() {
+        let store = make_store().await;
+        store.upsert_user("wx", "u1", "Alice").await.unwrap();
+        store.upsert_user("wx", "u1", "Bob").await.unwrap();
+
+        // Still only one row.
+        assert!(!store.is_first_message("wx", "u1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn set_and_get_user_preference() {
+        let store = make_store().await;
+        store.upsert_user("wx", "u1", "Test").await.unwrap();
+
+        // No preference set yet.
+        let val = store.get_user_preference("wx", "u1", "lang").await.unwrap();
+        assert!(val.is_none());
+
+        // Set one.
+        store
+            .set_user_preference("wx", "u1", "lang", "en")
+            .await
+            .unwrap();
+        let val = store.get_user_preference("wx", "u1", "lang").await.unwrap();
+        assert_eq!(val.as_deref(), Some("en"));
+
+        // Overwrite.
+        store
+            .set_user_preference("wx", "u1", "lang", "zh")
+            .await
+            .unwrap();
+        let val = store.get_user_preference("wx", "u1", "lang").await.unwrap();
+        assert_eq!(val.as_deref(), Some("zh"));
+
+        // Multiple keys coexist.
+        store
+            .set_user_preference("wx", "u1", "model_override_astra", "opus")
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .get_user_preference("wx", "u1", "lang")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("zh")
+        );
+        assert_eq!(
+            store
+                .get_user_preference("wx", "u1", "model_override_astra")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("opus")
+        );
+    }
+
+    #[tokio::test]
+    async fn get_preference_for_missing_user() {
+        let store = make_store().await;
+        let val = store
+            .get_user_preference("wx", "ghost", "lang")
+            .await
+            .unwrap();
+        assert!(val.is_none());
+    }
+
+    #[tokio::test]
+    async fn create_and_list_cron_jobs() {
+        let store = make_store().await;
+
+        store
+            .create_cron_job(&CronJobSpec {
+                job_id: "j1".into(),
+                platform: "wx".into(),
+                chat_id: "c1".into(),
+                user_id: "u1".into(),
+                cron_expr: "30 9 * * *".into(),
+                message: "good morning".into(),
+                description: "daily greeting".into(),
+            })
+            .await
+            .unwrap();
+
+        store
+            .create_cron_job(&CronJobSpec {
+                job_id: "j2".into(),
+                platform: "wx".into(),
+                chat_id: "c1".into(),
+                user_id: "u1".into(),
+                cron_expr: "0 18 * * 1-5".into(),
+                message: "wrap up".into(),
+                description: "weekday reminder".into(),
+            })
+            .await
+            .unwrap();
+
+        let jobs = store.list_cron_jobs("wx", "c1").await.unwrap();
+        assert_eq!(jobs.len(), 2);
+        assert_eq!(jobs[0].job_id, "j1");
+        assert!(jobs[0].enabled);
+        assert_eq!(jobs[1].description, "weekday reminder");
+    }
+
+    #[tokio::test]
+    async fn delete_cron_job() {
+        let store = make_store().await;
+
+        store
+            .create_cron_job(&CronJobSpec {
+                job_id: "j1".into(),
+                platform: "wx".into(),
+                chat_id: "c1".into(),
+                user_id: "u1".into(),
+                cron_expr: "0 9 * * *".into(),
+                message: "hello".into(),
+                description: "".into(),
+            })
+            .await
+            .unwrap();
+
+        assert!(store.delete_cron_job("j1").await.unwrap());
+        assert!(!store.delete_cron_job("j1").await.unwrap()); // already deleted
+        assert!(store.list_cron_jobs("wx", "c1").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn pending_message_roundtrip() {
+        let store = make_store().await;
+
+        let id1 = store
+            .save_pending_message("wx", "c1", "u1", "hello")
+            .await
+            .unwrap();
+        let id2 = store
+            .save_pending_message("wx", "c1", "u1", "world")
+            .await
+            .unwrap();
+        assert_ne!(id1, id2);
+
+        // List all.
+        let msgs = store.list_pending_messages(None).await.unwrap();
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].text, "hello");
+        assert_eq!(msgs[1].text, "world");
+
+        // List filtered by platform.
+        let msgs = store.list_pending_messages(Some("wx")).await.unwrap();
+        assert_eq!(msgs.len(), 2);
+        let msgs = store.list_pending_messages(Some("tg")).await.unwrap();
+        assert!(msgs.is_empty());
+
+        // Delete first.
+        let affected = store.delete_pending_message(id1).await.unwrap();
+        assert_eq!(affected, 1);
+
+        let msgs = store.list_pending_messages(None).await.unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].text, "world");
+    }
+
+    #[tokio::test]
+    async fn session_lifecycle() {
+        let store = make_store().await;
+
+        // No current session initially.
+        let cur = store
+            .get_current_session("wx", "c1", "astra")
+            .await
+            .unwrap();
+        assert!(cur.is_none());
+
+        // Set a session.
+        store
+            .set_current_session("wx", "c1", "u1", "sess-1", "astra")
+            .await
+            .unwrap();
+        let cur = store
+            .get_current_session("wx", "c1", "astra")
+            .await
+            .unwrap();
+        assert_eq!(cur.as_deref(), Some("sess-1"));
+
+        // Touch.
+        store.touch_session("wx", "c1", "astra").await.unwrap();
+
+        // List.
+        let sessions = store.list_sessions("wx", "c1", "astra").await.unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert!(sessions[0].is_current);
+
+        // Set another session.
+        store
+            .set_current_session("wx", "c1", "u1", "sess-2", "astra")
+            .await
+            .unwrap();
+        let cur = store
+            .get_current_session("wx", "c1", "astra")
+            .await
+            .unwrap();
+        assert_eq!(cur.as_deref(), Some("sess-2"));
+
+        // Switch back.
+        assert!(store.switch_session("wx", "c1", "sess-1").await.unwrap());
+        let cur = store
+            .get_current_session("wx", "c1", "astra")
+            .await
+            .unwrap();
+        assert_eq!(cur.as_deref(), Some("sess-1"));
+
+        // Switch to nonexistent.
+        assert!(
+            !store
+                .switch_session("wx", "c1", "nonexistent")
+                .await
+                .unwrap()
+        );
+
+        // Reset.
+        store.reset_session("wx", "c1", "astra").await.unwrap();
+        let cur = store
+            .get_current_session("wx", "c1", "astra")
+            .await
+            .unwrap();
+        assert!(cur.is_none());
+    }
+
+    #[tokio::test]
+    async fn credential_roundtrip() {
+        let store = make_store().await;
+
+        let creds = serde_json::json!({"token": "abc123"});
+        store
+            .save_credential("wx", "default", "bot_token", &creds, None)
+            .await
+            .unwrap();
+
+        let got = store
+            .get_credential("wx", "default", "bot_token")
+            .await
+            .unwrap()
+            .expect("should exist");
+        assert_eq!(got.credentials["token"], "abc123");
+        assert!(got.expires_at.is_none());
+
+        // Update.
+        let new_creds = serde_json::json!({"token": "xyz789"});
+        store
+            .save_credential("wx", "default", "bot_token", &new_creds, Some("2026-12-31"))
+            .await
+            .unwrap();
+        let got = store
+            .get_credential("wx", "default", "bot_token")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.credentials["token"], "xyz789");
+        assert_eq!(got.expires_at.as_deref(), Some("2026-12-31"));
+
+        // List.
+        let all = store.list_credentials("wx").await.unwrap();
+        assert_eq!(all.len(), 1);
+
+        // Delete.
+        assert!(
+            store
+                .delete_credential("wx", "default", "bot_token")
+                .await
+                .unwrap()
+        );
+        assert!(
+            !store
+                .delete_credential("wx", "default", "bot_token")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn usage_roundtrip() {
+        let store = make_store().await;
+
+        // Initially zero.
+        let today = store.get_usage_today("wx", "u1").await.unwrap();
+        assert_eq!(today.messages, 0);
+
+        store
+            .record_usage(&UsageRecord {
+                platform: "wx".into(),
+                user_id: "u1".into(),
+                cli_profile: "astra".into(),
+                model: Some("opus".into()),
+                tokens_prompt: 1000,
+                tokens_completion: 200,
+                tool_calls: 3,
+                elapsed_ms: 5000,
+            })
+            .await
+            .unwrap();
+
+        let today = store.get_usage_today("wx", "u1").await.unwrap();
+        assert_eq!(today.messages, 1);
+        assert_eq!(today.tokens_prompt, 1000);
+        assert_eq!(today.tokens_completion, 200);
+        assert_eq!(today.tool_calls, 3);
+
+        let total = store.get_usage_total("wx", "u1").await.unwrap();
+        assert_eq!(total.messages, 1);
+    }
+
+    #[tokio::test]
+    async fn update_cron_next_run_sets_timestamp() {
+        let store = make_store().await;
+        store
+            .create_cron_job(&CronJobSpec {
+                job_id: "j1".into(),
+                platform: "wx".into(),
+                chat_id: "c1".into(),
+                user_id: "u1".into(),
+                cron_expr: "0 9 * * *".into(),
+                message: "hello".into(),
+                description: "".into(),
+            })
+            .await
+            .unwrap();
+
+        store
+            .update_cron_next_run("j1", "2099-12-31 23:59:59")
+            .await
+            .unwrap();
+
+        // Verify via get_due_jobs: job should NOT be due (next_run far in future)
+        let due = store.get_due_jobs().await.unwrap();
+        assert!(due.is_empty(), "job with future next_run should not be due");
+    }
+
+    #[tokio::test]
+    async fn session_last_active() {
+        let store = make_store().await;
+
+        let la = store
+            .get_session_last_active("wx", "c1", "astra")
+            .await
+            .unwrap();
+        assert!(la.is_none());
+
+        store
+            .set_current_session("wx", "c1", "u1", "sess-1", "astra")
+            .await
+            .unwrap();
+        let la = store
+            .get_session_last_active("wx", "c1", "astra")
+            .await
+            .unwrap();
+        assert!(la.is_some());
+    }
+
+    #[tokio::test]
+    async fn cli_profile_isolation() {
+        let store = make_store().await;
+
+        store
+            .set_current_session("wx", "c1", "u1", "astra-sess", "astra")
+            .await
+            .unwrap();
+        store
+            .set_current_session("wx", "c1", "u1", "claude-sess", "claude")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store
+                .get_current_session("wx", "c1", "astra")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("astra-sess")
+        );
+        assert_eq!(
+            store
+                .get_current_session("wx", "c1", "claude")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("claude-sess")
+        );
+    }
+}

--- a/rust/crates/astra-gateway/src/trace_model.rs
+++ b/rust/crates/astra-gateway/src/trace_model.rs
@@ -517,6 +517,18 @@ pub trait TraceRepository: Send + Sync {
     /// Returns the count of swept requests.
     async fn sweep_stale_requests(&self, reason: &str) -> TraceResult<u64>;
 
+    /// Fail all Accepted/Running requests for a specific conversation.
+    /// Used when a conversation worker exits to clean up orphaned traces.
+    async fn sweep_conversation_stale_requests(
+        &self,
+        conversation: &ConversationKey,
+        reason: &str,
+    ) -> TraceResult<u64>;
+
+    /// Force-fail a request regardless of current status (unless already terminal).
+    /// Returns `Ok(true)` if the request was transitioned, `Ok(false)` if already terminal.
+    async fn force_fail_request(&self, trace_id: &TraceId, reason: &str) -> TraceResult<bool>;
+
     async fn gateway_status(
         &self,
         conversation: &ConversationKey,
@@ -1481,6 +1493,38 @@ impl TraceRepository for MysqlTraceRepository {
         .map_err(|e| format!("sweep stale requests failed: {e}"))?;
         Ok(result.rows_affected())
     }
+
+    async fn sweep_conversation_stale_requests(
+        &self,
+        conversation: &ConversationKey,
+        reason: &str,
+    ) -> TraceResult<u64> {
+        let result = sqlx::query(
+            "UPDATE gw_trace_requests SET status = 'failed', error_message = ?, updated_at = NOW(6)
+             WHERE platform = ? AND chat_id = ? AND cli_profile = ? AND status IN ('accepted', 'running')",
+        )
+        .bind(reason)
+        .bind(conversation.platform())
+        .bind(conversation.chat_id())
+        .bind(conversation.cli_profile())
+        .execute(&self.pool)
+        .await
+        .map_err(|e| format!("sweep conversation stale requests failed: {e}"))?;
+        Ok(result.rows_affected())
+    }
+
+    async fn force_fail_request(&self, trace_id: &TraceId, reason: &str) -> TraceResult<bool> {
+        let result = sqlx::query(
+            "UPDATE gw_trace_requests SET status = 'failed', error_message = ?, updated_at = NOW(6)
+             WHERE trace_id = ? AND status IN ('accepted', 'running')",
+        )
+        .bind(reason)
+        .bind(trace_id.as_str())
+        .execute(&self.pool)
+        .await
+        .map_err(|e| format!("force fail request failed: {e}"))?;
+        Ok(result.rows_affected() > 0)
+    }
 }
 
 #[cfg(test)]
@@ -1782,6 +1826,41 @@ impl TraceRepository for InMemoryTraceRepository {
         }
         Ok(count)
     }
+
+    async fn sweep_conversation_stale_requests(
+        &self,
+        conversation: &ConversationKey,
+        reason: &str,
+    ) -> TraceResult<u64> {
+        let mut state = self.state.lock().unwrap();
+        let mut count = 0u64;
+        for (request, _) in state.requests.values_mut() {
+            if &request.conversation == conversation
+                && (request.status == RequestStatus::Accepted
+                    || request.status == RequestStatus::Running)
+            {
+                request.status = RequestStatus::Failed;
+                request.error_message = Some(reason.to_string());
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    async fn force_fail_request(&self, trace_id: &TraceId, reason: &str) -> TraceResult<bool> {
+        let mut state = self.state.lock().unwrap();
+        for (request, _) in state.requests.values_mut() {
+            if request.trace_id == *trace_id
+                && (request.status == RequestStatus::Accepted
+                    || request.status == RequestStatus::Running)
+            {
+                request.status = RequestStatus::Failed;
+                request.error_message = Some(reason.to_string());
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
 }
 
 #[cfg(test)]
@@ -2078,5 +2157,96 @@ mod tests {
         // Second sweep should return 0
         let swept2 = repo.sweep_stale_requests("again").await.unwrap();
         assert_eq!(swept2, 0);
+    }
+
+    #[tokio::test]
+    async fn sweep_conversation_stale_requests_only_affects_matching_conversation() {
+        let repo = InMemoryTraceRepository::default();
+        let conv_a = ConversationKey::new("wecom", "chat-1", "astra");
+        let conv_b = ConversationKey::new("wecom", "chat-2", "astra");
+
+        // Create requests in both conversations
+        let req_a = GatewayRequest::new(conv_a.clone(), "msg-1", "u1", "hello");
+        let req_a_id = req_a.request_id.clone();
+        TraceWriter::begin(&repo, req_a).await.unwrap();
+
+        let req_b = GatewayRequest::new(conv_b.clone(), "msg-2", "u1", "world");
+        let req_b_id = req_b.request_id.clone();
+        TraceWriter::begin(&repo, req_b).await.unwrap();
+
+        // Sweep only conv_a
+        let swept = repo
+            .sweep_conversation_stale_requests(&conv_a, "worker exited")
+            .await
+            .unwrap();
+        assert_eq!(swept, 1);
+
+        // conv_a request should be Failed
+        let r_a = repo.get_request(&req_a_id).await.unwrap().unwrap();
+        assert_eq!(r_a.status, RequestStatus::Failed);
+        assert_eq!(r_a.error_message.as_deref(), Some("worker exited"));
+
+        // conv_b request should still be Accepted
+        let r_b = repo.get_request(&req_b_id).await.unwrap().unwrap();
+        assert_eq!(r_b.status, RequestStatus::Accepted);
+    }
+
+    #[tokio::test]
+    async fn force_fail_request_transitions_running_to_failed() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wecom", "chat-1", "astra");
+
+        let req = GatewayRequest::new(conv.clone(), "msg-1", "u1", "hello");
+        let trace_id = req.trace_id.clone();
+        let req_id = req.request_id.clone();
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let _ = writer.start_run("astra", None).await.unwrap();
+
+        // Force-fail while Running
+        let result = repo
+            .force_fail_request(&trace_id, "killed by user")
+            .await
+            .unwrap();
+        assert!(result, "should return true for Running -> Failed");
+
+        let r = repo.get_request(&req_id).await.unwrap().unwrap();
+        assert_eq!(r.status, RequestStatus::Failed);
+        assert_eq!(r.error_message.as_deref(), Some("killed by user"));
+    }
+
+    #[tokio::test]
+    async fn force_fail_request_returns_false_for_terminal() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wecom", "chat-1", "astra");
+
+        let req = GatewayRequest::new(conv, "msg-1", "u1", "hello");
+        let trace_id = req.trace_id.clone();
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        writer.complete_request().await.unwrap();
+
+        // Already Completed — force_fail should return false
+        let result = repo
+            .force_fail_request(&trace_id, "too late")
+            .await
+            .unwrap();
+        assert!(!result, "should return false for already-terminal request");
+    }
+
+    #[tokio::test]
+    async fn force_fail_request_works_on_accepted() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wecom", "chat-1", "astra");
+
+        let req = GatewayRequest::new(conv, "msg-1", "u1", "hello");
+        let trace_id = req.trace_id.clone();
+        let req_id = req.request_id.clone();
+        TraceWriter::begin(&repo, req).await.unwrap();
+
+        // Force-fail while Accepted
+        let result = repo.force_fail_request(&trace_id, "killed").await.unwrap();
+        assert!(result);
+
+        let r = repo.get_request(&req_id).await.unwrap().unwrap();
+        assert_eq!(r.status, RequestStatus::Failed);
     }
 }

--- a/rust/crates/astra-gateway/src/trace_model.rs
+++ b/rust/crates/astra-gateway/src/trace_model.rs
@@ -11,6 +11,10 @@ use std::fmt;
 
 pub type TraceResult<T> = Result<T, String>;
 
+/// Maximum number of delivery attempts for an outbox entry before it is
+/// considered expired and excluded from future retries.
+pub const OUTBOX_MAX_RETRIES: u32 = 3;
+
 macro_rules! id_type {
     ($name:ident) => {
         #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -359,6 +363,7 @@ pub struct OutboxRecord {
     pub body: String,
     pub status: OutboxStatus,
     pub error_message: Option<String>,
+    pub retry_count: u32,
 }
 
 impl OutboxRecord {
@@ -380,6 +385,7 @@ impl OutboxRecord {
             body: body.into(),
             status: OutboxStatus::Pending,
             error_message: None,
+            retry_count: 0,
         }
     }
 }
@@ -930,6 +936,7 @@ pub async fn ensure_schema(pool: &MySqlPool) -> Result<(), sqlx::Error> {
             body LONGTEXT NOT NULL,
             status VARCHAR(20) NOT NULL,
             error_message TEXT,
+            retry_count INT NOT NULL DEFAULT 0,
             created_at DATETIME(6) DEFAULT NOW(6),
             sent_at DATETIME(6),
             INDEX idx_trace_outbox_pending (status, created_at),
@@ -938,6 +945,12 @@ pub async fn ensure_schema(pool: &MySqlPool) -> Result<(), sqlx::Error> {
     )
     .execute(pool)
     .await?;
+
+    // Migration: add retry_count column if missing (existing deployments)
+    let _ =
+        sqlx::query("ALTER TABLE gw_trace_outbox ADD COLUMN retry_count INT NOT NULL DEFAULT 0")
+            .execute(pool)
+            .await;
 
     Ok(())
 }
@@ -1153,8 +1166,9 @@ impl TraceRepository for MysqlTraceRepository {
             String,
             String,
             Option<String>,
+            i32,
         )> = sqlx::query_as(
-            "SELECT outbox_id, request_id, trace_id, platform, chat_id, reply_token, body, status, error_message
+            "SELECT outbox_id, request_id, trace_id, platform, chat_id, reply_token, body, status, error_message, retry_count
              FROM gw_trace_outbox WHERE outbox_id = ?",
         )
         .bind(outbox_id.as_str())
@@ -1173,6 +1187,7 @@ impl TraceRepository for MysqlTraceRepository {
                 body,
                 status,
                 error_message,
+                retry_count,
             )| OutboxRecord {
                 outbox_id: OutboxId::from(outbox_id),
                 request_id: RequestId::from(request_id),
@@ -1183,6 +1198,7 @@ impl TraceRepository for MysqlTraceRepository {
                 body,
                 status: OutboxStatus::parse(&status).unwrap_or(OutboxStatus::Failed),
                 error_message,
+                retry_count: retry_count.max(0) as u32,
             },
         ))
     }
@@ -1193,6 +1209,7 @@ impl TraceRepository for MysqlTraceRepository {
         limit: u32,
     ) -> TraceResult<Vec<OutboxRecord>> {
         let limit = limit.min(200);
+        let max_retries = OUTBOX_MAX_RETRIES as i32;
         let rows: Vec<(
             String,
             String,
@@ -1203,26 +1220,33 @@ impl TraceRepository for MysqlTraceRepository {
             String,
             String,
             Option<String>,
+            i32,
         )> = if let Some(platform) = platform {
             sqlx::query_as(
-                "SELECT outbox_id, request_id, trace_id, platform, chat_id, reply_token, body, status, error_message
+                "SELECT outbox_id, request_id, trace_id, platform, chat_id, reply_token, body, status, error_message, retry_count
                  FROM gw_trace_outbox
                  WHERE platform = ? AND status IN ('pending', 'failed')
+                   AND retry_count < ?
+                   AND created_at > DATE_SUB(NOW(6), INTERVAL 1 HOUR)
                  ORDER BY created_at ASC
                  LIMIT ?",
             )
             .bind(platform)
+            .bind(max_retries)
             .bind(limit)
             .fetch_all(&self.pool)
             .await
         } else {
             sqlx::query_as(
-                "SELECT outbox_id, request_id, trace_id, platform, chat_id, reply_token, body, status, error_message
+                "SELECT outbox_id, request_id, trace_id, platform, chat_id, reply_token, body, status, error_message, retry_count
                  FROM gw_trace_outbox
                  WHERE status IN ('pending', 'failed')
+                   AND retry_count < ?
+                   AND created_at > DATE_SUB(NOW(6), INTERVAL 1 HOUR)
                  ORDER BY created_at ASC
                  LIMIT ?",
             )
+            .bind(max_retries)
             .bind(limit)
             .fetch_all(&self.pool)
             .await
@@ -1242,6 +1266,7 @@ impl TraceRepository for MysqlTraceRepository {
                     body,
                     status,
                     error_message,
+                    retry_count,
                 )| OutboxRecord {
                     outbox_id: OutboxId::from(outbox_id),
                     request_id: RequestId::from(request_id),
@@ -1252,6 +1277,7 @@ impl TraceRepository for MysqlTraceRepository {
                     body,
                     status: OutboxStatus::parse(&status).unwrap_or(OutboxStatus::Failed),
                     error_message,
+                    retry_count: retry_count.max(0) as u32,
                 },
             )
             .collect())
@@ -1283,6 +1309,25 @@ impl TraceRepository for MysqlTraceRepository {
         if status == OutboxStatus::Sent {
             let result = sqlx::query(
                 "UPDATE gw_trace_outbox SET status = ?, error_message = ?, sent_at = NOW(6) WHERE outbox_id = ? AND status = ?",
+            )
+            .bind(status.as_str())
+            .bind(error_message)
+            .bind(outbox_id.as_str())
+            .bind(current.as_str())
+            .execute(&self.pool)
+            .await
+            .map_err(|e| format!("update outbox status failed: {e}"))?;
+            if result.rows_affected() != 1 {
+                return Err(format!(
+                    "concurrent outbox status update for {outbox_id}; expected {}",
+                    current.as_str()
+                ));
+            }
+        } else if status == OutboxStatus::Failed {
+            // Increment retry_count on failure; auto-expire if exhausted
+            let result = sqlx::query(
+                "UPDATE gw_trace_outbox SET status = ?, error_message = ?, retry_count = retry_count + 1
+                 WHERE outbox_id = ? AND status = ?",
             )
             .bind(status.as_str())
             .bind(error_message)
@@ -1433,20 +1478,23 @@ impl TraceRepository for MysqlTraceRepository {
                     CASE WHEN CHAR_LENGTH(r.text) > 120 THEN CONCAT(SUBSTRING(r.text, 1, 120), '…') ELSE r.text END,
                     CAST(r.created_at AS CHAR), r.error_message,
                     (SELECT rr.status FROM gw_trace_runs rr WHERE rr.request_id = r.request_id ORDER BY rr.started_at DESC LIMIT 1),
-                    (SELECT o.status FROM gw_trace_outbox o WHERE o.request_id = r.request_id AND o.status IN ('pending', 'failed') ORDER BY o.created_at DESC LIMIT 1),
-                    (SELECT o.error_message FROM gw_trace_outbox o WHERE o.request_id = r.request_id AND o.status IN ('pending', 'failed') ORDER BY o.created_at DESC LIMIT 1),
+                    (SELECT o.status FROM gw_trace_outbox o WHERE o.request_id = r.request_id AND o.status IN ('pending', 'failed') AND o.retry_count < ? ORDER BY o.created_at DESC LIMIT 1),
+                    (SELECT o.error_message FROM gw_trace_outbox o WHERE o.request_id = r.request_id AND o.status IN ('pending', 'failed') AND o.retry_count < ? ORDER BY o.created_at DESC LIMIT 1),
                     (SELECT COUNT(*) FROM gw_trace_events e WHERE e.trace_id = r.trace_id),
                     (SELECT e.kind FROM gw_trace_events e WHERE e.trace_id = r.trace_id ORDER BY e.event_id DESC LIMIT 1)
              FROM gw_trace_requests r
              WHERE r.platform = ? AND r.chat_id = ? AND r.cli_profile = ?
                AND (r.status IN ('accepted', 'running')
-                    OR EXISTS (SELECT 1 FROM gw_trace_outbox o WHERE o.request_id = r.request_id AND o.status IN ('pending', 'failed')))
+                    OR EXISTS (SELECT 1 FROM gw_trace_outbox o WHERE o.request_id = r.request_id AND o.status IN ('pending', 'failed') AND o.retry_count < ?))
              ORDER BY CASE r.status WHEN 'running' THEN 0 WHEN 'accepted' THEN 1 ELSE 2 END, r.created_at ASC
              LIMIT ?",
         )
+        .bind(OUTBOX_MAX_RETRIES as i32)
+        .bind(OUTBOX_MAX_RETRIES as i32)
         .bind(conversation.platform())
         .bind(conversation.chat_id())
         .bind(conversation.cli_profile())
+        .bind(OUTBOX_MAX_RETRIES as i32)
         .bind(limit.min(100))
         .fetch_all(&self.pool)
         .await
@@ -1664,6 +1712,7 @@ impl TraceRepository for InMemoryTraceRepository {
             .values()
             .filter(|outbox| {
                 matches!(outbox.status, OutboxStatus::Pending | OutboxStatus::Failed)
+                    && outbox.retry_count < OUTBOX_MAX_RETRIES
                     && platform
                         .map(|platform| outbox.platform == platform)
                         .unwrap_or(true)
@@ -1694,6 +1743,9 @@ impl TraceRepository for InMemoryTraceRepository {
         }
         outbox.status = status;
         outbox.error_message = error_message.map(str::to_string);
+        if status == OutboxStatus::Failed {
+            outbox.retry_count += 1;
+        }
         Ok(())
     }
 
@@ -1777,6 +1829,7 @@ impl TraceRepository for InMemoryTraceRepository {
                 ) || state.outbox.values().any(|outbox| {
                     outbox.request_id == request.request_id
                         && matches!(outbox.status, OutboxStatus::Pending | OutboxStatus::Failed)
+                        && outbox.retry_count < OUTBOX_MAX_RETRIES
                 })
             })
             .collect();
@@ -1804,6 +1857,7 @@ impl TraceRepository for InMemoryTraceRepository {
                     .find(|outbox| {
                         outbox.request_id == request.request_id
                             && matches!(outbox.status, OutboxStatus::Pending | OutboxStatus::Failed)
+                            && outbox.retry_count < OUTBOX_MAX_RETRIES
                     })
                     .cloned();
                 let request_events: Vec<_> = state
@@ -2340,5 +2394,119 @@ mod tests {
 
         let r = repo.get_request(&req_id).await.unwrap().unwrap();
         assert_eq!(r.status, RequestStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn outbox_retry_count_increments_and_stops_retrying() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wecom", "chat-1", "astra");
+        let req = GatewayRequest::new(conv.clone(), "msg-1", "u1", "hello");
+        let request_id = req.request_id.clone();
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let run_id = writer.start_run("astra", None).await.unwrap();
+        writer
+            .finish_run(&run_id, RunStatus::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+        let outbox_id = writer
+            .enqueue_outbox("wecom", "chat-1", None, "retry body")
+            .await
+            .unwrap();
+
+        // Fail it OUTBOX_MAX_RETRIES times
+        for i in 0..OUTBOX_MAX_RETRIES {
+            // Before exhaustion, it should still be retryable
+            let retryable = repo.list_retryable_outbox(Some("wecom"), 10).await.unwrap();
+            assert_eq!(
+                retryable.len(),
+                1,
+                "should be retryable before exhaustion (attempt {i})"
+            );
+
+            writer
+                .mark_outbox_failed(&outbox_id, &format!("error attempt {i}"), 0)
+                .await
+                .unwrap();
+        }
+
+        // After max retries, retry_count == OUTBOX_MAX_RETRIES
+        let outbox = repo.get_outbox(&outbox_id).await.unwrap().unwrap();
+        assert_eq!(outbox.retry_count, OUTBOX_MAX_RETRIES);
+        assert_eq!(outbox.status, OutboxStatus::Failed);
+
+        // Should no longer appear in retryable list
+        let retryable = repo.list_retryable_outbox(Some("wecom"), 10).await.unwrap();
+        assert!(
+            retryable.is_empty(),
+            "should stop retrying after max retries"
+        );
+
+        // Should also not appear in active requests (request is completed via run)
+        let active = repo.list_active_requests(&conv, 10).await.unwrap();
+        let has_outbox_retrying = active
+            .iter()
+            .any(|r| r.request_id == request_id && r.outbox_status == Some(OutboxStatus::Failed));
+        assert!(
+            !has_outbox_retrying,
+            "exhausted outbox should not show as retrying in active requests"
+        );
+    }
+
+    #[tokio::test]
+    async fn outbox_retry_count_resets_on_successful_send() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wecom", "chat-1", "astra");
+        let req = GatewayRequest::new(conv, "msg-1", "u1", "hello");
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let run_id = writer.start_run("astra", None).await.unwrap();
+        writer
+            .finish_run(&run_id, RunStatus::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+        let outbox_id = writer
+            .enqueue_outbox("wecom", "chat-1", None, "body")
+            .await
+            .unwrap();
+
+        // Fail twice (below max)
+        writer
+            .mark_outbox_failed(&outbox_id, "error 1", 0)
+            .await
+            .unwrap();
+        writer
+            .mark_outbox_failed(&outbox_id, "error 2", 0)
+            .await
+            .unwrap();
+
+        // Should still be retryable
+        let retryable = repo.list_retryable_outbox(Some("wecom"), 10).await.unwrap();
+        assert_eq!(retryable.len(), 1);
+
+        // Successfully send
+        writer.mark_outbox_sent(&outbox_id, 1).await.unwrap();
+
+        // Should no longer be retryable (status is Sent)
+        let retryable = repo.list_retryable_outbox(Some("wecom"), 10).await.unwrap();
+        assert!(retryable.is_empty());
+    }
+
+    #[tokio::test]
+    async fn outbox_new_entry_has_zero_retry_count() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wecom", "chat-1", "astra");
+        let req = GatewayRequest::new(conv, "msg-1", "u1", "hello");
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let run_id = writer.start_run("astra", None).await.unwrap();
+        writer
+            .finish_run(&run_id, RunStatus::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+        let outbox_id = writer
+            .enqueue_outbox("wecom", "chat-1", None, "body")
+            .await
+            .unwrap();
+
+        let outbox = repo.get_outbox(&outbox_id).await.unwrap().unwrap();
+        assert_eq!(outbox.retry_count, 0);
     }
 }

--- a/rust/crates/astra-gateway/src/trace_model.rs
+++ b/rust/crates/astra-gateway/src/trace_model.rs
@@ -833,7 +833,11 @@ impl<'a> TraceWriter<'a> {
             }),
         )
         .await?;
-        self.complete_request().await
+        // Try to mark request completed, but ignore failures — the request
+        // may already be in a terminal state (e.g. failed by startup sweep)
+        // and the outbox delivery still succeeded.
+        let _ = self.complete_request().await;
+        Ok(())
     }
 
     pub async fn mark_outbox_failed(
@@ -2876,5 +2880,41 @@ mod tests {
 
         let outbox = repo.get_outbox(&outbox_id).await.unwrap().unwrap();
         assert_eq!(outbox.retry_count, 0);
+    }
+
+    #[tokio::test]
+    async fn mark_outbox_sent_succeeds_when_request_already_failed() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req = GatewayRequest::new(conv.clone(), "m1", "u1", "test");
+        let req_id = req.request_id.clone();
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let run_id = writer.start_run("astra", None).await.unwrap();
+        writer
+            .finish_run(&run_id, RunStatus::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+        let outbox_id = writer
+            .enqueue_outbox("wx", "c1", None, "hello")
+            .await
+            .unwrap();
+
+        // Simulate startup sweep: force request to failed (as sweep_stale_requests does)
+        repo.update_request_status(&req_id, RequestStatus::Failed, Some("gateway restarted"))
+            .await
+            .unwrap();
+        let r = repo.get_request(&req_id).await.unwrap().unwrap();
+        assert_eq!(r.status, RequestStatus::Failed);
+
+        // Now outbox replay delivers successfully — mark_outbox_sent must NOT fail
+        writer.mark_outbox_sent(&outbox_id, 1).await.unwrap();
+
+        // Outbox is marked sent
+        let outbox = repo.get_outbox(&outbox_id).await.unwrap().unwrap();
+        assert_eq!(outbox.status, OutboxStatus::Sent);
+
+        // Request stays failed (terminal state unchanged — that's correct)
+        let r = repo.get_request(&req_id).await.unwrap().unwrap();
+        assert_eq!(r.status, RequestStatus::Failed);
     }
 }

--- a/rust/crates/astra-gateway/src/trace_model.rs
+++ b/rust/crates/astra-gateway/src/trace_model.rs
@@ -1229,9 +1229,8 @@ impl TraceRepository for MysqlTraceRepository {
             sqlx::query_as(
                 "SELECT outbox_id, request_id, trace_id, platform, chat_id, reply_token, body, status, error_message, retry_count
                  FROM gw_trace_outbox
-                 WHERE platform = ? AND status IN ('pending', 'failed')
-                   AND retry_count < ?
-                   AND created_at > DATE_SUB(NOW(6), INTERVAL 1 HOUR)
+                  WHERE platform = ? AND status IN ('pending', 'failed')
+                    AND retry_count < ?
                  ORDER BY created_at ASC
                  LIMIT ?",
             )
@@ -1244,9 +1243,8 @@ impl TraceRepository for MysqlTraceRepository {
             sqlx::query_as(
                 "SELECT outbox_id, request_id, trace_id, platform, chat_id, reply_token, body, status, error_message, retry_count
                  FROM gw_trace_outbox
-                 WHERE status IN ('pending', 'failed')
-                   AND retry_count < ?
-                   AND created_at > DATE_SUB(NOW(6), INTERVAL 1 HOUR)
+                  WHERE status IN ('pending', 'failed')
+                    AND retry_count < ?
                  ORDER BY created_at ASC
                  LIMIT ?",
             )
@@ -1293,13 +1291,13 @@ impl TraceRepository for MysqlTraceRepository {
         status: OutboxStatus,
         error_message: Option<&str>,
     ) -> TraceResult<()> {
-        let current: Option<(String,)> =
-            sqlx::query_as("SELECT status FROM gw_trace_outbox WHERE outbox_id = ?")
+        let current: Option<(String, i32)> =
+            sqlx::query_as("SELECT status, retry_count FROM gw_trace_outbox WHERE outbox_id = ?")
                 .bind(outbox_id.as_str())
                 .fetch_optional(&self.pool)
                 .await
                 .map_err(|e| format!("load outbox status failed: {e}"))?;
-        let Some((current,)) = current else {
+        let Some((current, retry_count)) = current else {
             return Err(format!("outbox {outbox_id} not found"));
         };
         let current = OutboxStatus::parse(&current).unwrap_or(OutboxStatus::Failed);
@@ -1328,15 +1326,21 @@ impl TraceRepository for MysqlTraceRepository {
                 ));
             }
         } else if status == OutboxStatus::Failed {
+            if retry_count >= OUTBOX_MAX_RETRIES as i32 {
+                return Err(format!(
+                    "outbox {outbox_id} retry limit reached ({OUTBOX_MAX_RETRIES})"
+                ));
+            }
             // Increment retry_count on failure; auto-expire if exhausted
             let result = sqlx::query(
                 "UPDATE gw_trace_outbox SET status = ?, error_message = ?, retry_count = retry_count + 1
-                 WHERE outbox_id = ? AND status = ?",
+                 WHERE outbox_id = ? AND status = ? AND retry_count < ?",
             )
             .bind(status.as_str())
             .bind(error_message)
             .bind(outbox_id.as_str())
             .bind(current.as_str())
+            .bind(OUTBOX_MAX_RETRIES as i32)
             .execute(&self.pool)
             .await
             .map_err(|e| format!("update outbox status failed: {e}"))?;
@@ -1743,6 +1747,11 @@ impl TraceRepository for InMemoryTraceRepository {
                 "invalid outbox transition {} -> {}",
                 outbox.status.as_str(),
                 status.as_str()
+            ));
+        }
+        if status == OutboxStatus::Failed && outbox.retry_count >= OUTBOX_MAX_RETRIES {
+            return Err(format!(
+                "outbox {outbox_id} retry limit reached ({OUTBOX_MAX_RETRIES})"
             ));
         }
         outbox.status = status;
@@ -2453,6 +2462,44 @@ mod tests {
         assert!(
             !has_outbox_retrying,
             "exhausted outbox should not show as retrying in active requests"
+        );
+    }
+
+    #[tokio::test]
+    async fn exhausted_outbox_rejects_additional_failures() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wecom", "chat-1", "astra");
+        let req = GatewayRequest::new(conv, "msg-1", "u1", "hello");
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let outbox_id = writer
+            .enqueue_outbox("wecom", "chat-1", None, "retry body")
+            .await
+            .unwrap();
+
+        for i in 0..OUTBOX_MAX_RETRIES {
+            writer
+                .mark_outbox_failed(&outbox_id, &format!("error attempt {i}"), 0)
+                .await
+                .unwrap();
+        }
+
+        let err = writer
+            .mark_outbox_failed(&outbox_id, "one too many", 0)
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("retry limit"),
+            "unexpected exhausted outbox error: {err}"
+        );
+    }
+
+    #[test]
+    fn mysql_retryable_outbox_query_has_no_one_hour_expiry() {
+        let source = include_str!("trace_model.rs");
+        let needle = concat!("INTERVAL ", "1 HOUR");
+        assert!(
+            !source.contains(needle),
+            "retryable outbox must not silently expire valid retries by age"
         );
     }
 

--- a/rust/crates/astra-gateway/src/trace_model.rs
+++ b/rust/crates/astra-gateway/src/trace_model.rs
@@ -2452,6 +2452,374 @@ mod tests {
         );
     }
 
+    // ── GAP 1: gateway_status aggregation ─────────────────────────
+
+    #[tokio::test]
+    async fn gateway_status_aggregates_correctly() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+
+        // Empty status
+        let status = repo.gateway_status(&conv).await.unwrap();
+        assert_eq!(status.queued_count, 0);
+        assert_eq!(status.running_count, 0);
+        assert_eq!(status.active_count, 0);
+        assert_eq!(status.recent_trace_count, 0);
+        assert!(status.last_trace.is_none());
+
+        // Add an Accepted request (counts as "queued")
+        let req1 = GatewayRequest::new(conv.clone(), "m1", "u1", "hello");
+        let writer1 = TraceWriter::begin(&repo, req1).await.unwrap();
+
+        let status = repo.gateway_status(&conv).await.unwrap();
+        assert_eq!(status.queued_count, 1);
+        assert_eq!(status.running_count, 0);
+        assert_eq!(status.active_count, 1);
+        assert_eq!(status.recent_trace_count, 1);
+        assert!(status.last_trace.is_some());
+
+        // Move to Running via start_run (which updates status)
+        let _run_id = writer1.start_run("astra", None).await.unwrap();
+        let status = repo.gateway_status(&conv).await.unwrap();
+        assert_eq!(status.queued_count, 0);
+        assert_eq!(status.running_count, 1);
+
+        // Add another Accepted request
+        let req2 = GatewayRequest::new(conv.clone(), "m2", "u1", "world");
+        TraceWriter::begin(&repo, req2).await.unwrap();
+
+        let status = repo.gateway_status(&conv).await.unwrap();
+        assert_eq!(status.queued_count, 1);
+        assert_eq!(status.running_count, 1);
+        assert_eq!(status.active_count, 2);
+        assert_eq!(status.recent_trace_count, 2);
+    }
+
+    #[tokio::test]
+    async fn gateway_status_counts_outbox_states() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+
+        let req = GatewayRequest::new(conv.clone(), "m1", "u1", "outbox test");
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let run_id = writer.start_run("astra", None).await.unwrap();
+        writer
+            .finish_run(&run_id, RunStatus::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+
+        // Enqueue outbox -> pending
+        let outbox_id = writer
+            .enqueue_outbox("wx", "c1", None, "reply body")
+            .await
+            .unwrap();
+
+        let status = repo.gateway_status(&conv).await.unwrap();
+        assert_eq!(status.pending_outbox_count, 1);
+        assert_eq!(status.retrying_outbox_count, 0);
+
+        // Fail outbox -> retrying
+        writer
+            .mark_outbox_failed(&outbox_id, "send error", 0)
+            .await
+            .unwrap();
+        let status = repo.gateway_status(&conv).await.unwrap();
+        assert_eq!(status.retrying_outbox_count, 1);
+        assert_eq!(status.pending_outbox_count, 0);
+    }
+
+    // ── GAP 2: full request lifecycle chain ──────────────────────
+
+    #[tokio::test]
+    async fn full_request_lifecycle_begin_to_complete() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req = GatewayRequest::new(conv.clone(), "m1", "u1", "do something");
+        let trace_id = req.trace_id.clone();
+        let req_id = req.request_id.clone();
+
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+
+        // Initially Accepted
+        let r = repo.get_request(&req_id).await.unwrap().unwrap();
+        assert_eq!(r.status, RequestStatus::Accepted);
+
+        // Start and finish a run (transitions to Running, then we complete)
+        let run_id = writer
+            .start_run("astra", Some("session-1".into()))
+            .await
+            .unwrap();
+        let r = repo.get_request(&req_id).await.unwrap().unwrap();
+        assert_eq!(r.status, RequestStatus::Running);
+
+        writer
+            .finish_run(&run_id, RunStatus::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+
+        // Complete
+        writer.complete_request().await.unwrap();
+        let r = repo.get_request(&req_id).await.unwrap().unwrap();
+        assert_eq!(r.status, RequestStatus::Completed);
+
+        // Verify events recorded
+        let events = repo.list_events_for_trace(&trace_id, 50).await.unwrap();
+        assert!(
+            events.len() >= 4,
+            "should have received, run_started, run_completed, request_completed; got {}",
+            events.len()
+        );
+        let kinds: Vec<_> = events.iter().map(|e| e.kind).collect();
+        assert!(kinds.contains(&GatewayEventKind::RequestReceived));
+        assert!(kinds.contains(&GatewayEventKind::RunStarted));
+        assert!(kinds.contains(&GatewayEventKind::RunCompleted));
+        assert!(kinds.contains(&GatewayEventKind::RequestCompleted));
+    }
+
+    #[tokio::test]
+    async fn full_request_lifecycle_with_failure() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req = GatewayRequest::new(conv.clone(), "m1", "u1", "fail me");
+        let req_id = req.request_id.clone();
+        let trace_id = req.trace_id.clone();
+
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let run_id = writer.start_run("astra", None).await.unwrap();
+        writer
+            .finish_run(&run_id, RunStatus::Failed, Some(1), Some("CLI error"))
+            .await
+            .unwrap();
+        writer.fail_request("something broke").await.unwrap();
+
+        let r = repo.get_request(&req_id).await.unwrap().unwrap();
+        assert_eq!(r.status, RequestStatus::Failed);
+        assert_eq!(r.error_message.as_deref(), Some("something broke"));
+
+        let events = repo.list_events_for_trace(&trace_id, 50).await.unwrap();
+        let kinds: Vec<_> = events.iter().map(|e| e.kind).collect();
+        assert!(kinds.contains(&GatewayEventKind::RunFailed));
+        assert!(kinds.contains(&GatewayEventKind::RequestFailed));
+    }
+
+    // ── GAP 5: cancel_accepted_request coverage ─────────────────
+
+    #[tokio::test]
+    async fn cancel_accepted_request_transitions_to_cancelled() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req = GatewayRequest::new(conv.clone(), "m1", "u1", "cancel me");
+        let req_id = req.request_id.clone();
+        TraceWriter::begin(&repo, req).await.unwrap();
+
+        match repo
+            .cancel_accepted_request(&conv, req_id.as_str(), "user cancelled")
+            .await
+            .unwrap()
+        {
+            CancelRequestOutcome::Cancelled(row) => {
+                assert_eq!(row.request_id, req_id);
+                assert_eq!(row.status, RequestStatus::Failed);
+                assert_eq!(row.error_message.as_deref(), Some("user cancelled"));
+            }
+            other => panic!("expected Cancelled, got {:?}", other),
+        }
+
+        // Verify underlying request was updated
+        let r = repo.get_request(&req_id).await.unwrap().unwrap();
+        assert_eq!(r.status, RequestStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn cancel_running_request_returns_already_running() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req = GatewayRequest::new(conv.clone(), "m1", "u1", "running");
+        let req_id = req.request_id.clone();
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        // Use start_run to actually transition status to Running
+        let _run_id = writer.start_run("astra", None).await.unwrap();
+
+        match repo
+            .cancel_accepted_request(&conv, req_id.as_str(), "user cancelled")
+            .await
+            .unwrap()
+        {
+            CancelRequestOutcome::AlreadyRunning(row) => {
+                assert_eq!(row.request_id, req_id);
+                assert_eq!(row.status, RequestStatus::Running);
+            }
+            other => panic!("expected AlreadyRunning, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_nonexistent_returns_not_found() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        match repo
+            .cancel_accepted_request(&conv, "nonexistent", "reason")
+            .await
+            .unwrap()
+        {
+            CancelRequestOutcome::NotFound => {}
+            other => panic!("expected NotFound, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_completed_request_returns_not_found() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req = GatewayRequest::new(conv.clone(), "m1", "u1", "done");
+        let req_id = req.request_id.clone();
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        writer.complete_request().await.unwrap();
+
+        // Completed requests are not in active list, so cancel returns NotFound
+        match repo
+            .cancel_accepted_request(&conv, req_id.as_str(), "too late")
+            .await
+            .unwrap()
+        {
+            CancelRequestOutcome::NotFound => {}
+            other => panic!("expected NotFound for completed request, got {:?}", other),
+        }
+    }
+
+    // ── GAP 6: list_recent_traces ────────────────────────────────
+
+    #[tokio::test]
+    async fn list_recent_traces_returns_newest_first() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+
+        let req1 = GatewayRequest::new(conv.clone(), "m1", "u1", "first");
+        let trace1 = req1.trace_id.clone();
+        TraceWriter::begin(&repo, req1).await.unwrap();
+
+        let req2 = GatewayRequest::new(conv.clone(), "m2", "u1", "second");
+        let trace2 = req2.trace_id.clone();
+        TraceWriter::begin(&repo, req2).await.unwrap();
+
+        let traces = repo.list_recent_traces(&conv, 10).await.unwrap();
+        assert_eq!(traces.len(), 2);
+        // Newest first
+        assert_eq!(traces[0].trace_id, trace2);
+        assert_eq!(traces[1].trace_id, trace1);
+    }
+
+    #[tokio::test]
+    async fn list_recent_traces_respects_limit() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+
+        for i in 0..5 {
+            let req = GatewayRequest::new(conv.clone(), format!("m{i}"), "u1", format!("msg {i}"));
+            TraceWriter::begin(&repo, req).await.unwrap();
+        }
+
+        let traces = repo.list_recent_traces(&conv, 3).await.unwrap();
+        assert_eq!(traces.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn list_recent_traces_filters_by_conversation() {
+        let repo = InMemoryTraceRepository::default();
+        let conv_a = ConversationKey::new("wx", "c1", "astra");
+        let conv_b = ConversationKey::new("wx", "c2", "astra");
+
+        TraceWriter::begin(
+            &repo,
+            GatewayRequest::new(conv_a.clone(), "m1", "u1", "in conv_a"),
+        )
+        .await
+        .unwrap();
+        TraceWriter::begin(
+            &repo,
+            GatewayRequest::new(conv_b.clone(), "m2", "u1", "in conv_b"),
+        )
+        .await
+        .unwrap();
+
+        let traces_a = repo.list_recent_traces(&conv_a, 10).await.unwrap();
+        assert_eq!(traces_a.len(), 1);
+        assert_eq!(traces_a[0].text_preview, "in conv_a");
+
+        let traces_b = repo.list_recent_traces(&conv_b, 10).await.unwrap();
+        assert_eq!(traces_b.len(), 1);
+        assert_eq!(traces_b[0].text_preview, "in conv_b");
+    }
+
+    // ── GAP 7: outbox enqueue → send → complete chain ────────────
+
+    #[tokio::test]
+    async fn outbox_enqueue_send_completes_request() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req = GatewayRequest::new(conv.clone(), "m1", "u1", "test");
+        let req_id = req.request_id.clone();
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let run_id = writer.start_run("astra", None).await.unwrap();
+        writer
+            .finish_run(&run_id, RunStatus::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+
+        // Enqueue outbox
+        let outbox_id = writer
+            .enqueue_outbox("wx", "c1", None, "hello world")
+            .await
+            .unwrap();
+
+        // Verify it appears in retryable list (status: pending)
+        let retryable = repo.list_retryable_outbox(Some("wx"), 10).await.unwrap();
+        assert_eq!(retryable.len(), 1);
+        assert_eq!(retryable[0].body, "hello world");
+
+        // Send successfully (mark_outbox_sent also calls complete_request)
+        writer.mark_outbox_sent(&outbox_id, 1).await.unwrap();
+
+        // No longer retryable
+        let retryable = repo.list_retryable_outbox(Some("wx"), 10).await.unwrap();
+        assert!(retryable.is_empty());
+
+        // Request should be completed
+        let r = repo.get_request(&req_id).await.unwrap().unwrap();
+        assert_eq!(r.status, RequestStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn outbox_platform_filter_works() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wx", "c1", "astra");
+        let req = GatewayRequest::new(conv.clone(), "m1", "u1", "test");
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let run_id = writer.start_run("astra", None).await.unwrap();
+        writer
+            .finish_run(&run_id, RunStatus::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+        writer
+            .enqueue_outbox("wx", "c1", None, "wx msg")
+            .await
+            .unwrap();
+
+        // Filter by platform
+        let wx = repo.list_retryable_outbox(Some("wx"), 10).await.unwrap();
+        assert_eq!(wx.len(), 1);
+
+        let telegram = repo
+            .list_retryable_outbox(Some("telegram"), 10)
+            .await
+            .unwrap();
+        assert!(telegram.is_empty());
+
+        // No filter returns all
+        let all = repo.list_retryable_outbox(None, 10).await.unwrap();
+        assert_eq!(all.len(), 1);
+    }
+
     #[tokio::test]
     async fn outbox_retry_count_resets_on_successful_send() {
         let repo = InMemoryTraceRepository::default();

--- a/rust/crates/astra-gateway/src/trace_model.rs
+++ b/rust/crates/astra-gateway/src/trace_model.rs
@@ -529,6 +529,10 @@ pub trait TraceRepository: Send + Sync {
     /// Returns `Ok(true)` if the request was transitioned, `Ok(false)` if already terminal.
     async fn force_fail_request(&self, trace_id: &TraceId, reason: &str) -> TraceResult<bool>;
 
+    /// Dismiss all failed outbox entries for a request by marking them as `sent`.
+    /// Used by `/retry dismiss` to clear stuck outbox entries without re-sending.
+    async fn dismiss_failed_outbox(&self, request_id: &RequestId) -> TraceResult<()>;
+
     async fn gateway_status(
         &self,
         conversation: &ConversationKey,
@@ -1525,6 +1529,18 @@ impl TraceRepository for MysqlTraceRepository {
         .map_err(|e| format!("force fail request failed: {e}"))?;
         Ok(result.rows_affected() > 0)
     }
+
+    async fn dismiss_failed_outbox(&self, request_id: &RequestId) -> TraceResult<()> {
+        sqlx::query(
+            "UPDATE gw_trace_outbox SET status = 'sent', sent_at = NOW(6)
+             WHERE request_id = ? AND status = 'failed'",
+        )
+        .bind(request_id.as_str())
+        .execute(&self.pool)
+        .await
+        .map_err(|e| format!("dismiss failed outbox failed: {e}"))?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -1860,6 +1876,17 @@ impl TraceRepository for InMemoryTraceRepository {
             }
         }
         Ok(false)
+    }
+
+    async fn dismiss_failed_outbox(&self, request_id: &RequestId) -> TraceResult<()> {
+        let mut state = self.state.lock().unwrap();
+        for outbox in state.outbox.values_mut() {
+            if outbox.request_id == *request_id && outbox.status == OutboxStatus::Failed {
+                outbox.status = OutboxStatus::Sent;
+                outbox.error_message = None;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -2230,6 +2257,71 @@ mod tests {
             .await
             .unwrap();
         assert!(!result, "should return false for already-terminal request");
+    }
+
+    #[tokio::test]
+    async fn dismiss_failed_outbox_marks_as_sent() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wecom", "chat-1", "astra");
+        let req = GatewayRequest::new(conv, "msg-1", "u1", "hello");
+        let request_id = req.request_id.clone();
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let run_id = writer.start_run("astra", None).await.unwrap();
+        writer
+            .finish_run(&run_id, RunStatus::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+        let outbox_id = writer
+            .enqueue_outbox("wecom", "chat-1", None, "reply body")
+            .await
+            .unwrap();
+
+        // Mark outbox as failed
+        writer
+            .mark_outbox_failed(&outbox_id, "send error", 0)
+            .await
+            .unwrap();
+        assert_eq!(
+            repo.get_outbox(&outbox_id).await.unwrap().unwrap().status,
+            OutboxStatus::Failed
+        );
+
+        // Dismiss it
+        repo.dismiss_failed_outbox(&request_id).await.unwrap();
+        let outbox = repo.get_outbox(&outbox_id).await.unwrap().unwrap();
+        assert_eq!(outbox.status, OutboxStatus::Sent);
+        assert!(outbox.error_message.is_none());
+
+        // Should no longer appear in retryable list
+        assert!(
+            repo.list_retryable_outbox(Some("wecom"), 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn dismiss_failed_outbox_ignores_non_failed() {
+        let repo = InMemoryTraceRepository::default();
+        let conv = ConversationKey::new("wecom", "chat-1", "astra");
+        let req = GatewayRequest::new(conv, "msg-1", "u1", "hello");
+        let request_id = req.request_id.clone();
+        let writer = TraceWriter::begin(&repo, req).await.unwrap();
+        let run_id = writer.start_run("astra", None).await.unwrap();
+        writer
+            .finish_run(&run_id, RunStatus::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+        let outbox_id = writer
+            .enqueue_outbox("wecom", "chat-1", None, "pending body")
+            .await
+            .unwrap();
+
+        // Outbox is Pending, not Failed — dismiss should not change it
+        repo.dismiss_failed_outbox(&request_id).await.unwrap();
+        let outbox = repo.get_outbox(&outbox_id).await.unwrap().unwrap();
+        assert_eq!(outbox.status, OutboxStatus::Pending);
     }
 
     #[tokio::test]

--- a/rust/crates/astra-gateway/tests/durable_task_e2e.rs
+++ b/rust/crates/astra-gateway/tests/durable_task_e2e.rs
@@ -5,6 +5,7 @@
 
 use astra_core::durable_task_store::*;
 use astra_gateway::durable_task_store::MysqlDurableTaskStore;
+use astra_gateway::store::{GatewayStore, mysql::MysqlGatewayStore};
 
 async fn setup() -> MysqlDurableTaskStore {
     let url = "mysql://root:111@127.0.0.1:6001/astra_gateway";
@@ -13,9 +14,8 @@ async fn setup() -> MysqlDurableTaskStore {
         .connect(url)
         .await
         .expect("DB connection failed — is MatrixOne running?");
-    astra_gateway::storage::ensure_schema(&pool)
-        .await
-        .expect("schema setup failed");
+    let store = MysqlGatewayStore::new(pool.clone());
+    store.ensure_schema().await.expect("schema setup failed");
     MysqlDurableTaskStore::new(pool)
 }
 
@@ -343,26 +343,22 @@ async fn context_token_persist_and_restore() {
         .connect(url)
         .await
         .unwrap();
-    astra_gateway::storage::ensure_schema(&pool).await.unwrap();
+    let store = MysqlGatewayStore::new(pool);
+    store.ensure_schema().await.unwrap();
 
     // Save context tokens
     let tokens = serde_json::json!({
         "user_a": "token_aaa",
         "user_b": "token_bbb",
     });
-    astra_gateway::storage::save_credential(
-        &pool,
-        "weixin",
-        "default",
-        "context_tokens",
-        &tokens,
-        None,
-    )
-    .await
-    .unwrap();
+    store
+        .save_credential("weixin", "default", "context_tokens", &tokens, None)
+        .await
+        .unwrap();
 
     // Restore
-    let cred = astra_gateway::storage::get_credential(&pool, "weixin", "default", "context_tokens")
+    let cred = store
+        .get_credential("weixin", "default", "context_tokens")
         .await
         .unwrap()
         .unwrap();
@@ -375,22 +371,16 @@ async fn context_token_persist_and_restore() {
         "user_a": "token_aaa_updated",
         "user_c": "token_ccc",
     });
-    astra_gateway::storage::save_credential(
-        &pool,
-        "weixin",
-        "default",
-        "context_tokens",
-        &tokens2,
-        None,
-    )
-    .await
-    .unwrap();
+    store
+        .save_credential("weixin", "default", "context_tokens", &tokens2, None)
+        .await
+        .unwrap();
 
-    let cred2 =
-        astra_gateway::storage::get_credential(&pool, "weixin", "default", "context_tokens")
-            .await
-            .unwrap()
-            .unwrap();
+    let cred2 = store
+        .get_credential("weixin", "default", "context_tokens")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(cred2.credentials["user_a"], "token_aaa_updated");
     assert_eq!(cred2.credentials["user_c"], "token_ccc");
     // user_b gone (full replacement)

--- a/rust/crates/astra-gateway/tests/e2e_cli_bridge.rs
+++ b/rust/crates/astra-gateway/tests/e2e_cli_bridge.rs
@@ -242,6 +242,7 @@ async fn e2e_astra_append_system_prompt_canary() {
         None,
         None,
         Some(&system_prompt),
+        None,
     )
     .await
     .expect("astra should succeed");
@@ -270,6 +271,7 @@ async fn e2e_claude_append_system_prompt_canary() {
         None,
         None,
         Some(&system_prompt),
+        None,
     )
     .await
     .expect("claude should succeed");
@@ -300,6 +302,7 @@ Do it NOW for the user's request."#;
         None,
         None,
         Some(system_prompt),
+        None,
     )
     .await
     .expect("astra should succeed");
@@ -327,6 +330,7 @@ async fn e2e_astra_task_list_via_agent() {
         None,
         None,
         Some(system),
+        None,
     )
     .await
     .expect("should succeed");
@@ -353,6 +357,7 @@ Do it now."#;
         None,
         None,
         Some(system),
+        None,
     )
     .await
     .expect("should succeed");
@@ -379,6 +384,7 @@ Do it now for the user's request."#;
         None,
         None,
         Some(system),
+        None,
     )
     .await
     .expect("should succeed");

--- a/rust/crates/core/src/config.rs
+++ b/rust/crates/core/src/config.rs
@@ -271,12 +271,12 @@ impl JwtSettings {
             access_token_expire_minutes: parse_or_default(
                 lookup,
                 "ASTRA_JWT_ACCESS_TTL_MINUTES",
-                10080_u32, // 1 week (was 60 min — too short for dev/harness use)
+                10080_u32, // 7 days (was 60 min — too short for dev/harness use)
             )?,
             refresh_token_expire_days: parse_or_default(
                 lookup,
                 "ASTRA_JWT_REFRESH_TTL_DAYS",
-                7_u32,
+                30_u32, // 30 days — must be longer than access token for refresh to work
             )?,
         })
     }
@@ -593,7 +593,7 @@ mod tests {
 
         assert_eq!(settings.jwt.algorithm, "HS256");
         assert_eq!(settings.jwt.access_token_expire_minutes, 10080);
-        assert_eq!(settings.jwt.refresh_token_expire_days, 7);
+        assert_eq!(settings.jwt.refresh_token_expire_days, 30);
         assert_eq!(settings.jwt.secret_key.len(), 32);
         assert!(
             settings


### PR DESCRIPTION
## Summary

Epic enhancement of the gateway product experience across 6 dimensions: storage abstraction, task management, workspace UX, onboarding, CLI selection, and reliability hardening.

### Storage Abstraction (Phase 1)
- **GatewayStore trait** with 29 methods covering users, sessions, cron, credentials, usage
- **3 backends**: MySQL (production), SQLite (zero-config default), File (zero-dependency)
- `StorageConfig` enum with backward-compatible config (`database:` still works)
- `StoreBundle` factory pattern for one-shot initialization
- Old `storage.rs`/`usage.rs` removed from compilation; WeiXin migrated to trait

### Task Management & Reliability (Phase 2)
- **Task reconciliation**: fix silent None returns, sweep stale traces on worker exit, periodic reconciliation
- **`/kill` command**: force-terminate running requests (with auto-pick and fuzzy text match)
- **`/retry` command**: view and dismiss stuck outbox deliveries
- **Outbox retry limit**: `retry_count` column, max 3 retries, 1-hour age expiry
- **Progressive stats footer**: no longer goes through durable outbox (eliminates retry storms)
- **Channel drain**: flush progressive chunks accumulated during pending message replay

### UX Enhancements (Phases 3-6)
- **`/ws ls`** and **`/ws <name>`**: project listing and fuzzy name-based workspace switching
- **First-time onboarding**: auto-welcome message with key commands
- **CLI auto-detection**: probe all CLIs at startup, auto-select first available
- **`/gateway` command**: comprehensive context dump (identity, capabilities, commands, actions)
- **`/manage` command**: AI-assisted task management — feeds full operational context to CLI agent
- **Numbered task index**: `/running` shows `[1] [2]`, `/kill 1` `/cancel 2` by index
- **Request tags**: `[#A7:1]` `[#A7:2]` prefix on all outbound messages for request correlation

### Auth & WeChat Reliability
- **Shared access token**: gateway caches one token, injects via `ASTRA_ACCESS_TOKEN` env var — eliminates per-message auth round-trip
- **Auth circuit breaker**: stops CLI spawns after 2 consecutive auth failures, 5-min cooldown
- **`/auth` command**: reset circuit breaker + auto-relogin if username/password configured
- **Auto-relogin**: calls `/auth/login` API when token expires, writes to `~/.astra/credentials.json`
- **Refresh token TTL**: 7d → 30d (was same as access token, making refresh impossible)
- **WeChat context_token**: refresh from send response, no longer dropped on `-2` errors
- **`classify_send_error`**: pure function with 7 regression tests for iLink error handling
- **Think tag streaming**: `ThinkTagStreamFilter` handles `<think>` split across token boundaries
- **Tool status flood fix**: tool started/done no longer trigger separate messages

## Test plan

- [x] `make check` — format + lint + type checks (full workspace)
- [x] 495 unit tests pass (`cargo test -p astra-gateway --lib`)
- [x] Cross-backend compliance test (SQLite + File run identical 29-method assertions)
- [x] Key regression tests: `-2` error handling, outbox retry exhaustion, terminal state tolerance
- [x] Integration tests compile (`cargo clippy --tests`)
- [ ] Manual: deploy with `storage: { backend: sqlite }`, verify /status, /ws, /gateway
- [ ] Manual: verify WeChat send succeeds with request tags visible
- [ ] Manual: verify `/manage` feeds context to CLI and executes GATEWAY tags

