### PR TITLE
feat(cli): add stdio app-server serve mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ make dev-api-start    # API server (auto-creates database schema)
 
 Open `http://localhost:8000/health` to verify.
 
+You can also start the runtime directly from the CLI:
+
+```bash
+astra serve                         # HTTP API server, defaults to 127.0.0.1:8000
+astra serve http --port 8000        # explicit HTTP mode
+astra serve stdio                   # stdio JSON-RPC app-server mode
+```
+
+`serve http` exposes the Axum HTTP API. `serve stdio` starts a long-lived app-server transport: a parent process writes newline-delimited JSON-RPC requests to stdin, reads responses and notifications from stdout, and may keep the child alive across multiple turns so session and turn state stay warm. It is not an interactive terminal mode. In stdio mode, stdout is reserved for protocol messages; diagnostics should go to stderr or `ASTRA_LOG_FILE`.
+
 ### Logging (API server and CLI diagnostics)
 
 - **`RUST_LOG`**: standard `tracing` filter (e.g. `RUST_LOG=info`, or per-target `astra_runtime=debug`).

--- a/rust/crates/astra-cli/src/cli/app_server.rs
+++ b/rust/crates/astra-cli/src/cli/app_server.rs
@@ -1,0 +1,935 @@
+//! Stdio app-server for long-lived gateway integrations.
+//!
+//! The protocol intentionally mirrors the subset of Codex app-server that
+//! `astra-suite` already knows how to pool: JSON-RPC lines on stdin/stdout,
+//! with turn progress emitted as notifications.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::Value;
+use std::io::{BufRead, Write};
+use tokio::sync::{Mutex, oneshot};
+use tokio_util::sync::CancellationToken;
+
+use crate::chat_stream::{ApprovalRequest, ApprovalResponse, ChatTurnParams, StreamEvent};
+use crate::cli_utils::get_profile_and_token;
+use crate::permission_manager::{PermissionLoadPolicy, PermissionManager, PermissionMode};
+use crate::session_runtime;
+use crate::streaming_types::StreamResult;
+use crate::{ExplainMode, chat_stream::BasicCliChatContext};
+use astra_turn_core::chat_turn_heuristics::is_session_not_found_error;
+
+type JsonWriter = Arc<Mutex<std::io::Stdout>>;
+
+#[derive(Clone)]
+struct ServerContext {
+    api: astra_thin_client::ThinClient,
+    auth_profile: Option<String>,
+    default_model: Option<String>,
+    system_prompt: Option<String>,
+    auto_approve: bool,
+}
+
+#[derive(Default)]
+struct AppState {
+    thread_id: Option<String>,
+    developer_instructions: Option<String>,
+    active_turn: Option<ActiveTurn>,
+    pending_approvals: HashMap<String, PendingApproval>,
+}
+
+struct ActiveTurn {
+    turn_id: String,
+    cancel: Arc<CancellationToken>,
+}
+
+struct PendingApproval {
+    turn_id: String,
+    response_tx: oneshot::Sender<ApprovalResponse>,
+}
+
+struct TurnRequest {
+    state: Arc<Mutex<AppState>>,
+    thread_id: String,
+    turn_id: String,
+    message: String,
+    params: Value,
+    developer_instructions: Option<String>,
+    permission_mode: PermissionMode,
+    cancel: Arc<CancellationToken>,
+}
+
+pub(crate) async fn run_stdio_app_server(
+    listen: &str,
+    api: &astra_thin_client::ThinClient,
+    profile: Option<&str>,
+    default_model: Option<&str>,
+    system_prompt: Option<&str>,
+    auto_approve: bool,
+) -> Result<(), String> {
+    if listen != "stdio://" {
+        return Err(format!("unsupported app-server listener `{listen}`"));
+    }
+
+    let ctx = ServerContext {
+        api: api.clone(),
+        auth_profile: profile.map(str::to_string),
+        default_model: default_model.map(str::to_string),
+        system_prompt: system_prompt.map(str::to_string),
+        auto_approve,
+    };
+    let state = Arc::new(Mutex::new(AppState::default()));
+    let writer = Arc::new(Mutex::new(std::io::stdout()));
+    let stdin = std::io::stdin();
+    let lines = stdin.lock().lines();
+
+    for line in lines {
+        let line = line.map_err(|e| format!("stdin read failed: {e}"))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let parsed = match serde_json::from_str::<Value>(trimmed) {
+            Ok(v) => v,
+            Err(e) => {
+                write_notification(
+                    &writer,
+                    "error",
+                    serde_json::json!({"message": format!("invalid JSON-RPC: {e}")}),
+                )
+                .await?;
+                continue;
+            }
+        };
+        let id = parsed.get("id").cloned().unwrap_or(Value::Null);
+        let Some(method) = parsed.get("method").and_then(Value::as_str) else {
+            write_response_error(&writer, id, "missing method").await?;
+            continue;
+        };
+        let params = parsed.get("params").cloned().unwrap_or(Value::Null);
+
+        match method {
+            "initialize" => {
+                write_response(
+                    &writer,
+                    id,
+                    serde_json::json!({
+                        "serverInfo": {
+                            "name": "astra-cli",
+                            "version": env!("CARGO_PKG_VERSION"),
+                        }
+                    }),
+                )
+                .await?;
+            }
+            "thread/start" => {
+                let requested = match requested_thread_id(&params) {
+                    Ok(id) => id,
+                    Err(error) => {
+                        write_response_error(&writer, id, &error).await?;
+                        continue;
+                    }
+                };
+                let mut guard = state.lock().await;
+                let thread_id = requested
+                    .or_else(|| guard.thread_id.clone())
+                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+                guard.thread_id = Some(thread_id.clone());
+                guard.developer_instructions = developer_instructions(&params);
+                drop(guard);
+                write_response(
+                    &writer,
+                    id,
+                    serde_json::json!({"thread": {"id": thread_id}}),
+                )
+                .await?;
+            }
+            "thread/resume" => {
+                let thread_id = match requested_thread_id(&params) {
+                    Ok(Some(id)) => id,
+                    Ok(None) => {
+                        write_response_error(&writer, id, "thread/resume missing threadId").await?;
+                        continue;
+                    }
+                    Err(error) => {
+                        write_response_error(&writer, id, &error).await?;
+                        continue;
+                    }
+                };
+                let mut guard = state.lock().await;
+                guard.thread_id = Some(thread_id.clone());
+                guard.developer_instructions = developer_instructions(&params);
+                drop(guard);
+                write_response(
+                    &writer,
+                    id,
+                    serde_json::json!({"thread": {"id": thread_id}}),
+                )
+                .await?;
+            }
+            "turn/start" => {
+                let Some(message) = extract_turn_message(&params) else {
+                    write_response_error(&writer, id, "turn/start missing input text").await?;
+                    continue;
+                };
+                let turn_id = uuid::Uuid::new_v4().to_string();
+                let cancel = Arc::new(CancellationToken::new());
+                let requested = match requested_thread_id(&params) {
+                    Ok(id) => id,
+                    Err(error) => {
+                        write_response_error(&writer, id, &error).await?;
+                        continue;
+                    }
+                };
+                let permission_mode = match permission_mode_from_params(&params, ctx.auto_approve) {
+                    Ok(mode) => mode,
+                    Err(error) => {
+                        write_response_error(&writer, id, &error).await?;
+                        continue;
+                    }
+                };
+                let (thread_id, turn_developer_instructions) = {
+                    let mut guard = state.lock().await;
+                    let thread_id = requested
+                        .or_else(|| guard.thread_id.clone())
+                        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+                    let turn_developer_instructions = developer_instructions(&params)
+                        .or_else(|| guard.developer_instructions.clone());
+                    guard.thread_id = Some(thread_id.clone());
+                    guard.active_turn = Some(ActiveTurn {
+                        turn_id: turn_id.clone(),
+                        cancel: cancel.clone(),
+                    });
+                    (thread_id, turn_developer_instructions)
+                };
+                write_response(
+                    &writer,
+                    id,
+                    serde_json::json!({"turn": {"id": turn_id.clone()}}),
+                )
+                .await?;
+
+                let task_ctx = ctx.clone();
+                let task_state = state.clone();
+                let task_writer = writer.clone();
+                tokio::spawn(async move {
+                    let result = run_turn(
+                        task_ctx,
+                        task_writer.clone(),
+                        TurnRequest {
+                            state: task_state.clone(),
+                            thread_id,
+                            turn_id: turn_id.clone(),
+                            message,
+                            params,
+                            developer_instructions: turn_developer_instructions,
+                            permission_mode,
+                            cancel,
+                        },
+                    )
+                    .await;
+                    if let Err(error) = result {
+                        let _ = write_notification(
+                            &task_writer,
+                            "error",
+                            serde_json::json!({"message": error}),
+                        )
+                        .await;
+                        let _ = write_notification(
+                            &task_writer,
+                            "turn/completed",
+                            serde_json::json!({"turn": {"id": turn_id}, "status": "failed"}),
+                        )
+                        .await;
+                    }
+                    let mut guard = task_state.lock().await;
+                    if guard
+                        .active_turn
+                        .as_ref()
+                        .is_some_and(|active| active.turn_id == turn_id)
+                    {
+                        guard.active_turn = None;
+                    }
+                });
+            }
+            "turn/interrupt" => {
+                let turn_id = {
+                    let guard = state.lock().await;
+                    if let Some(active) = guard.active_turn.as_ref() {
+                        active.cancel.cancel();
+                        Some(active.turn_id.clone())
+                    } else {
+                        None
+                    }
+                };
+                if let Some(turn_id) = turn_id {
+                    deny_pending_approvals_for_turn(&state, &turn_id).await;
+                }
+                write_response(&writer, id, serde_json::json!({"ok": true})).await?;
+            }
+            "approval/respond" => {
+                let approval_id = match params
+                    .get("approvalId")
+                    .or_else(|| params.get("id"))
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.trim().is_empty())
+                {
+                    Some(id) => id.to_string(),
+                    None => {
+                        write_response_error(&writer, id, "approval/respond missing approvalId")
+                            .await?;
+                        continue;
+                    }
+                };
+                let response = match approval_response_from_params(&params) {
+                    Ok(response) => response,
+                    Err(error) => {
+                        write_response_error(&writer, id, &error).await?;
+                        continue;
+                    }
+                };
+                let pending = state.lock().await.pending_approvals.remove(&approval_id);
+                let Some(pending) = pending else {
+                    write_response_error(&writer, id, "unknown approvalId").await?;
+                    continue;
+                };
+                let _ = pending.response_tx.send(response);
+                write_response(&writer, id, serde_json::json!({"ok": true})).await?;
+            }
+            _ => {
+                write_response_error(&writer, id, &format!("unknown method `{method}`")).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_turn(
+    ctx: ServerContext,
+    writer: JsonWriter,
+    request: TurnRequest,
+) -> Result<(), String> {
+    let TurnRequest {
+        state,
+        thread_id,
+        turn_id,
+        message,
+        params,
+        developer_instructions,
+        permission_mode,
+        cancel,
+    } = request;
+
+    write_notification(
+        &writer,
+        "turn/started",
+        serde_json::json!({"turn": {"id": turn_id}, "threadId": thread_id}),
+    )
+    .await?;
+
+    let (_, _, _, token) = get_profile_and_token(ctx.auth_profile.as_deref())?;
+    let model = params
+        .get("model")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or(ctx.default_model.clone());
+    let (stream_tx, mut stream_rx) = tokio::sync::mpsc::unbounded_channel();
+    let event_writer = writer.clone();
+    let event_task = tokio::spawn(async move {
+        while let Some(event) = stream_rx.recv().await {
+            let _ = write_stream_notification(&event_writer, event).await;
+        }
+    });
+    let (approval_tx, mut approval_rx) = tokio::sync::mpsc::unbounded_channel();
+    let approval_writer = writer.clone();
+    let approval_state = state.clone();
+    let approval_thread_id = thread_id.clone();
+    let approval_turn_id = turn_id.clone();
+    let approval_task = tokio::spawn(async move {
+        while let Some(approval) = approval_rx.recv().await {
+            let approval_id = uuid::Uuid::new_v4().to_string();
+            let ApprovalRequest {
+                tool,
+                header,
+                detail,
+                reason,
+                args,
+                response_tx,
+                metadata: _,
+            } = approval;
+            if !register_pending_approval(
+                &approval_state,
+                &approval_id,
+                &approval_turn_id,
+                response_tx,
+            )
+            .await
+            {
+                continue;
+            }
+            let params = approval_notification_params(ApprovalNotification {
+                approval_id: &approval_id,
+                thread_id: &approval_thread_id,
+                turn_id: &approval_turn_id,
+                tool: &tool,
+                header: &header,
+                detail: detail.as_deref(),
+                reason: &reason,
+                args: &args,
+            });
+            if write_notification(&approval_writer, "approval/requested", params)
+                .await
+                .is_err()
+            {
+                deny_pending_approval(&approval_state, &approval_id).await;
+            }
+        }
+    });
+
+    let _pipeline =
+        session_runtime::create_pipeline_modules_quiet(&ctx.api, ctx.auth_profile.as_deref());
+    let mut pm = PermissionManager::with_load_policy(
+        permission_mode,
+        &std::env::current_dir().unwrap_or_default(),
+        &PermissionLoadPolicy::HeadlessSafe,
+    );
+    let mut skill_qt = astra_skills::quality::SkillQualityTracker::new();
+    let skill_search = astra_core::SkillSearchSettings::default();
+    let unified_skill_registry = astra_runtime::skills::default_unified_registry();
+    let agent_spawner = crate::agent_runtime::build_one_shot_spawner(
+        &ctx.api,
+        token.clone(),
+        unified_skill_registry.clone(),
+        pm.mode(),
+        skill_search.clone(),
+        Some(thread_id.clone()),
+    )
+    .await;
+    let spawner_for_drain = agent_spawner.clone();
+    let (chat_task_store, _chat_task_notify_tx) = session_runtime::resolve_task_store(
+        ctx.auth_profile.as_deref(),
+        Some(&ctx.api.api_origin()),
+    )
+    .await;
+    let chat_task_manager = Arc::new(crate::edge_tools::TaskManager::new(
+        thread_id.clone(),
+        chat_task_store,
+    ));
+    let chat_ctx = BasicCliChatContext {
+        api: &ctx.api,
+        auth_profile: ctx.auth_profile.as_deref(),
+        message: &message,
+        model: model.as_deref(),
+        provider: None,
+        explain: ExplainMode::Off,
+        render_md: false,
+        verbose_mode: false,
+        render_policy: crate::stream_render::RenderPolicy::Silent,
+        unified_skill_registry,
+        skill_search: &skill_search,
+        agent_spawner: Some(agent_spawner),
+        root_agent_id: Some("gateway-root"),
+        task_manager: Some(chat_task_manager),
+        task_notify_tx: None,
+        bg_task_commands: None,
+        bash_detach_slot: None,
+        stream_event_tx: Some(stream_tx),
+        #[cfg(feature = "harness")]
+        harness_sink: None,
+        #[cfg(feature = "harness")]
+        harness_trace: None,
+    };
+    let append_system_prompt = params
+        .get("developerInstructions")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or(developer_instructions)
+        .or(ctx.system_prompt.clone());
+    let mut turn_params =
+        ChatTurnParams::basic_cli(&chat_ctx, &token, Some(&thread_id), &mut pm, &mut skill_qt);
+    turn_params.cancel_token = Some(cancel.clone());
+    turn_params.append_system_prompt = append_system_prompt.clone();
+    turn_params.approval_request_tx = Some(approval_tx.clone());
+
+    let result = match crate::chat_stream::stream_chat_sse(turn_params).await {
+        Err(err) if is_session_not_found_error(&err.error) => {
+            let mut retry_params =
+                ChatTurnParams::basic_cli(&chat_ctx, &token, None, &mut pm, &mut skill_qt);
+            retry_params.cancel_token = Some(cancel);
+            retry_params.append_system_prompt = append_system_prompt;
+            retry_params.approval_request_tx = Some(approval_tx.clone());
+            crate::chat_stream::stream_chat_sse(retry_params).await
+        }
+        other => other,
+    };
+    drop(chat_ctx);
+    drop(approval_tx);
+    let _ = event_task.await;
+    let _ = approval_task.await;
+    deny_pending_approvals_for_turn(&state, &turn_id).await;
+    let mut sr = match result {
+        Ok(sr) => sr,
+        Err(err) => {
+            write_notification(&writer, "error", serde_json::json!({"message": err.error})).await?;
+            write_notification(
+                &writer,
+                "turn/completed",
+                serde_json::json!({"turn": {"id": turn_id}, "status": "failed"}),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+    sr.background_agent_results = spawner_for_drain
+        .shutdown_and_wait(std::time::Duration::from_secs(30))
+        .await;
+    write_turn_result(&writer, &thread_id, &turn_id, &sr).await?;
+    Ok(())
+}
+
+fn extract_turn_message(params: &Value) -> Option<String> {
+    if let Some(text) = params.get("message").and_then(Value::as_str) {
+        return Some(text.to_string());
+    }
+    let input = params.get("input")?.as_array()?;
+    let mut parts = Vec::new();
+    for item in input {
+        if let Some(text) = item.get("text").and_then(Value::as_str) {
+            parts.push(text);
+        }
+    }
+    (!parts.is_empty()).then(|| parts.join("\n"))
+}
+
+fn requested_thread_id(params: &Value) -> Result<Option<String>, String> {
+    let thread_id = params
+        .get("threadId")
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty());
+    let session_id = params
+        .get("sessionId")
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty());
+    match (thread_id, session_id) {
+        (Some(thread_id), Some(session_id)) if thread_id != session_id => {
+            Err("threadId and sessionId must match when both are provided".to_string())
+        }
+        (Some(thread_id), _) => Ok(Some(thread_id.to_string())),
+        (None, Some(session_id)) => Ok(Some(session_id.to_string())),
+        (None, None) => Ok(None),
+    }
+}
+
+fn developer_instructions(params: &Value) -> Option<String> {
+    params
+        .get("developerInstructions")
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn permission_mode_from_params(
+    params: &Value,
+    auto_approve: bool,
+) -> Result<PermissionMode, String> {
+    let Some(raw) = params
+        .get("permissionMode")
+        .or_else(|| params.get("permission_mode"))
+    else {
+        return Ok(PermissionMode::Auto);
+    };
+    let Some(raw) = raw.as_str().map(str::trim).filter(|s| !s.is_empty()) else {
+        return Err("permissionMode must be a non-empty string".to_string());
+    };
+    let parsed = raw.parse::<PermissionMode>()?;
+    Ok(if auto_approve {
+        PermissionMode::Auto
+    } else {
+        parsed
+    })
+}
+
+async fn register_pending_approval(
+    state: &Arc<Mutex<AppState>>,
+    approval_id: &str,
+    turn_id: &str,
+    response_tx: oneshot::Sender<ApprovalResponse>,
+) -> bool {
+    let mut guard = state.lock().await;
+    let active_matches = guard
+        .active_turn
+        .as_ref()
+        .is_some_and(|active| active.turn_id == turn_id);
+    if !active_matches {
+        let _ = response_tx.send(ApprovalResponse::Deny);
+        return false;
+    }
+    guard.pending_approvals.insert(
+        approval_id.to_string(),
+        PendingApproval {
+            turn_id: turn_id.to_string(),
+            response_tx,
+        },
+    );
+    true
+}
+
+async fn deny_pending_approval(state: &Arc<Mutex<AppState>>, approval_id: &str) {
+    if let Some(pending) = state.lock().await.pending_approvals.remove(approval_id) {
+        let _ = pending.response_tx.send(ApprovalResponse::Deny);
+    }
+}
+
+async fn deny_pending_approvals_for_turn(state: &Arc<Mutex<AppState>>, turn_id: &str) {
+    let pending = {
+        let mut guard = state.lock().await;
+        let ids: Vec<String> = guard
+            .pending_approvals
+            .iter()
+            .filter(|(_, pending)| pending.turn_id == turn_id)
+            .map(|(id, _)| id.clone())
+            .collect();
+        ids.into_iter()
+            .filter_map(|id| guard.pending_approvals.remove(&id))
+            .collect::<Vec<_>>()
+    };
+    for pending in pending {
+        let _ = pending.response_tx.send(ApprovalResponse::Deny);
+    }
+}
+
+struct ApprovalNotification<'a> {
+    approval_id: &'a str,
+    thread_id: &'a str,
+    turn_id: &'a str,
+    tool: &'a str,
+    header: &'a str,
+    detail: Option<&'a str>,
+    reason: &'a str,
+    args: &'a Value,
+}
+
+fn approval_notification_params(notification: ApprovalNotification<'_>) -> Value {
+    serde_json::json!({
+        "approval": {
+            "id": notification.approval_id,
+            "threadId": notification.thread_id,
+            "turnId": notification.turn_id,
+            "tool": notification.tool,
+            "header": notification.header,
+            "detail": notification.detail,
+            "reason": notification.reason,
+            "args": notification.args,
+        }
+    })
+}
+
+fn approval_response_from_params(params: &Value) -> Result<ApprovalResponse, String> {
+    let decision = params
+        .get("decision")
+        .or_else(|| params.get("response"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "approval/respond missing decision".to_string())?
+        .trim()
+        .to_ascii_lowercase();
+    match decision.as_str() {
+        "allow" | "approve" | "approved" | "allow_once" | "allow-once" | "once" => {
+            Ok(ApprovalResponse::AllowOnce)
+        }
+        "always" | "always_allow" | "always-allow" | "allow_always" | "allow-always" => {
+            Ok(ApprovalResponse::AlwaysAllow)
+        }
+        "deny" | "denied" | "reject" | "rejected" | "no" => Ok(ApprovalResponse::Deny),
+        _ => Err(format!("unsupported approval decision `{decision}`")),
+    }
+}
+
+async fn write_turn_result(
+    writer: &JsonWriter,
+    thread_id: &str,
+    turn_id: &str,
+    sr: &StreamResult,
+) -> Result<(), String> {
+    if let Some(session_id) = sr.session_id.as_deref()
+        && session_id != thread_id
+    {
+        write_notification(
+            writer,
+            "thread/started",
+            serde_json::json!({"thread": {"id": session_id}}),
+        )
+        .await?;
+    }
+    write_notification(
+        writer,
+        "item/completed",
+        serde_json::json!({"item": {"type": "agentMessage", "text": sr.full_text}}),
+    )
+    .await?;
+    write_notification(
+        writer,
+        "thread/tokenUsage/updated",
+        serde_json::json!({
+            "tokenUsage": {
+                "last": {
+                    "inputTokens": sr.prompt_tokens,
+                    "outputTokens": sr.completion_tokens,
+                }
+            }
+        }),
+    )
+    .await?;
+    write_notification(
+        writer,
+        "turn/completed",
+        serde_json::json!({"turn": {"id": turn_id}, "status": "completed"}),
+    )
+    .await
+}
+
+async fn write_stream_notification(writer: &JsonWriter, event: StreamEvent) -> Result<(), String> {
+    match event {
+        StreamEvent::Token(delta) if !delta.is_empty() => {
+            write_notification(
+                writer,
+                "item/agentMessage/delta",
+                serde_json::json!({"delta": delta}),
+            )
+            .await
+        }
+        StreamEvent::Thinking(true) => {
+            write_notification(
+                writer,
+                "item/started",
+                serde_json::json!({"item": {"type": "reasoning"}}),
+            )
+            .await
+        }
+        StreamEvent::Thinking(false) => {
+            write_notification(
+                writer,
+                "item/completed",
+                serde_json::json!({"item": {"type": "reasoning"}}),
+            )
+            .await
+        }
+        StreamEvent::ThinkingChunk(text) if !text.is_empty() => {
+            write_notification(
+                writer,
+                "item/reasoning/textDelta",
+                serde_json::json!({"delta": text}),
+            )
+            .await
+        }
+        StreamEvent::ToolStarted {
+            name, description, ..
+        } => {
+            write_notification(
+                writer,
+                "item/started",
+                serde_json::json!({
+                    "item": {
+                        "type": "dynamicToolCall",
+                        "tool": name,
+                        "name": name,
+                        "arguments": {"description": description},
+                        "input": {"description": description},
+                    }
+                }),
+            )
+            .await
+        }
+        StreamEvent::AgentControlStarted { action, label, .. } => {
+            write_notification(
+                writer,
+                "item/started",
+                serde_json::json!({
+                    "item": {
+                        "type": "dynamicToolCall",
+                        "tool": action,
+                        "name": action,
+                        "arguments": {"description": label},
+                        "input": {"description": label},
+                    }
+                }),
+            )
+            .await
+        }
+        StreamEvent::ToolCompleted {
+            name, duration_ms, ..
+        }
+        | StreamEvent::AgentControlCompleted {
+            action: name,
+            duration_ms,
+            ..
+        } => {
+            write_notification(
+                writer,
+                "item/completed",
+                serde_json::json!({
+                    "item": {
+                        "type": "dynamicToolCall",
+                        "tool": name,
+                        "name": name,
+                        "durationMs": duration_ms,
+                    }
+                }),
+            )
+            .await
+        }
+        _ => Ok(()),
+    }
+}
+
+async fn write_response(writer: &JsonWriter, id: Value, result: Value) -> Result<(), String> {
+    write_json_line(
+        writer,
+        serde_json::json!({
+            "id": id,
+            "result": result,
+        }),
+    )
+    .await
+}
+
+async fn write_response_error(writer: &JsonWriter, id: Value, error: &str) -> Result<(), String> {
+    write_json_line(
+        writer,
+        serde_json::json!({
+            "id": id,
+            "error": {"message": error},
+        }),
+    )
+    .await
+}
+
+async fn write_notification(
+    writer: &JsonWriter,
+    method: &str,
+    params: Value,
+) -> Result<(), String> {
+    write_json_line(
+        writer,
+        serde_json::json!({
+            "method": method,
+            "params": params,
+        }),
+    )
+    .await
+}
+
+async fn write_json_line(writer: &JsonWriter, value: Value) -> Result<(), String> {
+    let line = serde_json::to_string(&value).map_err(|e| e.to_string())?;
+    let mut stdout = writer.lock().await;
+    stdout
+        .write_all(line.as_bytes())
+        .map_err(|e| format!("stdout write failed: {e}"))?;
+    stdout
+        .write_all(b"\n")
+        .map_err(|e| format!("stdout write failed: {e}"))?;
+    stdout
+        .flush()
+        .map_err(|e| format!("stdout flush failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_turn_message_collects_text_items() {
+        let params = serde_json::json!({
+            "input": [
+                {"type": "text", "text": "hello"},
+                {"type": "text", "text": "world"}
+            ]
+        });
+        assert_eq!(
+            extract_turn_message(&params).as_deref(),
+            Some("hello\nworld")
+        );
+    }
+
+    #[test]
+    fn extract_turn_message_accepts_message_field() {
+        let params = serde_json::json!({"message": "hello"});
+        assert_eq!(extract_turn_message(&params).as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn requested_thread_id_prefers_turn_thread_id() {
+        let params = serde_json::json!({
+            "threadId": "thread-from-gateway",
+            "sessionId": "thread-from-gateway"
+        });
+        assert_eq!(
+            requested_thread_id(&params).unwrap().as_deref(),
+            Some("thread-from-gateway")
+        );
+    }
+
+    #[test]
+    fn requested_thread_id_rejects_conflicting_session_id() {
+        let params = serde_json::json!({
+            "threadId": "thread-from-gateway",
+            "sessionId": "stale-session"
+        });
+        assert!(requested_thread_id(&params).is_err());
+    }
+
+    #[test]
+    fn requested_thread_id_accepts_session_id_fallback() {
+        let params = serde_json::json!({"sessionId": "session-from-client"});
+        assert_eq!(
+            requested_thread_id(&params).unwrap().as_deref(),
+            Some("session-from-client")
+        );
+    }
+
+    #[test]
+    fn approval_response_accepts_gateway_decisions() {
+        assert_eq!(
+            approval_response_from_params(&serde_json::json!({"decision": "allow_once"})).unwrap(),
+            ApprovalResponse::AllowOnce
+        );
+        assert_eq!(
+            approval_response_from_params(&serde_json::json!({"decision": "always"})).unwrap(),
+            ApprovalResponse::AlwaysAllow
+        );
+        assert_eq!(
+            approval_response_from_params(&serde_json::json!({"decision": "deny"})).unwrap(),
+            ApprovalResponse::Deny
+        );
+    }
+
+    #[test]
+    fn approval_response_requires_explicit_decision() {
+        assert!(approval_response_from_params(&serde_json::json!({})).is_err());
+        assert!(approval_response_from_params(&serde_json::json!({"decision": ""})).is_err());
+    }
+
+    #[test]
+    fn permission_mode_rejects_invalid_values() {
+        let err =
+            permission_mode_from_params(&serde_json::json!({"permissionMode": "oops"}), false)
+                .unwrap_err();
+        assert!(err.contains("invalid permission mode"));
+    }
+
+    #[test]
+    fn permission_mode_validates_before_auto_approve_override() {
+        assert!(
+            permission_mode_from_params(&serde_json::json!({"permissionMode": "oops"}), true)
+                .is_err()
+        );
+        assert_eq!(
+            permission_mode_from_params(&serde_json::json!({"permissionMode": "prompt"}), true)
+                .unwrap(),
+            PermissionMode::Auto
+        );
+    }
+}

--- a/rust/crates/astra-cli/src/cli/cli_args.rs
+++ b/rust/crates/astra-cli/src/cli/cli_args.rs
@@ -129,7 +129,7 @@ pub(crate) struct Cli {
 pub(crate) enum Command {
     /// Start the interactive TUI (default when no args given)
     Interactive,
-    /// Start the HTTP API server
+    /// Start an Astra service process
     Serve(ServeArgs),
     /// Register a new account
     Register(RegisterArgs),
@@ -276,7 +276,34 @@ pub(crate) struct LoginArgs {
 }
 
 #[derive(Args, Debug)]
+#[command(
+    after_help = "Examples:\n  astra serve\n  astra serve http --host 127.0.0.1 --port 8000\n  astra serve stdio\n\nModes:\n  http   Starts the Axum HTTP API server. This is also the default when no mode is provided.\n  stdio  Starts a long-lived app-server over stdin/stdout JSON-RPC. A parent process sends requests on stdin and reads events/responses from stdout, allowing one child process to keep session and turn state across requests. In stdio mode stdout is reserved for protocol messages; diagnostics must go to stderr or a log file."
+)]
 pub(crate) struct ServeArgs {
+    /// Serve mode. Defaults to `http` for backwards compatibility.
+    #[command(subcommand)]
+    pub mode: Option<ServeMode>,
+    /// Address to listen on for the default HTTP mode
+    #[arg(long, default_value = "127.0.0.1")]
+    pub host: String,
+    /// Port to listen on for the default HTTP mode
+    #[arg(short, long, default_value_t = 8000)]
+    pub port: u16,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum ServeMode {
+    /// Start the HTTP API server
+    Http(ServeHttpArgs),
+    /// Start the stdio JSON-RPC app-server
+    #[command(
+        after_help = "This mode speaks newline-delimited JSON-RPC on stdin/stdout. The parent process writes requests to stdin, reads responses and notifications from stdout, and may keep the child alive for multiple turns. Do not print human-readable output to stdout in this mode; use stderr or ASTRA_LOG_FILE for diagnostics."
+    )]
+    Stdio,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct ServeHttpArgs {
     /// Address to listen on
     #[arg(long, default_value = "127.0.0.1")]
     pub host: String,

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -19,6 +19,21 @@ pub(super) enum ExitCode {
     ApiError = 3,
 }
 
+async fn start_http_server(host: &str, port: u16) -> Result<(), String> {
+    let addr: std::net::SocketAddr = format!("{host}:{port}")
+        .parse()
+        .map_err(|e| format!("Invalid listen address: {e}"))?;
+    eprintln!(
+        "  {} {} on {}",
+        "▸".bold().magenta(),
+        "Starting API server".bold(),
+        addr.to_string().magenta()
+    );
+    astra_runtime::serve(addr)
+        .await
+        .map_err(|e| format!("API server failed to start: {e}"))
+}
+
 impl From<ExitCode> for i32 {
     fn from(code: ExitCode) -> i32 {
         code as i32
@@ -1834,20 +1849,26 @@ pub(super) async fn execute_cli_command(
             Ok(ExitCode::Success)
         }
 
-        // Start embedded HTTP API server
         Some(Command::Serve(args)) => {
-            let addr: std::net::SocketAddr = format!("{}:{}", args.host, args.port)
-                .parse()
-                .map_err(|e| format!("Invalid listen address: {e}"))?;
-            eprintln!(
-                "  {} {} on {}",
-                "▸".bold().magenta(),
-                "Starting API server".bold(),
-                addr.to_string().magenta()
-            );
-            astra_runtime::serve(addr)
-                .await
-                .map_err(|e| format!("API server failed to start: {e}"))?;
+            match args.mode {
+                None => {
+                    start_http_server(&args.host, args.port).await?;
+                }
+                Some(crate::cli_args::ServeMode::Http(http_args)) => {
+                    start_http_server(&http_args.host, http_args.port).await?;
+                }
+                Some(crate::cli_args::ServeMode::Stdio) => {
+                    crate::app_server::run_stdio_app_server(
+                        "stdio://",
+                        api,
+                        profile.as_deref(),
+                        global_model.as_deref(),
+                        system_prompt.as_deref(),
+                        auto_approve,
+                    )
+                    .await?;
+                }
+            }
             Ok(ExitCode::Success)
         }
 

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -45,6 +45,8 @@ use serde::{Deserialize, Serialize};
 mod agent_loader;
 #[path = "cli/agent_runtime.rs"]
 mod agent_runtime;
+#[path = "cli/app_server.rs"]
+mod app_server;
 #[path = "cli/auth_flow.rs"]
 mod auth_flow;
 #[path = "cli/chat_stream/mod.rs"]

--- a/rust/crates/astra-cli/src/tests/cli_args_tests.rs
+++ b/rust/crates/astra-cli/src/tests/cli_args_tests.rs
@@ -378,6 +378,7 @@ fn cli_serve_defaults() {
     let cli = Cli::try_parse_from(["astra", "serve"]).unwrap();
     match cli.command {
         Some(Command::Serve(ref args)) => {
+            assert!(args.mode.is_none());
             assert_eq!(args.host, "127.0.0.1");
             assert_eq!(args.port, 8000);
         }
@@ -390,7 +391,34 @@ fn cli_serve_custom_port() {
     let cli = Cli::try_parse_from(["astra", "serve", "--port", "3000"]).unwrap();
     match cli.command {
         Some(Command::Serve(ref args)) => {
+            assert!(args.mode.is_none());
             assert_eq!(args.port, 3000);
+        }
+        _ => panic!("expected Serve command"),
+    }
+}
+
+#[test]
+fn cli_serve_http_subcommand() {
+    let cli = Cli::try_parse_from(["astra", "serve", "http", "--port", "3000"]).unwrap();
+    match cli.command {
+        Some(Command::Serve(ref args)) => match args.mode {
+            Some(ServeMode::Http(ref http)) => {
+                assert_eq!(http.host, "127.0.0.1");
+                assert_eq!(http.port, 3000);
+            }
+            _ => panic!("expected serve http mode"),
+        },
+        _ => panic!("expected Serve command"),
+    }
+}
+
+#[test]
+fn cli_serve_stdio_subcommand() {
+    let cli = Cli::try_parse_from(["astra", "serve", "stdio"]).unwrap();
+    match cli.command {
+        Some(Command::Serve(ref args)) => {
+            assert!(matches!(args.mode, Some(ServeMode::Stdio)));
         }
         _ => panic!("expected Serve command"),
     }


### PR DESCRIPTION
## Summary
- add `astra serve http` and `astra serve stdio` modes while keeping bare `astra serve` as the HTTP-compatible default
- move the stdio app-server under the `serve` command and remove the hidden `app-server` entry point
- document stdio JSON-RPC transport behavior and stdout/stderr constraints

## Verification
- `cargo test -p astra-cli app_server`
- `cargo test -p astra-cli cli_serve`
- `cargo clippy -p astra-cli --all-targets`
- `cargo build -p astra-cli`
- `./target/debug/astra serve --help`
- `./target/debug/astra serve stdio --help`