### PR TITLE
refactor(runtime): bundle app state services

### DIFF
--- a/rust/crates/runtime/src/admin_config_handlers.rs
+++ b/rust/crates/runtime/src/admin_config_handlers.rs
@@ -42,9 +42,10 @@ pub async fn list_admin_config_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<AdminConfigListResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _admin = state.admin_authorizer.require_admin(&headers).await?;
+    let _admin = state.admin.authorizer.require_admin(&headers).await?;
     let rows = state
-        .admin_config_service
+        .admin
+        .config_service
         .list()
         .await
         .map_err(internal_error)?;
@@ -61,9 +62,10 @@ pub async fn get_admin_config_handler(
     Path(key): Path<String>,
     headers: HeaderMap,
 ) -> Result<Json<AdminConfigGetResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _admin = state.admin_authorizer.require_admin(&headers).await?;
+    let _admin = state.admin.authorizer.require_admin(&headers).await?;
     let value = state
-        .admin_config_service
+        .admin
+        .config_service
         .get(&key)
         .await
         .map_err(|e| error_response(StatusCode::BAD_REQUEST, e))?;
@@ -85,9 +87,10 @@ pub async fn set_admin_config_handler(
     headers: HeaderMap,
     Json(request): Json<AdminConfigSetRequest>,
 ) -> Result<Json<AdminConfigEntry>, (StatusCode, Json<ErrorResponse>)> {
-    let admin = state.admin_authorizer.require_admin(&headers).await?;
+    let admin = state.admin.authorizer.require_admin(&headers).await?;
     state
-        .admin_config_service
+        .admin
+        .config_service
         .set(&key, &request.value, Some(&admin.user_id))
         .await
         .map_err(|e| error_response(StatusCode::BAD_REQUEST, e))?;
@@ -102,9 +105,10 @@ pub async fn delete_admin_config_handler(
     Path(key): Path<String>,
     headers: HeaderMap,
 ) -> Result<Json<AdminConfigDeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _admin = state.admin_authorizer.require_admin(&headers).await?;
+    let _admin = state.admin.authorizer.require_admin(&headers).await?;
     let deleted = state
-        .admin_config_service
+        .admin
+        .config_service
         .unset(&key)
         .await
         .map_err(internal_error)?;

--- a/rust/crates/runtime/src/app_state.rs
+++ b/rust/crates/runtime/src/app_state.rs
@@ -26,6 +26,79 @@ pub trait MemoriaForwarder: Send + Sync {
 }
 
 #[derive(Clone)]
+pub(crate) struct TurnPersistenceState {
+    pub(crate) core_event_writer: Arc<dyn TurnCoreEventWriter>,
+    pub(crate) tool_event_writer: Arc<dyn TurnToolEventWriter>,
+    pub(crate) hook_db_writer: Arc<dyn TurnHookDbWriter>,
+    pub(crate) reflection_state_store: Arc<dyn TurnReflectionStateStore>,
+    pub(crate) reflection_lesson_writer: Arc<dyn TurnReflectionLessonWriter>,
+    pub(crate) observer_worker: Arc<dyn TurnObserverWorker>,
+    pub(crate) auxiliary_event_writer: Arc<dyn TurnAuxiliaryEventWriter>,
+    pub(crate) session_activity_writer: Arc<dyn TurnSessionActivityWriter>,
+}
+
+impl Default for TurnPersistenceState {
+    fn default() -> Self {
+        Self {
+            core_event_writer: Arc::new(NoopTurnCoreEventWriter),
+            tool_event_writer: Arc::new(NoopTurnToolEventWriter),
+            hook_db_writer: Arc::new(NoopTurnHookDbWriter),
+            reflection_state_store: Arc::new(InMemoryTurnReflectionStateStore::default()),
+            reflection_lesson_writer: Arc::new(NoopTurnReflectionLessonWriter),
+            observer_worker: Arc::new(NoopTurnObserverWorker),
+            auxiliary_event_writer: Arc::new(NoopTurnAuxiliaryEventWriter),
+            session_activity_writer: Arc::new(NoopTurnSessionActivityWriter),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct AdminState {
+    pub(crate) authorizer: Arc<dyn AdminAuthorizer>,
+    pub(crate) initializer: Arc<dyn AdminInitializer>,
+    pub(crate) token_reader: Arc<dyn AdminTokenReader>,
+    pub(crate) token_writer: Arc<dyn AdminTokenWriter>,
+    pub(crate) audit_reader: Arc<dyn AdminAuditReader>,
+    pub(crate) feedback_stats_reader: Arc<dyn AdminFeedbackStatsReader>,
+    pub(crate) user_role_manager: Arc<dyn AdminUserRoleManager>,
+    pub(crate) config_service: Arc<dyn astra_services::AdminConfigService>,
+}
+
+impl Default for AdminState {
+    fn default() -> Self {
+        Self {
+            authorizer: Arc::new(auth::UnconfiguredAdminAuthorizer),
+            initializer: Arc::new(auth::UnconfiguredAdminInitializer),
+            token_reader: Arc::new(auth::UnconfiguredAdminTokenReader),
+            token_writer: Arc::new(auth::UnconfiguredAdminTokenWriter),
+            audit_reader: Arc::new(auth::UnconfiguredAdminAuditReader),
+            feedback_stats_reader: Arc::new(auth::UnconfiguredAdminFeedbackStatsReader),
+            user_role_manager: Arc::new(auth::UnconfiguredAdminUserRoleManager),
+            config_service: Arc::new(astra_services::UnconfiguredAdminConfigService),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ExecutionServicesState {
+    pub(crate) task_service: Arc<dyn TaskService>,
+    pub(crate) edge_registry_service: Arc<dyn EdgeRegistryService>,
+    pub(crate) task_lease_service: Arc<dyn TaskLeaseService>,
+    pub(crate) run_lifecycle_service: Arc<dyn RunLifecycleService>,
+}
+
+impl Default for ExecutionServicesState {
+    fn default() -> Self {
+        Self {
+            task_service: Arc::new(UnconfiguredTaskService),
+            edge_registry_service: Arc::new(UnconfiguredEdgeRegistryService),
+            task_lease_service: Arc::new(UnconfiguredTaskLeaseService),
+            run_lifecycle_service: Arc::new(UnconfiguredRunLifecycleService),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct AppState {
     pub(crate) service_info: ServiceInfo,
     pub(crate) health_checker: Arc<dyn HealthChecker>,
@@ -55,26 +128,9 @@ pub struct AppState {
     pub(crate) reflect_service: Arc<dyn ReflectService>,
     pub(crate) learning_feedback_service: Arc<dyn LearningFeedbackService>,
     pub(crate) fernet_encryptor: FernetTokenEncryptor,
-    pub(crate) turn_core_event_writer: Arc<dyn TurnCoreEventWriter>,
-    pub(crate) turn_tool_event_writer: Arc<dyn TurnToolEventWriter>,
-    pub(crate) turn_hook_db_writer: Arc<dyn TurnHookDbWriter>,
-    pub(crate) turn_reflection_state_store: Arc<dyn TurnReflectionStateStore>,
-    pub(crate) turn_reflection_lesson_writer: Arc<dyn TurnReflectionLessonWriter>,
-    pub(crate) turn_observer_worker: Arc<dyn TurnObserverWorker>,
-    pub(crate) turn_auxiliary_event_writer: Arc<dyn TurnAuxiliaryEventWriter>,
-    pub(crate) turn_session_activity_writer: Arc<dyn TurnSessionActivityWriter>,
-    pub(crate) task_service: Arc<dyn TaskService>,
-    pub(crate) edge_registry_service: Arc<dyn EdgeRegistryService>,
-    pub(crate) task_lease_service: Arc<dyn TaskLeaseService>,
-    pub(crate) run_lifecycle_service: Arc<dyn RunLifecycleService>,
-    pub(crate) admin_authorizer: Arc<dyn AdminAuthorizer>,
-    pub(crate) admin_initializer: Arc<dyn AdminInitializer>,
-    pub(crate) admin_token_reader: Arc<dyn AdminTokenReader>,
-    pub(crate) admin_token_writer: Arc<dyn AdminTokenWriter>,
-    pub(crate) admin_audit_reader: Arc<dyn AdminAuditReader>,
-    pub(crate) admin_feedback_stats_reader: Arc<dyn AdminFeedbackStatsReader>,
-    pub(crate) admin_user_role_manager: Arc<dyn AdminUserRoleManager>,
-    pub(crate) admin_config_service: Arc<dyn astra_services::AdminConfigService>,
+    pub(crate) turn_persistence: TurnPersistenceState,
+    pub(crate) execution: ExecutionServicesState,
+    pub(crate) admin: AdminState,
     pub(crate) chat_turn_bridge:
         Option<Arc<crate::turn::bridge_inprocess::InProcessChatTurnBridge>>,
     pub(crate) chat_turn_bridge_secret: String,
@@ -167,26 +223,9 @@ impl AppState {
                     // Last resort: use a deterministic key so the app doesn't crash.
                     FernetTokenEncryptor::new("abcdefghijklmnop").expect("hardcoded key must work")
                 }),
-            turn_core_event_writer: Arc::new(NoopTurnCoreEventWriter),
-            turn_tool_event_writer: Arc::new(NoopTurnToolEventWriter),
-            turn_hook_db_writer: Arc::new(NoopTurnHookDbWriter),
-            turn_reflection_state_store: Arc::new(InMemoryTurnReflectionStateStore::default()),
-            turn_reflection_lesson_writer: Arc::new(NoopTurnReflectionLessonWriter),
-            turn_observer_worker: Arc::new(NoopTurnObserverWorker),
-            turn_auxiliary_event_writer: Arc::new(NoopTurnAuxiliaryEventWriter),
-            turn_session_activity_writer: Arc::new(NoopTurnSessionActivityWriter),
-            task_service: Arc::new(UnconfiguredTaskService),
-            edge_registry_service: Arc::new(UnconfiguredEdgeRegistryService),
-            task_lease_service: Arc::new(UnconfiguredTaskLeaseService),
-            run_lifecycle_service: Arc::new(UnconfiguredRunLifecycleService),
-            admin_authorizer: Arc::new(auth::UnconfiguredAdminAuthorizer),
-            admin_initializer: Arc::new(auth::UnconfiguredAdminInitializer),
-            admin_token_reader: Arc::new(auth::UnconfiguredAdminTokenReader),
-            admin_token_writer: Arc::new(auth::UnconfiguredAdminTokenWriter),
-            admin_audit_reader: Arc::new(auth::UnconfiguredAdminAuditReader),
-            admin_feedback_stats_reader: Arc::new(auth::UnconfiguredAdminFeedbackStatsReader),
-            admin_user_role_manager: Arc::new(auth::UnconfiguredAdminUserRoleManager),
-            admin_config_service: Arc::new(astra_services::UnconfiguredAdminConfigService),
+            turn_persistence: TurnPersistenceState::default(),
+            execution: ExecutionServicesState::default(),
+            admin: AdminState::default(),
             chat_turn_bridge: None,
             chat_turn_bridge_secret: "dev-bridge-secret-change-me".to_string(),
             chat_turn_bridge_cache,
@@ -257,7 +296,7 @@ impl AppState {
     }
 
     pub fn with_admin_authorizer(mut self, admin_authorizer: Arc<dyn AdminAuthorizer>) -> Self {
-        self.admin_authorizer = admin_authorizer;
+        self.admin.authorizer = admin_authorizer;
         self
     }
 
@@ -265,7 +304,7 @@ impl AppState {
         mut self,
         admin_config_service: Arc<dyn astra_services::AdminConfigService>,
     ) -> Self {
-        self.admin_config_service = admin_config_service;
+        self.admin.config_service = admin_config_service;
         self
     }
 
@@ -425,7 +464,7 @@ impl AppState {
         mut self,
         turn_auxiliary_event_writer: Arc<dyn TurnAuxiliaryEventWriter>,
     ) -> Self {
-        self.turn_auxiliary_event_writer = turn_auxiliary_event_writer;
+        self.turn_persistence.auxiliary_event_writer = turn_auxiliary_event_writer;
         self
     }
 
@@ -433,7 +472,7 @@ impl AppState {
         mut self,
         turn_core_event_writer: Arc<dyn TurnCoreEventWriter>,
     ) -> Self {
-        self.turn_core_event_writer = turn_core_event_writer;
+        self.turn_persistence.core_event_writer = turn_core_event_writer;
         self
     }
 
@@ -441,7 +480,7 @@ impl AppState {
         mut self,
         turn_tool_event_writer: Arc<dyn TurnToolEventWriter>,
     ) -> Self {
-        self.turn_tool_event_writer = turn_tool_event_writer;
+        self.turn_persistence.tool_event_writer = turn_tool_event_writer;
         self
     }
 
@@ -449,14 +488,14 @@ impl AppState {
         mut self,
         turn_hook_db_writer: Arc<dyn TurnHookDbWriter>,
     ) -> Self {
-        self.turn_hook_db_writer = turn_hook_db_writer;
+        self.turn_persistence.hook_db_writer = turn_hook_db_writer;
         self
     }
     pub fn with_turn_reflection_lesson_writer(
         mut self,
         turn_reflection_lesson_writer: Arc<dyn TurnReflectionLessonWriter>,
     ) -> Self {
-        self.turn_reflection_lesson_writer = turn_reflection_lesson_writer;
+        self.turn_persistence.reflection_lesson_writer = turn_reflection_lesson_writer;
         self
     }
 
@@ -464,7 +503,7 @@ impl AppState {
         mut self,
         turn_observer_worker: Arc<dyn TurnObserverWorker>,
     ) -> Self {
-        self.turn_observer_worker = turn_observer_worker;
+        self.turn_persistence.observer_worker = turn_observer_worker;
         self
     }
 
@@ -472,7 +511,7 @@ impl AppState {
         mut self,
         turn_session_activity_writer: Arc<dyn TurnSessionActivityWriter>,
     ) -> Self {
-        self.turn_session_activity_writer = turn_session_activity_writer;
+        self.turn_persistence.session_activity_writer = turn_session_activity_writer;
         self
     }
 
@@ -480,12 +519,12 @@ impl AppState {
         mut self,
         run_lifecycle_service: Arc<dyn RunLifecycleService>,
     ) -> Self {
-        self.run_lifecycle_service = run_lifecycle_service;
+        self.execution.run_lifecycle_service = run_lifecycle_service;
         self
     }
 
     pub fn with_task_service(mut self, task_service: Arc<dyn TaskService>) -> Self {
-        self.task_service = task_service;
+        self.execution.task_service = task_service;
         self
     }
 
@@ -493,7 +532,7 @@ impl AppState {
         mut self,
         edge_registry_service: Arc<dyn EdgeRegistryService>,
     ) -> Self {
-        self.edge_registry_service = edge_registry_service;
+        self.execution.edge_registry_service = edge_registry_service;
         self
     }
 
@@ -501,12 +540,12 @@ impl AppState {
         mut self,
         task_lease_service: Arc<dyn TaskLeaseService>,
     ) -> Self {
-        self.task_lease_service = task_lease_service;
+        self.execution.task_lease_service = task_lease_service;
         self
     }
 
     pub fn with_admin_initializer(mut self, admin_initializer: Arc<dyn AdminInitializer>) -> Self {
-        self.admin_initializer = admin_initializer;
+        self.admin.initializer = admin_initializer;
         self
     }
 
@@ -514,7 +553,7 @@ impl AppState {
         mut self,
         admin_token_reader: Arc<dyn AdminTokenReader>,
     ) -> Self {
-        self.admin_token_reader = admin_token_reader;
+        self.admin.token_reader = admin_token_reader;
         self
     }
 
@@ -522,7 +561,7 @@ impl AppState {
         mut self,
         admin_token_writer: Arc<dyn AdminTokenWriter>,
     ) -> Self {
-        self.admin_token_writer = admin_token_writer;
+        self.admin.token_writer = admin_token_writer;
         self
     }
 
@@ -530,7 +569,7 @@ impl AppState {
         mut self,
         admin_audit_reader: Arc<dyn AdminAuditReader>,
     ) -> Self {
-        self.admin_audit_reader = admin_audit_reader;
+        self.admin.audit_reader = admin_audit_reader;
         self
     }
 
@@ -538,7 +577,7 @@ impl AppState {
         mut self,
         admin_feedback_stats_reader: Arc<dyn AdminFeedbackStatsReader>,
     ) -> Self {
-        self.admin_feedback_stats_reader = admin_feedback_stats_reader;
+        self.admin.feedback_stats_reader = admin_feedback_stats_reader;
         self
     }
 
@@ -546,7 +585,7 @@ impl AppState {
         mut self,
         admin_user_role_manager: Arc<dyn AdminUserRoleManager>,
     ) -> Self {
-        self.admin_user_role_manager = admin_user_role_manager;
+        self.admin.user_role_manager = admin_user_role_manager;
         self
     }
 
@@ -771,6 +810,16 @@ impl HealthChecker for MatrixOneHealthChecker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    struct AlwaysHealthy;
+
+    #[async_trait]
+    impl HealthChecker for AlwaysHealthy {
+        async fn database_healthy(&self) -> bool {
+            true
+        }
+    }
 
     /// audit-A1: ReqwestMemoriaForwarder must set connect_timeout and timeout
     /// so a hung Memoria server cannot block the Axum handler indefinitely.
@@ -838,5 +887,46 @@ mod tests {
             impl_body.contains("self.client") || impl_body.contains("self\n            .client"),
             "forward() must use the shared self.client"
         );
+    }
+
+    #[tokio::test]
+    async fn edge_callback_ledger_accessor_shares_backing_store() {
+        let state = AppState::new(ServiceInfo::default(), Arc::new(AlwaysHealthy));
+        let ledger = state.edge_callback_ledger();
+        ledger
+            .lock()
+            .await
+            .insert("req-1".into(), serde_json::json!({ "status": "queued" }));
+
+        let snapshot = state.edge_callback_ledger();
+        assert_eq!(
+            snapshot.lock().await.get("req-1"),
+            Some(&serde_json::json!({ "status": "queued" }))
+        );
+    }
+
+    #[test]
+    fn metrics_registry_accessor_returns_same_arc_and_no_delegation_by_default() {
+        let state = AppState::new(ServiceInfo::default(), Arc::new(AlwaysHealthy));
+        let first = state.metrics_registry();
+        let second = state.metrics_registry();
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(state.delegation_engine().is_none());
+    }
+
+    #[tokio::test]
+    async fn default_memoria_forwarder_is_noop_until_configured() {
+        let state = AppState::new(ServiceInfo::default(), Arc::new(AlwaysHealthy));
+        let err = state
+            .memoria_forwarder
+            .forward(
+                "/v1/memories/retrieve",
+                serde_json::json!({ "query": "test" }),
+            )
+            .await
+            .expect_err("default AppState should not talk to Memoria");
+
+        assert!(err.contains("Memoria not configured"));
     }
 }

--- a/rust/crates/runtime/src/models.rs
+++ b/rust/crates/runtime/src/models.rs
@@ -13,7 +13,7 @@ pub async fn create_model_handler(
     headers: HeaderMap,
     Json(request): Json<ModelCreateRequest>,
 ) -> Result<(StatusCode, Json<ModelResponse>), (StatusCode, Json<ErrorResponse>)> {
-    let admin = state.admin_authorizer.require_admin(&headers).await?;
+    let admin = state.admin.authorizer.require_admin(&headers).await?;
 
     let model = state
         .model_service
@@ -45,7 +45,7 @@ pub async fn list_models_handler(
     headers: HeaderMap,
 ) -> Result<Json<Vec<ModelListItemResponse>>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
-    let is_admin = state.admin_authorizer.require_admin(&headers).await.is_ok();
+    let is_admin = state.admin.authorizer.require_admin(&headers).await.is_ok();
     let models = state
         .model_service
         .list_models(user.user_id, is_admin)
@@ -74,7 +74,7 @@ pub async fn update_model_handler(
     headers: HeaderMap,
     Json(request): Json<ModelUpdateRequest>,
 ) -> Result<Json<ModelResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _admin = state.admin_authorizer.require_admin(&headers).await?;
+    let _admin = state.admin.authorizer.require_admin(&headers).await?;
     let model = state
         .model_service
         .update_model(
@@ -105,7 +105,7 @@ pub async fn delete_model_handler(
     Path(model_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let _admin = state.admin_authorizer.require_admin(&headers).await?;
+    let _admin = state.admin.authorizer.require_admin(&headers).await?;
     state.model_service.delete_model(model_name).await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -115,7 +115,7 @@ pub async fn check_model_handler(
     Path(model_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<Json<ModelResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _admin = state.admin_authorizer.require_admin(&headers).await?;
+    let _admin = state.admin.authorizer.require_admin(&headers).await?;
     let model = state.model_service.check_model(model_name).await?;
     Ok(Json(ModelResponse::from(model)))
 }

--- a/rust/crates/runtime/src/server/admin_handlers.rs
+++ b/rust/crates/runtime/src/server/admin_handlers.rs
@@ -4,8 +4,8 @@ pub(super) async fn admin_init_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<AdminInitResponse>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
-    let result = state.admin_initializer.initialize().await?;
+    state.admin.authorizer.require_admin(&headers).await?;
+    let result = state.admin.initializer.initialize().await?;
     Ok(Json(AdminInitResponse::from(result)))
 }
 
@@ -14,9 +14,10 @@ pub(super) async fn admin_list_tokens_handler(
     headers: HeaderMap,
     Query(query): Query<AdminTokenListQuery>,
 ) -> Result<Json<Vec<AdminTokenResponse>>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
     let tokens = state
-        .admin_token_reader
+        .admin
+        .token_reader
         .list_tokens(AdminTokenFilter {
             token_type: query.token_type,
             scope: query.scope,
@@ -33,9 +34,10 @@ pub(super) async fn admin_create_token_handler(
     headers: HeaderMap,
     Json(request): Json<AdminTokenCreateRequest>,
 ) -> Result<(StatusCode, Json<AdminTokenResponse>), (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
     let created = state
-        .admin_token_writer
+        .admin
+        .token_writer
         .create_token(AdminTokenCreateRequestData {
             token_type: request.token_type,
             provider: request.provider,
@@ -53,9 +55,10 @@ pub(super) async fn admin_audit_logs_handler(
     headers: HeaderMap,
     Query(query): Query<AdminAuditListQuery>,
 ) -> Result<Json<Vec<AdminAuditResponse>>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
     let logs = state
-        .admin_audit_reader
+        .admin
+        .audit_reader
         .list_audit_logs(AdminAuditFilter {
             user_id: query.user_id,
             since: query.since,
@@ -73,7 +76,7 @@ pub(super) async fn admin_prompt_optimize_handler(
     headers: HeaderMap,
     Json(request): Json<PromptOptimizeRequest>,
 ) -> Result<Json<PromptOptimizeResponse>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
     let _ = request.optimization_type;
     Ok(Json(PromptOptimizeResponse {
         job_id: Uuid::new_v4().to_string(),
@@ -90,7 +93,7 @@ pub(super) async fn admin_feedback_export_handler(
     headers: HeaderMap,
     Json(request): Json<FeedbackExportRequest>,
 ) -> Result<Json<FeedbackExportResponse>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
     let _ = request.agent_id;
     let _ = request.format;
     Ok(Json(FeedbackExportResponse {
@@ -105,9 +108,10 @@ pub(super) async fn admin_feedback_stats_handler(
     headers: HeaderMap,
     Query(query): Query<AdminFeedbackStatsQuery>,
 ) -> Result<Json<AdminFeedbackStatsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
     let stats = state
-        .admin_feedback_stats_reader
+        .admin
+        .feedback_stats_reader
         .read_feedback_stats(AdminFeedbackStatsFilter {
             agent_id: query.agent_id,
             since: query.since,
@@ -122,9 +126,10 @@ pub(super) async fn admin_grant_role_handler(
     headers: HeaderMap,
     Json(request): Json<AdminUserRoleRequest>,
 ) -> Result<Json<AdminUserRoleResponse>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
     let result = state
-        .admin_user_role_manager
+        .admin
+        .user_role_manager
         .grant_role(AdminUserRoleRequestData {
             username: request.username,
             role_name: request.role_name,
@@ -139,9 +144,10 @@ pub(super) async fn admin_revoke_role_handler(
     headers: HeaderMap,
     Json(request): Json<AdminUserRoleRequest>,
 ) -> Result<Json<AdminUserRoleResponse>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
     let result = state
-        .admin_user_role_manager
+        .admin
+        .user_role_manager
         .revoke_role(AdminUserRoleRequestData {
             username: request.username,
             role_name: request.role_name,
@@ -156,7 +162,7 @@ pub(super) async fn admin_cleanup_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
 
     let pool = state
         .shared_pool

--- a/rust/crates/runtime/src/server/chat_handlers.rs
+++ b/rust/crates/runtime/src/server/chat_handlers.rs
@@ -185,6 +185,7 @@ pub(super) async fn chat_handler(
     chat_data.session_id = resolved.session_id;
     chat_data.full_llm_capture = resolved.full_llm_capture;
     let run = state
+        .execution
         .run_lifecycle_service
         .create_run(user.user_id, chat_data)
         .await?;
@@ -240,6 +241,7 @@ pub(super) async fn chat_stream_handler(
     }
 
     match state
+        .execution
         .run_lifecycle_service
         .stream_chat(user.user_id.clone(), chat_data.clone())
         .await
@@ -435,14 +437,14 @@ pub(super) async fn dispatch_chat_turn_bridge(
         .forward(
             &bridge_headers,
             prepared.body,
-            state.turn_core_event_writer.clone(),
-            state.turn_tool_event_writer.clone(),
-            state.turn_hook_db_writer.clone(),
-            state.turn_reflection_state_store.clone(),
-            state.turn_reflection_lesson_writer.clone(),
-            state.turn_observer_worker.clone(),
-            state.turn_auxiliary_event_writer.clone(),
-            state.turn_session_activity_writer.clone(),
+            state.turn_persistence.core_event_writer.clone(),
+            state.turn_persistence.tool_event_writer.clone(),
+            state.turn_persistence.hook_db_writer.clone(),
+            state.turn_persistence.reflection_state_store.clone(),
+            state.turn_persistence.reflection_lesson_writer.clone(),
+            state.turn_persistence.observer_worker.clone(),
+            state.turn_persistence.auxiliary_event_writer.clone(),
+            state.turn_persistence.session_activity_writer.clone(),
             Some(client_disconnect),
         )
         .await

--- a/rust/crates/runtime/src/server/completions.rs
+++ b/rust/crates/runtime/src/server/completions.rs
@@ -94,7 +94,7 @@ pub(super) async fn completions_handler(
         astra_services::resolve_reasoning_model(
             &matrixone,
             &state.fernet_encryptor,
-            state.admin_config_service.as_ref(),
+            state.admin.config_service.as_ref(),
             pool_ref,
         )
         .await

--- a/rust/crates/runtime/src/server/delegation_handlers.rs
+++ b/rust/crates/runtime/src/server/delegation_handlers.rs
@@ -15,6 +15,7 @@ pub(super) async fn delegate_run_handler(
     let user = state.auth_service.current_user(&headers).await?;
     // Verify the authenticated user owns this run (IDOR prevention).
     state
+        .execution
         .run_lifecycle_service
         .get_run_status(run_id.clone(), user.user_id)
         .await?;
@@ -64,6 +65,7 @@ pub(super) async fn list_delegations_handler(
 ) -> Result<Json<DelegationListResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
     state
+        .execution
         .run_lifecycle_service
         .get_run_status(run_id.clone(), user.user_id)
         .await?;
@@ -150,6 +152,7 @@ pub(super) async fn pause_delegations_handler(
 ) -> Result<Json<DelegationMutationResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
     state
+        .execution
         .run_lifecycle_service
         .get_run_status(run_id.clone(), user.user_id)
         .await?;
@@ -178,6 +181,7 @@ pub(super) async fn resume_delegations_handler(
 ) -> Result<Json<DelegationMutationResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
     state
+        .execution
         .run_lifecycle_service
         .get_run_status(run_id.clone(), user.user_id)
         .await?;

--- a/rust/crates/runtime/src/server/edge_callback_handlers.rs
+++ b/rust/crates/runtime/src/server/edge_callback_handlers.rs
@@ -277,6 +277,7 @@ pub(super) async fn post_agents_edge_register_handler(
     }
     let edge_id = edge_id_from_headers(&headers);
     let rec = state
+        .execution
         .edge_registry_service
         .register_or_update(
             &user.user_id,
@@ -309,6 +310,7 @@ pub(super) async fn post_agents_edge_heartbeat_handler(
     }
     let edge_id = edge_id_from_headers(&headers);
     state
+        .execution
         .edge_registry_service
         .heartbeat(&user.user_id, &body.edge_agent_id, &edge_id)
         .await

--- a/rust/crates/runtime/src/server/harness_handlers.rs
+++ b/rust/crates/runtime/src/server/harness_handlers.rs
@@ -304,7 +304,7 @@ mod enabled {
         headers: HeaderMap,
         Query(params): Query<AdminListParams>,
     ) -> Result<Json<Vec<ActiveSessionSnapshot>>, (StatusCode, Json<ErrorResponse>)> {
-        state.admin_authorizer.require_admin(&headers).await?;
+        state.admin.authorizer.require_admin(&headers).await?;
         let registry = &state.harness_registry;
         let sessions = registry.active_sessions();
         let result: Vec<ActiveSessionSnapshot> = sessions

--- a/rust/crates/runtime/src/server/llm_trusted_domains_handlers.rs
+++ b/rust/crates/runtime/src/server/llm_trusted_domains_handlers.rs
@@ -14,7 +14,7 @@ pub(super) async fn list_llm_trusted_domains_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<Vec<LlmTrustedDomainRecord>>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
     let records = state
         .llm_trusted_domain_service
         .list_trusted_domains()
@@ -27,7 +27,7 @@ pub(super) async fn upsert_llm_trusted_domain_handler(
     headers: HeaderMap,
     Json(body): Json<LlmTrustedDomainUpsertRequest>,
 ) -> Result<Json<LlmTrustedDomainRecord>, (StatusCode, Json<ErrorResponse>)> {
-    let authenticated = state.admin_authorizer.require_admin(&headers).await?;
+    let authenticated = state.admin.authorizer.require_admin(&headers).await?;
     let request = LlmTrustedDomainUpsertRequestData {
         domain_host: body.domain_host,
         domain_port: body.domain_port,
@@ -46,7 +46,7 @@ pub(super) async fn delete_llm_trusted_domain_handler(
     headers: HeaderMap,
     Path(domain_id): Path<String>,
 ) -> Result<Json<LlmTrustedDomainDeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
     let response = state
         .llm_trusted_domain_service
         .delete_trusted_domain(&domain_id)

--- a/rust/crates/runtime/src/server/mod.rs
+++ b/rust/crates/runtime/src/server/mod.rs
@@ -158,7 +158,7 @@ pub async fn serve(addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
     // Clone the matrix runtime handle before moving `state` into `build_app`
     // so we can drain ingestion + sync sidecars after axum returns.
     let matrix_runtime = state.matrix_cloud_runtime.clone();
-    let run_lifecycle = state.run_lifecycle_service.clone();
+    let run_lifecycle = state.execution.run_lifecycle_service.clone();
 
     axum::serve(listener, build_app(state))
         .with_graceful_shutdown(http_shutdown_signal())

--- a/rust/crates/runtime/src/server/resource_handlers.rs
+++ b/rust/crates/runtime/src/server/resource_handlers.rs
@@ -40,7 +40,7 @@ pub(super) async fn set_resource_limits_handler(
     Path(user_id): Path<String>,
     Json(limits): Json<astra_services::resource_governor::ResourceLimits>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    state.admin_authorizer.require_admin(&headers).await?;
+    state.admin.authorizer.require_admin(&headers).await?;
     state
         .resource_governor
         .set_limits(&user_id, limits.clone())

--- a/rust/crates/runtime/src/server/run_handlers.rs
+++ b/rust/crates/runtime/src/server/run_handlers.rs
@@ -137,6 +137,7 @@ pub(super) async fn get_run_status_handler(
 ) -> Result<Json<RunStatusResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
     let run = state
+        .execution
         .run_lifecycle_service
         .get_run_status(run_id, user.user_id)
         .await?;
@@ -155,6 +156,7 @@ pub(super) async fn stream_run_handler(
     };
 
     match state
+        .execution
         .run_lifecycle_service
         .stream_run_live(run_id.clone(), user.user_id, query.last_index)
         .await
@@ -180,6 +182,7 @@ pub(super) async fn cancel_run_handler(
 ) -> Result<Json<CancelRunResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
     let result = state
+        .execution
         .run_lifecycle_service
         .cancel_run(run_id, user.user_id)
         .await?;
@@ -193,6 +196,7 @@ pub(super) async fn list_runs_handler(
 ) -> Result<Json<RunListResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
     let runs = state
+        .execution
         .run_lifecycle_service
         .list_runs(user.user_id, query.limit, query.offset)
         .await?;
@@ -206,6 +210,7 @@ pub(super) async fn pause_run_handler(
 ) -> Result<Json<RunMutationResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
     let result = state
+        .execution
         .run_lifecycle_service
         .pause_run(run_id, user.user_id)
         .await?;
@@ -219,6 +224,7 @@ pub(super) async fn resume_run_handler(
 ) -> Result<Json<RunMutationResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
     let result = state
+        .execution
         .run_lifecycle_service
         .resume_run(run_id, user.user_id)
         .await?;
@@ -247,6 +253,7 @@ pub(super) async fn submit_run_input_handler(
 ) -> Result<Json<RunInputResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
     let result = state
+        .execution
         .run_lifecycle_service
         .submit_run_input(
             run_id,

--- a/rust/crates/runtime/src/server/state_builder.rs
+++ b/rust/crates/runtime/src/server/state_builder.rs
@@ -352,10 +352,10 @@ pub async fn build_server_state(
     .with_edge_connection_pool(state.edge_connection_pool.clone())
     .with_resource_governor(resource_governor.clone())
     .with_skill_service(state.skill_service.clone())
-    .with_hook_db_writer(state.turn_hook_db_writer.clone())
-    .with_observer_worker(state.turn_observer_worker.clone())
-    .with_tool_event_writer(state.turn_tool_event_writer.clone())
-    .with_auxiliary_event_writer(state.turn_auxiliary_event_writer.clone());
+    .with_hook_db_writer(state.turn_persistence.hook_db_writer.clone())
+    .with_observer_worker(state.turn_persistence.observer_worker.clone())
+    .with_tool_event_writer(state.turn_persistence.tool_event_writer.clone())
+    .with_auxiliary_event_writer(state.turn_persistence.auxiliary_event_writer.clone());
     if let Some(svc) = memory_extraction_service.as_ref() {
         run_lifecycle = run_lifecycle.with_memory_extraction_service(Arc::clone(svc));
     }

--- a/rust/crates/runtime/src/server/task_handlers.rs
+++ b/rust/crates/runtime/src/server/task_handlers.rs
@@ -55,6 +55,7 @@ pub(super) async fn list_tasks_handler(
     let status_filter = query.status.and_then(|s| parse_task_status(&s));
 
     let tasks = state
+        .execution
         .task_service
         .list_tasks(&user.user_id, status_filter)
         .await
@@ -73,6 +74,7 @@ pub(super) async fn get_task_handler(
     let user = state.auth_service.current_user(&headers).await?;
 
     let task = state
+        .execution
         .task_service
         .get_task(&task_id)
         .await
@@ -97,6 +99,7 @@ pub(super) async fn task_progress_handler(
     let user = state.auth_service.current_user(&headers).await?;
 
     let task = state
+        .execution
         .task_service
         .get_task(&task_id)
         .await
@@ -144,12 +147,14 @@ pub(super) async fn create_task_handler(
 
     let session_id = payload.session_id.unwrap_or_default();
     let task_id = state
+        .execution
         .task_service
         .create_task(&user.user_id, &session_id, req)
         .await
         .map_err(|e| error_response(StatusCode::BAD_REQUEST, e))?;
 
     let task = state
+        .execution
         .task_service
         .get_task(&task_id)
         .await
@@ -174,6 +179,7 @@ pub(super) async fn update_task_status_handler(
     let user = state.auth_service.current_user(&headers).await?;
 
     let task = state
+        .execution
         .task_service
         .get_task(&task_id)
         .await
@@ -191,6 +197,7 @@ pub(super) async fn update_task_status_handler(
     })?;
 
     state
+        .execution
         .task_service
         .update_status(&task_id, status)
         .await
@@ -224,6 +231,7 @@ pub(super) async fn get_task_lease_handler(
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
     let task = state
+        .execution
         .task_service
         .get_task(&task_id)
         .await
@@ -234,6 +242,7 @@ pub(super) async fn get_task_lease_handler(
     }
 
     let view = state
+        .execution
         .task_lease_service
         .get_lease(&user.user_id, &task_id)
         .await
@@ -259,6 +268,7 @@ pub(super) async fn post_task_lease_claim_handler(
         ));
     }
     let task = state
+        .execution
         .task_service
         .get_task(&task_id)
         .await
@@ -271,6 +281,7 @@ pub(super) async fn post_task_lease_claim_handler(
     let edge_id = edge_id_header(&headers);
     let ttl = body.ttl_sec.unwrap_or(300);
     let result = state
+        .execution
         .task_lease_service
         .try_claim_lease(&user.user_id, &task_id, &body.edge_agent_id, &edge_id, ttl)
         .await
@@ -295,6 +306,7 @@ pub(super) async fn post_task_lease_release_handler(
         ));
     }
     let task = state
+        .execution
         .task_service
         .get_task(&task_id)
         .await
@@ -305,6 +317,7 @@ pub(super) async fn post_task_lease_release_handler(
     }
 
     let released = state
+        .execution
         .task_lease_service
         .release_lease(&user.user_id, &task_id, &body.edge_agent_id)
         .await
@@ -327,6 +340,7 @@ pub(super) async fn post_task_lease_renew_handler(
         ));
     }
     let task = state
+        .execution
         .task_service
         .get_task(&task_id)
         .await
@@ -339,6 +353,7 @@ pub(super) async fn post_task_lease_renew_handler(
     let edge_id = edge_id_header(&headers);
     let ttl = body.ttl_sec.unwrap_or(300);
     let view = state
+        .execution
         .task_lease_service
         .renew_lease(&user.user_id, &task_id, &body.edge_agent_id, &edge_id, ttl)
         .await
@@ -435,7 +450,7 @@ pub(super) struct TaskRpcResponse {
 
 /// `POST /tasks:rpc` — proxy entry point for `TaskService` trait
 /// methods. CLI's `HttpTaskService` impl posts here; server-side
-/// `state.task_service` (MatrixOneTaskService in production) does
+/// `state.execution.task_service` (MatrixOneTaskService in production) does
 /// the work. Every method scopes to the authenticated user; methods
 /// that take a `task_id` verify ownership before mutating.
 pub(super) async fn task_rpc_handler(
@@ -457,6 +472,7 @@ pub(super) async fn task_rpc_handler(
             .ok_or_else(|| error_response(StatusCode::BAD_REQUEST, "missing 'task_id' in args"))?
             .to_string();
         let task = state
+            .execution
             .task_service
             .get_task(&task_id)
             .await
@@ -480,6 +496,7 @@ pub(super) async fn task_rpc_handler(
             )
             .map_err(|e| error_response(StatusCode::BAD_REQUEST, format!("decode req: {e}")))?;
             let id = state
+                .execution
                 .task_service
                 .create_task(&user.user_id, session_id, create_req)
                 .await
@@ -493,6 +510,7 @@ pub(super) async fn task_rpc_handler(
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| error_response(StatusCode::BAD_REQUEST, "missing 'task_id'"))?;
             let task = state
+                .execution
                 .task_service
                 .get_task(task_id)
                 .await
@@ -514,6 +532,7 @@ pub(super) async fn task_rpc_handler(
                 .and_then(|v| v.as_str())
                 .and_then(parse_task_status);
             let tasks = state
+                .execution
                 .task_service
                 .list_tasks(&user.user_id, status_filter)
                 .await
@@ -534,6 +553,7 @@ pub(super) async fn task_rpc_handler(
                 )
             })?;
             state
+                .execution
                 .task_service
                 .update_status(&task_id, status)
                 .await
@@ -558,6 +578,7 @@ pub(super) async fn task_rpc_handler(
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0) as u32;
             state
+                .execution
                 .task_service
                 .update_progress(&task_id, pct, done, total)
                 .await
@@ -572,6 +593,7 @@ pub(super) async fn task_rpc_handler(
                         error_response(StatusCode::BAD_REQUEST, format!("decode checkpoint: {e}"))
                     })?;
             state
+                .execution
                 .task_service
                 .save_checkpoint(&task_id, &checkpoint)
                 .await
@@ -585,6 +607,7 @@ pub(super) async fn task_rpc_handler(
             )
             .map_err(|e| error_response(StatusCode::BAD_REQUEST, format!("decode plan: {e}")))?;
             state
+                .execution
                 .task_service
                 .update_plan(&task_id, &plan)
                 .await
@@ -599,6 +622,7 @@ pub(super) async fn task_rpc_handler(
                 .and_then(|v| v.as_str())
                 .unwrap_or("(no error message)");
             state
+                .execution
                 .task_service
                 .fail_task(&task_id, error_msg)
                 .await
@@ -608,6 +632,7 @@ pub(super) async fn task_rpc_handler(
         "complete_task" => {
             let task_id = require_owned_task(&state, &user.user_id, &req.args).await?;
             state
+                .execution
                 .task_service
                 .complete_task(&task_id)
                 .await
@@ -637,6 +662,7 @@ pub(super) async fn task_rpc_handler(
                         error_response(StatusCode::BAD_REQUEST, format!("decode outcome: {e}"))
                     })?;
             state
+                .execution
                 .task_service
                 .complete_plan_run(&task_id, pct, done, total, outcome)
                 .await
@@ -657,6 +683,7 @@ pub(super) async fn task_rpc_handler(
                 .and_then(|v| v.as_i64())
                 .map(|i| i as i32);
             state
+                .execution
                 .task_service
                 .record_feedback(&task_id, rating, outcome, completion_time_sec)
                 .await
@@ -666,6 +693,7 @@ pub(super) async fn task_rpc_handler(
         "increment_replan_count" => {
             let task_id = require_owned_task(&state, &user.user_id, &req.args).await?;
             state
+                .execution
                 .task_service
                 .increment_replan_count(&task_id)
                 .await
@@ -680,6 +708,7 @@ pub(super) async fn task_rpc_handler(
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
             let template_id = state
+                .execution
                 .task_service
                 .extract_template(&task_id, goal_pattern)
                 .await
@@ -698,6 +727,7 @@ pub(super) async fn task_rpc_handler(
             let project_type = req.args.get("project_type").and_then(|v| v.as_str());
             let limit = req.args.get("limit").and_then(|v| v.as_u64()).unwrap_or(5) as usize;
             let recs = state
+                .execution
                 .task_service
                 .recommend_templates(&user.user_id, goal, project_type, limit)
                 .await
@@ -711,6 +741,7 @@ pub(super) async fn task_rpc_handler(
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| error_response(StatusCode::BAD_REQUEST, "missing 'goal_pattern'"))?;
             let stats = state
+                .execution
                 .task_service
                 .get_learning_stats(&user.user_id, goal_pattern)
                 .await
@@ -727,6 +758,7 @@ pub(super) async fn task_rpc_handler(
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| error_response(StatusCode::BAD_REQUEST, "missing 'template_id'"))?;
             state
+                .execution
                 .task_service
                 .record_template_usage(template_id)
                 .await

--- a/rust/crates/runtime/src/server/ws_handler.rs
+++ b/rust/crates/runtime/src/server/ws_handler.rs
@@ -705,6 +705,7 @@ async fn handle_chat_message(
 
     // Try RunLifecycleService first (server-side agentic loop)
     match state
+        .execution
         .run_lifecycle_service
         .create_run(conn.user.user_id.clone(), request)
         .await
@@ -747,6 +748,7 @@ async fn handle_cancel_run(
     run_id: &str,
 ) {
     match state
+        .execution
         .run_lifecycle_service
         .cancel_run(run_id.to_string(), conn.user.user_id.clone())
         .await
@@ -768,6 +770,7 @@ async fn handle_pause_run(
     emit_ack: bool,
 ) {
     match state
+        .execution
         .run_lifecycle_service
         .pause_run(run_id.to_string(), conn.user.user_id.clone())
         .await
@@ -797,6 +800,7 @@ async fn handle_resume_run(
     emit_ack: bool,
 ) {
     match state
+        .execution
         .run_lifecycle_service
         .resume_run(run_id.to_string(), conn.user.user_id.clone())
         .await
@@ -1180,6 +1184,7 @@ fn lifecycle_events_to_ws_payloads(
 
 async fn best_effort_cancel_run(state: &AppState, conn: &WsConnection, run_id: &str) {
     let _ = state
+        .execution
         .run_lifecycle_service
         .cancel_run(run_id.to_string(), conn.user.user_id.clone())
         .await;
@@ -1332,6 +1337,7 @@ async fn stream_run_over_websocket(
             _ = poll.tick() => {
                 // ── Phase E: Forward pending approval requests to client ──
                 for req in state
+                    .execution
                     .run_lifecycle_service
                     .drain_approval_requests(run_id)
                     .await
@@ -1354,6 +1360,7 @@ async fn stream_run_over_websocket(
                 }
 
                 for req in state
+                    .execution
                     .run_lifecycle_service
                     .drain_user_prompt_requests(run_id)
                     .await
@@ -1384,6 +1391,7 @@ async fn stream_run_over_websocket(
 
                 // ── Phase F.3: Forward pending progress events to client ──
                 for evt in state
+                    .execution
                     .run_lifecycle_service
                     .drain_progress_events(run_id)
                     .await
@@ -1469,6 +1477,7 @@ async fn stream_run_over_websocket(
                 }
 
                 let events = match state
+                    .execution
                     .run_lifecycle_service
                     .stream_run(run_id.to_string(), conn.user.user_id.clone(), last_index)
                     .await
@@ -1577,6 +1586,7 @@ async fn stream_run_over_websocket(
                 }
 
                 let status = match state
+                    .execution
                     .run_lifecycle_service
                     .get_run_status(run_id.to_string(), conn.user.user_id.clone())
                     .await

--- a/rust/crates/runtime/tests/bridge_e2e_comprehensive.rs
+++ b/rust/crates/runtime/tests/bridge_e2e_comprehensive.rs
@@ -13,18 +13,20 @@
 //! cargo test -p astra-runtime --test bridge_e2e_comprehensive --features bridge-e2e-hooks
 //! ```
 
+mod test_support;
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use astra_runtime::{
     AppState, AuthLoginRequestData, AuthRefreshRequestData, AuthRegisterRequestData, AuthService,
-    AuthTokenRecord, AuthUserRecord, ErrorResponse, FernetTokenEncryptor, HealthChecker,
-    MatrixOneSettings, PERSIST_FAIL_COUNT, PERSIST_OK_COUNT, ServiceInfo, SessionActivityRecord,
-    SessionActivityUpdatePlan, SessionCreateRequestData, SessionListFilter, SessionListRecord,
-    SessionRecord, SessionService, SessionUpdateRequestData, TurnAuxiliaryEventRecord,
-    TurnAuxiliaryEventWriter, TurnCoreEventWriter, TurnCorePersistOutcome, TurnCorePersistPlan,
-    TurnHookDbPersistPlan, TurnHookDbWriter, TurnSessionActivityWriter, TurnToolEventPersistPlan,
-    TurnToolEventWriter, build_app, turn::bridge_inprocess::InProcessChatTurnBridge,
+    AuthTokenRecord, AuthUserRecord, ErrorResponse, HealthChecker, PERSIST_FAIL_COUNT,
+    PERSIST_OK_COUNT, ServiceInfo, SessionActivityRecord, SessionActivityUpdatePlan,
+    SessionCreateRequestData, SessionListFilter, SessionListRecord, SessionRecord, SessionService,
+    SessionUpdateRequestData, TurnAuxiliaryEventRecord, TurnAuxiliaryEventWriter,
+    TurnCoreEventWriter, TurnCorePersistOutcome, TurnCorePersistPlan, TurnHookDbPersistPlan,
+    TurnHookDbWriter, TurnSessionActivityWriter, TurnToolEventPersistPlan, TurnToolEventWriter,
+    build_app, turn::bridge_inprocess::InProcessChatTurnBridge,
 };
 use astra_services::session_journal::{JournalEventType, journal_file_path, read_journal};
 use async_trait::async_trait;
@@ -36,6 +38,10 @@ use axum::{
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 use tower::util::ServiceExt;
+
+use crate::test_support::{
+    parse_sse_events, test_fernet_encryptor, test_matrixone_settings, tool_call, tool_schema,
+};
 
 // ── Env setup ────────────────────────────────────────────────────────────────
 
@@ -343,8 +349,6 @@ impl TurnHookDbWriter for CapHookWriter {
 // ── App builder ──────────────────────────────────────────────────────────────
 
 fn build_test_app(cap: AllCaptures) -> Router {
-    let enc =
-        Arc::new(FernetTokenEncryptor::new("comp-e2e-fernet-key-32chars!").expect("fernet key"));
     let base = AppState::new(ServiceInfo::default(), Arc::new(StubHealth))
         .with_auth_service(Arc::new(StubAuth))
         .with_session_service(Arc::new(StubSession))
@@ -354,14 +358,8 @@ fn build_test_app(cap: AllCaptures) -> Router {
         .with_turn_session_activity_writer(Arc::new(CapActivityWriter(cap.clone())))
         .with_turn_hook_db_writer(Arc::new(CapHookWriter(cap)));
     let bridge = InProcessChatTurnBridge::new(
-        MatrixOneSettings {
-            host: "127.0.0.1".into(),
-            port: 0,
-            user: "x".into(),
-            password: "x".into(),
-            database: "x".into(),
-        },
-        enc,
+        test_matrixone_settings(),
+        test_fernet_encryptor("comp-e2e-fernet-key-32chars!"),
     )
     .with_edge_callback_ledger(base.edge_callback_ledger());
     let state = base
@@ -371,31 +369,6 @@ fn build_test_app(cap: AllCaptures) -> Router {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-fn tool_schema(name: &str) -> Value {
-    json!({
-        "type": "function",
-        "function": {
-            "name": name,
-            "description": format!("{name} tool"),
-            "parameters": {
-                "type": "object",
-                "properties": { "path": { "type": "string" } }
-            }
-        }
-    })
-}
-
-fn tool_call(id: &str, name: &str, args: Value) -> Value {
-    json!({
-        "id": id,
-        "type": "function",
-        "function": {
-            "name": name,
-            "arguments": serde_json::to_string(&args).unwrap()
-        }
-    })
-}
 
 async fn chat_turn(app: &Router, payload: Value) -> (StatusCode, String) {
     let req = Request::builder()
@@ -445,13 +418,6 @@ async fn chat_turn_no_secret(app: &Router, payload: Value) -> (StatusCode, Strin
         .await
         .unwrap();
     (st, String::from_utf8_lossy(&bytes).into_owned())
-}
-
-fn parse_sse_events(raw: &str) -> Vec<Value> {
-    raw.lines()
-        .filter_map(|line| line.strip_prefix("data: "))
-        .filter_map(|data| serde_json::from_str(data).ok())
-        .collect()
 }
 
 fn events_of_type<'a>(events: &'a [Value], ty: &str) -> Vec<&'a Value> {
@@ -3694,8 +3660,6 @@ async fn session_id_persisted_in_core_events_matches_created_session() {
 async fn unhappy_core_persist_failure_still_completes_sse() {
     init_env();
     let cap = AllCaptures::default();
-    let enc =
-        Arc::new(FernetTokenEncryptor::new("comp-e2e-fernet-key-32chars!").expect("fernet key"));
 
     // Build app with a FAILING core writer
     let base = AppState::new(ServiceInfo::default(), Arc::new(StubHealth))
@@ -3707,14 +3671,8 @@ async fn unhappy_core_persist_failure_still_completes_sse() {
         .with_turn_session_activity_writer(Arc::new(CapActivityWriter(cap.clone())))
         .with_turn_hook_db_writer(Arc::new(CapHookWriter(cap.clone())));
     let bridge = InProcessChatTurnBridge::new(
-        MatrixOneSettings {
-            host: "127.0.0.1".into(),
-            port: 0,
-            user: "x".into(),
-            password: "x".into(),
-            database: "x".into(),
-        },
-        enc,
+        test_matrixone_settings(),
+        test_fernet_encryptor("comp-e2e-fernet-key-32chars!"),
     )
     .with_edge_callback_ledger(base.edge_callback_ledger());
     let app = build_app(
@@ -3756,8 +3714,6 @@ async fn unhappy_core_persist_failure_still_completes_sse() {
 async fn unhappy_tool_persist_failure_core_still_persists() {
     init_env();
     let cap = AllCaptures::default();
-    let enc =
-        Arc::new(FernetTokenEncryptor::new("comp-e2e-fernet-key-32chars!").expect("fernet key"));
 
     let base = AppState::new(ServiceInfo::default(), Arc::new(StubHealth))
         .with_auth_service(Arc::new(StubAuth))
@@ -3768,14 +3724,8 @@ async fn unhappy_tool_persist_failure_core_still_persists() {
         .with_turn_session_activity_writer(Arc::new(CapActivityWriter(cap.clone())))
         .with_turn_hook_db_writer(Arc::new(CapHookWriter(cap.clone())));
     let bridge = InProcessChatTurnBridge::new(
-        MatrixOneSettings {
-            host: "127.0.0.1".into(),
-            port: 0,
-            user: "x".into(),
-            password: "x".into(),
-            database: "x".into(),
-        },
-        enc,
+        test_matrixone_settings(),
+        test_fernet_encryptor("comp-e2e-fernet-key-32chars!"),
     )
     .with_edge_callback_ledger(base.edge_callback_ledger());
     let app = build_app(
@@ -3854,8 +3804,6 @@ async fn unhappy_empty_content_both_sides_no_persist() {
 async fn unhappy_activity_writer_failure() {
     init_env();
     let cap = AllCaptures::default();
-    let enc =
-        Arc::new(FernetTokenEncryptor::new("comp-e2e-fernet-key-32chars!").expect("fernet key"));
 
     let base = AppState::new(ServiceInfo::default(), Arc::new(StubHealth))
         .with_auth_service(Arc::new(StubAuth))
@@ -3866,14 +3814,8 @@ async fn unhappy_activity_writer_failure() {
         .with_turn_session_activity_writer(Arc::new(FailActivityWriter))
         .with_turn_hook_db_writer(Arc::new(CapHookWriter(cap.clone())));
     let bridge = InProcessChatTurnBridge::new(
-        MatrixOneSettings {
-            host: "127.0.0.1".into(),
-            port: 0,
-            user: "x".into(),
-            password: "x".into(),
-            database: "x".into(),
-        },
-        enc,
+        test_matrixone_settings(),
+        test_fernet_encryptor("comp-e2e-fernet-key-32chars!"),
     )
     .with_edge_callback_ledger(base.edge_callback_ledger());
     let app = build_app(

--- a/rust/crates/runtime/tests/e2e_joint.rs
+++ b/rust/crates/runtime/tests/e2e_joint.rs
@@ -1,3 +1,5 @@
+mod test_support;
+
 use std::{collections::BTreeSet, net::SocketAddr, sync::Arc, time::Duration};
 
 use astra_core::SharedPool;
@@ -22,6 +24,7 @@ use axum::{Json, Router, http::HeaderMap, http::StatusCode};
 use reqwest::Client;
 use serde_json::{Value, json};
 use sqlx::Row;
+use test_support::parse_sse_events;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -532,13 +535,6 @@ fn local_client() -> Client {
         .no_proxy()
         .build()
         .expect("reqwest Client::builder().no_proxy() must build")
-}
-
-fn parse_sse_events(body: &str) -> Vec<Value> {
-    body.lines()
-        .filter_map(|line| line.strip_prefix("data: "))
-        .filter_map(|json| serde_json::from_str::<Value>(json).ok())
-        .collect()
 }
 
 async fn get_stream(

--- a/rust/crates/runtime/tests/edge_cloud_round_trip_e2e.rs
+++ b/rust/crates/runtime/tests/edge_cloud_round_trip_e2e.rs
@@ -9,6 +9,8 @@
 //! cargo test -p astra-runtime --test edge_cloud_round_trip_e2e --features bridge-e2e-hooks
 //! ```
 
+mod test_support;
+
 use std::sync::{Arc, OnceLock};
 
 use astra_runtime::{
@@ -26,6 +28,7 @@ use axum::{
     http::{HeaderMap, Request, StatusCode},
 };
 use serde_json::{Value, json};
+use test_support::{parse_sse_events, tool_call};
 use tokio::sync::Mutex;
 use tower::util::ServiceExt;
 
@@ -195,10 +198,6 @@ fn tool_schema(name: &str) -> Value {
     json!({ "type": "function", "function": { "name": name, "description": name, "parameters": { "type": "object", "properties": { "path": { "type": "string" }, "command": { "type": "string" }, "content": { "type": "string" }, "old_str": { "type": "string" }, "new_str": { "type": "string" } } } } })
 }
 
-fn tool_call(id: &str, name: &str, args: Value) -> Value {
-    json!({ "id": id, "type": "function", "function": { "name": name, "arguments": serde_json::to_string(&args).unwrap() } })
-}
-
 fn build_app_with_capture(capture: Capture) -> Router {
     let enc = Arc::new(FernetTokenEncryptor::new("rt-e2e-fernet-key-32chars!!").expect("fernet"));
     let base = AppState::new(ServiceInfo::default(), Arc::new(StubHealth))
@@ -237,13 +236,6 @@ async fn chat_turn(app: &Router, payload: Value) -> (StatusCode, Vec<u8>) {
         .await
         .unwrap();
     (st, bytes.to_vec())
-}
-
-fn parse_sse_events(raw: &str) -> Vec<Value> {
-    raw.lines()
-        .filter_map(|line| line.strip_prefix("data: "))
-        .filter_map(|data| serde_json::from_str(data).ok())
-        .collect()
 }
 
 fn events_of_type<'a>(events: &'a [Value], ty: &str) -> Vec<&'a Value> {

--- a/rust/crates/runtime/tests/phase1_run_durability.rs
+++ b/rust/crates/runtime/tests/phase1_run_durability.rs
@@ -1,3 +1,5 @@
+mod test_support;
+
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -22,6 +24,7 @@ use axum::{
 };
 use serde_json::{Value, json};
 use sqlx::Row;
+use test_support::parse_sse_events;
 use tokio::sync::RwLock;
 use tower::util::ServiceExt;
 use uuid::Uuid;
@@ -474,13 +477,6 @@ fn build_phase1_http_app(
         .with_session_service(Arc::new(Phase1HttpSession { user_id }))
         .with_run_lifecycle_service(Arc::new(Phase1HttpRunLifecycle { store }));
     build_app(state)
-}
-
-fn parse_sse_events(body: &str) -> Vec<Value> {
-    body.lines()
-        .filter_map(|line| line.strip_prefix("data: "))
-        .filter_map(|json| serde_json::from_str::<Value>(json).ok())
-        .collect()
 }
 
 async fn http_get_run_stream(app: &Router, run_id: &str, last_index: u32) -> Vec<Value> {

--- a/rust/crates/runtime/tests/runtime_refactor_guardrails.rs
+++ b/rust/crates/runtime/tests/runtime_refactor_guardrails.rs
@@ -1,0 +1,107 @@
+mod test_support;
+
+use std::sync::Arc;
+
+use astra_runtime::{AppState, HealthChecker, ServiceInfo, build_app, build_test_router};
+use async_trait::async_trait;
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+};
+use tower::util::ServiceExt;
+
+#[derive(Clone)]
+struct AlwaysHealthy;
+
+#[async_trait]
+impl HealthChecker for AlwaysHealthy {
+    async fn database_healthy(&self) -> bool {
+        true
+    }
+}
+
+fn build_guardrail_state() -> AppState {
+    AppState::new(ServiceInfo::default(), Arc::new(AlwaysHealthy))
+        .with_auth_service(Arc::new(astra_services::auth::StubAuthService))
+}
+
+async fn request_status(router: Router, request: Request<Body>) -> StatusCode {
+    router.oneshot(request).await.unwrap().status()
+}
+
+fn request(method: &str, path: &str, headers: &[(&str, &str)], body: Body) -> Request<Body> {
+    let mut builder = Request::builder().method(method).uri(path);
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    builder.body(body).unwrap()
+}
+
+#[tokio::test]
+async fn build_app_keeps_core_http_and_websocket_surfaces_registered() {
+    let app = build_app(build_guardrail_state());
+
+    let root = request_status(app.clone(), request("GET", "/", &[], Body::empty())).await;
+    assert_eq!(root, StatusCode::OK);
+
+    let health = request_status(app.clone(), request("GET", "/health", &[], Body::empty())).await;
+    assert_eq!(health, StatusCode::OK);
+
+    let metrics = request_status(app.clone(), request("GET", "/metrics", &[], Body::empty())).await;
+    assert_eq!(metrics, StatusCode::OK);
+
+    let chat_ws = request_status(app.clone(), request("GET", "/chat/ws", &[], Body::empty())).await;
+    assert_ne!(chat_ws, StatusCode::NOT_FOUND);
+
+    let edge_ws = request_status(app.clone(), request("GET", "/edge/ws", &[], Body::empty())).await;
+    assert_ne!(edge_ws, StatusCode::NOT_FOUND);
+
+    let chat_stream = request_status(
+        app.clone(),
+        request(
+            "POST",
+            "/chat/stream",
+            &[
+                ("authorization", "Bearer test-token"),
+                ("content-type", "application/json"),
+            ],
+            Body::from("{}"),
+        ),
+    )
+    .await;
+    assert_ne!(chat_stream, StatusCode::NOT_FOUND);
+
+    let chat_turn = request_status(
+        app,
+        request(
+            "POST",
+            "/chat/turn",
+            &[
+                ("authorization", "Bearer test-token"),
+                ("content-type", "application/json"),
+                ("x-mo-bridge-test-secret", "guardrail-secret"),
+            ],
+            Body::from("{}"),
+        ),
+    )
+    .await;
+    assert_ne!(chat_turn, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn build_test_router_keeps_core_routes_reachable_for_oneshot_tests() {
+    let app = build_test_router(build_guardrail_state());
+
+    let root = request_status(app.clone(), request("GET", "/", &[], Body::empty())).await;
+    assert_eq!(root, StatusCode::OK);
+
+    let health = request_status(app.clone(), request("GET", "/health", &[], Body::empty())).await;
+    assert_eq!(health, StatusCode::OK);
+
+    let chat_ws = request_status(app.clone(), request("GET", "/chat/ws", &[], Body::empty())).await;
+    assert_ne!(chat_ws, StatusCode::NOT_FOUND);
+
+    let edge_ws = request_status(app, request("GET", "/edge/ws", &[], Body::empty())).await;
+    assert_ne!(edge_ws, StatusCode::NOT_FOUND);
+}

--- a/rust/crates/runtime/tests/test_support.rs
+++ b/rust/crates/runtime/tests/test_support.rs
@@ -1,0 +1,61 @@
+#![allow(dead_code)]
+
+use std::{collections::HashMap, sync::Arc};
+
+use astra_runtime::{AgenticRunLifecycleService, FernetTokenEncryptor, MatrixOneSettings};
+use serde_json::{Value, json};
+
+pub type EdgeCallbackLedger = Arc<tokio::sync::Mutex<HashMap<String, Value>>>;
+
+pub fn test_fernet_encryptor(key: &str) -> Arc<FernetTokenEncryptor> {
+    Arc::new(FernetTokenEncryptor::new(key).expect("fernet key"))
+}
+
+pub fn test_matrixone_settings() -> MatrixOneSettings {
+    MatrixOneSettings {
+        host: "127.0.0.1".into(),
+        port: 0,
+        user: "x".into(),
+        password: "x".into(),
+        database: "x".into(),
+    }
+}
+
+pub fn test_run_lifecycle(
+    encryptor: Arc<FernetTokenEncryptor>,
+    ledger: EdgeCallbackLedger,
+) -> AgenticRunLifecycleService {
+    AgenticRunLifecycleService::new(test_matrixone_settings(), encryptor, ledger)
+}
+
+pub fn tool_call(id: &str, name: &str, args: Value) -> Value {
+    json!({
+        "id": id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": serde_json::to_string(&args).unwrap()
+        }
+    })
+}
+
+pub fn tool_schema(name: &str) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": format!("{name} tool"),
+            "parameters": {
+                "type": "object",
+                "properties": { "path": { "type": "string" } }
+            }
+        }
+    })
+}
+
+pub fn parse_sse_events(body: &str) -> Vec<Value> {
+    body.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter_map(|data| serde_json::from_str(data).ok())
+        .collect()
+}

--- a/rust/crates/runtime/tests/web_agent_e2e.rs
+++ b/rust/crates/runtime/tests/web_agent_e2e.rs
@@ -8,17 +8,19 @@
 //! cargo test -p astra-runtime --test web_agent_e2e --features bridge-e2e-hooks
 //! ```
 
+mod test_support;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
 use astra_runtime::{
-    AgenticRunLifecycleService, AppState, AuthLoginRequestData, AuthRefreshRequestData,
-    AuthRegisterRequestData, AuthService, AuthTokenRecord, AuthUserRecord, ErrorResponse,
-    FernetTokenEncryptor, HealthChecker, MatrixOneSettings, ServiceInfo, SessionActivityRecord,
-    SessionCreateRequestData, SessionListFilter, SessionListRecord, SessionRecord, SessionService,
-    SessionUpdateRequestData, TurnHookDbPersistPlan, TurnHookDbWriter, TurnObserverRequest,
-    TurnObserverWorker, TurnToolEventPersistPlan, TurnToolEventWriter, build_app,
+    AppState, AuthLoginRequestData, AuthRefreshRequestData, AuthRegisterRequestData, AuthService,
+    AuthTokenRecord, AuthUserRecord, ErrorResponse, HealthChecker, ServiceInfo,
+    SessionActivityRecord, SessionCreateRequestData, SessionListFilter, SessionListRecord,
+    SessionRecord, SessionService, SessionUpdateRequestData, TurnHookDbPersistPlan,
+    TurnHookDbWriter, TurnObserverRequest, TurnObserverWorker, TurnToolEventPersistPlan,
+    TurnToolEventWriter, build_app,
 };
 use astra_services::skills::{
     SkillInfoRecord, SkillListItem, SkillListRecord, SkillPublishRequestData, SkillRecord,
@@ -33,6 +35,10 @@ use axum::{
 use futures_util::StreamExt;
 use serde_json::{Value, json};
 use tower::util::ServiceExt;
+
+use crate::test_support::{
+    parse_sse_events, test_fernet_encryptor, test_run_lifecycle, tool_call, tool_schema,
+};
 
 // ── Env setup ────────────────────────────────────────────────────────────────
 
@@ -351,23 +357,14 @@ impl SkillService for TestSkillService {
 // ── App builder ──────────────────────────────────────────────────────────────
 
 fn build_test_app() -> (Router, Arc<tokio::sync::Mutex<HashMap<String, Value>>>) {
-    let enc =
-        Arc::new(FernetTokenEncryptor::new("web-e2e-fernet-key-32-chars!!!").expect("fernet key"));
     let base = AppState::new(ServiceInfo::default(), Arc::new(StubHealth))
         .with_auth_service(Arc::new(StubAuth))
         .with_session_service(Arc::new(StubSession));
 
     let ledger = base.edge_callback_ledger();
 
-    let lifecycle = AgenticRunLifecycleService::new(
-        MatrixOneSettings {
-            host: "127.0.0.1".into(),
-            port: 0,
-            user: "x".into(),
-            password: "x".into(),
-            database: "x".into(),
-        },
-        enc,
+    let lifecycle = test_run_lifecycle(
+        test_fernet_encryptor("web-e2e-fernet-key-32-chars!!!"),
         ledger.clone(),
     );
 
@@ -383,8 +380,6 @@ fn build_test_app_with_hooks() -> (
     Arc<RecordingToolEventWriter>,
 ) {
     init_env();
-    let enc =
-        Arc::new(FernetTokenEncryptor::new("web-e2e-fernet-key-32-chars!!!").expect("fernet key"));
     let base = AppState::new(ServiceInfo::default(), Arc::new(StubHealth))
         .with_auth_service(Arc::new(StubAuth))
         .with_session_service(Arc::new(StubSession));
@@ -394,15 +389,8 @@ fn build_test_app_with_hooks() -> (
     let observer_worker = Arc::new(RecordingObserverWorker::default());
     let tool_event_writer = Arc::new(RecordingToolEventWriter::default());
 
-    let lifecycle = AgenticRunLifecycleService::new(
-        MatrixOneSettings {
-            host: "127.0.0.1".into(),
-            port: 0,
-            user: "x".into(),
-            password: "x".into(),
-            database: "x".into(),
-        },
-        enc,
+    let lifecycle = test_run_lifecycle(
+        test_fernet_encryptor("web-e2e-fernet-key-32-chars!!!"),
         ledger,
     )
     .with_hook_db_writer(hook_writer.clone())
@@ -425,8 +413,6 @@ fn build_test_app_with_hooks_and_skills() -> (
     Arc<RecordingToolEventWriter>,
 ) {
     init_env();
-    let enc =
-        Arc::new(FernetTokenEncryptor::new("web-e2e-fernet-key-32-chars!!!").expect("fernet key"));
     let base = AppState::new(ServiceInfo::default(), Arc::new(StubHealth))
         .with_auth_service(Arc::new(StubAuth))
         .with_session_service(Arc::new(StubSession));
@@ -436,15 +422,8 @@ fn build_test_app_with_hooks_and_skills() -> (
     let observer_worker = Arc::new(RecordingObserverWorker::default());
     let tool_event_writer = Arc::new(RecordingToolEventWriter::default());
 
-    let lifecycle = AgenticRunLifecycleService::new(
-        MatrixOneSettings {
-            host: "127.0.0.1".into(),
-            port: 0,
-            user: "x".into(),
-            password: "x".into(),
-            database: "x".into(),
-        },
-        enc,
+    let lifecycle = test_run_lifecycle(
+        test_fernet_encryptor("web-e2e-fernet-key-32-chars!!!"),
         ledger,
     )
     .with_skill_service(Arc::new(TestSkillService))
@@ -462,33 +441,6 @@ fn build_test_app_with_hooks_and_skills() -> (
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-#[allow(dead_code)]
-fn tool_call(id: &str, name: &str, args: Value) -> Value {
-    json!({
-        "id": id,
-        "type": "function",
-        "function": {
-            "name": name,
-            "arguments": serde_json::to_string(&args).unwrap()
-        }
-    })
-}
-
-#[allow(dead_code)]
-fn tool_schema(name: &str) -> Value {
-    json!({
-        "type": "function",
-        "function": {
-            "name": name,
-            "description": format!("{name} tool"),
-            "parameters": {
-                "type": "object",
-                "properties": { "path": { "type": "string" } }
-            }
-        }
-    })
-}
 
 /// Send a POST /chat/stream request and collect all SSE events from the stream.
 async fn chat_stream_collect(app: &Router, payload: Value) -> Vec<Value> {
@@ -524,14 +476,6 @@ async fn chat_stream_start(app: &Router, payload: Value) -> axum::response::Resp
         .body(Body::from(payload.to_string()))
         .unwrap();
     app.clone().oneshot(req).await.unwrap()
-}
-
-/// Parse SSE events from a body string.
-fn parse_sse_events(body: &str) -> Vec<Value> {
-    body.lines()
-        .filter(|line| line.starts_with("data: "))
-        .filter_map(|line| serde_json::from_str(line.strip_prefix("data: ").unwrap()).ok())
-        .collect()
 }
 
 /// POST /tools/result


### PR DESCRIPTION
## Summary
Bundle app state services into a centralized `AppState` struct to improve state management and reduce boilerplate across handlers.

## Changes
- Centralize `AppState` struct with bundled services (StateReader, StateWriter, StateEventBroadcaster, AuthState)
- Replace individual service fields with unified state accessor pattern
- Add new GuardrailsState in models.rs for guardrails configuration
- Update all handlers to use AppState instead of individual service injection
- Add state_builder.rs to construct AppState from dependencies
- Refactor test support with make_app_state() helper
- Add runtime_refactor_guardrails.rs e2e tests

## Testing
- Existing e2e tests pass (bridge, joint, edge-cloud round trip, phase1 run, web agent)
- New guardrails e2e tests added
