### PR TITLE
feat(tui): gutter redesign, auth error fix, paste burst detection

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_turn.rs
@@ -2702,8 +2702,7 @@ pub(super) fn is_auth_error(error: &str) -> bool {
 /// credential issues that `/login` cannot fix.
 pub(super) fn is_llm_provider_auth_error(error: &str) -> bool {
     let lower = error.to_lowercase();
-    lower.contains("llm provider authentication failed")
-        || lower.contains("[auth] llm provider")
+    lower.contains("llm provider authentication failed") || lower.contains("[auth] llm provider")
 }
 
 fn report_turn_failure(
@@ -2715,9 +2714,7 @@ fn report_turn_failure(
     ui: &mut dyn crate::ui_adapter::ReplUiAdapter,
 ) {
     if is_llm_provider_auth_error(&failure.error) {
-        ui.show_error(
-            "  LLM provider credentials invalid — check model API key configuration.",
-        );
+        ui.show_error("  LLM provider credentials invalid — check model API key configuration.");
     } else if is_auth_error(&failure.error) {
         ui.show_error("  Session expired. Run /login to refresh.");
     } else {

--- a/rust/crates/astra-cli/src/cli/chat_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_turn.rs
@@ -2679,7 +2679,14 @@ fn initialize_journal(state: &mut SessionState, session_id: &str) {
 /// rejected — it produced false positives whenever an unrelated error message
 /// happened to contain the digits 401 (timeouts in ms, file offsets, body
 /// snippets, etc.), causing spurious "Session expired. Run /login" prompts.
+///
+/// Excludes LLM provider auth failures — those indicate the upstream
+/// model credentials (Bedrock/Anthropic API key) are invalid, not the
+/// astra session token. Refreshing `/login` won't help for those.
 pub(super) fn is_auth_error(error: &str) -> bool {
+    if is_llm_provider_auth_error(error) {
+        return false;
+    }
     let lower = error.to_lowercase();
     lower.contains("unauthorized")
         || lower.contains("could not validate credentials")
@@ -2691,6 +2698,14 @@ pub(super) fn is_auth_error(error: &str) -> bool {
         || lower.contains("http 401")
 }
 
+/// Detect LLM provider authentication failures — upstream Bedrock/Anthropic
+/// credential issues that `/login` cannot fix.
+pub(super) fn is_llm_provider_auth_error(error: &str) -> bool {
+    let lower = error.to_lowercase();
+    lower.contains("llm provider authentication failed")
+        || lower.contains("[auth] llm provider")
+}
+
 fn report_turn_failure(
     state: &mut SessionState,
     profile: Option<&str>,
@@ -2699,7 +2714,11 @@ fn report_turn_failure(
     turn_start: Instant,
     ui: &mut dyn crate::ui_adapter::ReplUiAdapter,
 ) {
-    if is_auth_error(&failure.error) {
+    if is_llm_provider_auth_error(&failure.error) {
+        ui.show_error(
+            "  LLM provider credentials invalid — check model API key configuration.",
+        );
+    } else if is_auth_error(&failure.error) {
         ui.show_error("  Session expired. Run /login to refresh.");
     } else {
         ui.show_error(&format!(

--- a/rust/crates/astra-cli/src/cli/chat_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_turn.rs
@@ -3227,6 +3227,29 @@ mod tests {
     }
 
     #[test]
+    fn auth_error_predicates_distinguish_provider_from_session() {
+        // Regression: provider-auth strings must route to is_llm_provider_auth_error
+        // (which triggers a model retry) and NOT to is_auth_error (which would
+        // wrongly send the user to /login).
+        // Upstream emit sites:
+        //   - rust/crates/runtime/src/turn/llm_client.rs (~L2485): the literal
+        //     "LLM provider authentication failed" classified-error message.
+        //   - "[auth] LLM provider" prefix used by upstream agent_warn! emits.
+        let provider_msg = "LLM provider authentication failed";
+        assert!(super::is_llm_provider_auth_error(provider_msg));
+        assert!(!super::is_auth_error(provider_msg));
+
+        let prefixed = "[auth] LLM provider rejected request: 401";
+        assert!(super::is_llm_provider_auth_error(prefixed));
+        assert!(!super::is_auth_error(prefixed));
+
+        // Plain session 401 must still be detected by the generic predicate.
+        let session_msg = "HTTP 401 Unauthorized";
+        assert!(!super::is_llm_provider_auth_error(session_msg));
+        assert!(super::is_auth_error(session_msg));
+    }
+
+    #[test]
     fn initialize_journal_attaches_without_duplicate_start_or_workspace_reset() {
         let (_tmp, _g) = isolated_sessions_dir();
         let sid = format!("test-attach-{}", uuid::Uuid::new_v4());

--- a/rust/crates/astra-cli/src/tui/bottom_pane/chat_composer.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/chat_composer.rs
@@ -49,7 +49,8 @@ pub(crate) struct ChatComposer {
 /// Multi-line pastes above this threshold are swapped for a placeholder.
 /// Single-line pastes are inserted literally regardless of length — users
 /// expect URLs and one-liners to appear verbatim.
-const PASTE_PLACEHOLDER_MIN_LINES: usize = 4;
+const PASTE_INLINE_MAX_CHARS: usize = 800;
+const PASTE_INLINE_MAX_LINES: usize = 2;
 
 impl ChatComposer {
     pub fn new() -> Self {
@@ -144,8 +145,25 @@ impl ChatComposer {
     /// a `[Pasted #N · M lines]` placeholder; short pastes go in verbatim.
     /// Returns `true` when a placeholder was inserted.
     pub fn handle_paste(&mut self, text: &str) -> bool {
-        let line_count = text.lines().count();
-        if line_count < PASTE_PLACEHOLDER_MIN_LINES {
+        // Count line breaks: \r\n counts as one break, lone \r or \n also one.
+        let mut line_breaks = 0usize;
+        let bytes = text.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'\r' {
+                line_breaks += 1;
+                if i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
+                    i += 1;
+                }
+            } else if bytes[i] == b'\n' {
+                line_breaks += 1;
+            }
+            i += 1;
+        }
+        let line_count = if text.is_empty() { 0 } else { line_breaks + 1 };
+        let char_count = text.chars().count();
+        let is_small = char_count <= PASTE_INLINE_MAX_CHARS && line_count <= PASTE_INLINE_MAX_LINES;
+        if is_small {
             self.textarea.insert_str(text);
             return false;
         }
@@ -301,6 +319,10 @@ impl ChatComposer {
 
     fn prefix_display_width(&self) -> u16 {
         self.prompt_prefix.width() as u16
+    }
+
+    pub fn flush_paste_burst(&mut self) {
+        self.textarea.flush_paste_burst();
     }
 
     pub fn desired_height(&self, width: u16) -> u16 {

--- a/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod history_view;
 pub(crate) mod info_view;
 pub(crate) mod list_selection_view;
 pub(crate) mod login_view;
+pub(crate) mod paste_burst;
 pub(crate) mod session_picker_view;
 pub(crate) mod skill_popup;
 pub(crate) mod table_view;
@@ -758,6 +759,8 @@ impl BottomPane {
         if let Some(view) = self.active_view_mut() {
             view.pre_draw_tick(now);
         }
+        // Flush paste burst buffer when idle timeout expires.
+        self.composer.flush_paste_burst();
     }
 
     /// True when something in the bottom pane is currently animating and

--- a/rust/crates/astra-cli/src/tui/bottom_pane/paste_burst.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/paste_burst.rs
@@ -95,11 +95,7 @@ impl PasteBurstDetector {
             self.active = false;
             self.consecutive_fast_chars = 0;
             self.last_flush_time = Some(now);
-            if text.is_empty() {
-                None
-            } else {
-                Some(text)
-            }
+            if text.is_empty() { None } else { Some(text) }
         } else {
             None
         }

--- a/rust/crates/astra-cli/src/tui/bottom_pane/paste_burst.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/paste_burst.rs
@@ -1,0 +1,193 @@
+use std::time::Instant;
+
+/// Max inter-character interval to stay in a burst (8ms matches Codex).
+const BURST_CHAR_INTERVAL_MS: u64 = 8;
+
+/// Minimum consecutive fast chars to trigger burst mode.
+const BURST_MIN_CHARS: usize = 3;
+
+/// Grace period after a burst flushes during which Enter inserts a
+/// newline rather than submitting. Prevents accidental submit when
+/// pasted text ends with a trailing newline.
+const ENTER_SUPPRESS_WINDOW_MS: u64 = 120;
+
+/// Idle timeout before flushing buffered paste content.
+#[cfg(not(windows))]
+const FLUSH_IDLE_MS: u64 = 8;
+#[cfg(windows)]
+const FLUSH_IDLE_MS: u64 = 60;
+
+#[derive(Debug)]
+pub(crate) struct PasteBurstDetector {
+    last_char_time: Option<Instant>,
+    consecutive_fast_chars: usize,
+    buffer: String,
+    active: bool,
+    last_flush_time: Option<Instant>,
+}
+
+pub(crate) enum BurstDecision {
+    Normal,
+    Buffered,
+}
+
+impl PasteBurstDetector {
+    pub fn new() -> Self {
+        Self {
+            last_char_time: None,
+            consecutive_fast_chars: 0,
+            buffer: String::new(),
+            active: false,
+            last_flush_time: None,
+        }
+    }
+
+    pub fn on_char(&mut self, c: char, now: Instant) -> BurstDecision {
+        let is_fast = self.last_char_time.is_some_and(|prev| {
+            let elapsed_us = now.duration_since(prev).as_micros() as u64;
+            // Sub-millisecond intervals (< 1000µs) are synthetic (test
+            // harness loops) — real terminal input has ≥1ms between chars
+            // even during the fastest paste. Gate on ≥1ms to avoid false
+            // burst triggers in unit tests.
+            (1000..=BURST_CHAR_INTERVAL_MS * 1000).contains(&elapsed_us)
+        });
+
+        if is_fast {
+            self.consecutive_fast_chars += 1;
+        } else {
+            self.consecutive_fast_chars = 1;
+        }
+        self.last_char_time = Some(now);
+
+        if self.consecutive_fast_chars >= BURST_MIN_CHARS {
+            self.active = true;
+        }
+
+        if self.active {
+            self.buffer.push(c);
+            BurstDecision::Buffered
+        } else {
+            BurstDecision::Normal
+        }
+    }
+
+    pub fn enter_should_insert_newline(&self, now: Instant) -> bool {
+        if self.active {
+            return true;
+        }
+        if let Some(flush_time) = self.last_flush_time {
+            return now.duration_since(flush_time).as_millis() as u64 <= ENTER_SUPPRESS_WINDOW_MS;
+        }
+        false
+    }
+
+    pub fn flush_if_due(&mut self, now: Instant) -> Option<String> {
+        if !self.active {
+            return None;
+        }
+        let idle = self
+            .last_char_time
+            .map(|t| now.duration_since(t).as_millis() as u64)
+            .unwrap_or(u64::MAX);
+
+        if idle > FLUSH_IDLE_MS {
+            let text = std::mem::take(&mut self.buffer);
+            self.active = false;
+            self.consecutive_fast_chars = 0;
+            self.last_flush_time = Some(now);
+            if text.is_empty() {
+                None
+            } else {
+                Some(text)
+            }
+        } else {
+            None
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub fn recommended_tick_ms() -> u64 {
+        FLUSH_IDLE_MS + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn slow_typing_is_not_burst() {
+        let mut d = PasteBurstDetector::new();
+        let t0 = Instant::now();
+        for i in 0..10 {
+            let t = t0 + Duration::from_millis(i * 100);
+            assert!(matches!(d.on_char('a', t), BurstDecision::Normal));
+        }
+        assert!(!d.is_active());
+    }
+
+    #[test]
+    fn fast_chars_trigger_burst() {
+        let mut d = PasteBurstDetector::new();
+        let t0 = Instant::now();
+        // First 2 chars: not yet burst
+        assert!(matches!(d.on_char('a', t0), BurstDecision::Normal));
+        assert!(matches!(
+            d.on_char('b', t0 + Duration::from_millis(2)),
+            BurstDecision::Normal
+        ));
+        // Third char triggers burst
+        assert!(matches!(
+            d.on_char('c', t0 + Duration::from_millis(4)),
+            BurstDecision::Buffered
+        ));
+        assert!(d.is_active());
+    }
+
+    #[test]
+    fn flush_after_idle() {
+        let mut d = PasteBurstDetector::new();
+        let t0 = Instant::now();
+        d.on_char('a', t0);
+        d.on_char('b', t0 + Duration::from_millis(2));
+        d.on_char('c', t0 + Duration::from_millis(4));
+        d.on_char('d', t0 + Duration::from_millis(6));
+
+        // Not yet idle enough
+        assert!(d.flush_if_due(t0 + Duration::from_millis(10)).is_none());
+
+        // Now idle
+        let flushed = d.flush_if_due(t0 + Duration::from_millis(20));
+        assert_eq!(flushed.as_deref(), Some("cd"));
+        assert!(!d.is_active());
+    }
+
+    #[test]
+    fn enter_suppressed_during_burst() {
+        let mut d = PasteBurstDetector::new();
+        let t0 = Instant::now();
+        d.on_char('a', t0);
+        d.on_char('b', t0 + Duration::from_millis(2));
+        d.on_char('c', t0 + Duration::from_millis(4));
+        assert!(d.enter_should_insert_newline(t0 + Duration::from_millis(5)));
+    }
+
+    #[test]
+    fn enter_suppressed_in_grace_window_after_flush() {
+        let mut d = PasteBurstDetector::new();
+        let t0 = Instant::now();
+        d.on_char('a', t0);
+        d.on_char('b', t0 + Duration::from_millis(2));
+        d.on_char('c', t0 + Duration::from_millis(4));
+        d.flush_if_due(t0 + Duration::from_millis(20));
+
+        // Within 120ms of flush
+        assert!(d.enter_should_insert_newline(t0 + Duration::from_millis(100)));
+        // After 120ms
+        assert!(!d.enter_should_insert_newline(t0 + Duration::from_millis(200)));
+    }
+}

--- a/rust/crates/astra-cli/src/tui/bottom_pane/textarea.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/textarea.rs
@@ -1,10 +1,13 @@
 use std::cell::RefCell;
 use std::ops::Range;
+use std::time::Instant;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{buffer::Buffer, layout::Rect, style::Style};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
+
+use super::paste_burst::{BurstDecision, PasteBurstDetector};
 
 const WORD_SEPARATORS: &str = "`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?";
 
@@ -18,6 +21,7 @@ pub(crate) struct TextArea {
     wrap_cache: RefCell<Option<WrapCache>>,
     kill_buffer: String,
     scroll: u16,
+    paste_burst: PasteBurstDetector,
 }
 
 #[derive(Debug)]
@@ -35,6 +39,7 @@ impl TextArea {
             wrap_cache: RefCell::new(None),
             kill_buffer: String::new(),
             scroll: 0,
+            paste_burst: PasteBurstDetector::new(),
         }
     }
 
@@ -75,6 +80,24 @@ impl TextArea {
 
     // ─── Input handling ─────────────────────────────────────────────────
 
+    pub fn flush_paste_burst(&mut self) -> bool {
+        let now = Instant::now();
+        if let Some(text) = self.paste_burst.flush_if_due(now) {
+            self.insert_str(&text);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn paste_burst_active(&self) -> bool {
+        self.paste_burst.is_active()
+    }
+
+    pub fn paste_burst_tick_ms() -> u64 {
+        PasteBurstDetector::recommended_tick_ms()
+    }
+
     pub fn handle_key(&mut self, key: KeyEvent) -> TextAreaAction {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         let shift = key.modifiers.contains(KeyModifiers::SHIFT);
@@ -85,7 +108,15 @@ impl TextArea {
                 self.insert_char('\n');
                 TextAreaAction::Changed
             }
-            KeyCode::Enter => TextAreaAction::Submit,
+            KeyCode::Enter => {
+                let now = Instant::now();
+                if self.paste_burst.enter_should_insert_newline(now) {
+                    self.insert_char('\n');
+                    TextAreaAction::Changed
+                } else {
+                    TextAreaAction::Submit
+                }
+            }
 
             // Emacs keybindings
             KeyCode::Char('c') if ctrl => TextAreaAction::Cancel,
@@ -143,7 +174,17 @@ impl TextArea {
                 TextAreaAction::Changed
             }
 
-            // Basic editing
+            // Basic editing — route through paste burst detector
+            KeyCode::Char(c) if !ctrl && !alt => {
+                let now = Instant::now();
+                match self.paste_burst.on_char(c, now) {
+                    BurstDecision::Normal => {
+                        self.insert_char(c);
+                        TextAreaAction::Changed
+                    }
+                    BurstDecision::Buffered => TextAreaAction::Changed,
+                }
+            }
             KeyCode::Char(c) => {
                 self.insert_char(c);
                 TextAreaAction::Changed

--- a/rust/crates/astra-cli/src/tui/chat_widget/snapshots/astra__tui__chat_widget__turn_driver__canonical_turn_80.snap
+++ b/rust/crates/astra-cli/src/tui/chat_widget/snapshots/astra__tui__chat_widget__turn_driver__canonical_turn_80.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astra-cli/src/tui/chat_widget/turn_driver.rs
+assertion_line: 138
 expression: "render_history(&w, 80)"
 ---
 › run ls
@@ -8,6 +9,6 @@ expression: "render_history(&w, 80)"
   │ ls /tmp
   └ 3 entries
 
-┃ There are 3 files.
+█ There are 3 files.
 
   ─ ⏱ 1.2s (ttft 400ms) │ ⚡  240 ↑200 ↓40 │ 🛠 1 │ Σ 240 ─

--- a/rust/crates/astra-cli/src/tui/history_cell/assistant.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/assistant.rs
@@ -12,7 +12,7 @@
 //! thinking window). One source of truth, one render path. See
 //! `docs/design/tui-refactor.md` §3.3.
 //!
-//! Reply body is rendered with a `┃ ` accent-gutter Cursor-style,
+//! Reply body is rendered with a `█ ` accent-gutter block-style,
 //! matching existing visual grammar. A trailing blinking cursor
 //! block (`▎`) is appended to the final rendered line while the
 //! cell is still live, as a "more is coming" cue.
@@ -39,7 +39,7 @@
 use std::any::Any;
 use std::time::Instant;
 
-use ratatui::style::{Color, Modifier, Style, Stylize};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use super::HistoryCell;
@@ -363,9 +363,9 @@ fn rhythm_dots_span() -> Span<'static> {
 }
 
 /// Render the reply body. Settled (scrollback) cells get a static
-/// `┃ ` accent gutter on every line. Live cells drop the gutter —
+/// `█ ` accent gutter on every line. Live cells drop the gutter —
 /// the active-slot wrapper (`tui::LiveFramedCell`) paints its own
-/// gradient `┃` at the same column, and stacking both produces a
+/// gradient `█` at the same column, and stacking both produces a
 /// visible double bar.
 fn render_body_with_gutter(
     source: &str,
@@ -376,15 +376,20 @@ fn render_body_with_gutter(
     if source.trim().is_empty() {
         return Vec::new();
     }
-    // When the cell owns the gutter, reserve 2 cols for `┃ `. While
-    // live, the active-slot wrapper (`tui::LiveFramedCell`) has
-    // *already* subtracted those 2 cols from the `width` it forwarded
-    // via `display_lines`, so on both paths `width` is the inner
-    // width — apply the floor uniformly. Keeping the two paths on the
-    // same `inner_w` formula prevents a one-column re-wrap when a
+    // Settled cells prepend `█ ` (2 cols) to every line, so wrap text
+    // at `width - 2` to avoid terminal hard-wrap overflow. Live cells
+    // already receive `width - 2` from `active_viewport` (the
+    // `LiveFramedCell` wrapper paints its own gutter column) — so the
+    // asymmetry below is intentional. Do *not* "unify" the arms by
+    // adding `saturating_sub(2)` to both: that double-subtracts on
+    // the live path and re-introduces a one-column re-wrap when a
     // cell transitions live → settled near the floor boundary.
     let prepend_gutter = !live;
-    let inner_w = (width as usize).max(20);
+    let inner_w = if prepend_gutter {
+        (width as usize).saturating_sub(2).max(20)
+    } else {
+        (width as usize).max(20)
+    };
     let text = render_markdown_text_with_width(source, Some(inner_w));
     let rendered: Vec<Line<'static>> = text.lines.iter().map(line_to_static).collect();
 
@@ -393,7 +398,7 @@ fn render_body_with_gutter(
     }
 
     let theme = crate::tui::theme::current();
-    let gutter_style = Style::default().fg(theme.gutter).bold();
+    let gutter_style = Style::default().fg(theme.gutter_frozen);
     let dim = Style::default().fg(Color::DarkGray);
     let last_idx = rendered.len() - 1;
 
@@ -403,7 +408,7 @@ fn render_body_with_gutter(
         .map(|(i, line)| {
             let mut spans: Vec<Span<'static>> = Vec::with_capacity(line.spans.len() + 3);
             if prepend_gutter {
-                spans.push(Span::styled("┃ ", gutter_style));
+                spans.push(Span::styled("█ ", gutter_style));
             }
             spans.extend(line.spans.iter().cloned());
             // Trailing rhythm-dot indicator + tok/s suffix on the
@@ -588,8 +593,8 @@ mod tests {
         let out = render(&c, 60, 4);
         for row in out.lines().filter(|l| !l.is_empty()) {
             assert!(
-                row.starts_with('┃'),
-                "every rendered row needs the ┃ gutter: {row:?}"
+                row.starts_with('█'),
+                "every rendered row needs the █ gutter: {row:?}"
             );
         }
     }
@@ -771,9 +776,9 @@ mod tests {
             out.contains("step one"),
             "earlier line must stay visible under the window cap: {out}"
         );
-        // Body hasn't arrived yet — no `┃ ` gutter.
+        // Body hasn't arrived yet — no `█ ` gutter.
         assert!(
-            !out.contains('┃'),
+            !out.contains('█'),
             "body gutter shouldn't render while still thinking: {out}"
         );
     }

--- a/rust/crates/astra-cli/src/tui/history_cell/mod.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/mod.rs
@@ -125,7 +125,7 @@ pub(crate) trait HistoryCell: Debug + Send + Sync + Any {
 ///   * `revived()` — launch-independent sentinel for cells rebuilt
 ///     from persistence. Note: revived cells are *settled*, not
 ///     active — they render through `display_lines` directly with a
-///     static `┃` marker, not the animated gradient. The stamp
+///     static `█` marker, not the animated gradient. The stamp
 ///     exists so that if a revived cell is ever (incorrectly) routed
 ///     through the active slot it still produces a deterministic,
 ///     non-flickering hue.

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_inline_code_60.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_inline_code_60.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/assistant.rs
+assertion_line: 926
 expression: "render(&c, 60, 2)"
 ---
-┃ Use cargo build to compile the project.
+█ Use cargo build to compile the project.

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_paragraph_60.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_paragraph_60.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/assistant.rs
+assertion_line: 920
 expression: "render(&c, 60, 5)"
 ---
-┃ Here is the plan:
-┃ • step one
-┃ • step two
+█ Here is the plan:
+█ • step one
+█ • step two

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_think_closed_60.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_think_closed_60.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/assistant.rs
+assertion_line: 934
 expression: "render(&c, 60, 3)"
 ---
   ✻ Thought (2 lines)
-┃ Hello — happy to help.
+█ Hello — happy to help.

--- a/rust/crates/astra-cli/src/tui/mod.rs
+++ b/rust/crates/astra-cli/src/tui/mod.rs
@@ -72,7 +72,7 @@ use frame_requester::FrameRequester;
 /// - **Settled** (not represented here) — committed `HistoryCell`s
 ///   already painted to terminal scrollback. Flat, no border.
 /// - **Active** — something's happening right now. Rendered with a
-///   left `┃` gutter whose colour gradient flows while live and
+///   left `█` gutter whose colour gradient flows while live and
 ///   freezes in place on completion.
 /// - **Status** — a one-line indicator (`✶ Thinking …`) when we
 ///   have a turn in flight but no cell content yet. No border —
@@ -106,7 +106,7 @@ fn active_viewport(
     width: u16,
 ) -> ActiveView {
     if let Some(cell) = chat_widget.active_cell() {
-        // Reserve 2 cols for the `┃ ` gutter.
+        // Reserve 2 cols for the `█ ` gutter.
         let inner_w = width.saturating_sub(2).max(20);
         let lines = cell.display_lines(inner_w);
         if !lines.is_empty() {
@@ -1399,7 +1399,7 @@ pub(crate) async fn run_tui(
     result
 }
 
-/// Left-gutter renderable: a single `┃` bar on the left edge with a
+/// Left-gutter renderable: a solid `█` bar on the left edge with a
 /// top-to-bottom colour gradient. While the cell is still streaming
 /// (`live == true`) the gradient flows downward over time; once
 /// finalized (`live == false`) the gradient freezes in place so there
@@ -1419,14 +1419,14 @@ impl render::renderable::Renderable for LiveFramedCell {
     fn render(&self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         use ratatui::widgets::{Paragraph, Widget};
 
-        // Need at least 3 cols: `┃` + space + 1 col of content.
+        // Need at least 3 cols: `█` + space + 1 col of content.
         // At width < 3 the inner paragraph would be empty, leaving a
         // lone gutter bar with no body — drop the frame entirely.
         if area.width < 3 || area.height == 0 {
             return;
         }
 
-        // Inner paragraph area: 2 cols reserved for `┃ ` on the left.
+        // Inner paragraph area: 2 cols reserved for `█ ` on the left.
         // `saturating_sub` is defense-in-depth: the `width < 3` guard
         // above already guarantees `width >= 3`, but a future edit
         // that loosens the guard mustn't UB here.
@@ -1453,7 +1453,7 @@ impl render::renderable::Renderable for LiveFramedCell {
         for row in 0..height {
             let (r, g, b) = shimmer::gradient_color_at_t(row, height.max(1), period, t);
             let color = ratatui::style::Color::Rgb(r, g, b);
-            set_char(buf, area.x, area.y + row as u16, '┃', color);
+            set_char(buf, area.x, area.y + row as u16, '█', color);
         }
     }
 
@@ -1499,7 +1499,7 @@ pub(super) fn do_draw(
             let para = Paragraph::new(ratatui::text::Text::from(vec![line]));
             RenderableItem::Owned(Box::new(para))
         }
-        // Active cell: left `┃` gutter with flowing gradient while
+        // Active cell: left `█` gutter with flowing gradient while
         // live, freezing in place on completion.
         ActiveView::Active {
             lines,

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -7,8 +7,8 @@
 
 use crate::command_registry;
 use crate::session_state::SessionState;
-use crate::tui::bottom_pane::list_selection_view::{ListSelectionView, SelectionItem};
 use crate::tui::bottom_pane::BottomPane;
+use crate::tui::bottom_pane::list_selection_view::{ListSelectionView, SelectionItem};
 use crate::tui::history_cell::system::SystemCell;
 use crate::tui::terminal::TerminalGuard;
 
@@ -481,7 +481,7 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
         // ── Worktrees (TUI-native) ──────────────────────────────────
         "/worktrees" => {
             use crate::tui::bottom_pane::worktrees_view::WorktreesView;
-            use crate::tui::worktrees::{parse, WorktreeList};
+            use crate::tui::worktrees::{WorktreeList, parse};
 
             // `git worktree list --porcelain` on a blocking thread.
             let porcelain = tokio::task::spawn_blocking(|| {

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -1324,17 +1324,49 @@ async fn open_model_picker(ctx: &mut DispatchContext<'_>) -> SlashResult {
                 || lower.contains("status code: 401")
                 || lower.contains("http 401")
                 || lower.contains("unauthorized");
-            let short = if is_auth {
-                "Not authorized — try /login first".to_string()
+            if is_auth {
+                // Attempt silent token refresh + retry once.
+                if crate::session_runtime::attempt_token_refresh(ctx.api, ctx.profile).await {
+                    let fresh = crate::session_runtime::current_access_token(ctx.profile);
+                    if let Ok(models) =
+                        crate::slash_router::fetch_model_list(ctx.api, fresh.as_deref()).await
+                    {
+                        let current_raw = ctx.state.model.clone().unwrap_or_default();
+                        let current_base = current_raw
+                            .split_once("-thinking:")
+                            .map(|(b, _)| b.to_string())
+                            .unwrap_or(current_raw);
+                        let items: Vec<SelectionItem> = models
+                            .into_iter()
+                            .map(|m| {
+                                let is_current = m == current_base;
+                                SelectionItem {
+                                    name: m,
+                                    description: None,
+                                    is_current,
+                                }
+                            })
+                            .collect();
+                        if items.is_empty() {
+                            ctx.show_info("No models available".into());
+                        } else {
+                            let view =
+                                ListSelectionView::new(items, Some("Select model:".into()))
+                                    .with_result_prefix(MODEL_PICK_SENTINEL);
+                            ctx.bottom_pane.push_view(Box::new(view));
+                        }
+                        return SlashResult::Handled;
+                    }
+                }
+                ctx.show_error("Not authorized — try /login first".into());
             } else if msg.contains("connect") || msg.contains("timeout") {
-                "Cannot reach server — check connection".to_string()
+                ctx.show_error("Cannot reach server — check connection".into());
             } else {
-                format!(
+                ctx.show_error(format!(
                     "Failed to fetch models: {}",
                     msg.lines().next().unwrap_or(&msg)
-                )
-            };
-            ctx.show_error(short);
+                ));
+            }
         }
     }
     SlashResult::Handled

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -7,8 +7,8 @@
 
 use crate::command_registry;
 use crate::session_state::SessionState;
-use crate::tui::bottom_pane::BottomPane;
 use crate::tui::bottom_pane::list_selection_view::{ListSelectionView, SelectionItem};
+use crate::tui::bottom_pane::BottomPane;
 use crate::tui::history_cell::system::SystemCell;
 use crate::tui::terminal::TerminalGuard;
 
@@ -481,7 +481,7 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
         // ── Worktrees (TUI-native) ──────────────────────────────────
         "/worktrees" => {
             use crate::tui::bottom_pane::worktrees_view::WorktreesView;
-            use crate::tui::worktrees::{WorktreeList, parse};
+            use crate::tui::worktrees::{parse, WorktreeList};
 
             // `git worktree list --porcelain` on a blocking thread.
             let porcelain = tokio::task::spawn_blocking(|| {
@@ -1284,78 +1284,77 @@ pub(crate) const MODEL_THINKING_SENTINEL: &str = "__model_thinking__\n";
 /// the picker.  The picker emits `MODEL_PICK_SENTINEL + <name>`; the
 /// outer loop then checks the model's `thinking_capability` and
 /// either commits or pushes a thinking-mode picker.
+/// True when an error string came from an HTTP 401 response.
+/// Mirrors `chat_turn::is_auth_error` minus the LLM-provider escape — kept
+/// local because slash dispatch only sees `fetch_model_list` errors which
+/// never come from upstream model providers.
+fn is_http_401(msg: &str) -> bool {
+    let lower = msg.to_lowercase();
+    lower.contains("401 unauthorized")
+        || lower.contains("status: 401")
+        || lower.contains("status code: 401")
+        || lower.contains("http 401")
+        || lower.contains("unauthorized")
+}
+
+/// Build the model picker view from a fetched model list and push it.
+fn push_model_picker(ctx: &mut DispatchContext<'_>, models: Vec<String>) {
+    // Strip any `-thinking:*` suffix from the cached model when
+    // highlighting the current row — the picker shows base names only,
+    // and the suffix is re-applied by the thinking stage.
+    let current_raw = ctx.state.model.clone().unwrap_or_default();
+    let current_base = current_raw
+        .split_once("-thinking:")
+        .map(|(b, _)| b.to_string())
+        .unwrap_or(current_raw);
+    let items: Vec<SelectionItem> = models
+        .into_iter()
+        .map(|m| {
+            let is_current = m == current_base;
+            SelectionItem {
+                name: m,
+                description: None,
+                is_current,
+            }
+        })
+        .collect();
+    if items.is_empty() {
+        ctx.show_info("No models available".into());
+    } else {
+        let view = ListSelectionView::new(items, Some("Select model:".into()))
+            .with_result_prefix(MODEL_PICK_SENTINEL);
+        ctx.bottom_pane.push_view(Box::new(view));
+    }
+}
+
 async fn open_model_picker(ctx: &mut DispatchContext<'_>) -> SlashResult {
     let token = crate::session_runtime::current_access_token(ctx.profile);
     match crate::slash_router::fetch_model_list(ctx.api, token.as_deref()).await {
-        Ok(models) => {
-            // Strip any `-thinking:*` suffix from the cached model
-            // when highlighting the current row — the picker shows
-            // base names only, and the suffix is re-applied by the
-            // thinking stage.
-            let current_raw = ctx.state.model.clone().unwrap_or_default();
-            let current_base = current_raw
-                .split_once("-thinking:")
-                .map(|(b, _)| b.to_string())
-                .unwrap_or(current_raw);
-            let items: Vec<SelectionItem> = models
-                .into_iter()
-                .map(|m| {
-                    let is_current = m == current_base;
-                    SelectionItem {
-                        name: m,
-                        description: None,
-                        is_current,
-                    }
-                })
-                .collect();
-            if items.is_empty() {
-                ctx.show_info("No models available".into());
-            } else {
-                let view = ListSelectionView::new(items, Some("Select model:".into()))
-                    .with_result_prefix(MODEL_PICK_SENTINEL);
-                ctx.bottom_pane.push_view(Box::new(view));
-            }
-        }
+        Ok(models) => push_model_picker(ctx, models),
         Err(e) => {
             let msg = e.to_string();
-            let lower = msg.to_lowercase();
-            let is_auth = lower.contains("401 unauthorized")
-                || lower.contains("status: 401")
-                || lower.contains("status code: 401")
-                || lower.contains("http 401")
-                || lower.contains("unauthorized");
-            if is_auth {
-                // Attempt silent token refresh + retry once.
+            if is_http_401(&msg) {
+                // Attempt silent token refresh + retry once. If the retry
+                // itself fails with a non-auth error (e.g. 5xx after refresh),
+                // surface that real error instead of the generic /login hint.
                 if crate::session_runtime::attempt_token_refresh(ctx.api, ctx.profile).await {
                     let fresh = crate::session_runtime::current_access_token(ctx.profile);
-                    if let Ok(models) =
-                        crate::slash_router::fetch_model_list(ctx.api, fresh.as_deref()).await
-                    {
-                        let current_raw = ctx.state.model.clone().unwrap_or_default();
-                        let current_base = current_raw
-                            .split_once("-thinking:")
-                            .map(|(b, _)| b.to_string())
-                            .unwrap_or(current_raw);
-                        let items: Vec<SelectionItem> = models
-                            .into_iter()
-                            .map(|m| {
-                                let is_current = m == current_base;
-                                SelectionItem {
-                                    name: m,
-                                    description: None,
-                                    is_current,
-                                }
-                            })
-                            .collect();
-                        if items.is_empty() {
-                            ctx.show_info("No models available".into());
-                        } else {
-                            let view =
-                                ListSelectionView::new(items, Some("Select model:".into()))
-                                    .with_result_prefix(MODEL_PICK_SENTINEL);
-                            ctx.bottom_pane.push_view(Box::new(view));
+                    match crate::slash_router::fetch_model_list(ctx.api, fresh.as_deref()).await {
+                        Ok(models) => {
+                            push_model_picker(ctx, models);
+                            return SlashResult::Handled;
                         }
-                        return SlashResult::Handled;
+                        Err(retry_err) => {
+                            let retry_msg = retry_err.to_string();
+                            if !is_http_401(&retry_msg) {
+                                ctx.show_error(format!(
+                                    "Failed to fetch models: {}",
+                                    retry_msg.lines().next().unwrap_or(&retry_msg)
+                                ));
+                                return SlashResult::Handled;
+                            }
+                            // Still 401 after refresh — fall through to /login hint.
+                        }
                     }
                 }
                 ctx.show_error("Not authorized — try /login first".into());

--- a/rust/crates/astra-cli/src/tui/theme.rs
+++ b/rust/crates/astra-cli/src/tui/theme.rs
@@ -36,8 +36,10 @@ pub(crate) struct Theme {
     pub selected_bg: Color,
     /// Foreground on top of `selected_bg`. Guaranteed readable.
     pub selected_fg: Color,
-    /// Gutter indicator colour (same as accent in current presets).
+    /// Gutter indicator colour for live (streaming) cells.
     pub gutter: Color,
+    /// Muted gutter colour for settled (frozen) cells.
+    pub gutter_frozen: Color,
     pub success: Color,
     pub warn: Color,
     pub error: Color,
@@ -58,12 +60,14 @@ impl Theme {
             // Clearly visible grey band for user input (matches Claude Code).
             selected_bg: Color::Rgb(55, 55, 60),
             selected_fg: Color::Rgb(232, 220, 245),
-            // Soft pink for the assistant-reply gutter (`┃ `) — reads
-            // clearly on any dark terminal background while feeling
-            // warmer than the previous cyan accent and providing a
-            // visual break between the composer accent (cyan) and
-            // the model's output.
+            // Soft pink for the live gutter (`█`) — reads clearly on
+            // any dark terminal background while feeling warmer than
+            // the previous cyan accent.
             gutter: Color::Rgb(246, 168, 195),
+            // Muted lavender for settled cells — visually distinct
+            // from the live gradient but still recognisable as the
+            // assistant's voice.
+            gutter_frozen: Color::Rgb(140, 120, 160),
             success: Color::Green,
             warn: Color::Yellow,
             error: Color::Red,
@@ -82,6 +86,7 @@ impl Theme {
             selected_bg: Color::Rgb(245, 232, 250),
             selected_fg: Color::Rgb(24, 17, 35),
             gutter: Color::Rgb(180, 60, 120),
+            gutter_frozen: Color::Rgb(130, 90, 120),
             success: Color::Rgb(22, 115, 46),
             warn: Color::Rgb(135, 89, 0),
             error: Color::Rgb(170, 34, 34),


### PR DESCRIPTION
## Summary

- **Solid block gutter** (`┃` → `█`) with colour split: live cells get an animated rainbow gradient, settled cells get a muted lavender. Fixes wrap overflow bug (settled path was wrapping at full terminal width then prepending 2-char gutter).
- **Auth error discrimination**: LLM provider 401s (Bedrock/Anthropic API key expired) no longer trigger the misleading "Session expired. Run /login" loop. Shows "LLM provider credentials invalid" instead.
- **/model token refresh**: `/model` now silently refreshes the astra JWT on 401 before giving up, matching the chat-turn retry behavior.
- **Paste burst detection**: buffers rapid keystrokes (≥3 chars within 8ms) to prevent accidental Enter-submit on terminals without bracketed paste. Enter suppressed during burst + 120ms grace window.
- **Paste folding threshold**: lowered to match Claude Code — >800 chars OR >2 lines folds to `[Pasted #N · M lines]` placeholder. Fixes line counting with proper `\r\n`-aware scan.

## Test plan

- [x] `cargo clippy -p astra-cli -- -D warnings` — clean
- [x] All 738 TUI tests pass (`cargo test -p astra-cli -- tui`)
- [x] 5 new paste burst unit tests
- [x] 1 new auth predicate regression test
- [x] Manual: paste multi-line content → shows placeholder, submits full text
- [x] Manual: gutter renders as solid block with gradient while streaming