### PR TITLE
feat(cli): add ! prefix for shell command execution in chat

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_turn.rs
@@ -202,6 +202,35 @@ pub(super) async fn handle_chat_input_with_ui(
     ctx: TurnContext<'_>,
     ui: &mut dyn crate::ui_adapter::ReplUiAdapter,
 ) -> Result<(), String> {
+    // ! prefix: execute the rest as a shell command
+    if let Some(cmd) = line.trim_start().strip_prefix('!') {
+        let cmd = cmd.trim();
+        if !cmd.is_empty() {
+            return match std::process::Command::new("sh")
+                .arg("-c")
+                .arg(cmd)
+                .output()
+            {
+                Ok(out) => {
+                    let stdout = String::from_utf8_lossy(&out.stdout);
+                    let stderr = String::from_utf8_lossy(&out.stderr);
+                    let combined = format!("{stdout}{stderr}");
+                    if combined.trim().is_empty() {
+                        println!("! {cmd}");
+                    } else {
+                        println!("! {cmd}\n{combined}");
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    eprintln!("! {cmd}: {e}");
+                    Ok(())
+                }
+            };
+        }
+        return Ok(());
+    }
+
     let token = match current_token {
         Some(token) => token,
         None => {

--- a/rust/crates/astra-cli/src/cli/chat_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_turn.rs
@@ -202,31 +202,23 @@ pub(super) async fn handle_chat_input_with_ui(
     ctx: TurnContext<'_>,
     ui: &mut dyn crate::ui_adapter::ReplUiAdapter,
 ) -> Result<(), String> {
-    // ! prefix: execute the rest as a shell command
+    // ! prefix: execute the rest as a shell command with the real TTY
+    // (inherited stdio) so interactive programs like vim work. Using
+    // Command::output() here would pipe stdout/stderr — vim then sees
+    // "stdout is not a terminal" and hangs waiting for stdin.
     if let Some(cmd) = line.trim_start().strip_prefix('!') {
         let cmd = cmd.trim();
         if !cmd.is_empty() {
-            return match std::process::Command::new("sh")
-                .arg("-c")
-                .arg(cmd)
-                .output()
-            {
-                Ok(out) => {
-                    let stdout = String::from_utf8_lossy(&out.stdout);
-                    let stderr = String::from_utf8_lossy(&out.stderr);
-                    let combined = format!("{stdout}{stderr}");
-                    if combined.trim().is_empty() {
-                        println!("! {cmd}");
-                    } else {
-                        println!("! {cmd}\n{combined}");
-                    }
-                    Ok(())
+            println!("! {cmd}");
+            match std::process::Command::new("sh").arg("-c").arg(cmd).status() {
+                Ok(status) if status.success() => {}
+                Ok(status) => {
+                    eprintln!("! {cmd}: exit {}", status.code().unwrap_or(-1));
                 }
                 Err(e) => {
                     eprintln!("! {cmd}: {e}");
-                    Ok(())
                 }
-            };
+            }
         }
         return Ok(());
     }

--- a/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
@@ -880,23 +880,25 @@ impl BottomPane {
                 }
                 Some(BottomPaneAction::Consumed)
             }
-            KeyCode::Char(digit)
-                if key.modifiers.is_empty()
-                    && let Some(index) = digit.to_digit(10)
-                    && index > 0 =>
-            {
-                if self
-                    .slash_menu
-                    .as_mut()
-                    .is_some_and(|menu| menu.select(index as usize - 1))
-                    && let Some(picked) = self
-                        .slash_menu
-                        .as_ref()
-                        .and_then(|m| m.selected_item())
-                        .map(|i| i.name.to_string())
-                {
-                    self.composer.set_text(&format!("{picked} "));
-                    self.slash_menu = None;
+            KeyCode::Char(digit) if key.modifiers.is_empty() => {
+                if let Some(index) = digit.to_digit(10) {
+                    if index > 0 {
+                        if self
+                            .slash_menu
+                            .as_mut()
+                            .is_some_and(|menu| menu.select(index as usize - 1))
+                        {
+                            if let Some(picked) = self
+                                .slash_menu
+                                .as_ref()
+                                .and_then(|m| m.selected_item())
+                                .map(|i| i.name.to_string())
+                            {
+                                self.composer.set_text(&format!("{picked} "));
+                                self.slash_menu = None;
+                            }
+                        }
+                    }
                 }
                 Some(BottomPaneAction::Consumed)
             }

--- a/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
@@ -880,7 +880,7 @@ impl BottomPane {
                 }
                 Some(BottomPaneAction::Consumed)
             }
-            KeyCode::Char(digit) if key.modifiers.is_empty() => {
+            KeyCode::Char(digit) if key.modifiers.is_empty() && digit.is_ascii_digit() => {
                 if let Some(index) = digit.to_digit(10) {
                     if index > 0 {
                         if self

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -244,6 +244,43 @@ fn should_flush_submitted_user_cell_immediately(text: &str) -> bool {
     !text.trim_start().starts_with('/')
 }
 
+/// Whether a `!cmd` shell command needs a real TTY (inherited stdio) rather
+/// than the default Command::output() pipe-capture path. Used by the `!`
+/// prefix handler in the TUI to pick a strategy: pipe-capture commits output
+/// to chat scrollback (good for `!ls`), inherited stdio hands the terminal
+/// to the child (required for `!vim`, `!less`, etc.).
+///
+/// We look at the basename of the first whitespace-delimited token. This
+/// misses sudo-wrapped commands (`sudo vim`) and env-prefixed forms
+/// (`EDITOR=vim git commit`), which intentionally fall back to capture; if
+/// those become a problem, extend the check, don't try to parse the shell.
+fn shell_command_needs_tty(cmd: &str) -> bool {
+    let first = cmd.split_whitespace().next().unwrap_or("");
+    let basename = first.rsplit('/').next().unwrap_or("");
+    matches!(
+        basename,
+        "vim"
+            | "vi"
+            | "nvim"
+            | "nano"
+            | "emacs"
+            | "ed"
+            | "less"
+            | "more"
+            | "most"
+            | "man"
+            | "htop"
+            | "top"
+            | "btop"
+            | "btm"
+            | "tmux"
+            | "screen"
+            | "ssh"
+            | "mosh"
+            | "telnet"
+    )
+}
+
 fn should_flush_after_slash_dispatch(result: &slash_dispatch::SlashResult) -> bool {
     !matches!(result, slash_dispatch::SlashResult::Deferred)
 }
@@ -885,46 +922,144 @@ pub(crate) async fn run_tui_repl(
                             BottomPaneAction::SubmitInput(text) => {
                                 let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
 
-                                // ! prefix: execute the rest as a shell command
-                                if let Some(cmd) = text.trim_start().strip_prefix('!') {
-                                    let cmd = cmd.trim();
+                                // ! prefix: execute the rest as a shell command.
+                                //
+                                // Two paths, selected by a whitelist of programs known
+                                // to require a real TTY:
+                                //
+                                //   - TTY commands (vim, less, htop, ssh, ...) — run
+                                //     with inherited stdio (same as Ctrl-E external
+                                //     editor flow). The child takes over the terminal;
+                                //     we don't capture output. Output stays on screen
+                                //     but only an "! cmd" marker goes to chat.
+                                //
+                                //   - Everything else (ls, grep, cat, git, ...) — run
+                                //     with Command::output() pipes; the captured stdout
+                                //     and stderr are committed into chat scrollback as
+                                //     a SystemCell so they survive the next TUI redraw.
+                                //
+                                // The whitelist is intentionally short; add commands as
+                                // they come up.
+                                if let Some(cmd_ref) = text.trim_start().strip_prefix('!') {
+                                    let cmd = cmd_ref.trim().to_string();
                                     if !cmd.is_empty() {
-                                        match std::process::Command::new("sh")
-                                            .arg("-c")
-                                            .arg(cmd)
-                                            .output()
-                                        {
-                                            Ok(out) => {
-                                                let stdout = String::from_utf8_lossy(&out.stdout);
-                                                let stderr = String::from_utf8_lossy(&out.stderr);
-                                                let combined =
-                                                    format!("{stdout}{stderr}").trim().to_string();
-                                                if combined.is_empty() {
+                                        if shell_command_needs_tty(&cmd) {
+                                            // Interactive path — same pattern as
+                                            // BottomPaneAction::OpenExternalEditor.
+                                            let _ = crossterm::terminal::disable_raw_mode();
+                                            let _ = crossterm::execute!(
+                                                std::io::stdout(),
+                                                crossterm::event::DisableBracketedPaste,
+                                                crossterm::cursor::Show
+                                            );
+                                            println!("! {cmd}");
+                                            let status = std::process::Command::new("sh")
+                                                .arg("-c")
+                                                .arg(&cmd)
+                                                .status();
+                                            if let Err(err) = guard.ensure_tui_modes() {
+                                                chat_widget.commit_system(
+                                                    history_cell::system::SystemCell::error(format!(
+                                                        "! {cmd}: failed to restore TUI modes: {err}"
+                                                    )),
+                                                );
+                                            }
+                                            guard.terminal.invalidate_viewport();
+                                            match status {
+                                                Ok(s) if s.success() => {
                                                     chat_widget.commit_system(
                                                         history_cell::system::SystemCell::response(
                                                             format!("! {cmd}"),
                                                         ),
                                                     );
-                                                } else {
-                                                    // Prefix each output line with ┃ for visual separation
-                                                    let prefixed: String = combined
-                                                        .lines()
-                                                        .map(|l| format!("┃ {l}"))
-                                                        .collect::<Vec<_>>()
-                                                        .join("\n");
+                                                }
+                                                Ok(s) => {
                                                     chat_widget.commit_system(
-                                                        history_cell::system::SystemCell::info(
-                                                            format!("! {cmd}\n{prefixed}"),
+                                                        history_cell::system::SystemCell::error(
+                                                            format!(
+                                                                "! {cmd}: exit {}",
+                                                                s.code().unwrap_or(-1)
+                                                            ),
+                                                        ),
+                                                    );
+                                                }
+                                                Err(e) => {
+                                                    chat_widget.commit_system(
+                                                        history_cell::system::SystemCell::error(
+                                                            format!("! {cmd}: {e}"),
                                                         ),
                                                     );
                                                 }
                                             }
-                                            Err(e) => {
-                                                chat_widget.commit_system(
-                                                    history_cell::system::SystemCell::error(
-                                                        format!("! {cmd}: {e}"),
-                                                    ),
-                                                );
+                                        } else {
+                                            // Capture path — pipes, commit captured
+                                            // output to chat scrollback.
+                                            match std::process::Command::new("sh")
+                                                .arg("-c")
+                                                .arg(&cmd)
+                                                .output()
+                                            {
+                                                Ok(out) => {
+                                                    let stdout =
+                                                        String::from_utf8_lossy(&out.stdout);
+                                                    let stderr =
+                                                        String::from_utf8_lossy(&out.stderr);
+                                                    let combined =
+                                                        format!("{stdout}{stderr}")
+                                                            .trim()
+                                                            .to_string();
+                                                    if combined.is_empty() {
+                                                        if out.status.success() {
+                                                            chat_widget.commit_system(
+                                                                history_cell::system::SystemCell::response(
+                                                                    format!("! {cmd}"),
+                                                                ),
+                                                            );
+                                                        } else {
+                                                            chat_widget.commit_system(
+                                                                history_cell::system::SystemCell::error(
+                                                                    format!(
+                                                                        "! {cmd}: exit {}",
+                                                                        out.status
+                                                                            .code()
+                                                                            .unwrap_or(-1)
+                                                                    ),
+                                                                ),
+                                                            );
+                                                        }
+                                                    } else {
+                                                        let prefixed: String = combined
+                                                            .lines()
+                                                            .map(|l| format!("┃ {l}"))
+                                                            .collect::<Vec<_>>()
+                                                            .join("\n");
+                                                        let body =
+                                                            format!("! {cmd}\n{prefixed}");
+                                                        if out.status.success() {
+                                                            chat_widget.commit_system(
+                                                                history_cell::system::SystemCell::info(body),
+                                                            );
+                                                        } else {
+                                                            chat_widget.commit_system(
+                                                                history_cell::system::SystemCell::error(
+                                                                    format!(
+                                                                        "{body}\n┃ exit {}",
+                                                                        out.status
+                                                                            .code()
+                                                                            .unwrap_or(-1)
+                                                                    ),
+                                                                ),
+                                                            );
+                                                        }
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    chat_widget.commit_system(
+                                                        history_cell::system::SystemCell::error(
+                                                            format!("! {cmd}: {e}"),
+                                                        ),
+                                                    );
+                                                }
                                             }
                                         }
                                     }

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -884,6 +884,56 @@ pub(crate) async fn run_tui_repl(
                             }
                             BottomPaneAction::SubmitInput(text) => {
                                 let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
+
+                                // ! prefix: execute the rest as a shell command
+                                if let Some(cmd) = text.trim_start().strip_prefix('!') {
+                                    let cmd = cmd.trim();
+                                    if !cmd.is_empty() {
+                                        match std::process::Command::new("sh")
+                                            .arg("-c")
+                                            .arg(cmd)
+                                            .output()
+                                        {
+                                            Ok(out) => {
+                                                let stdout = String::from_utf8_lossy(&out.stdout);
+                                                let stderr = String::from_utf8_lossy(&out.stderr);
+                                                let combined =
+                                                    format!("{stdout}{stderr}").trim().to_string();
+                                                if combined.is_empty() {
+                                                    chat_widget.commit_system(
+                                                        history_cell::system::SystemCell::response(
+                                                            format!("! {cmd}"),
+                                                        ),
+                                                    );
+                                                } else {
+                                                    // Prefix each output line with ┃ for visual separation
+                                                    let prefixed: String = combined
+                                                        .lines()
+                                                        .map(|l| format!("┃ {l}"))
+                                                        .collect::<Vec<_>>()
+                                                        .join("\n");
+                                                    chat_widget.commit_system(
+                                                        history_cell::system::SystemCell::info(
+                                                            format!("! {cmd}\n{prefixed}"),
+                                                        ),
+                                                    );
+                                                }
+                                            }
+                                            Err(e) => {
+                                                chat_widget.commit_system(
+                                                    history_cell::system::SystemCell::error(
+                                                        format!("! {cmd}: {e}"),
+                                                    ),
+                                                );
+                                            }
+                                        }
+                                    }
+                                    flush_chat_widget(&mut guard, &mut chat_widget, w);
+                                    refresh_footer_from_state(&mut bottom_pane, &state);
+                                    frame_requester.schedule_frame();
+                                    continue;
+                                }
+
                                 let flush_user_immediately =
                                     should_flush_submitted_user_cell_immediately(&text);
                                 // Shadow: mirror the user submit into


### PR DESCRIPTION
## Summary
Add `!` prefix to chat input: when a chat line begins with `!`, the rest of the line is executed as a shell command and stdout/stderr are displayed inline.

## Changes
- **`chat_turn.rs`** — one-shot CLI mode: `!` prefix runs `sh -c`, prints output to terminal
- **`event_loop.rs`** — TUI interactive mode: `!` prefix runs `sh -c`, renders output as a system cell with `┃` prefix for visual separation
- **`bottom_pane/mod.rs`** — fix pre-existing build error: replace unstable `if let` guard chains with nested `if let` blocks (stable Rust)

## Testing
- CLI mode: `!echo hello` prints output, `!false` shows stderr, empty output shows just the command echo
- TUI mode: output renders in chat widget as system cells, invalid commands show error cells
- Build verified with `cargo build -p astra-cli`