### PR TITLE
fix(tools): multi-edit fuzzy, hallucination tripwire, agent spawn resilience, actionable errors

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
@@ -677,25 +677,6 @@ async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
     }
     set_payload_tool_results_if_non_empty(&mut payload, ctx.tool_results);
 
-    // DEBUG: append tool_results to a temp file so we can see every payload
-    // the LLM receives. Unconditional on purpose — this is a temporary probe
-    // for the "{}" coercion bug; gating it would defeat the point (data lost
-    // if the env var isn't set when the bug reproduces).
-    // TODO(remove-before-merge): delete once the "{}" bug is root-caused.
-    if !ctx.tool_results.is_empty() {
-        use std::io::Write;
-        let dump = serde_json::json!({
-            "ts": chrono::Utc::now().to_rfc3339(),
-            "tool_results_count": ctx.tool_results.len(),
-            "tool_results": ctx.tool_results,
-        });
-        let path = std::env::temp_dir()
-            .join(format!("astra-tool-results-debug-{}.jsonl", std::process::id()));
-        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
-            let _ = writeln!(f, "{}", serde_json::to_string(&dump).unwrap_or_default());
-        }
-    }
-
     record_agentic_step_plan_after_payload_prep(
         ctx.step_recorder,
         ctx.telem.first_selection_report.as_ref(),

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
@@ -677,6 +677,25 @@ async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
     }
     set_payload_tool_results_if_non_empty(&mut payload, ctx.tool_results);
 
+    // DEBUG: append tool_results to a temp file so we can see every payload
+    // the LLM receives. Unconditional on purpose — this is a temporary probe
+    // for the "{}" coercion bug; gating it would defeat the point (data lost
+    // if the env var isn't set when the bug reproduces).
+    // TODO(remove-before-merge): delete once the "{}" bug is root-caused.
+    if !ctx.tool_results.is_empty() {
+        use std::io::Write;
+        let dump = serde_json::json!({
+            "ts": chrono::Utc::now().to_rfc3339(),
+            "tool_results_count": ctx.tool_results.len(),
+            "tool_results": ctx.tool_results,
+        });
+        let path = std::env::temp_dir()
+            .join(format!("astra-tool-results-debug-{}.jsonl", std::process::id()));
+        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+            let _ = writeln!(f, "{}", serde_json::to_string(&dump).unwrap_or_default());
+        }
+    }
+
     record_agentic_step_plan_after_payload_prep(
         ctx.step_recorder,
         ctx.telem.first_selection_report.as_ref(),

--- a/rust/crates/astra-cli/src/cli/journal_digest.rs
+++ b/rust/crates/astra-cli/src/cli/journal_digest.rs
@@ -1624,6 +1624,46 @@ mod tests {
     }
 
     #[test]
+    fn digest_does_not_flag_cross_turn_cache_hits_as_failures() {
+        // Regression guard for session 6d6c1041: cross-turn cache
+        // hits are recorded with `error: "cached_cross_turn"` (an
+        // info tag, not a failure) + a non-empty
+        // `result_preview` starting with "[cached_cross_turn:".
+        // Earlier versions with `result_preview: None` mis-reported
+        // the tool as having returned an empty body and the LLM
+        // hallucinated a `{}`-return bug. Pin both invariants:
+        // - cache hits are NOT counted in `tool_calls_failed`
+        // - `result_body_signals_failure` returns false for the
+        //   tagged preview shape
+        assert!(
+            !result_body_signals_failure(
+                "[cached_cross_turn: reused 2000 bytes — refer to earlier read_file]"
+            ),
+            "cache-hit preview must not trip the failure detector"
+        );
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _g = JournalDirGuard::new(tmp.path());
+
+        let sid = "test-cachehit-00000000-0000-0000-0000-0000000000aa";
+        fs::write(
+            tmp.path().join(format!("{sid}.jsonl")),
+            r#"{"type":"turn","ts":"2026-01-01T00:00:00Z","session_id":"S","turn":1,"tool_calls":[{"name":"read_file","ok":true,"ms":0,"error":"cached_cross_turn","output_bytes":2000,"result_preview":"[cached_cross_turn: reused 2000 bytes]","args_preview":"src/lib.rs"},{"name":"bash","ok":true,"ms":5,"result_preview":"ok"}]}"#,
+        )
+        .expect("write journal");
+
+        let d = build_digest(sid, DigestFocus::All).expect("digest");
+        assert_eq!(
+            d.aggregates.tool_calls_failed, 0,
+            "cross-turn cache hits must not count as failures"
+        );
+        assert!(
+            d.failed_tool_calls.is_empty(),
+            "cross-turn cache hits must not appear in failed_tool_calls"
+        );
+    }
+
+    #[test]
     fn digest_failed_tool_calls_empty_in_summary_focus() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let _g = JournalDirGuard::new(tmp.path());

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -6549,6 +6549,10 @@ fn append_skill_loaded_marker(result: &str, skill_name: &str) -> String {
     // (U+2028 / U+2029, which `is_control` does NOT catch) to
     // impersonate a different skill in LLM-visible output. Anything
     // outside the allowlist is replaced with `_`.
+    // The allowlist already rejects every XML-special character
+    // (`<`, `>`, `&`, `"`, `'`) by replacing it with `_`, so no
+    // subsequent XML-escape pass is needed — and adding one would be
+    // dead code that falsely suggests the allowlist is permissive.
     let safe_name: String = skill_name
         .chars()
         .map(|c| {
@@ -6558,12 +6562,17 @@ fn append_skill_loaded_marker(result: &str, skill_name: &str) -> String {
                 '_'
             }
         })
-        .collect::<String>()
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;");
+        .collect();
+    // Belt-and-suspenders: make the allowlist's XML-safety guarantee
+    // a runtime invariant, so any future relaxation of the allowlist
+    // that lets an XML-special char slip through trips tests
+    // immediately instead of silently enabling tag breakout.
+    debug_assert!(
+        !safe_name
+            .chars()
+            .any(|c| matches!(c, '<' | '>' | '&' | '"' | '\'')),
+        "allowlist must reject every XML-special character; got {safe_name:?}"
+    );
     format!("{result}\n\n<skill-loaded name=\"{safe_name}\"/>")
 }
 
@@ -8203,11 +8212,19 @@ diff --git a/src/a.rs b/src/a.rs\n\
     }
 
     #[test]
-    fn skill_loaded_marker_escapes_xml_special_chars() {
+    fn skill_loaded_marker_sanitizes_xml_special_chars() {
+        // XML-special characters (`<`, `>`, `&`, `"`, `'`) are outside
+        // the filename-safe allowlist, so they are replaced with `_`.
+        // This prevents a malicious skill name from breaking out of
+        // the `<skill-loaded name="..."/>` tag entirely.
         let result = append_skill_loaded_marker("ok", "a<b>&c\"d");
         assert!(
-            result.contains("a&lt;b&gt;&amp;c&quot;d"),
-            "XML special chars must be escaped: {result}"
+            result.contains("a_b__c_d"),
+            "XML special chars must be replaced with `_`: {result}"
+        );
+        assert!(
+            !result.contains('<') || result.matches('<').count() == 1,
+            "only the opening `<skill-loaded` angle bracket may remain: {result}"
         );
     }
 

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -6543,13 +6543,21 @@ fn append_skill_loaded_marker(result: &str, skill_name: &str) -> String {
     if result.starts_with("Error:") || result.starts_with("error:") || result.trim().is_empty() {
         return result.to_string();
     }
-    // Sanitize: XML escape + strip control chars (including \n\r\t)
-    // that could break the XML tag structure. Linux allows filenames
-    // with newlines; a malicious skill name with \n could inject
-    // extra XML attributes or content.
+    // Sanitize: allowlist to a conservative set of filename-safe
+    // characters. A malicious skill registry entry could otherwise
+    // use path-like names (`../evil`) or Unicode line separators
+    // (U+2028 / U+2029, which `is_control` does NOT catch) to
+    // impersonate a different skill in LLM-visible output. Anything
+    // outside the allowlist is replaced with `_`.
     let safe_name: String = skill_name
         .chars()
-        .filter(|c| !c.is_control())
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':' | '/') {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect::<String>()
         .replace('&', "&amp;")
         .replace('<', "&lt;")

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -2085,12 +2085,20 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     if let Some(exec) = self.streaming_tool_exec.clone() {
                         exec.discard(request_id).await;
                     }
-                    astra_runtime::turn::skill_tool::execute_skill_inline(
+                    let raw = astra_runtime::turn::skill_tool::execute_skill_inline(
                         resolver.as_ref(),
                         tool,
                         args,
                     )
-                    .await
+                    .await;
+                    // Append `<skill-loaded name="..."/>` so the LLM sees
+                    // the "do not re-invoke" signal. Without this, the
+                    // system-prompt rule "On seeing <skill-loaded/>, follow
+                    // instructions — do not re-invoke" never triggers on the
+                    // CLI edge path, and the LLM loads a second skill
+                    // (session 11825116 regression). Server-side path does
+                    // this in partition_discover_and_execute_skills:1098.
+                    append_skill_loaded_marker(&raw, &dedup_key)
                 } else {
                     "Error: skill resolver not available".to_string()
                 }
@@ -6519,6 +6527,31 @@ pub(super) fn dispatch_turn_event_block(
     apply_sse_render_effects(effects, render, policy);
 }
 
+/// Append `<skill-loaded name="..."/>` to a successful skill result.
+///
+/// The system prompt tells the LLM: "On seeing `<skill-loaded name="..."/>` in
+/// a tool result, follow that skill's instructions — do not re-invoke it."
+/// Without this marker, the LLM doesn't know the skill loaded and may
+/// invoke discover_skills + a second skill in the same turn.
+///
+/// Error results (starting with "Error:") are returned unchanged — the LLM
+/// should be free to retry or switch strategies on failures.
+///
+/// Mirrors the server-side logic in
+/// `runtime::turn::skill_tool::partition_discover_and_execute_skills` (line ~1098).
+fn append_skill_loaded_marker(result: &str, skill_name: &str) -> String {
+    if result.starts_with("Error:") || result.starts_with("error:") || result.trim().is_empty() {
+        return result.to_string();
+    }
+    let safe_name = skill_name
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;");
+    format!("{result}\n\n<skill-loaded name=\"{safe_name}\"/>")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -8114,6 +8147,53 @@ diff --git a/src/a.rs b/src/a.rs\n\
         );
         assert!(msg.contains("code-review"));
         assert!(msg.contains("already loaded"));
+    }
+
+    // ── CLI skill-loaded marker tests ──────────────────────────────────
+
+    #[test]
+    fn skill_loaded_marker_appended_to_successful_result() {
+        // Regression (session 11825116): the CLI edge path used
+        // `execute_skill_inline` which returned raw skill content
+        // WITHOUT appending `<skill-loaded name="..."/>`. The
+        // system prompt tells the LLM "On seeing <skill-loaded/>,
+        // do not re-invoke" — without the marker, the LLM loaded
+        // a second skill (review-code) after already loading
+        // review-changes, wasting context and confusing itself.
+        //
+        // Fix: `append_skill_loaded_marker` adds the tag to
+        // successful (non-error) results.
+        let raw = "# Skill: review-changes\n\nYou are now executing...";
+        let result = append_skill_loaded_marker(raw, "review-changes");
+        assert!(
+            result.contains("<skill-loaded name=\"review-changes\"/>"),
+            "successful skill result must carry the marker: {result}"
+        );
+        assert!(
+            result.ends_with("<skill-loaded name=\"review-changes\"/>"),
+            "marker must be at the very end so LLM sees it last: {result}"
+        );
+    }
+
+    #[test]
+    fn skill_loaded_marker_not_appended_to_error_result() {
+        // Error results must NOT carry the tag — the LLM should be
+        // free to retry or switch to another skill.
+        let raw = "Error: skill resolver not available";
+        let result = append_skill_loaded_marker(raw, "broken-skill");
+        assert!(
+            !result.contains("<skill-loaded"),
+            "error results must not carry the marker: {result}"
+        );
+    }
+
+    #[test]
+    fn skill_loaded_marker_escapes_xml_special_chars() {
+        let result = append_skill_loaded_marker("ok", "a<b>&c\"d");
+        assert!(
+            result.contains("a&lt;b&gt;&amp;c&quot;d"),
+            "XML special chars must be escaped: {result}"
+        );
     }
 
     // ── EdgeToolCache unit tests ─────────────────────────────────────────

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -6543,7 +6543,14 @@ fn append_skill_loaded_marker(result: &str, skill_name: &str) -> String {
     if result.starts_with("Error:") || result.starts_with("error:") || result.trim().is_empty() {
         return result.to_string();
     }
-    let safe_name = skill_name
+    // Sanitize: XML escape + strip control chars (including \n\r\t)
+    // that could break the XML tag structure. Linux allows filenames
+    // with newlines; a malicious skill name with \n could inject
+    // extra XML attributes or content.
+    let safe_name: String = skill_name
+        .chars()
+        .filter(|c| !c.is_control())
+        .collect::<String>()
         .replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -1743,6 +1743,7 @@ impl ToolExecutor {
         // deviated from a verbatim match and can re-inspect.
         let mut working = content.clone();
         let mut fuzzy_applications: Vec<(usize, &'static str)> = Vec::new();
+        let mut first_edit_start_byte: Option<usize> = None;
         for (i, edit) in edits.iter().enumerate() {
             let old_str = match edit.get("old_str").and_then(Value::as_str) {
                 Some(s) => s,
@@ -1767,6 +1768,9 @@ impl ToolExecutor {
                 ) {
                     Some(fuzzy_match) => {
                         let actual = fuzzy_match.actual.to_string();
+                        if i == 0 {
+                            first_edit_start_byte = working.find(&actual);
+                        }
                         fuzzy_applications.push((i, fuzzy_match.strategy));
                         working = working.replacen(&actual, new_str, 1);
                         continue;
@@ -1784,6 +1788,9 @@ impl ToolExecutor {
                     "Error: edit[{i}] old_str matches {count} times (must be unique). Aborting all edits.\n{}",
                     str_replace_ambiguous_hint(&working, old_str, count)
                 );
+            }
+            if i == 0 {
+                first_edit_start_byte = working.find(old_str);
             }
             working = working.replacen(old_str, new_str, 1);
         }
@@ -1837,15 +1844,9 @@ impl ToolExecutor {
 
                 // Scope context for the first edit location
                 if let Some(lang) = super::code_intel::detect_language(&path)
-                    && let Some(first_old) = edits
-                        .first()
-                        .and_then(|e| e.get("old_str"))
-                        .and_then(Value::as_str)
+                    && let Some(first_edit_start) = first_edit_start_byte
                 {
-                    let edit_line = content[..content.find(first_old).unwrap_or(0)]
-                        .matches('\n')
-                        .count()
-                        + 1;
+                    let edit_line = content[..first_edit_start].matches('\n').count() + 1;
                     let scope = super::code_intel::scope_at_line(&working, lang, edit_line);
                     if !scope.breadcrumbs.is_empty() {
                         result.push_str(&format!("\n📍 {}", scope.breadcrumbs.join(" > ")));
@@ -4397,6 +4398,39 @@ type Handler interface {
         assert!(result.contains("Applied 2 edit(s)"), "result: {result}");
         assert!(result.contains("📍"), "should show scope: {result}");
         assert!(result.contains("main"), "should mention fn main: {result}");
+    }
+
+    #[test]
+    fn multi_edit_fuzzy_match_scope_uses_actual_location() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let file = tmpdir.path().join("lib.rs");
+        std::fs::write(
+            &file,
+            "fn top_level() {\n    let unrelated = 1;\n}\n\nfn outer() {\n    fn inner() {\n        let  value = compute();\n    }\n}\n",
+        )
+        .unwrap();
+        let exe = ToolExecutor::new(tmpdir.path().to_path_buf());
+        exe.read_file(&serde_json::json!({"path": "lib.rs"}));
+        let result = exe.multi_edit(&json!({
+            "path": "lib.rs",
+            "edits": [
+                {
+                    "old_str": "        let value = compute();",
+                    "new_str": "        let value = finish();"
+                }
+            ]
+        }));
+
+        assert!(result.contains("Applied 1 edit(s)"), "result: {result}");
+        assert!(result.contains("📍"), "should show scope: {result}");
+        assert!(
+            result.contains("outer") && result.contains("inner"),
+            "scope should use actual fuzzy match location, not line 1: {result}"
+        );
+        assert!(
+            !result.contains("top_level"),
+            "scope must not fall back to the beginning of the file: {result}"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -1728,8 +1728,21 @@ impl ToolExecutor {
             Err(e) => return format!("Error reading file: {e}"),
         };
 
-        // Validate all edits first (atomic: all or nothing)
+        // Validate + apply all edits atomically (all or nothing).
+        //
+        // Exact-match first. When a given edit's old_str doesn't
+        // match verbatim, fall back to the same fuzzy cascade that
+        // single-edit `str_replace` uses — whitespace-normalized,
+        // indentation-flexible, etc. — so the common "LLM got the
+        // indent off by 4 spaces" case auto-succeeds instead of
+        // aborting the whole batch. Ambiguous fuzzy matches (more
+        // than one candidate) still bail out safely.
+        //
+        // We collect `(strategy_name, edit_index)` pairs for any
+        // fuzzy applications so the caller sees which edits
+        // deviated from a verbatim match and can re-inspect.
         let mut working = content.clone();
+        let mut fuzzy_applications: Vec<(usize, &'static str)> = Vec::new();
         for (i, edit) in edits.iter().enumerate() {
             let old_str = match edit.get("old_str").and_then(Value::as_str) {
                 Some(s) => s,
@@ -1746,10 +1759,25 @@ impl ToolExecutor {
             }
             let count = working.matches(old_str).count();
             if count == 0 {
-                return format!(
-                    "Error: edit[{i}] old_str not found. Aborting all edits.\n{}",
-                    str_replace_not_found_hint(&working, old_str)
-                );
+                // Try the fuzzy cascade. If it returns a unique
+                // match, apply it at that location using the
+                // caller's new_str; record which strategy matched.
+                match super::fuzzy_replacer::fuzzy_find_replacement(
+                    &working, old_str, /* replace_all */ false,
+                ) {
+                    Some(fuzzy_match) => {
+                        let actual = fuzzy_match.actual.to_string();
+                        fuzzy_applications.push((i, fuzzy_match.strategy));
+                        working = working.replacen(&actual, new_str, 1);
+                        continue;
+                    }
+                    None => {
+                        return format!(
+                            "Error: edit[{i}] old_str not found. Aborting all edits.\n{}",
+                            str_replace_not_found_hint(&working, old_str)
+                        );
+                    }
+                }
             }
             if count > 1 {
                 return format!(
@@ -1794,6 +1822,17 @@ impl ToolExecutor {
                 let mut result = format!("Applied {} edit(s) successfully", edits.len());
                 if let Some(fmt_note) = format_result {
                     result.push_str(&format!("\n{fmt_note}"));
+                }
+                // Disclose any edits that required fuzzy matching so
+                // the caller sees the old_str wasn't byte-exact.
+                // Format: one bullet per fuzzy edit, tagged with the
+                // strategy name (whitespace-normalized, line-trimmed,
+                // etc.) and the 1-based edit index.
+                if !fuzzy_applications.is_empty() {
+                    result.push_str("\n⚠ fuzzy match used (old_str did not match byte-exactly):");
+                    for (idx, strategy) in &fuzzy_applications {
+                        result.push_str(&format!("\n  edit[{idx}]: {strategy}"));
+                    }
                 }
 
                 // Scope context for the first edit location
@@ -4114,6 +4153,121 @@ type Handler interface {
         let exe = ToolExecutor::new(tmpdir.path().to_path_buf());
         let result = exe.multi_edit(&json!({"path": "f.txt", "edits": []}));
         assert!(result.contains("empty"), "result: {result}");
+    }
+
+    #[test]
+    fn multi_edit_auto_applies_whitespace_normalized_match() {
+        // Regression (session 5933ebce turn 4 rounds 17+20): LLM
+        // submitted old_str with 20-space indent but the actual
+        // file had 24-space indent. Single-edit `str_replace`
+        // already falls through to the fuzzy cascade for this case;
+        // `multi_edit` used to die with
+        // "Error: edit[0] old_str not found" even though the
+        // cascade's whitespace-normalized strategy has a unique
+        // match.
+        let tmpdir = tempfile::tempdir().unwrap();
+        let file = tmpdir.path().join("code.rs");
+        // Actual file: 24-space indent.
+        std::fs::write(
+            &file,
+            "fn outer() {\n                        Some(body.clone()),\n}\n",
+        )
+        .unwrap();
+        let exe = ToolExecutor::new(tmpdir.path().to_path_buf());
+        exe.read_file(&serde_json::json!({"path": "code.rs"}));
+        // LLM supplies 20-space indent — intent is clear, whitespace
+        // is the only mismatch.
+        let result = exe.multi_edit(&json!({
+            "path": "code.rs",
+            "edits": [
+                {
+                    "old_str": "                    Some(body.clone()),",
+                    "new_str": "                    Some(&body),"
+                }
+            ]
+        }));
+        assert!(
+            result.contains("Applied 1 edit(s)"),
+            "whitespace-only mismatch should auto-apply: {result}"
+        );
+        let content = std::fs::read_to_string(&file).unwrap();
+        assert!(
+            content.contains("Some(&body)"),
+            "new_str must be in file: {content}"
+        );
+        assert!(
+            !content.contains("Some(body.clone())"),
+            "old_str must be gone: {content}"
+        );
+        // Indentation of the replaced line must match the actual
+        // file's 24-space indent, not the LLM's 20-space version.
+        assert!(
+            content.contains("                        Some(&body),"),
+            "replacement must preserve file's own indentation: {content}"
+        );
+    }
+
+    #[test]
+    fn multi_edit_reports_fuzzy_strategy_in_success_message() {
+        // When multi_edit falls back to fuzzy matching, the result
+        // should say so — users/LLM can then see that the old_str
+        // didn't match exactly and inspect the diff, instead of
+        // silently losing awareness.
+        let tmpdir = tempfile::tempdir().unwrap();
+        let file = tmpdir.path().join("code.rs");
+        std::fs::write(&file, "fn f() {\n    let  x = 1;\n}\n").unwrap();
+        let exe = ToolExecutor::new(tmpdir.path().to_path_buf());
+        exe.read_file(&serde_json::json!({"path": "code.rs"}));
+        let result = exe.multi_edit(&json!({
+            "path": "code.rs",
+            "edits": [
+                {
+                    // Only one space between `let` and `x`, file has two.
+                    "old_str": "    let x = 1;",
+                    "new_str": "    let x = 2;"
+                }
+            ]
+        }));
+        assert!(
+            result.contains("Applied 1 edit(s)"),
+            "whitespace-normalized fuzzy match should succeed: {result}"
+        );
+        assert!(
+            result.to_ascii_lowercase().contains("fuzzy") || result.contains("whitespace"),
+            "result must disclose that fuzzy matching was used: {result}"
+        );
+    }
+
+    #[test]
+    fn multi_edit_rejects_fuzzy_match_when_ambiguous() {
+        // If the fuzzy cascade finds two+ candidates, multi_edit
+        // must NOT auto-apply — that's unsafe. User has to give
+        // more context.
+        let tmpdir = tempfile::tempdir().unwrap();
+        let file = tmpdir.path().join("code.rs");
+        // Two locations with whitespace-equivalent "Some(body.clone())".
+        std::fs::write(
+            &file,
+            "fn a() {\n    Some(body.clone())\n}\nfn b() {\n    Some(body.clone())\n}\n",
+        )
+        .unwrap();
+        let exe = ToolExecutor::new(tmpdir.path().to_path_buf());
+        exe.read_file(&serde_json::json!({"path": "code.rs"}));
+        let result = exe.multi_edit(&json!({
+            "path": "code.rs",
+            "edits": [
+                {
+                    "old_str": "Some(body.clone())",
+                    "new_str": "Some(&body)"
+                }
+            ]
+        }));
+        // With 2 exact matches, the original ambiguity path already
+        // handles this — keep it failing safely.
+        assert!(
+            result.starts_with("Error") || result.contains("must be unique"),
+            "ambiguous matches must not silently auto-apply: {result}"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -4398,10 +4398,7 @@ type Handler interface {
         ];
         for ((a_s, a_e), (b_s, b_e), expected) in cases {
             let overlaps = a_s < b_e && b_s < a_e;
-            assert_eq!(
-                overlaps, expected,
-                "[{a_s},{a_e}) vs [{b_s},{b_e})"
-            );
+            assert_eq!(overlaps, expected, "[{a_s},{a_e}) vs [{b_s},{b_e})");
         }
     }
 

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -4377,6 +4377,34 @@ type Handler interface {
         );
     }
 
+    // NOTE: An end-to-end test for the overlapping-fuzzy-span dedup
+    // path in `multi_edit` is structurally hard to construct because
+    // each edit runs sequentially on the buffer produced by the
+    // previous edit — so by the time edit[1] is evaluated, edit[0]'s
+    // fuzzy span has already been rewritten and no longer matches.
+    // The dedup guard remains valuable as a defence-in-depth check
+    // (e.g. against future refactors that batch fuzzy resolution up
+    // front); the overlap arithmetic itself is covered below.
+    #[test]
+    fn fuzzy_span_overlap_arithmetic_is_half_open() {
+        // Half-open interval overlap: [a,b) ∩ [c,d) non-empty ⇔ a < d && c < b.
+        let cases = [
+            // (span_a, span_b, expected_overlap)
+            ((0usize, 5usize), (5usize, 10usize), false), // touching, not overlapping
+            ((0, 5), (4, 10), true),                      // 1-byte overlap
+            ((0, 10), (3, 7), true),                      // fully contained
+            ((3, 7), (0, 10), true),                      // reverse fully contained
+            ((0, 5), (6, 10), false),                     // gap
+        ];
+        for ((a_s, a_e), (b_s, b_e), expected) in cases {
+            let overlaps = a_s < b_e && b_s < a_e;
+            assert_eq!(
+                overlaps, expected,
+                "[{a_s},{a_e}) vs [{b_s},{b_e})"
+            );
+        }
+    }
+
     #[test]
     fn multi_edit_sequential_edits_see_previous_results() {
         let tmpdir = tempfile::tempdir().unwrap();

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -309,11 +309,22 @@ impl ToolExecutor {
             let size = meta.len() as usize;
             let limit = self.scaled_output_limit();
             if size > limit {
-                let content = match read_to_string_lossy(&path) {
+                // Cap the read at 2× the output limit to avoid OOM on
+                // multi-GB files. We only need enough to generate an
+                // outline — symbols are typically in the first portion.
+                // `total_lines` is estimated from the capped read + the
+                // remaining unread bytes (assuming ~40 chars/line).
+                let cap = limit.saturating_mul(2).min(size);
+                let content = match read_capped_to_string_lossy(&path, cap) {
                     Ok(c) => c,
                     Err(e) => return format!("Error reading file: {e}"),
                 };
-                let total_lines = content.lines().count();
+                let lines_in_cap = content.lines().count();
+                let total_lines = if cap < size {
+                    lines_in_cap + (size - cap) / 40
+                } else {
+                    lines_in_cap
+                };
 
                 let outline_text = if let Some(lang) = super::code_intel::detect_language(&path) {
                     let generated = super::code_intel::generate_outline(&content, lang);
@@ -2689,6 +2700,22 @@ fn normalize_ws(s: &str) -> String {
 /// Returns a standard `io::Error` for I/O failures.
 fn read_to_string_lossy(path: &Path) -> std::io::Result<String> {
     let bytes = fs::read(path)?;
+    match String::from_utf8(bytes) {
+        Ok(s) => Ok(s),
+        Err(e) => Ok(String::from_utf8_lossy(e.as_bytes()).into_owned()),
+    }
+}
+
+/// Like `read_to_string_lossy` but reads at most `max_bytes` from the
+/// file. Used by the large-file auto-outline path to avoid OOM when the
+/// file is enormous (multi-GB). The returned string may be truncated
+/// mid-line; callers doing line analysis should be aware of the tail.
+fn read_capped_to_string_lossy(path: &Path, max_bytes: usize) -> std::io::Result<String> {
+    use std::io::Read;
+    let file = fs::File::open(path)?;
+    let mut reader = std::io::BufReader::new(file).take(max_bytes as u64);
+    let mut bytes = Vec::with_capacity(max_bytes.min(1 << 20)); // cap alloc at 1MB initial
+    reader.read_to_end(&mut bytes)?;
     match String::from_utf8(bytes) {
         Ok(s) => Ok(s),
         Err(e) => Ok(String::from_utf8_lossy(e.as_bytes()).into_owned()),

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -296,8 +296,12 @@ impl ToolExecutor {
             }
         }
 
-        // Pre-read size gate: check file size before reading.
-        // Large files without a line range should use outline or start_line/end_line.
+        // Pre-read size gate: large files without a line range auto-degrade
+        // to outline mode + guidance. Old behavior was a hard refusal ("Error:
+        // file is too large") which gave the LLM no useful content — it then
+        // had to guess start_line/end_line blind. New behavior: read the file
+        // anyway (for outline only), return the outline + explicit instructions
+        // on how to drill into specific ranges.
         if !has_range
             && !has_outline
             && let Ok(meta) = fs::metadata(&path)
@@ -305,12 +309,37 @@ impl ToolExecutor {
             let size = meta.len() as usize;
             let limit = self.scaled_output_limit();
             if size > limit {
-                let total_lines = size / 40; // rough estimate
+                let content = match read_to_string_lossy(&path) {
+                    Ok(c) => c,
+                    Err(e) => return format!("Error reading file: {e}"),
+                };
+                let total_lines = content.lines().count();
+
+                let outline_text = if let Some(lang) = super::code_intel::detect_language(&path) {
+                    let generated = super::code_intel::generate_outline(&content, lang);
+                    if generated.trim().is_empty() {
+                        format!(
+                            "(outline generation returned empty for this file — \
+                                 {total_lines} total lines)"
+                        )
+                    } else {
+                        generated
+                    }
+                } else {
+                    format!(
+                        "(no symbol outline available for this file type — \
+                             {total_lines} total lines)"
+                    )
+                };
+
                 return format!(
-                    "Error: file is too large ({} bytes, ~{} lines). \
-                     Use start_line/end_line to read a specific range, \
-                     or outline=true to see definitions only.",
-                    size, total_lines
+                    "File is large ({size} bytes, {total_lines} lines). \
+                     Auto-generated outline below.\n\n\
+                     {outline_text}\n\n\
+                     To read specific sections, use:\n\
+                     • read_file(path=\"{path_str}\", start_line=1, end_line=100) — first 100 lines\n\
+                     • read_file(path=\"{path_str}\", start_line=N, end_line=M) — specific range\n\
+                     • grep(pattern=\"keyword\", path=\"{path_str}\") — find specific symbols",
                 );
             }
         }
@@ -3361,16 +3390,16 @@ type Handler interface {
         let executor = test_executor_in(dir.path());
         let result = executor.read_file(&serde_json::json!({"path": "big.txt"}));
 
-        // Pre-read size gate: large files without a range return an error
-        // directing the LLM to use start_line/end_line or outline.
+        // Pre-read size gate: large files without a range now auto-degrade
+        // to an outline + guidance, not a hard refusal.
         assert!(
-            result.contains("too large") || result.contains("truncated"),
-            "should reject or truncate large file: last 100 chars: {}",
-            &result[result.len().saturating_sub(100)..]
+            result.contains("File is large") || result.contains("outline"),
+            "should auto-generate outline for large file: last 200 chars: {}",
+            &result[result.len().saturating_sub(200)..]
         );
         assert!(
-            result.contains("outline") || result.contains("start_line"),
-            "should suggest alternatives: last 200 chars: {}",
+            result.contains("start_line") || result.contains("read_file"),
+            "should suggest how to drill into specific ranges: last 200 chars: {}",
             &result[result.len().saturating_sub(200)..]
         );
     }
@@ -3388,18 +3417,21 @@ type Handler interface {
         drop(f);
 
         let executor = test_executor_in(dir.path());
-        // Full read should be rejected
+        // Full read should auto-degrade to outline (not a hard rejection)
         let full = executor.read_file(&serde_json::json!({"path": "big.txt"}));
         assert!(
-            full.contains("too large"),
-            "full read should be rejected: {}",
-            &full[..100.min(full.len())]
+            full.contains("File is large"),
+            "full read should auto-degrade: {}",
+            &full[..200.min(full.len())]
         );
 
-        // Ranged read should succeed
+        // Ranged read should succeed (bypass the size gate entirely)
         let ranged = executor
             .read_file(&serde_json::json!({"path": "big.txt", "start_line": 1, "end_line": 10}));
-        assert!(!ranged.contains("too large"), "ranged read should succeed");
+        assert!(
+            !ranged.contains("File is large"),
+            "ranged read must not trigger size gate"
+        );
         assert!(ranged.contains("line 0"), "should contain first line");
     }
 

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -329,8 +329,7 @@ impl ToolExecutor {
                     if lines_in_cap > 0 && cap > 0 {
                         // Scale: lines_in_cap * (size / cap), using
                         // u128 to avoid overflow on huge files.
-                        let scaled =
-                            (lines_in_cap as u128 * size as u128 / cap as u128) as usize;
+                        let scaled = (lines_in_cap as u128 * size as u128 / cap as u128) as usize;
                         scaled.max(lines_in_cap)
                     } else {
                         lines_in_cap + (size - cap) / 40
@@ -1797,6 +1796,14 @@ impl ToolExecutor {
         let mut working = content.clone();
         let mut fuzzy_applications: Vec<(usize, &'static str)> = Vec::new();
         let mut first_edit_start_byte: Option<usize> = None;
+        // Track byte-ranges modified by prior fuzzy edits so a later
+        // fuzzy edit can't silently land on the same span. Exact
+        // `working.matches(old_str)` already self-disambiguates via
+        // the count==0/count>1 checks, but two fuzzy edits whose
+        // normalized-whitespace candidates collapse to the same
+        // region would each succeed with `replace_all=false` and
+        // clobber each other. Abort with a dedup hint instead.
+        let mut fuzzy_spans: Vec<(usize, usize)> = Vec::new();
         for (i, edit) in edits.iter().enumerate() {
             let old_str = match edit.get("old_str").and_then(Value::as_str) {
                 Some(s) => s,
@@ -1821,10 +1828,37 @@ impl ToolExecutor {
                 ) {
                     Some(fuzzy_match) => {
                         let actual = fuzzy_match.actual.to_string();
+                        let match_start = match working.find(&actual) {
+                            Some(s) => s,
+                            None => {
+                                return format!(
+                                    "Error: edit[{i}] fuzzy match returned a span not present in working buffer (internal invariant violated). Aborting all edits."
+                                );
+                            }
+                        };
+                        let match_end = match_start + actual.len();
+                        // Reject if this fuzzy span overlaps a span
+                        // already consumed by an earlier fuzzy edit —
+                        // otherwise two fuzzy edits could silently
+                        // clobber the same region. Exact edits remain
+                        // immune because `working.matches(old_str)`
+                        // already self-disambiguates.
+                        if let Some((prev_i, _)) =
+                            fuzzy_spans.iter().enumerate().find(|(_, (ps, pe))| {
+                                // Overlap: [ps,pe) ∩ [match_start,match_end) non-empty
+                                match_start < *pe && *ps < match_end
+                            })
+                        {
+                            let (orig_idx, _) = fuzzy_applications[prev_i];
+                            return format!(
+                                "Error: edit[{i}] fuzzy-matched the same region as edit[{orig_idx}] (both resolved to overlapping spans via whitespace-normalized match). Aborting all edits — provide distinct exact old_str values or merge the two edits."
+                            );
+                        }
                         if i == 0 {
-                            first_edit_start_byte = working.find(&actual);
+                            first_edit_start_byte = Some(match_start);
                         }
                         fuzzy_applications.push((i, fuzzy_match.strategy));
+                        fuzzy_spans.push((match_start, match_end));
                         working = working.replacen(&actual, new_str, 1);
                         continue;
                     }

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -320,8 +320,21 @@ impl ToolExecutor {
                     Err(e) => return format!("Error reading file: {e}"),
                 };
                 let lines_in_cap = content.lines().count();
+                // Extrapolate total line count from the sampled portion
+                // rather than assuming a fixed 40 chars/line (which was
+                // wildly wrong for minified JS/CSS and near-binary files).
+                // Falls back to the old estimate only if the sample is
+                // empty (avoid div-by-zero).
                 let total_lines = if cap < size {
-                    lines_in_cap + (size - cap) / 40
+                    if lines_in_cap > 0 && cap > 0 {
+                        // Scale: lines_in_cap * (size / cap), using
+                        // u128 to avoid overflow on huge files.
+                        let scaled =
+                            (lines_in_cap as u128 * size as u128 / cap as u128) as usize;
+                        scaled.max(lines_in_cap)
+                    } else {
+                        lines_in_cap + (size - cap) / 40
+                    }
                 } else {
                     lines_in_cap
                 };

--- a/rust/crates/astra-cli/src/edge_tools/tests/aggregate_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/aggregate_tests.rs
@@ -223,8 +223,9 @@ fn multi_turn_review_scenario_read_file_downgrades_to_outline() {
     let result = executor.read_file(&json!({"path": "big.rs"}));
     assert!(
         result.contains("Auto-downgraded to outline")
-            || result.contains("too large")
-            || result.contains("Outline"),
+            || result.contains("File is large")
+            || result.contains("Outline")
+            || result.contains("outline"),
         "should downgrade or reject full read under aggregate pressure \
              (file={file_size}, agg={agg}, remaining={}), got first 300 chars: {}",
         AGGREGATE_OUTPUT_BUDGET.saturating_sub(agg),

--- a/rust/crates/astra-tools/src/executor.rs
+++ b/rust/crates/astra-tools/src/executor.rs
@@ -519,8 +519,12 @@ impl DefaultToolExecutor {
             "memory" => {
                 let action = args.get("action").and_then(|v| v.as_str()).unwrap_or("");
                 ToolResult::error(format!(
-                    "Error: Memory tool (action='{action}') requires a configured memoria endpoint. \
-                     Use ServerToolExecutor or CliToolExecutor instead of DefaultToolExecutor."
+                    "Error: Memory tool (action='{action}') is not available — the memoria \
+                     service endpoint is not configured in this session.\n\n\
+                     This usually means the session was started without `--memoria-url` or \
+                     the MEMORIA_URL environment variable is unset.\n\
+                     Workaround: skip memory operations for now, or ask the user to \
+                     configure the memoria endpoint and restart."
                 ))
             }
 
@@ -559,8 +563,13 @@ impl DefaultToolExecutor {
             Some(c) => c,
             None => {
                 return ToolResult::error(format!(
-                    "Error: GitHub tool '{name}' requires a configured GitHub client. \
-                     Call with_github_client() when building DefaultToolExecutor."
+                    "Error: GitHub tool '{name}' failed — no GitHub token is configured.\n\n\
+                     To fix, do ONE of:\n\
+                     1. Run `gh auth login` in a terminal (gh CLI stores the token)\n\
+                     2. Set the GITHUB_TOKEN environment variable before starting this session\n\n\
+                     After authenticating, restart the session and retry.\n\
+                     Workaround: use `bash` with `gh issue create ...` or `gh pr create ...` directly \
+                     (the gh CLI may already be authenticated separately)."
                 ));
             }
         };
@@ -1343,21 +1352,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dispatch_github_without_client() {
+    async fn dispatch_github_without_client_gives_actionable_guidance() {
         let (_tmp, exec) = test_executor();
         let result = exec
             .execute("github_list_prs", &serde_json::json!({}))
             .await;
         assert!(result.is_error);
         assert!(
-            result
-                .output
-                .contains("requires a configured GitHub client")
+            result.output.contains("no GitHub token is configured"),
+            "error must describe the problem, not the internal API: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("gh auth login"),
+            "error must suggest a concrete fix action: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("Workaround"),
+            "error must offer a fallback path: {}",
+            result.output
         );
     }
 
     #[tokio::test]
-    async fn dispatch_memory_without_endpoint() {
+    async fn dispatch_memory_without_endpoint_gives_actionable_guidance() {
         let (_tmp, exec) = test_executor();
         let result = exec
             .execute(
@@ -1367,9 +1386,19 @@ mod tests {
             .await;
         assert!(result.is_error);
         assert!(
-            result
-                .output
-                .contains("requires a configured memoria endpoint")
+            result.output.contains("not available"),
+            "error must describe unavailability: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("Workaround"),
+            "error must offer a fallback: {}",
+            result.output
+        );
+        assert!(
+            !result.output.contains("ServerToolExecutor"),
+            "error must not leak internal type names: {}",
+            result.output
         );
     }
 

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -1221,10 +1221,15 @@ fn resolve_existing_search_path(
 /// substring + basename match — no heavy fuzzy-matching dependency.
 fn suggest_near_miss_paths(workspace_root: &Path, requested: &str) -> Vec<String> {
     let full = workspace_root.join(requested);
-    // Walk up to find the deepest ancestor that exists.
+    // Walk up to find the deepest ancestor that exists, but never
+    // escape above workspace_root (security: prevents leaking
+    // /etc, /home, etc. via `../../../` traversals).
     let mut ancestor = full.as_path();
     loop {
         if let Some(parent) = ancestor.parent() {
+            if !parent.starts_with(workspace_root) {
+                return Vec::new();
+            }
             if parent.exists() {
                 break;
             }
@@ -1234,6 +1239,9 @@ fn suggest_near_miss_paths(workspace_root: &Path, requested: &str) -> Vec<String
         }
     }
     let search_dir = ancestor.parent().unwrap_or(workspace_root);
+    if !search_dir.starts_with(workspace_root) {
+        return Vec::new();
+    }
     let needle = full
         .file_name()
         .unwrap_or_default()
@@ -1247,7 +1255,8 @@ fn suggest_near_miss_paths(workspace_root: &Path, requested: &str) -> Vec<String
     let Ok(entries) = std::fs::read_dir(search_dir) else {
         return Vec::new();
     };
-    for entry in entries.flatten() {
+    // Cap iteration to avoid O(n) scan of huge dirs (node_modules etc.)
+    for entry in entries.flatten().take(500) {
         let name = entry.file_name().to_string_lossy().to_lowercase();
         if name.contains(&needle) || needle.contains(&name) {
             let rel = entry
@@ -1265,10 +1274,11 @@ fn suggest_near_miss_paths(workspace_root: &Path, requested: &str) -> Vec<String
     // its children and pick ones that substring-match the last component.
     if candidates.is_empty()
         && let Some(parent) = full.parent()
+        && parent.starts_with(workspace_root)
         && parent.exists()
         && let Ok(entries) = std::fs::read_dir(parent)
     {
-        for entry in entries.flatten() {
+        for entry in entries.flatten().take(500) {
             let name = entry.file_name().to_string_lossy().to_lowercase();
             if name.contains(&needle) || needle.contains(&name) {
                 let rel = entry

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -1196,12 +1196,94 @@ fn resolve_existing_search_path(
 ) -> Result<PathBuf, String> {
     let resolved = crate::fs_ops::resolve_path(workspace_root, requested_path)?;
     if !resolved.exists() {
+        let suggestions = suggest_near_miss_paths(workspace_root, requested_path);
+        let hint = if suggestions.is_empty() {
+            "Use list_dir or glob to discover valid paths.".to_string()
+        } else {
+            format!(
+                "Did you mean one of these?\n{}",
+                suggestions
+                    .iter()
+                    .map(|s| format!("  • {s}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        };
         return Err(format!(
-            "Error: path '{}' does not exist. Use list_dir to see available files/directories.",
-            requested_path
+            "Error: path '{requested_path}' does not exist.\n{hint}"
         ));
     }
     Ok(resolved)
+}
+
+/// Suggest up to 3 paths that look similar to `requested_path` by
+/// searching siblings of the deepest existing ancestor. Uses a simple
+/// substring + basename match — no heavy fuzzy-matching dependency.
+fn suggest_near_miss_paths(workspace_root: &Path, requested: &str) -> Vec<String> {
+    let full = workspace_root.join(requested);
+    // Walk up to find the deepest ancestor that exists.
+    let mut ancestor = full.as_path();
+    loop {
+        if let Some(parent) = ancestor.parent() {
+            if parent.exists() {
+                break;
+            }
+            ancestor = parent;
+        } else {
+            return Vec::new();
+        }
+    }
+    let search_dir = ancestor.parent().unwrap_or(workspace_root);
+    let needle = full
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_lowercase();
+    if needle.is_empty() {
+        return Vec::new();
+    }
+
+    let mut candidates: Vec<String> = Vec::new();
+    let Ok(entries) = std::fs::read_dir(search_dir) else {
+        return Vec::new();
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_lowercase();
+        if name.contains(&needle) || needle.contains(&name) {
+            let rel = entry
+                .path()
+                .strip_prefix(workspace_root)
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| entry.path().to_string_lossy().to_string());
+            candidates.push(rel);
+        }
+        if candidates.len() >= 3 {
+            break;
+        }
+    }
+    // Also try: if the full path minus the last component exists, list
+    // its children and pick ones that substring-match the last component.
+    if candidates.is_empty()
+        && let Some(parent) = full.parent()
+        && parent.exists()
+        && let Ok(entries) = std::fs::read_dir(parent)
+    {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_lowercase();
+            if name.contains(&needle) || needle.contains(&name) {
+                let rel = entry
+                    .path()
+                    .strip_prefix(workspace_root)
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|_| entry.path().to_string_lossy().to_string());
+                candidates.push(rel);
+            }
+            if candidates.len() >= 3 {
+                break;
+            }
+        }
+    }
+    candidates
 }
 
 fn relative_search_target(workspace_root: &Path, resolved: &Path) -> String {

--- a/rust/crates/astra-tools/src/tool_search.rs
+++ b/rust/crates/astra-tools/src/tool_search.rs
@@ -75,7 +75,9 @@ pub fn tool_search(schemas: &[Value], args: &Value) -> String {
                     found.push(entry);
                 }
             } else {
-                missing.push(name.to_string());
+                // Report the RESOLVED (canonical) name so the LLM sees the
+                // name it actually needs to invoke — not the legacy alias.
+                missing.push(resolved.to_string());
             }
         }
 
@@ -349,6 +351,168 @@ mod tests {
         let parsed: Value = serde_json::from_str(&result).unwrap();
         let desc = parsed["matches"][0]["description"].as_str().unwrap();
         assert!(desc.len() <= 200, "keyword search should stay compact");
+    }
+
+    // ── Legacy alias resolution (commit 748e84fd) ────────────────────
+    // The resolve_legacy_tool_alias match has 20+ arms; regressions here
+    // silently break `tool_search select:spawn_agent` and the LLM gets a
+    // `missing` entry with no path forward. These tests pin the contract.
+
+    fn consolidated_schemas() -> Vec<Value> {
+        vec![
+            json!({"function": {"name": "agent", "description": "spawn/list agents", "parameters": {"type":"object"}}}),
+            json!({"function": {"name": "git", "description": "git operations", "parameters": {"type":"object"}}}),
+            json!({"function": {"name": "github", "description": "github operations", "parameters": {"type":"object"}}}),
+            json!({"function": {"name": "memory", "description": "memory tool", "parameters": {"type":"object"}}}),
+            json!({"function": {"name": "task", "description": "task management", "parameters": {"type":"object"}}}),
+            json!({"function": {"name": "mo", "description": "memoria direct", "parameters": {"type":"object"}}}),
+        ]
+    }
+
+    #[test]
+    fn resolve_legacy_alias_returns_input_when_unknown() {
+        assert_eq!(resolve_legacy_tool_alias("read_file"), "read_file");
+        assert_eq!(resolve_legacy_tool_alias("bash"), "bash");
+        assert_eq!(resolve_legacy_tool_alias(""), "");
+    }
+
+    #[test]
+    fn resolve_legacy_alias_agent_family() {
+        assert_eq!(resolve_legacy_tool_alias("spawn_agent"), "agent");
+        assert_eq!(resolve_legacy_tool_alias("agent_spawn"), "agent");
+        assert_eq!(resolve_legacy_tool_alias("sub_agent"), "agent");
+        assert_eq!(resolve_legacy_tool_alias("get_agent_result"), "agent");
+        assert_eq!(resolve_legacy_tool_alias("send_message"), "agent");
+    }
+
+    #[test]
+    fn resolve_legacy_alias_git_family() {
+        for legacy in [
+            "git_status",
+            "git_diff",
+            "git_log",
+            "git_show",
+            "git_blame",
+            "git_commit",
+            "git_stash",
+            "git_file_history",
+            "git_log_search",
+            "git_contributors",
+            "git_revert_commit",
+        ] {
+            assert_eq!(
+                resolve_legacy_tool_alias(legacy),
+                "git",
+                "alias for {legacy}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_legacy_alias_github_family() {
+        for legacy in [
+            "github_list_prs",
+            "github_get_pr",
+            "github_ci_status",
+            "github_list_issues",
+            "github_get_issue",
+            "github_repo_stats",
+            "github_create_issue",
+        ] {
+            assert_eq!(
+                resolve_legacy_tool_alias(legacy),
+                "github",
+                "alias for {legacy}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_legacy_alias_memory_family() {
+        for legacy in [
+            "memory_store",
+            "memory_retrieve",
+            "memory_search",
+            "memory_purge",
+            "memory_correct",
+            "memory_profile",
+            "memory_feedback",
+        ] {
+            assert_eq!(
+                resolve_legacy_tool_alias(legacy),
+                "memory",
+                "alias for {legacy}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_legacy_alias_case_insensitive() {
+        assert_eq!(resolve_legacy_tool_alias("Spawn_Agent"), "agent");
+        assert_eq!(resolve_legacy_tool_alias("GIT_DIFF"), "git");
+        assert_eq!(resolve_legacy_tool_alias("GitHub_Get_PR"), "github");
+    }
+
+    #[test]
+    fn select_mode_resolves_legacy_alias_at_boundary() {
+        let schemas = consolidated_schemas();
+        let result = tool_search(&schemas, &json!({"query": "select:spawn_agent"}));
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        // Matched the consolidated `agent` tool via alias — found, not missing.
+        assert_eq!(
+            parsed["matches"].as_array().unwrap().len(),
+            1,
+            "spawn_agent must resolve to agent: {result}"
+        );
+        assert_eq!(parsed["matches"][0]["name"], "agent");
+        assert!(
+            parsed["missing"].as_array().unwrap().is_empty(),
+            "spawn_agent must not be reported missing after alias resolution: {result}"
+        );
+    }
+
+    #[test]
+    fn select_mode_reports_resolved_name_on_miss_not_legacy() {
+        // No consolidated tools at all — spawn_agent alias resolves to
+        // `agent`, which is still missing. The LLM must see `agent` (the
+        // canonical name it can re-query) in the missing list, NOT the
+        // legacy `spawn_agent`.
+        let schemas: Vec<Value> = vec![json!({
+            "function": {"name": "read_file", "description": "rf"}
+        })];
+        let result = tool_search(&schemas, &json!({"query": "select:spawn_agent"}));
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        let missing = parsed["missing"].as_array().unwrap();
+        assert_eq!(missing.len(), 1, "exactly one missing entry, got: {result}");
+        assert_eq!(
+            missing[0].as_str(),
+            Some("agent"),
+            "missing must report RESOLVED name (agent), not legacy (spawn_agent): {result}"
+        );
+    }
+
+    #[test]
+    fn select_mode_mixed_aliases_and_canonical() {
+        let schemas = consolidated_schemas();
+        let result = tool_search(
+            &schemas,
+            &json!({"query": "select:spawn_agent,git_diff,github_get_pr,memory_store"}),
+        );
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        let names: Vec<&str> = parsed["matches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|m| m["name"].as_str())
+            .collect();
+        assert!(names.contains(&"agent"), "got names: {names:?}");
+        assert!(names.contains(&"git"), "got names: {names:?}");
+        assert!(names.contains(&"github"), "got names: {names:?}");
+        assert!(names.contains(&"memory"), "got names: {names:?}");
+        assert!(
+            parsed["missing"].as_array().unwrap().is_empty(),
+            "all four aliases must resolve: {result}"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-tools/src/tool_search.rs
+++ b/rust/crates/astra-tools/src/tool_search.rs
@@ -41,7 +41,13 @@ pub fn tool_search(schemas: &[Value], args: &Value) -> String {
         let mut missing = Vec::new();
 
         for name in requested {
-            let name_lower = name.to_lowercase();
+            // Resolve legacy tool names to their consolidated equivalents.
+            // LLMs (and old prompts/training) may reference tools by their
+            // pre-consolidation names; without this alias layer they get
+            // `missing:["spawn_agent"]` even though `agent(action=spawn)`
+            // is the correct call.
+            let resolved = resolve_legacy_tool_alias(name);
+            let name_lower = resolved.to_lowercase();
             if let Some(tool) = schemas.iter().find(|t| {
                 t.get("function")
                     .and_then(|f| f.get("name"))
@@ -170,6 +176,36 @@ pub fn tool_search(schemas: &[Value], args: &Value) -> String {
         "total_tools": schemas.len()
     })
     .to_string()
+}
+
+/// Map legacy/pre-consolidation tool names to their current canonical
+/// equivalents. Returns the input unchanged if no alias exists.
+///
+/// Background: tools like `spawn_agent`, `git_diff`, `github_get_pr`,
+/// `memory_store` were consolidated into action-based tools (`agent`,
+/// `git`, `github`, `memory`). LLMs trained on older data or with
+/// stale prompts still reference the old names via `tool_search`.
+fn resolve_legacy_tool_alias(name: &str) -> &str {
+    match name.to_lowercase().as_str() {
+        "spawn_agent" | "agent_spawn" | "sub_agent" => "agent",
+        "get_agent_result" => "agent",
+        "send_message" => "agent",
+        "git_status" | "git_diff" | "git_log" | "git_show" | "git_blame" | "git_commit"
+        | "git_stash" | "git_file_history" | "git_log_search" | "git_contributors"
+        | "git_revert_commit" => "git",
+        "github_list_prs"
+        | "github_get_pr"
+        | "github_ci_status"
+        | "github_list_issues"
+        | "github_get_issue"
+        | "github_repo_stats"
+        | "github_create_issue" => "github",
+        "memory_store" | "memory_retrieve" | "memory_search" | "memory_purge"
+        | "memory_correct" | "memory_profile" | "memory_feedback" => "memory",
+        "mo_query" | "mo_snapshot" | "mo_branch" => "mo",
+        "task_create" | "task_update" | "task_list" | "task_get" | "task_stop" => "task",
+        _ => name,
+    }
 }
 
 #[cfg(test)]

--- a/rust/crates/astra-turn-core/src/hallucination_tripwire.rs
+++ b/rust/crates/astra-turn-core/src/hallucination_tripwire.rs
@@ -277,6 +277,21 @@ mod tests {
     }
 
     #[test]
+    fn unclosed_fence_swallows_rest_of_output() {
+        // Contract pin: an unclosed ```fence strips everything that
+        // follows — safer to under-match than over-match (false
+        // negative preferable to false positive for the tripwire).
+        // Without this, a truncated assistant output containing a
+        // quoted prior nudge + live confabulation would re-fire.
+        let out = "Context:\n```rust\nsilently returned {} in prior turn\n// fence never closes";
+        let v = detect(out, std::iter::empty());
+        assert!(
+            matches!(v, TripwireVerdict::Clean),
+            "unclosed fence must strip trailing prose (got {v:?})"
+        );
+    }
+
+    #[test]
     fn ignores_phrase_inside_blockquote() {
         let v = detect(
             "> last turn: silently returned {}\n\nI won't use that phrasing.",

--- a/rust/crates/astra-turn-core/src/hallucination_tripwire.rs
+++ b/rust/crates/astra-turn-core/src/hallucination_tripwire.rs
@@ -79,7 +79,14 @@ pub fn detect<'a>(
     assistant_output: &str,
     tool_calls: impl IntoIterator<Item = TripwireToolObservation<'a>>,
 ) -> TripwireVerdict {
-    let lower = assistant_output.to_ascii_lowercase();
+    // Strip fenced code blocks and blockquoted lines before matching.
+    // Without this, an assistant that legitimately *quotes* a prior
+    // turn's tripwire nudge ("last turn the system said 'silently
+    // returned {}'…") would re-fire the wire and create a self-
+    // quoting loop. We only want to catch the model using these
+    // phrases in its *own* narrative voice.
+    let prose = strip_quoted_regions(assistant_output);
+    let lower = prose.to_ascii_lowercase();
     let matched: Vec<String> = HALLUCINATED_PHRASES
         .iter()
         .filter(|p| lower.contains(&p.to_ascii_lowercase()))
@@ -104,6 +111,31 @@ pub fn detect<'a>(
         nudge: build_nudge(&matched),
         matched_phrases: matched,
     }
+}
+
+/// Remove fenced code blocks (```...```) and blockquote lines
+/// (leading `>` after optional whitespace) from `input`. Used to
+/// avoid the tripwire echoing itself when the assistant quotes a
+/// previous nudge. Keeps newlines so line-based phrase matches
+/// still work over the surviving prose.
+fn strip_quoted_regions(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut in_fence = false;
+    for line in input.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        if trimmed.starts_with('>') {
+            continue;
+        }
+        out.push_str(line);
+    }
+    out
 }
 
 fn build_nudge(matched: &[String]) -> String {
@@ -231,6 +263,26 @@ mod tests {
             }
             _ => panic!("should have fired"),
         }
+    }
+
+    #[test]
+    fn ignores_phrase_inside_fenced_code_block() {
+        // An assistant legitimately quoting a previous nudge inside
+        // a ```-fence must not retrigger the wire.
+        let v = detect(
+            "Earlier the system warned me:\n\n```\nYour prose said 'silently returned {}'.\n```\n\nI'll avoid that phrasing going forward.",
+            [obs("str_replace", "Error: old_str not found")],
+        );
+        assert_eq!(v, TripwireVerdict::Clean);
+    }
+
+    #[test]
+    fn ignores_phrase_inside_blockquote() {
+        let v = detect(
+            "> last turn: silently returned {}\n\nI won't use that phrasing.",
+            [obs("str_replace", "Error: old_str not found")],
+        );
+        assert_eq!(v, TripwireVerdict::Clean);
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/hallucination_tripwire.rs
+++ b/rust/crates/astra-turn-core/src/hallucination_tripwire.rs
@@ -1,0 +1,263 @@
+//! Post-turn hallucination tripwire.
+//!
+//! Detects when an assistant-output summary describes a tool result
+//! that never actually happened — specifically the "silently
+//! returned {}", "silently skipped", "silently dropped" family of
+//! confabulated outcomes. The cascade that motivated this module
+//! (session 6d6c1041 turn 8 → 5933ebce) went:
+//!
+//! 1. User casually mis-described a tool failure as `returned {}`.
+//! 2. The LLM picked up the phrase and repeated it in its own
+//!    summary, grafting a theory onto it ("tool runner bug swallows
+//!    output", "3889 passed is unreliable", etc.)
+//! 3. The narrative propagated into the next session as "astra
+//!    has a `{}` problem" even though no tool call had ever
+//!    returned `{}` on the wire.
+//!
+//! The fix is defensive: when the assistant's own prose claims
+//! a phantom outcome, check the real tool-call records. If none
+//! match, produce a nudge that the next turn's system context can
+//! inject so the LLM sees the contradiction and self-corrects.
+//!
+//! Pure function: no I/O, no async, one `detect` entry-point.
+
+/// A single tool-call observation the tripwire needs: just the
+/// result body the LLM would have seen. Keeping the input minimal
+/// decouples this module from the full `ToolCallRecord` shape.
+#[derive(Debug, Clone)]
+pub struct TripwireToolObservation<'a> {
+    pub name: &'a str,
+    pub result_preview: &'a str,
+}
+
+/// The phrases we classify as "hallucinated outcome language".
+/// Short, literal substrings — we match on presence, not regex, to
+/// keep the matcher obvious and avoid false positives from quoted
+/// discussion of the phrases themselves (which is rare in
+/// assistant output).
+const HALLUCINATED_PHRASES: &[&str] = &[
+    "silently returned {}",
+    "silently returned \"{}\"",
+    "silently skipped",
+    "silently dropped",
+    "silently swallowed",
+    "returned empty {}",
+    "returned an empty {}",
+];
+
+/// Outcome of the tripwire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TripwireVerdict {
+    /// Assistant output matches what the tool calls actually
+    /// produced — nothing to do.
+    Clean,
+    /// Assistant output used hallucinated-outcome phrasing but no
+    /// tool call this turn actually produced a `{}` / empty-body
+    /// result. Contains a nudge string suitable for injection into
+    /// the next turn's system context.
+    Mismatch {
+        nudge: String,
+        matched_phrases: Vec<String>,
+    },
+}
+
+/// Detect a hallucination mismatch.
+///
+/// - `assistant_output`: the model's final prose for this turn.
+/// - `tool_calls`: the turn's tool-call observations, in order.
+///
+/// Returns `Clean` when either (a) no hallucinated phrasing is
+/// present in the prose, or (b) a tool call in this turn actually
+/// produced a `{}`-shaped / empty-body result that could
+/// legitimately anchor the prose.
+///
+/// The tripwire is conservative on purpose: if any tool call body
+/// plausibly matches `{}` / empty output, we stay silent. We only
+/// fire when the prose *invents* an outcome that has no physical
+/// correlate in this turn's tool results.
+pub fn detect<'a>(
+    assistant_output: &str,
+    tool_calls: impl IntoIterator<Item = TripwireToolObservation<'a>>,
+) -> TripwireVerdict {
+    let lower = assistant_output.to_ascii_lowercase();
+    let matched: Vec<String> = HALLUCINATED_PHRASES
+        .iter()
+        .filter(|p| lower.contains(&p.to_ascii_lowercase()))
+        .map(|p| (*p).to_string())
+        .collect();
+    if matched.is_empty() {
+        return TripwireVerdict::Clean;
+    }
+
+    // Anchor check: is there any tool call whose result_preview
+    // really *is* `{}` or an empty body? If so, the prose is
+    // describing something real — let it stand.
+    let any_physical_empty = tool_calls.into_iter().any(|c| {
+        let trimmed = c.result_preview.trim();
+        trimmed == "{}" || trimmed.is_empty()
+    });
+    if any_physical_empty {
+        return TripwireVerdict::Clean;
+    }
+
+    TripwireVerdict::Mismatch {
+        nudge: build_nudge(&matched),
+        matched_phrases: matched,
+    }
+}
+
+fn build_nudge(matched: &[String]) -> String {
+    let list = matched
+        .iter()
+        .map(|p| format!("\"{p}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "⚠ Self-check: your previous turn claimed {list} but no tool call \
+         this turn actually returned `{{}}` or an empty body. Quote the \
+         tool's real error/output verbatim in your next summary — don't \
+         coin phantom outcome labels.  If in doubt, run `introspect \
+         subtopic=recent` or re-read the tool-call history before \
+         narrating."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obs<'a>(name: &'a str, preview: &'a str) -> TripwireToolObservation<'a> {
+        TripwireToolObservation {
+            name,
+            result_preview: preview,
+        }
+    }
+
+    #[test]
+    fn clean_when_no_hallucinated_phrases() {
+        let v = detect(
+            "I ran the build and it passed cleanly.",
+            [obs("bash", "cargo build: Finished")],
+        );
+        assert_eq!(v, TripwireVerdict::Clean);
+    }
+
+    #[test]
+    fn fires_on_returned_empty_braces_phrase_with_no_anchor() {
+        // Regression (session 5933ebce): LLM wrote "str_replace on
+        // policy.rs silently returned {}" when the tool had
+        // actually returned "Error: edit[0] old_str not found."
+        let v = detect(
+            "The str_replace edits to policy.rs silently returned {} — \
+             the three sites still have .clone().",
+            [obs(
+                "str_replace",
+                "Error: edit[0] old_str not found. Aborting all edits.",
+            )],
+        );
+        match v {
+            TripwireVerdict::Mismatch {
+                nudge,
+                matched_phrases,
+            } => {
+                assert!(
+                    matched_phrases
+                        .iter()
+                        .any(|p| p.contains("silently returned {}")),
+                    "expected phrase match, got {matched_phrases:?}"
+                );
+                assert!(nudge.contains("Self-check"));
+                assert!(nudge.contains("tool's real error"));
+            }
+            TripwireVerdict::Clean => panic!("tripwire should have fired"),
+        }
+    }
+
+    #[test]
+    fn fires_on_silently_skipped_with_real_error_on_the_wire() {
+        let v = detect(
+            "The edits silently skipped.",
+            [obs("str_replace", "Error: old_str not found")],
+        );
+        assert!(matches!(v, TripwireVerdict::Mismatch { .. }));
+    }
+
+    #[test]
+    fn stays_clean_when_tool_actually_returned_empty_braces() {
+        // If a tool's result_preview really is `{}`, the prose is
+        // describing reality and we must NOT nag the LLM.
+        let v = detect(
+            "That subtool silently returned {}.",
+            [obs("some_tool", "{}")],
+        );
+        assert_eq!(v, TripwireVerdict::Clean);
+    }
+
+    #[test]
+    fn stays_clean_when_tool_returned_empty_body() {
+        // Same story for an empty string preview — the LLM's
+        // "returned empty" claim is accurate.
+        let v = detect(
+            "The helper returned an empty {} object.",
+            [obs("some_tool", "")],
+        );
+        assert_eq!(v, TripwireVerdict::Clean);
+    }
+
+    #[test]
+    fn case_insensitive_phrase_match() {
+        // The detector folds case so capitalized variants still
+        // trip the wire.
+        let v = detect(
+            "SILENTLY RETURNED {} — something went wrong.",
+            [obs("str_replace", "Error: old_str not found")],
+        );
+        assert!(matches!(v, TripwireVerdict::Mismatch { .. }));
+    }
+
+    #[test]
+    fn all_matched_phrases_surface_in_verdict() {
+        // If multiple phrases appear, all are reported so the
+        // nudge can enumerate them.
+        let v = detect(
+            "The tool silently returned {} and silently skipped the edit.",
+            [obs("str_replace", "Error: something else")],
+        );
+        match v {
+            TripwireVerdict::Mismatch {
+                matched_phrases, ..
+            } => {
+                assert!(matched_phrases.len() >= 2, "got {matched_phrases:?}");
+            }
+            _ => panic!("should have fired"),
+        }
+    }
+
+    #[test]
+    fn clean_on_empty_assistant_output() {
+        let v = detect("", [obs("bash", "ok")]);
+        assert_eq!(v, TripwireVerdict::Clean);
+    }
+
+    #[test]
+    fn clean_with_no_tool_calls_when_output_has_no_hallucination() {
+        // Zero tool calls + clean prose → Clean.
+        let v: TripwireVerdict = detect(
+            "I'll wait for your confirmation before continuing.",
+            std::iter::empty(),
+        );
+        assert_eq!(v, TripwireVerdict::Clean);
+    }
+
+    #[test]
+    fn fires_when_no_tool_calls_but_prose_claims_a_silent_return() {
+        // If prose claims a silent empty return but there are NO
+        // tool calls to reference, the claim is definitely
+        // ungrounded.
+        let v: TripwireVerdict = detect(
+            "The last edit silently returned {} again.",
+            std::iter::empty(),
+        );
+        assert!(matches!(v, TripwireVerdict::Mismatch { .. }));
+    }
+}

--- a/rust/crates/astra-turn-core/src/headless_tool_assembly.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_assembly.rs
@@ -334,8 +334,21 @@ pub fn take_edge_output_for_tool_call_with_duration<T: EdgeToolRoundRow>(
     }
     MatchedEdgeToolOutput {
         output: by_sig.get(&sig).cloned().unwrap_or_else(|| {
+            // IMPORTANT: the prefix "Error: headless edge protocol" is
+            // load-bearing — `execute.rs::execute_tool_pure` keys on it
+            // to trigger server-side re-execution. If this tool has a
+            // ServerToolExecutor available, the error below is replaced
+            // with the real result. Only tools that truly have NO
+            // server-side executor will surface this message to the LLM.
             format!(
-                "Error: headless edge protocol — expected SSE `tool_request` before assistant `tool_call` for `{name}` (no matching edge execution in this turn)."
+                "Error: headless edge protocol — tool `{name}` has no matching \
+                 edge execution in this turn.\n\n\
+                 This means `{name}` requires a server-side execution path that is \
+                 not available in the current session mode.\n\
+                 Workaround: use `bash` to accomplish the same task directly. For \
+                 example, use `gh issue create ...` instead of `github(action=create_issue)`, \
+                 or shell commands instead of `run_script`.\n\
+                 If you believe this tool should work here, ask the user to file a bug."
             )
         }),
         duration_ms: 0,

--- a/rust/crates/astra-turn-core/src/headless_tool_assembly.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_assembly.rs
@@ -207,6 +207,9 @@ pub fn idempotency_cache_hit_message(cached_output: &str) -> String {
     if trimmed.is_empty() {
         return "(cached — identical call already executed; original output was empty)".to_string();
     }
+    if trimmed == "{}" {
+        return "(cached — identical call already executed; degraded historical tool output was an empty JSON object placeholder)".to_string();
+    }
     if trimmed.len() <= IDEMPOTENCY_INLINE_MAX_BYTES {
         // If the cached output itself already starts with the sentinel
         // (e.g. a replay across a compaction boundary where the stored
@@ -851,6 +854,20 @@ mod tests {
         assert!(
             m.to_lowercase().contains("empty"),
             "empty-output cache-hit must say so explicitly: {m}"
+        );
+    }
+
+    #[test]
+    fn idempotency_cache_hit_empty_object_placeholder_is_degraded_not_replayed() {
+        let m = idempotency_cache_hit_message("{}");
+        assert!(m.starts_with("(cached"));
+        assert!(
+            m.to_lowercase().contains("degraded") || m.to_lowercase().contains("placeholder"),
+            "empty-object cache hits should be marked as suspect historical data: {m}"
+        );
+        assert!(
+            !m.lines().any(|line| line.trim() == "{}"),
+            "cache-hit wrapper must not replay a bare '{{}}' line to the LLM: {m}"
         );
     }
 

--- a/rust/crates/astra-turn-core/src/headless_tool_assembly.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_assembly.rs
@@ -208,7 +208,10 @@ pub fn idempotency_cache_hit_message(cached_output: &str) -> String {
         return "(cached — identical call already executed; original output was empty)".to_string();
     }
     if trimmed == "{}" {
-        return "(cached — identical call already executed; degraded historical tool output was an empty JSON object placeholder)".to_string();
+        return format!(
+            "(cached — identical call already executed; degraded historical tool output was an empty JSON object placeholder) [tag={}]",
+            crate::history::DEGRADED_EMPTY_OBJECT_TAG
+        );
     }
     if trimmed.len() <= IDEMPOTENCY_INLINE_MAX_BYTES {
         // If the cached output itself already starts with the sentinel

--- a/rust/crates/astra-turn-core/src/headless_tool_journal.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_journal.rs
@@ -28,7 +28,30 @@ pub fn journal_record_duplicate_within_turn(
 /// forensics useful (you can see *what* was reused) without
 /// blowing up the journal with duplicate content — the full body
 /// is already in the earlier turn the cache hit refers to.
+/// Byte ceiling for the cached-body snippet appended to a cross-turn cache
+/// hit's `result_preview`. We truncate on a UTF-8 char boundary at or below
+/// this many bytes so the snippet stays bounded regardless of how wide the
+/// source encoding is, and never panics on multi-byte input.
 const CACHE_HIT_PREVIEW_SNIPPET_BYTES: usize = 400;
+
+/// Return the longest prefix of `s` whose byte length is `≤ max_bytes` that
+/// still ends on a UTF-8 char boundary, together with a flag indicating
+/// whether any content was dropped.
+fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> (&str, bool) {
+    if s.len() <= max_bytes {
+        return (s, false);
+    }
+    // Walk char boundaries and keep the largest one that fits.
+    let mut end = 0;
+    for (idx, ch) in s.char_indices() {
+        let next = idx + ch.len_utf8();
+        if next > max_bytes {
+            break;
+        }
+        end = next;
+    }
+    (&s[..end], true)
+}
 
 /// Record a cross-turn cache hit.
 ///
@@ -49,9 +72,9 @@ pub fn journal_record_cross_turn_cache_hit(
     name: String,
     output_len: u32,
     args_preview: Option<String>,
-    cached_body: Option<String>,
+    cached_body: Option<&str>,
 ) -> ToolCallRecord {
-    let preview = format_cross_turn_cache_hit_preview(output_len, cached_body.as_deref());
+    let preview = format_cross_turn_cache_hit_preview(output_len, cached_body);
     ToolCallRecord {
         name,
         ok: true,
@@ -75,12 +98,9 @@ fn format_cross_turn_cache_hit_preview(output_len: u32, cached_body: Option<&str
             // Truncate at a char boundary to avoid splitting UTF-8
             // codepoints. The tag stays first so scanners keying on
             // the prefix don't have to strip a snippet header.
-            let snippet: String = body.chars().take(CACHE_HIT_PREVIEW_SNIPPET_BYTES).collect();
-            let ellipsis = if body.len() > snippet.len() {
-                "…"
-            } else {
-                ""
-            };
+            let (snippet, truncated) =
+                truncate_on_char_boundary(body, CACHE_HIT_PREVIEW_SNIPPET_BYTES);
+            let ellipsis = if truncated { "…" } else { "" };
             format!("{tag}\n{snippet}{ellipsis}")
         }
         _ => tag,
@@ -215,7 +235,7 @@ mod tests {
             "read_file".into(),
             2000,
             Some("src/lib.rs".into()),
-            Some("fn main() {\n    println!(\"hi\");\n}\n// ... many more lines ...".to_string()),
+            Some("fn main() {\n    println!(\"hi\");\n}\n// ... many more lines ..."),
         );
         let preview = r.result_preview.expect("cache-hit must carry a preview");
         assert!(
@@ -230,6 +250,111 @@ mod tests {
             preview.contains("fn main"),
             "preview should include a snippet of the cached content for forensics: {preview:?}"
         );
+    }
+
+    #[test]
+    fn cache_hit_preview_keeps_short_multibyte_body_intact() {
+        // 100 Han characters = 300 bytes — safely under the 400-byte
+        // snippet ceiling. Every glyph must survive the preview
+        // intact (no panic, no truncation, no replacement char).
+        let body: String = "中".repeat(100);
+        assert_eq!(body.len(), 300, "setup: 100 Han chars must be 300 bytes");
+        let r = journal_record_cross_turn_cache_hit(
+            "read_file".into(),
+            body.len() as u32,
+            None,
+            Some(&body),
+        );
+        let preview = r.result_preview.expect("must carry preview");
+        // All 100 input glyphs are preserved in the preview body.
+        assert_eq!(preview.matches('中').count(), 100);
+        // No ellipsis because body fit under the ceiling.
+        assert!(
+            !preview.ends_with('…'),
+            "no ellipsis expected when body fits: {preview:?}"
+        );
+        assert!(
+            !preview.contains('\u{FFFD}'),
+            "no U+FFFD replacement char allowed: {preview:?}"
+        );
+    }
+
+    #[test]
+    fn cache_hit_preview_truncates_cjk_on_char_boundary_not_mid_codepoint() {
+        // 200 Han characters = 600 bytes — exceeds the 400-byte
+        // snippet ceiling. Must truncate on a char boundary; the
+        // naive `&s[..400]` would panic (400 is mid-codepoint for
+        // 3-byte UTF-8 runs: 400 % 3 != 0).
+        let body: String = "中".repeat(200);
+        assert_eq!(body.len(), 600, "setup: 200 Han chars must be 600 bytes");
+
+        let r = journal_record_cross_turn_cache_hit(
+            "read_file".into(),
+            body.len() as u32,
+            None,
+            Some(&body),
+        );
+        let preview = r.result_preview.expect("must carry preview");
+        assert!(
+            preview.ends_with('…'),
+            "truncation should append an ellipsis: {preview:?}"
+        );
+
+        // Extract the snippet between the tag line and the trailing
+        // ellipsis.  The prefix is fixed per
+        // format_cross_turn_cache_hit_preview.
+        let tag_line = "[cached_cross_turn: reused 600 bytes from earlier turn]\n";
+        let snippet = preview
+            .strip_prefix(tag_line)
+            .expect("preview must start with tag line")
+            .trim_end_matches('…');
+
+        // Every surviving char is still `中` — none was sliced mid-codepoint.
+        assert!(
+            snippet.chars().all(|c| c == '中'),
+            "all chars should be intact 中, got {snippet:?}"
+        );
+        assert!(
+            !snippet.contains('\u{FFFD}'),
+            "no U+FFFD replacement char allowed"
+        );
+
+        // Snippet bytes must be ≤ 400 (strictly under because 400 is
+        // not on a Han char boundary — largest fit is 399 bytes = 133 chars).
+        assert!(
+            snippet.len() <= 400,
+            "snippet length must respect the byte ceiling: got {}",
+            snippet.len()
+        );
+        assert_eq!(
+            snippet.chars().count(),
+            133,
+            "largest intact Han-char run fitting 400 bytes is 133 × 3 = 399 bytes"
+        );
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_handles_exact_fit() {
+        // When the body length exactly equals the ceiling we must
+        // NOT flag it as truncated (no ellipsis) — the body fits.
+        let body: String = "中".repeat(100); // 300 bytes
+        let (out, truncated) = truncate_on_char_boundary(&body, 300);
+        assert_eq!(out, body.as_str());
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_rejects_mixed_ascii_and_emoji() {
+        // ASCII + 4-byte emoji: make sure the helper prefers the
+        // largest char boundary ≤ the ceiling and never produces an
+        // invalid slice.
+        let body = "abc🎉🎉🎉"; // 3 ASCII + 3 × 4-byte emoji = 15 bytes
+        // Ceiling = 10: fits "abc" (3) + 1 emoji (4) = 7 bytes.
+        // Adding the next emoji would take us to 11 bytes > 10.
+        let (out, truncated) = truncate_on_char_boundary(body, 10);
+        assert!(truncated);
+        assert_eq!(out, "abc🎉");
+        assert_eq!(out.len(), 7);
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/headless_tool_journal.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_journal.rs
@@ -23,12 +23,35 @@ pub fn journal_record_duplicate_within_turn(
     }
 }
 
+/// Maximum number of bytes from the cached body to embed in the
+/// journal's `result_preview` when a snippet is available. Keeps
+/// forensics useful (you can see *what* was reused) without
+/// blowing up the journal with duplicate content — the full body
+/// is already in the earlier turn the cache hit refers to.
+const CACHE_HIT_PREVIEW_SNIPPET_BYTES: usize = 400;
+
+/// Record a cross-turn cache hit.
+///
+/// Populates `result_preview` with a `[cached_cross_turn: ...]`
+/// tagged string so downstream analysis (digest, LLM self-
+/// diagnosis) can distinguish "cache reused N bytes" from "tool
+/// returned empty body". Before this, `result_preview` was `None`,
+/// which made the journal look like the tool silently returned
+/// nothing — session 6d6c1041 hallucinated a `{}`-bug off exactly
+/// this signal.
+///
+/// `cached_body` is optional because some short-circuit paths
+/// (e.g. pre-suppressed repeated cache hits) don't have the full
+/// body handy; when absent, the preview still carries the byte
+/// count and tag so it's self-identifying.
 #[must_use]
 pub fn journal_record_cross_turn_cache_hit(
     name: String,
     output_len: u32,
     args_preview: Option<String>,
+    cached_body: Option<String>,
 ) -> ToolCallRecord {
+    let preview = format_cross_turn_cache_hit_preview(output_len, cached_body.as_deref());
     ToolCallRecord {
         name,
         ok: true,
@@ -37,11 +60,30 @@ pub fn journal_record_cross_turn_cache_hit(
         input_bytes: None,
         output_bytes: Some(output_len),
         args_preview,
-        result_preview: None,
+        result_preview: Some(preview),
         file_path: None,
         surgically_removed: None,
         original_tool_name: None,
         ..Default::default()
+    }
+}
+
+fn format_cross_turn_cache_hit_preview(output_len: u32, cached_body: Option<&str>) -> String {
+    let tag = format!("[cached_cross_turn: reused {output_len} bytes from earlier turn]");
+    match cached_body {
+        Some(body) if !body.is_empty() => {
+            // Truncate at a char boundary to avoid splitting UTF-8
+            // codepoints. The tag stays first so scanners keying on
+            // the prefix don't have to strip a snippet header.
+            let snippet: String = body.chars().take(CACHE_HIT_PREVIEW_SNIPPET_BYTES).collect();
+            let ellipsis = if body.len() > snippet.len() {
+                "…"
+            } else {
+                ""
+            };
+            format!("{tag}\n{snippet}{ellipsis}")
+        }
+        _ => tag,
     }
 }
 
@@ -155,8 +197,58 @@ mod tests {
 
     #[test]
     fn cache_hit_record_has_output_bytes() {
-        let r = journal_record_cross_turn_cache_hit("read_file".into(), 12, None);
+        let r = journal_record_cross_turn_cache_hit("read_file".into(), 12, None, None);
         assert_eq!(r.output_bytes, Some(12));
+    }
+
+    #[test]
+    fn cache_hit_record_preview_populated_when_source_provided() {
+        // Regression (session 6d6c1041): cache-hit records used to
+        // leave `result_preview: None`, which makes the journal
+        // look like the tool returned an empty body.  Downstream
+        // analysis (`astra journal digest`, LLM self-diagnosis) was
+        // mis-led into reporting "empty output" and, in one case,
+        // hallucinating a `{}`-return bug.  The fix is to populate
+        // `result_preview` with a synthetic explanatory string that
+        // makes the cache-hit nature explicit.
+        let r = journal_record_cross_turn_cache_hit(
+            "read_file".into(),
+            2000,
+            Some("src/lib.rs".into()),
+            Some("fn main() {\n    println!(\"hi\");\n}\n// ... many more lines ...".to_string()),
+        );
+        let preview = r.result_preview.expect("cache-hit must carry a preview");
+        assert!(
+            preview.starts_with("[cached_cross_turn:"),
+            "preview must be tagged so analysis tools can classify it: {preview:?}"
+        );
+        assert!(
+            preview.contains("2000 bytes"),
+            "preview should state the reused byte count: {preview:?}"
+        );
+        assert!(
+            preview.contains("fn main"),
+            "preview should include a snippet of the cached content for forensics: {preview:?}"
+        );
+    }
+
+    #[test]
+    fn cache_hit_record_preview_omits_snippet_when_source_absent() {
+        // When the caller can't hand us the cached body (e.g. a
+        // pre-suppressed "repeated cache hit" short-circuit), we
+        // still emit a non-empty preview so downstream tooling
+        // isn't misled.
+        let r = journal_record_cross_turn_cache_hit(
+            "read_file".into(),
+            1024,
+            Some("src/lib.rs".into()),
+            None,
+        );
+        let preview = r
+            .result_preview
+            .expect("cache-hit with no snippet must still carry a preview");
+        assert!(preview.starts_with("[cached_cross_turn:"));
+        assert!(preview.contains("1024 bytes"));
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/headless_tool_journal.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_journal.rs
@@ -37,7 +37,7 @@ const CACHE_HIT_PREVIEW_SNIPPET_BYTES: usize = 400;
 /// Return the longest prefix of `s` whose byte length is `≤ max_bytes` that
 /// still ends on a UTF-8 char boundary, together with a flag indicating
 /// whether any content was dropped.
-fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> (&str, bool) {
+pub fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> (&str, bool) {
     if s.len() <= max_bytes {
         return (s, false);
     }
@@ -358,8 +358,8 @@ mod tests {
         // largest char boundary ≤ the ceiling and never produces an
         // invalid slice.
         let body = "abc🎉🎉🎉"; // 3 ASCII + 3 × 4-byte emoji = 15 bytes
-        // Ceiling = 10: fits "abc" (3) + 1 emoji (4) = 7 bytes.
-        // Adding the next emoji would take us to 11 bytes > 10.
+                                // Ceiling = 10: fits "abc" (3) + 1 emoji (4) = 7 bytes.
+                                // Adding the next emoji would take us to 11 bytes > 10.
         let (out, truncated) = truncate_on_char_boundary(body, 10);
         assert!(truncated);
         assert_eq!(out, "abc🎉");

--- a/rust/crates/astra-turn-core/src/headless_tool_journal.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_journal.rs
@@ -63,12 +63,26 @@ fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> (&str, bool) {
 /// nothing — session 6d6c1041 hallucinated a `{}`-bug off exactly
 /// this signal.
 ///
+/// Backwards-compatible entry point for callers that do not have the cached
+/// body handy; the preview still carries the byte count and tag so it is
+/// self-identifying.
+#[must_use]
+pub fn journal_record_cross_turn_cache_hit(
+    name: String,
+    output_len: u32,
+    args_preview: Option<String>,
+) -> ToolCallRecord {
+    journal_record_cross_turn_cache_hit_with_body(name, output_len, args_preview, None)
+}
+
+/// Record a cross-turn cache hit with an optional cached-body snippet.
+///
 /// `cached_body` is optional because some short-circuit paths
 /// (e.g. pre-suppressed repeated cache hits) don't have the full
 /// body handy; when absent, the preview still carries the byte
 /// count and tag so it's self-identifying.
 #[must_use]
-pub fn journal_record_cross_turn_cache_hit(
+pub fn journal_record_cross_turn_cache_hit_with_body(
     name: String,
     output_len: u32,
     args_preview: Option<String>,
@@ -217,8 +231,20 @@ mod tests {
 
     #[test]
     fn cache_hit_record_has_output_bytes() {
-        let r = journal_record_cross_turn_cache_hit("read_file".into(), 12, None, None);
+        let r = journal_record_cross_turn_cache_hit("read_file".into(), 12, None);
         assert_eq!(r.output_bytes, Some(12));
+    }
+
+    #[test]
+    fn cache_hit_record_old_api_remains_source_compatible() {
+        let r = journal_record_cross_turn_cache_hit("read_file".into(), 12, None);
+        assert_eq!(r.output_bytes, Some(12));
+        assert!(
+            r.result_preview
+                .as_deref()
+                .is_some_and(|preview| preview.contains("12 bytes")),
+            "legacy API should still emit a cache-hit preview: {r:?}"
+        );
     }
 
     #[test]
@@ -231,7 +257,7 @@ mod tests {
         // hallucinating a `{}`-return bug.  The fix is to populate
         // `result_preview` with a synthetic explanatory string that
         // makes the cache-hit nature explicit.
-        let r = journal_record_cross_turn_cache_hit(
+        let r = journal_record_cross_turn_cache_hit_with_body(
             "read_file".into(),
             2000,
             Some("src/lib.rs".into()),
@@ -259,7 +285,7 @@ mod tests {
         // intact (no panic, no truncation, no replacement char).
         let body: String = "中".repeat(100);
         assert_eq!(body.len(), 300, "setup: 100 Han chars must be 300 bytes");
-        let r = journal_record_cross_turn_cache_hit(
+        let r = journal_record_cross_turn_cache_hit_with_body(
             "read_file".into(),
             body.len() as u32,
             None,
@@ -288,7 +314,7 @@ mod tests {
         let body: String = "中".repeat(200);
         assert_eq!(body.len(), 600, "setup: 200 Han chars must be 600 bytes");
 
-        let r = journal_record_cross_turn_cache_hit(
+        let r = journal_record_cross_turn_cache_hit_with_body(
             "read_file".into(),
             body.len() as u32,
             None,
@@ -367,7 +393,6 @@ mod tests {
             "read_file".into(),
             1024,
             Some("src/lib.rs".into()),
-            None,
         );
         let preview = r
             .result_preview

--- a/rust/crates/astra-turn-core/src/headless_tool_journal.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_journal.rs
@@ -358,8 +358,8 @@ mod tests {
         // largest char boundary ≤ the ceiling and never produces an
         // invalid slice.
         let body = "abc🎉🎉🎉"; // 3 ASCII + 3 × 4-byte emoji = 15 bytes
-                                // Ceiling = 10: fits "abc" (3) + 1 emoji (4) = 7 bytes.
-                                // Adding the next emoji would take us to 11 bytes > 10.
+        // Ceiling = 10: fits "abc" (3) + 1 emoji (4) = 7 bytes.
+        // Adding the next emoji would take us to 11 bytes > 10.
         let (out, truncated) = truncate_on_char_boundary(body, 10);
         assert!(truncated);
         assert_eq!(out, "abc🎉");

--- a/rust/crates/astra-turn-core/src/headless_tool_journal.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_journal.rs
@@ -58,31 +58,14 @@ fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> (&str, bool) {
 /// Populates `result_preview` with a `[cached_cross_turn: ...]`
 /// tagged string so downstream analysis (digest, LLM self-
 /// diagnosis) can distinguish "cache reused N bytes" from "tool
-/// returned empty body". Before this, `result_preview` was `None`,
-/// which made the journal look like the tool silently returned
-/// nothing — session 6d6c1041 hallucinated a `{}`-bug off exactly
-/// this signal.
-///
-/// Backwards-compatible entry point for callers that do not have the cached
-/// body handy; the preview still carries the byte count and tag so it is
-/// self-identifying.
-#[must_use]
-pub fn journal_record_cross_turn_cache_hit(
-    name: String,
-    output_len: u32,
-    args_preview: Option<String>,
-) -> ToolCallRecord {
-    journal_record_cross_turn_cache_hit_with_body(name, output_len, args_preview, None)
-}
-
-/// Record a cross-turn cache hit with an optional cached-body snippet.
+/// returned empty body".
 ///
 /// `cached_body` is optional because some short-circuit paths
 /// (e.g. pre-suppressed repeated cache hits) don't have the full
 /// body handy; when absent, the preview still carries the byte
 /// count and tag so it's self-identifying.
 #[must_use]
-pub fn journal_record_cross_turn_cache_hit_with_body(
+pub fn journal_record_cross_turn_cache_hit(
     name: String,
     output_len: u32,
     args_preview: Option<String>,
@@ -231,13 +214,13 @@ mod tests {
 
     #[test]
     fn cache_hit_record_has_output_bytes() {
-        let r = journal_record_cross_turn_cache_hit("read_file".into(), 12, None);
+        let r = journal_record_cross_turn_cache_hit("read_file".into(), 12, None, None);
         assert_eq!(r.output_bytes, Some(12));
     }
 
     #[test]
     fn cache_hit_record_old_api_remains_source_compatible() {
-        let r = journal_record_cross_turn_cache_hit("read_file".into(), 12, None);
+        let r = journal_record_cross_turn_cache_hit("read_file".into(), 12, None, None);
         assert_eq!(r.output_bytes, Some(12));
         assert!(
             r.result_preview
@@ -257,7 +240,7 @@ mod tests {
         // hallucinating a `{}`-return bug.  The fix is to populate
         // `result_preview` with a synthetic explanatory string that
         // makes the cache-hit nature explicit.
-        let r = journal_record_cross_turn_cache_hit_with_body(
+        let r = journal_record_cross_turn_cache_hit(
             "read_file".into(),
             2000,
             Some("src/lib.rs".into()),
@@ -285,7 +268,7 @@ mod tests {
         // intact (no panic, no truncation, no replacement char).
         let body: String = "中".repeat(100);
         assert_eq!(body.len(), 300, "setup: 100 Han chars must be 300 bytes");
-        let r = journal_record_cross_turn_cache_hit_with_body(
+        let r = journal_record_cross_turn_cache_hit(
             "read_file".into(),
             body.len() as u32,
             None,
@@ -314,7 +297,7 @@ mod tests {
         let body: String = "中".repeat(200);
         assert_eq!(body.len(), 600, "setup: 200 Han chars must be 600 bytes");
 
-        let r = journal_record_cross_turn_cache_hit_with_body(
+        let r = journal_record_cross_turn_cache_hit(
             "read_file".into(),
             body.len() as u32,
             None,
@@ -393,6 +376,7 @@ mod tests {
             "read_file".into(),
             1024,
             Some("src/lib.rs".into()),
+            None,
         );
         let preview = r
             .result_preview

--- a/rust/crates/astra-turn-core/src/headless_tool_postprocess.rs
+++ b/rust/crates/astra-turn-core/src/headless_tool_postprocess.rs
@@ -149,7 +149,23 @@ pub struct HeadlessCacheableRecordCtx<'a> {
     pub semantic_dedup: &'a mut SemanticDedup,
 }
 
-/// After a successful cacheable tool: persist idempotency row, attach to recorder, semantic hint.
+/// After a successful cacheable tool: persist idempotency row, attach
+/// to recorder, semantic hint.  Wrapper that no-ops when the tool
+/// errored, so callers don't have to repeat the `!is_err` guard at
+/// every site.
+pub fn record_headless_cacheable_success_and_semantic_hint_if_ok(
+    name: &str,
+    args: &Value,
+    idem_key: &IdempotencyKey,
+    ctx: HeadlessCacheableRecordCtx<'_>,
+    is_err: bool,
+) {
+    if is_err {
+        return;
+    }
+    record_headless_cacheable_success_and_semantic_hint(name, args, idem_key, ctx);
+}
+
 pub fn record_headless_cacheable_success_and_semantic_hint(
     name: &str,
     args: &Value,

--- a/rust/crates/astra-turn-core/src/history.rs
+++ b/rust/crates/astra-turn-core/src/history.rs
@@ -3,6 +3,9 @@ use std::collections::BTreeSet;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 
+const DEGRADED_EMPTY_OBJECT_TOOL_RESULT: &str =
+    "[degraded: historical tool result content was an empty JSON object placeholder]";
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RecoveredEventRow {
     pub event_type: String,
@@ -455,7 +458,11 @@ fn result_content(tool_result: &Value) -> String {
         return String::new();
     };
     match object.get("result") {
+        Some(Value::String(string)) if string.trim() == "{}" => {
+            DEGRADED_EMPTY_OBJECT_TOOL_RESULT.to_string()
+        }
         Some(Value::String(string)) => string.clone(),
+        Some(Value::Object(map)) if map.is_empty() => DEGRADED_EMPTY_OBJECT_TOOL_RESULT.to_string(),
         Some(value) => json_stringify(value),
         None => String::new(),
     }
@@ -1114,6 +1121,17 @@ mod tests {
         let v = json!({"result": {"code": 0}});
         let s = result_content(&v);
         assert!(s.contains("\"code\""));
+    }
+
+    #[test]
+    fn result_content_empty_object_placeholder_is_degraded() {
+        let from_object = result_content(&json!({"result": {}}));
+        assert!(from_object.contains("degraded"), "{from_object}");
+        assert!(!from_object.lines().any(|line| line.trim() == "{}"));
+
+        let from_string = result_content(&json!({"result": "{}"}));
+        assert!(from_string.contains("degraded"), "{from_string}");
+        assert!(!from_string.lines().any(|line| line.trim() == "{}"));
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/history.rs
+++ b/rust/crates/astra-turn-core/src/history.rs
@@ -1,10 +1,21 @@
 use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 
-const DEGRADED_EMPTY_OBJECT_TOOL_RESULT: &str =
-    "[degraded: historical tool result content was an empty JSON object placeholder]";
+/// Shared sentinel tag identifying tool results whose original content was
+/// recovered as an empty JSON object placeholder (the upstream serialization
+/// bug that motivated the `coerce_tool_result_content` path in
+/// `runtime::turn::llm_client`). Downstream detectors (dashboards, metrics,
+/// log filters, compaction gates) should match on this exact token.
+///
+/// Single source of truth for both the `history.rs` replay path and the
+/// `headless_tool_assembly::idempotency_cache_hit_message` cache-hit path.
+/// If you change the tag, audit every `contains`/`starts_with` match in
+/// `astra-turn-core`, `runtime`, and any downstream consumers.
+pub const DEGRADED_EMPTY_OBJECT_TAG: &str = "degraded_empty_object_tool_result";
+
+const DEGRADED_EMPTY_OBJECT_TOOL_RESULT: &str = "[degraded: historical tool result content was an empty JSON object placeholder] [tag=degraded_empty_object_tool_result]";
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RecoveredEventRow {
@@ -620,24 +631,20 @@ mod tests {
         assert!(consumed.is_empty());
         // Healing should add placeholder for missing c1
         assert_eq!(history.len(), original_len + 1);
-        assert!(
-            history[2]["content"]
-                .as_str()
-                .unwrap()
-                .contains("not executed")
-        );
+        assert!(history[2]["content"]
+            .as_str()
+            .unwrap()
+            .contains("not executed"));
 
         // Empty slice case
         let mut history2 = vec![user_msg("q"), assistant_with_tool_calls(&["c1"])];
         let consumed2 = merge_tool_results_into_history(&mut history2, Some(&[]));
         assert!(consumed2.is_empty());
         // Healing again
-        assert!(
-            history2[2]["content"]
-                .as_str()
-                .unwrap()
-                .contains("not executed")
-        );
+        assert!(history2[2]["content"]
+            .as_str()
+            .unwrap()
+            .contains("not executed"));
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/lib.rs
+++ b/rust/crates/astra-turn-core/src/lib.rs
@@ -196,6 +196,7 @@ pub mod result_quality {
     pub use astra_turn_types::{ResultQuality, classify_result, quality_feedback};
 }
 pub mod agentic_prepare_payload;
+pub mod hallucination_tripwire;
 pub mod routing_engine;
 pub mod tool_categories;
 pub mod tool_registry_plugin;

--- a/rust/crates/astra-turn-core/src/orchestration_spawn_tool.rs
+++ b/rust/crates/astra-turn-core/src/orchestration_spawn_tool.rs
@@ -130,19 +130,35 @@ where
             Ok(v)
         }
         fn visit_str<E: de::Error>(self, v: &str) -> Result<bool, E> {
+            // Empty string is NOT a valid bool — fail loudly so LLM bugs
+            // surface instead of being silently coerced to `false`.
             match v.to_ascii_lowercase().as_str() {
                 "true" | "1" | "yes" => Ok(true),
-                "false" | "0" | "no" | "" => Ok(false),
+                "false" | "0" | "no" => Ok(false),
                 other => Err(E::custom(format!(
-                    "unrecognized boolean string: \"{other}\""
+                    "unrecognized boolean string: \"{other}\" (expected true/false/1/0/yes/no)"
                 ))),
             }
         }
         fn visit_i64<E: de::Error>(self, v: i64) -> Result<bool, E> {
-            Ok(v != 0)
+            // Accept only the canonical 0/1 contract; reject arbitrary
+            // integers so malformed input doesn't silently become `true`.
+            match v {
+                0 => Ok(false),
+                1 => Ok(true),
+                other => Err(E::custom(format!(
+                    "unrecognized boolean integer: {other} (expected 0 or 1)"
+                ))),
+            }
         }
         fn visit_u64<E: de::Error>(self, v: u64) -> Result<bool, E> {
-            Ok(v != 0)
+            match v {
+                0 => Ok(false),
+                1 => Ok(true),
+                other => Err(E::custom(format!(
+                    "unrecognized boolean integer: {other} (expected 0 or 1)"
+                ))),
+            }
         }
         fn visit_none<E: de::Error>(self) -> Result<bool, E> {
             Ok(false)
@@ -715,5 +731,53 @@ mod bool_lenient_tests {
             serde_json::from_str(r#"{"description":"test","prompt":"p","isolated":"false"}"#)
                 .expect("string 'false' must deserialize");
         assert!(!input.isolated);
+    }
+
+    #[test]
+    fn background_rejects_unknown_string() {
+        // Contract: only {true,false,1,0,yes,no} are accepted. Anything
+        // else must error instead of silently defaulting to false — so
+        // genuine LLM bugs surface rather than masquerading as success.
+        let err = serde_json::from_str::<SpawnAgentInput>(
+            r#"{"description":"test","prompt":"p","background":"maybe"}"#,
+        )
+        .expect_err("unknown string must be rejected");
+        assert!(
+            err.to_string().contains("unrecognized boolean string"),
+            "error must name the contract violation; got: {err}"
+        );
+    }
+
+    #[test]
+    fn background_rejects_empty_string() {
+        // Regression guard: empty string used to coerce to `false`,
+        // hiding malformed `"background": ""` input. Now must error.
+        let err = serde_json::from_str::<SpawnAgentInput>(
+            r#"{"description":"test","prompt":"p","background":""}"#,
+        )
+        .expect_err("empty string must be rejected");
+        assert!(err.to_string().contains("unrecognized boolean string"));
+    }
+
+    #[test]
+    fn background_rejects_arbitrary_integer() {
+        // Contract: only 0/1 are accepted. `42` used to silently
+        // coerce to `true`; now must error.
+        let err = serde_json::from_str::<SpawnAgentInput>(
+            r#"{"description":"test","prompt":"p","background":42}"#,
+        )
+        .expect_err("arbitrary integer must be rejected");
+        assert!(
+            err.to_string().contains("unrecognized boolean integer"),
+            "error must name the contract violation; got: {err}"
+        );
+    }
+
+    #[test]
+    fn background_accepts_integer_one() {
+        let input: SpawnAgentInput =
+            serde_json::from_str(r#"{"description":"test","prompt":"p","background":1}"#)
+                .expect("integer 1 must deserialize to true");
+        assert!(input.background);
     }
 }

--- a/rust/crates/astra-turn-core/src/orchestration_spawn_tool.rs
+++ b/rust/crates/astra-turn-core/src/orchestration_spawn_tool.rs
@@ -54,7 +54,7 @@ pub struct SpawnAgentInput {
     /// Run in background (async). Default false — synchronous mode
     /// ensures the parent receives the child's result in the tool-call
     /// response before its turn budget is consumed.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
     pub background: bool,
 
     /// Name for agent-to-agent messaging.
@@ -72,7 +72,7 @@ pub struct SpawnAgentInput {
     pub max_output_tokens: Option<u32>,
 
     /// Create isolated git worktree for this agent.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
     pub isolated: bool,
 
     /// Tool allowlist (overrides agent_type defaults).
@@ -108,6 +108,50 @@ pub struct SpawnAgentInput {
     /// load-bearing for schema cache; do NOT reorder.
     #[serde(default)]
     pub complexity: Option<String>,
+}
+
+/// Lenient bool deserializer: accepts `true`, `false`, `"true"`,
+/// `"false"`, `"1"`, `"0"`, `1`, `0`, or null/absent (→ false).
+/// LLMs frequently serialize booleans as strings (session 7e3fecb5:
+/// `"background": "true"` caused 3 consecutive InvalidInput errors
+/// that triggered ToolHealthTracker restriction).
+fn deserialize_bool_lenient<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+    struct BoolVisitor;
+    impl<'de> de::Visitor<'de> for BoolVisitor {
+        type Value = bool;
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("a boolean or string-encoded boolean")
+        }
+        fn visit_bool<E: de::Error>(self, v: bool) -> Result<bool, E> {
+            Ok(v)
+        }
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<bool, E> {
+            match v.to_ascii_lowercase().as_str() {
+                "true" | "1" | "yes" => Ok(true),
+                "false" | "0" | "no" | "" => Ok(false),
+                other => Err(E::custom(format!(
+                    "unrecognized boolean string: \"{other}\""
+                ))),
+            }
+        }
+        fn visit_i64<E: de::Error>(self, v: i64) -> Result<bool, E> {
+            Ok(v != 0)
+        }
+        fn visit_u64<E: de::Error>(self, v: u64) -> Result<bool, E> {
+            Ok(v != 0)
+        }
+        fn visit_none<E: de::Error>(self) -> Result<bool, E> {
+            Ok(false)
+        }
+        fn visit_unit<E: de::Error>(self) -> Result<bool, E> {
+            Ok(false)
+        }
+    }
+    deserializer.deserialize_any(BoolVisitor)
 }
 
 /// Lenient deserializer for `inherit_prefix`: accepts a JSON object
@@ -632,5 +676,44 @@ mod tests {
             "inherit_prefix description must show the `{{}}` opt-in \
              shorthand so models know the minimum call form; got: {ip_desc}"
         );
+    }
+}
+
+#[cfg(test)]
+mod bool_lenient_tests {
+    use super::SpawnAgentInput;
+
+    #[test]
+    fn background_accepts_string_true() {
+        // Regression (session 7e3fecb5): LLM passed "true" (string)
+        // instead of true (bool) → serde rejected → 3 failures →
+        // tool restricted. Lenient deserializer fixes this.
+        let input: SpawnAgentInput =
+            serde_json::from_str(r#"{"description":"test","prompt":"p","background":"true"}"#)
+                .expect("string 'true' must deserialize");
+        assert!(input.background);
+    }
+
+    #[test]
+    fn background_accepts_bool_true() {
+        let input: SpawnAgentInput =
+            serde_json::from_str(r#"{"description":"test","prompt":"p","background":true}"#)
+                .expect("bool true must deserialize");
+        assert!(input.background);
+    }
+
+    #[test]
+    fn background_defaults_false_on_absence() {
+        let input: SpawnAgentInput = serde_json::from_str(r#"{"description":"test","prompt":"p"}"#)
+            .expect("absent background must default to false");
+        assert!(!input.background);
+    }
+
+    #[test]
+    fn isolated_accepts_string_false() {
+        let input: SpawnAgentInput =
+            serde_json::from_str(r#"{"description":"test","prompt":"p","isolated":"false"}"#)
+                .expect("string 'false' must deserialize");
+        assert!(!input.isolated);
     }
 }

--- a/rust/crates/astra-turn-core/src/tool_health.rs
+++ b/rust/crates/astra-turn-core/src/tool_health.rs
@@ -284,6 +284,25 @@ impl ToolHealthTracker {
         self.dirty_tools.insert(tool_name.to_string());
     }
 
+    /// Record an input-validation failure (LLM passed wrong arg types,
+    /// missing required fields, etc.). The TOOL is fine — the caller's
+    /// arguments are wrong. Does NOT increment `consecutive_failures`
+    /// or trigger deprioritization, because the tool itself isn't
+    /// broken and will succeed if the LLM fixes its args next round.
+    ///
+    /// Session 7e3fecb5: 3× `"background": "true"` (string instead of
+    /// bool) caused agent tool to be deprioritized. The tool was
+    /// perfectly healthy — serde just rejected the input shape.
+    pub fn record_input_validation_failure(&mut self, tool_name: &str) {
+        let health = self.tools.entry(tool_name.to_string()).or_default();
+        health.total_calls += 1;
+        health.total_failures += 1;
+        // Deliberately NOT incrementing consecutive_failures or
+        // clearing consecutive_successes — the tool isn't broken,
+        // the caller just needs to fix their args.
+        self.dirty_tools.insert(tool_name.to_string());
+    }
+
     /// Record an empty result (not error, but useless).
     /// Counts as a "soft failure" — doesn't trigger deprioritization alone,
     /// but contributes to overall health metrics.

--- a/rust/crates/astra-turn-core/src/tool_health.rs
+++ b/rust/crates/astra-turn-core/src/tool_health.rs
@@ -293,6 +293,18 @@ impl ToolHealthTracker {
     /// Session 7e3fecb5: 3× `"background": "true"` (string instead of
     /// bool) caused agent tool to be deprioritized. The tool was
     /// perfectly healthy — serde just rejected the input shape.
+    ///
+    /// ## Reporting note
+    /// Both `total_calls` and `total_failures` are incremented, so
+    /// `failure_rate = total_failures / total_calls` WILL reflect
+    /// input-validation failures. Operator dashboards that use
+    /// `failure_rate` to flag "unhealthy" tools should either
+    /// (a) separately surface `input_validation_failures` (TODO:
+    /// add as dedicated counter), or (b) cross-check with
+    /// `consecutive_failures` / `deprioritized` before alerting —
+    /// a tool with high `failure_rate` but `consecutive_failures == 0`
+    /// and `!deprioritized` is almost certainly being misused by the
+    /// LLM, not broken.
     pub fn record_input_validation_failure(&mut self, tool_name: &str) {
         let health = self.tools.entry(tool_name.to_string()).or_default();
         health.total_calls += 1;

--- a/rust/crates/astra-turn-core/src/turn_guard.rs
+++ b/rust/crates/astra-turn-core/src/turn_guard.rs
@@ -237,6 +237,14 @@ impl TurnGuard {
                     | error_recovery::ErrorCategory::ResourceLimit => {
                         self.health.record_resource_limit_failure(tool_name);
                     }
+                    // Schema / input-validation failures are the *caller*'s fault
+                    // (bad args from the LLM), not the tool's. Don't deprioritize
+                    // the tool — otherwise a few malformed calls can banish a
+                    // perfectly healthy tool (regression from session 7e3fecb5).
+                    // See commit 60203cab for the new API; this is the wiring.
+                    error_recovery::ErrorCategory::ToolInvalidArgs => {
+                        self.health.record_input_validation_failure(tool_name);
+                    }
                     _ => {
                         self.health.record_failure(tool_name);
                     }

--- a/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_finalization.rs
@@ -5,14 +5,57 @@ use astra_services::SessionArtifactStore;
 
 use super::agentic_adaptive_tuning::record_loop_completion_feedback;
 use super::agentic_loop_host::{
-    AgenticLoopHost, AgenticLoopOutcome, AgenticLoopState, run_agentic_loop_impl,
+    AgenticLoopHost, AgenticLoopOutcome, AgenticLoopState, VolatileKind, run_agentic_loop_impl,
 };
 use super::agentic_loop_lifecycle::{current_agentic_step, session_turn_number};
+
+fn inject_hallucination_tripwire_nudge_if_fired(state: &mut AgenticLoopState) {
+    use astra_turn_core::hallucination_tripwire::{
+        TripwireToolObservation, TripwireVerdict, detect,
+    };
+
+    if state.final_text.is_empty() {
+        return;
+    }
+
+    let observations: Vec<TripwireToolObservation<'_>> = state
+        .stall
+        .tool_call_records
+        .iter()
+        .map(|record| {
+            let result_preview = record
+                .result_preview
+                .as_deref()
+                .or(record.result_full.as_deref())
+                .or(record.error.as_deref())
+                .unwrap_or_else(|| {
+                    if record.output_bytes == Some(0) {
+                        ""
+                    } else {
+                        "[tool result unavailable]"
+                    }
+                });
+            TripwireToolObservation {
+                name: record.name.as_str(),
+                result_preview,
+            }
+        })
+        .collect();
+
+    if let TripwireVerdict::Mismatch { nudge, .. } = detect(state.final_text.as_str(), observations)
+    {
+        state.push_volatile(VolatileKind::HallucinationTripwire, nudge);
+    }
+}
 
 /// Finalize the turn trace collector: record measured token budget, feed to
 /// observability session, and persist to journal. Called from every exit path
 /// in the agentic loop so `/context breakdown` always reflects the latest turn.
 pub(crate) async fn finalize_turn_trace(state: &mut AgenticLoopState) {
+    // Detect phantom tool-outcome claims in the assistant's completed prose and
+    // queue a correction for the next LLM call before this turn's records reset.
+    inject_hallucination_tripwire_nudge_if_fired(state);
+
     // ── Update L1a SessionFacts from this turn's tool call records ──
     update_session_facts_from_turn(state);
 
@@ -216,6 +259,53 @@ async fn persist_context_trace_to_workspace_if_present(
                 err
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod hallucination_tripwire_integration_tests {
+    use super::*;
+    use astra_services::session_journal::ToolCallRecord;
+
+    #[test]
+    fn queues_next_turn_nudge_when_final_text_claims_phantom_empty_result() {
+        let mut state = super::super::agentic_loop_host::tests::make_state();
+        state.final_text =
+            "The str_replace edit silently returned {}, so the file stayed unchanged.".to_string();
+        state.stall.tool_call_records.push(ToolCallRecord {
+            name: "str_replace".to_string(),
+            ok: false,
+            error: Some("Error: old_str not found. Aborting edit.".to_string()),
+            output_bytes: Some(42),
+            ..Default::default()
+        });
+
+        inject_hallucination_tripwire_nudge_if_fired(&mut state);
+
+        assert_eq!(state.volatile_pending.len(), 1);
+        assert_eq!(
+            state.volatile_pending[0].kind,
+            VolatileKind::HallucinationTripwire
+        );
+        assert!(state.volatile_pending[0].content.contains("Self-check"));
+        assert!(state.volatile_pending[0].content.contains("no tool call"));
+    }
+
+    #[test]
+    fn stays_silent_when_tool_record_anchors_empty_result_claim() {
+        let mut state = super::super::agentic_loop_host::tests::make_state();
+        state.final_text = "The helper silently returned {}.".to_string();
+        state.stall.tool_call_records.push(ToolCallRecord {
+            name: "helper".to_string(),
+            ok: true,
+            output_bytes: Some(2),
+            result_preview: Some("{}".to_string()),
+            ..Default::default()
+        });
+
+        inject_hallucination_tripwire_nudge_if_fired(&mut state);
+
+        assert!(state.volatile_pending.is_empty());
     }
 }
 

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -756,8 +756,9 @@ impl VolatileKind {
             | Self::CompactResume
             | Self::ExecutionRetry
             | Self::ExplorationBudget
-            | Self::BudgetReview
-            | Self::HallucinationTripwire => "user",
+            | Self::BudgetReview => "user",
+            // System-role: prevents injection via attacker-crafted file content.
+            Self::HallucinationTripwire => "system",
             // System-role: in-band runtime snapshots or coaching.
             Self::WorkingSet
             | Self::AlreadyFetched

--- a/rust/crates/runtime/src/turn/agentic_loop_host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop_host.rs
@@ -708,6 +708,12 @@ pub enum VolatileKind {
     ExplorationBudget,
     /// Execution retry with corrective reason.
     ExecutionRetry,
+    /// Post-turn hallucination self-check nudge. Fires when the
+    /// assistant's prose for the just-finished turn claimed a
+    /// phantom tool outcome (e.g. "silently returned {}") that no
+    /// tool call actually produced. See
+    /// [`astra_turn_core::hallucination_tripwire`] for the detector.
+    HallucinationTripwire,
     /// Catch-all for producers we haven't categorized yet. Prefer
     /// adding a new variant over reusing this — introspect reports
     /// by kind and a generic bucket degrades the signal.
@@ -750,7 +756,8 @@ impl VolatileKind {
             | Self::CompactResume
             | Self::ExecutionRetry
             | Self::ExplorationBudget
-            | Self::BudgetReview => "user",
+            | Self::BudgetReview
+            | Self::HallucinationTripwire => "user",
             // System-role: in-band runtime snapshots or coaching.
             Self::WorkingSet
             | Self::AlreadyFetched

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -266,9 +266,11 @@ fn build_bridge_tool_call_records(
             other => {
                 // Non-string output is a serialization bug upstream —
                 // the contract is `output: Option<String>`. Log the
-                // anomaly so we can trace the source instead of silently
-                // passing `"{}"` to the LLM (which it mis-reads as
-                // "tool returned empty JSON object").
+                // anomaly so we can trace the source, but preserve the
+                // real JSON payload for the LLM instead of replacing it
+                // with a synthetic error sentinel (the old behavior
+                // silently discarded real tool data if the upstream
+                // bug ever fired in prod).
                 let type_label = if other.is_object() {
                     "object"
                 } else if other.is_array() {
@@ -289,16 +291,14 @@ fn build_bridge_tool_call_records(
                     );
                 astra_core::agent_warn!(
                     "bridge",
-                    "tool_result.output is {} (not String); coercing. request_id={}, value={}",
+                    "tool_result.output is {} (not String); coercing to JSON repr. request_id={}, value={}",
                     type_label,
                     request_id,
                     preview
                 );
-                format!(
-                    "[BRIDGE_OUTPUT_TYPE_BUG] tool_result.output was JSON {} \
-                     (expected String). request_id={}. raw={}",
-                    type_label, request_id, preview
-                )
+                // Preserve the real payload. The warn! above still fires
+                // so operators can trace the upstream serialization bug.
+                stringified
             }
         });
         let error = tool_result
@@ -6617,10 +6617,9 @@ mod tests {
     #[test]
     fn build_bridge_records_object_output_coerces_to_string_not_silent() {
         // Regression: if upstream serialization bug puts an object `{}`
-        // in the `output` field instead of a string, the old code would
-        // silently pass `"{}"` to the LLM — the model then says "tool
-        // returned {}". The fix logs a warning and still coerces, but
-        // the string is at least traceable.
+        // in the `output` field instead of a string, we now preserve the
+        // real JSON form (not a synthetic sentinel) and log a warning so
+        // operators can trace the upstream bug.
         let tool_calls = vec![json!({
             "id": "call-1",
             "function": {"name": "bash", "arguments": "{}"}
@@ -6638,14 +6637,139 @@ mod tests {
             &std::collections::HashMap::new(),
         );
         assert_eq!(records.len(), 1);
-        // Coerced to string representation of the JSON value
+        // Empty Object coerces to the JSON literal "{}"
         assert_eq!(
             records[0].result_preview.as_deref(),
             Some("{}"),
-            "object output gets coerced to its JSON string form"
+            "empty-object output coerces to its JSON string form '{{}}'"
         );
-        // The key assertion is that this path now logs a warning
-        // (verified by the agent_warn! call presence in the code).
+        // Must NOT contain the old sentinel marker
+        assert!(
+            !records[0]
+                .result_preview
+                .as_deref()
+                .unwrap_or("")
+                .contains("[BRIDGE_OUTPUT_TYPE_BUG]"),
+            "must NOT replace real data with sentinel"
+        );
+    }
+
+    // ── Finding 🟡 6: non-empty Object output must preserve real data ──
+    //
+    // Regression guard: an earlier iteration of the bridge replaced
+    // Object-shaped output with a `[BRIDGE_OUTPUT_TYPE_BUG] ...` sentinel,
+    // silently discarding the actual tool payload. If the upstream
+    // serialization bug ever fires in prod, we want the LLM to see the
+    // real JSON — not a synthetic error tag.
+    #[test]
+    fn build_bridge_records_nonempty_object_output_preserves_real_payload() {
+        let tool_calls = vec![json!({
+            "id": "call-1",
+            "function": {"name": "bash", "arguments": "{}"}
+        })];
+        let tool_results = vec![json!({
+            "request_id": "call-1",
+            "name": "bash",
+            "status": "ok",
+            "output": {"stdout": "hello", "exit": 0},
+            "duration_ms": 50
+        })];
+        let records = build_bridge_tool_call_records(
+            &tool_calls,
+            &tool_results,
+            &std::collections::HashMap::new(),
+        );
+        assert_eq!(records.len(), 1);
+        let preview = records[0]
+            .result_preview
+            .as_deref()
+            .expect("object payload must surface, not None");
+        // Real keys must survive coercion
+        assert!(
+            preview.contains("stdout") && preview.contains("hello"),
+            "real object data must be preserved, got: {preview}"
+        );
+        assert!(
+            !preview.contains("[BRIDGE_OUTPUT_TYPE_BUG]"),
+            "must NOT replace real data with sentinel: {preview}"
+        );
+    }
+
+    // ── Finding 🟡 8: Value::Array path ──
+    //
+    // Array outputs (e.g. list of content blocks) must also be preserved
+    // as JSON, not replaced with a sentinel.
+    #[test]
+    fn build_bridge_records_array_output_preserves_elements() {
+        let tool_calls = vec![json!({
+            "id": "call-1",
+            "function": {"name": "bash", "arguments": "{}"}
+        })];
+        let tool_results = vec![json!({
+            "request_id": "call-1",
+            "name": "bash",
+            "status": "ok",
+            "output": [{"type": "text", "text": "hello"}],
+            "duration_ms": 50
+        })];
+        let records = build_bridge_tool_call_records(
+            &tool_calls,
+            &tool_results,
+            &std::collections::HashMap::new(),
+        );
+        assert_eq!(records.len(), 1);
+        let preview = records[0]
+            .result_preview
+            .as_deref()
+            .expect("array payload must surface, not None");
+        assert!(
+            preview.contains("hello"),
+            "array element content must survive: {preview}"
+        );
+        assert!(
+            !preview.contains("[BRIDGE_OUTPUT_TYPE_BUG]"),
+            "must NOT replace real data with sentinel: {preview}"
+        );
+    }
+
+    // ── Finding 🟡 7: null → "" is intentional, tripwire anchor ──
+    //
+    // Explicitly pin down the contract: `Value::Null` coerces to empty
+    // string (not the literal "null"), which is what the hallucination
+    // tripwire's `any_physical_empty` check relies on to distinguish
+    // "tool really returned nothing" from "tool returned valid JSON".
+    // If this ever changes, the tripwire will silently stop firing.
+    #[test]
+    fn build_bridge_records_null_output_contract_matches_tripwire_anchor() {
+        let tool_calls = vec![json!({
+            "id": "call-1",
+            "function": {"name": "bash", "arguments": "{}"}
+        })];
+        let tool_results = vec![json!({
+            "request_id": "call-1",
+            "name": "bash",
+            "status": "ok",
+            "output": null,
+            "duration_ms": 50
+        })];
+        let records = build_bridge_tool_call_records(
+            &tool_calls,
+            &tool_results,
+            &std::collections::HashMap::new(),
+        );
+        assert_eq!(records.len(), 1);
+        // Must NOT be the literal string "null"
+        assert_ne!(
+            records[0].result_preview.as_deref(),
+            Some("null"),
+            "null JSON must not surface as literal 'null' string"
+        );
+        // Must be empty (None or "") — the tripwire anchor
+        let preview = records[0].result_preview.as_deref().unwrap_or("");
+        assert!(
+            preview.is_empty(),
+            "null output must coerce to empty, got: {preview:?}"
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -277,14 +277,28 @@ fn build_bridge_tool_call_records(
                     "non-string"
                 };
                 let stringified = other.to_string();
+                // Byte-slice is UTF-8-unsafe: serde_json emits ASCII-escaped
+                // today, but one config flip to raw UTF-8 would turn this
+                // into a panic on multi-byte boundaries. Route through the
+                // shared char-boundary helper instead — same helper that
+                // fixed the cross-turn cache-hit preview regression.
+                let (preview, _truncated) =
+                    astra_turn_core::headless_tool_journal::truncate_on_char_boundary(
+                        &stringified,
+                        200,
+                    );
                 astra_core::agent_warn!(
                     "bridge",
                     "tool_result.output is {} (not String); coercing. request_id={}, value={}",
                     type_label,
                     request_id,
-                    &stringified[..stringified.len().min(200)]
+                    preview
                 );
-                stringified
+                format!(
+                    "[BRIDGE_OUTPUT_TYPE_BUG] tool_result.output was JSON {} \
+                     (expected String). request_id={}. raw={}",
+                    type_label, request_id, preview
+                )
             }
         });
         let error = tool_result

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -264,10 +264,15 @@ fn build_bridge_tool_call_records(
             Value::String(s) => s.clone(),
             Value::Null => String::new(),
             Value::Object(map) if map.is_empty() => {
+                // Tagged with the shared sentinel so log pipelines / metrics
+                // can count this specific degraded path and measure whether
+                // the upstream serialization bug is decreasing over time.
+                // See `astra_turn_core::history::DEGRADED_EMPTY_OBJECT_TAG`.
                 astra_core::agent_warn!(
                     "bridge",
-                    "tool_result.output is an empty object (not String); degrading to empty string. request_id={}",
-                    request_id
+                    "tool_result.output is an empty object (not String); degrading to empty string. request_id={} tag={}",
+                    request_id,
+                    astra_turn_core::history::DEGRADED_EMPTY_OBJECT_TAG
                 );
                 String::new()
             }

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -263,6 +263,14 @@ fn build_bridge_tool_call_records(
         let output = tool_result.get("output").map(|output| match output {
             Value::String(s) => s.clone(),
             Value::Null => String::new(),
+            Value::Object(map) if map.is_empty() => {
+                astra_core::agent_warn!(
+                    "bridge",
+                    "tool_result.output is an empty object (not String); degrading to empty string. request_id={}",
+                    request_id
+                );
+                String::new()
+            }
             other => {
                 // Non-string output is a serialization bug upstream —
                 // the contract is `output: Option<String>`. Log the
@@ -6637,11 +6645,13 @@ mod tests {
             &std::collections::HashMap::new(),
         );
         assert_eq!(records.len(), 1);
-        // Empty Object coerces to the JSON literal "{}"
+        // Empty Object is the historical pollution shape that made the
+        // model claim "tool returned {}". Treat it as degraded empty
+        // content rather than replaying a bare "{}" tool result.
         assert_eq!(
             records[0].result_preview.as_deref(),
-            Some("{}"),
-            "empty-object output coerces to its JSON string form '{{}}'"
+            Some(""),
+            "empty-object output must not be surfaced as bare '{{}}'"
         );
         // Must NOT contain the old sentinel marker
         assert!(

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -261,8 +261,31 @@ fn build_bridge_tool_call_records(
             Some(0)
         );
         let output = tool_result.get("output").map(|output| match output {
-            Value::String(output) => output.clone(),
-            other => other.to_string(),
+            Value::String(s) => s.clone(),
+            Value::Null => String::new(),
+            other => {
+                // Non-string output is a serialization bug upstream —
+                // the contract is `output: Option<String>`. Log the
+                // anomaly so we can trace the source instead of silently
+                // passing `"{}"` to the LLM (which it mis-reads as
+                // "tool returned empty JSON object").
+                let type_label = if other.is_object() {
+                    "object"
+                } else if other.is_array() {
+                    "array"
+                } else {
+                    "non-string"
+                };
+                let stringified = other.to_string();
+                astra_core::agent_warn!(
+                    "bridge",
+                    "tool_result.output is {} (not String); coercing. request_id={}, value={}",
+                    type_label,
+                    request_id,
+                    &stringified[..stringified.len().min(200)]
+                );
+                stringified
+            }
         });
         let error = tool_result
             .get("error")
@@ -6547,5 +6570,118 @@ mod tests {
             Value::Number(42.into()),
         );
         assert!(bridge_should_run_memoria_prefetch(&ep));
+    }
+
+    // ── tool_result.output non-string coercion tests ──────────────────
+
+    #[test]
+    fn build_bridge_records_string_output_passes_through() {
+        let tool_calls = vec![json!({
+            "id": "call-1",
+            "function": {"name": "bash", "arguments": "{\"command\":\"echo hello\"}"}
+        })];
+        let tool_results = vec![json!({
+            "request_id": "call-1",
+            "name": "bash",
+            "status": "ok",
+            "output": "hello\n",
+            "duration_ms": 50
+        })];
+        let records = build_bridge_tool_call_records(
+            &tool_calls,
+            &tool_results,
+            &std::collections::HashMap::new(),
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].result_preview.as_deref(),
+            Some("hello\n"),
+            "string output must pass through verbatim"
+        );
+    }
+
+    #[test]
+    fn build_bridge_records_object_output_coerces_to_string_not_silent() {
+        // Regression: if upstream serialization bug puts an object `{}`
+        // in the `output` field instead of a string, the old code would
+        // silently pass `"{}"` to the LLM — the model then says "tool
+        // returned {}". The fix logs a warning and still coerces, but
+        // the string is at least traceable.
+        let tool_calls = vec![json!({
+            "id": "call-1",
+            "function": {"name": "bash", "arguments": "{}"}
+        })];
+        let tool_results = vec![json!({
+            "request_id": "call-1",
+            "name": "bash",
+            "status": "ok",
+            "output": {},
+            "duration_ms": 50
+        })];
+        let records = build_bridge_tool_call_records(
+            &tool_calls,
+            &tool_results,
+            &std::collections::HashMap::new(),
+        );
+        assert_eq!(records.len(), 1);
+        // Coerced to string representation of the JSON value
+        assert_eq!(
+            records[0].result_preview.as_deref(),
+            Some("{}"),
+            "object output gets coerced to its JSON string form"
+        );
+        // The key assertion is that this path now logs a warning
+        // (verified by the agent_warn! call presence in the code).
+    }
+
+    #[test]
+    fn build_bridge_records_null_output_becomes_empty() {
+        let tool_calls = vec![json!({
+            "id": "call-1",
+            "function": {"name": "bash", "arguments": "{}"}
+        })];
+        let tool_results = vec![json!({
+            "request_id": "call-1",
+            "name": "bash",
+            "status": "ok",
+            "output": null,
+            "duration_ms": 50
+        })];
+        let records = build_bridge_tool_call_records(
+            &tool_calls,
+            &tool_results,
+            &std::collections::HashMap::new(),
+        );
+        assert_eq!(records.len(), 1);
+        // null output → empty string (not "null")
+        assert!(
+            records[0].result_preview.is_none() || records[0].result_preview.as_deref() == Some(""),
+            "null output should become empty, got: {:?}",
+            records[0].result_preview
+        );
+    }
+
+    #[test]
+    fn build_bridge_records_missing_output_is_none() {
+        let tool_calls = vec![json!({
+            "id": "call-1",
+            "function": {"name": "bash", "arguments": "{}"}
+        })];
+        let tool_results = vec![json!({
+            "request_id": "call-1",
+            "name": "bash",
+            "status": "ok",
+            "duration_ms": 50
+        })];
+        let records = build_bridge_tool_call_records(
+            &tool_calls,
+            &tool_results,
+            &std::collections::HashMap::new(),
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].result_preview, None,
+            "missing output field → None (not empty string)"
+        );
     }
 }

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
@@ -517,8 +517,11 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
         } = validated;
         if self.ctx.restricted_tools.contains(&execution.name) {
             let err_msg = format!(
-                "Tool '{}' is currently restricted and cannot be executed. \
-                 Use only the tools whose schemas were provided.",
+                "Tool '{}' is currently restricted due to repeated failures in \
+                 this session. The tool itself is not broken — it was blocked \
+                 because previous calls failed (possibly due to argument errors).\n\n\
+                 Workaround: use `bash` to accomplish the same task directly, \
+                 or describe what you need and ask the user to run the command.",
                 execution.name
             );
             emit_blocked_tool_result(

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
@@ -13,7 +13,7 @@ use astra_turn_core::headless_tool_assembly::{
 };
 use astra_turn_core::headless_tool_body_preview::emit_headless_tool_body_preview;
 use astra_turn_core::headless_tool_journal::{
-    journal_record_blocked_tool, journal_record_cross_turn_cache_hit,
+    journal_record_blocked_tool, journal_record_cross_turn_cache_hit_with_body,
     journal_record_duplicate_within_turn, journal_record_unknown_tool,
 };
 use astra_turn_core::headless_tool_stderr_lines::{
@@ -302,7 +302,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                     .record_cache_hit_for_signature(&slot.name, &call_sig);
                 self.ctx
                     .tool_call_records
-                    .push(journal_record_cross_turn_cache_hit(
+                    .push(journal_record_cross_turn_cache_hit_with_body(
                         slot.name.clone(),
                         body.len() as u32,
                         args_preview,
@@ -355,7 +355,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                 .record_cache_hit_for_signature(&slot.name, &call_sig);
             self.ctx
                 .tool_call_records
-                .push(journal_record_cross_turn_cache_hit(
+                .push(journal_record_cross_turn_cache_hit_with_body(
                     slot.name.clone(),
                     cached.output.len() as u32,
                     args_preview,
@@ -412,7 +412,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                 .record_cache_hit_for_signature(&slot.name, &call_sig);
             self.ctx
                 .tool_call_records
-                .push(journal_record_cross_turn_cache_hit(
+                .push(journal_record_cross_turn_cache_hit_with_body(
                     slot.name.clone(),
                     cached_output.len() as u32,
                     args_preview,

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
@@ -306,7 +306,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                         slot.name.clone(),
                         body.len() as u32,
                         args_preview,
-                        Some(body.clone()),
+                        Some(&body),
                     ));
                 return HeadlessPipelineStage::ShortCircuit;
             }
@@ -359,7 +359,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                     slot.name.clone(),
                     cached.output.len() as u32,
                     args_preview,
-                    Some(cached.output.clone()),
+                    Some(&cached.output),
                 ));
             return HeadlessPipelineStage::ShortCircuit;
         }
@@ -416,7 +416,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                     slot.name.clone(),
                     cached_output.len() as u32,
                     args_preview,
-                    Some(cached_output.clone()),
+                    Some(&cached_output),
                 ));
             agent_warn!(
                 "dedup",

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
@@ -13,7 +13,7 @@ use astra_turn_core::headless_tool_assembly::{
 };
 use astra_turn_core::headless_tool_body_preview::emit_headless_tool_body_preview;
 use astra_turn_core::headless_tool_journal::{
-    journal_record_blocked_tool, journal_record_cross_turn_cache_hit_with_body,
+    journal_record_blocked_tool, journal_record_cross_turn_cache_hit,
     journal_record_duplicate_within_turn, journal_record_unknown_tool,
 };
 use astra_turn_core::headless_tool_stderr_lines::{
@@ -302,7 +302,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                     .record_cache_hit_for_signature(&slot.name, &call_sig);
                 self.ctx
                     .tool_call_records
-                    .push(journal_record_cross_turn_cache_hit_with_body(
+                    .push(journal_record_cross_turn_cache_hit(
                         slot.name.clone(),
                         body.len() as u32,
                         args_preview,
@@ -355,7 +355,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                 .record_cache_hit_for_signature(&slot.name, &call_sig);
             self.ctx
                 .tool_call_records
-                .push(journal_record_cross_turn_cache_hit_with_body(
+                .push(journal_record_cross_turn_cache_hit(
                     slot.name.clone(),
                     cached.output.len() as u32,
                     args_preview,
@@ -412,7 +412,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                 .record_cache_hit_for_signature(&slot.name, &call_sig);
             self.ctx
                 .tool_call_records
-                .push(journal_record_cross_turn_cache_hit_with_body(
+                .push(journal_record_cross_turn_cache_hit(
                     slot.name.clone(),
                     cached_output.len() as u32,
                     args_preview,

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
@@ -306,6 +306,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                         slot.name.clone(),
                         body.len() as u32,
                         args_preview,
+                        Some(body.clone()),
                     ));
                 return HeadlessPipelineStage::ShortCircuit;
             }
@@ -358,6 +359,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                     slot.name.clone(),
                     cached.output.len() as u32,
                     args_preview,
+                    Some(cached.output.clone()),
                 ));
             return HeadlessPipelineStage::ShortCircuit;
         }
@@ -414,6 +416,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                     slot.name.clone(),
                     cached_output.len() as u32,
                     args_preview,
+                    Some(cached_output.clone()),
                 ));
             agent_warn!(
                 "dedup",

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline/record.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline/record.rs
@@ -12,7 +12,8 @@ use astra_turn_core::headless_tool_body_preview::emit_headless_tool_body_preview
 use astra_turn_core::headless_tool_journal::journal_record_executed_tool_call;
 use astra_turn_core::headless_tool_postprocess::{
     HeadlessCacheableRecordCtx, format_headless_tool_duration,
-    record_headless_cacheable_success_and_semantic_hint, try_write_light_headless_step_checkpoint,
+    record_headless_cacheable_success_and_semantic_hint_if_ok,
+    try_write_light_headless_step_checkpoint,
 };
 use astra_turn_core::headless_tool_status_display::{tool_call_detail, tool_result_summary};
 use astra_turn_core::headless_tool_stderr_lines::{
@@ -169,8 +170,12 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
             self.ctx.idempotency_cache.evict_tools(&READ_ONLY_TOOLS);
         }
 
-        if !is_err && READ_ONLY_TOOLS.contains(&execution.name.as_str()) {
-            record_headless_cacheable_success_and_semantic_hint(
+        if READ_ONLY_TOOLS.contains(&execution.name.as_str()) {
+            // The `_if_ok` helper no-ops on `is_err`, so the outer
+            // guard is redundant — keep the READ_ONLY_TOOLS filter
+            // (tool-name scope) but hand `is_err` to the helper for
+            // the error-branch decision.
+            record_headless_cacheable_success_and_semantic_hint_if_ok(
                 &execution.name,
                 &execution.args,
                 &idem_key,
@@ -181,6 +186,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                     step_recorder: self.ctx.step_recorder,
                     semantic_dedup: self.ctx.semantic_dedup,
                 },
+                is_err,
             );
         }
 

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -1693,15 +1693,43 @@ fn anthropic_message_from_openai(msg: &Value) -> Option<Value> {
                 carry_cache_annotations(msg, &mut out);
                 return Some(out);
             }
-            let content = msg
-                .get("content")
-                .and_then(Value::as_str)
-                .map(|text| Value::String(text.to_string()))
-                .unwrap_or_else(|| {
-                    msg.get("content")
-                        .cloned()
-                        .unwrap_or(Value::String(String::new()))
-                });
+            let content = match msg.get("content") {
+                Some(Value::String(text)) => Value::String(text.clone()),
+                Some(Value::Null) | None => Value::String(String::new()),
+                Some(other) => {
+                    // Non-string content on a tool-role message is a
+                    // serialization bug upstream (compaction, fold, or
+                    // format conversion set it to an object/array instead
+                    // of a string). Coerce to string representation so
+                    // the LLM sees SOMETHING — not a bare `{}` that it
+                    // misreads as "tool returned empty JSON object".
+                    astra_core::agent_warn!(
+                        "llm_client",
+                        "tool-role msg has non-string content (type={}); \
+                         coercing to string for tool_result_block. \
+                         tool_use_id={}",
+                        if other.is_object() { "object" }
+                        else if other.is_array() { "array" }
+                        else { "other" },
+                        tool_use_id
+                    );
+                    match other {
+                        Value::Array(arr) => {
+                            // Content-array: extract text blocks
+                            let text: String = arr.iter()
+                                .filter_map(|b| b.get("text").and_then(Value::as_str))
+                                .collect::<Vec<_>>()
+                                .join("");
+                            if text.is_empty() {
+                                Value::String(other.to_string())
+                            } else {
+                                Value::String(text)
+                            }
+                        }
+                        _ => Value::String(other.to_string()),
+                    }
+                }
+            };
             let tool_result_block = json!({
                 "type": "tool_result",
                 "tool_use_id": tool_use_id,

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -830,6 +830,11 @@ fn build_bedrock_message_content(msg: &Value, include_reasoning_content: bool) -
                     // booleans, and null must use the `text` branch — or
                     // Bedrock rejects with "messages.N.content.M.toolResult
                     // .content.0.json is invalid — provide a json object".
+                    //
+                    // Empty content uses `{"text": ""}` (not `{"json": {}}`)
+                    // because Bedrock accepts an empty string here but rejects
+                    // an empty JSON object as "invalid". Do not switch to
+                    // `{"json": {}}` — it will 400 at the provider.
                     let result_block = if content.is_empty() {
                         json!({"text": ""})
                     } else {

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -664,7 +664,16 @@ fn coerce_tool_result_content(content: Option<&Value>) -> String {
                 .collect::<Vec<_>>()
                 .join("");
             if joined.is_empty() {
-                Value::Array(parts.clone()).to_string()
+                // No joinable text parts (e.g. image-only array). Returning the
+                // raw JSON-stringified array would leak structural noise to the
+                // model; prefer empty string + a warn so the degradation is
+                // observable without polluting the prompt.
+                tracing::warn!(
+                    target: "astra::tool_result",
+                    parts = parts.len(),
+                    "tool_result content array had no text parts; coercing to empty string"
+                );
+                String::new()
             } else {
                 joined
             }
@@ -678,6 +687,17 @@ fn normalize_openai_tool_message_content(messages: &[Value]) -> Vec<Value> {
         .iter()
         .map(|message| {
             if message.get("role").and_then(Value::as_str) != Some("tool") {
+                return message.clone();
+            }
+            // Only rewrite content that OpenAI would reject or misread:
+            // bare objects (most notably the empty `{}` placeholder) and nulls.
+            // Leave well-formed String and Array content untouched so future
+            // multi-part tool messages pass through intact.
+            let needs_rewrite = matches!(
+                message.get("content"),
+                Some(Value::Object(_)) | Some(Value::Null) | None
+            );
+            if !needs_rewrite {
                 return message.clone();
             }
             let mut normalized = message.clone();

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -652,9 +652,11 @@ fn json_string_to_value_or_string(raw: &str) -> Value {
     serde_json::from_str(raw).unwrap_or_else(|_| Value::String(raw.to_string()))
 }
 
-fn content_text_value(content: Option<&Value>) -> Option<String> {
+fn coerce_tool_result_content(content: Option<&Value>) -> String {
     match content {
-        Some(Value::String(s)) if !s.is_empty() => Some(s.clone()),
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Null) | None => String::new(),
+        Some(Value::Object(map)) if map.is_empty() => String::new(),
         Some(Value::Array(parts)) => {
             let joined = parts
                 .iter()
@@ -662,13 +664,32 @@ fn content_text_value(content: Option<&Value>) -> Option<String> {
                 .collect::<Vec<_>>()
                 .join("");
             if joined.is_empty() {
-                None
+                Value::Array(parts.clone()).to_string()
             } else {
-                Some(joined)
+                joined
             }
         }
-        _ => None,
+        Some(other) => other.to_string(),
     }
+}
+
+fn normalize_openai_tool_message_content(messages: &[Value]) -> Vec<Value> {
+    messages
+        .iter()
+        .map(|message| {
+            if message.get("role").and_then(Value::as_str) != Some("tool") {
+                return message.clone();
+            }
+            let mut normalized = message.clone();
+            if let Some(obj) = normalized.as_object_mut() {
+                obj.insert(
+                    "content".to_string(),
+                    Value::String(coerce_tool_result_content(message.get("content"))),
+                );
+            }
+            normalized
+        })
+        .collect()
 }
 
 fn is_nonblank_text(text: &str) -> bool {
@@ -781,7 +802,7 @@ fn build_bedrock_message_content(msg: &Value, include_reasoning_content: bool) -
     match role {
         "tool" => {
             let tool_use_id = msg.get("tool_call_id").and_then(Value::as_str);
-            let content = content_text_value(msg.get("content")).unwrap_or_default();
+            let content = coerce_tool_result_content(msg.get("content"));
             tool_use_id
                 .map(|tool_use_id| {
                     // Bedrock's `toolResult.content[].json` field requires a
@@ -790,7 +811,7 @@ fn build_bedrock_message_content(msg: &Value, include_reasoning_content: bool) -
                     // Bedrock rejects with "messages.N.content.M.toolResult
                     // .content.0.json is invalid — provide a json object".
                     let result_block = if content.is_empty() {
-                        json!({"json": {}})
+                        json!({"text": ""})
                     } else {
                         match serde_json::from_str::<Value>(&content) {
                             Ok(parsed) if parsed.is_object() => json!({"json": parsed}),
@@ -1321,9 +1342,10 @@ pub(crate) fn build_provider_request_body(
                 thinking.apply_anthropic(&mut body);
                 return body;
             }
+            let normalized_messages = normalize_openai_tool_message_content(messages);
             let mut body = json!({
                 "model": model_name,
-                "messages": messages,
+                "messages": normalized_messages,
                 "stream": streaming,
             });
             if streaming {
@@ -1696,6 +1718,14 @@ fn anthropic_message_from_openai(msg: &Value) -> Option<Value> {
             let content = match msg.get("content") {
                 Some(Value::String(text)) => Value::String(text.clone()),
                 Some(Value::Null) | None => Value::String(String::new()),
+                Some(Value::Object(map)) if map.is_empty() => {
+                    astra_core::agent_warn!(
+                        "llm_client",
+                        "tool-role msg has empty-object content; degrading to empty string for tool_result_block. tool_use_id={}",
+                        tool_use_id
+                    );
+                    Value::String(String::new())
+                }
                 Some(other) => {
                     // Non-string content on a tool-role message is a
                     // serialization bug upstream (compaction, fold, or
@@ -5261,8 +5291,8 @@ mod tests {
     #[test]
     fn anthropic_tool_message_object_content_coerced_to_string_not_empty_json() {
         // Upstream bug: tool content ended up as `{}` (empty object).
-        // The converter must stringify it so the LLM never sees a
-        // bare JSON object as the tool_result body.
+        // The converter must degrade it to an empty string so the LLM
+        // never sees a bare JSON object as the tool_result body.
         let msg = json!({
             "role": "tool",
             "tool_call_id": "call_obj",
@@ -5277,8 +5307,64 @@ mod tests {
         );
         assert_eq!(
             body.as_str().unwrap(),
-            "{}",
-            "object content stringified to its JSON repr",
+            "",
+            "empty object content must be degraded to empty string, not bare '{{}}'",
+        );
+    }
+
+    #[test]
+    fn openai_request_body_tool_message_empty_object_content_becomes_empty_string() {
+        let messages = vec![json!({
+            "role": "tool",
+            "tool_call_id": "call_obj",
+            "content": {},
+        })];
+        let body = build_provider_request_body(
+            &messages,
+            &[],
+            "gpt-test",
+            "openai",
+            None,
+            None,
+            true,
+            &ThinkingConfig::Off,
+        );
+        assert_eq!(body["messages"][0]["content"].as_str(), Some(""));
+    }
+
+    #[test]
+    fn bedrock_tool_message_empty_object_content_becomes_text_empty_string() {
+        let messages = vec![
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_obj",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": "{}"}
+                }]
+            }),
+            json!({
+                "role": "tool",
+                "tool_call_id": "call_obj",
+                "content": {},
+            }),
+        ];
+        let body = build_provider_request_body(
+            &messages,
+            &[],
+            "anthropic.claude-3-5-sonnet-v1:0",
+            "bedrock",
+            None,
+            None,
+            false,
+            &ThinkingConfig::Off,
+        );
+        let result_block = &body["messages"][1]["content"][0]["toolResult"]["content"][0];
+        assert_eq!(result_block.get("text").and_then(Value::as_str), Some(""));
+        assert!(
+            result_block.get("json").is_none(),
+            "empty object must not be sent as Bedrock json {{}}: {result_block:?}"
         );
     }
 

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -1708,15 +1708,20 @@ fn anthropic_message_from_openai(msg: &Value) -> Option<Value> {
                         "tool-role msg has non-string content (type={}); \
                          coercing to string for tool_result_block. \
                          tool_use_id={}",
-                        if other.is_object() { "object" }
-                        else if other.is_array() { "array" }
-                        else { "other" },
+                        if other.is_object() {
+                            "object"
+                        } else if other.is_array() {
+                            "array"
+                        } else {
+                            "other"
+                        },
                         tool_use_id
                     );
                     match other {
                         Value::Array(arr) => {
                             // Content-array: extract text blocks
-                            let text: String = arr.iter()
+                            let text: String = arr
+                                .iter()
                                 .filter_map(|b| b.get("text").and_then(Value::as_str))
                                 .collect::<Vec<_>>()
                                 .join("");

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -5243,6 +5243,154 @@ mod tests {
         assert_eq!(blocks[0]["content"], "hello");
     }
 
+    // ── Tool-role content-coercion boundary tests ─────────────────────────
+    //
+    // Regression guards for the six-session `{}` cascade bug
+    // (commit 104b4502). When compaction / fold / format-conversion
+    // produces a non-string `content` on a tool-role message, the
+    // converter must coerce the payload to a string rather than pass
+    // `{}`, `[]`, or `null` through verbatim — otherwise downstream
+    // LLM reads the empty object as "tool returned nothing" and
+    // hallucinates a retry or an error.
+    //
+    // These tests pin the FUNCTION-BOUNDARY contract of
+    // `anthropic_message_from_openai` for every shape
+    // (`Value::Object`, `Value::Array` with/without text, `Value::Null`,
+    // and content-field absent).
+
+    #[test]
+    fn anthropic_tool_message_object_content_coerced_to_string_not_empty_json() {
+        // Upstream bug: tool content ended up as `{}` (empty object).
+        // The converter must stringify it so the LLM never sees a
+        // bare JSON object as the tool_result body.
+        let msg = json!({
+            "role": "tool",
+            "tool_call_id": "call_obj",
+            "content": {},
+        });
+        let converted = anthropic_message_from_openai(&msg).unwrap();
+        let blocks = converted["content"].as_array().unwrap();
+        let body = &blocks[0]["content"];
+        assert!(
+            body.is_string(),
+            "tool_result.content must be a string after coercion, got: {body}",
+        );
+        assert_eq!(
+            body.as_str().unwrap(),
+            "{}",
+            "object content stringified to its JSON repr",
+        );
+    }
+
+    #[test]
+    fn anthropic_tool_message_nonempty_object_content_stringified_verbatim() {
+        // An object payload (e.g. `{"error": "boom"}`) must survive
+        // as a readable string — not be silently elided.
+        let msg = json!({
+            "role": "tool",
+            "tool_call_id": "call_obj2",
+            "content": {"error": "boom", "code": 42},
+        });
+        let converted = anthropic_message_from_openai(&msg).unwrap();
+        let body = converted["content"][0]["content"].as_str().unwrap();
+        // serde_json preserves key order as inserted; both fields must be present.
+        assert!(
+            body.contains("\"error\":\"boom\""),
+            "error preserved: {body}"
+        );
+        assert!(body.contains("\"code\":42"), "code preserved: {body}");
+    }
+
+    #[test]
+    fn anthropic_tool_message_array_with_text_blocks_extracts_joined_text() {
+        // Content-block array shape: Anthropic-style
+        // `[{type:"text", text:"..."}]` — the coercion branch extracts
+        // the joined `text` fields rather than the raw JSON dump.
+        let msg = json!({
+            "role": "tool",
+            "tool_call_id": "call_arr",
+            "content": [
+                {"type": "text", "text": "hello "},
+                {"type": "text", "text": "world"},
+            ],
+        });
+        let converted = anthropic_message_from_openai(&msg).unwrap();
+        let body = converted["content"][0]["content"].as_str().unwrap();
+        assert_eq!(
+            body, "hello world",
+            "text blocks must be joined into a single string, got: {body}",
+        );
+    }
+
+    #[test]
+    fn anthropic_tool_message_array_without_text_falls_back_to_json_repr() {
+        // An array of objects with NO `text` fields must round-trip
+        // as its JSON representation, not the empty string — else the
+        // LLM sees `""` and treats the tool as silent.
+        let msg = json!({
+            "role": "tool",
+            "tool_call_id": "call_arr2",
+            "content": [{"kind": "image"}, {"kind": "ref"}],
+        });
+        let converted = anthropic_message_from_openai(&msg).unwrap();
+        let body = converted["content"][0]["content"].as_str().unwrap();
+        assert!(
+            body.contains("\"kind\":\"image\""),
+            "non-text array serialized verbatim: {body}",
+        );
+        assert!(
+            body.contains("\"kind\":\"ref\""),
+            "all array elements preserved: {body}",
+        );
+        assert_ne!(body, "", "must not collapse to empty string");
+    }
+
+    #[test]
+    fn anthropic_tool_message_null_content_becomes_empty_string() {
+        // `Value::Null` is the documented empty-payload case. The
+        // converter MUST emit `""` (not null, not absent) so downstream
+        // wire serialization doesn't drop the tool_result.content key.
+        let msg = json!({
+            "role": "tool",
+            "tool_call_id": "call_null",
+            "content": serde_json::Value::Null,
+        });
+        let converted = anthropic_message_from_openai(&msg).unwrap();
+        let body = &converted["content"][0]["content"];
+        assert_eq!(body.as_str(), Some(""), "null → empty string, got: {body}");
+    }
+
+    #[test]
+    fn anthropic_tool_message_absent_content_becomes_empty_string() {
+        // No `content` key at all: same as Null — converter still emits
+        // a well-formed tool_result with an empty string body.
+        let msg = json!({
+            "role": "tool",
+            "tool_call_id": "call_missing",
+        });
+        let converted = anthropic_message_from_openai(&msg).unwrap();
+        let blocks = converted["content"].as_array().unwrap();
+        assert_eq!(blocks.len(), 1, "still wraps into exactly one block");
+        assert_eq!(blocks[0]["type"], "tool_result");
+        assert_eq!(blocks[0]["tool_use_id"], "call_missing");
+        assert_eq!(blocks[0]["content"].as_str(), Some(""));
+    }
+
+    #[test]
+    fn anthropic_tool_message_number_content_stringified_not_dropped() {
+        // A numeric payload (rare but possible from a misbehaving
+        // upstream) must stringify to its JSON form, not be silently
+        // dropped to `""`.
+        let msg = json!({
+            "role": "tool",
+            "tool_call_id": "call_num",
+            "content": 42,
+        });
+        let converted = anthropic_message_from_openai(&msg).unwrap();
+        let body = converted["content"][0]["content"].as_str().unwrap();
+        assert_eq!(body, "42", "number content stringified, got: {body}");
+    }
+
     #[test]
     fn anthropic_system_and_messages_preserves_cache_control_on_system_blocks() {
         let messages = vec![

--- a/rust/crates/runtime/src/turn/session_end_debounce.rs
+++ b/rust/crates/runtime/src/turn/session_end_debounce.rs
@@ -168,4 +168,87 @@ mod tests {
         assert_eq!(d.should_run("sess1"), DebounceDecision::Run);
         assert_eq!(d.session_count(), 0);
     }
+
+    // ─── Caller-sequence integration tests ─────────────────────────────
+    //
+    // These lock the exact should_run/record/forget sequence used by
+    // `server::run_lifecycle::post_loop_memory_cleanup` (lines 98-147
+    // and the final `forget` at the end of cleanup). Regressions in
+    // the caller — e.g. recording on failure, skipping forget, or
+    // reversing the order — will show up here rather than only in a
+    // six-session production cascade.
+
+    #[test]
+    fn caller_sequence_success_path_skips_on_second_turn() {
+        // Simulates: first terminal run completes governance successfully,
+        // then the user issues another turn on the same session within
+        // the window. Caller path:
+        //   should_run=Run → governance Ok → record → forget-at-teardown
+        // Second turn (before forget, e.g. still active) must Skip.
+        let d = SessionEndDebouncer::with_interval(Duration::from_secs(60));
+        assert_eq!(d.should_run("sess-caller-1"), DebounceDecision::Run);
+        // caller: governance succeeded → record()
+        d.record("sess-caller-1");
+        // Second turn arrives on same session_id before forget/teardown:
+        assert_eq!(d.should_run("sess-caller-1"), DebounceDecision::Skip);
+    }
+
+    #[test]
+    fn caller_sequence_governance_failure_does_not_consume_window() {
+        // Simulates: should_run=Run, governance returns Err, caller
+        // logs warn and SKIPS record (see run_lifecycle.rs ~132 vs 134).
+        // Next turn must still get Run — a failed governance attempt
+        // must not burn the 15-min window.
+        let d = SessionEndDebouncer::with_interval(Duration::from_secs(60));
+        assert_eq!(d.should_run("sess-fail"), DebounceDecision::Run);
+        // caller: governance returned Err → NO record() call.
+        // Next turn:
+        assert_eq!(d.should_run("sess-fail"), DebounceDecision::Run);
+        assert_eq!(d.session_count(), 0);
+    }
+
+    #[test]
+    fn caller_sequence_forget_allows_immediate_rerun_on_same_session_id() {
+        // Simulates: long-lived server reaches explicit teardown for a
+        // session_id, calls forget(), then the user reconnects with the
+        // same session_id (sticky IDs). Next should_run must be Run so
+        // the new conversation gets its own governance window.
+        let d = SessionEndDebouncer::with_interval(Duration::from_secs(60));
+        d.record("sess-sticky");
+        assert_eq!(d.should_run("sess-sticky"), DebounceDecision::Skip);
+        // Explicit teardown path:
+        d.forget("sess-sticky");
+        // Reconnect with same id:
+        assert_eq!(d.should_run("sess-sticky"), DebounceDecision::Run);
+    }
+
+    #[test]
+    fn caller_sequence_empty_session_id_is_noop_throughout() {
+        // run_lifecycle.rs: `if session_id.is_empty() { return; }` at the
+        // top of post_loop_memory_cleanup. But if a future refactor drops
+        // that guard, the debouncer itself must still no-op cleanly for
+        // every method in the caller sequence.
+        let d = SessionEndDebouncer::with_interval(Duration::from_secs(60));
+        assert_eq!(d.should_run(""), DebounceDecision::Skip);
+        d.record("");
+        d.forget("");
+        assert_eq!(d.session_count(), 0);
+        assert_eq!(d.should_run(""), DebounceDecision::Skip);
+    }
+
+    #[test]
+    fn caller_sequence_concurrent_sessions_do_not_cross_contaminate() {
+        // Server handles multiple sessions in flight. One session's
+        // record()/forget() must not affect another's window — regression
+        // guard against a future HashMap keying bug.
+        let d = SessionEndDebouncer::with_interval(Duration::from_secs(60));
+        d.record("sess-A");
+        d.record("sess-B");
+        assert_eq!(d.should_run("sess-A"), DebounceDecision::Skip);
+        assert_eq!(d.should_run("sess-B"), DebounceDecision::Skip);
+        d.forget("sess-A");
+        assert_eq!(d.should_run("sess-A"), DebounceDecision::Run);
+        // B's window must be untouched:
+        assert_eq!(d.should_run("sess-B"), DebounceDecision::Skip);
+    }
 }


### PR DESCRIPTION
## Summary

Systematic fixes for tool reliability issues discovered across sessions 6d6c1041, 5933ebce, 19ad8393, 34a2c5ac, 11825116, 7e3fecb5, ab27a02c:

- **multi_edit fuzzy cascade**: `str_replace` multi-edit mode now falls back to the same 8-strategy fuzzy cascade that single-edit uses. Whitespace-only mismatches (wrong indent depth) auto-apply instead of aborting the entire batch.
- **Hallucination tripwire**: detects when assistant prose claims phantom tool outcomes ("silently returned {}") that no tool call actually produced. Injects a system-role nudge on the next turn to break the confabulation loop.
- **Cross-turn cache-hit preview**: journal records now carry `[cached_cross_turn: reused N bytes]` + content snippet instead of `result_preview: None`, preventing downstream analysis from misreading cache hits as "empty output".
- **Agent spawn lenient bool**: `"background": "true"` (string) no longer causes serde rejection → 3 consecutive failures → tool restriction. `deserialize_bool_lenient` accepts string/bool/int variants.
- **ToolHealthTracker input-validation immunity**: `ErrorCategory::ToolInvalidArgs` routes to `record_input_validation_failure` (doesn't increment consecutive_failures or trigger deprioritization).
- **CLI skill-loaded marker**: `<skill-loaded name="..."/>` appended on CLI edge path (was server-only), so the system-prompt "do not re-invoke" rule fires.
- **4 LLM-hostile error messages → actionable**: github no-token, memory no-endpoint, headless edge protocol, restricted-tool block — all rewritten with concrete workarounds.
- **Security hardening**: large-file read capped via `BufReader::take(limit*2)` (no OOM); `suggest_near_miss_paths` clamped to workspace root + iteration capped at 500; skill-loaded marker strips control chars; tripwire uses system-role (not user-role).

## Commits (11)
1. `67687af5` refactor(headless): finish _if_ok wrapper
2. `80d514fa` fix(journal): cache hits carry explanatory preview
3. `bc9b38e7` fix(journal): byte-bounded UTF-8-safe snippet
4. `bf293909` fix(fs): multi_edit fuzzy cascade
5. `614eae99` feat(turn-core): hallucination_tripwire module
6. `95d4b17a` feat(runtime): wire tripwire into finalization
7. `b00b57ed` fix(tools): 4 LLM-hostile error messages
8. `21a26d3d` fix(cli): skill-loaded marker on CLI edge path
9. `eddbe361` fix(review): 5 security/perf findings
10. `60203cab` fix(agent): lenient bool + health tracker API
11. `2b9dfa42` fix(agent): tighten lenient bool + wire ToolInvalidArgs

## Test plan
- [x] `make check` (clippy -D warnings + rustfmt + compile) ✓
- [x] 3917 astra-cli tests, 3208 turn-core tests, 2790 runtime tests, 791 astra-tools tests — all green
- [x] Verified on real sessions: 19ad8393 (agent spawn), 6d6c1041 (cache-hit), 5933ebce (multi-edit), 7e3fecb5 (bool type), 34a2c5ac (github/run_script errors)
- [x] Prompt-cache safety: no changes to system.rs / cache_placement / wire_assembly. Tripwire uses volatile lane (post-cache). Skill marker modifies tool_result body (post-cache).
- [ ] Live smoke test on Bedrock with new binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)