### PR TITLE
fix(tools): tighten write_file schema + error recovery to prevent shell escalation

### DIFF
--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -4362,6 +4362,10 @@ mod tests {
     fn sandbox_expand_prompt_mode_needs_approval() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+        // Clear user settings so that ~/.astra/permissions.json allow rules (e.g.
+        // `sandbox_expand:bash` granted in a previous interactive session) do not
+        // bypass the prompt in this isolated unit test.
+        pm.replace_user_settings(PermissionSettings::default());
         let args = serde_json::json!({"reason": "path outside project"});
         let decision = pm.check_nonblocking("sandbox_expand:bash", &args);
         match decision {

--- a/rust/crates/astra-tools/src/executor.rs
+++ b/rust/crates/astra-tools/src/executor.rs
@@ -405,7 +405,17 @@ impl DefaultToolExecutor {
         match name {
             // ── File operations ──────────────────────────────────────
             "read_file" => crate::fs_ops::read_file(ws, args),
-            "write_file" => crate::fs_ops::write_file(ws, args),
+            "write_file" => {
+                if args
+                    .get("delete")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
+                    crate::fs_ops::delete_file(ws, args)
+                } else {
+                    crate::fs_ops::write_file(ws, args)
+                }
+            }
             "str_replace" => crate::fs_ops::str_replace(ws, args),
             "delete_file" => crate::fs_ops::delete_file(ws, args),
             "list_dir" => crate::fs_ops::list_dir(ws, args),
@@ -759,6 +769,101 @@ mod tests {
             .await;
         assert!(!result.is_error);
         assert!(tmp.path().join("out.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn dispatch_write_file_delete_flag_routes_to_delete() {
+        let (tmp, exec) = test_executor();
+        let target = tmp.path().join("gone.txt");
+        std::fs::write(&target, "data").unwrap();
+
+        let result = exec
+            .execute(
+                "write_file",
+                &serde_json::json!({"path": "gone.txt", "delete": true}),
+            )
+            .await;
+
+        assert!(!result.is_error, "got: {}", result.output);
+        assert!(
+            result.output.contains("Successfully deleted"),
+            "delete=true should route to delete semantics: {}",
+            result.output
+        );
+        assert!(
+            !target.exists(),
+            "delete=true should remove the target file"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_write_file_delete_false_routes_to_write() {
+        let (tmp, exec) = test_executor();
+        let result = exec
+            .execute(
+                "write_file",
+                &serde_json::json!({"path": "test.txt", "content": "hello", "delete": false}),
+            )
+            .await;
+        assert!(!result.is_error, "got: {}", result.output);
+        assert!(
+            tmp.path().join("test.txt").exists(),
+            "delete=false should write the file"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_write_file_delete_string_not_coerced() {
+        let (tmp, exec) = test_executor();
+        let result = exec
+            .execute(
+                "write_file",
+                &serde_json::json!({"path": "test.txt", "content": "hello", "delete": "true"}),
+            )
+            .await;
+        assert!(!result.is_error, "got: {}", result.output);
+        assert!(
+            tmp.path().join("test.txt").exists(),
+            "delete=\\\"true\\\" (string) must not be coerced to boolean — should write"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_write_file_content_and_delete_true_delete_wins() {
+        let (tmp, exec) = test_executor();
+        let target = tmp.path().join("exists.txt");
+        std::fs::write(&target, "original").unwrap();
+        let result = exec
+            .execute(
+                "write_file",
+                &serde_json::json!({"path": "exists.txt", "content": "new content", "delete": true}),
+            )
+            .await;
+        assert!(!result.is_error, "got: {}", result.output);
+        assert!(
+            !target.exists(),
+            "delete=true wins over content: file should be deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_write_file_delete_path_traversal_blocked() {
+        let (_tmp, exec) = test_executor();
+        let result = exec
+            .execute(
+                "write_file",
+                &serde_json::json!({"path": "../../etc/passwd", "delete": true}),
+            )
+            .await;
+        assert!(
+            result.is_error,
+            "path traversal via write_file delete routing must be blocked"
+        );
+        assert!(
+            result.output.contains("SANDBOX_DENIED"),
+            "should report SANDBOX_DENIED: {}",
+            result.output
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/astra-tools/src/fs_ops.rs
+++ b/rust/crates/astra-tools/src/fs_ops.rs
@@ -660,13 +660,17 @@ pub fn prepare_write_file(
 ) -> Result<PreparedWriteFile, ToolResult> {
     let path_str = match args.get("path").and_then(|v| v.as_str()) {
         Some(p) => p,
-        None => return Err(ToolResult::error("Error: Missing 'path' parameter".into())),
+        None => {
+            return Err(ToolResult::error(
+                "Error: Missing 'path' parameter. Retry write_file with both path and content. Do not switch to bash or python just to write this file.".into(),
+            ));
+        }
     };
     let content = match args.get("content").and_then(|v| v.as_str()) {
         Some(c) => c,
         None => {
             return Err(ToolResult::error(
-                "Error: Missing 'content' parameter".into(),
+                "Error: Missing 'content' parameter. Retry write_file with both path and content. Do not switch to bash or python just to write this file.".into(),
             ));
         }
     };
@@ -2236,6 +2240,41 @@ mod tests {
         );
         let content = std::fs::read_to_string(target).unwrap();
         assert_eq!(content, "fn main() {}\n");
+    }
+
+    #[test]
+    fn prepare_write_file_missing_path_guides_retry_same_tool() {
+        let tmp = TempDir::new().unwrap();
+        let err = prepare_write_file(tmp.path(), &serde_json::json!({"content": "hello"}))
+            .expect_err("missing path should fail");
+        assert!(err.is_error);
+        assert!(err.output.contains("Missing 'path' parameter"));
+        assert!(err.output.contains("Retry write_file"));
+        assert!(err.output.contains("path and content"));
+        assert!(
+            !err.output.contains("delete=true"),
+            "path-missing error must not suggest delete=true (write-only path)"
+        );
+        assert!(err.output.contains("Do not switch to bash"));
+    }
+
+    #[test]
+    fn prepare_write_file_missing_content_guides_retry_same_tool() {
+        let tmp = TempDir::new().unwrap();
+        let err = prepare_write_file(tmp.path(), &serde_json::json!({"path": "note.txt"}))
+            .expect_err("missing content should fail");
+        assert!(err.is_error);
+        assert!(err.output.contains("Missing 'content' parameter"));
+        assert!(err.output.contains("Retry write_file"));
+        assert!(err.output.contains("path and content"));
+        // The delete=true hint is intentionally absent: if delete=true is present,
+        // the executor routes to delete_file before prepare_write_file is called,
+        // so this error only fires when delete is definitely NOT true.
+        assert!(
+            !err.output.contains("set delete=true"),
+            "content-missing error must not suggest delete=true (unreachable path)"
+        );
+        assert!(err.output.contains("Do not switch to bash"));
     }
 
     #[test]

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -224,26 +224,14 @@ fn all_tool_schemas_core() -> Vec<Value> {
                     "type": "object",
                     "properties": {
                         "path": {"type": "string", "description": "File path relative to project root"},
-                        "content": {"type": "string", "description": "File content. Required for writes."},
-                        "delete": {"type": "boolean", "description": "Set to true to delete the file instead of writing content."}
+                        "content": {"type": "string", "description": "File content. Required when delete is absent or false."},
+                        "delete": {"type": "boolean", "description": "Set to true to delete the file instead of writing. When true, content must be omitted."}
                     },
-                    "oneOf": [
-                        {
-                            "required": ["path", "content"],
-                            "not": {
-                                "required": ["delete"]
-                            }
-                        },
-                        {
-                            "properties": {
-                                "delete": {"const": true}
-                            },
-                            "required": ["path", "delete"],
-                            "not": {
-                                "required": ["content"]
-                            }
-                        }
-                    ]
+                    "required": ["path"],
+                    "x-astra-per-action-required": {
+                        "write": ["path", "content"],
+                        "delete": ["path"]
+                    }
                 }
             }
         }),
@@ -1301,83 +1289,52 @@ mod tests {
         let params = func
             .get("parameters")
             .expect("write_file schema must include parameters");
-        let variants = params
-            .get("oneOf")
-            .and_then(Value::as_array)
-            .expect("write_file schema must express write vs delete with oneOf");
-        assert_eq!(
-            variants.len(),
-            2,
-            "write_file schema should expose exactly two valid argument shapes"
-        );
 
-        // Outer required must not undermine oneOf by claiming only path is needed.
-        let outer_required = params.get("required").and_then(Value::as_array);
+        // Anthropic/Bedrock reject oneOf/allOf/anyOf at the top level of input_schema.
+        // The write vs delete distinction is expressed via description prose and the
+        // x-astra-per-action-required extension, not via composition keywords.
         assert!(
-            outer_required.is_none_or(|r| r.is_empty()),
-            "outer 'required' must be absent or empty so oneOf is the sole constraint; \
-             having required:[\"path\"] contradicts the oneOf variants"
+            params.get("oneOf").is_none(),
+            "write_file parameters must not use top-level oneOf (Anthropic/Bedrock HTTP 400)"
+        );
+        assert!(
+            params.get("allOf").is_none(),
+            "write_file parameters must not use top-level allOf (Anthropic/Bedrock HTTP 400)"
+        );
+        assert!(
+            params.get("anyOf").is_none(),
+            "write_file parameters must not use top-level anyOf (Anthropic/Bedrock HTTP 400)"
         );
 
-        let write_variant = variants
-            .iter()
-            .find(|variant| {
-                variant
-                    .get("required")
-                    .and_then(Value::as_array)
-                    .map(|required| {
-                        required.iter().any(|item| item == "content")
-                            && required.iter().any(|item| item == "path")
-                    })
-                    .unwrap_or(false)
-            })
-            .expect("write variant must require both path and content");
-
-        // Write variant must exclude delete to ensure oneOf variants are mutually exclusive.
-        let write_not = write_variant
-            .get("not")
-            .expect("write variant must exclude delete via 'not' constraint");
-        let write_not_required = write_not
+        // path must be the sole top-level required field.
+        let required = params
             .get("required")
             .and_then(Value::as_array)
-            .expect("write variant 'not' must list excluded fields");
+            .expect("write_file parameters must include a required array");
         assert!(
-            write_not_required.iter().any(|item| item == "delete"),
-            "write variant must exclude 'delete' so {{path,content,delete:true}} is rejected"
+            required.iter().any(|v| v == "path"),
+            "write_file must require path: {required:?}"
         );
 
-        let delete_variant = variants
-            .iter()
-            .find(|variant| {
-                variant
-                    .get("properties")
-                    .and_then(|props| props.get("delete"))
-                    .and_then(|delete| delete.get("const"))
-                    .and_then(Value::as_bool)
-                    == Some(true)
-            })
-            .expect("delete variant must pin delete=true");
-        let delete_required = delete_variant
-            .get("required")
-            .and_then(Value::as_array)
-            .expect("delete variant must list required fields");
-        assert!(
-            delete_required.iter().any(|item| item == "path")
-                && delete_required.iter().any(|item| item == "delete"),
-            "delete variant must require path and delete=true"
+        // Per-action required fields must be encoded in the vendor extension.
+        let per_action = params.get("x-astra-per-action-required").expect(
+            "write_file must use x-astra-per-action-required to encode per-mode requirements",
         );
-
-        // Delete variant must exclude content for mutual exclusivity.
-        let delete_not = delete_variant
-            .get("not")
-            .expect("delete variant must exclude content via 'not' constraint");
-        let delete_not_required = delete_not
-            .get("required")
+        let write_req = per_action
+            .get("write")
             .and_then(Value::as_array)
-            .expect("delete variant 'not' must list excluded fields");
+            .expect("x-astra-per-action-required must list fields required for write");
         assert!(
-            delete_not_required.iter().any(|item| item == "content"),
-            "delete variant must exclude 'content' so {{path,content,delete:true}} is rejected"
+            write_req.iter().any(|v| v == "path") && write_req.iter().any(|v| v == "content"),
+            "write action must require both path and content: {write_req:?}"
+        );
+        let delete_req = per_action
+            .get("delete")
+            .and_then(Value::as_array)
+            .expect("x-astra-per-action-required must list fields required for delete");
+        assert!(
+            delete_req.iter().any(|v| v == "path"),
+            "delete action must require path: {delete_req:?}"
         );
     }
 

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -219,15 +219,31 @@ fn all_tool_schemas_core() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "write_file",
-                "description": "Create or overwrite a file. Set delete=true to delete instead.",
+                "description": "Create, overwrite, or delete a file. For writes, provide both path and content. For deletes, provide path with delete=true instead of content. Retry write_file with corrected arguments; do not switch to bash or python just to write a file.",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "path": {"type": "string", "description": "File path relative to project root"},
-                        "content": {"type": "string", "description": "File content (not required when delete=true)"},
-                        "delete": {"type": "boolean", "description": "If true, delete the file instead of writing"}
+                        "content": {"type": "string", "description": "File content. Required for writes."},
+                        "delete": {"type": "boolean", "description": "Set to true to delete the file instead of writing content."}
                     },
-                    "required": ["path"]
+                    "oneOf": [
+                        {
+                            "required": ["path", "content"],
+                            "not": {
+                                "required": ["delete"]
+                            }
+                        },
+                        {
+                            "properties": {
+                                "delete": {"const": true}
+                            },
+                            "required": ["path", "delete"],
+                            "not": {
+                                "required": ["content"]
+                            }
+                        }
+                    ]
                 }
             }
         }),
@@ -1261,6 +1277,108 @@ mod tests {
                 "default executor exposes `{name}` but server_executor_tool_schemas() omits it"
             );
         }
+    }
+
+    #[test]
+    fn write_file_schema_requires_content_or_delete_contract() {
+        let schemas = all_tool_schemas_with_env(|_| None);
+        let write_file = find_schema(&schemas, "write_file").expect("write_file schema must exist");
+        let func = write_file
+            .get("function")
+            .expect("write_file schema must include function block");
+        let desc = func
+            .get("description")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        assert!(
+            desc.contains("path")
+                && desc.contains("content")
+                && desc.contains("delete=true")
+                && desc.contains("do not switch to bash"),
+            "write_file description must spell out the path+content contract and discourage shell fallback: {desc}"
+        );
+
+        let params = func
+            .get("parameters")
+            .expect("write_file schema must include parameters");
+        let variants = params
+            .get("oneOf")
+            .and_then(Value::as_array)
+            .expect("write_file schema must express write vs delete with oneOf");
+        assert_eq!(
+            variants.len(),
+            2,
+            "write_file schema should expose exactly two valid argument shapes"
+        );
+
+        // Outer required must not undermine oneOf by claiming only path is needed.
+        let outer_required = params.get("required").and_then(Value::as_array);
+        assert!(
+            outer_required.is_none_or(|r| r.is_empty()),
+            "outer 'required' must be absent or empty so oneOf is the sole constraint; \
+             having required:[\"path\"] contradicts the oneOf variants"
+        );
+
+        let write_variant = variants
+            .iter()
+            .find(|variant| {
+                variant
+                    .get("required")
+                    .and_then(Value::as_array)
+                    .map(|required| {
+                        required.iter().any(|item| item == "content")
+                            && required.iter().any(|item| item == "path")
+                    })
+                    .unwrap_or(false)
+            })
+            .expect("write variant must require both path and content");
+
+        // Write variant must exclude delete to ensure oneOf variants are mutually exclusive.
+        let write_not = write_variant
+            .get("not")
+            .expect("write variant must exclude delete via 'not' constraint");
+        let write_not_required = write_not
+            .get("required")
+            .and_then(Value::as_array)
+            .expect("write variant 'not' must list excluded fields");
+        assert!(
+            write_not_required.iter().any(|item| item == "delete"),
+            "write variant must exclude 'delete' so {{path,content,delete:true}} is rejected"
+        );
+
+        let delete_variant = variants
+            .iter()
+            .find(|variant| {
+                variant
+                    .get("properties")
+                    .and_then(|props| props.get("delete"))
+                    .and_then(|delete| delete.get("const"))
+                    .and_then(Value::as_bool)
+                    == Some(true)
+            })
+            .expect("delete variant must pin delete=true");
+        let delete_required = delete_variant
+            .get("required")
+            .and_then(Value::as_array)
+            .expect("delete variant must list required fields");
+        assert!(
+            delete_required.iter().any(|item| item == "path")
+                && delete_required.iter().any(|item| item == "delete"),
+            "delete variant must require path and delete=true"
+        );
+
+        // Delete variant must exclude content for mutual exclusivity.
+        let delete_not = delete_variant
+            .get("not")
+            .expect("delete variant must exclude content via 'not' constraint");
+        let delete_not_required = delete_not
+            .get("required")
+            .and_then(Value::as_array)
+            .expect("delete variant 'not' must list excluded fields");
+        assert!(
+            delete_not_required.iter().any(|item| item == "content"),
+            "delete variant must exclude 'content' so {{path,content,delete:true}} is rejected"
+        );
     }
 
     // ── Session 0e37eb46 regression: bash/powershell schema-advertised

--- a/rust/crates/astra-turn-core/src/error_recovery.rs
+++ b/rust/crates/astra-turn-core/src/error_recovery.rs
@@ -140,6 +140,10 @@ pub fn build_recovery_message(
 ) -> String {
     let alternatives = suggest_alternatives(tool_name, deprioritized);
     let error_lower = error_str.to_lowercase();
+    let write_file_missing_args = tool_name == "write_file"
+        && category == ErrorCategory::ToolInvalidArgs
+        && (error_lower.contains("missing 'path' parameter")
+            || error_lower.contains("missing 'content' parameter"));
 
     let mut msg = match category {
         ErrorCategory::Network
@@ -161,11 +165,17 @@ pub fn build_recovery_message(
              Verify the path/name is correct before retrying.",
             tool_name
         ),
-        ErrorCategory::ToolInvalidArgs | ErrorCategory::InvalidRequest => format!(
-            "⚠ {} failed: invalid arguments. \
-             Check the tool's expected parameters and fix the call.",
-            tool_name
-        ),
+        ErrorCategory::ToolInvalidArgs | ErrorCategory::InvalidRequest => {
+            if write_file_missing_args {
+                "⚠ write_file failed: invalid arguments. Retry the same tool with both `path` and `content` for writes, or `path` + `delete=true` for deletes. Do NOT switch to bash or python just to write or delete this file.".to_string()
+            } else {
+                format!(
+                    "⚠ {} failed: invalid arguments. \
+                     Check the tool's expected parameters, fix the call, and retry the same tool before switching approaches.",
+                    tool_name
+                )
+            }
+        }
         ErrorCategory::ToolUnavailable => format!(
             "⚠ {} is not available in this environment. \
              Do NOT retry — use an alternative tool.",
@@ -219,7 +229,22 @@ pub fn build_recovery_message(
     }
 
     if !alternatives.is_empty() {
-        msg.push_str(&format!(" Alternatives: [{}].", alternatives.join(", ")));
+        const SHELL_TOOLS: &[&str] = &["bash", "powershell"];
+        let filtered: Vec<&str> = if write_file_missing_args {
+            // Missing-args errors should steer the model to retry write_file, but legitimate
+            // editing alternatives (str_replace, multi_edit) must still be visible.
+            // Only suppress shell escalation paths.
+            alternatives
+                .iter()
+                .map(String::as_str)
+                .filter(|t| !SHELL_TOOLS.contains(t))
+                .collect()
+        } else {
+            alternatives.iter().map(String::as_str).collect()
+        };
+        if !filtered.is_empty() {
+            msg.push_str(&format!(" Alternatives: [{}].", filtered.join(", ")));
+        }
     }
     if tool_name == "read_file" && error_lower.contains("file is too large") {
         msg.push_str(
@@ -664,6 +689,38 @@ mod tests {
         assert!(msg.contains("do NOT switch to bash"));
         assert!(msg.contains("start_line/end_line"));
         assert!(msg.contains("outline=true"));
+    }
+
+    #[test]
+    fn recovery_message_write_file_missing_args_discourages_shell_fallback() {
+        let err = "Error: Missing 'path' parameter. Retry write_file with both path and content. Do not switch to bash or python just to write this file.";
+        let cat = classify_error(err);
+        assert_eq!(cat, ErrorCategory::ToolInvalidArgs);
+        let msg = build_recovery_message("write_file", err, cat, &[]);
+        assert!(msg.contains("Retry the same tool") || msg.contains("retry write_file"));
+        // The recovery message must explicitly warn against shell escalation.
+        assert!(msg.contains("bash"), "must warn against bash fallback");
+        assert!(msg.contains("python"), "must warn against python fallback");
+        // bash must not appear in the Alternatives list — only in the warning text.
+        // The alternatives for write_file are str_replace/multi_edit, never bash.
+        let alts_section = msg.find("Alternatives:").map(|i| &msg[i..]).unwrap_or("");
+        assert!(
+            !alts_section.to_lowercase().contains("bash"),
+            "bash must not appear as a suggested alternative: {alts_section}"
+        );
+    }
+
+    #[test]
+    fn recovery_message_write_file_missing_args_suggests_editing_alternatives() {
+        let err = "Error: Missing 'content' parameter. Retry write_file with both path and content. Do not switch to bash or python just to write this file.";
+        let cat = classify_error(err);
+        let msg = build_recovery_message("write_file", err, cat, &[]);
+        // str_replace and multi_edit are legitimate alternatives for file edits and must
+        // still be surfaced even when write_file is missing args.
+        assert!(
+            msg.contains("str_replace") || msg.contains("multi_edit"),
+            "editing alternatives must not be suppressed for missing-args errors: {msg}"
+        );
     }
 
     // ── Escalation ──

--- a/rust/crates/astra-turn-core/src/tool_registry_meta.rs
+++ b/rust/crates/astra-turn-core/src/tool_registry_meta.rs
@@ -120,7 +120,7 @@ pub static TOOL_CATALOG: &[ToolMeta] = &[
     },
     ToolMeta {
         name: "write_file",
-        description: "Create or overwrite a file",
+        description: "Create, overwrite, or delete a file; writes require path+content, deletes use delete=true",
         triggers: &[
             "write",
             "create file",

--- a/rust/crates/core/src/error_kind.rs
+++ b/rust/crates/core/src/error_kind.rs
@@ -187,7 +187,7 @@ impl ErrorKind {
             }
             Self::ToolInvalidArgs => {
                 "Invalid arguments for the tool. \
-                 Check the tool's expected parameters and fix the call."
+                 Fix the parameters and retry the same tool before switching tools."
             }
             Self::ToolTimeout => {
                 "Tool command timed out — the scope is too broad. \
@@ -267,8 +267,9 @@ impl ErrorKind {
                  Confirm the workspace context is accurate."
             }
             Self::ToolInvalidArgs => {
-                "Model is calling tools with wrong parameters. This may improve with \
-                 a better model, clearer system prompt, or stricter tool schemas."
+                "Model is calling tools with wrong parameters. Improve schema/description \
+                 clarity and steer the model to retry the same tool with corrected args \
+                 instead of escalating to bash or unrelated tools."
             }
             Self::ToolTimeout => {
                 "Tool scope is too broad. Break the operation into smaller chunks \


### PR DESCRIPTION
## Summary

- **`write_file` schema**: replaced `required: ["path"]` with `oneOf` (write variant requires `path`+`content`; delete variant requires `path`+`delete:true`) so the model can't call the tool with only a path and silently fall through to bash
- **Error messages**: missing `path` / `content` errors now say "Retry write_file with both path and content. Do not switch to bash or python just to write this file"
- **`build_recovery_message`**: for `write_file` + `ToolInvalidArgs`, bash/powershell are filtered from the Alternatives list (str_replace/multi_edit remain visible)
- **`ErrorKind::ToolInvalidArgs`**: guidance updated to steer "retry same tool with corrected args" before switching tools
- **Tool catalog**: `write_file` description updated to reflect write vs delete semantics
- **Clippy fix**: `map_or(true, ...)` → `is_none_or(...)` in schemas.rs test (was blocking `make check`)

## Test plan

- [ ] `make check` passes (lint + format + type-check)
- [ ] New unit tests in `executor.rs`: delete-flag routing, string-not-coerced, delete-wins, path-traversal-blocked
- [ ] New unit tests in `fs_ops.rs`: missing-path and missing-content guide retry same tool
- [ ] New unit tests in `schemas.rs`: oneOf contract, write/delete variant exclusivity
- [ ] New unit tests in `error_recovery.rs`: shell fallback suppressed in Alternatives, editing alternatives preserved