### PR TITLE
feat(gateway): implement full Codex CLI client with streaming support

### DIFF
--- a/docs/codex-client-implementation.md
+++ b/docs/codex-client-implementation.md
@@ -1,0 +1,258 @@
+# Codex Client 配置实现 — 新人学习文档
+
+## 一句话总结
+
+我们把 Astra Gateway 中的 Codex CLI 集成从一个只能"跑起来"的 stub（桩代码），升级为与 Claude 对等的完整 client，支持流式/非流式输出、模型选择、session 恢复等能力。
+
+---
+
+## 项目背景：这个仓库是什么？
+
+**Astra** 是一个 Agent 平台，核心架构如下：
+
+```
+用户 (微信/企微/...)
+     │
+     ▼
+┌─────────────┐
+│  Gateway    │  ← 接收消息，调度 CLI 后端，返回结果
+└─────────────┘
+     │  spawn 子进程
+     ▼
+┌─────────────┐
+│  CLI Agent  │  ← 实际干活的 AI 编程助手
+└─────────────┘
+  astra / claude / codex
+```
+
+**Gateway** 是一个中间层服务，它：
+1. 接收来自各平台（微信、企微等）的消息
+2. 选择一个 CLI Agent 后端来处理
+3. 把 CLI 的输出翻译后发回给用户
+
+Gateway 支持多种 CLI 后端（通过 `CliProfile` 枚举），用户可以在运行时通过 `/cli` 命令切换。
+
+---
+
+## 改动前的状况
+
+| Client | 能力 | 流式 | 模型选择 | Session |
+|--------|------|------|---------|---------|
+| Claude | 完整 | stream-json | --model | --resume |
+| Codex  | 最简 | 无 | 无 | 无 |
+
+Codex 的旧实现：
+```rust
+Codex {
+    bin: String,          // 可执行文件路径
+    approval_mode: String // "full-auto" — 已废弃的旧参数
+}
+```
+
+命令构建也很粗糙：
+```rust
+cmd.arg(message).arg("--full-auto").arg("--json");
+```
+
+---
+
+## 改动后的状况
+
+| Client | 能力 | 流式 | 模型选择 | Session |
+|--------|------|------|---------|---------|
+| Claude | 完整 | stream-json | --model | --resume |
+| **Codex** | **完整** | **--json (JSONL)** | **--model** | **exec resume** |
+
+---
+
+## 修改了哪些文件？为什么？
+
+### 1. `rust/crates/astra-gateway/src/cli_bridge.rs` — 核心改动
+
+**这个文件是什么：** Gateway 与 CLI Agent 交互的桥接层。定义了如何构建命令、如何解析输出、如何处理流式事件。
+
+**改了什么：**
+
+#### a) 扩展 `CliProfile::Codex` 结构体
+
+```rust
+// 新字段
+Codex {
+    bin: String,
+    model: Option<String>,        // 模型选择 (o4-mini, gpt-5.2-codex, ...)
+    sandbox: String,              // 沙箱策略 (read-only / workspace-write / danger-full-access)
+    stream_json: bool,            // 是否开启 JSONL 流式输出
+    extra_args: Vec<String>,      // 额外参数
+    skip_git_repo_check: bool,    // 非 git 目录时跳过检查
+    ephemeral: bool,              // 临时模式，不保存 session
+}
+```
+
+**为什么：** 旧的 `approval_mode: "full-auto"` 是 Codex CLI 早期版本的参数，新版已废弃。新版用 `--sandbox` 控制权限，支持 `--model`、`--json` 等丰富参数。
+
+#### b) 重写 `build_command_with_context` 中的 Codex 分支
+
+```rust
+// 新版命令构建
+cmd.arg("exec").arg(message);          // 用 exec 子命令（非交互模式）
+cmd.arg("--sandbox").arg(sandbox);
+cmd.arg("--json");                     // JSONL 流式输出
+cmd.arg("--model").arg(model);
+```
+
+**为什么：** Codex 的非交互模式必须用 `codex exec` 子命令。Session 恢复通过 `codex exec resume <session_id>` 实现。
+
+#### c) 新增 `parse_codex_stream_json_stdout` — 最终结果解析
+
+从 Codex 的 JSONL 输出中提取：
+- `thread.started` → session_id（会话 ID）
+- `turn.completed` → tokens 使用量
+- `item.completed` (agent_message) → 最终文本回复
+- `item.completed` (command_execution / file_change) → 工具使用统计
+
+**为什么：** Codex 的 JSON 格式与 Claude 完全不同。Claude 用 `type: "result"` 包含最终答案，Codex 用事件流（thread → turn → item）。
+
+#### d) 新增 `parse_codex_stream_json_line` — 实时进度解析
+
+每一行 JSONL 实时解析为进度事件：
+- `item.started` (command_execution) → "工具开始执行"
+- `item.completed` (command_execution) → "工具执行完成"
+- `item.started` (agent_message) → 文本 token 流
+
+**为什么：** 让 Gateway 能实时把进度推送给用户（比如微信里看到"正在执行命令 ls -la..."），而不是等一分钟后才收到完整回复。
+
+#### e) 更新流式 stdout 分发逻辑
+
+```rust
+let ev = match cli_name.as_str() {
+    "codex" => parse_codex_stream_json_line(&line),
+    _ => parse_claude_stream_json_line(&line),
+};
+```
+
+**为什么：** 原来硬编码只用 Claude 的解析器。现在根据 CLI 名称选择正确的解析器。
+
+---
+
+### 2. `rust/crates/astra-gateway/src/runner.rs` — 运行时集成
+
+**这个文件是什么：** Gateway 的主运行循环，处理消息调度、模型切换、用量统计。
+
+**改了什么：** 在两处 model override 逻辑中加入 `CliProfile::Codex` 分支。
+
+**为什么：** 用户通过 `/model o4-mini` 切换模型时，需要把选择的模型名注入到 Codex 的 profile 中。
+
+---
+
+### 3. `rust/crates/astra-gateway/src/gateway_context.rs` — 测试修复
+
+**改了什么：** 更新测试中 Codex 的结构体字段，把"session 不支持"的测试改为用 Custom profile。
+
+**为什么：** Codex 现在支持 session 了，旧测试的断言条件不成立了。用 Custom profile 代替，它确实不支持 session。
+
+---
+
+### 4. 配置文件
+
+| 文件 | 说明 |
+|------|------|
+| `gateway.example.yaml` | 更新 codex profile 示例配置 |
+| `gateway-codex-minimal.yaml` | 新增：最小化 Codex-only 部署配置 |
+| `setup.sh` | 修复自动配置脚本中的旧参数 |
+
+---
+
+## 核心概念解释
+
+### CliProfile（CLI 配置文件）
+
+一个枚举，定义了不同 CLI Agent 的"身份证"：
+- 用什么可执行文件
+- 传什么参数
+- 怎么解析输出
+- 支持什么能力
+
+### 流式 vs 非流式
+
+| 模式 | Codex 参数 | 输出格式 | 用户体验 |
+|------|-----------|---------|---------|
+| 非流式 | 不加 `--json` | 纯文本 stdout | 等完了才能看到回复 |
+| 流式 | `--json` | JSONL (每行一个 JSON) | 实时看到 token、工具执行进度 |
+
+### Codex 的 JSONL 事件流示例
+
+```jsonl
+{"type":"thread.started","thread_id":"thread_abc123"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_1","type":"reasoning","text":"Let me analyze..."}}
+{"type":"item.completed","item":{"id":"item_1","type":"reasoning","text":"Let me analyze the code..."}}
+{"type":"item.started","item":{"id":"item_2","type":"command_execution","command":"ls -la"}}
+{"type":"item.completed","item":{"id":"item_2","type":"command_execution","command":"ls -la","exit_code":0,"status":"completed"}}
+{"type":"item.started","item":{"id":"item_3","type":"agent_message","text":""}}
+{"type":"item.completed","item":{"id":"item_3","type":"agent_message","text":"Here are the files..."}}
+{"type":"turn.completed","usage":{"input_tokens":1200,"output_tokens":150}}
+```
+
+### Claude 的 stream-json 对比
+
+```jsonl
+{"type":"system","tools":["Read","Edit","Bash"]}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Let me check..."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{}}]}}
+{"type":"result","session_id":"abc","result":"Done!","usage":{"input_tokens":500,"output_tokens":100}}
+```
+
+可以看到两者的格式完全不同，所以需要分别实现解析器。
+
+---
+
+## 关键设计决策
+
+### 1. 为什么用 `codex exec` 而不是直接 `codex`？
+
+`codex` 默认启动交互式 TUI（终端界面），需要键盘输入。`codex exec` 是非交互模式，适合被程序调用。
+
+### 2. 为什么用 `--sandbox` 替代 `--full-auto`？
+
+`--full-auto` 是旧版参数，已被废弃。新版 Codex CLI 把权限控制重构为 sandbox 模型，更精细：
+- `read-only`：只读（安全但功能受限）
+- `workspace-write`：可以修改工作目录（推荐）
+- `danger-full-access`：完全不限制（危险）
+
+### 3. 为什么 Codex 的 `--json` 本身就是流式的？
+
+Claude 区分 `--output-format json`（最终一次性输出）和 `--output-format stream-json`（逐行流式）。
+
+Codex 只有 `--json`，它天然就是流式的——每个事件发生时就输出一行 JSONL。这是设计哲学的差异。
+
+### 4. 为什么 `supports_session` 改为 `true`？
+
+因为 Codex 确实支持 session：通过 `codex exec resume <session_id>` 可以恢复之前的对话。只是实现方式不同——不是 flag 而是子命令。
+
+---
+
+## 如何验证这些改动？
+
+1. **安装 Codex CLI**：`npm install -g @openai/codex`
+2. **设置 API Key**：`export OPENAI_API_KEY=sk-...`
+3. **用最小配置启动 Gateway**：
+   ```bash
+   cargo run -p astra-gateway --release -- --config rust/crates/astra-gateway/gateway-codex-minimal.yaml
+   ```
+4. **发送消息测试**（通过微信或 API 直接调用）
+
+---
+
+## 文件改动清单
+
+```
+Modified:
+  rust/crates/astra-gateway/src/cli_bridge.rs       (+180, -10)  核心实现
+  rust/crates/astra-gateway/src/runner.rs           (+4, -4)     运行时集成
+  rust/crates/astra-gateway/src/gateway_context.rs  (+8, -3)     测试修复
+  rust/crates/astra-gateway/gateway.example.yaml    (+7, -2)     配置示例
+  rust/crates/astra-gateway/setup.sh               (+2, -1)     安装脚本
+
+Added:
+  rust/crates/astra-gateway/gateway-codex-minimal.yaml           最小化部署配置
+```

--- a/rust/crates/astra-gateway/gateway-codex-minimal.yaml
+++ b/rust/crates/astra-gateway/gateway-codex-minimal.yaml
@@ -1,0 +1,42 @@
+# Gateway — minimal Codex-only deployment
+#
+# Features:
+#   - No DB required (storage: none)
+#   - OpenAI Codex CLI as the only backend
+#   - JSONL streaming output for real-time progress events
+#   - Supports model selection, session resume, sandbox control
+#
+# Start:
+#   cargo run -p astra-gateway --release -- --config rust/crates/astra-gateway/gateway-codex-minimal.yaml
+#
+# Required env:
+#   OPENAI_API_KEY — OpenAI API key (read by codex CLI)
+#
+# Install codex:
+#   npm install -g @openai/codex
+
+storage:
+  backend: none
+
+cli:
+  type: codex
+  bin: codex                    # assumes `codex` is on PATH; or set full path
+  model: o4-mini               # override per-session with /model
+  sandbox: workspace-write     # read-only | workspace-write | danger-full-access
+  stream_json: true            # enables --json JSONL streaming in exec mode
+  skip_git_repo_check: false   # set true for non-git directories
+  ephemeral: false             # set true to skip session persistence
+  extra_args: []
+
+max_concurrent_runs: 2
+
+action_policy:
+  allow_slash_mutations: true
+  allow_model_generated_mutations: false
+  workspace_roots: []
+
+platforms:
+  weixin:
+    enabled: true
+    token: ""       # set here or via WEIXIN_TOKEN env var
+    account_id: ""  # set here or via WEIXIN_ACCOUNT_ID env var

--- a/rust/crates/astra-gateway/gateway.example.yaml
+++ b/rust/crates/astra-gateway/gateway.example.yaml
@@ -97,7 +97,12 @@ cli:
 #   codex:
 #     type: codex
 #     bin: codex
-#     approval_mode: full-auto  # full-auto | suggest | ask
+#     model: o4-mini
+#     sandbox: workspace-write   # read-only | workspace-write | danger-full-access
+#     stream_json: true          # JSONL streaming output (events printed as they occur)
+#     skip_git_repo_check: false
+#     ephemeral: false
+#     extra_args: []
 
 # ─── Astra Server (only needed if using astra CLI type) ─────────────────────
 

--- a/rust/crates/astra-gateway/setup.sh
+++ b/rust/crates/astra-gateway/setup.sh
@@ -144,7 +144,8 @@ cli:
 $([ "$CLI_TYPE" = "astra" ] && echo "  permission_mode: auto")
 $([ "$CLI_TYPE" = "astra" ] && echo "  model: $MODEL")
 $([ "$CLI_TYPE" = "claude" ] && echo "  model: null")
-$([ "$CLI_TYPE" = "codex" ] && echo "  approval_mode: full-auto")
+$([ "$CLI_TYPE" = "codex" ] && echo "  sandbox: workspace-write")
+$([ "$CLI_TYPE" = "codex" ] && echo "  stream_json: true")
 
 platforms:
   wecom:

--- a/rust/crates/astra-gateway/src/cli_bridge.rs
+++ b/rust/crates/astra-gateway/src/cli_bridge.rs
@@ -123,8 +123,23 @@ pub enum CliProfile {
     Codex {
         #[serde(default = "default_codex_bin")]
         bin: String,
-        #[serde(default = "default_codex_approval")]
-        approval_mode: String,
+        model: Option<String>,
+        /// Sandbox policy: "read-only" | "workspace-write" | "danger-full-access".
+        #[serde(default = "default_codex_sandbox")]
+        sandbox: String,
+        /// Use `--json` for JSONL streaming output in exec mode.
+        /// Codex `--json` is inherently streaming (each event prints as it occurs).
+        #[serde(default)]
+        stream_json: bool,
+        /// Extra args appended to the codex invocation before the prompt.
+        #[serde(default)]
+        extra_args: Vec<String>,
+        /// Skip git repo check (useful for non-git directories).
+        #[serde(default)]
+        skip_git_repo_check: bool,
+        /// Ephemeral mode: don't persist session files to disk.
+        #[serde(default)]
+        ephemeral: bool,
     },
     #[serde(rename = "custom")]
     Custom {
@@ -150,8 +165,8 @@ fn default_codex_bin() -> String {
 fn default_permission_mode() -> String {
     "auto".into()
 }
-fn default_codex_approval() -> String {
-    "full-auto".into()
+fn default_codex_sandbox() -> String {
+    "workspace-write".into()
 }
 
 impl Default for CliProfile {
@@ -192,8 +207,8 @@ impl CliProfile {
                 supports_tools: true,
             },
             Self::Codex { .. } => CliCapabilities {
-                supports_session: false,
-                supports_model_switch: false,
+                supports_session: true,
+                supports_model_switch: true,
                 supports_json_output: true,
                 supports_harness: false,
                 supports_tools: true,
@@ -293,11 +308,40 @@ impl CliProfile {
                 }
                 cmd
             }
-            Self::Codex { bin, approval_mode } => {
+            Self::Codex {
+                bin,
+                model,
+                sandbox,
+                stream_json,
+                extra_args,
+                skip_git_repo_check,
+                ephemeral,
+            } => {
                 let mut cmd = Command::new(bin);
-                cmd.arg(message)
-                    .arg(format!("--{approval_mode}"))
-                    .arg("--json");
+                if let Some(sid) = session_id {
+                    cmd.arg("exec").arg("resume").arg(sid);
+                    if !message.is_empty() {
+                        cmd.arg(message);
+                    }
+                } else {
+                    cmd.arg("exec").arg(message);
+                }
+                cmd.arg("--sandbox").arg(sandbox);
+                if *stream_json {
+                    cmd.arg("--json");
+                }
+                if *skip_git_repo_check {
+                    cmd.arg("--skip-git-repo-check");
+                }
+                if *ephemeral {
+                    cmd.arg("--ephemeral");
+                }
+                if let Some(m) = model {
+                    cmd.arg("--model").arg(m);
+                }
+                for arg in extra_args {
+                    cmd.arg(arg);
+                }
                 if let Some(dir) = working_dir {
                     cmd.current_dir(dir);
                 }
@@ -332,7 +376,13 @@ impl CliProfile {
                     parse_claude_json(stdout, exit_code)
                 }
             }
-            Self::Codex { .. } => parse_generic_json(stdout, exit_code, "result", "session_id"),
+            Self::Codex { stream_json, .. } => {
+                if *stream_json {
+                    parse_codex_stream_json_stdout(stdout, exit_code)
+                } else {
+                    parse_generic_json(stdout, exit_code, "result", "session_id")
+                }
+            }
             Self::Custom {
                 json_output,
                 text_field,
@@ -669,6 +719,187 @@ fn parse_claude_stream_json_line(line: &str) -> Option<CliProgress> {
     }
 }
 
+/// Parse accumulated stdout of a Codex `--json` (JSONL streaming) run.
+///
+/// Codex exec --json emits these event types:
+///   - `thread.started`: session init with thread_id
+///   - `turn.started` / `turn.completed`: turn lifecycle with usage
+///   - `item.started` / `item.updated` / `item.completed`: content items
+///   - `error`: error events
+///
+/// Item types: agent_message, reasoning, command_execution, file_change, mcp_tool_call
+fn parse_codex_stream_json_stdout(stdout: &str, exit_code: i32) -> CliResult {
+    let mut session_id: Option<String> = None;
+    let mut text = String::new();
+    let mut tokens_prompt: Option<u64> = None;
+    let mut tokens_completion: Option<u64> = None;
+    let mut tools_used: Vec<String> = Vec::new();
+    let mut tool_use_count: u32 = 0;
+
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        match v["type"].as_str() {
+            Some("thread.started") => {
+                session_id = v["thread_id"].as_str().map(String::from);
+            }
+            Some("turn.completed") => {
+                let usage = &v["usage"];
+                tokens_prompt = usage["input_tokens"]
+                    .as_u64()
+                    .or_else(|| usage["cached_input_tokens"].as_u64());
+                tokens_completion = usage["output_tokens"]
+                    .as_u64()
+                    .or_else(|| usage["reasoning_output_tokens"].as_u64());
+            }
+            Some("item.completed") => {
+                let item = &v["item"];
+                match item["type"].as_str() {
+                    Some("agent_message") => {
+                        if let Some(t) = item["text"].as_str() {
+                            if !text.is_empty() {
+                                text.push('\n');
+                            }
+                            text.push_str(t);
+                        }
+                    }
+                    Some("command_execution") => {
+                        tool_use_count += 1;
+                        if !tools_used.iter().any(|n| n == "command_execution") {
+                            tools_used.push("command_execution".to_string());
+                        }
+                    }
+                    Some("file_change") => {
+                        tool_use_count += 1;
+                        if !tools_used.iter().any(|n| n == "file_change") {
+                            tools_used.push("file_change".to_string());
+                        }
+                    }
+                    Some("mcp_tool_call") => {
+                        tool_use_count += 1;
+                        let tool_name = item["tool"]
+                            .as_str()
+                            .unwrap_or("mcp_tool")
+                            .to_string();
+                        if !tools_used.iter().any(|n| n == &tool_name) {
+                            tools_used.push(tool_name);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if !text.is_empty() || session_id.is_some() {
+        let tool_calls_count = if tool_use_count == 0 {
+            None
+        } else {
+            Some(tool_use_count)
+        };
+        CliResult {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code,
+            success: exit_code == 0,
+            error_kind: default_error_kind(exit_code),
+            trace_id: None,
+            request_id: None,
+            run_id: None,
+            session_id,
+            text: if text.is_empty() { None } else { Some(text) },
+            tool_calls_count,
+            tools_used,
+            tokens_prompt,
+            tokens_completion,
+        }
+    } else {
+        plain_result(stdout, exit_code)
+    }
+}
+
+/// Parse a single stdout JSONL line from Codex `--json` into a progress event.
+///
+/// Codex events: thread.started, turn.started, turn.completed, item.started,
+/// item.updated, item.completed, error.
+fn parse_codex_stream_json_line(line: &str) -> Option<CliProgress> {
+    let v = serde_json::from_str::<serde_json::Value>(line).ok()?;
+    match v["type"].as_str()? {
+        "item.started" | "item.updated" => {
+            let item = &v["item"];
+            match item["type"].as_str() {
+                Some("agent_message") => {
+                    if let Some(t) = item["text"].as_str()
+                        && !t.is_empty()
+                    {
+                        return Some(CliProgress::Token(t.to_string()));
+                    }
+                }
+                Some("reasoning") => {
+                    return Some(CliProgress::Thinking(true));
+                }
+                Some("command_execution") => {
+                    let cmd = item["command"].as_str().unwrap_or("shell").to_string();
+                    return Some(CliProgress::ToolStarted { name: cmd });
+                }
+                Some("file_change") => {
+                    return Some(CliProgress::ToolStarted {
+                        name: "file_change".to_string(),
+                    });
+                }
+                Some("mcp_tool_call") => {
+                    let tool = item["tool"].as_str().unwrap_or("mcp_tool").to_string();
+                    return Some(CliProgress::ToolStarted { name: tool });
+                }
+                _ => {}
+            }
+            None
+        }
+        "item.completed" => {
+            let item = &v["item"];
+            match item["type"].as_str() {
+                Some("command_execution") => {
+                    let cmd = item["command"].as_str().unwrap_or("shell").to_string();
+                    return Some(CliProgress::ToolDone {
+                        name: cmd,
+                        duration_ms: None,
+                    });
+                }
+                Some("file_change") => {
+                    return Some(CliProgress::ToolDone {
+                        name: "file_change".to_string(),
+                        duration_ms: None,
+                    });
+                }
+                Some("mcp_tool_call") => {
+                    let tool = item["tool"].as_str().unwrap_or("mcp_tool").to_string();
+                    return Some(CliProgress::ToolDone {
+                        name: tool,
+                        duration_ms: None,
+                    });
+                }
+                Some("reasoning") => {
+                    return Some(CliProgress::Thinking(false));
+                }
+                _ => {}
+            }
+            None
+        }
+        "turn.started" => Some(CliProgress::Status("codex turn started".to_string())),
+        "error" => {
+            let msg = v["message"].as_str().unwrap_or("unknown error").to_string();
+            Some(CliProgress::Status(format!("[error] {msg}")))
+        }
+        _ => None,
+    }
+}
+
 fn parse_generic_json(
     stdout: &str,
     exit_code: i32,
@@ -896,6 +1127,9 @@ pub async fn run_cli_with_cancel(
         CliProfile::Claude {
             stream_json: true,
             ..
+        } | CliProfile::Codex {
+            stream_json: true,
+            ..
         }
     );
     let (stdout_text, stderr_text, exit_code) = if stream_stdout {
@@ -1000,6 +1234,7 @@ async fn run_child_with_cancel_inner(
         collected
     });
 
+    let cli_name = name.to_string();
     let stdout_task = tokio::spawn(async move {
         let reader = BufReader::new(stdout);
         let mut lines = reader.lines();
@@ -1009,10 +1244,14 @@ async fn run_child_with_cancel_inner(
                 output.push('\n');
             }
             output.push_str(&line);
-            if let Some(ref tx) = stdout_progress_tx
-                && let Some(ev) = parse_claude_stream_json_line(&line)
-            {
-                let _ = tx.send(ev).await;
+            if let Some(ref tx) = stdout_progress_tx {
+                let ev = match cli_name.as_str() {
+                    "codex" => parse_codex_stream_json_line(&line),
+                    _ => parse_claude_stream_json_line(&line),
+                };
+                if let Some(ev) = ev {
+                    let _ = tx.send(ev).await;
+                }
             }
         }
         output

--- a/rust/crates/astra-gateway/src/gateway_context.rs
+++ b/rust/crates/astra-gateway/src/gateway_context.rs
@@ -335,11 +335,14 @@ mod tests {
 
     #[test]
     fn template_session_only_when_supported() {
-        let codex = CliProfile::Codex {
-            bin: "codex".into(),
-            approval_mode: "full-auto".into(),
+        let custom = CliProfile::Custom {
+            bin: "my-agent".into(),
+            args_template: Vec::new(),
+            json_output: false,
+            session_id_field: None,
+            text_field: None,
         };
-        let ctx = GatewayContext::new("u1", "Test", "weixin", &codex, true);
+        let ctx = GatewayContext::new("u1", "Test", "weixin", &custom, true);
         let prompt = ctx.to_system_prompt();
         assert!(!prompt.contains("/session list"));
     }

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -581,7 +581,9 @@ impl GatewayRunner {
                 .await
         {
             match &mut profile {
-                CliProfile::Astra { model, .. } | CliProfile::Claude { model, .. } => {
+                CliProfile::Astra { model, .. }
+                | CliProfile::Claude { model, .. }
+                | CliProfile::Codex { model, .. } => {
                     *model = Some(model_name);
                 }
                 _ => {}
@@ -1631,9 +1633,9 @@ impl GatewayRunner {
                     user_id: msg.user_id.clone(),
                     cli_profile: cli_name.clone(),
                     model: match &cli_profile {
-                        CliProfile::Astra { model, .. } | CliProfile::Claude { model, .. } => {
-                            model.clone()
-                        }
+                        CliProfile::Astra { model, .. }
+                        | CliProfile::Claude { model, .. }
+                        | CliProfile::Codex { model, .. } => model.clone(),
                         _ => None,
                     },
                     tokens_prompt: result.tokens_prompt.unwrap_or(0),


### PR DESCRIPTION
Upgrade CliProfile::Codex from a minimal stub to a full-featured client on par with the Claude integration. Adds model selection, sandbox control, JSONL streaming output, session resume via `codex exec resume`, and real-time progress event parsing.

## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes #

## What this PR does / why we need it
