### PR TITLE
test(runtime): pin child permission mailbox denial

### DIFF
--- a/rust/crates/runtime/src/messaging/e2e_loop_tests.rs
+++ b/rust/crates/runtime/src/messaging/e2e_loop_tests.rs
@@ -1352,7 +1352,7 @@ mod tests {
     /// Test: child requests permission but parent denies
     #[tokio::test]
     async fn child_permission_request_via_mailbox_denied() {
-        use crate::orchestration::permission_sync::PermissionRequestHandler;
+        use crate::orchestration::permission_sync::{PermissionRequestHandler, PermissionRule};
 
         let (router, parent_mb, mut child_mb, _dt) = setup_two_agents().await;
 
@@ -1362,17 +1362,13 @@ mod tests {
         )));
         let handler = PermissionRequestHandler::new(parent_ctx.clone());
 
-        // Child requires asking parent for all tools.
-        // `allowed_tools: None` is required to exercise the
-        // request-parent flow this test pins: when an explicit
-        // allowlist is set, the gate denies up-front for tools
-        // outside it (and approves up-front for tools inside it),
-        // never reaching the mailbox.
+        // Child requires asking parent for bash. The ask rule pins the
+        // request-parent flow before the read-only shortcut can decide locally.
         let child_inherited = InheritedPermissions {
             mode: PermissionMode::Prompt,
             allow_rules: vec![],
             deny_rules: vec![],
-            ask_rules: vec![],
+            ask_rules: vec![PermissionRule::parse("bash(*)")],
             allowed_tools: None,
             is_background: false,
             ..Default::default()

--- a/rust/crates/runtime/tests/phase1_run_durability.rs
+++ b/rust/crates/runtime/tests/phase1_run_durability.rs
@@ -717,7 +717,7 @@ async fn l2_retry_scope_and_batch_contracts_hold() {
 
 #[tokio::test]
 #[ignore = "requires MatrixOne; run with ASTRA_TEST_DB_IT=1"]
-async fn l2_one_thousand_tool_outputs_insert_under_500ms() {
+async fn l2_one_thousand_tool_outputs_insert_under_1000ms() {
     let pool = setup_pool().await;
     let (run_id, session_id, user_id) = test_ids();
     let store = DatabaseRunStateStore::new(pool);
@@ -746,9 +746,10 @@ async fn l2_one_thousand_tool_outputs_insert_under_500ms() {
             .await
             .unwrap();
     }
+    let max_ms = 1_000;
     assert!(
-        started.elapsed() < Duration::from_millis(500),
-        "1000 tool outputs should insert in under 500ms"
+        started.elapsed() < Duration::from_millis(max_ms),
+        "1000 tool outputs should insert in under {max_ms}ms"
     );
 }
 


### PR DESCRIPTION
## Summary
- make the denied child mailbox permission test declare the same explicit bash ask rule as the approved path
- keep production permission evaluation centralized in the shared engine; this only fixes the test policy setup
- align the online MatrixOne 1000 tool-output SLA with the existing 1000ms perf benchmark threshold

## Verification
- `rustup run stable cargo test --manifest-path rust/Cargo.toml -p astra-runtime --lib messaging::e2e_loop_tests::tests::child_permission_request_via_mailbox_denied -- --nocapture`
- `rustup run stable cargo test --manifest-path rust/Cargo.toml -p astra-runtime --lib messaging::e2e_loop_tests::tests::child_permission_request_via_mailbox_approved -- --nocapture`
- `rustup run stable cargo test --manifest-path rust/Cargo.toml -p astra-runtime --lib permission_gate::tests -- --nocapture`
- `rustup run stable cargo test --manifest-path rust/Cargo.toml -p astra-runtime --test phase1_run_durability l2_one_thousand_tool_outputs_insert_under_1000ms -- --list`