### PR TITLE
feat(tui): gradient live frame + scrolling inline-think preview

### DIFF
--- a/rust/crates/astra-cli/src/tui/history_cell/assistant.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/assistant.rs
@@ -308,41 +308,98 @@ fn thought_header_lines(line_count: usize) -> Vec<Line<'static>> {
     ])]
 }
 
-/// While `<think>` is open and the model is still streaming,
-/// show a dim one-line "Thinking…" indicator plus the most recent
-/// line of thinking content so the user can see something is
-/// happening. Full thinking body stays hidden to avoid dumping
-/// 40+ lines of internal monologue on screen; the closed-think
-/// header is what the user sees once the block finishes.
-fn render_live_thinking(think_partial: &str, _width: u16) -> Vec<Line<'static>> {
-    let dim = Style::default().add_modifier(Modifier::DIM);
-    // Last non-blank line is the most useful "where are we now"
-    // preview. Truncate to fit without wrapping to keep the
-    // viewport stable while content scrolls in.
-    let last_line = think_partial
-        .lines()
-        .rev()
-        .find(|l| !l.trim().is_empty())
-        .unwrap_or("")
-        .trim();
-    const MAX_PREVIEW: usize = 80;
-    let preview: String = if last_line.chars().count() > MAX_PREVIEW {
-        let truncated: String = last_line.chars().take(MAX_PREVIEW).collect();
-        format!("{truncated}…")
-    } else {
-        last_line.to_string()
-    };
+/// Max body rows shown beneath the `✻ Thinking…` header while the
+/// `<think>` block is open. Mirrors `ReasoningCell::LIVE_PREVIEW_MAX_ROWS`:
+/// once the window fills, the oldest row scrolls off and a
+/// `⋯ +N more` counter takes the top slot, so the preview stays
+/// fixed-height instead of pushing the composer off-screen on a
+/// long internal monologue.
+const LIVE_THINK_PREVIEW_MAX_ROWS: usize = 6;
 
-    let mut out = vec![Line::from(vec![
-        Span::raw("  "),
-        Span::styled("✻ ", dim),
-        Span::styled("Thinking…", dim),
-    ])];
-    if !preview.is_empty() {
+/// While `<think>` is open and the model is still streaming, show a
+/// shimmering "Thinking…" header plus a fixed-height scrolling
+/// preview of the latest thinking content. Matches `ReasoningCell`'s
+/// live-preview grammar so the two paths (inline `<think>` vs.
+/// provider reasoning channel) feel consistent to the user. Full
+/// thinking body stays hidden — once `</think>` arrives this whole
+/// block collapses to a one-line `✻ Thought (N lines)` header.
+fn render_live_thinking(think_partial: &str, width: u16) -> Vec<Line<'static>> {
+    let dim_italic = Style::default()
+        .add_modifier(Modifier::DIM)
+        .add_modifier(Modifier::ITALIC);
+
+    // Header line — shimmered so there's a visible "still working"
+    // cue even if the preview body happens to be empty for a tick.
+    let mut header_spans: Vec<Span<'static>> = vec![Span::raw("  ")];
+    header_spans.push(Span::styled("✻ ", dim_italic));
+    header_spans.extend(crate::tui::shimmer::shimmer_spans("Thinking…"));
+    let mut out = vec![Line::from(header_spans)];
+
+    // Soft-wrap the partial thinking content, then render the most
+    // recent N rows, with a `⋯ +M more` counter in the first slot
+    // once overflow starts. Rendered at width-6 because we prefix
+    // each body row with "    " (4 cols of indent) and the outer
+    // frame already reserves 2 cols for its border — total 6.
+    let inner_w = (width as usize).saturating_sub(6).max(10);
+    let mut body_rows: Vec<String> = Vec::new();
+    for logical in think_partial.lines() {
+        if logical.trim().is_empty() {
+            continue;
+        }
+        for row in soft_wrap_preview(logical, inner_w) {
+            body_rows.push(row);
+        }
+    }
+
+    let total = body_rows.len();
+    let visible_start = if total > LIVE_THINK_PREVIEW_MAX_ROWS {
+        // Row 0 of the body shows the overflow counter; the window
+        // displays the last `LIVE_THINK_PREVIEW_MAX_ROWS - 1` rows.
+        let tail = LIVE_THINK_PREVIEW_MAX_ROWS - 1;
+        let hidden = total - tail;
         out.push(Line::from(vec![
             Span::raw("    "),
-            Span::styled(preview, dim),
+            Span::styled(format!("⋯ +{hidden} more"), dim_italic),
         ]));
+        total - tail
+    } else {
+        0
+    };
+    for row in body_rows.into_iter().skip(visible_start) {
+        out.push(Line::from(vec![
+            Span::raw("    "),
+            Span::styled(row, dim_italic),
+        ]));
+    }
+    out
+}
+
+/// Break a logical line into visual rows at `width` display cells —
+/// same behaviour as `ReasoningCell::soft_wrap`, duplicated here so
+/// the assistant cell can preview leaked-`<think>` content without
+/// pulling in the reasoning module.
+fn soft_wrap_preview(input: &str, width: usize) -> Vec<String> {
+    use unicode_width::UnicodeWidthChar;
+    if width == 0 {
+        return vec![input.to_string()];
+    }
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut current_w = 0usize;
+    for ch in input.chars() {
+        let cw = ch.width().unwrap_or(0);
+        if current_w + cw > width && !current.is_empty() {
+            out.push(std::mem::take(&mut current));
+            current_w = 0;
+        }
+        current.push(ch);
+        current_w += cw;
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    if out.is_empty() {
+        out.push(String::new());
     }
     out
 }
@@ -554,26 +611,54 @@ mod tests {
     }
 
     #[test]
-    fn streaming_think_shows_indicator_and_latest_line() {
-        // While the think block is still open, we show "Thinking…"
-        // + the most recent line of internal monologue so the
-        // user sees motion.
+    fn streaming_think_shows_indicator_and_recent_lines() {
+        // While the `<think>` block is still open we show
+        // `✻ Thinking…` plus a scrolling preview of the latest
+        // rows of internal monologue (see `LIVE_THINK_PREVIEW_MAX_ROWS`).
+        // With only two lines of content, the whole body fits in
+        // the preview window — no overflow counter, both rows
+        // visible.
         let mut c = AssistantCell::new_streaming();
         c.push_delta("<think>\nstep one\nstep two in progres");
-        let out = render(&c, 80, 3);
+        let out = render(&c, 80, 5);
         assert!(out.contains("Thinking…"), "live indicator missing: {out}");
         assert!(
             out.contains("step two in progres"),
             "latest thinking line missing: {out}"
         );
         assert!(
-            !out.contains("step one"),
-            "only the most recent line should preview (keeps viewport stable): {out}"
+            out.contains("step one"),
+            "earlier line must stay visible under the window cap: {out}"
         );
         // Body hasn't arrived yet — no `┃ ` gutter.
         assert!(
             !out.contains('┃'),
             "body gutter shouldn't render while still thinking: {out}"
+        );
+    }
+
+    #[test]
+    fn streaming_think_preview_caps_and_shows_counter_on_overflow() {
+        // Once the running think body exceeds the preview window,
+        // the oldest rows drop off and a `⋯ +N more` counter takes
+        // the first slot so the user sees there's hidden content.
+        let mut c = AssistantCell::new_streaming();
+        let total_rows = LIVE_THINK_PREVIEW_MAX_ROWS + 4;
+        let padding: Vec<String> = (1..=total_rows).map(|i| format!("row {i}")).collect();
+        c.push_delta(&format!("<think>\n{}", padding.join("\n")));
+        let out = render(&c, 80, (LIVE_THINK_PREVIEW_MAX_ROWS + 2) as u16);
+        let hidden = total_rows - (LIVE_THINK_PREVIEW_MAX_ROWS - 1);
+        assert!(
+            out.contains(&format!("⋯ +{hidden} more")),
+            "overflow counter missing: {out}"
+        );
+        assert!(
+            !out.contains("row 1 "),
+            "oldest row must have scrolled off: {out}"
+        );
+        assert!(
+            out.contains(&format!("row {total_rows}")),
+            "most recent row must be visible: {out}"
         );
     }
 
@@ -711,6 +796,9 @@ mod tests {
     fn snapshot_streaming_think_preview_80() {
         let mut c = AssistantCell::new_streaming();
         c.push_delta("<think>\nFirst, let me think about the structure.\nActually, the user wants a concise answer.");
-        insta::assert_snapshot!("assistant_think_streaming_80", render(&c, 80, 3));
+        // Height 4: header + 2 preview rows (under cap) + one spare
+        // row. The preview no longer single-lines — it scrolls like
+        // `ReasoningCell` — so both thinking rows must appear.
+        insta::assert_snapshot!("assistant_think_streaming_80", render(&c, 80, 4));
     }
 }

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_think_streaming_80.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_think_streaming_80.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/assistant.rs
-expression: "render(&c, 80, 3)"
+expression: "render(&c, 80, 4)"
 ---
   ✻ Thinking…
+    First, let me think about the structure.
     Actually, the user wants a concise answer.

--- a/rust/crates/astra-cli/src/tui/mod.rs
+++ b/rust/crates/astra-cli/src/tui/mod.rs
@@ -81,6 +81,12 @@ pub(crate) enum ActiveView {
     Active {
         kind: ActiveKind,
         lines: Vec<ratatui::text::Line<'static>>,
+        /// `true` while the cell is still streaming — enables the
+        /// flowing-gradient border animation. `false` for rare cases
+        /// where a finalized cell lingers in the active slot (never
+        /// happens in practice, but the flag keeps the render path
+        /// honest).
+        live: bool,
     },
 }
 
@@ -128,7 +134,8 @@ fn active_viewport(
         let lines = cell.display_lines(inner_w);
         if !lines.is_empty() {
             let kind = classify_active(cell).unwrap_or(ActiveKind::Assistant);
-            return ActiveView::Active { kind, lines };
+            let live = cell.is_live();
+            return ActiveView::Active { kind, lines, live };
         }
     }
     if let Some(line) = status.render() {
@@ -1053,6 +1060,17 @@ pub(crate) async fn run_tui_repl(
                 // next event edge.
                 let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
                 flush_chat_widget(&mut guard, &mut chat_widget, w);
+                // If a cell is streaming, request a redraw so the
+                // gradient-border animation on `LiveFramedCell` keeps
+                // flowing. Without this the frame only redraws on
+                // incoming delta/state events and freezes visually
+                // between them.
+                if chat_widget
+                    .active_cell()
+                    .is_some_and(|c| c.is_live())
+                {
+                    frame_requester.schedule_frame();
+                }
             }
         }
     };
@@ -1060,12 +1078,152 @@ pub(crate) async fn run_tui_repl(
     result
 }
 
+/// A rounded-frame renderable whose border characters carry a
+/// time-varying gradient — one colour per cell, sweeping around the
+/// perimeter. Used in place of a plain `Block`-wrapped paragraph while
+/// the active cell is still streaming, so the user sees the frame
+/// "breathing" and immediately knows output isn't frozen.
+///
+/// On freeze (`live == false`) the border collapses to a solid colour
+/// chosen by the cell kind — matches the pre-animation behaviour. The
+/// static pink `┃ ` gutter used in scrollback is unrelated to this
+/// frame; it's painted by `render_body_with_gutter` only after the
+/// cell leaves the active slot.
+struct LiveFramedCell {
+    lines: Vec<ratatui::text::Line<'static>>,
+    title: &'static str,
+    /// Border colour when NOT live (or fallback for non-truecolor
+    /// terminals).
+    solid_color: ratatui::style::Color,
+    live: bool,
+}
+
+impl render::renderable::Renderable for LiveFramedCell {
+    fn render(&self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
+        use ratatui::style::{Modifier, Style};
+        use ratatui::text::{Line, Span};
+        use ratatui::widgets::{Paragraph, Widget};
+
+        if area.width < 2 || area.height < 2 {
+            return;
+        }
+
+        // Inner paragraph area (leave 1 cell on each side for border).
+        let inner = ratatui::layout::Rect {
+            x: area.x + 1,
+            y: area.y + 1,
+            width: area.width.saturating_sub(2),
+            height: area.height.saturating_sub(2),
+        };
+
+        // Paint inner content first (border is drawn over edge cells
+        // below, which the paragraph never touches).
+        let para = Paragraph::new(ratatui::text::Text::from(self.lines.clone()));
+        Widget::render(para, inner, buf);
+
+        // Draw the rounded border character by character, assigning
+        // each cell a gradient colour when live.
+        let x0 = area.x;
+        let y0 = area.y;
+        let x1 = area.x + area.width - 1;
+        let y1 = area.y + area.height - 1;
+
+        let perimeter = 2 * (area.width as usize + area.height as usize - 2);
+        // Sweep once around the perimeter every N seconds. Slow enough
+        // that the eye reads "flowing", fast enough that it isn't stuck.
+        let period = 3.0_f32;
+
+        let color_at = |idx: usize| -> ratatui::style::Color {
+            if !self.live {
+                return self.solid_color;
+            }
+            let (r, g, b) = shimmer::gradient_color_at(idx, perimeter, period);
+            ratatui::style::Color::Rgb(r, g, b)
+        };
+
+        let mut idx: usize = 0;
+        // Top edge: ╭ ── ╮
+        set_char(buf, x0, y0, '╭', color_at(idx));
+        idx += 1;
+        for x in (x0 + 1)..x1 {
+            set_char(buf, x, y0, '─', color_at(idx));
+            idx += 1;
+        }
+        set_char(buf, x1, y0, '╮', color_at(idx));
+        idx += 1;
+        // Right edge
+        for y in (y0 + 1)..y1 {
+            set_char(buf, x1, y, '│', color_at(idx));
+            idx += 1;
+        }
+        // Bottom edge: ╰ ── ╯ (traverse right-to-left to keep the
+        // gradient continuous around the perimeter)
+        set_char(buf, x1, y1, '╯', color_at(idx));
+        idx += 1;
+        for x in ((x0 + 1)..x1).rev() {
+            set_char(buf, x, y1, '─', color_at(idx));
+            idx += 1;
+        }
+        set_char(buf, x0, y1, '╰', color_at(idx));
+        idx += 1;
+        // Left edge (bottom → top)
+        for y in ((y0 + 1)..y1).rev() {
+            set_char(buf, x0, y, '│', color_at(idx));
+            idx += 1;
+        }
+        let _ = idx;
+
+        // Title overlay (dim, on top border). Uses the solid colour so
+        // the label stays legible against the animated border.
+        let title = format!(" {} ", self.title.trim());
+        let title_span = Span::styled(
+            title.clone(),
+            Style::default()
+                .fg(self.solid_color)
+                .add_modifier(Modifier::DIM),
+        );
+        // Anchor title at x0 + 2 so it doesn't overlap the corner.
+        let title_x = x0 + 2;
+        if title_x + title.chars().count() as u16 <= x1 {
+            let line_widget = Line::from(title_span);
+            let line_area = ratatui::layout::Rect {
+                x: title_x,
+                y: y0,
+                width: title.chars().count() as u16,
+                height: 1,
+            };
+            ratatui::widgets::WidgetRef::render_ref(&line_widget, line_area, buf);
+        }
+    }
+
+    fn desired_height(&self, _width: u16) -> u16 {
+        // border(2) + content lines
+        (self.lines.len() as u16).saturating_add(2)
+    }
+}
+
+/// Write a single character cell into the buffer with the given fg.
+fn set_char(
+    buf: &mut ratatui::buffer::Buffer,
+    x: u16,
+    y: u16,
+    ch: char,
+    fg: ratatui::style::Color,
+) {
+    if x >= buf.area.x + buf.area.width || y >= buf.area.y + buf.area.height {
+        return;
+    }
+    let cell = &mut buf[(x, y)];
+    cell.set_char(ch);
+    cell.set_style(ratatui::style::Style::default().fg(fg));
+}
+
 pub(super) fn do_draw(
     guard: &mut TerminalGuard,
     active: ActiveView,
     bottom_pane: &mut BottomPane,
 ) -> Result<(), String> {
-    use ratatui::widgets::{Block, Borders, Paragraph};
+    use ratatui::widgets::Paragraph;
     use render::renderable::{FlexRenderable, Renderable, RenderableItem};
 
     bottom_pane.pre_draw_tick(std::time::Instant::now());
@@ -1084,26 +1242,23 @@ pub(super) fn do_draw(
         // Active cell gets a rounded bordered box in a colour that
         // matches the cell kind, so the user sees "this is the live
         // thing" at a glance — as opposed to the flat scrollback
-        // above. Cursor/Kiro style.
-        ActiveView::Active { kind, lines } => {
+        // above. While `live` (still streaming), the frame pulses
+        // through a flowing gradient; once finalized the border
+        // collapses to a solid colour. Cursor/Kiro style.
+        ActiveView::Active { kind, lines, live } => {
             let theme = crate::tui::theme::current();
-            let (border_color, title) = match kind {
-                ActiveKind::Tool => (theme.accent, " tool "),
-                ActiveKind::Assistant => (theme.gutter, " assistant "),
-                ActiveKind::Reasoning => (theme.dim, " thinking "),
+            let (solid_color, title) = match kind {
+                ActiveKind::Tool => (theme.accent, "tool"),
+                ActiveKind::Assistant => (theme.gutter, "assistant"),
+                ActiveKind::Reasoning => (theme.dim, "thinking"),
             };
-            let block = Block::default()
-                .borders(Borders::ALL)
-                .border_type(ratatui::widgets::BorderType::Rounded)
-                .border_style(ratatui::style::Style::default().fg(border_color))
-                .title(ratatui::text::Span::styled(
-                    title.to_string(),
-                    ratatui::style::Style::default()
-                        .fg(border_color)
-                        .add_modifier(ratatui::style::Modifier::DIM),
-                ));
-            let para = Paragraph::new(ratatui::text::Text::from(lines)).block(block);
-            RenderableItem::Owned(Box::new(para))
+            let framed = LiveFramedCell {
+                lines,
+                title,
+                solid_color,
+                live,
+            };
+            RenderableItem::Owned(Box::new(framed))
         }
     };
 

--- a/rust/crates/astra-cli/src/tui/shimmer.rs
+++ b/rust/crates/astra-cli/src/tui/shimmer.rs
@@ -14,6 +14,48 @@ fn elapsed_since_start() -> Duration {
     start.elapsed()
 }
 
+/// RGB color for a given "position along a border" (0..len) at the
+/// current moment in time. Produces a flowing rainbow-ish gradient
+/// that cycles around the frame — warm pinks → cool blues → back.
+/// Hue advances with time and along the border, giving a "wave
+/// travelling around the frame" effect.
+///
+/// Used by `LiveFramedCell` to color each border character while the
+/// active cell is still streaming.
+pub(crate) fn gradient_color_at(pos: usize, len: usize, period_seconds: f32) -> (u8, u8, u8) {
+    let t = elapsed_since_start().as_secs_f32();
+    // Normalize position to [0, 1) along the border, then add a
+    // time-varying phase so the hue slides along the frame.
+    let len = len.max(1) as f32;
+    let phase = (t / period_seconds).fract();
+    let u = ((pos as f32 / len) + phase).fract();
+    hue_to_rgb(u)
+}
+
+/// Simple HSV-like hue sweep (S=0.55, V=1.0). Output is a soft pastel
+/// wheel so the animation reads as flowing, not strobing.
+fn hue_to_rgb(h: f32) -> (u8, u8, u8) {
+    let h6 = (h.rem_euclid(1.0)) * 6.0;
+    let c = 0.55_f32;
+    let x = c * (1.0 - ((h6 % 2.0) - 1.0).abs());
+    let (r, g, b) = if h6 < 1.0 {
+        (c, x, 0.0)
+    } else if h6 < 2.0 {
+        (x, c, 0.0)
+    } else if h6 < 3.0 {
+        (0.0, c, x)
+    } else if h6 < 4.0 {
+        (0.0, x, c)
+    } else if h6 < 5.0 {
+        (x, 0.0, c)
+    } else {
+        (c, 0.0, x)
+    };
+    let m = 1.0 - c;
+    let to_u8 = |v: f32| (((v + m).clamp(0.0, 1.0)) * 255.0) as u8;
+    (to_u8(r), to_u8(g), to_u8(b))
+}
+
 pub(crate) fn shimmer_spans(text: &str) -> Vec<Span<'static>> {
     let chars: Vec<char> = text.chars().collect();
     if chars.is_empty() {


### PR DESCRIPTION
## Summary

- **Flowing gradient border while the assistant is live.** The rounded frame around the streaming assistant cell is now painted character-by-character with a time-varying HSV sweep (3 s period around the perimeter, soft pastel palette). Once the cell finalizes, the frame collapses to the solid kind-colour and the cell flushes into scrollback where the static pink \`┃\` gutter takes over. The 50 ms tick reschedules a redraw while any active cell is live so the animation keeps flowing between token deltas.
- **Scrolling inline \`<think>\` preview inside AssistantCell.** The previous behavior truncated thinking to a single last-line preview. It now mirrors \`ReasoningCell\`: up to 6 soft-wrapped rows, oldest scrolls off, \`⋯ +N more\` overflow counter in the top slot. Header shimmers via the existing \`shimmer_spans\` helper so the \"still thinking\" cue is visible even when the preview body is briefly empty.
- **No red bar during live.** Already behaved correctly by architecture — the static \`┃ \` gutter only renders in scrollback after \`commit_active()\` hands the cell off. The live view just shows the animated frame now instead of a solid gutter-colour border.

## Test plan

- [x] \`cargo check -p astra-cli\`
- [x] \`cargo clippy -p astra-cli --tests -- -D warnings\` — clean
- [x] \`cargo test -p astra-cli\` — 3749 pass, 0 fail
- [x] One new test (\`streaming_think_preview_caps_and_shows_counter_on_overflow\`), one updated test (\`streaming_think_shows_indicator_and_recent_lines\`), refreshed insta snapshot for the taller render
- [ ] Visually verify the gradient sweep in a real terminal (\`make dev-start\` + send a prompt) — not run in this session