### PR TITLE
fix(gateway): wecom DM routing, streaming multi-chunk, mention strip, reconnect

### DIFF
--- a/rust/crates/astra-gateway/src/cli_bridge.rs
+++ b/rust/crates/astra-gateway/src/cli_bridge.rs
@@ -625,18 +625,13 @@ fn parse_claude_stream_json_stdout(stdout: &str, exit_code: i32) -> CliResult {
 fn parse_claude_stream_json_line(line: &str) -> Option<CliProgress> {
     let v = serde_json::from_str::<serde_json::Value>(line).ok()?;
     match v["type"].as_str()? {
-        // Assistant message — may contain text tokens or tool_use blocks.
+        // Assistant message — complete snapshot after streaming finishes.
+        // Text is already delivered incrementally via stream_event/text_delta,
+        // so skip text here to avoid duplicates. Only extract tool lifecycle.
         "assistant" => {
             let content = v["message"]["content"].as_array()?;
             for block in content {
                 match block["type"].as_str() {
-                    Some("text") => {
-                        if let Some(text) = block["text"].as_str()
-                            && !text.is_empty()
-                        {
-                            return Some(CliProgress::Token(text.to_string()));
-                        }
-                    }
                     Some("tool_use") => {
                         let name = block["name"].as_str().unwrap_or("tool").to_string();
                         return Some(CliProgress::ToolStarted { name });
@@ -653,6 +648,33 @@ fn parse_claude_stream_json_line(line: &str) -> Option<CliProgress> {
                     }
                     _ => {}
                 }
+            }
+            None
+        }
+        // Streaming events from --include-partial-messages: incremental text deltas.
+        "stream_event" => {
+            let event = &v["event"];
+            match event["type"].as_str() {
+                Some("content_block_delta") => {
+                    let delta = &event["delta"];
+                    match delta["type"].as_str() {
+                        Some("text_delta") => {
+                            let text = delta["text"].as_str().unwrap_or_default();
+                            if !text.is_empty() {
+                                return Some(CliProgress::Token(text.to_string()));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                Some("content_block_start") => {
+                    let block = &event["content_block"];
+                    if block["type"].as_str() == Some("tool_use") {
+                        let name = block["name"].as_str().unwrap_or("tool").to_string();
+                        return Some(CliProgress::ToolStarted { name });
+                    }
+                }
+                _ => {}
             }
             None
         }

--- a/rust/crates/astra-gateway/src/platforms/wecom.rs
+++ b/rust/crates/astra-gateway/src/platforms/wecom.rs
@@ -16,6 +16,7 @@ use tokio::sync::{Mutex, mpsc};
 use tokio_tungstenite::tungstenite::Message;
 
 const HEARTBEAT_INTERVAL_SECS: u64 = 30;
+const PONG_TIMEOUT_SECS: u64 = 60;
 const MAX_TEXT_LENGTH: usize = 4000;
 const RECONNECT_DELAYS: &[u64] = &[2, 5, 10, 30, 60];
 const WECOM_CAPABILITIES: &[AdapterCapability] = &[
@@ -39,6 +40,8 @@ pub struct WeComAdapter {
     msg_rx: Mutex<mpsc::Receiver<InboundMessage>>,
     out_tx: mpsc::Sender<OutboundMessage>,
     shutdown: Option<tokio::sync::broadcast::Sender<()>>,
+    /// Tracks reply_tokens already used via aibot_respond_msg (one-shot per inbound request).
+    used_reply_tokens: std::sync::Arc<tokio::sync::Mutex<std::collections::HashSet<String>>>,
 }
 
 impl WeComAdapter {
@@ -51,6 +54,9 @@ impl WeComAdapter {
             msg_rx: Mutex::new(msg_rx),
             out_tx,
             shutdown: None,
+            used_reply_tokens: std::sync::Arc::new(tokio::sync::Mutex::new(
+                std::collections::HashSet::new(),
+            )),
         }
     }
 }
@@ -145,11 +151,24 @@ impl PlatformAdapter for WeComAdapter {
             text.to_string()
         };
 
+        // aibot_respond_msg is one-shot per inbound request: once used, fall back to aibot_send_msg.
+        let effective_reply_token = if let Some(token) = reply_token {
+            let mut used = self.used_reply_tokens.lock().await;
+            if used.contains(token) {
+                None
+            } else {
+                used.insert(token.to_string());
+                Some(token.to_string())
+            }
+        } else {
+            None
+        };
+
         self.out_tx
             .send(OutboundMessage {
                 chat_id: chat_id.to_string(),
                 text,
-                reply_token: reply_token.map(String::from),
+                reply_token: effective_reply_token,
             })
             .await
             .map_err(|e| format!("outbound channel send failed: {e}"))
@@ -208,8 +227,14 @@ async fn run_wecom_connection(
         tokio::time::interval(std::time::Duration::from_secs(HEARTBEAT_INTERVAL_SECS));
     heartbeat.tick().await;
     let bot_id = config.bot_id.clone();
+    let mut last_recv = tokio::time::Instant::now();
 
     loop {
+        // If we haven't received anything for PONG_TIMEOUT_SECS, the connection is dead.
+        if last_recv.elapsed().as_secs() > PONG_TIMEOUT_SECS {
+            return Err("wecom connection timed out (no message received)".into());
+        }
+
         let mut out_guard = out_rx.lock().await;
 
         tokio::select! {
@@ -253,7 +278,10 @@ async fn run_wecom_connection(
             msg = ws_read.next() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
+                        last_recv = tokio::time::Instant::now();
                         if let Ok(data) = serde_json::from_str::<Value>(&text) {
+                            let cmd = data["cmd"].as_str().unwrap_or("unknown");
+                            tracing::debug!(cmd, "wecom ws recv");
                             handle_wecom_message(&data, msg_tx, &mut dedup).await;
                         }
                     }
@@ -355,7 +383,6 @@ async fn handle_wecom_message(
         return;
     }
 
-    let chat_id = body["chatid"].as_str().unwrap_or("").to_string();
     let user_id = body["from"]["userid"]
         .as_str()
         .unwrap_or("unknown")
@@ -365,7 +392,22 @@ async fn handle_wecom_message(
     } else {
         ChatType::DirectMessage
     };
+    // DM: chatid is empty; fall back to userid so replies can be routed back.
+    let chatid_raw = body["chatid"].as_str().unwrap_or("").to_string();
+    let chat_id = if chatid_raw.is_empty() {
+        user_id.clone()
+    } else {
+        chatid_raw
+    };
     let reply_token = data["headers"]["req_id"].as_str().map(String::from);
+
+    tracing::debug!(
+        chat_type = ?chat_type,
+        chat_id = %chat_id,
+        user_id = %user_id,
+        reply_token = ?reply_token,
+        "wecom inbound message"
+    );
 
     let msg = InboundMessage {
         platform: "wecom",

--- a/rust/crates/astra-gateway/src/runner.rs
+++ b/rust/crates/astra-gateway/src/runner.rs
@@ -26,8 +26,8 @@ use tokio_util::sync::CancellationToken;
 const MAX_CHUNK_LEN: usize = 3800;
 const INITIAL_ACK_DELAY: Duration = Duration::from_secs(3);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(25);
-const PROGRESSIVE_FLUSH_INTERVAL: Duration = Duration::from_secs(8);
-const PROGRESSIVE_MIN_CHARS: usize = 200;
+const PROGRESSIVE_FLUSH_INTERVAL: Duration = Duration::from_secs(20);
+const PROGRESSIVE_MIN_CHARS: usize = 800;
 
 // ─── Send Circuit Breaker ───────────────────────────────────────────────────
 
@@ -610,6 +610,22 @@ impl GatewayRunner {
             return Ok(None);
         }
 
+        // Strip @mention prefix so slash commands and CLI see clean text
+        let msg = &{
+            let mut m = msg.clone();
+            m.text = strip_mention(&m.text, &self.config.bot_name);
+            m
+        };
+
+        // If stripping the mention left an empty message, treat as a greeting
+        let msg = &if msg.text.is_empty() {
+            let mut m = msg.clone();
+            m.text = "你好".to_string();
+            m
+        } else {
+            msg.clone()
+        };
+
         // Group chat: per-user session isolation
         let effective_chat_id = if msg.chat_type == crate::platforms::ChatType::Group
             && self.config.group_sessions_per_user
@@ -1008,6 +1024,7 @@ impl GatewayRunner {
         let message_text = msg.text.clone();
         let sid = session_id.clone();
         let chat_id = effective_chat_id.clone();
+        let outbound_chat_id = msg.chat_id.clone();
         let cli_name = cli_profile.name().to_string();
         let cli_timeout = Duration::from_secs(self.config.cli_timeout_secs.max(1));
 
@@ -1126,7 +1143,7 @@ impl GatewayRunner {
                                 token_buf.push_str(&filtered);
                                 if token_buf.len() >= PROGRESSIVE_MIN_CHARS {
                                     chunk_counter += 1;
-                                    progressive_text_len += flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &chat_id, &request_tag, chunk_counter);
+                                    progressive_text_len += flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &outbound_chat_id, &request_tag, chunk_counter);
                                     next_timer.as_mut().reset(tokio::time::Instant::now() + PROGRESSIVE_FLUSH_INTERVAL);
                                 }
                             }
@@ -1155,7 +1172,7 @@ impl GatewayRunner {
                                 token_buf.push_str(&tail);
                             }
                             chunk_counter += 1;
-                            progressive_text_len += flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &chat_id, &request_tag, chunk_counter);
+                            progressive_text_len += flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &outbound_chat_id, &request_tag, chunk_counter);
                             break;
                         }
                     }
@@ -1168,7 +1185,7 @@ impl GatewayRunner {
                     }
                     if !token_buf.is_empty() {
                         chunk_counter += 1;
-                        progressive_text_len += flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &chat_id, &request_tag, chunk_counter);
+                        progressive_text_len += flush_buf(&mut token_buf, &self.outbound_tx, msg.platform, &outbound_chat_id, &request_tag, chunk_counter);
                         next_timer.as_mut().reset(tokio::time::Instant::now() + PROGRESSIVE_FLUSH_INTERVAL);
                     } else if !sent_initial_ack {
                         sent_initial_ack = true;
@@ -1177,7 +1194,7 @@ impl GatewayRunner {
                             // try_send: drop heartbeat if channel backpressured —
                             // stale heartbeats are worse than missing ones.
                             let _ = tx.try_send(OutboundMessage::plain(
-                                msg.platform.to_string(), chat_id.clone(), heartbeat,
+                                msg.platform.to_string(), outbound_chat_id.clone(), heartbeat,
                             ));
                         }
                         next_timer.as_mut().reset(tokio::time::Instant::now() + HEARTBEAT_INTERVAL);
@@ -1191,7 +1208,7 @@ impl GatewayRunner {
                         };
                         if let Some(ref tx) = self.outbound_tx {
                             let _ = tx.try_send(OutboundMessage::plain(
-                                msg.platform.to_string(), chat_id.clone(), heartbeat,
+                                msg.platform.to_string(), outbound_chat_id.clone(), heartbeat,
                             ));
                         }
                         next_timer.as_mut().reset(tokio::time::Instant::now() + HEARTBEAT_INTERVAL);
@@ -4793,6 +4810,31 @@ fn is_mentioned(text: &str, bot_name: &str) -> bool {
     } else {
         let pattern = format!("@{}", bot_name);
         text.to_lowercase().contains(&pattern.to_lowercase())
+    }
+}
+
+/// Remove `@BotName` from text so downstream handlers see clean input.
+fn strip_mention(text: &str, bot_name: &str) -> String {
+    if bot_name.is_empty() {
+        // Strip any single @word at the start
+        let trimmed = text.trim_start();
+        if let Some(rest) = trimmed.strip_prefix('@') {
+            // Skip the word after @
+            let after_word = rest.trim_start_matches(|c: char| !c.is_whitespace());
+            after_word.trim_start().to_string()
+        } else {
+            text.to_string()
+        }
+    } else {
+        let lower = text.to_lowercase();
+        let pattern = format!("@{}", bot_name).to_lowercase();
+        if let Some(pos) = lower.find(&pattern) {
+            let before = &text[..pos];
+            let after = &text[pos + pattern.len()..];
+            format!("{}{}", before, after).trim().to_string()
+        } else {
+            text.to_string()
+        }
     }
 }
 


### PR DESCRIPTION
## Background

Multiple bugs discovered during real-world WeCom (Enterprise WeChat) integration testing with astra-gateway. All fixes verified in production.

## Changes

**1. WeCom DM chat_id empty — private messages not delivered**
WeCom DM messages have an empty `chatid` field, causing `aibot_send_msg` to fail silently. Fixed by falling back to `from.userid` as chat_id for direct messages.

**2. Group streaming shows only stats footer — aibot_respond_msg is one-shot**
`aibot_respond_msg` can only be called once per req_id. With `stream_json: true`, the first chunk consumed the reply_token and subsequent chunks were silently dropped by WeCom. Fixed by tracking used reply_tokens; first chunk uses `aibot_respond_msg`, subsequent chunks fall back to `aibot_send_msg`.

**3. Silent WebSocket disconnect with no reconnect**
WeCom WebSocket silently drops connections during idle periods (no Close frame sent). Gateway stopped receiving messages without any error. Fixed by tracking last-received timestamp; triggers reconnect after 60 seconds of no frames.

**4. Group @mention prefix breaks slash command detection**
Messages like `@BotName /model` start with `@`, causing `handle_command`'s `starts_with('/')` check to fail — slash commands were routed to the CLI instead. Fixed by stripping `@BotName` after mention check. Bare @mention with no content defaults to a greeting to avoid empty prompt errors.

**5. Progressive chunks and heartbeats sent to wrong chat_id**
In progressive mode, chunks and heartbeats used the session-isolated `effective_chat_id` (with user suffix) instead of the original platform `chat_id`. Introduced `outbound_chat_id` to distinguish the two.

**6. Duplicate tokens in cli_bridge stream_json mode**
Both the `assistant` snapshot message and `stream_event/content_block_delta` emitted Token events, causing duplicated content. Fixed by only extracting tool_use from `assistant` messages and reading tokens exclusively from `stream_event text_delta`.

## Testing

All fixes verified end-to-end in a real WeCom AI Bot environment: DM replies, group chat, progressive streaming, slash commands, and WebSocket reconnection all working correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)