### PR TITLE
fix: explain reports and streaming improvements

### DIFF
--- a/rust/crates/astra-cli/src/cli/app_server.rs
+++ b/rust/crates/astra-cli/src/cli/app_server.rs
@@ -397,6 +397,7 @@ async fn run_turn(
     );
     let mut skill_qt = astra_skills::quality::SkillQualityTracker::new();
     let skill_search = astra_core::SkillSearchSettings::default();
+    let explain_mode = explain_mode_from_params(&params)?;
     let unified_skill_registry = astra_runtime::skills::default_unified_registry();
     let agent_spawner = crate::agent_runtime::build_one_shot_spawner(
         &ctx.api,
@@ -424,7 +425,7 @@ async fn run_turn(
         message: &message,
         model: model.as_deref(),
         provider: None,
-        explain: ExplainMode::Off,
+        explain: explain_mode,
         render_md: false,
         verbose_mode: false,
         render_policy: crate::stream_render::RenderPolicy::Silent,
@@ -529,6 +530,28 @@ fn developer_instructions(params: &Value) -> Option<String> {
         .and_then(Value::as_str)
         .filter(|s| !s.trim().is_empty())
         .map(str::to_string)
+}
+
+fn explain_mode_from_params(params: &Value) -> Result<ExplainMode, String> {
+    let Some(raw) = params.get("explain") else {
+        return Ok(ExplainMode::Off);
+    };
+    if let Some(enabled) = raw.as_bool() {
+        return Ok(if enabled {
+            ExplainMode::On
+        } else {
+            ExplainMode::Off
+        });
+    }
+    let Some(raw) = raw.as_str().map(str::trim) else {
+        return Err("explain must be a boolean or string".to_string());
+    };
+    match raw {
+        "off" | "false" => Ok(ExplainMode::Off),
+        "on" | "true" => Ok(ExplainMode::On),
+        "verbose" => Ok(ExplainMode::Verbose),
+        _ => Err(format!("unsupported explain mode `{raw}`")),
+    }
 }
 
 fn permission_mode_from_params(
@@ -693,73 +716,56 @@ async fn write_turn_result(
 }
 
 async fn write_stream_notification(writer: &JsonWriter, event: StreamEvent) -> Result<(), String> {
+    let Some((method, params)) = stream_event_notification(&event) else {
+        return Ok(());
+    };
+    write_notification(writer, method, params).await
+}
+
+fn stream_event_notification(event: &StreamEvent) -> Option<(&'static str, Value)> {
     match event {
-        StreamEvent::Token(delta) if !delta.is_empty() => {
-            write_notification(
-                writer,
-                "item/agentMessage/delta",
-                serde_json::json!({"delta": delta}),
-            )
-            .await
-        }
-        StreamEvent::Thinking(true) => {
-            write_notification(
-                writer,
-                "item/started",
-                serde_json::json!({"item": {"type": "reasoning"}}),
-            )
-            .await
-        }
-        StreamEvent::Thinking(false) => {
-            write_notification(
-                writer,
-                "item/completed",
-                serde_json::json!({"item": {"type": "reasoning"}}),
-            )
-            .await
-        }
-        StreamEvent::ThinkingChunk(text) if !text.is_empty() => {
-            write_notification(
-                writer,
-                "item/reasoning/textDelta",
-                serde_json::json!({"delta": text}),
-            )
-            .await
-        }
+        StreamEvent::Token(delta) if !delta.is_empty() => Some((
+            "item/agentMessage/delta",
+            serde_json::json!({"delta": delta}),
+        )),
+        StreamEvent::Thinking(true) => Some((
+            "item/started",
+            serde_json::json!({"item": {"type": "reasoning"}}),
+        )),
+        StreamEvent::Thinking(false) => Some((
+            "item/completed",
+            serde_json::json!({"item": {"type": "reasoning"}}),
+        )),
+        StreamEvent::ThinkingChunk(text) if !text.is_empty() => Some((
+            "item/reasoning/textDelta",
+            serde_json::json!({"delta": text}),
+        )),
         StreamEvent::ToolStarted {
             name, description, ..
-        } => {
-            write_notification(
-                writer,
-                "item/started",
-                serde_json::json!({
-                    "item": {
-                        "type": "dynamicToolCall",
-                        "tool": name,
-                        "name": name,
-                        "arguments": {"description": description},
-                        "input": {"description": description},
-                    }
-                }),
-            )
-            .await
-        }
-        StreamEvent::AgentControlStarted { action, label, .. } => {
-            write_notification(
-                writer,
-                "item/started",
-                serde_json::json!({
-                    "item": {
-                        "type": "dynamicToolCall",
-                        "tool": action,
-                        "name": action,
-                        "arguments": {"description": label},
-                        "input": {"description": label},
-                    }
-                }),
-            )
-            .await
-        }
+        } => Some((
+            "item/started",
+            serde_json::json!({
+                "item": {
+                    "type": "dynamicToolCall",
+                    "tool": name,
+                    "name": name,
+                    "arguments": {"description": description},
+                    "input": {"description": description},
+                }
+            }),
+        )),
+        StreamEvent::AgentControlStarted { action, label, .. } => Some((
+            "item/started",
+            serde_json::json!({
+                "item": {
+                    "type": "dynamicToolCall",
+                    "tool": action,
+                    "name": action,
+                    "arguments": {"description": label},
+                    "input": {"description": label},
+                }
+            }),
+        )),
         StreamEvent::ToolCompleted {
             name, duration_ms, ..
         }
@@ -767,22 +773,22 @@ async fn write_stream_notification(writer: &JsonWriter, event: StreamEvent) -> R
             action: name,
             duration_ms,
             ..
-        } => {
-            write_notification(
-                writer,
-                "item/completed",
-                serde_json::json!({
-                    "item": {
-                        "type": "dynamicToolCall",
-                        "tool": name,
-                        "name": name,
-                        "durationMs": duration_ms,
-                    }
-                }),
-            )
-            .await
-        }
-        _ => Ok(()),
+        } => Some((
+            "item/completed",
+            serde_json::json!({
+                "item": {
+                    "type": "dynamicToolCall",
+                    "tool": name,
+                    "name": name,
+                    "durationMs": duration_ms,
+                }
+            }),
+        )),
+        StreamEvent::ExplainText(text) if !text.trim().is_empty() => Some((
+            "turn/explain",
+            serde_json::json!({"format": "dag", "text": text}),
+        )),
+        _ => None,
     }
 }
 
@@ -932,5 +938,43 @@ mod tests {
                 .unwrap(),
             PermissionMode::Auto
         );
+    }
+
+    #[test]
+    fn explain_mode_from_params_accepts_verbose() {
+        let params = serde_json::json!({"explain": "verbose"});
+        assert_eq!(
+            explain_mode_from_params(&params).unwrap(),
+            ExplainMode::Verbose
+        );
+    }
+
+    #[test]
+    fn explain_mode_from_params_accepts_bool_true() {
+        let params = serde_json::json!({"explain": true});
+        assert_eq!(explain_mode_from_params(&params).unwrap(), ExplainMode::On);
+    }
+
+    #[test]
+    fn explain_mode_from_params_defaults_off() {
+        let params = serde_json::json!({});
+        assert_eq!(explain_mode_from_params(&params).unwrap(), ExplainMode::Off);
+    }
+
+    #[test]
+    fn explain_mode_from_params_rejects_invalid_string() {
+        let params = serde_json::json!({"explain": "laser"});
+        assert!(explain_mode_from_params(&params).is_err());
+    }
+
+    #[test]
+    fn stream_event_notification_maps_explain_text() {
+        let (method, params) = stream_event_notification(&StreamEvent::ExplainText(
+            "Explain Analyze DAG — turn-1".into(),
+        ))
+        .expect("notification");
+        assert_eq!(method, "turn/explain");
+        assert_eq!(params["format"], "dag");
+        assert_eq!(params["text"], "Explain Analyze DAG — turn-1");
     }
 }

--- a/rust/crates/astra-cli/src/cli/chat_stream/explain_reports.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/explain_reports.rs
@@ -1,338 +1,35 @@
 use astra_turn_core::explain_report_lines::{
-    EXPLAIN_REPORT_HEADER, REPORT_SEPARATOR_LINE, VERDICT_REPORT_HEADER,
-    explain_auxiliary_llm_call_line, explain_auxiliary_llm_header_line,
-    explain_content_preview_line, explain_l0_profile_line, explain_l1_retrieval_line,
-    explain_llm_tokens_suffix, explain_memory_candidate_line, explain_memory_total_line,
-    explain_phase_timing_line, explain_routing_active_line, explain_routing_skipped_line,
-    explain_step_generic_line, explain_step_llm_line, explain_tool_info_line, explain_totals_line,
-    explain_turn_summary_line, verdict_avoid_tools_line, verdict_event_summary_line,
-    verdict_injection_count_line, verdict_injection_preview_line, verdict_severity_icon,
+    REPORT_SEPARATOR_LINE, VERDICT_REPORT_HEADER, verdict_avoid_tools_line,
+    verdict_event_summary_line, verdict_injection_count_line, verdict_injection_preview_line,
+    verdict_severity_icon,
 };
 use crossterm::style::Stylize;
 
 use crate::VerdictEvent;
+use crate::explain_dag::{ExplainTurnMeta, context_trace_from_json, render_explain_dag};
 
-/// Verbose explain `content_preview` can echo tool-shaped dumps (e.g. read_file line grids). Omit those.
-fn scrub_explain_content_preview(raw: &str, max_chars: usize) -> Option<String> {
-    let t = raw.trim();
-    if t.is_empty() {
-        return None;
-    }
-    let digit_prefix_lines = t
-        .lines()
-        .filter(|l| {
-            let s = l.trim_start();
-            s.chars().next().is_some_and(|c| c.is_ascii_digit())
-        })
-        .count();
-    if digit_prefix_lines >= 4 {
-        return None;
-    }
-    let lower = t.to_ascii_lowercase();
-    if lower.contains("\"read_file\"") && t.contains('{') {
-        return None;
-    }
-    let mut out: String = t.chars().take(max_chars).collect();
-    if t.chars().count() > max_chars {
-        out.push('…');
-    }
-    Some(out)
+pub(super) fn render_explain_report_text(
+    turns: &[serde_json::Value],
+    meta: Option<&ExplainTurnMeta<'_>>,
+    pending_context_assembly_trace: Option<&serde_json::Value>,
+    verbose: bool,
+) -> Option<String> {
+    let trace = pending_context_assembly_trace.and_then(context_trace_from_json);
+    render_explain_dag(trace.as_ref(), meta, turns, verbose)
 }
 
-pub(super) fn print_explain_report(turns: &[serde_json::Value], verbose: bool) {
-    eprintln!("\n{}", EXPLAIN_REPORT_HEADER.dim());
-    let mut total_ms = 0i64;
-    let mut total_prompt = 0i64;
-    let mut total_completion = 0i64;
-    let mut total_prompt_known = true;
-    let mut total_completion_known = true;
-    for (idx, turn) in turns.iter().enumerate() {
-        let ms = turn.get("total_ms").and_then(|v| v.as_i64()).unwrap_or(0);
-        let prompt = turn.get("prompt_tokens").and_then(|v| v.as_i64());
-        let completion = turn.get("completion_tokens").and_then(|v| v.as_i64());
-        total_ms += ms;
-        if let Some(value) = prompt {
-            total_prompt += value;
-        } else {
-            total_prompt_known = false;
-        }
-        if let Some(value) = completion {
-            total_completion += value;
-        } else {
-            total_completion_known = false;
-        }
-
-        let selected = turn
-            .get("tools_selected")
-            .and_then(|v| v.as_u64())
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "?".to_string());
-        let selected_skills = turn
-            .get("selected_skills")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            })
-            .unwrap_or_default();
-        let available = turn
-            .get("tools_available")
-            .and_then(|v| v.as_u64())
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "?".to_string());
-        let prompt_s = prompt
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "?".to_string());
-        let completion_s = completion
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "?".to_string());
-        let tool_info = explain_tool_info_line(
-            selected.as_str(),
-            available.as_str(),
-            turn.get("tool_selection")
-                .filter(|value| !value.is_null())
-                .map(|v| format!(" → {v}")),
-            turn.get("tool_selection_fallback")
-                .filter(|value| !value.is_null())
-                .map(|v| format!(" ⚠fallback:{v}")),
-            selected_skills.as_str(),
-        );
-        eprintln!(
-            "{}",
-            explain_turn_summary_line(idx + 1, ms, &prompt_s, &completion_s, tool_info.as_str())
-                .dim()
-        );
-
-        if let Some(routing) = turn.get("routing").and_then(|v| v.as_object()) {
-            if routing.get("skipped").and_then(|v| v.as_bool()) == Some(true) {
-                let reason = routing
-                    .get("reason")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("?");
-                eprintln!("{}", explain_routing_skipped_line(reason).dim());
-            } else {
-                let intent = routing
-                    .get("intent")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("?");
-                let confidence = routing.get("confidence").and_then(|v| v.as_f64());
-                let tier = routing
-                    .get("tier")
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "?".to_string());
-                let latency_ms = routing
-                    .get("latency_ms")
-                    .and_then(|v| v.as_f64())
-                    .unwrap_or(0.0);
-                let est = routing
-                    .get("estimated_tokens")
-                    .and_then(|v| v.as_i64())
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "?".to_string());
-                let confidence_s = if intent == "default" {
-                    "-".to_string()
-                } else {
-                    confidence
-                        .map(|v| format!("{v:.2}"))
-                        .unwrap_or_else(|| "?".to_string())
-                };
-                eprintln!(
-                    "{}",
-                    explain_routing_active_line(
-                        intent,
-                        confidence_s.as_str(),
-                        tier.as_str(),
-                        latency_ms,
-                        est.as_str(),
-                    )
-                    .dim()
-                );
-            }
-        }
-
-        if let Some(memory) = turn.get("memory").and_then(|v| v.as_object()) {
-            if let Some(l0) = memory.get("l0").and_then(|v| v.as_object()) {
-                let loaded = if l0.get("loaded").and_then(|v| v.as_bool()) == Some(true) {
-                    "✓"
-                } else {
-                    "✗"
-                };
-                let l0_tokens = l0.get("tokens").and_then(|v| v.as_i64()).unwrap_or(0);
-                let l0_ms = l0.get("ms").and_then(|v| v.as_f64()).unwrap_or(0.0);
-                eprintln!(
-                    "{}",
-                    explain_l0_profile_line(loaded, l0_tokens, l0_ms).dim()
-                );
-            }
-            if let Some(ret) = memory.get("retrieval").and_then(|v| v.as_object()) {
-                let kw_hit = if ret.get("keyword_hit").and_then(|v| v.as_bool()) == Some(true) {
-                    "✓"
-                } else {
-                    "✗"
-                };
-                let vec_hit = if ret.get("vector_hit").and_then(|v| v.as_bool()) == Some(true) {
-                    "✓"
-                } else {
-                    "✗"
-                };
-                let p1 = ret
-                    .get("phase1_candidates")
-                    .and_then(|v| v.as_i64())
-                    .unwrap_or(0);
-                let p2 = ret
-                    .get("phase2_candidates")
-                    .and_then(|v| v.as_i64())
-                    .unwrap_or(0);
-                let merged = ret
-                    .get("merged_candidates")
-                    .and_then(|v| v.as_i64())
-                    .unwrap_or(0);
-                let final_count = ret.get("final_count").and_then(|v| v.as_i64()).unwrap_or(0);
-                let ret_ms = ret.get("total_ms").and_then(|v| v.as_f64()).unwrap_or(0.0);
-                let l1_tokens = memory
-                    .get("l1")
-                    .and_then(|v| v.as_object())
-                    .and_then(|l1| l1.get("tokens"))
-                    .and_then(|v| v.as_i64())
-                    .unwrap_or(0);
-                eprintln!(
-                    "{}",
-                    explain_l1_retrieval_line(
-                        ret_ms,
-                        kw_hit,
-                        p1,
-                        vec_hit,
-                        p2,
-                        merged,
-                        final_count,
-                        l1_tokens,
-                    )
-                    .dim()
-                );
-            } else if let Some(mem_ms) = memory.get("total_ms").and_then(|v| v.as_f64()) {
-                eprintln!("{}", explain_memory_total_line(mem_ms).dim());
-            }
-        }
-
-        if let Some(steps) = turn.get("steps").and_then(|v| v.as_array()) {
-            for step in steps {
-                let label = step.get("step").and_then(|v| v.as_str()).unwrap_or("?");
-                let dur = step
-                    .get("duration_ms")
-                    .and_then(|v| v.as_i64())
-                    .unwrap_or(0);
-                if label == "llm" {
-                    let sin = step
-                        .get("in")
-                        .and_then(|v| v.as_i64())
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| "?".to_string());
-                    let sout = step
-                        .get("out")
-                        .and_then(|v| v.as_i64())
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| "?".to_string());
-                    let tc = step.get("tool_calls").and_then(|v| v.as_u64()).unwrap_or(0);
-                    let suffix = explain_llm_tokens_suffix(sin.as_str(), sout.as_str(), tc);
-                    eprintln!("{}", explain_step_llm_line(dur, suffix.as_str()).dim());
-                } else {
-                    eprintln!("{}", explain_step_generic_line(label, dur).dim());
-                }
-            }
-        }
-
-        if let Some(aux) = turn.get("auxiliary_llm_calls").and_then(|v| v.as_array()) {
-            let mut aux_tokens_known = true;
-            let aux_tokens = aux
-                .iter()
-                .map(|item| {
-                    let tin = item.get("tokens_in").and_then(|v| v.as_i64());
-                    let tout = item.get("tokens_out").and_then(|v| v.as_i64());
-                    if tin.is_none() || tout.is_none() {
-                        aux_tokens_known = false;
-                    }
-                    tin.unwrap_or(0) + tout.unwrap_or(0)
-                })
-                .sum::<i64>();
-            let tokens_display = if aux_tokens_known {
-                aux_tokens.to_string()
-            } else {
-                "?".to_string()
-            };
-            eprintln!(
-                "{}",
-                explain_auxiliary_llm_header_line(aux.len(), tokens_display.as_str()).dim()
-            );
-            for call in aux {
-                let purpose = call.get("purpose").and_then(|v| v.as_str()).unwrap_or("?");
-                let ms = call.get("ms").and_then(|v| v.as_i64()).unwrap_or(0);
-                let tin = call
-                    .get("tokens_in")
-                    .and_then(|v| v.as_i64())
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "?".to_string());
-                let tout = call
-                    .get("tokens_out")
-                    .and_then(|v| v.as_i64())
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "?".to_string());
-                eprintln!(
-                    "{}",
-                    explain_auxiliary_llm_call_line(purpose, ms, tin.as_str(), tout.as_str()).dim()
-                );
-            }
-        }
-        if verbose {
-            if let Some(preview) = turn
-                .get("content_preview")
-                .and_then(|v| v.as_str())
-                .and_then(|p| scrub_explain_content_preview(p, 220))
-            {
-                eprintln!("{}", explain_content_preview_line(preview.as_str()).dim());
-            }
-            if let Some(phase_timing) = turn.get("phase_timing").and_then(|v| v.as_array()) {
-                for entry in phase_timing {
-                    let step = entry.get("step").and_then(|v| v.as_str()).unwrap_or("?");
-                    let ms = entry.get("ms").and_then(|v| v.as_i64()).unwrap_or(0);
-                    eprintln!("{}", explain_phase_timing_line(step, ms).dim());
-                }
-            }
-            if let Some(candidates) = turn
-                .get("memory")
-                .and_then(|v| v.get("retrieval"))
-                .and_then(|v| v.get("candidates"))
-                .and_then(|v| v.as_array())
-            {
-                for cand in candidates {
-                    let score = cand.get("score").and_then(|v| v.as_f64()).unwrap_or(0.0);
-                    let id = cand.get("id").and_then(|v| v.as_str()).unwrap_or("?");
-                    eprintln!("{}", explain_memory_candidate_line(id, score).dim());
-                }
-            }
-        }
+pub(super) fn print_explain_report(
+    turns: &[serde_json::Value],
+    meta: Option<&ExplainTurnMeta<'_>>,
+    pending_context_assembly_trace: Option<&serde_json::Value>,
+    verbose: bool,
+) {
+    if let Some(text) =
+        render_explain_report_text(turns, meta, pending_context_assembly_trace, verbose)
+    {
+        eprintln!("\n{text}");
+        eprintln!("{}", REPORT_SEPARATOR_LINE.dim());
     }
-    let total_prompt_s = if total_prompt_known {
-        total_prompt.to_string()
-    } else {
-        "?".to_string()
-    };
-    let total_completion_s = if total_completion_known {
-        total_completion.to_string()
-    } else {
-        "?".to_string()
-    };
-    eprintln!(
-        "{}",
-        explain_totals_line(
-            total_ms,
-            total_prompt_s.as_str(),
-            total_completion_s.as_str()
-        )
-        .dim()
-    );
-    eprintln!("{}", REPORT_SEPARATOR_LINE.dim());
 }
 
 /// Print TurnGuard verdict details in explain mode.
@@ -382,24 +79,55 @@ pub(super) fn print_verdict_report(verdict_events: &[VerdictEvent], verbose: boo
 
 #[cfg(test)]
 mod explain_preview_tests {
-    use super::scrub_explain_content_preview;
+    use super::*;
 
     #[test]
-    fn scrub_drops_numbered_line_grids() {
-        let raw = "    1|a\n    2|b\n    3|c\n    4|d\n";
-        assert!(scrub_explain_content_preview(raw, 80).is_none());
-    }
-
-    #[test]
-    fn scrub_drops_read_file_json_snippet() {
-        let raw = r#"{"tool":"read_file","path":"x"}"#;
-        assert!(scrub_explain_content_preview(raw, 80).is_none());
-    }
-
-    #[test]
-    fn scrub_keeps_short_prose() {
-        let raw = "Here is a concise summary of the change.";
-        let s = scrub_explain_content_preview(raw, 80).expect("some");
-        assert!(s.contains("concise"));
+    fn render_explain_report_text_uses_dag_and_cache_fields() {
+        let tool_calls = vec![astra_services::session_journal::ToolCallRecord {
+            tool_call_id: Some("call-1".into()),
+            name: "git".into(),
+            ok: true,
+            ms: 12,
+            batch_id: Some("b-0-0".into()),
+            parallel: Some(true),
+            round: Some(0),
+            ..Default::default()
+        }];
+        let meta = ExplainTurnMeta {
+            turn_label: Some("turn-2".into()),
+            duration_ms: Some(1200),
+            ttft_ms: Some(900),
+            context_ms: Some(21),
+            memoria_ms: Some(0),
+            total_llm_ms: Some(1100),
+            total_tool_ms: Some(12),
+            prompt_tokens: Some(2211),
+            completion_tokens: Some(525),
+            cache_read_tokens: Some(19904),
+            cache_creation_tokens: Some(0),
+            tool_count: Some(1),
+            llm_rounds: Some(1),
+            routing_domain_hint: None,
+            assistant_output: Some("done"),
+            tool_call_records: &tool_calls,
+            selection_strategy: None,
+            selection_confidence: None,
+            selected_tools: Vec::new(),
+        };
+        let turns = vec![serde_json::json!({
+            "steps": [{
+                "step": "llm",
+                "duration_ms": 1100,
+                "in": 2211,
+                "cached_in": 19904,
+                "cache_write": 0,
+                "out": 525,
+                "tool_calls": 1
+            }]
+        })];
+        let text = render_explain_report_text(&turns, Some(&meta), None, false).expect("text");
+        assert!(text.contains("Explain Analyze DAG — turn-2"));
+        assert!(text.contains("cache_read=19904"));
+        assert!(text.contains("batch[b-0-0] parallel tools=1"));
     }
 }

--- a/rust/crates/astra-cli/src/cli/chat_stream/params.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/params.rs
@@ -135,6 +135,12 @@ pub enum StreamEvent {
     AgentLive(astra_turn_core::agent_live_event::AgentLiveEvent),
     /// Local policy approved a tool without showing an interactive prompt.
     PermissionAutoApproved { tool: String, reason: String },
+    /// Explain report from the turn (debug / introspection data).
+    ExplainReport(Vec<serde_json::Value>),
+    /// Final explain-analyze DAG text rendered for non-TUI consumers.
+    ExplainText(String),
+    /// Verdict audit events from the turn.
+    VerdictReport(Vec<crate::VerdictEvent>),
 }
 
 pub type StreamEventTx = mpsc::UnboundedSender<StreamEvent>;

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_sse_loop.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_sse_loop.rs
@@ -16,6 +16,7 @@ use astra_services::session_journal::ToolCallRecord;
 use crossterm::style::Stylize;
 use serde_json::Value;
 
+use crate::explain_dag::ExplainTurnMeta;
 use crate::{ExplainMode, StreamResult, VerdictEvent};
 
 use super::super::explain_reports::{print_explain_report, print_verdict_report};
@@ -27,6 +28,13 @@ pub(crate) struct StreamLoopSidecarEprint<'a> {
     pub(crate) start: Instant,
     pub(crate) model: Option<&'a str>,
     pub(crate) explain_turns: &'a [Value],
+    pub(crate) pending_context_assembly_trace: Option<&'a serde_json::Value>,
+    pub(crate) tool_call_records: &'a [ToolCallRecord],
+    pub(crate) assistant_output: &'a str,
+    pub(crate) ttft_ms: Option<u64>,
+    pub(crate) context_ms: Option<u64>,
+    pub(crate) memoria_ms: Option<u64>,
+    pub(crate) llm_rounds: Option<u32>,
     pub(crate) verdict_events: &'a [VerdictEvent],
     pub(crate) has_any_usage: bool,
     pub(crate) total_prompt: u64,
@@ -44,6 +52,13 @@ pub(crate) fn eprint_stream_loop_sidecars(ctx: StreamLoopSidecarEprint<'_>) {
         start,
         model,
         explain_turns,
+        pending_context_assembly_trace,
+        tool_call_records,
+        assistant_output,
+        ttft_ms,
+        context_ms,
+        memoria_ms,
+        llm_rounds,
         verdict_events,
         has_any_usage,
         total_prompt,
@@ -53,8 +68,42 @@ pub(crate) fn eprint_stream_loop_sidecars(ctx: StreamLoopSidecarEprint<'_>) {
         current_session_id,
     } = ctx;
 
-    if explain != ExplainMode::Off && !explain_turns.is_empty() && !quiet {
-        print_explain_report(explain_turns, explain == ExplainMode::Verbose);
+    if explain != ExplainMode::Off && !quiet {
+        let tool_count =
+            resolved_tool_metrics(0, std::iter::empty::<String>(), tool_call_records).0;
+        let meta = ExplainTurnMeta {
+            turn_label: None,
+            duration_ms: Some(start.elapsed().as_millis() as u64),
+            ttft_ms,
+            context_ms,
+            memoria_ms,
+            total_llm_ms: None,
+            total_tool_ms: Some(
+                tool_call_records
+                    .iter()
+                    .filter(|record| !record.is_synthetic_placeholder())
+                    .map(|record| record.ms)
+                    .sum(),
+            ),
+            prompt_tokens: Some(total_prompt),
+            completion_tokens: Some(total_completion),
+            cache_read_tokens: Some(total_cache_read),
+            cache_creation_tokens: Some(total_cache_creation),
+            tool_count: Some(tool_count),
+            llm_rounds,
+            routing_domain_hint: None,
+            assistant_output: Some(assistant_output),
+            tool_call_records,
+            selection_strategy: None,
+            selection_confidence: None,
+            selected_tools: Vec::new(),
+        };
+        print_explain_report(
+            explain_turns,
+            Some(&meta),
+            pending_context_assembly_trace,
+            explain == ExplainMode::Verbose,
+        );
     }
     if explain != ExplainMode::Off && !verdict_events.is_empty() && !quiet {
         print_verdict_report(verdict_events, explain == ExplainMode::Verbose);

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -36,9 +36,11 @@ use astra_runtime::{
     turn::turn_guard::TurnGuard,
 };
 
-use crate::{StreamResult, cli_utils::terminal_width_usize, edge_tools};
+use crate::{ExplainMode, StreamResult, cli_utils::terminal_width_usize, edge_tools};
 
 use super::ChatTurnParams;
+use super::StreamEvent;
+use super::explain_reports;
 use agentic_sse_loop::{
     StreamLoopSidecarEprint, StreamResultBuild, build_stream_result, eprint_stream_loop_sidecars,
     resolved_tool_metrics,
@@ -508,7 +510,7 @@ pub(crate) async fn stream_chat_sse(
         is_plan_subtask: p.is_plan_subtask,
         plan_subtask_id: p.plan_subtask_id,
         plan_assemble_line_release: p.plan_assemble_line_release.clone(),
-        stream_event_tx: p.stream_event_tx,
+        stream_event_tx: p.stream_event_tx.clone(),
         approval_request_tx: p.approval_request_tx,
         ask_user_request_tx: p.ask_user_request_tx,
         plan_review_request_tx: p.plan_review_request_tx,
@@ -882,6 +884,17 @@ pub(crate) async fn stream_chat_sse(
         start,
         model: p.model,
         explain_turns: &state.telemetry.explain_turns,
+        pending_context_assembly_trace: state
+            .telemetry
+            .pending_context_assembly_trace
+            .as_ref()
+            .map(|(_, trace_json)| trace_json),
+        tool_call_records: &state.stall.tool_call_records,
+        assistant_output: &state.final_text,
+        ttft_ms: state.telemetry.first_ttft_ms,
+        context_ms: state.telemetry.first_context_assembly_ms,
+        memoria_ms: state.telemetry.first_memoria_ms,
+        llm_rounds: Some(state.llm_rounds_completed),
         verdict_events: &state.stall.verdict_events,
         has_any_usage: state.has_any_usage,
         total_prompt: state.total_prompt,
@@ -890,6 +903,63 @@ pub(crate) async fn stream_chat_sse(
         total_completion: state.total_completion,
         current_session_id: state.current_session_id.as_deref(),
     });
+
+    // Forward explain / verdict to TUI stream (if wired).
+    if let Some(ref tx) = p.stream_event_tx {
+        let explain_turns = state.telemetry.explain_turns.clone();
+        let verdict_events = state.stall.verdict_events.clone();
+        let _ = tx.send(StreamEvent::ExplainReport(explain_turns));
+        if p.explain != ExplainMode::Off {
+            let tool_count = resolved_tool_metrics(
+                0,
+                std::iter::empty::<String>(),
+                &state.stall.tool_call_records,
+            )
+            .0;
+            let meta = crate::explain_dag::ExplainTurnMeta {
+                turn_label: None,
+                duration_ms: Some(start.elapsed().as_millis() as u64),
+                ttft_ms: state.telemetry.first_ttft_ms,
+                context_ms: state.telemetry.first_context_assembly_ms,
+                memoria_ms: state.telemetry.first_memoria_ms,
+                total_llm_ms: None,
+                total_tool_ms: Some(
+                    state
+                        .stall
+                        .tool_call_records
+                        .iter()
+                        .filter(|record| !record.is_synthetic_placeholder())
+                        .map(|record| record.ms)
+                        .sum(),
+                ),
+                prompt_tokens: Some(state.total_prompt),
+                completion_tokens: Some(state.total_completion),
+                cache_read_tokens: Some(state.total_cache_read),
+                cache_creation_tokens: Some(state.total_cache_creation),
+                tool_count: Some(tool_count),
+                llm_rounds: Some(state.llm_rounds_completed),
+                routing_domain_hint: None,
+                assistant_output: Some(&state.final_text),
+                tool_call_records: &state.stall.tool_call_records,
+                selection_strategy: None,
+                selection_confidence: None,
+                selected_tools: Vec::new(),
+            };
+            if let Some(text) = explain_reports::render_explain_report_text(
+                &state.telemetry.explain_turns,
+                Some(&meta),
+                state
+                    .telemetry
+                    .pending_context_assembly_trace
+                    .as_ref()
+                    .map(|(_, trace_json)| trace_json),
+                p.explain == ExplainMode::Verbose,
+            ) {
+                let _ = tx.send(StreamEvent::ExplainText(text));
+            }
+        }
+        let _ = tx.send(StreamEvent::VerdictReport(verdict_events));
+    }
 
     let final_messages = std::mem::take(&mut state.messages);
 

--- a/rust/crates/astra-cli/src/cli/chat_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_turn.rs
@@ -1,8 +1,7 @@
 use std::time::Instant;
 
-use astra_services::session_workspace::ContextTraceSignal;
-#[cfg(test)]
-use astra_services::session_workspace::{ContextTraceBudgetSignal, ContextTraceToolSelection};
+use astra_services::session_workspace::ContextTraceBudgetSignal;
+use astra_services::session_workspace::{ContextTraceSignal, ContextTraceToolSelection};
 use astra_text_utils::str_preview::truncate_str;
 use astra_tools::task_mgmt::SessionTask;
 
@@ -19,6 +18,17 @@ fn enqueue_ingestion(_state: &SessionState, _event: &session_journal::JournalEve
 /// Public wrapper for enqueue_ingestion — used by main.rs for session_end.
 pub(super) fn enqueue_ingestion_pub(state: &SessionState, event: &session_journal::JournalEvent) {
     enqueue_ingestion(state, event);
+}
+
+fn cache_pending_context_assembly_trace(state: &mut SessionState, trace_json: &serde_json::Value) {
+    match serde_json::from_value::<astra_turn_core::context_assembly_trace::ContextAssemblyTrace>(
+        trace_json.clone(),
+    ) {
+        Ok(trace) => state.latest_context_assembly_trace = Some(trace),
+        Err(err) => {
+            astra_core::agent_warn!("context_trace", "failed to cache context trace: {err}")
+        }
+    }
 }
 
 /// Map a runtime stall event's `stall_type` string to the journal confidence.
@@ -1788,6 +1798,9 @@ fn commit_turn_journal_workspace_and_sidecars(
 ) {
     // Capture stall flag before entering the journal borrow scope.
     let has_stalls = !result.stall_events.is_empty();
+    if let Some((_internal_turn, trace_json)) = &result.pending_context_assembly_trace {
+        cache_pending_context_assembly_trace(state, trace_json);
+    }
 
     if let Some(journal) = state.journal.as_ref() {
         // Flush turn observability events (llm_round, tool timing) before the turn summary.
@@ -3588,7 +3601,89 @@ pub(super) fn apply_pending_adaptive_state(state: &mut SessionState) {
     }
 }
 
+fn context_trace_signal_from_trace(
+    trace: &astra_turn_core::context_assembly_trace::ContextAssemblyTrace,
+) -> ContextTraceSignal {
+    let tool_selection = (!trace.tools.selection_strategy.is_empty()
+        || !trace.tools.tools_selected.is_empty()
+        || trace.tools.tools_available > 0)
+        .then(|| ContextTraceToolSelection {
+            tools_available: trace.tools.tools_available,
+            selected_tools: trace
+                .tools
+                .tools_selected
+                .iter()
+                .map(|tool| tool.tool_name.clone())
+                .collect(),
+            selection_scope: "latest_round".to_string(),
+            rejected_tools: trace.tools.tools_rejected.len(),
+            strategy: trace.tools.selection_strategy.clone(),
+            confidence: trace.tools.selection_confidence,
+            latency_ms: trace.tools.selection_latency_ms,
+        });
+    let memory = (!trace.memory.query.trim().is_empty()
+        || !trace.memory.memories_selected.is_empty()
+        || trace.memory.candidates_considered > 0)
+        .then(
+            || astra_services::session_workspace::ContextTraceMemorySignal {
+                query: trace.memory.query.trim().chars().take(160).collect(),
+                candidates_considered: trace.memory.candidates_considered,
+                selected_memory_ids: trace
+                    .memory
+                    .memories_selected
+                    .iter()
+                    .map(|memory| memory.memory_id.clone())
+                    .collect(),
+                total_tokens: trace.memory.total_tokens,
+                latency_ms: trace.memory.retrieval_latency_ms,
+            },
+        );
+    let history = (trace.history.total_turns_available > 0
+        || !trace.history.turns_retained.is_empty()
+        || !trace.history.turns_compressed.is_empty()
+        || !trace.history.turns_dropped.is_empty())
+    .then_some(
+        astra_services::session_workspace::ContextTraceHistorySignal {
+            total_turns_available: trace.history.total_turns_available,
+            retained_turns: trace.history.turns_retained.len(),
+            compressed_turns: trace.history.turns_compressed.len(),
+            dropped_turns: trace.history.turns_dropped.len(),
+            compression_ratio: trace.history.compression_ratio,
+            tokens_before: trace.history.tokens_before,
+            tokens_after: trace.history.tokens_after,
+        },
+    );
+    let budget = (trace.token_budget.max_tokens > 0 || trace.token_budget.total_used > 0)
+        .then_some(ContextTraceBudgetSignal {
+            max_tokens: trace.token_budget.max_tokens,
+            total_used: trace.token_budget.total_used,
+            budget_pressure: trace.token_budget.budget_pressure,
+            compression_triggered: trace.token_budget.compression_triggered,
+        });
+
+    ContextTraceSignal {
+        turn_id: trace.turn_id.clone(),
+        captured_at: Some(chrono::DateTime::<chrono::Utc>::from(trace.timestamp).to_rfc3339()),
+        tool_selection,
+        memory,
+        history,
+        budget,
+        timing: None,
+        explanations: trace
+            .explanations
+            .iter()
+            .filter_map(|explanation| {
+                let trimmed = explanation.reasoning.trim();
+                (!trimmed.is_empty()).then(|| trimmed.chars().take(200).collect::<String>())
+            })
+            .collect(),
+    }
+}
+
 fn latest_context_trace_signal(state: &SessionState) -> Option<ContextTraceSignal> {
+    if let Some(trace) = state.latest_context_assembly_trace.as_ref() {
+        return Some(context_trace_signal_from_trace(trace));
+    }
     let obs = state.observability_session.as_ref()?;
     let guard = obs.read().ok()?;
     astra_runtime::observability_integration::latest_context_trace_signal(&guard)
@@ -5772,19 +5867,27 @@ mod tests {
             "finish_reason": "tool_calls",
         }));
         result.turn_observability_events = vec![llm_round];
-        result.pending_context_assembly_trace = Some((
-            99,
-            serde_json::json!({
-                "turn_id": "turn-99",
-                "tools": {
-                    "tools_selected": [
-                        {"tool_name": "git_diff"},
-                        {"tool_name": "read_file"}
-                    ]
-                },
-                "token_budget": {"total_used": 12_345}
-            }),
-        ));
+        let mut trace = astra_turn_core::context_assembly_trace::ContextAssemblyTrace {
+            turn_id: "turn-99".into(),
+            session_id: sid.clone(),
+            ..Default::default()
+        };
+        trace.tools.tools_selected = vec![
+            astra_turn_core::context_assembly_trace::ToolSelected {
+                tool_name: "git_diff".into(),
+                score: 0.0,
+                tokens: 0,
+                selection_factors: Vec::new(),
+            },
+            astra_turn_core::context_assembly_trace::ToolSelected {
+                tool_name: "read_file".into(),
+                score: 0.0,
+                tokens: 0,
+                selection_factors: Vec::new(),
+            },
+        ];
+        trace.token_budget.total_used = 12_345;
+        result.pending_context_assembly_trace = Some((99, trace.to_json_value()));
 
         let learning = analyze_chat_turn_learning("continue", state.turn, &[], &result);
         commit_turn_journal_workspace_and_sidecars(
@@ -5838,6 +5941,12 @@ mod tests {
             assembly_event.metadata.as_ref().unwrap()["total_tokens"],
             12_345
         );
+        let cached_trace = state
+            .latest_context_assembly_trace
+            .as_ref()
+            .expect("cached context trace");
+        assert_eq!(cached_trace.turn_id, "turn-99");
+        assert_eq!(cached_trace.token_budget.total_used, 12_345);
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/cli_args.rs
+++ b/rust/crates/astra-cli/src/cli/cli_args.rs
@@ -26,6 +26,17 @@ fn parse_permission_mode_arg(value: &str) -> Result<String, String> {
         .map(|mode| mode.to_string())
 }
 
+fn parse_explain_mode_arg(value: &str) -> Result<crate::ExplainMode, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "on" | "true" => Ok(crate::ExplainMode::On),
+        "off" | "false" => Ok(crate::ExplainMode::Off),
+        "verbose" => Ok(crate::ExplainMode::Verbose),
+        other => Err(format!(
+            "invalid explain mode `{other}` (expected on, off, or verbose)"
+        )),
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(name = "astra")]
 #[command(about = "AI agent CLI — run `astra` for interactive chat")]
@@ -326,9 +337,15 @@ pub(crate) struct ChatArgs {
     /// Model override
     #[arg(long)]
     pub model: Option<String>,
-    /// Enable explain mode
-    #[arg(long, default_value_t = false)]
-    pub explain: bool,
+    /// Enable explain mode (`--explain` => on, `--explain verbose` => verbose)
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_missing_value = "on",
+        value_name = "MODE",
+        value_parser = parse_explain_mode_arg
+    )]
+    pub explain: Option<crate::ExplainMode>,
     /// Auto-approve tool calls
     #[arg(short = 'y', long = "auto-approve", default_value_t = false)]
     pub auto_approve: bool,

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -2367,11 +2367,7 @@ pub(super) async fn execute_cli_command(
                     )
                 }
             };
-            let explain_mode = if args.explain {
-                ExplainMode::On
-            } else {
-                ExplainMode::Off
-            };
+            let explain_mode = args.explain.unwrap_or(ExplainMode::Off);
 
             // --json implies --quiet
             let quiet = args.quiet || args.json;

--- a/rust/crates/astra-cli/src/cli/plan_monitor.rs
+++ b/rust/crates/astra-cli/src/cli/plan_monitor.rs
@@ -745,7 +745,11 @@ fn display_plan_updates_live(
                     }
                     // Plan monitor runs headless (no TUI cells) — the
                     // progress ticks have no visual home here. Drop.
-                    StreamEvent::ToolOutput { .. } | StreamEvent::AgentLive(_) => continue,
+                    StreamEvent::ToolOutput { .. }
+                    | StreamEvent::AgentLive(_)
+                    | StreamEvent::ExplainReport(_)
+                    | StreamEvent::ExplainText(_)
+                    | StreamEvent::VerdictReport(_) => continue,
                 }
             }
             PlanUpdate::ApprovalNeeded {

--- a/rust/crates/astra-cli/src/cli/session_state.rs
+++ b/rust/crates/astra-cli/src/cli/session_state.rs
@@ -203,6 +203,9 @@ pub(crate) struct SessionState {
     pub last_turn_interrupted: bool,
     /// Last turn's journal event — for /turn command display.
     pub last_turn_event: Option<session_journal::JournalEvent>,
+    /// Full context-assembly trace from the last successfully committed turn.
+    pub latest_context_assembly_trace:
+        Option<astra_turn_core::context_assembly_trace::ContextAssemblyTrace>,
     /// Unified skill registry (single source of truth for all skill resolution).
     pub unified_skill_registry: std::sync::Arc<astra_runtime::skills::UnifiedSkillRegistry>,
     /// Session-scoped skill quality tracker for learning loop.
@@ -497,6 +500,7 @@ impl Default for SessionState {
             current_plan_subtask_id: None,
             last_turn_interrupted: false,
             last_turn_event: None,
+            latest_context_assembly_trace: None,
             unified_skill_registry: astra_runtime::skills::default_unified_registry().clone(),
             skill_quality_tracker: astra_skills::quality::SkillQualityTracker::new(),
             skill_search: astra_core::SkillSearchSettings::default(),

--- a/rust/crates/astra-cli/src/cli/spawn_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/spawn_subrun.rs
@@ -283,7 +283,11 @@ fn stream_event_to_agent_live_kind(
         StreamEvent::ToolOutput { name, lines, bytes } => Some(AgentLiveEventKind::Status(
             format!("{name} streaming: {lines} lines, {bytes} bytes"),
         )),
-        StreamEvent::Thinking(_) | StreamEvent::AgentLive(_) => None,
+        StreamEvent::Thinking(_)
+        | StreamEvent::AgentLive(_)
+        | StreamEvent::ExplainReport(_)
+        | StreamEvent::ExplainText(_)
+        | StreamEvent::VerdictReport(_) => None,
     }
 }
 

--- a/rust/crates/astra-cli/src/cli/stream_events_writer.rs
+++ b/rust/crates/astra-cli/src/cli/stream_events_writer.rs
@@ -142,6 +142,12 @@ fn event_to_json(event: &StreamEvent) -> String {
         StreamEvent::PermissionAutoApproved { tool, reason } => {
             serde_json::json!({"type": "permission_auto_approved", "tool": tool, "reason": reason})
         }
+        StreamEvent::ExplainText(text) => {
+            serde_json::json!({"type": "explain", "format": "dag", "text": text})
+        }
+        StreamEvent::ExplainReport(_) | StreamEvent::VerdictReport(_) => {
+            serde_json::json!({"type": "ignored"})
+        }
     };
     serde_json::to_string(&value).unwrap_or_default()
 }
@@ -164,6 +170,17 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["type"], "thinking");
         assert_eq!(v["active"], true);
+    }
+
+    #[test]
+    fn explain_text_event_serializes() {
+        let json = event_to_json(&StreamEvent::ExplainText(
+            "Explain Analyze DAG — turn-1".into(),
+        ));
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "explain");
+        assert_eq!(v["format"], "dag");
+        assert_eq!(v["text"], "Explain Analyze DAG — turn-1");
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/explain_dag.rs
+++ b/rust/crates/astra-cli/src/explain_dag.rs
@@ -1,0 +1,770 @@
+use astra_services::session_journal::{JournalEvent, ToolCallRecord};
+use astra_text_utils::str_preview::truncate_str;
+use astra_turn_core::context_assembly_trace::{ContextAssemblyTrace, DecisionType};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ExplainTurnMeta<'a> {
+    pub(crate) turn_label: Option<String>,
+    pub(crate) duration_ms: Option<u64>,
+    pub(crate) ttft_ms: Option<u64>,
+    pub(crate) context_ms: Option<u64>,
+    pub(crate) memoria_ms: Option<u64>,
+    pub(crate) total_llm_ms: Option<u64>,
+    pub(crate) total_tool_ms: Option<u64>,
+    pub(crate) prompt_tokens: Option<u64>,
+    pub(crate) completion_tokens: Option<u64>,
+    pub(crate) cache_read_tokens: Option<u64>,
+    pub(crate) cache_creation_tokens: Option<u64>,
+    pub(crate) tool_count: Option<u32>,
+    pub(crate) llm_rounds: Option<u32>,
+    pub(crate) routing_domain_hint: Option<String>,
+    pub(crate) assistant_output: Option<&'a str>,
+    pub(crate) tool_call_records: &'a [ToolCallRecord],
+    pub(crate) selection_strategy: Option<String>,
+    pub(crate) selection_confidence: Option<f64>,
+    pub(crate) selected_tools: Vec<String>,
+}
+
+impl<'a> ExplainTurnMeta<'a> {
+    pub(crate) fn from_journal_event(event: &'a JournalEvent) -> Self {
+        let selection = event.selection_trace.as_ref();
+        Self {
+            turn_label: event.turn.map(|turn| format!("turn-{turn}")),
+            duration_ms: event.duration_ms,
+            ttft_ms: event.ttft_ms,
+            context_ms: event.context_ms,
+            memoria_ms: event.memoria_ms,
+            total_llm_ms: event.total_llm_ms,
+            total_tool_ms: event.total_tool_ms,
+            prompt_tokens: event.tokens_in,
+            completion_tokens: event.tokens_out,
+            cache_read_tokens: event.cache_read_tokens,
+            cache_creation_tokens: event.cache_creation_tokens,
+            tool_count: event.tool_count,
+            llm_rounds: event.llm_rounds,
+            routing_domain_hint: event.routing_domain_hint.clone(),
+            assistant_output: event.assistant_output.as_deref(),
+            tool_call_records: event.tool_calls.as_deref().unwrap_or(&[]),
+            selection_strategy: selection.map(|trace| trace.strategy.clone()),
+            selection_confidence: selection.map(|trace| trace.confidence),
+            selected_tools: selection
+                .map(|trace| trace.final_tools.clone())
+                .unwrap_or_default(),
+        }
+    }
+}
+
+pub(crate) fn context_trace_from_json(
+    trace_json: &serde_json::Value,
+) -> Option<ContextAssemblyTrace> {
+    serde_json::from_value(trace_json.clone()).ok()
+}
+
+fn push_tree_sections(out: &mut Vec<String>, prefix: &str, sections: Vec<Vec<String>>) {
+    let section_count = sections.len();
+    for (idx, section) in sections.into_iter().enumerate() {
+        if section.is_empty() {
+            continue;
+        }
+        let is_last = idx + 1 == section_count;
+        let head = if is_last { "└─" } else { "├─" };
+        let cont = if is_last { "   " } else { "│  " };
+        out.push(format!("{prefix}{head} {}", section[0]));
+        for line in section.into_iter().skip(1) {
+            out.push(format!("{prefix}{cont}{line}"));
+        }
+    }
+}
+
+fn format_ms(value: Option<u64>) -> String {
+    value
+        .map(|ms| {
+            if ms >= 1000 {
+                format!("{:.1}s", ms as f64 / 1000.0)
+            } else {
+                format!("{ms}ms")
+            }
+        })
+        .unwrap_or_else(|| "?".to_string())
+}
+
+fn shorten_joined(names: &[String], max_items: usize) -> String {
+    if names.is_empty() {
+        return "-".to_string();
+    }
+    let mut parts: Vec<String> = names.iter().take(max_items).cloned().collect();
+    if names.len() > max_items {
+        parts.push(format!("+{}", names.len() - max_items));
+    }
+    parts.join(", ")
+}
+
+fn tool_call_status(record: &ToolCallRecord) -> &'static str {
+    if record.was_blocked_by_policy() {
+        "blocked"
+    } else if record.ok {
+        "ok"
+    } else {
+        "error"
+    }
+}
+
+#[derive(Debug)]
+struct ExplainBatch<'a> {
+    label: String,
+    parallel: bool,
+    records: Vec<&'a ToolCallRecord>,
+}
+
+#[derive(Debug)]
+struct ExplainRound<'a> {
+    round: u32,
+    batches: Vec<ExplainBatch<'a>>,
+}
+
+fn explain_rounds(tool_call_records: &[ToolCallRecord]) -> Vec<ExplainRound<'_>> {
+    let mut rounds: Vec<ExplainRound<'_>> = Vec::new();
+    for (idx, record) in tool_call_records
+        .iter()
+        .filter(|record| !record.is_synthetic_placeholder())
+        .enumerate()
+    {
+        let round_index = record.round.unwrap_or(0);
+        let round_slot =
+            if let Some(pos) = rounds.iter().position(|round| round.round == round_index) {
+                pos
+            } else {
+                rounds.push(ExplainRound {
+                    round: round_index,
+                    batches: Vec::new(),
+                });
+                rounds.len() - 1
+            };
+        let batch_key = record
+            .batch_id
+            .clone()
+            .unwrap_or_else(|| format!("serial-{}", idx + 1));
+        if let Some(batch) = rounds[round_slot]
+            .batches
+            .iter_mut()
+            .find(|batch| batch.label == batch_key)
+        {
+            batch.parallel |= record.parallel.unwrap_or(false);
+            batch.records.push(record);
+        } else {
+            rounds[round_slot].batches.push(ExplainBatch {
+                label: batch_key,
+                parallel: record.parallel.unwrap_or(false),
+                records: vec![record],
+            });
+        }
+    }
+    rounds.sort_by_key(|round| round.round);
+    rounds
+}
+
+fn explain_value_u64(value: &serde_json::Value, key: &str) -> Option<u64> {
+    value.get(key).and_then(|v| {
+        v.as_u64()
+            .or_else(|| v.as_i64().and_then(|n| u64::try_from(n).ok()))
+    })
+}
+
+fn decision_label(decision_type: &DecisionType) -> String {
+    match decision_type {
+        DecisionType::ToolSelection { tools } => format!("tool selection ({} tools)", tools.len()),
+        DecisionType::HistoryCompression { turns_affected } => {
+            format!("history compression ({} turns)", turns_affected.len())
+        }
+        DecisionType::MemoryRetrieval { memories } => {
+            format!("memory retrieval ({} memories)", memories.len())
+        }
+        DecisionType::StrategyChoice { strategy } => format!("strategy: {strategy}"),
+    }
+}
+
+fn render_context_section(
+    trace: &ContextAssemblyTrace,
+    meta: Option<&ExplainTurnMeta<'_>>,
+    verbose: bool,
+) -> Vec<String> {
+    let total_tokens = trace.token_budget.total_used;
+    let limit = trace.token_budget.max_tokens;
+    let pressure = if limit > 0 {
+        (total_tokens as f64 / limit as f64) * 100.0
+    } else {
+        0.0
+    };
+    let mut lines = vec![format!(
+        "context_assembly ms={} budget={}/{} ({pressure:.1}%)",
+        format_ms(meta.and_then(|meta| meta.context_ms)),
+        total_tokens,
+        limit
+    )];
+    let mut children = Vec::new();
+    children.push(vec![format!(
+        "prompt system={} history={} memory={} tool_schemas={} user={}",
+        trace.token_budget.system_prompt_tokens,
+        trace.token_budget.history_tokens,
+        trace.token_budget.memory_tokens,
+        trace.token_budget.tool_schema_tokens,
+        trace.token_budget.user_message_tokens
+    )]);
+    let selected_tools: Vec<String> = trace
+        .tools
+        .tools_selected
+        .iter()
+        .map(|tool| tool.tool_name.clone())
+        .collect();
+    if !selected_tools.is_empty() || !trace.tools.selection_strategy.is_empty() {
+        children.push(vec![format!(
+            "tool_selection strategy={} conf={:.2} selected={}/{} [{}]",
+            if trace.tools.selection_strategy.is_empty() {
+                "-".to_string()
+            } else {
+                trace.tools.selection_strategy.clone()
+            },
+            trace.tools.selection_confidence,
+            selected_tools.len(),
+            trace.tools.tools_available,
+            shorten_joined(&selected_tools, if verbose { 10 } else { 6 })
+        )]);
+    } else if let Some(meta) = meta
+        && (!meta.selected_tools.is_empty() || meta.selection_strategy.is_some())
+    {
+        children.push(vec![format!(
+            "tool_selection strategy={} conf={:.2} selected={} [{}]",
+            meta.selection_strategy.as_deref().unwrap_or("-"),
+            meta.selection_confidence.unwrap_or(0.0),
+            meta.selected_tools.len(),
+            shorten_joined(&meta.selected_tools, if verbose { 10 } else { 6 })
+        )]);
+    }
+    children.push(vec![format!(
+        "memory query={:?} considered={} selected={} tokens={} ms={}",
+        trace.memory.query,
+        trace.memory.candidates_considered,
+        trace.memory.memories_selected.len(),
+        trace.memory.total_tokens,
+        format_ms(Some(trace.memory.retrieval_latency_ms))
+    )]);
+    if verbose && !trace.explanations.is_empty() {
+        let mut decision_section = vec![format!("decisions {}", trace.explanations.len())];
+        let mut decision_children = Vec::new();
+        for explanation in &trace.explanations {
+            let mut entry = vec![format!(
+                "{} conf={:.2}",
+                decision_label(&explanation.decision_type),
+                explanation.confidence
+            )];
+            if !explanation.reasoning.trim().is_empty() {
+                entry.push(format!(
+                    "└─ why {}",
+                    truncate_str(explanation.reasoning.trim(), 180)
+                ));
+            }
+            if !explanation.alternatives_considered.is_empty() {
+                let alternatives = explanation
+                    .alternatives_considered
+                    .iter()
+                    .take(3)
+                    .map(|alternative| {
+                        format!(
+                            "{}@{:.2} {}",
+                            alternative.description,
+                            alternative.score,
+                            truncate_str(&alternative.why_not_chosen, 80)
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" | ");
+                entry.push(format!("└─ alts {alternatives}"));
+            }
+            decision_children.push(entry);
+        }
+        push_tree_sections(&mut decision_section, "", decision_children);
+        children.push(decision_section);
+    }
+    push_tree_sections(&mut lines, "", children);
+    lines
+}
+
+fn render_llm_section(
+    round_index: u32,
+    explain_item: Option<&serde_json::Value>,
+    meta: Option<&ExplainTurnMeta<'_>>,
+    round_batches: &[ExplainBatch<'_>],
+    verbose: bool,
+) -> Vec<String> {
+    let llm_step = explain_item
+        .and_then(|item| item.get("steps"))
+        .and_then(serde_json::Value::as_array)
+        .and_then(|steps| {
+            steps
+                .iter()
+                .find(|step| step.get("step").and_then(|value| value.as_str()) == Some("llm"))
+        });
+    let fresh_in = llm_step
+        .and_then(|step| explain_value_u64(step, "in"))
+        .or_else(|| explain_item.and_then(|item| explain_value_u64(item, "prompt_tokens")))
+        .or_else(|| meta.and_then(|meta| meta.prompt_tokens));
+    let cache_read = llm_step
+        .and_then(|step| explain_value_u64(step, "cached_in"))
+        .or_else(|| meta.and_then(|meta| meta.cache_read_tokens));
+    let cache_write = llm_step
+        .and_then(|step| explain_value_u64(step, "cache_write"))
+        .or_else(|| meta.and_then(|meta| meta.cache_creation_tokens));
+    let out = llm_step
+        .and_then(|step| explain_value_u64(step, "out"))
+        .or_else(|| explain_item.and_then(|item| explain_value_u64(item, "completion_tokens")))
+        .or_else(|| meta.and_then(|meta| meta.completion_tokens));
+    let tool_calls = llm_step
+        .and_then(|step| explain_value_u64(step, "tool_calls"))
+        .or_else(|| meta.and_then(|meta| meta.tool_count.map(u64::from)))
+        .unwrap_or_else(|| {
+            round_batches
+                .iter()
+                .map(|batch| batch.records.len() as u64)
+                .sum()
+        });
+    let duration_ms = llm_step
+        .and_then(|step| explain_value_u64(step, "duration_ms"))
+        .or_else(|| explain_item.and_then(|item| explain_value_u64(item, "total_ms")))
+        .or_else(|| meta.and_then(|meta| meta.total_llm_ms));
+    let mut lines = vec![format!(
+        "llm ms={} fresh_in={} cache_read={} cache_write={} out={} tool_calls={}",
+        format_ms(duration_ms),
+        fresh_in
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "?".to_string()),
+        cache_read
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "?".to_string()),
+        cache_write
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "?".to_string()),
+        out.map(|value| value.to_string())
+            .unwrap_or_else(|| "?".to_string()),
+        tool_calls
+    )];
+    let mut children = Vec::new();
+    if let Some(routing) = explain_item
+        .and_then(|item| item.get("routing"))
+        .and_then(serde_json::Value::as_object)
+    {
+        let skipped = routing
+            .get("skipped")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        let reason = routing
+            .get("reason")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("-");
+        let intent = routing
+            .get("intent")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("default");
+        let tier = routing
+            .get("tier")
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let confidence = routing
+            .get("confidence")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(0.0);
+        children.push(vec![format!(
+            "routing intent={intent} conf={confidence:.2} tier={tier} skipped={skipped} reason={reason}"
+        )]);
+    } else if let Some(domain) = meta.and_then(|meta| meta.routing_domain_hint.as_deref()) {
+        children.push(vec![format!("routing domain_hint={domain}")]);
+    }
+    if let Some(steps) = explain_item
+        .and_then(|item| item.get("steps"))
+        .and_then(serde_json::Value::as_array)
+    {
+        for step in steps {
+            let label = step
+                .get("step")
+                .and_then(|value| value.as_str())
+                .unwrap_or("?");
+            if label == "llm" {
+                continue;
+            }
+            children.push(vec![format!(
+                "step[{label}] ms={}",
+                format_ms(explain_value_u64(step, "duration_ms"))
+            )]);
+        }
+    }
+    if verbose
+        && let Some(aux) = explain_item
+            .and_then(|item| item.get("auxiliary_llm_calls"))
+            .and_then(serde_json::Value::as_array)
+    {
+        for call in aux {
+            let purpose = call
+                .get("purpose")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("aux");
+            children.push(vec![format!(
+                "aux_llm[{purpose}] ms={} in={} out={}",
+                format_ms(explain_value_u64(call, "ms")),
+                explain_value_u64(call, "tokens_in")
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "?".to_string()),
+                explain_value_u64(call, "tokens_out")
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "?".to_string()),
+            )]);
+        }
+    }
+    if verbose && round_index == 0 {
+        children.push(vec![format!(
+            "timing ttft={} context={} memoria={}",
+            format_ms(meta.and_then(|meta| meta.ttft_ms)),
+            format_ms(meta.and_then(|meta| meta.context_ms)),
+            format_ms(meta.and_then(|meta| meta.memoria_ms))
+        )]);
+    }
+    push_tree_sections(&mut lines, "", children);
+    lines
+}
+
+fn render_batch_section(batch: &ExplainBatch<'_>, verbose: bool) -> Vec<String> {
+    let max_ms = batch
+        .records
+        .iter()
+        .map(|record| record.ms)
+        .max()
+        .unwrap_or(0);
+    let total_ms: u64 = batch.records.iter().map(|record| record.ms).sum();
+    let mut lines = vec![format!(
+        "batch[{}] {} tools={} max={} total={}",
+        batch.label,
+        if batch.parallel { "parallel" } else { "serial" },
+        batch.records.len(),
+        format_ms(Some(max_ms)),
+        format_ms(Some(total_ms))
+    )];
+    let mut children = Vec::new();
+    for record in &batch.records {
+        let mut tool_line = format!(
+            "{} {} ms={}{}{}",
+            record.name,
+            tool_call_status(record),
+            format_ms(Some(record.ms)),
+            record
+                .start_offset_ms
+                .map(|offset| format!(" offset={offset}ms"))
+                .unwrap_or_default(),
+            record
+                .tool_call_id
+                .as_deref()
+                .map(|id| format!(" id={id}"))
+                .unwrap_or_default()
+        );
+        if let Some(path) = record.file_path.as_deref() {
+            tool_line.push_str(&format!(" path={path}"));
+        }
+        let mut entry = vec![tool_line];
+        if verbose {
+            if let Some(args) = record
+                .args_preview
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+            {
+                entry.push(format!("└─ args {}", truncate_str(args, 160)));
+            }
+            if let Some(output) = record
+                .result_preview
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+            {
+                entry.push(format!("└─ out {}", truncate_str(output, 160)));
+            }
+            if let Some(error) = record
+                .error
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+            {
+                entry.push(format!("└─ err {}", truncate_str(error, 160)));
+            }
+        }
+        children.push(entry);
+    }
+    push_tree_sections(&mut lines, "", children);
+    lines
+}
+
+fn render_round_section(
+    round_index: u32,
+    explain_item: Option<&serde_json::Value>,
+    meta: Option<&ExplainTurnMeta<'_>>,
+    round_batches: &[ExplainBatch<'_>],
+    verbose: bool,
+) -> Vec<String> {
+    let mut lines = vec![format!("round[{}]", round_index + 1)];
+    let mut children = vec![render_llm_section(
+        round_index,
+        explain_item,
+        meta,
+        round_batches,
+        verbose,
+    )];
+    for batch in round_batches {
+        children.push(render_batch_section(batch, verbose));
+    }
+    push_tree_sections(&mut lines, "", children);
+    lines
+}
+
+fn render_assistant_section(meta: &ExplainTurnMeta<'_>, verbose: bool) -> Vec<String> {
+    let text = meta.assistant_output.unwrap_or("");
+    let mut lines = vec![format!(
+        "assistant out_tokens={} chars={}",
+        meta.completion_tokens
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "?".to_string()),
+        text.chars().count()
+    )];
+    if !text.trim().is_empty() {
+        let preview_len = if verbose { 220 } else { 120 };
+        lines.push(format!(
+            "└─ preview {}",
+            truncate_str(text.trim(), preview_len)
+        ));
+    }
+    lines
+}
+
+pub(crate) fn render_explain_dag(
+    trace: Option<&ContextAssemblyTrace>,
+    meta: Option<&ExplainTurnMeta<'_>>,
+    explain_items: &[serde_json::Value],
+    verbose: bool,
+) -> Option<String> {
+    if trace.is_none() && meta.is_none() && explain_items.is_empty() {
+        return None;
+    }
+    let turn_label = trace
+        .map(|trace| trace.turn_id.clone())
+        .or_else(|| meta.and_then(|meta| meta.turn_label.clone()))
+        .unwrap_or_else(|| "turn-?".to_string());
+    let total_ms = meta.and_then(|meta| meta.duration_ms).or_else(|| {
+        let total: u64 = explain_items
+            .iter()
+            .filter_map(|item| explain_value_u64(item, "total_ms"))
+            .sum();
+        (total > 0).then_some(total)
+    });
+    let total_tools = meta.and_then(|meta| meta.tool_count).unwrap_or_else(|| {
+        meta.map(|meta| meta.tool_call_records.len() as u32)
+            .unwrap_or(0)
+    });
+    let total_rounds = meta
+        .and_then(|meta| meta.llm_rounds)
+        .unwrap_or_else(|| explain_items.len().max(1) as u32);
+    let mut lines = vec![
+        format!("Explain Analyze DAG — {turn_label}"),
+        format!(
+            "● turn total={} ttft={} context={} llm={} tools={} rounds={} tool_calls={}",
+            format_ms(total_ms),
+            format_ms(meta.and_then(|meta| meta.ttft_ms)),
+            format_ms(meta.and_then(|meta| meta.context_ms)),
+            format_ms(meta.and_then(|meta| meta.total_llm_ms)),
+            format_ms(meta.and_then(|meta| meta.total_tool_ms)),
+            total_rounds,
+            total_tools
+        ),
+        format!(
+            "  tokens fresh_in={} cache_read={} cache_write={} out={}",
+            meta.and_then(|meta| meta.prompt_tokens)
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "?".to_string()),
+            meta.and_then(|meta| meta.cache_read_tokens)
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "?".to_string()),
+            meta.and_then(|meta| meta.cache_creation_tokens)
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "?".to_string()),
+            meta.and_then(|meta| meta.completion_tokens)
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "?".to_string())
+        ),
+    ];
+    let round_batches = meta
+        .map(|meta| explain_rounds(meta.tool_call_records))
+        .unwrap_or_default();
+    let total_round_count = explain_items.len().max(round_batches.len());
+    let mut sections = Vec::new();
+    if let Some(trace) = trace {
+        sections.push(render_context_section(trace, meta, verbose));
+    }
+    for idx in 0..total_round_count.max(meta.is_some() as usize) {
+        let explain_item = explain_items.get(idx);
+        let round_index = idx as u32;
+        let batches = round_batches
+            .iter()
+            .find(|round| round.round == round_index)
+            .map(|round| round.batches.as_slice())
+            .unwrap_or(&[]);
+        if explain_item.is_none() && batches.is_empty() && idx > 0 {
+            continue;
+        }
+        sections.push(render_round_section(
+            round_index,
+            explain_item,
+            meta,
+            batches,
+            verbose,
+        ));
+    }
+    if let Some(meta) = meta {
+        sections.push(render_assistant_section(meta, verbose));
+    }
+    push_tree_sections(&mut lines, "", sections);
+    Some(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astra_services::session_journal::SelectionTrace;
+
+    #[test]
+    fn render_explain_dag_includes_cache_and_parallel_batches() {
+        let mut trace = ContextAssemblyTrace {
+            turn_id: "turn-2".into(),
+            session_id: "sess-1".into(),
+            ..Default::default()
+        };
+        trace.system_prompt.total_tokens = 3943;
+        trace.token_budget.total_used = 7658;
+        trace.token_budget.max_tokens = 160_000;
+        trace.token_budget.history_tokens = 7;
+        trace.token_budget.tool_schema_tokens = 3708;
+        trace.tools.tools_available = 27;
+        trace.tools.selection_strategy = "registry".into();
+        trace
+            .tools
+            .tools_selected
+            .push(astra_turn_core::context_assembly_trace::ToolSelected {
+                tool_name: "bash".into(),
+                score: 1.0,
+                tokens: 243,
+                selection_factors: Vec::new(),
+            });
+
+        let tool_calls = vec![
+            ToolCallRecord {
+                tool_call_id: Some("call-1".into()),
+                name: "bash".into(),
+                ok: true,
+                ms: 3000,
+                batch_id: Some("parallel-1".into()),
+                parallel: Some(true),
+                round: Some(0),
+                start_offset_ms: Some(40),
+                ..Default::default()
+            },
+            ToolCallRecord {
+                tool_call_id: Some("call-2".into()),
+                name: "read_file".into(),
+                ok: true,
+                ms: 48,
+                batch_id: Some("parallel-1".into()),
+                parallel: Some(true),
+                round: Some(0),
+                file_path: Some("README.md".into()),
+                ..Default::default()
+            },
+        ];
+        let meta = ExplainTurnMeta {
+            turn_label: Some("turn-2".into()),
+            duration_ms: Some(2930),
+            ttft_ms: Some(1900),
+            context_ms: Some(88),
+            memoria_ms: Some(51),
+            total_llm_ms: Some(2930),
+            total_tool_ms: Some(3048),
+            prompt_tokens: Some(10023),
+            completion_tokens: Some(32),
+            cache_read_tokens: Some(900),
+            cache_creation_tokens: Some(200),
+            tool_count: Some(2),
+            llm_rounds: Some(1),
+            routing_domain_hint: None,
+            assistant_output: Some("done"),
+            tool_call_records: &tool_calls,
+            selection_strategy: None,
+            selection_confidence: None,
+            selected_tools: Vec::new(),
+        };
+        let explain_items = vec![serde_json::json!({
+            "total_ms": 2930,
+            "steps": [{
+                "step": "llm",
+                "duration_ms": 2930,
+                "in": 10023,
+                "cached_in": 900,
+                "cache_write": 200,
+                "out": 32,
+                "tool_calls": 2
+            }]
+        })];
+
+        let text =
+            render_explain_dag(Some(&trace), Some(&meta), &explain_items, false).expect("text");
+        assert!(text.contains("Explain Analyze DAG — turn-2"));
+        assert!(text.contains(
+            "llm ms=2.9s fresh_in=10023 cache_read=900 cache_write=200 out=32 tool_calls=2"
+        ));
+        assert!(text.contains("batch[parallel-1] parallel tools=2"));
+        assert!(text.contains("read_file ok ms=48ms id=call-2 path=README.md"));
+    }
+
+    #[test]
+    fn context_trace_from_json_parses_full_trace() {
+        let trace = ContextAssemblyTrace {
+            turn_id: "turn-7".into(),
+            session_id: "sid".into(),
+            ..Default::default()
+        };
+        let parsed = context_trace_from_json(&trace.to_json_value()).expect("parsed trace");
+        assert_eq!(parsed.turn_id, "turn-7");
+    }
+
+    #[test]
+    fn explain_turn_meta_from_journal_event_preserves_unknown_cache_write() {
+        let mut event =
+            JournalEvent::turn(Some("sid"), 3, Some("gpt-5"), "hi", "hello", 1, 21, 8, 1200)
+                .with_tool_calls(vec![ToolCallRecord {
+                    tool_call_id: Some("call-1".into()),
+                    name: "bash".into(),
+                    ok: true,
+                    ms: 30,
+                    ..Default::default()
+                }]);
+        event.cache_read_tokens = Some(144);
+        event.cache_creation_tokens = None;
+        event.selection_trace = Some(SelectionTrace {
+            candidate_scores: None,
+            boost_terms: None,
+            learned_context_summary: None,
+            final_tools: vec!["bash".into()],
+            confidence: 0.91,
+            strategy: "registry".into(),
+        });
+
+        let meta = ExplainTurnMeta::from_journal_event(&event);
+        let text = render_explain_dag(None, Some(&meta), &[], false).expect("text");
+
+        assert_eq!(meta.turn_label.as_deref(), Some("turn-3"));
+        assert_eq!(meta.selection_strategy.as_deref(), Some("registry"));
+        assert_eq!(meta.selected_tools, vec!["bash".to_string()]);
+        assert!(text.contains("tokens fresh_in=21 cache_read=144 cache_write=? out=8"));
+        assert!(
+            text.contains("llm ms=? fresh_in=21 cache_read=144 cache_write=? out=8 tool_calls=1")
+        );
+    }
+}

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -71,6 +71,7 @@ mod command_usage;
 mod context_dump;
 #[path = "cli/context_references.rs"]
 mod context_references;
+mod explain_dag;
 
 #[path = "cli/chat_turn.rs"]
 mod chat_turn;

--- a/rust/crates/astra-cli/src/tests/cli_args_tests.rs
+++ b/rust/crates/astra-cli/src/tests/cli_args_tests.rs
@@ -293,6 +293,45 @@ fn cli_chat_auto_approve() {
 }
 
 #[test]
+fn cli_chat_explain_flag_defaults_to_on() {
+    let cli = Cli::try_parse_from(["astra", "chat", "--explain"]).unwrap();
+    match cli.command {
+        Some(Command::Chat(ref args)) => {
+            assert_eq!(args.explain, Some(ExplainMode::On));
+        }
+        _ => panic!("expected Chat command"),
+    }
+}
+
+#[test]
+fn cli_chat_explain_flag_accepts_verbose_mode() {
+    let cli = Cli::try_parse_from(["astra", "chat", "--explain", "verbose"]).unwrap();
+    match cli.command {
+        Some(Command::Chat(ref args)) => {
+            assert_eq!(args.explain, Some(ExplainMode::Verbose));
+        }
+        _ => panic!("expected Chat command"),
+    }
+}
+
+#[test]
+fn cli_chat_explain_flag_accepts_explicit_off() {
+    let cli = Cli::try_parse_from(["astra", "chat", "--explain", "off"]).unwrap();
+    match cli.command {
+        Some(Command::Chat(ref args)) => {
+            assert_eq!(args.explain, Some(ExplainMode::Off));
+        }
+        _ => panic!("expected Chat command"),
+    }
+}
+
+#[test]
+fn cli_chat_explain_flag_rejects_invalid_mode() {
+    let result = Cli::try_parse_from(["astra", "chat", "--explain", "laser"]);
+    assert!(result.is_err(), "invalid explain mode should be rejected");
+}
+
+#[test]
 fn cli_chat_permission_mode() {
     let cli = Cli::try_parse_from(["astra", "chat", "--permission-mode", "auto"]).unwrap();
     match cli.command {

--- a/rust/crates/astra-cli/src/tui/app_event.rs
+++ b/rust/crates/astra-cli/src/tui/app_event.rs
@@ -56,4 +56,6 @@ pub(crate) enum TuiAppEvent {
     // ── Turn lifecycle ──────────────────────────────────────────────────
     TurnComplete,
     TurnError(String),
+    ExplainReport(Vec<serde_json::Value>),
+    VerdictReport(Vec<crate::VerdictEvent>),
 }

--- a/rust/crates/astra-cli/src/tui/chat_widget/bridge.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/bridge.rs
@@ -125,6 +125,8 @@ pub(crate) fn translate(ev: TuiAppEvent, ctx: TurnContext) -> Option<AppEvent> {
             ctx.into_stats(),
         )))),
         TuiAppEvent::TurnError(msg) => Some(AppEvent::Wire(WireEvent::TurnError(msg))),
+        TuiAppEvent::ExplainReport(items) => Some(AppEvent::Wire(WireEvent::ExplainReport(items))),
+        TuiAppEvent::VerdictReport(items) => Some(AppEvent::Wire(WireEvent::VerdictReport(items))),
         // Bottom-pane-only events — ChatWidget doesn't care.
         TuiAppEvent::ThinkingStarted
         | TuiAppEvent::WaitingForModel

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -41,6 +41,7 @@ use super::history_cell::{
 };
 use super::transcript_jsonl;
 use super::turn_event::TurnEvent;
+use crate::VerdictEvent;
 
 /// Events the ChatWidget knows how to route. Grouped by origin so
 /// `handle_event` can scale to more variants without bloating a
@@ -135,6 +136,8 @@ pub(crate) enum WireEvent {
     /// Turn ended with an error. Error text gets humanised by
     /// `SystemCell::error` before storage.
     TurnError(String),
+    ExplainReport(Vec<serde_json::Value>),
+    VerdictReport(Vec<crate::VerdictEvent>),
 }
 
 /// Per-turn metrics the outer loop collects and hands to
@@ -854,6 +857,8 @@ impl ChatWidget {
             }
             WireEvent::TurnComplete(stats) => self.on_turn_complete(*stats),
             WireEvent::TurnError(msg) => self.on_turn_error(msg),
+            WireEvent::ExplainReport(items) => self.on_explain_report(items),
+            WireEvent::VerdictReport(items) => self.on_verdict_report(items),
         }
     }
 
@@ -1615,6 +1620,78 @@ impl ChatWidget {
         self.commit_cell(Box::new(SystemCell::error(msg)));
     }
 
+    fn on_explain_report(&mut self, items: Vec<serde_json::Value>) {
+        if items.is_empty() {
+            return;
+        }
+        let mut parts = Vec::new();
+        for item in &items {
+            let mut line = String::new();
+            if let Some(ms) = item.get("total_ms").and_then(|v| v.as_i64()) {
+                line.push_str(&format!("⏱ {:.1}s", ms as f64 / 1000.0));
+            }
+            if let Some(selected) = item.get("tools_selected").and_then(|v| v.as_u64()) {
+                if let Some(available) = item.get("tools_available").and_then(|v| v.as_u64()) {
+                    if !line.is_empty() {
+                        line.push_str(" | ");
+                    }
+                    line.push_str(&format!("🛠 {}/{} tools", selected, available));
+                }
+            }
+            if let Some(steps) = item.get("steps").and_then(|v| v.as_array()) {
+                if !line.is_empty() {
+                    line.push_str(" | ");
+                }
+                line.push_str(&format!("📋 {} steps", steps.len()));
+            }
+            if !line.is_empty() {
+                parts.push(line);
+                continue;
+            }
+            if let Some(content) = item.get("content").and_then(|v| v.as_str()) {
+                let content = content.trim();
+                if !content.is_empty() {
+                    parts.push(content.to_string());
+                }
+            }
+        }
+        if !parts.is_empty() {
+            let text = format!("Context Explain\n{}", parts.join("\n"));
+            self.commit_cell(Box::new(SystemCell::info(text)));
+        }
+    }
+
+    fn on_verdict_report(&mut self, items: Vec<VerdictEvent>) {
+        if items.is_empty() {
+            return;
+        }
+        let mut parts = Vec::new();
+        for item in &items {
+            let severity: &str = &item.severity;
+            let icon = match severity {
+                "error" => "❌",
+                "warn" => "⚠️",
+                _ => "ℹ️",
+            };
+            let mut desc = format!("{} severity={}", icon, severity);
+            if item.force_stop {
+                desc.push_str(" force_stop");
+            }
+            if item.total_errors > 0 {
+                desc.push_str(&format!(" errors={}", item.total_errors));
+            }
+            if item.nudge_count > 0 {
+                desc.push_str(&format!(" nudges={}", item.nudge_count));
+            }
+            if !item.avoid_tools.is_empty() {
+                desc.push_str(&format!(" avoid=[{}]", item.avoid_tools.join(", ")));
+            }
+            parts.push(desc);
+        }
+        let text = format!("Verdict report\n{}", parts.join("\n"));
+        self.commit_cell(Box::new(SystemCell::info(text)));
+    }
+
     // ── Invariant-preserving mutators ────────────────────────────
 
     /// Take the currently-live cell, finalise it, append to
@@ -2357,6 +2434,30 @@ mod tests {
             w.cancelled_task_ids.is_empty(),
             "turn complete must clear prior-turn cancelled ids: {:?}",
             w.cancelled_task_ids
+        );
+    }
+
+    #[test]
+    fn explain_report_with_content_fallback_commits_system_cell() {
+        let mut w = fresh();
+        w.handle_event(AppEvent::Wire(WireEvent::ExplainReport(vec![
+            serde_json::json!(
+                {
+                    "type": "explain",
+                    "content": "why this happened"
+                }
+            ),
+        ])));
+
+        let sys = w
+            .history
+            .last()
+            .and_then(|cell| cell.as_any_ref().downcast_ref::<SystemCell>())
+            .expect("explain report should append a system cell");
+        assert!(
+            sys.message().contains("why this happened"),
+            "content fallback should render the explain text: {}",
+            sys.message()
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -18,8 +18,14 @@
 
 use std::{sync::Arc, time::Duration};
 
+#[cfg(test)]
+use astra_services::session_journal::ToolCallRecord;
+use astra_services::session_journal::{JournalEvent, JournalEventType};
+use astra_turn_core::context_assembly_trace::ContextAssemblyTrace;
 use tokio::sync::broadcast;
 use tokio_stream::StreamExt;
+
+use crate::explain_dag::{ExplainTurnMeta, render_explain_dag};
 
 use super::app_event::TuiAppEvent;
 use super::bottom_pane::{BottomPane, BottomPaneAction};
@@ -107,6 +113,65 @@ fn surface_status_line_system_cell(event: &TuiAppEvent, chat_widget: &mut chat_w
                 .to_string(),
         ));
     };
+}
+
+fn context_trace_count(state: &crate::SessionState) -> usize {
+    state
+        .observability_session
+        .as_ref()
+        .map(|session| {
+            let guard = session.read().unwrap_or_else(|e| e.into_inner());
+            guard.context_traces.len()
+        })
+        .unwrap_or(0)
+}
+
+fn latest_context_trace_since(
+    state: &crate::SessionState,
+    baseline_cached_turn_id: Option<&str>,
+    baseline_count: usize,
+) -> Option<ContextAssemblyTrace> {
+    if let Some(trace) = state.latest_context_assembly_trace.as_ref()
+        && baseline_cached_turn_id != Some(trace.turn_id.as_str())
+    {
+        return Some(trace.clone());
+    }
+    let session = state.observability_session.as_ref()?;
+    let guard = session.read().unwrap_or_else(|e| e.into_inner());
+    (guard.context_traces.len() > baseline_count)
+        .then(|| guard.context_traces.last().cloned())
+        .flatten()
+}
+
+fn current_turn_event(state: &crate::SessionState) -> Option<&JournalEvent> {
+    state.last_turn_event.as_ref().filter(|event| {
+        event.event_type == JournalEventType::Turn && event.turn == Some(state.turn)
+    })
+}
+
+fn commit_explain_dag(
+    state: &crate::SessionState,
+    explain_items: &[serde_json::Value],
+    baseline_cached_turn_id: Option<&str>,
+    baseline_context_traces: usize,
+    chat_widget: &mut chat_widget::ChatWidget,
+) -> bool {
+    if state.explain == crate::ExplainMode::Off {
+        return false;
+    }
+    let trace = latest_context_trace_since(state, baseline_cached_turn_id, baseline_context_traces);
+    let turn_event = current_turn_event(state);
+    let meta = turn_event.map(ExplainTurnMeta::from_journal_event);
+    let Some(text) = render_explain_dag(
+        trace.as_ref(),
+        meta.as_ref(),
+        explain_items,
+        state.explain == crate::ExplainMode::Verbose,
+    ) else {
+        return false;
+    };
+    chat_widget.commit_system(history_cell::system::SystemCell::info(text));
+    true
 }
 
 fn reopen_agents_view(
@@ -1560,8 +1625,14 @@ pub(crate) async fn run_tui_session(
                                     let _pre_cost = state.total_session_cost;
                                     let pre_cache_read = state.total_cache_read_tokens;
                                     let pre_cache_creation = state.total_cache_creation_tokens;
+                                    let pre_cached_context_trace_turn_id = state
+                                        .latest_context_assembly_trace
+                                        .as_ref()
+                                        .map(|trace| trace.turn_id.clone());
+                                    let pre_context_trace_count = context_trace_count(&state);
                                     let mut turn_tool_count: u32 = 0;
                                     let mut turn_ttft: Option<std::time::Instant> = None;
+                                    let mut explain_items: Vec<serde_json::Value> = Vec::new();
                                     let mut ctrl_b_pressed = false;
                                     // Phase 3b.3c: prime the bash detach slot for this
                                     // turn. The bash runner takes the handle on entry;
@@ -1979,6 +2050,10 @@ pub(crate) async fn run_tui_session(
                                                         TuiAppEvent::ToolStarted { .. } => {
                                                             turn_tool_count += 1;
                                                         }
+                                                        TuiAppEvent::ExplainReport(items) if !items.is_empty() => {
+                                                            explain_items.extend(items.clone());
+                                                            continue;
+                                                        }
                                                         _ => {}
                                                     }
                                                     let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
@@ -2135,6 +2210,10 @@ pub(crate) async fn run_tui_session(
                                                     TuiAppEvent::ToolStarted { .. } => {
                                                         turn_tool_count += 1;
                                                     }
+                                                    TuiAppEvent::ExplainReport(items) if !items.is_empty() => {
+                                                        explain_items.extend(items.clone());
+                                                        continue;
+                                                    }
                                                     _ => {}
                                                 }
                                                 if let Some(new_ev) = chat_widget::translate(
@@ -2152,6 +2231,18 @@ pub(crate) async fn run_tui_session(
                                                     flush_chat_widget(&mut guard, &mut chat_widget, w);
                                             }
                                         }
+                                    }
+
+                                    if turn_result.is_ok()
+                                        && commit_explain_dag(
+                                            &state,
+                                            &explain_items,
+                                            pre_cached_context_trace_turn_id.as_deref(),
+                                            pre_context_trace_count,
+                                            &mut chat_widget,
+                                        )
+                                    {
+                                        flush_chat_widget(&mut guard, &mut chat_widget, w);
                                     }
 
                                     // Turn end — ChatWidget handles any
@@ -3051,6 +3142,8 @@ fn handle_app_event(
         TuiAppEvent::AgentLive(_)
         | TuiAppEvent::AgentLiveBatch(_)
         | TuiAppEvent::StatusLine(_)
+        | TuiAppEvent::ExplainReport(_)
+        | TuiAppEvent::VerdictReport(_)
         | TuiAppEvent::PermissionAutoApproved { .. } => {}
         TuiAppEvent::TurnComplete | TuiAppEvent::TurnError(_) => {
             bottom_pane.set_task_status(TaskStatus::Idle);
@@ -3564,5 +3657,224 @@ mod tests {
             .collect();
         assert!(rendered[0].contains("/allow"));
         assert!(rendered[1].contains("Mode → auto"));
+    }
+
+    #[test]
+    fn render_explain_dag_formats_rounds_cache_and_batches() {
+        let mut trace = ContextAssemblyTrace {
+            turn_id: "turn-2".into(),
+            session_id: "sess-1".into(),
+            ..Default::default()
+        };
+        trace.system_prompt.total_tokens = 3943;
+        trace.token_budget.total_used = 7658;
+        trace.token_budget.max_tokens = 160_000;
+        trace.token_budget.history_tokens = 7;
+        trace.token_budget.tool_schema_tokens = 3708;
+        trace
+            .history
+            .turns_retained
+            .push(astra_turn_core::context_assembly_trace::TurnRetention {
+                turn_index: 0,
+                role: "assistant".into(),
+                tokens: 7,
+                has_tool_calls: false,
+            });
+        trace.memory.candidates_considered = 5;
+        trace.memory.retrieval_latency_ms = 51;
+        trace.tools.tools_available = 27;
+        trace.tools.selection_strategy = "registry".into();
+        trace
+            .tools
+            .tools_selected
+            .push(astra_turn_core::context_assembly_trace::ToolSelected {
+                tool_name: "bash".into(),
+                score: 1.0,
+                tokens: 243,
+                selection_factors: Vec::new(),
+            });
+        trace
+            .tools
+            .tools_selected
+            .push(astra_turn_core::context_assembly_trace::ToolSelected {
+                tool_name: "read_file".into(),
+                score: 0.9,
+                tokens: 128,
+                selection_factors: Vec::new(),
+            });
+        let mut turn_event = astra_services::session_journal::JournalEvent::turn(
+            Some("sess-1"),
+            2,
+            Some("gpt-5"),
+            "hi",
+            "done",
+            2,
+            10_023,
+            32,
+            2_930,
+        )
+        .with_cache_tokens(900, 200)
+        .with_tool_calls(vec![
+            ToolCallRecord {
+                tool_call_id: Some("call-1".into()),
+                name: "bash".into(),
+                ok: true,
+                ms: 3000,
+                batch_id: Some("parallel-1".into()),
+                parallel: Some(true),
+                round: Some(0),
+                start_offset_ms: Some(40),
+                args_preview: Some("{\"command\":\"git status\"}".into()),
+                ..Default::default()
+            },
+            ToolCallRecord {
+                tool_call_id: Some("call-2".into()),
+                name: "read_file".into(),
+                ok: true,
+                ms: 48,
+                batch_id: Some("parallel-1".into()),
+                parallel: Some(true),
+                round: Some(0),
+                file_path: Some("README.md".into()),
+                ..Default::default()
+            },
+        ]);
+        turn_event.ttft_ms = Some(1900);
+        turn_event.context_ms = Some(88);
+        turn_event.memoria_ms = Some(51);
+        turn_event.total_llm_ms = Some(2930);
+        turn_event.total_tool_ms = Some(3048);
+        turn_event.llm_rounds = Some(1);
+        let explain_items = vec![serde_json::json!({
+            "total_ms": 2930,
+            "prompt_tokens": 10023,
+            "completion_tokens": 32,
+            "steps": [{
+                "step": "llm",
+                "duration_ms": 2930,
+                "in": 10023,
+                "cached_in": 900,
+                "cache_write": 200,
+                "out": 32,
+                "tool_calls": 2
+            }],
+            "routing": {
+                "intent": "default",
+                "confidence": 0.0,
+                "tier": 0,
+                "skipped": false,
+                "reason": ""
+            }
+        })];
+
+        let meta = ExplainTurnMeta::from_journal_event(&turn_event);
+        let text =
+            render_explain_dag(Some(&trace), Some(&meta), &explain_items, false).expect("text");
+        assert!(text.contains("Explain Analyze DAG — turn-2"));
+        assert!(text.contains("context_assembly ms=88ms budget=7658/160000 (4.8%)"));
+        assert!(text.contains(
+            "llm ms=2.9s fresh_in=10023 cache_read=900 cache_write=200 out=32 tool_calls=2"
+        ));
+        assert!(text.contains("batch[parallel-1] parallel tools=2"));
+        assert!(text.contains("bash ok ms=3.0s offset=40ms id=call-1"));
+        assert!(text.contains("read_file ok ms=48ms id=call-2 path=README.md"));
+    }
+
+    #[test]
+    fn commit_explain_dag_commits_trace_to_history() {
+        let mut state = crate::SessionState::default();
+        state.explain = crate::ExplainMode::On;
+        state.turn = 9;
+        state.latest_context_assembly_trace = Some(ContextAssemblyTrace {
+            turn_id: "turn-9".into(),
+            session_id: "sid-trace".into(),
+            token_budget: astra_turn_core::context_assembly_trace::TokenBudgetTrace {
+                total_used: 1024,
+                max_tokens: 4096,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        state.last_turn_event = Some(astra_services::session_journal::JournalEvent::turn(
+            Some("sid-trace"),
+            9,
+            Some("gpt-5"),
+            "hi",
+            "hello",
+            0,
+            12,
+            8,
+            1200,
+        ));
+        let mut widget = chat_widget::ChatWidget::new("");
+
+        assert!(commit_explain_dag(&state, &[], None, 0, &mut widget));
+
+        let sys = widget
+            .history()
+            .last()
+            .and_then(|cell| {
+                cell.as_any_ref()
+                    .downcast_ref::<history_cell::system::SystemCell>()
+            })
+            .expect("expected a committed system cell");
+        assert!(sys.message().contains("Explain Analyze DAG — turn-9"));
+    }
+
+    #[test]
+    fn commit_explain_dag_skips_unchanged_cached_trace() {
+        let mut state = crate::SessionState::default();
+        state.explain = crate::ExplainMode::On;
+        state.latest_context_assembly_trace = Some(ContextAssemblyTrace {
+            turn_id: "turn-9".into(),
+            session_id: "sid-trace".into(),
+            ..Default::default()
+        });
+        let mut widget = chat_widget::ChatWidget::new("");
+
+        assert!(!commit_explain_dag(
+            &state,
+            &[],
+            Some("turn-9"),
+            0,
+            &mut widget,
+        ));
+        assert!(widget.history().is_empty());
+    }
+
+    #[test]
+    fn commit_explain_dag_preserves_unknown_cache_write_marker() {
+        let mut state = crate::SessionState::default();
+        state.explain = crate::ExplainMode::On;
+        state.turn = 4;
+        state.last_turn_event = Some(astra_services::session_journal::JournalEvent::turn(
+            Some("sid-trace"),
+            4,
+            Some("gpt-5"),
+            "hi",
+            "hello",
+            0,
+            12,
+            8,
+            1200,
+        ));
+        state
+            .last_turn_event
+            .as_mut()
+            .expect("turn event")
+            .cache_read_tokens = Some(144);
+        let mut widget = chat_widget::ChatWidget::new("");
+
+        assert!(commit_explain_dag(&state, &[], None, 0, &mut widget));
+
+        let sys = widget
+            .history()
+            .last()
+            .and_then(|cell| {
+                cell.as_any_ref()
+                    .downcast_ref::<history_cell::system::SystemCell>()
+            })
+            .expect("expected a committed system cell");
+        assert!(sys.message().contains("cache_write=?"));
     }
 }

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -5,6 +5,7 @@
 //! produce output render to scrollback. Unrecognized or complex commands
 //! fall back to `with_restored()` which temporarily exits the TUI.
 
+use crate::ExplainMode;
 use crate::command_registry;
 use crate::command_registry::TuiHandler;
 use crate::session_state::SessionState;
@@ -372,8 +373,22 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
         }
 
         // ── State commands → with_restored (share full logic with non-TUI) ──
-        "/clear" | "/undo" | "/redo" | "/compact" | "/explain" | "/reflect" => {
-            SlashResult::Fallback
+        "/clear" | "/undo" | "/redo" | "/compact" | "/reflect" => SlashResult::Fallback,
+
+        // ── Explain ─────────────────────────────────────────────────
+        "/explain" => {
+            ctx.state.explain = match ctx.state.explain {
+                ExplainMode::Off => ExplainMode::On,
+                ExplainMode::On => ExplainMode::Verbose,
+                ExplainMode::Verbose => ExplainMode::Off,
+            };
+            let label = match ctx.state.explain {
+                ExplainMode::Off => "off",
+                ExplainMode::On => "on",
+                ExplainMode::Verbose => "verbose",
+            };
+            ctx.show_response(format!("Explain mode: {label}"));
+            SlashResult::Handled
         }
 
         // ── Inspect (TUI-native) ────────────────────────────────────

--- a/rust/crates/astra-cli/src/tui/stream_bridge.rs
+++ b/rust/crates/astra-cli/src/tui/stream_bridge.rs
@@ -28,8 +28,9 @@ pub(crate) fn create_per_turn_bridge(tui_tx: TuiAppEventTx) -> crate::chat_strea
 
     tokio::spawn(async move {
         while let Some(event) = stream_rx.recv().await {
-            let tui_event = map_stream_event(event);
-            if tui_tx.send(tui_event).is_err() {
+            if let Some(tui_event) = map_stream_event(event)
+                && tui_tx.send(tui_event).is_err()
+            {
                 break;
             }
         }
@@ -221,8 +222,8 @@ async fn recv_next_live_event(
     }
 }
 
-fn map_stream_event(event: StreamEvent) -> TuiAppEvent {
-    match event {
+fn map_stream_event(event: StreamEvent) -> Option<TuiAppEvent> {
+    Some(match event {
         StreamEvent::Token(text) => TuiAppEvent::Token(text),
         StreamEvent::Thinking(true) => TuiAppEvent::ThinkingStarted,
         StreamEvent::Thinking(false) => TuiAppEvent::ThinkingStopped,
@@ -312,7 +313,10 @@ fn map_stream_event(event: StreamEvent) -> TuiAppEvent {
         StreamEvent::PermissionAutoApproved { tool, reason } => {
             TuiAppEvent::PermissionAutoApproved { tool, reason }
         }
-    }
+        StreamEvent::ExplainReport(items) => TuiAppEvent::ExplainReport(items),
+        StreamEvent::VerdictReport(items) => TuiAppEvent::VerdictReport(items),
+        StreamEvent::ExplainText(_) => return None,
+    })
 }
 
 #[cfg(test)]

--- a/rust/crates/runtime/src/turn/bridge_inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge_inprocess.rs
@@ -1126,10 +1126,7 @@ impl InProcessChatTurnBridge {
             .and_then(Value::as_object)
             .cloned()
             .unwrap_or_default();
-        let explain = payload
-            .get("explain")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
+        let explain = explain_requested(&payload);
         let model_override = payload
             .get("model")
             .and_then(Value::as_str)
@@ -4142,6 +4139,14 @@ fn header_str(headers: &HeaderMap, name: &str) -> Option<String> {
         .map(ToString::to_string)
 }
 
+fn explain_requested(payload: &Value) -> bool {
+    match payload.get("explain") {
+        Some(Value::Bool(enabled)) => *enabled,
+        Some(Value::String(mode)) => mode.eq_ignore_ascii_case("verbose"),
+        _ => false,
+    }
+}
+
 fn classify_llm_error(msg: &str) -> astra_core::ErrorKind {
     // Delegate to the canonical classifier in llm_client.
     crate::turn::llm_client::classify_llm_error(msg)
@@ -5613,6 +5618,14 @@ mod tests {
             header_str(&headers, "x-mo-user-id").as_deref(),
             Some("user-123")
         );
+    }
+
+    #[test]
+    fn explain_requested_accepts_verbose_string() {
+        assert!(explain_requested(&json!({ "explain": "verbose" })));
+        assert!(explain_requested(&json!({ "explain": true })));
+        assert!(!explain_requested(&json!({ "explain": false })));
+        assert!(!explain_requested(&json!({ "explain": "off" })));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Adds explain mode support to the CLI via `--explain` parameter, enabling users to see explain reports and streaming improvements.

## Changes
- Add `explain_mode_from_params()` to parse `explain` from params (bool or string: `off`/`on`/`verbose`)
- Wire explain mode through to agent runtime in `run_turn()`
- Expose explain mode in session results

## Testing
Changes follow existing patterns; no new test files were added.