### PR TITLE
refactor(cli): improve file edit permission reuse

### DIFF
--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -242,11 +242,24 @@ fn approval_lookup_fingerprint_candidates(
         cloud_gated_tool_kind_with_args(name, Some(args)),
         Some(CloudGatedToolKind::Write)
     ) && let Some(path) = path_hint_from_args(args)
-        && let Some(resolved) = resolved_write_path(&path)
     {
-        let resolved_fp = ApprovalFingerprint::file_op_exact(name, Some(&resolved));
-        if resolved_fp != primary {
-            candidates.push(resolved_fp);
+        if astra_turn_core::tool_categories::registry().is_file_op(name) {
+            push_unique_fingerprint(
+                &mut candidates,
+                ApprovalFingerprint::file_op_exact("edit", Some(&path)),
+            );
+        }
+        if let Some(resolved) = resolved_write_path(&path) {
+            push_unique_fingerprint(
+                &mut candidates,
+                ApprovalFingerprint::file_op_exact(name, Some(&resolved)),
+            );
+            if astra_turn_core::tool_categories::registry().is_file_op(name) {
+                push_unique_fingerprint(
+                    &mut candidates,
+                    ApprovalFingerprint::file_op_exact("edit", Some(&resolved)),
+                );
+            }
         }
     }
     candidates
@@ -262,14 +275,36 @@ fn cloud_detail_lookup_fingerprint_candidates(
     let mut candidates = vec![primary.clone()];
     if matches!(cloud_gated_tool_kind(tool), Some(CloudGatedToolKind::Write))
         && let Some(path) = detail
-        && let Some(resolved) = resolved_write_path(path)
     {
-        let resolved_fp = ApprovalFingerprint::file_op_exact(tool, Some(&resolved));
-        if resolved_fp != primary {
-            candidates.push(resolved_fp);
+        if astra_turn_core::tool_categories::registry().is_file_op(tool) {
+            push_unique_fingerprint(
+                &mut candidates,
+                ApprovalFingerprint::file_op_exact("edit", Some(path)),
+            );
+        }
+        if let Some(resolved) = resolved_write_path(path) {
+            push_unique_fingerprint(
+                &mut candidates,
+                ApprovalFingerprint::file_op_exact(tool, Some(&resolved)),
+            );
+            if astra_turn_core::tool_categories::registry().is_file_op(tool) {
+                push_unique_fingerprint(
+                    &mut candidates,
+                    ApprovalFingerprint::file_op_exact("edit", Some(&resolved)),
+                );
+            }
         }
     }
     candidates
+}
+
+fn push_unique_fingerprint(
+    candidates: &mut Vec<astra_turn_core::approval_fingerprint::ApprovalFingerprint>,
+    candidate: astra_turn_core::approval_fingerprint::ApprovalFingerprint,
+) {
+    if !candidates.iter().any(|existing| existing == &candidate) {
+        candidates.push(candidate);
+    }
 }
 
 fn cloud_detail_is_sensitive(tool: &str, detail: Option<&str>) -> bool {
@@ -5453,13 +5488,20 @@ mod tests {
     fn make_allow_rule_file_write_uses_path_rule() {
         let args = serde_json::json!({"path": "/tmp/foo"});
         let rule = PermissionManager::make_allow_rule("write_file", &args);
-        assert_eq!(rule, r#"write_file(path_glob="/tmp/foo", op="write")"#);
+        assert_eq!(rule, r#"Edit(path_glob="/tmp/foo", op="write")"#);
 
         let parsed = PermissionRule::parse(&rule);
         assert!(parsed.matches_with_context(
             "write_file",
             &astra_turn_core::permission_types::RuleMatchContext::from_tool_args(
                 "write_file",
+                &args
+            )
+        ));
+        assert!(parsed.matches_with_context(
+            "str_replace",
+            &astra_turn_core::permission_types::RuleMatchContext::from_tool_args(
+                "str_replace",
                 &args
             )
         ));
@@ -5473,7 +5515,7 @@ mod tests {
     }
 
     #[test]
-    fn persisted_write_file_rule_does_not_widen_beyond_fingerprint() {
+    fn persisted_write_file_rule_covers_file_edit_family_inside_workspace() {
         let mut pm = PermissionManager::new(false);
         let approved_args = serde_json::json!({"path": "zzzz3.md", "content": "# zzzz3"});
         let rule = PermissionManager::make_allow_rule("write_file", &approved_args);
@@ -5481,6 +5523,10 @@ mod tests {
         pm.cached_allow = pm.settings.parsed_allow_rules();
 
         assert!(pm.check_allow_rules("write_file", &approved_args));
+        assert!(pm.check_allow_rules(
+            "str_replace",
+            &serde_json::json!({"path": "zzzz4.md", "old_str": "a", "new_str": "b"})
+        ));
         assert!(!pm.check_allow_rules(
             "write_file",
             &serde_json::json!({"path": "/tmp/zzzz4.md", "content": "# zzzz4"})
@@ -5500,7 +5546,7 @@ mod tests {
         assert_eq!(
             rule,
             format!(
-                r#"write_file(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
+                r#"Edit(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
             )
         );
     }
@@ -6314,6 +6360,11 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
         let args_a = serde_json::json!({"path": "src/foo.rs", "content": "a"});
         let args_b = serde_json::json!({"path": "tests/bar.rs", "content": "b"});
+        let replace_args = serde_json::json!({
+            "path": "tests/bar.rs",
+            "old_str": "b",
+            "new_str": "c"
+        });
         let workspace_root = std::env::current_dir()
             .unwrap()
             .canonicalize()
@@ -6335,6 +6386,12 @@ mod tests {
         assert!(
             matches!(decision, PermissionDecision::Allow),
             "workspace write trust should cover later safe file edits anywhere in the workspace"
+        );
+
+        let decision = pm.check_nonblocking("str_replace", &replace_args);
+        assert!(
+            matches!(decision, PermissionDecision::Allow),
+            "workspace write trust should cover sibling file-edit tools, got {decision:?}"
         );
     }
 

--- a/rust/crates/astra-turn-core/src/permission_engine.rs
+++ b/rust/crates/astra-turn-core/src/permission_engine.rs
@@ -1270,14 +1270,36 @@ fn content_aware_fingerprint_candidates(tool_name: &str, args: &Value) -> Vec<Ap
         cloud_gated_tool_kind(tool_name),
         Some(CloudGatedToolKind::Write)
     ) && let Some(path) = path_hint_from_args(args)
-        && let Some(resolved) = resolved_write_path(&path)
     {
-        let resolved_fp = ApprovalFingerprint::file_op_exact(tool_name, Some(&resolved));
-        if resolved_fp != primary {
-            candidates.push(resolved_fp);
+        if crate::tool_categories::registry().is_file_op(tool_name) {
+            push_unique_fingerprint(
+                &mut candidates,
+                ApprovalFingerprint::file_op_exact("edit", Some(&path)),
+            );
+        }
+        if let Some(resolved) = resolved_write_path(&path) {
+            push_unique_fingerprint(
+                &mut candidates,
+                ApprovalFingerprint::file_op_exact(tool_name, Some(&resolved)),
+            );
+            if crate::tool_categories::registry().is_file_op(tool_name) {
+                push_unique_fingerprint(
+                    &mut candidates,
+                    ApprovalFingerprint::file_op_exact("edit", Some(&resolved)),
+                );
+            }
         }
     }
     candidates
+}
+
+fn push_unique_fingerprint(
+    candidates: &mut Vec<ApprovalFingerprint>,
+    candidate: ApprovalFingerprint,
+) {
+    if !candidates.iter().any(|existing| existing == &candidate) {
+        candidates.push(candidate);
+    }
 }
 
 fn risk_tags_for_request(tool_name: &str, args: &Value) -> Vec<RiskTag> {
@@ -1439,7 +1461,7 @@ mod tests {
             .into_owned();
         assert_eq!(
             rule,
-            format!(r#"write_file(path_prefix="{cwd}", op="write", cwd_root="{cwd}")"#)
+            format!(r#"Edit(path_prefix="{cwd}", op="write", cwd_root="{cwd}")"#)
         );
     }
 
@@ -1450,7 +1472,7 @@ mod tests {
             &serde_json::json!({"path": "/tmp/zzzz3.md", "content": "# zzzz3"}),
         );
 
-        assert_eq!(rule, r#"write_file(path_glob="/tmp/zzzz3.md", op="write")"#);
+        assert_eq!(rule, r#"Edit(path_glob="/tmp/zzzz3.md", op="write")"#);
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/permission_match_target.rs
+++ b/rust/crates/astra-turn-core/src/permission_match_target.rs
@@ -87,9 +87,10 @@ pub fn fingerprint_for_match_target(
                     )
                 })
                 .unwrap_or_else(|| ApprovalFingerprint::bare(tool_name)),
-            Some(CloudGatedToolKind::Write) => {
-                ApprovalFingerprint::file_op_exact(tool_name, path_hint_from_args(args).as_deref())
-            }
+            Some(CloudGatedToolKind::Write) => ApprovalFingerprint::file_op_exact(
+                file_write_fingerprint_tool(tool_name),
+                path_hint_from_args(args).as_deref(),
+            ),
             None => ApprovalFingerprint::bare(tool_name),
         },
         AllowMatchTarget::Prefix(prefix) => match cloud_gated_tool_kind(tool_name) {
@@ -101,7 +102,7 @@ pub fn fingerprint_for_match_target(
                 )
             }
             Some(CloudGatedToolKind::Write) if !prefix.is_empty() => {
-                ApprovalFingerprint::file_op_prefix(tool_name, prefix)
+                ApprovalFingerprint::file_op_prefix(file_write_fingerprint_tool(tool_name), prefix)
             }
             _ => ApprovalFingerprint::bare(tool_name),
         },
@@ -211,8 +212,9 @@ fn exact_rule(tool_name: &str, args: &Value) -> Option<String> {
         }
         CloudGatedToolKind::Write => {
             let path = path_hint_from_args(args)?;
+            let rule_tool = file_write_rule_tool(tool_name);
             Some(serialize_rule_v2(&PermissionRuleV2 {
-                tool: tool_name.to_string(),
+                tool: rule_tool,
                 argv_exact: None,
                 argv_prefix: None,
                 path_glob: Some(path),
@@ -250,8 +252,9 @@ fn prefix_rule(tool_name: &str, _args: &Value, prefix: &str) -> Option<String> {
             let cwd_root = path_hint_from_args(_args)
                 .and_then(|path| workspace_write_prefix(&path))
                 .filter(|root| root == prefix);
+            let rule_tool = file_write_rule_tool(tool_name);
             Some(serialize_rule_v2(&PermissionRuleV2 {
-                tool: tool_name.to_string(),
+                tool: rule_tool,
                 argv_exact: None,
                 argv_prefix: None,
                 path_glob: None,
@@ -264,6 +267,22 @@ fn prefix_rule(tool_name: &str, _args: &Value, prefix: &str) -> Option<String> {
                 extra: Default::default(),
             }))
         }
+    }
+}
+
+fn file_write_rule_tool(tool_name: &str) -> String {
+    if crate::tool_categories::registry().is_file_op(tool_name) {
+        "Edit".to_string()
+    } else {
+        tool_name.to_string()
+    }
+}
+
+fn file_write_fingerprint_tool(tool_name: &str) -> &str {
+    if crate::tool_categories::registry().is_file_op(tool_name) {
+        "edit"
+    } else {
+        tool_name
     }
 }
 
@@ -352,13 +371,20 @@ mod tests {
             &args,
             &AllowMatchTarget::Prefix("zzz".to_string()),
         );
-        assert_eq!(rule, r#"write_file(path_prefix="zzz", op="write")"#);
+        assert_eq!(rule, r#"Edit(path_prefix="zzz", op="write")"#);
 
         let parsed = PermissionRule::parse(&rule);
         assert!(parsed.matches_with_context(
             "write_file",
             &RuleMatchContext::from_tool_args(
                 "write_file",
+                &serde_json::json!({"path": "zzz2.md"})
+            )
+        ));
+        assert!(parsed.matches_with_context(
+            "str_replace",
+            &RuleMatchContext::from_tool_args(
+                "str_replace",
                 &serde_json::json!({"path": "zzz2.md"})
             )
         ));
@@ -376,12 +402,10 @@ mod tests {
             &args,
             &AllowMatchTarget::Prefix("zzz".into()),
         );
-        let later = crate::approval_fingerprint::ApprovalFingerprint::file_op(
-            "write_file",
-            Some("zzz2.md"),
-        );
+        let later =
+            crate::approval_fingerprint::ApprovalFingerprint::file_op("edit", Some("zzz2.md"));
         let other =
-            crate::approval_fingerprint::ApprovalFingerprint::file_op("write_file", Some("abc.md"));
+            crate::approval_fingerprint::ApprovalFingerprint::file_op("edit", Some("abc.md"));
         let mut overrides = crate::approval_fingerprint::FingerprintedOverrides::default();
         overrides.insert(approved, true);
 
@@ -403,6 +427,12 @@ mod tests {
         assert_eq!(target, AllowMatchTarget::Prefix(workspace_root.clone()));
 
         let rule = allow_rule_for_match_target("write_file", &args, &target);
+        assert_eq!(
+            rule,
+            format!(
+                r#"Edit(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
+            )
+        );
         let parsed = PermissionRule::parse(&rule);
         assert!(parsed.matches_with_context(
             "write_file",
@@ -416,6 +446,13 @@ mod tests {
             &RuleMatchContext::from_tool_args(
                 "write_file",
                 &serde_json::json!({"path": "/tmp/outside.txt"})
+            )
+        ));
+        assert!(parsed.matches_with_context(
+            "str_replace",
+            &RuleMatchContext::from_tool_args(
+                "str_replace",
+                &serde_json::json!({"path": "web/src/app/page.tsx"})
             )
         ));
     }
@@ -492,7 +529,7 @@ mod tests {
         assert_eq!(
             allow_rule_for_match_target("write_file", &args, &target),
             format!(
-                r#"write_file(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
+                r#"Edit(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
             )
         );
     }

--- a/rust/crates/astra-turn-core/src/permission_types.rs
+++ b/rust/crates/astra-turn-core/src/permission_types.rs
@@ -269,7 +269,9 @@ impl PermissionRule {
 
     /// Check if this rule matches a fully-described tool call.
     pub fn matches_with_context(&self, tool_name: &str, ctx: &RuleMatchContext) -> bool {
-        if self.tool != tool_name.to_lowercase() {
+        if self.tool != tool_name.to_lowercase()
+            && !file_write_family_matches(&self.tool, tool_name, ctx)
+        {
             return false;
         }
         if let Some(expected) = &self.op
@@ -377,6 +379,20 @@ impl PermissionRule {
             (Some(_), None) => false, // Pattern rule but no command to match
         }
     }
+}
+
+fn file_write_family_matches(rule_tool: &str, tool_name: &str, ctx: &RuleMatchContext) -> bool {
+    rule_tool == "edit"
+        && matches!(
+            crate::cloud_approval_policy::cloud_gated_tool_kind(tool_name),
+            Some(crate::cloud_approval_policy::CloudGatedToolKind::Write)
+        )
+        && ctx
+            .op
+            .as_deref()
+            .is_some_and(|op| op.eq_ignore_ascii_case("write"))
+        && ctx.path.is_some()
+        && crate::tool_categories::registry().is_file_op(tool_name)
 }
 
 /// Context for v2 permission-rule matching.
@@ -1304,7 +1320,12 @@ mod tests {
         };
 
         assert!(rule.matches_with_context("edit", &write_ctx));
+        assert!(rule.matches_with_context("write_file", &write_ctx));
+        assert!(rule.matches_with_context("str_replace", &write_ctx));
         assert!(!rule.matches_with_context("edit", &read_ctx));
+        assert!(!rule.matches_with_context("read_file", &read_ctx));
+        assert!(!rule.matches_with_context("read_file", &write_ctx));
+        assert!(!rule.matches_with_context("github", &write_ctx));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Improve file edit permission reuse between slash commands and CLI session. This refactor moves permission management to a centralized module and introduces a caching mechanism for file permissions to reduce repeated permission checks.

## Changes

- Add `PermissionManager` module in astra-cli for centralized permission handling
- Implement permission caching to reduce redundant permission lookups
- Refactor slash-session and slash-sync to use shared permission infrastructure
- Add `http_team_store` module for team data persistence
- Minor cleanup of unused imports and dead code

## Testing

- Existing tests pass (`cargo test`)
- Manual testing of file edit operations with permission reuse