### PR TITLE
perf: Improve slash command routing and TUI migration

### DIFF
--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -4,7 +4,7 @@ Complete reference for slash commands available in the `astra` TUI.
 
 ## Overview
 
-astra supports 62 slash commands organized into 9 groups. Type `/help` to see all available commands, or `/help keys` for keyboard shortcuts.
+astra supports dozens of slash commands organized into 9 groups. Type `/help` to see all available commands, or `/help keys` for keyboard shortcuts.
 
 ## Command Groups
 
@@ -33,13 +33,21 @@ Show available commands and usage hints.
 /help keys   # Show keyboard shortcuts
 ```
 
-### `/model [name]`
+### `/model [subcommand]`
 
-List available models or switch to a different model.
+Open the model picker, inspect the current model, or switch directly.
+
+| Subcommand           | Description                 |
+| -------------------- | --------------------------- |
+| (none) or `list`     | Open the model picker       |
+| `info`               | Show current model details  |
+| `clear`              | Reset to the API default    |
+| `<name>`             | Switch directly to a model  |
 
 ```
-/model                    # List models
-/model claude-sonnet-4   # Switch to Sonnet 4
+/model                      # Open picker
+/model info                 # Inspect current model
+/model claude-sonnet-4.6    # Switch directly
 ```
 
 ### `/clear`
@@ -225,13 +233,20 @@ Task management for async work.
 
 ## 🔭 Observability Commands
 
+Use these as:
+
+1. `/stats` for operator-facing analytics and health.
+2. `/inspect` for harness snapshots and exports.
+3. `/telemetry` for deep observability traces.
+4. `/debug` for developer-oriented low-level inspection.
+
 ### `/explain`
 
 Cycle through explanation modes: off → on (API) → verbose (+stderr).
 
-### `/verbose`
+### `/verbose` *(removed)*
 
-Enable verbose streaming output.
+Migration: use `/stats` for metrics and `/timeline` for turn traces.
 
 ### `/compact [mode]`
 
@@ -248,21 +263,30 @@ Summarize and trim conversation history.
 
 Reflect on session (skill_failure, performance, etc.).
 
-### `/turn [selector]`
+### `/turn` *(removed)*
 
-Inspect specific turns.
-
-```
-/turn              # Latest turn
-/turn list         # List all turns
-/turn 5            # Turn by index
-/turn -1           # Last turn
-/turn id:abc123    # By turn ID
-```
+Migration: use `/timeline` and press Enter to drill into a turn.
 
 ### `/debug`
 
-Interactive session inspector for messages, tools, and context injections.
+Developer-oriented low-level inspection for messages, tools, and context injections.
+
+### `/inspect [subcommand]`
+
+Harness inspection utilities. Today these open the text fallback view directly.
+
+| Subcommand   | Description                      |
+| ------------ | -------------------------------- |
+| (none)       | Show inspect help / overview     |
+| `budget`     | Token budget breakdown           |
+| `tools`      | Tool dashboard                   |
+| `context`    | Context snapshot                 |
+| `json`       | Raw snapshot JSON                |
+| `diff`       | Session state diff               |
+| `history`    | Recent turn history              |
+| `trace`      | Permission trace                 |
+| `forensics`  | Forensics dump                   |
+| `export`     | Export inspect output            |
 
 ### `/stats [subcommand]`
 
@@ -277,24 +301,35 @@ Session analytics.
 | `learn`    | Learning insights               |
 | `tools`    | Tool performance metrics        |
 
+### `/health [detail]`
+
+Alias for `/stats health`. Use `detail` for the per-tool breakdown.
+
+### `/config [subcommand]`
+
+Runtime configuration inspection and editing.
+
+| Subcommand | Description                                  |
+| ---------- | -------------------------------------------- |
+| (none)     | Open the interactive config editor panel     |
+| `edit`     | Explicit alias for opening the editor panel  |
+| `show`     | Print the current config                     |
+| `paths`    | Show config file locations                   |
+| `sources`  | Show where each value came from              |
+| `diff`     | Show differences from defaults               |
+| `export`   | Export config to a file or stdout            |
+
 ### `/lsp [status]`
 
 LSP (Language Server Protocol) backend status.
 
 ### `/telemetry [subcommand]`
 
-Session telemetry: turns, drift, decisions, profile.
+Deep observability traces: turns, drift, decisions, profile, and context.
 
-### `/tuning [subcommand]`
+### `/tuning` *(removed)*
 
-Auto-tuning status and history.
-
-| Subcommand | Description          |
-| ---------- | -------------------- |
-| `status`   | Current tuning state |
-| `history`  | Tuning history       |
-| `config`   | Tuning configuration |
-| `reset`    | Reset tuning state   |
+Migration: evolution/tuning commands were deleted; use `/stats`, `/inspect`, and `/profile experiments` instead.
 
 ### `/sync [subcommand]`
 
@@ -318,6 +353,10 @@ Rewind conversation to an earlier turn.
 ### `/version`
 
 Display version information.
+
+### `/info`, `/whoami`
+
+System and session identity at a glance: version, session, model, permissions, loaded skills, pending improvements, and recent tools.
 
 ---
 
@@ -444,6 +483,21 @@ Register a new account.
 
 Logout from the API.
 
+### `/profile [subcommand]`
+
+Manage user profile preferences.
+
+| Subcommand      | Description                    |
+| --------------- | ------------------------------ |
+| `show`          | Show current profile           |
+| `edit <k> <v>`  | Edit a preference              |
+| `scenario`      | Show detected work scenario    |
+| `stats`         | Show profile usage stats       |
+| `tools`         | Show tool preferences          |
+| `experiments`   | Show enrolled experiments      |
+| `reset`         | Reset preferences              |
+| `help`          | Show profile help              |
+
 ### `/memory-setup`
 
 Guided Memoria configuration wizard.
@@ -460,6 +514,8 @@ Set permission mode for tool execution.
 | -------- | ----------------------------- |
 | `auto`   | Auto-approve all tool use     |
 | `all`    | Alias for auto                |
+| `plan`   | Read-only investigation mode  |
+| `accept_edits` / `accept-edits` / `edit` | Auto-approve local file edits |
 | `prompt` | Prompt before each tool       |
 | `deny`   | Deny all tool use             |
 | `rules`  | Show current permission rules |

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -8,23 +8,24 @@ astra supports 62 slash commands organized into 9 groups. Type `/help` to see al
 
 ## Command Groups
 
-| Icon | Group | Description |
-|------|-------|-------------|
-| ⚡ | Core | Essential commands (help, model, session control) |
-| 📂 | Workspace | Code search, diff, and review |
-| 🔭 | Observability | Debugging, stats, and telemetry |
-| 📋 | Session & Plan | Session management and structured planning |
-| 🧠 | Memory & Tasks | Memoria integration and task management |
-| 📦 | Skills | Skill management and marketplace |
-| 🔌 | MCP | Model Context Protocol servers |
-| 👥 | Team & Account | Multi-agent teams and authentication |
-| 🔧 | System | Permissions, style, and diagnostics |
+| Icon | Group          | Description                                       |
+| ---- | -------------- | ------------------------------------------------- |
+| ⚡   | Core           | Essential commands (help, model, session control) |
+| 📂   | Workspace      | Code search, diff, and review                     |
+| 🔭   | Observability  | Debugging, stats, and telemetry                   |
+| 📋   | Session & Plan | Session management and structured planning        |
+| 🧠   | Memory & Tasks | Memoria integration and task management           |
+| 📦   | Skills         | Skill management and marketplace                  |
+| 🔌   | MCP            | Model Context Protocol servers                    |
+| 👥   | Team & Account | Multi-agent teams and authentication              |
+| 🔧   | System         | Permissions, style, and diagnostics               |
 
 ---
 
 ## ⚡ Core Commands
 
 ### `/help [keys]`
+
 Show available commands and usage hints.
 
 ```
@@ -33,6 +34,7 @@ Show available commands and usage hints.
 ```
 
 ### `/model [name]`
+
 List available models or switch to a different model.
 
 ```
@@ -41,9 +43,11 @@ List available models or switch to a different model.
 ```
 
 ### `/clear`
+
 Start a fresh session (clears conversation history).
 
 ### `/undo [N]`
+
 Undo the last N turns (default: 1).
 
 ```
@@ -52,6 +56,7 @@ Undo the last N turns (default: 1).
 ```
 
 ### `/checkpoint [label]`
+
 Save a manual checkpoint with optional label.
 
 ```
@@ -60,6 +65,7 @@ Save a manual checkpoint with optional label.
 ```
 
 ### `/history`
+
 Display conversation turns. Supports in-memory grep.
 
 ```
@@ -68,9 +74,11 @@ Display conversation turns. Supports in-memory grep.
 ```
 
 ### `/copy`
+
 Copy the last assistant response to clipboard.
 
 ### `/resume [session_id]`
+
 Resume a previous session.
 
 ```
@@ -79,6 +87,7 @@ Resume a previous session.
 ```
 
 ### `/exit`, `/quit`
+
 Exit astra.
 
 ---
@@ -86,6 +95,7 @@ Exit astra.
 ## 📂 Workspace Commands
 
 ### `/grep <pattern>`
+
 Search workspace using ripgrep.
 
 ```
@@ -95,15 +105,16 @@ Search workspace using ripgrep.
 ```
 
 ### `/diff [subcommand]`
+
 Show git diffs with syntax highlighting.
 
-| Subcommand | Description |
-|------------|-------------|
-| (none) | Show unstaged changes |
-| `staged` | Staged vs HEAD |
-| `stat` | Diff stat summary |
+| Subcommand   | Description            |
+| ------------ | ---------------------- |
+| (none)       | Show unstaged changes  |
+| `staged`     | Staged vs HEAD         |
+| `stat`       | Diff stat summary      |
 | `show <rev>` | Show specific revision |
-| `patch` | Alias for unstaged |
+| `patch`      | Alias for unstaged     |
 
 ```
 /diff                # Unstaged changes
@@ -112,6 +123,7 @@ Show git diffs with syntax highlighting.
 ```
 
 ### `/review [latest|working|<rev>]`
+
 Request LLM review of git changes.
 
 ```
@@ -125,17 +137,18 @@ Request LLM review of git changes.
 ## 📋 Session & Plan Commands
 
 ### `/session [subcommand]`
+
 Session management.
 
-| Subcommand | Description |
-|------------|-------------|
-| `history` | Journal-style conversation history |
-| `errors` | Show session errors |
-| `export` | Export to Markdown in cwd |
-| `fork` | Fork session for experiments |
-| `list` | List all sessions |
-| `cleanup` | Clean stale sessions |
-| `verify` | Verify session integrity |
+| Subcommand | Description                        |
+| ---------- | ---------------------------------- |
+| `history`  | Journal-style conversation history |
+| `errors`   | Show session errors                |
+| `export`   | Export to Markdown in cwd          |
+| `fork`     | Fork session for experiments       |
+| `list`     | List all sessions                  |
+| `cleanup`  | Clean stale sessions               |
+| `verify`   | Verify session integrity           |
 
 ```
 /session list                    # List all
@@ -144,11 +157,12 @@ Session management.
 ```
 
 ### `/plan [description]`
+
 Structured planning mode for complex tasks.
 
-| Form | Description |
-|------|-------------|
-| `/plan` | Enter plan mode, or leave it if already in `plan>` |
+| Form                  | Description                                              |
+| --------------------- | -------------------------------------------------------- |
+| `/plan`               | Enter plan mode, or leave it if already in `plan>`       |
 | `/plan <description>` | Enter plan mode and immediately start planning that goal |
 
 ```
@@ -160,6 +174,7 @@ Inside `plan>` mode, use plain commands like `execute`, `step`, `status`, `show`
 `pause`, `resume`, `cancel`, and `help`.
 
 ### `/report [save]`
+
 Show the last delivery report from plan execution.
 
 ```
@@ -172,12 +187,13 @@ Show the last delivery report from plan execution.
 ## 🧠 Memory & Tasks Commands
 
 ### `/memory [subcommand]`
+
 Memoria semantic memory operations.
 
-| Subcommand | Description |
-|------------|-------------|
-| `list` | List memories |
-| `search <q>` | Semantic search |
+| Subcommand     | Description             |
+| -------------- | ----------------------- |
+| `list`         | List memories           |
+| `search <q>`   | Semantic search         |
 | `inspect <id>` | Inspect specific memory |
 
 ```
@@ -187,16 +203,17 @@ Memoria semantic memory operations.
 ```
 
 ### `/task [subcommand]`
+
 Task management for async work.
 
-| Subcommand | Description |
-|------------|-------------|
-| `list` | List tasks |
-| `add <title>` | Create task |
-| `done <id>` | Mark complete |
-| `status <id>` | Check status |
+| Subcommand     | Description     |
+| -------------- | --------------- |
+| `list`         | List tasks      |
+| `add <title>`  | Create task     |
+| `done <id>`    | Mark complete   |
+| `status <id>`  | Check status    |
 | `run <prompt>` | Run task prompt |
-| `result <id>` | Get task result |
+| `result <id>`  | Get task result |
 
 ```
 /task list                       # List tasks
@@ -209,25 +226,30 @@ Task management for async work.
 ## 🔭 Observability Commands
 
 ### `/explain`
+
 Cycle through explanation modes: off → on (API) → verbose (+stderr).
 
 ### `/verbose`
+
 Enable verbose streaming output.
 
 ### `/compact [mode]`
+
 Summarize and trim conversation history.
 
-| Mode | Description |
-|------|-------------|
-| (none) | Standard compaction |
-| `quick` | Fast compaction without summary |
-| `no-memoria` | Compact without Memoria |
-| `summary-only` | Summarize without trimming |
+| Mode           | Description                     |
+| -------------- | ------------------------------- |
+| (none)         | Standard compaction             |
+| `quick`        | Fast compaction without summary |
+| `no-memoria`   | Compact without Memoria         |
+| `summary-only` | Summarize without trimming      |
 
 ### `/reflect [mode]`
+
 Reflect on session (skill_failure, performance, etc.).
 
 ### `/turn [selector]`
+
 Inspect specific turns.
 
 ```
@@ -239,53 +261,62 @@ Inspect specific turns.
 ```
 
 ### `/debug`
+
 Interactive session inspector for messages, tools, and context injections.
 
 ### `/stats [subcommand]`
+
 Session analytics.
 
-| Subcommand | Description |
-|------------|-------------|
-| (none) | Current session stats |
-| `cost` | API cost estimate |
-| `health` | Tool health dashboard |
-| `history` | Aggregate stats across sessions |
-| `learn` | Learning insights |
-| `tools` | Tool performance metrics |
+| Subcommand | Description                     |
+| ---------- | ------------------------------- |
+| (none)     | Current session stats           |
+| `cost`     | API cost estimate               |
+| `health`   | Tool health dashboard           |
+| `history`  | Aggregate stats across sessions |
+| `learn`    | Learning insights               |
+| `tools`    | Tool performance metrics        |
 
 ### `/lsp [status]`
+
 LSP (Language Server Protocol) backend status.
 
 ### `/telemetry [subcommand]`
+
 Session telemetry: turns, drift, decisions, profile.
 
 ### `/tuning [subcommand]`
+
 Auto-tuning status and history.
 
-| Subcommand | Description |
-|------------|-------------|
-| `status` | Current tuning state |
-| `history` | Tuning history |
-| `config` | Tuning configuration |
-| `reset` | Reset tuning state |
+| Subcommand | Description          |
+| ---------- | -------------------- |
+| `status`   | Current tuning state |
+| `history`  | Tuning history       |
+| `config`   | Tuning configuration |
+| `reset`    | Reset tuning state   |
 
 ### `/sync [subcommand]`
+
 Cloud sync status hint. Sync orchestration is server-owned; the CLI no longer opens MatrixOne connections or forces sync domains directly.
 
-| Subcommand | Description |
-|------------|-------------|
-| (none) | Explain server-owned sync status |
-| `log` | Point to server/API diagnostics |
-| `push` | Deprecated; no direct CLI DB operation |
-| `pull` | Deprecated; no direct CLI DB operation |
+| Subcommand | Description                            |
+| ---------- | -------------------------------------- |
+| (none)     | Explain server-owned sync status       |
+| `log`      | Point to server/API diagnostics        |
+| `push`     | Deprecated; no direct CLI DB operation |
+| `pull`     | Deprecated; no direct CLI DB operation |
 
 ### `/context`
+
 Show context window and token budget summary.
 
 ### `/rewind <turn>`
+
 Rewind conversation to an earlier turn.
 
 ### `/version`
+
 Display version information.
 
 ---
@@ -293,24 +324,25 @@ Display version information.
 ## 📦 Skills Commands
 
 ### `/skill [subcommand]`
+
 Skill management and marketplace.
 
-| Subcommand | Description |
-|------------|-------------|
-| `list [filter]` | List skills |
-| `info <name>` | Skill details |
-| `search <q>` | Keyword search |
-| `browse` | Browse marketplace |
-| `install <name>` | Install from marketplace |
-| `new <name>` | Create new skill |
-| `test <name>` | Run skill test |
-| `dev <name>` | Enter dev mode |
-| `health` | Catalog health |
-| `surfacing` | Agent catalog surfacing |
-| `pin <name>` | Pin skill to always load |
-| `create` | Generate skill from session |
-| `system` | System skill helpers |
-| `stats` | Learning summary |
+| Subcommand       | Description                 |
+| ---------------- | --------------------------- |
+| `list [filter]`  | List skills                 |
+| `info <name>`    | Skill details               |
+| `search <q>`     | Keyword search              |
+| `browse`         | Browse marketplace          |
+| `install <name>` | Install from marketplace    |
+| `new <name>`     | Create new skill            |
+| `test <name>`    | Run skill test              |
+| `dev <name>`     | Enter dev mode              |
+| `health`         | Catalog health              |
+| `surfacing`      | Agent catalog surfacing     |
+| `pin <name>`     | Pin skill to always load    |
+| `create`         | Generate skill from session |
+| `system`         | System skill helpers        |
+| `stats`          | Learning summary            |
 
 ```
 /skill list                      # List all skills
@@ -325,23 +357,24 @@ Skill management and marketplace.
 ## 🔌 MCP Commands
 
 ### `/mcp [subcommand]`
+
 Model Context Protocol server management.
 
-| Subcommand | Description |
-|------------|-------------|
-| `status` | Connection status table |
-| `servers` | Server details and tools |
-| `prompts` | List available prompts |
-| `resources` | List available resources |
-| `add <name> <cmd>` | Add MCP server |
-| `remove <name>` | Remove server |
-| `ping [server]` | Ping server(s) |
-| `prompt <server>:<name>` | Invoke prompt |
-| `resource <server>:<uri>` | Read resource |
-| `subscribe <server>:<uri>` | Subscribe to resource |
-| `unsubscribe <server>:<uri>` | Unsubscribe |
-| `log-level <server> <level>` | Set log level |
-| `complete <ref> <arg>` | Get completions |
+| Subcommand                   | Description              |
+| ---------------------------- | ------------------------ |
+| `status`                     | Connection status table  |
+| `servers`                    | Server details and tools |
+| `prompts`                    | List available prompts   |
+| `resources`                  | List available resources |
+| `add <name> <cmd>`           | Add MCP server           |
+| `remove <name>`              | Remove server            |
+| `ping [server]`              | Ping server(s)           |
+| `prompt <server>:<name>`     | Invoke prompt            |
+| `resource <server>:<uri>`    | Read resource            |
+| `subscribe <server>:<uri>`   | Subscribe to resource    |
+| `unsubscribe <server>:<uri>` | Unsubscribe              |
+| `log-level <server> <level>` | Set log level            |
+| `complete <ref> <arg>`       | Get completions          |
 
 ```
 /mcp status                                           # Status table
@@ -355,21 +388,22 @@ Model Context Protocol server management.
 ## 👥 Team & Account Commands
 
 ### `/team [subcommand]`
+
 Multi-agent team management.
 
-| Subcommand | Description |
-|------------|-------------|
-| `list` | List teams |
-| `info <name>` | Team information |
-| `create <name>` | Create team |
-| `add-member <team> <agent>` | Add member |
-| `context <team> <ctx>` | Set shared context |
-| `run <team> <task>` | Run task with team |
-| `history <team>` | Execution history |
-| `snapshot <team>` | Save snapshot |
-| `restore <team> <snap>` | Restore snapshot |
-| `delete <team>` | Delete team |
-| `help` | Show team help |
+| Subcommand                  | Description        |
+| --------------------------- | ------------------ |
+| `list`                      | List teams         |
+| `info <name>`               | Team information   |
+| `create <name>`             | Create team        |
+| `add-member <team> <agent>` | Add member         |
+| `context <team> <ctx>`      | Set shared context |
+| `run <team> <task>`         | Run task with team |
+| `history <team>`            | Execution history  |
+| `snapshot <team>`           | Save snapshot      |
+| `restore <team> <snap>`     | Restore snapshot   |
+| `delete <team>`             | Delete team        |
+| `help`                      | Show team help     |
 
 ```
 /team create code-review                              # Create team
@@ -378,34 +412,40 @@ Multi-agent team management.
 ```
 
 ### `/agent [subcommand]`
+
 Spawned agent management.
 
-| Subcommand | Description |
-|------------|-------------|
-| `list` | List spawned agents |
-| `status <id>` | Agent status |
-| `stop <id>` | Stop agent |
-| `logs <id>` | Agent logs |
+| Subcommand    | Description         |
+| ------------- | ------------------- |
+| `list`        | List spawned agents |
+| `status <id>` | Agent status        |
+| `stop <id>`   | Stop agent          |
+| `logs <id>`   | Agent logs          |
 
 ### `/messaging [subcommand]`
+
 Inter-agent messaging inspection.
 
-| Subcommand | Description |
-|------------|-------------|
-| `metrics` | Metrics snapshot |
-| `dlq` | Dead letter queue |
-| `status` | Mailbox status |
+| Subcommand | Description       |
+| ---------- | ----------------- |
+| `metrics`  | Metrics snapshot  |
+| `dlq`      | Dead letter queue |
+| `status`   | Mailbox status    |
 
 ### `/login`
+
 Authenticate with the API.
 
 ### `/register`
+
 Register a new account.
 
 ### `/logout`
+
 Logout from the API.
 
 ### `/memory-setup`
+
 Guided Memoria configuration wizard.
 
 ---
@@ -413,15 +453,16 @@ Guided Memoria configuration wizard.
 ## 🔧 System Commands
 
 ### `/allow [mode]`
+
 Set permission mode for tool execution.
 
-| Mode | Description |
-|------|-------------|
-| `auto` | Auto-approve all tool use |
-| `all` | Alias for auto |
-| `prompt` | Prompt before each tool |
-| `deny` | Deny all tool use |
-| `rules` | Show current permission rules |
+| Mode     | Description                   |
+| -------- | ----------------------------- |
+| `auto`   | Auto-approve all tool use     |
+| `all`    | Alias for auto                |
+| `prompt` | Prompt before each tool       |
+| `deny`   | Deny all tool use             |
+| `rules`  | Show current permission rules |
 
 ```
 /allow auto      # Trust all tools
@@ -430,29 +471,33 @@ Set permission mode for tool execution.
 ```
 
 ### `/instructions [subcommand]`
+
 Project instructions from `.astra/instructions.md`.
 
-| Subcommand | Description |
-|------------|-------------|
-| `show` | Display loaded instructions |
-| `reload` | Reload from file |
-| `off` | Disable for this session |
+| Subcommand | Description                 |
+| ---------- | --------------------------- |
+| `show`     | Display loaded instructions |
+| `reload`   | Reload from file            |
+| `off`      | Disable for this session    |
 
 ### `/style [theme]`
+
 Set output theme.
 
-| Theme | Description |
-|-------|-------------|
-| `default` | Standard theme |
-| `minimal` | Minimal output |
-| `colorful` | Enhanced colors |
-| `high-contrast` | Accessibility theme |
-| `list` | List available themes |
+| Theme           | Description           |
+| --------------- | --------------------- |
+| `default`       | Standard theme        |
+| `minimal`       | Minimal output        |
+| `colorful`      | Enhanced colors       |
+| `high-contrast` | Accessibility theme   |
+| `list`          | List available themes |
 
 ### `/diagnostics`
+
 Run diagnostic checks (binary, API, auth, environment).
 
 ### `/bug [copy|save]`
+
 Generate a bug report.
 
 ```
@@ -465,14 +510,14 @@ Generate a bug report.
 
 ## Keyboard Shortcuts
 
-| Key | Action |
-|-----|--------|
-| `Tab` | Command/subcommand completion |
-| `Ctrl+C` | Cancel current input |
-| `Ctrl+D` | Exit astra |
-| `Up/Down` | History navigation |
-| `Ctrl+R` | Reverse history search |
-| `Ctrl+L` | Clear screen |
+| Key       | Action                        |
+| --------- | ----------------------------- |
+| `Tab`     | Command/subcommand completion |
+| `Ctrl+C`  | Cancel current input          |
+| `Ctrl+D`  | Exit astra                    |
+| `Up/Down` | History navigation            |
+| `Ctrl+R`  | Reverse history search        |
+| `Ctrl+L`  | Clear screen                  |
 
 ---
 
@@ -490,6 +535,57 @@ Generate a bug report.
 4. **Project instructions**: Create `.astra/instructions.md` for project-specific context.
 
 5. **Skills**: Use `/skill new <name>` to create custom skills in `.astra/skills/`.
+
+---
+
+## REPL-to-TUI Migration Evaluation
+
+This section tracks the evaluation of 23 legacy REPL `slash_*.rs` handler files
+and their migration status towards TUI-native panels.
+
+### Evaluation Criteria
+
+| Fate          | Description                                              |
+| ------------- | -------------------------------------------------------- |
+| **KEEP**      | Core routing logic required by TUI fallback or dispatch  |
+| **PORT**      | Logic to port into a native TUI panel (ViewStack portal) |
+| **WRAP**      | Thin TUI selector/filter wrapping existing logic         |
+| **DEPRECATE** | REPL-only command with no TUI value; superseded          |
+
+### Handler Evaluation Table
+
+| File                 | Lines | Fate          | TUI Equivalent                 | Notes                                                          |
+| -------------------- | ----- | ------------- | ------------------------------ | -------------------------------------------------------------- |
+| `slash_router.rs`    | 767   | **KEEP**      | `slash_dispatch.rs` (fallback) | Core dispatch orchestrator; called via `SlashResult::Fallback` |
+| `slash_state.rs`     | 1524  | **KEEP**      | `SessionState`                 | State management used by many handlers                         |
+| `slash_info.rs`      | 2712  | **PORT**      | `ContextPanel`                 | Session info → `/context` panel (Phase 1.3)                    |
+| `slash_config.rs`    | 864   | **PORT**      | `ConfigPanel`                  | Config editor → `/config` panel (Phase 1.3)                    |
+| `slash_skill.rs`     | 4170  | **PORT**      | `SkillBrowser`                 | Skill management → `/skill` selector (Phase 1.3)               |
+| `slash_agent.rs`     | 2385  | **PORT**      | `AgentPanel`                   | Agent inspection → `/agent` panel (Phase 1.4)                  |
+| `slash_team.rs`      | 2411  | **PORT**      | `TeamPanel`                    | Team management → `/team` panel (Phase 1.4)                    |
+| `slash_mcp.rs`       | 1322  | **PORT**      | `McpPanel`                     | MCP server mgmt → `/mcp` panel (Phase 1.4)                     |
+| `slash_memory.rs`    | 508   | **PORT**      | `MemoryPanel`                  | Memoria inspection → `/memory` panel (Phase 1.4)               |
+| `slash_session.rs`   | 6198  | **PORT**      | `SessionPicker`                | Session mgmt → `/session` handler (Phase 1.3)                  |
+| `slash_inspect.rs`   | 495   | **PORT**      | `InspectPanel`                 | Harness snapshot → `/inspect` handler (Phase 1.3)              |
+| `slash_stats.rs`     | 670   | **WRAP**      | `StatsPanel`                   | Stats viewer → `/stats` selector (done)                        |
+| `slash_plan.rs`      | 210   | **WRAP**      | `PlanMode`                     | Plan mode → `/plan` inline (done)                              |
+| `slash_task.rs`      | 501   | **WRAP**      | `TaskBoard`                    | Task mgmt → `/task` panel (Phase 1.3)                          |
+| `slash_profile.rs`   | 613   | **WRAP**      | Fallback                       | Profile mgmt → fallback to REPL handler                        |
+| `slash_telemetry.rs` | 2196  | **DEPRECATE** | `StatusLine` + observability   | Replaced by TUI-native telemetry                               |
+| `slash_health.rs`    | 225   | **DEPRECATE** | `StatusLine`                   | Health replaced by status bar indicators                       |
+| `slash_debug.rs`     | 1414  | **DEPRECATE** | Dev tools                      | Debug tools; keep as fallback for dev builds                   |
+| `slash_sync.rs`      | 28    | **DEPRECATE** | `StatusLine`                   | Sync status replaced by cloud sync indicator                   |
+| `slash_tools.rs`     | 65    | **DEPRECATE** | N/A                            | Tools listing superseded by `/skill` browser                   |
+| `slash_bug.rs`       | 174   | **DEPRECATE** | Chat                           | Bug report via chat composer                                   |
+| `slash_messaging.rs` | 269   | **DEPRECATE** | `AgentPanel`                   | Messaging inspection folded into agent panel                   |
+| `slash_account.rs`   | 258   | **DEPRECATE** | `LoginPanel`                   | Account mgmt via `/login` panel (done)                         |
+
+### Migration Progress
+
+- **Phase 1.1** (✅ complete): `TuiHandler` annotations on all commands
+- **Phase 1.2** (✅ complete): Evaluation + catch-all routing in `slash_dispatch.rs`
+- **Phase 1.3** (🔜 next): Wire Panel handlers to open native TUI panels
+- **Phase 1.4**: Portalize remaining high-value commands
 
 ---
 

--- a/rust/crates/astra-cli/src/cli/command_registry.rs
+++ b/rust/crates/astra-cli/src/cli/command_registry.rs
@@ -72,6 +72,21 @@ impl CommandGroup {
     }
 }
 
+/// How a slash command is handled inside the TUI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TuiHandler {
+    /// Opens a native TUI panel (e.g. /context → ContextPanel).
+    Panel,
+    /// Opens a TUI selector or picker (e.g. /model → model picker).
+    Selector,
+    /// Sent as chat input to the LLM (original REPL behavior).
+    ChatForward,
+    /// Handled inline in the dispatch function (e.g. /exit, /help).
+    Inline,
+    /// Tears down the TUI, runs the REPL handler, then restores the TUI.
+    Fallback,
+}
+
 /// Metadata for a single slash command.
 #[derive(Debug, Clone, Copy)]
 pub struct CommandMeta {
@@ -87,6 +102,10 @@ pub struct CommandMeta {
     pub subcommands: &'static [(&'static str, &'static str)],
     /// Argument hint shown inline (e.g., "<name>").
     pub arg_hint: Option<&'static str>,
+    /// How this command is handled inside the TUI.
+    pub tui_handler: TuiHandler,
+    /// Usage examples for the help display (without leading `/`).
+    pub usage_examples: &'static [&'static str],
 }
 
 impl CommandMeta {
@@ -99,6 +118,8 @@ impl CommandMeta {
             is_alias: false,
             subcommands: &[],
             arg_hint: None,
+            tui_handler: TuiHandler::ChatForward,
+            usage_examples: &[],
         }
     }
 
@@ -120,6 +141,18 @@ impl CommandMeta {
     /// Add argument hint.
     pub const fn with_arg_hint(mut self, hint: &'static str) -> Self {
         self.arg_hint = Some(hint);
+        self
+    }
+
+    /// Set how this command is handled inside the TUI.
+    pub const fn with_tui_handler(mut self, handler: TuiHandler) -> Self {
+        self.tui_handler = handler;
+        self
+    }
+
+    /// Add usage examples for help display.
+    pub const fn with_usage_examples(mut self, examples: &'static [&'static str]) -> Self {
+        self.usage_examples = examples;
         self
     }
 }
@@ -316,23 +349,28 @@ pub static COMMANDS: &[CommandMeta] = &[
         "Show available commands; /help keys for shortcuts",
         CommandGroup::Core,
     )
-    .with_subcommands(HELP_SUBCOMMANDS),
+    .with_subcommands(HELP_SUBCOMMANDS)
+    .with_tui_handler(TuiHandler::Inline),
     CommandMeta::new(
         "/model",
         "Open the model picker, show current model, or switch",
         CommandGroup::Core,
     )
     .with_subcommands(MODEL_SUBCOMMANDS)
-    .with_arg_hint("[info | list | clear | <name>]"),
-    CommandMeta::new("/clear", "Start a new session", CommandGroup::Core),
+    .with_arg_hint("[info | list | clear | <name>]")
+    .with_tui_handler(TuiHandler::Selector),
+    CommandMeta::new("/clear", "Start a new session", CommandGroup::Core)
+        .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new("/undo", "Undo last turn(s): /undo [N]", CommandGroup::Core)
-        .with_arg_hint("[N]"),
+        .with_arg_hint("[N]")
+        .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/redo",
         "Redo undone turn(s): /redo [N]",
         CommandGroup::Core,
     )
-    .with_arg_hint("[N]"),
+    .with_arg_hint("[N]")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/checkpoint",
         "Manual save: /checkpoint [label] — JSON + session md + journal",
@@ -354,29 +392,35 @@ pub static COMMANDS: &[CommandMeta] = &[
         "Resume a session: /resume [session_id]",
         CommandGroup::Core,
     )
-    .with_arg_hint("[session_id]"),
+    .with_arg_hint("[session_id]")
+    .with_tui_handler(TuiHandler::Panel),
     CommandMeta::new(
         "/timeline",
         "Browse this session's turn-by-turn journal timeline",
         CommandGroup::Core,
-    ),
+    )
+    .with_tui_handler(TuiHandler::Panel),
     CommandMeta::new(
         "/table",
         "Run a SQL query and render the result as a navigable table",
         CommandGroup::Core,
     )
-    .with_arg_hint("<sql>"),
+    .with_arg_hint("<sql>")
+    .with_tui_handler(TuiHandler::Panel),
     CommandMeta::new(
         "/worktrees",
         "List git worktrees for this repo with per-worktree session counts",
         CommandGroup::Core,
-    ),
+    )
+    .with_tui_handler(TuiHandler::Panel),
     CommandMeta::new(
         "/panels",
         "Cheat sheet of all TUI-native panels",
         CommandGroup::Core,
-    ),
-    CommandMeta::new("/exit", "Exit astra", CommandGroup::Core),
+    )
+    .with_tui_handler(TuiHandler::Inline),
+    CommandMeta::new("/exit", "Exit astra", CommandGroup::Core)
+        .with_tui_handler(TuiHandler::Inline),
     CommandMeta::new("/quit", "Exit astra (alias for /exit)", CommandGroup::Core).alias(),
     // ── Workspace ─────────────────────────────────────────────────────────
     CommandMeta::new(
@@ -407,6 +451,7 @@ pub static COMMANDS: &[CommandMeta] = &[
     )
     .with_subcommands(SESSION_SUBCOMMANDS)
     .with_arg_hint("[list | history | fork | analyze | export]"),
+    // session sub-commands — aliases, no TUI handler needed
     CommandMeta::new(
         "/session history",
         "Session journal-style history",
@@ -447,7 +492,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         "Enter plan mode; optionally start with a description",
         CommandGroup::SessionPlan,
     )
-    .with_arg_hint("[description]"),
+    .with_arg_hint("[description]")
+    .with_tui_handler(TuiHandler::Inline),
     CommandMeta::new(
         "/report",
         "Last delivery report (/report save = JSON)",
@@ -473,7 +519,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         "/explain",
         "Cycle explain: off → on (API) → verbose (+stderr)",
         CommandGroup::Observability,
-    ),
+    )
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/verbose",
         "(removed — use /stats)",
@@ -486,12 +533,14 @@ pub static COMMANDS: &[CommandMeta] = &[
         CommandGroup::Observability,
     )
     .with_subcommands(COMPACT_SUBCOMMANDS)
-    .with_arg_hint("[quick|no-memoria|summary-only]"),
+    .with_arg_hint("[quick|no-memoria|summary-only]")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/reflect",
         "Reflect on session (modes: skill_failure, performance, …)",
         CommandGroup::Observability,
-    ),
+    )
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/turn",
         "(removed — use /timeline, Enter to drill into a turn)",
@@ -515,7 +564,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         CommandGroup::Observability,
     )
     .with_subcommands(STATS_SUBCOMMANDS)
-    .with_arg_hint("[cost|health|history|learn|tools]"),
+    .with_arg_hint("[cost|health|history|learn|tools]")
+    .with_tui_handler(TuiHandler::Selector),
     CommandMeta::new(
         "/lsp",
         "LSP backend status: /lsp [status]",
@@ -539,7 +589,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         CommandGroup::Observability,
     )
     .with_subcommands(CONFIG_SUBCOMMANDS)
-    .with_arg_hint("[show|paths|sources|diff|export [path]]"),
+    .with_arg_hint("[show|paths|sources|diff|export [path]]")
+    .with_tui_handler(TuiHandler::Panel),
     CommandMeta::new(
         "/sync",
         "Cloud sync status (server-owned)",
@@ -553,7 +604,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         CommandGroup::Observability,
     )
     .with_subcommands(&[("dump", "Write a JSON snapshot of the live context to disk")])
-    .with_arg_hint("[dump [path]]"),
+    .with_arg_hint("[dump [path]]")
+    .with_tui_handler(TuiHandler::Panel),
     CommandMeta::new(
         "/rewind",
         "Rewind conversation to an earlier turn",
@@ -579,7 +631,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         CommandGroup::Skills,
     )
     .with_subcommands(SKILL_SUBCOMMANDS)
-    .with_arg_hint("[browse|list|info|install|publish|search|new|test|dev|feedback|…]"),
+    .with_arg_hint("[browse|list|info|install|publish|search|new|test|dev|feedback|…]")
+    .with_tui_handler(TuiHandler::Selector),
     // ── MCP ───────────────────────────────────────────────────────────────
     CommandMeta::new(
         "/mcp",
@@ -614,12 +667,14 @@ pub static COMMANDS: &[CommandMeta] = &[
         "/login",
         "Authenticate with the API",
         CommandGroup::TeamAccount,
-    ),
+    )
+    .with_tui_handler(TuiHandler::Panel),
     CommandMeta::new(
         "/register",
         "Register a new account",
         CommandGroup::TeamAccount,
-    ),
+    )
+    .with_tui_handler(TuiHandler::Panel),
     CommandMeta::new("/logout", "Logout from the API", CommandGroup::TeamAccount),
     CommandMeta::new(
         "/memory-setup",
@@ -633,7 +688,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         CommandGroup::System,
     )
     .with_subcommands(ALLOW_SUBCOMMANDS)
-    .with_arg_hint("[auto|accept_edits|plan|prompt|deny|all|rules]"),
+    .with_arg_hint("[auto|accept_edits|plan|prompt|deny|all|rules]")
+    .with_tui_handler(TuiHandler::Inline),
     CommandMeta::new(
         "/instructions",
         "Project instructions: /instructions [show|reload|off]",
@@ -679,6 +735,13 @@ pub fn resolve_command(input: &str) -> Result<&'static str, Vec<&'static str>> {
     } else {
         Err(matches)
     }
+}
+
+/// Resolve a command input to its full metadata, including TUI handler info.
+/// Returns `None` when the command can't be resolved.
+pub fn resolve_command_meta(input: &str) -> Option<&'static CommandMeta> {
+    let name = resolve_command(input).ok()?;
+    COMMANDS.iter().find(|m| m.name == name)
 }
 
 /// Suggest commands similar to the input (for typo correction / fuzzy matching).
@@ -1018,5 +1081,75 @@ mod tests {
         });
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].0, "/quit");
+    }
+
+    // ── resolve_command_meta / TuiHandler routing tests ──────────────────
+
+    #[test]
+    fn resolve_command_meta_returns_tui_handler_panel() {
+        // /context is explicitly marked as Panel
+        let meta = resolve_command_meta("/context").expect("should resolve /context");
+        assert_eq!(meta.tui_handler, TuiHandler::Panel);
+    }
+
+    #[test]
+    fn resolve_command_meta_returns_tui_handler_selector() {
+        // /model is explicitly marked as Selector
+        let meta = resolve_command_meta("/model").expect("should resolve /model");
+        assert_eq!(meta.tui_handler, TuiHandler::Selector);
+    }
+
+    #[test]
+    fn resolve_command_meta_returns_tui_handler_fallback() {
+        // /clear is explicitly marked as Fallback
+        let meta = resolve_command_meta("/clear").expect("should resolve /clear");
+        assert_eq!(meta.tui_handler, TuiHandler::Fallback);
+    }
+
+    #[test]
+    fn resolve_command_meta_returns_tui_handler_inline() {
+        // /help is explicitly marked as Inline
+        let meta = resolve_command_meta("/help").expect("should resolve /help");
+        assert_eq!(meta.tui_handler, TuiHandler::Inline);
+    }
+
+    #[test]
+    fn resolve_command_meta_default_chat_forward_no_handler_set() {
+        // /mcp has NO tui_handler set → should default to ChatForward
+        // The COMMANDS array shows /mcp without .with_tui_handler()
+        // ChatForward is the default in CommandMeta::new()
+        let meta = resolve_command_meta("/mcp").expect("should resolve /mcp");
+        assert_eq!(meta.tui_handler, TuiHandler::ChatForward);
+    }
+
+    #[test]
+    fn resolve_command_meta_returns_none_for_unknown_command() {
+        assert!(resolve_command_meta("/nonexistent_cmd_xyz").is_none());
+    }
+
+    #[test]
+    fn resolve_command_meta_prefix_match_also_resolves_handler() {
+        // /reg prefixes to /register which is marked as Panel
+        let meta = resolve_command_meta("/reg").expect("should resolve /reg → /register");
+        assert_eq!(meta.name, "/register");
+        assert_eq!(meta.tui_handler, TuiHandler::Panel);
+    }
+
+    #[test]
+    fn all_handled_commands_have_explicit_handler_or_default_chat_forward() {
+        // Sanity check: every command has a tui_handler set (ChatForward is the default)
+        for cmd in COMMANDS {
+            if cmd.is_alias {
+                continue;
+            }
+            // All handlers are valid variants
+            match cmd.tui_handler {
+                TuiHandler::Panel
+                | TuiHandler::Selector
+                | TuiHandler::Inline
+                | TuiHandler::Fallback
+                | TuiHandler::ChatForward => {}
+            }
+        }
     }
 }

--- a/rust/crates/astra-cli/src/cli/command_registry.rs
+++ b/rust/crates/astra-cli/src/cli/command_registry.rs
@@ -83,7 +83,7 @@ pub enum TuiHandler {
     ChatForward,
     /// Handled inline in the dispatch function (e.g. /exit, /help).
     Inline,
-    /// Tears down the TUI, runs the REPL handler, then restores the TUI.
+    /// Tears down the TUI, runs the legacy slash handler, then restores the TUI.
     Fallback,
 }
 
@@ -173,6 +173,8 @@ const STATS_SUBCOMMANDS: &[(&str, &str)] = &[
     ("tools", "Tool performance: calls, timing, success rate"),
 ];
 
+const HEALTH_SUBCOMMANDS: &[(&str, &str)] = &[("detail", "Per-tool breakdown")];
+
 const SYNC_SUBCOMMANDS: &[(&str, &str)] = &[
     ("log", "Server-owned sync log hint"),
     ("pull", "Deprecated: server-owned"),
@@ -246,6 +248,17 @@ const MEMORY_SUBCOMMANDS: &[(&str, &str)] = &[
     ("search", "Search memories (needs query)"),
 ];
 
+const PROFILE_SUBCOMMANDS: &[(&str, &str)] = &[
+    ("show", "Show the current user profile"),
+    ("edit", "Edit a preference"),
+    ("scenario", "Show the detected working scenario"),
+    ("stats", "Show profile usage stats"),
+    ("tools", "Show tool preferences"),
+    ("experiments", "Show enrolled experiments"),
+    ("reset", "Reset profile preferences"),
+    ("help", "Show profile help"),
+];
+
 // Subcommands surfaced by the `/session ` popup.  Kept tight so
 // completion shows only the high-value entry points; rarer
 // diagnostic forms (cleanup / drift / errors / trace / verify /
@@ -278,7 +291,7 @@ const ALLOW_SUBCOMMANDS: &[(&str, &str)] = &[
     ("auto", "Auto-approve all tool use"),
     ("plan", "Read-only investigation mode; mutations are denied"),
     (
-        "accept_edits",
+        "accept-edits",
         "Auto-approve workspace-local file edits while still prompting for shell and external writes",
     ),
     ("deny", "Deny all tool use"),
@@ -376,7 +389,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         "Manual save: /checkpoint [label] — JSON + session md + journal",
         CommandGroup::Core,
     )
-    .with_arg_hint("[label]"),
+    .with_arg_hint("[label]")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/history",
         "Conversation turns; /history grep <q> filters in-memory",
@@ -428,21 +442,24 @@ pub static COMMANDS: &[CommandMeta] = &[
         "Workspace ripgrep: <pattern> | files <glob> | review <pattern>",
         CommandGroup::Workspace,
     )
-    .with_arg_hint("<pattern>"),
+    .with_arg_hint("<pattern>")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/diff",
         "Colored git diff (staged, stat, show <rev>, …)",
         CommandGroup::Workspace,
     )
     .with_subcommands(DIFF_SUBCOMMANDS)
-    .with_arg_hint("[staged|unstaged|stat|show <rev>]"),
+    .with_arg_hint("[staged|unstaged|stat|show <rev>]")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/review",
         "LLM review of git changes: /review [latest|<rev>|working]",
         CommandGroup::Workspace,
     )
     .with_subcommands(REVIEW_SUBCOMMANDS)
-    .with_arg_hint("[latest|<rev>|working]"),
+    .with_arg_hint("[latest|<rev>|working]")
+    .with_tui_handler(TuiHandler::Fallback),
     // ── Session & plan ───────────────────────────────────────────────────
     CommandMeta::new(
         "/session",
@@ -498,7 +515,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         "/report",
         "Last delivery report (/report save = JSON)",
         CommandGroup::SessionPlan,
-    ),
+    )
+    .with_tui_handler(TuiHandler::Fallback),
     // ── Memory & tasks ────────────────────────────────────────────────────
     CommandMeta::new(
         "/memory",
@@ -513,7 +531,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         CommandGroup::MemoryTasks,
     )
     .with_subcommands(TASK_SUBCOMMANDS)
-    .with_arg_hint("[list|add <title>|done <id>|status <id>|run <prompt>|result <id>]"),
+    .with_arg_hint("[list|add <title>|done <id>|status <id>|run <prompt>|result <id>]")
+    .with_tui_handler(TuiHandler::Fallback),
     // ── Observability ─────────────────────────────────────────────────────
     CommandMeta::new(
         "/explain",
@@ -549,18 +568,19 @@ pub static COMMANDS: &[CommandMeta] = &[
     .alias(),
     CommandMeta::new(
         "/debug",
-        "Interactive session inspector (messages, tools, injections)",
+        "Developer-oriented session debugger: messages, tools, injections",
         CommandGroup::Observability,
-    ),
+    )
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/inspect",
-        "Harness: /inspect [budget|tools|context|json|diff|history|trace|forensics|export]",
+        "Harness snapshots and exports: budget, tools, context, diff, trace, …",
         CommandGroup::Observability,
     )
     .with_arg_hint("[budget|tools|context|json|diff|history N|trace|forensics|export path]"),
     CommandMeta::new(
         "/stats",
-        "Session analytics: /stats [history|tools|cost|health|learn]",
+        "Session analytics: overview, history, tools, cost, health, learning",
         CommandGroup::Observability,
     )
     .with_subcommands(STATS_SUBCOMMANDS)
@@ -571,12 +591,14 @@ pub static COMMANDS: &[CommandMeta] = &[
         "LSP backend status: /lsp [status]",
         CommandGroup::Observability,
     )
-    .with_arg_hint("[status]"),
+    .with_arg_hint("[status]")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/telemetry",
-        "Session telemetry: turns, drift, decisions, profile",
+        "Deep observability traces: turns, drift, decisions, profile, context",
         CommandGroup::Observability,
-    ),
+    )
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/tuning",
         "(removed — evolution subsystem deleted)",
@@ -585,11 +607,11 @@ pub static COMMANDS: &[CommandMeta] = &[
     .alias(),
     CommandMeta::new(
         "/config",
-        "Runtime config: show|paths|sources|diff|export [path]",
+        "Runtime config: panel for edit; show|paths|sources|diff|export stay text-first",
         CommandGroup::Observability,
     )
     .with_subcommands(CONFIG_SUBCOMMANDS)
-    .with_arg_hint("[show|paths|sources|diff|export [path]]")
+    .with_arg_hint("[edit|show|paths|sources|diff|export [path]]")
     .with_tui_handler(TuiHandler::Panel),
     CommandMeta::new(
         "/sync",
@@ -597,7 +619,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         CommandGroup::Observability,
     )
     .with_subcommands(SYNC_SUBCOMMANDS)
-    .with_arg_hint("[log|push|pull]"),
+    .with_arg_hint("[log|push|pull]")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/context",
         "Open the context panel (TUI) or dump a snapshot to disk",
@@ -611,13 +634,31 @@ pub static COMMANDS: &[CommandMeta] = &[
         "Rewind conversation to an earlier turn",
         CommandGroup::Observability,
     )
-    .with_arg_hint("<turn>"),
+    .with_arg_hint("<turn>")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new("/version", "Version info", CommandGroup::Observability),
     CommandMeta::new(
-        "/whoami",
-        "Agent self-awareness: identity, session, skills, pending proposals",
+        "/info",
+        "System info at a glance: version, session, model, permissions, skills",
         CommandGroup::Observability,
-    ),
+    )
+    .with_tui_handler(TuiHandler::Panel),
+    CommandMeta::new(
+        "/whoami",
+        "Alias for /info",
+        CommandGroup::Observability,
+    )
+    .alias()
+    .with_tui_handler(TuiHandler::Panel),
+    CommandMeta::new(
+        "/health",
+        "Alias for /stats health",
+        CommandGroup::Observability,
+    )
+    .alias()
+    .with_subcommands(HEALTH_SUBCOMMANDS)
+    .with_arg_hint("[detail]")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/experiment",
         "(removed — use /profile experiments)",
@@ -640,7 +681,8 @@ pub static COMMANDS: &[CommandMeta] = &[
         CommandGroup::Mcp,
     )
     .with_subcommands(MCP_SUBCOMMANDS)
-    .with_arg_hint("[status|servers|prompts|resources|add|remove|ping|…]"),
+    .with_arg_hint("[status|servers|prompts|resources|add|remove|ping|…]")
+    .with_tui_handler(TuiHandler::Fallback),
     // ── Team & account ───────────────────────────────────────────────────
     CommandMeta::new(
         "/team",
@@ -648,21 +690,24 @@ pub static COMMANDS: &[CommandMeta] = &[
         CommandGroup::TeamAccount,
     )
     .with_subcommands(TEAM_SUBCOMMANDS)
-    .with_arg_hint("[list|info|create|add-member|context|run|…]"),
+    .with_arg_hint("[list|info|create|add-member|context|run|…]")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/agent",
         "Spawned agents: list, status, stop, logs",
         CommandGroup::TeamAccount,
     )
     .with_subcommands(AGENT_SUBCOMMANDS)
-    .with_arg_hint("[list|status|stop|logs|help]"),
+    .with_arg_hint("[list|status|stop|logs|help]")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/messaging",
         "Inter-agent messaging: metrics, dlq, status",
         CommandGroup::TeamAccount,
     )
     .with_subcommands(MESSAGING_SUBCOMMANDS)
-    .with_arg_hint("[metrics|dlq|status|help]"),
+    .with_arg_hint("[metrics|dlq|status|help]")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/login",
         "Authenticate with the API",
@@ -675,20 +720,30 @@ pub static COMMANDS: &[CommandMeta] = &[
         CommandGroup::TeamAccount,
     )
     .with_tui_handler(TuiHandler::Panel),
-    CommandMeta::new("/logout", "Logout from the API", CommandGroup::TeamAccount),
+    CommandMeta::new("/logout", "Logout from the API", CommandGroup::TeamAccount)
+        .with_tui_handler(TuiHandler::Fallback),
+    CommandMeta::new(
+        "/profile",
+        "Profile preferences: show, edit, scenario, stats, tools, experiments, reset",
+        CommandGroup::TeamAccount,
+    )
+    .with_subcommands(PROFILE_SUBCOMMANDS)
+    .with_arg_hint("[show|edit <key> <value>|scenario|stats|tools|experiments|reset]")
+    .with_tui_handler(TuiHandler::Fallback),
     CommandMeta::new(
         "/memory-setup",
         "Guided Memoria configuration",
         CommandGroup::TeamAccount,
-    ),
+    )
+    .with_tui_handler(TuiHandler::Fallback),
     // ── System ────────────────────────────────────────────────────────────
     CommandMeta::new(
         "/allow",
-        "Permission mode: /allow [auto|plan|accept_edits|prompt|deny|all|rules|trust|untrust|trace]",
+        "Permission mode: /allow [auto|plan|accept-edits|prompt|deny|all|rules|trust|untrust|trace]",
         CommandGroup::System,
     )
     .with_subcommands(ALLOW_SUBCOMMANDS)
-    .with_arg_hint("[auto|accept_edits|plan|prompt|deny|all|rules]")
+    .with_arg_hint("[auto|accept-edits|plan|prompt|deny|all|rules]")
     .with_tui_handler(TuiHandler::Inline),
     CommandMeta::new(
         "/instructions",
@@ -702,14 +757,16 @@ pub static COMMANDS: &[CommandMeta] = &[
         "Binary, API, auth, environment checks",
         CommandGroup::System,
     )
-    .with_arg_hint("— run all checks"),
+    .with_arg_hint("— run all checks")
+    .with_tui_handler(TuiHandler::Fallback),
     // Note: /lsp is in Observability group, not duplicated here
     CommandMeta::new(
         "/bug",
         "Generate bug report: /bug [copy|save]",
         CommandGroup::System,
     )
-    .with_arg_hint("[copy|save]"),
+    .with_arg_hint("[copy|save]")
+    .with_tui_handler(TuiHandler::Fallback),
 ];
 
 // ── Query functions ─────────────────────────────────────────────────────────
@@ -990,15 +1047,15 @@ mod tests {
             .iter()
             .find(|meta| meta.name == "/allow")
             .expect("/allow command");
-        assert!(allow.description.contains("accept_edits"));
+        assert!(allow.description.contains("accept-edits"));
         assert!(allow.description.contains("plan"));
         assert_eq!(
             allow.arg_hint,
-            Some("[auto|accept_edits|plan|prompt|deny|all|rules]")
+            Some("[auto|accept-edits|plan|prompt|deny|all|rules]")
         );
 
         let subs = subcommand_completions("/allow").expect("/allow subcommands");
-        assert!(subs.iter().any(|(tok, _)| *tok == "accept_edits"));
+        assert!(subs.iter().any(|(tok, _)| *tok == "accept-edits"));
         assert!(subs.iter().any(|(tok, _)| *tok == "plan"));
     }
 
@@ -1114,12 +1171,9 @@ mod tests {
     }
 
     #[test]
-    fn resolve_command_meta_default_chat_forward_no_handler_set() {
-        // /mcp has NO tui_handler set → should default to ChatForward
-        // The COMMANDS array shows /mcp without .with_tui_handler()
-        // ChatForward is the default in CommandMeta::new()
+    fn resolve_command_meta_uses_fallback_for_non_native_commands() {
         let meta = resolve_command_meta("/mcp").expect("should resolve /mcp");
-        assert_eq!(meta.tui_handler, TuiHandler::ChatForward);
+        assert_eq!(meta.tui_handler, TuiHandler::Fallback);
     }
 
     #[test]
@@ -1133,6 +1187,52 @@ mod tests {
         let meta = resolve_command_meta("/reg").expect("should resolve /reg → /register");
         assert_eq!(meta.name, "/register");
         assert_eq!(meta.tui_handler, TuiHandler::Panel);
+    }
+
+    #[test]
+    fn info_and_aliases_are_discoverable() {
+        let info = resolve_command_meta("/info").expect("should resolve /info");
+        assert_eq!(info.tui_handler, TuiHandler::Panel);
+
+        let whoami = resolve_command_meta("/whoami").expect("should resolve /whoami");
+        assert!(whoami.is_alias, "/whoami should be treated as an alias");
+
+        let health = resolve_command_meta("/health").expect("should resolve /health");
+        assert!(health.is_alias, "/health should be treated as an alias");
+    }
+
+    #[test]
+    fn fallback_commands_do_not_drop_into_chat_forward() {
+        for cmd in [
+            "/checkpoint",
+            "/grep",
+            "/diff",
+            "/review",
+            "/report",
+            "/task",
+            "/debug",
+            "/lsp",
+            "/telemetry",
+            "/health",
+            "/sync",
+            "/rewind",
+            "/mcp",
+            "/team",
+            "/agent",
+            "/messaging",
+            "/logout",
+            "/profile",
+            "/memory-setup",
+            "/diagnostics",
+            "/bug",
+        ] {
+            let meta = resolve_command_meta(cmd).unwrap_or_else(|| panic!("missing {cmd}"));
+            assert_eq!(
+                meta.tui_handler,
+                TuiHandler::Fallback,
+                "{cmd} should preserve slash execution instead of forwarding to chat"
+            );
+        }
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -1696,7 +1696,7 @@ fn handle_permission_command(arg: &str, state: &mut SessionState) {
             eprintln!(
                 "  {} Permission mode → {}",
                 theme::icon_info(),
-                next.to_string().magenta()
+                permission_mode_display_label(next).magenta()
             );
         }
         "all" => {
@@ -1720,7 +1720,7 @@ fn handle_permission_command(arg: &str, state: &mut SessionState) {
             eprintln!(
                 "  {} Permission mode → {} (workspace-local edits auto-approved)",
                 theme::icon_info(),
-                "accept_edits".magenta()
+                permission_mode_display_label(PermissionMode::AcceptEdits).magenta()
             );
         }
         "rules" | "status" => {
@@ -1772,17 +1772,40 @@ fn handle_permission_command(arg: &str, state: &mut SessionState) {
                 eprintln!(
                     "  {} Permission mode → {}",
                     theme::icon_info(),
-                    mode.to_string().magenta()
+                    permission_mode_display_label(mode).magenta()
                 );
             }
             Err(_) => {
                 eprintln!(
-                    "  {} Unknown mode '{}'. Use: auto, plan, accept_edits, prompt, deny, all, rules, trust, untrust, trace",
+                    "  {} Unknown mode '{}'. Use: auto, plan, accept-edits, prompt, deny, all, rules, trust, untrust, trace",
                     theme::icon_warn(),
                     arg
                 );
             }
         },
+    }
+}
+
+pub(crate) fn permission_mode_display_label(mode: PermissionMode) -> &'static str {
+    match mode {
+        PermissionMode::Prompt => "prompt",
+        PermissionMode::Auto => "auto",
+        PermissionMode::AcceptEdits => "accept-edits",
+        PermissionMode::Plan => "plan",
+        PermissionMode::Deny => "deny",
+    }
+}
+
+#[cfg(test)]
+mod permission_mode_display_tests {
+    use super::{PermissionMode, permission_mode_display_label};
+
+    #[test]
+    fn accept_edits_displays_as_kebab_case() {
+        assert_eq!(
+            permission_mode_display_label(PermissionMode::AcceptEdits),
+            "accept-edits"
+        );
     }
 }
 

--- a/rust/crates/astra-cli/src/cli/session_todo_client.rs
+++ b/rust/crates/astra-cli/src/cli/session_todo_client.rs
@@ -416,7 +416,7 @@ mod wiring_e2e {
         let (store, notify_tx) = HttpTaskStore::new(server.uri(), None);
         let store_dyn: Arc<dyn TaskStore> = store.clone();
         // Observer constructed BEFORE the server allocates a SID — same
-        // shape as `run_tui_repl` building it from `state.session_id =
+        // shape as `run_tui_session` building it from `state.session_id =
         // None.unwrap_or_default() = ""`.
         let observer = TaskBoardObserver::new(store_dyn, "");
 

--- a/rust/crates/astra-cli/src/cli/slash_debug.rs
+++ b/rust/crates/astra-cli/src/cli/slash_debug.rs
@@ -14,6 +14,10 @@ use std::path::{Path, PathBuf};
 /// numeric prefix). UI and JSON dumps show **message delta** (suffix after shared prefix with the
 /// previous heavy snapshot), not the entire accumulated history. If there are fewer heavy files
 /// than journal turns, the latest heavy file is used and a warning is recorded.
+/// Retention: REPL fallback handler for `/debug` — called from slash_router.rs.
+/// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
+/// Kept for headless / non-interactive execution paths.
+#[allow(dead_code)]
 pub(super) fn handle_debug_command(arg: &str, state: &SessionState) {
     let session_id = if arg.is_empty() {
         match &state.session_id {

--- a/rust/crates/astra-cli/src/cli/slash_debug.rs
+++ b/rust/crates/astra-cli/src/cli/slash_debug.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 /// numeric prefix). UI and JSON dumps show **message delta** (suffix after shared prefix with the
 /// previous heavy snapshot), not the entire accumulated history. If there are fewer heavy files
 /// than journal turns, the latest heavy file is used and a warning is recorded.
-/// Retention: REPL fallback handler for `/debug` — called from slash_router.rs.
+/// Retention: fallback handler for `/debug` — called from slash_router.rs.
 /// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
 /// Kept for headless / non-interactive execution paths.
 #[allow(dead_code)]

--- a/rust/crates/astra-cli/src/cli/slash_health.rs
+++ b/rust/crates/astra-cli/src/cli/slash_health.rs
@@ -1,8 +1,8 @@
 #![allow(unused_imports)]
 use super::*;
 
-/// Retention: REPL fallback handler for `/health` — called from slash_router.rs.
-/// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
+/// Retention: fallback handler for `/health` — called from slash_router.rs.
+/// In TUI mode this is typically reached via `/stats health` or the `/health` alias.
 /// Kept for headless / non-interactive execution paths.
 #[allow(dead_code)]
 pub(super) async fn handle_health_command(arg: &str, state: &SessionState) {

--- a/rust/crates/astra-cli/src/cli/slash_health.rs
+++ b/rust/crates/astra-cli/src/cli/slash_health.rs
@@ -1,6 +1,10 @@
 #![allow(unused_imports)]
 use super::*;
 
+/// Retention: REPL fallback handler for `/health` — called from slash_router.rs.
+/// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
+/// Kept for headless / non-interactive execution paths.
+#[allow(dead_code)]
 pub(super) async fn handle_health_command(arg: &str, state: &SessionState) {
     use astra_turn_core::tool_health::ToolHealthTracker;
 

--- a/rust/crates/astra-cli/src/cli/slash_info.rs
+++ b/rust/crates/astra-cli/src/cli/slash_info.rs
@@ -1066,6 +1066,10 @@ fn print_turn_trace(ev: &session_journal::JournalEvent, journal_seq: Option<u32>
     eprintln!();
 }
 
+/// Retention: REPL fallback handler for `/info` — called from slash_router.rs.
+/// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
+/// Kept for headless / non-interactive execution paths.
+#[allow(dead_code)]
 pub(super) async fn handle_info_command(
     cmd: &str,
     arg: &str,

--- a/rust/crates/astra-cli/src/cli/slash_info.rs
+++ b/rust/crates/astra-cli/src/cli/slash_info.rs
@@ -1066,8 +1066,8 @@ fn print_turn_trace(ev: &session_journal::JournalEvent, journal_seq: Option<u32>
     eprintln!();
 }
 
-/// Retention: REPL fallback handler for `/info` — called from slash_router.rs.
-/// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
+/// Retention: fallback handler for `/info` / `/whoami` — called from slash_router.rs.
+/// In TUI mode this is shadowed by the native info panel.
 /// Kept for headless / non-interactive execution paths.
 #[allow(dead_code)]
 pub(super) async fn handle_info_command(
@@ -1901,7 +1901,7 @@ pub(super) async fn handle_info_command(
             eprintln!("{}", "  astra version 0.1.0 (Rust)".bold());
         }
 
-        "/whoami" => {
+        "/info" | "/whoami" => {
             print_whoami(state);
         }
 

--- a/rust/crates/astra-cli/src/cli/slash_inspect.rs
+++ b/rust/crates/astra-cli/src/cli/slash_inspect.rs
@@ -2,6 +2,10 @@
 use super::*;
 
 #[cfg(feature = "harness")]
+/// Retention: REPL fallback handler for `/inspect` — called from slash_router.rs.
+/// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
+/// Kept for headless / non-interactive execution paths.
+#[allow(dead_code)]
 pub(super) fn handle_inspect_command(arg: &str, state: &SessionState) {
     use astra_harness::SnapshotSink;
 

--- a/rust/crates/astra-cli/src/cli/slash_inspect.rs
+++ b/rust/crates/astra-cli/src/cli/slash_inspect.rs
@@ -2,7 +2,7 @@
 use super::*;
 
 #[cfg(feature = "harness")]
-/// Retention: REPL fallback handler for `/inspect` — called from slash_router.rs.
+/// Retention: fallback handler for `/inspect` — called from slash_router.rs.
 /// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
 /// Kept for headless / non-interactive execution paths.
 #[allow(dead_code)]

--- a/rust/crates/astra-cli/src/cli/slash_mcp.rs
+++ b/rust/crates/astra-cli/src/cli/slash_mcp.rs
@@ -7,6 +7,10 @@ fn eprint_server_not_found(name: &str) {
     eprintln!("  {}", "Use /mcp servers to see connected servers".dim());
 }
 
+/// Retention: REPL fallback handler for `/mcp` — called from slash_router.rs.
+/// In TUI mode this is shadowed by TuiHandler::Selector (McpView).
+/// Kept for headless / non-interactive execution paths.
+#[allow(dead_code)]
 pub(super) async fn handle_mcp_command(arg: &str, state: &mut SessionState) -> Result<(), String> {
     let sub = arg.trim();
 
@@ -1273,18 +1277,14 @@ mod tests {
             .as_object_mut()
             .unwrap()
             .remove("github");
-        assert!(
-            !config["mcpServers"]
-                .as_object()
-                .unwrap()
-                .contains_key("github")
-        );
-        assert!(
-            config["mcpServers"]
-                .as_object()
-                .unwrap()
-                .contains_key("other")
-        );
+        assert!(!config["mcpServers"]
+            .as_object()
+            .unwrap()
+            .contains_key("github"));
+        assert!(config["mcpServers"]
+            .as_object()
+            .unwrap()
+            .contains_key("other"));
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/slash_mcp.rs
+++ b/rust/crates/astra-cli/src/cli/slash_mcp.rs
@@ -7,7 +7,7 @@ fn eprint_server_not_found(name: &str) {
     eprintln!("  {}", "Use /mcp servers to see connected servers".dim());
 }
 
-/// Retention: REPL fallback handler for `/mcp` — called from slash_router.rs.
+/// Retention: fallback handler for `/mcp` — called from slash_router.rs.
 /// In TUI mode this is shadowed by TuiHandler::Selector (McpView).
 /// Kept for headless / non-interactive execution paths.
 #[allow(dead_code)]
@@ -1277,14 +1277,18 @@ mod tests {
             .as_object_mut()
             .unwrap()
             .remove("github");
-        assert!(!config["mcpServers"]
-            .as_object()
-            .unwrap()
-            .contains_key("github"));
-        assert!(config["mcpServers"]
-            .as_object()
-            .unwrap()
-            .contains_key("other"));
+        assert!(
+            !config["mcpServers"]
+                .as_object()
+                .unwrap()
+                .contains_key("github")
+        );
+        assert!(
+            config["mcpServers"]
+                .as_object()
+                .unwrap()
+                .contains_key("other")
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/slash_profile.rs
+++ b/rust/crates/astra-cli/src/cli/slash_profile.rs
@@ -24,6 +24,10 @@ pub struct ProfileCommandContext<'a> {
 }
 
 /// Handle `/profile [subcommand]` command.
+/// Retention: REPL fallback handler for `/profile` — called from main.rs / slash_router.rs.
+/// In TUI mode this is shadowed by TuiHandler::Selector (ConfigEditView).
+/// Kept for headless / non-interactive execution paths.
+#[allow(dead_code)]
 pub fn handle_profile_command(arg: &str, ctx: &ProfileCommandContext<'_>) {
     let parts: Vec<&str> = arg.split_whitespace().collect();
     let subcmd = parts.first().copied().unwrap_or("show");

--- a/rust/crates/astra-cli/src/cli/slash_profile.rs
+++ b/rust/crates/astra-cli/src/cli/slash_profile.rs
@@ -24,8 +24,8 @@ pub struct ProfileCommandContext<'a> {
 }
 
 /// Handle `/profile [subcommand]` command.
-/// Retention: REPL fallback handler for `/profile` — called from main.rs / slash_router.rs.
-/// In TUI mode this is shadowed by TuiHandler::Selector (ConfigEditView).
+/// Retention: fallback handler for `/profile` — called from main.rs / slash_router.rs.
+/// In TUI mode this stays on the text fallback path.
 /// Kept for headless / non-interactive execution paths.
 #[allow(dead_code)]
 pub fn handle_profile_command(arg: &str, ctx: &ProfileCommandContext<'_>) {

--- a/rust/crates/astra-cli/src/cli/slash_router.rs
+++ b/rust/crates/astra-cli/src/cli/slash_router.rs
@@ -1,4 +1,4 @@
-//! Slash command routing for the REPL.
+//! Slash command fallback routing for the interactive session.
 
 use std::io::IsTerminal;
 
@@ -330,7 +330,7 @@ pub(crate) async fn handle_slash_command(
         }
 
         "/history" | "/grep" | "/review" | "/copy" | "/diagnostics" | "/lsp" | "/context"
-        | "/version" | "/whoami" | "/rewind" | "/report" => {
+        | "/version" | "/info" | "/whoami" | "/rewind" | "/report" => {
             handle_info_command(cmd, arg, api, state, profile, token).await?;
         }
 

--- a/rust/crates/astra-cli/src/cli/slash_router.rs
+++ b/rust/crates/astra-cli/src/cli/slash_router.rs
@@ -391,7 +391,7 @@ pub(crate) async fn handle_slash_command(
                     eprintln!(
                         "  {} Permission mode → {}",
                         theme::icon_info(),
-                        next.to_string().magenta()
+                        crate::command_router::permission_mode_display_label(next).magenta()
                     );
                 }
                 "all" => {
@@ -415,7 +415,10 @@ pub(crate) async fn handle_slash_command(
                     eprintln!(
                         "  {} Permission mode → {} (workspace-local edits auto-approved)",
                         theme::icon_info(),
-                        "accept_edits".magenta()
+                        crate::command_router::permission_mode_display_label(
+                            PermissionMode::AcceptEdits
+                        )
+                        .magenta()
                     );
                 }
                 "rules" | "status" => {
@@ -470,12 +473,12 @@ pub(crate) async fn handle_slash_command(
                         eprintln!(
                             "  {} Permission mode → {}",
                             theme::icon_info(),
-                            mode.to_string().magenta()
+                            crate::command_router::permission_mode_display_label(mode).magenta()
                         );
                     }
                     Err(_) => {
                         eprintln!(
-                            "  {} Unknown mode '{}'. Use: auto, plan, accept_edits, prompt, deny, all, rules, trust, untrust, trace",
+                            "  {} Unknown mode '{}'. Use: auto, plan, accept-edits, prompt, deny, all, rules, trust, untrust, trace",
                             theme::icon_warn(),
                             arg
                         );

--- a/rust/crates/astra-cli/src/cli/slash_stats.rs
+++ b/rust/crates/astra-cli/src/cli/slash_stats.rs
@@ -3,8 +3,8 @@ use super::*;
 
 // ═══════════════════════════════════════════════════════ Stats ════════════
 
-/// Retention: REPL fallback handler for `/stats` — called from slash_router.rs.
-/// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
+/// Retention: fallback handler for `/stats` — called from slash_router.rs.
+/// In TUI mode this is shadowed by the native stats views.
 /// Kept for headless / non-interactive execution paths.
 #[allow(dead_code)]
 pub(super) async fn handle_stats_command(arg: &str, state: &SessionState) {

--- a/rust/crates/astra-cli/src/cli/slash_stats.rs
+++ b/rust/crates/astra-cli/src/cli/slash_stats.rs
@@ -3,6 +3,10 @@ use super::*;
 
 // ═══════════════════════════════════════════════════════ Stats ════════════
 
+/// Retention: REPL fallback handler for `/stats` — called from slash_router.rs.
+/// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
+/// Kept for headless / non-interactive execution paths.
+#[allow(dead_code)]
 pub(super) async fn handle_stats_command(arg: &str, state: &SessionState) {
     use astra_services::session_analytics;
 

--- a/rust/crates/astra-cli/src/cli/slash_telemetry.rs
+++ b/rust/crates/astra-cli/src/cli/slash_telemetry.rs
@@ -7,8 +7,9 @@ use super::*;
 /// - `turns`      List per-turn timing breakdowns
 /// - `drift`      Check focus drift analysis
 /// - `decisions`  List tool selection decisions with confidence
-/// Retention: REPL fallback handler for `/telemetry` — called from slash_router.rs.
-/// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
+///
+/// Retention: fallback handler for `/telemetry` — called from slash_router.rs.
+/// In TUI mode this stays on the text fallback path.
 /// Kept for headless / non-interactive execution paths.
 #[allow(dead_code)]
 pub(super) fn handle_telemetry_command(arg: &str, state: &SessionState) {

--- a/rust/crates/astra-cli/src/cli/slash_telemetry.rs
+++ b/rust/crates/astra-cli/src/cli/slash_telemetry.rs
@@ -7,6 +7,10 @@ use super::*;
 /// - `turns`      List per-turn timing breakdowns
 /// - `drift`      Check focus drift analysis
 /// - `decisions`  List tool selection decisions with confidence
+/// Retention: REPL fallback handler for `/telemetry` — called from slash_router.rs.
+/// In TUI mode this is shadowed by TuiHandler::Panel (InfoView).
+/// Kept for headless / non-interactive execution paths.
+#[allow(dead_code)]
 pub(super) fn handle_telemetry_command(arg: &str, state: &SessionState) {
     let (sub_cmd, sub_arg) = match arg.find(char::is_whitespace) {
         Some(pos) => (arg[..pos].trim(), arg[pos..].trim()),

--- a/rust/crates/astra-cli/src/tui/bottom_pane/slash_integration_tests.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/slash_integration_tests.rs
@@ -47,13 +47,15 @@ fn items_with_aliases() -> Vec<SlashItem> {
             subcommands: &[],
             aliases: &["h", "?"],
             usage_boost: 0,
+            ..Default::default()
         },
         SlashItem {
             name: "/history",
             description: "browse history",
             subcommands: &[],
             aliases: &[],
-            usage_boost: 100, // boosted so it wins ties with /help
+            usage_boost: 100,
+            ..Default::default()
         },
         SlashItem::simple("/model", "pick a model"),
         SlashItem::simple("/resume", "resume a session"),

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -1,6 +1,6 @@
 //! TUI outer event loop.
 //!
-//! Owns [`run_tui_repl`] — the entry point that ratatui mode
+//! Owns [`run_tui_session`] — the entry point that ratatui mode
 //! runs under for the lifetime of the interactive session. The loop:
 //!
 //! 1. Completes business bootstrap (auth, state, task stores,
@@ -483,7 +483,7 @@ pub(crate) fn can_run_tui() -> bool {
         && std::env::var("TERM").map_or(true, |t| t != "dumb")
 }
 
-pub(crate) async fn run_tui_repl(
+pub(crate) async fn run_tui_session(
     api: &astra_thin_client::ThinClient,
     profile: Option<&str>,
     initial_model: Option<&str>,
@@ -3087,7 +3087,7 @@ mod tests {
         let source = include_str!("event_loop.rs");
         assert!(
             source.contains("workspace_trust_startup_prompt()"),
-            "run_tui_repl should query the permission manager for a startup trust prompt"
+            "run_tui_session should query the permission manager for a startup trust prompt"
         );
         assert!(
             source.contains("Trust Workspace")
@@ -3273,7 +3273,7 @@ mod tests {
     }
 
     /// REGRESSION (review M4): every branch of the ViewCompleted arm
-    /// in `run_tui_repl` must clear `pending_deferred_slash_flush`,
+    /// in `run_tui_session` must clear `pending_deferred_slash_flush`,
     /// otherwise the flag can stick `true` forever and `should_flush_ambient_commits`
     /// permanently suppresses TUI tick + app-event flushes — breaking
     /// every subsequent slash menu, ambient banner, and live update.
@@ -3290,7 +3290,7 @@ mod tests {
     #[test]
     fn every_view_completed_branch_clears_deferred_flush_flag() {
         let source = include_str!("event_loop.rs");
-        // Locate the outer ViewCompleted arm in run_tui_repl by a
+        // Locate the outer ViewCompleted arm in run_tui_session by a
         // distinctive opening (the inner `tokio::select!` at line ~870
         // also has a ViewCompleted arm but its body is much shorter).
         // The outer arm runs from "BottomPaneAction::ViewCompleted { result, reopen }"

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -596,6 +596,9 @@ pub(crate) async fn run_tui_repl(
                 name: m.name,
                 description: m.description,
                 subcommands: m.subcommands,
+                group: Some(m.group),
+                tui_handler: m.tui_handler,
+                usage_examples: m.usage_examples,
                 ..Default::default()
             })
             .collect();
@@ -1193,6 +1196,9 @@ pub(crate) async fn run_tui_repl(
                                                     chat_widget.commit_system(history_cell::system::SystemCell::error(format!("Terminal restore failed: {e}")));
                                                 }
                                             }
+                                        }
+                                        slash_dispatch::SlashResult::Forward(ref forward_text) => {
+                                            bottom_pane.composer.set_text(forward_text);
                                         }
                                     }
                                     // Flush the slash-command response

--- a/rust/crates/astra-cli/src/tui/mod.rs
+++ b/rust/crates/astra-cli/src/tui/mod.rs
@@ -68,7 +68,7 @@ mod worktrees;
 mod wrapping;
 
 pub(crate) use draw::{ActiveView, do_draw};
-pub(crate) use event_loop::{can_run_tui, run_tui_repl as run_tui};
+pub(crate) use event_loop::{can_run_tui, run_tui_session as run_tui};
 
 /// Walk the chat widget's committed history and emit role/text
 /// pairs for the `/context dump` JSON file.

--- a/rust/crates/astra-cli/src/tui/shimmer.rs
+++ b/rust/crates/astra-cli/src/tui/shimmer.rs
@@ -16,7 +16,7 @@ static PROCESS_START: OnceLock<Instant> = OnceLock::new();
 pub(crate) const LIVE_GUTTER_PERIOD_SECS: f32 = 3.0;
 
 /// Eagerly initialize the shimmer time origin. Call once near the
-/// top of `run_tui_repl` so any `Instant` captured later by a cell's
+/// top of `run_tui_session` so any `Instant` captured later by a cell's
 /// `finalize()` is guaranteed to be `>= PROCESS_START`. Without this,
 /// the first cell to finalize before any `elapsed_since_start()` /
 /// `gradient_color_at_t` call would saturate `time_at` to 0 and the

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -945,6 +945,31 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             }
         }
 
+        // ── /info — system info at a glance ────────────────────────
+        "/info" => {
+            use crate::tui::bottom_pane::info_view::InfoView;
+
+            let model = ctx.state.model.as_deref().unwrap_or("<unset>");
+            let session = ctx.state.session_id.as_deref().unwrap_or("<none>");
+            let perm = format!("{:?}", ctx.state.perm_manager.mode());
+            let skills = ctx.state.unified_skill_registry.len();
+            let version = env!("CARGO_PKG_VERSION");
+
+            let pairs: Vec<(&str, String)> = vec![
+                ("version", format!("astra v{version}")),
+                ("session", session.to_string()),
+                ("model", model.to_string()),
+                ("permission", perm),
+                ("skills loaded", skills.to_string()),
+                ("context width", format!("{} cols", ctx.width)),
+            ];
+
+            ctx.bottom_pane.push_view(Box::new(
+                InfoView::from_key_value("System Info", pairs).with_reopen("/info"),
+            ));
+            SlashResult::Handled
+        }
+
         // ── Everything else → route via TuiHandler metadata ────────
         _ => match cmd {
             // Commands already explicitly handled above → shouldn't reach here.
@@ -1121,6 +1146,11 @@ pub(crate) fn build_panels_cheat_sheet_lines() -> Vec<String> {
             "/inspect",
             "session introspection: budget, tools, history, traces",
             "type subcommand · Esc close",
+        ),
+        (
+            "/info",
+            "system info at a glance — version, model, session, skills",
+            "↑↓ scroll · Esc close",
         ),
         (
             "/help",
@@ -2584,6 +2614,19 @@ mod panels_tests {
             assert!(
                 text.contains(sub),
                 "cheat sheet /memory entry missing subcommand: {sub}"
+            );
+        }
+    }
+
+    #[test]
+    fn info_entry_shows_system_info() {
+        let text = build_panels_cheat_sheet_lines().join("\n");
+        assert!(text.contains("/info"), "cheat sheet missing /info");
+        // The /info entry should mention key system details.
+        for kw in &["version", "model", "session", "skills"] {
+            assert!(
+                text.contains(kw),
+                "cheat sheet /info entry missing keyword: {kw}"
             );
         }
     }

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -8,8 +8,8 @@
 use crate::command_registry;
 use crate::command_registry::TuiHandler;
 use crate::session_state::SessionState;
-use crate::tui::bottom_pane::list_selection_view::{ListSelectionView, SelectionItem};
 use crate::tui::bottom_pane::BottomPane;
+use crate::tui::bottom_pane::list_selection_view::{ListSelectionView, SelectionItem};
 use crate::tui::history_cell::system::SystemCell;
 use crate::tui::terminal::TerminalGuard;
 
@@ -409,11 +409,7 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
                 return handle_context_dump(rest.trim(), ctx);
             }
             if !args_trim.is_empty() {
-                use crate::tui::history_cell::system::SystemCell;
-                ctx.chat_widget.commit_system(SystemCell::info(
-                    "Usage: /context          — open the context panel\n       \
-                     /context dump [path] — write a JSON snapshot",
-                ));
+                ctx.show_info(CONTEXT_USAGE_MESSAGE.into());
                 return SlashResult::Handled;
             }
             use crate::tui::bottom_pane::context_panel_view::ContextPanelView;
@@ -506,17 +502,21 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             SlashResult::Handled
         }
 
-        // ── /config (TUI-native panel) ─────────────────────────────
-        // All /config subcommands (edit, show, paths, sources, diff,
-        // export) open the interactive ConfigEditView.  The panel
-        // provides search, pick, edit, diff, and export in one place.
-        "/config" => {
-            use crate::tui::bottom_pane::config_edit_view::ConfigEditView;
-            let cfg = astra_config::runtime_config::RuntimeConfig::load();
-            ctx.bottom_pane
-                .push_view(Box::new(ConfigEditView::new(cfg)));
-            SlashResult::Handled
-        }
+        // ── /config (panel for edit, text fallback for read-only forms) ──
+        "/config" => match config_command_route(args) {
+            Ok(ConfigCommandRoute::Panel) => {
+                use crate::tui::bottom_pane::config_edit_view::ConfigEditView;
+                let cfg = astra_config::runtime_config::RuntimeConfig::load();
+                ctx.bottom_pane
+                    .push_view(Box::new(ConfigEditView::new(cfg)));
+                SlashResult::Handled
+            }
+            Ok(ConfigCommandRoute::Fallback) => SlashResult::Fallback,
+            Err(usage) => {
+                ctx.show_error(usage.to_string());
+                SlashResult::Handled
+            }
+        },
 
         // ── SQL table view (TUI-native, astra-unique) ───────────────
         //
@@ -594,7 +594,7 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
         // ── Worktrees (TUI-native) ──────────────────────────────────
         "/worktrees" => {
             use crate::tui::bottom_pane::worktrees_view::WorktreesView;
-            use crate::tui::worktrees::{parse, WorktreeList};
+            use crate::tui::worktrees::{WorktreeList, parse};
 
             // `git worktree list --porcelain` on a blocking thread.
             let porcelain = tokio::task::spawn_blocking(|| {
@@ -735,8 +735,50 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             SlashResult::Handled
         }
 
-        // /whoami is now folded into /session — redirect for muscle memory
-        "/whoami" => handle_session_hub(ctx),
+        "/whoami" | "/info" => {
+            use crate::tui::bottom_pane::info_view::InfoView;
+
+            let model = ctx.state.model.as_deref().unwrap_or("<unset>");
+            let session = ctx.state.session_id.as_deref().unwrap_or("<none>");
+            let perm = format!("{:?}", ctx.state.perm_manager.mode());
+            let skills = ctx.state.unified_skill_registry.len();
+            let version = env!("CARGO_PKG_VERSION");
+            let pending = ctx
+                .state
+                .skill_improvement_tracker
+                .pending_proposal
+                .as_ref()
+                .map(|p| p.skill_name.clone())
+                .unwrap_or_else(|| "<none>".into());
+            let recent_tools = if ctx.state.recent_tools.is_empty() {
+                "<none>".to_string()
+            } else {
+                ctx.state
+                    .recent_tools
+                    .iter()
+                    .take(8)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+
+            let pairs: Vec<(&str, String)> = vec![
+                ("version", format!("astra v{version}")),
+                ("session", session.to_string()),
+                ("model", model.to_string()),
+                ("permission", perm),
+                ("skills loaded", skills.to_string()),
+                ("turn", ctx.state.turn.to_string()),
+                ("pending improve", pending),
+                ("recent tools", recent_tools),
+                ("context width", format!("{} cols", ctx.width)),
+            ];
+
+            ctx.bottom_pane.push_view(Box::new(
+                InfoView::from_key_value("System Info", pairs).with_reopen("/info"),
+            ));
+            SlashResult::Handled
+        }
 
         // ── History — interactive search view ────────────────────────
         "/history" => {
@@ -859,30 +901,27 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             }
         }
 
-        // ── /memory — list / search / inspect in a TUI panel ───────
+        // ── /memory — list/search in TUI; inspect falls back to text detail ──
         "/memory" => {
-            let subcmd = args.split_whitespace().next().unwrap_or("list");
-            let sub_arg = args.strip_prefix(subcmd).unwrap_or("").trim();
+            let route = match memory_command_route(args) {
+                Ok(route) => route,
+                Err(msg) => {
+                    ctx.show_error(msg.into());
+                    return SlashResult::Handled;
+                }
+            };
             let token = crate::session_runtime::fresh_access_token(ctx.api, ctx.profile).await;
             let Some(token) = token else {
                 ctx.show_error("Not logged in. Use /login.".into());
                 return SlashResult::Handled;
             };
 
-            let (query, top_k) = match subcmd {
-                "search" if !sub_arg.is_empty() => (sub_arg.to_string(), 20),
-                "list" | "" => ("user preferences knowledge plans tasks".to_string(), 20),
-                "inspect" if !sub_arg.is_empty() => {
-                    // Inspect a single memory by id — forward to chat
-                    // which has richer formatting for the detail view.
-                    return SlashResult::Forward(text.to_string());
+            let (query, top_k) = match route {
+                MemoryCommandRoute::Search(query) => (query, 20),
+                MemoryCommandRoute::List => {
+                    ("user preferences knowledge plans tasks".to_string(), 20)
                 }
-                _ => {
-                    ctx.show_error(
-                        "Unknown subcommand. Try: list, search <query>, inspect <id>".into(),
-                    );
-                    return SlashResult::Handled;
-                }
+                MemoryCommandRoute::Inspect(_) => return SlashResult::Fallback,
             };
 
             let payload = serde_json::json!({
@@ -950,63 +989,32 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             }
         }
 
-        // ── /info — system info at a glance ────────────────────────
-        "/info" => {
-            use crate::tui::bottom_pane::info_view::InfoView;
-
-            let model = ctx.state.model.as_deref().unwrap_or("<unset>");
-            let session = ctx.state.session_id.as_deref().unwrap_or("<none>");
-            let perm = format!("{:?}", ctx.state.perm_manager.mode());
-            let skills = ctx.state.unified_skill_registry.len();
-            let version = env!("CARGO_PKG_VERSION");
-
-            let pairs: Vec<(&str, String)> = vec![
-                ("version", format!("astra v{version}")),
-                ("session", session.to_string()),
-                ("model", model.to_string()),
-                ("permission", perm),
-                ("skills loaded", skills.to_string()),
-                ("context width", format!("{} cols", ctx.width)),
-            ];
-
-            ctx.bottom_pane.push_view(Box::new(
-                InfoView::from_key_value("System Info", pairs).with_reopen("/info"),
-            ));
-            SlashResult::Handled
-        }
-
         // ── Everything else → route via TuiHandler metadata ────────
-        _ => match cmd {
-            // Commands already explicitly handled above → shouldn't reach here.
-            // The catch-all routes everything else according to its TuiHandler:
-            _ => {
-                match command_registry::resolve_command_meta(cmd).map(|m| m.tui_handler) {
-                    // ChatForward (default, no tui_handler set) → forward to chat composer
-                    None | Some(TuiHandler::ChatForward) => SlashResult::Forward(text.to_string()),
-                    // Fallback → tear down TUI, run REPL handler, restore
-                    Some(TuiHandler::Fallback) => SlashResult::Fallback,
-                    // Panel → open native TUI panel (portals built in later phases)
-                    Some(TuiHandler::Panel) => {
-                        ctx.show_info(format!(
-                            "`{}` panel is not yet implemented in TUI — forwarding to chat",
-                            resolved
-                        ));
-                        SlashResult::Forward(text.to_string())
-                    }
-                    // Selector → open picker/selector (built in later phases)
-                    Some(TuiHandler::Selector) => {
-                        ctx.show_info(format!(
-                            "`{}` selector is not yet implemented in TUI — forwarding to chat",
-                            resolved
-                        ));
-                        SlashResult::Forward(text.to_string())
-                    }
-                    // Inline → should have been matched explicitly above
-                    Some(TuiHandler::Inline) => {
-                        ctx.show_error(format!("Command `{resolved}` not handled inline"));
-                        SlashResult::Handled
-                    }
-                }
+        _ => match command_registry::resolve_command_meta(cmd).map(|m| m.tui_handler) {
+            // ChatForward (default, no tui_handler set) → forward to chat composer
+            None | Some(TuiHandler::ChatForward) => SlashResult::Forward(text.to_string()),
+            // Fallback → tear down TUI, run REPL handler, restore
+            Some(TuiHandler::Fallback) => SlashResult::Fallback,
+            // Panel → open native TUI panel (portals built in later phases)
+            Some(TuiHandler::Panel) => {
+                ctx.show_info(format!(
+                    "`{}` panel is not yet implemented in TUI — forwarding to chat",
+                    resolved
+                ));
+                SlashResult::Forward(text.to_string())
+            }
+            // Selector → open picker/selector (built in later phases)
+            Some(TuiHandler::Selector) => {
+                ctx.show_info(format!(
+                    "`{}` selector is not yet implemented in TUI — forwarding to chat",
+                    resolved
+                ));
+                SlashResult::Forward(text.to_string())
+            }
+            // Inline → should have been matched explicitly above
+            Some(TuiHandler::Inline) => {
+                ctx.show_error(format!("Command `{resolved}` not handled inline"));
+                SlashResult::Handled
             }
         },
     }
@@ -1119,8 +1127,8 @@ pub(crate) fn build_panels_cheat_sheet_lines() -> Vec<String> {
         ),
         (
             "/config [edit|show|paths|sources|diff|export]",
-            "interactive panel — search, pick, edit, diff, and export config",
-            "↑↓ navigate · Enter edit/set · type to search · Esc save/close",
+            "edit opens the panel; show/paths/sources/diff/export stay text-first",
+            "panel: ↑↓ navigate · Enter edit/set · type to search · Esc save/close",
         ),
         (
             "/model",
@@ -1676,6 +1684,62 @@ fn split_sub(text: &str) -> (&str, &str) {
         None => (t, ""),
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigCommandRoute {
+    Panel,
+    Fallback,
+}
+
+fn config_command_route(args: &str) -> Result<ConfigCommandRoute, &'static str> {
+    let trimmed = args.trim();
+    if trimmed.is_empty() {
+        return Ok(ConfigCommandRoute::Panel);
+    }
+
+    let (sub, _) = split_sub(trimmed);
+    match sub {
+        "edit" => Ok(ConfigCommandRoute::Panel),
+        "show" | "paths" | "sources" | "diff" | "export" | "help" | "-h" | "--help" => {
+            Ok(ConfigCommandRoute::Fallback)
+        }
+        _ => Err("Usage: /config [edit|show|paths|sources|diff|export [path]]"),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MemoryCommandRoute {
+    List,
+    Search(String),
+    Inspect(String),
+}
+
+fn memory_command_route(args: &str) -> Result<MemoryCommandRoute, &'static str> {
+    let trimmed = args.trim();
+    if trimmed.is_empty() {
+        return Ok(MemoryCommandRoute::List);
+    }
+
+    let (sub, rest) = split_sub(trimmed);
+    match sub {
+        "list" if rest.is_empty() => Ok(MemoryCommandRoute::List),
+        "search" if !rest.is_empty() => Ok(MemoryCommandRoute::Search(rest.to_string())),
+        "inspect" if !rest.is_empty() => Ok(MemoryCommandRoute::Inspect(rest.to_string())),
+        _ => Err("Unknown subcommand. Try: list, search <query>, inspect <id>."),
+    }
+}
+
+fn inspect_command_supported(args: &str) -> Result<(), String> {
+    let sub = args.trim();
+    match sub {
+        "" => Ok(()),
+        "budget" | "tools" | "context" | "json" | "diff" | "history" | "trace" | "forensics"
+        | "export" => Ok(()),
+        _ => Err(format!("Unknown `/inspect` subcommand: `{sub}`.")),
+    }
+}
+
+const CONTEXT_USAGE_MESSAGE: &str = "Usage: /context — open the context panel\n       /context dump [path] — write a JSON snapshot.";
 
 // ── /model subcommand helpers ───────────────────────────────────
 
@@ -2539,32 +2603,14 @@ fn handle_context_dump(arg: &str, ctx: &mut DispatchContext<'_>) -> SlashResult 
 
 // ── /inspect dispatch ────────────────────────────────────────────────
 //
-// Routes `/inspect` subcommands. Full TUI-native panels (budget, tools,
-// context, diff, history) will be wired in later phases once the
-// ViewStack portal infrastructure is ready.  For Phase 1.2 the
-// handler forwards unimplemented subcommands to chat so the user sees
-// progress instead of an error.
+// Routes `/inspect` subcommands. Until the dedicated TUI panel ships,
+// all supported forms fall back to the text renderer immediately so the
+// command still executes instead of being bounced back into the composer.
 async fn handle_inspect_dispatch(args: &str, ctx: &mut DispatchContext<'_>) -> SlashResult {
-    let sub = args.trim();
-    match sub {
-        "" => {
-            // No subcommand → show picker (Phase 1.4)
-            ctx.show_info(
-                "`/inspect` subcommands: budget, tools, context, json, diff, history, trace, forensics, export"
-                    .to_string(),
-            );
-            SlashResult::Handled
-        }
-        "budget" | "tools" | "context" | "json" | "diff" | "history" | "trace" | "forensics"
-        | "export" => {
-            // Subcommand recognized but panel not yet built
-            ctx.show_info(format!(
-                "`/inspect {sub}` panel will be available soon — forwarding to chat for now"
-            ));
-            SlashResult::Forward(format!("/inspect {}", args))
-        }
-        _ => {
-            ctx.show_error(format!("Unknown `/inspect` subcommand: `{sub}`"));
+    match inspect_command_supported(args) {
+        Ok(()) => SlashResult::Fallback,
+        Err(message) => {
+            ctx.show_error(message);
             SlashResult::Handled
         }
     }
@@ -2634,6 +2680,76 @@ mod panels_tests {
                 "cheat sheet /info entry missing keyword: {kw}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod routing_tests {
+    use super::{
+        CONTEXT_USAGE_MESSAGE, ConfigCommandRoute, MemoryCommandRoute, config_command_route,
+        inspect_command_supported, memory_command_route,
+    };
+
+    #[test]
+    fn config_route_keeps_read_only_forms_on_text_path() {
+        for form in [
+            "show",
+            "paths",
+            "sources",
+            "diff",
+            "export ./runtime.toml",
+            "help",
+        ] {
+            assert_eq!(
+                config_command_route(form),
+                Ok(ConfigCommandRoute::Fallback),
+                "{form} should keep the text fallback behavior"
+            );
+        }
+    }
+
+    #[test]
+    fn config_route_opens_panel_for_edit_forms() {
+        assert_eq!(config_command_route(""), Ok(ConfigCommandRoute::Panel));
+        assert_eq!(config_command_route("edit"), Ok(ConfigCommandRoute::Panel));
+    }
+
+    #[test]
+    fn memory_route_distinguishes_list_search_and_inspect() {
+        assert_eq!(memory_command_route(""), Ok(MemoryCommandRoute::List));
+        assert_eq!(memory_command_route("list"), Ok(MemoryCommandRoute::List));
+        assert_eq!(
+            memory_command_route("search auth preferences"),
+            Ok(MemoryCommandRoute::Search("auth preferences".into()))
+        );
+        assert_eq!(
+            memory_command_route("inspect mem_123"),
+            Ok(MemoryCommandRoute::Inspect("mem_123".into()))
+        );
+    }
+
+    #[test]
+    fn inspect_route_accepts_known_subcommands_and_rejects_unknown_ones() {
+        for form in [
+            "", "budget", "tools", "context", "json", "diff", "history", "trace",
+        ] {
+            assert!(
+                inspect_command_supported(form).is_ok(),
+                "{form} should be accepted"
+            );
+        }
+        assert_eq!(
+            inspect_command_supported("mystery"),
+            Err("Unknown `/inspect` subcommand: `mystery`.".into())
+        );
+    }
+
+    #[test]
+    fn context_usage_message_is_aligned() {
+        assert_eq!(
+            CONTEXT_USAGE_MESSAGE,
+            "Usage: /context — open the context panel\n       /context dump [path] — write a JSON snapshot."
+        );
     }
 }
 

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -506,19 +506,11 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             SlashResult::Handled
         }
 
-        // ── /config (TUI-native, matches the reference CLI) ──────────
-        //
-        // `/config` with no args opens the interactive panel directly —
-        // this is the user's primary entry point, same as the reference
-        // implementation's `/config` (aliased `/settings`).
-        //
-        // `/config edit` is kept as an alias for muscle memory / docs.
-        //
-        // Subcommands that only print static text (`show`, `paths`,
-        // `diff`, `sources`, `export`) fall back to the line-mode
-        // printer via `with_restored`. Those briefly tear down the TUI
-        // which is acceptable for a print-and-done flow.
-        "/config" if args.trim().is_empty() || args.trim() == "edit" => {
+        // ── /config (TUI-native panel) ─────────────────────────────
+        // All /config subcommands (edit, show, paths, sources, diff,
+        // export) open the interactive ConfigEditView.  The panel
+        // provides search, pick, edit, diff, and export in one place.
+        "/config" => {
             use crate::tui::bottom_pane::config_edit_view::ConfigEditView;
             let cfg = astra_config::runtime_config::RuntimeConfig::load();
             ctx.bottom_pane
@@ -1010,9 +1002,9 @@ pub(crate) fn build_panels_cheat_sheet_lines() -> Vec<String> {
             "↑↓ navigate · q / Esc close",
         ),
         (
-            "/config",
-            "interactive panel — search, pick, and edit runtime config",
-            "↑↓ navigate · Enter edit · type to search · Esc save/close",
+            "/config [edit|show|paths|sources|diff|export]",
+            "interactive panel — search, pick, edit, diff, and export config",
+            "↑↓ navigate · Enter edit/set · type to search · Esc save/close",
         ),
         (
             "/model",
@@ -2477,6 +2469,19 @@ mod panels_tests {
             "panels_cheat_sheet",
             build_panels_cheat_sheet_lines().join("\n")
         );
+    }
+
+    #[test]
+    fn config_entry_lists_all_subcommands() {
+        let text = build_panels_cheat_sheet_lines().join("\n");
+        // The /config entry MUST mention each subcommand so users
+        // discover show / paths / sources / diff / export.
+        for sub in &["show", "paths", "sources", "diff", "export"] {
+            assert!(
+                text.contains(sub),
+                "cheat sheet /config entry missing subcommand: {sub}"
+            );
+        }
     }
 }
 

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -877,7 +877,12 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
                     // which has richer formatting for the detail view.
                     return SlashResult::Forward(text.to_string());
                 }
-                _ => return SlashResult::Forward(text.to_string()),
+                _ => {
+                    ctx.show_error(
+                        "Unknown subcommand. Try: list, search <query>, inspect <id>".into(),
+                    );
+                    return SlashResult::Handled;
+                }
             };
 
             let payload = serde_json::json!({

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -859,6 +859,92 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             }
         }
 
+        // ── /memory — list / search / inspect in a TUI panel ───────
+        "/memory" => {
+            let subcmd = args.split_whitespace().next().unwrap_or("list");
+            let sub_arg = args.strip_prefix(subcmd).unwrap_or("").trim();
+            let token = crate::session_runtime::fresh_access_token(ctx.api, ctx.profile).await;
+            let Some(token) = token else {
+                ctx.show_error("Not logged in. Use /login.".into());
+                return SlashResult::Handled;
+            };
+
+            let (query, top_k) = match subcmd {
+                "search" if !sub_arg.is_empty() => (sub_arg.to_string(), 20),
+                "list" | "" => ("user preferences knowledge plans tasks".to_string(), 20),
+                "inspect" if !sub_arg.is_empty() => {
+                    // Inspect a single memory by id — forward to chat
+                    // which has richer formatting for the detail view.
+                    return SlashResult::Forward(text.to_string());
+                }
+                _ => return SlashResult::Forward(text.to_string()),
+            };
+
+            let payload = serde_json::json!({
+                "query": query,
+                "top_k": top_k,
+            });
+            match ctx.api.post_memory_search_json(&token, &payload).await {
+                Ok(r) if r.status().is_success() => {
+                    let body = r.text().await.unwrap_or_default();
+                    match serde_json::from_str::<Vec<serde_json::Value>>(&body) {
+                        Ok(arr) if !arr.is_empty() => {
+                            let items: Vec<SelectionItem> = arr
+                                .iter()
+                                .map(|m| {
+                                    let content =
+                                        m.get("content").and_then(|v| v.as_str()).unwrap_or("?");
+                                    let id = m
+                                        .get("memory_id")
+                                        .or(m.get("id"))
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("");
+                                    let short_id = &id[..std::cmp::min(8, id.len())];
+                                    let mtype = m
+                                        .get("memory_type")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("?");
+                                    let preview: String = content.chars().take(80).collect();
+                                    SelectionItem {
+                                        name: format!("[{mtype}] {preview}"),
+                                        description: Some(format!("id:{short_id}")),
+                                        is_current: false,
+                                    }
+                                })
+                                .collect();
+                            let header = format!(
+                                "Memory — {} result{} for: {}",
+                                items.len(),
+                                if items.len() == 1 { "" } else { "s" },
+                                query
+                            );
+                            ctx.bottom_pane.push_view(Box::new(
+                                ListSelectionView::new(items, Some(header))
+                                    .with_footer_hint("↑↓ navigate · q / Esc close"),
+                            ));
+                            SlashResult::Handled
+                        }
+                        Ok(_) => {
+                            ctx.show_info("No memories found.".into());
+                            SlashResult::Handled
+                        }
+                        Err(_) => {
+                            ctx.show_error("Failed to parse memory results.".into());
+                            SlashResult::Handled
+                        }
+                    }
+                }
+                Ok(r) => {
+                    ctx.show_error(format!("Memory search failed (HTTP {})", r.status()));
+                    SlashResult::Handled
+                }
+                Err(e) => {
+                    ctx.show_error(format!("Memory unreachable: {e}"));
+                    SlashResult::Handled
+                }
+            }
+        }
+
         // ── Everything else → route via TuiHandler metadata ────────
         _ => match cmd {
             // Commands already explicitly handled above → shouldn't reach here.
@@ -1015,6 +1101,11 @@ pub(crate) fn build_panels_cheat_sheet_lines() -> Vec<String> {
             "/skill",
             "browse, search, install, and manage skills",
             "type to filter · Enter select · Esc close",
+        ),
+        (
+            "/memory [list|search <q>|inspect <id>]",
+            "browse, search, and inspect episodic and semantic memories",
+            "↑↓ navigate · Enter select · Esc close",
         ),
         (
             "/session",
@@ -2480,6 +2571,19 @@ mod panels_tests {
             assert!(
                 text.contains(sub),
                 "cheat sheet /config entry missing subcommand: {sub}"
+            );
+        }
+    }
+
+    #[test]
+    fn memory_entry_lists_all_subcommands() {
+        let text = build_panels_cheat_sheet_lines().join("\n");
+        // The /memory entry MUST mention list / search / inspect
+        // so users discover they can search and inspect memories.
+        for sub in &["list", "search", "inspect"] {
+            assert!(
+                text.contains(sub),
+                "cheat sheet /memory entry missing subcommand: {sub}"
             );
         }
     }

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -6,9 +6,10 @@
 //! fall back to `with_restored()` which temporarily exits the TUI.
 
 use crate::command_registry;
+use crate::command_registry::TuiHandler;
 use crate::session_state::SessionState;
-use crate::tui::bottom_pane::BottomPane;
 use crate::tui::bottom_pane::list_selection_view::{ListSelectionView, SelectionItem};
+use crate::tui::bottom_pane::BottomPane;
 use crate::tui::history_cell::system::SystemCell;
 use crate::tui::terminal::TerminalGuard;
 
@@ -17,6 +18,9 @@ pub(crate) enum SlashResult {
     Deferred,
     Exit,
     Fallback,
+    /// Forward the raw slash command text to the chat composer for the user
+    /// to review and send as a normal message (ChatForward handler).
+    Forward(String),
 }
 
 /// Context needed by slash dispatch — avoids passing 8+ loose arguments.
@@ -372,6 +376,23 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             SlashResult::Fallback
         }
 
+        // ── Inspect (TUI-native) ────────────────────────────────────
+        //
+        // Routes to the harness snapshot for session introspection.
+        //   `/inspect`                → subcommand picker
+        //   `/inspect budget`         → token budget breakdown
+        //   `/inspect tools`          → tool call dashboard
+        //   `/inspect context`        → context window snapshot
+        //   `/inspect json`           → raw snapshot as JSON
+        //   `/inspect diff`           → state diff vs start-of-session
+        //   `/inspect history [N]`    → recent turn history
+        //   `/inspect trace`          → permission trace
+        //   `/inspect forensics`      → forensics dump
+        //   `/inspect export [path]`  → export to file
+        "/inspect" => {
+            return handle_inspect_dispatch(args, ctx).await;
+        }
+
         // ── Context panel (TUI-native) ──────────────────────────────
         //
         // Only two forms are supported:
@@ -581,7 +602,7 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
         // ── Worktrees (TUI-native) ──────────────────────────────────
         "/worktrees" => {
             use crate::tui::bottom_pane::worktrees_view::WorktreesView;
-            use crate::tui::worktrees::{WorktreeList, parse};
+            use crate::tui::worktrees::{parse, WorktreeList};
 
             // `git worktree list --porcelain` on a blocking thread.
             let porcelain = tokio::task::spawn_blocking(|| {
@@ -846,8 +867,40 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             }
         }
 
-        // ── Everything else → with_restored fallback ────────────────
-        _ => SlashResult::Fallback,
+        // ── Everything else → route via TuiHandler metadata ────────
+        _ => match cmd {
+            // Commands already explicitly handled above → shouldn't reach here.
+            // The catch-all routes everything else according to its TuiHandler:
+            _ => {
+                match command_registry::resolve_command_meta(cmd).map(|m| m.tui_handler) {
+                    // ChatForward (default, no tui_handler set) → forward to chat composer
+                    None | Some(TuiHandler::ChatForward) => SlashResult::Forward(text.to_string()),
+                    // Fallback → tear down TUI, run REPL handler, restore
+                    Some(TuiHandler::Fallback) => SlashResult::Fallback,
+                    // Panel → open native TUI panel (portals built in later phases)
+                    Some(TuiHandler::Panel) => {
+                        ctx.show_info(format!(
+                            "`{}` panel is not yet implemented in TUI — forwarding to chat",
+                            resolved
+                        ));
+                        SlashResult::Forward(text.to_string())
+                    }
+                    // Selector → open picker/selector (built in later phases)
+                    Some(TuiHandler::Selector) => {
+                        ctx.show_info(format!(
+                            "`{}` selector is not yet implemented in TUI — forwarding to chat",
+                            resolved
+                        ));
+                        SlashResult::Forward(text.to_string())
+                    }
+                    // Inline → should have been matched explicitly above
+                    Some(TuiHandler::Inline) => {
+                        ctx.show_error(format!("Command `{resolved}` not handled inline"));
+                        SlashResult::Handled
+                    }
+                }
+            }
+        },
     }
 }
 
@@ -2339,6 +2392,39 @@ fn handle_context_dump(arg: &str, ctx: &mut DispatchContext<'_>) -> SlashResult 
         path.display()
     )));
     SlashResult::Handled
+}
+
+// ── /inspect dispatch ────────────────────────────────────────────────
+//
+// Routes `/inspect` subcommands. Full TUI-native panels (budget, tools,
+// context, diff, history) will be wired in later phases once the
+// ViewStack portal infrastructure is ready.  For Phase 1.2 the
+// handler forwards unimplemented subcommands to chat so the user sees
+// progress instead of an error.
+async fn handle_inspect_dispatch(args: &str, ctx: &mut DispatchContext<'_>) -> SlashResult {
+    let sub = args.trim();
+    match sub {
+        "" => {
+            // No subcommand → show picker (Phase 1.4)
+            ctx.show_info(
+                "`/inspect` subcommands: budget, tools, context, json, diff, history, trace, forensics, export"
+                    .to_string(),
+            );
+            SlashResult::Handled
+        }
+        "budget" | "tools" | "context" | "json" | "diff" | "history" | "trace" | "forensics"
+        | "export" => {
+            // Subcommand recognized but panel not yet built
+            ctx.show_info(format!(
+                "`/inspect {sub}` panel will be available soon — forwarding to chat for now"
+            ));
+            SlashResult::Forward(format!("/inspect {}", args))
+        }
+        _ => {
+            ctx.show_error(format!("Unknown `/inspect` subcommand: `{sub}`"));
+            SlashResult::Handled
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -1015,6 +1015,31 @@ pub(crate) fn build_panels_cheat_sheet_lines() -> Vec<String> {
             "↑↓ navigate · Enter edit · type to search · Esc save/close",
         ),
         (
+            "/model",
+            "fuzzy-search model picker; switch or inspect current model",
+            "type to filter · Enter select · Esc close",
+        ),
+        (
+            "/skill",
+            "browse, search, install, and manage skills",
+            "type to filter · Enter select · Esc close",
+        ),
+        (
+            "/session",
+            "list, fork, history, analyze, or export sessions",
+            "↑↓ navigate · Enter select · Esc close",
+        ),
+        (
+            "/stats",
+            "view token cost, tool usage, and session statistics",
+            "Enter / q / Esc close",
+        ),
+        (
+            "/inspect",
+            "session introspection: budget, tools, history, traces",
+            "type subcommand · Esc close",
+        ),
+        (
             "/help",
             "list every slash command grouped by category",
             "↑↓ browse · Esc close",

--- a/rust/crates/astra-cli/src/tui/slash_menu/menu.rs
+++ b/rust/crates/astra-cli/src/tui/slash_menu/menu.rs
@@ -12,13 +12,14 @@
 
 #![allow(dead_code)]
 
+use crate::command_registry::TuiHandler;
 use nucleo_matcher::{
-    Config, Matcher, Utf32Str,
     pattern::{Atom, AtomKind, CaseMatching, Normalization},
+    Config, Matcher, Utf32Str,
 };
 
 /// A single slash command exposed to the menu.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SlashItem {
     /// Full command token including leading `/`, e.g. `/help`.
     pub name: &'static str,
@@ -32,6 +33,27 @@ pub(crate) struct SlashItem {
     pub aliases: &'static [&'static str],
     /// Frequency hint — higher means "show sooner on ties".
     pub usage_boost: u32,
+    /// Command group for categorized rendering in the popup.
+    pub group: Option<crate::command_registry::CommandGroup>,
+    /// How the command behaves in the TUI — e.g. shows a panel or modal.
+    pub tui_handler: crate::command_registry::TuiHandler,
+    /// Example usages shown in help output.
+    pub usage_examples: &'static [&'static str],
+}
+
+impl Default for SlashItem {
+    fn default() -> Self {
+        Self {
+            name: "",
+            description: "",
+            subcommands: &[],
+            aliases: &[],
+            usage_boost: 0,
+            group: None,
+            tui_handler: TuiHandler::Inline,
+            usage_examples: &[],
+        }
+    }
 }
 
 impl SlashItem {
@@ -43,6 +65,9 @@ impl SlashItem {
             subcommands: &[],
             aliases: &[],
             usage_boost: 0,
+            group: None,
+            tui_handler: TuiHandler::Inline,
+            usage_examples: &[],
         }
     }
 }

--- a/rust/crates/astra-cli/src/tui/slash_menu/menu.rs
+++ b/rust/crates/astra-cli/src/tui/slash_menu/menu.rs
@@ -14,8 +14,8 @@
 
 use crate::command_registry::TuiHandler;
 use nucleo_matcher::{
-    pattern::{Atom, AtomKind, CaseMatching, Normalization},
     Config, Matcher, Utf32Str,
+    pattern::{Atom, AtomKind, CaseMatching, Normalization},
 };
 
 /// A single slash command exposed to the menu.

--- a/rust/crates/astra-cli/src/tui/slash_menu/mod.rs
+++ b/rust/crates/astra-cli/src/tui/slash_menu/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod menu;
 pub(crate) mod popup;
 
 #[allow(unused_imports)]
-pub(crate) use menu::{SlashItem, SlashMenu, is_open_for, score_token};
+pub(crate) use menu::{is_open_for, score_token, SlashItem, SlashMenu};
 
 #[cfg(test)]
 mod tests;

--- a/rust/crates/astra-cli/src/tui/slash_menu/mod.rs
+++ b/rust/crates/astra-cli/src/tui/slash_menu/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod menu;
 pub(crate) mod popup;
 
 #[allow(unused_imports)]
-pub(crate) use menu::{is_open_for, score_token, SlashItem, SlashMenu};
+pub(crate) use menu::{SlashItem, SlashMenu, is_open_for, score_token};
 
 #[cfg(test)]
 mod tests;

--- a/rust/crates/astra-cli/src/tui/slash_menu/popup.rs
+++ b/rust/crates/astra-cli/src/tui/slash_menu/popup.rs
@@ -232,18 +232,19 @@ pub(crate) fn render(menu: &SlashMenu, area: Rect, buf: &mut Buffer) {
         if is_selected && !item.subcommands.is_empty() {
             let max_subs = 3.min(item.subcommands.len());
             for (name, desc) in item.subcommands.iter().take(max_subs) {
-                let mut sub_spans: Vec<Span<'static>> = Vec::new();
-                sub_spans.push(Span::raw("   · "));
-                sub_spans.push(Span::styled(
-                    format!("{name}"),
-                    Style::default()
-                        .fg(theme.accent_dim())
-                        .add_modifier(Modifier::ITALIC),
-                ));
-                sub_spans.push(Span::styled(
-                    format!(" — {desc}"),
-                    Style::default().fg(theme.dim).add_modifier(Modifier::DIM),
-                ));
+                let sub_spans: Vec<Span<'static>> = vec![
+                    Span::raw("   · "),
+                    Span::styled(
+                        name.to_string(),
+                        Style::default()
+                            .fg(theme.accent_dim())
+                            .add_modifier(Modifier::ITALIC),
+                    ),
+                    Span::styled(
+                        [" — ", desc].concat(),
+                        Style::default().fg(theme.dim).add_modifier(Modifier::DIM),
+                    ),
+                ];
                 lines.push(Line::from(sub_spans));
             }
             if item.subcommands.len() > max_subs {

--- a/rust/crates/astra-cli/src/tui/slash_menu/popup.rs
+++ b/rust/crates/astra-cli/src/tui/slash_menu/popup.rs
@@ -13,14 +13,24 @@
 //! ```
 //!
 //! Key features:
-//! * **Selected row** gets a cursor-gutter (`▌`), tinted background, and
-//!   bold accent-coloured name.
+//! * **Group headers**: items are grouped by category (Core, Session & Plan, Observability, …)
+//!   with dim `── Group Name ──` dividers when the filtered set spans multiple groups.
 //! * **Matched characters** (from the filter token) render in the
 //!   accent colour with UNDERLINE so the user can see why the row ranked.
 //! * **Scroll hints**: `↑ N more` / `↓ N more` above/below the window
 //!   when the list overflows.
 //! * **Aliases**: shown inline as a dim `(h)` badge right of the name.
 //! * **Responsive**: at <18 cols descriptions drop and only names render.
+//!
+//! Group-aware anatomy:
+//! ```text
+//!     ── Core ──
+//!   ▌ /help        show this help screen
+//!     /clear       clear screen
+//!     ── Session & Plan ──
+//!     /resume      resume a session
+//!     ↓ 2 more
+//! ```
 
 #![allow(dead_code)]
 
@@ -31,6 +41,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
 
 use super::SlashMenu;
+use crate::command_registry::CommandGroup;
 
 /// Maximum number of **data rows** shown at once. Does not include the
 /// scroll-indicator rows (↑ N more / ↓ N more).
@@ -129,12 +140,46 @@ pub(crate) fn render(menu: &SlashMenu, area: Rect, buf: &mut Buffer) {
         lines.push(scroll_hint(format!("↑ {} more", window_start), theme));
     }
 
-    // ── Visible data rows ───────────────────────────────────────
+    // ── Visible data rows (with group headers) ─────────────────
     let highlights = menu.match_indices();
+    let prev_group_idx = matches
+        .get(window_start.saturating_sub(1))
+        .and_then(|it| it.group);
+    let mut cur_group: Option<CommandGroup> = prev_group_idx;
+
     for (idx, item) in matches[window_start..window_end].iter().enumerate() {
         let absolute = window_start + idx;
         let is_selected = absolute == selected;
         let hi = highlights.get(absolute).cloned().unwrap_or_default();
+
+        // Insert group header when group changes.
+        let item_group = item.group;
+        if item_group != cur_group {
+            cur_group = item_group;
+            if let Some(g) = item_group {
+                let label = group_display_name(g);
+                // Ensure the gutter column is included.
+                let mut group_spans: Vec<Span<'static>> = Vec::with_capacity(3);
+                group_spans.push(Span::raw("  "));
+                group_spans.push(Span::styled(
+                    format!("── {label} ──"),
+                    Style::default()
+                        .fg(theme.accent_dim())
+                        .add_modifier(Modifier::ITALIC)
+                        .add_modifier(Modifier::DIM),
+                ));
+                // Add the rest as separator.
+                group_spans.push(Span::styled(
+                    "─".repeat(
+                        content_width
+                            .saturating_sub(label.chars().count() + 8)
+                            .min(80),
+                    ),
+                    Style::default().fg(theme.dim).add_modifier(Modifier::DIM),
+                ));
+                lines.push(Line::from(group_spans));
+            }
+        }
 
         let mut spans: Vec<Span<'static>> = Vec::with_capacity(8);
 
@@ -325,6 +370,21 @@ fn truncate_ellipsis(s: &str, width: usize) -> String {
     out
 }
 
+/// Human-readable display name for a command group.
+fn group_display_name(group: CommandGroup) -> &'static str {
+    match group {
+        CommandGroup::Core => "Core",
+        CommandGroup::Workspace => "Workspace",
+        CommandGroup::SessionPlan => "Session & Plan",
+        CommandGroup::MemoryTasks => "Memory & Tasks",
+        CommandGroup::Observability => "Observability",
+        CommandGroup::Skills => "Skills",
+        CommandGroup::Mcp => "MCP",
+        CommandGroup::TeamAccount => "Team & Account",
+        CommandGroup::System => "System",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::{SlashItem, SlashMenu};
@@ -403,7 +463,54 @@ mod tests {
         insta::assert_snapshot!("slash_popup_long_list_sel11_80", render_menu(&menu, 80, 12));
     }
 
-    // ─── Non-snapshot unit tests ──────────────────────────────────
+    #[test]
+    fn snapshot_groups_with_headers() {
+        // 6 items across 3 groups — should render group headers.
+        use crate::command_registry::CommandGroup;
+        let items: Vec<SlashItem> = vec![
+            SlashItem {
+                name: "/help",
+                description: "show help",
+                group: Some(CommandGroup::Core),
+                ..Default::default()
+            },
+            SlashItem {
+                name: "/clear",
+                description: "clear screen",
+                group: Some(CommandGroup::Core),
+                ..Default::default()
+            },
+            SlashItem {
+                name: "/resume",
+                description: "resume a session",
+                group: Some(CommandGroup::SessionPlan),
+                ..Default::default()
+            },
+            SlashItem {
+                name: "/plan",
+                description: "manage plan",
+                group: Some(CommandGroup::SessionPlan),
+                ..Default::default()
+            },
+            SlashItem {
+                name: "/model",
+                description: "pick a model",
+                group: Some(CommandGroup::Core),
+                ..Default::default()
+            },
+            SlashItem {
+                name: "/config",
+                description: "runtime config",
+                group: Some(CommandGroup::Observability),
+                ..Default::default()
+            },
+        ];
+        let menu = SlashMenu::new(items);
+        insta::assert_snapshot!(
+            "slash_popup_groups_with_headers_80",
+            render_menu(&menu, 80, 10)
+        );
+    }
 
     #[test]
     fn desired_height_clamps_at_max_plus_chrome() {

--- a/rust/crates/astra-cli/src/tui/slash_menu/popup.rs
+++ b/rust/crates/astra-cli/src/tui/slash_menu/popup.rs
@@ -228,6 +228,31 @@ pub(crate) fn render(menu: &SlashMenu, area: Rect, buf: &mut Buffer) {
             line = line.style(Style::default().bg(theme.selected_bg));
         }
         lines.push(line);
+        // Show subcommands below the selected item (single-line, compact).
+        if is_selected && !item.subcommands.is_empty() {
+            let max_subs = 3.min(item.subcommands.len());
+            for (name, desc) in item.subcommands.iter().take(max_subs) {
+                let mut sub_spans: Vec<Span<'static>> = Vec::new();
+                sub_spans.push(Span::raw("   · "));
+                sub_spans.push(Span::styled(
+                    format!("{name}"),
+                    Style::default()
+                        .fg(theme.accent_dim())
+                        .add_modifier(Modifier::ITALIC),
+                ));
+                sub_spans.push(Span::styled(
+                    format!(" — {desc}"),
+                    Style::default().fg(theme.dim).add_modifier(Modifier::DIM),
+                ));
+                lines.push(Line::from(sub_spans));
+            }
+            if item.subcommands.len() > max_subs {
+                lines.push(Line::from(Span::styled(
+                    format!("   … {} more", item.subcommands.len() - max_subs),
+                    Style::default().fg(theme.dim).add_modifier(Modifier::DIM),
+                )));
+            }
+        }
     }
 
     // ── Scroll-down hint ────────────────────────────────────────
@@ -567,5 +592,36 @@ mod tests {
             "narrow popup should not draw box: {out}"
         );
         assert!(out.contains("/help"), "name must still render: {out}");
+    }
+
+    #[test]
+    fn selected_item_shows_subcommands() {
+        use crate::command_registry::TuiHandler;
+
+        const SUBS: &[(&str, &str)] = &[
+            ("list", "List all memories"),
+            ("search", "Search memories by query"),
+            ("inspect", "Inspect a single memory by ID"),
+        ];
+        let item = SlashItem {
+            name: "/memory",
+            description: "Memory operations",
+            subcommands: SUBS,
+            aliases: &[],
+            usage_boost: 0,
+            group: Some(CommandGroup::MemoryTasks),
+            tui_handler: TuiHandler::Panel,
+            usage_examples: &[],
+        };
+        let menu = SlashMenu::new(vec![item]);
+        let output = render_menu(&menu, 80, 10);
+        assert!(
+            output.contains("list"),
+            "should show 'list' subcommand: {output}"
+        );
+        assert!(
+            output.contains("Search memories"),
+            "should show 'search' subcommand desc: {output}"
+        );
     }
 }

--- a/rust/crates/astra-cli/src/tui/slash_menu/snapshots/astra__tui__slash_menu__popup__tests__slash_popup_groups_with_headers_80.snap
+++ b/rust/crates/astra-cli/src/tui/slash_menu/snapshots/astra__tui__slash_menu__popup__tests__slash_popup_groups_with_headers_80.snap
@@ -1,0 +1,13 @@
+---
+source: crates/astra-cli/src/tui/slash_menu/popup.rs
+expression: "render_menu(&menu, 80, 10)"
+---
+▌ /help    show help
+  /clear   clear screen
+  ── Session & Plan ────────────────────────────────────────────────────────────
+  /resume  resume a session
+  /plan    manage plan
+  ── Core ──────────────────────────────────────────────────────────────────────
+  /model   pick a model
+  ── Observability ─────────────────────────────────────────────────────────────
+  /config  runtime config

--- a/rust/crates/astra-cli/src/tui/slash_menu/tests.rs
+++ b/rust/crates/astra-cli/src/tui/slash_menu/tests.rs
@@ -2,7 +2,7 @@
 
 #![cfg(test)]
 
-use super::{is_open_for, SlashItem, SlashMenu};
+use super::{SlashItem, SlashMenu, is_open_for};
 
 fn items() -> Vec<SlashItem> {
     vec![

--- a/rust/crates/astra-cli/src/tui/slash_menu/tests.rs
+++ b/rust/crates/astra-cli/src/tui/slash_menu/tests.rs
@@ -2,7 +2,7 @@
 
 #![cfg(test)]
 
-use super::{SlashItem, SlashMenu, is_open_for};
+use super::{is_open_for, SlashItem, SlashMenu};
 
 fn items() -> Vec<SlashItem> {
     vec![

--- a/rust/crates/astra-cli/src/tui/snapshots/astra__tui__slash_dispatch__panels_tests__panels_cheat_sheet.snap
+++ b/rust/crates/astra-cli/src/tui/snapshots/astra__tui__slash_dispatch__panels_tests__panels_cheat_sheet.snap
@@ -50,6 +50,10 @@ expression: "build_panels_cheat_sheet_lines().join(\"\\n\")"
       session introspection: budget, tools, history, traces
       type subcommand · Esc close
 
+  /info
+      system info at a glance — version, model, session, skills
+      ↑↓ scroll · Esc close
+
   /help
       list every slash command grouped by category
       ↑↓ browse · Esc close

--- a/rust/crates/astra-cli/src/tui/snapshots/astra__tui__slash_dispatch__panels_tests__panels_cheat_sheet.snap
+++ b/rust/crates/astra-cli/src/tui/snapshots/astra__tui__slash_dispatch__panels_tests__panels_cheat_sheet.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/slash_dispatch.rs
-assertion_line: 2476
 expression: "build_panels_cheat_sheet_lines().join(\"\\n\")"
 ---
   /resume
@@ -23,9 +22,9 @@ expression: "build_panels_cheat_sheet_lines().join(\"\\n\")"
       list git worktrees with per-worktree session counts
       ↑↓ navigate · q / Esc close
 
-  /config
-      interactive panel — search, pick, and edit runtime config
-      ↑↓ navigate · Enter edit · type to search · Esc save/close
+  /config [edit|show|paths|sources|diff|export]
+      interactive panel — search, pick, edit, diff, and export config
+      ↑↓ navigate · Enter edit/set · type to search · Esc save/close
 
   /model
       fuzzy-search model picker; switch or inspect current model

--- a/rust/crates/astra-cli/src/tui/snapshots/astra__tui__slash_dispatch__panels_tests__panels_cheat_sheet.snap
+++ b/rust/crates/astra-cli/src/tui/snapshots/astra__tui__slash_dispatch__panels_tests__panels_cheat_sheet.snap
@@ -23,8 +23,8 @@ expression: "build_panels_cheat_sheet_lines().join(\"\\n\")"
       ↑↓ navigate · q / Esc close
 
   /config [edit|show|paths|sources|diff|export]
-      interactive panel — search, pick, edit, diff, and export config
-      ↑↓ navigate · Enter edit/set · type to search · Esc save/close
+      edit opens the panel; show/paths/sources/diff/export stay text-first
+      panel: ↑↓ navigate · Enter edit/set · type to search · Esc save/close
 
   /model
       fuzzy-search model picker; switch or inspect current model

--- a/rust/crates/astra-cli/src/tui/snapshots/astra__tui__slash_dispatch__panels_tests__panels_cheat_sheet.snap
+++ b/rust/crates/astra-cli/src/tui/snapshots/astra__tui__slash_dispatch__panels_tests__panels_cheat_sheet.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/astra-cli/src/tui/slash_dispatch.rs
-assertion_line: 1211
+assertion_line: 2476
 expression: "build_panels_cheat_sheet_lines().join(\"\\n\")"
 ---
   /resume
@@ -26,6 +26,26 @@ expression: "build_panels_cheat_sheet_lines().join(\"\\n\")"
   /config
       interactive panel — search, pick, and edit runtime config
       ↑↓ navigate · Enter edit · type to search · Esc save/close
+
+  /model
+      fuzzy-search model picker; switch or inspect current model
+      type to filter · Enter select · Esc close
+
+  /skill
+      browse, search, install, and manage skills
+      type to filter · Enter select · Esc close
+
+  /session
+      list, fork, history, analyze, or export sessions
+      ↑↓ navigate · Enter select · Esc close
+
+  /stats
+      view token cost, tool usage, and session statistics
+      Enter / q / Esc close
+
+  /inspect
+      session introspection: budget, tools, history, traces
+      type subcommand · Esc close
 
   /help
       list every slash command grouped by category

--- a/rust/crates/astra-cli/src/tui/snapshots/astra__tui__slash_dispatch__panels_tests__panels_cheat_sheet.snap
+++ b/rust/crates/astra-cli/src/tui/snapshots/astra__tui__slash_dispatch__panels_tests__panels_cheat_sheet.snap
@@ -34,6 +34,10 @@ expression: "build_panels_cheat_sheet_lines().join(\"\\n\")"
       browse, search, install, and manage skills
       type to filter · Enter select · Esc close
 
+  /memory [list|search <q>|inspect <id>]
+      browse, search, and inspect episodic and semantic memories
+      ↑↓ navigate · Enter select · Esc close
+
   /session
       list, fork, history, analyze, or export sessions
       ↑↓ navigate · Enter select · Esc close


### PR DESCRIPTION
## Summary
- refine slash command routing between TUI-native handlers and fallback paths
- restore text-first behavior for /config read-only subcommands and /memory inspect
- add /info, /health aliasing, profile registry coverage, docs sync, and REPL cleanup
- normalize user-facing permission feedback to `accept-edits`

## Testing
- cargo test --manifest-path rust/Cargo.toml -p astra-cli --bin astra --quiet
- make check
- make test-offline