### PR TITLE
feat(tui): /timeline drill-in, slash cleanup, input history fix

### DIFF
--- a/rust/crates/astra-cli/src/cli/command_registry.rs
+++ b/rust/crates/astra-cli/src/cli/command_registry.rs
@@ -246,17 +246,9 @@ const DIFF_SUBCOMMANDS: &[(&str, &str)] = &[
     ("unstaged", "Unstaged only"),
 ];
 
-const TURN_SUBCOMMANDS: &[(&str, &str)] = &[("list", "List all journal turns")];
+// TURN_SUBCOMMANDS removed — /turn merged into /timeline
 
-const EXPERIMENT_SUBCOMMANDS: &[(&str, &str)] = &[
-    ("analyze", "Analyze experiment results"),
-    ("create", "Create new experiment"),
-    ("list", "List all experiments"),
-    ("show", "Show experiment details"),
-    ("start", "Start an experiment"),
-    ("status", "Show active experiment"),
-    ("stop", "Stop an experiment"),
-];
+// EXPERIMENT_SUBCOMMANDS removed — /experiment is dead code
 
 const STYLE_SUBCOMMANDS: &[(&str, &str)] = &[
     ("colorful", "Colorful theme"),
@@ -315,12 +307,7 @@ const COMPACT_SUBCOMMANDS: &[(&str, &str)] = &[
     ("summary-only", "Summarize without trimming"),
 ];
 
-const TUNING_SUBCOMMANDS: &[(&str, &str)] = &[
-    ("config", "Show tuning configuration"),
-    ("history", "Show tuning history"),
-    ("reset", "Reset tuning state"),
-    ("status", "Show tuning status (default)"),
-];
+// TUNING_SUBCOMMANDS removed — evolution subsystem deleted
 
 const CONFIG_SUBCOMMANDS: &[(&str, &str)] = &[
     ("diff", "Show differences from defaults"),
@@ -544,9 +531,10 @@ pub static COMMANDS: &[CommandMeta] = &[
     ),
     CommandMeta::new(
         "/verbose",
-        "Verbose streaming on",
+        "(removed — use /stats)",
         CommandGroup::Observability,
-    ),
+    )
+    .alias(),
     CommandMeta::new(
         "/compact",
         "Summarize & trim history (quick | no-memoria, …)",
@@ -561,10 +549,10 @@ pub static COMMANDS: &[CommandMeta] = &[
     ),
     CommandMeta::new(
         "/turn",
-        "Turn trace: /turn | list | N | seq:N | #N | id:N | @N | -1",
+        "(removed — use /timeline, Enter to drill into a turn)",
         CommandGroup::Observability,
     )
-    .with_subcommands(TURN_SUBCOMMANDS),
+    .alias(),
     CommandMeta::new(
         "/debug",
         "Interactive session inspector (messages, tools, injections)",
@@ -596,11 +584,10 @@ pub static COMMANDS: &[CommandMeta] = &[
     ),
     CommandMeta::new(
         "/tuning",
-        "Auto-tuning: status, history, config, reset",
+        "(removed — evolution subsystem deleted)",
         CommandGroup::Observability,
     )
-    .with_subcommands(TUNING_SUBCOMMANDS)
-    .with_arg_hint("[status|history|config|reset]"),
+    .alias(),
     CommandMeta::new(
         "/config",
         "Runtime config: show|paths|sources|diff|export [path]",
@@ -636,11 +623,10 @@ pub static COMMANDS: &[CommandMeta] = &[
     ),
     CommandMeta::new(
         "/experiment",
-        "A/B testing: list, start, stop, analyze experiments",
+        "(removed — use /profile experiments)",
         CommandGroup::Observability,
     )
-    .with_subcommands(EXPERIMENT_SUBCOMMANDS)
-    .with_arg_hint("[list|create|show|start|stop|status|analyze] [name]"),
+    .alias(),
     // ── Skills ────────────────────────────────────────────────────────────
     CommandMeta::new(
         "/skill",

--- a/rust/crates/astra-cli/src/cli/slash_router.rs
+++ b/rust/crates/astra-cli/src/cli/slash_router.rs
@@ -343,7 +343,7 @@ pub(super) async fn handle_slash_command(
         }
 
         "/history" | "/grep" | "/review" | "/copy" | "/diagnostics" | "/lsp" | "/context"
-        | "/version" | "/whoami" | "/rewind" | "/turn" | "/report" => {
+        | "/version" | "/whoami" | "/rewind" | "/report" => {
             handle_info_command(cmd, arg, api, state, profile, token).await?;
         }
 
@@ -508,7 +508,7 @@ pub(super) async fn handle_slash_command(
             }
         },
 
-        "/clear" | "/explain" | "/verbose" | "/compact" | "/reflect" | "/undo" | "/redo" => {
+        "/clear" | "/explain" | "/compact" | "/reflect" | "/undo" | "/redo" => {
             handle_state_command(
                 cmd,
                 arg,

--- a/rust/crates/astra-cli/src/cli/slash_state.rs
+++ b/rust/crates/astra-cli/src/cli/slash_state.rs
@@ -280,8 +280,7 @@ pub(super) async fn handle_state_command(
         }
 
         "/verbose" => {
-            state.verbose_mode = true;
-            eprintln!("  Verbose mode on");
+            eprintln!("  /verbose has been removed. Use /stats for per-turn metrics.");
         }
 
         "/compact" => {

--- a/rust/crates/astra-cli/src/tui/bottom_pane/chat_composer.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/chat_composer.rs
@@ -101,6 +101,13 @@ impl ChatComposer {
         self.textarea.is_empty()
     }
 
+    /// True when the user is browsing history (Up/Down navigation).
+    /// Callers use this to suppress popup menus that would capture
+    /// arrow keys and block further history traversal.
+    pub fn is_browsing_history(&self) -> bool {
+        self.history_index.is_some()
+    }
+
     pub fn clear_and_submit(&mut self) -> String {
         let raw = self.textarea.text().to_string();
         let expanded = self.expand_pastes(&raw);

--- a/rust/crates/astra-cli/src/tui/bottom_pane/context_panel_view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/context_panel_view.rs
@@ -404,6 +404,9 @@ impl BottomPaneView for ContextPanelView {
                 } else if self.focus.is_some() {
                     self.toggle_expand();
                     self.scroll_to_focus();
+                    if self.selectable_count() > 0 {
+                        self.scroll_to_selected_item();
+                    }
                 } else {
                     self.completed = true;
                 }

--- a/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
@@ -205,6 +205,17 @@ impl BottomPane {
     pub fn sync_popups(&mut self) {
         let text = self.composer.text();
 
+        // Suppress all popups while the user is browsing history with
+        // Up/Down — otherwise a history entry starting with '/' or '@'
+        // opens a menu that captures arrow keys and blocks further
+        // history traversal.
+        if self.composer.is_browsing_history() {
+            self.slash_menu = None;
+            self.close_mention();
+            self.skill_popup = None;
+            return;
+        }
+
         // Slash menu: open whenever the first line starts with '/'. Empty
         // matches still keep the menu open so users see a "no matches"
         // message rather than silent closure.

--- a/rust/crates/astra-cli/src/tui/bottom_pane/timeline_view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/timeline_view.rs
@@ -33,10 +33,15 @@ impl BottomPaneView for TimelineView {
     }
 
     fn handle_key(&mut self, key: KeyEvent) {
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => {
-                self.completed = true;
+        if self.timeline.is_drilled() {
+            if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
+                self.timeline.exit_drill();
             }
+            return;
+        }
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.completed = true,
+            KeyCode::Enter => self.timeline.enter_drill(),
             KeyCode::Up => self.timeline.move_up(),
             KeyCode::Down => self.timeline.move_down(),
             KeyCode::PageUp => {
@@ -82,7 +87,11 @@ impl BottomPaneView for TimelineView {
     }
 
     fn hint_keys(&self) -> Option<String> {
-        Some("↑↓ navigate · PgUp/PgDn page · q / Esc close".into())
+        if self.timeline.is_drilled() {
+            Some("Esc back".into())
+        } else {
+            Some("↑↓ navigate · Enter trace · PgUp/PgDn page · Esc close".into())
+        }
     }
 
     fn reserve_status_footer(&self) -> bool {
@@ -115,6 +124,20 @@ mod tests {
                 error: None,
                 cumulative_tokens_in: 0,
                 cumulative_tokens_out: 0,
+                ttft_ms: None,
+                context_ms: None,
+                selector_ms: None,
+                selector_strategy: None,
+                memoria_ms: None,
+                llm_rounds: None,
+                selected_skills: None,
+                total_tool_ms: None,
+                total_llm_ms: None,
+                tool_calls: Vec::new(),
+                user_input: None,
+                assistant_output: None,
+                selector_tokens_in: None,
+                selector_tokens_out: None,
             },
             TimelineTurn {
                 turn: 2,
@@ -129,6 +152,20 @@ mod tests {
                 error: None,
                 cumulative_tokens_in: 0,
                 cumulative_tokens_out: 0,
+                ttft_ms: None,
+                context_ms: None,
+                selector_ms: None,
+                selector_strategy: None,
+                memoria_ms: None,
+                llm_rounds: None,
+                selected_skills: None,
+                total_tool_ms: None,
+                total_llm_ms: None,
+                tool_calls: Vec::new(),
+                user_input: None,
+                assistant_output: None,
+                selector_tokens_in: None,
+                selector_tokens_out: None,
             },
         ]);
         TimelineView::new(Timeline::new(src, "sess_test"))

--- a/rust/crates/astra-cli/src/tui/mod.rs
+++ b/rust/crates/astra-cli/src/tui/mod.rs
@@ -1403,6 +1403,7 @@ impl render::renderable::Renderable for LiveFramedCell {
         let y1 = area.y + area.height - 1;
 
         let perimeter = 2 * (area.width as usize + area.height as usize - 2);
+        let left_height = area.height.saturating_sub(2) as usize;
         // Sweep once around the perimeter every N seconds. Slow enough
         // that the eye reads "flowing", fast enough that it isn't stuck.
         let period = 3.0_f32;
@@ -1415,9 +1416,22 @@ impl render::renderable::Renderable for LiveFramedCell {
             ratatui::style::Color::Rgb(r, g, b)
         };
 
+        // Left edge uses a dedicated top-to-bottom gradient sweep:
+        // position along the left bar drives hue, time adds a
+        // downward-flowing phase. Gives a "color falling down the
+        // gutter" effect while running.
+        let left_color_at = |row: usize| -> ratatui::style::Color {
+            if !self.live {
+                return self.solid_color;
+            }
+            let len = left_height.max(1);
+            let (r, g, b) = shimmer::gradient_color_at(row, len, period);
+            ratatui::style::Color::Rgb(r, g, b)
+        };
+
         let mut idx: usize = 0;
         // Top edge: ╭ ── ╮
-        set_char(buf, x0, y0, '╭', color_at(idx));
+        set_char(buf, x0, y0, '╭', left_color_at(0));
         idx += 1;
         for x in (x0 + 1)..x1 {
             set_char(buf, x, y0, '─', color_at(idx));
@@ -1438,13 +1452,19 @@ impl render::renderable::Renderable for LiveFramedCell {
             set_char(buf, x, y1, '─', color_at(idx));
             idx += 1;
         }
-        set_char(buf, x0, y1, '╰', color_at(idx));
+        set_char(
+            buf,
+            x0,
+            y1,
+            '╰',
+            left_color_at(left_height.saturating_sub(1)),
+        );
         idx += 1;
-        // Left edge (bottom → top)
-        for y in ((y0 + 1)..y1).rev() {
-            set_char(buf, x0, y, '│', color_at(idx));
-            idx += 1;
+        // Left edge (top → bottom) with vertical gradient
+        for (row, y) in ((y0 + 1)..y1).enumerate() {
+            set_char(buf, x0, y, '│', left_color_at(row));
         }
+        idx += left_height;
         let _ = idx;
 
         // Title overlay (dim, on top border). Uses the solid colour so

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -281,7 +281,7 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
         }
 
         // ── State commands → with_restored (share full logic with non-TUI) ──
-        "/clear" | "/undo" | "/redo" | "/compact" | "/explain" | "/verbose" | "/reflect" => {
+        "/clear" | "/undo" | "/redo" | "/compact" | "/explain" | "/reflect" => {
             SlashResult::Fallback
         }
 
@@ -536,6 +536,16 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             SlashResult::Handled
         }
 
+        // Deprecated commands — graceful hints
+        "/turn" => {
+            ctx.show_info("Use /timeline (Enter to drill into a turn).".into());
+            SlashResult::Handled
+        }
+        "/verbose" | "/tuning" | "/experiment" => {
+            ctx.show_info("Removed. Use /stats for metrics, /timeline for turn traces.".into());
+            SlashResult::Handled
+        }
+
         // ── Resume picker (TUI-native) ──────────────────────────────
         "/resume" => {
             if !args.is_empty() {
@@ -612,56 +622,8 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             SlashResult::Handled
         }
 
-        // ── Whoami — matches render_whoami() from slash_info.rs ─────
-        "/whoami" => {
-            use crate::tui::bottom_pane::info_view::InfoView;
-            let recent_tools = if ctx.state.recent_tools.is_empty() {
-                "<none>".to_string()
-            } else {
-                ctx.state
-                    .recent_tools
-                    .iter()
-                    .take(8)
-                    .cloned()
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            };
-            let pending = ctx
-                .state
-                .skill_improvement_tracker
-                .pending_proposal
-                .as_ref()
-                .map(|p| p.skill_name.clone())
-                .unwrap_or_else(|| "<none>".into());
-            let pairs: Vec<(&str, String)> = vec![
-                ("version", format!("astra v{}", env!("CARGO_PKG_VERSION"))),
-                (
-                    "model",
-                    ctx.state.model.clone().unwrap_or_else(|| "<unset>".into()),
-                ),
-                (
-                    "session",
-                    ctx.state
-                        .session_id
-                        .clone()
-                        .unwrap_or_else(|| "<none>".into()),
-                ),
-                ("turn", ctx.state.turn.to_string()),
-                ("exchanges", ctx.state.history.len().to_string()),
-                ("skills", ctx.state.unified_skill_registry.len().to_string()),
-                ("pending improve", pending),
-                ("recent tools", recent_tools),
-                ("permission", format!("{}", ctx.state.perm_manager.mode())),
-                ("explain", format!("{}", ctx.state.explain)),
-                (
-                    "verbose",
-                    if ctx.state.verbose_mode { "on" } else { "off" }.into(),
-                ),
-            ];
-            ctx.bottom_pane
-                .push_view(Box::new(InfoView::from_key_value("whoami", pairs)));
-            SlashResult::Handled
-        }
+        // /whoami is now folded into /session — redirect for muscle memory
+        "/whoami" => handle_session_hub(ctx),
 
         // ── History — interactive search view ────────────────────────
         "/history" => {
@@ -1502,6 +1464,7 @@ fn fmt_tokens(n: u64) -> String {
 /// fork / export).
 fn handle_session_hub(ctx: &mut DispatchContext<'_>) -> SlashResult {
     use crate::tui::bottom_pane::info_view::InfoView;
+    use astra_services::session_workspace;
 
     let sid = ctx.state.session_id.clone().unwrap_or_default();
     let sid_short = if sid.len() > 8 {
@@ -1524,18 +1487,39 @@ fn handle_session_hub(ctx: &mut DispatchContext<'_>) -> SlashResult {
                 sid.clone()
             },
         ),
-        (
-            "short id",
-            if sid.is_empty() {
-                "—".into()
-            } else {
-                sid_short.to_string()
-            },
-        ),
         ("turn", ctx.state.turn.to_string()),
         ("model", model),
-        ("cost", format!("${:.4}", ctx.state.total_session_cost)),
     ];
+
+    // Workspace info (cwd, git, timestamps)
+    let ws = (!sid.is_empty())
+        .then(|| session_workspace::read_workspace(&sid).ok())
+        .flatten();
+    if let Some(ref ws) = ws {
+        pairs.push(("cwd", tilde_session_path(&ws.cwd)));
+        let git_line = match (&ws.git_branch, &ws.git_head) {
+            (Some(b), Some(h)) => format!("{b} @ {}", &h[..h.len().min(8)]),
+            (Some(b), None) => b.clone(),
+            (None, Some(h)) => format!("@ {}", &h[..h.len().min(8)]),
+            (None, None) => "—".into(),
+        };
+        pairs.push(("git", git_line));
+        let started = ws.created_at.get(..19).unwrap_or(&ws.created_at);
+        pairs.push(("started", started.to_string()));
+        let saved = ws.updated_at.get(..19).unwrap_or(&ws.updated_at);
+        pairs.push(("last saved", saved.to_string()));
+        if ws.status != "active" {
+            pairs.push(("status", ws.status.clone()));
+        }
+    } else {
+        let cwd = std::env::current_dir()
+            .map(|p| tilde_session_path(&p.to_string_lossy()))
+            .unwrap_or_else(|_| "?".into());
+        pairs.push(("cwd", cwd));
+    }
+
+    // Live state
+    pairs.push(("cost", format!("${:.4}", ctx.state.total_session_cost)));
     if ctx.state.max_budget_limit > 0.0 {
         pairs.push(("budget", format!("${:.2}", ctx.state.max_budget_limit)));
     }
@@ -1548,32 +1532,48 @@ fn handle_session_hub(ctx: &mut DispatchContext<'_>) -> SlashResult {
         "cache-read tokens",
         fmt_tokens(ctx.state.total_cache_read_tokens),
     ));
-    pairs.push((
-        "cache-creation tokens",
-        fmt_tokens(ctx.state.total_cache_creation_tokens),
-    ));
     pairs.push(("total tokens", fmt_tokens(cumulative_tokens)));
 
-    // Compaction + drift counters from the observability session
-    // when it's available.  Best-effort — a missing session just
-    // means the counters stay off the hub.
-    if let Some(obs) = ctx.state.observability_session.as_ref() {
-        let guard = obs.read().unwrap_or_else(|e| e.into_inner());
-        pairs.push(("compactions", guard.compressed_turns.len().to_string()));
-        pairs.push(("context traces", guard.context_traces.len().to_string()));
+    // Agent identity (from former /whoami)
+    pairs.push(("permission", format!("{}", ctx.state.perm_manager.mode())));
+    pairs.push(("explain", format!("{}", ctx.state.explain)));
+    pairs.push(("skills", ctx.state.unified_skill_registry.len().to_string()));
+    if !ctx.state.recent_tools.is_empty() {
+        let tools: String = ctx
+            .state
+            .recent_tools
+            .iter()
+            .take(6)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        pairs.push(("recent tools", tools));
+    }
+    if let Some(ref rid) = ctx.state.run_id {
+        pairs.push(("run_id", rid.clone()));
     }
 
-    // Action cheatsheet, rendered as value-less rows so the user
-    // sees what every subcommand does without leaving the panel.
+    // Compaction + drift counters
+    if let Some(obs) = ctx.state.observability_session.as_ref() {
+        let guard = obs.read().unwrap_or_else(|e| e.into_inner());
+        if !guard.compressed_turns.is_empty() {
+            pairs.push(("compactions", guard.compressed_turns.len().to_string()));
+        }
+    }
+
+    // Journal path
+    if let Some(ref j) = ctx.state.journal {
+        let jp = j.path().display().to_string();
+        pairs.push(("journal", tilde_session_path(&jp)));
+    }
+
+    // Action cheatsheet
     pairs.push(("", String::new()));
     pairs.push(("/session list", "pick a session to resume".into()));
-    pairs.push((
-        "/session history",
-        "scroll this session's transcript".into(),
-    ));
-    pairs.push(("/context", "context panel for this session".into()));
+    pairs.push(("/session history", "scroll transcript".into()));
+    pairs.push(("/timeline", "per-turn trace timeline".into()));
+    pairs.push(("/context", "context panel".into()));
     pairs.push(("/session fork", "branch a parallel session".into()));
-    pairs.push(("/session analyze", "run session diagnostics".into()));
     pairs.push(("/session export", "write markdown transcript".into()));
 
     let title = if sid.is_empty() {
@@ -1584,6 +1584,22 @@ fn handle_session_hub(ctx: &mut DispatchContext<'_>) -> SlashResult {
     ctx.bottom_pane
         .push_view(Box::new(InfoView::from_key_value(&title, pairs)));
     SlashResult::Handled
+}
+
+fn tilde_session_path(abs: &str) -> String {
+    let Some(home) = dirs::home_dir() else {
+        return abs.to_string();
+    };
+    let home = home.to_string_lossy();
+    let home = home.trim_end_matches('/');
+    if abs == home {
+        return "~".to_string();
+    }
+    let prefix = format!("{home}/");
+    if let Some(rest) = abs.strip_prefix(&prefix) {
+        return format!("~/{rest}");
+    }
+    abs.to_string()
 }
 
 /// `/session list` — same picker as `/resume`, but reached via

--- a/rust/crates/astra-cli/src/tui/timeline/model.rs
+++ b/rust/crates/astra-cli/src/tui/timeline/model.rs
@@ -4,6 +4,21 @@
 
 use std::sync::Arc;
 
+/// Detail record for one tool call within a turn (mirrors journal's `ToolCallRecord`).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ToolCallDetail {
+    pub name: String,
+    pub ok: bool,
+    pub ms: u64,
+    pub error: Option<String>,
+    pub input_bytes: Option<u32>,
+    pub output_bytes: Option<u32>,
+    pub args_preview: Option<String>,
+    pub start_offset_ms: Option<u64>,
+    pub parallel: Option<bool>,
+    pub round: Option<u32>,
+}
+
 /// A single turn's worth of journal metadata rendered in the timeline.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct TimelineTurn {
@@ -21,6 +36,21 @@ pub(crate) struct TimelineTurn {
     pub cumulative_tokens_in: u64,
     /// Cumulative total tokens out (including this turn).
     pub cumulative_tokens_out: u64,
+    // ── Trace detail (populated from journal observability fields) ──
+    pub ttft_ms: Option<u64>,
+    pub context_ms: Option<u64>,
+    pub selector_ms: Option<u64>,
+    pub selector_strategy: Option<String>,
+    pub selector_tokens_in: Option<u64>,
+    pub selector_tokens_out: Option<u64>,
+    pub memoria_ms: Option<u64>,
+    pub llm_rounds: Option<u32>,
+    pub selected_skills: Option<Vec<String>>,
+    pub total_tool_ms: Option<u64>,
+    pub total_llm_ms: Option<u64>,
+    pub tool_calls: Vec<ToolCallDetail>,
+    pub user_input: Option<String>,
+    pub assistant_output: Option<String>,
 }
 
 impl TimelineTurn {
@@ -64,8 +94,34 @@ impl TurnSource for JournalTurnSource {
         };
         events
             .into_iter()
-            .filter(|e| matches!(e.event_type, JournalEventType::Turn))
+            .filter(|e| {
+                matches!(
+                    e.event_type,
+                    JournalEventType::Turn | JournalEventType::TurnError
+                )
+            })
             .filter_map(|e| {
+                let tool_calls = e
+                    .tool_calls
+                    .as_ref()
+                    .map(|calls| {
+                        calls
+                            .iter()
+                            .map(|tc| ToolCallDetail {
+                                name: tc.name.clone(),
+                                ok: tc.ok,
+                                ms: tc.ms,
+                                error: tc.error.clone(),
+                                input_bytes: tc.input_bytes,
+                                output_bytes: tc.output_bytes,
+                                args_preview: tc.args_preview.clone(),
+                                start_offset_ms: tc.start_offset_ms,
+                                parallel: tc.parallel,
+                                round: tc.round,
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
                 Some(TimelineTurn {
                     turn: e.turn?,
                     started_at: e.ts.clone(),
@@ -79,6 +135,20 @@ impl TurnSource for JournalTurnSource {
                     error: e.error.clone(),
                     cumulative_tokens_in: 0,
                     cumulative_tokens_out: 0,
+                    ttft_ms: e.ttft_ms,
+                    context_ms: e.context_ms,
+                    selector_ms: e.selector_ms,
+                    selector_strategy: e.selector_strategy.clone(),
+                    selector_tokens_in: e.selector_tokens_in,
+                    selector_tokens_out: e.selector_tokens_out,
+                    memoria_ms: e.memoria_ms,
+                    llm_rounds: e.llm_rounds,
+                    selected_skills: e.selected_skills.clone(),
+                    total_tool_ms: e.total_tool_ms,
+                    total_llm_ms: e.total_llm_ms,
+                    tool_calls,
+                    user_input: e.user_input.clone(),
+                    assistant_output: e.assistant_output.clone(),
                 })
             })
             .collect()
@@ -110,6 +180,7 @@ pub(crate) struct Timeline {
     source: Arc<dyn TurnSource>,
     turns: Vec<TimelineTurn>,
     selected: usize,
+    drilled: bool,
 }
 
 impl std::fmt::Debug for Timeline {
@@ -141,6 +212,7 @@ impl Timeline {
             source,
             turns,
             selected: 0,
+            drilled: false,
         }
     }
 
@@ -184,6 +256,20 @@ impl Timeline {
             return;
         }
         self.selected = (self.selected + 1) % self.turns.len();
+    }
+
+    pub fn is_drilled(&self) -> bool {
+        self.drilled
+    }
+
+    pub fn enter_drill(&mut self) {
+        if !self.turns.is_empty() {
+            self.drilled = true;
+        }
+    }
+
+    pub fn exit_drill(&mut self) {
+        self.drilled = false;
     }
 
     pub fn grand_total_tokens_in(&self) -> u64 {

--- a/rust/crates/astra-cli/src/tui/timeline/tests.rs
+++ b/rust/crates/astra-cli/src/tui/timeline/tests.rs
@@ -16,10 +16,22 @@ fn turn(t: u32, tin: u64, tout: u64, tools: u32, user: &str, err: Option<&str>) 
         user_preview: Some(user.into()),
         assistant_preview: Some(format!("reply to turn {t}")),
         error: err.map(String::from),
-        // cumulative fields are what the engine computes; raw fixture
-        // starts at zero and the engine should overwrite them.
         cumulative_tokens_in: 0,
         cumulative_tokens_out: 0,
+        ttft_ms: None,
+        context_ms: None,
+        selector_ms: None,
+        selector_strategy: None,
+        selector_tokens_in: None,
+        selector_tokens_out: None,
+        memoria_ms: None,
+        llm_rounds: None,
+        selected_skills: None,
+        total_tool_ms: None,
+        total_llm_ms: None,
+        tool_calls: Vec::new(),
+        user_input: None,
+        assistant_output: None,
     }
 }
 

--- a/rust/crates/astra-cli/src/tui/timeline/view.rs
+++ b/rust/crates/astra-cli/src/tui/timeline/view.rs
@@ -39,6 +39,12 @@ pub(crate) fn render(tl: &Timeline, area: Rect, buf: &mut Buffer) {
     if area.width == 0 || area.height == 0 {
         return;
     }
+
+    if tl.is_drilled() {
+        render_drill(tl, area, buf);
+        return;
+    }
+
     let outer = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::DarkGray))
@@ -262,6 +268,285 @@ fn fmt_tokens_u64(n: u64) -> String {
     }
 }
 
+// ─── Drill view (full turn trace) ──────────────────────────────────────
+
+fn render_drill(tl: &Timeline, area: Rect, buf: &mut Buffer) {
+    let Some(t) = tl.selected_turn() else { return };
+    let dim = Style::default().fg(Color::DarkGray);
+    let label = Style::default().fg(Color::Cyan);
+    let bold = Style::default().add_modifier(Modifier::BOLD);
+
+    let title = format!(" Turn {} · trace ", t.turn);
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title(Line::from(Span::styled(
+            title,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )));
+    let inner = outer.inner(area);
+    outer.render(area, buf);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Summary
+    if let Some(ms) = t.duration_ms {
+        lines.push(Line::from(vec![
+            Span::styled("  Total    ", label),
+            Span::styled(format!("{:.2}s", ms as f64 / 1000.0), bold),
+        ]));
+    }
+    if let Some(ttft) = t.ttft_ms {
+        lines.push(Line::from(vec![
+            Span::styled("  TTFT     ", label),
+            Span::styled(format!("{ttft}ms"), dim),
+        ]));
+    }
+    if let Some(ctx) = t.context_ms {
+        let mut detail_parts: Vec<String> = Vec::new();
+        if let Some(sel) = t.selector_ms {
+            let strat = t.selector_strategy.as_deref().unwrap_or("?");
+            detail_parts.push(format!("selector: {sel}ms [{strat}]"));
+        }
+        if let Some(m) = t.memoria_ms {
+            detail_parts.push(format!("memoria: {m}ms"));
+        }
+        let detail = if detail_parts.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", detail_parts.join(", "))
+        };
+        lines.push(Line::from(vec![
+            Span::styled("  Context  ", label),
+            Span::styled(format!("{ctx}ms{detail}"), dim),
+        ]));
+    }
+    if let Some(ref skills) = t.selected_skills {
+        if !skills.is_empty() {
+            lines.push(Line::from(vec![
+                Span::styled("  Skills   ", label),
+                Span::styled(skills.join(", "), dim),
+            ]));
+        }
+    }
+    if let Some(rounds) = t.llm_rounds {
+        lines.push(Line::from(vec![
+            Span::styled("  Rounds   ", label),
+            Span::styled(format!("{rounds} LLM→tool cycles"), dim),
+        ]));
+    }
+    if let (Some(tin), Some(tout)) = (t.tokens_in, t.tokens_out) {
+        let sel_note = match (t.selector_tokens_in, t.selector_tokens_out) {
+            (Some(si), Some(so)) if si > 0 || so > 0 => format!(" (+sel: {si}→{so})"),
+            _ => String::new(),
+        };
+        lines.push(Line::from(vec![
+            Span::styled("  Tokens   ", label),
+            Span::styled(format!("{tin} in / {tout} out{sel_note}"), dim),
+        ]));
+    }
+    if let Some(ref model) = t.model {
+        lines.push(Line::from(vec![
+            Span::styled("  Model    ", label),
+            Span::styled(model.clone(), dim),
+        ]));
+    }
+    // Throughput
+    if let (Some(t_out), Some(ms)) = (t.tokens_out, t.duration_ms) {
+        if ms > 0 {
+            let tps = t_out as f64 / (ms as f64 / 1000.0);
+            lines.push(Line::from(vec![
+                Span::styled("  Thruput  ", label),
+                Span::styled(format!("{tps:.1} tokens/s"), dim),
+            ]));
+        }
+    }
+
+    lines.push(Line::default());
+
+    // Timeline bar chart
+    let total_ms = t.duration_ms.unwrap_or(1) as f64;
+    let tool_time_ms = t
+        .total_tool_ms
+        .unwrap_or_else(|| t.tool_calls.iter().map(|tc| tc.ms).sum());
+    let llm_time_ms = t
+        .total_llm_ms
+        .unwrap_or_else(|| t.duration_ms.unwrap_or(0).saturating_sub(tool_time_ms));
+    let bar_width = (inner.width as usize).saturating_sub(24).min(40);
+
+    if bar_width > 4 {
+        lines.push(Line::from(Span::styled("  Timeline", bold)));
+        let llm_pct = (llm_time_ms as f64 / total_ms * 100.0).min(100.0) as usize;
+        let llm_bar_len = (llm_pct * bar_width / 100).max(1);
+        lines.push(Line::from(vec![
+            Span::styled("    LLM      ", label),
+            Span::styled(format!("{:>5}ms {:>3}% ", llm_time_ms, llm_pct), dim),
+            Span::styled("█".repeat(llm_bar_len), Style::default().fg(Color::Blue)),
+        ]));
+
+        for tc in &t.tool_calls {
+            let pct = (tc.ms as f64 / total_ms * 100.0).min(100.0) as usize;
+            let bar_len = (pct * bar_width / 100).max(1);
+            let bar_color = if tc.ok { Color::Green } else { Color::Red };
+            let name: String = tc.name.chars().take(10).collect();
+            lines.push(Line::from(vec![
+                Span::styled(format!("    {:<10} ", name), label),
+                Span::styled(format!("{:>5}ms {:>3}% ", tc.ms, pct), dim),
+                Span::styled("█".repeat(bar_len), Style::default().fg(bar_color)),
+            ]));
+        }
+        lines.push(Line::default());
+    }
+
+    // Trace tree
+    if !t.tool_calls.is_empty() || t.context_ms.is_some() {
+        lines.push(Line::from(Span::styled("  Trace", bold)));
+        let mut offset: u64 = 0;
+
+        if let Some(ctx) = t.context_ms {
+            lines.push(Line::from(vec![
+                Span::styled(format!("    [{:>5}ms] ", offset), dim),
+                Span::styled("├─ ", dim),
+                Span::raw("Context assembly"),
+            ]));
+            offset = ctx;
+        }
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("    [{:>5}ms] ", offset), dim),
+            Span::styled("├─ ", dim),
+            Span::raw("LLM request"),
+        ]));
+        if let Some(ttft) = t.ttft_ms {
+            lines.push(Line::from(vec![
+                Span::styled(format!("    [{:>5}ms] ", offset + ttft), dim),
+                Span::styled("│  ", dim),
+                Span::styled("first token", Style::default().fg(Color::Yellow)),
+            ]));
+        }
+        offset += llm_time_ms;
+        lines.push(Line::from(vec![
+            Span::styled(format!("    [{:>5}ms] ", offset), dim),
+            Span::styled("│  ", dim),
+            Span::styled(format!("LLM complete ({llm_time_ms}ms)"), dim),
+        ]));
+
+        let has_real_offsets = t.tool_calls.iter().any(|tc| tc.start_offset_ms.is_some());
+        for (i, tc) in t.tool_calls.iter().enumerate() {
+            let is_last = i == t.tool_calls.len() - 1;
+            let branch = if is_last { "└─ " } else { "├─ " };
+            let status = if tc.ok { "✓" } else { "✗" };
+            let status_color = if tc.ok { Color::Green } else { Color::Red };
+
+            let tool_offset = if has_real_offsets {
+                tc.start_offset_ms.unwrap_or(offset)
+            } else {
+                offset
+            };
+
+            let round_tag = tc.round.map(|r| format!(" R{r}")).unwrap_or_default();
+            let par_tag = if tc.parallel == Some(true) {
+                " ∥"
+            } else {
+                ""
+            };
+
+            let display = tc
+                .args_preview
+                .as_deref()
+                .map(|a| format!("{} {}", tc.name, a.chars().take(30).collect::<String>()))
+                .unwrap_or_else(|| tc.name.clone());
+
+            lines.push(Line::from(vec![
+                Span::styled(format!("    [{:>5}ms] ", tool_offset), dim),
+                Span::styled(branch, dim),
+                Span::styled(format!("{status} "), Style::default().fg(status_color)),
+                Span::styled(display, Style::default().fg(Color::Cyan)),
+                Span::styled(format!(" {}ms{round_tag}{par_tag}", tc.ms), dim),
+            ]));
+
+            if let Some(ref err) = tc.error {
+                let sub = if is_last { "   " } else { "│  " };
+                let preview: String = err.chars().take(60).collect();
+                lines.push(Line::from(vec![
+                    Span::styled("             ", dim),
+                    Span::styled(sub, dim),
+                    Span::styled(preview, Style::default().fg(Color::Red)),
+                ]));
+            }
+
+            if !has_real_offsets {
+                offset += tc.ms;
+            }
+        }
+    }
+
+    // Breakdown summary
+    lines.push(Line::default());
+    lines.push(Line::from(Span::styled("  Breakdown", bold)));
+    let llm_pct = if total_ms > 0.0 {
+        (llm_time_ms as f64 / total_ms * 100.0) as u32
+    } else {
+        0
+    };
+    let tool_pct = 100u32.saturating_sub(llm_pct);
+    let llm_note = if llm_pct > 80 { " ← bottleneck" } else { "" };
+    let tool_note = if tool_pct > 80 { " ← bottleneck" } else { "" };
+    lines.push(Line::from(vec![
+        Span::styled("    LLM          ", label),
+        Span::styled(
+            format!("{:>5}ms  {:>3}%{llm_note}", llm_time_ms, llm_pct),
+            dim,
+        ),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("    Tools        ", label),
+        Span::styled(
+            format!("{:>5}ms  {:>3}%{tool_note}", tool_time_ms, tool_pct),
+            dim,
+        ),
+    ]));
+
+    // Error
+    if let Some(ref err) = t.error {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            format!("  Error: {err}"),
+            Style::default().fg(Color::Red),
+        )));
+    }
+
+    // User input / assistant output
+    if let Some(ref input) = t.user_input {
+        let preview: String = input.chars().take(200).collect();
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled("  User", label)));
+        for line in preview.lines().take(4) {
+            lines.push(Line::from(Span::styled(format!("    {line}"), dim)));
+        }
+        if input.lines().count() > 4 {
+            lines.push(Line::from(Span::styled("    …", dim)));
+        }
+    }
+    if let Some(ref output) = t.assistant_output {
+        let preview: String = output.chars().take(300).collect();
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled("  Assistant", label)));
+        for line in preview.lines().take(6) {
+            lines.push(Line::from(Span::styled(format!("    {line}"), dim)));
+        }
+        if output.lines().count() > 6 {
+            lines.push(Line::from(Span::styled("    …", dim)));
+        }
+    }
+
+    Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .render(inner, buf);
+}
+
 /// Truncate an RFC3339 ISO timestamp to `HH:MM:SS`.
 fn short_time(iso: &str) -> String {
     // Find the 'T' separator; take 8 chars after.
@@ -293,6 +578,20 @@ mod tests {
             error: err.map(String::from),
             cumulative_tokens_in: 0,
             cumulative_tokens_out: 0,
+            ttft_ms: None,
+            context_ms: None,
+            selector_ms: None,
+            selector_strategy: None,
+            memoria_ms: None,
+            llm_rounds: None,
+            selected_skills: None,
+            total_tool_ms: None,
+            total_llm_ms: None,
+            tool_calls: Vec::new(),
+            user_input: None,
+            assistant_output: None,
+            selector_tokens_in: None,
+            selector_tokens_out: None,
         }
     }
 

--- a/rust/crates/astra-turn-core/src/history.rs
+++ b/rust/crates/astra-turn-core/src/history.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 /// Shared sentinel tag identifying tool results whose original content was
 /// recovered as an empty JSON object placeholder (the upstream serialization
@@ -631,20 +631,24 @@ mod tests {
         assert!(consumed.is_empty());
         // Healing should add placeholder for missing c1
         assert_eq!(history.len(), original_len + 1);
-        assert!(history[2]["content"]
-            .as_str()
-            .unwrap()
-            .contains("not executed"));
+        assert!(
+            history[2]["content"]
+                .as_str()
+                .unwrap()
+                .contains("not executed")
+        );
 
         // Empty slice case
         let mut history2 = vec![user_msg("q"), assistant_with_tool_calls(&["c1"])];
         let consumed2 = merge_tool_results_into_history(&mut history2, Some(&[]));
         assert!(consumed2.is_empty());
         // Healing again
-        assert!(history2[2]["content"]
-            .as_str()
-            .unwrap()
-            .contains("not executed"));
+        assert!(
+            history2[2]["content"]
+                .as_str()
+                .unwrap()
+                .contains("not executed")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **`/timeline` drill-in trace**: Enter on a selected turn shows full OpenTrace-style view — TTFT, context assembly (selector + memoria breakdown), LLM rounds, bar chart timeline, per-tool trace tree with status/round/parallel, breakdown with bottleneck indicator, throughput (tokens/s), user/assistant content preview
- **Dead command removal**: `/verbose`, `/tuning`, `/experiment`, `/turn` hidden from slash menu (`.alias()`), typing them shows graceful deprecation hints
- **`/whoami` → `/session`**: session hub now includes cwd, git branch, timestamps, permission mode, explain mode, skills count, recent tools, run_id, journal path
- **Input history fix**: Up/Down navigation through history no longer blocked when a history entry starts with `/` (slash menu was capturing arrow keys)
- **Context panel scroll fix**: expanding a section now scrolls to the first selected item
- **Assist frame gradient**: left border uses a dedicated top-to-bottom color sweep during running state

## Test plan

- [x] `cargo clippy -p astra-cli -- -D warnings` — zero warnings
- [x] `cargo nextest run -p astra-cli` — 3957 tests pass
- [ ] Manual: `/timeline` → select turn → Enter → verify trace shows timing/tools/breakdown → Esc back
- [ ] Manual: type `/verbose` → see deprecation hint
- [ ] Manual: `/session` → verify cwd, git, permission, etc. shown
- [ ] Manual: Up arrow through history past a `/slash` entry → verify no menu capture