### PR TITLE
feat: Add fork inheritance guardrails

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -276,6 +276,7 @@ pub(crate) async fn stream_chat_sse(
                 agent_id: root_agent_id.to_string(),
                 current_model: p.model.map(str::to_string),
                 recursion_depth: 0,
+                is_fork_child: false,
                 working_dir: project_root.clone(),
                 spawner: spawner.clone(),
                 inherited_permissions: p.perm_manager.inherited_permissions_for_child(false),

--- a/rust/crates/astra-cli/src/cli/slash_agent.rs
+++ b/rust/crates/astra-cli/src/cli/slash_agent.rs
@@ -2307,6 +2307,7 @@ mod tests {
             parent_run_id: "root-run".to_string(),
             parent_agent_id: "main".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             inherited_permissions: None,
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),

--- a/rust/crates/astra-cli/src/edge_tools/agent_spawning.rs
+++ b/rust/crates/astra-cli/src/edge_tools/agent_spawning.rs
@@ -41,6 +41,8 @@ pub struct SpawnAgentContext {
     pub current_model: Option<String>,
     /// Current nested agent/sub-run depth of the agent.
     pub recursion_depth: u8,
+    /// Whether this agent is already a fork child.
+    pub is_fork_child: bool,
     /// Working directory
     pub working_dir: PathBuf,
     /// The spawner instance
@@ -95,6 +97,7 @@ pub async fn handle_spawn_agent_tool(args: &Value, ctx: Option<&SpawnAgentContex
         parent_run_id: ctx.run_id.clone(),
         parent_agent_id: ctx.agent_id.clone(),
         recursion_depth: ctx.recursion_depth,
+        parent_is_fork_child: ctx.is_fork_child,
         working_dir: ctx.working_dir.clone(),
         inherited_permissions: Some(inherited_permissions),
         inherited_skills: ctx.active_skills.clone(),
@@ -552,6 +555,7 @@ mod tests {
             agent_id: "root-agent".into(),
             current_model: current_model.map(str::to_string),
             recursion_depth: 0,
+            is_fork_child: false,
             working_dir: PathBuf::from("."),
             spawner,
             inherited_permissions: InheritedPermissions::auto_approve(),
@@ -636,6 +640,27 @@ mod tests {
 
         assert!(result.contains("\"status\":\"completed\""), "{result}");
         assert_eq!(executor.take_captured_model(), None);
+    }
+
+    #[tokio::test]
+    async fn handle_spawn_agent_tool_rejects_nested_fork_inheritance() {
+        let executor = Arc::new(CapturingModelExecutor::new());
+        let spawner = test_spawner(executor);
+        let mut ctx = test_spawn_context(spawner, Some("claude-test-model"));
+        ctx.is_fork_child = true;
+        let args = json!({
+            "description": "Nested fork",
+            "prompt": "Try to fork again",
+            "inherit_context": {}
+        });
+
+        let result = handle_spawn_agent_tool(&args, Some(&ctx)).await;
+
+        assert!(result.contains("\"status\":\"failed\""), "{result}");
+        assert!(
+            result.contains("Nested fork inheritance"),
+            "nested fork guard error should surface to the model: {result}"
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/astra-turn-core/src/orchestration_spawn_tool.rs
+++ b/rust/crates/astra-turn-core/src/orchestration_spawn_tool.rs
@@ -92,7 +92,11 @@ pub struct SpawnAgentInput {
     /// spec instead of the whole tool call failing with a schema
     /// validation error. Proper JSON objects continue to parse as
     /// before.
-    #[serde(default, deserialize_with = "deserialize_inherit_prefix_lenient")]
+    #[serde(
+        default,
+        alias = "inherit_context",
+        deserialize_with = "deserialize_inherit_prefix_lenient"
+    )]
     pub inherit_prefix: Option<InheritPrefixSpec>,
 
     /// Optional task-complexity hint used to scale the default
@@ -527,6 +531,21 @@ pub fn spawn_agent_schema() -> serde_json::Value {
                                 "default": false
                             }
                         }
+                    },
+                    "inherit_context": {
+                        "type": "object",
+                        "description": "Alias for inherit_prefix. Prefer inherit_prefix in generated calls; accepted for product-facing P0 wording.",
+                        "properties": {
+                            "from_run_id": {
+                                "type": "string",
+                                "description": "Parent run id. Omit to use the caller's run."
+                            },
+                            "required": {
+                                "type": "boolean",
+                                "description": "If true, fail when the prefix is missing or incompatible. Default false.",
+                                "default": false
+                            }
+                        }
                     }
                 },
                 "required": ["description", "prompt"]
@@ -654,7 +673,66 @@ mod tests {
         let schema = spawn_agent_schema();
         let props = &schema["function"]["parameters"]["properties"];
         assert!(props["inherit_prefix"].is_object());
+        assert!(
+            props["inherit_context"].is_object(),
+            "schema must expose the product-facing inherit_context alias"
+        );
         assert!(props["max_output_tokens"].is_object());
+    }
+
+    #[test]
+    fn inherit_context_alias_populates_inherit_prefix() {
+        let json = r#"{
+            "description": "D",
+            "prompt": "P",
+            "inherit_context": {"required": true}
+        }"#;
+        let input: SpawnAgentInput = serde_json::from_str(json).unwrap();
+        let spec = input
+            .inherit_prefix
+            .expect("inherit_context must opt into prefix inheritance");
+        assert!(spec.required);
+        assert_eq!(spec.from_run_id, None);
+    }
+
+    #[test]
+    fn inherit_context_conflicts_with_inherit_prefix() {
+        let err = serde_json::from_str::<SpawnAgentInput>(
+            r#"{
+                "description": "D",
+                "prompt": "P",
+                "inherit_prefix": {"required": false},
+                "inherit_context": {"required": true}
+            }"#,
+        )
+        .expect_err("ambiguous dual inheritance fields must fail");
+        assert!(
+            err.to_string().contains("duplicate field"),
+            "error should reject conflicting inheritance aliases as duplicate fields, got: {err}"
+        );
+    }
+
+    #[test]
+    fn inherit_context_alias_accepts_empty_object_string() {
+        let input: SpawnAgentInput =
+            serde_json::from_str(r#"{"description":"d","prompt":"p","inherit_context":"{}"}"#)
+                .unwrap();
+        let spec = input
+            .inherit_prefix
+            .expect("inherit_context alias should use the same lenient parser");
+        assert_eq!(spec.from_run_id, None);
+        assert!(!spec.required);
+    }
+
+    #[test]
+    fn inherit_context_alias_accepts_null() {
+        let input: SpawnAgentInput =
+            serde_json::from_str(r#"{"description":"d","prompt":"p","inherit_context":null}"#)
+                .unwrap();
+        assert!(
+            input.inherit_prefix.is_none(),
+            "null alias should behave like null inherit_prefix"
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/orchestration/spawner.rs
+++ b/rust/crates/runtime/src/orchestration/spawner.rs
@@ -39,6 +39,11 @@ pub struct SpawnContext {
     pub parent_agent_id: String,
     /// Current nested agent/sub-run depth of the parent.
     pub recursion_depth: u8,
+    /// Whether the parent is itself a fork child. Fork children must
+    /// not request another inherited prefix; their prompt already
+    /// contains an inherited parent prefix, so recursively forking
+    /// would drift from the byte-exact cache chain.
+    pub parent_is_fork_child: bool,
     /// Working directory for the spawned agent.
     pub working_dir: PathBuf,
     /// Permissions inherited from the parent agent.
@@ -447,6 +452,10 @@ impl DynamicAgentSpawner {
         input: SpawnAgentInput,
         context: &SpawnContext,
     ) -> Result<SpawnAgentOutput, SpawnError> {
+        if context.parent_is_fork_child && input.inherit_prefix.is_some() {
+            return Err(SpawnError::NestedForkInheritanceRejected);
+        }
+
         // 1. Validate agent type
         let agent_def = self
             .agent_registry
@@ -1289,6 +1298,12 @@ pub enum SpawnError {
     #[error("Delegation failed: {0}")]
     DelegationFailed(String),
 
+    /// Fork children are allowed to spawn normal children, but not
+    /// another inherit-prefix fork. This mirrors Claude Code's
+    /// `isInForkChild()` guard and prevents recursive cache-key drift.
+    #[error("Nested fork inheritance is not allowed from a fork child")]
+    NestedForkInheritanceRejected,
+
     /// Fired when `inherit_prefix.required=true` but the resolver
     /// could not attach a matching prefix (missing, incompatible,
     /// or feature-disabled). Soft failures (`required=false`)
@@ -1352,11 +1367,26 @@ pub(crate) fn build_inherited_child_prefix(
                 provider: prefix.provider.clone(),
                 prefix_messages: r.messages,
                 frozen_tool_schemas: frozen_tools,
-                expected_cache_read_tokens: 0,
+                expected_cache_read_tokens: estimate_cache_read_tokens(prefix),
             })
         }
         Err(_) => None,
     }
+}
+
+fn estimate_cache_read_tokens(prefix: &astra_turn_core::fork_prefix::ForkPrefix) -> u64 {
+    fn bytes_to_tokens(bytes: usize) -> u64 {
+        // Conservative, provider-neutral approximation: four bytes per
+        // token, rounded up. The probe only needs a nonzero baseline
+        // good enough to distinguish full misses from useful reuse.
+        u64::try_from(bytes.div_ceil(4)).unwrap_or(u64::MAX)
+    }
+
+    // `size_bytes()` is already the canonical serialized prefix region
+    // (system + tools + messages). Re-adding system/tool payload sizes
+    // would double-count those bytes and systematically understate the
+    // observed/expected cache-hit ratio in telemetry.
+    bytes_to_tokens(prefix.size_bytes()).max(1)
 }
 
 /// Build permission summary from spawn context.
@@ -1445,6 +1475,7 @@ mod tests {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "parent".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
             inherited_permissions: None,
             inherited_skills: vec![],
@@ -1468,6 +1499,7 @@ mod tests {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "parent".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
             inherited_permissions: None,
             inherited_skills: vec![],
@@ -1485,6 +1517,7 @@ mod tests {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "parent".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
             inherited_permissions: None,
             inherited_skills: vec![],
@@ -1530,6 +1563,7 @@ mod tests {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "parent".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
             inherited_permissions: None,
             inherited_skills: vec![],
@@ -1575,6 +1609,7 @@ mod tests {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "main".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             inherited_permissions: None,
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
@@ -1753,6 +1788,7 @@ mod tests {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "main".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             inherited_permissions: None,
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
@@ -1796,6 +1832,7 @@ mod tests {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "main".to_string(),
             recursion_depth: 2,
+            parent_is_fork_child: false,
             inherited_permissions: None,
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
@@ -1821,6 +1858,7 @@ mod tests {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "main".to_string(),
             recursion_depth: astra_turn_core::agentic_recursion_guard::MAX_AGENT_RECURSION_DEPTH,
+            parent_is_fork_child: false,
             inherited_permissions: None,
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
@@ -1851,6 +1889,7 @@ mod tests {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "main".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             inherited_permissions: None,
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
@@ -1920,6 +1959,7 @@ mod tests {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "parent".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
             inherited_permissions: None,
             inherited_skills: vec!["review-changes".to_string(), "analyze-session".to_string()],
@@ -1943,6 +1983,7 @@ mod tests {
             parent_run_id: "run-1".to_string(),
             parent_agent_id: "agent-1".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
             inherited_permissions: None,
             inherited_skills: Vec::new(),
@@ -2013,6 +2054,7 @@ mod tests {
             parent_run_id: "root".to_string(),
             parent_agent_id: "root".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
             inherited_permissions: None,
             inherited_skills: vec![],
@@ -2481,6 +2523,7 @@ mod tests {
             parent_run_id: run_id.to_string(),
             parent_agent_id: "parent".to_string(),
             recursion_depth: 0,
+            parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
             inherited_permissions: None,
             inherited_skills: vec![],
@@ -2728,6 +2771,80 @@ mod tests {
             reserialized.as_slice(),
             captured_canonical.as_slice(),
             "re-serialized prefix_messages must equal captured canonical bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn fork_child_cannot_request_nested_prefix_inheritance() {
+        let store: Arc<dyn PrefixCaptureSink> = Arc::new(InMemoryPrefixStore::new());
+        let spawner = DynamicAgentSpawner::new(mock_router()).with_prefix_store(store.clone());
+        capture_parent_for(&*store, "run-fork-parent", TEST_CHILD_MODEL);
+
+        let mut ctx = parent_context("run-fork-parent");
+        ctx.parent_is_fork_child = true;
+
+        let result = spawner.spawn(child_with_inherit(false), &ctx).await;
+        match result {
+            Err(SpawnError::NestedForkInheritanceRejected) => {}
+            other => panic!("expected nested fork inheritance rejection, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fork_child_can_still_spawn_fresh_child_without_inheritance() {
+        let spawner = DynamicAgentSpawner::new(mock_router());
+        let mut ctx = parent_context("run-fork-parent");
+        ctx.parent_is_fork_child = true;
+        let input = SpawnAgentInput {
+            description: "fresh child".into(),
+            prompt: "do unrelated work".into(),
+            agent_type: "explore".into(),
+            ..Default::default()
+        };
+
+        let result = spawner.spawn(input, &ctx).await;
+        assert!(
+            matches!(result, Ok(SpawnAgentOutput::Launched { .. })),
+            "fork children must still be able to spawn ordinary non-inheriting children: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn inherited_prefix_expected_cache_read_tokens_uses_nonzero_estimate() {
+        let store: Arc<dyn PrefixCaptureSink> = Arc::new(InMemoryPrefixStore::new());
+        let exec = Arc::new(CapturingPrefixExecutor::new());
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_prefix_store(store.clone())
+            .with_executor(exec.clone() as Arc<dyn SpawnAgentExecutor>);
+        capture_parent_for(&*store, "run-parent-estimate", TEST_CHILD_MODEL);
+
+        let mut input = child_with_inherit(false);
+        input.run_in_background = false;
+        let _ = spawner
+            .spawn(input, &parent_context("run-parent-estimate"))
+            .await
+            .unwrap();
+
+        let inherited = exec.take_captured().unwrap().unwrap();
+        assert!(
+            inherited.expected_cache_read_tokens > 0,
+            "resolved fork children need a nonzero expected cache-read baseline"
+        );
+    }
+
+    #[test]
+    fn inherited_prefix_expected_cache_read_tokens_matches_canonical_prefix_size() {
+        let store = InMemoryPrefixStore::new();
+        capture_parent_for(&store, "run-parent-estimate-shape", TEST_CHILD_MODEL);
+        let prefix = store
+            .get_prefix("run-parent-estimate-shape")
+            .expect("capture must have persisted");
+
+        let expected = u64::try_from(prefix.size_bytes().div_ceil(4)).unwrap_or(u64::MAX);
+        assert_eq!(
+            estimate_cache_read_tokens(&prefix),
+            expected,
+            "cache-read estimate should be derived from the canonical serialized prefix once"
         );
     }
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

N/A

## What this PR does / why we need it:

Support inherit_context as an alias for inherit_prefix, reject nested fork inheritance from fork children, and estimate inherited cache reads from the canonical prefix size. Also add unhappy-path coverage for alias parsing and fork-child spawn behavior.

## Additional information

5 files changed, 224 insertions(+), 2 deletions(-)