### PR TITLE
feat(permissions): improve permission UX, workspace trust, and approval flow

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/params.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/params.rs
@@ -154,28 +154,11 @@ pub enum ApprovalResponse {
     Deny,
     /// Always allow this tool pattern (persistent rule).
     AlwaysAllow,
-    /// Always allow with an explicit user-selected scope from the
-    /// TUI scope picker.
-    AlwaysAllowScoped(astra_turn_core::permission_scope::AllowScope),
-    /// Always allow with both dimensions selected by the user:
-    /// lifetime/sink scope and match target.
-    AlwaysAllowScopedTarget {
-        scope: astra_turn_core::permission_scope::AllowScope,
-        match_target: astra_turn_core::permission_match_target::AllowMatchTarget,
-    },
-    /// Skip this tool (deny without recording).
-    Skip,
 }
 
 impl ApprovalResponse {
     pub fn is_approved(&self) -> bool {
-        matches!(
-            self,
-            Self::AllowOnce
-                | Self::AlwaysAllow
-                | Self::AlwaysAllowScoped(_)
-                | Self::AlwaysAllowScopedTarget { .. }
-        )
+        matches!(self, Self::AllowOnce | Self::AlwaysAllow)
     }
 
     pub fn always_scope(
@@ -184,8 +167,6 @@ impl ApprovalResponse {
     ) -> Option<astra_turn_core::permission_scope::AllowScope> {
         match self {
             Self::AlwaysAllow => Some(default_scope),
-            Self::AlwaysAllowScoped(scope) => Some(*scope),
-            Self::AlwaysAllowScopedTarget { scope, .. } => Some(*scope),
             _ => None,
         }
     }
@@ -193,10 +174,7 @@ impl ApprovalResponse {
     pub fn match_target(
         &self,
     ) -> Option<&astra_turn_core::permission_match_target::AllowMatchTarget> {
-        match self {
-            Self::AlwaysAllowScopedTarget { match_target, .. } => Some(match_target),
-            _ => None,
-        }
+        None
     }
 }
 

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -114,6 +114,20 @@ fn derive_turn_interaction_mode(
         // which in turn disabled the nudge-suppression gate the user
         // opted into.
         PermissionMode::Auto => TurnInteractionMode::Auto,
+        PermissionMode::Plan => {
+            if has_approval_request_tx || render_is_silent || !stdin_is_terminal {
+                TurnInteractionMode::NonInteractive
+            } else {
+                TurnInteractionMode::Deny
+            }
+        }
+        PermissionMode::AcceptEdits => {
+            if has_approval_request_tx || render_is_silent || !stdin_is_terminal {
+                TurnInteractionMode::NonInteractive
+            } else {
+                TurnInteractionMode::Prompt
+            }
+        }
         // Prompt requires user interaction; if we can't actually prompt
         // (no tty, alternate approval channel, silenced UI), fall back
         // to NonInteractive so callers don't block on a human.
@@ -684,6 +698,10 @@ mod tests {
             TurnInteractionMode::Prompt
         );
         assert_eq!(
+            derive_turn_interaction_mode(PermissionMode::AcceptEdits, false, false, false, true),
+            TurnInteractionMode::Prompt
+        );
+        assert_eq!(
             derive_turn_interaction_mode(PermissionMode::Auto, false, false, false, true),
             TurnInteractionMode::Auto
         );
@@ -783,6 +801,22 @@ mod tests {
         // denial, same as NonInteractive's restrictive default).
         assert_eq!(
             derive_turn_interaction_mode(PermissionMode::Deny, false, false, false, false),
+            TurnInteractionMode::NonInteractive
+        );
+    }
+
+    #[test]
+    fn derive_turn_interaction_mode_uses_deny_for_interactive_plan() {
+        assert_eq!(
+            derive_turn_interaction_mode(PermissionMode::Plan, false, false, false, true),
+            TurnInteractionMode::Deny
+        );
+    }
+
+    #[test]
+    fn derive_turn_interaction_mode_uses_noninteractive_for_structural_plan() {
+        assert_eq!(
+            derive_turn_interaction_mode(PermissionMode::Plan, false, false, true, true),
             TurnInteractionMode::NonInteractive
         );
     }

--- a/rust/crates/astra-cli/src/cli/chat_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_turn.rs
@@ -4197,6 +4197,25 @@ mod tests {
     }
 
     #[test]
+    fn pending_recovery_restore_is_gated_to_low_information_followups() {
+        let source = include_str!("chat_turn.rs");
+        let start = source
+            .find("pub(super) async fn handle_chat_input_with_ui")
+            .expect("handle_chat_input_with_ui should exist");
+        let body = &source[start..];
+        let gate_end = body
+            .find("ui.blank_line();")
+            .expect("pre-turn gate should reach the blank-line boundary");
+        let pre_turn_gate = &body[..gate_end];
+        assert!(
+            pre_turn_gate.contains("restore_session_into_state(&session_id")
+                && pre_turn_gate.contains("is_low_information_followup(&line)")
+                && pre_turn_gate.contains("state.pending_recovery = None;"),
+            "interactive chat should only restore pending recovery for low-information resume/repair follow-ups"
+        );
+    }
+
+    #[test]
     fn build_effective_line_leaves_normal_prompt_untouched() {
         let state = SessionState {
             continuation_anchor: Some("Latest user task: debug Chinese input drops".to_string()),

--- a/rust/crates/astra-cli/src/cli/cli_args.rs
+++ b/rust/crates/astra-cli/src/cli/cli_args.rs
@@ -20,6 +20,12 @@
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 
+fn parse_permission_mode_arg(value: &str) -> Result<String, String> {
+    value
+        .parse::<crate::permission_manager::PermissionMode>()
+        .map(|mode| mode.to_string())
+}
+
 #[derive(Parser, Debug)]
 #[command(name = "astra")]
 #[command(about = "AI agent CLI — run `astra` for interactive chat")]
@@ -319,12 +325,9 @@ pub(crate) struct ChatArgs {
     /// Auto-approve tool calls
     #[arg(short = 'y', long = "auto-approve", default_value_t = false)]
     pub auto_approve: bool,
-    /// Permission mode: auto (approve all), prompt (interactive, default), deny (reject all writes)
+    /// Permission mode: auto, plan, accept_edits, prompt (interactive, default), or deny.
     /// Legacy aliases yolo/bypass-safety map to auto for backward compatibility.
-    #[arg(
-        long = "permission-mode",
-        value_parser = ["auto", "prompt", "deny", "yolo", "bypass-safety", "bypass_safety"]
-    )]
+    #[arg(long = "permission-mode", value_parser = parse_permission_mode_arg)]
     pub permission_mode: Option<String>,
     /// Suppress spinner and progress output (result still printed)
     #[arg(long, default_value_t = false)]
@@ -683,7 +686,7 @@ pub(crate) struct GrepPatternArgs {
 
 #[derive(Args, Debug)]
 #[command(
-    after_help = "Examples:\n  astra permissions status\n  astra permissions auto\n  astra permissions prompt\n  astra permissions rules\n  astra permissions trust\n  astra permissions trace"
+    after_help = "Examples:\n  astra permissions status\n  astra permissions auto\n  astra permissions plan\n  astra permissions accept_edits\n  astra permissions prompt\n  astra permissions rules\n  astra permissions trust\n  astra permissions trace"
 )]
 pub(crate) struct PermissionsArgs {
     #[command(subcommand)]
@@ -696,6 +699,11 @@ pub(crate) enum PermissionsSubcommand {
     Status,
     /// Auto-approve allowed tool calls
     Auto,
+    /// Auto-approve workspace-local edits while still prompting for shell and external writes
+    #[command(name = "accept_edits", alias = "accept-edits")]
+    AcceptEdits,
+    /// Read-only investigation mode: allow reads, deny mutations
+    Plan,
     /// Prompt before running allowed tool calls
     Prompt,
     /// Deny writes and high-risk tools
@@ -704,9 +712,9 @@ pub(crate) enum PermissionsSubcommand {
     All,
     /// Show permission rules summary
     Rules,
-    /// Trust this workspace's project permission allow rules
+    /// Trust this workspace and enable saved workspace allow rules
     Trust,
-    /// Mark this workspace untrusted and ignore project allow rules
+    /// Mark this workspace untrusted and ignore saved workspace allow rules
     Untrust,
     /// Show recent permission audit events
     Trace(PermissionsTraceArgs),

--- a/rust/crates/astra-cli/src/cli/command_registry.rs
+++ b/rust/crates/astra-cli/src/cli/command_registry.rs
@@ -254,6 +254,11 @@ const DIFF_SUBCOMMANDS: &[(&str, &str)] = &[
 const ALLOW_SUBCOMMANDS: &[(&str, &str)] = &[
     ("all", "Auto-approve all (alias for auto)"),
     ("auto", "Auto-approve all tool use"),
+    ("plan", "Read-only investigation mode; mutations are denied"),
+    (
+        "accept_edits",
+        "Auto-approve workspace-local file edits while still prompting for shell and external writes",
+    ),
     ("deny", "Deny all tool use"),
     ("prompt", "Prompt before tool use"),
     ("rules", "Show current permission rules"),
@@ -672,11 +677,11 @@ pub static COMMANDS: &[CommandMeta] = &[
     // ── System ────────────────────────────────────────────────────────────
     CommandMeta::new(
         "/allow",
-        "Permission mode: /allow [auto|prompt|deny|all|rules|trust|untrust|trace]",
+        "Permission mode: /allow [auto|plan|accept_edits|prompt|deny|all|rules|trust|untrust|trace]",
         CommandGroup::System,
     )
     .with_subcommands(ALLOW_SUBCOMMANDS)
-    .with_arg_hint("[auto|prompt|deny|all|rules]"),
+    .with_arg_hint("[auto|accept_edits|plan|prompt|deny|all|rules]"),
     CommandMeta::new(
         "/instructions",
         "Project instructions: /instructions [show|reload|off]",
@@ -962,6 +967,24 @@ mod tests {
         assert!(subs.iter().any(|(tok, _)| *tok == "uninstall"));
         assert!(subs.iter().any(|(tok, _)| *tok == "unpin"));
         assert!(subs.iter().any(|(tok, _)| *tok == "upgrade"));
+    }
+
+    #[test]
+    fn allow_command_lists_accept_edits_mode() {
+        let allow = COMMANDS
+            .iter()
+            .find(|meta| meta.name == "/allow")
+            .expect("/allow command");
+        assert!(allow.description.contains("accept_edits"));
+        assert!(allow.description.contains("plan"));
+        assert_eq!(
+            allow.arg_hint,
+            Some("[auto|accept_edits|plan|prompt|deny|all|rules]")
+        );
+
+        let subs = subcommand_completions("/allow").expect("/allow subcommands");
+        assert!(subs.iter().any(|(tok, _)| *tok == "accept_edits"));
+        assert!(subs.iter().any(|(tok, _)| *tok == "plan"));
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -261,6 +261,8 @@ fn render_permissions_args(args: &PermissionsArgs) -> String {
         None => String::new(),
         Some(PermissionsSubcommand::Status) => "status".to_string(),
         Some(PermissionsSubcommand::Auto) => "auto".to_string(),
+        Some(PermissionsSubcommand::AcceptEdits) => "accept_edits".to_string(),
+        Some(PermissionsSubcommand::Plan) => "plan".to_string(),
         Some(PermissionsSubcommand::Prompt) => "prompt".to_string(),
         Some(PermissionsSubcommand::Deny) => "deny".to_string(),
         Some(PermissionsSubcommand::All) => "all".to_string(),
@@ -1680,7 +1682,9 @@ fn handle_permission_command(arg: &str, state: &mut SessionState) {
     match arg {
         "" => {
             let next = match state.perm_manager.mode() {
-                PermissionMode::Prompt => PermissionMode::Auto,
+                PermissionMode::Prompt => PermissionMode::Plan,
+                PermissionMode::Plan => PermissionMode::AcceptEdits,
+                PermissionMode::AcceptEdits => PermissionMode::Auto,
                 PermissionMode::Auto => PermissionMode::Deny,
                 PermissionMode::Deny => PermissionMode::Prompt,
             };
@@ -1697,6 +1701,22 @@ fn handle_permission_command(arg: &str, state: &mut SessionState) {
                 "  {} Permission mode → {} (all tools auto-approved)",
                 "⚡".yellow(),
                 "auto".magenta()
+            );
+        }
+        "plan" => {
+            state.perm_manager.set_mode(PermissionMode::Plan);
+            eprintln!(
+                "  {} Permission mode → {} (read-only investigation mode)",
+                theme::icon_info(),
+                "plan".magenta()
+            );
+        }
+        "accept_edits" | "accept-edits" => {
+            state.perm_manager.set_mode(PermissionMode::AcceptEdits);
+            eprintln!(
+                "  {} Permission mode → {} (workspace-local edits auto-approved)",
+                theme::icon_info(),
+                "accept_edits".magenta()
             );
         }
         "rules" | "status" => {
@@ -1753,7 +1773,7 @@ fn handle_permission_command(arg: &str, state: &mut SessionState) {
             }
             Err(_) => {
                 eprintln!(
-                    "  {} Unknown mode '{}'. Use: auto, prompt, deny, all, rules, trust, untrust, trace",
+                    "  {} Unknown mode '{}'. Use: auto, plan, accept_edits, prompt, deny, all, rules, trust, untrust, trace",
                     theme::icon_warn(),
                     arg
                 );
@@ -3946,7 +3966,7 @@ const KNOWN_SETTINGS: &[(&str, &str)] = &[
     ("theme", "Color theme (auto/dark/light)"),
     (
         "permission_mode",
-        "Default permission mode (auto/prompt/deny)",
+        "Default permission mode (auto/plan/accept_edits/prompt/deny)",
     ),
 ];
 

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -1,16 +1,15 @@
 use super::*;
 
-use crate::workspace_trust::{
-    TrustState, WorkspaceTrustEvaluation, WorkspaceTrustLedger, evaluate_workspace_trust,
-    project_permissions_hash,
-};
 #[cfg(test)]
-use crate::workspace_trust::{WorkspaceTrustReason, evaluate_workspace_trust_from_path};
+use crate::workspace_trust::evaluate_workspace_trust_from_path;
+use crate::workspace_trust::{
+    TrustState, WorkspaceTrustEvaluation, WorkspaceTrustLedger, WorkspaceTrustReason,
+    evaluate_workspace_trust, project_permissions_hash,
+};
 use astra_runtime::tool_sandbox::{
     CommandRisk, GitSafetyViolation, analyze_command_risks, is_dangerous_file_path,
     validate_git_command,
 };
-use astra_runtime::{compensation_prompt_note, explicit_approval_reason};
 use astra_thin_client::ApprovalKind;
 use astra_turn_core::cloud_approval_policy::{
     CloudGatedToolKind, bash_command_approval_reason, cloud_gated_tool_kind,
@@ -20,7 +19,10 @@ use astra_turn_core::permission_engine::{
     DecisionEnvelope, DecisionSource, HardDecision, allow_rule_preview,
     allow_rule_preview_for_match_target,
 };
-use astra_turn_core::permission_match_target::{AllowMatchTarget, fingerprint_for_match_target};
+use astra_turn_core::permission_match_target::{
+    AllowMatchTarget, default_match_target, fingerprint_for_match_target,
+};
+use astra_turn_core::permission_memory_profile::resolved_write_path;
 use astra_turn_core::tool_argument_hints::{
     command_hint_from_args, path_hint_from_args, permission_prompt_display_label,
 };
@@ -75,6 +77,26 @@ pub(super) fn format_denied_message(reason: &str) -> String {
         Some(alt) => format!("Error: {reason}\nSafe alternative: {alt}"),
         None => format!("Error: {reason}"),
     }
+}
+
+fn cloud_always_feedback_message(
+    remember_preview: &str,
+    scope: &str,
+    persist_error: Option<&str>,
+    sensitive_path: bool,
+) -> String {
+    if sensitive_path {
+        return format!(
+            "  ✓ {remember_preview}: allowed for this session only. \
+To auto-allow sensitive paths across sessions, set allow_sensitive_path_writes=true in .kiro/permissions.json."
+        );
+    }
+    if let Some(err) = persist_error {
+        return format!(
+            "  ⚠ {remember_preview}: allowed for this session; failed to save {scope} rule: {err}"
+        );
+    }
+    format!("  ✓ Always remembers: {remember_preview}")
 }
 
 /// Canonicalize an existing path, or a missing path whose parent chain
@@ -163,8 +185,7 @@ fn content_aware_fingerprint(
 /// Candidate fingerprint for looking up a specific request in the override set.
 ///
 /// Stored path rules may be exact, literal-prefix, directory-pattern, or bare
-/// tool rules. The lookup side must keep the raw path so exact rules for deep
-/// paths still match; broader stored patterns continue to subsume it.
+/// tool rules.
 fn approval_lookup_fingerprint(
     name: &str,
     args: &serde_json::Value,
@@ -209,6 +230,48 @@ fn cloud_detail_lookup_fingerprint(
     }
 }
 
+fn approval_lookup_fingerprint_candidates(
+    name: &str,
+    args: &serde_json::Value,
+) -> Vec<astra_turn_core::approval_fingerprint::ApprovalFingerprint> {
+    use astra_turn_core::approval_fingerprint::ApprovalFingerprint;
+
+    let primary = approval_lookup_fingerprint(name, args);
+    let mut candidates = vec![primary.clone()];
+    if matches!(
+        cloud_gated_tool_kind_with_args(name, Some(args)),
+        Some(CloudGatedToolKind::Write)
+    ) && let Some(path) = path_hint_from_args(args)
+        && let Some(resolved) = resolved_write_path(&path)
+    {
+        let resolved_fp = ApprovalFingerprint::file_op_exact(name, Some(&resolved));
+        if resolved_fp != primary {
+            candidates.push(resolved_fp);
+        }
+    }
+    candidates
+}
+
+fn cloud_detail_lookup_fingerprint_candidates(
+    tool: &str,
+    detail: Option<&str>,
+) -> Vec<astra_turn_core::approval_fingerprint::ApprovalFingerprint> {
+    use astra_turn_core::approval_fingerprint::ApprovalFingerprint;
+
+    let primary = cloud_detail_lookup_fingerprint(tool, detail);
+    let mut candidates = vec![primary.clone()];
+    if matches!(cloud_gated_tool_kind(tool), Some(CloudGatedToolKind::Write))
+        && let Some(path) = detail
+        && let Some(resolved) = resolved_write_path(path)
+    {
+        let resolved_fp = ApprovalFingerprint::file_op_exact(tool, Some(&resolved));
+        if resolved_fp != primary {
+            candidates.push(resolved_fp);
+        }
+    }
+    candidates
+}
+
 fn cloud_detail_is_sensitive(tool: &str, detail: Option<&str>) -> bool {
     match (cloud_gated_tool_kind(tool), detail) {
         (Some(CloudGatedToolKind::Execute), Some(cmd)) => {
@@ -216,6 +279,25 @@ fn cloud_detail_is_sensitive(tool: &str, detail: Option<&str>) -> bool {
         }
         (Some(CloudGatedToolKind::Write), Some(path)) => {
             sensitive_path_match(&serde_json::json!({ "path": path })).is_some()
+        }
+        _ => false,
+    }
+}
+
+fn accept_edits_auto_allows_tool_args(tool: &str, args: &serde_json::Value) -> bool {
+    matches!(
+        (
+            cloud_gated_tool_kind_with_args(tool, Some(args)),
+            default_match_target(tool, args),
+        ),
+        (Some(CloudGatedToolKind::Write), AllowMatchTarget::Prefix(_))
+    )
+}
+
+fn accept_edits_auto_allows_cloud_request(tool: &str, detail: Option<&str>) -> bool {
+    match (cloud_gated_tool_kind(tool), detail) {
+        (Some(CloudGatedToolKind::Write), Some(path)) => {
+            accept_edits_auto_allows_tool_args(tool, &serde_json::json!({ "path": path }))
         }
         _ => false,
     }
@@ -884,6 +966,10 @@ pub(super) struct PermissionManager {
     active_session_id: Option<String>,
 }
 
+pub(crate) struct WorkspaceTrustStartupPrompt {
+    pub header: String,
+}
+
 impl PermissionManager {
     /// Format the cloud-approval banner, appending a rationale when the
     /// classifier can explain *why* a bash command tripped.
@@ -953,6 +1039,48 @@ impl PermissionManager {
         self.load_policy.applies_project_allow()
     }
 
+    pub(crate) fn workspace_trust_notice(&self) -> Option<String> {
+        let trust = self.workspace_trust.as_ref()?;
+        let root = self.project_root.as_ref()?;
+        match trust.reason {
+            WorkspaceTrustReason::Trusted => None,
+            WorkspaceTrustReason::UnknownWorkspace => Some(format!(
+                "Workspace not trusted yet: {}. Saved workspace rules are off. Run `/allow trust` or `astra permissions trust` to trust this path.",
+                root.display()
+            )),
+            WorkspaceTrustReason::ExplicitlyUntrusted => Some(format!(
+                "Workspace is marked untrusted: {}. Saved workspace rules are off. Run `/allow trust` or `astra permissions trust` to trust this path.",
+                root.display()
+            )),
+            WorkspaceTrustReason::RulesHashChanged => Some(format!(
+                "Workspace rules changed since you last trusted this path: {}. Review them, then run `/allow trust` or `astra permissions trust` to re-trust it.",
+                root.display()
+            )),
+            WorkspaceTrustReason::LedgerError(_) | WorkspaceTrustReason::RulesHashError(_) => {
+                Some(trust.summary_line())
+            }
+        }
+    }
+
+    pub(crate) fn workspace_trust_startup_prompt(&self) -> Option<WorkspaceTrustStartupPrompt> {
+        let trust = self.workspace_trust.as_ref()?;
+        let root = self.project_root.as_ref()?;
+        let header = match trust.reason {
+            WorkspaceTrustReason::UnknownWorkspace => {
+                format!("Trust this workspace? {}", root.display())
+            }
+            WorkspaceTrustReason::RulesHashChanged => format!(
+                "Workspace rules changed — trust this path again? {}",
+                root.display()
+            ),
+            WorkspaceTrustReason::Trusted
+            | WorkspaceTrustReason::ExplicitlyUntrusted
+            | WorkspaceTrustReason::LedgerError(_)
+            | WorkspaceTrustReason::RulesHashError(_) => return None,
+        };
+        Some(WorkspaceTrustStartupPrompt { header })
+    }
+
     /// Snapshot of cumulative denial pressure for the SelfModel surface.
     /// Returns `(total_denials, max_total)` from the session-scoped
     /// [`DenialTracker`]. Surfaced to the agent via `SelfModel` so it can
@@ -1013,6 +1141,13 @@ impl PermissionManager {
             .or_else(|| self.session_overrides.check(fp))
     }
 
+    fn check_overrides_any(
+        &self,
+        fps: &[astra_turn_core::approval_fingerprint::ApprovalFingerprint],
+    ) -> Option<bool> {
+        fps.iter().find_map(|fp| self.check_overrides(fp))
+    }
+
     fn matching_override(
         &self,
         fp: &astra_turn_core::approval_fingerprint::ApprovalFingerprint,
@@ -1026,12 +1161,22 @@ impl PermissionManager {
             .map(|(stored, allowed)| (stored, *allowed))
     }
 
+    fn matching_override_any(
+        &self,
+        fps: &[astra_turn_core::approval_fingerprint::ApprovalFingerprint],
+    ) -> Option<(
+        &astra_turn_core::approval_fingerprint::ApprovalFingerprint,
+        bool,
+    )> {
+        fps.iter().find_map(|fp| self.matching_override(fp))
+    }
+
     fn check_overrides_for_request(
         &self,
-        fp: &astra_turn_core::approval_fingerprint::ApprovalFingerprint,
+        fps: &[astra_turn_core::approval_fingerprint::ApprovalFingerprint],
         sensitive_path: bool,
     ) -> Option<bool> {
-        let (stored, allowed) = self.matching_override(fp)?;
+        let (stored, allowed) = self.matching_override_any(fps)?;
         if !sensitive_path || !allowed || stored_override_allows_sensitive_path(stored) {
             Some(allowed)
         } else {
@@ -1234,6 +1379,10 @@ impl PermissionManager {
         // Use inherited mode, but load project settings too
         let mode = match inherited.mode {
             astra_runtime::orchestration::PermissionMode::Auto => PermissionMode::Auto,
+            astra_runtime::orchestration::PermissionMode::Plan => PermissionMode::Plan,
+            astra_runtime::orchestration::PermissionMode::AcceptEdits => {
+                PermissionMode::AcceptEdits
+            }
             astra_runtime::orchestration::PermissionMode::Prompt => PermissionMode::Prompt,
             astra_runtime::orchestration::PermissionMode::Deny => PermissionMode::Deny,
         };
@@ -1386,6 +1535,8 @@ impl PermissionManager {
 
         let mode = match self.mode {
             PermissionMode::Auto => RuntimePermissionMode::Auto,
+            PermissionMode::Plan => RuntimePermissionMode::Plan,
+            PermissionMode::AcceptEdits => RuntimePermissionMode::AcceptEdits,
             PermissionMode::Prompt => RuntimePermissionMode::Prompt,
             PermissionMode::Deny => RuntimePermissionMode::Deny,
         };
@@ -1695,9 +1846,10 @@ impl PermissionManager {
         //
         // The lookup fingerprint uses the tool-name-only classifier for
         // cloud details so read-only bash commands do not collapse to `bare`.
-        // For path-shaped tools it preserves the raw path; exact, prefix,
-        // pattern, and bare stored overrides can all match that candidate.
-        let fp = cloud_detail_lookup_fingerprint(tool, detail);
+        // For path-shaped tools we probe both the raw detail and the
+        // workspace-resolved absolute path so legacy exact/prefix rules and
+        // workspace-scoped write memory can both match.
+        let fps = cloud_detail_lookup_fingerprint_candidates(tool, detail);
         let sensitive_path = cloud_detail_is_sensitive(tool, detail);
 
         // Session override check — applies to every kind. A matched
@@ -1706,7 +1858,7 @@ impl PermissionManager {
         // re-ask regardless of `approval_kind` or `quiet`. This also
         // means silent sub-runs can honour `Always` instead of
         // auto-denying.
-        if let Some(allowed) = self.check_overrides_for_request(&fp, sensitive_path) {
+        if let Some(allowed) = self.check_overrides_for_request(&fps, sensitive_path) {
             return Some(if allowed {
                 ApprovalDecision::Allow
             } else {
@@ -1715,14 +1867,19 @@ impl PermissionManager {
         }
 
         if sensitive_path {
-            if self.mode == PermissionMode::Deny {
+            if matches!(self.mode, PermissionMode::Plan | PermissionMode::Deny) {
                 return Some(ApprovalDecision::Deny);
             }
-            if self.mode == PermissionMode::Auto
-                && (self.settings.allow_sensitive_path_writes
-                    || self.user_settings.allow_sensitive_path_writes)
-            {
-                return Some(ApprovalDecision::Allow);
+            if self.mode == PermissionMode::Auto {
+                return Some(
+                    if self.settings.allow_sensitive_path_writes
+                        || self.user_settings.allow_sensitive_path_writes
+                    {
+                        ApprovalDecision::Allow
+                    } else {
+                        ApprovalDecision::Deny
+                    },
+                );
             }
             return if quiet {
                 Some(ApprovalDecision::Deny)
@@ -1732,16 +1889,25 @@ impl PermissionManager {
         }
 
         if quiet {
-            return Some(if self.mode == PermissionMode::Auto {
-                ApprovalDecision::Allow
-            } else {
-                ApprovalDecision::Deny
+            return Some(match self.mode {
+                PermissionMode::Auto => ApprovalDecision::Allow,
+                PermissionMode::Plan => ApprovalDecision::Deny,
+                PermissionMode::AcceptEdits
+                    if accept_edits_auto_allows_cloud_request(tool, detail) =>
+                {
+                    ApprovalDecision::Allow
+                }
+                PermissionMode::AcceptEdits | PermissionMode::Prompt | PermissionMode::Deny => {
+                    ApprovalDecision::Deny
+                }
             });
         }
 
         if Self::cloud_approval_is_explicit(approval_kind) {
             return match self.mode {
                 PermissionMode::Auto => Some(ApprovalDecision::Allow),
+                PermissionMode::Plan => Some(ApprovalDecision::Deny),
+                PermissionMode::AcceptEdits => None,
                 PermissionMode::Deny => Some(ApprovalDecision::Deny),
                 PermissionMode::Prompt => None,
             };
@@ -1749,14 +1915,19 @@ impl PermissionManager {
 
         match self.mode {
             PermissionMode::Auto => return Some(ApprovalDecision::Allow),
+            PermissionMode::Plan => return Some(ApprovalDecision::Deny),
+            PermissionMode::AcceptEdits if accept_edits_auto_allows_cloud_request(tool, detail) => {
+                return Some(ApprovalDecision::Allow);
+            }
             PermissionMode::Deny => return Some(ApprovalDecision::Deny),
             PermissionMode::Prompt => {}
+            PermissionMode::AcceptEdits => {}
         }
 
         // Standard-kind: consult the denial tracker. The session
         // override check already ran at the top of the function, so
         // here we only care about repeated-denial short-circuits.
-        match self.denial_tracker.should_prompt(&fp) {
+        match self.denial_tracker.should_prompt(&fps[0]) {
             astra_turn_core::approval_fingerprint::DenialAction::SkipTool => {
                 Some(ApprovalDecision::Deny)
             }
@@ -1804,13 +1975,11 @@ impl PermissionManager {
         if self.is_inherited_allowed_with_context(name, &ctx) {
             return true;
         }
-        self.cached_allow
-            .iter()
-            .any(|rule| rule.matches_with_context(name, &ctx))
-            || self
-                .cached_user_allow
-                .iter()
-                .any(|rule| rule.matches_with_context(name, &ctx))
+        self.cached_allow.iter().any(|rule| {
+            !rule.is_dangerous_bash_allow_shape() && rule.matches_with_context(name, &ctx)
+        }) || self.cached_user_allow.iter().any(|rule| {
+            !rule.is_dangerous_bash_allow_shape() && rule.matches_with_context(name, &ctx)
+        })
     }
 
     fn evaluation_context(&self) -> astra_turn_core::permission_types::PermissionSyncContext {
@@ -1824,6 +1993,7 @@ impl PermissionManager {
             .cached_allow
             .iter()
             .chain(self.cached_user_allow.iter())
+            .filter(|rule| !rule.is_dangerous_bash_allow_shape())
         {
             inherited.add_allow(rule.clone());
         }
@@ -1985,14 +2155,7 @@ impl PermissionManager {
         // function — see `permission_prompt_primary_detail`.)
         let brief = permission_prompt_display_label(name, args);
         let header = format!("{icon} {name}");
-        let mut detail_lines = vec![Self::format_prompt_detail(&brief)];
-        if let Some(explicit) = explicit_approval_reason(name, args) {
-            detail_lines.push(Self::format_prompt_detail(&explicit));
-        }
-        if let Some(compensation) = compensation_prompt_note(name, args) {
-            detail_lines.push(Self::format_prompt_detail(&compensation));
-        }
-        let detail = Some(detail_lines.join("\n"));
+        let detail = Some(Self::format_prompt_detail(&brief));
 
         // Issue #326 P3 / scenario #8: redact secret-looking
         // content from the detail block before it lands in the
@@ -2078,49 +2241,54 @@ impl PermissionManager {
                 // shape to match so `make_allow_rule` produces the
                 // right pattern (`Bash(cargo:*)` vs `write_file`).
                 let kind = cloud_gated_tool_kind(tool);
-                let (fp, rule_args) = match (kind, detail) {
-                    (Some(CloudGatedToolKind::Execute), Some(cmd)) => (
-                        astra_turn_core::approval_fingerprint::ApprovalFingerprint::shell(
-                            tool, cmd, false,
-                        ),
-                        serde_json::json!({ "command": cmd }),
-                    ),
-                    (Some(CloudGatedToolKind::Write), d) => (
-                        astra_turn_core::approval_fingerprint::ApprovalFingerprint::file_op(
-                            tool, d,
-                        ),
-                        match d {
-                            Some(p) => serde_json::json!({ "path": p }),
-                            None => serde_json::Value::Null,
-                        },
-                    ),
-                    _ => (
-                        astra_turn_core::approval_fingerprint::ApprovalFingerprint::bare(tool),
-                        serde_json::Value::Null,
-                    ),
+                let rule_args = match (kind, detail) {
+                    (Some(CloudGatedToolKind::Execute), Some(cmd)) => {
+                        serde_json::json!({ "command": cmd })
+                    }
+                    (Some(CloudGatedToolKind::Write), Some(p)) => {
+                        serde_json::json!({ "path": p })
+                    }
+                    (Some(CloudGatedToolKind::Write), None) => serde_json::Value::Null,
+                    _ => serde_json::Value::Null,
                 };
+                let fp = fingerprint_for_match_target(
+                    tool,
+                    &rule_args,
+                    &default_match_target(tool, &rule_args),
+                );
                 self.session_overrides.insert(fp, true);
                 let rule = Self::make_allow_rule(tool, &rule_args);
+                let scope = if self.project_root.is_some() {
+                    "workspace"
+                } else {
+                    "session"
+                };
+                let location = if self.project_root.is_some() {
+                    "in this workspace"
+                } else {
+                    "in this session"
+                };
+                let remember_preview = astra_turn_core::permission_match_target::remember_preview(
+                    tool, &rule_args, location,
+                );
                 if sensitive_path_match(&rule_args).is_some() {
-                    eprintln!("{}", format!("  ✓ {rule}: allowed for this session").dim());
+                    eprintln!(
+                        "{}",
+                        cloud_always_feedback_message(&remember_preview, scope, None, true).dim()
+                    );
                 } else {
                     self.add_allow_rule(&rule);
                     let persist_error = self.take_last_save_error();
-                    let scope = if self.project_root.is_some() {
-                        "project"
+                    let feedback = cloud_always_feedback_message(
+                        &remember_preview,
+                        scope,
+                        persist_error.as_deref(),
+                        false,
+                    );
+                    if persist_error.is_some() {
+                        eprintln!("{}", feedback.yellow());
                     } else {
-                        "session"
-                    };
-                    if let Some(err) = persist_error {
-                        eprintln!(
-                            "{}",
-                            format!(
-                                "  ⚠ {rule}: allowed for this session; failed to save {scope} rule: {err}"
-                            )
-                            .yellow()
-                        );
-                    } else {
-                        eprintln!("{}", format!("  ✓ {rule}: always allowed ({scope})").dim());
+                        eprintln!("{}", feedback.dim());
                     }
                 }
                 ApprovalDecision::AllowSession
@@ -2553,7 +2721,7 @@ impl PermissionManager {
                     eprintln!("  {}", format!("⚠  Git safety: {v}").yellow());
                 }
                 // In deny mode, reject git safety violations outright.
-                if self.mode == PermissionMode::Deny {
+                if matches!(self.mode, PermissionMode::Plan | PermissionMode::Deny) {
                     eprintln!("  {}", "  Git safety violation — blocked".red());
                     return false;
                 }
@@ -2563,8 +2731,7 @@ impl PermissionManager {
                         return true;
                     }
                     if let Some(allowed) = self
-                        .session_overrides
-                        .check(&approval_lookup_fingerprint(name, args))
+                        .check_overrides_any(&approval_lookup_fingerprint_candidates(name, args))
                     {
                         return allowed;
                     }
@@ -2588,7 +2755,7 @@ impl PermissionManager {
         // Step 3: Dangerous file path check (bypass-immune).
         if let Some(warning) = Self::check_dangerous_path(name, args) {
             eprintln!("  {}", warning.yellow());
-            if self.mode == PermissionMode::Deny {
+            if matches!(self.mode, PermissionMode::Plan | PermissionMode::Deny) {
                 eprintln!("  {}", "  Sensitive path — blocked".red());
                 return false;
             }
@@ -2624,21 +2791,24 @@ impl PermissionManager {
             return false;
         }
 
-        if side_effect == SideEffect::Read && explicit_approval_reason(name, args).is_none() {
+        if side_effect == SideEffect::Read
+            && astra_turn_core::action_compensation::explicit_approval_reason(name, args).is_none()
+        {
             return true;
         }
 
         // Step 5: Session overrides (AFTER bypass-immune safety checks, BEFORE
         // explicit-approval and mode gating so a prior approval isn't re-prompted).
-        if let Some(allowed) = self
-            .session_overrides
-            .check(&approval_lookup_fingerprint(name, args))
+        if let Some(allowed) =
+            self.check_overrides_any(&approval_lookup_fingerprint_candidates(name, args))
         {
             return allowed;
         }
 
-        if let Some(reason) = explicit_approval_reason(name, args) {
-            if self.mode == PermissionMode::Deny {
+        if let Some(reason) =
+            astra_turn_core::action_compensation::explicit_approval_reason(name, args)
+        {
+            if matches!(self.mode, PermissionMode::Plan | PermissionMode::Deny) {
                 eprintln!("  {}", reason.red());
                 return false;
             }
@@ -2658,12 +2828,20 @@ impl PermissionManager {
         // Step 7: Permission mode determines final action.
         match self.mode {
             PermissionMode::Auto => return true,
+            PermissionMode::Plan => {
+                let (header, _) = Self::format_tool_display(name, args);
+                eprintln!("  {}", format!("  ✗ {header} — blocked").red());
+                return false;
+            }
+            PermissionMode::AcceptEdits if accept_edits_auto_allows_tool_args(name, args) => {
+                return true;
+            }
             PermissionMode::Deny => {
                 let (header, _) = Self::format_tool_display(name, args);
                 eprintln!("  {}", format!("  ✗ {header} — blocked").red());
                 return false;
             }
-            PermissionMode::Prompt => {} // fall through to interactive prompt
+            PermissionMode::AcceptEdits | PermissionMode::Prompt => {}
         }
 
         let (header, detail) = Self::format_tool_display(name, args);
@@ -2694,7 +2872,7 @@ impl PermissionManager {
                 let rule = Self::make_allow_rule(name, args);
                 self.add_allow_rule(&rule);
                 let scope = if self.project_root.is_some() {
-                    "project"
+                    "workspace"
                 } else {
                     "session"
                 };
@@ -2769,7 +2947,9 @@ impl PermissionManager {
         if matches!(envelope.source, DecisionSource::SandboxExpansion)
             && matches!(envelope.decision, HardDecision::NeedExternal { .. })
         {
-            if let Some(allowed) = self.check_overrides(&approval_lookup_fingerprint(name, args)) {
+            if let Some(allowed) =
+                self.check_overrides_any(&approval_lookup_fingerprint_candidates(name, args))
+            {
                 return if allowed {
                     PermissionDecision::Allow
                 } else {
@@ -2793,9 +2973,10 @@ impl PermissionManager {
         if matches!(envelope.source, DecisionSource::SensitivePath { .. })
             && matches!(envelope.decision, HardDecision::NeedExternal { .. })
         {
-            if let Some(allowed) =
-                self.check_overrides_for_request(&approval_lookup_fingerprint(name, args), true)
-            {
+            if let Some(allowed) = self.check_overrides_for_request(
+                &approval_lookup_fingerprint_candidates(name, args),
+                true,
+            ) {
                 return if allowed {
                     PermissionDecision::Allow
                 } else {
@@ -2811,6 +2992,11 @@ impl PermissionManager {
                     "Auto mode allowed write to sensitive path (opt-in): tool={name}"
                 );
                 return PermissionDecision::Allow;
+            }
+            if self.mode == PermissionMode::Auto {
+                return PermissionDecision::Deny(
+                    "Sensitive path requires explicit opt-in in Auto mode".to_string(),
+                );
             }
         }
 
@@ -3227,6 +3413,38 @@ mod tests {
     }
 
     #[test]
+    fn cloud_always_feedback_message_explains_sensitive_path_session_only() {
+        let out = super::cloud_always_feedback_message(
+            "this file edit in this workspace",
+            "workspace",
+            None,
+            true,
+        );
+        assert!(
+            out.contains("session only"),
+            "missing session-only hint: {out}"
+        );
+        assert!(
+            out.contains("allow_sensitive_path_writes=true"),
+            "missing sensitive-path opt-in guidance: {out}"
+        );
+    }
+
+    #[test]
+    fn cloud_always_feedback_message_uses_command_family_language() {
+        let out = super::cloud_always_feedback_message(
+            "the `cargo test` command family in this workspace",
+            "workspace",
+            None,
+            false,
+        );
+        assert_eq!(
+            out,
+            "  ✓ Always remembers: the `cargo test` command family in this workspace"
+        );
+    }
+
+    #[test]
     fn resolve_cloud_approval_quiet_denies_without_auto() {
         let mut pm = PermissionManager::new(false);
         assert!(matches!(
@@ -3253,6 +3471,67 @@ mod tests {
                 true
             ),
             astra_thin_client::ApprovalDecision::Allow
+        ));
+    }
+
+    #[test]
+    fn plan_mode_cloud_preflight_denies_mutating_requests() {
+        let mut pm = PermissionManager::new(false);
+        pm.set_mode(PermissionMode::Plan);
+
+        assert!(matches!(
+            pm.preflight_cloud_approval_decision(
+                "write_file",
+                Some("src/lib.rs"),
+                ApprovalKind::Standard,
+                true
+            ),
+            Some(astra_thin_client::ApprovalDecision::Deny)
+        ));
+        assert!(matches!(
+            pm.preflight_cloud_approval_decision(
+                "write_file",
+                Some("src/lib.rs"),
+                ApprovalKind::Standard,
+                false
+            ),
+            Some(astra_thin_client::ApprovalDecision::Deny)
+        ));
+        assert!(matches!(
+            pm.preflight_cloud_approval_decision(
+                "bash",
+                Some("touch plan.txt"),
+                ApprovalKind::Explicit,
+                true
+            ),
+            Some(astra_thin_client::ApprovalDecision::Deny)
+        ));
+        assert!(matches!(
+            pm.preflight_cloud_approval_decision(
+                "bash",
+                Some("touch plan.txt"),
+                ApprovalKind::Explicit,
+                false
+            ),
+            Some(astra_thin_client::ApprovalDecision::Deny)
+        ));
+        assert!(matches!(
+            pm.preflight_cloud_approval_decision(
+                "write_file",
+                Some(".env"),
+                ApprovalKind::Standard,
+                true
+            ),
+            Some(astra_thin_client::ApprovalDecision::Deny)
+        ));
+        assert!(matches!(
+            pm.preflight_cloud_approval_decision(
+                "write_file",
+                Some(".env"),
+                ApprovalKind::Standard,
+                false
+            ),
+            Some(astra_thin_client::ApprovalDecision::Deny)
         ));
     }
 
@@ -3697,6 +3976,28 @@ mod tests {
     }
 
     #[test]
+    fn allow_rules_ignore_dangerous_broad_bash_shapes() {
+        let mut pm = PermissionManager::new(false);
+        pm.settings.allow.push("bash".to_string());
+        pm.settings
+            .allow
+            .push(r#"Bash(argv_prefix="python", op="execute")"#.to_string());
+        pm.settings
+            .allow
+            .push(r#"Bash(argv_prefix="npm test", op="execute")"#.to_string());
+        pm.cached_allow = pm.settings.parsed_allow_rules();
+
+        assert!(!pm.check_allow_rules(
+            "bash",
+            &serde_json::json!({"command": "python -c 'print(1)'"})
+        ));
+        assert!(pm.check_allow_rules(
+            "bash",
+            &serde_json::json!({"command": "npm test -- --watch"})
+        ));
+    }
+
+    #[test]
     fn allow_rules_enforce_v2_op_and_path_context() {
         let mut pm = PermissionManager::new(false);
         pm.settings
@@ -4069,6 +4370,41 @@ mod tests {
     }
 
     #[test]
+    fn workspace_trust_unknown_surfaces_startup_notice() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger_path = dir.path().join("trusted_workspaces.json");
+        let pm = PermissionManager::with_workspace_trust_mode_from_ledger_path(
+            PermissionMode::Prompt,
+            dir.path(),
+            ledger_path,
+        );
+
+        let notice = pm
+            .workspace_trust_notice()
+            .expect("unknown workspace should surface a trust notice");
+        assert!(notice.contains("Workspace not trusted yet"));
+        assert!(notice.contains("/allow trust"));
+        assert!(notice.contains("astra permissions trust"));
+    }
+
+    #[test]
+    fn workspace_trust_unknown_surfaces_startup_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger_path = dir.path().join("trusted_workspaces.json");
+        let pm = PermissionManager::with_workspace_trust_mode_from_ledger_path(
+            PermissionMode::Prompt,
+            dir.path(),
+            ledger_path,
+        );
+
+        let prompt = pm
+            .workspace_trust_startup_prompt()
+            .expect("unknown workspace should surface a startup prompt");
+        assert!(prompt.header.contains("Trust this workspace?"));
+        assert!(prompt.header.contains(&dir.path().display().to_string()));
+    }
+
+    #[test]
     fn workspace_trust_matching_hash_loads_project_allow() {
         let dir = tempfile::tempdir().unwrap();
         let kiro = dir.path().join(".kiro");
@@ -4191,6 +4527,14 @@ mod tests {
             PermissionMode::Auto
         );
         assert_eq!(
+            "accept_edits".parse::<PermissionMode>().unwrap(),
+            PermissionMode::AcceptEdits
+        );
+        assert_eq!(
+            "plan".parse::<PermissionMode>().unwrap(),
+            PermissionMode::Plan
+        );
+        assert_eq!(
             "prompt".parse::<PermissionMode>().unwrap(),
             PermissionMode::Prompt
         );
@@ -4202,12 +4546,18 @@ mod tests {
             "AUTO".parse::<PermissionMode>().unwrap(),
             PermissionMode::Auto
         );
+        assert_eq!(
+            "accept-edits".parse::<PermissionMode>().unwrap(),
+            PermissionMode::AcceptEdits
+        );
         assert!("invalid".parse::<PermissionMode>().is_err());
     }
 
     #[test]
     fn permission_mode_display() {
         assert_eq!(PermissionMode::Auto.to_string(), "auto");
+        assert_eq!(PermissionMode::Plan.to_string(), "plan");
+        assert_eq!(PermissionMode::AcceptEdits.to_string(), "accept_edits");
         assert_eq!(PermissionMode::Prompt.to_string(), "prompt");
         assert_eq!(PermissionMode::Deny.to_string(), "deny");
     }
@@ -4653,7 +5003,7 @@ mod tests {
     }
 
     #[test]
-    fn write_file_prompt_includes_compensation_hint() {
+    fn write_file_prompt_keeps_recovery_jargon_out_of_primary_prompt() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
         let args = serde_json::json!({"path": "src/main.rs", "content": "fn main() {}"});
@@ -4664,10 +5014,42 @@ mod tests {
                 ..
             } => {
                 assert!(detail.contains("src/main.rs"));
-                assert!(detail.contains("Compensation:"));
-                assert!(detail.contains("restore prior contents"));
+                assert!(!detail.contains("Compensation:"));
+                assert!(!detail.contains("rollback"));
+                assert!(!detail.contains("restore prior contents"));
             }
             other => panic!("expected NeedApproval with detail, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explicit_prompt_uses_user_facing_copy_not_policy_jargon() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+        let args = serde_json::json!({"command": "cargo test -p astra-cli"});
+        let decision = pm.check_nonblocking("bash", &args);
+        match decision {
+            PermissionDecision::NeedApproval {
+                detail: Some(detail),
+                reason,
+                ..
+            } => {
+                assert!(detail.contains("cargo test -p astra-cli"));
+                let combined = format!("{detail}\n{reason}");
+                for forbidden in [
+                    "Explicit approval required:",
+                    "action scope is unbounded",
+                    "rollback is not automatic",
+                    "Compensation:",
+                    "manual rollback required",
+                ] {
+                    assert!(
+                        !combined.contains(forbidden),
+                        "primary approval prompt must not expose {forbidden:?}: {combined}"
+                    );
+                }
+            }
+            other => panic!("expected NeedApproval with user-facing copy, got: {other:?}"),
         }
     }
 
@@ -4768,17 +5150,16 @@ mod tests {
 
     #[test]
     fn session_override_cannot_bypass_dangerous_path() {
-        // Hard boundary: Auto mode is strict on sensitive paths by default,
-        // even with a broad tool-level session override. The operator must
-        // flip the explicit `allow_sensitive_path_writes` opt-in to proceed
-        // unattended without a content-specific approval.
+        // Hard boundary: Auto mode never opens an interactive prompt for
+        // sensitive paths. Without a content-specific approval or explicit
+        // opt-in it fails closed.
         let mut pm = PermissionManager::new(true);
         pm.session_overrides.insert(bare_fp("write_file"), true);
         let args = serde_json::json!({"path": ".git/config", "content": "bad"});
         let decision = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::NeedApproval { .. }),
-            "Auto mode must require approval for sensitive paths by default: got {decision:?}"
+            matches!(decision, PermissionDecision::Deny(_)),
+            "Auto mode must deny sensitive paths by default instead of prompting: got {decision:?}"
         );
 
         // Opt-in unlocks it.
@@ -4813,8 +5194,8 @@ mod tests {
 
         let decision = pm.check_nonblocking("write_file", &sensitive);
         assert!(
-            matches!(decision, PermissionDecision::NeedApproval { .. }),
-            "non-sensitive directory approval must not unlock sensitive sibling: got {decision:?}"
+            matches!(decision, PermissionDecision::Deny(_)),
+            "non-sensitive directory approval must not unlock sensitive sibling in Auto mode: got {decision:?}"
         );
     }
 
@@ -5009,37 +5390,70 @@ mod tests {
         assert!(pm.check_allow_rules("write_file", &approved_args));
         assert!(!pm.check_allow_rules(
             "write_file",
-            &serde_json::json!({"path": "zzzz4.md", "content": "# zzzz4"})
+            &serde_json::json!({"path": "/tmp/zzzz4.md", "content": "# zzzz4"})
         ));
+    }
+
+    #[test]
+    fn make_allow_rule_file_write_uses_workspace_tool_scope() {
+        let args = serde_json::json!({"path": "rust/crates/astra-cli/src/main.rs"});
+        let rule = PermissionManager::make_allow_rule("write_file", &args);
+        let workspace_root = std::env::current_dir()
+            .unwrap()
+            .canonicalize()
+            .unwrap_or_else(|_| std::env::current_dir().unwrap())
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            rule,
+            format!(
+                r#"write_file(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
+            )
+        );
     }
 
     #[test]
     fn make_allow_rule_empty_command_falls_back() {
         let args = serde_json::json!({"command": ""});
         let rule = PermissionManager::make_allow_rule("bash", &args);
-        assert_eq!(rule, "bash");
+        assert_eq!(rule, r#"Bash(argv_exact="", op="execute")"#);
     }
 
     #[test]
     fn make_allow_rule_stops_at_pipe_or_redirect() {
-        // Compound commands: don't bake the pipe target into the rule.
+        // Stable command families still persist as reusable prefixes.
         let args = serde_json::json!({"command": "cargo test | tee log.txt"});
         let rule = PermissionManager::make_allow_rule("bash", &args);
         assert_eq!(rule, r#"Bash(argv_prefix="cargo test", op="execute")"#);
 
+        // Single-word / flag-shaped commands fall back to exact rules instead
+        // of broad `Bash(ls:*)` or `Bash(true:*)` allow rules.
         let args = serde_json::json!({"command": "ls -la > /tmp/out"});
         let rule = PermissionManager::make_allow_rule("bash", &args);
-        assert_eq!(rule, r#"Bash(argv_prefix="ls", op="execute")"#);
+        assert_eq!(
+            rule,
+            r#"Bash(argv_exact="ls -la > /tmp/out", op="execute")"#
+        );
 
         let args = serde_json::json!({"command": "true && rm -rf"});
         let rule = PermissionManager::make_allow_rule("bash", &args);
-        assert_eq!(rule, r#"Bash(argv_prefix="true", op="execute")"#);
+        assert_eq!(rule, r#"Bash(argv_exact="true && rm -rf", op="execute")"#);
     }
 
     #[test]
-    fn make_allow_rule_caps_at_three_tokens() {
-        // For deeply-nested subcommands, three tokens is enough to
-        // distinguish `npm run deploy:prod` from `npm run test:unit`.
+    fn make_allow_rule_interpreter_commands_are_exact_not_broad_prefix() {
+        let args = serde_json::json!({"command": "python -c 'print(1)'"});
+        let rule = PermissionManager::make_allow_rule("bash", &args);
+        assert_eq!(
+            rule,
+            r#"Bash(argv_exact="python -c 'print(1)'", op="execute")"#
+        );
+    }
+
+    #[test]
+    fn make_allow_rule_uses_command_subcommand_prefix() {
+        // Match Claude Code's safe default: reusable bash rules use a
+        // command+subcommand family, not arbitrary first-word prefixes.
         let args = serde_json::json!({"command": "kubectl apply -f deployment.yaml"});
         let rule = PermissionManager::make_allow_rule("bash", &args);
         // -f stops the prefix, so we get `kubectl apply`.
@@ -5782,27 +6196,52 @@ mod tests {
         );
     }
 
+    #[test]
+    fn bash_command_family_approval_skips_cd_wrapped_reprompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+        let approved_args = serde_json::json!({"command": "cargo test --lib"});
+        let similar_args =
+            serde_json::json!({"command": "cd rust && cargo test -p astra-cli tui::approval"});
+
+        pm.record_approval("bash", Some(&approved_args), true);
+
+        let decision = pm.check_nonblocking("bash", &similar_args);
+        assert!(
+            matches!(decision, PermissionDecision::Allow),
+            "workspace command-family approval should cover cd-wrapped cargo test; got {decision:?}"
+        );
+    }
+
     // ── record_approval: content-aware fingerprints ───────────────────────────
 
     #[test]
-    fn record_approval_with_args_creates_content_aware_fingerprint() {
+    fn record_approval_with_match_target_trusts_safe_writes_across_workspace() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
         let args_a = serde_json::json!({"path": "src/foo.rs", "content": "a"});
         let args_b = serde_json::json!({"path": "tests/bar.rs", "content": "b"});
+        let workspace_root = std::env::current_dir()
+            .unwrap()
+            .canonicalize()
+            .unwrap_or_else(|_| std::env::current_dir().unwrap())
+            .to_string_lossy()
+            .into_owned();
 
-        // Approve write_file for src/foo.rs.
-        pm.record_approval("write_file", Some(&args_a), true);
+        pm.record_approval_with_match_target(
+            "write_file",
+            &args_a,
+            &AllowMatchTarget::Prefix(workspace_root),
+            true,
+        );
 
-        // Same directory pattern should match.
         let decision = pm.check_nonblocking("write_file", &args_a);
         assert!(matches!(decision, PermissionDecision::Allow));
 
-        // Different directory should NOT be auto-approved (content-aware, not bare).
         let decision = pm.check_nonblocking("write_file", &args_b);
         assert!(
-            !matches!(decision, PermissionDecision::Allow),
-            "different path should not be auto-approved by content-aware fingerprint"
+            matches!(decision, PermissionDecision::Allow),
+            "workspace write trust should cover later safe file edits anywhere in the workspace"
         );
     }
 
@@ -5980,8 +6419,8 @@ mod tests {
         let args = serde_json::json!({"path": ".ssh/id_rsa", "content": "x"});
         let d = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(d, PermissionDecision::NeedApproval { .. }),
-            "Auto mode must be strict on sensitive paths by default, got {d:?}"
+            matches!(d, PermissionDecision::Deny(_)),
+            "Auto mode must deny sensitive paths by default instead of prompting, got {d:?}"
         );
 
         // Non-sensitive path still auto-allowed.
@@ -6009,9 +6448,10 @@ mod tests {
             ApprovalKind::Standard,
             false,
         );
-        assert!(
-            interactive.is_none(),
-            "interactive Auto mode should prompt for sensitive cloud writes: got {interactive:?}"
+        assert_eq!(
+            interactive,
+            Some(astra_thin_client::ApprovalDecision::Deny),
+            "interactive Auto mode must deny sensitive cloud writes instead of prompting"
         );
 
         let quiet = pm.preflight_cloud_approval_decision(
@@ -6067,6 +6507,98 @@ mod tests {
             quiet,
             Some(astra_thin_client::ApprovalDecision::Deny),
             "quiet cloud sensitive path with only broad override must deny"
+        );
+    }
+
+    #[test]
+    fn accept_edits_cloud_preflight_auto_allows_safe_writes_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::AcceptEdits, dir.path());
+
+        let safe_write = pm.preflight_cloud_approval_decision(
+            "write_file",
+            Some("src/lib.rs"),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert_eq!(
+            safe_write,
+            Some(astra_thin_client::ApprovalDecision::Allow),
+            "accept_edits should auto-allow workspace-local writes"
+        );
+
+        let bash = pm.preflight_cloud_approval_decision(
+            "bash",
+            Some("cargo test"),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert!(
+            bash.is_none(),
+            "accept_edits should still prompt for bash execution"
+        );
+
+        let external_write = pm.preflight_cloud_approval_decision(
+            "write_file",
+            Some("/var/log/astra.log"),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert!(
+            external_write.is_none(),
+            "accept_edits should still prompt for workspace-external writes"
+        );
+
+        let escaped_relative = pm.preflight_cloud_approval_decision(
+            "write_file",
+            Some("../outside.rs"),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert!(
+            escaped_relative.is_none(),
+            "accept_edits must not auto-allow parent-relative writes that escape the workspace"
+        );
+    }
+
+    #[test]
+    fn accept_edits_cloud_preflight_keeps_sensitive_and_quiet_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::AcceptEdits, dir.path());
+
+        let interactive_sensitive = pm.preflight_cloud_approval_decision(
+            "write_file",
+            Some(".env"),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert!(
+            interactive_sensitive.is_none(),
+            "accept_edits should still prompt for sensitive writes"
+        );
+
+        let quiet_bash = pm.preflight_cloud_approval_decision(
+            "bash",
+            Some("cargo test"),
+            ApprovalKind::Explicit,
+            true,
+        );
+        assert_eq!(
+            quiet_bash,
+            Some(astra_thin_client::ApprovalDecision::Deny),
+            "quiet accept_edits cannot prompt for bash"
+        );
+
+        let quiet_sensitive = pm.preflight_cloud_approval_decision(
+            "write_file",
+            Some(".env"),
+            ApprovalKind::Standard,
+            true,
+        );
+        assert_eq!(
+            quiet_sensitive,
+            Some(astra_thin_client::ApprovalDecision::Deny),
+            "quiet accept_edits must fail closed for sensitive writes"
         );
     }
 
@@ -6590,6 +7122,66 @@ mod tests {
         );
     }
 
+    #[test]
+    fn cloud_always_workspace_write_survives_restart_for_other_workspace_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+            pm.apply_cloud_approval_choice("write_file", Some("src/main.rs"), 'a');
+        }
+
+        let mut reborn = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+        let decision = reborn.check_nonblocking(
+            "write_file",
+            &serde_json::json!({"path": "tests/another.rs", "content": "hi"}),
+        );
+        assert!(
+            matches!(decision, PermissionDecision::Allow),
+            "workspace write trust should survive restart for later safe paths; got {decision:?}"
+        );
+    }
+
+    #[test]
+    fn cloud_always_sensitive_write_stays_session_only_after_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+            let first = pm.apply_cloud_approval_choice("write_file", Some(".env"), 'a');
+            assert_eq!(first, astra_thin_client::ApprovalDecision::AllowSession);
+
+            let same_session = pm.check_nonblocking(
+                "write_file",
+                &serde_json::json!({"path": ".env", "content": "TOKEN=1"}),
+            );
+            assert!(
+                matches!(same_session, PermissionDecision::Allow),
+                "same-session sensitive override should still work; got {same_session:?}"
+            );
+        }
+
+        let settings_path = dir.path().join(".kiro").join("permissions.json");
+        if settings_path.exists() {
+            let on_disk = std::fs::read_to_string(&settings_path).unwrap();
+            let saved: PermissionSettings = serde_json::from_str(&on_disk).unwrap();
+            assert!(
+                !saved.allow.iter().any(|rule| rule.contains(".env")),
+                "sensitive path Always must not persist to disk: {on_disk}"
+            );
+        }
+
+        let mut reborn = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+        let after_restart = reborn.preflight_cloud_approval_decision(
+            "write_file",
+            Some(".env"),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert!(
+            after_restart.is_none(),
+            "after restart, sensitive write should prompt again instead of persisting"
+        );
+    }
+
     // ── Explicit-kind `Always` must not re-prompt (user-reported) ──
     //
     // bash / shell_exec / other unbounded+irreversible tools go
@@ -6634,6 +7226,30 @@ mod tests {
             decision,
             astra_thin_client::ApprovalDecision::Allow,
             "Explicit-kind second call must honour the prior `Always`; got {decision:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_bash_always_covers_cd_wrapped_command_family() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+
+        let first = pm.apply_cloud_approval_choice("bash", Some("cargo test --lib"), 'a');
+        assert_eq!(first, astra_thin_client::ApprovalDecision::AllowSession);
+
+        let decision = pm
+            .resolve_cloud_approval_async(
+                "bash",
+                Some("cd rust && cargo test -p astra-cli tui::approval"),
+                None,
+                ApprovalKind::Explicit,
+                false,
+            )
+            .await;
+        assert_eq!(
+            decision,
+            astra_thin_client::ApprovalDecision::Allow,
+            "stored command-family approval should cover later cd-wrapped cargo test, got {decision:?}"
         );
     }
 

--- a/rust/crates/astra-cli/src/cli/session_cleanup.rs
+++ b/rust/crates/astra-cli/src/cli/session_cleanup.rs
@@ -17,7 +17,6 @@ use std::time::Duration;
 use super::SessionState;
 use super::auth_flow::clear_profile_last_session;
 use super::chat_turn::enqueue_ingestion_pub;
-use super::cli_utils::prefix_chars;
 use super::edge_tools;
 use super::session_guard::{ShutdownSignal, clear_panic_guard};
 
@@ -25,7 +24,7 @@ use super::session_guard::{ShutdownSignal, clear_panic_guard};
 /// decisions in `finalize_session_exit`:
 ///   * whether to print the "Session … saved. To resume: …" hint
 ///   * whether to clear `last_session_id` from the credentials file
-///     (so the next `astra` launch does NOT auto-resume into this sid)
+///     (so the next `astra` launch does NOT keep offering this sid for resume)
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SessionExit {
     /// User typed `/exit` / `/quit` (or any slash command that returned
@@ -36,7 +35,7 @@ pub(crate) enum SessionExit {
     Eof,
     /// Ctrl-C at idle. Treated like a "cancel" rather than EOF: the
     /// session is saved (and resumable via the hint) but
-    /// `last_session_id` stays put so a plain `astra` reattaches.
+    /// `last_session_id` stays put so the next launch can still offer `/resume`.
     Interrupt,
     /// `--max-budget` reached during a turn.
     BudgetLimit,
@@ -44,7 +43,7 @@ pub(crate) enum SessionExit {
     Shutdown(ShutdownSignal),
     /// The TUI loop bailed with an error (terminal draw failure, etc.).
     /// Session stays addressable so the user can investigate and
-    /// `astra` reattaches on next launch.
+    /// the next launch can still offer `/resume`.
     Error,
 }
 
@@ -61,11 +60,10 @@ pub(crate) async fn finalize_session_exit(
         && state.turn > 0
         && let Some(ref sid) = state.session_id
     {
-        let short = prefix_chars(sid, 8);
-        eprintln!(
-            "{}",
-            format!("  Session {short}… saved. To resume: /resume {sid}").dim()
-        );
+        let (label, command) = resume_hint_lines(sid);
+        eprintln!();
+        eprintln!("{}", format!("  {label}").dim());
+        eprintln!("{}", format!("    {command}").cyan());
     }
 
     if should_clear_last_session_id(reason) && state.session_id.is_some() {
@@ -79,10 +77,17 @@ fn should_show_resume_hint(reason: SessionExit) -> bool {
     !matches!(reason, SessionExit::Error)
 }
 
+fn resume_hint_lines(session_id: &str) -> (String, String) {
+    (
+        "Resume this session with:".to_string(),
+        format!("/resume {session_id}"),
+    )
+}
+
 fn should_clear_last_session_id(reason: SessionExit) -> bool {
     // Only true EOF clears the persisted "last session". Ctrl-C, `/exit`,
     // budget cap, signals, and errors all leave it alone so the next
-    // `astra` launch reattaches.
+    // `astra` launch can still offer explicit resume.
     matches!(reason, SessionExit::Eof)
 }
 
@@ -285,5 +290,12 @@ mod tests {
             ShutdownSignal::Sighup
         )));
         assert!(!should_clear_last_session_id(SessionExit::Error));
+    }
+
+    #[test]
+    fn resume_hint_prints_copyable_resume_command() {
+        let (label, command) = resume_hint_lines("1234-5678");
+        assert_eq!(label, "Resume this session with:");
+        assert_eq!(command, "/resume 1234-5678");
     }
 }

--- a/rust/crates/astra-cli/src/cli/session_runtime.rs
+++ b/rust/crates/astra-cli/src/cli/session_runtime.rs
@@ -651,10 +651,9 @@ fn detect_pending_recovery_session(cli_profile: Option<&str>) -> Option<String> 
 }
 
 fn pending_recovery_status_line(state: &SessionState) -> Option<String> {
-    state
-        .pending_recovery
-        .as_ref()
-        .map(|_| "previous session available via /resume".to_string())
+    state.pending_recovery.as_ref().map(|_| {
+        "previous session available via /resume or a short continue/fix/test follow-up".to_string()
+    })
 }
 
 /// P3.3 — if a persisted plan_state.json exists for the active user, load it
@@ -1591,14 +1590,14 @@ mod tests {
     }
 
     #[test]
-    fn pending_recovery_status_line_requires_explicit_resume() {
+    fn pending_recovery_status_line_describes_explicit_resume_intents() {
         let state = SessionState {
             pending_recovery: Some("sess-123".to_string()),
             ..SessionState::default()
         };
         assert_eq!(
             pending_recovery_status_line(&state).as_deref(),
-            Some("previous session available via /resume")
+            Some("previous session available via /resume or a short continue/fix/test follow-up")
         );
         assert_eq!(pending_recovery_status_line(&SessionState::default()), None);
     }

--- a/rust/crates/astra-cli/src/cli/session_runtime.rs
+++ b/rust/crates/astra-cli/src/cli/session_runtime.rs
@@ -650,6 +650,13 @@ fn detect_pending_recovery_session(cli_profile: Option<&str>) -> Option<String> 
     workspace_matches_current_project(&workspace).then_some(session_id)
 }
 
+fn pending_recovery_status_line(state: &SessionState) -> Option<String> {
+    state
+        .pending_recovery
+        .as_ref()
+        .map(|_| "previous session available via /resume".to_string())
+}
+
 /// P3.3 — if a persisted plan_state.json exists for the active user, load it
 /// and compute a compact resume digest. The digest is a one-shot hint: it is
 /// only injected into the next turn's system prompt when the user message
@@ -907,6 +914,9 @@ pub(super) fn print_session_banner(profile: Option<&str>, state: &SessionState) 
         .dim()
         .to_string(),
     );
+    if let Some(line) = pending_recovery_status_line(state) {
+        right.push(line.dim().to_string());
+    }
     if let Ok(proxy) = std::env::var("http_proxy").or_else(|_| std::env::var("HTTP_PROXY")) {
         if !proxy.is_empty() {
             let max_proxy = right_col_w.saturating_sub(8);
@@ -1578,6 +1588,19 @@ mod tests {
         assert_eq!(state.pending_recovery.as_deref(), Some(sid.as_str()));
         assert!(state.history.is_empty());
         assert_eq!(state.turn, 0);
+    }
+
+    #[test]
+    fn pending_recovery_status_line_requires_explicit_resume() {
+        let state = SessionState {
+            pending_recovery: Some("sess-123".to_string()),
+            ..SessionState::default()
+        };
+        assert_eq!(
+            pending_recovery_status_line(&state).as_deref(),
+            Some("previous session available via /resume")
+        );
+        assert_eq!(pending_recovery_status_line(&SessionState::default()), None);
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/slash_router.rs
+++ b/rust/crates/astra-cli/src/cli/slash_router.rs
@@ -390,7 +390,9 @@ pub(crate) async fn handle_slash_command(
             match arg {
                 "" => {
                     let next = match state.perm_manager.mode() {
-                        PermissionMode::Prompt => PermissionMode::Auto,
+                        PermissionMode::Prompt => PermissionMode::Plan,
+                        PermissionMode::Plan => PermissionMode::AcceptEdits,
+                        PermissionMode::AcceptEdits => PermissionMode::Auto,
                         PermissionMode::Auto => PermissionMode::Deny,
                         PermissionMode::Deny => PermissionMode::Prompt,
                     };
@@ -407,6 +409,22 @@ pub(crate) async fn handle_slash_command(
                         "  {} Permission mode → {} (all tools auto-approved)",
                         "⚡".yellow(),
                         "auto".magenta()
+                    );
+                }
+                "plan" => {
+                    state.perm_manager.set_mode(PermissionMode::Plan);
+                    eprintln!(
+                        "  {} Permission mode → {} (read-only investigation mode)",
+                        theme::icon_info(),
+                        "plan".magenta()
+                    );
+                }
+                "accept_edits" | "accept-edits" => {
+                    state.perm_manager.set_mode(PermissionMode::AcceptEdits);
+                    eprintln!(
+                        "  {} Permission mode → {} (workspace-local edits auto-approved)",
+                        theme::icon_info(),
+                        "accept_edits".magenta()
                     );
                 }
                 "rules" | "status" => {
@@ -466,7 +484,7 @@ pub(crate) async fn handle_slash_command(
                     }
                     Err(_) => {
                         eprintln!(
-                            "  {} Unknown mode '{}'. Use: auto, prompt, deny, all, rules, trust, untrust, trace",
+                            "  {} Unknown mode '{}'. Use: auto, plan, accept_edits, prompt, deny, all, rules, trust, untrust, trace",
                             theme::icon_warn(),
                             arg
                         );

--- a/rust/crates/astra-cli/src/cli/spawn_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/spawn_subrun.rs
@@ -697,6 +697,10 @@ impl SpawnAgentExecutor for CliSpawnAgentExecutor {
                 let telemetry = ctx_guard.telemetry();
                 let mode = match ctx_guard.mode() {
                     astra_runtime::orchestration::PermissionMode::Auto => "auto".to_string(),
+                    astra_runtime::orchestration::PermissionMode::Plan => "plan".to_string(),
+                    astra_runtime::orchestration::PermissionMode::AcceptEdits => {
+                        "accept_edits".to_string()
+                    }
                     astra_runtime::orchestration::PermissionMode::Prompt => "prompt".to_string(),
                     astra_runtime::orchestration::PermissionMode::Deny => "deny".to_string(),
                 };

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -183,12 +183,21 @@ fn approval_scope_context_for_tool(
     workspace_untrusted: bool,
 ) -> astra_turn_core::permission_scope::ScopeAvailabilityContext {
     use astra_turn_core::permission_engine::RiskTag;
+    use astra_turn_core::permission_memory_profile::{
+        PersistentMemoryBlock, permission_memory_profile,
+    };
 
     let mut ctx = astra_turn_core::permission_scope::ScopeAvailabilityContext {
         source_agent_present,
         workspace_untrusted,
         ..Default::default()
     };
+    let memory_profile = permission_memory_profile(tool, args);
+    ctx.unsafe_rule_shape = !memory_profile.has_stable_target
+        || matches!(
+            memory_profile.persistent_block,
+            Some(PersistentMemoryBlock::UnsafeRuleShape)
+        );
 
     let base_tag = match astra_turn_core::cloud_approval_policy::cloud_gated_tool_kind_with_args(
         tool,
@@ -210,14 +219,19 @@ fn approval_scope_context_for_tool(
         push_risk_tag(&mut ctx.risk_tags, RiskTag::WritesSensitiveFile);
     }
 
-    if tool == "bash"
+    if matches!(tool, "bash" | "powershell")
         && let Some(cmd) = args.get("command").and_then(|v| v.as_str())
     {
-        let parsed = astra_turn_core::permission_compound_command::tokenize_compound_command(cmd);
-        ctx.is_compound_command = parsed.steps.len() > 1;
-        ctx.has_dynamic_eval = parsed.has_dynamic_eval;
+        ctx.is_compound_command = matches!(
+            memory_profile.persistent_block,
+            Some(PersistentMemoryBlock::CompoundCommand)
+        );
+        ctx.has_dynamic_eval = matches!(
+            memory_profile.persistent_block,
+            Some(PersistentMemoryBlock::DynamicEval)
+        );
 
-        if !astra_runtime::tool_sandbox::validate_git_command(cmd).is_empty() {
+        if tool == "bash" && !astra_runtime::tool_sandbox::validate_git_command(cmd).is_empty() {
             push_risk_tag(&mut ctx.risk_tags, RiskTag::GitDestructive);
         }
     }
@@ -232,6 +246,11 @@ fn approval_scope_context_for_tool(
     }
 
     ctx
+}
+
+fn approval_has_stable_memory_target(tool: &str, args: &Value) -> bool {
+    astra_turn_core::permission_memory_profile::permission_memory_profile(tool, args)
+        .has_stable_target
 }
 
 fn approval_default_always_scope(
@@ -257,6 +276,14 @@ fn approval_default_always_scope(
     }
 
     AllowScope::OnceThisCall
+}
+
+fn approval_memory_preview(tool: &str, args: &Value, scope_label: Option<&str>) -> String {
+    let location = scope_label
+        .map(|label| format!("under `{label}/`"))
+        .unwrap_or_else(|| "in this workspace".to_string());
+
+    astra_turn_core::permission_match_target::remember_preview(tool, args, &location)
 }
 
 fn audit_scope_for_always(
@@ -305,9 +332,7 @@ fn approval_memory_action(
 
     match response {
         ApprovalResponse::AllowOnce => ApprovalMemoryAction::None,
-        ApprovalResponse::AlwaysAllow
-        | ApprovalResponse::AlwaysAllowScoped(_)
-        | ApprovalResponse::AlwaysAllowScopedTarget { .. } => {
+        ApprovalResponse::AlwaysAllow => {
             let selected_scope = response.always_scope(always_scope).unwrap_or(always_scope);
             match selected_scope {
                 AllowScope::Project => ApprovalMemoryAction::PersistProjectRule,
@@ -317,7 +342,7 @@ fn approval_memory_action(
                 AllowScope::User => ApprovalMemoryAction::PersistUserRule,
             }
         }
-        ApprovalResponse::Skip | ApprovalResponse::Deny => ApprovalMemoryAction::None,
+        ApprovalResponse::Deny => ApprovalMemoryAction::None,
     }
 }
 
@@ -331,6 +356,12 @@ fn persist_scoped_allow_rule(
 ) {
     let default_target = astra_turn_core::permission_match_target::default_match_target(tool, args);
     let match_target = match_target.unwrap_or(&default_target);
+    let location = match target {
+        astra_turn_core::permission_audit::PersistTarget::Project => "in this workspace",
+        astra_turn_core::permission_audit::PersistTarget::User => "for this user",
+    };
+    let remember_preview =
+        astra_turn_core::permission_match_target::remember_preview(tool, args, location);
     pm.record_approval_with_match_target(tool, args, match_target, true);
     let rule = crate::permission_manager::PermissionManager::make_allow_rule_with_match_target(
         tool,
@@ -348,11 +379,11 @@ fn persist_scoped_allow_rule(
         };
         astra_core::agent_warn!(
             "permission",
-            "Always allow for {tool} is session-only; failed to save rule {rule} to {target_label}: {err}"
+            "Always allow for {remember_preview} is session-only; failed to save rule {rule} to {target_label}: {err}"
         );
         if let Some(tx) = save_warning_tx {
             let _ = tx.send(super::chat_stream::StreamEvent::StatusLine(format!(
-                "Failed to save permission rule {rule} to {target_label}: {err}"
+                "Failed to save Always allow for {remember_preview} to {target_label}: {err}"
             )));
         }
     }
@@ -2105,7 +2136,7 @@ impl CliSseStreamHost<'_> {
         let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
         let header = format!("Cloud approval required: {tool}");
         let reason = if matches!(approval_kind, astra_thin_client::ApprovalKind::Explicit) {
-            "This tool call requires explicit approval before it can run.".to_string()
+            "This tool call requires approval before it can run.".to_string()
         } else {
             "Cloud approval required before this tool can run.".to_string()
         };
@@ -2146,20 +2177,10 @@ impl CliSseStreamHost<'_> {
         ));
         match response {
             ApprovalResponse::AllowOnce => ApprovalDecision::Allow,
-            // The current TUI button row has one Always button.
             // Explicit cloud approvals are confirm-once by contract,
-            // so treat Always as AllowOnce until the P3 scope picker
-            // can disable persistent scopes for this prompt kind.
-            ApprovalResponse::AlwaysAllow
-            | ApprovalResponse::AlwaysAllowScoped(_)
-            | ApprovalResponse::AlwaysAllowScopedTarget { .. }
-                if explicit =>
-            {
-                ApprovalDecision::Allow
-            }
-            ApprovalResponse::AlwaysAllow
-            | ApprovalResponse::AlwaysAllowScoped(_)
-            | ApprovalResponse::AlwaysAllowScopedTarget { .. } => {
+            // so treat Always as AllowOnce for this prompt kind.
+            ApprovalResponse::AlwaysAllow if explicit => ApprovalDecision::Allow,
+            ApprovalResponse::AlwaysAllow => {
                 let action = approval_memory_action(&response, always_scope, true);
                 let save_warning_tx = self.stream_event_tx.clone();
                 if let Some(pm) = self.perm_manager.as_mut() {
@@ -2181,12 +2202,6 @@ impl CliSseStreamHost<'_> {
                         ApprovalDecision::Allow
                     }
                 }
-            }
-            ApprovalResponse::Skip => {
-                if let Some(pm) = self.perm_manager.as_mut() {
-                    pm.record_approval(tool, Some(&approval_args), false);
-                }
-                ApprovalDecision::Deny
             }
             ApprovalResponse::Deny => ApprovalDecision::Deny,
         }
@@ -2494,7 +2509,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     use super::chat_stream::ApprovalResponse;
                     let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
                     // Issue #326 P3: compute the metadata bundle so
-                    // the TUI card can render the will-save preview,
+                    // the TUI card can render the remember preview,
                     // risk badge, and (if applicable) compound-
                     // command split. Senders without this context
                     // would call ApprovalRequest::bare instead.
@@ -2519,7 +2534,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
 
                     // Issue #326 P3/P5: one shared host-side
                     // classifier feeds the risk badges, batch-group
-                    // safety gate, will-save visibility, and the
+                    // safety gate, remember-preview visibility, and the
                     // actual Always storage action.
                     let workspace_untrusted = self
                         .perm_manager
@@ -2535,30 +2550,15 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     metadata.workspace_untrusted = scope_ctx.workspace_untrusted;
                     metadata.is_compound_command = scope_ctx.is_compound_command;
                     metadata.has_dynamic_eval = scope_ctx.has_dynamic_eval;
+                    metadata.unsafe_rule_shape = scope_ctx.unsafe_rule_shape;
                     let always_scope = approval_default_always_scope(&scope_ctx);
-                    metadata.custom_match_source =
-                        astra_turn_core::permission_match_target::custom_prefix_source(&t, args);
-
-                    // Will-save: what would Always persist? We use
-                    // the same make_allow_rule the post-resolve
-                    // path uses, so the user sees an exact preview
-                    // of what permissions.json will gain. Only show
-                    // it when the actual default Always scope is
-                    // Project; session-only / call-only approvals
-                    // must not advertise an on-disk write.
+                    // Show what Always will remember in product
+                    // language. The persisted rule remains an internal
+                    // detail; the UI must not leak `Bash(...:*)` or
+                    // other permissions.json DSL.
                     if always_scope == astra_turn_core::permission_scope::AllowScope::Project {
-                        let will_save =
-                            crate::permission_manager::PermissionManager::make_allow_rule(&t, args);
-                        // Issue #326 P5 / scenario #28: include
-                        // the package root in the will-save
-                        // preview so the user knows the rule will
-                        // be scoped to (say) `packages/web`, not
-                        // promoted globally. nearest_package_root
-                        // walks up from the cwd looking for a
-                        // package marker (Cargo.toml, package.json,
-                        // pyproject.toml, …); None means
-                        // "workspace root" — we use a literal
-                        // marker so the user sees something.
+                        // Include the package root when available so
+                        // the user understands the memory boundary.
                         let cwd = std::env::current_dir().unwrap_or_default();
                         let scope_label =
                             astra_turn_core::permission_cwd_root::nearest_package_root(&cwd, None)
@@ -2583,12 +2583,8 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                                         })
                                         .unwrap_or_else(|| p.to_string_lossy().into_owned())
                                 });
-                        let will_save_with_scope = if let Some(label) = scope_label {
-                            format!("{will_save}  (scope: {label}/)")
-                        } else {
-                            will_save
-                        };
-                        metadata.will_save_preview = Some(will_save_with_scope);
+                        metadata.remember_preview =
+                            Some(approval_memory_preview(&t, args, scope_label.as_deref()));
                     }
                     metadata.batch_group_key =
                         Some(approval_batch_group_key(&t, args, &metadata.risk_tags));
@@ -2743,17 +2739,8 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                             ApprovalResponse::AlwaysAllow => {
                                 astra_turn_core::approval_sink::ApprovalResponse::AlwaysAllow
                             }
-                            ApprovalResponse::AlwaysAllowScoped(_) => {
-                                astra_turn_core::approval_sink::ApprovalResponse::AlwaysAllow
-                            }
-                            ApprovalResponse::AlwaysAllowScopedTarget { .. } => {
-                                astra_turn_core::approval_sink::ApprovalResponse::AlwaysAllow
-                            }
                             ApprovalResponse::Deny => {
                                 astra_turn_core::approval_sink::ApprovalResponse::Deny
-                            }
-                            ApprovalResponse::Skip => {
-                                astra_turn_core::approval_sink::ApprovalResponse::Skip
                             }
                         };
                         let scope = response
@@ -2887,7 +2874,13 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                  before the parent agent finishes."
                     .to_string()
             } else {
-                let mut outcome = self.executor.execute_with_metadata(tool, args).await;
+                let mut outcome = execute_with_metadata_responsive(
+                    std::sync::Arc::clone(&self.executor),
+                    tool.to_string(),
+                    args.clone(),
+                    self.cancel_token.cloned(),
+                )
+                .await;
                 // If the sandbox denied the operation, prompt the user for
                 // authorization. On approval, temporarily expand the sandbox
                 // boundary and retry the tool.
@@ -2943,15 +2936,23 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                                             // Persistent: writes a tool-level allow
                                             // rule to settings for future sessions.
                                             let rule = crate::permission_manager::PermissionManager::make_allow_rule(&sandbox_tool_key, &guard_args);
+                                            let remember_preview =
+                                                astra_turn_core::permission_match_target::remember_preview(
+                                                    &sandbox_tool_key,
+                                                    &guard_args,
+                                                    "in this workspace",
+                                                );
                                             pm.add_allow_rule(&rule);
                                             if let Some(err) = pm.take_last_save_error() {
                                                 astra_core::agent_warn!(
                                                     "permission",
-                                                    "Always allow for {sandbox_tool_key} is session-only; failed to save rule {rule}: {err}"
+                                                    "Always allow for {remember_preview} is session-only; failed to save rule {rule}: {err}"
                                                 );
                                                 if let Some(tx) = &self.stream_event_tx {
                                                     let _ = tx.send(super::chat_stream::StreamEvent::StatusLine(
-                                                        format!("Failed to save permission rule {rule}: {err}"),
+                                                        format!(
+                                                            "Failed to save Always allow for {remember_preview}: {err}"
+                                                        ),
                                                     ));
                                                 }
                                             }
@@ -2966,15 +2967,23 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                                             astra_turn_core::permission_scope::AllowScope::User,
                                         ) => {
                                             let rule = crate::permission_manager::PermissionManager::make_allow_rule(&sandbox_tool_key, &guard_args);
+                                            let remember_preview =
+                                                astra_turn_core::permission_match_target::remember_preview(
+                                                    &sandbox_tool_key,
+                                                    &guard_args,
+                                                    "for this user",
+                                                );
                                             pm.add_user_allow_rule(&rule);
                                             if let Some(err) = pm.take_last_save_error() {
                                                 astra_core::agent_warn!(
                                                     "permission",
-                                                    "Always allow for {sandbox_tool_key} is session-only; failed to save user rule {rule}: {err}"
+                                                    "Always allow for {remember_preview} is session-only; failed to save user rule {rule}: {err}"
                                                 );
                                                 if let Some(tx) = &self.stream_event_tx {
                                                     let _ = tx.send(super::chat_stream::StreamEvent::StatusLine(
-                                                        format!("Failed to save user permission rule {rule}: {err}"),
+                                                        format!(
+                                                            "Failed to save Always allow for {remember_preview}: {err}"
+                                                        ),
                                                     ));
                                                 }
                                             }
@@ -3032,7 +3041,13 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                             {
                                 self.executor.expand_sandbox_path(dir);
                             }
-                            outcome = self.executor.execute_with_metadata(tool, args).await;
+                            outcome = execute_with_metadata_responsive(
+                                std::sync::Arc::clone(&self.executor),
+                                tool.to_string(),
+                                args.clone(),
+                                self.cancel_token.cloned(),
+                            )
+                            .await;
                             tool_result_fields = outcome.tool_result_fields;
                             outcome.output
                         } else {
@@ -3525,7 +3540,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
         // from saturating edge I/O or exhausting file descriptors.
         // Each future is wrapped with `catch_unwind` so a panicking tool is surfaced as
         // a tool failure instead of aborting the whole batch/turn.
-        let executor: &crate::edge_tools::ToolExecutor = &self.executor;
+        let executor = std::sync::Arc::clone(&self.executor);
         // Use the process-wide shared semaphore so the concurrency cap
         // genuinely spans every batch and every concurrent session in this
         // process — previously each batch constructed its own `Semaphore::new(10)`,
@@ -3544,6 +3559,8 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     let args = req.args.clone();
                     let request_id = req.request_id.clone();
                     let sem = sem.clone();
+                    let executor = std::sync::Arc::clone(&executor);
+                    let cancel_token_for_tool = self.cancel_token.cloned();
                     let speculative = speculative_by_id.get(&req.request_id).cloned();
                     let cancel_token = self.cancel_token.cloned();
                     async move {
@@ -3595,9 +3612,12 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                         // (it lives only for this batch), so acquire() won't fail; the
                         // `ok()` fallback is defensive.
                         let _permit = sem.acquire_owned().await.ok();
-                        let exec = catch_tool_execution_panic(
-                            executor.execute_with_metadata(&tool, &effective_args),
-                        );
+                        let exec = catch_tool_execution_panic(execute_with_metadata_responsive(
+                            std::sync::Arc::clone(&executor),
+                            tool.clone(),
+                            effective_args.clone(),
+                            cancel_token_for_tool,
+                        ));
                         let (outcome, dur) = if let Some(token) = cancel_token {
                             tokio::select! {
                                 biased;
@@ -3788,7 +3808,13 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                 pm.record_approval(&sandbox_tool_key, Some(&args), true);
             }
             let (retried, retry_dur) =
-                catch_tool_execution_panic(self.executor.execute_with_metadata(&tool, &args)).await;
+                catch_tool_execution_panic(execute_with_metadata_responsive(
+                    std::sync::Arc::clone(&self.executor),
+                    tool.clone(),
+                    args.clone(),
+                    self.cancel_token.cloned(),
+                ))
+                .await;
             outputs[pos] = (retried, retry_dur);
         }
 
@@ -3976,7 +4002,8 @@ fn build_streaming_tool_exec(
                         other => other.clone(),
                     })
                     .unwrap_or_else(|| serde_json::json!({}));
-                let outcome = executor.execute_with_metadata(&tool_name, &args).await;
+                let outcome =
+                    execute_with_metadata_responsive(executor, tool_name.clone(), args, None).await;
                 (call_id, tool_name, outcome.output, true)
             })
         });
@@ -6065,6 +6092,69 @@ where
     }
 }
 
+/// Whether a tool's edge implementation is dominated by a long-running
+/// blocking syscall (e.g. spawning a child shell + busy-polling for exit) and
+/// should therefore be moved off the async runtime worker via
+/// `spawn_blocking`. Gated by `cfg(windows)` because `powershell` only has a
+/// cancelable sync path on Windows — on non-Windows it falls through to the
+/// generic async path inside `execute_with_metadata`, where `spawn_blocking`
+/// would just add latency without preventing a stall.
+fn should_offload_blocking_tool(tool_name: &str) -> bool {
+    #[cfg(windows)]
+    {
+        matches!(tool_name, "bash" | "powershell")
+    }
+    #[cfg(not(windows))]
+    {
+        matches!(tool_name, "bash")
+    }
+}
+
+async fn execute_with_metadata_responsive(
+    executor: std::sync::Arc<crate::edge_tools::ToolExecutor>,
+    tool_name: String,
+    args: Value,
+    cancel_token: Option<tokio_util::sync::CancellationToken>,
+) -> crate::edge_tools::ToolExecutionOutcome {
+    if !should_offload_blocking_tool(&tool_name) {
+        return executor
+            .execute_with_metadata_cancelable(&tool_name, &args, cancel_token.as_ref())
+            .await;
+    }
+
+    // The cancelable bash/powershell paths are sync work wrapped in an
+    // `async fn`, so we can call the sync core directly inside
+    // `spawn_blocking`. This avoids re-entering the runtime via
+    // `Handle::block_on` from a blocking-pool thread, which is fragile on
+    // `current_thread` runtimes and a well-known anti-pattern.
+    let executor_for_blocking = std::sync::Arc::clone(&executor);
+    let tool_for_blocking = tool_name.clone();
+    let args_for_blocking = args.clone();
+    let cancel_for_blocking = cancel_token.clone();
+    let blocking_outcome = tokio::task::spawn_blocking(move || {
+        executor_for_blocking.execute_blocking_shell_tool(
+            &tool_for_blocking,
+            &args_for_blocking,
+            cancel_for_blocking.as_ref(),
+        )
+    })
+    .await;
+    match blocking_outcome {
+        Ok(Some(outcome)) => outcome,
+        // `should_offload_blocking_tool` can only return true for tool names
+        // that `execute_blocking_shell_tool` handles, so `None` here is
+        // unreachable; fall back to the async path defensively.
+        Ok(None) => {
+            executor
+                .execute_with_metadata_cancelable(&tool_name, &args, cancel_token.as_ref())
+                .await
+        }
+        Err(join_error) => crate::edge_tools::ToolExecutionOutcome::error(format!(
+            "Tool execution panicked: {join_error}"
+        )),
+    }
+}
+
 /// Human-friendly tool description from a `ToolCallRecord`'s name + args_preview.
 /// Mirrors `format_tool_description_with_output` but works without full args JSON.
 pub(crate) fn format_tool_display_from_preview(name: &str, args_preview: Option<&str>) -> String {
@@ -6441,6 +6531,36 @@ mod tests {
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocking_bash_execution_yields_to_runtime_ticks() {
+        let dir = tempdir().expect("tempdir");
+        let executor = std::sync::Arc::new(crate::edge_tools::ToolExecutor::new(dir.path()));
+        let execution = execute_with_metadata_responsive(
+            executor,
+            "bash".to_string(),
+            serde_json::json!({
+                "command": "sleep 0.2 && echo responsive",
+                "timeout": 2.0,
+            }),
+            None,
+        );
+        tokio::pin!(execution);
+
+        tokio::select! {
+            biased;
+            outcome = &mut execution => {
+                panic!(
+                    "foreground bash completed before the runtime could tick; output={}",
+                    outcome.output
+                );
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
+        }
+
+        let outcome = execution.await;
+        assert!(outcome.output.contains("responsive"), "{}", outcome.output);
+    }
+
     // ── D-9 regression: speculative success flag must gate reuse ──
     //
     // Guards against the cascade bug where a speculative tool execution that
@@ -6596,6 +6716,159 @@ mod tests {
         assert_eq!(
             approval_default_always_scope(&ctx),
             AllowScope::RestOfSession
+        );
+    }
+
+    #[test]
+    fn approval_scope_context_allows_always_for_cd_wrapped_single_command() {
+        use astra_turn_core::permission_scope::AllowScope;
+
+        let ctx = approval_scope_context_for_tool(
+            "bash",
+            &serde_json::json!({"command": r#"cd rust && grep -n "restore_session_into_state\|is_low_information_followup" rust/crates/astra-cli/src/cli/chat_turn.rs"#}),
+            false,
+            false,
+        );
+
+        assert!(
+            !ctx.is_compound_command,
+            "cd-wrapper around one real command should not disable Always"
+        );
+        assert_eq!(approval_default_always_scope(&ctx), AllowScope::Project);
+    }
+
+    #[test]
+    fn approval_scope_context_allows_always_for_cd_wrapped_cargo_build() {
+        use astra_turn_core::permission_scope::AllowScope;
+
+        let ctx = approval_scope_context_for_tool(
+            "bash",
+            &serde_json::json!({"command": "cd /home/xupeng/github/astra/rust && cargo build -p astra-turn-core -p astra-cli"}),
+            false,
+            false,
+        );
+
+        assert!(
+            !ctx.is_compound_command,
+            "cd-wrapper cargo build should not disable Always"
+        );
+        assert_eq!(approval_default_always_scope(&ctx), AllowScope::Project);
+    }
+
+    #[test]
+    fn approval_scope_context_allows_always_for_cd_wrapped_cargo_test() {
+        use astra_turn_core::permission_scope::AllowScope;
+
+        let ctx = approval_scope_context_for_tool(
+            "bash",
+            &serde_json::json!({"command": "cd /home/xupeng/github/astra/rust && cargo test -p astra-turn-core --lib cloud_approval_policy -- --nocapture"}),
+            false,
+            false,
+        );
+
+        assert!(
+            !ctx.is_compound_command,
+            "cd-wrapper cargo test should not disable Always"
+        );
+        assert_eq!(approval_default_always_scope(&ctx), AllowScope::Project);
+    }
+
+    #[test]
+    fn approval_scope_context_allows_always_for_read_only_pipe_chain() {
+        use astra_turn_core::permission_scope::AllowScope;
+
+        let ctx = approval_scope_context_for_tool(
+            "bash",
+            &serde_json::json!({"command": r#"cd rust && grep -n "is_unsafe_bare_shell_prefix\|UNSAFE_SHELL\|is_dangerous_bash_allow_shape" crates/astra-cli/src/edge_tools/shell.rs | head -n 20"#}),
+            false,
+            false,
+        );
+
+        assert!(
+            !ctx.is_compound_command,
+            "read-only pipe chains should still allow Always"
+        );
+        assert_eq!(approval_default_always_scope(&ctx), AllowScope::Project);
+    }
+
+    #[test]
+    fn approval_scope_context_allows_always_for_quoted_grep_regex() {
+        use astra_turn_core::permission_scope::AllowScope;
+
+        let ctx = approval_scope_context_for_tool(
+            "bash",
+            &serde_json::json!({"command": r#"cd /home/xupeng/github/astra && grep -n "fn powershell\|fn bash_with_cancel\|execute_with_metadata_responsive" rust/crates/astra-cli/src/edge_tools/shell.rs rust/crates/astra-cli/src/cli/stream_render.rs"#}),
+            false,
+            false,
+        );
+
+        assert!(
+            !ctx.is_compound_command,
+            "quoted grep regex alternation should not disable Always"
+        );
+        assert_eq!(approval_default_always_scope(&ctx), AllowScope::Project);
+    }
+
+    #[test]
+    fn approval_memory_preview_uses_product_language_not_permission_dsl() {
+        let preview = approval_memory_preview(
+            "bash",
+            &serde_json::json!({"command": "npm test -- --watch"}),
+            Some("web"),
+        );
+
+        assert_eq!(preview, "the `npm test` command family under `web/`");
+        assert!(
+            !preview.contains("Bash(") && !preview.contains("argv_prefix"),
+            "approval prompt must not expose permission-rule syntax: {preview}"
+        );
+    }
+
+    #[test]
+    fn approval_memory_preview_describes_file_edits_without_exact_scope_terms() {
+        let preview = approval_memory_preview(
+            "write_file",
+            &serde_json::json!({"path": "src/lib.rs"}),
+            None,
+        );
+
+        assert_eq!(preview, "file edits in this workspace");
+        assert!(
+            !preview.contains("Exact") && !preview.contains("Prefix"),
+            "approval prompt must not expose match-target terms: {preview}"
+        );
+    }
+
+    #[test]
+    fn approval_scope_context_blocks_persistent_memory_without_command_shape() {
+        use astra_turn_core::permission_scope::AllowScope;
+
+        let ctx = approval_scope_context_for_tool("bash", &serde_json::json!({}), false, false);
+
+        assert!(ctx.unsafe_rule_shape);
+        assert_eq!(approval_default_always_scope(&ctx), AllowScope::RestOfTurn);
+    }
+
+    #[test]
+    fn approval_scope_context_allows_exact_memory_for_interpreter_command() {
+        use astra_turn_core::permission_scope::AllowScope;
+
+        let ctx = approval_scope_context_for_tool(
+            "bash",
+            &serde_json::json!({"command": "python -c 'print(1)'"}),
+            false,
+            false,
+        );
+
+        assert!(!ctx.unsafe_rule_shape);
+        assert_eq!(approval_default_always_scope(&ctx), AllowScope::Project);
+        assert_eq!(
+            approval_memory_preview(
+                "bash",
+                &serde_json::json!({"command": "python -c 'print(1)'"}),
+                None
+            ),
+            "this shell command in this workspace"
         );
     }
 

--- a/rust/crates/astra-cli/src/cli/workspace_trust.rs
+++ b/rust/crates/astra-cli/src/cli/workspace_trust.rs
@@ -135,10 +135,10 @@ impl WorkspaceTrustEvaluation {
     #[must_use]
     pub fn summary_line(&self) -> String {
         if self.applies_project_allow() {
-            return "Workspace trust: trusted; project allow rules are active".to_string();
+            return "Workspace trust: trusted; saved workspace rules are active".to_string();
         }
         format!(
-            "Workspace trust: {}; project allow rules are ignored",
+            "Workspace trust: {}; saved workspace rules are ignored",
             self.reason.display()
         )
     }

--- a/rust/crates/astra-cli/src/edge_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools.rs
@@ -2401,6 +2401,55 @@ impl ToolExecutor {
         self.maybe_persist_large_output(output, name)
     }
 
+    pub async fn execute_with_metadata_cancelable(
+        &self,
+        name: &str,
+        args: &Value,
+        cancel_token: Option<&tokio_util::sync::CancellationToken>,
+    ) -> ToolExecutionOutcome {
+        if let Some(outcome) = self.execute_blocking_shell_tool(name, args, cancel_token) {
+            return outcome;
+        }
+        self.execute_with_metadata(name, args).await
+    }
+
+    /// Synchronous core for `bash` / `powershell` execution. Returns
+    /// `Some(outcome)` when `name` matches a cancel-aware shell tool, allowing
+    /// the caller to invoke this directly inside `tokio::task::spawn_blocking`
+    /// without re-entering the runtime via `Handle::block_on`. Returns `None`
+    /// for any other tool, signaling that the caller should fall back to the
+    /// generic async path.
+    pub fn execute_blocking_shell_tool(
+        &self,
+        name: &str,
+        args: &Value,
+        cancel_token: Option<&tokio_util::sync::CancellationToken>,
+    ) -> Option<ToolExecutionOutcome> {
+        if name == "bash" {
+            let output = self.finalize_tool_output(self.bash_with_cancel(args, cancel_token), name);
+            self.record_output_size(output.len());
+            return Some(if output.starts_with("Error") {
+                ToolExecutionOutcome::error(output)
+            } else {
+                ToolExecutionOutcome::ok(output)
+            });
+        }
+        #[cfg(windows)]
+        if name == "powershell" {
+            let output =
+                self.finalize_tool_output(self.powershell_with_cancel(args, cancel_token), name);
+            self.record_output_size(output.len());
+            return Some(if output.starts_with("Error") {
+                ToolExecutionOutcome::error(output)
+            } else {
+                ToolExecutionOutcome::ok(output)
+            });
+        }
+        #[cfg(not(windows))]
+        let _ = cancel_token; // powershell branch is the only other cancel-aware tool
+        None
+    }
+
     pub async fn execute_with_metadata(&self, name: &str, args: &Value) -> ToolExecutionOutcome {
         if name == "mo_query" {
             let mut outcome = self.mo_query_with_metadata(args);

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -2927,6 +2927,7 @@ struct ShellRunConfig {
     effective_project_root: PathBuf,
     sandbox_policy: Option<SandboxPolicy>,
     progress_sink: Option<std::sync::Arc<crate::chat_stream::ToolProgressSink>>,
+    cancel_token: Option<tokio_util::sync::CancellationToken>,
 }
 
 fn run_shell_output_with_config(config: ShellRunConfig) -> Result<std::process::Output, String> {
@@ -3007,6 +3008,15 @@ fn run_shell_output_with_config(config: ShellRunConfig) -> Result<std::process::
                 break;
             }
             Ok(None) => {
+                if config
+                    .cancel_token
+                    .as_ref()
+                    .is_some_and(|token| token.is_cancelled())
+                {
+                    sigkill_process_group(&mut child);
+                    let _ = child.wait();
+                    return Err("Error: command cancelled by user".to_string());
+                }
                 if std::time::Instant::now() > deadline {
                     // Kill entire process group (bash + all children)
                     sigkill_process_group(&mut child);
@@ -3682,6 +3692,7 @@ impl ToolExecutor {
         command: &str,
         timeout_secs: f64,
         harden_command: bool,
+        cancel_token: Option<&tokio_util::sync::CancellationToken>,
     ) -> ShellRunConfig {
         let sandbox_policy = self
             .sandbox_policy
@@ -3697,6 +3708,7 @@ impl ToolExecutor {
             effective_project_root: self.effective_project_root(),
             sandbox_policy,
             progress_sink: self.current_bash_progress_sink(),
+            cancel_token: cancel_token.cloned(),
         }
     }
 
@@ -3707,9 +3719,16 @@ impl ToolExecutor {
         command: &str,
         timeout_secs: f64,
         harden_command: bool,
+        cancel_token: Option<&tokio_util::sync::CancellationToken>,
     ) -> Result<std::process::Output, String> {
-        let config =
-            self.shell_run_config(program, shell_flag, command, timeout_secs, harden_command);
+        let config = self.shell_run_config(
+            program,
+            shell_flag,
+            command,
+            timeout_secs,
+            harden_command,
+            cancel_token,
+        );
         run_shell_output_with_config(config)
     }
 
@@ -3718,19 +3737,36 @@ impl ToolExecutor {
         command: &str,
         timeout_secs: f64,
     ) -> Result<std::process::Output, String> {
-        self.run_shell_output_with_program("bash", "-c", command, timeout_secs, true)
+        self.run_shell_output_with_program("bash", "-c", command, timeout_secs, true, None)
+    }
+
+    pub(crate) fn run_shell_output_cancelable(
+        &self,
+        command: &str,
+        timeout_secs: f64,
+        cancel_token: Option<&tokio_util::sync::CancellationToken>,
+    ) -> Result<std::process::Output, String> {
+        self.run_shell_output_with_program("bash", "-c", command, timeout_secs, true, cancel_token)
     }
 
     fn run_powershell_output(
         &self,
         command: &str,
         timeout_secs: f64,
+        cancel_token: Option<&tokio_util::sync::CancellationToken>,
     ) -> Result<std::process::Output, String> {
         let program = find_powershell_program().ok_or_else(|| {
             "Error: PowerShell not available. Install 'pwsh' (PowerShell 7+) or 'powershell'."
                 .to_string()
         })?;
-        self.run_shell_output_with_program(program, "-Command", command, timeout_secs, false)
+        self.run_shell_output_with_program(
+            program,
+            "-Command",
+            command,
+            timeout_secs,
+            false,
+            cancel_token,
+        )
     }
 
     /// Register file paths that were read by a successful bash command so
@@ -3969,7 +4005,7 @@ impl ToolExecutor {
             Ok(invocation) => invocation,
             Err(message) => return message,
         };
-        let config = self.shell_run_config("bash", "-c", &command, timeout_secs, true);
+        let config = self.shell_run_config("bash", "-c", &command, timeout_secs, true, None);
         match tokio::task::spawn_blocking(move || run_shell_output_with_config(config)).await {
             Ok(Ok(out)) => self.render_bash_output(&command, out),
             Ok(Err(error)) => error,
@@ -3978,17 +4014,33 @@ impl ToolExecutor {
     }
 
     pub(crate) fn bash(&self, args: &Value) -> String {
+        self.bash_with_cancel(args, None)
+    }
+
+    pub(crate) fn bash_with_cancel(
+        &self,
+        args: &Value,
+        cancel_token: Option<&tokio_util::sync::CancellationToken>,
+    ) -> String {
         let (command, timeout_secs) = match self.prepare_bash_invocation(args) {
             Ok(invocation) => invocation,
             Err(message) => return message,
         };
-        match self.run_shell_output(&command, timeout_secs) {
+        match self.run_shell_output_cancelable(&command, timeout_secs, cancel_token) {
             Ok(out) => self.render_bash_output(&command, out),
             Err(error) => error,
         }
     }
 
     pub(crate) fn powershell(&self, args: &Value) -> String {
+        self.powershell_with_cancel(args, None)
+    }
+
+    pub(crate) fn powershell_with_cancel(
+        &self,
+        args: &Value,
+        cancel_token: Option<&tokio_util::sync::CancellationToken>,
+    ) -> String {
         let command = match args.get("command").and_then(Value::as_str) {
             Some(c) => c,
             None => return "Error: missing 'command'".to_string(),
@@ -4009,7 +4061,7 @@ impl ToolExecutor {
             }
         }
 
-        match self.run_powershell_output(command, timeout_secs) {
+        match self.run_powershell_output(command, timeout_secs, cancel_token) {
             Err(error) => error,
             Ok(out) => {
                 let stdout = String::from_utf8_lossy(&out.stdout);

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -2460,10 +2460,33 @@ total_tokens_out: 500
             let cli = Cli::try_parse_from(["astra", "chat", "--permission-mode", mode]).unwrap();
             match cli.command {
                 Some(Command::Chat(ref args)) => {
-                    assert_eq!(args.permission_mode.as_deref(), Some(mode));
+                    assert_eq!(args.permission_mode.as_deref(), Some("auto"));
                 }
                 _ => panic!("expected Chat command"),
             }
+        }
+    }
+
+    #[test]
+    fn cli_chat_permission_mode_accept_edits() {
+        let cli =
+            Cli::try_parse_from(["astra", "chat", "--permission-mode", "accept-edits"]).unwrap();
+        match cli.command {
+            Some(Command::Chat(ref args)) => {
+                assert_eq!(args.permission_mode.as_deref(), Some("accept_edits"));
+            }
+            _ => panic!("expected Chat command"),
+        }
+    }
+
+    #[test]
+    fn cli_chat_permission_mode_plan() {
+        let cli = Cli::try_parse_from(["astra", "chat", "--permission-mode", "plan"]).unwrap();
+        match cli.command {
+            Some(Command::Chat(ref args)) => {
+                assert_eq!(args.permission_mode.as_deref(), Some("plan"));
+            }
+            _ => panic!("expected Chat command"),
         }
     }
 
@@ -2934,6 +2957,30 @@ total_tokens_out: 500
     }
 
     #[test]
+    fn cli_permissions_command_accept_edits_mode() {
+        let cli = Cli::try_parse_from(["astra", "permissions", "accept_edits"]).unwrap();
+        match cli.command {
+            Some(Command::Permissions(args)) => match args.command {
+                Some(PermissionsSubcommand::AcceptEdits) => {}
+                other => panic!("unexpected permissions subcommand: {other:?}"),
+            },
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_permissions_command_plan_mode() {
+        let cli = Cli::try_parse_from(["astra", "permissions", "plan"]).unwrap();
+        match cli.command {
+            Some(Command::Permissions(args)) => match args.command {
+                Some(PermissionsSubcommand::Plan) => {}
+                other => panic!("unexpected permissions subcommand: {other:?}"),
+            },
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
     fn cli_allow_alias_parses_permissions_command() {
         let cli = Cli::try_parse_from(["astra", "allow", "prompt"]).unwrap();
         match cli.command {
@@ -3352,6 +3399,8 @@ total_tokens_out: 500
             &std::path::PathBuf::from("/tmp"),
         );
         assert_eq!(pm.mode(), permission_manager::PermissionMode::Prompt);
+        pm.set_mode(permission_manager::PermissionMode::AcceptEdits);
+        assert_eq!(pm.mode(), permission_manager::PermissionMode::AcceptEdits);
         pm.set_mode(permission_manager::PermissionMode::Auto);
         assert_eq!(pm.mode(), permission_manager::PermissionMode::Auto);
         pm.set_mode(permission_manager::PermissionMode::Deny);
@@ -3360,7 +3409,7 @@ total_tokens_out: 500
 
     #[test]
     fn permission_mode_roundtrip_parse() {
-        for mode_str in &["auto", "prompt", "deny"] {
+        for mode_str in &["auto", "accept_edits", "plan", "prompt", "deny"] {
             let mode: permission_manager::PermissionMode = mode_str.parse().unwrap();
             assert_eq!(mode.to_string().to_lowercase(), *mode_str);
         }

--- a/rust/crates/astra-cli/src/tests/cli_args_tests.rs
+++ b/rust/crates/astra-cli/src/tests/cli_args_tests.rs
@@ -309,10 +309,56 @@ fn cli_chat_permission_mode_legacy_aliases() {
         let cli = Cli::try_parse_from(["astra", "chat", "--permission-mode", mode]).unwrap();
         match cli.command {
             Some(Command::Chat(ref args)) => {
-                assert_eq!(args.permission_mode.as_deref(), Some(mode));
+                assert_eq!(args.permission_mode.as_deref(), Some("auto"));
             }
             _ => panic!("expected Chat command"),
         }
+    }
+}
+
+#[test]
+fn cli_chat_permission_mode_accept_edits() {
+    let cli = Cli::try_parse_from(["astra", "chat", "--permission-mode", "accept-edits"]).unwrap();
+    match cli.command {
+        Some(Command::Chat(ref args)) => {
+            assert_eq!(args.permission_mode.as_deref(), Some("accept_edits"));
+        }
+        _ => panic!("expected Chat command"),
+    }
+}
+
+#[test]
+fn cli_chat_permission_mode_plan() {
+    let cli = Cli::try_parse_from(["astra", "chat", "--permission-mode", "plan"]).unwrap();
+    match cli.command {
+        Some(Command::Chat(ref args)) => {
+            assert_eq!(args.permission_mode.as_deref(), Some("plan"));
+        }
+        _ => panic!("expected Chat command"),
+    }
+}
+
+#[test]
+fn cli_permissions_command_accept_edits_mode() {
+    let cli = Cli::try_parse_from(["astra", "permissions", "accept_edits"]).unwrap();
+    match cli.command {
+        Some(Command::Permissions(args)) => match args.command {
+            Some(PermissionsSubcommand::AcceptEdits) => {}
+            other => panic!("unexpected permissions subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command: {other:?}"),
+    }
+}
+
+#[test]
+fn cli_permissions_command_plan_mode() {
+    let cli = Cli::try_parse_from(["astra", "permissions", "plan"]).unwrap();
+    match cli.command {
+        Some(Command::Permissions(args)) => match args.command {
+            Some(PermissionsSubcommand::Plan) => {}
+            other => panic!("unexpected permissions subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command: {other:?}"),
     }
 }
 
@@ -1016,6 +1062,8 @@ fn permission_mode_set_mode() {
         &std::path::PathBuf::from("/tmp"),
     );
     assert_eq!(pm.mode(), permission_manager::PermissionMode::Prompt);
+    pm.set_mode(permission_manager::PermissionMode::AcceptEdits);
+    assert_eq!(pm.mode(), permission_manager::PermissionMode::AcceptEdits);
     pm.set_mode(permission_manager::PermissionMode::Auto);
     assert_eq!(pm.mode(), permission_manager::PermissionMode::Auto);
     pm.set_mode(permission_manager::PermissionMode::Deny);
@@ -1024,7 +1072,7 @@ fn permission_mode_set_mode() {
 
 #[test]
 fn permission_mode_roundtrip_parse() {
-    for mode_str in &["auto", "prompt", "deny"] {
+    for mode_str in &["auto", "accept_edits", "plan", "prompt", "deny"] {
         let mode: permission_manager::PermissionMode = mode_str.parse().unwrap();
         assert_eq!(mode.to_string().to_lowercase(), *mode_str);
     }

--- a/rust/crates/astra-cli/src/tui/approval/button_row.rs
+++ b/rust/crates/astra-cli/src/tui/approval/button_row.rs
@@ -1,8 +1,7 @@
 //! Pure logic for the Cursor-style button row on an approval cell.
 //!
 //! The cell renders a horizontal row of buttons with a focus index. Arrow
-//! keys shift focus; Enter either resolves the approval or advances from
-//! scope selection into match-target selection.
+//! keys shift focus; Enter resolves the approval.
 //!
 //! When the pending queue contains more than one entry we prepend two
 //! **batch buttons** (Accept all / Reject all). Those are surfaced
@@ -12,8 +11,6 @@
 #![allow(dead_code)]
 
 use crate::chat_stream::ApprovalResponse;
-use astra_turn_core::permission_match_target::AllowMatchTarget;
-use astra_turn_core::permission_scope::AllowScope;
 
 /// What a single button does when Enter fires.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,14 +19,6 @@ pub(crate) enum ButtonAction {
     Respond(ApprovalResponse),
     /// Resolve the focused approval's batch group with this response.
     RespondAll(ApprovalResponse),
-    /// Move from scope selection into match-target selection.
-    SelectScope(AllowScope),
-    /// Resolve the selected scope with this match target.
-    SelectMatch(AllowMatchTarget),
-    /// Return from match-target selection to scope selection.
-    BackToScopes,
-    /// Enter custom-prefix input mode.
-    EditCustomPrefix,
 }
 
 /// Static metadata for a button.
@@ -39,46 +28,19 @@ pub(crate) struct Button {
     pub action: ButtonAction,
 }
 
-/// The four single-approval buttons in presentation order.
+/// Primary approval buttons in presentation order.
 pub(crate) const PRIMARY_BUTTONS: &[Button] = &[
     Button {
-        label: "Accept",
+        label: "Allow once",
         action: ButtonAction::Respond(ApprovalResponse::AllowOnce),
     },
-    // Issue #326 P5e: Reject is intentionally **one-shot** — it
-    // resolves THIS approval as Deny and does NOT persist a deny
-    // rule. The user's "no" is local to this call. The only way
-    // to add a permanent deny is the explicit
-    // `/permissions add deny <rule>` slash command, so accidental
-    // Rejects never grow the deny list.
-    //
-    // The user-visible label is short ("Reject") for terminal-
-    // width reasons; the tooltip / footer text spells out the
-    // semantics ("Reject (this call only)") so first-time users
-    // aren't surprised.
+    Button {
+        label: "Always",
+        action: ButtonAction::Respond(ApprovalResponse::AlwaysAllow),
+    },
     Button {
         label: "Reject",
         action: ButtonAction::Respond(ApprovalResponse::Deny),
-    },
-    Button {
-        label: "Turn",
-        action: ButtonAction::SelectScope(AllowScope::RestOfTurn),
-    },
-    Button {
-        label: "Session",
-        action: ButtonAction::SelectScope(AllowScope::RestOfSession),
-    },
-    Button {
-        label: "Project",
-        action: ButtonAction::SelectScope(AllowScope::Project),
-    },
-    Button {
-        label: "User",
-        action: ButtonAction::SelectScope(AllowScope::User),
-    },
-    Button {
-        label: "Skip",
-        action: ButtonAction::Respond(ApprovalResponse::Skip),
     },
 ];
 
@@ -99,32 +61,16 @@ pub(crate) const BATCH_BUTTONS: &[Button] = &[
 /// cell when the queue has more than one entry.
 pub(crate) const PRIMARY_WITH_BATCH: &[Button] = &[
     Button {
-        label: "Accept",
+        label: "Allow once",
         action: ButtonAction::Respond(ApprovalResponse::AllowOnce),
+    },
+    Button {
+        label: "Always",
+        action: ButtonAction::Respond(ApprovalResponse::AlwaysAllow),
     },
     Button {
         label: "Reject",
         action: ButtonAction::Respond(ApprovalResponse::Deny),
-    },
-    Button {
-        label: "Turn",
-        action: ButtonAction::SelectScope(AllowScope::RestOfTurn),
-    },
-    Button {
-        label: "Session",
-        action: ButtonAction::SelectScope(AllowScope::RestOfSession),
-    },
-    Button {
-        label: "Project",
-        action: ButtonAction::SelectScope(AllowScope::Project),
-    },
-    Button {
-        label: "User",
-        action: ButtonAction::SelectScope(AllowScope::User),
-    },
-    Button {
-        label: "Skip",
-        action: ButtonAction::Respond(ApprovalResponse::Skip),
     },
     Button {
         label: "Accept all",
@@ -136,25 +82,6 @@ pub(crate) const PRIMARY_WITH_BATCH: &[Button] = &[
     },
 ];
 
-pub(crate) const MATCH_TARGET_BUTTONS: &[Button] = &[
-    Button {
-        label: "Exact",
-        action: ButtonAction::SelectMatch(AllowMatchTarget::Exact),
-    },
-    Button {
-        label: "This tool",
-        action: ButtonAction::SelectMatch(AllowMatchTarget::Tool),
-    },
-    Button {
-        label: "Custom prefix",
-        action: ButtonAction::EditCustomPrefix,
-    },
-    Button {
-        label: "Back",
-        action: ButtonAction::BackToScopes,
-    },
-];
-
 /// Pure button-row state. Owned per focused approval cell.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ButtonRow {
@@ -163,7 +90,7 @@ pub(crate) struct ButtonRow {
 }
 
 impl ButtonRow {
-    /// Row for a single pending approval (Accept / Reject / Always / Skip).
+    /// Row for a single pending approval.
     pub fn primary() -> Self {
         Self {
             buttons: PRIMARY_BUTTONS,
@@ -184,13 +111,6 @@ impl ButtonRow {
     pub fn primary_with_batch() -> Self {
         Self {
             buttons: PRIMARY_WITH_BATCH,
-            focus: 0,
-        }
-    }
-
-    pub fn match_targets() -> Self {
-        Self {
-            buttons: MATCH_TARGET_BUTTONS,
             focus: 0,
         }
     }

--- a/rust/crates/astra-cli/src/tui/approval/button_row_tests.rs
+++ b/rust/crates/astra-cli/src/tui/approval/button_row_tests.rs
@@ -2,25 +2,16 @@
 
 #![cfg(test)]
 
-use super::button_row::{
-    BATCH_BUTTONS, ButtonAction, ButtonRow, MATCH_TARGET_BUTTONS, PRIMARY_BUTTONS,
-};
+use super::button_row::{BATCH_BUTTONS, ButtonAction, ButtonRow, PRIMARY_BUTTONS};
 use crate::chat_stream::ApprovalResponse;
-use astra_turn_core::permission_match_target::AllowMatchTarget;
-use astra_turn_core::permission_scope::AllowScope;
 
 // ─── Primary row invariants ───────────────────────────────────────
 
 #[test]
-fn primary_row_has_scope_picker_buttons_in_expected_order() {
+fn primary_row_has_simple_ux_buttons_in_expected_order() {
     let row = ButtonRow::primary();
     let labels: Vec<&str> = row.buttons().iter().map(|b| b.label).collect();
-    assert_eq!(
-        labels,
-        vec![
-            "Accept", "Reject", "Turn", "Session", "Project", "User", "Skip"
-        ]
-    );
+    assert_eq!(labels, vec!["Allow once", "Always", "Reject"]);
 }
 
 #[test]
@@ -28,7 +19,7 @@ fn primary_row_starts_with_accept_focused() {
     let row = ButtonRow::primary();
     assert_eq!(row.focus(), 0);
     let focused = row.focused().expect("focused button");
-    assert_eq!(focused.label, "Accept");
+    assert_eq!(focused.label, "Allow once");
 }
 
 #[test]
@@ -47,7 +38,7 @@ fn right_arrow_advances_focus() {
     let mut row = ButtonRow::primary();
     row.move_right();
     assert_eq!(row.focus(), 1);
-    assert_eq!(row.focused().unwrap().label, "Reject");
+    assert_eq!(row.focused().unwrap().label, "Always");
 }
 
 #[test]
@@ -72,11 +63,22 @@ fn focus_wraps_around_at_row_ends() {
     assert_eq!(row.focus(), 0, "right from last wraps to first");
 }
 
-// ─── Activate on each button ──────────────────────────────────────
+// ─── Activate on each primary button ──────────────────────────────
+
+#[test]
+fn activate_always_returns_workspace_allow() {
+    let mut row = ButtonRow::primary();
+    row.move_right();
+    assert_eq!(
+        row.activate(),
+        Some(ButtonAction::Respond(ApprovalResponse::AlwaysAllow))
+    );
+}
 
 #[test]
 fn activate_reject_returns_deny() {
     let mut row = ButtonRow::primary();
+    row.move_right();
     row.move_right();
     assert_eq!(
         row.activate(),
@@ -85,42 +87,15 @@ fn activate_reject_returns_deny() {
 }
 
 #[test]
-fn activate_turn_enters_match_target_selection() {
-    let mut row = ButtonRow::primary();
-    row.move_right();
-    row.move_right();
-    assert_eq!(
-        row.activate(),
-        Some(ButtonAction::SelectScope(AllowScope::RestOfTurn))
-    );
-}
-
-#[test]
-fn match_target_row_has_expected_order_and_actions() {
-    let mut row = ButtonRow::match_targets();
+fn primary_row_does_not_expose_legacy_scope_or_match_target_labels() {
+    let row = ButtonRow::primary();
     let labels: Vec<&str> = row.buttons().iter().map(|b| b.label).collect();
-    assert_eq!(labels, vec!["Exact", "This tool", "Custom prefix", "Back"]);
-    assert_eq!(
-        row.activate(),
-        Some(ButtonAction::SelectMatch(AllowMatchTarget::Exact))
-    );
-    row.move_right();
-    assert_eq!(
-        row.activate(),
-        Some(ButtonAction::SelectMatch(AllowMatchTarget::Tool))
-    );
-}
-
-#[test]
-fn activate_skip_returns_skip() {
-    let mut row = ButtonRow::primary();
-    for _ in 0..6 {
-        row.move_right();
+    for forbidden in ["Turn", "Session", "Project", "User", "Skip", "Exact"] {
+        assert!(
+            !labels.contains(&forbidden),
+            "{forbidden} must not appear in the primary approval UI"
+        );
     }
-    assert_eq!(
-        row.activate(),
-        Some(ButtonAction::Respond(ApprovalResponse::Skip))
-    );
 }
 
 // ─── focus_reject shortcut ────────────────────────────────────────
@@ -131,7 +106,7 @@ fn focus_reject_jumps_to_reject_regardless_of_origin() {
     row.focus_reject();
     assert_eq!(row.focused().unwrap().label, "Reject");
 
-    row.move_right(); // now on Turn
+    row.move_left(); // now on Always
     row.focus_reject();
     assert_eq!(row.focused().unwrap().label, "Reject");
 }
@@ -168,7 +143,6 @@ fn batch_activate_reject_all_returns_deny_all() {
 
 #[test]
 fn exported_constants_match_the_primary_and_batch_rows() {
-    assert_eq!(PRIMARY_BUTTONS.len(), 7);
+    assert_eq!(PRIMARY_BUTTONS.len(), 3);
     assert_eq!(BATCH_BUTTONS.len(), 2);
-    assert_eq!(MATCH_TARGET_BUTTONS.len(), 4);
 }

--- a/rust/crates/astra-cli/src/tui/approval/queue.rs
+++ b/rust/crates/astra-cli/src/tui/approval/queue.rs
@@ -7,20 +7,12 @@ use tokio::sync::oneshot;
 
 use super::button_row::ButtonRow;
 use crate::chat_stream::ApprovalResponse;
-use astra_turn_core::permission_match_target::AllowMatchTarget;
 use astra_turn_core::permission_scope::AllowScope;
 
 /// Monotonic id assigned by the queue. Stable across the session so the
 /// reducer and tool cells can refer to a pending approval without owning
 /// the non-Clone `oneshot::Sender`.
 pub(crate) type ApprovalId = u64;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ApprovalSelection {
-    Scope,
-    MatchTarget { scope: AllowScope },
-    CustomPrefix { scope: AllowScope, input: String },
-}
 
 /// One pending approval. The `response_txs` vec lets dedup
 /// merge multiple in-flight requests with byte-identical
@@ -40,7 +32,6 @@ pub(crate) struct PendingApproval {
     /// Live button row owned per entry so arrow-key focus sticks
     /// through navigation even when focus cycles between entries.
     pub buttons: ButtonRow,
-    pub selection: ApprovalSelection,
     /// Issue #326 P3 / R1 Major 11 / scenarios #21-#25: when a sub-agent
     /// owns this request, the agent identifier is recorded here.
     /// `None` for requests originating in the main TUI session.
@@ -72,21 +63,16 @@ pub(crate) struct PendingApproval {
     /// tags emitted by the engine"; the UI falls back to the
     /// existing reason text.
     pub risk_tags: Vec<astra_turn_core::permission_engine::RiskTag>,
-    /// Issue #326 P3: precomputed "Will save" preview — what
-    /// would be persisted if the user pressed Always with the
-    /// default Project scope. The TUI renders this verbatim in
-    /// the approval card so users see exactly what
-    /// `permissions.json` would gain. `None` means the request
-    /// is not eligible for Always (e.g. compound shell command,
-    /// MCP unknown capability).
-    pub will_save_preview: Option<String>,
-    pub custom_match_source: String,
+    /// Human-readable preview of what pressing Always will remember.
+    /// This must not expose permission-rule DSL.
+    pub remember_preview: Option<String>,
     /// Workspace trust gate for Project scope. When true, Project
     /// is rendered but cannot be activated; project allow rules are
     /// not trusted for this session.
     pub workspace_untrusted: bool,
     pub is_compound_command: bool,
     pub has_dynamic_eval: bool,
+    pub unsafe_rule_shape: bool,
     /// Issue #326 P3 / P5f / R2 Major 3: host-computed digest of
     /// the file the tool will mutate, snapshotted at the moment
     /// the approval enters the queue. The executor compares this
@@ -122,11 +108,11 @@ pub(crate) struct ApprovalMetadata {
     pub mcp_capability: Option<astra_turn_core::permission_engine::ToolCapabilityMetadata>,
     pub host: Option<String>,
     pub risk_tags: Vec<astra_turn_core::permission_engine::RiskTag>,
-    pub will_save_preview: Option<String>,
-    pub custom_match_source: String,
+    pub remember_preview: Option<String>,
     pub workspace_untrusted: bool,
     pub is_compound_command: bool,
     pub has_dynamic_eval: bool,
+    pub unsafe_rule_shape: bool,
     /// Host-computed snapshot of the file the tool will mutate;
     /// see [`PendingApproval::base_digest`].
     pub base_digest: Option<astra_turn_core::approval_base_digest::BaseDigest>,
@@ -160,8 +146,8 @@ impl ApprovalMetadata {
     }
 
     #[must_use]
-    pub fn with_will_save_preview(mut self, preview: impl Into<String>) -> Self {
-        self.will_save_preview = Some(preview.into());
+    pub fn with_remember_preview(mut self, preview: impl Into<String>) -> Self {
+        self.remember_preview = Some(preview.into());
         self
     }
 
@@ -175,6 +161,12 @@ impl ApprovalMetadata {
     pub fn with_scope_shape(mut self, is_compound_command: bool, has_dynamic_eval: bool) -> Self {
         self.is_compound_command = is_compound_command;
         self.has_dynamic_eval = has_dynamic_eval;
+        self
+    }
+
+    #[must_use]
+    pub fn with_unsafe_rule_shape(mut self, unsafe_rule_shape: bool) -> Self {
+        self.unsafe_rule_shape = unsafe_rule_shape;
         self
     }
 
@@ -240,7 +232,7 @@ impl std::fmt::Debug for PendingApproval {
             .field("source_agent", &self.source_agent)
             .field("host", &self.host)
             .field("risk_tag_count", &self.risk_tags.len())
-            .field("will_save_preview", &self.will_save_preview)
+            .field("remember_preview", &self.remember_preview)
             .field(
                 "base_digest",
                 &self.base_digest.as_ref().map(|d| d.short_display()),
@@ -271,15 +263,14 @@ pub(crate) struct ApprovalView {
     /// `Eq` / `Hash`-friendly (the engine's `RiskTag` enum is
     /// not currently `Eq`-derived for use as a HashSet key).
     pub risk_tag_labels: Vec<String>,
-    /// "Will save: …" preview, mirrored from
-    /// [`PendingApproval::will_save_preview`].
-    pub will_save_preview: Option<String>,
+    /// Always-remembers preview, mirrored from
+    /// [`PendingApproval::remember_preview`].
+    pub remember_preview: Option<String>,
     pub selection_hint: Option<String>,
-    pub custom_match_input: Option<String>,
-    pub custom_match_source: Option<String>,
     pub workspace_untrusted: bool,
     pub is_compound_command: bool,
     pub has_dynamic_eval: bool,
+    pub unsafe_rule_shape: bool,
 }
 
 impl From<&PendingApproval> for ApprovalView {
@@ -293,68 +284,17 @@ impl From<&PendingApproval> for ApprovalView {
             source_agent: p.source_agent.clone(),
             host: p.host.clone(),
             risk_tag_labels: p.risk_tags.iter().map(|tag| format!("{tag:?}")).collect(),
-            will_save_preview: p.will_save_preview.clone(),
+            remember_preview: p.remember_preview.clone(),
             selection_hint: p.selection_hint(),
-            custom_match_input: match &p.selection {
-                ApprovalSelection::CustomPrefix { input, .. } => Some(input.clone()),
-                _ => None,
-            },
-            custom_match_source: match &p.selection {
-                ApprovalSelection::CustomPrefix { .. } if !p.custom_match_source.is_empty() => {
-                    Some(p.custom_match_source.clone())
-                }
-                _ => None,
-            },
             workspace_untrusted: p.workspace_untrusted,
             is_compound_command: p.is_compound_command,
             has_dynamic_eval: p.has_dynamic_eval,
+            unsafe_rule_shape: p.unsafe_rule_shape,
         }
     }
 }
 
 impl PendingApproval {
-    fn selection_hint(&self) -> Option<String> {
-        match &self.selection {
-            ApprovalSelection::Scope => None,
-            ApprovalSelection::MatchTarget { scope } => {
-                let action = self.buttons.focused().map(|b| &b.action);
-                Some(match action {
-                    Some(super::button_row::ButtonAction::SelectMatch(AllowMatchTarget::Exact)) => {
-                        format!("Approve exactly this request {}.", scope_duration(*scope))
-                    }
-                    Some(super::button_row::ButtonAction::SelectMatch(AllowMatchTarget::Tool)) => {
-                        format!(
-                            "Approve this tool for all future permission requests {}.",
-                            scope_duration(*scope)
-                        )
-                    }
-                    Some(super::button_row::ButtonAction::EditCustomPrefix) => format!(
-                        "Type a prefix of `{}` {}.",
-                        self.custom_match_source,
-                        scope_duration(*scope)
-                    ),
-                    Some(super::button_row::ButtonAction::BackToScopes) => {
-                        "Return to scope selection.".to_string()
-                    }
-                    _ => format!(
-                        "Choose what this {} approval should match.",
-                        scope_label(*scope)
-                    ),
-                })
-            }
-            ApprovalSelection::CustomPrefix { scope, input } if input.is_empty() => Some(format!(
-                "Type a prefix of `{}` {}.",
-                self.custom_match_source,
-                scope_duration(*scope)
-            )),
-            ApprovalSelection::CustomPrefix { scope, input } => Some(format!(
-                "Approve requests matching `{}` {}. Only real prefixes are accepted.",
-                input,
-                scope_duration(*scope)
-            )),
-        }
-    }
-
     fn scope_context(&self) -> astra_turn_core::permission_scope::ScopeAvailabilityContext {
         astra_turn_core::permission_scope::ScopeAvailabilityContext {
             risk_tags: self.risk_tags.clone(),
@@ -369,6 +309,7 @@ impl PendingApproval {
             workspace_untrusted: self.workspace_untrusted,
             is_compound_command: self.is_compound_command,
             has_dynamic_eval: self.has_dynamic_eval,
+            unsafe_rule_shape: self.unsafe_rule_shape,
         }
     }
 
@@ -377,25 +318,40 @@ impl PendingApproval {
             .into_iter()
             .any(|entry| entry.scope == scope && entry.available)
     }
-}
 
-fn scope_label(scope: AllowScope) -> &'static str {
-    match scope {
-        AllowScope::OnceThisCall => "request",
-        AllowScope::RestOfTurn => "turn",
-        AllowScope::RestOfSession => "session",
-        AllowScope::Project => "project",
-        AllowScope::User => "user",
+    fn always_action_disabled(&self) -> bool {
+        use astra_turn_core::permission_engine::RiskTag;
+
+        if self.source_agent.is_some()
+            || self.is_compound_command
+            || self.has_dynamic_eval
+            || self.unsafe_rule_shape
+            || self.risk_tags.contains(&RiskTag::WritesSensitiveFile)
+            || self.risk_tags.contains(&RiskTag::GitDestructive)
+            || self.risk_tags.contains(&RiskTag::WritesOutsideWorkspace)
+            || self.risk_tags.contains(&RiskTag::CredentialAccess)
+            || self.risk_tags.contains(&RiskTag::MCPUnknownCapability)
+        {
+            return true;
+        }
+
+        !self.workspace_untrusted && !self.scope_available(AllowScope::Project)
     }
-}
 
-fn scope_duration(scope: AllowScope) -> &'static str {
-    match scope {
-        AllowScope::OnceThisCall => "for this request",
-        AllowScope::RestOfTurn => "for the rest of this turn",
-        AllowScope::RestOfSession => "in this session",
-        AllowScope::Project => "for this project",
-        AllowScope::User => "for this user",
+    fn always_uses_session_fallback(&self) -> bool {
+        self.workspace_untrusted
+            && !self.always_action_disabled()
+            && !self.scope_available(AllowScope::Project)
+    }
+
+    fn selection_hint(&self) -> Option<String> {
+        if self.always_uses_session_fallback() {
+            return Some(
+                "Always remembers for this session only. Choose Trust Workspace or run `/allow trust` to save workspace rules."
+                    .to_string(),
+            );
+        }
+        None
     }
 }
 
@@ -484,16 +440,15 @@ impl ApprovalQueue {
             reason,
             response_txs: vec![response_tx],
             buttons,
-            selection: ApprovalSelection::Scope,
             source_agent: metadata.source_agent,
             mcp_capability: metadata.mcp_capability,
             host: metadata.host,
             risk_tags: metadata.risk_tags,
-            will_save_preview: metadata.will_save_preview,
-            custom_match_source: metadata.custom_match_source,
+            remember_preview: metadata.remember_preview,
             workspace_untrusted: metadata.workspace_untrusted,
             is_compound_command: metadata.is_compound_command,
             has_dynamic_eval: metadata.has_dynamic_eval,
+            unsafe_rule_shape: metadata.unsafe_rule_shape,
             base_digest: metadata.base_digest,
             request_key: metadata.request_key,
             batch_group_key: metadata.batch_group_key,
@@ -555,126 +510,6 @@ impl ApprovalQueue {
         sent
     }
 
-    pub fn select_scope_for_focused(&mut self, scope: AllowScope) -> bool {
-        let total = self.entries.len();
-        let Some(entry) = self.entries.get_mut(self.focus) else {
-            return false;
-        };
-        if !entry.scope_available(scope) {
-            return false;
-        }
-        entry.selection = ApprovalSelection::MatchTarget { scope };
-        entry.buttons = ButtonRow::match_targets();
-        if total > 1 {
-            // Batch buttons are intentionally scope-step only; once a
-            // single entry is choosing a match target, batch approval no
-            // longer has one unambiguous match object.
-        }
-        true
-    }
-
-    pub fn back_to_scope_for_focused(&mut self) -> bool {
-        let total = self.entries.len();
-        let Some(entry) = self.entries.get_mut(self.focus) else {
-            return false;
-        };
-        entry.selection = ApprovalSelection::Scope;
-        entry.buttons = if total > 1 {
-            ButtonRow::primary_with_batch()
-        } else {
-            ButtonRow::primary()
-        };
-        true
-    }
-
-    pub fn enter_custom_prefix_for_focused(&mut self) -> bool {
-        let Some(entry) = self.entries.get_mut(self.focus) else {
-            return false;
-        };
-        let ApprovalSelection::MatchTarget { scope } = entry.selection else {
-            return false;
-        };
-        entry.selection = ApprovalSelection::CustomPrefix {
-            scope,
-            input: String::new(),
-        };
-        true
-    }
-
-    pub fn focused_custom_prefix_active(&self) -> bool {
-        self.entries
-            .get(self.focus)
-            .is_some_and(|entry| matches!(entry.selection, ApprovalSelection::CustomPrefix { .. }))
-    }
-
-    pub fn push_custom_prefix_char(&mut self, ch: char) -> bool {
-        let Some(entry) = self.entries.get_mut(self.focus) else {
-            return false;
-        };
-        if let ApprovalSelection::CustomPrefix { input, .. } = &mut entry.selection {
-            let mut proposed = input.clone();
-            proposed.push(ch);
-            if astra_turn_core::permission_match_target::is_valid_custom_prefix(
-                &proposed,
-                &entry.custom_match_source,
-            ) {
-                *input = proposed;
-                return true;
-            }
-        }
-        false
-    }
-
-    pub fn pop_custom_prefix_char(&mut self) -> bool {
-        let Some(entry) = self.entries.get_mut(self.focus) else {
-            return false;
-        };
-        if let ApprovalSelection::CustomPrefix { input, .. } = &mut entry.selection {
-            input.pop();
-            return true;
-        }
-        false
-    }
-
-    pub fn cancel_custom_prefix_for_focused(&mut self) -> bool {
-        let Some(entry) = self.entries.get_mut(self.focus) else {
-            return false;
-        };
-        let ApprovalSelection::CustomPrefix { scope, .. } = entry.selection.clone() else {
-            return false;
-        };
-        entry.selection = ApprovalSelection::MatchTarget { scope };
-        true
-    }
-
-    pub fn submit_custom_prefix_for_focused(&mut self) -> Option<ApprovalResponse> {
-        let entry = self.entries.get(self.focus)?;
-        let ApprovalSelection::CustomPrefix { scope, input } = &entry.selection else {
-            return None;
-        };
-        if !astra_turn_core::permission_match_target::is_valid_custom_prefix(
-            input,
-            &entry.custom_match_source,
-        ) {
-            return None;
-        }
-        Some(ApprovalResponse::AlwaysAllowScopedTarget {
-            scope: *scope,
-            match_target: AllowMatchTarget::Prefix(input.clone()),
-        })
-    }
-
-    pub fn response_for_match_target(&self, target: AllowMatchTarget) -> Option<ApprovalResponse> {
-        let entry = self.entries.get(self.focus)?;
-        let ApprovalSelection::MatchTarget { scope } = entry.selection else {
-            return None;
-        };
-        Some(ApprovalResponse::AlwaysAllowScopedTarget {
-            scope,
-            match_target: target,
-        })
-    }
-
     pub fn respond_by_id(&mut self, id: ApprovalId, response: ApprovalResponse) -> bool {
         let Some(idx) = self.entries.iter().position(|e| e.id == id) else {
             return false;
@@ -733,16 +568,15 @@ impl ApprovalQueue {
     pub fn focused_button_action(&self) -> Option<super::button_row::ButtonAction> {
         let entry = self.entries.get(self.focus)?;
         let action = entry.buttons.activate()?;
-        if let super::button_row::ButtonAction::SelectScope(scope) = &action
-            && !entry.scope_available(*scope)
+        if matches!(
+            action,
+            super::button_row::ButtonAction::Respond(ApprovalResponse::AlwaysAllow)
+        ) && entry.always_action_disabled()
         {
             return None;
         }
         match action {
             super::button_row::ButtonAction::RespondAll(ref response) if response.is_approved() => {
-                if !matches!(entry.selection, ApprovalSelection::Scope) {
-                    return None;
-                }
                 match entry.batch_group_key.as_ref() {
                     Some(group) if group.allows_accept_all() => Some(action.clone()),
                     Some(_) => None,
@@ -911,9 +745,9 @@ mod tests {
     }
 
     #[test]
-    fn push_with_metadata_carries_risk_tags_and_will_save() {
-        // Issue #326 P3 / R1 Major 7: risk tags and the will-save
-        // preview must reach the view layer.
+    fn push_with_metadata_carries_risk_tags_and_remember_preview() {
+        // Risk tags and the human-readable remember preview must
+        // reach the view layer.
         use astra_turn_core::permission_engine::RiskTag;
         let mut q = ApprovalQueue::new();
         let (tx, _rx) = oneshot::channel();
@@ -925,11 +759,14 @@ mod tests {
             tx,
             ApprovalMetadata::default()
                 .with_risk_tags(vec![RiskTag::BashExecute])
-                .with_will_save_preview("Bash(npm test:*)"),
+                .with_remember_preview("similar `npm test` commands in this workspace"),
         );
         let view = q.focused_view().unwrap();
         assert_eq!(view.risk_tag_labels, vec!["BashExecute"]);
-        assert_eq!(view.will_save_preview.as_deref(), Some("Bash(npm test:*)"));
+        assert_eq!(
+            view.remember_preview.as_deref(),
+            Some("similar `npm test` commands in this workspace")
+        );
     }
 
     // ── Issue #326 P3 / P5f / R2 Major 3: base digest ──
@@ -1303,8 +1140,8 @@ mod tests {
             ApprovalMetadata::default().with_batch_group_key(group),
         );
 
-        // Move from Accept to Accept all (index 7).
-        for _ in 0..7 {
+        // Move from Allow once to Accept all (index 3).
+        for _ in 0..3 {
             q.focused_button_move_right();
         }
         assert!(
@@ -1323,7 +1160,7 @@ mod tests {
     }
 
     #[test]
-    fn focused_button_action_blocks_unavailable_project_scope() {
+    fn focused_button_action_blocks_unavailable_workspace_always() {
         let mut q = ApprovalQueue::new();
         let (tx, _rx) = oneshot::channel();
         q.push_with_metadata(
@@ -1335,139 +1172,89 @@ mod tests {
             ApprovalMetadata::default().with_workspace_untrusted(true),
         );
 
-        // Accept, Reject, Turn, Session, Project.
-        for _ in 0..4 {
-            q.focused_button_move_right();
-        }
-        assert!(
-            q.focused_button_action().is_none(),
-            "Project scope must be inactive when workspace trust is missing"
+        // Allow once -> Always.
+        q.focused_button_move_right();
+        assert_eq!(
+            q.focused_button_action(),
+            Some(super::super::button_row::ButtonAction::Respond(
+                ApprovalResponse::AlwaysAllow
+            )),
+            "benign untrusted-workspace request should keep Always available via session fallback"
         );
 
         q.focused_button_move_left();
         assert_eq!(
             q.focused_button_action(),
-            Some(super::super::button_row::ButtonAction::SelectScope(
-                astra_turn_core::permission_scope::AllowScope::RestOfSession
+            Some(super::super::button_row::ButtonAction::Respond(
+                ApprovalResponse::AllowOnce
             )),
-            "Session scope remains available for untrusted workspaces"
+            "Allow once remains available for untrusted workspaces"
         );
     }
 
     #[test]
-    fn scope_selection_requires_match_target_before_resolving() {
-        let mut q = ApprovalQueue::new();
-        let (tx, mut rx) = oneshot::channel();
-        q.push(
-            "bash".into(),
-            "git status".into(),
-            None,
-            "execute".into(),
-            tx,
-        );
-
-        assert!(q.select_scope_for_focused(
-            astra_turn_core::permission_scope::AllowScope::RestOfSession
-        ));
-        assert!(rx.try_recv().is_err(), "scope selection must not resolve");
-
-        let response = q
-            .response_for_match_target(AllowMatchTarget::Tool)
-            .expect("match target response");
-        assert!(q.respond_focused(response));
-        assert_eq!(
-            rx.try_recv().unwrap(),
-            ApprovalResponse::AlwaysAllowScopedTarget {
-                scope: astra_turn_core::permission_scope::AllowScope::RestOfSession,
-                match_target: AllowMatchTarget::Tool,
-            }
-        );
-    }
-
-    #[test]
-    fn custom_prefix_input_accepts_only_source_prefixes() {
+    fn focused_button_action_blocks_always_for_compound_commands() {
         let mut q = ApprovalQueue::new();
         let (tx, _rx) = oneshot::channel();
-        let mut meta = ApprovalMetadata::default();
-        meta.custom_match_source = "git status --short".to_string();
         q.push_with_metadata(
             "bash".into(),
-            "git status --short".into(),
+            "cd rust && cargo test".into(),
             None,
             "execute".into(),
             tx,
-            meta,
-        );
-        assert!(q.select_scope_for_focused(
-            astra_turn_core::permission_scope::AllowScope::RestOfSession
-        ));
-        assert!(q.enter_custom_prefix_for_focused());
-        let empty_view = q.focused_view().unwrap();
-        assert_eq!(empty_view.custom_match_input.as_deref(), Some(""));
-        assert_eq!(
-            empty_view.custom_match_source.as_deref(),
-            Some("git status --short")
-        );
-        assert!(
-            empty_view
-                .selection_hint
-                .as_deref()
-                .unwrap()
-                .contains("Type a prefix of `git status --short`")
+            ApprovalMetadata::default().with_scope_shape(true, false),
         );
 
-        for ch in "git st".chars() {
-            assert!(q.push_custom_prefix_char(ch), "{ch:?} should extend prefix");
-        }
+        q.focused_button_move_right();
         assert!(
-            !q.push_custom_prefix_char('x'),
-            "non-prefix character must be rejected"
-        );
-        assert_eq!(
-            q.focused_view().unwrap().custom_match_input.as_deref(),
-            Some("git st")
-        );
-        assert_eq!(
-            q.submit_custom_prefix_for_focused(),
-            Some(ApprovalResponse::AlwaysAllowScopedTarget {
-                scope: astra_turn_core::permission_scope::AllowScope::RestOfSession,
-                match_target: AllowMatchTarget::Prefix("git st".to_string()),
-            })
+            q.focused_button_action().is_none(),
+            "compound shell commands must keep Always disabled"
         );
     }
 
     #[test]
-    fn custom_prefix_input_rejects_trailing_chars_outside_source_prefix() {
+    fn focused_button_action_blocks_always_for_unsafe_rule_shape() {
         let mut q = ApprovalQueue::new();
         let (tx, _rx) = oneshot::channel();
-        let mut meta = ApprovalMetadata::default();
-        meta.custom_match_source = "git status --short".to_string();
         q.push_with_metadata(
             "bash".into(),
-            "git status --short".into(),
+            "bash".into(),
             None,
             "execute".into(),
             tx,
-            meta,
+            ApprovalMetadata::default().with_unsafe_rule_shape(true),
         );
-        assert!(q.select_scope_for_focused(
-            astra_turn_core::permission_scope::AllowScope::RestOfSession
-        ));
-        assert!(q.enter_custom_prefix_for_focused());
 
-        for ch in "git ".chars() {
-            assert!(q.push_custom_prefix_char(ch), "{ch:?} should extend prefix");
-        }
+        q.focused_button_move_right();
         assert!(
-            !q.push_custom_prefix_char(' '),
-            "second space is not a prefix of the original command"
+            q.focused_button_action().is_none(),
+            "requests without a safe match target must not offer Always"
         );
+    }
+
+    #[test]
+    fn untrusted_workspace_view_explains_how_to_trust() {
+        let mut q = ApprovalQueue::new();
+        let (tx, _rx) = oneshot::channel();
+        q.push_with_metadata(
+            "git_show".into(),
+            "Git show HEAD".into(),
+            None,
+            "This command needs your approval before it runs.".into(),
+            tx,
+            ApprovalMetadata::default().with_workspace_untrusted(true),
+        );
+
+        let view = q
+            .views()
+            .into_iter()
+            .next()
+            .expect("pending approval should exist");
         assert_eq!(
-            q.submit_custom_prefix_for_focused(),
-            Some(ApprovalResponse::AlwaysAllowScopedTarget {
-                scope: astra_turn_core::permission_scope::AllowScope::RestOfSession,
-                match_target: AllowMatchTarget::Prefix("git ".to_string()),
-            })
+            view.selection_hint.as_deref(),
+            Some(
+                "Always remembers for this session only. Choose Trust Workspace or run `/allow trust` to save workspace rules."
+            )
         );
     }
 }

--- a/rust/crates/astra-cli/src/tui/approval/tests.rs
+++ b/rust/crates/astra-cli/src/tui/approval/tests.rs
@@ -145,11 +145,11 @@ fn respond_by_id_finds_nonfocused_entry() {
     let (id_b, rx_b) = enqueue(&mut q, "b");
     let (id_c, _rx_c) = enqueue(&mut q, "c");
     // Focus is on a; resolve b out of order.
-    assert!(q.respond_by_id(id_b, ApprovalResponse::Skip));
+    assert!(q.respond_by_id(id_b, ApprovalResponse::Deny));
     assert_eq!(q.len(), 2);
     let remaining: Vec<_> = q.views().iter().map(|v| v.tool.clone()).collect();
     assert_eq!(remaining, vec!["a", "c"]);
-    assert_eq!(rx_b.blocking_recv().unwrap(), ApprovalResponse::Skip);
+    assert_eq!(rx_b.blocking_recv().unwrap(), ApprovalResponse::Deny);
 
     // rx_a still pending — the queue shouldn't have resolved it.
     // Drop q to release the sender without firing.

--- a/rust/crates/astra-cli/src/tui/bottom_pane/approval_integration_tests.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/approval_integration_tests.rs
@@ -10,8 +10,6 @@ use super::{ApprovalActivation, BottomPane, BottomPaneAction};
 use crate::chat_stream::ApprovalResponse;
 use crate::tui::approval::queue::ApprovalMetadata;
 use crate::tui::slash_menu::SlashItem;
-use astra_turn_core::permission_match_target::AllowMatchTarget;
-use astra_turn_core::permission_scope::AllowScope;
 
 fn key(c: char) -> KeyEvent {
     KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
@@ -103,23 +101,23 @@ fn enter_activates_accept_by_default() {
 }
 
 #[test]
-fn right_moves_focus_then_enter_rejects() {
+fn right_moves_focus_to_always_and_enter_remembers_workspace_default() {
     let mut bp = BottomPane::new();
     let rx = enqueue(&mut bp, "bash");
 
-    // Accept → Reject
+    // Allow once -> Always
     let _ = bp.handle_key(special(KeyCode::Right));
     let _ = bp.handle_key(special(KeyCode::Enter));
-    assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::Deny);
+    assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::AlwaysAllow);
 }
 
 #[test]
-fn left_from_accept_wraps_to_skip() {
+fn left_from_allow_once_wraps_to_reject() {
     let mut bp = BottomPane::new();
     let rx = enqueue(&mut bp, "bash");
     let _ = bp.handle_key(special(KeyCode::Left));
     let _ = bp.handle_key(special(KeyCode::Enter));
-    assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::Skip);
+    assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::Deny);
 }
 
 #[test]
@@ -312,8 +310,8 @@ fn batch_button_resolves_focused_group_only() {
     let rx_c = enqueue_grouped(&mut bp, "c", group_a);
     assert_eq!(bp.footer.pending_approvals, 3);
 
-    // Navigate to Accept-all (index 7 in the scoped + batch row).
-    for _ in 0..7 {
+    // Navigate to Accept-all (index 3 in the simplified + batch row).
+    for _ in 0..3 {
         bp.handle_key(special(KeyCode::Right));
     }
     let action = bp.handle_key(special(KeyCode::Enter));
@@ -363,8 +361,8 @@ fn activation_single_vs_batch_reports_correct_variant() {
     ));
     assert_eq!(bp.footer.pending_approvals, 1);
 
-    // Navigate to Accept-all (index 7 in the scoped + batch row).
-    for _ in 0..7 {
+    // Navigate to Accept-all (index 3 in the simplified + batch row).
+    for _ in 0..3 {
         bp.handle_key(special(KeyCode::Right));
     }
     let act = bp.activate_focused_approval_button();
@@ -390,40 +388,30 @@ fn activation_single_vs_batch_reports_correct_variant() {
 fn down_moves_focus_like_right() {
     let mut bp = BottomPane::new();
     let rx = enqueue(&mut bp, "bash");
-    // Down from Accept → Reject. Enter rejects.
+    // Down from Allow once -> Always.
     let _ = bp.handle_key(special(KeyCode::Down));
+    let _ = bp.handle_key(special(KeyCode::Enter));
+    assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::AlwaysAllow);
+}
+
+#[test]
+fn up_moves_focus_like_left_wrapping_to_reject() {
+    let mut bp = BottomPane::new();
+    let rx = enqueue(&mut bp, "bash");
+    // Up from Allow once wraps to the last button (Reject).
+    let _ = bp.handle_key(special(KeyCode::Up));
     let _ = bp.handle_key(special(KeyCode::Enter));
     assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::Deny);
 }
 
 #[test]
-fn up_moves_focus_like_left_wrapping_to_skip() {
+fn primary_always_resolves_without_second_match_target_step() {
     let mut bp = BottomPane::new();
     let rx = enqueue(&mut bp, "bash");
-    // Up from Accept wraps to the last button (Skip).
-    let _ = bp.handle_key(special(KeyCode::Up));
-    let _ = bp.handle_key(special(KeyCode::Enter));
-    assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::Skip);
-}
-
-#[test]
-fn up_down_reach_turn_scope_then_exact_match_button() {
-    // End-to-end: scope selection is step one; match target is step two.
-    // From Accept (index 0), Down twice lands on Turn (index 2), then
-    // Enter opens match targets where Exact is focused by default.
-    let mut bp = BottomPane::new();
-    let rx = enqueue(&mut bp, "bash");
-    let _ = bp.handle_key(special(KeyCode::Down));
+    // From Allow once (index 0), Down once lands on Always.
     let _ = bp.handle_key(special(KeyCode::Down));
     let _ = bp.handle_key(special(KeyCode::Enter));
-    let _ = bp.handle_key(special(KeyCode::Enter));
-    assert_eq!(
-        rx.blocking_recv().unwrap(),
-        ApprovalResponse::AlwaysAllowScopedTarget {
-            scope: AllowScope::RestOfTurn,
-            match_target: AllowMatchTarget::Exact,
-        }
-    );
+    assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::AlwaysAllow);
 }
 
 #[test]

--- a/rust/crates/astra-cli/src/tui/bottom_pane/footer.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/footer.rs
@@ -57,6 +57,8 @@ impl Footer {
     fn permission_mode_enum(&self) -> PermissionMode {
         match self.permission_mode.as_deref() {
             Some("auto") => PermissionMode::Auto,
+            Some("plan") => PermissionMode::Plan,
+            Some("accept_edits") => PermissionMode::AcceptEdits,
             Some("deny") => PermissionMode::Deny,
             _ => PermissionMode::Ask,
         }

--- a/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
@@ -440,23 +440,6 @@ impl BottomPane {
                     response: resp,
                 })
             }
-            ButtonAction::SelectScope(scope) => {
-                self.approval_queue.select_scope_for_focused(scope);
-                None
-            }
-            ButtonAction::SelectMatch(target) => {
-                let response = self.approval_queue.response_for_match_target(target)?;
-                let id = self.respond_focused_approval(response.clone())?;
-                Some(ApprovalActivation::Single { id, response })
-            }
-            ButtonAction::EditCustomPrefix => {
-                self.approval_queue.enter_custom_prefix_for_focused();
-                None
-            }
-            ButtonAction::BackToScopes => {
-                self.approval_queue.back_to_scope_for_focused();
-                None
-            }
         }
     }
 
@@ -517,7 +500,7 @@ impl BottomPane {
         cell.buttons = buttons;
         // Issue #326 P3: forward the view's metadata so the
         // approval card renders the source-agent / host /
-        // risk-tag / will-save lines populated by
+        // risk-tag / remember-preview lines populated by
         // enqueue_approval_with_metadata.
         if let Some(agent) = view.source_agent {
             cell = cell.with_source_agent(agent);
@@ -528,22 +511,17 @@ impl BottomPane {
         if !view.risk_tag_labels.is_empty() {
             cell = cell.with_risk_tag_labels(view.risk_tag_labels);
         }
-        if let Some(preview) = view.will_save_preview {
-            cell = cell.with_will_save_preview(preview);
+        if let Some(preview) = view.remember_preview {
+            cell = cell.with_remember_preview(preview);
         }
         if let Some(hint) = view.selection_hint {
             cell = cell.with_selection_hint(hint);
-        }
-        if let Some(input) = view.custom_match_input {
-            cell = cell.with_custom_match_input(input);
-        }
-        if let Some(source) = view.custom_match_source {
-            cell = cell.with_custom_match_source(source);
         }
         cell = cell.with_scope_context(
             view.workspace_untrusted,
             view.is_compound_command,
             view.has_dynamic_eval,
+            view.unsafe_rule_shape,
         );
         Some(cell)
     }
@@ -682,31 +660,6 @@ impl BottomPane {
             return None;
         }
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        if self.approval_queue.focused_custom_prefix_active() {
-            return match key.code {
-                KeyCode::Enter => {
-                    if let Some(response) = self.approval_queue.submit_custom_prefix_for_focused() {
-                        if let Some(id) = self.respond_focused_approval(response) {
-                            return Some(BottomPaneAction::ApprovalResolved { id });
-                        }
-                    }
-                    Some(BottomPaneAction::Consumed)
-                }
-                KeyCode::Esc => {
-                    self.approval_queue.cancel_custom_prefix_for_focused();
-                    Some(BottomPaneAction::Consumed)
-                }
-                KeyCode::Backspace => {
-                    self.approval_queue.pop_custom_prefix_char();
-                    Some(BottomPaneAction::Consumed)
-                }
-                KeyCode::Char(ch) if !ctrl => {
-                    self.approval_queue.push_custom_prefix_char(ch);
-                    Some(BottomPaneAction::Consumed)
-                }
-                _ => None,
-            };
-        }
 
         // Ctrl+Enter → quick accept regardless of button focus.
         if key.code == KeyCode::Enter && ctrl {

--- a/rust/crates/astra-cli/src/tui/chat_widget/resume.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/resume.rs
@@ -218,7 +218,7 @@ mod tests {
                 .collect::<Vec<_>>()
                 .join("\n");
             assert!(
-                summary_text.contains("💾 75%"),
+                summary_text.contains("▓░ 75%"),
                 "cache-read stats must remain user-visible after resume"
             );
         });

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -36,6 +36,7 @@ use super::{
 };
 
 const AGENT_DRILLDOWN_RECENT_COMPLETED: usize = 5;
+const WORKSPACE_TRUST_SENTINEL: &str = "__workspace_trust__\n";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ReopenTarget {
@@ -451,6 +452,38 @@ pub(crate) async fn run_tui_repl(
         }
         _ => chat_widget::ChatWidget::new(String::new()),
     };
+
+    if let Some(prompt) = state.perm_manager.workspace_trust_startup_prompt() {
+        use crate::tui::bottom_pane::list_selection_view::{ListSelectionView, SelectionItem};
+
+        let items = vec![
+            SelectionItem {
+                name: "Trust Workspace".into(),
+                description: Some("Enable saved workspace rules for this path".into()),
+                is_current: false,
+            },
+            SelectionItem {
+                name: "Continue This Session".into(),
+                description: Some(
+                    "Keep saved workspace rules off for now; ask again next time".into(),
+                ),
+                is_current: false,
+            },
+            SelectionItem {
+                name: "Mark Untrusted".into(),
+                description: Some(
+                    "Keep saved workspace rules off and stop asking on startup".into(),
+                ),
+                is_current: false,
+            },
+        ];
+        bottom_pane.push_view(Box::new(
+            ListSelectionView::new(items, Some(prompt.header))
+                .with_result_prefix(WORKSPACE_TRUST_SENTINEL),
+        ));
+    } else if let Some(notice) = state.perm_manager.workspace_trust_notice() {
+        chat_widget.commit_system(history_cell::system::SystemCell::info(notice));
+    }
 
     // Resume-time summary: surface background tasks that reached
     // terminal state while the user was away. One ResumeSummary
@@ -1425,6 +1458,59 @@ pub(crate) async fn run_tui_repl(
                                         frame_requester.schedule_frame();
                                         continue;
                                     }
+                                    if let Some(choice) =
+                                        name.strip_prefix(WORKSPACE_TRUST_SENTINEL)
+                                    {
+                                        match choice {
+                                            "Trust Workspace" => {
+                                                match state.perm_manager.trust_workspace() {
+                                                    Ok(message) => chat_widget.commit_system(
+                                                        history_cell::system::SystemCell::response(
+                                                            message,
+                                                        ),
+                                                    ),
+                                                    Err(err) => chat_widget.commit_system(
+                                                        history_cell::system::SystemCell::error(
+                                                            format!(
+                                                                "Failed to trust workspace: {err}"
+                                                            ),
+                                                        ),
+                                                    ),
+                                                }
+                                            }
+                                            "Continue This Session" => {
+                                                chat_widget.commit_system(
+                                                    history_cell::system::SystemCell::info(
+                                                        "Continuing without trusting this workspace. Saved workspace rules stay off for this session."
+                                                            .to_string(),
+                                                    ),
+                                                );
+                                            }
+                                            "Mark Untrusted" => {
+                                                match state.perm_manager.untrust_workspace() {
+                                                    Ok(message) => chat_widget.commit_system(
+                                                        history_cell::system::SystemCell::response(
+                                                            message,
+                                                        ),
+                                                    ),
+                                                    Err(err) => chat_widget.commit_system(
+                                                        history_cell::system::SystemCell::error(
+                                                            format!(
+                                                                "Failed to mark workspace untrusted: {err}"
+                                                            ),
+                                                        ),
+                                                    ),
+                                                }
+                                            }
+                                            _ => {}
+                                        }
+                                        pending_deferred_slash_flush = false;
+                                        let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
+                                        flush_chat_widget(&mut guard, &mut chat_widget, w);
+                                        bottom_pane.sync_popups();
+                                        frame_requester.schedule_frame();
+                                        continue;
+                                    }
                                     // credentials arrive as a sentinel-
                                     // prefixed string so we can dispatch
                                     // auth without leaving the TUI (no
@@ -2096,6 +2182,36 @@ mod tests {
             let decoded = ReopenTarget::parse(encoded).expect("known variant must round-trip");
             assert_eq!(decoded, target, "variant {encoded} did not round-trip");
         }
+    }
+
+    #[test]
+    fn startup_workspace_trust_prompt_is_wired_into_tui_boot() {
+        let source = include_str!("event_loop.rs");
+        assert!(
+            source.contains("workspace_trust_startup_prompt()"),
+            "run_tui_repl should query the permission manager for a startup trust prompt"
+        );
+        assert!(
+            source.contains("Trust Workspace")
+                && source.contains("Continue This Session")
+                && source.contains("Mark Untrusted"),
+            "startup trust picker should offer trust / continue-once / untrust choices"
+        );
+    }
+
+    #[test]
+    fn startup_workspace_trust_picker_results_are_handled() {
+        let source = include_str!("event_loop.rs");
+        let arm = source
+            .find("name.strip_prefix(WORKSPACE_TRUST_SENTINEL)")
+            .expect("view completion should handle the workspace trust picker sentinel");
+        let body = &source[arm..];
+        assert!(
+            body.contains("trust_workspace()")
+                && body.contains("untrust_workspace()")
+                && body.contains("Continuing without trusting this workspace."),
+            "workspace trust picker must wire all three outcomes"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/history_cell/approval.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/approval.rs
@@ -7,7 +7,7 @@
 //!   rm -rf /tmp/scratch
 //!   destructive path outside cwd
 //!
-//! ▸ Accept      Reject    Always   Skip
+//! ▸ Allow once    Always    Reject
 //!   ← → navigate · Enter confirm · Esc reject
 //! ```
 //!
@@ -74,11 +74,10 @@ pub(crate) struct ApprovalCell {
     /// badge line. Each tag becomes a coloured chip in the
     /// header. Empty = no badge displayed.
     pub risk_tag_labels: Vec<String>,
-    /// Issue #326 P3: precomputed "Will save" preview. Renders
-    /// as a separate line `Will save: <rule>` so the user sees
-    /// exactly what permissions.json would gain before pressing
-    /// Always.
-    pub will_save_preview: Option<String>,
+    /// Human-readable preview of what pressing Always will remember.
+    /// This deliberately avoids permission-rule syntax such as
+    /// `Bash(npm test:*)`; users should see product language, not DSL.
+    pub remember_preview: Option<String>,
     /// Issue #326 P3 / R1 Major 11 / scenarios #21-#25: agent
     /// that issued the request. Renders as `[agent: <id>]` chip
     /// next to the header.
@@ -87,8 +86,8 @@ pub(crate) struct ApprovalCell {
     /// as `host:` prefix on the detail block.
     pub host: Option<String>,
     /// Issue #326 P5d / R2 Minor 1: post-save confirmation
-    /// message. Distinct from `will_save_preview` (the *future*
-    /// rule shown before the user clicks Always) — this is the
+    /// message. Distinct from `remember_preview` (the *future*
+    /// memory shown before the user clicks Always) — this is the
     /// *past* outcome shown after the save attempt:
     ///
     ///   None        -> not yet attempted (or no Always pressed)
@@ -97,11 +96,10 @@ pub(crate) struct ApprovalCell {
     ///                  "Failed to save rule: <reason>"
     pub save_outcome: Option<String>,
     pub selection_hint: Option<String>,
-    pub custom_match_input: Option<String>,
-    pub custom_match_source: Option<String>,
     pub workspace_untrusted: bool,
     pub is_compound_command: bool,
     pub has_dynamic_eval: bool,
+    pub unsafe_rule_shape: bool,
 }
 
 impl ApprovalCell {
@@ -122,16 +120,15 @@ impl ApprovalCell {
             focused,
             buttons: ButtonRow::primary(),
             risk_tag_labels: Vec::new(),
-            will_save_preview: None,
+            remember_preview: None,
             source_agent: None,
             host: None,
             save_outcome: None,
             selection_hint: None,
-            custom_match_input: None,
-            custom_match_source: None,
             workspace_untrusted: false,
             is_compound_command: false,
             has_dynamic_eval: false,
+            unsafe_rule_shape: false,
         }
     }
 
@@ -155,23 +152,22 @@ impl ApprovalCell {
             focused,
             buttons: ButtonRow::primary_with_batch(),
             risk_tag_labels: Vec::new(),
-            will_save_preview: None,
+            remember_preview: None,
             source_agent: None,
             host: None,
             save_outcome: None,
             selection_hint: None,
-            custom_match_input: None,
-            custom_match_source: None,
             workspace_untrusted: false,
             is_compound_command: false,
             has_dynamic_eval: false,
+            unsafe_rule_shape: false,
         }
     }
 
     /// Issue #326 P3: builder for the approval card's display
     /// metadata. Threading these through positionally would
     /// churn every call site; a builder keeps the API local to
-    /// the few places that compute risk/will_save/agent.
+    /// the few places that compute risk/remember-preview/agent.
     #[must_use]
     pub fn with_risk_tag_labels(mut self, labels: Vec<String>) -> Self {
         self.risk_tag_labels = labels;
@@ -179,8 +175,8 @@ impl ApprovalCell {
     }
 
     #[must_use]
-    pub fn with_will_save_preview(mut self, preview: impl Into<String>) -> Self {
-        self.will_save_preview = Some(preview.into());
+    pub fn with_remember_preview(mut self, preview: impl Into<String>) -> Self {
+        self.remember_preview = Some(preview.into());
         self
     }
 
@@ -212,27 +208,17 @@ impl ApprovalCell {
     }
 
     #[must_use]
-    pub fn with_custom_match_input(mut self, input: impl Into<String>) -> Self {
-        self.custom_match_input = Some(input.into());
-        self
-    }
-
-    #[must_use]
-    pub fn with_custom_match_source(mut self, source: impl Into<String>) -> Self {
-        self.custom_match_source = Some(source.into());
-        self
-    }
-
-    #[must_use]
     pub fn with_scope_context(
         mut self,
         workspace_untrusted: bool,
         is_compound_command: bool,
         has_dynamic_eval: bool,
+        unsafe_rule_shape: bool,
     ) -> Self {
         self.workspace_untrusted = workspace_untrusted;
         self.is_compound_command = is_compound_command;
         self.has_dynamic_eval = has_dynamic_eval;
+        self.unsafe_rule_shape = unsafe_rule_shape;
         self
     }
 
@@ -262,7 +248,7 @@ impl ApprovalCell {
         // Sub-agent requests can never persist on the parent's
         // permissions.json.
         if self.source_agent.is_some() {
-            return Some("sub-agent");
+            return Some("sub-agent request");
         }
         for label in &self.risk_tag_labels {
             match label.as_str() {
@@ -274,7 +260,22 @@ impl ApprovalCell {
                 _ => {}
             }
         }
+        if self.has_dynamic_eval {
+            return Some("shell command built at runtime");
+        }
+        if self.is_compound_command {
+            return Some("multi-step shell command");
+        }
+        if self.unsafe_rule_shape {
+            return Some("command shape too broad to remember");
+        }
         None
+    }
+
+    fn always_action_disabled(&self) -> bool {
+        self.always_disabled_reason().is_some()
+            || (!self.workspace_untrusted
+                && !self.scope_available(astra_turn_core::permission_scope::AllowScope::Project))
     }
 
     fn risk_tags_for_scope(&self) -> Vec<astra_turn_core::permission_engine::RiskTag> {
@@ -325,6 +326,7 @@ impl ApprovalCell {
             workspace_untrusted: self.workspace_untrusted,
             is_compound_command: self.is_compound_command,
             has_dynamic_eval: self.has_dynamic_eval,
+            unsafe_rule_shape: self.unsafe_rule_shape,
         }
     }
 
@@ -336,7 +338,9 @@ impl ApprovalCell {
 
     fn button_disabled(&self, btn: &crate::tui::approval::Button) -> bool {
         match &btn.action {
-            crate::tui::approval::ButtonAction::SelectScope(scope) => !self.scope_available(*scope),
+            crate::tui::approval::ButtonAction::Respond(
+                crate::chat_stream::ApprovalResponse::AlwaysAllow,
+            ) => self.always_action_disabled(),
             _ => false,
         }
     }
@@ -483,13 +487,12 @@ impl HistoryCell for ApprovalCell {
             ]));
         }
 
-        // Will-save preview (issue #326 P3): users see exactly
-        // what permissions.json would gain before pressing
-        // Always.
-        if let Some(preview) = &self.will_save_preview {
+        // Memory preview: keep this as product language, never raw
+        // permission-rule syntax.
+        if let Some(preview) = &self.remember_preview {
             lines.push(Line::from(vec![
                 bar.clone(),
-                Span::styled("Will save: ".to_string(), muted),
+                Span::styled("Always remembers: ".to_string(), muted),
                 Span::styled(preview.clone(), body_style.add_modifier(Modifier::BOLD)),
             ]));
         }
@@ -514,52 +517,26 @@ impl HistoryCell for ApprovalCell {
         if let Some(hint) = &self.selection_hint {
             lines.push(Line::from(vec![
                 bar.clone(),
-                Span::styled("Match: ".to_string(), muted),
+                Span::styled("Note: ".to_string(), muted),
                 Span::styled(hint.clone(), body_style),
             ]));
         }
 
-        if let Some(input) = &self.custom_match_input {
-            let ghost_suffix = self
-                .custom_match_source
-                .as_deref()
-                .and_then(|source| source.strip_prefix(input.as_str()))
-                .filter(|suffix| !suffix.is_empty());
-            let mut spans = vec![
-                bar.clone(),
-                Span::styled("Prefix: ".to_string(), muted),
-                Span::styled(input.clone(), body_style.add_modifier(Modifier::BOLD)),
-                Span::styled("▌".to_string(), accent_style.add_modifier(Modifier::BOLD)),
-            ];
-            if let Some(suffix) = ghost_suffix {
-                spans.push(Span::styled(
-                    suffix.to_string(),
-                    Style::default().fg(Color::DarkGray),
-                ));
-            }
-            lines.push(Line::from(spans));
-        }
-
-        // Issue #326 P3 / scenarios #6/#9/#15: when the request
-        // carries destructive risk tags, advertise that the
-        // Always button can't be used to persist a project /
-        // user rule. The button row itself stays clickable —
-        // the Always-resolve handler upstream still records
-        // the override in session-only memory — but the user
-        // sees up-front why no on-disk rule landed.
+        // Keep high-risk persistence disabled in plain language; the
+        // UI should not expose old scope internals.
         if self.always_disabled_reason().is_some() {
             let reason_text = self.always_disabled_reason().unwrap_or_default();
             lines.push(Line::from(vec![
                 bar.clone(),
-                Span::styled("Always: ".to_string(), Style::default().fg(Color::DarkGray)),
                 Span::styled(
-                    "session-only ".to_string(),
+                    "Always disabled".to_string(),
                     Style::default()
                         .fg(Color::Yellow)
                         .add_modifier(Modifier::BOLD),
                 ),
+                Span::styled(": ".to_string(), Style::default().fg(Color::DarkGray)),
                 Span::styled(
-                    format!("({reason_text})"),
+                    reason_text.to_string(),
                     Style::default().fg(Color::DarkGray),
                 ),
             ]));
@@ -578,11 +555,7 @@ impl HistoryCell for ApprovalCell {
         // style. Unfocused: plain border close — the user isn't
         // looking at this card for actions yet.
         let bottom = if self.focused {
-            let hint = if self.custom_match_input.is_some() {
-                "type prefix · Enter approve · Esc back"
-            } else {
-                "↑↓←→ select · Enter confirm · Esc reject · Ctrl+Enter quick accept"
-            };
+            let hint = "↑↓←→ select · Enter confirm · Esc reject · Ctrl+Enter quick accept";
             Line::from(vec![
                 Span::styled("╰─ ".to_string(), accent_style),
                 Span::styled(hint.to_string(), muted),
@@ -682,38 +655,12 @@ mod tests {
     }
 
     #[test]
-    fn custom_prefix_input_renders_source_suffix_as_placeholder() {
-        let cell = ApprovalCell::new(
-            1,
-            "bash".into(),
-            "git status --short".into(),
-            None,
-            "execute".into(),
-            true,
-        )
-        .with_custom_match_input("git ")
-        .with_custom_match_source("git status --short");
-        let lines = cell.display_lines(80);
-        let prefix_line = lines
-            .iter()
-            .find(|line| line.spans.iter().any(|span| span.content == "Prefix: "))
-            .expect("prefix input line should render");
-        let rendered = prefix_line
-            .spans
-            .iter()
-            .map(|span| span.content.as_ref())
-            .collect::<String>();
-        assert_eq!(rendered, "│ Prefix: git ▌status --short");
-        assert_eq!(prefix_line.spans[4].style.fg, Some(Color::DarkGray));
-    }
-
-    #[test]
     fn never_persists() {
         let cell = ApprovalCell::new(1, "t".into(), "h".into(), None, "r".into(), true);
         assert!(cell.to_persist().is_none());
     }
 
-    // ── Issue #326 P3 enrichment: risk badge / will-save / agent / host ──
+    // ── Issue #326 P3 enrichment: risk badge / remember preview / agent / host ──
 
     #[test]
     fn renders_risk_tag_badge_when_present() {
@@ -735,7 +682,7 @@ mod tests {
     }
 
     #[test]
-    fn renders_will_save_preview_when_present() {
+    fn renders_remember_preview_when_present() {
         let cell = ApprovalCell::new(
             1,
             "bash".into(),
@@ -744,18 +691,22 @@ mod tests {
             "execute".into(),
             true,
         )
-        .with_will_save_preview("Bash(npm test:*)");
+        .with_remember_preview("similar `npm test` commands in this workspace");
         let rendered = render(&cell);
         assert!(
-            rendered.contains("Will save: Bash(npm test:*)"),
-            "expected Will save preview line, got:\n{rendered}"
+            rendered.contains("Always remembers: similar `npm test` commands in this workspace"),
+            "expected remember preview line, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("Bash("),
+            "must not expose permission DSL:\n{rendered}"
         );
     }
 
     #[test]
     fn renders_save_outcome_when_present() {
         // Issue #326 P5d / R2 Minor 1: post-save confirmation
-        // line appears below Will save and tells the user the
+        // line appears below the approval details and tells the user the
         // rule actually persisted.
         let cell = ApprovalCell::new(
             1,
@@ -819,14 +770,14 @@ mod tests {
 
     #[test]
     fn omits_optional_lines_when_unset() {
-        // Default cell has no risk tags / will-save / agent /
+        // Default cell has no risk tags / remember-preview / agent /
         // host, and should not render those lines.
         let cell = ApprovalCell::new(1, "bash".into(), "h".into(), None, "r".into(), true);
         let rendered = render(&cell);
         assert!(!rendered.contains("⚑ "), "no risk badge expected");
         assert!(
-            !rendered.contains("Will save:"),
-            "no will-save row expected"
+            !rendered.contains("Always remembers:"),
+            "no remember-preview row expected"
         );
         assert!(!rendered.contains("[agent:"), "no agent chip expected");
     }
@@ -889,7 +840,24 @@ mod tests {
             true,
         )
         .with_source_agent("review-subagent");
-        assert_eq!(cell.always_disabled_reason(), Some("sub-agent"));
+        assert_eq!(cell.always_disabled_reason(), Some("sub-agent request"));
+    }
+
+    #[test]
+    fn always_disabled_reason_mentions_runtime_built_shell_command() {
+        let cell = ApprovalCell::new(
+            1,
+            "bash".into(),
+            "echo $(pwd)".into(),
+            None,
+            "execute".into(),
+            true,
+        )
+        .with_scope_context(false, false, true, false);
+        assert_eq!(
+            cell.always_disabled_reason(),
+            Some("shell command built at runtime")
+        );
     }
 
     #[test]
@@ -907,6 +875,62 @@ mod tests {
     }
 
     #[test]
+    fn always_enabled_for_untrusted_workspace_benign_request() {
+        let cell = ApprovalCell::new(
+            1,
+            "git_show".into(),
+            "Git show HEAD".into(),
+            None,
+            "This command needs your approval before it runs.".into(),
+            true,
+        )
+        .with_risk_tag_labels(vec!["BashExecute".into()])
+        .with_scope_context(true, false, false, false);
+        let rendered = render(&cell);
+        assert!(
+            !rendered.contains("Always×"),
+            "workspace-untrusted benign request should still allow session-level Always, got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn always_disabled_reason_mentions_multi_step_shell_command() {
+        let cell = ApprovalCell::new(
+            1,
+            "bash".into(),
+            "cd rust && cargo test".into(),
+            None,
+            "This command needs your approval before it runs.".into(),
+            true,
+        )
+        .with_risk_tag_labels(vec!["BashExecute".into()])
+        .with_scope_context(false, true, false, false);
+        assert_eq!(
+            cell.always_disabled_reason(),
+            Some("multi-step shell command")
+        );
+    }
+
+    #[test]
+    fn always_disabled_reason_mentions_unsafe_rule_shape() {
+        let cell = ApprovalCell::new(
+            1,
+            "bash".into(),
+            "bash".into(),
+            None,
+            "execute".into(),
+            true,
+        )
+        .with_scope_context(false, false, false, true);
+
+        assert_eq!(
+            cell.always_disabled_reason(),
+            Some("command shape too broad to remember")
+        );
+        assert!(cell.always_action_disabled());
+    }
+
+    #[test]
     fn always_disabled_renders_in_card() {
         let cell = ApprovalCell::new(
             1,
@@ -919,10 +943,33 @@ mod tests {
         .with_risk_tag_labels(vec!["GitDestructive".into()]);
         let rendered = render(&cell);
         assert!(
-            rendered.contains("Always: session-only"),
+            rendered.contains("Always disabled: git destructive"),
             "destructive cell must advertise the disabled-Always state, got:\n{rendered}"
         );
-        assert!(rendered.contains("git destructive"));
+    }
+
+    #[test]
+    fn selection_hint_renders_as_note_not_match() {
+        let cell = ApprovalCell::new(
+            1,
+            "str_replace".into(),
+            "Editing rust/crates/astra-cli/src/tui/approval/queue.rs".into(),
+            None,
+            "This command needs your approval before it runs.".into(),
+            true,
+        )
+        .with_selection_hint(
+            "Always remembers for this session only. Run `astra permissions trust` to save workspace rules.",
+        );
+        let rendered = render(&cell);
+        assert!(
+            rendered.contains("Note: Always remembers for this session only."),
+            "selection hints should render as a note, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("Match:"),
+            "selection hint must not reuse the retired match-target label, got:\n{rendered}"
+        );
     }
 
     // ── Issue #326 P3 / R1 Major 11: snapshot tests at 3 widths ──
@@ -946,11 +993,11 @@ mod tests {
             "bash".into(),
             "npm test --filter auth".into(),
             Some("npm test --filter auth -- --verbose".into()),
-            "execute (Prompt mode, no allow rule matches)".into(),
+            "This command needs your approval before it runs.".into(),
             true,
         )
         .with_risk_tag_labels(vec!["BashExecute".into()])
-        .with_will_save_preview("Bash(npm test:*)")
+        .with_remember_preview("similar `npm test` commands in this workspace")
     }
 
     /// Smoke-snapshot the rendered card at three terminal widths

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_100.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_100.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/approval.rs
-assertion_line: 875
+assertion_line: 987
 expression: "render_at(&fixture_full(), 100)"
 ---
 ╭─ ⏸ npm test --filter auth
 │ ⚑ BashExecute
 │ npm test --filter auth -- --verbose
-│ ⚠ execute (Prompt mode, no allow rule matches)
-│ Will save: Bash(npm test:*)
+│ ⚠ This command needs your approval before it runs.
+│ Always remembers: similar `npm test` commands in this workspace
 │
-│  Accept   Reject   Turn   Session   Project   User   Skip
+│  Allow once   Always   Reject
 ╰─ ↑↓←→ select · Enter confirm · Esc reject · Ctrl+Enter quick accept

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_160.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_160.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/approval.rs
-assertion_line: 880
+assertion_line: 992
 expression: "render_at(&fixture_full(), 160)"
 ---
 ╭─ ⏸ npm test --filter auth
 │ ⚑ BashExecute
 │ npm test --filter auth -- --verbose
-│ ⚠ execute (Prompt mode, no allow rule matches)
-│ Will save: Bash(npm test:*)
+│ ⚠ This command needs your approval before it runs.
+│ Always remembers: similar `npm test` commands in this workspace
 │
-│  Accept   Reject   Turn   Session   Project   User   Skip
+│  Allow once   Always   Reject
 ╰─ ↑↓←→ select · Enter confirm · Esc reject · Ctrl+Enter quick accept

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_80.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_80.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/approval.rs
-assertion_line: 870
+assertion_line: 982
 expression: "render_at(&fixture_full(), 80)"
 ---
 ╭─ ⏸ npm test --filter auth
 │ ⚑ BashExecute
 │ npm test --filter auth -- --verbose
-│ ⚠ execute (Prompt mode, no allow rule matches)
-│ Will save: Bash(npm test:*)
+│ ⚠ This command needs your approval before it runs.
+│ Always remembers: similar `npm test` commands in this workspace
 │
-│  Accept   Reject   Turn   Session   Project   User   Skip
+│  Allow once   Always   Reject
 ╰─ ↑↓←→ select · Enter confirm · Esc reject · Ctrl+Enter quick accept

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_agent_and_host_80.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_agent_and_host_80.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/approval.rs
-assertion_line: 890
+assertion_line: 1002
 expression: "render_at(&cell, 80)"
 ---
 ╭─ ⏸ npm test --filter auth [agent: review-subagent] [ssh:bastion-prod]
 │ ⚑ BashExecute
 │ npm test --filter auth -- --verbose
-│ ⚠ execute (Prompt mode, no allow rule matches)
-│ Will save: Bash(npm test:*)
-│ Always: session-only (sub-agent)
+│ ⚠ This command needs your approval before it runs.
+│ Always remembers: similar `npm test` commands in this workspace
+│ Always disabled: sub-agent request
 │
-│  Accept   Reject   Turn   Session   Project×   User×   Skip
+│  Allow once   Always×   Reject
 ╰─ ↑↓←→ select · Enter confirm · Esc reject · Ctrl+Enter quick accept

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_destructive_80.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_destructive_80.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/approval.rs
-assertion_line: 909
 expression: "render_at(&cell, 80)"
 ---
 ╭─ ⏸ edit /etc/hosts
 │ ⚑ WritesOutsideWorkspace  ⚑ WritesSensitiveFile
 │ /etc/hosts
 │ ⚠ writes outside workspace
-│ Always: session-only (outside workspace)
+│ Always disabled: outside workspace
 │
-│  Accept   Reject   Turn   Session   Project×   User×   Skip
+│  Allow once   Always×   Reject
 ╰─ ↑↓←→ select · Enter confirm · Esc reject · Ctrl+Enter quick accept

--- a/rust/crates/astra-cli/src/tui/history_cell/turn_summary.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/turn_summary.rs
@@ -27,7 +27,7 @@ pub(crate) struct TurnSummaryCell {
     pub ttft_ms: Option<u64>,
     pub tokens_in: Option<u64>,
     pub tokens_out: Option<u64>,
-    /// Cache-read portion of `tokens_in`. Drives the `💾 N%` band.
+    /// Cache-read portion of `tokens_in`. Drives the `▓░ N%` band.
     pub cache_read_tokens: Option<u64>,
     pub tools: u32,
     pub cumulative_tokens: Option<u64>,
@@ -100,7 +100,7 @@ impl HistoryCell for TurnSummaryCell {
             segments.push(format!("🛠 {}", self.tools));
         }
 
-        // 💾 cache-hit percentage of input tokens. Only shown when
+        // ▓░ cache-hit percentage of input tokens. Only shown when
         // the provider actually reported a non-zero `cache_read`
         // this turn — first turn and non-caching providers elide
         // the segment entirely so the band doesn't lie about 0%
@@ -110,7 +110,7 @@ impl HistoryCell for TurnSummaryCell {
             && tin > 0
         {
             let pct = ((cache_read as f64 / tin as f64) * 100.0).round() as u32;
-            segments.push(format!("💾 {pct}%"));
+            segments.push(format!("▓░ {pct}%"));
         }
 
         // Σ session totals — either the running cumulative token
@@ -276,7 +276,7 @@ mod tests {
         // 23.2k tokens in, 18k cache read → ~78%
         c.cache_read_tokens = Some(18_000);
         let out = render(&c, 120);
-        assert!(out.contains("💾"), "cache icon missing: {out}");
+        assert!(out.contains("▓░"), "cache icon missing: {out}");
         assert!(out.contains("78%"), "expected ~78% hit rate in: {out}");
     }
 
@@ -288,7 +288,7 @@ mod tests {
         let mut c = mk_full();
         c.cache_read_tokens = None;
         let out = render(&c, 120);
-        assert!(!out.contains("💾"), "cache chip must be elided: {out}");
+        assert!(!out.contains("▓░"), "cache chip must be elided: {out}");
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -243,6 +243,22 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
                             is_current: current == PermissionMode::Auto,
                         },
                         SelectionItem {
+                            name: "Plan".into(),
+                            description: Some(
+                                "Read-only investigation mode; write and shell mutations are denied"
+                                    .into(),
+                            ),
+                            is_current: current == PermissionMode::Plan,
+                        },
+                        SelectionItem {
+                            name: "Accept Edits".into(),
+                            description: Some(
+                                "Auto-approve workspace-local edits; still ask for shell/external writes"
+                                    .into(),
+                            ),
+                            is_current: current == PermissionMode::AcceptEdits,
+                        },
+                        SelectionItem {
                             name: "Prompt".into(),
                             description: Some("Ask before write/execute tools".into()),
                             is_current: current == PermissionMode::Prompt,
@@ -262,14 +278,14 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
                         SelectionItem {
                             name: "Trust Workspace".into(),
                             description: Some(
-                                "Apply project allow rules after hash validation".into(),
+                                "Apply saved workspace rules after hash validation".into(),
                             ),
                             is_current: false,
                         },
                         SelectionItem {
                             name: "Untrust Workspace".into(),
                             description: Some(
-                                "Ignore project allow rules for this workspace".into(),
+                                "Ignore saved workspace rules for this workspace".into(),
                             ),
                             is_current: false,
                         },
@@ -290,6 +306,21 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
                 "all" | "auto" => {
                     ctx.state.perm_manager.set_mode(PermissionMode::Auto);
                     ctx.show_response("Permission mode → auto (all tools auto-approved)".into());
+                    SlashResult::Handled
+                }
+                "plan" => {
+                    ctx.state.perm_manager.set_mode(PermissionMode::Plan);
+                    ctx.show_response(
+                        "Permission mode → plan (read-only investigation mode)".into(),
+                    );
+                    SlashResult::Handled
+                }
+                "accept_edits" | "accept-edits" => {
+                    ctx.state.perm_manager.set_mode(PermissionMode::AcceptEdits);
+                    ctx.show_response(
+                        "Permission mode → accept_edits (workspace-local edits auto-approved)"
+                            .into(),
+                    );
                     SlashResult::Handled
                 }
                 "prompt" => {
@@ -358,7 +389,7 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
                 }
                 _ => {
                     ctx.show_error(format!(
-                        "Unknown mode '{args}'. Use: auto, prompt, deny, all, rules, trust, untrust, trace"
+                        "Unknown mode '{args}'. Use: auto, plan, accept_edits, prompt, deny, all, rules, trust, untrust, trace"
                     ));
                     SlashResult::Handled
                 }
@@ -1006,6 +1037,18 @@ pub(crate) fn handle_view_result(
             use crate::permission_manager::PermissionMode;
             state.perm_manager.set_mode(PermissionMode::Auto);
             chat_widget.commit_system(SystemCell::response("Permission mode → auto"));
+            return;
+        }
+        "Accept Edits" => {
+            use crate::permission_manager::PermissionMode;
+            state.perm_manager.set_mode(PermissionMode::AcceptEdits);
+            chat_widget.commit_system(SystemCell::response("Permission mode → accept_edits"));
+            return;
+        }
+        "Plan" => {
+            use crate::permission_manager::PermissionMode;
+            state.perm_manager.set_mode(PermissionMode::Plan);
+            chat_widget.commit_system(SystemCell::response("Permission mode → plan"));
             return;
         }
         "Prompt" => {
@@ -2389,6 +2432,41 @@ mod view_result_tests {
         assert_eq!(
             last_system_message(&chat_widget).as_deref(),
             Some("Permission mode → auto")
+        );
+    }
+
+    #[test]
+    fn accept_edits_selection_updates_state_and_commits_feedback() {
+        let mut state = SessionState::default();
+        let mut bottom_pane = BottomPane::new();
+        let mut chat_widget = ChatWidget::new("");
+
+        handle_view_result(
+            "Accept Edits",
+            &mut state,
+            &mut bottom_pane,
+            &mut chat_widget,
+        );
+
+        assert_eq!(state.perm_manager.mode(), PermissionMode::AcceptEdits);
+        assert_eq!(
+            last_system_message(&chat_widget).as_deref(),
+            Some("Permission mode → accept_edits")
+        );
+    }
+
+    #[test]
+    fn plan_selection_updates_state_and_commits_feedback() {
+        let mut state = SessionState::default();
+        let mut bottom_pane = BottomPane::new();
+        let mut chat_widget = ChatWidget::new("");
+
+        handle_view_result("Plan", &mut state, &mut bottom_pane, &mut chat_widget);
+
+        assert_eq!(state.perm_manager.mode(), PermissionMode::Plan);
+        assert_eq!(
+            last_system_message(&chat_widget).as_deref(),
+            Some("Permission mode → plan")
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/status_line/line.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/line.rs
@@ -16,6 +16,8 @@ pub(crate) enum PermissionMode {
     #[default]
     Ask,
     Auto,
+    Plan,
+    AcceptEdits,
     Deny,
 }
 
@@ -24,6 +26,8 @@ impl PermissionMode {
         match self {
             Self::Ask => "",
             Self::Auto => "⚡auto",
+            Self::Plan => "plan",
+            Self::AcceptEdits => "✎edits",
             Self::Deny => "⚡deny",
         }
     }
@@ -126,6 +130,18 @@ impl StatusLine {
                 out.left.push(Segment::styled(
                     PermissionMode::Auto.chip_text(),
                     Style::default().fg(Color::Yellow),
+                ));
+            }
+            PermissionMode::Plan => {
+                out.left.push(Segment::styled(
+                    PermissionMode::Plan.chip_text(),
+                    Style::default().fg(Color::Blue),
+                ));
+            }
+            PermissionMode::AcceptEdits => {
+                out.left.push(Segment::styled(
+                    PermissionMode::AcceptEdits.chip_text(),
+                    Style::default().fg(Color::Cyan),
                 ));
             }
             PermissionMode::Deny => {

--- a/rust/crates/astra-cli/src/tui/status_line/tests.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/tests.rs
@@ -100,6 +100,36 @@ fn auto_mode_renders_yellow_chip() {
 }
 
 #[test]
+fn accept_edits_mode_renders_cyan_chip() {
+    let c = StatusContext {
+        permission_mode: PermissionMode::AcceptEdits,
+        ..ctx()
+    };
+    let s = StatusLine::from_context(&c);
+    let chip = s
+        .left
+        .iter()
+        .find(|seg| seg.text.contains("✎edits"))
+        .expect("accept_edits chip segment");
+    assert_eq!(chip.style.fg, Some(ratatui::style::Color::Cyan));
+}
+
+#[test]
+fn plan_mode_renders_blue_chip() {
+    let c = StatusContext {
+        permission_mode: PermissionMode::Plan,
+        ..ctx()
+    };
+    let s = StatusLine::from_context(&c);
+    let chip = s
+        .left
+        .iter()
+        .find(|seg| seg.text.contains("plan"))
+        .expect("plan chip segment");
+    assert_eq!(chip.style.fg, Some(ratatui::style::Color::Blue));
+}
+
+#[test]
 fn deny_mode_renders_red_chip() {
     let c = StatusContext {
         permission_mode: PermissionMode::Deny,

--- a/rust/crates/astra-turn-core/src/action_compensation.rs
+++ b/rust/crates/astra-turn-core/src/action_compensation.rs
@@ -815,6 +815,27 @@ pub fn explicit_approval_reason(tool_name: &str, args: &Value) -> Option<String>
     Some(reason.to_string())
 }
 
+pub fn primary_approval_reason(tool_name: &str, args: &Value) -> Option<String> {
+    let profile = tool_action_profile(tool_name, args);
+    if !profile_requires_explicit_approval(tool_name, Some(args), &profile) {
+        return None;
+    }
+
+    let reason = match cloud_gated_tool_kind_with_args(tool_name, Some(args)) {
+        Some(CloudGatedToolKind::Execute) if profile.category == ActionCategory::Destructive => {
+            "This command can make destructive changes, so it needs your approval."
+        }
+        Some(CloudGatedToolKind::Execute) => {
+            "This command runs in your shell and can change files or system state."
+        }
+        Some(CloudGatedToolKind::Write) => {
+            "This action can change files or project state, so it needs your approval."
+        }
+        None => "This action can change project state, so it needs your approval.",
+    };
+    Some(reason.to_string())
+}
+
 pub fn tool_action_profile_value(tool_name: &str, args: &Value) -> Value {
     serde_json::to_value(tool_action_profile(tool_name, args)).unwrap_or(Value::Null)
 }

--- a/rust/crates/astra-turn-core/src/approval_fingerprint.rs
+++ b/rust/crates/astra-turn-core/src/approval_fingerprint.rs
@@ -218,9 +218,9 @@ impl ApprovalFingerprint {
         // If self has no command prefix, it matches any command for this tool.
         if let Some(ref my_prefix) = self.command_prefix {
             let Some(their_command) = other
-                .command_exact
+                .command_prefix
                 .as_deref()
-                .or(other.command_prefix.as_deref())
+                .or(other.command_exact.as_deref())
             else {
                 return false;
             };
@@ -327,13 +327,15 @@ fn command_prefix_matches(prefix: &str, command: &str) -> bool {
 #[must_use]
 pub fn normalize_path_pattern(path: &str) -> String {
     let path = path.trim();
+    let is_absolute = path.starts_with('/');
     // Keep the directory and immediate parent for grouping.
     let parts: Vec<&str> = path.split('/').filter(|p| !p.is_empty()).collect();
     if parts.len() <= 2 {
         path.to_string()
     } else {
         // Keep first two path segments + wildcard.
-        format!("{}/{}/**", parts[0], parts[1])
+        let prefix = if is_absolute { "/" } else { "" };
+        format!("{prefix}{}/{}/**", parts[0], parts[1])
     }
 }
 
@@ -675,9 +677,29 @@ mod tests {
     }
 
     #[test]
+    fn shell_prefix_rule_matches_cd_wrapped_command_family() {
+        let stored = ApprovalFingerprint::shell_prefix("bash", "cargo test", false);
+        let candidate =
+            ApprovalFingerprint::shell("bash", "cd rust && cargo test -p astra-cli", false);
+        assert!(
+            stored.matches(&candidate),
+            "stored command-family approval should match cd-wrapped cargo test"
+        );
+    }
+
+    #[test]
     fn file_op_normalizes_deep_paths() {
         let fp = ApprovalFingerprint::file_op("write_file", Some("src/turn/interruption.rs"));
         assert_eq!(fp.path_pattern.as_deref(), Some("src/turn/**"));
+    }
+
+    #[test]
+    fn file_op_preserves_absolute_root_when_normalizing() {
+        let fp = ApprovalFingerprint::file_op(
+            "write_file",
+            Some("/home/xupeng/github/astra/src/turn/interruption.rs"),
+        );
+        assert_eq!(fp.path_pattern.as_deref(), Some("/home/xupeng/**"));
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/approval_sink.rs
+++ b/rust/crates/astra-turn-core/src/approval_sink.rs
@@ -45,7 +45,6 @@ pub enum ApprovalResponse {
     AllowOnce,
     AlwaysAllow,
     Deny,
-    Skip,
 }
 
 impl ApprovalResponse {
@@ -72,9 +71,7 @@ pub trait ApprovalSink: Send + Sync {
 
     /// Convenience wrapper that converts the sink's response back
     /// into a `HardDecision`. Default impl is enough for most
-    /// sinks; override only if you need special handling for
-    /// `Skip` (e.g. mailbox-based sinks that want to surface
-    /// "parent didn't answer in time" as a distinct outcome).
+    /// sinks.
     async fn resolve(&self, prompt: ApprovalPrompt) -> HardDecision {
         let prompt_for_deny = prompt.clone();
         match self.ask(prompt).await {
@@ -84,9 +81,6 @@ pub trait ApprovalSink: Send + Sync {
                     "User denied approval for {}: {}",
                     prompt_for_deny.tool, prompt_for_deny.header
                 ),
-            },
-            ApprovalResponse::Skip => HardDecision::Deny {
-                reason: format!("Tool {} skipped without recording", prompt_for_deny.tool),
             },
         }
     }
@@ -141,7 +135,6 @@ mod tests {
         assert!(ApprovalResponse::AllowOnce.is_approved());
         assert!(ApprovalResponse::AlwaysAllow.is_approved());
         assert!(!ApprovalResponse::Deny.is_approved());
-        assert!(!ApprovalResponse::Skip.is_approved());
     }
 
     #[tokio::test]

--- a/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
+++ b/rust/crates/astra-turn-core/src/cloud_approval_policy.rs
@@ -341,15 +341,6 @@ fn has_shell_injection_vector(command: &str) -> bool {
     has_shell_injection_patterns(command) || command.contains(';')
 }
 
-fn split_compound_segments(command: &str) -> impl Iterator<Item = &str> {
-    command
-        .split('\n')
-        .flat_map(|chunk| chunk.split("&&"))
-        .flat_map(|chunk| chunk.split("||"))
-        .map(str::trim)
-        .filter(|segment| !segment.is_empty())
-}
-
 /// Why a bash command was classified as **requiring approval** (not read-only).
 ///
 /// Returned by [`bash_command_approval_reason`]. Surfaced in CLI approval
@@ -479,37 +470,16 @@ pub fn bash_command_approval_reason(command: &str) -> Option<BashApprovalReason>
         return Some(BashApprovalReason::ShellInjection);
     }
 
-    let mut saw_segment = false;
-    let mut first_failure: Option<BashApprovalReason> = None;
-    for segment in split_compound_segments(normalized) {
-        saw_segment = true;
-        let reason = if segment.contains('|') {
-            let mut saw_pipe_segment = false;
-            let mut pipe_failure: Option<BashApprovalReason> = None;
-            for pipe_segment in segment.split('|').map(str::trim).filter(|s| !s.is_empty()) {
-                saw_pipe_segment = true;
-                if let Some(r) = bash_segment_approval_reason(pipe_segment) {
-                    pipe_failure = Some(r);
-                    break;
-                }
-            }
-            if !saw_pipe_segment {
-                Some(BashApprovalReason::Empty)
-            } else {
-                pipe_failure
-            }
-        } else {
-            bash_segment_approval_reason(segment)
-        };
-        if let Some(r) = reason {
-            first_failure = Some(r);
-            break;
-        }
-    }
-    if !saw_segment {
+    let parsed = crate::permission_compound_command::tokenize_compound_command(normalized);
+    if parsed.steps.is_empty() {
         return Some(BashApprovalReason::Empty);
     }
-    first_failure
+    for step in parsed.steps {
+        if let Some(reason) = bash_segment_approval_reason(step.command.as_str()) {
+            return Some(reason);
+        }
+    }
+    None
 }
 
 /// Segment-level classifier with rationale. Returns `None` if the segment is
@@ -751,6 +721,12 @@ mod tests {
         assert!(bash_command_is_read_only(
             "cd rust && cargo test --no-run 2>&1 | tail -20"
         ));
+        assert!(bash_command_is_read_only(
+            r#"cd /home/xupeng/github/astra && grep -n "fn powershell\|fn bash_with_cancel\|execute_with_metadata_responsive" rust/crates/astra-cli/src/edge_tools/shell.rs rust/crates/astra-cli/src/cli/stream_render.rs"#
+        ));
+        assert!(bash_command_is_read_only(
+            r#"cd rust && grep -n "is_unsafe_bare_shell_prefix\|UNSAFE_SHELL\|is_dangerous_bash_allow_shape" crates/astra-cli/src/edge_tools/shell.rs | head -n 20"#
+        ));
 
         // cd-prefixed commands
         assert!(bash_command_is_read_only("cd project && ls"));
@@ -803,6 +779,10 @@ mod tests {
         assert!(!bash_command_is_read_only(
             "cargo check 2>&1 | tee build.log"
         ));
+        // Regression for the compound-parsing unification: an unsafe step on
+        // the RHS of a pipe must still mark the chain as approval-required.
+        assert!(!bash_command_is_read_only("ls | rm -rf /"));
+        assert!(!bash_command_is_read_only("git status | sh"));
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/cloud_tool_delivery.rs
+++ b/rust/crates/astra-turn-core/src/cloud_tool_delivery.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 #[cfg(test)]
 use futures_util::stream::StreamExt;
 
-use crate::action_compensation::{compensation_prompt_note, explicit_approval_reason};
+use crate::action_compensation::explicit_approval_reason;
 use crate::cloud_approval_policy::edge_tool_requires_cloud_approval_with_args;
 use crate::edge_ledger::{
     DEFAULT_POLL_INTERVAL_MS, MSG_TOOL_LEDGER_TIMEOUT, approval_callback_key,
@@ -77,13 +77,7 @@ fn tool_approval_detail(tool_call: &Value) -> Option<String> {
     let raw = raw_tool_arguments(tool_call);
     let parsed = normalize_llm_function_arguments(&raw);
     let primary = permission_prompt_primary_detail(tool_name, &parsed);
-    let explicit = explicit_approval_reason(tool_name, &parsed);
-    let compensation = compensation_prompt_note(tool_name, &parsed);
-    let detail = [primary, explicit, compensation]
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>()
-        .join("\n");
+    let detail = primary.into_iter().collect::<Vec<_>>().join("\n");
     (!detail.is_empty()).then_some(detail)
 }
 
@@ -969,18 +963,29 @@ mod tests {
     }
 
     #[test]
-    fn approval_detail_includes_compensation_note_for_write_tool() {
+    fn approval_detail_keeps_recovery_jargon_out_of_primary_prompt() {
         let detail = tool_approval_detail(&write_tool("w1")).expect("detail");
         assert!(detail.contains("b.rs"));
-        assert!(detail.contains("Compensation:"));
-        assert!(detail.contains("restore prior contents"));
+        assert!(!detail.contains("Compensation:"));
+        assert!(!detail.contains("rollback"));
+        assert!(!detail.contains("restore prior contents"));
     }
 
     #[test]
-    fn approval_detail_includes_explicit_note_for_irreversible_tool() {
+    fn approval_detail_keeps_explicit_policy_jargon_out_of_primary_prompt() {
         let detail = tool_approval_detail(&destructive_bash_tool("b1")).expect("detail");
-        assert!(detail.contains("Explicit approval required:"));
-        assert!(detail.contains("Compensation:"));
+        assert!(detail.contains("rm -rf tmp"));
+        for forbidden in [
+            "Explicit approval required:",
+            "Compensation:",
+            "unbounded",
+            "rollback is not automatic",
+        ] {
+            assert!(
+                !detail.contains(forbidden),
+                "primary approval detail must not expose {forbidden:?}: {detail}"
+            );
+        }
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/lib.rs
+++ b/rust/crates/astra-turn-core/src/lib.rs
@@ -137,6 +137,7 @@ pub mod permission_compound_command;
 pub mod permission_cwd_root;
 pub mod permission_engine;
 pub mod permission_match_target;
+pub mod permission_memory_profile;
 pub mod permission_path_glob;
 pub mod permission_redact;
 pub mod permission_rule_grammar;

--- a/rust/crates/astra-turn-core/src/permission_compound_command.rs
+++ b/rust/crates/astra-turn-core/src/permission_compound_command.rs
@@ -235,6 +235,19 @@ pub fn tokenize_compound_command(input: &str) -> CompoundCommand {
     }
 }
 
+/// Returns true when the shell input is just a workspace-local `cd … &&`
+/// wrapper around one real command. We treat this as a single-command
+/// approval shape so persistent command-family rules can still work.
+#[must_use]
+pub fn is_cd_wrapper_single_command(compound: &CompoundCommand) -> bool {
+    if compound.steps.len() != 2 {
+        return false;
+    }
+
+    compound.steps[0].trailing_separator == Some(CompoundSeparator::AndThen)
+        && compound.steps[0].command.trim_start().starts_with("cd ")
+}
+
 fn detect_dynamic_eval(input: &str) -> bool {
     // Outside-of-quotes detection of $(…) and `…`. We accept some
     // false-positives — single quote tracking in shell is itself
@@ -357,6 +370,19 @@ mod tests {
     fn escaped_separator_is_not_split() {
         let c = tokenize_compound_command(r#"echo a\&\&b && pwd"#);
         assert_eq!(cmds(&c), vec![r#"echo a\&\&b"#, "pwd"]);
+    }
+
+    #[test]
+    fn cd_wrapper_single_command_is_recognized() {
+        let c = tokenize_compound_command(r#"cd rust && grep -n "a\|b" file.rs"#);
+        assert_eq!(cmds(&c), vec!["cd rust", r#"grep -n "a\|b" file.rs"#]);
+        assert!(is_cd_wrapper_single_command(&c));
+    }
+
+    #[test]
+    fn real_compound_command_is_not_cd_wrapper() {
+        let c = tokenize_compound_command("cd rust && cargo test && cargo fmt");
+        assert!(!is_cd_wrapper_single_command(&c));
     }
 
     // ── Subshell / brace / paren grouping is preserved ─────────

--- a/rust/crates/astra-turn-core/src/permission_engine.rs
+++ b/rust/crates/astra-turn-core/src/permission_engine.rs
@@ -51,7 +51,7 @@
 use astra_sandbox::{is_dangerous_file_path, is_soft_violation, validate_git_command};
 use serde_json::Value;
 
-use crate::action_compensation::explicit_approval_reason;
+use crate::action_compensation::{explicit_approval_reason, primary_approval_reason};
 use crate::approval_fingerprint::{ApprovalFingerprint, FingerprintedOverrides};
 use crate::cloud_approval_policy::{
     CloudGatedToolKind, cloud_gated_tool_kind, cloud_gated_tool_kind_with_args,
@@ -60,6 +60,7 @@ use crate::parallel_tool_exec::is_read_only_tool_with_args;
 use crate::permission_match_target::{
     AllowMatchTarget, allow_rule_for_match_target, default_match_target,
 };
+use crate::permission_memory_profile::resolved_write_path;
 use crate::permission_types::{PermissionMode, PermissionSyncContext};
 use crate::safety_middleware::{SafetyMiddlewareDecision, evaluate_tool_safety_request};
 use crate::tool_argument_hints::{
@@ -356,9 +357,9 @@ pub struct DecisionEnvelope {
     /// the `?` / `/permissions why` views.
     pub trace: Vec<DecisionTraceStep>,
     /// If the decision was `NeedExternal` and the user pressed
-    /// "Always", this is the rule we'd persist. Pre-computed so
-    /// the UI can show "Will save: Bash(npm test:*)" before the
-    /// user actually clicks.
+    /// "Always", this is the internal rule we'd persist. User-facing
+    /// UI must translate this to product language instead of showing
+    /// permission-rule syntax directly.
     pub will_save: Option<String>,
     /// Multi-tag risk classification.
     pub risk_tags: Vec<RiskTag>,
@@ -581,9 +582,9 @@ pub fn evaluate_permission(
                     risk_tags,
                 )
             }
-            PermissionMode::Deny => {
+            PermissionMode::Plan => {
                 let decision = HardDecision::Deny {
-                    reason: "Sandbox expansion denied (deny mode)".to_string(),
+                    reason: "Sandbox expansion denied (plan mode)".to_string(),
                 };
                 push_matched(
                     &mut trace,
@@ -599,7 +600,7 @@ pub fn evaluate_permission(
                     risk_tags,
                 )
             }
-            PermissionMode::Prompt => {
+            PermissionMode::AcceptEdits | PermissionMode::Prompt => {
                 let reason = args
                     .get("reason")
                     .and_then(Value::as_str)
@@ -619,6 +620,24 @@ pub fn evaluate_permission(
                     EvaluationStep::SandboxExpand,
                     &decision,
                     "sandbox expansion requires approval",
+                );
+                envelope(
+                    decision,
+                    DecisionSource::SandboxExpansion,
+                    trace,
+                    will_save,
+                    risk_tags,
+                )
+            }
+            PermissionMode::Deny => {
+                let decision = HardDecision::Deny {
+                    reason: "Sandbox expansion denied (deny mode)".to_string(),
+                };
+                push_matched(
+                    &mut trace,
+                    EvaluationStep::SandboxExpand,
+                    &decision,
+                    "sandbox expansion denied by mode",
                 );
                 envelope(
                     decision,
@@ -684,6 +703,36 @@ pub fn evaluate_permission(
         "not read-only",
     );
 
+    if ctx.mode() == PermissionMode::Plan {
+        push_skipped(
+            &mut trace,
+            EvaluationStep::SessionOverride,
+            "plan mode ignores mutating session overrides",
+        );
+        push_skipped(
+            &mut trace,
+            EvaluationStep::ExplicitApproval,
+            "plan mode never escalates mutating requests",
+        );
+        push_skipped(
+            &mut trace,
+            EvaluationStep::AllowRules,
+            "plan mode ignores mutating allow rules",
+        );
+        let mode_label = ctx.mode().to_string();
+        let decision = HardDecision::Deny {
+            reason: format!("Tool '{tool_name}' denied by permission mode"),
+        };
+        push_matched(&mut trace, EvaluationStep::Mode, &decision, &mode_label);
+        return envelope(
+            decision,
+            DecisionSource::Mode { mode: mode_label },
+            trace,
+            will_save,
+            risk_tags,
+        );
+    }
+
     if let Some(allowed) = fingerprinted_override(tool_name, args, ctx) {
         let decision = if allowed {
             HardDecision::Allow
@@ -712,8 +761,30 @@ pub fn evaluate_permission(
         "no fingerprinted override",
     );
 
-    if let Some(reason) = explicit_approval_reason(tool_name, args) {
+    if let Some(policy_reason) = explicit_approval_reason(tool_name, args) {
+        let prompt_reason =
+            primary_approval_reason(tool_name, args).unwrap_or_else(|| policy_reason.clone());
         return match ctx.mode() {
+            PermissionMode::Plan => {
+                let decision = HardDecision::Deny {
+                    reason: "Explicit approval required (plan mode)".to_string(),
+                };
+                push_matched(
+                    &mut trace,
+                    EvaluationStep::ExplicitApproval,
+                    &decision,
+                    &policy_reason,
+                );
+                envelope(
+                    decision,
+                    DecisionSource::ExplicitApprovalGate {
+                        reason: policy_reason,
+                    },
+                    trace,
+                    will_save,
+                    risk_tags,
+                )
+            }
             PermissionMode::Deny => {
                 let decision = HardDecision::Deny {
                     reason: "Explicit approval required (deny mode)".to_string(),
@@ -722,11 +793,13 @@ pub fn evaluate_permission(
                     &mut trace,
                     EvaluationStep::ExplicitApproval,
                     &decision,
-                    &reason,
+                    &policy_reason,
                 );
                 envelope(
                     decision,
-                    DecisionSource::ExplicitApprovalGate { reason },
+                    DecisionSource::ExplicitApprovalGate {
+                        reason: policy_reason,
+                    },
                     trace,
                     will_save,
                     risk_tags,
@@ -748,7 +821,37 @@ pub fn evaluate_permission(
                 );
                 envelope(
                     decision,
-                    DecisionSource::ExplicitApprovalGate { reason },
+                    DecisionSource::ExplicitApprovalGate {
+                        reason: policy_reason,
+                    },
+                    trace,
+                    will_save,
+                    risk_tags,
+                )
+            }
+            PermissionMode::AcceptEdits => {
+                let decision = if ctx.inherited.allowed_tools.is_some()
+                    && !ctx.inherited.is_tool_allowed_by_allowlist(tool_name)
+                {
+                    HardDecision::Deny {
+                        reason: format!("Tool '{tool_name}' not in allowed tools list"),
+                    }
+                } else {
+                    HardDecision::NeedExternal {
+                        prompt: approval_prompt(tool_name, args, prompt_reason, risk_tags.clone()),
+                    }
+                };
+                push_matched(
+                    &mut trace,
+                    EvaluationStep::ExplicitApproval,
+                    &decision,
+                    &policy_reason,
+                );
+                envelope(
+                    decision,
+                    DecisionSource::ExplicitApprovalGate {
+                        reason: policy_reason,
+                    },
                     trace,
                     will_save,
                     risk_tags,
@@ -756,17 +859,19 @@ pub fn evaluate_permission(
             }
             PermissionMode::Prompt => {
                 let decision = HardDecision::NeedExternal {
-                    prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.clone()),
+                    prompt: approval_prompt(tool_name, args, prompt_reason, risk_tags.clone()),
                 };
                 push_matched(
                     &mut trace,
                     EvaluationStep::ExplicitApproval,
                     &decision,
-                    &reason,
+                    &policy_reason,
                 );
                 envelope(
                     decision,
-                    DecisionSource::ExplicitApprovalGate { reason },
+                    DecisionSource::ExplicitApprovalGate {
+                        reason: policy_reason,
+                    },
                     trace,
                     will_save,
                     risk_tags,
@@ -817,6 +922,53 @@ pub fn evaluate_permission(
                 )
             } else {
                 (HardDecision::Allow, mode.to_string())
+            }
+        }
+        PermissionMode::Plan => (
+            HardDecision::Deny {
+                reason: format!("Tool '{tool_name}' denied by permission mode"),
+            },
+            mode.to_string(),
+        ),
+        PermissionMode::AcceptEdits if ctx.inherited.allowed_tools.is_some() => {
+            if !ctx.inherited.is_tool_allowed_by_allowlist(tool_name) {
+                (
+                    HardDecision::Deny {
+                        reason: format!("Tool '{tool_name}' not in allowed tools list"),
+                    },
+                    "agent policy allowlist".to_string(),
+                )
+            } else if accept_edits_auto_allows(tool_name, args) {
+                (HardDecision::Allow, mode.to_string())
+            } else {
+                (
+                    HardDecision::NeedExternal {
+                        prompt: approval_prompt(
+                            tool_name,
+                            args,
+                            "Write/execute tool requires approval".to_string(),
+                            risk_tags.clone(),
+                        ),
+                    },
+                    mode.to_string(),
+                )
+            }
+        }
+        PermissionMode::AcceptEdits => {
+            if accept_edits_auto_allows(tool_name, args) {
+                (HardDecision::Allow, mode.to_string())
+            } else {
+                (
+                    HardDecision::NeedExternal {
+                        prompt: approval_prompt(
+                            tool_name,
+                            args,
+                            "Write/execute tool requires approval".to_string(),
+                            risk_tags.clone(),
+                        ),
+                    },
+                    mode.to_string(),
+                )
             }
         }
         PermissionMode::Deny => (
@@ -1020,7 +1172,19 @@ fn fingerprinted_override(
 ) -> Option<bool> {
     let json = ctx.inherited.fingerprinted_overrides.as_ref()?;
     let overrides = serde_json::from_value::<FingerprintedOverrides>(json.clone()).ok()?;
-    overrides.check(&content_aware_fingerprint(tool_name, args))
+    content_aware_fingerprint_candidates(tool_name, args)
+        .into_iter()
+        .find_map(|fp| overrides.check(&fp))
+}
+
+fn accept_edits_auto_allows(tool_name: &str, args: &Value) -> bool {
+    matches!(
+        (
+            cloud_gated_tool_kind_with_args(tool_name, Some(args)),
+            default_match_target(tool_name, args),
+        ),
+        (Some(CloudGatedToolKind::Write), AllowMatchTarget::Prefix(_))
+    )
 }
 
 fn content_aware_fingerprint(tool_name: &str, args: &Value) -> ApprovalFingerprint {
@@ -1044,6 +1208,23 @@ fn content_aware_fingerprint(tool_name: &str, args: &Value) -> ApprovalFingerpri
         }
         None => ApprovalFingerprint::bare(tool_name),
     }
+}
+
+fn content_aware_fingerprint_candidates(tool_name: &str, args: &Value) -> Vec<ApprovalFingerprint> {
+    let primary = content_aware_fingerprint(tool_name, args);
+    let mut candidates = vec![primary.clone()];
+    if matches!(
+        cloud_gated_tool_kind(tool_name),
+        Some(CloudGatedToolKind::Write)
+    ) && let Some(path) = path_hint_from_args(args)
+        && let Some(resolved) = resolved_write_path(&path)
+    {
+        let resolved_fp = ApprovalFingerprint::file_op_exact(tool_name, Some(&resolved));
+        if resolved_fp != primary {
+            candidates.push(resolved_fp);
+        }
+    }
+    candidates
 }
 
 fn risk_tags_for_request(tool_name: &str, args: &Value) -> Vec<RiskTag> {
@@ -1191,13 +1372,32 @@ mod tests {
     }
 
     #[test]
-    fn allow_rule_preview_scopes_file_writes_to_path_pattern() {
+    fn allow_rule_preview_uses_workspace_scope_for_safe_writes() {
         let rule = allow_rule_preview(
             "write_file",
             &serde_json::json!({"path": "zzzz3.md", "content": "# zzzz3"}),
         );
 
-        assert_eq!(rule, r#"write_file(path_glob="zzzz3.md", op="write")"#);
+        let cwd = std::env::current_dir()
+            .unwrap()
+            .canonicalize()
+            .unwrap_or_else(|_| std::env::current_dir().unwrap())
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            rule,
+            format!(r#"write_file(path_prefix="{cwd}", op="write", cwd_root="{cwd}")"#)
+        );
+    }
+
+    #[test]
+    fn allow_rule_preview_keeps_exact_scope_for_workspace_external_writes() {
+        let rule = allow_rule_preview(
+            "write_file",
+            &serde_json::json!({"path": "/tmp/zzzz3.md", "content": "# zzzz3"}),
+        );
+
+        assert_eq!(rule, r#"write_file(path_glob="/tmp/zzzz3.md", op="write")"#);
     }
 
     #[test]
@@ -1261,6 +1461,39 @@ mod tests {
                 mode: "agent policy allowlist".to_string()
             }
         );
+    }
+
+    #[test]
+    fn plan_mode_allows_read_only_tools_but_denies_mutations() {
+        let ctx = crate::permission_types::PermissionSyncContext::new(
+            crate::permission_types::InheritedPermissions {
+                mode: crate::permission_types::PermissionMode::Plan,
+                allowed_tools: Some(std::collections::HashSet::from([
+                    "read_file".to_string(),
+                    "write_file".to_string(),
+                    "bash".to_string(),
+                ])),
+                ..Default::default()
+            },
+        );
+
+        let read_only =
+            evaluate_permission("read_file", &serde_json::json!({"path": "README.md"}), &ctx);
+        assert!(matches!(read_only.decision, HardDecision::Allow));
+
+        let write_file = evaluate_permission(
+            "write_file",
+            &serde_json::json!({"path": "src/lib.rs", "content": "pub fn x() {}\n"}),
+            &ctx,
+        );
+        assert!(matches!(write_file.decision, HardDecision::Deny { .. }));
+
+        let mutating_bash = evaluate_permission(
+            "bash",
+            &serde_json::json!({"command": "touch plan.txt"}),
+            &ctx,
+        );
+        assert!(matches!(mutating_bash.decision, HardDecision::Deny { .. }));
     }
 
     #[test]
@@ -1360,6 +1593,91 @@ mod tests {
         assert!(matches!(
             envelope.source,
             DecisionSource::SensitivePath { .. }
+        ));
+    }
+
+    #[test]
+    fn accept_edits_mode_allows_workspace_write_tools() {
+        let ctx = crate::permission_types::PermissionSyncContext::root(
+            crate::permission_types::PermissionMode::AcceptEdits,
+        );
+
+        for (tool, args) in [
+            (
+                "write_file",
+                serde_json::json!({"path": "src/lib.rs", "content": "pub fn demo() {}\n"}),
+            ),
+            (
+                "str_replace",
+                serde_json::json!({"path": "src/lib.rs", "old_str": "demo", "new_str": "ship"}),
+            ),
+        ] {
+            let envelope = evaluate_permission(tool, &args, &ctx);
+            assert!(
+                matches!(envelope.decision, HardDecision::Allow),
+                "{tool} should auto-allow in accept_edits: {:?}",
+                envelope
+            );
+            assert_eq!(
+                envelope.source,
+                DecisionSource::Mode {
+                    mode: "accept_edits".to_string()
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn accept_edits_mode_prompts_for_bash_execution() {
+        let ctx = crate::permission_types::PermissionSyncContext::root(
+            crate::permission_types::PermissionMode::AcceptEdits,
+        );
+        let envelope =
+            evaluate_permission("bash", &serde_json::json!({"command": "cargo test"}), &ctx);
+
+        assert!(matches!(
+            envelope.decision,
+            HardDecision::NeedExternal { .. }
+        ));
+        assert!(matches!(
+            envelope.source,
+            DecisionSource::ExplicitApprovalGate { .. }
+        ));
+    }
+
+    #[test]
+    fn accept_edits_mode_prompts_for_parent_relative_write_escape() {
+        let ctx = crate::permission_types::PermissionSyncContext::root(
+            crate::permission_types::PermissionMode::AcceptEdits,
+        );
+        let envelope = evaluate_permission(
+            "write_file",
+            &serde_json::json!({"path": "../outside.rs", "content": "nope"}),
+            &ctx,
+        );
+
+        assert!(matches!(
+            envelope.decision,
+            HardDecision::NeedExternal { .. }
+        ));
+    }
+
+    #[test]
+    fn accept_edits_mode_allowlist_blocks_unlisted_bash() {
+        let ctx = crate::permission_types::PermissionSyncContext::new(
+            crate::permission_types::InheritedPermissions {
+                mode: crate::permission_types::PermissionMode::AcceptEdits,
+                allowed_tools: Some(std::collections::HashSet::from(["write_file".to_string()])),
+                ..Default::default()
+            },
+        );
+        let envelope =
+            evaluate_permission("bash", &serde_json::json!({"command": "cargo test"}), &ctx);
+
+        assert!(matches!(envelope.decision, HardDecision::Deny { .. }));
+        assert!(matches!(
+            envelope.source,
+            DecisionSource::ExplicitApprovalGate { .. }
         ));
     }
 

--- a/rust/crates/astra-turn-core/src/permission_match_target.rs
+++ b/rust/crates/astra-turn-core/src/permission_match_target.rs
@@ -10,13 +10,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::approval_fingerprint::ApprovalFingerprint;
-use crate::cloud_approval_policy::{CloudGatedToolKind, cloud_gated_tool_kind};
+use crate::cloud_approval_policy::{
+    CloudGatedToolKind, cloud_gated_tool_kind, cloud_gated_tool_kind_with_args,
+};
 use crate::parallel_tool_exec::is_read_only_tool_with_args;
+use crate::permission_memory_profile::{permission_memory_profile, workspace_write_prefix};
 use crate::permission_rule_grammar::{PermissionRuleV2, serialize_rule_v2};
 use crate::permission_scope::AllowScope;
-use crate::tool_argument_hints::{
-    command_hint_from_args, normalized_argv_prefix, path_hint_from_args,
-};
+use crate::tool_argument_hints::{command_hint_from_args, path_hint_from_args};
 
 /// The second dimension of an approval choice: what future tool call
 /// should the selected scope apply to?
@@ -43,45 +44,12 @@ impl AllowMatchTarget {
     }
 }
 
-/// The default used by legacy one-step Always paths. The TUI now sends
-/// explicit match targets, but non-TUI and older paths still need a
-/// conservative, content-aware choice.
+/// Conservative content-aware match target used when the user chooses
+/// Always. The UI exposes this as "remember similar commands/actions"
+/// instead of raw exact/prefix/tool terminology.
 #[must_use]
 pub fn default_match_target(tool_name: &str, args: &Value) -> AllowMatchTarget {
-    match cloud_gated_tool_kind(tool_name) {
-        Some(CloudGatedToolKind::Execute) => command_hint_from_args(args)
-            .map(normalized_argv_prefix)
-            .filter(|prefix| !prefix.is_empty())
-            .map(AllowMatchTarget::Prefix)
-            .unwrap_or(AllowMatchTarget::Tool),
-        Some(CloudGatedToolKind::Write) => {
-            if path_hint_from_args(args).is_some() {
-                AllowMatchTarget::Exact
-            } else {
-                AllowMatchTarget::Tool
-            }
-        }
-        None => AllowMatchTarget::Tool,
-    }
-}
-
-#[must_use]
-pub fn custom_prefix_source(tool_name: &str, args: &Value) -> String {
-    match cloud_gated_tool_kind(tool_name) {
-        Some(CloudGatedToolKind::Execute) => command_hint_from_args(args)
-            .map(ToOwned::to_owned)
-            .unwrap_or_default(),
-        Some(CloudGatedToolKind::Write) => path_hint_from_args(args).unwrap_or_default(),
-        None => String::new(),
-    }
-}
-
-#[must_use]
-pub fn is_valid_custom_prefix(prefix: &str, source: &str) -> bool {
-    if prefix.is_empty() {
-        return false;
-    }
-    source.starts_with(prefix)
+    permission_memory_profile(tool_name, args).match_target
 }
 
 #[must_use]
@@ -145,13 +113,13 @@ pub fn match_target_description(
     scope: AllowScope,
     target: &AllowMatchTarget,
     tool_name: &str,
-    _args: &Value,
+    args: &Value,
 ) -> String {
     let duration = match scope {
         AllowScope::OnceThisCall => "for this request",
         AllowScope::RestOfTurn => "for the rest of this turn",
         AllowScope::RestOfSession => "in this session",
-        AllowScope::Project => "for this project",
+        AllowScope::Project => "for this workspace",
         AllowScope::User => "for this user",
     };
     let is_execute = matches!(
@@ -171,9 +139,55 @@ pub fn match_target_description(
         AllowMatchTarget::Prefix(prefix) if is_execute => {
             format!("Approve commands starting with `{prefix}` {duration}.")
         }
+        AllowMatchTarget::Prefix(prefix)
+            if matches!(
+                cloud_gated_tool_kind(tool_name),
+                Some(CloudGatedToolKind::Write)
+            ) && path_hint_from_args(args)
+                .and_then(|path| workspace_write_prefix(&path))
+                .as_deref()
+                == Some(prefix.as_str()) =>
+        {
+            format!("Approve file edits in this workspace {duration}.")
+        }
         AllowMatchTarget::Prefix(prefix) => {
             format!("Approve paths matching `{prefix}` {duration}.")
         }
+    }
+}
+
+#[must_use]
+pub fn remember_preview(tool_name: &str, args: &Value, location: &str) -> String {
+    match (
+        cloud_gated_tool_kind_with_args(tool_name, Some(args)),
+        tool_name,
+        default_match_target(tool_name, args),
+    ) {
+        (_, "bash", AllowMatchTarget::Prefix(prefix)) => {
+            format!("the `{prefix}` command family {location}")
+        }
+        (_, "bash", AllowMatchTarget::Exact) => format!("this shell command {location}"),
+        (_, "bash", AllowMatchTarget::Tool) => format!("safe shell commands {location}"),
+        (Some(CloudGatedToolKind::Write), _, AllowMatchTarget::Exact) => {
+            format!("this file edit {location}")
+        }
+        (Some(CloudGatedToolKind::Write), _, AllowMatchTarget::Prefix(prefix))
+            if path_hint_from_args(args)
+                .and_then(|path| workspace_write_prefix(&path))
+                .as_deref()
+                == Some(prefix.as_str()) =>
+        {
+            format!("file edits {location}")
+        }
+        (Some(CloudGatedToolKind::Write), _, AllowMatchTarget::Tool) => {
+            format!("file edits {location}")
+        }
+        (Some(CloudGatedToolKind::Write), _, AllowMatchTarget::Prefix(prefix)) => {
+            format!("similar file edits under `{prefix}`")
+        }
+        (_, _, AllowMatchTarget::Prefix(prefix)) => format!("similar `{prefix}` calls {location}"),
+        (_, _, AllowMatchTarget::Exact) => format!("this `{tool_name}` action {location}"),
+        (_, _, AllowMatchTarget::Tool) => format!("`{tool_name}` calls {location}"),
     }
 }
 
@@ -232,19 +246,24 @@ fn prefix_rule(tool_name: &str, _args: &Value, prefix: &str) -> Option<String> {
             capability: None,
             extra: Default::default(),
         })),
-        CloudGatedToolKind::Write => Some(serialize_rule_v2(&PermissionRuleV2 {
-            tool: tool_name.to_string(),
-            argv_exact: None,
-            argv_prefix: None,
-            path_glob: None,
-            path_prefix: Some(prefix.to_string()),
-            op: Some("write".to_string()),
-            cwd_root: None,
-            git_branch: None,
-            domain: None,
-            capability: None,
-            extra: Default::default(),
-        })),
+        CloudGatedToolKind::Write => {
+            let cwd_root = path_hint_from_args(_args)
+                .and_then(|path| workspace_write_prefix(&path))
+                .filter(|root| root == prefix);
+            Some(serialize_rule_v2(&PermissionRuleV2 {
+                tool: tool_name.to_string(),
+                argv_exact: None,
+                argv_prefix: None,
+                path_glob: None,
+                path_prefix: Some(prefix.to_string()),
+                op: Some("write".to_string()),
+                cwd_root,
+                git_branch: None,
+                domain: None,
+                capability: None,
+                extra: Default::default(),
+            }))
+        }
     }
 }
 
@@ -303,6 +322,29 @@ mod tests {
     }
 
     #[test]
+    fn default_bash_target_uses_command_family_not_broad_tool_or_cd_wrapper() {
+        let args = serde_json::json!({
+            "command": "cd /home/xupeng/github/astra/rust && cargo test -p astra-cli -- --nocapture"
+        });
+        let target = default_match_target("bash", &args);
+        assert_eq!(target, AllowMatchTarget::Prefix("cargo test".to_string()));
+        let rule = allow_rule_for_match_target("bash", &args, &target);
+        assert_eq!(rule, r#"Bash(argv_prefix="cargo test", op="execute")"#);
+    }
+
+    #[test]
+    fn default_bash_target_uses_exact_for_unstable_command_family() {
+        let args = serde_json::json!({"command": "python -c 'print(1)'"});
+        let target = default_match_target("bash", &args);
+        assert_eq!(target, AllowMatchTarget::Exact);
+        let rule = allow_rule_for_match_target("bash", &args, &target);
+        assert_eq!(
+            rule,
+            r#"Bash(argv_exact="python -c 'print(1)'", op="execute")"#
+        );
+    }
+
+    #[test]
     fn path_prefix_rule_uses_literal_path_prefix() {
         let args = serde_json::json!({"path": "zzz1.md"});
         let rule = allow_rule_for_match_target(
@@ -348,10 +390,52 @@ mod tests {
     }
 
     #[test]
-    fn custom_prefix_validation_rejects_non_source_trailing_chars() {
-        assert!(is_valid_custom_prefix("git ", "git status --short"));
-        assert!(!is_valid_custom_prefix("git  ", "git status --short"));
-        assert!(!is_valid_custom_prefix("git sx", "git status --short"));
+    fn default_write_target_uses_workspace_prefix_for_safe_paths() {
+        let args =
+            serde_json::json!({"path": "rust/crates/astra-cli/src/cli/permission_manager.rs"});
+        let target = default_match_target("write_file", &args);
+        let workspace_root = std::env::current_dir()
+            .unwrap()
+            .canonicalize()
+            .unwrap_or_else(|_| std::env::current_dir().unwrap())
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(target, AllowMatchTarget::Prefix(workspace_root.clone()));
+
+        let rule = allow_rule_for_match_target("write_file", &args, &target);
+        let parsed = PermissionRule::parse(&rule);
+        assert!(parsed.matches_with_context(
+            "write_file",
+            &RuleMatchContext::from_tool_args(
+                "write_file",
+                &serde_json::json!({"path": "web/src/app/page.tsx"})
+            )
+        ));
+        assert!(!parsed.matches_with_context(
+            "write_file",
+            &RuleMatchContext::from_tool_args(
+                "write_file",
+                &serde_json::json!({"path": "/tmp/outside.txt"})
+            )
+        ));
+    }
+
+    #[test]
+    fn default_write_target_keeps_sensitive_paths_exact() {
+        let args = serde_json::json!({"path": ".env"});
+        assert_eq!(
+            default_match_target("write_file", &args),
+            AllowMatchTarget::Exact
+        );
+    }
+
+    #[test]
+    fn default_write_target_keeps_absolute_outside_workspace_exact() {
+        let args = serde_json::json!({"path": "/tmp/astra-permission-test.txt"});
+        assert_eq!(
+            default_match_target("write_file", &args),
+            AllowMatchTarget::Exact
+        );
     }
 
     #[test]
@@ -376,6 +460,40 @@ mod tests {
         assert_eq!(
             text,
             "Approve this tool for all future permission requests in this session."
+        );
+    }
+
+    #[test]
+    fn remember_preview_describes_command_family() {
+        let preview = remember_preview(
+            "bash",
+            &serde_json::json!({"command": "cd rust && cargo test -p astra-cli"}),
+            "in this workspace",
+        );
+        assert_eq!(preview, "the `cargo test` command family in this workspace");
+    }
+
+    #[test]
+    fn remember_preview_describes_workspace_writes() {
+        let preview = remember_preview(
+            "write_file",
+            &serde_json::json!({"path": "src/main.rs"}),
+            "in this workspace",
+        );
+        assert_eq!(preview, "file edits in this workspace");
+    }
+
+    #[test]
+    fn workspace_write_rule_uses_workspace_guard_not_bare_tool() {
+        let args = serde_json::json!({"path": "src/main.rs"});
+        let target = default_match_target("write_file", &args);
+        let workspace_root = workspace_write_prefix("src/main.rs").unwrap();
+        assert_eq!(target, AllowMatchTarget::Prefix(workspace_root.clone()));
+        assert_eq!(
+            allow_rule_for_match_target("write_file", &args, &target),
+            format!(
+                r#"write_file(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
+            )
         );
     }
 }

--- a/rust/crates/astra-turn-core/src/permission_memory_profile.rs
+++ b/rust/crates/astra-turn-core/src/permission_memory_profile.rs
@@ -1,0 +1,308 @@
+use serde_json::Value;
+use std::path::{Component, Path, PathBuf};
+
+use crate::cloud_approval_policy::{CloudGatedToolKind, cloud_gated_tool_kind};
+use crate::parallel_tool_exec::is_read_only_tool_with_args;
+use crate::permission_compound_command::{is_cd_wrapper_single_command, tokenize_compound_command};
+use crate::permission_match_target::AllowMatchTarget;
+use crate::permission_redact::matches_sensitive_path;
+use crate::tool_argument_hints::{
+    command_hint_from_args, normalized_argv_prefix, path_hint_from_args,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PersistentMemoryBlock {
+    CompoundCommand,
+    DynamicEval,
+    UnsafeRuleShape,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PermissionMemoryProfile {
+    pub match_target: AllowMatchTarget,
+    pub persistent_block: Option<PersistentMemoryBlock>,
+    pub has_stable_target: bool,
+}
+
+#[must_use]
+pub fn permission_memory_profile(tool_name: &str, args: &Value) -> PermissionMemoryProfile {
+    match cloud_gated_tool_kind(tool_name) {
+        Some(CloudGatedToolKind::Execute) => execute_memory_profile(tool_name, args),
+        Some(CloudGatedToolKind::Write) => write_memory_profile(args),
+        None => PermissionMemoryProfile {
+            match_target: AllowMatchTarget::Tool,
+            persistent_block: None,
+            has_stable_target: true,
+        },
+    }
+}
+
+fn execute_memory_profile(tool_name: &str, args: &Value) -> PermissionMemoryProfile {
+    let Some(command) = command_hint_from_args(args) else {
+        return PermissionMemoryProfile {
+            match_target: AllowMatchTarget::Tool,
+            persistent_block: Some(PersistentMemoryBlock::UnsafeRuleShape),
+            has_stable_target: false,
+        };
+    };
+
+    let match_target = command_match_target(command);
+    let has_stable_target = match match_target {
+        AllowMatchTarget::Prefix(ref prefix) => !prefix.trim().is_empty(),
+        AllowMatchTarget::Exact => !command.trim().is_empty(),
+        AllowMatchTarget::Tool => false,
+    };
+
+    let persistent_block = shell_persistent_block(tool_name, args, has_stable_target);
+    PermissionMemoryProfile {
+        match_target,
+        persistent_block,
+        has_stable_target,
+    }
+}
+
+fn command_match_target(command: &str) -> AllowMatchTarget {
+    let prefix = normalized_argv_prefix(command);
+    if prefix.is_empty() {
+        AllowMatchTarget::Exact
+    } else {
+        AllowMatchTarget::Prefix(prefix)
+    }
+}
+
+fn shell_persistent_block(
+    tool_name: &str,
+    args: &Value,
+    has_stable_target: bool,
+) -> Option<PersistentMemoryBlock> {
+    if !has_stable_target {
+        return Some(PersistentMemoryBlock::UnsafeRuleShape);
+    }
+
+    if !matches!(tool_name, "bash" | "powershell") {
+        return None;
+    }
+
+    let Some(command) = command_hint_from_args(args) else {
+        return Some(PersistentMemoryBlock::UnsafeRuleShape);
+    };
+    let parsed = tokenize_compound_command(command);
+    if parsed.has_dynamic_eval || powershell_dynamic_eval(tool_name, command) {
+        return Some(PersistentMemoryBlock::DynamicEval);
+    }
+
+    let safe_read_only = is_read_only_tool_with_args(tool_name, Some(args));
+    if parsed.steps.len() > 1 && !safe_read_only && !is_cd_wrapper_single_command(&parsed) {
+        return Some(PersistentMemoryBlock::CompoundCommand);
+    }
+
+    None
+}
+
+fn write_memory_profile(args: &Value) -> PermissionMemoryProfile {
+    let Some(path) = path_hint_from_args(args) else {
+        return PermissionMemoryProfile {
+            match_target: AllowMatchTarget::Tool,
+            persistent_block: None,
+            has_stable_target: true,
+        };
+    };
+
+    let match_target = if matches_sensitive_path(&path) {
+        AllowMatchTarget::Exact
+    } else if let Some(workspace_root) = workspace_write_prefix(&path) {
+        AllowMatchTarget::Prefix(workspace_root)
+    } else {
+        AllowMatchTarget::Exact
+    };
+
+    PermissionMemoryProfile {
+        match_target,
+        persistent_block: None,
+        has_stable_target: !path.trim().is_empty(),
+    }
+}
+
+fn powershell_dynamic_eval(tool_name: &str, command: &str) -> bool {
+    if tool_name != "powershell" {
+        return false;
+    }
+    command
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '-')
+        .any(|token| {
+            matches!(
+                token.to_ascii_lowercase().as_str(),
+                "iex" | "invoke-expression"
+            )
+        })
+}
+
+#[must_use]
+pub fn current_workspace_root() -> Option<PathBuf> {
+    std::env::current_dir()
+        .ok()
+        .map(|cwd| canonicalize_path_best_effort(&cwd))
+}
+
+#[must_use]
+pub fn resolve_write_path_from_cwd(cwd: &Path, path: &str) -> Option<PathBuf> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let candidate = {
+        let path = Path::new(trimmed);
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            cwd.join(path)
+        }
+    };
+    Some(canonicalize_path_best_effort(&candidate))
+}
+
+#[must_use]
+pub fn resolved_write_path(path: &str) -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    let resolved = resolve_write_path_from_cwd(&cwd, path)?;
+    Some(resolved.to_string_lossy().into_owned())
+}
+
+#[must_use]
+pub fn workspace_write_prefix(path: &str) -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    let workspace_root = current_workspace_root()?;
+    let candidate = resolve_write_path_from_cwd(&cwd, path)?;
+    if candidate.starts_with(&workspace_root) {
+        Some(workspace_root.to_string_lossy().into_owned())
+    } else {
+        None
+    }
+}
+
+fn canonicalize_path_best_effort(path: &Path) -> PathBuf {
+    let mut existing = Some(path);
+    while let Some(candidate) = existing {
+        if candidate.exists() {
+            let canonical = candidate
+                .canonicalize()
+                .unwrap_or_else(|_| normalize_path_components(candidate));
+            if candidate == path {
+                return canonical;
+            }
+            if let Ok(suffix) = path.strip_prefix(candidate) {
+                return normalize_path_components(&canonical.join(suffix));
+            }
+        }
+        existing = candidate.parent();
+    }
+    normalize_path_components(path)
+}
+
+fn normalize_path_components(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cargo_build_cd_wrapper_uses_command_family_without_block() {
+        let args = serde_json::json!({
+            "command": "cd /home/xupeng/github/astra/rust && cargo build -p astra-turn-core -p astra-cli"
+        });
+        let profile = permission_memory_profile("bash", &args);
+        assert_eq!(
+            profile.match_target,
+            AllowMatchTarget::Prefix("cargo build".to_string())
+        );
+        assert_eq!(profile.persistent_block, None);
+        assert!(profile.has_stable_target);
+    }
+
+    #[test]
+    fn quoted_grep_regex_stays_exact_without_compound_block() {
+        let args = serde_json::json!({
+            "command": r#"cd /home/xupeng/github/astra && grep -n "fn powershell\|fn bash_with_cancel\|execute_with_metadata_responsive" rust/crates/astra-cli/src/edge_tools/shell.rs rust/crates/astra-cli/src/cli/stream_render.rs"#
+        });
+        let profile = permission_memory_profile("bash", &args);
+        assert_eq!(profile.match_target, AllowMatchTarget::Exact);
+        assert_eq!(profile.persistent_block, None);
+        assert!(profile.has_stable_target);
+    }
+
+    #[test]
+    fn read_only_pipe_chain_stays_persistable() {
+        let args = serde_json::json!({
+            "command": r#"cd rust && grep -n "is_unsafe_bare_shell_prefix\|UNSAFE_SHELL\|is_dangerous_bash_allow_shape" crates/astra-cli/src/edge_tools/shell.rs | head -n 20"#
+        });
+        let profile = permission_memory_profile("bash", &args);
+        assert_eq!(profile.persistent_block, None);
+        assert!(profile.has_stable_target);
+    }
+
+    #[test]
+    fn true_multi_step_mutating_shell_stays_blocked() {
+        let args = serde_json::json!({"command": "cargo build && cargo test"});
+        let profile = permission_memory_profile("bash", &args);
+        assert_eq!(
+            profile.persistent_block,
+            Some(PersistentMemoryBlock::CompoundCommand)
+        );
+    }
+
+    #[test]
+    fn workspace_write_uses_workspace_prefix() {
+        let args = serde_json::json!({"path": "rust/crates/astra-turn-core/src/permission_match_target.rs"});
+        let profile = permission_memory_profile("write_file", &args);
+        assert_eq!(
+            profile.match_target,
+            AllowMatchTarget::Prefix(
+                current_workspace_root()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            )
+        );
+        assert_eq!(profile.persistent_block, None);
+        assert!(profile.has_stable_target);
+    }
+
+    #[test]
+    fn sensitive_write_stays_exact() {
+        let args = serde_json::json!({"path": ".env"});
+        let profile = permission_memory_profile("write_file", &args);
+        assert_eq!(profile.match_target, AllowMatchTarget::Exact);
+        assert_eq!(profile.persistent_block, None);
+    }
+
+    #[test]
+    fn parent_relative_write_outside_workspace_stays_exact() {
+        let args = serde_json::json!({"path": "../outside.txt"});
+        let profile = permission_memory_profile("write_file", &args);
+        assert_eq!(profile.match_target, AllowMatchTarget::Exact);
+    }
+
+    #[test]
+    fn powershell_dynamic_eval_stays_blocked() {
+        let args = serde_json::json!({"command": "Invoke-Expression $payload"});
+        let profile = permission_memory_profile("powershell", &args);
+        assert_eq!(
+            profile.persistent_block,
+            Some(PersistentMemoryBlock::DynamicEval)
+        );
+    }
+}

--- a/rust/crates/astra-turn-core/src/permission_scope.rs
+++ b/rust/crates/astra-turn-core/src/permission_scope.rs
@@ -77,6 +77,9 @@ pub enum ScopeUnavailableReason {
     /// Dynamic-eval shell ($(…) / backticks) — same reason as
     /// CompoundCommand: rule shape is undefined.
     DynamicEvalCommand,
+    /// The tool request lacks a stable match target, so persisting
+    /// an Always rule would become broader than the user approved.
+    UnsafeRuleShape,
 }
 
 /// Inputs to the scope-availability decision. Aggregated as a
@@ -89,6 +92,7 @@ pub struct ScopeAvailabilityContext {
     pub source_agent_present: bool,
     pub mcp_unknown_capability: bool,
     pub workspace_untrusted: bool,
+    pub unsafe_rule_shape: bool,
 }
 
 /// Decision for one scope: available or not, and why.
@@ -144,6 +148,9 @@ fn unavailable_reason_for(
     }
     if ctx.has_dynamic_eval && scope.outlives_turn() {
         return Some(ScopeUnavailableReason::DynamicEvalCommand);
+    }
+    if ctx.unsafe_rule_shape && scope.outlives_turn() {
+        return Some(ScopeUnavailableReason::UnsafeRuleShape);
     }
 
     // Sub-agent requests can never extend project / user rules
@@ -257,6 +264,21 @@ mod tests {
         assert!(matches!(
             availability(&scopes, AllowScope::Project).reason,
             Some(ScopeUnavailableReason::DynamicEvalCommand)
+        ));
+    }
+
+    #[test]
+    fn unsafe_rule_shape_blocks_anything_beyond_turn() {
+        let mut c = ctx();
+        c.unsafe_rule_shape = true;
+        let scopes = permitted_scopes(&c);
+        assert!(availability(&scopes, AllowScope::OnceThisCall).available);
+        assert!(availability(&scopes, AllowScope::RestOfTurn).available);
+        assert!(!availability(&scopes, AllowScope::RestOfSession).available);
+        assert!(!availability(&scopes, AllowScope::Project).available);
+        assert!(matches!(
+            availability(&scopes, AllowScope::Project).reason,
+            Some(ScopeUnavailableReason::UnsafeRuleShape)
         ));
     }
 

--- a/rust/crates/astra-turn-core/src/permission_sync.rs
+++ b/rust/crates/astra-turn-core/src/permission_sync.rs
@@ -5,6 +5,8 @@
 
 pub use crate::permission_types::*;
 
+use crate::cloud_approval_policy::{CloudGatedToolKind, cloud_gated_tool_kind_with_args};
+use crate::permission_match_target::{AllowMatchTarget, default_match_target};
 use astra_messaging::types::{
     AgentAddress, AgentMessage, MessagePayload, MessageTarget, RequestType,
 };
@@ -237,6 +239,16 @@ mod tests {
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+fn accept_edits_auto_allows_request(request: &PermissionRequest) -> bool {
+    matches!(
+        (
+            cloud_gated_tool_kind_with_args(&request.tool_name, Some(&request.args)),
+            default_match_target(&request.tool_name, &request.args),
+        ),
+        (Some(CloudGatedToolKind::Write), AllowMatchTarget::Prefix(_))
+    )
+}
+
 /// Handler for incoming permission requests from child agents.
 ///
 /// The parent agent creates a handler and registers a callback to make
@@ -304,11 +316,28 @@ impl PermissionRequestHandler {
 
                 response
             }
+            PermissionMode::AcceptEdits if accept_edits_auto_allows_request(request) => {
+                let response = if let Some(ref rule_str) = request.suggested_rule {
+                    PermissionResponse::approve()
+                        .with_update(PermissionUpdate::allow(PermissionRule::parse(rule_str)))
+                } else {
+                    PermissionResponse::approve()
+                };
+
+                drop(ctx);
+                if !response.updates.is_empty() {
+                    let mut ctx_mut = self.sync_context.write().await;
+                    ctx_mut.apply_response(&response);
+                }
+
+                response
+            }
             PermissionMode::Deny => {
                 // Deny mode: reject without escalation
                 PermissionResponse::deny("permission mode is deny")
             }
-            PermissionMode::Prompt => {
+            PermissionMode::Plan => PermissionResponse::deny("permission mode is plan"),
+            PermissionMode::AcceptEdits | PermissionMode::Prompt => {
                 // Prompt mode: use callback or default logic
                 drop(ctx);
 
@@ -393,6 +422,8 @@ impl PermissionRequestHandler {
 #[cfg(test)]
 mod handler_tests {
     use super::*;
+    use std::sync::Arc as StdArc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[tokio::test]
     async fn handler_auto_mode_approves() {
@@ -415,6 +446,91 @@ mod handler_tests {
 
         assert!(!response.approved);
         assert!(response.reason.as_ref().unwrap().contains("deny"));
+    }
+
+    #[tokio::test]
+    async fn handler_plan_mode_denies() {
+        let ctx = PermissionSyncContext::root(PermissionMode::Plan);
+        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+
+        let request = PermissionRequest::new("write_file", serde_json::json!({"path": "plan.txt"}));
+        let response = handler.handle_request(&request).await;
+
+        assert!(!response.approved);
+        assert!(response.reason.as_ref().unwrap().contains("plan"));
+    }
+
+    #[tokio::test]
+    async fn handler_accept_edits_auto_approves_workspace_write_without_callback() {
+        let ctx = PermissionSyncContext::root(PermissionMode::AcceptEdits);
+        let callback_calls = StdArc::new(AtomicUsize::new(0));
+        let seen = StdArc::clone(&callback_calls);
+        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx))).with_callback(
+            Box::new(move |_req, _ctx| {
+                seen.fetch_add(1, Ordering::SeqCst);
+                PermissionDecision::deny("callback should not run for workspace edits")
+            }),
+        );
+
+        let request = PermissionRequest::new(
+            "write_file",
+            serde_json::json!({"path": "src/lib.rs", "content": "pub fn shipped() {}\n"}),
+        );
+        let response = handler.handle_request(&request).await;
+
+        assert!(response.approved);
+        assert_eq!(callback_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn handler_accept_edits_background_denies_external_write_escalation() {
+        let mut inherited = InheritedPermissions::new(PermissionMode::AcceptEdits);
+        inherited.is_background = true;
+        let ctx = PermissionSyncContext::new(inherited);
+        let callback_calls = StdArc::new(AtomicUsize::new(0));
+        let seen = StdArc::clone(&callback_calls);
+        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx))).with_callback(
+            Box::new(move |_req, _ctx| {
+                seen.fetch_add(1, Ordering::SeqCst);
+                PermissionDecision::Escalate
+            }),
+        );
+
+        let request = PermissionRequest::new(
+            "write_file",
+            serde_json::json!({"path": "/tmp/outside.rs", "content": "pub fn nope() {}\n"}),
+        );
+        let response = handler.handle_request(&request).await;
+
+        assert!(!response.approved);
+        assert_eq!(callback_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            response.reason.as_deref(),
+            Some("cannot escalate in background mode")
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_accept_edits_still_asks_callback_for_bash() {
+        let ctx = PermissionSyncContext::root(PermissionMode::AcceptEdits);
+        let callback_calls = StdArc::new(AtomicUsize::new(0));
+        let seen = StdArc::clone(&callback_calls);
+        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx))).with_callback(
+            Box::new(move |_req, _ctx| {
+                seen.fetch_add(1, Ordering::SeqCst);
+                PermissionDecision::deny("bash still needs approval")
+            }),
+        );
+
+        let request = PermissionRequest::new("bash", serde_json::json!({"command": "cargo test"}));
+        let response = handler.handle_request(&request).await;
+
+        assert!(!response.approved);
+        assert_eq!(callback_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            response.reason.as_deref(),
+            Some("bash still needs approval")
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/astra-turn-core/src/permission_types.rs
+++ b/rust/crates/astra-turn-core/src/permission_types.rs
@@ -26,6 +26,10 @@ pub enum PermissionMode {
     /// Auto-approve all tools (except bypass-immune safety checks).
     #[serde(alias = "yolo", alias = "bypass-safety", alias = "bypass_safety")]
     Auto,
+    /// Read-only investigation/planning mode: allow read tools, deny mutations.
+    Plan,
+    /// Auto-approve safe workspace-local edit/write operations only.
+    AcceptEdits,
     /// Prompt the user for write/execute tools (default interactive mode).
     #[default]
     Prompt,
@@ -37,6 +41,8 @@ impl std::fmt::Display for PermissionMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Auto => write!(f, "auto"),
+            Self::Plan => write!(f, "plan"),
+            Self::AcceptEdits => write!(f, "accept_edits"),
             Self::Prompt => write!(f, "prompt"),
             Self::Deny => write!(f, "deny"),
         }
@@ -48,10 +54,12 @@ impl std::str::FromStr for PermissionMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "auto" | "yolo" | "bypass-safety" | "bypass_safety" => Ok(Self::Auto),
+            "plan" => Ok(Self::Plan),
+            "accept_edits" | "accept-edits" => Ok(Self::AcceptEdits),
             "prompt" => Ok(Self::Prompt),
             "deny" => Ok(Self::Deny),
             _ => Err(format!(
-                "invalid permission mode '{s}': expected auto, prompt, or deny"
+                "invalid permission mode '{s}': expected auto, plan, accept_edits, prompt, or deny"
             )),
         }
     }
@@ -240,6 +248,25 @@ impl PermissionRule {
         self.matches_with_context(tool_name, &RuleMatchContext::legacy(command))
     }
 
+    /// True when a bash allow rule is broad enough to bypass the safety
+    /// classifier for arbitrary code execution. Deny rules may still use these
+    /// shapes; callers should apply this only when evaluating allow rules.
+    #[must_use]
+    pub fn is_dangerous_bash_allow_shape(&self) -> bool {
+        if self.tool != "bash" || self.pattern_match == PermissionPatternMatch::Exact {
+            return false;
+        }
+        let Some(pattern) = self.pattern.as_deref() else {
+            return true;
+        };
+        let pattern = pattern.trim();
+        if pattern.is_empty() || pattern == "*" {
+            return true;
+        }
+        let first = pattern.split_whitespace().next().unwrap_or_default();
+        crate::tool_argument_hints::is_unsafe_shell_prefix_token(first)
+    }
+
     /// Check if this rule matches a fully-described tool call.
     pub fn matches_with_context(&self, tool_name: &str, ctx: &RuleMatchContext) -> bool {
         if self.tool != tool_name.to_lowercase() {
@@ -283,13 +310,28 @@ impl PermissionRule {
             return false;
         }
 
+        let target_is_constrained_path =
+            self.tool != "bash" && ctx.path.is_some() && self.op.is_some();
+        let resolved_constrained_path = if target_is_constrained_path && self.cwd_root.is_some() {
+            ctx.path.as_deref().and_then(|path| {
+                ctx.cwd
+                    .as_deref()
+                    .and_then(|cwd| {
+                        crate::permission_memory_profile::resolve_write_path_from_cwd(cwd, path)
+                    })
+                    .map(|resolved| resolved.to_string_lossy().into_owned())
+            })
+        } else {
+            None
+        };
         let target = if self.tool == "bash" {
             ctx.command.as_deref()
         } else {
-            ctx.path.as_deref().or(ctx.command.as_deref())
+            resolved_constrained_path
+                .as_deref()
+                .or(ctx.path.as_deref())
+                .or(ctx.command.as_deref())
         };
-        let target_is_constrained_path =
-            self.tool != "bash" && ctx.path.is_some() && self.op.is_some();
         match (&self.pattern, target) {
             (None, _) => true, // Bare tool name matches all
             (Some(pattern), Some(cmd)) => {
@@ -632,7 +674,7 @@ impl InheritedPermissions {
     pub fn is_allowed_with_context(&self, tool_name: &str, ctx: &RuleMatchContext) -> bool {
         self.allow_rules
             .iter()
-            .any(|r| r.matches_with_context(tool_name, ctx))
+            .any(|r| !r.is_dangerous_bash_allow_shape() && r.matches_with_context(tool_name, ctx))
     }
 
     /// Check if a tool is explicitly denied by inherited rules.
@@ -897,7 +939,7 @@ impl PermissionSyncContext {
         if self
             .session_allow
             .iter()
-            .any(|r| r.matches_with_context(tool_name, ctx))
+            .any(|r| !r.is_dangerous_bash_allow_shape() && r.matches_with_context(tool_name, ctx))
         {
             return true;
         }
@@ -1059,6 +1101,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn permission_mode_roundtrip_includes_accept_edits() {
+        let parsed = "accept_edits".parse::<PermissionMode>().unwrap();
+        assert_eq!(parsed, PermissionMode::AcceptEdits);
+        assert_eq!(parsed.to_string(), "accept_edits");
+        assert_eq!(
+            "accept-edits".parse::<PermissionMode>().unwrap(),
+            PermissionMode::AcceptEdits
+        );
+    }
+
+    #[test]
+    fn permission_mode_roundtrip_includes_plan() {
+        let parsed = "plan".parse::<PermissionMode>().unwrap();
+        assert_eq!(parsed, PermissionMode::Plan);
+        assert_eq!(parsed.to_string(), "plan");
+    }
+
+    #[test]
     fn test_permission_rule_parse() {
         let rule = PermissionRule::parse("bash");
         assert_eq!(rule.tool, "bash");
@@ -1094,6 +1154,38 @@ mod tests {
         assert!(!rule.matches("bash", Some("git commitizen")));
         assert!(!rule.matches("bash", Some("git push")));
         assert!(!rule.matches("edit", Some("git commit")));
+    }
+
+    #[test]
+    fn dangerous_bash_allow_shapes_are_not_honored_as_allow_rules() {
+        let mut inherited = InheritedPermissions::new(PermissionMode::Prompt);
+        inherited.add_allow(PermissionRule::parse("bash"));
+        inherited.add_allow(PermissionRule::parse(
+            r#"Bash(argv_prefix="python", op="execute")"#,
+        ));
+        inherited.add_allow(PermissionRule::parse(
+            r#"Bash(argv_prefix="npm test", op="execute")"#,
+        ));
+        inherited.add_deny(PermissionRule::parse("Bash(python:*)"));
+
+        assert!(!inherited.is_allowed_with_context(
+            "bash",
+            &RuleMatchContext::from_tool_args(
+                "bash",
+                &serde_json::json!({"command": "python -c 'print(1)'"})
+            )
+        ));
+        assert!(inherited.is_allowed_with_context(
+            "bash",
+            &RuleMatchContext::from_tool_args(
+                "bash",
+                &serde_json::json!({"command": "npm test -- --watch"})
+            )
+        ));
+        assert!(
+            inherited.is_denied("bash", Some("python -c 'print(1)'")),
+            "dangerous bash shapes remain valid for deny rules"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/tool_argument_hints.rs
+++ b/rust/crates/astra-turn-core/src/tool_argument_hints.rs
@@ -29,13 +29,21 @@ pub fn command_hint_from_args(args: &Value) -> Option<&str> {
 
 /// Extract the persistent allow-rule prefix from a shell command.
 ///
-/// We stop at the first flag, the first shell metacharacter, or after at most
-/// three tokens. That keeps "Always allow" precise enough for subcommands
-/// without baking user data or flags into the rule.
+/// Mirrors Claude Code's safety posture: only stable command+subcommand
+/// shapes become reusable prefixes (`git commit`, `npm test`, `cargo test`).
+/// Single-word commands, interpreter invocations (`python -c`, `bash -c`),
+/// shell wrappers (`sudo`, `env`, `timeout`), flags, paths, and filenames fall
+/// back to exact-command rules instead of broad `Bash(foo:*)` rules.
 #[must_use]
 pub fn normalized_argv_prefix(cmd: &str) -> String {
-    const MAX_PREFIX_TOKENS: usize = 3;
     const SHELL_METACHARS: &[&str] = &["|", ";", "&&", "||", ">", "<", ">>", "<<", "&"];
+
+    let mut cmd = cmd.trim();
+    if let Some((head, tail)) = cmd.split_once("&&")
+        && head.trim_start().starts_with("cd ")
+    {
+        cmd = tail.trim();
+    }
 
     let mut tokens = Vec::new();
     for raw in cmd.split_whitespace() {
@@ -45,13 +53,153 @@ pub fn normalized_argv_prefix(cmd: &str) -> String {
         if raw.starts_with('-') {
             break;
         }
+        if tokens.is_empty() && looks_like_env_assignment(raw) {
+            let Some((key, _)) = raw.split_once('=') else {
+                return String::new();
+            };
+            if is_safe_env_prefix(key) {
+                continue;
+            }
+            return String::new();
+        }
         tokens.push(raw);
-        if tokens.len() >= MAX_PREFIX_TOKENS {
+        if tokens.len() >= 2 {
             break;
         }
     }
 
-    tokens.join(" ")
+    let [command, subcommand] = tokens.as_slice() else {
+        return String::new();
+    };
+    if is_unsafe_bare_shell_prefix(command) || !looks_like_subcommand(subcommand) {
+        return String::new();
+    }
+
+    format!("{command} {subcommand}")
+}
+
+fn looks_like_env_assignment(token: &str) -> bool {
+    let Some((key, value)) = token.split_once('=') else {
+        return false;
+    };
+    !key.is_empty()
+        && !value.is_empty()
+        && key
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        && key
+            .chars()
+            .next()
+            .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+}
+
+fn is_safe_env_prefix(key: &str) -> bool {
+    matches!(
+        key,
+        "GOEXPERIMENT"
+            | "GOOS"
+            | "GOARCH"
+            | "CGO_ENABLED"
+            | "GO111MODULE"
+            | "RUST_BACKTRACE"
+            | "RUST_LOG"
+            | "NODE_ENV"
+            | "CI"
+            | "PYTHONUNBUFFERED"
+            | "PYTHONDONTWRITEBYTECODE"
+            | "PYTEST_DISABLE_PLUGIN_AUTOLOAD"
+            | "PYTEST_DEBUG"
+            | "LANG"
+            | "LANGUAGE"
+            | "LC_ALL"
+            | "LC_CTYPE"
+            | "LC_TIME"
+            | "CHARSET"
+            | "TERM"
+            | "COLORTERM"
+            | "NO_COLOR"
+            | "FORCE_COLOR"
+            | "TZ"
+    )
+}
+
+fn is_unsafe_bare_shell_prefix(command: &str) -> bool {
+    is_unsafe_shell_prefix_token(command)
+}
+
+/// Single source of truth for shell/interpreter/wrapper command tokens that
+/// must never anchor a broad allow rule (case-insensitive). Used by both the
+/// argument-hint prefix extractor and the allow-rule safety classifier in
+/// `PermissionRule::is_dangerous_bash_allow_shape`.
+///
+/// Invariants:
+/// - All entries are ASCII lowercase; matching lowercases the input.
+/// - Tokens here either spawn arbitrary code (shells, interpreters), elevate
+///   privileges (`sudo`, `doas`, `pkexec`), or wrap an arbitrary inner
+///   command (`env`, `xargs`, `nice`, `stdbuf`, `nohup`, `timeout`, `time`,
+///   `exec`, `busybox`).
+/// - Adding an entry tightens both code paths simultaneously; do not
+///   duplicate this list elsewhere.
+pub fn is_unsafe_shell_prefix_token(token: &str) -> bool {
+    matches!(
+        token.to_ascii_lowercase().as_str(),
+        // Shells
+        "sh"
+            | "bash"
+            | "zsh"
+            | "fish"
+            | "csh"
+            | "tcsh"
+            | "ksh"
+            | "dash"
+            | "ash"
+            | "cmd"
+            | "powershell"
+            | "pwsh"
+            // Interpreters
+            | "python"
+            | "python2"
+            | "python3"
+            | "node"
+            | "nodejs"
+            | "deno"
+            | "bun"
+            | "ruby"
+            | "perl"
+            | "php"
+            | "lua"
+            // Wrappers that pass through to an arbitrary inner command
+            | "env"
+            | "xargs"
+            | "nice"
+            | "stdbuf"
+            | "nohup"
+            | "timeout"
+            | "time"
+            | "exec"
+            | "busybox"
+            // Privilege elevation
+            | "sudo"
+            | "doas"
+            | "pkexec"
+    )
+}
+
+fn looks_like_subcommand(token: &str) -> bool {
+    // Subcommands are conventionally lowercase ASCII identifiers; allow `-`
+    // and `_` in trailing chars (e.g. `make install_deps`, `cargo nextest-run`).
+    // The first char must be a lowercase ASCII letter or digit so flag-like
+    // tokens (`-v`, `--all`) and underscore-led tokens (`_foo`) don't sneak
+    // through and get mistaken for subcommands. Rejects paths, redirection,
+    // quoting, env-style `KEY=value`, etc.
+    let mut chars = token.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
 }
 
 /// Raw hint used for **permission rule matching** — `starts_with`
@@ -155,11 +303,59 @@ mod tests {
         assert_eq!(normalized_argv_prefix("cargo test --release"), "cargo test");
         assert_eq!(
             normalized_argv_prefix("npm run deploy:prod -- --foo"),
-            "npm run deploy:prod"
+            "npm run"
         );
         assert_eq!(normalized_argv_prefix("git commit -m 'fix'"), "git commit");
-        assert_eq!(normalized_argv_prefix("bash -c 'rm -rf tmp'"), "bash");
+        assert_eq!(normalized_argv_prefix("bash -c 'rm -rf tmp'"), "");
         assert_eq!(normalized_argv_prefix("echo hi > out.txt"), "echo hi");
+    }
+
+    #[test]
+    fn normalized_argv_prefix_uses_main_command_after_cd_and_env() {
+        assert_eq!(
+            normalized_argv_prefix("cd rust && cargo test -p astra-cli"),
+            "cargo test"
+        );
+        assert_eq!(
+            normalized_argv_prefix("RUST_LOG=debug cargo check --workspace"),
+            "cargo check"
+        );
+        assert_eq!(
+            normalized_argv_prefix("cd web && CI=1 npm test -- --runInBand"),
+            "npm test"
+        );
+    }
+
+    #[test]
+    fn normalized_argv_prefix_rejects_broad_shell_and_wrapper_rules() {
+        assert_eq!(normalized_argv_prefix("python -c 'print(1)'"), "");
+        assert_eq!(normalized_argv_prefix("python3 script.py"), "");
+        assert_eq!(normalized_argv_prefix("sudo apt install ripgrep"), "");
+        assert_eq!(normalized_argv_prefix("cat src/lib.rs"), "");
+        assert_eq!(normalized_argv_prefix("UNSAFE=1 npm run build"), "");
+        assert_eq!(
+            normalized_argv_prefix("NODE_ENV=test npm run build"),
+            "npm run"
+        );
+    }
+
+    #[test]
+    fn unsafe_shell_prefix_token_covers_new_interpreters_and_wrappers() {
+        for token in ["ash", "nodejs", "deno", "bun", "exec", "busybox", "BusyBox"] {
+            assert!(
+                is_unsafe_shell_prefix_token(token),
+                "{token} should stay blocked as a reusable shell prefix"
+            );
+        }
+    }
+
+    #[test]
+    fn subcommand_shape_allows_underscores_without_allowing_flags_or_paths() {
+        assert!(looks_like_subcommand("install_deps"));
+        assert!(looks_like_subcommand("nextest-run"));
+        assert!(!looks_like_subcommand("_hidden"));
+        assert!(!looks_like_subcommand("--workspace"));
+        assert!(!looks_like_subcommand("src/lib.rs"));
     }
 
     #[test]

--- a/rust/crates/runtime/src/orchestration/spawner.rs
+++ b/rust/crates/runtime/src/orchestration/spawner.rs
@@ -59,7 +59,7 @@ pub use astra_turn_core::orchestration_types::{
 /// Permission summary for display purposes.
 #[derive(Debug, Clone, Default)]
 pub struct PermissionSummary {
-    /// Permission mode (auto, prompt, deny).
+    /// Permission mode (auto, plan, accept_edits, prompt, deny).
     pub mode: String,
     /// Number of explicit allow rules.
     pub allow_rules: u32,
@@ -1379,6 +1379,8 @@ fn build_permission_summary(context: &SpawnContext) -> PermissionSummary {
     if let Some(ref inherited) = context.inherited_permissions {
         summary.mode = match inherited.mode {
             super::permission_sync::PermissionMode::Auto => "auto".to_string(),
+            super::permission_sync::PermissionMode::Plan => "plan".to_string(),
+            super::permission_sync::PermissionMode::AcceptEdits => "accept_edits".to_string(),
             super::permission_sync::PermissionMode::Prompt => "prompt".to_string(),
             super::permission_sync::PermissionMode::Deny => "deny".to_string(),
         };

--- a/rust/crates/runtime/src/turn/permission_gate.rs
+++ b/rust/crates/runtime/src/turn/permission_gate.rs
@@ -248,6 +248,7 @@ mod tests {
     use crate::orchestration::permission_sync::{
         InheritedPermissions, PermissionMode, PermissionResponseMessaging, PermissionRule,
     };
+    use astra_turn_core::permission_types::RuleMatchContext;
     use std::collections::HashSet;
 
     fn is_allowed(result: &PermissionCheckResult) -> bool {
@@ -731,7 +732,9 @@ mod tests {
                     let correlation_id = msg.correlation_id.clone().unwrap();
                     let response =
                         crate::orchestration::permission_sync::PermissionResponse::approve()
-                            .with_update(PermissionUpdate::allow(PermissionRule::parse("bash")));
+                            .with_update(PermissionUpdate::allow(PermissionRule::parse(
+                                "Bash(touch:*)",
+                            )));
                     router_clone
                         .send(response.to_message(
                             &parent_addr_clone,
@@ -764,10 +767,11 @@ mod tests {
         }
 
         let ctx_guard = ctx.read().await;
-        assert!(ctx_guard.is_allowed(
+        let rule_ctx = RuleMatchContext::from_tool_args(
             "bash",
-            Some(r#"{"command":"touch astra-permission-gate-test"}"#)
-        ));
+            &serde_json::json!({"command":"touch astra-permission-gate-test"}),
+        );
+        assert!(ctx_guard.is_allowed_with_context("bash", &rule_ctx));
         let telemetry = ctx_guard.telemetry();
         assert_eq!(telemetry.permission_requests, 1);
         assert_eq!(telemetry.permission_requests_approved, 1);

--- a/rust/crates/runtime/src/turn/permission_gate.rs
+++ b/rust/crates/runtime/src/turn/permission_gate.rs
@@ -189,6 +189,14 @@ fn is_read_only_in_plan_mode(tool_name: &str) -> bool {
             | "grep"
             | "glob"
             | "list_dir"
+            | "git_status"
+            | "git_diff"
+            | "git_log"
+            | "git_file_history"
+            | "git_contributors"
+            | "git_log_search"
+            | "git_show"
+            | "git_blame"
             | "symbols"
             | "introspect"
             | "lsp"
@@ -865,7 +873,21 @@ mod tests {
         };
         let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
 
-        for tool in &["read_file", "grep", "glob", "list_dir", "symbols"] {
+        for tool in &[
+            "read_file",
+            "grep",
+            "glob",
+            "list_dir",
+            "git_status",
+            "git_diff",
+            "git_log",
+            "git_file_history",
+            "git_contributors",
+            "git_log_search",
+            "git_show",
+            "git_blame",
+            "symbols",
+        ] {
             let result = check_tool_permission_in_plan_mode(
                 tool,
                 None,


### PR DESCRIPTION
## Summary

This PR improves the permission system with better UX, workspace trust management, and approval flow refinements.

## Changes

- **Refactor permission trust UX**: Improved workspace trust picker at startup with explicit fallback explanations
- **Tighten bash approval safety**: Enhanced safety checks for shell command approvals
- **Remove legacy approval rule UI**: Cleaned up deprecated approval UI elements
- **Simplify approval permissions**: Streamlined permission model for auto/always/ask/deny
- **Require explicit session resume**: Sessions now require explicit user action to resume
- **Add startup workspace trust picker**: New trust picker for first-time workspace interactions
- **Plan mode improvements**: Task board unification and enhanced TUI

## Testing

- Tests updated and passing
- Auto-mode sensitive path tests fixed
- Permission integration tests verified