### PR TITLE
Revert "fix(tui): preserve scrollback for overlays"

### DIFF
--- a/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
@@ -256,11 +256,6 @@ impl BottomPane {
         !self.view_stack.is_empty()
     }
 
-    pub fn has_overlay_view(&self) -> bool {
-        self.active_view()
-            .is_some_and(|view| view.render_as_overlay())
-    }
-
     #[allow(clippy::borrowed_box)]
     fn active_view(&self) -> Option<&Box<dyn BottomPaneView>> {
         self.view_stack.last()
@@ -618,19 +613,17 @@ impl BottomPane {
 
     pub fn desired_height(&self, width: u16) -> u16 {
         if let Some(view) = self.active_view() {
-            if !view.render_as_overlay() {
-                let mut h = view.desired_height(width);
-                // Reserve a 1-row footer when the view advertises a hint.
-                if view.hint_keys().is_some() {
-                    h = h.saturating_add(1);
-                }
-                // …and another row for the status line when the view
-                // opts in (panels that want context preserved).
-                if view.reserve_status_footer() {
-                    h = h.saturating_add(1);
-                }
-                return h;
+            let mut h = view.desired_height(width);
+            // Reserve a 1-row footer when the view advertises a hint.
+            if view.hint_keys().is_some() {
+                h = h.saturating_add(1);
             }
+            // …and another row for the status line when the view
+            // opts in (panels that want context preserved).
+            if view.reserve_status_footer() {
+                h = h.saturating_add(1);
+            }
+            return h;
         }
         let content_h = self.composer.desired_height(width);
         let queue_h = self.queue_preview_height();
@@ -1062,36 +1055,35 @@ impl BottomPane {
 
     pub fn render(&self, area: Rect, buf: &mut Buffer) {
         if let Some(view) = self.active_view() {
-            if !view.render_as_overlay() {
-                // Stack optional footers under the view area:
-                //   [view]
-                //   [hint bar]        — when hint_keys() is Some
-                //   [status line]     — when reserve_status_footer()
-                let want_status = view.reserve_status_footer();
-                let hint = view.hint_keys();
-                let footer_rows = u16::from(want_status) + u16::from(hint.is_some());
-                if footer_rows > 0 && area.height > footer_rows {
-                    let view_h = area.height - footer_rows;
-                    let view_rect = Rect::new(area.x, area.y, area.width, view_h);
-                    view.render(view_rect, buf);
-                    let mut y = area.y + view_h;
-                    if let Some(h) = hint {
-                        render_hint_bar(&h, Rect::new(area.x, y, area.width, 1), buf);
-                        y += 1;
-                    }
-                    if want_status {
-                        self.footer.render(Rect::new(area.x, y, area.width, 1), buf);
-                    }
-                    return;
+            // Stack optional footers under the view area:
+            //   [view]
+            //   [hint bar]        — when hint_keys() is Some
+            //   [status line]     — when reserve_status_footer()
+            let want_status = view.reserve_status_footer();
+            let hint = view.hint_keys();
+            let footer_rows = u16::from(want_status) + u16::from(hint.is_some());
+            if footer_rows > 0 && area.height > footer_rows {
+                let view_h = area.height - footer_rows;
+                let view_rect = Rect::new(area.x, area.y, area.width, view_h);
+                view.render(view_rect, buf);
+                let mut y = area.y + view_h;
+                if let Some(h) = hint {
+                    render_hint_bar(&h, Rect::new(area.x, y, area.width, 1), buf);
+                    y += 1;
                 }
-                view.render(area, buf);
+                if want_status {
+                    self.footer.render(Rect::new(area.x, y, area.width, 1), buf);
+                }
                 return;
             }
+            view.render(area, buf);
+            return;
         }
 
         let popup_h = self.popup_height();
         let content_h = self.composer.desired_height(area.width);
         let queue_h = self.queue_preview_height();
+
         let approval_h = self.focused_approval_height(area.width);
         if popup_h > 0 {
             let chunks = Layout::vertical([
@@ -1147,9 +1139,7 @@ impl BottomPane {
 
     pub fn cursor_position(&self, area: Rect) -> Option<(u16, u16)> {
         if let Some(view) = self.active_view() {
-            if !view.render_as_overlay() {
-                return view.cursor_pos(area);
-            }
+            return view.cursor_pos(area);
         }
 
         let content_h = self.composer.desired_height(area.width);
@@ -1157,18 +1147,6 @@ impl BottomPane {
             Layout::vertical([Constraint::Length(content_h), Constraint::Min(0)]).split(area);
 
         self.composer.cursor_position(chunks[0])
-    }
-
-    pub fn render_overlay(&self, area: Rect, buf: &mut Buffer) {
-        let Some(view) = self.active_view() else {
-            return;
-        };
-        if !view.render_as_overlay() {
-            return;
-        }
-        use ratatui::widgets::{Clear, Widget};
-        Clear.render(area, buf);
-        view.render(area, buf);
     }
 }
 

--- a/rust/crates/astra-cli/src/tui/bottom_pane/timeline_view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/timeline_view.rs
@@ -2,8 +2,6 @@
 
 #![allow(dead_code)]
 
-use std::cell::Cell;
-
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -13,8 +11,6 @@ use crate::tui::timeline::{Timeline, view as timeline_view};
 
 pub(crate) struct TimelineView {
     timeline: Timeline,
-    drill_scroll: u16,
-    last_drill_max_scroll: Cell<u16>,
     completed: bool,
 }
 
@@ -22,39 +18,14 @@ impl TimelineView {
     pub fn new(timeline: Timeline) -> Self {
         Self {
             timeline,
-            drill_scroll: 0,
-            last_drill_max_scroll: Cell::new(0),
             completed: false,
         }
-    }
-
-    fn enter_drill(&mut self) {
-        self.timeline.enter_drill();
-        self.drill_scroll = 0;
-        self.last_drill_max_scroll.set(0);
-    }
-
-    fn exit_drill(&mut self) {
-        self.timeline.exit_drill();
-        self.drill_scroll = 0;
-        self.last_drill_max_scroll.set(0);
-    }
-
-    fn scroll_drill_down(&mut self, amount: u16) {
-        let max = self.last_drill_max_scroll.get();
-        self.drill_scroll = self.drill_scroll.saturating_add(amount).min(max);
-    }
-
-    fn scroll_drill_up(&mut self, amount: u16) {
-        self.drill_scroll = self.drill_scroll.saturating_sub(amount);
     }
 }
 
 impl BottomPaneView for TimelineView {
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let max_scroll =
-            timeline_view::render_with_drill_scroll(&self.timeline, area, buf, self.drill_scroll);
-        self.last_drill_max_scroll.set(max_scroll);
+        timeline_view::render(&self.timeline, area, buf);
     }
 
     fn desired_height(&self, _width: u16) -> u16 {
@@ -63,21 +34,14 @@ impl BottomPaneView for TimelineView {
 
     fn handle_key(&mut self, key: KeyEvent) {
         if self.timeline.is_drilled() {
-            match key.code {
-                KeyCode::Esc | KeyCode::Char('q') => self.exit_drill(),
-                KeyCode::Up => self.scroll_drill_up(1),
-                KeyCode::Down => self.scroll_drill_down(1),
-                KeyCode::PageUp => self.scroll_drill_up(10),
-                KeyCode::PageDown => self.scroll_drill_down(10),
-                KeyCode::Home => self.drill_scroll = 0,
-                KeyCode::End => self.drill_scroll = self.last_drill_max_scroll.get(),
-                _ => {}
+            if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
+                self.timeline.exit_drill();
             }
             return;
         }
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => self.completed = true,
-            KeyCode::Enter => self.enter_drill(),
+            KeyCode::Enter => self.timeline.enter_drill(),
             KeyCode::Up => self.timeline.move_up(),
             KeyCode::Down => self.timeline.move_down(),
             KeyCode::PageUp => {
@@ -124,17 +88,13 @@ impl BottomPaneView for TimelineView {
 
     fn hint_keys(&self) -> Option<String> {
         if self.timeline.is_drilled() {
-            Some("↑↓ scroll · PgUp/PgDn page · Home/End · Esc back".into())
+            Some("Esc back".into())
         } else {
             Some("↑↓ navigate · Enter trace · PgUp/PgDn page · Esc close".into())
         }
     }
 
     fn reserve_status_footer(&self) -> bool {
-        true
-    }
-
-    fn render_as_overlay(&self) -> bool {
         true
     }
 }
@@ -204,21 +164,6 @@ mod tests {
     }
 
     #[test]
-    fn timeline_overlay_does_not_inflate_bottom_pane_height() {
-        let mut pane = crate::tui::bottom_pane::BottomPane::new();
-        let before = pane.desired_height(80);
-
-        pane.push_view(Box::new(fixture()));
-
-        assert!(pane.has_overlay_view());
-        assert_eq!(
-            pane.desired_height(80),
-            before,
-            "timeline must not resize the native scrollback viewport"
-        );
-    }
-
-    #[test]
     fn esc_closes() {
         let mut v = fixture();
         v.handle_key(press(KeyCode::Esc));
@@ -240,31 +185,5 @@ mod tests {
         assert_eq!(v.timeline.selected(), Some(1));
         v.handle_key(press(KeyCode::Up));
         assert_eq!(v.timeline.selected(), Some(0));
-    }
-
-    #[test]
-    fn drilled_view_scrolls_detail() {
-        let mut v = fixture();
-        v.handle_key(press(KeyCode::Enter));
-        assert!(v.timeline.is_drilled());
-        assert_eq!(v.drill_scroll, 0);
-
-        v.last_drill_max_scroll.set(12);
-        v.handle_key(press(KeyCode::Down));
-        assert_eq!(v.drill_scroll, 1);
-        v.handle_key(press(KeyCode::PageDown));
-        assert_eq!(v.drill_scroll, 11);
-        v.handle_key(press(KeyCode::PageDown));
-        assert_eq!(v.drill_scroll, 12);
-        v.handle_key(press(KeyCode::Up));
-        assert_eq!(v.drill_scroll, 11);
-        v.handle_key(press(KeyCode::Home));
-        assert_eq!(v.drill_scroll, 0);
-        v.handle_key(press(KeyCode::End));
-        assert_eq!(v.drill_scroll, 12);
-
-        v.handle_key(press(KeyCode::Esc));
-        assert!(!v.timeline.is_drilled());
-        assert_eq!(v.drill_scroll, 0);
     }
 }

--- a/rust/crates/astra-cli/src/tui/bottom_pane/transcript_view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/transcript_view.rs
@@ -295,10 +295,6 @@ impl BottomPaneView for TranscriptView {
         None
     }
 
-    fn render_as_overlay(&self) -> bool {
-        true
-    }
-
     fn on_ctrl_c(&mut self) -> CancellationEvent {
         self.completed = true;
         CancellationEvent::Consumed
@@ -333,21 +329,6 @@ mod tests {
         // 50-row terminal → 80% budget = 40 → minus chrome (4) = 36
         let v = TranscriptView::new(lines(100), 50);
         assert_eq!(v.max_visible, 36);
-    }
-
-    #[test]
-    fn transcript_overlay_does_not_inflate_bottom_pane_height() {
-        let mut pane = crate::tui::bottom_pane::BottomPane::new();
-        let before = pane.desired_height(80);
-
-        pane.push_view(Box::new(TranscriptView::new(lines(100), 50)));
-
-        assert!(pane.has_overlay_view());
-        assert_eq!(
-            pane.desired_height(80),
-            before,
-            "transcript must not resize the native scrollback viewport"
-        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/bottom_pane/view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/view.rs
@@ -89,11 +89,4 @@ pub(crate) trait BottomPaneView: Send {
     fn reserve_status_footer(&self) -> bool {
         false
     }
-
-    /// Render this view as a draw-layer overlay instead of letting it
-    /// determine the inline viewport height. Use for large read-only
-    /// panels that must not resize the native terminal scrollback area.
-    fn render_as_overlay(&self) -> bool {
-        false
-    }
 }

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -700,28 +700,6 @@ impl ChatWidget {
         out
     }
 
-    /// Drain committed cells for terminal scrollback, but keep trailing
-    /// user-only cells pending until a response/status cell follows.
-    ///
-    /// Terminal insertion is stateful and later large batches can disturb
-    /// earlier tiny batches on some terminals. Pairing a user prompt with
-    /// the first following assistant/tool/system/summary cell keeps turn
-    /// boundaries atomic in the native scrollback while transcript
-    /// persistence remains immediate.
-    pub fn drain_new_committed_for_scrollback(&mut self) -> Vec<Arc<dyn HistoryCell>> {
-        let start = self.committed_watermark;
-        let mut end = self.history.len();
-        while end > start && cell_kind(self.history[end - 1].as_ref()) == CellKind::User {
-            end -= 1;
-        }
-        if end == start {
-            return Vec::new();
-        }
-        let out = self.history[start..end].to_vec();
-        self.committed_watermark = end;
-        out
-    }
-
     /// Reset the commit watermark to the current history length.
     /// Used on resume so replayed cells don't get reflushed.
     pub fn mark_all_flushed(&mut self) {
@@ -2579,37 +2557,6 @@ mod tests {
         w.handle_event(AppEvent::User(UserEvent::Submit("c".into())));
         let third = w.drain_new_committed();
         assert_eq!(third.len(), 1);
-    }
-
-    #[test]
-    fn scrollback_drain_holds_trailing_user_until_response_cell() {
-        let mut w = fresh();
-        w.handle_event(AppEvent::User(UserEvent::Submit("question".into())));
-
-        let first = w.drain_new_committed_for_scrollback();
-        assert!(
-            first.is_empty(),
-            "a lone user prompt should wait for the response batch"
-        );
-
-        w.handle_event(AppEvent::Wire(WireEvent::AnswerDelta("answer".into())));
-        w.handle_event(AppEvent::Wire(WireEvent::TurnComplete(Box::default())));
-
-        let second = w.drain_new_committed_for_scrollback();
-        assert_eq!(second.len(), 3, "user + assistant + summary drain together");
-        assert_eq!(cell_kind(second[0].as_ref()), CellKind::User);
-        assert_eq!(cell_kind(second[1].as_ref()), CellKind::Assistant);
-        assert_eq!(cell_kind(second[2].as_ref()), CellKind::TurnSummary);
-    }
-
-    #[test]
-    fn normal_drain_still_replays_trailing_user_cells() {
-        let mut w = fresh();
-        w.handle_event(AppEvent::User(UserEvent::Submit("/session".into())));
-
-        let out = w.drain_new_committed();
-        assert_eq!(out.len(), 1);
-        assert_eq!(cell_kind(out[0].as_ref()), CellKind::User);
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/draw.rs
+++ b/rust/crates/astra-cli/src/tui/draw.rs
@@ -9,7 +9,7 @@
 //! See `ARCHITECTURE.md` for the visual-hierarchy grammar.
 
 use ratatui::text::Line;
-use ratatui::widgets::Paragraph;
+use ratatui::widgets::{Clear, Paragraph, Widget};
 
 use super::bottom_pane::{BottomPane, footer::Footer};
 use super::render::renderable::{FlexRenderable, Renderable, RenderableItem};
@@ -456,7 +456,6 @@ pub(crate) fn do_draw(
     ));
     let sep_renderable = RenderableItem::Owned(Box::new(sep_line));
 
-    let overlay_active = bottom_pane.has_overlay_view();
     let bp_renderable = BottomPaneRenderable(bottom_pane);
     let bp_item = RenderableItem::Owned(Box::new(bp_renderable) as Box<dyn Renderable>);
 
@@ -503,29 +502,15 @@ pub(crate) fn do_draw(
     }
     flex.push(0, bp_item);
 
-    let total_h = if overlay_active {
-        guard
-            .terminal
-            .size()
-            .map(|s| s.height)
-            .unwrap_or_else(|_| flex.desired_height(width))
-    } else {
-        flex.desired_height(width)
-    };
-
-    guard
-        .set_alternate_screen_overlay(overlay_active)
-        .map_err(|e| format!("alternate screen overlay: {e}"))?;
+    let total_h = flex.desired_height(width);
 
     guard
         .draw(total_h, |frame| {
             let area = frame.area();
+            Clear.render(area, frame.buffer_mut());
             flex.render(area, frame.buffer_mut());
-            if overlay_active {
-                bottom_pane.render_overlay(area, frame.buffer_mut());
-            }
 
-            if !overlay_active && let Some((x, y)) = flex.cursor_pos(area) {
+            if let Some((x, y)) = flex.cursor_pos(area) {
                 frame.set_cursor_position((x, y));
             }
         })
@@ -533,7 +518,7 @@ pub(crate) fn do_draw(
     Ok(())
 }
 
-struct BottomPaneRenderable<'a>(&'a BottomPane);
+struct BottomPaneRenderable<'a>(&'a mut BottomPane);
 
 impl<'a> Renderable for BottomPaneRenderable<'a> {
     fn render(&self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -70,24 +70,7 @@ fn flush_chat_widget(
     chat_widget: &mut chat_widget::ChatWidget,
     width: u16,
 ) {
-    let new_cells = chat_widget.drain_new_committed_for_scrollback();
-    flush_chat_cells(guard, new_cells, width);
-}
-
-fn flush_chat_widget_all(
-    guard: &mut TerminalGuard,
-    chat_widget: &mut chat_widget::ChatWidget,
-    width: u16,
-) {
     let new_cells = chat_widget.drain_new_committed();
-    flush_chat_cells(guard, new_cells, width);
-}
-
-fn flush_chat_cells(
-    guard: &mut TerminalGuard,
-    new_cells: Vec<Arc<dyn history_cell::HistoryCell>>,
-    width: u16,
-) {
     if new_cells.is_empty() {
         return;
     }
@@ -476,7 +459,7 @@ fn replay_session_into_widget(
     // Paint the restored cells exactly once via the same rendering
     // path that streaming flushes use, so the visual match is
     // lossless.
-    flush_chat_widget_all(guard, &mut widget, width);
+    flush_chat_widget(guard, &mut widget, width);
     // Belt-and-suspenders: if flush_chat_widget's implementation
     // ever changes to not advance the watermark, this keeps us
     // safe.

--- a/rust/crates/astra-cli/src/tui/terminal.rs
+++ b/rust/crates/astra-cli/src/tui/terminal.rs
@@ -5,13 +5,9 @@ use crossterm::{
     event::{DisableBracketedPaste, EnableBracketedPaste},
     execute, queue,
     style::Print,
-    terminal::{
-        EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
-        is_raw_mode_enabled,
-    },
+    terminal::{disable_raw_mode, enable_raw_mode, is_raw_mode_enabled},
 };
 use ratatui::backend::CrosstermBackend;
-use ratatui::layout::Rect;
 use ratatui::text::Line;
 
 use super::custom_terminal;
@@ -22,8 +18,6 @@ pub(crate) struct TerminalGuard {
     pub terminal: CustomTerminal,
     pub pending_history: Vec<Line<'static>>,
     is_zellij: bool,
-    alternate_screen_active: bool,
-    saved_main_viewport_area: Option<Rect>,
 }
 
 struct RawModeGuard;
@@ -59,8 +53,6 @@ impl TerminalGuard {
             terminal,
             pending_history: Vec::new(),
             is_zellij,
-            alternate_screen_active: false,
-            saved_main_viewport_area: None,
         };
         std::mem::forget(early_guard);
         Ok(guard)
@@ -83,30 +75,7 @@ impl TerminalGuard {
         self.pending_history.extend(lines);
     }
 
-    pub fn set_alternate_screen_overlay(&mut self, enabled: bool) -> io::Result<()> {
-        if enabled == self.alternate_screen_active {
-            return Ok(());
-        }
-
-        if enabled {
-            self.saved_main_viewport_area = Some(self.terminal.viewport_area);
-            execute!(self.terminal.backend_mut(), EnterAlternateScreen)?;
-            self.terminal.set_viewport_area(Rect::new(0, 0, 0, 0));
-            self.terminal.invalidate_viewport();
-            self.alternate_screen_active = true;
-        } else {
-            execute!(self.terminal.backend_mut(), LeaveAlternateScreen)?;
-            if let Some(area) = self.saved_main_viewport_area.take() {
-                self.terminal.set_viewport_area(area);
-            }
-            self.terminal.invalidate_viewport();
-            self.alternate_screen_active = false;
-        }
-
-        Ok(())
-    }
-
-    /// Draw the viewport using the same high-level ordering as Codex:
+    /// Draw the viewport — matches Codex tui.rs::draw() sequence:
     /// 1. update_inline_viewport (scroll if height changed, clear if viewport moved)
     /// 2. flush_pending_history (insert above viewport)
     /// 3. invalidate_viewport only when needed (viewport moved or Zellij flush)
@@ -119,15 +88,11 @@ impl TerminalGuard {
         stdout().sync_update(|_| {
             let terminal = &mut self.terminal;
 
-            let mut needs_full_repaint = Self::update_inline_viewport(terminal, height)?;
+            let mut needs_full_repaint =
+                Self::update_inline_viewport(terminal, height, self.is_zellij)?;
 
-            if !self.alternate_screen_active {
-                needs_full_repaint |= Self::flush_pending_history(
-                    terminal,
-                    &mut self.pending_history,
-                    self.is_zellij,
-                )?;
-            }
+            needs_full_repaint |=
+                Self::flush_pending_history(terminal, &mut self.pending_history, self.is_zellij)?;
 
             if needs_full_repaint {
                 terminal.invalidate_viewport();
@@ -145,13 +110,15 @@ impl TerminalGuard {
         self.terminal.clear()
     }
 
-    /// If viewport would extend past screen bottom, scroll the full screen with
-    /// newlines so rows displaced from the top enter native terminal scrollback.
-    /// A scroll-region update can discard those rows on some terminals.
+    /// Matches Codex tui.rs::update_inline_viewport():
+    /// If viewport would extend past screen bottom, scroll content above it up.
     /// If viewport area changed, clear old area and set new one.
-    fn update_inline_viewport(terminal: &mut CustomTerminal, height: u16) -> io::Result<bool> {
+    fn update_inline_viewport(
+        terminal: &mut CustomTerminal,
+        height: u16,
+        is_zellij: bool,
+    ) -> io::Result<bool> {
         let size = terminal.size()?;
-        let previous_area = terminal.viewport_area;
         let mut area = terminal.viewport_area;
         area.height = height.min(size.height);
         area.width = size.width;
@@ -159,21 +126,28 @@ impl TerminalGuard {
 
         if area.bottom() > size.height {
             let scroll_by = area.bottom() - size.height;
-            queue!(
-                terminal.backend_mut(),
-                cursor::MoveTo(0, size.height.saturating_sub(1))
-            )?;
-            for _ in 0..scroll_by {
-                queue!(terminal.backend_mut(), Print("\n"))?;
+            if is_zellij {
+                queue!(
+                    terminal.backend_mut(),
+                    cursor::MoveTo(0, size.height.saturating_sub(1))
+                )?;
+                for _ in 0..scroll_by {
+                    queue!(terminal.backend_mut(), Print("\n"))?;
+                }
+                needs_full_repaint = true;
+            } else {
+                let region_bottom = area.top();
+                if region_bottom > 0 {
+                    queue!(
+                        terminal.backend_mut(),
+                        Print(format!("\x1b[1;{}r", region_bottom)),
+                        cursor::MoveTo(0, 0),
+                        Print(format!("\x1b[{}S", scroll_by)),
+                        Print("\x1b[r"),
+                    )?;
+                }
             }
-            needs_full_repaint = true;
             area.y = size.height - area.height;
-        } else if previous_area.bottom() == size.height && area.height < previous_area.height {
-            // Keep the inline viewport bottom-anchored when a large overlay
-            // closes. Otherwise shrinking from fullscreen leaves y=0 and the
-            // subsequent clear starts at the top of the screen, erasing
-            // visible native scrollback.
-            area.y = size.height.saturating_sub(area.height);
         }
 
         if area != terminal.viewport_area {
@@ -262,9 +236,6 @@ impl TerminalGuard {
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
-        if self.alternate_screen_active {
-            let _ = execute!(stdout(), LeaveAlternateScreen);
-        }
         let area = self.terminal.viewport_area;
         let _ = execute!(stdout(), cursor::MoveTo(0, area.bottom()), cursor::Show);
         let _ = disable_raw_mode();

--- a/rust/crates/astra-cli/src/tui/timeline/view.rs
+++ b/rust/crates/astra-cli/src/tui/timeline/view.rs
@@ -18,7 +18,7 @@
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span, Text};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
 
 use super::Timeline;
@@ -36,21 +36,13 @@ pub(crate) fn desired_height(tl: &Timeline) -> u16 {
 }
 
 pub(crate) fn render(tl: &Timeline, area: Rect, buf: &mut Buffer) {
-    render_with_drill_scroll(tl, area, buf, 0);
-}
-
-pub(crate) fn render_with_drill_scroll(
-    tl: &Timeline,
-    area: Rect,
-    buf: &mut Buffer,
-    drill_scroll: u16,
-) -> u16 {
     if area.width == 0 || area.height == 0 {
-        return 0;
+        return;
     }
 
     if tl.is_drilled() {
-        return render_drill(tl, area, buf, drill_scroll);
+        render_drill(tl, area, buf);
+        return;
     }
 
     let outer = Block::default()
@@ -66,19 +58,18 @@ pub(crate) fn render_with_drill_scroll(
             Style::default().add_modifier(Modifier::DIM),
         )))
         .render(inner, buf);
-        return 0;
+        return;
     }
 
     if inner.width < MIN_SPLIT_WIDTH {
         render_list(tl, inner, buf);
-        return 0;
+        return;
     }
 
     let chunks =
         Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)]).split(inner);
     render_list(tl, chunks[0], buf);
     render_detail(tl, chunks[1], buf);
-    0
 }
 
 fn title_line(tl: &Timeline) -> Line<'static> {
@@ -279,10 +270,8 @@ fn fmt_tokens_u64(n: u64) -> String {
 
 // ─── Drill view (full turn trace) ──────────────────────────────────────
 
-fn render_drill(tl: &Timeline, area: Rect, buf: &mut Buffer, scroll: u16) -> u16 {
-    let Some(t) = tl.selected_turn() else {
-        return 0;
-    };
+fn render_drill(tl: &Timeline, area: Rect, buf: &mut Buffer) {
+    let Some(t) = tl.selected_turn() else { return };
     let dim = Style::default().fg(Color::DarkGray);
     let label = Style::default().fg(crate::tui::theme::current().accent);
     let bold = Style::default().add_modifier(Modifier::BOLD);
@@ -521,31 +510,31 @@ fn render_drill(tl: &Timeline, area: Rect, buf: &mut Buffer, scroll: u16) -> u16
 
     // User input / assistant output
     if let Some(ref input) = t.user_input {
+        let preview: String = input.chars().take(200).collect();
         lines.push(Line::default());
         lines.push(Line::from(Span::styled("  User", label)));
-        for line in input.lines() {
+        for line in preview.lines().take(4) {
             lines.push(Line::from(Span::styled(format!("    {line}"), dim)));
+        }
+        if input.lines().count() > 4 {
+            lines.push(Line::from(Span::styled("    …", dim)));
         }
     }
     if let Some(ref output) = t.assistant_output {
+        let preview: String = output.chars().take(300).collect();
         lines.push(Line::default());
         lines.push(Line::from(Span::styled("  Assistant", label)));
-        for line in output.lines() {
+        for line in preview.lines().take(6) {
             lines.push(Line::from(Span::styled(format!("    {line}"), dim)));
+        }
+        if output.lines().count() > 6 {
+            lines.push(Line::from(Span::styled("    …", dim)));
         }
     }
 
-    let text = Text::from(lines);
-    let paragraph = Paragraph::new(text.clone()).wrap(Wrap { trim: false });
-    let line_count = paragraph.line_count(inner.width) as u16;
-    let max_scroll = line_count.saturating_sub(inner.height);
-    let scroll = scroll.min(max_scroll);
-
-    Paragraph::new(text)
+    Paragraph::new(lines)
         .wrap(Wrap { trim: false })
-        .scroll((scroll, 0))
         .render(inner, buf);
-    max_scroll
 }
 
 /// Truncate an RFC3339 ISO timestamp to `HH:MM:SS`.
@@ -561,7 +550,7 @@ fn short_time(iso: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::super::model::{StaticTurnSource, TimelineTurn, ToolCallDetail};
+    use super::super::model::{StaticTurnSource, TimelineTurn};
     use super::*;
     use crate::tui::testing::render::{buffer_to_string, draw_widget};
 
@@ -608,20 +597,8 @@ mod tests {
         }
     }
 
-    struct ScrolledWidget<'a>(&'a Timeline, u16);
-    impl ratatui::widgets::Widget for ScrolledWidget<'_> {
-        fn render(self, area: Rect, buf: &mut Buffer) {
-            render_with_drill_scroll(self.0, area, buf, self.1);
-        }
-    }
-
     fn render_tl(tl: &Timeline, w: u16, h: u16) -> String {
         let buf = draw_widget(Widget(tl), w, h);
-        buffer_to_string(&buf)
-    }
-
-    fn render_tl_scrolled(tl: &Timeline, w: u16, h: u16, scroll: u16) -> String {
-        let buf = draw_widget(ScrolledWidget(tl, scroll), w, h);
         buffer_to_string(&buf)
     }
 
@@ -660,62 +637,6 @@ mod tests {
         let mut tl = Timeline::new(src, "sess_err");
         tl.move_down();
         insta::assert_snapshot!("timeline_error_turn_100x10", render_tl(&tl, 100, 10));
-    }
-
-    #[test]
-    fn drill_view_applies_scroll_offset() {
-        let mut turn = mk(1, 500, 200, 12, "long trace", None);
-        turn.duration_ms = Some(12_000);
-        turn.total_llm_ms = Some(2_000);
-        turn.tool_calls = (0..12)
-            .map(|idx| ToolCallDetail {
-                name: format!("tool_{idx:02}"),
-                ok: true,
-                ms: 200 + idx as u64,
-                error: None,
-                input_bytes: None,
-                output_bytes: None,
-                args_preview: None,
-                start_offset_ms: None,
-                parallel: None,
-                round: None,
-            })
-            .collect();
-        let src = StaticTurnSource::new(vec![turn]);
-        let mut tl = Timeline::new(src, "sess_trace");
-        tl.enter_drill();
-
-        let top = render_tl_scrolled(&tl, 80, 8, 0);
-        let scrolled = render_tl_scrolled(&tl, 80, 8, 8);
-
-        assert_ne!(top, scrolled);
-        assert!(top.contains("Total"));
-        assert!(!scrolled.contains("Total"));
-    }
-
-    #[test]
-    fn drill_view_renders_full_user_and_assistant_content() {
-        let mut turn = mk(1, 500, 200, 0, "full text", None);
-        turn.user_input = Some(
-            (0..8)
-                .map(|idx| format!("user line {idx:02}"))
-                .collect::<Vec<_>>()
-                .join("\n"),
-        );
-        turn.assistant_output = Some(
-            (0..12)
-                .map(|idx| format!("assistant line {idx:02}"))
-                .collect::<Vec<_>>()
-                .join("\n"),
-        );
-        let src = StaticTurnSource::new(vec![turn]);
-        let mut tl = Timeline::new(src, "sess_full_text");
-        tl.enter_drill();
-
-        let bottom = render_tl_scrolled(&tl, 80, 8, u16::MAX);
-
-        assert!(bottom.contains("assistant line 11"));
-        assert!(!bottom.contains("…"));
     }
 
     // ─── Helpers ──────────────────────────────────────────────────


### PR DESCRIPTION
Reverts 84abfdfc / #383 because the overlay scrollback fix caused regressions in the TUI view/scrollback behavior.

This PR contains only the generated revert commit.