### PR TITLE
fix(gateway): prevent duplicate starts and mysql seed failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ dev-deps-wait:
 .PHONY: dev-db-connect
 dev-db-connect:
 	@set -a; [ -f .env ] && . ./.env; set +a; \
-	mysql -h$${MATRIXONE_HOST:-127.0.0.1} -P$${MATRIXONE_PORT:-6001} -u$${MATRIXONE_USER:-root} -p$${MATRIXONE_PASSWORD:-111}
+	mysql --protocol=TCP -h$${MATRIXONE_HOST:-127.0.0.1} -P$${MATRIXONE_PORT:-6001} -u$${MATRIXONE_USER:-root} -p$${MATRIXONE_PASSWORD:-111}
 
 # ============================================================================
 # API Server (Source Code Mode)
@@ -383,12 +383,18 @@ dev-seed:
 	DB_USER=$${MATRIXONE_USER:-root}; \
 	DB_PASS=$${MATRIXONE_PASSWORD:-111}; \
 	DB_NAME=$${ASTRA_DATABASE:-astra_runtime}; \
-	mysql -h$$DB_HOST -P$$DB_PORT -u$$DB_USER -p$$DB_PASS \
-		-e "DROP DATABASE IF EXISTS $$DB_NAME; CREATE DATABASE $$DB_NAME;" 2>/dev/null || \
-	mysql -h$$DB_HOST -P$$DB_PORT -u$$DB_USER -p$$DB_PASS --skip-ssl \
-		-e "DROP DATABASE IF EXISTS $$DB_NAME; CREATE DATABASE $$DB_NAME;" 2>/dev/null || \
-	mysql -h$$DB_HOST -P$$DB_PORT -u$$DB_USER -p$$DB_PASS --skip_ssl \
-		-e "DROP DATABASE IF EXISTS $$DB_NAME; CREATE DATABASE $$DB_NAME;"
+	SQL="DROP DATABASE IF EXISTS $$DB_NAME; CREATE DATABASE $$DB_NAME;"; \
+	run_mysql_ddl() { mysql --protocol=TCP -h"$$DB_HOST" -P"$$DB_PORT" -u"$$DB_USER" -p"$$DB_PASS" "$$@" -e "$$SQL"; }; \
+	mysql_ssl_disable_arg() { \
+		if mysql --no-defaults --ssl-mode=DISABLED --version >/dev/null 2>&1; then printf '%s\n' "--ssl-mode=DISABLED"; \
+		elif mysql --no-defaults --ssl=0 --version >/dev/null 2>&1; then printf '%s\n' "--ssl=0"; \
+		elif mysql --no-defaults --skip-ssl --version >/dev/null 2>&1; then printf '%s\n' "--skip-ssl"; \
+		fi; \
+	}; \
+	MYSQL_SSL_ARG=$$(mysql_ssl_disable_arg); \
+	run_mysql_ddl 2>/dev/null || { \
+		if [ -n "$$MYSQL_SSL_ARG" ]; then run_mysql_ddl "$$MYSQL_SSL_ARG"; else run_mysql_ddl; fi; \
+	}
 	@$(MAKE) dev-api-restart build-cli-release
 	@sleep 2
 	@echo "Registering admin (admin@mo.com)..."
@@ -607,10 +613,18 @@ test-online:
 	DB_USER=$${MATRIXONE_USER:-root}; \
 	DB_PASS=$${MATRIXONE_PASSWORD:-111}; \
 	echo "Recreating test database $$TEST_DB ..."; \
-	mysql -h$$DB_HOST -P$$DB_PORT -u$$DB_USER -p$$DB_PASS \
-		-e "DROP DATABASE IF EXISTS $$TEST_DB; CREATE DATABASE $$TEST_DB;" 2>/dev/null || \
-	mysql -h$$DB_HOST -P$$DB_PORT -u$$DB_USER -p$$DB_PASS --skip-ssl \
-		-e "DROP DATABASE IF EXISTS $$TEST_DB; CREATE DATABASE $$TEST_DB;" 2>/dev/null || true; \
+	SQL="DROP DATABASE IF EXISTS $$TEST_DB; CREATE DATABASE $$TEST_DB;"; \
+	run_mysql_ddl() { mysql --protocol=TCP -h"$$DB_HOST" -P"$$DB_PORT" -u"$$DB_USER" -p"$$DB_PASS" "$$@" -e "$$SQL"; }; \
+	mysql_ssl_disable_arg() { \
+		if mysql --no-defaults --ssl-mode=DISABLED --version >/dev/null 2>&1; then printf '%s\n' "--ssl-mode=DISABLED"; \
+		elif mysql --no-defaults --ssl=0 --version >/dev/null 2>&1; then printf '%s\n' "--ssl=0"; \
+		elif mysql --no-defaults --skip-ssl --version >/dev/null 2>&1; then printf '%s\n' "--skip-ssl"; \
+		fi; \
+	}; \
+	MYSQL_SSL_ARG=$$(mysql_ssl_disable_arg); \
+	run_mysql_ddl 2>/dev/null || { \
+		if [ -n "$$MYSQL_SSL_ARG" ]; then run_mysql_ddl "$$MYSQL_SSL_ARG"; else run_mysql_ddl; fi; \
+	} 2>/dev/null || true; \
 	echo "Running astra-runtime ignored unit tests (live DB; nextest profile=$(NEXTEST_ONLINE_PROFILE); live-LLM suite gated by ASTRA_LIVE_LLM)..."; \
 	FAILED=""; \
 	ASTRA_DATABASE=$$TEST_DB ASTRA_DATABASE_PREFIX="" ASTRA_AUTO_CREATE_DATABASE=1 \
@@ -836,9 +850,18 @@ db-reset:
 		DB_PORT=$${MATRIXONE_PORT:-6001}; \
 		DB_USER=$${MATRIXONE_USER:-root}; \
 		DB_PASS=$${MATRIXONE_PASSWORD:-111}; \
-		mysql -h$$DB_HOST -P$$DB_PORT -u$$DB_USER -p$$DB_PASS -e "DROP DATABASE IF EXISTS $$DB_NAME; CREATE DATABASE $$DB_NAME;" 2>/dev/null || \
-		mysql -h$$DB_HOST -P$$DB_PORT -u$$DB_USER -p$$DB_PASS --skip-ssl -e "DROP DATABASE IF EXISTS $$DB_NAME; CREATE DATABASE $$DB_NAME;" 2>/dev/null || \
-		mysql -h$$DB_HOST -P$$DB_PORT -u$$DB_USER -p$$DB_PASS --skip_ssl -e "DROP DATABASE IF EXISTS $$DB_NAME; CREATE DATABASE $$DB_NAME;"; \
+		SQL="DROP DATABASE IF EXISTS $$DB_NAME; CREATE DATABASE $$DB_NAME;"; \
+		run_mysql_ddl() { mysql --protocol=TCP -h"$$DB_HOST" -P"$$DB_PORT" -u"$$DB_USER" -p"$$DB_PASS" "$$@" -e "$$SQL"; }; \
+		mysql_ssl_disable_arg() { \
+			if mysql --no-defaults --ssl-mode=DISABLED --version >/dev/null 2>&1; then printf '%s\n' "--ssl-mode=DISABLED"; \
+			elif mysql --no-defaults --ssl=0 --version >/dev/null 2>&1; then printf '%s\n' "--ssl=0"; \
+			elif mysql --no-defaults --skip-ssl --version >/dev/null 2>&1; then printf '%s\n' "--skip-ssl"; \
+			fi; \
+		}; \
+		MYSQL_SSL_ARG=$$(mysql_ssl_disable_arg); \
+		run_mysql_ddl 2>/dev/null || { \
+			if [ -n "$$MYSQL_SSL_ARG" ]; then run_mysql_ddl "$$MYSQL_SSL_ARG"; else run_mysql_ddl; fi; \
+		}; \
 		echo "✅ Database reset complete"; \
 	else \
 		echo "Cancelled"; \

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "dashmap",
  "dotenvy",
  "ecb",
+ "fs2",
  "futures-util",
  "hex",
  "libc",

--- a/rust/crates/astra-cli/src/edge_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools.rs
@@ -655,7 +655,9 @@ impl ToolExecutor {
                     // initial flush. Then load sid2's own disk state.
                     *journal = astra_turn_core::file_edit_journal::FileEditJournal::new(500);
                     if let Ok(disk_journal) =
-                        astra_turn_core::file_edit_journal::FileEditJournal::load_from_dir(&dir, 500)
+                        astra_turn_core::file_edit_journal::FileEditJournal::load_from_dir(
+                            &dir, 500,
+                        )
                     {
                         journal.merge_older_entries(disk_journal);
                     }
@@ -664,7 +666,9 @@ impl ToolExecutor {
                 None => {
                     // Case (c): first binding — R9.1 merge policy.
                     if let Ok(disk_journal) =
-                        astra_turn_core::file_edit_journal::FileEditJournal::load_from_dir(&dir, 500)
+                        astra_turn_core::file_edit_journal::FileEditJournal::load_from_dir(
+                            &dir, 500,
+                        )
                     {
                         journal.merge_older_entries(disk_journal);
                     }
@@ -1914,10 +1918,11 @@ mod tests {
         let _guard = CheckpointRootGuard::set(tmp.path());
 
         // Simulate ReplState: a shared in-memory journal with no persistence.
-        let shared: std::sync::Arc<std::sync::Mutex<astra_turn_core::file_edit_journal::FileEditJournal>> =
-            std::sync::Arc::new(std::sync::Mutex::new(
-                astra_turn_core::file_edit_journal::FileEditJournal::new(500),
-            ));
+        let shared: std::sync::Arc<
+            std::sync::Mutex<astra_turn_core::file_edit_journal::FileEditJournal>,
+        > = std::sync::Arc::new(std::sync::Mutex::new(
+            astra_turn_core::file_edit_journal::FileEditJournal::new(500),
+        ));
         assert!(
             shared.lock().unwrap().persist_dir().is_none(),
             "fresh shared journal starts in-memory"
@@ -1956,10 +1961,11 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let _guard = CheckpointRootGuard::set(tmp.path());
 
-        let shared: std::sync::Arc<std::sync::Mutex<astra_turn_core::file_edit_journal::FileEditJournal>> =
-            std::sync::Arc::new(std::sync::Mutex::new(
-                astra_turn_core::file_edit_journal::FileEditJournal::new(500),
-            ));
+        let shared: std::sync::Arc<
+            std::sync::Mutex<astra_turn_core::file_edit_journal::FileEditJournal>,
+        > = std::sync::Arc::new(std::sync::Mutex::new(
+            astra_turn_core::file_edit_journal::FileEditJournal::new(500),
+        ));
 
         // Record something into the shared journal BEFORE either builder
         // call. This validates R8.7: the reverse order must preserve
@@ -1981,12 +1987,19 @@ mod tests {
         let j = shared.lock().unwrap();
         assert_eq!(j.persist_dir(), Some(expected.as_path()));
         assert!(std::sync::Arc::ptr_eq(&executor.file_journal, &shared));
-        assert_eq!(j.len(), 1, "pre-session entry must survive late session binding");
+        assert_eq!(
+            j.len(),
+            1,
+            "pre-session entry must survive late session binding"
+        );
         // Entry was also flushed to disk via enable_persistence's initial save.
         let on_disk = std::fs::read_dir(&expected)
             .map(|r| r.flatten().count())
             .unwrap_or(0);
-        assert!(on_disk >= 1, "pre-session entry should have been flushed to disk");
+        assert!(
+            on_disk >= 1,
+            "pre-session entry should have been flushed to disk"
+        );
     }
 
     /// R8.2 regression: if the shared journal already has in-memory entries
@@ -2007,10 +2020,11 @@ mod tests {
         let file = work.path().join("pre-session.txt");
         std::fs::write(&file, b"before").unwrap();
 
-        let shared: std::sync::Arc<std::sync::Mutex<astra_turn_core::file_edit_journal::FileEditJournal>> =
-            std::sync::Arc::new(std::sync::Mutex::new(
-                astra_turn_core::file_edit_journal::FileEditJournal::new(500),
-            ));
+        let shared: std::sync::Arc<
+            std::sync::Mutex<astra_turn_core::file_edit_journal::FileEditJournal>,
+        > = std::sync::Arc::new(std::sync::Mutex::new(
+            astra_turn_core::file_edit_journal::FileEditJournal::new(500),
+        ));
         {
             let mut j = shared.lock().unwrap();
             j.record_before(&file, "early-call", 0);
@@ -2025,11 +2039,7 @@ mod tests {
 
         // The pre-session entry MUST survive the binding.
         let j = shared.lock().unwrap();
-        assert_eq!(
-            j.len(),
-            1,
-            "pre-session in-memory entry must not be lost"
-        );
+        assert_eq!(j.len(), 1, "pre-session in-memory entry must not be lost");
         let entries: Vec<_> = j.entries().collect();
         assert_eq!(entries[0].path, file);
         assert_eq!(entries[0].after_content, b"after");
@@ -2057,17 +2067,14 @@ mod tests {
             tool_call_id: "prior".into(),
             edit_type: astra_turn_core::file_edit_journal::EditType::Overwrite,
         };
-        std::fs::write(
-            dir.join("000000.json"),
-            serde_json::to_vec(&prior).unwrap(),
-        )
-        .unwrap();
+        std::fs::write(dir.join("000000.json"), serde_json::to_vec(&prior).unwrap()).unwrap();
 
         // Empty shared journal + set session-id → should load the disk entry.
-        let shared: std::sync::Arc<std::sync::Mutex<astra_turn_core::file_edit_journal::FileEditJournal>> =
-            std::sync::Arc::new(std::sync::Mutex::new(
-                astra_turn_core::file_edit_journal::FileEditJournal::new(500),
-            ));
+        let shared: std::sync::Arc<
+            std::sync::Mutex<astra_turn_core::file_edit_journal::FileEditJournal>,
+        > = std::sync::Arc::new(std::sync::Mutex::new(
+            astra_turn_core::file_edit_journal::FileEditJournal::new(500),
+        ));
 
         let _executor = test_executor()
             .with_shared_file_journal(shared.clone())
@@ -2116,10 +2123,11 @@ mod tests {
         let work = tempfile::tempdir().unwrap();
         let pre_file = work.path().join("pre.txt");
         std::fs::write(&pre_file, b"v0").unwrap();
-        let shared: std::sync::Arc<std::sync::Mutex<astra_turn_core::file_edit_journal::FileEditJournal>> =
-            std::sync::Arc::new(std::sync::Mutex::new(
-                astra_turn_core::file_edit_journal::FileEditJournal::new(500),
-            ));
+        let shared: std::sync::Arc<
+            std::sync::Mutex<astra_turn_core::file_edit_journal::FileEditJournal>,
+        > = std::sync::Arc::new(std::sync::Mutex::new(
+            astra_turn_core::file_edit_journal::FileEditJournal::new(500),
+        ));
         {
             let mut j = shared.lock().unwrap();
             j.record_before(&pre_file, "pre-session", 0);
@@ -2138,10 +2146,7 @@ mod tests {
             3,
             "both disk (2) and pre-session (1) entries must survive"
         );
-        let tags: Vec<String> = j
-            .entries()
-            .map(|e| e.tool_call_id.clone())
-            .collect();
+        let tags: Vec<String> = j.entries().map(|e| e.tool_call_id.clone()).collect();
         assert_eq!(tags, vec!["prior-0", "prior-1", "pre-session"]);
 
         // All 3 entries should now be on disk.

--- a/rust/crates/astra-gateway/Cargo.toml
+++ b/rust/crates/astra-gateway/Cargo.toml
@@ -36,6 +36,7 @@ urlencoding = "2"
 rand = "0.9"
 dotenvy.workspace = true
 dashmap = "6.1.0"
+fs2 = "0.4.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/crates/astra-gateway/Makefile
+++ b/rust/crates/astra-gateway/Makefile
@@ -55,24 +55,40 @@ run: build _ensure_config _ensure_astra_auth
 # ── Background (production) ──
 
 start: build _ensure_config _ensure_astra_auth
-	@if [ -f $(PID_FILE) ] && kill -0 $$(cat $(PID_FILE)) 2>/dev/null; then \
-		echo "✅ Gateway already running (PID $$(cat $(PID_FILE)))"; \
-		exit 0; \
-	fi
-	@echo "Starting gateway in background..."
-	@nohup $(RELEASE_BIN) --config $(CONFIG) > $(LOG_FILE) 2>&1 &
-	@sleep 1
-	@if [ -f $(PID_FILE) ] && kill -0 $$(cat $(PID_FILE)) 2>/dev/null; then \
-		echo "✅ Gateway started (PID $$(cat $(PID_FILE)))"; \
-		echo "   Logs: $(LOG_FILE)"; \
+	@if [ -f $(PID_FILE) ]; then \
+		PID=$$(cat $(PID_FILE)); \
+		if kill -0 $$PID 2>/dev/null && ps -p $$PID -o command= 2>/dev/null | grep -q 'astra-gateway'; then \
+			echo "✅ Gateway already running (PID $$PID)"; \
+		else \
+			rm -f $(PID_FILE); \
+			echo "Starting gateway in background..."; \
+			nohup $(RELEASE_BIN) --config $(CONFIG) </dev/null > $(LOG_FILE) 2>&1 & \
+			sleep 1; \
+			if [ -f $(PID_FILE) ] && kill -0 $$(cat $(PID_FILE)) 2>/dev/null && ps -p $$(cat $(PID_FILE)) -o command= 2>/dev/null | grep -q 'astra-gateway'; then \
+				echo "✅ Gateway started (PID $$(cat $(PID_FILE)))"; \
+				echo "   Logs: $(LOG_FILE)"; \
+			else \
+				echo "❌ Gateway failed to start. Check $(LOG_FILE)"; \
+				tail -10 $(LOG_FILE); \
+				exit 1; \
+			fi; \
+		fi; \
 	else \
-		echo "❌ Gateway failed to start. Check $(LOG_FILE)"; \
-		tail -10 $(LOG_FILE); \
-		exit 1; \
+		echo "Starting gateway in background..."; \
+		nohup $(RELEASE_BIN) --config $(CONFIG) </dev/null > $(LOG_FILE) 2>&1 & \
+		sleep 1; \
+		if [ -f $(PID_FILE) ] && kill -0 $$(cat $(PID_FILE)) 2>/dev/null && ps -p $$(cat $(PID_FILE)) -o command= 2>/dev/null | grep -q 'astra-gateway'; then \
+			echo "✅ Gateway started (PID $$(cat $(PID_FILE)))"; \
+			echo "   Logs: $(LOG_FILE)"; \
+		else \
+			echo "❌ Gateway failed to start. Check $(LOG_FILE)"; \
+			tail -10 $(LOG_FILE); \
+			exit 1; \
+		fi; \
 	fi
 
 stop:
-	@if [ -f $(PID_FILE) ] && kill -0 $$(cat $(PID_FILE)) 2>/dev/null; then \
+	@if [ -f $(PID_FILE) ] && kill -0 $$(cat $(PID_FILE)) 2>/dev/null && ps -p $$(cat $(PID_FILE)) -o command= 2>/dev/null | grep -q 'astra-gateway'; then \
 		echo "Stopping gateway (PID $$(cat $(PID_FILE)))..."; \
 		kill $$(cat $(PID_FILE)); \
 		sleep 1; \
@@ -90,7 +106,7 @@ stop:
 restart: stop start
 
 status:
-	@if [ -f $(PID_FILE) ] && kill -0 $$(cat $(PID_FILE)) 2>/dev/null; then \
+	@if [ -f $(PID_FILE) ] && kill -0 $$(cat $(PID_FILE)) 2>/dev/null && ps -p $$(cat $(PID_FILE)) -o command= 2>/dev/null | grep -q 'astra-gateway'; then \
 		PID=$$(cat $(PID_FILE)); \
 		UPTIME=$$(ps -o etime= -p $$PID 2>/dev/null | tr -d ' '); \
 		MEM=$$(ps -o rss= -p $$PID 2>/dev/null | tr -d ' '); \

--- a/rust/crates/astra-gateway/src/main.rs
+++ b/rust/crates/astra-gateway/src/main.rs
@@ -46,6 +46,7 @@ fn acquire_gateway_instance_guard() -> Result<GatewayInstanceGuard, String> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(&lock_path)
         .map_err(|e| format!("failed to open {}: {e}", lock_path.display()))?;
 

--- a/rust/crates/astra-gateway/src/main.rs
+++ b/rust/crates/astra-gateway/src/main.rs
@@ -1,4 +1,6 @@
 use clap::{Parser, Subcommand};
+use fs2::FileExt;
+use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -20,6 +22,53 @@ enum Command {
     LoginWeixin,
 }
 
+struct GatewayInstanceGuard {
+    _lock_file: File,
+    pid_file: PathBuf,
+}
+
+impl Drop for GatewayInstanceGuard {
+    fn drop(&mut self) {
+        let current_pid = std::process::id().to_string();
+        if std::fs::read_to_string(&self.pid_file)
+            .map(|pid| pid.trim() == current_pid)
+            .unwrap_or(false)
+        {
+            let _ = std::fs::remove_file(&self.pid_file);
+        }
+    }
+}
+
+fn acquire_gateway_instance_guard() -> Result<GatewayInstanceGuard, String> {
+    let lock_path = PathBuf::from("/tmp/astra-gateway.lock");
+    let pid_file = PathBuf::from("/tmp/astra-gateway.pid");
+    let lock_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(&lock_path)
+        .map_err(|e| format!("failed to open {}: {e}", lock_path.display()))?;
+
+    if let Err(e) = lock_file.try_lock_exclusive() {
+        let pid = std::fs::read_to_string(&pid_file)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "unknown".to_string());
+        return Err(format!(
+            "astra-gateway is already running (pid: {pid}); stop it with `make gateway-stop` before starting another instance: {e}"
+        ));
+    }
+
+    std::fs::write(&pid_file, std::process::id().to_string())
+        .map_err(|e| format!("failed to write {}: {e}", pid_file.display()))?;
+
+    Ok(GatewayInstanceGuard {
+        _lock_file: lock_file,
+        pid_file,
+    })
+}
+
 #[tokio::main]
 async fn main() {
     // Load .env file if present (before logging init so RUST_LOG works)
@@ -33,22 +82,6 @@ async fn main() {
         .init();
 
     let cli = Cli::parse();
-
-    let pid_file = std::path::PathBuf::from("/tmp/astra-gateway.pid");
-    if pid_file.exists()
-        && let Ok(old_pid) = std::fs::read_to_string(&pid_file)
-    {
-        let old_pid = old_pid.trim();
-        let cmdline_path = format!("/proc/{old_pid}/cmdline");
-        if let Ok(cmdline) = std::fs::read_to_string(&cmdline_path)
-            && cmdline.contains("astra-gateway")
-        {
-            tracing::warn!(pid = old_pid, "killing stale gateway process");
-            let _ = std::process::Command::new("kill").arg(old_pid).status();
-            std::thread::sleep(std::time::Duration::from_secs(1));
-        }
-    }
-    std::fs::write(&pid_file, std::process::id().to_string()).ok();
 
     if let Some(Command::LoginWeixin) = cli.command {
         match astra_gateway::platforms::weixin::qr_login().await {
@@ -126,6 +159,15 @@ async fn main() {
         }
         return;
     }
+
+    let _instance_guard = match acquire_gateway_instance_guard() {
+        Ok(guard) => guard,
+        Err(e) => {
+            tracing::error!(error = %e, "gateway already running");
+            eprintln!("❌ {e}");
+            std::process::exit(1);
+        }
+    };
 
     let mut config = match astra_gateway::config::GatewayConfig::load(&cli.config) {
         Ok(c) => c,

--- a/rust/crates/astra-tools/src/executor.rs
+++ b/rust/crates/astra-tools/src/executor.rs
@@ -931,9 +931,7 @@ mod tests {
     #[tokio::test]
     async fn dispatch_run_script_missing_script_returns_error() {
         let (_tmp, exec) = test_executor();
-        let result = exec
-            .execute("run_script", &serde_json::json!({}))
-            .await;
+        let result = exec.execute("run_script", &serde_json::json!({})).await;
         assert!(result.is_error);
         assert!(result.output.contains("Missing 'script'"));
     }

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -17,10 +17,6 @@ pub mod build_test;
 // It uses Unix domain sockets for the script↔host RPC channel. Windows
 // would need named pipes — deferred. Gate the modules so the crate still
 // builds cross-platform.
-#[cfg(unix)]
-pub mod rpc_bridge;
-#[cfg(unix)]
-pub mod run_script;
 pub mod code_intel;
 pub mod config_tool;
 pub mod env_tools;
@@ -32,6 +28,10 @@ pub mod git_ops;
 pub mod github;
 pub mod passive_cargo_check;
 pub mod passive_tsc_check;
+#[cfg(unix)]
+pub mod rpc_bridge;
+#[cfg(unix)]
+pub mod run_script;
 pub mod shell_ops;
 pub mod task_mgmt;
 pub mod tool_search;

--- a/rust/crates/astra-tools/src/rpc_bridge.rs
+++ b/rust/crates/astra-tools/src/rpc_bridge.rs
@@ -120,10 +120,16 @@ pub(crate) struct RpcResponse {
 
 impl RpcResponse {
     pub fn success(output: String) -> Self {
-        Self { output: Some(output), error: None }
+        Self {
+            output: Some(output),
+            error: None,
+        }
     }
     pub fn error(msg: String) -> Self {
-        Self { output: None, error: Some(msg) }
+        Self {
+            output: None,
+            error: Some(msg),
+        }
     }
 }
 
@@ -518,7 +524,10 @@ mod tests {
             }
         }
         fn with_payload(size: usize) -> Self {
-            Self { payload_size: size, ..Self::new() }
+            Self {
+                payload_size: size,
+                ..Self::new()
+            }
         }
         fn call_count(&self) -> usize {
             self.call_log.lock().unwrap().len()
@@ -527,20 +536,30 @@ mod tests {
     #[async_trait]
     impl ToolExecutor for MockExecutor {
         async fn execute(&self, name: &str, args: &Value) -> ToolResult {
-            self.call_log.lock().unwrap().push((name.to_string(), args.clone()));
+            self.call_log
+                .lock()
+                .unwrap()
+                .push((name.to_string(), args.clone()));
             if self.payload_size > 0 {
                 ToolResult::text("A".repeat(self.payload_size))
             } else {
                 ToolResult::text(format!("ok: {name}"))
             }
         }
-        fn tool_schemas(&self) -> Vec<Value> { vec![] }
-        fn project_root(&self) -> &Path { &self.root }
+        fn tool_schemas(&self) -> Vec<Value> {
+            vec![]
+        }
+        fn project_root(&self) -> &Path {
+            &self.root
+        }
     }
 
     fn default_policy() -> RpcPolicy {
         RpcPolicy {
-            allowed_tools: ["read_file", "grep"].iter().map(|s| s.to_string()).collect(),
+            allowed_tools: ["read_file", "grep"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
             max_tool_calls: 50,
             max_response_bytes: 256 * 1024,
         }
@@ -607,7 +626,10 @@ mod tests {
         // No auth_token field → deserialize error before allowlist/executor run.
         let req = r#"{"tool":"read_file","args":{"path":"x"}}"#;
         let (resp, _) = rpc_roundtrip(req, &policy, &token, &exec, &counter).await;
-        assert!(resp.contains("Invalid JSON") || resp.contains("auth"), "resp: {resp}");
+        assert!(
+            resp.contains("Invalid JSON") || resp.contains("auth"),
+            "resp: {resp}"
+        );
         assert_eq!(exec.call_count(), 0);
     }
 
@@ -659,15 +681,25 @@ mod tests {
         let counter = AtomicUsize::new(0);
         let req = r#"{"tool":"read_file","args":{},"auth_token":"tok"}"#;
         let (resp, _) = rpc_roundtrip(req, &policy, &token, &exec, &counter).await;
-        assert!(resp.len() < 3_000, "response not capped: {} bytes", resp.len());
-        assert!(resp.contains("OUTPUT TRUNCATED"), "resp: {}", &resp[..resp.len().min(200)]);
+        assert!(
+            resp.len() < 3_000,
+            "response not capped: {} bytes",
+            resp.len()
+        );
+        assert!(
+            resp.contains("OUTPUT TRUNCATED"),
+            "resp: {}",
+            &resp[..resp.len().min(200)]
+        );
     }
 
     // R2: write_response never hangs — even with a pathological writer.
     #[tokio::test]
     async fn write_response_writes_newline_terminator() {
         let mut buf = Vec::<u8>::new();
-        write_response(&mut buf, &RpcResponse::success("hi".into())).await.unwrap();
+        write_response(&mut buf, &RpcResponse::success("hi".into()))
+            .await
+            .unwrap();
         assert!(buf.ends_with(b"\n"));
         assert!(String::from_utf8_lossy(&buf).contains("\"output\":\"hi\""));
     }
@@ -707,7 +739,10 @@ mod tests {
     async fn reply_and_shutdown_survives_shutdown_failure() {
         let mut w = FailOnShutdown { buf: Vec::new() };
         let result = reply_and_shutdown(&mut w, &RpcResponse::success("payload".into())).await;
-        assert!(result.is_ok(), "write succeeded; shutdown failure shouldn't propagate");
+        assert!(
+            result.is_ok(),
+            "write succeeded; shutdown failure shouldn't propagate"
+        );
         assert!(w.buf.ends_with(b"\n"));
         assert!(String::from_utf8_lossy(&w.buf).contains("payload"));
     }

--- a/rust/crates/astra-tools/src/run_script.rs
+++ b/rust/crates/astra-tools/src/run_script.rs
@@ -246,7 +246,7 @@ pub enum RunScriptError {
     #[error(
         "Script exited with code {code}:\nstderr: {}\nstdout: {}",
         preview_stream(stderr),
-        preview_stream(stdout),
+        preview_stream(stdout)
     )]
     ScriptFailed {
         code: i32,
@@ -396,14 +396,38 @@ struct ToolDocLine {
 }
 
 const TOOL_DOC_LINES: &[ToolDocLine] = &[
-    ToolDocLine { name: "read_file", doc: "  read_file(path, offset=None, limit=None) — read file contents" },
-    ToolDocLine { name: "write_file", doc: "  write_file(path, content) — write/overwrite a file" },
-    ToolDocLine { name: "list_dir", doc: "  list_dir(path='.') — list directory" },
-    ToolDocLine { name: "grep", doc: "  grep(pattern, path=None, include=None) — search files" },
-    ToolDocLine { name: "web_fetch", doc: "  web_fetch(url, format='markdown') — fetch URL content" },
-    ToolDocLine { name: "search_files", doc: "  search_files(pattern, target='content', path='.', file_glob=None, limit=50) — search/find files" },
-    ToolDocLine { name: "patch", doc: "  patch(path, old_string, new_string, replace_all=False) — find-and-replace" },
-    ToolDocLine { name: "bash", doc: "  bash(command, timeout=None) — shell command (hardened)" },
+    ToolDocLine {
+        name: "read_file",
+        doc: "  read_file(path, offset=None, limit=None) — read file contents",
+    },
+    ToolDocLine {
+        name: "write_file",
+        doc: "  write_file(path, content) — write/overwrite a file",
+    },
+    ToolDocLine {
+        name: "list_dir",
+        doc: "  list_dir(path='.') — list directory",
+    },
+    ToolDocLine {
+        name: "grep",
+        doc: "  grep(pattern, path=None, include=None) — search files",
+    },
+    ToolDocLine {
+        name: "web_fetch",
+        doc: "  web_fetch(url, format='markdown') — fetch URL content",
+    },
+    ToolDocLine {
+        name: "search_files",
+        doc: "  search_files(pattern, target='content', path='.', file_glob=None, limit=50) — search/find files",
+    },
+    ToolDocLine {
+        name: "patch",
+        doc: "  patch(path, old_string, new_string, replace_all=False) — find-and-replace",
+    },
+    ToolDocLine {
+        name: "bash",
+        doc: "  bash(command, timeout=None) — shell command (hardened)",
+    },
 ];
 
 const BUILTIN_HELPERS: &str = r#"
@@ -545,21 +569,25 @@ pub fn build_run_script_schema(
         .join("\n");
 
     let mode_note = match mode {
-        ExecutionMode::Project =>
+        ExecutionMode::Project => {
             "Scripts run in the session's working directory with the active venv's python, \
-             so project deps and relative paths work naturally.",
-        ExecutionMode::Strict =>
+             so project deps and relative paths work naturally."
+        }
+        ExecutionMode::Strict => {
             "Scripts run in an isolated temp directory — use absolute paths or tool calls \
-             for file access.",
+             for file access."
+        }
     };
 
     let priority_note = match priority {
-        PriorityHint::Pinned =>
+        PriorityHint::Pinned => {
             "\n\n**PREFERRED**: This tool is pinned as the preferred approach for multi-step tasks \
-             in this session. Use it when you need 3+ tool calls with processing logic between them.",
-        PriorityHint::Deprioritized =>
+             in this session. Use it when you need 3+ tool calls with processing logic between them."
+        }
+        PriorityHint::Deprioritized => {
             "\n\n**DEPRIORITIZED**: Prefer individual tool calls unless you specifically need \
-             batch processing with conditional logic.",
+             batch processing with conditional logic."
+        }
         PriorityHint::Neutral => "",
     };
 
@@ -572,7 +600,8 @@ pub fn build_run_script_schema(
     // Empty enabled_tools → degrade gracefully rather than emitting broken Python hints.
     let available_block = if tool_lines.is_empty() {
         "No sandbox tools are enabled for this session. run_script can only \
-         execute pure Python (stdlib) without calling any agent tool.".to_string()
+         execute pure Python (stdlib) without calling any agent tool."
+            .to_string()
     } else {
         let example = if import_examples.is_empty() {
             let mut names: Vec<_> = enabled_tools.iter().take(2).cloned().collect();
@@ -581,9 +610,7 @@ pub fn build_run_script_schema(
         } else {
             import_examples.join(", ")
         };
-        format!(
-            "Available via `from astra_tools import {example}, ...`:\n\n{tool_lines}"
-        )
+        format!("Available via `from astra_tools import {example}, ...`:\n\n{tool_lines}")
     };
 
     let script_param_desc = if tool_lines.is_empty() {
@@ -682,7 +709,11 @@ pub(crate) fn resolve_python(mode: ExecutionMode) -> String {
 /// The caller is responsible for ensuring `fallback` actually exists
 /// before spawning. The public `run_script` entry point always passes
 /// its freshly-created tmpdir, so the guarantee holds in practice.
-pub(crate) fn resolve_cwd(mode: ExecutionMode, session_cwd: Option<&Path>, fallback: &Path) -> PathBuf {
+pub(crate) fn resolve_cwd(
+    mode: ExecutionMode,
+    session_cwd: Option<&Path>,
+    fallback: &Path,
+) -> PathBuf {
     if mode == ExecutionMode::Strict {
         return fallback.to_path_buf();
     }
@@ -861,9 +892,7 @@ pub async fn run_script(
     );
 
     let mut cmd = Command::new(&python);
-    cmd.arg(&script_path)
-        .current_dir(&cwd)
-        .env_clear();
+    cmd.arg(&script_path).current_dir(&cwd).env_clear();
     for (k, v) in &env_pairs {
         cmd.env(k, v);
     }
@@ -884,11 +913,8 @@ pub async fn run_script(
     // until the child has exited and been waited on — otherwise Drop
     // tries to remove a non-empty cgroup directory. Silent fallback when
     // cgroup v2 is unavailable: the guard is inactive and does nothing.
-    let _cgroup_guard = astra_sandbox::apply_cgroup(
-        &mut cmd,
-        config.memory_limit_bytes,
-        config.cpu_quota,
-    );
+    let _cgroup_guard =
+        astra_sandbox::apply_cgroup(&mut cmd, config.memory_limit_bytes, config.cpu_quota);
 
     let mut child = cmd
         .spawn()
@@ -896,7 +922,8 @@ pub async fn run_script(
 
     let stdout = child.stdout.take().expect("stdout piped");
     let max_stdout = config.max_stdout_bytes;
-    let stdout_handle = tokio::spawn(async move { collect_stdout_head_tail(stdout, max_stdout).await });
+    let stdout_handle =
+        tokio::spawn(async move { collect_stdout_head_tail(stdout, max_stdout).await });
 
     let stderr = child.stderr.take().expect("stderr piped");
     let stderr_handle = tokio::spawn(async move { collect_stderr_with_notice(stderr).await });
@@ -938,8 +965,7 @@ pub async fn run_script(
             // Await both IO tasks concurrently so one panicking doesn't leak
             // the other. try_join! short-circuits on first Err; the
             // #[from] JoinError impl does the structured wrap.
-            let (stdout_content, stderr_content) =
-                tokio::try_join!(stdout_handle, stderr_handle)?;
+            let (stdout_content, stderr_content) = tokio::try_join!(stdout_handle, stderr_handle)?;
 
             if !status.success() {
                 let code = status.code().unwrap_or(-1);
@@ -989,9 +1015,7 @@ fn build_child_env(
 ) -> Vec<(String, String)> {
     let path = match mode {
         ExecutionMode::Strict => STRICT_PATH.to_string(),
-        ExecutionMode::Project => {
-            std::env::var("PATH").unwrap_or_else(|_| STRICT_PATH.to_string())
-        }
+        ExecutionMode::Project => std::env::var("PATH").unwrap_or_else(|_| STRICT_PATH.to_string()),
     };
     let home = if isolate_home {
         tmp_path.display().to_string()
@@ -1005,8 +1029,14 @@ fn build_child_env(
     };
 
     let mut out: Vec<(String, String)> = vec![
-        ("ASTRA_RPC_SOCKET".to_string(), socket_path.display().to_string()),
-        ("ASTRA_RPC_AUTH_TOKEN".to_string(), auth_token.as_str().to_string()),
+        (
+            "ASTRA_RPC_SOCKET".to_string(),
+            socket_path.display().to_string(),
+        ),
+        (
+            "ASTRA_RPC_AUTH_TOKEN".to_string(),
+            auth_token.as_str().to_string(),
+        ),
         ("HOME".to_string(), home),
         ("LANG".to_string(), "C.UTF-8".to_string()),
         ("PATH".to_string(), path),
@@ -1215,7 +1245,10 @@ mod tests {
     #[async_trait]
     impl ToolExecutor for MockToolExecutor {
         async fn execute(&self, name: &str, args: &Value) -> ToolResult {
-            self.call_log.lock().unwrap().push((name.to_string(), args.clone()));
+            self.call_log
+                .lock()
+                .unwrap()
+                .push((name.to_string(), args.clone()));
             match name {
                 "read_file" => {
                     let path = args.get("path").and_then(Value::as_str).unwrap_or("");
@@ -1230,8 +1263,12 @@ mod tests {
                 _ => ToolResult::error(format!("Unknown tool: {name}")),
             }
         }
-        fn tool_schemas(&self) -> Vec<Value> { vec![] }
-        fn project_root(&self) -> &Path { &self.project_root }
+        fn tool_schemas(&self) -> Vec<Value> {
+            vec![]
+        }
+        fn project_root(&self) -> &Path {
+            &self.project_root
+        }
     }
 
     // ── Config defaults (A3.3: pin secure-by-default choices) ────────────
@@ -1534,8 +1571,12 @@ mod tests {
 
     #[test]
     fn schema_lists_only_enabled_tools() {
-        let enabled: HashSet<String> = ["read_file", "write_file"].iter().map(|s| s.to_string()).collect();
-        let schema = build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
+        let enabled: HashSet<String> = ["read_file", "write_file"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let schema =
+            build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
         let desc = schema["function"]["description"].as_str().unwrap();
         assert!(desc.contains("read_file"));
         assert!(desc.contains("write_file"));
@@ -1548,7 +1589,8 @@ mod tests {
     #[test]
     fn schema_timeout_description_reflects_constants() {
         let enabled: HashSet<String> = ["read_file"].iter().map(|s| s.to_string()).collect();
-        let schema = build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
+        let schema =
+            build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
         let timeout_desc = schema["function"]["parameters"]["properties"]["timeout"]["description"]
             .as_str()
             .unwrap();
@@ -1582,7 +1624,8 @@ mod tests {
             .iter()
             .map(|s| s.to_string())
             .collect();
-        let schema = build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
+        let schema =
+            build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
         let desc = schema["function"]["description"].as_str().unwrap();
         // Known tool appears; unknown one is omitted (no panic, no raw name leak).
         assert!(desc.contains("read_file"));
@@ -1598,22 +1641,36 @@ mod tests {
     // allowlist layer but produce a noisy error.
     #[test]
     fn schema_omits_bash_when_disabled() {
-        let enabled: HashSet<String> = ["read_file", "grep"].iter().map(|s| s.to_string()).collect();
-        let schema = build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
+        let enabled: HashSet<String> = ["read_file", "grep"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let schema =
+            build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
         let desc = schema["function"]["description"].as_str().unwrap();
         let script_desc = schema["function"]["parameters"]["properties"]["script"]["description"]
             .as_str()
             .unwrap();
         // No `bash(` call suggestion, no `bash,` import example token.
-        assert!(!desc.contains("bash("), "desc leaks bash when disabled: {desc}");
-        assert!(!desc.contains(" bash,"), "desc lists bash in imports when disabled: {desc}");
-        assert!(!script_desc.contains("bash("), "script desc leaks bash: {script_desc}");
+        assert!(
+            !desc.contains("bash("),
+            "desc leaks bash when disabled: {desc}"
+        );
+        assert!(
+            !desc.contains(" bash,"),
+            "desc lists bash in imports when disabled: {desc}"
+        );
+        assert!(
+            !script_desc.contains("bash("),
+            "script desc leaks bash: {script_desc}"
+        );
     }
 
     #[test]
     fn schema_pinned_hint_present() {
         let enabled: HashSet<String> = ["read_file"].iter().map(|s| s.to_string()).collect();
-        let schema = build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Pinned);
+        let schema =
+            build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Pinned);
         let desc = schema["function"]["description"].as_str().unwrap();
         assert!(desc.contains("PREFERRED"));
         assert!(desc.contains("pinned"));
@@ -1622,8 +1679,11 @@ mod tests {
     #[test]
     fn schema_deprioritized_hint_present() {
         let enabled: HashSet<String> = ["read_file"].iter().map(|s| s.to_string()).collect();
-        let schema =
-            build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Deprioritized);
+        let schema = build_run_script_schema(
+            &enabled,
+            ExecutionMode::Project,
+            PriorityHint::Deprioritized,
+        );
         let desc = schema["function"]["description"].as_str().unwrap();
         assert!(desc.contains("DEPRIORITIZED"));
         // T48: Deprioritized is exclusive of Pinned — no PREFERRED marker leak.
@@ -1637,7 +1697,8 @@ mod tests {
     #[test]
     fn schema_pinned_hint_excludes_deprioritized_marker() {
         let enabled: HashSet<String> = ["read_file"].iter().map(|s| s.to_string()).collect();
-        let schema = build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Pinned);
+        let schema =
+            build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Pinned);
         let desc = schema["function"]["description"].as_str().unwrap();
         assert!(desc.contains("PREFERRED"));
         assert!(
@@ -1649,7 +1710,8 @@ mod tests {
     #[test]
     fn schema_neutral_has_no_priority_hint() {
         let enabled: HashSet<String> = ["read_file"].iter().map(|s| s.to_string()).collect();
-        let schema = build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
+        let schema =
+            build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
         let desc = schema["function"]["description"].as_str().unwrap();
         assert!(!desc.contains("PREFERRED"));
         assert!(!desc.contains("DEPRIORITIZED"));
@@ -1659,7 +1721,8 @@ mod tests {
     #[test]
     fn schema_empty_enabled_tools_graceful() {
         let enabled: HashSet<String> = HashSet::new();
-        let schema = build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
+        let schema =
+            build_run_script_schema(&enabled, ExecutionMode::Project, PriorityHint::Neutral);
         let desc = schema["function"]["description"].as_str().unwrap();
         let script_desc = schema["function"]["parameters"]["properties"]["script"]["description"]
             .as_str()
@@ -1667,11 +1730,7 @@ mod tests {
 
         // ── Negative: no broken import hint leaks through.
         // Catches `from astra_tools import , ...` and its moral equivalents.
-        let broken_patterns = [
-            "import , ",
-            "import , `",
-            "import , .",
-        ];
+        let broken_patterns = ["import , ", "import , `", "import , ."];
         for bad in broken_patterns {
             assert!(
                 !desc.contains(bad),
@@ -1704,7 +1763,10 @@ mod tests {
 
     #[test]
     fn stub_contains_only_enabled_tools() {
-        let enabled: HashSet<String> = ["read_file", "grep"].iter().map(|s| s.to_string()).collect();
+        let enabled: HashSet<String> = ["read_file", "grep"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
         let stub = generate_python_stub(&enabled);
         assert!(stub.contains("def read_file("));
         assert!(stub.contains("def grep("));
@@ -1725,8 +1787,14 @@ mod tests {
     fn stub_has_try_finally_for_fd_safety() {
         let enabled: HashSet<String> = ["read_file"].iter().map(|s| s.to_string()).collect();
         let stub = generate_python_stub(&enabled);
-        assert!(stub.contains("try:"), "stub must wrap socket in try/finally");
-        assert!(stub.contains("finally:"), "stub must close socket in finally");
+        assert!(
+            stub.contains("try:"),
+            "stub must wrap socket in try/finally"
+        );
+        assert!(
+            stub.contains("finally:"),
+            "stub must close socket in finally"
+        );
         assert!(stub.contains("sock.close()"));
     }
 
@@ -1856,7 +1924,10 @@ mod tests {
             std::fs::set_permissions(tmp.path(), perms).unwrap();
         }
         let path = tmp.path().to_str().unwrap();
-        assert!(!is_usable_python(path), "non-executable file must probe false");
+        assert!(
+            !is_usable_python(path),
+            "non-executable file must probe false"
+        );
     }
 
     // R6: repeated is_usable_python calls hit the cache (same result +
@@ -2110,7 +2181,10 @@ mod tests {
         let _guard = EnvGuard::set("PATH", "/opt/suspicious:/usr/bin:/bin");
         let env = test_env_bundle(ExecutionMode::Strict, true);
         let path = env_get(&env, "PATH").unwrap();
-        assert_eq!(path, STRICT_PATH, "Strict mode must not inherit parent PATH");
+        assert_eq!(
+            path, STRICT_PATH,
+            "Strict mode must not inherit parent PATH"
+        );
         assert!(!path.contains("/opt/suspicious"));
     }
 
@@ -2155,12 +2229,17 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(not(feature = "python_tests"), ignore)]
     async fn live_happy_path_multiple_rpc_calls() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
         let exec = MockToolExecutor::new();
         let config = RunScriptConfig {
             timeout: Duration::from_secs(10),
             mode: ExecutionMode::Strict,
-            allowed_tools: ["read_file", "grep"].iter().map(|s| s.to_string()).collect(),
+            allowed_tools: ["read_file", "grep"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
             ..Default::default()
         };
         let script = r#"
@@ -2179,7 +2258,9 @@ print(f"{r1}|{r2}")
     #[tokio::test]
     #[cfg_attr(not(feature = "python_tests"), ignore)]
     async fn live_script_partial_stdout_preserved_on_error() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
         let exec = MockToolExecutor::new();
         let config = RunScriptConfig {
             timeout: Duration::from_secs(10),
@@ -2192,7 +2273,11 @@ raise ValueError("boom")
 "#;
         let err = run_script(script, &config, &exec).await.unwrap_err();
         match err {
-            RunScriptError::ScriptFailed { code, stdout, stderr } => {
+            RunScriptError::ScriptFailed {
+                code,
+                stdout,
+                stderr,
+            } => {
                 assert_ne!(code, 0);
                 // Partial stdout lives in its OWN field — cleanly separable.
                 assert!(
@@ -2216,7 +2301,9 @@ raise ValueError("boom")
     #[tokio::test]
     #[cfg_attr(not(feature = "python_tests"), ignore)]
     async fn live_scripts_run_concurrently_without_cross_talk() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
 
         async fn run_one(label: &'static str) -> String {
             let exec = MockToolExecutor::new();
@@ -2230,8 +2317,14 @@ raise ValueError("boom")
         }
 
         let (a, b) = tokio::join!(run_one("alpha-marker"), run_one("bravo-marker"));
-        assert!(a.contains("alpha-marker") && !a.contains("bravo"), "A tainted: {a}");
-        assert!(b.contains("bravo-marker") && !b.contains("alpha"), "B tainted: {b}");
+        assert!(
+            a.contains("alpha-marker") && !a.contains("bravo"),
+            "A tainted: {a}"
+        );
+        assert!(
+            b.contains("bravo-marker") && !b.contains("alpha"),
+            "B tainted: {b}"
+        );
     }
 
     // R5.8 / T31 (inner layer): the raw API returns an empty string for
@@ -2241,7 +2334,9 @@ raise ValueError("boom")
     #[tokio::test]
     #[cfg_attr(not(feature = "python_tests"), ignore)]
     async fn live_run_script_empty_source_returns_empty_ok() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
         let exec = MockToolExecutor::new();
         let config = RunScriptConfig {
             timeout: Duration::from_secs(5),
@@ -2258,20 +2353,21 @@ raise ValueError("boom")
     #[tokio::test]
     #[cfg_attr(not(feature = "python_tests"), ignore)]
     async fn handle_run_script_empty_source_returns_notice() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
         let exec = MockToolExecutor::new();
         let config = RunScriptConfig {
             timeout: Duration::from_secs(5),
             mode: ExecutionMode::Strict,
             ..Default::default()
         };
-        let result = handle_run_script(
-            &serde_json::json!({"script": ""}),
-            &exec,
-            config,
-        )
-        .await;
-        assert!(!result.is_error, "empty script must exit cleanly: {}", result.output);
+        let result = handle_run_script(&serde_json::json!({"script": ""}), &exec, config).await;
+        assert!(
+            !result.is_error,
+            "empty script must exit cleanly: {}",
+            result.output
+        );
         assert!(
             result.output.contains("completed with no output"),
             "expected empty-output notice, got: {}",
@@ -2284,7 +2380,9 @@ raise ValueError("boom")
     #[tokio::test]
     #[cfg_attr(not(feature = "python_tests"), ignore)]
     async fn live_script_stderr_only_nonzero_exit() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
         let exec = MockToolExecutor::new();
         let config = RunScriptConfig {
             timeout: Duration::from_secs(10),
@@ -2297,10 +2395,17 @@ sys.stderr.write("only-on-stderr\n")
 sys.exit(7)
 "#;
         match run_script(script, &config, &exec).await {
-            Err(RunScriptError::ScriptFailed { code, stdout, stderr }) => {
+            Err(RunScriptError::ScriptFailed {
+                code,
+                stdout,
+                stderr,
+            }) => {
                 assert_eq!(code, 7);
                 assert!(stdout.is_empty(), "stdout should be empty, got: {stdout:?}");
-                assert!(stderr.contains("only-on-stderr"), "stderr missing content: {stderr}");
+                assert!(
+                    stderr.contains("only-on-stderr"),
+                    "stderr missing content: {stderr}"
+                );
             }
             other => panic!("expected ScriptFailed, got {other:?}"),
         }
@@ -2311,7 +2416,9 @@ sys.exit(7)
     #[tokio::test]
     #[cfg_attr(not(feature = "python_tests"), ignore)]
     async fn live_script_failed_exit_still_caps_stdout() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
         let exec = MockToolExecutor::new();
         let config = RunScriptConfig {
             timeout: Duration::from_secs(10),
@@ -2327,7 +2434,10 @@ raise RuntimeError("after noise")
         match run_script(script, &config, &exec).await {
             Err(RunScriptError::ScriptFailed { stdout, stderr, .. }) => {
                 // stdout got truncated — notice present + first line retained.
-                assert!(stdout.contains("OUTPUT TRUNCATED"), "stdout cap not applied: {stdout}");
+                assert!(
+                    stdout.contains("OUTPUT TRUNCATED"),
+                    "stdout cap not applied: {stdout}"
+                );
                 assert!(stdout.contains("line_000"), "head lost: {stdout}");
                 assert!(stderr.contains("RuntimeError"), "stderr missing: {stderr}");
             }
@@ -2339,7 +2449,9 @@ raise RuntimeError("after noise")
     #[tokio::test]
     #[cfg_attr(not(feature = "python_tests"), ignore)]
     async fn live_script_stderr_truncation_notice_present() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
         let exec = MockToolExecutor::new();
         let config = RunScriptConfig {
             timeout: Duration::from_secs(10),
@@ -2384,7 +2496,9 @@ sys.exit(2)
     #[tokio::test]
     #[cfg_attr(not(feature = "python_tests"), ignore)]
     async fn live_script_exceeded_call_limit_kills_child_fast() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
         let exec = MockToolExecutor::new();
         let config = RunScriptConfig {
             timeout: Duration::from_secs(60),
@@ -2424,7 +2538,9 @@ print("LEAK: should not have reached here")
     #[serial]
     #[cfg_attr(not(feature = "python_tests"), ignore)]
     async fn live_script_secret_env_not_visible_to_child() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
         let _guard = EnvGuard::set("MY_SUPER_SECRET", "should-not-leak");
         let exec = MockToolExecutor::new();
         let config = RunScriptConfig {
@@ -2450,7 +2566,9 @@ print(os.environ.get("MY_SUPER_SECRET", "UNSET"))
     #[serial]
     #[cfg_attr(not(feature = "python_tests"), ignore)]
     async fn live_script_home_is_isolated_by_default() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
         let _guard = EnvGuard::set("HOME", "/tmp/sentinel-parent-home");
         let exec = MockToolExecutor::new();
         let config = RunScriptConfig {
@@ -2487,7 +2605,9 @@ print(os.environ["HOME"])
     #[tokio::test]
     #[cfg_attr(not(feature = "cgroup_tests"), ignore)]
     async fn live_script_cgroup_memory_limit_kills_runaway() {
-        if !python3_available() { return; }
+        if !python3_available() {
+            return;
+        }
         let exec = MockToolExecutor::new();
         let config = RunScriptConfig {
             timeout: Duration::from_secs(10),
@@ -2504,9 +2624,7 @@ print(f"allocated {len(data)} bytes — cgroup did not enforce limit")
         let result = run_script(script, &config, &exec).await;
         match result {
             Ok(out) => {
-                panic!(
-                    "script completed despite memory cap; cgroup not enforced: {out}"
-                );
+                panic!("script completed despite memory cap; cgroup not enforced: {out}");
             }
             Err(RunScriptError::ScriptFailed { code, .. }) => {
                 // SIGKILL → exit code 137 (128 + 9) on typical shells,
@@ -2515,9 +2633,7 @@ print(f"allocated {len(data)} bytes — cgroup did not enforce limit")
                 assert_ne!(code, 0, "cgroup-killed child must exit nonzero");
             }
             Err(other) => {
-                panic!(
-                    "expected ScriptFailed from cgroup OOM-kill, got: {other:?}"
-                );
+                panic!("expected ScriptFailed from cgroup OOM-kill, got: {other:?}");
             }
         }
     }

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -2059,8 +2059,14 @@ mod tests {
         let desc = rs["function"]["description"].as_str().unwrap();
         // At least read_file and web_fetch should be mentioned — they're
         // the staple tools for multi-step pipelines.
-        assert!(desc.contains("read_file"), "default schema should list read_file");
-        assert!(desc.contains("web_fetch"), "default schema should list web_fetch");
+        assert!(
+            desc.contains("read_file"),
+            "default schema should list read_file"
+        );
+        assert!(
+            desc.contains("web_fetch"),
+            "default schema should list web_fetch"
+        );
     }
 
     #[cfg(not(unix))]

--- a/rust/crates/astra-turn-core/src/file_edit_journal.rs
+++ b/rust/crates/astra-turn-core/src/file_edit_journal.rs
@@ -542,8 +542,8 @@ impl FileEditJournal {
         let tmp = dir.join(format!(".{:06}.tmp", entry.sequence));
         match serde_json::to_vec(entry) {
             Ok(bytes) => {
-                if let Err(e) = std::fs::write(&tmp, &bytes)
-                    .and_then(|_| std::fs::rename(&tmp, &dest))
+                if let Err(e) =
+                    std::fs::write(&tmp, &bytes).and_then(|_| std::fs::rename(&tmp, &dest))
                 {
                     astra_core::agent_warn!(
                         "file_edit_journal",
@@ -581,8 +581,8 @@ impl FileEditJournal {
         let tmp = dir.join(format!(".{:06}.tmp", seq));
         match serde_json::to_vec(entry) {
             Ok(bytes) => {
-                if let Err(e) = std::fs::write(&tmp, &bytes)
-                    .and_then(|_| std::fs::rename(&tmp, &dest))
+                if let Err(e) =
+                    std::fs::write(&tmp, &bytes).and_then(|_| std::fs::rename(&tmp, &dest))
                 {
                     astra_core::agent_warn!(
                         "file_edit_journal",
@@ -687,7 +687,10 @@ mod tests {
         std::fs::write(&file_x, b"x1").unwrap();
         j.record_before(&file_x, "Y", 2);
         let new_seq = j.entries_for_test().last().unwrap().sequence;
-        assert!(new_seq > max_existing, "next_sequence must advance past max");
+        assert!(
+            new_seq > max_existing,
+            "next_sequence must advance past max"
+        );
     }
 
     /// When combined length exceeds max_entries, oldest entries are evicted
@@ -933,9 +936,7 @@ mod tests {
         let files: Vec<_> = std::fs::read_dir(&persist)
             .unwrap()
             .flatten()
-            .filter(|e| {
-                e.path().extension().and_then(|x| x.to_str()) == Some("json")
-            })
+            .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
             .collect();
         assert_eq!(files.len(), 2, "evicted entries must be removed from disk");
     }


### PR DESCRIPTION
## Summary
- make MatrixOne mysql CLI calls TCP-first and choose a supported SSL-disable option dynamically
- prevent duplicate astra-gateway instances with a cross-platform lock file
- fix gateway Makefile start/stop/status pid handling so `make gateway` does not launch another process after detecting one is already running

## Root Cause
- macOS MySQL resolves `localhost` to a Unix socket, while MatrixOne is expected over TCP in these dev targets
- MySQL/MariaDB client variants do not all accept the same SSL-disable flag, so the previous hardcoded fallback could fail on Linux/macOS setups
- gateway startup relied on pid files and Linux `/proc`, which did not prevent duplicate macOS gateway processes
- Make recipe line separation meant the already-running check did not stop later startup commands from launching another gateway

## Validation
- `cargo check --manifest-path rust/Cargo.toml -p astra-gateway`
- `cargo build --manifest-path rust/Cargo.toml -p astra-gateway --release`
- `make dev-seed`
- verified a second `astra-gateway --config gateway.yaml` is rejected by the lock
- verified `make gateway` reports the existing PID instead of starting another instance
