### PR TITLE
fix: unified credential store & tool result content loss fix

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
 name = "astra-admin-cli"
 version = "0.1.0"
 dependencies = [
+ "astra-credentials",
  "astra-thin-client",
  "clap",
  "crossterm 0.27.0",
@@ -133,6 +134,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "temp-env",
  "tempfile",
  "tokio",
 ]
@@ -143,6 +145,7 @@ version = "0.1.0"
 dependencies = [
  "astra-config",
  "astra-core",
+ "astra-credentials",
  "astra-harness",
  "astra-learning",
  "astra-logging",
@@ -254,6 +257,19 @@ dependencies = [
  "temp-env",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "astra-credentials"
+version = "0.1.0"
+dependencies = [
+ "dirs 6.0.0",
+ "fs2",
+ "serde",
+ "serde_json",
+ "temp-env",
+ "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/astra-learning",
     "crates/astra-test-harness",
     "crates/astra-harness",
+    "crates/astra-credentials",
 ]
 resolver = "2"
 
@@ -32,6 +33,7 @@ edition = "2024"
 
 [workspace.dependencies]
 astra-core = { path = "crates/core" }
+astra-credentials = { path = "crates/astra-credentials" }
 astra-harness = { path = "crates/astra-harness" }
 astra-logging = { path = "crates/astra-logging" }
 astra-config = { path = "crates/astra-config" }

--- a/rust/crates/astra-admin/Cargo.toml
+++ b/rust/crates/astra-admin/Cargo.toml
@@ -8,6 +8,7 @@ name = "astra-admin"
 path = "src/main.rs"
 
 [dependencies]
+astra-credentials.workspace = true
 astra-thin-client.workspace = true
 clap = { version = "4.5.38", features = ["derive"] }
 crossterm = "0.27"
@@ -21,4 +22,5 @@ serde_yaml_ng.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
+temp-env = "0.3"
 tempfile = "3"

--- a/rust/crates/astra-admin/src/credentials.rs
+++ b/rust/crates/astra-admin/src/credentials.rs
@@ -1,49 +1,19 @@
-use std::{collections::HashMap, fs, path::PathBuf};
+pub(crate) use astra_credentials::{CredentialStore, CredentialsFile, Profile};
 
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub(crate) struct CredentialsFile {
-    pub current_profile: Option<String>,
-    pub profiles: HashMap<String, Profile>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub(crate) struct Profile {
-    pub username: Option<String>,
-    pub access_token: Option<String>,
-    pub refresh_token: Option<String>,
-}
-
-pub(crate) fn credentials_path() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".astra")
-        .join("credentials.json")
+pub(crate) fn store() -> CredentialStore {
+    CredentialStore::new()
 }
 
 pub(crate) fn load_credentials() -> CredentialsFile {
-    let path = credentials_path();
-    let Ok(content) = fs::read_to_string(path) else {
-        return CredentialsFile::default();
-    };
-    serde_json::from_str(&content).unwrap_or_default()
-}
-
-pub(crate) fn save_credentials(data: &CredentialsFile) -> Result<(), String> {
-    let path = credentials_path();
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-    }
-    let body = serde_json::to_string_pretty(data).map_err(|e| e.to_string())?;
-    fs::write(path, body).map_err(|e| e.to_string())
+    store().load().unwrap_or_default()
 }
 
 pub(crate) fn profile_name(cli_profile: Option<&str>, data: &CredentialsFile) -> String {
-    cli_profile
-        .map(ToString::to_string)
-        .or_else(|| data.current_profile.clone())
-        .unwrap_or_else(|| "admin".to_string())
+    CredentialStore::resolve_profile_name_with_default(
+        cli_profile,
+        data.current_profile.as_deref(),
+        "admin",
+    )
 }
 
 #[cfg(test)]
@@ -51,42 +21,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn profile_name_cli_override() {
-        let creds = CredentialsFile::default();
-        assert_eq!(profile_name(Some("staging"), &creds), "staging");
-    }
-
-    #[test]
-    fn profile_name_from_creds() {
-        let creds = CredentialsFile {
-            current_profile: Some("prod".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(profile_name(None, &creds), "prod");
-    }
-
-    #[test]
-    fn profile_name_default_admin() {
-        let creds = CredentialsFile::default();
-        assert_eq!(profile_name(None, &creds), "admin");
-    }
-
-    #[test]
-    fn credentials_roundtrip() {
-        let creds = CredentialsFile {
-            current_profile: Some("test".to_string()),
-            profiles: HashMap::from([(
-                "test".to_string(),
-                Profile {
-                    username: Some("user1".to_string()),
-                    access_token: Some("tok".to_string()),
-                    refresh_token: None,
-                },
-            )]),
-        };
-        let json = serde_json::to_string(&creds).unwrap();
-        let parsed: CredentialsFile = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.current_profile, Some("test".to_string()));
-        assert!(parsed.profiles.contains_key("test"));
+    fn default_profile_remains_admin_for_compatibility() {
+        temp_env::with_var("ASTRA_PROFILE", None::<&str>, || {
+            assert_eq!(profile_name(None, &CredentialsFile::default()), "admin");
+        });
     }
 }

--- a/rust/crates/astra-admin/src/interactive.rs
+++ b/rust/crates/astra-admin/src/interactive.rs
@@ -13,7 +13,7 @@ use rustyline::{
     validate::{ValidationContext, ValidationResult, Validator},
 };
 
-use super::credentials::{load_credentials, profile_name, save_credentials};
+use super::credentials::{load_credentials, profile_name, store};
 use super::http_helpers::{get_profile_and_token, map_thin_err, print_json_or_raw};
 
 const ADMIN_COMMANDS: &[(&str, &str)] = &[
@@ -197,7 +197,7 @@ pub(crate) async fn run_interactive(api: &ThinClient, profile: Option<&str>) -> 
             print_json_or_raw(&body);
             Ok(())
         } else if line.eq("refresh") {
-            let mut creds = load_credentials();
+            let creds = load_credentials();
             let name = profile_name(profile, &creds);
             let saved = creds
                 .profiles
@@ -216,19 +216,25 @@ pub(crate) async fn run_interactive(api: &ThinClient, profile: Option<&str>) -> 
             let new_access = value
                 .get("access_token")
                 .and_then(serde_json::Value::as_str)
-                .ok_or("missing access_token")?;
+                .ok_or("missing access_token")?
+                .to_string();
             let new_refresh = value
                 .get("refresh_token")
                 .and_then(serde_json::Value::as_str)
-                .ok_or("missing refresh_token")?;
-            let entry = creds.profiles.entry(name).or_default();
-            entry.access_token = Some(new_access.to_string());
-            entry.refresh_token = Some(new_refresh.to_string());
-            save_credentials(&creds)?;
+                .ok_or("missing refresh_token")?
+                .to_string();
+            store()
+                .mutate(|creds| {
+                    let name = profile_name(profile, creds);
+                    let entry = creds.profiles.entry(name).or_default();
+                    entry.access_token = Some(new_access.clone());
+                    entry.refresh_token = Some(new_refresh.clone());
+                })
+                .map_err(|e| e.to_string())?;
             eprintln!("{}", "✓ Token refreshed".green());
             Ok(())
         } else if line.eq("logout") {
-            let mut creds = load_credentials();
+            let creds = load_credentials();
             let name = profile_name(profile, &creds);
             let saved = creds
                 .profiles
@@ -241,11 +247,15 @@ pub(crate) async fn run_interactive(api: &ThinClient, profile: Option<&str>) -> 
             let _ = api
                 .post_auth_logout_json(&serde_json::json!({ "refresh_token": refresh_token }))
                 .await;
-            if let Some(entry) = creds.profiles.get_mut(&name) {
-                entry.access_token = None;
-                entry.refresh_token = None;
-            }
-            save_credentials(&creds)?;
+            store()
+                .mutate(|creds| {
+                    let name = profile_name(profile, creds);
+                    if let Some(entry) = creds.profiles.get_mut(&name) {
+                        entry.access_token = None;
+                        entry.refresh_token = None;
+                    }
+                })
+                .map_err(|e| e.to_string())?;
             eprintln!("{}", "✓ Logged out".green());
             Ok(())
         } else if line.starts_with("audit") {

--- a/rust/crates/astra-admin/src/main.rs
+++ b/rust/crates/astra-admin/src/main.rs
@@ -200,18 +200,22 @@ async fn main() -> Result<(), String> {
                 .and_then(serde_json::Value::as_str)
                 .ok_or_else(|| "missing refresh_token".to_string())?
                 .to_string();
-            let mut creds = load_credentials();
-            let name = profile_name(cli.profile.as_deref(), &creds);
-            creds.current_profile = Some(name.clone());
-            creds.profiles.insert(
-                name,
-                Profile {
-                    username: Some(username),
-                    access_token: Some(access),
-                    refresh_token: Some(refresh),
-                },
-            );
-            save_credentials(&creds)?;
+            let cli_profile = cli.profile.clone();
+            credentials::store()
+                .mutate(|creds| {
+                    let name = profile_name(cli_profile.as_deref(), creds);
+                    creds.current_profile = Some(name.clone());
+                    creds.profiles.insert(
+                        name,
+                        Profile {
+                            username: Some(username),
+                            access_token: Some(access),
+                            refresh_token: Some(refresh),
+                            ..Default::default()
+                        },
+                    );
+                })
+                .map_err(|e| e.to_string())?;
             println!("logged in");
             Ok(())
         }
@@ -239,7 +243,7 @@ async fn main() -> Result<(), String> {
             Ok(())
         }
         Command::Refresh => {
-            let mut creds = load_credentials();
+            let creds = load_credentials();
             let name = profile_name(cli.profile.as_deref(), &creds);
             let profile = creds
                 .profiles
@@ -258,20 +262,27 @@ async fn main() -> Result<(), String> {
             let new_access = value
                 .get("access_token")
                 .and_then(serde_json::Value::as_str)
-                .ok_or_else(|| "missing access_token".to_string())?;
+                .ok_or_else(|| "missing access_token".to_string())?
+                .to_string();
             let new_refresh = value
                 .get("refresh_token")
                 .and_then(serde_json::Value::as_str)
-                .ok_or_else(|| "missing refresh_token".to_string())?;
-            let entry = creds.profiles.entry(name).or_default();
-            entry.access_token = Some(new_access.to_string());
-            entry.refresh_token = Some(new_refresh.to_string());
-            save_credentials(&creds)?;
+                .ok_or_else(|| "missing refresh_token".to_string())?
+                .to_string();
+            let cli_profile = cli.profile.clone();
+            credentials::store()
+                .mutate(|creds| {
+                    let name = profile_name(cli_profile.as_deref(), creds);
+                    let entry = creds.profiles.entry(name).or_default();
+                    entry.access_token = Some(new_access.clone());
+                    entry.refresh_token = Some(new_refresh.clone());
+                })
+                .map_err(|e| e.to_string())?;
             println!("token refreshed");
             Ok(())
         }
         Command::Logout => {
-            let mut creds = load_credentials();
+            let creds = load_credentials();
             let name = profile_name(cli.profile.as_deref(), &creds);
             let profile = creds
                 .profiles
@@ -285,11 +296,16 @@ async fn main() -> Result<(), String> {
                 .post_auth_logout_json(&serde_json::json!({ "refresh_token": refresh_token }))
                 .await
                 .map_err(map_thin_err)?;
-            if let Some(entry) = creds.profiles.get_mut(&name) {
-                entry.access_token = None;
-                entry.refresh_token = None;
-            }
-            save_credentials(&creds)?;
+            let cli_profile = cli.profile.clone();
+            credentials::store()
+                .mutate(|creds| {
+                    let name = profile_name(cli_profile.as_deref(), creds);
+                    if let Some(entry) = creds.profiles.get_mut(&name) {
+                        entry.access_token = None;
+                        entry.refresh_token = None;
+                    }
+                })
+                .map_err(|e| e.to_string())?;
             print_json_or_raw(&body);
             Ok(())
         }

--- a/rust/crates/astra-cli/Cargo.toml
+++ b/rust/crates/astra-cli/Cargo.toml
@@ -13,6 +13,7 @@ harness = ["astra-runtime/harness", "dep:astra-harness"]
 
 [dependencies]
 astra-core.workspace = true
+astra-credentials.workspace = true
 astra-harness = { workspace = true, optional = true }
 astra-logging.workspace = true
 astra-prompts.workspace = true

--- a/rust/crates/astra-cli/src/cli/auth_flow.rs
+++ b/rust/crates/astra-cli/src/cli/auth_flow.rs
@@ -1,23 +1,28 @@
+use super::cli_utils::{credential_store, CredentialStore, Profile};
 use super::*;
 
 pub(super) fn clear_profile_last_session(profile: Option<&str>) -> Result<(), String> {
-    let mut creds = load_credentials();
-    let name = profile_name(profile, &creds);
-    if let Some(entry) = creds.profiles.get_mut(&name) {
-        entry.last_session_id = None;
-    }
-    save_credentials(&creds)
+    credential_store()
+        .mutate(|creds| {
+            let name = profile_name(profile, creds);
+            if let Some(entry) = creds.profiles.get_mut(&name) {
+                entry.last_session_id = None;
+            }
+        })
+        .map_err(|e| e.to_string())
 }
 
 pub(super) fn clear_profile_auth(profile: Option<&str>) -> Result<(), String> {
-    let mut creds = load_credentials();
-    let name = profile_name(profile, &creds);
-    if let Some(entry) = creds.profiles.get_mut(&name) {
-        entry.access_token = None;
-        entry.refresh_token = None;
-        entry.last_session_id = None;
-    }
-    save_credentials(&creds)
+    credential_store()
+        .mutate(|creds| {
+            let name = profile_name(profile, creds);
+            if let Some(entry) = creds.profiles.get_mut(&name) {
+                entry.access_token = None;
+                entry.refresh_token = None;
+                entry.last_session_id = None;
+            }
+        })
+        .map_err(|e| e.to_string())
 }
 
 pub(super) async fn do_login(
@@ -41,16 +46,29 @@ pub(super) async fn do_login(
         .and_then(|v| v.as_str())
         .ok_or("missing refresh_token")?
         .to_string();
-    let mut creds = load_credentials();
-    let name = profile_name(profile, &creds);
-    creds.current_profile = Some(name.clone());
-    let mut updated = creds.profiles.get(&name).cloned().unwrap_or_default();
-    updated.username = Some(username.to_string());
-    updated.access_token = Some(access.clone());
-    updated.refresh_token = Some(refresh);
-    updated.last_session_id = None;
-    creds.profiles.insert(name, updated);
-    save_credentials(&creds)?;
+    let username = username.to_string();
+    let access_clone = access.clone();
+    credential_store()
+        .mutate(|creds| {
+            let name =
+                CredentialStore::resolve_profile_name(profile, creds.current_profile.as_deref());
+            let existing = creds.profiles.get(&name).cloned().unwrap_or_default();
+            let prev_session = if existing.username.as_deref() == Some(&username) {
+                existing.last_session_id
+            } else {
+                None
+            };
+            let updated = Profile {
+                username: Some(username.clone()),
+                access_token: Some(access_clone.clone()),
+                refresh_token: Some(refresh.clone()),
+                last_session_id: prev_session,
+                memoria_api_key: existing.memoria_api_key,
+            };
+            creds.current_profile = Some(name.clone());
+            creds.profiles.insert(name, updated);
+        })
+        .map_err(|e| e.to_string())?;
     Ok(access)
 }
 

--- a/rust/crates/astra-cli/src/cli/auth_flow.rs
+++ b/rust/crates/astra-cli/src/cli/auth_flow.rs
@@ -1,4 +1,4 @@
-use super::cli_utils::{credential_store, CredentialStore, Profile};
+use super::cli_utils::{CredentialStore, Profile, credential_store};
 use super::*;
 
 pub(super) fn clear_profile_last_session(profile: Option<&str>) -> Result<(), String> {

--- a/rust/crates/astra-cli/src/cli/cli_utils.rs
+++ b/rust/crates/astra-cli/src/cli/cli_utils.rs
@@ -1,77 +1,38 @@
 use super::*;
 
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub(super) struct CredentialsFile {
-    pub(super) current_profile: Option<String>,
-    pub(super) profiles: HashMap<String, Profile>,
-}
+pub(super) use astra_credentials::{CredentialStore, CredentialsFile, Profile};
 
-#[derive(Clone, Serialize, Deserialize, Default)]
-pub(super) struct Profile {
-    pub(super) username: Option<String>,
-    pub(super) access_token: Option<String>,
-    pub(super) refresh_token: Option<String>,
-    pub(super) last_session_id: Option<String>,
-    pub(super) memoria_api_key: Option<String>,
-}
-
-impl std::fmt::Debug for Profile {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Profile")
-            .field("username", &self.username)
-            .field("access_token", &self.access_token.as_ref().map(|_| "***"))
-            .field("refresh_token", &self.refresh_token.as_ref().map(|_| "***"))
-            .field("last_session_id", &self.last_session_id)
-            .field(
-                "memoria_api_key",
-                &self.memoria_api_key.as_ref().map(|_| "***"),
-            )
-            .finish()
-    }
+pub(super) fn credential_store() -> CredentialStore {
+    CredentialStore::new()
 }
 
 pub(super) fn credentials_path() -> PathBuf {
-    // Allow tests to override the credentials path via env var to avoid polluting real credentials.
-    if let Ok(dir) = std::env::var("ASTRA_CLI_CREDENTIALS_DIR") {
-        return PathBuf::from(dir).join("credentials.json");
-    }
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".astra")
-        .join("credentials.json")
+    credential_store().path().clone()
 }
 
-/// Fetch relevant memories from Memoria synchronously and return as a string for context injection.
-/// Returns empty string if Memoria is not configured or unavailable.
 pub(super) fn load_credentials() -> CredentialsFile {
-    let path = credentials_path();
-    let Ok(content) = fs::read_to_string(path) else {
-        return CredentialsFile::default();
-    };
-    serde_json::from_str(&content).unwrap_or_default()
+    credential_store().load().unwrap_or_default()
 }
 
+#[cfg(test)]
 pub(super) fn save_credentials(data: &CredentialsFile) -> Result<(), String> {
-    let path = credentials_path();
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-    }
-    let body = serde_json::to_string_pretty(data).map_err(|e| e.to_string())?;
-    fs::write(&path, body).map_err(|e| e.to_string())?;
-    // Restrict to owner-only (0o600) — credentials contain tokens and secrets
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
-    }
-    Ok(())
+    let store = credential_store();
+    store
+        .mutate(|d| {
+            *d = data.clone();
+        })
+        .map_err(|e| e.to_string())
+}
+
+pub(super) fn mutate_credentials<F, R>(f: F) -> Result<R, String>
+where
+    F: FnOnce(&mut CredentialsFile) -> R,
+{
+    credential_store().mutate(f).map_err(|e| e.to_string())
 }
 
 pub(super) fn profile_name(cli_profile: Option<&str>, data: &CredentialsFile) -> String {
-    cli_profile
-        .map(ToString::to_string)
-        .or_else(|| data.current_profile.clone())
-        .unwrap_or_else(|| "default".to_string())
+    CredentialStore::resolve_profile_name(cli_profile, data.current_profile.as_deref())
 }
 
 pub(super) fn get_profile_and_token(
@@ -121,17 +82,39 @@ pub(super) fn clear_profile_last_session_if_matches(
     cli_profile: Option<&str>,
     session_id: &str,
 ) -> Result<bool, String> {
-    let mut creds = load_credentials();
-    let name = profile_name(cli_profile, &creds);
-    let Some(entry) = creds.profiles.get_mut(&name) else {
-        return Ok(false);
-    };
-    if entry.last_session_id.as_deref() != Some(session_id) {
-        return Ok(false);
-    }
-    entry.last_session_id = None;
-    save_credentials(&creds)?;
-    Ok(true)
+    mutate_credentials(|creds| {
+        let name = profile_name(cli_profile, creds);
+        let Some(entry) = creds.profiles.get_mut(&name) else {
+            return false;
+        };
+        if entry.last_session_id.as_deref() != Some(session_id) {
+            return false;
+        }
+        entry.last_session_id = None;
+        true
+    })
+}
+
+pub(super) fn persist_profile_last_session(
+    cli_profile: Option<&str>,
+    session_id: &str,
+) -> Result<(), String> {
+    mutate_credentials(|creds| {
+        let name = profile_name(cli_profile, creds);
+        let entry = creds.profiles.entry(name).or_default();
+        entry.last_session_id = Some(session_id.to_string());
+    })
+}
+
+pub(super) fn persist_profile_memoria_api_key(
+    cli_profile: Option<&str>,
+    api_key: &str,
+) -> Result<(), String> {
+    mutate_credentials(|creds| {
+        let name = profile_name(cli_profile, creds);
+        let entry = creds.profiles.entry(name).or_default();
+        entry.memoria_api_key = Some(api_key.to_string());
+    })
 }
 
 pub(super) async fn preflight_remote_resume_session(
@@ -877,6 +860,56 @@ mod tests {
     }
 
     #[test]
+    fn persist_profile_last_session_updates_only_target_field() {
+        let _creds_guard = crate::tests::isolate_credentials();
+        let mut creds = CredentialsFile::default();
+        creds.profiles.insert(
+            "default".to_string(),
+            Profile {
+                username: Some("user".to_string()),
+                access_token: Some("tok".to_string()),
+                refresh_token: Some("ref".to_string()),
+                memoria_api_key: Some("mem-key".to_string()),
+                ..Default::default()
+            },
+        );
+        save_credentials(&creds).unwrap();
+
+        persist_profile_last_session(None, "sess-new").unwrap();
+
+        let creds = load_credentials();
+        let profile = &creds.profiles["default"];
+        assert_eq!(profile.last_session_id.as_deref(), Some("sess-new"));
+        assert_eq!(profile.memoria_api_key.as_deref(), Some("mem-key"));
+        assert_eq!(profile.access_token.as_deref(), Some("tok"));
+        assert_eq!(profile.refresh_token.as_deref(), Some("ref"));
+    }
+
+    #[test]
+    fn persist_profile_memoria_api_key_updates_only_target_field() {
+        let _creds_guard = crate::tests::isolate_credentials();
+        let mut creds = CredentialsFile::default();
+        creds.profiles.insert(
+            "default".to_string(),
+            Profile {
+                username: Some("user".to_string()),
+                last_session_id: Some("sess-old".to_string()),
+                access_token: Some("tok".to_string()),
+                ..Default::default()
+            },
+        );
+        save_credentials(&creds).unwrap();
+
+        persist_profile_memoria_api_key(None, "mem-new").unwrap();
+
+        let creds = load_credentials();
+        let profile = &creds.profiles["default"];
+        assert_eq!(profile.memoria_api_key.as_deref(), Some("mem-new"));
+        assert_eq!(profile.last_session_id.as_deref(), Some("sess-old"));
+        assert_eq!(profile.access_token.as_deref(), Some("tok"));
+    }
+
+    #[test]
     fn session_is_not_resumable_after_clean_end() {
         let (_tmp, _guard) = isolated_sessions_dir();
         let sid = format!("test-ended-{}", uuid::Uuid::new_v4());
@@ -1118,8 +1151,8 @@ mod tests {
     fn test_credentials_file_permissions() {
         let _creds_guard = crate::tests::isolate_credentials();
         let creds = CredentialsFile {
-            current_profile: Some("default".into()),
-            profiles: HashMap::new(),
+            current_profile: Some("default".to_string()),
+            ..Default::default()
         };
         save_credentials(&creds).unwrap();
 

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -525,7 +525,7 @@ pub(super) async fn execute_cli_command(
         Some(Command::Message(words)) => {
             let raw_message = words.join(" ");
             let message = apply_system_prompt(&raw_message, system_prompt.as_deref());
-            let (mut creds, name, _, token) = get_profile_and_token(profile.as_deref())?;
+            let (_, _, _, token) = get_profile_and_token(profile.as_deref())?;
             let session_id = validated_resumable_last_session_id(api, profile.as_deref()).await;
             let mut continuation_messages = session_id
                 .as_deref()
@@ -611,9 +611,7 @@ pub(super) async fn execute_cli_command(
                 Err(e) => return Err(e.error),
             };
             if let Some(ref sid) = sr.session_id {
-                let p = creds.profiles.entry(name).or_default();
-                p.last_session_id = Some(sid.clone());
-                save_credentials(&creds)?;
+                persist_profile_last_session(profile.as_deref(), sid)?;
             }
             Ok(compute_exit_code(&sr))
         }
@@ -670,14 +668,14 @@ pub(super) async fn execute_cli_command(
         }
 
         Some(Command::Refresh) => {
-            let mut creds = load_credentials();
+            let creds = load_credentials();
             let name = profile_name(profile.as_deref(), &creds);
-            let profile = creds
+            let saved_profile = creds
                 .profiles
                 .get(&name)
                 .cloned()
                 .ok_or_else(|| format!("no profile '{name}'"))?;
-            let refresh_token = profile
+            let refresh_token = saved_profile
                 .refresh_token
                 .ok_or_else(|| format!("profile '{name}' has no refresh token"))?;
             let body = api
@@ -689,40 +687,46 @@ pub(super) async fn execute_cli_command(
             let new_access = value
                 .get("access_token")
                 .and_then(serde_json::Value::as_str)
-                .ok_or_else(|| "missing access_token".to_string())?;
+                .ok_or_else(|| "missing access_token".to_string())?
+                .to_string();
             let new_refresh = value
                 .get("refresh_token")
                 .and_then(serde_json::Value::as_str)
-                .ok_or_else(|| "missing refresh_token".to_string())?;
-            let entry = creds.profiles.entry(name).or_default();
-            entry.access_token = Some(new_access.to_string());
-            entry.refresh_token = Some(new_refresh.to_string());
-            save_credentials(&creds)?;
+                .ok_or_else(|| "missing refresh_token".to_string())?
+                .to_string();
+            mutate_credentials(|creds| {
+                let name = profile_name(profile.as_deref(), creds);
+                let entry = creds.profiles.entry(name).or_default();
+                entry.access_token = Some(new_access.clone());
+                entry.refresh_token = Some(new_refresh.clone());
+            })?;
             println!("  {} {}", theme::icon_ok(), "Token refreshed".green());
             Ok(ExitCode::Success)
         }
 
         Some(Command::Logout) => {
-            let mut creds = load_credentials();
+            let creds = load_credentials();
             let name = profile_name(profile.as_deref(), &creds);
-            let profile = creds
+            let saved_profile = creds
                 .profiles
                 .get(&name)
                 .cloned()
                 .ok_or_else(|| format!("no profile '{name}'"))?;
-            let refresh_token = profile
+            let refresh_token = saved_profile
                 .refresh_token
                 .ok_or_else(|| format!("profile '{name}' has no refresh token"))?;
             let body = api
                 .post_auth_logout_json(&serde_json::json!({ "refresh_token": refresh_token }))
                 .await
                 .map_err(map_thin_err)?;
-            if let Some(entry) = creds.profiles.get_mut(&name) {
-                entry.access_token = None;
-                entry.refresh_token = None;
-                entry.last_session_id = None;
-            }
-            save_credentials(&creds)?;
+            mutate_credentials(|creds| {
+                let name = profile_name(profile.as_deref(), creds);
+                if let Some(entry) = creds.profiles.get_mut(&name) {
+                    entry.access_token = None;
+                    entry.refresh_token = None;
+                    entry.last_session_id = None;
+                }
+            })?;
             print_json_or_raw(&body);
             Ok(ExitCode::Success)
         }
@@ -976,7 +980,7 @@ pub(super) async fn execute_cli_command(
                 return Ok(ExitCode::Success);
             };
 
-            let (mut creds, name, _, token) = get_profile_and_token(profile.as_deref())?;
+            let (_, _, _, token) = get_profile_and_token(profile.as_deref())?;
             let session_id = match args.session_id {
                 Some(session_id) => Some(session_id),
                 None => validated_resumable_last_session_id(api, profile.as_deref()).await,
@@ -1110,9 +1114,7 @@ pub(super) async fn execute_cli_command(
 
             // Save session for resumption
             if let Some(sid) = &sr.session_id {
-                let p = creds.profiles.entry(name).or_default();
-                p.last_session_id = Some(sid.clone());
-                save_credentials(&creds)?;
+                persist_profile_last_session(profile.as_deref(), sid)?;
             }
 
             // Drain any background-spawned child agents before
@@ -1806,7 +1808,7 @@ pub(super) async fn run_print_mode(
     };
     let message = apply_system_prompt(&raw_message, system_prompt);
 
-    let (mut creds, name, _, token) = get_profile_and_token(profile)?;
+    let (_, _, _, token) = get_profile_and_token(profile)?;
     let session_id = validated_resumable_last_session_id(api, profile).await;
     let mut continuation_messages = session_id
         .as_deref()
@@ -1870,9 +1872,7 @@ pub(super) async fn run_print_mode(
 
     // Save session for resumption
     if let Some(sid) = &sr.session_id {
-        let p = creds.profiles.entry(name).or_default();
-        p.last_session_id = Some(sid.clone());
-        save_credentials(&creds)?;
+        persist_profile_last_session(profile, sid)?;
     }
 
     let exit_code = compute_exit_code(&sr);

--- a/rust/crates/astra-cli/src/cli/repl_runtime.rs
+++ b/rust/crates/astra-cli/src/cli/repl_runtime.rs
@@ -382,12 +382,16 @@ async fn try_refresh_token(
     let new_refresh = value.get("refresh_token").and_then(|v| v.as_str()).ok_or(
         SilentRefreshError::BadResponse("refresh response: missing refresh_token"),
     )?;
-    let mut creds = load_credentials();
-    let name = profile_name(profile, &creds);
-    let entry = creds.profiles.entry(name).or_default();
-    entry.access_token = Some(new_access.to_string());
-    entry.refresh_token = Some(new_refresh.to_string());
-    save_credentials(&creds).map_err(SilentRefreshError::SaveFailed)?;
+    let new_access = new_access.to_string();
+    let new_refresh = new_refresh.to_string();
+    credential_store()
+        .mutate(|creds| {
+            let name = profile_name(profile, creds);
+            let entry = creds.profiles.entry(name).or_default();
+            entry.access_token = Some(new_access.clone());
+            entry.refresh_token = Some(new_refresh.clone());
+        })
+        .map_err(|e| SilentRefreshError::SaveFailed(e.to_string()))?;
     Ok(())
 }
 
@@ -1783,18 +1787,19 @@ mod tests {
         // Make sure ASTRA_ACCESS_TOKEN is not set (empty = ignored)
         let _env_clear = EnvGuard::set("ASTRA_ACCESS_TOKEN", "");
         // Write a credentials file to the isolated path
-        let creds = CredentialsFile {
-            current_profile: Some("default".into()),
-            profiles: std::collections::HashMap::from([(
-                "default".to_string(),
-                Profile {
-                    username: Some("user".into()),
-                    access_token: Some("file-token-abc".into()),
-                    refresh_token: None,
-                    ..Default::default()
-                },
-            )]),
+        let mut creds = CredentialsFile {
+            current_profile: Some("default".to_string()),
+            ..Default::default()
         };
+        creds.profiles.insert(
+            "default".to_string(),
+            Profile {
+                username: Some("user".into()),
+                access_token: Some("file-token-abc".into()),
+                refresh_token: None,
+                ..Default::default()
+            },
+        );
         let path = crate::cli_utils::credentials_path();
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);

--- a/rust/crates/astra-cli/src/cli/repl_turn.rs
+++ b/rust/crates/astra-cli/src/cli/repl_turn.rs
@@ -2586,11 +2586,7 @@ pub(super) fn initialize_journal_pub(state: &mut ReplState, session_id: &str) {
 }
 
 pub(super) fn persist_last_session_id(profile: Option<&str>, session_id: &str) {
-    let mut creds = load_credentials();
-    let name = profile_name(profile, &creds);
-    let entry = creds.profiles.entry(name).or_default();
-    entry.last_session_id = Some(session_id.to_string());
-    let _ = save_credentials(&creds);
+    let _ = persist_profile_last_session(profile, session_id);
 }
 
 fn initialize_journal(state: &mut ReplState, session_id: &str) {

--- a/rust/crates/astra-cli/src/cli/slash_account.rs
+++ b/rust/crates/astra-cli/src/cli/slash_account.rs
@@ -93,11 +93,7 @@ pub(super) async fn handle_account_command(
                     "Get a key from Memoria: curl -X POST http://localhost:8100/auth/keys -H 'Authorization: Bearer <master_key>' -H 'Content-Type: application/json' -d '{{\"user_id\":\"<user>\",\"name\":\"astra\"}}'"
                 );
             } else {
-                let mut creds = load_credentials();
-                let pname = profile_name(profile, &creds);
-                let p = creds.profiles.entry(pname).or_default();
-                p.memoria_api_key = Some(arg.to_string());
-                let _ = save_credentials(&creds);
+                let _ = persist_profile_memoria_api_key(profile, arg);
                 // SAFETY: This runs during single-threaded REPL command processing.
                 // No concurrent threads read MEMORIA_MASTER_KEY at this point.
                 unsafe {

--- a/rust/crates/astra-cli/src/cli/slash_state.rs
+++ b/rust/crates/astra-cli/src/cli/slash_state.rs
@@ -36,11 +36,7 @@ pub(super) async fn handle_state_command(
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
             if let Some(sid) = &new_sid {
-                let mut creds = load_credentials();
-                let pname = profile_name(profile, &creds);
-                let p = creds.profiles.entry(pname).or_default();
-                p.last_session_id = Some(sid.clone());
-                let _ = save_credentials(&creds);
+                let _ = persist_profile_last_session(profile, sid);
             }
             state.session_id = new_sid.clone();
             state.turn = 0;

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -234,11 +234,14 @@ use astra_turn_core::chat_turn_heuristics::{
 };
 use auth_flow::{clear_profile_last_session, do_login, do_register};
 use chat_stream::{ChatTurnParams, stream_chat_sse};
+#[cfg(test)]
+use cli_utils::save_credentials;
 use cli_utils::{
     SessionResumePreflight, clear_profile_last_session_if_matches, compact_or_raw,
-    get_profile_and_token, interactive_select, load_credentials, map_thin_err, prefix_chars,
-    preflight_remote_resume_session, print_json_or_raw, profile_name, prompt_or,
-    prompt_password_masked, resumable_last_session_id, save_credentials, truncate_str, urlencoding,
+    credential_store, get_profile_and_token, interactive_select, load_credentials, map_thin_err,
+    mutate_credentials, persist_profile_last_session, persist_profile_memoria_api_key,
+    prefix_chars, preflight_remote_resume_session, print_json_or_raw, profile_name, prompt_or,
+    prompt_password_masked, resumable_last_session_id, truncate_str, urlencoding,
     validated_resumable_last_session_id,
 };
 use command_router::{ExitCode, execute_cli_command, run_print_mode};

--- a/rust/crates/astra-cli/src/tests/auth_tests.rs
+++ b/rust/crates/astra-cli/src/tests/auth_tests.rs
@@ -76,6 +76,116 @@ async fn do_login_preserves_existing_memoria_api_key() {
 }
 
 #[tokio::test]
+async fn do_login_preserves_last_session_for_same_username() {
+    let _creds_dir = isolate_credentials();
+    let mut creds = CredentialsFile::default();
+    creds.profiles.insert(
+        "test-profile".to_string(),
+        Profile {
+            username: Some("user1".to_string()),
+            last_session_id: Some("sess-123".to_string()),
+            ..Default::default()
+        },
+    );
+    save_credentials(&creds).unwrap();
+
+    let app = Router::new().route(
+        "/auth/login",
+        post(|| async {
+            axum::Json(serde_json::json!({
+                "access_token": "tok-new",
+                "refresh_token": "ref-new"
+            }))
+        }),
+    );
+    let base = spawn_mock(app).await;
+    let api = astra_thin_client::ThinClient::new(&base, None).unwrap();
+
+    do_login(&api, Some("test-profile"), "user1", "pass1")
+        .await
+        .unwrap();
+
+    let creds = load_credentials();
+    assert_eq!(
+        creds.profiles["test-profile"].last_session_id.as_deref(),
+        Some("sess-123")
+    );
+}
+
+#[tokio::test]
+async fn do_login_clears_last_session_for_different_username() {
+    let _creds_dir = isolate_credentials();
+    let mut creds = CredentialsFile::default();
+    creds.profiles.insert(
+        "test-profile".to_string(),
+        Profile {
+            username: Some("user1".to_string()),
+            last_session_id: Some("sess-123".to_string()),
+            memoria_api_key: Some("mem-key".to_string()),
+            ..Default::default()
+        },
+    );
+    save_credentials(&creds).unwrap();
+
+    let app = Router::new().route(
+        "/auth/login",
+        post(|| async {
+            axum::Json(serde_json::json!({
+                "access_token": "tok-new",
+                "refresh_token": "ref-new"
+            }))
+        }),
+    );
+    let base = spawn_mock(app).await;
+    let api = astra_thin_client::ThinClient::new(&base, None).unwrap();
+
+    do_login(&api, Some("test-profile"), "user2", "pass1")
+        .await
+        .unwrap();
+
+    let creds = load_credentials();
+    let profile = &creds.profiles["test-profile"];
+    assert_eq!(profile.last_session_id, None);
+    assert_eq!(profile.memoria_api_key.as_deref(), Some("mem-key"));
+}
+
+#[tokio::test]
+async fn do_login_uses_astra_profile_when_cli_profile_absent() {
+    let _creds_dir = isolate_credentials();
+    // Use a manual guard because this async test must keep ASTRA_PROFILE set
+    // across awaits while the credentials env mutex serializes related tests.
+    struct ProfileEnvGuard(Option<String>);
+    impl Drop for ProfileEnvGuard {
+        fn drop(&mut self) {
+            match self.0.as_deref() {
+                Some(value) => unsafe { std::env::set_var("ASTRA_PROFILE", value) },
+                None => unsafe { std::env::remove_var("ASTRA_PROFILE") },
+            }
+        }
+    }
+    let _profile_env = ProfileEnvGuard(std::env::var("ASTRA_PROFILE").ok());
+    unsafe { std::env::set_var("ASTRA_PROFILE", "from-env") };
+
+    let app = Router::new().route(
+        "/auth/login",
+        post(|| async {
+            axum::Json(serde_json::json!({
+                "access_token": "tok-env",
+                "refresh_token": "ref-env"
+            }))
+        }),
+    );
+    let base = spawn_mock(app).await;
+    let api = astra_thin_client::ThinClient::new(&base, None).unwrap();
+
+    do_login(&api, None, "user1", "pass1").await.unwrap();
+
+    let creds = load_credentials();
+    assert!(creds.profiles.contains_key("from-env"));
+    assert_eq!(creds.current_profile.as_deref(), Some("from-env"));
+}
+
+#[tokio::test]
 async fn do_register_success() {
     let _creds_dir = isolate_credentials();
     let app = Router::new().route(

--- a/rust/crates/astra-credentials/Cargo.toml
+++ b/rust/crates/astra-credentials/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "astra-credentials"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+dirs = "6"
+fs2 = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]
+temp-env = "0.3"
+tempfile = "3"

--- a/rust/crates/astra-credentials/src/lib.rs
+++ b/rust/crates/astra-credentials/src/lib.rs
@@ -1,0 +1,492 @@
+use std::{
+    collections::HashMap,
+    fs::{self, File, OpenOptions},
+    io::Write,
+    path::PathBuf,
+};
+
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CredentialError {
+    #[error("io error on {path}: {source}")]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("json parse error on {path}: {source}")]
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    #[error("json serialize error: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CredentialsFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_profile: Option<String>,
+
+    #[serde(default)]
+    pub profiles: HashMap<String, Profile>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct Profile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memoria_api_key: Option<String>,
+}
+
+impl std::fmt::Debug for Profile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Profile")
+            .field("username", &self.username)
+            .field("access_token", &self.access_token.as_ref().map(|_| "***"))
+            .field("refresh_token", &self.refresh_token.as_ref().map(|_| "***"))
+            .field("last_session_id", &self.last_session_id)
+            .field(
+                "memoria_api_key",
+                &self.memoria_api_key.as_ref().map(|_| "***"),
+            )
+            .finish()
+    }
+}
+
+pub struct CredentialStore {
+    path: PathBuf,
+}
+
+impl CredentialStore {
+    pub fn new() -> Self {
+        Self {
+            path: default_path(),
+        }
+    }
+
+    pub fn with_path(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+
+    /// Resolve active profile name.
+    /// Priority: cli_override > ASTRA_PROFILE env > file current_profile > "default"
+    pub fn resolve_profile_name(cli_override: Option<&str>, file_current: Option<&str>) -> String {
+        Self::resolve_profile_name_with_default(cli_override, file_current, "default")
+    }
+
+    /// Resolve active profile name with a caller-specific legacy default.
+    /// Priority: cli_override > ASTRA_PROFILE env > file current_profile > fallback_default.
+    pub fn resolve_profile_name_with_default(
+        cli_override: Option<&str>,
+        file_current: Option<&str>,
+        fallback_default: &str,
+    ) -> String {
+        if let Some(name) = cli_override {
+            return name.to_string();
+        }
+        if let Ok(env_val) = std::env::var("ASTRA_PROFILE")
+            && !env_val.is_empty()
+        {
+            return env_val;
+        }
+        if let Some(name) = file_current {
+            return name.to_string();
+        }
+        fallback_default.to_string()
+    }
+
+    /// Load credentials with a shared (read) lock.
+    ///
+    /// Returns `CredentialsFile::default()` without creating the sibling `.lock`
+    /// file when the credentials file does not yet exist — pure readers must not
+    /// litter the credentials directory on first run.
+    pub fn load(&self) -> Result<CredentialsFile, CredentialError> {
+        if !self.path.exists() {
+            return Ok(CredentialsFile::default());
+        }
+        let _lock_file = self.lock_for_read_if_possible()?;
+        let content = fs::read_to_string(&self.path).map_err(|e| CredentialError::Io {
+            path: self.path.clone(),
+            source: e,
+        })?;
+        if content.trim().is_empty() {
+            return Ok(CredentialsFile::default());
+        }
+        serde_json::from_str(&content).map_err(|e| CredentialError::Parse {
+            path: self.path.clone(),
+            source: e,
+        })
+    }
+
+    fn lock_for_read_if_possible(&self) -> Result<Option<File>, CredentialError> {
+        if let Some(parent) = self.path.parent()
+            && !parent.exists()
+        {
+            return Ok(None);
+        }
+        let lock_path = self.path.with_extension("json.lock");
+        let lock_file = open_lock_file(&lock_path)?;
+        lock_file.lock_shared().map_err(|e| CredentialError::Io {
+            path: lock_path.clone(),
+            source: e,
+        })?;
+        Ok(Some(lock_file))
+    }
+
+    /// Acquire exclusive lock, read current state, apply mutator, write back atomically.
+    pub fn mutate<F, R>(&self, f: F) -> Result<R, CredentialError>
+    where
+        F: FnOnce(&mut CredentialsFile) -> R,
+    {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|e| CredentialError::Io {
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
+        }
+
+        // Use a separate .lock file so that rename-based atomicity doesn't
+        // invalidate the lock fd (renaming the data file would leave the old
+        // fd pointing at the unlinked inode).
+        let lock_path = self.path.with_extension("json.lock");
+        let lock_file = open_lock_file(&lock_path)?;
+
+        lock_file
+            .lock_exclusive()
+            .map_err(|e| CredentialError::Io {
+                path: lock_path.clone(),
+                source: e,
+            })?;
+
+        // Read current data from the actual credentials file
+        let mut data: CredentialsFile = if self.path.exists() {
+            let content = fs::read_to_string(&self.path).map_err(|e| CredentialError::Io {
+                path: self.path.clone(),
+                source: e,
+            })?;
+            if content.trim().is_empty() {
+                CredentialsFile::default()
+            } else {
+                serde_json::from_str(&content).map_err(|e| CredentialError::Parse {
+                    path: self.path.clone(),
+                    source: e,
+                })?
+            }
+        } else {
+            CredentialsFile::default()
+        };
+
+        let result = f(&mut data);
+
+        let body = serde_json::to_string_pretty(&data)?;
+
+        // Write to tmp file then rename for atomicity. On any failure between
+        // creating the tmp file and the successful rename we best-effort remove
+        // the tmp — a stale `.tmp` would otherwise leave sensitive bytes behind
+        // (mode 0o600, but still) across process restarts.
+        let tmp_path = self.path.with_extension("json.tmp");
+        if let Err(e) = write_private_file(&tmp_path, &body) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(e);
+        }
+
+        if let Err(e) = fs::rename(&tmp_path, &self.path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(CredentialError::Io {
+                path: self.path.clone(),
+                source: e,
+            });
+        }
+
+        // lock released when `lock_file` drops
+        Ok(result)
+    }
+}
+
+impl Default for CredentialStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn open_lock_file(path: &PathBuf) -> Result<File, CredentialError> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|e| CredentialError::Io {
+            path: path.clone(),
+            source: e,
+        })
+}
+
+fn write_private_file(path: &PathBuf, body: &str) -> Result<(), CredentialError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|e| CredentialError::Io {
+                path: path.clone(),
+                source: e,
+            })?;
+        file.write_all(body.as_bytes())
+            .map_err(|e| CredentialError::Io {
+                path: path.clone(),
+                source: e,
+            })?;
+        file.sync_all().map_err(|e| CredentialError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        // TODO(windows): this fallback does not restrict ACLs and does not
+        // fsync before the caller renames. On shared Windows machines the
+        // tmp file may be readable by other users, and a crash between
+        // write + rename can leave a zero-length credentials file. Revisit
+        // if/when Windows becomes a supported target — likely needs
+        // `CreateFileW` with a restrictive SECURITY_ATTRIBUTES and an
+        // explicit `FlushFileBuffers`.
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)
+            .map_err(|e| CredentialError::Io {
+                path: path.clone(),
+                source: e,
+            })?;
+        file.write_all(body.as_bytes())
+            .map_err(|e| CredentialError::Io {
+                path: path.clone(),
+                source: e,
+            })?;
+        file.sync_all().map_err(|e| CredentialError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        Ok(())
+    }
+}
+
+fn default_path() -> PathBuf {
+    if let Ok(dir) = std::env::var("ASTRA_CLI_CREDENTIALS_DIR") {
+        return PathBuf::from(dir).join("credentials.json");
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".astra")
+        .join("credentials.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn store_in(dir: &TempDir) -> CredentialStore {
+        CredentialStore::with_path(dir.path().join("credentials.json"))
+    }
+
+    #[test]
+    fn load_missing_file_returns_default() {
+        let dir = TempDir::new().unwrap();
+        let store = store_in(&dir);
+        let creds = store.load().unwrap();
+        assert!(creds.profiles.is_empty());
+    }
+
+    #[test]
+    fn mutate_creates_file_and_roundtrips() {
+        let dir = TempDir::new().unwrap();
+        let store = store_in(&dir);
+
+        store
+            .mutate(|data| {
+                data.profiles.insert(
+                    "test".to_string(),
+                    Profile {
+                        username: Some("alice".to_string()),
+                        access_token: Some("tok123".to_string()),
+                        ..Default::default()
+                    },
+                );
+            })
+            .unwrap();
+
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded.profiles["test"].username.as_deref(), Some("alice"));
+        assert_eq!(
+            loaded.profiles["test"].access_token.as_deref(),
+            Some("tok123")
+        );
+    }
+
+    #[test]
+    fn mutate_is_atomic_under_contention() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("credentials.json");
+
+        let handles: Vec<_> = (0..10)
+            .map(|i| {
+                let p = path.clone();
+                std::thread::spawn(move || {
+                    let store = CredentialStore::with_path(p);
+                    store
+                        .mutate(|data| {
+                            let entry = data.profiles.entry("shared".to_string()).or_default();
+                            let current: i32 = entry
+                                .username
+                                .as_deref()
+                                .and_then(|s| s.parse().ok())
+                                .unwrap_or(0);
+                            entry.username = Some((current + 1).to_string());
+                            // Simulate some work
+                            std::thread::sleep(std::time::Duration::from_millis(i));
+                        })
+                        .unwrap();
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let store = CredentialStore::with_path(path);
+        let data = store.load().unwrap();
+        let final_val: i32 = data.profiles["shared"]
+            .username
+            .as_deref()
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(final_val, 10);
+    }
+
+    #[test]
+    fn resolve_profile_name_priority() {
+        // cli_override wins
+        assert_eq!(
+            CredentialStore::resolve_profile_name(Some("staging"), Some("prod")),
+            "staging"
+        );
+
+        // env var wins over file current_profile
+        temp_env::with_var("ASTRA_PROFILE", Some("from_env"), || {
+            assert_eq!(
+                CredentialStore::resolve_profile_name(None, Some("prod")),
+                "from_env"
+            );
+        });
+
+        // file current_profile fallback
+        temp_env::with_var("ASTRA_PROFILE", None::<&str>, || {
+            assert_eq!(
+                CredentialStore::resolve_profile_name(None, Some("prod")),
+                "prod"
+            );
+        });
+
+        // default fallback
+        temp_env::with_var("ASTRA_PROFILE", None::<&str>, || {
+            assert_eq!(CredentialStore::resolve_profile_name(None, None), "default");
+        });
+    }
+
+    #[test]
+    fn resolve_profile_name_supports_legacy_admin_default() {
+        temp_env::with_var("ASTRA_PROFILE", None::<&str>, || {
+            assert_eq!(
+                CredentialStore::resolve_profile_name_with_default(None, None, "admin"),
+                "admin"
+            );
+        });
+        temp_env::with_var("ASTRA_PROFILE", Some("from-env"), || {
+            assert_eq!(
+                CredentialStore::resolve_profile_name_with_default(None, None, "admin"),
+                "from-env"
+            );
+        });
+    }
+
+    #[test]
+    fn invalid_json_returns_parse_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("credentials.json");
+        fs::write(&path, "{not-json").unwrap();
+        let store = CredentialStore::with_path(path.clone());
+
+        let err = store.load().unwrap_err();
+
+        assert!(matches!(err, CredentialError::Parse { path: p, .. } if p == path));
+    }
+
+    #[test]
+    fn current_profile_roundtrips() {
+        let dir = TempDir::new().unwrap();
+        let store = store_in(&dir);
+
+        store
+            .mutate(|d| {
+                d.current_profile = Some("staging".to_string());
+                d.profiles.insert("staging".to_string(), Profile::default());
+            })
+            .unwrap();
+
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded.current_profile.as_deref(), Some("staging"));
+    }
+
+    #[test]
+    fn file_permissions_are_restricted() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let dir = TempDir::new().unwrap();
+            let store = store_in(&dir);
+            store.mutate(|_| {}).unwrap();
+            let meta = fs::metadata(store.path()).unwrap();
+            assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+        }
+    }
+
+    #[test]
+    fn private_tmp_writer_creates_restricted_file() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let dir = TempDir::new().unwrap();
+            let tmp = dir.path().join("credentials.json.tmp");
+
+            write_private_file(&tmp, "secret-token").unwrap();
+
+            let meta = fs::metadata(&tmp).unwrap();
+            assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+            assert_eq!(fs::read_to_string(&tmp).unwrap(), "secret-token");
+        }
+    }
+}

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -660,7 +660,11 @@ fn coerce_tool_result_content(content: Option<&Value>) -> String {
         Some(Value::Array(parts)) => {
             let joined = parts
                 .iter()
-                .filter_map(|part| part.get("text").and_then(Value::as_str))
+                .filter_map(|part| {
+                    part.get("text")
+                        .and_then(Value::as_str)
+                        .or_else(|| part.get("content").and_then(Value::as_str))
+                })
                 .collect::<Vec<_>>()
                 .join("");
             if joined.is_empty() {
@@ -5454,6 +5458,73 @@ mod tests {
             "all array elements preserved: {body}",
         );
         assert_ne!(body, "", "must not collapse to empty string");
+    }
+
+    #[test]
+    fn coerce_tool_result_content_extracts_from_cache_annotated_tool_result_block() {
+        // Regression: wire_cache_annotations rewrites tool message content from
+        // a plain string into `[{type: "tool_result", content: "...", tool_use_id: "...",
+        // cache_control: {...}}]`. The Bedrock body builder calls
+        // `coerce_tool_result_content` which must extract the `content` field,
+        // not return empty string (which makes the model think the tool had no output).
+        let content = json!([{
+            "type": "tool_result",
+            "tool_use_id": "tooluse_abc123",
+            "content": "gh version 2.46.0 (2025-01-13)\nhttps://github.com/cli/cli/releases/tag/v2.46.0",
+            "cache_control": {"type": "ephemeral"},
+        }]);
+        let result = coerce_tool_result_content(Some(&content));
+        assert_eq!(
+            result,
+            "gh version 2.46.0 (2025-01-13)\nhttps://github.com/cli/cli/releases/tag/v2.46.0",
+            "must extract content from tool_result block, got empty or wrong: {result:?}",
+        );
+    }
+
+    #[test]
+    fn bedrock_body_preserves_tool_output_after_cache_annotation() {
+        // End-to-end: simulate the full path where cache annotation rewrites
+        // tool content, then Bedrock body builder processes it.
+        let messages = vec![
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "tooluse_abc",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": "{\"command\":\"gh --version\"}"}
+                }]
+            }),
+            json!({
+                "role": "tool",
+                "tool_call_id": "tooluse_abc",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "tooluse_abc",
+                    "content": "gh version 2.46.0\nhttps://github.com/cli/cli/releases/tag/v2.46.0",
+                    "cache_control": {"type": "ephemeral"},
+                }],
+            }),
+        ];
+        let body = build_provider_request_body(
+            &messages,
+            &[],
+            "us.anthropic.claude-opus-4-7",
+            "bedrock",
+            None,
+            None,
+            false,
+            &ThinkingConfig::Off,
+        );
+        let tool_result_content = &body["messages"][1]["content"][0]["toolResult"]["content"][0];
+        let text = tool_result_content
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        assert!(
+            text.contains("gh version 2.46.0"),
+            "Bedrock toolResult must contain the actual tool output, got: {text:?}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Credential store refactoring**: New `astra-credentials` crate eliminates duplication between CLI and admin. Adds `fs2` file locking + atomic writes (tmp+rename) to prevent concurrent corruption. Login preserves `last_session_id` on same-user re-login. Profile resolution: `--profile` > `ASTRA_PROFILE` env > file `current_profile` > `"default"`.

- **Wire format bug fix**: `coerce_tool_result_content` only checked for `text` field in Array content blocks, but `wire_cache_annotations` rewrites tool content to `[{type: "tool_result", content: "...", cache_control: {...}}]` — using the `content` field. This caused all tool output to be sent as empty string to Bedrock after the first turn (when cache annotations are applied). The model correctly reported "no output" — not a hallucination.

## Test plan

- [x] `astra-credentials`: 9 unit tests (roundtrip, contention, profile resolution, permissions, current_profile persistence)
- [x] `astra-admin`: 25 tests pass
- [x] `astra-cli`: 3,914 tests pass  
- [x] `astra-runtime` llm_client: 180 tests pass (2 new TDD regression tests for the wire bug)
- [x] Manual: verified via `llm_capture` JSON that tool result content now reaches Bedrock correctly
- [ ] Manual: multi-terminal concurrent login (file locking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)