### PR TITLE
feat(tui): permission mode sync fix and ask-user UX improvements

### DIFF
--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -447,6 +447,15 @@ impl PermissionModeMirror {
             std::sync::atomic::Ordering::Release,
         );
     }
+
+    /// Test-only constructor: build a mirror from a pre-encoded u8.
+    /// Use `encode_mode_for_mirror` to get the correct encoding.
+    #[cfg(test)]
+    pub(crate) fn from_encoded(encoded: u8) -> Self {
+        Self {
+            inner: std::sync::Arc::new(std::sync::atomic::AtomicU8::new(encoded)),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/rust/crates/astra-cli/src/tui/bottom_pane/ask_user_view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/ask_user_view.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Layout, Rect},
@@ -409,7 +409,11 @@ impl AskUserView {
             let focused = state.cursor_row == idx;
             let selected = state.selected.contains(&idx);
             let selector = if question.multi_select {
-                if selected { "[x]" } else { "[ ]" }
+                if selected {
+                    "[x]"
+                } else {
+                    "[ ]"
+                }
             } else if selected {
                 "(*)"
             } else {
@@ -457,12 +461,19 @@ impl AskUserView {
                     .fg(Color::Green)
                     .add_modifier(Modifier::BOLD)
             } else {
-                Style::default()
+                Style::default().fg(Color::Cyan)
             };
             Widget::render(
                 Line::from(vec![
                     Span::styled(if focused { "  › " } else { "    " }, style),
-                    Span::styled("Other", style),
+                    Span::styled(
+                        if focused {
+                            "Other"
+                        } else {
+                            "✎ Other (free-text)"
+                        },
+                        style,
+                    ),
                 ]),
                 Rect::new(chunks[1].x, y, chunks[1].width, 1),
                 buf,
@@ -970,7 +981,30 @@ impl BottomPaneView for AskUserView {
         let other_focused = Self::is_other_row(&question, state);
 
         match key.code {
-            KeyCode::Esc => self.send(AskUserResponse::Cancelled),
+            KeyCode::Esc => {
+                // In multi-select mode, Esc first clears all selections.
+                // Only when nothing is selected does it cancel the
+                // form — matching Claude Code's two-stage Esc for
+                // multi-select safety.
+                if question.multi_select && !state.selected.is_empty() {
+                    let state = self.current_state_mut().expect("state for active question");
+                    state.selected.clear();
+                    self.validation = None;
+                } else {
+                    self.send(AskUserResponse::Cancelled);
+                }
+            }
+            KeyCode::Char('a')
+                if key.modifiers.contains(KeyModifiers::CONTROL) && question.multi_select =>
+            {
+                // Ctrl+A: select all options in multi-select mode.
+                let state = self.current_state_mut().expect("state for active question");
+                state.selected.clear();
+                for i in 0..question.options.len() {
+                    state.selected.insert(i);
+                }
+                self.validation = None;
+            }
             KeyCode::Left | KeyCode::BackTab => self.prev_tab(),
             KeyCode::Right | KeyCode::Tab => self.next_tab(),
             KeyCode::Up => {

--- a/rust/crates/astra-cli/src/tui/bottom_pane/footer.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/footer.rs
@@ -8,7 +8,8 @@ use std::time::Duration;
 
 use ratatui::{buffer::Buffer, layout::Rect};
 
-use crate::tui::status_line::{PermissionMode, StatusContext, StatusLine};
+use crate::permission_manager::{PermissionMode, PermissionModeMirror};
+use crate::tui::status_line::{StatusContext, StatusLine};
 
 pub(crate) struct Footer {
     pub model: Option<String>,
@@ -16,7 +17,7 @@ pub(crate) struct Footer {
     pub token_usage: Option<String>,
     pub cwd: Option<String>,
     pub is_turn_active: bool,
-    pub permission_mode: Option<String>,
+    pub permission_mode: Option<PermissionMode>,
     pub git_branch: Option<String>,
     pub token_budget: Option<(u64, u64)>,
     pub current_objective: Option<String>,
@@ -28,6 +29,13 @@ pub(crate) struct Footer {
     /// Updated by the TUI event-loop tick; rendered as the `BG: …`
     /// chip on the status line. `None` keeps the chip hidden.
     pub bg_task_counts: Option<(usize, usize)>,
+    /// Lock-free mirror of the current permission mode. When set,
+    /// `to_context()` reads the live mode from this mirror on every
+    /// render instead of relying on the cached `permission_mode`
+    /// field. Eliminates the ~50 ms staleness window between a mode
+    /// change (e.g. `/plan`, `/auto`, exit_plan_mode) and the next
+    /// event-loop tick that calls `refresh_footer_from_state`.
+    mode_mirror: Option<PermissionModeMirror>,
 }
 
 impl Footer {
@@ -47,6 +55,7 @@ impl Footer {
             task_counts: None,
             task_board_expanded: false,
             bg_task_counts: None,
+            mode_mirror: None,
         }
     }
 
@@ -58,14 +67,21 @@ impl Footer {
         self.git_branch = detect_git_branch();
     }
 
-    fn permission_mode_enum(&self) -> PermissionMode {
-        match self.permission_mode.as_deref() {
-            Some("auto") => PermissionMode::Auto,
-            Some("plan") => PermissionMode::Plan,
-            Some("accept_edits") => PermissionMode::AcceptEdits,
-            Some("deny") => PermissionMode::Deny,
-            _ => PermissionMode::Ask,
-        }
+    /// Install a lock-free mirror so every frame reads the *current*
+    /// permission mode directly from the atomic state rather than a
+    /// cached copy that may be up to one event-loop tick stale.
+    pub fn set_mode_mirror(&mut self, mirror: PermissionModeMirror) {
+        self.mode_mirror = Some(mirror);
+    }
+
+    /// Resolve the live permission mode: prefer the lock-free mirror
+    /// when available; otherwise fall back to the cached field (for
+    /// tests and early-init renders before the mirror is wired).
+    fn live_mode(&self) -> PermissionMode {
+        self.mode_mirror
+            .as_ref()
+            .map(|m| m.current())
+            .unwrap_or(self.permission_mode.unwrap_or_default())
     }
 
     fn to_context(&self) -> StatusContext {
@@ -75,7 +91,7 @@ impl Footer {
             token_budget: self.token_budget,
             current_objective: self.current_objective.clone(),
             turn_elapsed: self.turn_elapsed,
-            permission_mode: self.permission_mode_enum(),
+            permission_mode: self.live_mode(),
             turn_active: self.is_turn_active,
             session_id: self.session_id.clone(),
             cost_usd: None,

--- a/rust/crates/astra-cli/src/tui/bottom_pane/keyboard_tests.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/keyboard_tests.rs
@@ -2,6 +2,8 @@
 
 use super::{BottomPane, BottomPaneAction};
 use crate::chat_stream::ApprovalResponse;
+use crate::permission_manager::PermissionMode;
+use crate::tui::slash_dispatch::next_permission_mode_for_cycle;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tokio::sync::oneshot;
 
@@ -30,6 +32,72 @@ fn backtab_keeps_approval_navigation_when_approval_is_pending() {
     let action = pane.handle_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
 
     assert!(matches!(action, BottomPaneAction::Consumed));
+}
+
+#[test]
+fn backtab_cycles_mode_when_idle_no_view_no_approval() {
+    // Verify BackTab falls through to CyclePermissionMode when there
+    // is no active view, no pending approval, and no popups — the
+    // baseline "idle TUI" path that users rely on for Shift+Tab.
+    let mut pane = BottomPane::new();
+    // Composer is empty; no view; no approval.
+    assert!(pane.composer.is_empty());
+    assert!(!pane.has_pending_approvals());
+
+    let action = pane.handle_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
+
+    assert!(matches!(action, BottomPaneAction::CyclePermissionMode));
+}
+
+#[test]
+fn backtab_cycles_mode_when_composer_has_text() {
+    // When the user has typed something, BackTab should still cycle
+    // the permission mode — the CyclePermissionMode branch is before
+    // route_to_composer so composing doesn't block mode cycling.
+    let mut pane = BottomPane::new();
+    pane.composer.set_text("hello world");
+
+    let action = pane.handle_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
+
+    assert!(matches!(action, BottomPaneAction::CyclePermissionMode));
+}
+
+#[test]
+fn next_mode_cycle_full_loop_skips_deny() {
+    // Prompt → Auto → AcceptEdits → Plan → Prompt (wrap).
+    // Deny → Auto (same as Prompt — both return to Auto).
+    // Deny is intentionally excluded from the Shift+Tab cycle;
+    // cycling past it lands on Auto.
+    assert_eq!(
+        next_permission_mode_for_cycle(PermissionMode::Prompt),
+        PermissionMode::Auto
+    );
+    assert_eq!(
+        next_permission_mode_for_cycle(PermissionMode::Deny),
+        PermissionMode::Auto
+    );
+    assert_eq!(
+        next_permission_mode_for_cycle(PermissionMode::Auto),
+        PermissionMode::AcceptEdits
+    );
+    assert_eq!(
+        next_permission_mode_for_cycle(PermissionMode::AcceptEdits),
+        PermissionMode::Plan
+    );
+    assert_eq!(
+        next_permission_mode_for_cycle(PermissionMode::Plan),
+        PermissionMode::Prompt
+    );
+}
+
+#[test]
+fn next_mode_cycle_starting_from_default() {
+    // Starting from Prompt (the default), verify the first Shift+Tab
+    // goes to Auto.
+    assert_eq!(
+        next_permission_mode_for_cycle(PermissionMode::Prompt),
+        PermissionMode::Auto
+    );
 }
 
 #[test]

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -491,7 +491,7 @@ fn refresh_footer_from_state(
         .session_id
         .as_ref()
         .map(|sid| sid[..8.min(sid.len())].to_string());
-    bottom_pane.footer.permission_mode = Some(format!("{}", state.perm_manager.mode()));
+    bottom_pane.footer.permission_mode = Some(state.perm_manager.mode());
 }
 
 /// Replay a session's JSONL transcript into a fresh `ChatWidget`,
@@ -629,13 +629,18 @@ pub(crate) async fn run_tui_session(
     if let Some(ref sid) = state.session_id {
         bottom_pane.footer.session_id = Some(sid[..8.min(sid.len())].to_string());
     }
-    bottom_pane.footer.permission_mode = Some(format!("{}", state.perm_manager.mode()));
+    bottom_pane.footer.permission_mode = Some(state.perm_manager.mode());
     // Lock-free observer of `perm_manager.mode()` so the inner-tick
     // path can refresh the status-line chip while the agentic loop
     // holds `&mut state`. Without this, mid-turn pivots
     // (`exit_plan_mode` flipping Plan → Auto on the next-turn
     // boundary) only land on screen when the outer select wakes up.
     let perm_mode_mirror = state.perm_manager.mode_mirror_handle();
+    // Wire the same mirror into the footer so every frame render
+    // reads the live mode from the atomic mirror rather than the
+    // cached `permission_mode` field. This eliminates the ~50 ms
+    // staleness window that the tick-based self-healing had.
+    bottom_pane.footer.set_mode_mirror(perm_mode_mirror.clone());
 
     // Load skill items for $ mention popup
     {
@@ -1699,7 +1704,7 @@ pub(crate) async fn run_tui_session(
                                                                 // catches up.
                                                                 perm_mode_mirror.stage(next_mode);
                                                                 bottom_pane.footer.permission_mode =
-                                                                    Some(format!("{}", next_mode));
+                                                                    Some(next_mode);
                                                                 // Reflect the staged mode in the approval queue
                                                                 // immediately so the chip and pending count
                                                                 // agree. perm_manager.mode() will catch up at
@@ -2130,6 +2135,15 @@ pub(crate) async fn run_tui_session(
                                 }
                                                  }
                                                 Some(req) = ask_user_rx.recv() => {
+                                                    // Draft transition: show a brief
+                                                    // indicator before the ask-user form
+                                                    // opens so the user isn't surprised by
+                                                    // a sudden modal.
+                                                    chat_widget.commit_system(
+                                                        crate::tui::history_cell::system::SystemCell::response(
+                                                            "🤔 The agent needs your input — opening question…",
+                                                        ),
+                                                    );
                                                     bottom_pane.enqueue_ask_user(req.prompt, req.response_tx);
                                                     frame_requester.schedule_frame();
                                                     {
@@ -2170,9 +2184,9 @@ pub(crate) async fn run_tui_session(
                                                     // here would clash. Catches turn-boundary
                                                     // pivots (e.g. exit_plan_mode → Auto) within
                                                     // one inner tick.
-                                                    let live_mode = format!("{}", perm_mode_mirror.current());
-                                                    if bottom_pane.footer.permission_mode.as_deref()
-                                                        != Some(live_mode.as_str())
+                                                    let live_mode = perm_mode_mirror.current();
+                                                    if bottom_pane.footer.permission_mode
+                                                        != Some(live_mode)
                                                     {
                                                         bottom_pane.footer.permission_mode = Some(live_mode);
                                                     }
@@ -2284,7 +2298,7 @@ pub(crate) async fn run_tui_session(
                                     if let Some(ref m) = state.model { bottom_pane.footer.model = Some(m.clone()); }
                                     if let Some(ref s) = state.session_id { bottom_pane.footer.session_id = Some(s[..8.min(s.len())].to_string()); }
                                     bottom_pane.footer.token_usage = Some(format!("{}↑ {}↓", state.total_prompt_tokens, state.total_completion_tokens));
-                                    bottom_pane.footer.permission_mode = Some(format!("{}", state.perm_manager.mode()));
+                                    bottom_pane.footer.permission_mode = Some(state.perm_manager.mode());
                                     // Footer "N% (Mk)" chip shows the CONTEXT WINDOW for
                                     // the most recent turn — i.e. how many input tokens
                                     // the model saw this turn, not cumulative session
@@ -2762,7 +2776,7 @@ pub(crate) async fn run_tui_session(
                                     bottom_pane.sync_popups();
                                     // Update footer after view actions (model/permission may change)
                                     if let Some(ref m) = state.model { bottom_pane.footer.model = Some(m.clone()); }
-                                    bottom_pane.footer.permission_mode = Some(format!("{}", state.perm_manager.mode()));
+                                    bottom_pane.footer.permission_mode = Some(state.perm_manager.mode());
                                     // Clear the deferred-flush flag for any
                                     // ViewCompleted-with-name path that fell
                                     // through to here without an explicit
@@ -2900,9 +2914,8 @@ pub(crate) async fn run_tui_session(
                 // happens to call `refresh_footer_from_state`. Cheap:
                 // a string format and an Option<u64> compare per 50ms.
                 let live_mode_enum = state.perm_manager.mode();
-                let live_mode = format!("{live_mode_enum}");
-                if bottom_pane.footer.permission_mode.as_deref() != Some(live_mode.as_str()) {
-                    bottom_pane.footer.permission_mode = Some(live_mode);
+                if bottom_pane.footer.permission_mode != Some(live_mode_enum) {
+                    bottom_pane.footer.permission_mode = Some(live_mode_enum);
                     // Mode just shifted (driven by host-side
                     // pull_mode_from_mirror after exit_plan_mode
                     // overlay or mid-turn Shift+Tab). Re-evaluate

--- a/rust/crates/astra-cli/src/tui/status_line/line.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/line.rs
@@ -11,33 +11,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Widget;
 use unicode_width::UnicodeWidthStr;
 
-/// Permission mode expressed as an enum rather than a string so the
-/// status line can't silently render typo'd values.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub(crate) enum PermissionMode {
-    #[default]
-    Ask,
-    Auto,
-    Plan,
-    AcceptEdits,
-    Deny,
-}
-
-impl PermissionMode {
-    pub fn chip_text(self) -> &'static str {
-        // Plain words — emojis varied wildly across themes and got
-        // flagged as visually noisy ("🔍" and "✎" never landed). The
-        // chip's colour already carries the urgency signal: blue for
-        // plan, cyan for edit, yellow for auto, red for deny.
-        match self {
-            Self::Ask => "default",
-            Self::Auto => "auto",
-            Self::Plan => "plan",
-            Self::AcceptEdits => "edit",
-            Self::Deny => "deny",
-        }
-    }
-}
+pub(crate) use crate::permission_manager::PermissionMode;
 
 /// Inputs that feed the status line. Owned so the struct is `Clone`
 /// and easy to fixture.
@@ -165,9 +139,9 @@ impl StatusLine {
         }
 
         match ctx.permission_mode {
-            PermissionMode::Ask => {
+            PermissionMode::Prompt => {
                 out.left.push(Segment::styled(
-                    PermissionMode::Ask.chip_text(),
+                    ctx.permission_mode.chip_text(),
                     Style::default()
                         .fg(Color::White)
                         .add_modifier(Modifier::BOLD),
@@ -175,7 +149,7 @@ impl StatusLine {
             }
             PermissionMode::Auto => {
                 out.left.push(Segment::styled(
-                    PermissionMode::Auto.chip_text(),
+                    ctx.permission_mode.chip_text(),
                     Style::default()
                         .fg(Color::Yellow)
                         .add_modifier(Modifier::BOLD),
@@ -183,7 +157,7 @@ impl StatusLine {
             }
             PermissionMode::Plan => {
                 out.left.push(Segment::styled(
-                    PermissionMode::Plan.chip_text(),
+                    ctx.permission_mode.chip_text(),
                     Style::default()
                         .fg(Color::Blue)
                         .add_modifier(Modifier::BOLD),
@@ -191,7 +165,7 @@ impl StatusLine {
             }
             PermissionMode::AcceptEdits => {
                 out.left.push(Segment::styled(
-                    PermissionMode::AcceptEdits.chip_text(),
+                    ctx.permission_mode.chip_text(),
                     Style::default()
                         .fg(Color::Cyan)
                         .add_modifier(Modifier::BOLD),
@@ -199,7 +173,7 @@ impl StatusLine {
             }
             PermissionMode::Deny => {
                 out.left.push(Segment::styled(
-                    PermissionMode::Deny.chip_text(),
+                    ctx.permission_mode.chip_text(),
                     Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                 ));
             }

--- a/rust/crates/astra-cli/src/tui/status_line/snapshot_tests.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/snapshot_tests.rs
@@ -25,7 +25,7 @@ fn base_ctx() -> StatusContext {
     StatusContext {
         model: Some("sonnet-4.6".into()),
         cwd: Some("~/projects/astra".into()),
-        permission_mode: PermissionMode::Ask,
+        permission_mode: PermissionMode::Prompt,
         ..StatusContext::default()
     }
 }

--- a/rust/crates/astra-turn-core/src/permission_types.rs
+++ b/rust/crates/astra-turn-core/src/permission_types.rs
@@ -37,6 +37,32 @@ pub enum PermissionMode {
     Deny,
 }
 
+impl PermissionMode {
+    /// Human label for the status-line mode chip.
+    pub fn chip_text(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Plan => "plan",
+            Self::AcceptEdits => "edit",
+            Self::Prompt => "default",
+            Self::Deny => "deny",
+        }
+    }
+
+    /// Color hint for the status-line mode chip.
+    /// Returns `(red, green, blue)` for a ratatui-style `Color::Rgb`.
+    pub fn chip_color_rgb(self) -> (u8, u8, u8) {
+        // Blue for plan, cyan for edit, yellow for auto, red for deny, white for default.
+        match self {
+            Self::Auto => (255, 255, 0),
+            Self::Plan => (100, 149, 237),
+            Self::AcceptEdits => (0, 255, 255),
+            Self::Prompt => (255, 255, 255),
+            Self::Deny => (255, 0, 0),
+        }
+    }
+}
+
 impl std::fmt::Display for PermissionMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
## Summary

### 1. Permission Mode Sync Fix (T1)
- **`PermissionMode::Ask` → `PermissionMode::Prompt`**: Unified enum naming across 6 files
- **Footer frame-level self-healing sync**: Added `mode_mirror` + `live_mode()` — reads from atomic mirror each frame, eliminating ~50ms cache lag
- **`Shift+Tab` (BackTab) integration**: 5 new tests covering idle state, text state, full cycle, default value navigation

### 2. Ask-User UX Improvements (T2)
- **Multi-select shortcuts**: `Ctrl+A` to select all options in multi-select mode
- **Esc improvements**: First Esc clears selections in multi-select, second Esc cancels the form
- **"Other" option visual prominence**: Shows `✎ Other (free-text)` with cyan highlight instead of gray plain text
- **Draft transition**: Submits "🤔 The agent needs your input — opening question…" before opening the form

### Files Changed
| File | Change |
|------|--------|
| `permission_types.rs` | `PermissionMode::Prompt` + `from_encoded()` constructor |
| `footer.rs` | `mode_mirror` + `live_mode()` frame-level sync |
| `event_loop.rs` | Mirror wiring + draft transition |
| `ask_user_view.rs` | Ctrl+A / Esc shortcuts + Other visual prominence |
| `keyboard_tests.rs` | 5 new BackTab / cycle navigation tests |
| `permission_manager.rs` | Test helper `from_encoded()` |
| `line.rs` | `PermissionMode::Prompt` rename |
| `snapshot_tests.rs` | `PermissionMode::Prompt` rename |

### Verification
- `cargo check -p astra-cli` ✅
- `cargo test -p astra-cli` ✅ 12 passed