### PR TITLE
fix(dev-deps): use Docker named volume for MatrixOne /mo-data

### DIFF
--- a/deployment/all-in-one/docker-compose.deps.yml
+++ b/deployment/all-in-one/docker-compose.deps.yml
@@ -13,7 +13,7 @@ services:
     user: root
     entrypoint: ["sh", "-c", "chown -R ${UID:-1000}:${GID:-1000} /mo-data && mkdir -p /mo-logs && chown -R ${UID:-1000}:${GID:-1000} /mo-logs"]
     volumes:
-      - ${MATRIXONE_DATA_DIR:-./data/matrixone}:/mo-data
+      - matrixone-data:/mo-data
       - ${MATRIXONE_LOG_DIR:-./data/matrixone/logs}:/mo-logs
     networks:
       - mo-net
@@ -31,7 +31,7 @@ services:
       - "${MATRIXONE_PORT:-6001}:6001"
       - "${MATRIXONE_DEBUG_HTTP_PORT:-6060}:6060"
     volumes:
-      - ${MATRIXONE_DATA_DIR:-./data/matrixone}:/mo-data
+      - matrixone-data:/mo-data
       - ${MATRIXONE_LOG_DIR:-./data/matrixone/logs}:/mo-logs
       - ./matrixone-entrypoint.sh:/entrypoint.sh:ro
     environment:
@@ -92,3 +92,10 @@ services:
 networks:
   mo-net:
     driver: bridge
+
+volumes:
+  # /mo-data lives in a Docker-managed volume rather than a host bind mount.
+  # On macOS, bind mounts go through Docker's file-sharing layer which doesn't
+  # fully support the syscalls dragonboat/pebble use, causing the logservice
+  # to panic with "operation not supported" at startup.
+  matrixone-data:


### PR DESCRIPTION
## Summary

- `make dev-deps-up` reliably fails on macOS: MatrixOne's logservice panics at startup with `panic: operation not supported` from dragonboat's HAKeeper bootstrap, even on a freshly-wiped data dir.
- Root cause: bind-mounting `/mo-data` through Docker Desktop's file-sharing layer (virtiofs/osxfs) doesn't fully support the fsync / file-locking syscalls that dragonboat/pebble require. The container restart-loops, `dev-deps-up` reports "container is unhealthy", and the dev workflow is blocked.
- Fix: move `/mo-data` to a Docker-managed named volume (`matrixone-data`), which lives on the Linux VM's native filesystem. `/mo-logs` stays bind-mounted so host-side log tailing still works.

This is platform-neutral: named volumes work the same on Linux, just with the data living under `/var/lib/docker/volumes/` instead of `./deployment/all-in-one/data/matrixone/`. Existing host-side dev data is not migrated — anyone with state worth keeping should dump/restore before pulling.

## Test plan

- [x] `make dev-deps-up` on macOS — MatrixOne reaches `healthy`, Memoria starts, port 6001 reachable.
- [x] `make dev-deps-down` cleanly tears down containers and network.
- [ ] Sanity check on Linux: `make dev-deps-up` still works (named volumes are a Docker primitive — should be uneventful).
- [ ] Run a quick MatrixOne smoke query (`mysql -h 127.0.0.1 -P 6001 -uroot -p111 -e 'SHOW DATABASES'`) post-startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
