### PR TITLE
fix: Anthropic orphaned tool_result requests

### DIFF
--- a/rust/crates/runtime/src/server/run_lifecycle.rs
+++ b/rust/crates/runtime/src/server/run_lifecycle.rs
@@ -2238,6 +2238,37 @@ fn is_run_finished_event(event: &Value) -> bool {
     event.get("event_type").and_then(Value::as_str) == Some("run_finished")
 }
 
+fn is_completed_run_finished_event(event: &Value) -> bool {
+    if !is_run_finished_event(event) {
+        return false;
+    }
+    let data = event.get("data").and_then(Value::as_object);
+    let cancelled = data
+        .and_then(|obj| obj.get("cancelled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let interrupted = data
+        .and_then(|obj| obj.get("interrupted"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    !cancelled && !interrupted
+}
+
+fn has_buffered_terminal_completion(events: &[Value]) -> bool {
+    events
+        .iter()
+        .rev()
+        .find(|event| is_run_finished_event(event))
+        .is_some_and(is_completed_run_finished_event)
+}
+
+fn should_preserve_manual_pause_on_completion(
+    current_status: &RunStatus,
+    final_status: &RunStatus,
+) -> bool {
+    *current_status == RunStatus::Paused && *final_status == RunStatus::Completed
+}
+
 fn merge_run_finished_event_data(target: &mut Value, source: &Value) {
     let source_data = source
         .get("data")
@@ -4095,21 +4126,17 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             bg_progress_channels.lock().await.remove(&bg_run_id);
             let terminal_events = terminal_events_for_persistence(&events);
 
-            // Schedule eviction of the terminal run from the in-memory cache.
-            // Waiting runs are NOT evicted — they need to remain in memory for resume.
-            if final_status != RunStatus::Waiting {
-                Self::schedule_run_eviction(&runs, bg_run_id.clone());
-            }
-
             // Publish terminal run state before best-effort post-run side effects
             // so background observers do not stay stuck in "running" because a
             // hook, event write, or learning save is slow.
-            let status_str = final_status.as_str();
-            let mut persist_terminal_state = true;
+            let mut persisted_status = final_status.clone();
+            let mut persist_status_update = true;
+            let mut persist_terminal_events = true;
 
             if let Some(run) = runs.write().await.get_mut(&bg_run_id) {
                 if run.status == RunStatus::Cancelled {
-                    persist_terminal_state = false;
+                    persist_status_update = false;
+                    persist_terminal_events = false;
                     merge_cancelled_run_events(run, events);
                     if final_status != RunStatus::Waiting {
                         run.live_tx = None;
@@ -4117,19 +4144,36 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                     flush_turn_observability(&mut loop_state, &bg_session_id, true);
                 } else {
                     run.events.extend(events);
-                    if run.status.try_transition(&final_status).is_ok() {
+                    if should_preserve_manual_pause_on_completion(&run.status, &final_status) {
+                        persist_status_update = false;
+                        persisted_status = RunStatus::Paused;
+                        run.waiting_for
+                            .get_or_insert_with(|| "user_resume".to_string());
+                        run.live_tx = None;
+                    } else if run.status.try_transition(&final_status).is_ok() {
                         run.status = final_status.clone();
                     }
-                    if run.status != RunStatus::Waiting {
+                    if run.status != RunStatus::Waiting && run.status != RunStatus::Paused {
                         run.live_tx = None;
                     }
                 }
             }
 
-            if persist_terminal_state {
+            // Schedule eviction of the terminal run from the in-memory cache.
+            // Waiting and paused runs are NOT evicted — they may still be resumed.
+            if persisted_status != RunStatus::Waiting && persisted_status != RunStatus::Paused {
+                Self::schedule_run_eviction(&runs, bg_run_id.clone());
+            }
+
+            if persist_status_update {
                 astra_core::log_persist!(
                     run_engine
-                        .persist_status(&bg_run_id, status_str, None, error_msg.as_deref())
+                        .persist_status(
+                            &bg_run_id,
+                            persisted_status.as_str(),
+                            None,
+                            error_msg.as_deref()
+                        )
                         .await,
                     "run_lifecycle",
                     &bg_run_id,
@@ -4156,7 +4200,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                     gov.record_tokens(&bg_user_id, total).await;
                 }
             }
-            if persist_terminal_state {
+            if persist_terminal_events {
                 for event in terminal_events {
                     astra_core::log_persist!(
                         run_engine.append_event(&bg_run_id, event).await,
@@ -4167,7 +4211,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 }
             }
 
-            if persist_terminal_state {
+            if persist_terminal_events {
                 flush_turn_observability(&mut loop_state, &bg_session_id, false);
                 persist_turn_evaluation_journal(&bg_session_id, "server_runtime", &loop_state);
             }
@@ -4496,13 +4540,14 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             let mut all_events = vec![json!({"event_type": "run_started", "data": {}})];
             all_events.append(&mut final_events);
 
-            let mut persist_terminal_state = true;
+            let mut persisted_status = final_status.clone();
+            let mut persist_status_update = true;
             // Extract terminal events before the branch — both branches consume
             // all_events by move, so this must happen first.
             let terminal_events = terminal_events_for_persistence(&all_events);
             if let Some(run) = runs.write().await.get_mut(&bg_run_id) {
                 if run.status == RunStatus::Cancelled {
-                    persist_terminal_state = false;
+                    persist_status_update = false;
                     merge_cancelled_run_events(run, all_events);
                     if final_status != RunStatus::Waiting {
                         run.live_tx = None;
@@ -4510,10 +4555,16 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                     flush_turn_observability(&mut state, &bg_session_id, true);
                 } else {
                     run.events.extend(all_events);
-                    if run.status.try_transition(&final_status).is_ok() {
+                    if should_preserve_manual_pause_on_completion(&run.status, &final_status) {
+                        persist_status_update = false;
+                        persisted_status = RunStatus::Paused;
+                        run.waiting_for
+                            .get_or_insert_with(|| "user_resume".to_string());
+                        run.live_tx = None;
+                    } else if run.status.try_transition(&final_status).is_ok() {
                         run.status = final_status.clone();
                     }
-                    if run.status != RunStatus::Waiting {
+                    if run.status != RunStatus::Waiting && run.status != RunStatus::Paused {
                         run.live_tx = None;
                     }
                     flush_turn_observability(&mut state, &bg_session_id, false);
@@ -4521,8 +4572,8 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             }
 
             // Schedule eviction of the terminal run from the in-memory cache.
-            // Waiting runs are NOT evicted — they need to remain in memory for resume.
-            if final_status != RunStatus::Waiting {
+            // Waiting and paused runs are NOT evicted — they may still be resumed.
+            if persisted_status != RunStatus::Waiting && persisted_status != RunStatus::Paused {
                 Self::schedule_run_eviction(&runs, bg_run_id.clone());
             }
 
@@ -4535,12 +4586,12 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 }
             }
 
-            if persist_terminal_state {
+            if persist_status_update {
                 astra_core::log_persist!(
                     run_engine
                         .persist_status(
                             &bg_run_id,
-                            final_status.as_str(),
+                            persisted_status.as_str(),
                             None,
                             error_msg.as_deref()
                         )
@@ -5037,6 +5088,28 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         let durable = self.require_durable_run_for_user(&run_id, &user_id).await?;
         if durable.status != STATUS_PAUSED {
             return Err(Self::run_state_conflict("resume", &durable.status));
+        }
+
+        if has_buffered_terminal_completion(&durable.events) {
+            self.run_engine
+                .persist_status(&run_id, STATUS_COMPLETED, None, None)
+                .await
+                .map_err(|error| Self::durable_persist_error("resume completed status", error))?;
+            {
+                let mut runs = self.runs.write().await;
+                if let Some(run) = runs.get_mut(&run_id) {
+                    run.status = RunStatus::Completed;
+                    run.pause_flag.store(false, Ordering::SeqCst);
+                    run.waiting_for = None;
+                    run.live_tx = None;
+                }
+            }
+            Self::schedule_run_eviction(&self.runs, run_id.clone());
+            return Ok(RunMutationRecord {
+                run_id,
+                status: STATUS_COMPLETED.to_string(),
+                previous_status: durable.status,
+            });
         }
 
         let resume_event = json!({"event_type": "run_resumed", "data": {}});
@@ -7468,6 +7541,38 @@ mod tests {
         assert!(server_loop_causal_chain_id("server-loop-tools").len() <= 64);
     }
 
+    #[test]
+    fn has_buffered_terminal_completion_ignores_cancelled_and_interrupted_finishes() {
+        assert!(has_buffered_terminal_completion(&[json!({
+            "event_type": "run_finished",
+            "data": {"total_prompt_tokens": 1, "total_completion_tokens": 1}
+        })]));
+        assert!(!has_buffered_terminal_completion(&[json!({
+            "event_type": "run_finished",
+            "data": {"cancelled": true}
+        })]));
+        assert!(!has_buffered_terminal_completion(&[json!({
+            "event_type": "run_finished",
+            "data": {"interrupted": true}
+        })]));
+    }
+
+    #[test]
+    fn preserve_manual_pause_wins_over_late_completed_status() {
+        assert!(should_preserve_manual_pause_on_completion(
+            &RunStatus::Paused,
+            &RunStatus::Completed
+        ));
+        assert!(!should_preserve_manual_pause_on_completion(
+            &RunStatus::Paused,
+            &RunStatus::Failed
+        ));
+        assert!(!should_preserve_manual_pause_on_completion(
+            &RunStatus::Running,
+            &RunStatus::Completed
+        ));
+    }
+
     #[tokio::test]
     async fn pause_run_transitions_running_to_paused() {
         let svc = test_service();
@@ -7513,6 +7618,29 @@ mod tests {
         assert_eq!(result.previous_status, "paused");
         let status = ok(svc.get_run_status(run.run_id, "user-1".into()).await);
         assert_eq!(status.status, "running");
+    }
+
+    #[tokio::test]
+    async fn resume_run_promotes_buffered_completed_pause_to_completed() {
+        let svc = test_service_with_engine();
+        let run = ok(svc.create_run("user-1".into(), test_request("task")).await);
+        ok(svc.pause_run(run.run_id.clone(), "user-1".into()).await);
+        svc.run_engine
+            .append_event(
+                &run.run_id,
+                json!({
+                    "event_type": "run_finished",
+                    "data": {"total_prompt_tokens": 1, "total_completion_tokens": 1}
+                }),
+            )
+            .await
+            .unwrap();
+
+        let result = ok(svc.resume_run(run.run_id.clone(), "user-1".into()).await);
+        assert_eq!(result.status, "completed");
+        assert_eq!(result.previous_status, "paused");
+        let status = ok(svc.get_run_status(run.run_id, "user-1".into()).await);
+        assert_eq!(status.status, "completed");
     }
 
     #[tokio::test]
@@ -8300,8 +8428,9 @@ mod tests {
         assert_eq!(events[0]["data"]["reason"], "waiting: tool_approval");
     }
 
-    /// P1-F: stream_chat must persist usage unconditionally (not gated by persist_terminal_state).
-    /// Cancelled runs still consumed tokens and must have accurate durable records.
+    /// P1-F: stream_chat must persist usage unconditionally.
+    /// Cancelled runs still consumed tokens and must have accurate durable records,
+    /// even when status persistence is skipped.
     #[test]
     fn stream_chat_persists_usage_unconditionally() {
         let source = include_str!("run_lifecycle.rs");
@@ -8315,12 +8444,15 @@ mod tests {
             .unwrap_or(source.len());
         let fn_body = &source[fn_start..fn_end];
 
-        // persist_usage must NOT be inside the persist_terminal_state block.
-        // Find the persist_terminal_state block and verify persist_usage is outside it.
+        let usage_pos = fn_body
+            .find(".persist_usage(")
+            .expect("stream_chat must call persist_usage");
+
+        // persist_usage must NOT be inside the status-persistence guard.
+        // Cancelled runs skip persist_status, but usage must still be written.
         let guard_pos = fn_body
-            .find("if persist_terminal_state {")
-            .expect("persist_terminal_state guard must exist");
-        // Find the closing brace of the guard block
+            .find("if persist_status_update {")
+            .expect("persist_status_update guard must exist");
         let guard_block = &fn_body[guard_pos..];
         let mut depth = 0;
         let mut guard_end = 0;
@@ -8335,17 +8467,10 @@ mod tests {
                 }
             }
         }
-        let guard_body = &fn_body[guard_pos..guard_end];
         assert!(
-            !guard_body.contains("persist_usage"),
-            "persist_usage must NOT be inside persist_terminal_state guard — \
+            usage_pos > guard_end,
+            "persist_usage must remain outside the persist_status_update guard — \
              cancelled stream_chat runs must still persist usage for billing/audit"
-        );
-
-        // persist_usage must exist somewhere in stream_chat
-        assert!(
-            fn_body.contains("persist_usage"),
-            "stream_chat must call persist_usage"
         );
     }
 

--- a/rust/crates/runtime/src/turn/llm_client.rs
+++ b/rust/crates/runtime/src/turn/llm_client.rs
@@ -17,7 +17,7 @@
 //! Re-exported as [`apply_env_proxy`] for in-crate call sites.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::Arc,
     sync::atomic::{AtomicBool, Ordering},
     time::Instant,
@@ -1032,6 +1032,168 @@ pub(crate) fn repair_openai_tool_pairing_for_bedrock(messages: &[Value]) -> Vec<
     repaired
 }
 
+fn anthropic_tool_use_ids(msg: &Value) -> Vec<String> {
+    msg.get("content")
+        .map(anthropic_content_as_blocks)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some("tool_use"))
+        .filter_map(|block| block.get("id").and_then(Value::as_str).map(String::from))
+        .collect()
+}
+
+fn is_anthropic_tool_result_block(block: &Value) -> bool {
+    block.get("type").and_then(Value::as_str) == Some("tool_result")
+}
+
+fn synthetic_anthropic_tool_result_block(tool_use_id: &str) -> Value {
+    json!({
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "content": SYNTHETIC_TOOL_INTERRUPTED_CONTENT,
+    })
+}
+
+/// Repair Anthropic Messages tool_use/tool_result mismatches after conversion to
+/// Anthropic-native roles/content blocks.
+///
+/// Anthropic enforces a stricter adjacency rule than OpenAI wire format: any
+/// `tool_result` block must live on the `user` message immediately following the
+/// `assistant` message that declared the matching `tool_use`. Compaction and
+/// resume can leave three classes of corruption:
+///
+/// 1. Missing tool_result for a declared tool_use.
+/// 2. Orphaned tool_result whose `tool_use_id` no longer appears in the
+///    previous assistant message.
+/// 3. Duplicate tool_result blocks for the same `tool_use_id`.
+///
+/// We repair in-place at the Anthropic wire layer so both native `role=tool`
+/// inputs (after conversion) and already-native `role=user` tool_result blocks
+/// are handled consistently.
+fn repair_anthropic_tool_pairing(messages: &[Value]) -> Vec<Value> {
+    let mut repaired: Vec<Value> = Vec::with_capacity(messages.len() + 1);
+    let mut missing_counts: usize = 0;
+    let mut orphan_counts: usize = 0;
+    let mut dup_counts: usize = 0;
+
+    let mut i = 0;
+    while i < messages.len() {
+        let msg = &messages[i];
+        let role = msg.get("role").and_then(Value::as_str).unwrap_or_default();
+
+        if role == "assistant" {
+            let declared_ids = anthropic_tool_use_ids(msg);
+            repaired.push(msg.clone());
+            i += 1;
+
+            if declared_ids.is_empty() {
+                continue;
+            }
+
+            let declared_set: HashSet<&str> = declared_ids.iter().map(String::as_str).collect();
+
+            if i < messages.len() && messages[i].get("role").and_then(Value::as_str) == Some("user")
+            {
+                let mut user_msg = messages[i].clone();
+                let mut seen_ids: HashSet<String> = HashSet::new();
+                let mut kept_tool_results: Vec<Value> = Vec::new();
+                let mut other_blocks: Vec<Value> = Vec::new();
+
+                for block in messages[i]
+                    .get("content")
+                    .map(anthropic_content_as_blocks)
+                    .unwrap_or_default()
+                {
+                    if !is_anthropic_tool_result_block(&block) {
+                        other_blocks.push(block);
+                        continue;
+                    }
+                    let tool_use_id = block
+                        .get("tool_use_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    if tool_use_id.is_empty() || !declared_set.contains(tool_use_id) {
+                        orphan_counts += 1;
+                        continue;
+                    }
+                    if !seen_ids.insert(tool_use_id.to_string()) {
+                        dup_counts += 1;
+                        continue;
+                    }
+                    kept_tool_results.push(block);
+                }
+
+                for declared in &declared_ids {
+                    if !seen_ids.contains(declared) {
+                        missing_counts += 1;
+                        kept_tool_results.push(synthetic_anthropic_tool_result_block(declared));
+                    }
+                }
+
+                kept_tool_results.extend(other_blocks);
+                user_msg["content"] = Value::Array(kept_tool_results);
+                repaired.push(user_msg);
+                i += 1;
+                continue;
+            }
+
+            missing_counts += declared_ids.len();
+            repaired.push(json!({
+                "role": "user",
+                "content": declared_ids
+                    .iter()
+                    .map(|id| synthetic_anthropic_tool_result_block(id))
+                    .collect::<Vec<_>>(),
+            }));
+            continue;
+        }
+
+        if role == "user" {
+            let blocks = msg
+                .get("content")
+                .map(anthropic_content_as_blocks)
+                .unwrap_or_default();
+            if blocks.iter().any(is_anthropic_tool_result_block) {
+                let kept_blocks: Vec<Value> = blocks
+                    .into_iter()
+                    .filter_map(|block| {
+                        if is_anthropic_tool_result_block(&block) {
+                            orphan_counts += 1;
+                            None
+                        } else {
+                            Some(block)
+                        }
+                    })
+                    .collect();
+                if kept_blocks.is_empty() {
+                    i += 1;
+                    continue;
+                }
+                let mut user_msg = msg.clone();
+                user_msg["content"] = Value::Array(kept_blocks);
+                repaired.push(user_msg);
+                i += 1;
+                continue;
+            }
+        }
+
+        repaired.push(msg.clone());
+        i += 1;
+    }
+
+    if missing_counts + orphan_counts + dup_counts > 0 {
+        tracing::warn!(
+            missing = missing_counts,
+            orphaned = orphan_counts,
+            duplicate = dup_counts,
+            input_len = messages.len(),
+            output_len = repaired.len(),
+            "repaired tool_use/tool_result pairing for Anthropic request"
+        );
+    }
+    repaired
+}
+
 fn flush_tool_buffer(out: &mut Vec<Value>, buffer: &mut Vec<Value>) {
     if buffer.is_empty() {
         return;
@@ -1371,6 +1533,7 @@ pub(crate) fn build_provider_request_body(
             let is_anthropic = provider_uses_anthropic_messages(provider);
             if is_anthropic {
                 let (system, anthropic_messages) = build_anthropic_system_and_messages(messages);
+                let anthropic_messages = repair_anthropic_tool_pairing(&anthropic_messages);
                 let mut body = json!({
                     "model": model_name,
                     "messages": anthropic_messages,
@@ -5918,6 +6081,160 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn repair_anthropic_tool_pairing_strips_orphaned_leading_tool_results() {
+        let messages = vec![json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "resume"},
+                {"type": "text", "text": " context"},
+                {"type": "tool_result", "tool_use_id": "ghost", "content": "stale output"},
+            ],
+        })];
+
+        let repaired = repair_anthropic_tool_pairing(&messages);
+        assert_eq!(repaired.len(), 1, "{repaired:#?}");
+        let blocks = repaired[0]["content"].as_array().unwrap();
+        assert_eq!(blocks.len(), 2, "{blocks:#?}");
+        assert!(blocks.iter().all(|b| !is_anthropic_tool_result_block(b)));
+        assert_eq!(blocks[0]["text"], "resume");
+        assert_eq!(blocks[1]["text"], " context");
+    }
+
+    #[test]
+    fn repair_anthropic_tool_pairing_synthesizes_missing_results_into_next_user_message() {
+        let messages = vec![
+            json!({
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "call_a",
+                    "name": "glob",
+                    "input": {"pattern": "**/*.rs"},
+                }],
+            }),
+            json!({
+                "role": "user",
+                "content": [{"type": "text", "text": "continue"}],
+            }),
+        ];
+
+        let repaired = repair_anthropic_tool_pairing(&messages);
+        assert_eq!(repaired.len(), 2, "{repaired:#?}");
+        let blocks = repaired[1]["content"].as_array().unwrap();
+        assert_eq!(blocks[0]["type"], "tool_result");
+        assert_eq!(blocks[0]["tool_use_id"], "call_a");
+        assert_eq!(
+            blocks[0]["content"].as_str(),
+            Some(SYNTHETIC_TOOL_INTERRUPTED_CONTENT)
+        );
+        assert_eq!(blocks[1]["type"], "text");
+        assert_eq!(blocks[1]["text"], "continue");
+    }
+
+    #[test]
+    fn build_provider_request_body_anthropic_drops_orphaned_tool_result_history() {
+        let messages = vec![
+            json!({"role": "tool", "tool_call_id": "ghost", "content": "stale output"}),
+            json!({"role": "user", "content": "continue"}),
+        ];
+
+        let body = build_provider_request_body(
+            &messages,
+            &[],
+            "claude-test",
+            "anthropic",
+            None,
+            None,
+            true,
+            &ThinkingConfig::Off,
+        );
+
+        let wire_messages = body["messages"].as_array().unwrap();
+        assert_eq!(wire_messages.len(), 1, "{wire_messages:#?}");
+        assert_eq!(wire_messages[0]["role"], "user");
+        let blocks = wire_messages[0]["content"].as_array().unwrap();
+        assert_eq!(blocks.len(), 1, "{blocks:#?}");
+        assert_eq!(blocks[0]["type"], "text");
+        assert_eq!(blocks[0]["text"], "continue");
+    }
+
+    #[test]
+    fn build_provider_request_body_anthropic_strips_mixed_user_orphan_without_losing_cache_control()
+    {
+        // Minimal shape from the real 400: `messages[0].content[2]` is an
+        // orphaned tool_result inside an otherwise normal user content array.
+        // We intentionally keep only the trigger shape — not a full session log.
+        let messages = vec![json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "resume", "cache_control": {"type": "ephemeral"}},
+                {"type": "text", "text": " context"},
+                {"type": "tool_result", "tool_use_id": "ghost", "content": "stale output"},
+            ],
+        })];
+
+        let body = build_provider_request_body(
+            &messages,
+            &[],
+            "claude-test",
+            "anthropic",
+            None,
+            None,
+            true,
+            &ThinkingConfig::Off,
+        );
+
+        let wire_messages = body["messages"].as_array().unwrap();
+        assert_eq!(wire_messages.len(), 1, "{wire_messages:#?}");
+        let blocks = wire_messages[0]["content"].as_array().unwrap();
+        assert_eq!(blocks.len(), 2, "{blocks:#?}");
+        assert_eq!(blocks[0]["type"], "text");
+        assert_eq!(blocks[0]["text"], "resume");
+        assert_eq!(blocks[0]["cache_control"]["type"], "ephemeral");
+        assert_eq!(blocks[1]["type"], "text");
+        assert_eq!(blocks[1]["text"], " context");
+        assert!(
+            blocks
+                .iter()
+                .all(|block| block.get("type").and_then(Value::as_str) != Some("tool_result")),
+            "orphaned tool_result must be removed without touching text cache markers: {blocks:#?}"
+        );
+    }
+
+    #[test]
+    fn repair_anthropic_tool_pairing_is_noop_for_valid_cached_tool_result() {
+        let messages = vec![
+            json!({
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "call_a",
+                    "name": "glob",
+                    "input": {"pattern": "**/*.rs"},
+                }],
+            }),
+            json!({
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_a",
+                        "content": "ok",
+                        "cache_control": {"type": "ephemeral"}
+                    },
+                    {"type": "text", "text": "continue"},
+                ],
+            }),
+        ];
+
+        let repaired = repair_anthropic_tool_pairing(&messages);
+        assert_eq!(
+            repaired, messages,
+            "valid cached tool_result must survive unchanged"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- repair Anthropic wire requests when orphaned tool_result blocks survive without a matching preceding tool_use
- keep valid cached tool_result blocks unchanged and protect cache_control behavior
- add focused regressions for the minimal failing shape plus prompt-cache safety checks

## Testing
- make check
- cargo test -p astra-runtime repair_anthropic_tool_pairing --lib
- cargo test -p astra-runtime build_provider_request_body_anthropic --lib
- cargo test -p astra-runtime --features bridge-e2e-hooks --test phase_j_prompt_cache_gaps
- cargo test -p astra-runtime --features bridge-e2e-hooks --test mock_llm_prompt_cache_e2e
