### PR TITLE
feat(tui): OSC 8 terminal hyperlinks, OSC 9 notifications, terminal color query

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_turn.rs
@@ -1827,6 +1827,7 @@ async fn apply_turn_success_async(
     let elapsed = turn_start.elapsed();
     let notif_config = super::notifications::NotificationConfig {
         enabled: state.notifications_enabled,
+        method: state.notification_method,
         min_duration_secs: state.notification_threshold_secs,
     };
     if notif_config.enabled && notif_config.exceeds_threshold(elapsed) {

--- a/rust/crates/astra-cli/src/cli/cloud_sync.rs
+++ b/rust/crates/astra-cli/src/cli/cloud_sync.rs
@@ -123,6 +123,14 @@ pub(super) async fn try_cloud_pull_preferences(state: &mut SessionState) -> Vec<
             pref_keys::NOTIFICATIONS_ENABLED => {
                 state.notifications_enabled = parse_bool_pref(value, true);
             }
+            pref_keys::NOTIFICATION_METHOD => match value.parse() {
+                Ok(method) => state.notification_method = method,
+                Err(err) => tracing::warn!(
+                    value = %value,
+                    error = %err,
+                    "ignoring invalid notification_method preference"
+                ),
+            },
             pref_keys::NOTIFICATION_THRESHOLD_SECS => {
                 if let Ok(n) = value.parse::<u64>() {
                     state.notification_threshold_secs = n;
@@ -164,6 +172,10 @@ pub(super) async fn try_cloud_push_preferences(state: &SessionState) {
         (
             pref_keys::NOTIFICATIONS_ENABLED,
             state.notifications_enabled.to_string(),
+        ),
+        (
+            pref_keys::NOTIFICATION_METHOD,
+            state.notification_method.to_string(),
         ),
         (
             pref_keys::NOTIFICATION_THRESHOLD_SECS,

--- a/rust/crates/astra-cli/src/cli/diff_presenter.rs
+++ b/rust/crates/astra-cli/src/cli/diff_presenter.rs
@@ -10,6 +10,8 @@ use std::process::Command;
 
 use crossterm::style::Stylize;
 
+use crate::terminal_hyperlinks::{osc8_link, sanitize_osc8_component, terminal_hyperlinks_enabled};
+
 /// Max bytes read from `git diff` / `git show` (avoid OOM on huge trees).
 const MAX_DIFF_BYTES: usize = 2_000_000;
 /// Stop rendering after this many lines (tail message points to narrowed `/diff -- <path>`).
@@ -95,6 +97,37 @@ impl TerminalDiffSink {
     }
 }
 
+fn strip_diff_path_prefix(path: &str) -> &str {
+    path.strip_prefix("a/")
+        .or_else(|| path.strip_prefix("b/"))
+        .unwrap_or(path)
+}
+
+fn file_uri_for_diff_path(path: &str) -> String {
+    let clean = sanitize_osc8_component(strip_diff_path_prefix(path));
+    if clean.starts_with('/') {
+        format!("file://{clean}")
+    } else {
+        format!("file://./{clean}")
+    }
+}
+
+fn hyperlink_diff_path_meta(line: &str) -> String {
+    if !terminal_hyperlinks_enabled() {
+        return line.to_string();
+    }
+    for prefix in ["--- ", "+++ "] {
+        if let Some(path) = line.strip_prefix(prefix) {
+            if path == "/dev/null" {
+                return line.to_string();
+            }
+            let link = osc8_link(&file_uri_for_diff_path(path), path);
+            return format!("{prefix}{link}");
+        }
+    }
+    line.to_string()
+}
+
 impl DiffSink for TerminalDiffSink {
     fn header(&mut self, line: &str) {
         if !self.bump() {
@@ -118,7 +151,8 @@ impl DiffSink for TerminalDiffSink {
         if !self.bump() {
             return;
         }
-        let _ = writeln!(io::stdout(), "{}", self.clip(line).dim());
+        let line = hyperlink_diff_path_meta(line);
+        let _ = writeln!(io::stdout(), "{}", self.clip(&line).dim());
     }
 
     fn hunk_header(&mut self, line: &str) {
@@ -581,5 +615,21 @@ diff --git a/y b/y
         assert!(c.0.iter().any(|l| l.starts_with("H:")));
         assert!(c.0.iter().any(|l| l.starts_with("A:+y")));
         assert!(c.0.iter().any(|l| l.starts_with("D:-x")));
+    }
+
+    #[test]
+    fn diff_path_meta_formats_osc8_file_links() {
+        let rendered = hyperlink_diff_path_meta("+++ b/rust/crates/astra-cli/src/main.rs");
+        assert!(rendered.contains("\x1b]8;;file://./rust/crates/astra-cli/src/main.rs\x1b\\"));
+        assert!(rendered.contains("b/rust/crates/astra-cli/src/main.rs"));
+        assert!(rendered.ends_with("\x1b]8;;\x1b\\"));
+    }
+
+    #[test]
+    fn diff_path_meta_sanitizes_controls_and_skips_dev_null() {
+        assert_eq!(hyperlink_diff_path_meta("--- /dev/null"), "--- /dev/null");
+        let rendered = hyperlink_diff_path_meta("+++ b/src/\x1bmain.rs");
+        assert!(!rendered.contains("src/\x1bmain.rs"));
+        assert!(rendered.contains("src/main.rs"));
     }
 }

--- a/rust/crates/astra-cli/src/cli/notifications.rs
+++ b/rust/crates/astra-cli/src/cli/notifications.rs
@@ -4,8 +4,10 @@
 //! focused, sends an OS-level notification to alert them. Supports macOS
 //! (`osascript`), Linux (`notify-send`), and a terminal bell fallback.
 
+use std::io::IsTerminal as _;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{fmt, str::FromStr};
 
 /// Minimum interval between notifications to prevent toast spam.
 const NOTIFICATION_COOLDOWN_SECS: u64 = 30;
@@ -23,6 +25,8 @@ static LAST_NOTIFICATION_AT: AtomicU64 = AtomicU64::new(0);
 pub struct NotificationConfig {
     /// Whether notifications are enabled.
     pub enabled: bool,
+    /// User-selected delivery method.
+    pub method: NotificationMethod,
     /// Minimum task duration (in seconds) before a notification is sent.
     pub min_duration_secs: u64,
 }
@@ -31,6 +35,7 @@ impl Default for NotificationConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            method: NotificationMethod::Auto,
             min_duration_secs: 10,
         }
     }
@@ -43,6 +48,39 @@ impl NotificationConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotificationMethod {
+    Auto,
+    Osc9,
+    Bell,
+    Off,
+}
+
+impl fmt::Display for NotificationMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Auto => f.write_str("auto"),
+            Self::Osc9 => f.write_str("osc9"),
+            Self::Bell => f.write_str("bell"),
+            Self::Off => f.write_str("off"),
+        }
+    }
+}
+
+impl FromStr for NotificationMethod {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "" | "auto" => Ok(Self::Auto),
+            "osc9" | "osc-9" | "terminal" => Ok(Self::Osc9),
+            "bell" | "bel" => Ok(Self::Bell),
+            "off" | "none" | "disabled" | "false" => Ok(Self::Off),
+            other => Err(format!("unknown notification method: {other}")),
+        }
+    }
+}
+
 /// The notification backend to use, determined by the current platform.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NotificationBackend {
@@ -52,27 +90,64 @@ pub enum NotificationBackend {
     Linux,
     /// Fallback: emit the terminal bell character (`\x07`).
     TerminalBell,
+    /// Terminal notification via OSC 9 on stderr.
+    Osc9,
     /// Notifications are disabled by configuration.
     Disabled,
 }
 
 /// Detect the appropriate notification backend for the current platform.
 pub fn detect_backend(config: &NotificationConfig) -> NotificationBackend {
-    if !config.enabled {
+    detect_backend_with(
+        config,
+        current_platform(),
+        which_exists("notify-send"),
+        std::io::stderr().is_terminal(),
+    )
+}
+
+fn current_platform() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else {
+        "other"
+    }
+}
+
+fn detect_backend_with(
+    config: &NotificationConfig,
+    platform: &str,
+    has_notify_send: bool,
+    stderr_is_terminal: bool,
+) -> NotificationBackend {
+    if !config.enabled || config.method == NotificationMethod::Off {
         return NotificationBackend::Disabled;
     }
 
-    if cfg!(target_os = "macos") {
-        NotificationBackend::MacOs
-    } else if cfg!(target_os = "linux") {
-        // Check if notify-send is available
-        if which_exists("notify-send") {
-            NotificationBackend::Linux
-        } else {
-            NotificationBackend::TerminalBell
+    match config.method {
+        NotificationMethod::Osc9 => {
+            if stderr_is_terminal {
+                NotificationBackend::Osc9
+            } else {
+                NotificationBackend::Disabled
+            }
         }
-    } else {
-        NotificationBackend::TerminalBell
+        NotificationMethod::Bell => {
+            if stderr_is_terminal {
+                NotificationBackend::TerminalBell
+            } else {
+                NotificationBackend::Disabled
+            }
+        }
+        NotificationMethod::Off => NotificationBackend::Disabled,
+        NotificationMethod::Auto => match platform {
+            "macos" => NotificationBackend::MacOs,
+            "linux" if has_notify_send => NotificationBackend::Linux,
+            _ if stderr_is_terminal => NotificationBackend::Osc9,
+            _ => NotificationBackend::Disabled,
+        },
     }
 }
 
@@ -193,6 +268,9 @@ async fn send_notification(backend: NotificationBackend, title: &str, body: &str
         NotificationBackend::TerminalBell => {
             send_terminal_bell();
         }
+        NotificationBackend::Osc9 => {
+            send_osc9_notification(title, body);
+        }
         NotificationBackend::Disabled => {}
     }
 }
@@ -227,6 +305,18 @@ fn send_terminal_bell() {
     eprint!("\x07");
 }
 
+fn send_osc9_notification(title: &str, body: &str) {
+    let title = sanitize_terminal_notification(title);
+    let body = sanitize_terminal_notification(body);
+    eprint!("\x1b]9;{title}: {body}\x07");
+}
+
+fn sanitize_terminal_notification(s: &str) -> String {
+    s.chars()
+        .filter(|c| !matches!(*c, '\x1b' | '\x07') && !c.is_control())
+        .collect()
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -239,7 +329,23 @@ mod tests {
     fn test_config_default() {
         let config = NotificationConfig::default();
         assert!(config.enabled);
+        assert_eq!(config.method, NotificationMethod::Auto);
         assert_eq!(config.min_duration_secs, 10);
+    }
+
+    #[test]
+    fn notification_method_roundtrips_and_rejects_unknown() {
+        for (raw, expected) in [
+            ("auto", NotificationMethod::Auto),
+            ("OSC9", NotificationMethod::Osc9),
+            ("bel", NotificationMethod::Bell),
+            ("off", NotificationMethod::Off),
+        ] {
+            let parsed: NotificationMethod = raw.parse().unwrap();
+            assert_eq!(parsed, expected);
+            assert_eq!(parsed.to_string(), expected.to_string());
+        }
+        assert!("native".parse::<NotificationMethod>().is_err());
     }
 
     // ── Duration threshold ──────────────────────────────────────────────
@@ -248,6 +354,7 @@ mod tests {
     fn test_exceeds_threshold_below() {
         let config = NotificationConfig {
             enabled: true,
+            method: NotificationMethod::Auto,
             min_duration_secs: 10,
         };
         assert!(!config.exceeds_threshold(Duration::from_secs(5)));
@@ -257,6 +364,7 @@ mod tests {
     fn test_exceeds_threshold_exact() {
         let config = NotificationConfig {
             enabled: true,
+            method: NotificationMethod::Auto,
             min_duration_secs: 10,
         };
         assert!(config.exceeds_threshold(Duration::from_secs(10)));
@@ -266,6 +374,7 @@ mod tests {
     fn test_exceeds_threshold_above() {
         let config = NotificationConfig {
             enabled: true,
+            method: NotificationMethod::Auto,
             min_duration_secs: 10,
         };
         assert!(config.exceeds_threshold(Duration::from_secs(42)));
@@ -277,20 +386,53 @@ mod tests {
     fn test_detect_backend_disabled() {
         let config = NotificationConfig {
             enabled: false,
+            method: NotificationMethod::Auto,
             min_duration_secs: 10,
         };
         assert_eq!(detect_backend(&config), NotificationBackend::Disabled);
     }
 
     #[test]
-    fn test_detect_backend_enabled_returns_valid_variant() {
+    fn auto_detect_prefers_notify_send_on_linux_and_disables_non_tty_fallback() {
         let config = NotificationConfig {
             enabled: true,
+            method: NotificationMethod::Auto,
             min_duration_secs: 10,
         };
-        let backend = detect_backend(&config);
-        // On any platform, we should get a non-Disabled variant when enabled.
-        assert_ne!(backend, NotificationBackend::Disabled);
+        assert_eq!(
+            detect_backend_with(&config, "linux", true, true),
+            NotificationBackend::Linux
+        );
+        assert_eq!(
+            detect_backend_with(&config, "linux", false, true),
+            NotificationBackend::Osc9
+        );
+        assert_eq!(
+            detect_backend_with(&config, "linux", false, false),
+            NotificationBackend::Disabled
+        );
+    }
+
+    #[test]
+    fn explicit_terminal_methods_require_tty() {
+        let mut config = NotificationConfig {
+            enabled: true,
+            method: NotificationMethod::Osc9,
+            min_duration_secs: 10,
+        };
+        assert_eq!(
+            detect_backend_with(&config, "linux", true, true),
+            NotificationBackend::Osc9
+        );
+        assert_eq!(
+            detect_backend_with(&config, "linux", true, false),
+            NotificationBackend::Disabled
+        );
+        config.method = NotificationMethod::Bell;
+        assert_eq!(
+            detect_backend_with(&config, "linux", true, true),
+            NotificationBackend::TerminalBell
+        );
     }
 
     // ── Message formatting ──────────────────────────────────────────────
@@ -330,6 +472,7 @@ mod tests {
     async fn test_notify_completion_disabled_config_is_noop() {
         let config = NotificationConfig {
             enabled: false,
+            method: NotificationMethod::Auto,
             min_duration_secs: 1,
         };
         // Should return immediately without side effects.
@@ -340,6 +483,7 @@ mod tests {
     async fn test_notify_completion_below_threshold_is_noop() {
         let config = NotificationConfig {
             enabled: true,
+            method: NotificationMethod::Auto,
             min_duration_secs: 60,
         };
         // 5 seconds < 60 threshold — should be a no-op.
@@ -369,6 +513,11 @@ mod tests {
     async fn send_notification_terminal_bell_does_not_panic() {
         // eprint! the bell — no subprocess, no await, just stderr write.
         send_notification(NotificationBackend::TerminalBell, "t", "b").await;
+    }
+
+    #[tokio::test]
+    async fn send_notification_osc9_does_not_panic() {
+        send_notification(NotificationBackend::Osc9, "t\x1b", "b\x07").await;
     }
 
     #[tokio::test]

--- a/rust/crates/astra-cli/src/cli/session_state.rs
+++ b/rust/crates/astra-cli/src/cli/session_state.rs
@@ -119,6 +119,9 @@ pub(crate) struct SessionState {
     /// User preference: send desktop notifications when turns complete.
     /// Synced via `pref_keys::NOTIFICATIONS_ENABLED`.
     pub notifications_enabled: bool,
+    /// User preference: notification delivery method.
+    /// Synced via `pref_keys::NOTIFICATION_METHOD`.
+    pub notification_method: crate::notifications::NotificationMethod,
     /// User preference: minimum elapsed seconds before a notification fires.
     /// Synced via `pref_keys::NOTIFICATION_THRESHOLD_SECS`.
     pub notification_threshold_secs: u64,
@@ -457,6 +460,7 @@ impl Default for SessionState {
             verbose_mode: true,
             auto_memory_enabled: true,
             notifications_enabled: true,
+            notification_method: crate::notifications::NotificationMethod::Auto,
             notification_threshold_secs: 10,
             history: Vec::new(),
             total_prompt_tokens: 0,

--- a/rust/crates/astra-cli/src/cli/slash_bug.rs
+++ b/rust/crates/astra-cli/src/cli/slash_bug.rs
@@ -1,7 +1,5 @@
 use super::*;
 use crate::{cli_dim, cli_err, cli_ok, cli_warn};
-use std::io::Write;
-use std::process::{Command as SysCommand, Stdio};
 
 /// Handle the `/bug` slash command — generate a diagnostic report for bug reports.
 ///
@@ -13,14 +11,14 @@ pub(super) fn handle_bug_command(arg: &str, state: &SessionState) {
     let report = build_bug_report(state);
 
     match arg.trim() {
-        "copy" => {
-            if copy_to_clipboard(&report) {
-                cli_ok!("Bug report copied to clipboard.");
-            } else {
-                cli_warn!("Could not copy to clipboard — printing instead:");
+        "copy" => match crate::slash_info::copy_to_clipboard(&report) {
+            Ok(()) => cli_ok!("Bug report copied to clipboard."),
+            Err(error) => {
+                cli_warn!("Could not copy to clipboard: {}", error);
+                cli_warn!("Printing bug report instead:");
                 eprintln!("{report}");
             }
-        }
+        },
         "save" => {
             let filename = format!(
                 "astra-bug-{}.md",
@@ -44,34 +42,6 @@ pub(super) fn handle_bug_command(arg: &str, state: &SessionState) {
             cli_warn!("Unknown sub-command '{}'. Usage: /bug [copy|save]", other);
         }
     }
-}
-
-fn copy_to_clipboard(text: &str) -> bool {
-    let wayland = std::env::var("WAYLAND_DISPLAY").is_ok();
-    let mut candidates: Vec<(&str, &[&str])> = Vec::new();
-    if wayland {
-        candidates.push(("wl-copy", &[]));
-    }
-    candidates.extend_from_slice(&[
-        ("xclip", &["-selection", "clipboard"] as &[&str]),
-        ("xsel", &["--clipboard", "--input"]),
-        ("pbcopy", &[]),
-    ]);
-    for (cmd, args) in &candidates {
-        if let Ok(mut child) = SysCommand::new(cmd)
-            .args(*args)
-            .stdin(Stdio::piped())
-            .spawn()
-        {
-            if let Some(mut stdin) = child.stdin.take() {
-                let _ = stdin.write_all(text.as_bytes());
-            }
-            if child.wait().map(|s| s.success()).unwrap_or(false) {
-                return true;
-            }
-        }
-    }
-    false
 }
 
 fn build_bug_report(state: &SessionState) -> String {

--- a/rust/crates/astra-cli/src/cli/slash_info.rs
+++ b/rust/crates/astra-cli/src/cli/slash_info.rs
@@ -21,7 +21,7 @@ fn format_bytes(bytes: u32) -> String {
     }
 }
 
-pub(crate) fn copy_to_clipboard(text: &str) -> bool {
+pub(crate) fn copy_to_clipboard(text: &str) -> Result<(), String> {
     // Try Wayland first (if WAYLAND_DISPLAY is set), then X11 tools, then macOS.
     let wayland = std::env::var("WAYLAND_DISPLAY").is_ok();
     let mut candidates: Vec<(&str, &[&str])> = Vec::new();
@@ -33,21 +33,48 @@ pub(crate) fn copy_to_clipboard(text: &str) -> bool {
         ("xsel", &["--clipboard", "--input"]),
         ("pbcopy", &[]),
     ]);
+    let mut attempts = Vec::new();
     for (cmd, args) in &candidates {
-        if let Ok(mut child) = SysCommand::new(cmd)
+        let mut child = match SysCommand::new(cmd)
             .args(*args)
             .stdin(Stdio::piped())
             .spawn()
         {
-            if let Some(mut stdin) = child.stdin.take() {
-                let _ = stdin.write_all(text.as_bytes());
+            Ok(child) => child,
+            Err(error) => {
+                attempts.push(format!("{cmd}: failed to start: {error}"));
+                continue;
             }
-            if child.wait().map(|s| s.success()).unwrap_or(false) {
-                return true;
+        };
+        match child.stdin.take() {
+            Some(mut stdin) => {
+                if let Err(error) = stdin.write_all(text.as_bytes()) {
+                    attempts.push(format!("{cmd}: failed to write clipboard payload: {error}"));
+                    if let Err(wait_error) = child.wait() {
+                        attempts.push(format!(
+                            "{cmd}: failed to reap after write error: {wait_error}"
+                        ));
+                    }
+                    continue;
+                }
+            }
+            None => {
+                attempts.push(format!("{cmd}: stdin pipe was unavailable"));
+                if let Err(wait_error) = child.wait() {
+                    attempts.push(format!(
+                        "{cmd}: failed to reap after missing stdin: {wait_error}"
+                    ));
+                }
+                continue;
             }
         }
+        match child.wait() {
+            Ok(status) if status.success() => return Ok(()),
+            Ok(status) => attempts.push(format!("{cmd}: exited with status {status}")),
+            Err(error) => attempts.push(format!("{cmd}: failed to wait for process: {error}")),
+        }
     }
-    false
+    Err(format!("clipboard unavailable ({})", attempts.join("; ")))
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1324,14 +1351,12 @@ pub(super) async fn handle_info_command(
                 } else {
                     preview
                 };
-                if copy_to_clipboard(&text) {
-                    eprintln!("{}", format!("  ✓ Copied ({n} chars)").green());
+                if let Err(error) = copy_to_clipboard(&text) {
+                    eprintln!("{}", format!("  ✗ Could not copy: {error}").yellow());
                     eprintln!("  {}", preview_display.dim());
                 } else {
-                    eprintln!(
-                        "{}",
-                        "  ✗ No clipboard tool found (install xclip or xsel)".yellow()
-                    );
+                    eprintln!("{}", format!("  ✓ Copied ({n} chars)").green());
+                    eprintln!("  {}", preview_display.dim());
                 }
             }
             None => eprintln!("{}", "  ✗ No response to copy yet".yellow()),

--- a/rust/crates/astra-cli/src/cli/terminal_hyperlinks.rs
+++ b/rust/crates/astra-cli/src/cli/terminal_hyperlinks.rs
@@ -1,0 +1,199 @@
+use ratatui::text::{Line, Span};
+use std::path::{Path, PathBuf};
+
+pub(crate) fn terminal_hyperlinks_enabled() -> bool {
+    std::env::var("ASTRA_OSC8")
+        .map(|v| !matches!(v.as_str(), "0" | "false" | "off" | "no"))
+        .unwrap_or(true)
+}
+
+pub(crate) fn sanitize_osc8_component(value: &str) -> String {
+    value
+        .chars()
+        .filter(|c| !matches!(*c, '\x1b' | '\x07') && !c.is_control())
+        .collect()
+}
+
+pub(crate) fn osc8_link(uri: &str, label: &str) -> String {
+    let uri = sanitize_osc8_component(uri);
+    let label = sanitize_osc8_component(label);
+    format!("\x1b]8;;{uri}\x1b\\{label}\x1b]8;;\x1b\\")
+}
+
+pub(crate) fn hyperlink_line_file_paths(line: &Line<'static>, cwd: Option<&Path>) -> Line<'static> {
+    if !terminal_hyperlinks_enabled() {
+        return line.clone();
+    }
+
+    let mut changed = false;
+    let spans: Vec<Span<'static>> = line
+        .spans
+        .iter()
+        .map(|span| {
+            let content = hyperlink_text_file_paths(span.content.as_ref(), cwd);
+            if content != span.content.as_ref() {
+                changed = true;
+            }
+            Span::styled(content, span.style)
+        })
+        .collect();
+
+    if !changed {
+        return line.clone();
+    }
+
+    let mut out = Line::from(spans);
+    out.style = line.style;
+    out.alignment = line.alignment;
+    out
+}
+
+fn hyperlink_text_file_paths(text: &str, cwd: Option<&Path>) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut changed = false;
+    let mut cursor = 0usize;
+
+    while cursor < text.len() {
+        let Some(ch) = text[cursor..].chars().next() else {
+            break;
+        };
+        if ch.is_whitespace() {
+            out.push(ch);
+            cursor += ch.len_utf8();
+            continue;
+        }
+
+        let start = cursor;
+        cursor += ch.len_utf8();
+        while cursor < text.len() {
+            let Some(next) = text[cursor..].chars().next() else {
+                break;
+            };
+            if next.is_whitespace() {
+                break;
+            }
+            cursor += next.len_utf8();
+        }
+
+        let token = &text[start..cursor];
+        if let Some(linked) = hyperlink_file_path_token(token, cwd) {
+            out.push_str(&linked);
+            changed = true;
+        } else {
+            out.push_str(token);
+        }
+    }
+
+    if changed { out } else { text.to_string() }
+}
+
+fn hyperlink_file_path_token(raw_token: &str, cwd: Option<&Path>) -> Option<String> {
+    if raw_token.contains("\x1b]8;;") {
+        return None;
+    }
+
+    let (prefix, core, suffix) = split_surrounding_punctuation(raw_token);
+    if core.is_empty() || looks_like_url(core) {
+        return None;
+    }
+
+    let (path, _) = split_optional_line_suffix(core);
+    if !is_file_path_like(path) {
+        return None;
+    }
+
+    let uri = file_uri_for_path(path, cwd)?;
+    Some(format!("{prefix}{}{suffix}", osc8_link(&uri, core)))
+}
+
+fn split_surrounding_punctuation(token: &str) -> (&str, &str, &str) {
+    let start = token
+        .char_indices()
+        .find(|(_, c)| !is_leading_trimmed_token_punctuation(*c))
+        .map(|(idx, _)| idx)
+        .unwrap_or(token.len());
+    let end = token
+        .char_indices()
+        .rev()
+        .find(|(_, c)| !is_trailing_trimmed_token_punctuation(*c))
+        .map(|(idx, c)| idx + c.len_utf8())
+        .unwrap_or(start);
+    (&token[..start], &token[start..end], &token[end..])
+}
+
+fn is_leading_trimmed_token_punctuation(c: char) -> bool {
+    matches!(c, '(' | '[' | '{' | '<' | '\'' | '"')
+}
+
+fn is_trailing_trimmed_token_punctuation(c: char) -> bool {
+    matches!(
+        c,
+        ')' | ']' | '}' | '>' | ',' | '.' | ';' | ':' | '!' | '\'' | '"'
+    )
+}
+
+fn looks_like_url(token: &str) -> bool {
+    token.contains("://")
+        || token.starts_with("www.")
+        || token.starts_with("localhost:")
+        || token.starts_with("localhost/")
+}
+
+fn split_optional_line_suffix(token: &str) -> (&str, Option<&str>) {
+    let Some((path, suffix)) = token.rsplit_once(':') else {
+        return (token, None);
+    };
+    if suffix.chars().all(|c| c.is_ascii_digit()) && path.contains('/') {
+        (path, Some(suffix))
+    } else {
+        (token, None)
+    }
+}
+
+fn is_file_path_like(path: &str) -> bool {
+    is_absolute_path_like(path) || is_relative_path_like(path)
+}
+
+fn is_absolute_path_like(path: &str) -> bool {
+    path.starts_with('/')
+        && path.len() > 1
+        && path
+            .chars()
+            .all(|c| !c.is_control() && !matches!(c, '\x1b' | '\x07'))
+}
+
+fn is_relative_path_like(path: &str) -> bool {
+    if !(path.starts_with("./") || path.starts_with("../") || path.contains('/')) {
+        return false;
+    }
+    if path.ends_with('/') || path.contains("://") {
+        return false;
+    }
+    let Some(last) = path.rsplit('/').next() else {
+        return false;
+    };
+    last.contains('.')
+        && !last.starts_with('.')
+        && path
+            .chars()
+            .all(|c| !c.is_control() && !matches!(c, '\x1b' | '\x07' | '*' | '?'))
+}
+
+fn file_uri_for_path(path: &str, cwd: Option<&Path>) -> Option<String> {
+    let clean = sanitize_osc8_component(path);
+    if clean.is_empty() {
+        return None;
+    }
+
+    let candidate = if clean.starts_with('/') {
+        PathBuf::from(&clean)
+    } else if let Some(cwd) = cwd {
+        cwd.join(&clean)
+    } else {
+        return Some(format!("file://./{clean}"));
+    };
+
+    url::Url::from_file_path(candidate)
+        .ok()
+        .map(|url| url.to_string())
+}

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -205,6 +205,8 @@ mod streaming_md;
 mod streaming_types;
 #[path = "cli/task_summary.rs"]
 mod task_summary;
+#[path = "cli/terminal_hyperlinks.rs"]
+mod terminal_hyperlinks;
 #[path = "cli/terminal_region.rs"]
 mod terminal_region;
 #[path = "cli/theme.rs"]

--- a/rust/crates/astra-cli/src/tui/custom_terminal.rs
+++ b/rust/crates/astra-cli/src/tui/custom_terminal.rs
@@ -59,15 +59,19 @@ fn display_width(s: &str) -> usize {
         return s.width();
     }
 
-    // Strip OSC sequences: ESC ] ... BEL
+    // Strip OSC sequences: ESC ] ... BEL or ESC ] ... ST
     let mut visible = String::with_capacity(s.len());
     let mut chars = s.chars();
     while let Some(ch) = chars.next() {
         if ch == '\x1B' && chars.clone().next() == Some(']') {
-            // Consume the ']' and everything up to and including BEL.
+            // Consume the ']' and everything up to and including BEL or ST.
             chars.next(); // skip ']'
-            for c in chars.by_ref() {
+            while let Some(c) = chars.next() {
                 if c == '\x07' {
+                    break;
+                }
+                if c == '\x1B' && chars.clone().next() == Some('\\') {
+                    chars.next();
                     break;
                 }
             }
@@ -759,5 +763,11 @@ mod tests {
                 .any(|command| matches!(command, DrawCommand::ClearToEnd { x: 2, y: 0, .. })),
             "expected clear-to-end to start after the remaining wide char; commands: {commands:?}"
         );
+    }
+
+    #[test]
+    fn display_width_ignores_osc8_payload_terminated_by_st() {
+        let linked = "\x1b]8;;file:///tmp/example.rs\x1b\\example.rs\x1b]8;;\x1b\\";
+        assert_eq!(display_width(linked), "example.rs".width());
     }
 }

--- a/rust/crates/astra-cli/src/tui/markdown_render.rs
+++ b/rust/crates/astra-cli/src/tui/markdown_render.rs
@@ -3,7 +3,7 @@ use super::render::line_utils::line_to_static;
 use pulldown_cmark::{Alignment, CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use ratatui::style::{Style, Stylize};
 use ratatui::text::{Line, Span, Text};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use unicode_width::UnicodeWidthStr;
 
 struct MarkdownStyles {
@@ -49,13 +49,13 @@ pub(crate) fn render_markdown_text_with_width(input: &str, width: Option<usize>)
 pub(crate) fn render_markdown_text_with_width_and_cwd(
     input: &str,
     width: Option<usize>,
-    _cwd: Option<&Path>,
+    cwd: Option<&Path>,
 ) -> Text<'static> {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
     options.insert(Options::ENABLE_TABLES);
     let parser = Parser::new_ext(input, options);
-    let mut writer = Writer::new(width);
+    let mut writer = Writer::new(width, cwd.map(Path::to_path_buf));
     writer.run(parser);
     writer.into_text()
 }
@@ -74,6 +74,7 @@ struct Writer {
     /// Total render width, used for horizontal rules and wrap-aware
     /// tables. `None` means "no hint — fall back to a reasonable default".
     width: Option<usize>,
+    cwd: Option<PathBuf>,
     /// Active table state. `None` outside of `Tag::Table`.
     table: Option<TableBuilder>,
 }
@@ -108,7 +109,7 @@ impl TableBuilder {
 }
 
 impl Writer {
-    fn new(width: Option<usize>) -> Self {
+    fn new(width: Option<usize>, cwd: Option<PathBuf>) -> Self {
         Self {
             styles: MarkdownStyles::default(),
             lines: Vec::new(),
@@ -121,6 +122,7 @@ impl Writer {
             in_blockquote: false,
             link_url: None,
             width,
+            cwd,
             table: None,
         }
     }
@@ -569,6 +571,14 @@ impl Writer {
         while self.lines.last().is_some_and(|l| l.spans.is_empty()) {
             self.lines.pop();
         }
+        if !self.lines.is_empty() {
+            let cwd = self.cwd.as_deref();
+            self.lines = self
+                .lines
+                .into_iter()
+                .map(|line| crate::terminal_hyperlinks::hyperlink_line_file_paths(&line, cwd))
+                .collect();
+        }
         Text::from(self.lines)
     }
 }
@@ -691,7 +701,7 @@ fn list_item_hang_wrap(spans: &[Span<'static>], width: usize) -> Option<Vec<Line
         )))
         .subsequent_indent(Line::from(Span::raw(hang)));
 
-    let wrapped = super::wrapping::word_wrap_line(&body_line, opts);
+    let wrapped = super::wrapping::adaptive_wrap_line(&body_line, opts);
     if wrapped.is_empty() {
         return None;
     }
@@ -729,7 +739,7 @@ fn blockquote_wrap(
         .initial_indent(bar())
         .subsequent_indent(bar());
     let body_line = Line::from(spans.to_vec());
-    let wrapped = super::wrapping::word_wrap_line(&body_line, opts);
+    let wrapped = super::wrapping::adaptive_wrap_line(&body_line, opts);
     if wrapped.is_empty() {
         return None;
     }
@@ -754,7 +764,7 @@ fn paragraph_wrap(spans: &[Span<'static>], width: usize) -> Option<Vec<Line<'sta
     }
     let body_line = Line::from(spans.to_vec());
     let opts = super::wrapping::RtOptions::new(width);
-    let wrapped = super::wrapping::word_wrap_line(&body_line, opts);
+    let wrapped = super::wrapping::adaptive_wrap_line(&body_line, opts);
     if wrapped.is_empty() {
         return None;
     }
@@ -837,6 +847,7 @@ fn pad_cell(text: &str, width: usize, align: Alignment) -> String {
 #[cfg(test)]
 mod polish_tests {
     use super::*;
+    use std::path::Path;
 
     fn lines(md: &str) -> Vec<String> {
         render_markdown_text(md)
@@ -853,6 +864,19 @@ mod polish_tests {
 
     fn lines_at(md: &str, width: usize) -> Vec<String> {
         render_markdown_text_with_width(md, Some(width))
+            .lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    fn lines_at_cwd(md: &str, width: usize, cwd: &Path) -> Vec<String> {
+        render_markdown_text_with_width_and_cwd(md, Some(width), Some(cwd))
             .lines
             .iter()
             .map(|l| {
@@ -1076,5 +1100,33 @@ mod polish_tests {
             .expect("rule line");
         // Previous implementation was hardcoded to 40 — now it's 60.
         assert_eq!(rule_line.chars().count(), 60);
+    }
+
+    #[test]
+    fn renders_relative_file_paths_as_osc8_links() {
+        let out = lines_at_cwd(
+            "See src/tui/wrapping.rs:42 for details.",
+            80,
+            Path::new("/home/xupeng/astra/rust/crates/astra-cli"),
+        );
+        let joined = out.join("\n");
+        assert!(joined.contains(
+            "\x1b]8;;file:///home/xupeng/astra/rust/crates/astra-cli/src/tui/wrapping.rs\x1b\\src/tui/wrapping.rs:42\x1b]8;;\x1b\\"
+        ));
+    }
+
+    #[test]
+    fn long_file_paths_wrap_without_splitting_the_token() {
+        let out = lines_at_cwd(
+            "inspect ./rust/crates/astra-cli/src/tui/markdown_render.rs:757 before changing anything",
+            34,
+            Path::new("/home/xupeng/astra"),
+        );
+        assert!(out.len() >= 2, "expected wrapped output; got {out:?}");
+        assert!(
+            out.iter()
+                .any(|line| line.contains("./rust/crates/astra-cli/src/tui/markdown_render.rs:757")),
+            "expected intact path token in wrapped output; got {out:?}"
+        );
     }
 }

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -703,12 +703,12 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             match &ctx.state.last_response {
                 Some(resp) if !resp.is_empty() => {
                     let n = resp.chars().count();
-                    if crate::slash_info::copy_to_clipboard(resp) {
+                    if let Err(error) = crate::slash_info::copy_to_clipboard(resp) {
+                        ctx.show_error(format!("Copy failed: {error}"));
+                    } else {
                         let preview: String = resp.chars().take(60).collect();
                         let suffix = if n > 60 { "…" } else { "" };
                         ctx.show_response(format!("Copied {n} chars: {preview}{suffix}"));
-                    } else {
-                        ctx.show_error("No clipboard tool found (install xclip or xsel)".into());
                     }
                 }
                 _ => ctx.show_info("No response to copy".into()),

--- a/rust/crates/astra-cli/src/tui/status_indicator.rs
+++ b/rust/crates/astra-cli/src/tui/status_indicator.rs
@@ -92,6 +92,8 @@ pub(crate) struct StatusIndicator {
 /// reassure the user during Bedrock extended-thinking pauses,
 /// long enough to avoid flickering in/out for a normal prompt.
 const SILENT_WINDOW_BEFORE_THOUGHT_CHIP: Duration = Duration::from_secs(5);
+const STALL_WARN_AFTER: Duration = Duration::from_secs(5);
+const STALL_ERROR_AFTER: Duration = Duration::from_secs(10);
 const DEFAULT_TURN_LABEL: &str = "Thinking";
 
 impl StatusIndicator {
@@ -184,11 +186,12 @@ fn render_for(
     let elapsed = elapsed_origin.and_then(|t| now.checked_duration_since(t));
 
     let theme = crate::tui::theme::current();
+    let intensity_color = stall_intensity_color(elapsed, theme);
     let star_style = Style::default()
-        .fg(theme.accent)
+        .fg(intensity_color)
         .add_modifier(Modifier::BOLD);
     let label_style = Style::default()
-        .fg(theme.accent)
+        .fg(intensity_color)
         .add_modifier(Modifier::BOLD);
     let dim = Style::default().fg(Color::DarkGray);
 
@@ -268,6 +271,14 @@ fn thought_for_duration(
     }
 }
 
+fn stall_intensity_color(elapsed: Option<Duration>, theme: &crate::tui::theme::Theme) -> Color {
+    match elapsed {
+        Some(d) if d >= STALL_ERROR_AFTER => theme.error,
+        Some(d) if d >= STALL_WARN_AFTER => theme.warn,
+        _ => theme.accent,
+    }
+}
+
 /// Parenthesised suffix: `(elapsed · thought for Ns · ↓ N tokens · esc to interrupt)`.
 /// Sections elide when they'd be meaningless (token counter
 /// before first delta, no-yet elapsed at state flip, thought-for
@@ -343,10 +354,10 @@ fn label_spans_for_mode(
         return Vec::new();
     }
 
-    let base = match style.fg {
-        Some(Color::Rgb(r, g, b)) => (r, g, b),
-        _ => (150, 120, 255),
-    };
+    let base = style
+        .fg
+        .and_then(color_to_rgb_approx)
+        .unwrap_or((150, 120, 255));
     let highlight = crate::tui::terminal_palette::default_fg().unwrap_or((255, 255, 255));
     let padding = 2usize;
     let period = chars.len() + padding * 2;
@@ -372,6 +383,29 @@ fn label_spans_for_mode(
             )
         })
         .collect()
+}
+
+fn color_to_rgb_approx(color: Color) -> Option<(u8, u8, u8)> {
+    match color {
+        Color::Rgb(r, g, b) => Some((r, g, b)),
+        Color::Black => Some((0, 0, 0)),
+        Color::Red => Some((205, 49, 49)),
+        Color::Green => Some((13, 188, 121)),
+        Color::Yellow => Some((229, 229, 16)),
+        Color::Blue => Some((36, 114, 200)),
+        Color::Magenta => Some((188, 63, 188)),
+        Color::Cyan => Some((17, 168, 205)),
+        Color::Gray => Some((204, 204, 204)),
+        Color::DarkGray => Some((118, 118, 118)),
+        Color::LightRed => Some((241, 76, 76)),
+        Color::LightGreen => Some((35, 209, 139)),
+        Color::LightYellow => Some((245, 245, 67)),
+        Color::LightBlue => Some((59, 142, 234)),
+        Color::LightMagenta => Some((214, 112, 214)),
+        Color::LightCyan => Some((41, 184, 219)),
+        Color::White => Some((255, 255, 255)),
+        Color::Indexed(_) | Color::Reset => None,
+    }
 }
 
 /// Rotating star glyph. Time-keyed to a 500 ms window — slow
@@ -471,6 +505,35 @@ mod tests {
         assert!(text.contains("Thinking"));
         assert!(text.contains("3s"));
         assert!(text.contains("esc to interrupt"));
+    }
+
+    #[test]
+    fn thinking_stall_intensity_warns_at_5s_and_errors_at_10s() {
+        let theme = crate::tui::theme::Theme::dark();
+        assert_eq!(
+            stall_intensity_color(Some(Duration::from_secs(4)), &theme),
+            theme.accent
+        );
+        assert_eq!(
+            stall_intensity_color(Some(Duration::from_secs(5)), &theme),
+            theme.warn
+        );
+        assert_eq!(
+            stall_intensity_color(Some(Duration::from_secs(10)), &theme),
+            theme.error
+        );
+    }
+
+    #[test]
+    fn rendered_spinner_uses_stall_color_on_first_span() {
+        let mut s = StatusIndicator::new();
+        let t0 = Instant::now();
+        s.set_state(IndicatorState::Thinking { started_at: t0 });
+        let line = s.render_at(t0 + Duration::from_secs(10)).unwrap();
+        assert_eq!(
+            line.spans[0].style.fg,
+            Some(crate::tui::theme::current().error)
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/terminal_palette.rs
+++ b/rust/crates/astra-cli/src/tui/terminal_palette.rs
@@ -1,5 +1,6 @@
 use super::color::perceptual_distance;
 use ratatui::style::Color;
+use std::sync::OnceLock;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum StdoutColorLevel {
@@ -41,7 +42,7 @@ pub(crate) fn requery_default_colors() {
     imp::requery_default_colors();
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct DefaultColors {
     pub fg: (u8, u8, u8),
     pub bg: (u8, u8, u8),
@@ -60,17 +61,160 @@ pub(crate) fn default_bg() -> Option<(u8, u8, u8)> {
     default_colors().map(|c| c.bg)
 }
 
-// crossterm 0.28 removed query_background_color/query_foreground_color.
-// For now we return None; adaptive theming falls back to dark theme defaults.
-// Future: use terminal OSC queries or COLORTERM heuristics.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OscColorSlot {
+    Foreground,
+    Background,
+}
+
+impl OscColorSlot {
+    fn selector(self) -> &'static str {
+        match self {
+            Self::Foreground => "10",
+            Self::Background => "11",
+        }
+    }
+}
+
+pub(crate) fn parse_osc_color_response(response: &str, slot: OscColorSlot) -> Option<(u8, u8, u8)> {
+    let selector = slot.selector();
+    let mut rest = response;
+    while let Some(start) = rest.find("\x1b]") {
+        rest = &rest[start + 2..];
+        let Some((body, tail)) = split_osc_body(rest) else {
+            break;
+        };
+        rest = tail;
+        let Some((got_selector, spec)) = body.split_once(';') else {
+            continue;
+        };
+        if got_selector == selector
+            && let Some(rgb) = parse_color_spec(spec.trim())
+        {
+            return Some(rgb);
+        }
+    }
+    None
+}
+
+fn split_osc_body(s: &str) -> Option<(&str, &str)> {
+    let bel = s.find('\x07');
+    let st = s.find("\x1b\\");
+    match (bel, st) {
+        (Some(b), Some(t)) if b < t => Some((&s[..b], &s[b + 1..])),
+        (Some(_), Some(t)) => Some((&s[..t], &s[t + 2..])),
+        (Some(b), None) => Some((&s[..b], &s[b + 1..])),
+        (None, Some(t)) => Some((&s[..t], &s[t + 2..])),
+        (None, None) => None,
+    }
+}
+
+fn parse_color_spec(spec: &str) -> Option<(u8, u8, u8)> {
+    if let Some(hex) = spec.strip_prefix('#') {
+        return parse_hex_rgb(hex);
+    }
+    if let Some(rest) = spec.strip_prefix("rgb:") {
+        let mut parts = rest.split('/');
+        let r = parse_x_color_component(parts.next()?)?;
+        let g = parse_x_color_component(parts.next()?)?;
+        let b = parse_x_color_component(parts.next()?)?;
+        if parts.next().is_some() {
+            return None;
+        }
+        return Some((r, g, b));
+    }
+    if let Some(rest) = spec.strip_prefix("rgba:") {
+        let mut parts = rest.split('/');
+        let r = parse_x_color_component(parts.next()?)?;
+        let g = parse_x_color_component(parts.next()?)?;
+        let b = parse_x_color_component(parts.next()?)?;
+        let _alpha = parts.next()?;
+        if parts.next().is_some() {
+            return None;
+        }
+        return Some((r, g, b));
+    }
+    let mut parts = spec.split(',');
+    let r = parts.next()?.trim().parse::<u8>().ok()?;
+    let g = parts.next()?.trim().parse::<u8>().ok()?;
+    let b = parts.next()?.trim().parse::<u8>().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((r, g, b))
+}
+
+fn parse_hex_rgb(hex: &str) -> Option<(u8, u8, u8)> {
+    match hex.len() {
+        6 => Some((
+            u8::from_str_radix(&hex[0..2], 16).ok()?,
+            u8::from_str_radix(&hex[2..4], 16).ok()?,
+            u8::from_str_radix(&hex[4..6], 16).ok()?,
+        )),
+        12 => Some((
+            parse_x_color_component(&hex[0..4])?,
+            parse_x_color_component(&hex[4..8])?,
+            parse_x_color_component(&hex[8..12])?,
+        )),
+        _ => None,
+    }
+}
+
+fn parse_x_color_component(part: &str) -> Option<u8> {
+    if part.is_empty() || part.len() > 4 || !part.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let value = u16::from_str_radix(part, 16).ok()?;
+    let max = (1u32 << (part.len() * 4)) - 1;
+    Some(((value as u32 * 255 + max / 2) / max) as u8)
+}
+
+fn env_default_colors() -> Option<DefaultColors> {
+    let fg = std::env::var("ASTRA_TERMINAL_FG")
+        .ok()
+        .and_then(|v| parse_color_spec(v.trim()));
+    let bg = std::env::var("ASTRA_TERMINAL_BG")
+        .ok()
+        .and_then(|v| parse_color_spec(v.trim()));
+    let colorfgbg = std::env::var("COLORFGBG")
+        .ok()
+        .and_then(|v| parse_colorfgbg(v.trim()));
+    match (fg, bg) {
+        (Some(fg), Some(bg)) => Some(DefaultColors { fg, bg }),
+        (fg, bg) => colorfgbg.map(|defaults| DefaultColors {
+            fg: fg.unwrap_or(defaults.fg),
+            bg: bg.unwrap_or(defaults.bg),
+        }),
+    }
+}
+
+fn parse_colorfgbg(value: &str) -> Option<DefaultColors> {
+    let (fg, bg) = value.rsplit_once(';')?;
+    Some(DefaultColors {
+        fg: ansi_index_rgb(fg.trim().parse::<u8>().ok()?),
+        bg: ansi_index_rgb(bg.trim().parse::<u8>().ok()?),
+    })
+}
+
+fn ansi_index_rgb(index: u8) -> (u8, u8, u8) {
+    XTERM_COLORS[index.min(15) as usize]
+}
+
+static DEFAULT_COLORS: OnceLock<Option<DefaultColors>> = OnceLock::new();
+
 mod imp {
-    use super::DefaultColors;
+    use super::{DEFAULT_COLORS, DefaultColors, env_default_colors};
+    use std::io::IsTerminal as _;
 
     pub(super) fn default_colors() -> Option<DefaultColors> {
-        None
+        *DEFAULT_COLORS.get_or_init(env_default_colors)
     }
 
-    pub(super) fn requery_default_colors() {}
+    pub(super) fn requery_default_colors() {
+        if std::io::stderr().is_terminal() {
+            eprint!("\x1b]10;?\x1b\\\x1b]11;?\x1b\\");
+        }
+    }
 }
 
 fn xterm_fixed_colors() -> impl Iterator<Item = (usize, (u8, u8, u8))> {
@@ -112,3 +256,63 @@ pub(crate) const XTERM_COLORS: [(u8, u8, u8); 256] = [
     (88,88,88),(98,98,98),(108,108,108),(118,118,118),(128,128,128),(138,138,138),(148,148,148),(158,158,158),
     (168,168,168),(178,178,178),(188,188,188),(198,198,198),(208,208,208),(218,218,218),(228,228,228),(238,238,238),
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_osc11_rgb_response_with_st_terminator() {
+        let response = "\x1b]11;rgb:ffff/eeee/dddd\x1b\\";
+        assert_eq!(
+            parse_osc_color_response(response, OscColorSlot::Background),
+            Some((255, 238, 221))
+        );
+    }
+
+    #[test]
+    fn parses_osc10_hash_response_with_bel_terminator() {
+        let response = "\x1b]10;#102030\x07";
+        assert_eq!(
+            parse_osc_color_response(response, OscColorSlot::Foreground),
+            Some((16, 32, 48))
+        );
+    }
+
+    #[test]
+    fn ignores_wrong_osc_selector_and_malformed_color() {
+        assert_eq!(
+            parse_osc_color_response("\x1b]10;rgb:ffff/eeee/dddd\x1b\\", OscColorSlot::Background),
+            None
+        );
+        assert_eq!(
+            parse_osc_color_response("\x1b]11;rgb:ffff/nope/dddd\x1b\\", OscColorSlot::Background),
+            None
+        );
+    }
+
+    #[test]
+    fn parses_env_color_specs() {
+        assert_eq!(parse_color_spec("#abcdef"), Some((171, 205, 239)));
+        assert_eq!(parse_color_spec("10,20,30"), Some((10, 20, 30)));
+        assert_eq!(parse_color_spec("rgb:0000/8000/ffff"), Some((0, 128, 255)));
+    }
+
+    #[test]
+    fn parses_colorfgbg_indexes() {
+        assert_eq!(
+            parse_colorfgbg("15;0"),
+            Some(DefaultColors {
+                fg: (255, 255, 255),
+                bg: (0, 0, 0),
+            })
+        );
+        assert_eq!(
+            parse_colorfgbg("7;10"),
+            Some(DefaultColors {
+                fg: (192, 192, 192),
+                bg: (0, 255, 0),
+            })
+        );
+    }
+}

--- a/rust/crates/astra-cli/src/tui/wrapping.rs
+++ b/rust/crates/astra-cli/src/tui/wrapping.rs
@@ -1,4 +1,4 @@
-//! Word-wrapping with URL-aware heuristics.
+//! Word-wrapping with URL/path-aware heuristics.
 //!
 //! The TUI renders text that frequently contains URLs — command output,
 //! markdown, agent messages, tool-call results. Standard `textwrap`
@@ -21,10 +21,9 @@
 //! functions. Callers that definitely will not (code blocks, pure
 //! numeric output) can use the standard path for speed.
 //!
-//! URL detection is heuristic — see [`text_contains_url_like`] for the
-//! rules. False positives suppress hyphenation for that line; false
-//! negatives let a URL get split. The heuristic is intentionally
-//! conservative: file paths like `src/main.rs` are not matched.
+//! Link detection is heuristic — see [`text_contains_wrapping_protected_token`]
+//! for the rules. False positives suppress hyphenation for that line; false
+//! negatives let a clickable token get split.
 
 use ratatui::text::Line;
 use ratatui::text::Span;
@@ -185,6 +184,15 @@ pub(crate) fn line_contains_url_like(line: &Line<'_>) -> bool {
     text_contains_url_like(&text)
 }
 
+pub(crate) fn line_contains_wrapping_protected_token(line: &Line<'_>) -> bool {
+    let text: String = line
+        .spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect();
+    text_contains_wrapping_protected_token(&text)
+}
+
 /// Returns `true` if `line` contains both a URL-like token and at least one
 /// substantive non-URL token.
 ///
@@ -242,6 +250,69 @@ fn text_has_mixed_url_and_non_url_tokens(text: &str) -> bool {
 fn is_url_like_token(raw_token: &str) -> bool {
     let token = trim_url_token(raw_token);
     !token.is_empty() && (is_absolute_url_like(token) || is_bare_url_like(token))
+}
+
+fn text_contains_wrapping_protected_token(text: &str) -> bool {
+    text.split_ascii_whitespace()
+        .any(is_wrapping_protected_token)
+}
+
+fn is_wrapping_protected_token(raw_token: &str) -> bool {
+    is_osc8_token(raw_token) || is_url_like_token(raw_token) || is_file_path_like_token(raw_token)
+}
+
+fn is_osc8_token(raw_token: &str) -> bool {
+    raw_token.contains("\x1b]8;;") && raw_token.contains("\x1b]8;;\x1b")
+}
+
+fn is_file_path_like_token(raw_token: &str) -> bool {
+    let token = trim_url_token(raw_token);
+    if token.is_empty() || is_url_like_token(token) {
+        return false;
+    }
+    let (path, line_part) = split_optional_line_suffix(token);
+    if let Some(line) = line_part
+        && (line.is_empty() || !line.chars().all(|c| c.is_ascii_digit()))
+    {
+        return false;
+    }
+    is_absolute_path_like(path) || is_relative_path_like(path)
+}
+
+fn split_optional_line_suffix(token: &str) -> (&str, Option<&str>) {
+    let Some((path, suffix)) = token.rsplit_once(':') else {
+        return (token, None);
+    };
+    if suffix.chars().all(|c| c.is_ascii_digit()) && path.contains('/') {
+        (path, Some(suffix))
+    } else {
+        (token, None)
+    }
+}
+
+fn is_absolute_path_like(path: &str) -> bool {
+    path.starts_with('/')
+        && path.len() > 1
+        && path
+            .chars()
+            .all(|c| !c.is_control() && !matches!(c, '\x1b' | '\x07'))
+}
+
+fn is_relative_path_like(path: &str) -> bool {
+    if !(path.starts_with("./") || path.starts_with("../") || path.contains('/')) {
+        return false;
+    }
+    if path.ends_with('/') || path.contains("://") {
+        return false;
+    }
+    let Some(last) = path.rsplit('/').next() else {
+        return false;
+    };
+    last.contains('.')
+        && !last.starts_with('.')
+        && path
+            .chars()
+            .all(|c| !c.is_control() && !matches!(c, '\x1b' | '\x07' | '*' | '?'))
 }
 
 fn is_substantive_non_url_token(raw_token: &str) -> bool {
@@ -463,7 +534,7 @@ fn is_domain_label(label: &str) -> bool {
 /// while still allowing character-level splitting for non-URL words.
 pub(crate) fn url_preserving_wrap_options<'a>(opts: RtOptions<'a>) -> RtOptions<'a> {
     opts.word_separator(textwrap::WordSeparator::AsciiSpace)
-        .word_splitter(textwrap::WordSplitter::Custom(split_non_url_word))
+        .word_splitter(textwrap::WordSplitter::Custom(split_unprotected_word))
         .break_words(/*break_words*/ false)
 }
 
@@ -471,8 +542,8 @@ pub(crate) fn url_preserving_wrap_options<'a>(opts: RtOptions<'a>) -> RtOptions<
 /// points) for URL-like tokens so they are kept intact; returns every
 /// char-boundary index for everything else so non-URL words can still
 /// break at any position.
-fn split_non_url_word(word: &str) -> Vec<usize> {
-    if is_url_like_token(word) {
+fn split_unprotected_word(word: &str) -> Vec<usize> {
+    if is_wrapping_protected_token(word) {
         return Vec::new();
     }
 
@@ -488,7 +559,7 @@ fn split_non_url_word(word: &str) -> Vec<usize> {
 /// words on the same line still break normally.
 #[must_use]
 pub(crate) fn adaptive_wrap_line<'a>(line: &'a Line<'a>, base: RtOptions<'a>) -> Vec<Line<'a>> {
-    let selected = if line_contains_url_like(line) {
+    let selected = if line_contains_wrapping_protected_token(line) {
         url_preserving_wrap_options(base)
     } else {
         base
@@ -1187,6 +1258,45 @@ them."#
     }
 
     #[test]
+    fn text_contains_wrapping_protected_token_accepts_file_paths() {
+        let positives = [
+            "src/tui/wrapping.rs",
+            "./rust/crates/astra-cli/src/main.rs:42",
+            "../docs/reference/config.md",
+            "/home/xupeng/astra/rust/Cargo.toml:12",
+        ];
+        for text in positives {
+            assert!(
+                text_contains_wrapping_protected_token(text),
+                "expected path-like protected token for {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn text_contains_wrapping_protected_token_rejects_globs_and_plain_words() {
+        let negatives = [
+            "src/**/*.rs",
+            "hello.world",
+            "foo/bar/baz",
+            "key:value",
+            "just-some-text-with-dashes",
+        ];
+        for text in negatives {
+            assert!(
+                !text_contains_wrapping_protected_token(text),
+                "did not expect protected token for {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn text_contains_wrapping_protected_token_accepts_osc8_links() {
+        let link = "\x1b]8;;file:///tmp/example.rs:9\x1b\\/tmp/example.rs:9\x1b]8;;\x1b\\";
+        assert!(text_contains_wrapping_protected_token(link));
+    }
+
+    #[test]
     fn line_contains_url_like_checks_across_spans() {
         let line = Line::from(vec![
             "see ".into(),
@@ -1235,6 +1345,16 @@ them."#
             concat_line(&out[0]),
             "example.test/a-very-long-path-with-many-segments-and-query?x=1&y=2"
         );
+    }
+
+    #[test]
+    fn adaptive_wrap_line_keeps_long_file_path_token_intact() {
+        let path =
+            "rust/crates/astra-cli/src/tui/very-long-component-name/wrapping_regression_case.rs:99";
+        let line = Line::from(path);
+        let out = adaptive_wrap_line(&line, RtOptions::new(/*width*/ 20));
+        assert_eq!(out.len(), 1);
+        assert_eq!(concat_line(&out[0]), path);
     }
 
     #[test]

--- a/rust/crates/services/src/state_sync.rs
+++ b/rust/crates/services/src/state_sync.rs
@@ -1179,6 +1179,8 @@ pub mod pref_keys {
     pub const AUTO_MEMORY_ENABLED: &str = "auto_memory_enabled";
     /// Desktop notifications on turn completion. "true"/"false". Default: true.
     pub const NOTIFICATIONS_ENABLED: &str = "notifications_enabled";
+    /// Notification delivery method: "auto", "osc9", "bell", or "off". Default: "auto".
+    pub const NOTIFICATION_METHOD: &str = "notification_method";
     /// Minimum elapsed seconds before a desktop notification is sent. Default: 10.
     pub const NOTIFICATION_THRESHOLD_SECS: &str = "notification_threshold_secs";
 }
@@ -1297,6 +1299,7 @@ mod tests {
         assert_eq!(pref_keys::EXPLAIN_MODE, "explain_mode");
         assert_eq!(pref_keys::DEFAULT_MODEL, "default_model");
         assert_eq!(pref_keys::TOOL_BUDGET, "tool_budget_tokens");
+        assert_eq!(pref_keys::NOTIFICATION_METHOD, "notification_method");
     }
 
     // ── SyncStatus ──


### PR DESCRIPTION
## Summary

Add terminal-native path linking via OSC 8 hyperlinks and notification backend detection (OSC 9) to the TUI layer. Also adds terminal color-query parsing (OSC 10/11) to read the terminal's default foreground/background colors for theme-aware UI. Refactors copy_to_clipboard to return Result instead of bool for better error surfacing.

## Changes

- terminal_hyperlinks.rs (new): OSC 8 hyperlink generation for file paths. Supports both absolute (file:///path) and relative (file://./path) URIs with correct display-text stripping.
- terminal_palette.rs (new): TerminalPalette struct with DEFAULT_COLORS OnceLock; parse_osc_color_response for OSC 10/11 query parsing; requery_default_colors() emits VT query sequences; sanitize_osc8_component / sanitize_terminal_notification for security (ESC/BEL stripping).
- notifications.rs: NotificationMethod enum (Off, NotifySend, Osc9Bell, Print) replaces bool; detect_backend_with() helper for testable detection; send_osc9_notification for Bell-based alerts.
- copy_to_clipboard refactored to Result<(), String> across slash_bug, slash_info, slash_dispatch.
- display_width fix in custom_terminal.rs: strips OSC sequences terminated by ST before measuring width (required for OSC 8 links not inflating visible character count).
- Snapshot updates for approval_card tests reflecting new status indicator rendering.
- Minor: status_indicator.rs constants clarified; markdown_render.rs path link handling improved; wrapping.rs added split_optional_line_suffix.

## Testing

- detect_backend_with tests: non-tty Osc9/Bell forced to Disabled; Osc9/Bell on tty to Osc9; Bell only to Bell; NotifySend available to NotifySend.
- parse_osc_color_response + parse_x_color_component tests: handles both rgb:XXXX/YYYY/ZZZZ (16-bit) and #RRGGBB formats with correct 16-to-8-bit normalization.
- display_width test: OSC 8 link escape sequences correctly stripped before width measurement.

## Review Notes

2 issues flagged for follow-up:
1. requery_default_colors() sends OSC 10/11 queries but the response is never read back — reply bytes land in stdin (needs verification against event loop).
2. Path heuristics (is_absolute_path_like, is_relative_path_like, split_optional_line_suffix) are duplicated between terminal_hyperlinks.rs and wrapping.rs — should be extracted to a shared module.