### PR TITLE
feat(mcp): call logging, TUI-native /mcp commands, mock server, and integration tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "rmcp",
  "rpassword",
  "rustyline",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -4332,6 +4333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4919,6 +4926,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5046,9 +5073,12 @@ dependencies = [
  "chrono",
  "futures",
  "http",
+ "pastey",
  "pin-project-lite",
  "process-wrap",
  "reqwest 0.13.3",
+ "rmcp-macros",
+ "schemars",
  "serde",
  "serde_json",
  "sse-stream",
@@ -5057,6 +5087,19 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -5263,6 +5306,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5361,6 +5430,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/crates/astra-cli/Cargo.toml
+++ b/rust/crates/astra-cli/Cargo.toml
@@ -97,3 +97,6 @@ serial_test = "3"
 temp-env = "0.3"
 wiremock = "0.6"
 insta.workspace = true
+# rmcp server features for mock MCP server example (integration tests)
+rmcp = { version = "1.3", default-features = false, features = ["server", "macros", "schemars", "transport-io"] }
+schemars = "1"

--- a/rust/crates/astra-cli/examples/mock_mcp_server.rs
+++ b/rust/crates/astra-cli/examples/mock_mcp_server.rs
@@ -1,0 +1,60 @@
+//! Mock MCP server for integration testing.
+//!
+//! Exposes three tools: echo, add, get_time.
+//! Uses stdio transport — spawn as a subprocess from integration tests.
+//!
+//! Build: `cargo build --example mock_mcp_server`
+//! Binary: `target/debug/examples/mock_mcp_server`
+
+use rmcp::handler::server::router::Router;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::transport::io::stdio;
+use rmcp::{serve_server, tool, tool_router};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Clone)]
+struct MockMcpServer;
+
+#[derive(Deserialize, JsonSchema)]
+struct EchoParams {
+    /// The message to echo back
+    message: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct AddParams {
+    /// First integer
+    a: i64,
+    /// Second integer
+    b: i64,
+}
+
+#[tool_router(server_handler)]
+impl MockMcpServer {
+    #[tool(description = "Echo back the input message")]
+    async fn echo(&self, Parameters(params): Parameters<EchoParams>) -> String {
+        params.message
+    }
+
+    #[tool(description = "Add two integers together")]
+    async fn add(&self, Parameters(params): Parameters<AddParams>) -> String {
+        (params.a + params.b).to_string()
+    }
+
+    #[tool(description = "Get the current server time in RFC 3339 format")]
+    async fn get_time(&self) -> String {
+        chrono::Utc::now().to_rfc3339()
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Router::new takes the service, then register tools from the generated ToolRouter.
+    // ToolRouter<S> implements IntoIterator<Item = ToolRoute<S>>, so we pass it to with_tools.
+    let tool_router = MockMcpServer::tool_router();
+    let router = Router::new(MockMcpServer).with_tools(tool_router);
+    let service = serve_server(router, stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/rust/crates/astra-cli/src/cli/command_registry.rs
+++ b/rust/crates/astra-cli/src/cli/command_registry.rs
@@ -212,20 +212,25 @@ const SKILL_SUBCOMMANDS: &[(&str, &str)] = &[
 ];
 
 const MCP_SUBCOMMANDS: &[(&str, &str)] = &[
+    ("help", "Quick MCP help and examples"),
+    ("list", "Overview of servers, tools, prompts, and resources"),
+    ("tools", "List callable tools: /mcp tools [server]"),
+    ("inspect", "Tool details: /mcp inspect <server>:<tool>"),
+    ("prompts", "List available MCP prompts"),
+    ("resources", "List readable MCP resources"),
+    ("read", "Read a resource: /mcp read <server>:<uri>"),
+    ("ping", "Ping: /mcp ping [server]"),
     ("add", "Add: /mcp add <name> <command> [args…]"),
+    ("prompt", "Invoke: /mcp prompt <server>:<name> [args]"),
+    ("remove", "Remove: /mcp remove <name>"),
+    ("history", "Recent MCP tool-call history"),
+    ("servers", "Show server details and tools"),
+    ("status", "Alias for /mcp list"),
     (
         "complete",
         "Completions: /mcp complete <server>:prompt:<name> <arg> [value]",
     ),
     ("log-level", "Set level: /mcp log-level <server> <level>"),
-    ("ping", "Ping: /mcp ping [server]"),
-    ("prompt", "Invoke: /mcp prompt <server>:<name> [args]"),
-    ("prompts", "List available MCP prompts"),
-    ("remove", "Remove: /mcp remove <name>"),
-    ("resource", "Read: /mcp resource <server>:<uri>"),
-    ("resources", "List available MCP resources"),
-    ("servers", "Show server details and tools"),
-    ("status", "Show connection status table"),
     ("subscribe", "Subscribe: /mcp subscribe <server>:<uri>"),
     (
         "unsubscribe",
@@ -684,11 +689,11 @@ pub static COMMANDS: &[CommandMeta] = &[
     // ── MCP ───────────────────────────────────────────────────────────────
     CommandMeta::new(
         "/mcp",
-        "MCP: status|servers|prompts|resources|add|remove|ping|complete|…",
+        "MCP: help|list|tools|inspect|prompts|resources|read|ping|…",
         CommandGroup::Mcp,
     )
     .with_subcommands(MCP_SUBCOMMANDS)
-    .with_arg_hint("[status|servers|prompts|resources|add|remove|ping|…]")
+    .with_arg_hint("[help|list|tools|inspect|prompts|resources|read|ping|…]")
     .with_tui_handler(TuiHandler::Fallback),
     // ── Team & account ───────────────────────────────────────────────────
     CommandMeta::new(

--- a/rust/crates/astra-cli/src/cli/slash_mcp.rs
+++ b/rust/crates/astra-cli/src/cli/slash_mcp.rs
@@ -2,66 +2,280 @@ use super::*;
 use crate::manifest_loader::project_mcp_json_path;
 use crate::mcp_client::{ConnectionState, McpClientManager};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ParsedMcpCommand<'a> {
+    Help,
+    Overview,
+    Servers,
+    Tools(Option<&'a str>),
+    Prompts,
+    Resources,
+    Read(Option<&'a str>),
+    History,
+    Inspect(Option<&'a str>),
+    Add(Option<&'a str>),
+    Remove(Option<&'a str>),
+    Subscribe(Option<&'a str>),
+    Unsubscribe(Option<&'a str>),
+    LogLevel(Option<&'a str>),
+    Prompt(Option<&'a str>),
+    Complete(Option<&'a str>),
+    Ping(Option<&'a str>),
+    Unknown(&'a str),
+}
+
+fn split_mcp_subcommand(text: &str) -> (&str, &str) {
+    let trimmed = text.trim();
+    match trimmed.find(char::is_whitespace) {
+        Some(pos) => (&trimmed[..pos], trimmed[pos..].trim()),
+        None => (trimmed, ""),
+    }
+}
+
+pub(crate) fn parse_mcp_command(arg: &str) -> ParsedMcpCommand<'_> {
+    let trimmed = arg.trim();
+    if trimmed.is_empty() {
+        return ParsedMcpCommand::Help;
+    }
+
+    let (sub, rest) = split_mcp_subcommand(trimmed);
+    match sub {
+        "help" => ParsedMcpCommand::Help,
+        "status" => ParsedMcpCommand::Overview,
+        "list" => {
+            if rest.is_empty() {
+                ParsedMcpCommand::Overview
+            } else {
+                let (category, tail) = split_mcp_subcommand(rest);
+                match category {
+                    "status" => ParsedMcpCommand::Overview,
+                    "servers" => {
+                        if tail.is_empty() {
+                            ParsedMcpCommand::Servers
+                        } else {
+                            ParsedMcpCommand::Unknown(trimmed)
+                        }
+                    }
+                    "tools" => ParsedMcpCommand::Tools((!tail.is_empty()).then_some(tail)),
+                    "prompts" => {
+                        if tail.is_empty() {
+                            ParsedMcpCommand::Prompts
+                        } else {
+                            ParsedMcpCommand::Unknown(trimmed)
+                        }
+                    }
+                    "resources" => {
+                        if tail.is_empty() {
+                            ParsedMcpCommand::Resources
+                        } else {
+                            ParsedMcpCommand::Unknown(trimmed)
+                        }
+                    }
+                    _ => ParsedMcpCommand::Unknown(trimmed),
+                }
+            }
+        }
+        "servers" => ParsedMcpCommand::Servers,
+        "tools" => ParsedMcpCommand::Tools((!rest.is_empty()).then_some(rest)),
+        "prompts" => ParsedMcpCommand::Prompts,
+        "resources" => ParsedMcpCommand::Resources,
+        "resource" | "read" => ParsedMcpCommand::Read((!rest.is_empty()).then_some(rest)),
+        "history" => ParsedMcpCommand::History,
+        "inspect" => ParsedMcpCommand::Inspect((!rest.is_empty()).then_some(rest)),
+        "add" => ParsedMcpCommand::Add((!rest.is_empty()).then_some(rest)),
+        "remove" => ParsedMcpCommand::Remove((!rest.is_empty()).then_some(rest)),
+        "subscribe" => ParsedMcpCommand::Subscribe((!rest.is_empty()).then_some(rest)),
+        "unsubscribe" => ParsedMcpCommand::Unsubscribe((!rest.is_empty()).then_some(rest)),
+        "log-level" => ParsedMcpCommand::LogLevel((!rest.is_empty()).then_some(rest)),
+        "prompt" => ParsedMcpCommand::Prompt((!rest.is_empty()).then_some(rest)),
+        "complete" => ParsedMcpCommand::Complete((!rest.is_empty()).then_some(rest)),
+        "ping" => ParsedMcpCommand::Ping((!rest.is_empty()).then_some(rest)),
+        _ => ParsedMcpCommand::Unknown(trimmed),
+    }
+}
+
+pub(crate) fn resolve_protocol_tool_query<'a>(
+    manager: &'a McpClientManager,
+    query: &str,
+) -> Result<(&'a str, &'a rmcp::model::Tool), String> {
+    let query = query.trim();
+    if query.is_empty() {
+        return Err("Usage: /mcp inspect <server>:<tool>  ·  try `/mcp tools` first.".into());
+    }
+
+    if let Some((server, tool_name)) = query.split_once(':') {
+        if let Some((resolved_server, tool)) = manager
+            .all_tools()
+            .into_iter()
+            .find(|(resolved_server, tool)| *resolved_server == server && tool.name == tool_name)
+        {
+            return Ok((resolved_server, tool));
+        }
+        if manager.get(server).is_none() {
+            return Err(format!(
+                "Server '{server}' not found. Try `/mcp list` or `/mcp servers`."
+            ));
+        }
+        return Err(format!(
+            "Tool '{tool_name}' not found on server '{server}'. Try `/mcp tools {server}`."
+        ));
+    }
+
+    let exact: Vec<(&str, &rmcp::model::Tool)> = manager
+        .all_tools()
+        .into_iter()
+        .filter(|(_, tool)| tool.name == query)
+        .collect();
+    match exact.len() {
+        1 => return Ok(exact[0]),
+        n if n > 1 => {
+            let locations = exact
+                .iter()
+                .map(|(server, _)| (*server).to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(format!(
+                "Tool '{query}' exists on multiple servers ({locations}). Use `/mcp inspect <server>:<tool>`."
+            ));
+        }
+        _ => {}
+    }
+
+    let sanitized: Vec<(&str, &rmcp::model::Tool)> = manager
+        .all_tools()
+        .into_iter()
+        .filter(|(server, tool)| {
+            crate::mcp_client::sanitize_tool_name(&format!("mcp_{server}_{}", tool.name)) == query
+        })
+        .collect();
+    match sanitized.len() {
+        1 => Ok(sanitized[0]),
+        n if n > 1 => Err(format!(
+            "Tool id '{query}' is ambiguous across {n} servers. Use `/mcp inspect <server>:<tool>`."
+        )),
+        _ => Err(format!(
+            "Tool '{query}' not found. Try `/mcp tools` or `/mcp tools <server>`."
+        )),
+    }
+}
+
 fn eprint_server_not_found(name: &str) {
     eprintln!("  {} Server '{}' not found", theme::icon_warn(), name);
-    eprintln!("  {}", "Use /mcp servers to see connected servers".dim());
+    eprintln!(
+        "  {}",
+        "Use /mcp list or /mcp servers to see connected servers".dim()
+    );
+}
+
+async fn show_help(state: &SessionState) {
+    let manager = state.mcp_manager.read().await;
+    let count = manager.connection_count();
+
+    eprintln!("{}", "  MCP commands".bold().magenta());
+    if count == 0 {
+        eprintln!(
+            "{}",
+            "  No MCP servers connected yet. Add one with /mcp add <name> <command> [args...]"
+                .dim()
+        );
+    } else {
+        eprintln!(
+            "{}",
+            format!("  {count} server(s) connected. Start with /mcp list.").dim()
+        );
+    }
+    eprintln!(
+        "{}",
+        "  /mcp list                 overview of connected servers".dim()
+    );
+    eprintln!(
+        "{}",
+        "  /mcp tools [server]       list callable tools (best first step)".dim()
+    );
+    eprintln!(
+        "{}",
+        "  /mcp inspect <server>:<tool>  show tool parameters".dim()
+    );
+    eprintln!(
+        "{}",
+        "  /mcp prompts              list prompt templates exposed by MCP servers".dim()
+    );
+    eprintln!(
+        "{}",
+        "  /mcp resources            list readable resources".dim()
+    );
+    eprintln!("{}", "  /mcp read <server>:<uri>  read one resource".dim());
+    eprintln!("{}", "  /mcp ping [server]        connectivity check".dim());
+    eprintln!(
+        "{}",
+        "  Advanced: add, remove, prompt, complete, log-level, subscribe, unsubscribe, history"
+            .dim()
+    );
 }
 
 /// Retention: fallback handler for `/mcp` — called from slash_router.rs.
-/// In TUI mode this is shadowed by TuiHandler::Selector (McpView).
+/// In TUI mode, common read-only forms are handled natively by
+/// `tui::slash_dispatch`; advanced mutating forms still fall back here.
 /// Kept for headless / non-interactive execution paths.
 #[allow(dead_code)]
 pub(super) async fn handle_mcp_command(arg: &str, state: &mut SessionState) -> Result<(), String> {
-    let sub = arg.trim();
-
-    match sub {
-        "" | "status" => show_status(state).await,
-        "servers" => show_servers(state).await,
-        "prompts" => show_prompts(state).await,
-        "resources" => show_resources(state).await,
-        s if s.starts_with("add ") => handle_mcp_add(&s[4..]).await,
-        "add" => {
+    match parse_mcp_command(arg) {
+        ParsedMcpCommand::Help => show_help(state).await,
+        ParsedMcpCommand::Overview => show_status(state).await,
+        ParsedMcpCommand::Servers => show_servers(state).await,
+        ParsedMcpCommand::Prompts => show_prompts(state).await,
+        ParsedMcpCommand::Resources => show_resources(state).await,
+        ParsedMcpCommand::Tools(None) => show_tools(state).await,
+        ParsedMcpCommand::Tools(Some(server)) => show_tools_for_server(server, state).await,
+        ParsedMcpCommand::History => show_history(state).await,
+        ParsedMcpCommand::Inspect(Some(tool_name)) => show_inspect(tool_name, state).await,
+        ParsedMcpCommand::Inspect(None) => {
+            eprintln!("{}", "  Usage: /mcp inspect <server>:<tool>".dim());
+            eprintln!("{}", "  Example: /mcp inspect github:list_prs".dim());
+        }
+        ParsedMcpCommand::Add(Some(rest)) => handle_mcp_add(rest).await,
+        ParsedMcpCommand::Add(None) => {
             eprintln!("{}", "  Usage: /mcp add <name> <command> [args...]".dim());
             eprintln!(
                 "{}",
                 "  Example: /mcp add github npx @modelcontextprotocol/server-github".dim()
             );
         }
-        s if s.starts_with("remove ") => handle_mcp_remove(&s[7..]).await,
-        "remove" => {
+        ParsedMcpCommand::Remove(Some(name)) => handle_mcp_remove(name).await,
+        ParsedMcpCommand::Remove(None) => {
             eprintln!("{}", "  Usage: /mcp remove <name>".dim());
         }
-        s if s.starts_with("resource ") => handle_mcp_resource_read(&s[9..], state).await,
-        "resource" => {
-            eprintln!("{}", "  Usage: /mcp resource <server>:<uri>".dim());
+        ParsedMcpCommand::Read(Some(spec)) => handle_mcp_resource_read(spec, state).await,
+        ParsedMcpCommand::Read(None) => {
+            eprintln!("{}", "  Usage: /mcp read <server>:<uri>".dim());
         }
-        s if s.starts_with("subscribe ") => handle_mcp_subscribe(&s[10..], state).await,
-        "subscribe" => {
+        ParsedMcpCommand::Subscribe(Some(spec)) => handle_mcp_subscribe(spec, state).await,
+        ParsedMcpCommand::Subscribe(None) => {
             eprintln!("{}", "  Usage: /mcp subscribe <server>:<uri>".dim());
         }
-        s if s.starts_with("unsubscribe ") => handle_mcp_unsubscribe(&s[12..], state).await,
-        "unsubscribe" => {
+        ParsedMcpCommand::Unsubscribe(Some(spec)) => handle_mcp_unsubscribe(spec, state).await,
+        ParsedMcpCommand::Unsubscribe(None) => {
             eprintln!("{}", "  Usage: /mcp unsubscribe <server>:<uri>".dim());
         }
-        s if s.starts_with("log-level ") => handle_mcp_log_level(&s[10..], state).await,
-        "log-level" => {
+        ParsedMcpCommand::LogLevel(Some(spec)) => handle_mcp_log_level(spec, state).await,
+        ParsedMcpCommand::LogLevel(None) => {
             eprintln!("{}", "  Usage: /mcp log-level <server> <level>".dim());
             eprintln!(
                 "{}",
                 "  Levels: debug, info, notice, warning, error, critical, alert, emergency".dim()
             );
         }
-        s if s.starts_with("prompt ") => {
-            handle_mcp_prompt_invoke(arg, state).await?;
+        ParsedMcpCommand::Prompt(Some(rest)) => {
+            handle_mcp_prompt_invoke(&format!("prompt {rest}"), state).await?;
         }
-        "prompt" => {
+        ParsedMcpCommand::Prompt(None) => {
             eprintln!(
                 "{}",
                 "  Usage: /mcp prompt <server>:<name> [arg1 arg2 ...]".dim()
             );
         }
-        s if s.starts_with("complete ") => handle_mcp_complete(&s[9..], state).await,
-        "complete" => {
+        ParsedMcpCommand::Complete(Some(rest)) => handle_mcp_complete(rest, state).await,
+        ParsedMcpCommand::Complete(None) => {
             eprintln!(
                 "{}",
                 "  Usage: /mcp complete <server>:<prompt|resource> <arg_name> [partial_value]"
@@ -77,24 +291,14 @@ pub(super) async fn handle_mcp_command(arg: &str, state: &mut SessionState) -> R
                 "    /mcp complete myserver:resource:file://path arg val".dim()
             );
         }
-        s if s.starts_with("ping ") => handle_mcp_ping(Some(&s[5..]), state).await,
-        "ping" => handle_mcp_ping(None, state).await,
-        _ => {
+        ParsedMcpCommand::Ping(server) => handle_mcp_ping(server, state).await,
+        ParsedMcpCommand::Unknown(sub) => {
             eprintln!(
                 "  {} Unknown subcommand: {}",
                 theme::icon_warn(),
                 sub.yellow()
             );
-            eprintln!(
-                "  {} status {} add {} remove {} servers {} prompts {} resources {} ping",
-                "Use:".dim(),
-                "│".dim(),
-                "│".dim(),
-                "│".dim(),
-                "│".dim(),
-                "│".dim(),
-                "│".dim()
-            );
+            eprintln!("{}", "  Try /mcp help for the core commands.".dim());
         }
     }
 
@@ -111,30 +315,78 @@ async fn show_status(state: &SessionState) {
             "{}",
             "  Use /mcp add <name> <command> or configure .astra/mcp.json".dim()
         );
-        return;
+    } else {
+        eprintln!(
+            "{}",
+            format!("  Servers: {count} connected").bold().magenta()
+        );
+        let mut caps = Vec::new();
+        if manager.has_sampling() {
+            caps.push("sampling");
+        }
+        caps.push("elicitation");
+        eprintln!("  {}", format!("Capabilities: {}", caps.join(", ")).dim());
+        let roots = manager.roots().read().await;
+        if !roots.is_empty() {
+            let names: Vec<&str> = roots
+                .iter()
+                .map(|r| r.name.as_deref().unwrap_or(&r.uri))
+                .collect();
+            eprintln!("  {}", format!("Roots: {}", names.join(", ")).dim());
+        }
+
+        // Tool summary
+        let tools = manager.all_tools();
+        let total_tools = tools.len();
+        let schemas = manager.all_tool_schemas().len();
+        eprintln!(
+            "  {}",
+            format!("MCP Tools: {total_tools} ({schemas} schemas for LLM injection)").dim()
+        );
+        eprintln!(
+            "  {}",
+            "Try: /mcp tools [server] · /mcp prompts · /mcp resources".dim()
+        );
+
+        // Per-server breakdown
+        let servers = manager.connected_servers();
+        for name in &servers {
+            if let Some(conn) = manager.get(name) {
+                let tc = conn.tools().len();
+                eprintln!("  {}", format!("    {name}: {tc} tools").dim());
+            }
+        }
+
+        eprintln!();
+        print_server_table(&manager);
     }
 
-    eprintln!(
-        "{}",
-        format!("  Servers: {count} connected").bold().magenta()
-    );
-    let mut caps = Vec::new();
-    if manager.has_sampling() {
-        caps.push("sampling");
+    // Memoria health check (independent of MCP servers)
+    let memoria_status = crate::edge_tools::memoria::memoria_health().await;
+    match memoria_status {
+        Ok(body) => {
+            let short = body.lines().next().unwrap_or(&body);
+            let truncated = if short.len() > 80 {
+                format!("{}…", &short[..short.floor_char_boundary(80)])
+            } else {
+                short.to_string()
+            };
+            eprintln!(
+                "  {} {} {}",
+                "Memoria:".bold(),
+                "✓".green(),
+                truncated.dim()
+            );
+        }
+        Err(e) => {
+            let truncated = if e.len() > 60 {
+                format!("{}…", &e[..e.floor_char_boundary(60)])
+            } else {
+                e.to_string()
+            };
+            eprintln!("  {} {} {}", "Memoria:".bold(), "✗".red(), truncated.dim());
+        }
     }
-    caps.push("elicitation");
-    eprintln!("  {}", format!("Capabilities: {}", caps.join(", ")).dim());
-    let roots = manager.roots().read().await;
-    if !roots.is_empty() {
-        let names: Vec<&str> = roots
-            .iter()
-            .map(|r| r.name.as_deref().unwrap_or(&r.uri))
-            .collect();
-        eprintln!("  {}", format!("Roots: {}", names.join(", ")).dim());
-    }
-    eprintln!();
-
-    print_server_table(&manager);
 }
 
 async fn show_servers(state: &SessionState) {
@@ -224,6 +476,10 @@ async fn show_prompts(state: &SessionState) {
             .bold()
             .magenta()
     );
+    eprintln!(
+        "{}",
+        "  Invoke one with /mcp prompt <server>:<name> [args...]".dim()
+    );
     eprintln!();
 
     for (server, prompt) in &prompts {
@@ -284,6 +540,7 @@ async fn show_resources(state: &SessionState) {
             .bold()
             .magenta()
     );
+    eprintln!("{}", "  Read one with /mcp read <server>:<uri>".dim());
     eprintln!();
 
     for (server, resource) in &resources {
@@ -310,15 +567,402 @@ async fn show_resources(state: &SessionState) {
     }
 }
 
-/// `/mcp resource <server>:<uri>` — read an MCP resource by URI.
+/// `/mcp history` — show recent MCP tool call history from all connected servers.
+async fn show_history(state: &SessionState) {
+    let manager = state.mcp_manager.read().await;
+
+    if manager.connection_count() == 0 {
+        eprintln!("{}", "  No MCP servers connected.".dim());
+        return;
+    }
+
+    // Collect all log entries from all servers, sorted by timestamp (newest first)
+    let mut entries: Vec<crate::mcp_client::CallLogEntry> = Vec::new();
+    for name in manager.server_names() {
+        if let Some(conn) = manager.get_connection(name) {
+            let log = conn.call_log.read().await;
+            entries.extend(log.iter().cloned());
+        }
+    }
+    entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+    if entries.is_empty() {
+        eprintln!("{}", "  No MCP tool calls recorded yet.".dim());
+        return;
+    }
+
+    eprintln!(
+        "{}",
+        format!(
+            "  MCP Call History: {} entries (newest first)",
+            entries.len()
+        )
+        .bold()
+        .magenta()
+    );
+    eprintln!(
+        "  {}",
+        format!(
+            "{:<22} {:<30} {:<15} {:<10} {}",
+            "TIMESTAMP", "TOOL", "SERVER", "LATENCY", "STATUS"
+        )
+        .dim()
+    );
+
+    for entry in &entries {
+        let status_str = if entry.success {
+            theme::success("✓ OK")
+        } else {
+            theme::error("✗ FAIL")
+        };
+        let latency = format!("{}ms", entry.latency_ms);
+        eprintln!(
+            "  {:<22} {:<30} {:<15} {:<10} {}",
+            entry.timestamp.as_str().dim(),
+            entry.tool.as_str().yellow(),
+            entry.server.as_str().dim(),
+            latency.dim(),
+            status_str,
+        );
+        if let Some(ref err) = entry.error {
+            eprintln!("  {:>22} {}", " ".dim(), theme::error(err));
+        }
+    }
+    eprintln!();
+}
+
+/// `/mcp tools` — list all MCP tools from all connected servers.
+async fn show_tools(state: &SessionState) {
+    let manager = state.mcp_manager.read().await;
+
+    if manager.connection_count() == 0 {
+        eprintln!("{}", "  No MCP servers connected.".dim());
+        return;
+    }
+
+    let tools: Vec<(&str, &rmcp::model::Tool)> = manager.all_tools();
+
+    if tools.is_empty() {
+        eprintln!(
+            "{}",
+            "  No tools available from connected MCP servers.".dim()
+        );
+        return;
+    }
+
+    eprintln!(
+        "{}",
+        format!("  MCP Tools: {} available", tools.len())
+            .bold()
+            .magenta()
+    );
+    eprintln!(
+        "{}",
+        "  Inspect one with /mcp inspect <server>:<tool>".dim()
+    );
+
+    for (server, tool) in &tools {
+        let desc = tool.description.as_deref().unwrap_or("");
+        let short_desc = if desc.len() > 80 {
+            format!("{}…", &desc[..desc.floor_char_boundary(80)])
+        } else {
+            desc.to_string()
+        };
+
+        eprintln!();
+        eprintln!(
+            "  {} {} {}",
+            format!("{server}:{}", tool.name).bold(),
+            "─".dim(),
+            short_desc.dim(),
+        );
+
+        // Show parameter schema if available
+        let schema = &*tool.input_schema;
+        if let Some(props) = schema.get("properties").and_then(|v| v.as_object()) {
+            let required: Vec<&str> = schema
+                .get("required")
+                .and_then(|v| v.as_array())
+                .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+                .unwrap_or_default();
+            for (param_name, param_schema) in props {
+                let req_mark = if required.contains(&param_name.as_str()) {
+                    "*"
+                } else {
+                    " "
+                };
+                let ptype = param_schema
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("any");
+                let pdesc = param_schema
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                eprintln!(
+                    "  {}     {} {} {}",
+                    " ".dim(),
+                    req_mark.bold(),
+                    format!("{param_name}: {ptype}").yellow(),
+                    pdesc.dim(),
+                );
+            }
+        }
+    }
+    eprintln!();
+}
+
+/// `/mcp tools <server>` — list tools from a specific server.
+async fn show_tools_for_server(server_name: &str, state: &SessionState) {
+    let server_name = server_name.trim();
+    let manager = state.mcp_manager.read().await;
+
+    let conn = match manager.get(server_name) {
+        Some(c) => c,
+        None => {
+            eprint_server_not_found(server_name);
+            return;
+        }
+    };
+
+    let tools = conn.tools();
+
+    if tools.is_empty() {
+        eprintln!(
+            "{}",
+            format!("  No tools available from server '{server_name}'.").dim()
+        );
+        return;
+    }
+
+    eprintln!(
+        "{}",
+        format!("  Tools from {server_name}: {} available", tools.len())
+            .bold()
+            .magenta()
+    );
+    eprintln!(
+        "{}",
+        format!("  Inspect one with /mcp inspect {server_name}:<tool>").dim()
+    );
+
+    for tool in tools {
+        let desc = tool.description.as_deref().unwrap_or("");
+        let short_desc = if desc.len() > 80 {
+            format!("{}…", &desc[..desc.floor_char_boundary(80)])
+        } else {
+            desc.to_string()
+        };
+
+        eprintln!();
+        eprintln!(
+            "  {} {}",
+            tool.name.clone().bold().magenta(),
+            short_desc.dim(),
+        );
+
+        // Show parameter schema if available
+        let schema = &*tool.input_schema;
+        if let Some(props) = schema.get("properties").and_then(|v| v.as_object()) {
+            let required: Vec<&str> = schema
+                .get("required")
+                .and_then(|v| v.as_array())
+                .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+                .unwrap_or_default();
+            for (param_name, param_schema) in props {
+                let req_mark = if required.contains(&param_name.as_str()) {
+                    "*"
+                } else {
+                    " "
+                };
+                let ptype = param_schema
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("any");
+                let pdesc = param_schema
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                eprintln!(
+                    "  {}     {} {} {}",
+                    " ".dim(),
+                    req_mark.bold(),
+                    format!("{param_name}: {ptype}").yellow(),
+                    pdesc.dim(),
+                );
+            }
+        }
+    }
+    eprintln!();
+}
+
+/// `/mcp inspect <server>:<tool>` — show full JSON schema for a specific MCP tool.
+async fn show_inspect(tool_name: &str, state: &SessionState) {
+    let tool_name = tool_name.trim();
+
+    if tool_name.is_empty() {
+        eprintln!("{}", "  Usage: /mcp inspect <server>:<tool>".dim());
+        return;
+    }
+
+    // 1) Check MCP protocol tools (from connected MCP servers)
+    let manager = state.mcp_manager.read().await;
+    let protocol_error = match resolve_protocol_tool_query(&manager, tool_name) {
+        Ok((server, tool)) => {
+            show_mcp_protocol_tool_schema(&tool.name, server, tool);
+            return;
+        }
+        Err(message) => message,
+    };
+
+    // 2) Check built-in mcp_memoria_* tools
+    for meta in astra_turn_core::tool::registry::meta::TOOL_CATALOG {
+        if meta.name == tool_name
+            || format!("mcp_{}", meta.name) == tool_name
+            || format!("mcp_memoria_{}", meta.name) == tool_name
+        {
+            show_builtin_tool_info(meta);
+            return;
+        }
+    }
+
+    if manager.connection_count() > 0 {
+        eprintln!("  {}", protocol_error.yellow());
+    } else {
+        eprintln!(
+            "  {} Tool '{}' not found",
+            theme::icon_warn(),
+            tool_name.yellow()
+        );
+    }
+    eprintln!(
+        "  {}",
+        "Use /mcp tools or /mcp tools <server>, then inspect with /mcp inspect <server>:<tool>"
+            .dim()
+    );
+}
+
+/// Display detailed schema for an MCP protocol tool.
+fn show_mcp_protocol_tool_schema(name: &str, server: &str, tool: &rmcp::model::Tool) {
+    let desc = tool.description.as_deref().unwrap_or("(no description)");
+
+    eprintln!();
+    eprintln!(
+        "  {} {} {}",
+        "Tool:".bold(),
+        format!("{server}:{name}").bold().magenta(),
+        "[MCP protocol]".to_string().dim(),
+    );
+    eprintln!("  {} {}", "Description:".bold(), desc.dim());
+    eprintln!();
+
+    let schema = &*tool.input_schema;
+    let prop_count = schema
+        .get("properties")
+        .and_then(|v| v.as_object())
+        .map(|p| p.len())
+        .unwrap_or(0);
+
+    eprintln!(
+        "  {} {} parameter(s)",
+        "Parameters:".bold(),
+        prop_count.to_string().yellow(),
+    );
+
+    if let Some(props) = schema.get("properties").and_then(|v| v.as_object()) {
+        let required: Vec<&str> = schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+
+        for (param_name, param_schema) in props {
+            let req_mark = if required.contains(&param_name.as_str()) {
+                "*"
+            } else {
+                " "
+            };
+            let ptype = param_schema
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("any");
+            let pdesc = param_schema
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let enum_vals = param_schema
+                .get("enum")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .map(|v| v.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_default();
+
+            eprintln!();
+            eprintln!(
+                "  {} {} {}",
+                req_mark.bold(),
+                param_name.clone().bold().yellow(),
+                format!(": {ptype}").dim(),
+            );
+            if !enum_vals.is_empty() {
+                eprintln!("  {} {}", "      enum:".dim(), enum_vals.dim());
+            }
+            if !pdesc.is_empty() {
+                eprintln!("  {} {}", "      desc:".dim(), pdesc.dim());
+            }
+        }
+    }
+
+    if prop_count == 0 {
+        eprintln!("  {}", "  (no parameters)".dim());
+    }
+
+    eprintln!();
+}
+
+/// Display info for a built-in tool (from TOOL_CATALOG).
+fn show_builtin_tool_info(meta: &astra_turn_core::tool::registry::meta::ToolMeta) {
+    eprintln!();
+    eprintln!(
+        "  {} {} {}",
+        "Tool:".bold(),
+        meta.name.bold().magenta(),
+        "[built-in]".to_string().dim(),
+    );
+    eprintln!("  {} {}", "Description:".bold(), meta.description.dim());
+    eprintln!(
+        "  {} {:?}",
+        "Intents:".bold(),
+        format!("{:?}", meta.intents).dim(),
+    );
+    eprintln!(
+        "  {} {:?}",
+        "Scope:".bold(),
+        format!("{:?}", meta.scope).dim(),
+    );
+    eprintln!(
+        "  {} {}",
+        "Schema tokens:".bold(),
+        meta.schema_tokens.to_string().yellow(),
+    );
+    eprintln!(
+        "  {}",
+        "  Note: built-in tools use auto-generated schemas; use /mcp list for LLM injection count"
+            .dim(),
+    );
+    eprintln!();
+}
+
+/// `/mcp read <server>:<uri>` — read an MCP resource by URI.
 async fn handle_mcp_resource_read(arg: &str, state: &SessionState) {
     let rest = arg.trim();
     if rest.is_empty() {
-        eprintln!("{}", "  Usage: /mcp resource <server>:<uri>".dim());
-        eprintln!(
-            "{}",
-            "  Example: /mcp resource github:file:///README.md".dim()
-        );
+        eprintln!("{}", "  Usage: /mcp read <server>:<uri>".dim());
+        eprintln!("{}", "  Example: /mcp read github:file:///README.md".dim());
         return;
     }
 
@@ -1039,6 +1683,39 @@ async fn handle_mcp_ping(server: Option<&str>, state: &SessionState) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_mcp_command_defaults_to_help() {
+        assert_eq!(parse_mcp_command(""), ParsedMcpCommand::Help);
+        assert_eq!(parse_mcp_command("help"), ParsedMcpCommand::Help);
+    }
+
+    #[test]
+    fn parse_mcp_command_supports_list_aliases() {
+        assert_eq!(parse_mcp_command("list"), ParsedMcpCommand::Overview);
+        assert_eq!(parse_mcp_command("status"), ParsedMcpCommand::Overview);
+        assert_eq!(
+            parse_mcp_command("list tools github"),
+            ParsedMcpCommand::Tools(Some("github"))
+        );
+        assert_eq!(parse_mcp_command("list prompts"), ParsedMcpCommand::Prompts);
+        assert_eq!(
+            parse_mcp_command("list resources"),
+            ParsedMcpCommand::Resources
+        );
+    }
+
+    #[test]
+    fn parse_mcp_command_supports_read_alias() {
+        assert_eq!(
+            parse_mcp_command("read github:file:///README.md"),
+            ParsedMcpCommand::Read(Some("github:file:///README.md"))
+        );
+        assert_eq!(
+            parse_mcp_command("resource github:file:///README.md"),
+            ParsedMcpCommand::Read(Some("github:file:///README.md"))
+        );
+    }
 
     #[test]
     fn format_duration_seconds() {

--- a/rust/crates/astra-cli/src/edge_tools/mcp_dispatch.rs
+++ b/rust/crates/astra-cli/src/edge_tools/mcp_dispatch.rs
@@ -92,3 +92,45 @@ impl ToolExecutor {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    /// Create a bare ToolExecutor with mcp_manager = None.
+    fn executor_no_mcp() -> ToolExecutor {
+        ToolExecutor::new("/tmp")
+    }
+
+    /// Create a ToolExecutor with an empty McpClientManager (no tools, no servers).
+    fn executor_empty_mcp() -> ToolExecutor {
+        let manager = Arc::new(RwLock::new(crate::mcp_client::McpClientManager::new()));
+        ToolExecutor::new("/tmp").with_mcp_manager(manager)
+    }
+
+    // ── Error path: MCP not available ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn dispatch_no_mcp_manager() {
+        let executor = executor_no_mcp();
+        let result = executor
+            .execute_mcp_tool("mcp_test_tool", &serde_json::Value::Null)
+            .await;
+        assert!(result.contains("MCP not available"));
+        assert!(result.contains("mcp_test_tool"));
+    }
+
+    // ── Error path: tool not found ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn dispatch_tool_not_found() {
+        let executor = executor_empty_mcp();
+        let result = executor
+            .execute_mcp_tool("mcp_nonexistent_tool", &serde_json::Value::Null)
+            .await;
+        assert!(result.contains("not found on any connected server"));
+        assert!(result.contains("mcp_nonexistent_tool"));
+    }
+}

--- a/rust/crates/astra-cli/src/mcp_client.rs
+++ b/rust/crates/astra-cli/src/mcp_client.rs
@@ -713,6 +713,26 @@ async fn do_elicitation(
 /// these are lock-free and safe for concurrent access. For WebSocket
 /// connections, the bridge `JoinHandle`s are stored so task failures can be
 /// detected instead of silently degrading the connection.
+/// A logged MCP tool call entry.
+#[derive(Debug, Clone, Serialize)]
+pub struct CallLogEntry {
+    /// When the call was made.
+    pub timestamp: String,
+    /// Tool name used in the call.
+    pub tool: String,
+    /// Server this call was routed to.
+    pub server: String,
+    /// Whether the call succeeded.
+    pub success: bool,
+    /// Call latency.
+    pub latency_ms: u64,
+    /// Error message if the call failed.
+    pub error: Option<String>,
+}
+
+/// Maximum number of call log entries kept per connection.
+const CALL_LOG_MAX_ENTRIES: usize = 100;
+
 pub struct McpConnection {
     /// Server name.
     pub name: String,
@@ -734,6 +754,19 @@ pub struct McpConnection {
     /// Stored so that task panics or unexpected exits are detectable instead of
     /// silently degrading the connection.
     ws_bridge_handles: Option<(tokio::task::JoinHandle<()>, tokio::task::JoinHandle<()>)>,
+    /// Total number of tool calls made through this connection.
+    pub call_count: AtomicU64,
+    /// Number of failed tool calls.
+    pub error_count: AtomicU64,
+    /// Latency of the most recent tool call.
+    pub last_latency: RwLock<Option<std::time::Duration>>,
+    /// Error message from the most recent failed call, if any.
+    pub last_error: RwLock<Option<String>>,
+    /// Ring buffer of recent call log entries (max CALL_LOG_MAX_ENTRIES).
+    pub call_log: RwLock<Vec<CallLogEntry>>,
+    /// Keep-alive handle for the background MCP service task.
+    /// Stored to prevent transport closure when `RunningService` is dropped.
+    keepalive_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl Drop for McpConnection {
@@ -746,6 +779,9 @@ impl Drop for McpConnection {
         if let Some((read_handle, write_handle)) = self.ws_bridge_handles.take() {
             read_handle.abort();
             write_handle.abort();
+        }
+        if let Some(keepalive) = self.keepalive_handle.take() {
+            keepalive.abort();
         }
     }
 }
@@ -913,6 +949,9 @@ impl McpConnection {
         name: &str,
         arguments: serde_json::Value,
     ) -> Result<CallToolResult, ServiceError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+        let start = Instant::now();
+
         let arguments = match arguments {
             serde_json::Value::Object(map) => Some(map),
             serde_json::Value::Null => None,
@@ -926,19 +965,18 @@ impl McpConnection {
         } else {
             CallToolRequestParams::new(name.to_string())
         };
-        match &self.backend {
+        let result = match &self.backend {
             McpConnectionBackend::Stateful(peer) => tokio::time::timeout(
                 std::time::Duration::from_secs(MCP_TOOL_CALL_TIMEOUT_SECS),
                 peer.call_tool(params),
             )
             .await
             .map_err(|_| {
-                eprintln!(
-                    "  {} MCP tool '{}' on server '{}' timed out after {}s",
-                    "✗".red(),
-                    name.magenta(),
-                    self.name.as_str().magenta(),
-                    MCP_TOOL_CALL_TIMEOUT_SECS
+                tracing::warn!(
+                    server = %self.name,
+                    tool = name,
+                    timeout_secs = MCP_TOOL_CALL_TIMEOUT_SECS,
+                    "MCP: tool call timed out"
                 );
                 ServiceError::Timeout {
                     timeout: std::time::Duration::from_secs(MCP_TOOL_CALL_TIMEOUT_SECS),
@@ -960,7 +998,42 @@ impl McpConnection {
                     )
                     .await
             }
+        };
+
+        let latency = start.elapsed();
+        let latency_ms = latency.as_millis() as u64;
+        *self.last_latency.write().await = Some(latency);
+
+        let mut success = true;
+        let mut error_msg: Option<String> = None;
+        match &result {
+            Ok(_) => {}
+            Err(e) => {
+                self.error_count.fetch_add(1, Ordering::Relaxed);
+                let err_str = e.to_string();
+                *self.last_error.write().await = Some(err_str.clone());
+                success = false;
+                error_msg = Some(err_str);
+            }
         }
+
+        // Push to call log ring buffer (oldest evicted when full).
+        {
+            let mut log = self.call_log.write().await;
+            if log.len() >= CALL_LOG_MAX_ENTRIES {
+                log.remove(0);
+            }
+            log.push(CallLogEntry {
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                tool: name.to_string(),
+                server: self.name.clone(),
+                success,
+                latency_ms,
+                error: error_msg,
+            });
+        }
+
+        result
     }
 
     /// Check if this server has a specific tool.
@@ -1216,6 +1289,16 @@ impl McpClientManager {
         self.sampling.is_some()
     }
 
+    /// Get a reference to a connection by server name.
+    pub fn get_connection(&self, server: &str) -> Option<&Arc<McpConnection>> {
+        self.connections.get(server)
+    }
+
+    /// Return all active server names.
+    pub fn server_names(&self) -> Vec<&str> {
+        self.connections.keys().map(|s| s.as_str()).collect()
+    }
+
     /// Low-level connect (no skill discovery). Use `connect_and_discover_skills`
     /// for production code paths that should register `skill://` resources.
     async fn connect_internal(&mut self, config: McpServerConfig) -> Result<(), McpError> {
@@ -1224,19 +1307,44 @@ impl McpClientManager {
         }
 
         let name = config.name.clone();
+        tracing::info!(
+            server = %name,
+            transport = ?config.transport,
+            "MCP: connecting to server"
+        );
         self.states
             .insert(name.clone(), ConnectionState::Connecting);
         match connect_to_server(config, self.sampling.clone(), self.roots.clone()).await {
             Ok(connection) => {
+                let tool_count = connection.tools.len();
+                tracing::info!(
+                    server = %name,
+                    tools = tool_count,
+                    "MCP: connected to server"
+                );
                 self.states.insert(name.clone(), ConnectionState::Connected);
                 self.connections.insert(name, Arc::new(connection));
                 Ok(())
             }
             Err(e) => {
+                tracing::error!(
+                    server = %name,
+                    error = %e,
+                    "MCP: failed to connect to server"
+                );
                 self.states.insert(name, ConnectionState::Failed);
                 Err(e)
             }
         }
+    }
+
+    /// Test-only helper: connect to an MCP server without skill discovery.
+    #[cfg(test)]
+    pub(crate) async fn connect_for_test(
+        &mut self,
+        config: McpServerConfig,
+    ) -> Result<(), McpError> {
+        self.connect_internal(config).await
     }
 
     /// Connect to an MCP server and register any `skill://` resources into the
@@ -1264,13 +1372,20 @@ impl McpClientManager {
             {
                 Ok(_) => registered += 1,
                 Err(e) => {
-                    eprintln!(
-                        "  {} {}",
-                        theme::icon_warn(),
-                        format!("Failed to register MCP skill from {server_name}: {e}").dim()
+                    tracing::warn!(
+                        server = %server_name,
+                        error = %e,
+                        "MCP: failed to register skill"
                     );
                 }
             }
+        }
+        if registered > 0 {
+            tracing::info!(
+                server = %server_name,
+                skills = registered,
+                "MCP: registered skills from server"
+            );
         }
         Ok(registered)
     }
@@ -1285,13 +1400,14 @@ impl McpClientManager {
     ) -> bool {
         let removed = self.connections.remove(name).is_some();
         if removed {
+            tracing::info!(server = name, "MCP: disconnecting from server");
             self.states
                 .insert(name.to_string(), ConnectionState::Disconnected);
             if let Err(e) = skill_registry.remove_mcp_server_skills(name).await {
-                astra_core::agent_warn!(
-                    "mcp",
-                    "failed to remove skills for server '{}': {e}",
-                    name
+                tracing::warn!(
+                    server = name,
+                    error = %e,
+                    "MCP: failed to remove skills for server"
                 );
             }
         }
@@ -1303,6 +1419,10 @@ impl McpClientManager {
     pub fn disconnect(&mut self, name: &str) -> bool {
         let removed = self.connections.remove(name).is_some();
         if removed {
+            tracing::info!(
+                server = name,
+                "MCP: disconnected server (no registry cleanup)"
+            );
             self.states
                 .insert(name.to_string(), ConnectionState::Disconnected);
         }
@@ -1463,14 +1583,37 @@ impl McpClientManager {
             .find_tool(tool_name)
             .ok_or_else(|| McpError::ToolNotFound(tool_name.to_string()))?;
 
+        tracing::debug!(
+            server = server_name,
+            tool = tool_name,
+            "MCP: dispatching tool call"
+        );
+
         let conn = self
             .connections
             .get(server_name)
             .ok_or_else(|| McpError::ServerNotConnected(server_name.to_string()))?;
 
-        conn.call_tool(tool_name, arguments)
+        let result = conn
+            .call_tool(tool_name, arguments)
             .await
-            .map_err(McpError::Service)
+            .map_err(McpError::Service);
+
+        match &result {
+            Ok(_) => tracing::debug!(
+                server = server_name,
+                tool = tool_name,
+                "MCP: tool call succeeded"
+            ),
+            Err(e) => tracing::warn!(
+                server = server_name,
+                tool = tool_name,
+                error = %e,
+                "MCP: tool call failed"
+            ),
+        }
+
+        result
     }
     /// Request argument completions from a specific server.
     pub async fn complete(
@@ -1501,8 +1644,21 @@ impl McpClientManager {
             .ok_or_else(|| McpError::ServerNotConnected(server.to_string()))?;
         let start = Instant::now();
         match conn.ping().await {
-            Ok(()) => Ok(start.elapsed()),
+            Ok(()) => {
+                let latency = start.elapsed();
+                tracing::debug!(
+                    server = server,
+                    latency_ms = latency.as_millis() as u64,
+                    "MCP: ping succeeded"
+                );
+                Ok(latency)
+            }
             Err(e) if service_error_requires_reconnect(&e) => {
+                tracing::warn!(
+                    server = server,
+                    error = %e,
+                    "MCP: ping failed, attempting reconnect"
+                );
                 self.reconnect(server).await?;
                 let conn = self
                     .connections
@@ -1510,9 +1666,22 @@ impl McpClientManager {
                     .ok_or_else(|| McpError::ServerNotConnected(server.to_string()))?;
                 let retry_start = Instant::now();
                 conn.ping().await.map_err(McpError::Service)?;
-                Ok(retry_start.elapsed())
+                let latency = retry_start.elapsed();
+                tracing::info!(
+                    server = server,
+                    latency_ms = latency.as_millis() as u64,
+                    "MCP: ping succeeded after reconnect"
+                );
+                Ok(latency)
             }
-            Err(e) => Err(McpError::Service(e)),
+            Err(e) => {
+                tracing::warn!(
+                    server = server,
+                    error = %e,
+                    "MCP: ping failed"
+                );
+                Err(McpError::Service(e))
+            }
         }
     }
 
@@ -1542,6 +1711,7 @@ impl McpClientManager {
     /// Reconnect a server using its stored config.
     /// Replaces the existing connection. Returns new tool count on success.
     pub async fn reconnect(&mut self, name: &str) -> Result<usize, McpError> {
+        tracing::info!(server = name, "MCP: reconnecting to server");
         let config = match self.connections.get(name) {
             Some(conn) => conn.config.clone(),
             None => return Err(McpError::ServerNotConnected(name.to_string())),
@@ -1555,6 +1725,11 @@ impl McpClientManager {
         match connect_to_server(config, self.sampling.clone(), self.roots.clone()).await {
             Ok(connection) => {
                 let tool_count = connection.tools.len();
+                tracing::info!(
+                    server = name,
+                    tools = tool_count,
+                    "MCP: reconnected to server"
+                );
                 self.states
                     .insert(name.to_string(), ConnectionState::Connected);
                 self.connections
@@ -1562,6 +1737,11 @@ impl McpClientManager {
                 Ok(tool_count)
             }
             Err(e) => {
+                tracing::error!(
+                    server = name,
+                    error = %e,
+                    "MCP: reconnect failed"
+                );
                 self.states
                     .insert(name.to_string(), ConnectionState::Failed);
                 Err(e)
@@ -1576,23 +1756,23 @@ impl McpClientManager {
             if conn.has_pending_tool_change() {
                 if let Some(inner) = Arc::get_mut(conn) {
                     match inner.refresh_tools_if_changed().await {
-                        Ok(true) => refreshed.push(name.clone()),
+                        Ok(true) => {
+                            tracing::info!(
+                                server = name.as_str(),
+                                tools = inner.tools.len(),
+                                "MCP: refreshed tool list"
+                            );
+                            refreshed.push(name.clone());
+                        }
                         Ok(false) => {}
-                        Err(e) => eprintln!(
-                            "  {} {}",
-                            theme::icon_warn(),
-                            format!("Failed to refresh tools for {name}: {e}").dim()
+                        Err(e) => tracing::warn!(
+                            server = name.as_str(),
+                            error = %e,
+                            "MCP: failed to refresh tools"
                         ),
                     }
                 }
             }
-        }
-        if !refreshed.is_empty() {
-            eprintln!(
-                "  {} Refreshed tool lists for: {}",
-                "↻".magenta(),
-                refreshed.join(", ")
-            );
         }
         refreshed
     }
@@ -1694,9 +1874,12 @@ async fn connect_to_server(
                 retry.initial_delay_ms * 2u64.saturating_pow(attempt - 1),
                 retry.max_delay_ms,
             );
-            eprintln!(
-                "  ↻ Retrying {name} (attempt {attempt}/{max}, backoff {delay_ms}ms)",
+            tracing::warn!(
+                server = name.as_str(),
+                attempt,
                 max = retry.max_retries,
+                delay_ms,
+                "MCP: retrying connection"
             );
             tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
         }
@@ -1706,19 +1889,37 @@ async fn connect_to_server(
             Err(e) => {
                 // Don't retry config errors — they won't resolve themselves.
                 if matches!(e, McpError::InvalidConfig(_)) {
+                    tracing::error!(
+                        server = name.as_str(),
+                        error = %e,
+                        "MCP: invalid config, not retrying"
+                    );
                     return Err(e);
                 }
+                tracing::warn!(
+                    server = name.as_str(),
+                    attempt,
+                    error = %e,
+                    "MCP: connection attempt failed"
+                );
                 last_error = Some(e);
             }
         }
     }
 
-    Err(last_error.unwrap_or_else(|| {
+    let final_error = last_error.unwrap_or_else(|| {
         McpError::Initialize(format!(
             "{name}: all {n} retries exhausted",
             n = retry.max_retries
         ))
-    }))
+    });
+    tracing::error!(
+        server = name.as_str(),
+        retries = retry.max_retries,
+        error = %final_error,
+        "MCP: all connection attempts exhausted"
+    );
+    Err(final_error)
 }
 
 /// Single connection attempt (no retry).
@@ -1791,6 +1992,12 @@ async fn connect_stdio(
         ));
     }
 
+    tracing::info!(
+        server = name,
+        command = command.join(" ").as_str(),
+        "MCP: connecting via stdio"
+    );
+
     // Build the command using tokio::process::Command
     let mut cmd = tokio::process::Command::new(&command[0]);
     if command.len() > 1 {
@@ -1801,11 +2008,10 @@ async fn connect_stdio(
     // escalation or library injection attacks.
     for (key, value) in env {
         if is_dangerous_env_var(key) {
-            eprintln!(
-                "  {} MCP server '{}': blocked dangerous env var '{}'",
-                theme::icon_warn(),
-                name.magenta(),
-                key.as_str().yellow()
+            tracing::warn!(
+                server = name,
+                var = key.as_str(),
+                "MCP: blocked dangerous env var"
             );
             continue;
         }
@@ -1833,8 +2039,17 @@ async fn connect_stdio(
     .map_err(|e| McpError::Initialize(e.to_string()))?;
 
     let peer = running.peer().clone();
+    let keepalive = tokio::spawn(async move {
+        let _ = running.waiting().await;
+    });
 
     let tools = fetch_tools_with_timeout(&peer, name).await?;
+
+    tracing::info!(
+        server = name,
+        tools = tools.len(),
+        "MCP: stdio connection established"
+    );
 
     Ok(McpConnection {
         name: name.to_string(),
@@ -1846,6 +2061,12 @@ async fn connect_stdio(
         prompts_changed,
         resources_changed,
         ws_bridge_handles: None,
+        call_count: AtomicU64::new(0),
+        error_count: AtomicU64::new(0),
+        last_latency: RwLock::new(None),
+        last_error: RwLock::new(None),
+        call_log: RwLock::new(Vec::new()),
+        keepalive_handle: Some(keepalive),
     })
 }
 
@@ -1866,6 +2087,8 @@ async fn connect_sse(
     if url.is_empty() {
         return Err(McpError::InvalidConfig("url cannot be empty".to_string()));
     }
+
+    tracing::info!(server = name, url, "MCP: connecting via SSE");
 
     if let Some(connection) =
         probe_stateless_http_connection(name, url, auth_token, headers, config.clone()).await?
@@ -1903,9 +2126,25 @@ async fn connect_sse(
     match serve_client(handler, transport).await {
         Ok(running) => {
             let peer = running.peer().clone();
+            let keepalive = tokio::spawn(async move {
+                let _ = running.waiting().await;
+            });
             let tools = match fetch_tools_with_timeout(&peer, name).await {
-                Ok(tools) => tools,
+                Ok(tools) => {
+                    tracing::info!(
+                        server = name,
+                        tools = tools.len(),
+                        "MCP: SSE connection established"
+                    );
+                    tools
+                }
                 Err(err) if mcp_error_supports_stateless_fallback(&err) => {
+                    tracing::info!(
+                        server = name,
+                        url,
+                        error = %err,
+                        "MCP: SSE connect failed, falling back to stateless HTTP"
+                    );
                     return connect_stateless_http(name, url, auth_token, headers, config).await;
                 }
                 Err(err) => return Err(err),
@@ -1920,6 +2159,12 @@ async fn connect_sse(
                 prompts_changed,
                 resources_changed,
                 ws_bridge_handles: None,
+                call_count: AtomicU64::new(0),
+                error_count: AtomicU64::new(0),
+                last_latency: RwLock::new(None),
+                last_error: RwLock::new(None),
+                call_log: RwLock::new(Vec::new()),
+                keepalive_handle: Some(keepalive),
             })
         }
         Err(e) => {
@@ -1939,6 +2184,7 @@ async fn connect_stateless_http(
     headers: &HashMap<String, String>,
     config: McpServerConfig,
 ) -> Result<McpConnection, McpError> {
+    tracing::info!(server = name, url, "MCP: connecting via stateless HTTP");
     let client = StatelessHttpMcpClient::new(url, auth_token, headers)?;
     let _: serde_json::Value = client
         .request(
@@ -1986,6 +2232,12 @@ async fn connect_stateless_http(
         prompts_changed,
         resources_changed,
         ws_bridge_handles: None,
+        call_count: AtomicU64::new(0),
+        error_count: AtomicU64::new(0),
+        last_latency: RwLock::new(None),
+        last_error: RwLock::new(None),
+        call_log: RwLock::new(Vec::new()),
+        keepalive_handle: None,
     })
 }
 
@@ -2067,6 +2319,12 @@ async fn probe_stateless_http_connection(
         prompts_changed,
         resources_changed,
         ws_bridge_handles: None,
+        call_count: AtomicU64::new(0),
+        error_count: AtomicU64::new(0),
+        last_latency: RwLock::new(None),
+        last_error: RwLock::new(None),
+        call_log: RwLock::new(Vec::new()),
+        keepalive_handle: None,
     }))
 }
 
@@ -2099,6 +2357,8 @@ async fn connect_ws(
     if url.is_empty() {
         return Err(McpError::InvalidConfig("url cannot be empty".to_string()));
     }
+
+    tracing::info!(server = name, url, "MCP: connecting via WebSocket");
 
     // Build WebSocket request with optional auth and custom headers
     let mut request = tungstenite::http::Request::builder()
@@ -2149,10 +2409,10 @@ async fn connect_ws(
                 Some(Ok(tungstenite::Message::Close(_))) => break,
                 Some(Ok(_)) => {} // ignore binary, ping, pong
                 Some(Err(e)) => {
-                    eprintln!(
-                        "  {} {}",
-                        theme::icon_warn(),
-                        format!("MCP WebSocket read error [{reader_name}]: {e}").dim()
+                    tracing::warn!(
+                        server = reader_name.as_str(),
+                        error = %e,
+                        "MCP: WebSocket read error"
                     );
                     break;
                 }
@@ -2184,10 +2444,10 @@ async fn connect_ws(
                     line.clear();
                 }
                 Err(e) => {
-                    eprintln!(
-                        "  {} {}",
-                        theme::icon_warn(),
-                        format!("MCP WebSocket write-bridge error [{writer_name}]: {e}").dim()
+                    tracing::warn!(
+                        server = writer_name.as_str(),
+                        error = %e,
+                        "MCP: WebSocket write-bridge error"
                     );
                     break;
                 }
@@ -2203,7 +2463,16 @@ async fn connect_ws(
         .map_err(|e| McpError::Initialize(format!("MCP init over WebSocket {url}: {e}")))?;
 
     let peer = running.peer().clone();
+    let keepalive = tokio::spawn(async move {
+        let _ = running.waiting().await;
+    });
     let tools = fetch_tools_with_timeout(&peer, name).await?;
+
+    tracing::info!(
+        server = name,
+        tools = tools.len(),
+        "MCP: WebSocket connection established"
+    );
 
     Ok(McpConnection {
         name: name.to_string(),
@@ -2215,6 +2484,12 @@ async fn connect_ws(
         prompts_changed,
         resources_changed,
         ws_bridge_handles: Some((ws_read_handle, ws_write_handle)),
+        call_count: AtomicU64::new(0),
+        error_count: AtomicU64::new(0),
+        last_latency: RwLock::new(None),
+        last_error: RwLock::new(None),
+        call_log: RwLock::new(Vec::new()),
+        keepalive_handle: Some(keepalive),
     })
 }
 
@@ -2415,6 +2690,51 @@ pub fn extract_result_text_with_limit(result: &CallToolResult, max_len: usize) -
     } else {
         joined
     }
+}
+
+#[cfg(test)]
+pub(crate) fn ensure_mock_mcp_server_binary() -> std::path::PathBuf {
+    static BINARY: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+
+    BINARY
+        .get_or_init(|| {
+            let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let profile = if cfg!(debug_assertions) {
+                "debug"
+            } else {
+                "release"
+            };
+            let binary_name = format!("mock_mcp_server{}", std::env::consts::EXE_SUFFIX);
+            let binary = manifest_dir
+                .join("../..")
+                .join("target")
+                .join(profile)
+                .join("examples")
+                .join(binary_name);
+
+            if binary.exists() {
+                return binary;
+            }
+
+            let status = std::process::Command::new("cargo")
+                .args(["build", "-p", "astra-cli", "--example", "mock_mcp_server"])
+                .current_dir(manifest_dir.join("../.."))
+                .status()
+                .unwrap_or_else(|e| panic!("failed to build mock_mcp_server example: {e}"));
+
+            assert!(
+                status.success(),
+                "cargo build -p astra-cli --example mock_mcp_server failed with status {status}"
+            );
+            assert!(
+                binary.exists(),
+                "mock_mcp_server binary missing after build at {:?}",
+                binary
+            );
+
+            binary
+        })
+        .clone()
 }
 
 #[cfg(test)]
@@ -4088,5 +4408,527 @@ mcp_servers:
         let text = extract_result_text_with_limit(&result, 100);
         assert!(text.contains("[OUTPUT TRUNCATED"));
         assert!(text.len() < 500);
+    }
+
+    // ── extract_result_text: non-text content handling ─────────────────────
+
+    #[test]
+    fn extract_result_text_skips_image_content() {
+        use rmcp::model::{Content, RawContent};
+        let result = CallToolResult::success(vec![
+            Content::new(RawContent::text("text output"), None),
+            Content::new(
+                RawContent::Image(rmcp::model::RawImageContent {
+                    mime_type: "image/png".into(),
+                    data: "base64data".into(),
+                    meta: None,
+                }),
+                None,
+            ),
+        ]);
+        let text = extract_result_text(&result);
+        // Image content should be skipped; only text is returned
+        assert_eq!(text, "text output");
+    }
+
+    #[test]
+    fn extract_result_text_image_only_returns_empty() {
+        use rmcp::model::{Content, RawContent, RawImageContent};
+        let result = CallToolResult::success(vec![Content::new(
+            RawContent::Image(RawImageContent {
+                mime_type: "image/png".into(),
+                data: "base64data".into(),
+                meta: None,
+            }),
+            None,
+        )]);
+        let text = extract_result_text(&result);
+        assert!(text.is_empty());
+    }
+
+    #[test]
+    fn extract_result_text_mixed_audio_content_skipped() {
+        use rmcp::model::{Content, RawContent};
+        // Audio content should also be skipped (non-text)
+        let result = CallToolResult::success(vec![
+            Content::new(RawContent::text("line 1"), None),
+            Content::new(
+                RawContent::Audio(rmcp::model::RawAudioContent {
+                    mime_type: "audio/wav".into(),
+                    data: "audio-data".into(),
+                }),
+                None,
+            ),
+            Content::new(RawContent::text("line 2"), None),
+        ]);
+        let text = extract_result_text(&result);
+        assert_eq!(text, "line 1\nline 2");
+    }
+
+    #[test]
+    fn extract_result_text_embedded_resource_skipped() {
+        use rmcp::model::{Content, RawContent, RawEmbeddedResource, ResourceContents};
+        let result = CallToolResult::success(vec![
+            Content::new(RawContent::text("before"), None),
+            Content::new(
+                RawContent::Resource(RawEmbeddedResource {
+                    meta: None,
+                    resource: ResourceContents::TextResourceContents {
+                        uri: "file:///data.txt".into(),
+                        mime_type: Some("text/plain".into()),
+                        text: "embedded data".into(),
+                        meta: None,
+                    },
+                }),
+                None,
+            ),
+            Content::new(RawContent::text("after"), None),
+        ]);
+        let text = extract_result_text(&result);
+        assert_eq!(text, "before\nafter");
+    }
+
+    #[test]
+    fn extract_result_text_with_limit_skips_non_text() {
+        use rmcp::model::{Content, RawContent};
+        let result = CallToolResult::success(vec![
+            Content::new(RawContent::text("a"), None),
+            Content::new(
+                RawContent::Image(rmcp::model::RawImageContent {
+                    mime_type: "image/png".into(),
+                    data: "x".repeat(1000),
+                    meta: None,
+                }),
+                None,
+            ),
+            Content::new(RawContent::text("b"), None),
+        ]);
+        let text = extract_result_text_with_limit(&result, 100);
+        // Image skipped, only text a\nb should appear
+        assert_eq!(text, "a\nb");
+        assert!(!text.contains("[OUTPUT TRUNCATED"));
+    }
+
+    // ── WebSocket transport with headers ───────────────────────────────────
+
+    #[test]
+    fn ws_transport_with_custom_headers() {
+        let yaml = r#"
+name: ws-headers
+transport:
+  type: ws
+  url: "wss://api.example.com/mcp"
+  auth_token: "bearer-token"
+  headers:
+    X-Custom-1: "val1"
+    X-Custom-2: "val2"
+"#;
+        let config: McpServerConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        match &config.transport {
+            Transport::Ws {
+                url,
+                auth_token,
+                headers,
+            } => {
+                assert_eq!(url, "wss://api.example.com/mcp");
+                assert_eq!(auth_token.as_deref(), Some("bearer-token"));
+                assert_eq!(headers.get("X-Custom-1"), Some(&"val1".to_string()));
+                assert_eq!(headers.get("X-Custom-2"), Some(&"val2".to_string()));
+            }
+            _ => panic!("expected Ws transport"),
+        }
+    }
+
+    #[test]
+    fn ws_transport_wss_alias() {
+        // "wss" is NOT a valid alias — only "ws" and "websocket" are accepted.
+        // Verify that "wss" URLs must use type: ws instead.
+        let yaml = r#"
+name: wss-test
+transport:
+  type: ws
+  url: "wss://secure.example.com/mcp"
+"#;
+        let config: McpServerConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        match &config.transport {
+            Transport::Ws { url, .. } => {
+                assert_eq!(url, "wss://secure.example.com/mcp");
+            }
+            _ => panic!("expected Ws transport for 'ws' type with wss:// URL"),
+        }
+    }
+
+    // ── McpClientManager tool lookup with populated state ─────────────────
+
+    #[test]
+    fn find_tool_by_mcp_name_exact_match() {
+        // We can't inject tools without a real connection, but we can verify
+        // the sanitized-name resolution logic directly.
+        let server = "my-server";
+        let tool_name = "read file";
+        let sanitized = sanitize_tool_name(&format!("mcp_{}_{}", server, tool_name));
+        assert_eq!(sanitized, "mcp_my-server_read_file");
+    }
+
+    #[test]
+    fn find_tool_by_mcp_name_special_chars_in_server() {
+        let server = "api.example.com";
+        let tool_name = "getData";
+        let sanitized = sanitize_tool_name(&format!("mcp_{}_{}", server, tool_name));
+        // Dots in server name become underscores
+        assert_eq!(sanitized, "mcp_api_example_com_getData");
+    }
+
+    // ── McpClientManager sampling config ──────────────────────────────────
+
+    #[test]
+    fn manager_has_sampling_returns_false_by_default() {
+        let manager = McpClientManager::new();
+        assert!(!manager.has_sampling());
+    }
+
+    #[test]
+    fn manager_has_sampling_returns_true_after_set() {
+        let mut manager = McpClientManager::new();
+        let config = SamplingConfig {
+            api: Arc::new(
+                astra_thin_client::ThinClient::new("http://localhost:8000", None).unwrap(),
+            ),
+            token: "tok".to_string(),
+            model: "m".to_string(),
+            max_tokens_cap: DEFAULT_SAMPLING_MAX_TOKENS_CAP,
+        };
+        manager.set_sampling_config(Some(config));
+        assert!(manager.has_sampling());
+    }
+
+    #[test]
+    fn manager_has_sampling_returns_false_after_clear() {
+        let mut manager = McpClientManager::new();
+        let config = SamplingConfig {
+            api: Arc::new(
+                astra_thin_client::ThinClient::new("http://localhost:8000", None).unwrap(),
+            ),
+            token: "tok".to_string(),
+            model: "m".to_string(),
+            max_tokens_cap: DEFAULT_SAMPLING_MAX_TOKENS_CAP,
+        };
+        manager.set_sampling_config(Some(config));
+        manager.set_sampling_config(None);
+        assert!(!manager.has_sampling());
+    }
+
+    // ── McpError conversion from ServiceError ──────────────────────────────
+
+    #[test]
+    fn mcp_error_from_service_error() {
+        let svc_err = ServiceError::TransportClosed;
+        let mcp_err = McpError::from(svc_err);
+        assert!(matches!(mcp_err, McpError::Service(_)));
+    }
+
+    #[test]
+    fn mcp_error_from_service_error_mcp_error() {
+        let svc_err = ServiceError::McpError(rmcp::model::ErrorData::new(
+            rmcp::model::ErrorCode::INTERNAL_ERROR,
+            "internal failure",
+            None,
+        ));
+        let mcp_err = McpError::from(svc_err);
+        assert!(mcp_err.to_string().contains("internal failure"));
+    }
+
+    // ── Transport enum round-trip ──────────────────────────────────────────
+
+    #[test]
+    fn transport_stdio_roundtrip_yaml() {
+        let transport = Transport::Stdio {
+            command: vec!["node".into(), "server.js".into()],
+            args: vec!["--debug".into()],
+            env: [("NODE_ENV".into(), "production".into())].into(),
+        };
+        let yaml = serde_yaml_ng::to_string(&transport).unwrap();
+        let back: Transport = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert!(matches!(back, Transport::Stdio { .. }));
+    }
+
+    #[test]
+    fn transport_sse_roundtrip_yaml() {
+        let transport = Transport::Sse {
+            url: "https://api.example.com/mcp".into(),
+            auth_token: Some("secret".into()),
+            headers: [("X-Key".into(), "val".into())].into(),
+        };
+        let yaml = serde_yaml_ng::to_string(&transport).unwrap();
+        let back: Transport = serde_yaml_ng::from_str(&yaml).unwrap();
+        match back {
+            Transport::Sse {
+                url,
+                auth_token,
+                headers,
+            } => {
+                assert_eq!(url, "https://api.example.com/mcp");
+                assert_eq!(auth_token, Some("secret".into()));
+                assert_eq!(headers.get("X-Key"), Some(&"val".into()));
+            }
+            _ => panic!("expected Sse"),
+        }
+    }
+
+    #[test]
+    fn transport_ws_roundtrip_yaml() {
+        let transport = Transport::Ws {
+            url: "wss://api.example.com/ws".into(),
+            auth_token: Some("token".into()),
+            headers: Default::default(),
+        };
+        let yaml = serde_yaml_ng::to_string(&transport).unwrap();
+        let back: Transport = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert!(matches!(back, Transport::Ws { .. }));
+    }
+
+    // ── ConnectionState Copy + Eq verification ────────────────────────────
+
+    #[test]
+    fn connection_state_is_copy() {
+        // Verify ConnectionState implements Copy (compile-time check)
+        let state = ConnectionState::Connected;
+        let copied = state;
+        assert_eq!(state, copied);
+    }
+
+    #[test]
+    fn connection_state_eq() {
+        assert_eq!(ConnectionState::Connected, ConnectionState::Connected);
+        assert_ne!(ConnectionState::Connected, ConnectionState::Disconnected);
+        assert_eq!(ConnectionState::Failed, ConnectionState::Failed);
+        assert_ne!(ConnectionState::Connecting, ConnectionState::Reconnecting);
+    }
+
+    // ── McpServerConfig defaults ──────────────────────────────────────────
+
+    #[test]
+    fn mcp_server_config_defaults() {
+        let config = McpServerConfig {
+            name: "test".into(),
+            transport: Transport::Stdio {
+                command: vec!["echo".into()],
+                args: vec![],
+                env: Default::default(),
+            },
+            description: Default::default(),
+            enabled: true,
+            retry: Default::default(),
+        };
+        assert!(config.enabled);
+        assert_eq!(config.retry.max_retries, 5);
+        assert_eq!(config.retry.initial_delay_ms, 1000);
+        assert_eq!(config.retry.max_delay_ms, 30_000);
+    }
+
+    #[test]
+    fn mcp_server_config_disabled_server() {
+        let config = McpServerConfig {
+            name: "off".into(),
+            transport: Transport::Stdio {
+                command: vec!["echo".into()],
+                args: vec![],
+                env: Default::default(),
+            },
+            description: Default::default(),
+            enabled: false,
+            retry: Default::default(),
+        };
+        assert!(!config.enabled);
+    }
+
+    // ── Max constants sanity ──────────────────────────────────────────────
+
+    #[test]
+    fn max_description_length_reasonable() {
+        const { assert!(MAX_DESCRIPTION_LENGTH > 0) };
+        const { assert!(MAX_DESCRIPTION_LENGTH <= 4096) };
+    }
+
+    #[test]
+    fn max_result_content_length_reasonable() {
+        const { assert!(MAX_RESULT_CONTENT_LENGTH > 0) };
+        const { assert!(MAX_RESULT_CONTENT_LENGTH <= 1_000_000) };
+    }
+
+    // ── Integration tests with mock MCP server (stdio) ──────────────────
+
+    /// Locate the mock MCP server Rust binary (workspace example).
+    fn mock_server_binary() -> std::path::PathBuf {
+        ensure_mock_mcp_server_binary()
+    }
+
+    /// Build a McpServerConfig for the mock server with zero retries
+    /// (tests should not hang on retries when the process fails to start).
+    fn mock_server_config() -> McpServerConfig {
+        McpServerConfig {
+            name: "mock-server".to_string(),
+            description: "Integration test mock MCP server".to_string(),
+            transport: Transport::Stdio {
+                command: vec![mock_server_binary().to_string_lossy().to_string()],
+                args: vec![],
+                env: Default::default(),
+            },
+            enabled: true,
+            retry: RetryConfig {
+                max_retries: 0,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Connect to the mock MCP server via stdio.
+    async fn connect_mock_server() -> McpConnection {
+        let config = mock_server_config();
+        connect_to_server(config, None, Arc::new(RwLock::new(Vec::new())))
+            .await
+            .expect("Failed to connect to mock MCP server")
+    }
+
+    #[tokio::test]
+    async fn integration_mock_server_list_tools() {
+        let conn = connect_mock_server().await;
+        let tool_names: Vec<&str> = conn.tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(tool_names.contains(&"echo"), "expected 'echo' tool");
+        assert!(tool_names.contains(&"add"), "expected 'add' tool");
+        assert!(tool_names.contains(&"get_time"), "expected 'get_time' tool");
+        assert_eq!(
+            tool_names.len(),
+            3,
+            "mock server should expose exactly 3 tools"
+        );
+    }
+
+    #[tokio::test]
+    async fn integration_mock_server_call_echo() {
+        let conn = connect_mock_server().await;
+        let result = conn
+            .call_tool("echo", serde_json::json!({"message": "hello-mcp"}))
+            .await
+            .expect("echo call failed");
+        let text = extract_result_text(&result);
+        assert_eq!(text, "hello-mcp");
+    }
+
+    #[tokio::test]
+    async fn integration_mock_server_call_add() {
+        let conn = connect_mock_server().await;
+        let result = conn
+            .call_tool("add", serde_json::json!({"a": 7, "b": 3}))
+            .await
+            .expect("add call failed");
+        let text = extract_result_text(&result);
+        assert_eq!(text, "10");
+    }
+
+    #[tokio::test]
+    async fn integration_mock_server_call_get_time() {
+        let conn = connect_mock_server().await;
+        let result = conn
+            .call_tool("get_time", serde_json::json!({}))
+            .await
+            .expect("get_time call failed");
+        let text = extract_result_text(&result);
+        // Should be an ISO 8601 datetime string
+        assert!(
+            !text.is_empty(),
+            "get_time should return a non-empty string"
+        );
+        assert!(
+            text.contains("T"),
+            "get_time should return ISO 8601, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn integration_mock_server_call_unknown_tool() {
+        let conn = connect_mock_server().await;
+        let result = conn
+            .call_tool("nonexistent_tool", serde_json::json!({}))
+            .await;
+        assert!(result.is_err(), "calling unknown tool should return error");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("nonexistent_tool") || err_msg.contains("not found"),
+            "error should mention tool name, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn integration_mock_server_ping() {
+        let conn = connect_mock_server().await;
+        conn.ping().await.expect("ping should succeed");
+    }
+
+    #[tokio::test]
+    async fn integration_mock_server_call_count_increments() {
+        let conn = connect_mock_server().await;
+        let before = conn.call_count.load(Ordering::Relaxed);
+        conn.call_tool("echo", serde_json::json!({"message": "x"}))
+            .await
+            .unwrap();
+        conn.call_tool("add", serde_json::json!({"a": 1, "b": 2}))
+            .await
+            .unwrap();
+        let after = conn.call_count.load(Ordering::Relaxed);
+        assert_eq!(after - before, 2, "call_count should increment by 2");
+    }
+
+    #[tokio::test]
+    async fn integration_mock_server_error_count_stays_zero_on_success() {
+        let conn = connect_mock_server().await;
+        conn.call_tool("echo", serde_json::json!({"message": "ok"}))
+            .await
+            .unwrap();
+        assert_eq!(
+            conn.error_count.load(Ordering::Relaxed),
+            0,
+            "error_count should be 0 after successful calls"
+        );
+    }
+
+    #[tokio::test]
+    async fn integration_mock_server_last_latency_updated() {
+        let conn = connect_mock_server().await;
+        conn.call_tool("echo", serde_json::json!({"message": "lat"}))
+            .await
+            .unwrap();
+        let latency = conn.last_latency.read().await;
+        assert!(
+            latency.is_some(),
+            "last_latency should be set after a tool call"
+        );
+        assert!(
+            latency.unwrap() > std::time::Duration::ZERO,
+            "last_latency should be positive"
+        );
+    }
+
+    #[tokio::test]
+    async fn integration_mock_server_call_log_appended() {
+        let conn = connect_mock_server().await;
+        conn.call_tool("echo", serde_json::json!({"message": "log-me"}))
+            .await
+            .unwrap();
+        let log = conn.call_log.read().await;
+        assert_eq!(log.len(), 1, "call_log should have 1 entry");
+        assert_eq!(log[0].tool, "echo");
+        assert!(log[0].success, "echo call should be successful");
+    }
+
+    #[tokio::test]
+    async fn integration_mock_server_discover_skill_resources() {
+        let conn = connect_mock_server().await;
+        let skills = conn.discover_skill_resources().await;
+        // Mock server doesn't expose skill:// resources — should be empty.
+        assert!(
+            skills.is_empty(),
+            "mock server should not have skill resources, got {skills:?}"
+        );
     }
 }

--- a/rust/crates/astra-cli/src/tests/chat_stream_tests.rs
+++ b/rust/crates/astra-cli/src/tests/chat_stream_tests.rs
@@ -17,6 +17,10 @@ pub(super) fn sse_text_response(text: &str, session_id: &str) -> String {
     )
 }
 
+fn mock_mcp_server_binary() -> std::path::PathBuf {
+    crate::mcp_client::ensure_mock_mcp_server_binary()
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn stream_chat_sse_persists_first_turn_step_events_under_adopted_session_id() {
     let temp = tempfile::tempdir().unwrap();
@@ -1037,5 +1041,154 @@ async fn stream_chat_sse_reuses_authoritative_turn_identity_across_chat_turn_ret
     assert_eq!(
         payloads[0]["user_query_event_id"],
         payloads[1]["user_query_event_id"]
+    );
+}
+
+// ── Phase 3C: Chat stream MCP integration tests ──────────────────────────────
+
+#[tokio::test]
+async fn stream_chat_sse_dispatches_mcp_tool_call() {
+    let mock_server_bin = mock_mcp_server_binary();
+
+    // Connect McpClientManager to mock server via stdio
+    let mut manager = crate::mcp_client::McpClientManager::new();
+    let config = crate::mcp_client::McpServerConfig {
+        name: "mock".to_string(),
+        transport: crate::mcp_client::Transport::Stdio {
+            command: vec![mock_server_bin.to_string_lossy().to_string()],
+            args: vec![],
+            env: std::collections::HashMap::new(),
+        },
+        description: String::new(),
+        enabled: true,
+        retry: crate::mcp_client::RetryConfig::default(),
+    };
+    manager
+        .connect_for_test(config)
+        .await
+        .expect("connect to mock MCP server");
+
+    // Verify tools were discovered (echo, add, get_time)
+    let tools = manager.all_tools();
+    assert!(!tools.is_empty(), "mock MCP server should expose tools");
+    let tool_names: Vec<String> = tools.iter().map(|t| t.1.name.to_string()).collect();
+    assert!(
+        tool_names.iter().any(|n| n.contains("echo")),
+        "expected echo tool, got: {:?}",
+        tool_names
+    );
+
+    // Tool name as it will appear in SSE: mcp_{server}_{tool}
+    let mcp_tool_name = crate::mcp_client::sanitize_tool_name("mcp_mock_echo");
+
+    // HTTP mock: first call returns MCP tool_call, second returns text
+    let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let cc = call_count.clone();
+    let tool_name_clone = mcp_tool_name.clone();
+    let app = axum::Router::new().route(
+        "/chat/turn",
+        axum::routing::post(move || {
+            let cc = cc.clone();
+            let tn = tool_name_clone.clone();
+            async move {
+                let n = cc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let body = if n == 0 {
+                    format!(
+                        "data: {{\"type\":\"session_info\",\"session_id\":\"sess-mcp\"}}\n\n\
+                         data: {{\"type\":\"tool_call\",\"id\":\"mcp-1\",\"name\":\"{}\",\"arguments\":{{\"message\":\"hello from test\"}}}}\n\n\
+                         data: {{\"type\":\"turn_complete\",\"has_tool_calls\":true}}\n\n\
+                         data: [DONE]\n\n",
+                        tn
+                    )
+                } else {
+                    sse_text_response("MCP done!", "sess-mcp")
+                };
+                (
+                    [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                    body,
+                )
+            }
+        }),
+    );
+    let base = spawn_mock(app).await;
+    let api = astra_thin_client::ThinClient::new(&base, None).unwrap();
+
+    let mcp_arc = std::sync::Arc::new(tokio::sync::RwLock::new(manager));
+    let mut pm = PermissionManager::new(true);
+    let mut skill_qt = astra_skills::quality::SkillQualityTracker::new();
+    let skill_search = astra_core::SkillSearchSettings::default();
+
+    let result = stream_chat_sse(ChatTurnParams {
+        api: &api,
+        token: "fake-token",
+        auth_profile: None,
+        message: "call echo",
+        session_id: None,
+        model: None,
+        provider: None,
+        explain: ExplainMode::Off,
+        render_md: false,
+        history: &[],
+        perm_manager: &mut pm,
+        verbose_mode: false,
+        render_policy: crate::stream_render::RenderPolicy::Silent,
+        recent_tools: &[],
+        tool_health_entries: &[],
+        session_lessons: &[],
+        latest_skill_diagnosis: None,
+        latest_turn_quality_feedback: None,
+        unified_skill_registry: astra_runtime::skills::empty_unified_registry(),
+        is_plan_subtask: false,
+        plan_subtask_id: None,
+        delegation_engine: None,
+        cancel_token: None,
+        plan_assemble_line_release: None,
+        stream_event_tx: None,
+        agent_live_event_sink: None,
+        approval_request_tx: None,
+        ask_user_request_tx: None,
+        plan_review_request_tx: None,
+        mcp_manager: Some(mcp_arc),
+        skill_search: &skill_search,
+        skill_quality_tracker: &mut skill_qt,
+        discovered_skills: None,
+        messaging_metrics: None,
+        agent_spawner: None,
+        root_agent_id: None,
+        root_mailbox_slot: None,
+        observability_hub: None,
+        observability_session: None,
+        file_journal: None,
+        file_state: None,
+        database_snapshot_journal: None,
+        git_stash_journal: None,
+        git_commit_journal: None,
+        git_worktree_journal: None,
+        session_state_journal: None,
+        task_manager: None,
+        task_notify_tx: None,
+        bg_task_commands: None,
+        bash_detach_slot: None,
+        turn_index: 0,
+        pipeline_state: None,
+        pre_loaded_messages: None,
+        append_system_prompt: None,
+        session_memory_extractor: None,
+        #[cfg(feature = "harness")]
+        harness_sink: None,
+        #[cfg(feature = "harness")]
+        harness_trace: None,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(result.full_text, "MCP done!");
+    assert!(
+        result.tool_calls_count > 0,
+        "expected at least one MCP tool call"
+    );
+    assert!(
+        call_count.load(std::sync::atomic::Ordering::SeqCst) >= 2,
+        "expected at least 2 HTTP rounds (tool_call + final text)"
     );
 }

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -160,6 +160,8 @@ pub(crate) async fn dispatch(text: &str, ctx: &mut DispatchContext<'_>) -> Slash
             }
         }
 
+        "/mcp" => handle_mcp_dispatch(args, ctx).await,
+
         "/plan" => {
             let trimmed = args.trim();
             if !trimmed.is_empty() {
@@ -1700,6 +1702,607 @@ fn split_sub(text: &str) -> (&str, &str) {
     }
 }
 
+async fn handle_mcp_dispatch(args: &str, ctx: &mut DispatchContext<'_>) -> SlashResult {
+    use crate::slash_mcp::ParsedMcpCommand as Cmd;
+
+    match crate::slash_mcp::parse_mcp_command(args) {
+        Cmd::Help => {
+            ctx.show_response(mcp_help_text(ctx.state).await);
+            SlashResult::Handled
+        }
+        Cmd::Overview => {
+            ctx.show_response(mcp_overview_text(ctx.state).await);
+            SlashResult::Handled
+        }
+        Cmd::Servers => {
+            ctx.show_response(mcp_servers_text(ctx.state).await);
+            SlashResult::Handled
+        }
+        Cmd::Tools(server) => {
+            ctx.show_response(mcp_tools_text(ctx.state, server).await);
+            SlashResult::Handled
+        }
+        Cmd::Prompts => {
+            ctx.show_response(mcp_prompts_text(ctx.state).await);
+            SlashResult::Handled
+        }
+        Cmd::Resources => {
+            ctx.show_response(mcp_resources_text(ctx.state).await);
+            SlashResult::Handled
+        }
+        Cmd::Read(Some(spec)) => {
+            ctx.show_response(mcp_read_text(ctx.state, spec).await);
+            SlashResult::Handled
+        }
+        Cmd::Read(None) => {
+            ctx.show_error("Usage: /mcp read <server>:<uri>".into());
+            SlashResult::Handled
+        }
+        Cmd::History => {
+            ctx.show_response(mcp_history_text(ctx.state).await);
+            SlashResult::Handled
+        }
+        Cmd::Inspect(Some(query)) => {
+            ctx.show_response(mcp_inspect_text(ctx.state, query).await);
+            SlashResult::Handled
+        }
+        Cmd::Inspect(None) => {
+            ctx.show_error(
+                "Usage: /mcp inspect <server>:<tool>  ·  try `/mcp tools` first.".into(),
+            );
+            SlashResult::Handled
+        }
+        Cmd::Ping(server) => {
+            ctx.show_response(mcp_ping_text(ctx.state, server).await);
+            SlashResult::Handled
+        }
+        Cmd::Add(Some(_)) => mcp_fallback_notice(ctx, "add"),
+        Cmd::Add(None) => {
+            ctx.show_error("Usage: /mcp add <name> <command> [args…]".into());
+            SlashResult::Handled
+        }
+        Cmd::Remove(Some(_)) => mcp_fallback_notice(ctx, "remove"),
+        Cmd::Remove(None) => {
+            ctx.show_error("Usage: /mcp remove <name>".into());
+            SlashResult::Handled
+        }
+        Cmd::Subscribe(Some(_)) => mcp_fallback_notice(ctx, "subscribe"),
+        Cmd::Subscribe(None) => {
+            ctx.show_error("Usage: /mcp subscribe <server>:<uri>".into());
+            SlashResult::Handled
+        }
+        Cmd::Unsubscribe(Some(_)) => mcp_fallback_notice(ctx, "unsubscribe"),
+        Cmd::Unsubscribe(None) => {
+            ctx.show_error("Usage: /mcp unsubscribe <server>:<uri>".into());
+            SlashResult::Handled
+        }
+        Cmd::LogLevel(Some(_)) => mcp_fallback_notice(ctx, "log-level"),
+        Cmd::LogLevel(None) => {
+            ctx.show_error("Usage: /mcp log-level <server> <level>".into());
+            SlashResult::Handled
+        }
+        Cmd::Prompt(Some(_)) => mcp_fallback_notice(ctx, "prompt"),
+        Cmd::Prompt(None) => {
+            ctx.show_error("Usage: /mcp prompt <server>:<name> [args…]".into());
+            SlashResult::Handled
+        }
+        Cmd::Complete(Some(_)) => mcp_fallback_notice(ctx, "complete"),
+        Cmd::Complete(None) => {
+            ctx.show_error("Usage: /mcp complete <server>:<prompt|resource> <arg> [value]".into());
+            SlashResult::Handled
+        }
+        Cmd::Unknown(sub) => {
+            ctx.show_error(format!(
+                "Unknown `/mcp` subcommand: `{sub}`. Try `/mcp help`."
+            ));
+            SlashResult::Handled
+        }
+    }
+}
+
+fn mcp_fallback_notice(ctx: &mut DispatchContext<'_>, subcommand: &str) -> SlashResult {
+    ctx.show_info(format!(
+        "`/mcp {subcommand}` still uses terminal fallback. Core discovery commands (`/mcp list`, `/mcp tools`, `/mcp prompts`, `/mcp resources`, `/mcp read`, `/mcp inspect`, `/mcp ping`) are native in TUI."
+    ));
+    SlashResult::Fallback
+}
+
+async fn mcp_help_text(state: &SessionState) -> String {
+    let count = state.mcp_manager.read().await.connection_count();
+    let mut lines = vec!["MCP commands".to_string()];
+    if count == 0 {
+        lines.push("No MCP servers connected yet.".into());
+        lines.push("Add one with: /mcp add <name> <command> [args…]".into());
+    } else {
+        lines.push(format!(
+            "{count} server(s) connected. Start with `/mcp list`."
+        ));
+    }
+    lines.push("/mcp list                 overview of connected servers".into());
+    lines.push("/mcp tools [server]       list callable tools".into());
+    lines.push("/mcp inspect <server>:<tool>  show tool parameters".into());
+    lines.push("/mcp prompts              list prompt templates".into());
+    lines.push("/mcp resources            list readable resources".into());
+    lines.push("/mcp read <server>:<uri>  read one resource".into());
+    lines.push("/mcp ping [server]        connectivity check".into());
+    lines.push(
+        "Advanced: /mcp add, remove, prompt, complete, log-level, subscribe, unsubscribe, history"
+            .into(),
+    );
+    lines.join("\n")
+}
+
+fn mcp_no_servers_text() -> String {
+    "No MCP servers connected.\nAdd one with: /mcp add <name> <command> [args…]\nThen use `/mcp list` or `/mcp tools`.".into()
+}
+
+fn mcp_format_duration(d: std::time::Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m {}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+    }
+}
+
+fn mcp_state_text(state: crate::mcp_client::ConnectionState) -> &'static str {
+    match state {
+        crate::mcp_client::ConnectionState::Connected => "connected",
+        crate::mcp_client::ConnectionState::Connecting => "connecting",
+        crate::mcp_client::ConnectionState::Reconnecting => "reconnecting",
+        crate::mcp_client::ConnectionState::Disconnected => "disconnected",
+        crate::mcp_client::ConnectionState::Failed => "failed",
+    }
+}
+
+fn mcp_trim_text(text: &str, max_chars: usize) -> String {
+    let text = text.trim();
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let end = text
+        .char_indices()
+        .nth(max_chars)
+        .map(|(idx, _)| idx)
+        .unwrap_or(text.len());
+    format!("{}…", &text[..end])
+}
+
+fn mcp_truncate_block(text: &str, max_lines: usize, max_chars_per_line: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut out = lines
+        .iter()
+        .take(max_lines)
+        .map(|line| mcp_trim_text(line, max_chars_per_line))
+        .collect::<Vec<_>>();
+    if lines.len() > max_lines {
+        out.push(format!("… (+{} more lines)", lines.len() - max_lines));
+    }
+    out.join("\n")
+}
+
+async fn mcp_overview_text(state: &SessionState) -> String {
+    let manager = state.mcp_manager.read().await;
+    let count = manager.connection_count();
+    if count == 0 {
+        return mcp_no_servers_text();
+    }
+
+    let tools = manager.all_tools().len();
+    let prompts = manager.all_prompts().await.len();
+    let resources = manager.all_resources().await.len();
+    let mut capabilities = vec!["elicitation"];
+    if manager.has_sampling() {
+        capabilities.insert(0, "sampling");
+    }
+
+    let mut lines = vec![
+        "MCP overview".into(),
+        format!("Servers: {count} connected"),
+        format!("Capabilities: {}", capabilities.join(", ")),
+        format!("Tools: {tools}  ·  Prompts: {prompts}  ·  Resources: {resources}"),
+    ];
+
+    let roots = manager.roots().read().await;
+    if !roots.is_empty() {
+        let names = roots
+            .iter()
+            .map(|root| root.name.clone().unwrap_or_else(|| root.uri.clone()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        lines.push(format!("Roots: {names}"));
+    }
+    drop(roots);
+
+    lines.push(String::new());
+    lines.push("Servers".into());
+
+    let mut servers = manager.connected_servers();
+    servers.sort_unstable();
+    for name in servers {
+        if let Some(conn) = manager.get(name) {
+            let state_text = mcp_state_text(
+                manager
+                    .server_state(name)
+                    .unwrap_or(crate::mcp_client::ConnectionState::Connected),
+            );
+            let uptime = conn
+                .uptime()
+                .map(mcp_format_duration)
+                .unwrap_or_else(|| "n/a".into());
+            lines.push(format!(
+                "- {name} — {state_text} · {} tools · uptime {uptime}",
+                conn.tools().len()
+            ));
+        }
+    }
+
+    lines.push(String::new());
+    lines.push("Next: /mcp tools [server] · /mcp prompts · /mcp resources".into());
+    lines.join("\n")
+}
+
+async fn mcp_servers_text(state: &SessionState) -> String {
+    let manager = state.mcp_manager.read().await;
+    if manager.connection_count() == 0 {
+        return mcp_no_servers_text();
+    }
+
+    let mut lines = vec!["MCP servers".into()];
+    let mut servers = manager.connected_servers();
+    servers.sort_unstable();
+    for name in servers {
+        if let Some(conn) = manager.get(name) {
+            let state_text = mcp_state_text(
+                manager
+                    .server_state(name)
+                    .unwrap_or(crate::mcp_client::ConnectionState::Connected),
+            );
+            let uptime = conn
+                .uptime()
+                .map(mcp_format_duration)
+                .unwrap_or_else(|| "n/a".into());
+            let preview = conn
+                .tools()
+                .iter()
+                .take(4)
+                .map(|tool| tool.name.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            lines.push(format!(
+                "- {name} — {state_text} · {} tools · uptime {uptime}",
+                conn.tools().len()
+            ));
+            if !preview.is_empty() {
+                let more = conn.tools().len().saturating_sub(4);
+                if more > 0 {
+                    lines.push(format!("  tools: {preview}, … (+{more} more)"));
+                } else {
+                    lines.push(format!("  tools: {preview}"));
+                }
+            }
+        }
+    }
+    lines.push(String::new());
+    lines.push("Inspect one server's tools: /mcp tools <server>".into());
+    lines.join("\n")
+}
+
+async fn mcp_tools_text(state: &SessionState, server: Option<&str>) -> String {
+    let manager = state.mcp_manager.read().await;
+    if manager.connection_count() == 0 {
+        return mcp_no_servers_text();
+    }
+
+    let mut lines = Vec::new();
+    match server.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(server_name) => {
+            let Some(conn) = manager.get(server_name) else {
+                return format!(
+                    "Server '{server_name}' not found.\nTry `/mcp list` or `/mcp servers`."
+                );
+            };
+            lines.push(format!(
+                "MCP tools from {server_name} ({})",
+                conn.tools().len()
+            ));
+            for tool in conn.tools() {
+                let desc = tool.description.as_deref().unwrap_or("(no description)");
+                lines.push(format!("- {} — {}", tool.name, mcp_trim_text(desc, 90)));
+            }
+            lines.push(String::new());
+            lines.push(format!("Inspect one: /mcp inspect {server_name}:<tool>"));
+        }
+        None => {
+            let mut tools = manager
+                .all_tools()
+                .into_iter()
+                .map(|(server_name, tool)| {
+                    (
+                        server_name.to_string(),
+                        tool.name.to_string(),
+                        tool.description
+                            .as_deref()
+                            .map(|text| mcp_trim_text(text, 90))
+                            .unwrap_or_else(|| "(no description)".into()),
+                    )
+                })
+                .collect::<Vec<_>>();
+            tools.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+            lines.push(format!("MCP tools ({})", tools.len()));
+            for (server_name, tool_name, desc) in tools {
+                lines.push(format!("- {server_name}:{tool_name} — {desc}"));
+            }
+            lines.push(String::new());
+            lines.push("Inspect one: /mcp inspect <server>:<tool>".into());
+        }
+    }
+    lines.join("\n")
+}
+
+async fn mcp_prompts_text(state: &SessionState) -> String {
+    let manager = state.mcp_manager.read().await;
+    if manager.connection_count() == 0 {
+        return mcp_no_servers_text();
+    }
+
+    let mut prompts = manager.all_prompts().await;
+    if prompts.is_empty() {
+        return "No MCP prompts available from connected servers.".into();
+    }
+    prompts.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.name.cmp(&b.1.name)));
+
+    let mut lines = vec![format!("MCP prompts ({})", prompts.len())];
+    for (server_name, prompt) in prompts {
+        let args = prompt
+            .arguments
+            .as_ref()
+            .map(|args| {
+                args.iter()
+                    .map(|arg| {
+                        if arg.required.unwrap_or(false) {
+                            format!("<{}>", arg.name)
+                        } else {
+                            format!("[{}]", arg.name)
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            })
+            .unwrap_or_default();
+        let desc = prompt
+            .description
+            .as_deref()
+            .map(|text| mcp_trim_text(text, 90))
+            .unwrap_or_else(|| "(no description)".into());
+        if args.is_empty() {
+            lines.push(format!("- {server_name}:{} — {desc}", prompt.name));
+        } else {
+            lines.push(format!("- {server_name}:{} {args} — {desc}", prompt.name));
+        }
+    }
+    lines.push(String::new());
+    lines.push("Run one: /mcp prompt <server>:<name> [args…]".into());
+    lines.join("\n")
+}
+
+async fn mcp_resources_text(state: &SessionState) -> String {
+    let manager = state.mcp_manager.read().await;
+    if manager.connection_count() == 0 {
+        return mcp_no_servers_text();
+    }
+
+    let mut resources = manager.all_resources().await;
+    if resources.is_empty() {
+        return "No MCP resources available from connected servers.".into();
+    }
+    resources.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.raw.uri.cmp(&b.1.raw.uri)));
+
+    let mut lines = vec![format!("MCP resources ({})", resources.len())];
+    for (server_name, resource) in resources {
+        let mime = resource.raw.mime_type.as_deref().unwrap_or("unknown");
+        let desc = resource
+            .description
+            .as_deref()
+            .map(|text| mcp_trim_text(text, 80))
+            .unwrap_or_default();
+        if desc.is_empty() {
+            lines.push(format!("- {server_name}:{} [{mime}]", resource.raw.uri));
+        } else {
+            lines.push(format!(
+                "- {server_name}:{} [{mime}] — {desc}",
+                resource.raw.uri
+            ));
+        }
+    }
+    lines.push(String::new());
+    lines.push("Read one: /mcp read <server>:<uri>".into());
+    lines.join("\n")
+}
+
+async fn mcp_read_text(state: &SessionState, spec: &str) -> String {
+    let spec = spec.trim();
+    let (server_name, uri) = match spec.split_once(':') {
+        Some((server_name, uri)) if !server_name.is_empty() && !uri.is_empty() => {
+            (server_name, uri)
+        }
+        _ => return "Usage: /mcp read <server>:<uri>".into(),
+    };
+
+    let conn = {
+        let manager = state.mcp_manager.read().await;
+        if manager.connection_count() == 0 {
+            return mcp_no_servers_text();
+        }
+        match manager.get(server_name) {
+            Some(conn) => conn,
+            None => {
+                return format!(
+                    "Server '{server_name}' not found.\nTry `/mcp list` or `/mcp servers`."
+                );
+            }
+        }
+    };
+
+    match conn.read_resource(uri).await {
+        Ok(content) if content.trim().is_empty() => {
+            format!("{server_name}:{uri}\n(empty resource)")
+        }
+        Ok(content) => format!(
+            "{server_name}:{uri}\n\n{}",
+            mcp_truncate_block(&content, 40, 140)
+        ),
+        Err(error) => format!("Failed to read '{uri}' from '{server_name}': {error}"),
+    }
+}
+
+async fn mcp_history_text(state: &SessionState) -> String {
+    let manager = state.mcp_manager.read().await;
+    if manager.connection_count() == 0 {
+        return mcp_no_servers_text();
+    }
+
+    let mut entries = Vec::new();
+    for name in manager.server_names() {
+        if let Some(conn) = manager.get_connection(name) {
+            let log = conn.call_log.read().await;
+            entries.extend(log.iter().cloned());
+        }
+    }
+    if entries.is_empty() {
+        return "No MCP tool calls recorded yet.\nUse an MCP tool, then run `/mcp history` again."
+            .into();
+    }
+    entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+    let mut lines = vec![format!("MCP call history ({})", entries.len())];
+    for entry in entries.into_iter().take(20) {
+        let status = if entry.success { "ok" } else { "fail" };
+        lines.push(format!(
+            "- {} · {}:{} · {}ms · {status}",
+            entry.timestamp, entry.server, entry.tool, entry.latency_ms
+        ));
+        if let Some(error) = entry.error {
+            lines.push(format!("  error: {}", mcp_trim_text(&error, 120)));
+        }
+    }
+    lines.join("\n")
+}
+
+fn mcp_protocol_tool_text(server: &str, tool: &rmcp::model::Tool) -> String {
+    let mut lines = vec![
+        format!("Tool: {server}:{}", tool.name),
+        format!(
+            "Description: {}",
+            tool.description.as_deref().unwrap_or("(no description)")
+        ),
+    ];
+    let schema = &*tool.input_schema;
+    if let Some(props) = schema.get("properties").and_then(|value| value.as_object()) {
+        let required = schema
+            .get("required")
+            .and_then(|value| value.as_array())
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|value| value.as_str())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if props.is_empty() {
+            lines.push("Parameters: none".into());
+        } else {
+            lines.push("Parameters:".into());
+            for (name, param_schema) in props {
+                let required_marker = if required.contains(&name.as_str()) {
+                    "required"
+                } else {
+                    "optional"
+                };
+                let param_type = param_schema
+                    .get("type")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("any");
+                let desc = param_schema
+                    .get("description")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("");
+                if desc.is_empty() {
+                    lines.push(format!("- {name}: {param_type} ({required_marker})"));
+                } else {
+                    lines.push(format!(
+                        "- {name}: {param_type} ({required_marker}) — {}",
+                        mcp_trim_text(desc, 100)
+                    ));
+                }
+            }
+        }
+    } else {
+        lines.push("Parameters: none".into());
+    }
+    lines.join("\n")
+}
+
+fn mcp_builtin_tool_text(meta: &astra_turn_core::tool::registry::meta::ToolMeta) -> String {
+    [
+        format!("Tool: {}", meta.name),
+        format!("Description: {}", meta.description),
+        format!("Scope: {:?}", meta.scope),
+        format!("Intents: {:?}", meta.intents),
+        format!("Schema tokens: {}", meta.schema_tokens),
+    ]
+    .join("\n")
+}
+
+async fn mcp_inspect_text(state: &SessionState, query: &str) -> String {
+    let manager = state.mcp_manager.read().await;
+    match crate::slash_mcp::resolve_protocol_tool_query(&manager, query) {
+        Ok((server, tool)) => mcp_protocol_tool_text(server, tool),
+        Err(protocol_error) => {
+            for meta in astra_turn_core::tool::registry::meta::TOOL_CATALOG {
+                if meta.name == query
+                    || format!("mcp_{}", meta.name) == query
+                    || format!("mcp_memoria_{}", meta.name) == query
+                {
+                    return mcp_builtin_tool_text(meta);
+                }
+            }
+            protocol_error
+        }
+    }
+}
+
+async fn mcp_ping_text(state: &SessionState, server: Option<&str>) -> String {
+    let mut manager = state.mcp_manager.write().await;
+    if manager.connection_count() == 0 {
+        return mcp_no_servers_text();
+    }
+
+    match server.map(str::trim).filter(|name| !name.is_empty()) {
+        Some(name) => match manager.ping(name).await {
+            Ok(duration) => format!("✓ {name}: {:.1}ms", duration.as_secs_f64() * 1000.0),
+            Err(error) => format!("✗ {name}: {error}"),
+        },
+        None => {
+            let mut results = manager.ping_all().await;
+            if results.is_empty() {
+                return "No MCP servers connected.".into();
+            }
+            results.sort_by(|a, b| a.0.cmp(&b.0));
+            results
+                .into_iter()
+                .map(|(name, result)| match result {
+                    Ok(duration) => format!("✓ {name}: {:.1}ms", duration.as_secs_f64() * 1000.0),
+                    Err(error) => format!("✗ {name}: {error}"),
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ConfigCommandRoute {
     Panel,
@@ -2765,6 +3368,31 @@ mod routing_tests {
             CONTEXT_USAGE_MESSAGE,
             "Usage: /context — open the context panel\n       /context dump [path] — write a JSON snapshot."
         );
+    }
+}
+
+#[cfg(test)]
+mod mcp_ux_tests {
+    use super::{mcp_help_text, mcp_no_servers_text};
+
+    #[tokio::test]
+    async fn mcp_help_mentions_core_commands() {
+        let state = crate::session_state::SessionState::default();
+        let text = mcp_help_text(&state).await;
+        assert!(text.contains("/mcp list"), "missing list help: {text}");
+        assert!(text.contains("/mcp tools"), "missing tools help: {text}");
+        assert!(text.contains("/mcp read"), "missing read help: {text}");
+        assert!(
+            text.contains("/mcp inspect"),
+            "missing inspect help: {text}"
+        );
+    }
+
+    #[test]
+    fn mcp_no_servers_text_guides_user_to_add_then_list() {
+        let text = mcp_no_servers_text();
+        assert!(text.contains("/mcp add"), "missing add guidance: {text}");
+        assert!(text.contains("/mcp list"), "missing list guidance: {text}");
     }
 }
 


### PR DESCRIPTION
## Summary

Major MCP client improvements: call logging with stats, TUI-native `/mcp` subcommand dispatch, a mock MCP server for integration testing, and chat-stream MCP integration tests.

## Changes

### MCP client (`mcp_client.rs`)
- Add `CallLogEntry` struct and ring-buffer call logging (`call_log`, `call_count`, `error_count`, `last_latency`, `last_error`)
- Replace `eprintln!` error output with `tracing::*` instrumentation
- Add `get_connection()` and `server_names()` methods to `McpClientManager`
- Add `connect_for_test()` helper for integration tests
- Add `keepalive_handle` to prevent premature transport closure

### `/mcp` slash command overhaul (`slash_mcp.rs`)
- New `ParsedMcpCommand` enum covering 16 subcommands: `help`, `list`, `tools`, `inspect`, `prompts`, `resources`, `read`, `history`, `servers`, `status`, `ping`, `add`, `remove`, `prompt`, `complete`, `subscribe`, `unsubscribe`, `log-level`
- Structured parser `parse_mcp_command()` with `split_mcp_subcommand()`
- `resolve_protocol_tool_query()` for `<server>:<tool>` lookup with disambiguation

### TUI MCP dispatch (`tui/slash_dispatch.rs`)
- Add `/mcp` to TUI dispatch routing
- `handle_mcp_dispatch()` with rich inline responses per subcommand
- Graceful fallback for mutation commands (`add`, `remove`, etc.)

### Mock MCP server (`examples/mock_mcp_server.rs`)
- New stdio-transport MCP server exposing `echo`, `add`, `get_time` tools
- Used by integration tests via subprocess spawn

### Tests
- MCP dispatch error-path tests (`mcp_dispatch.rs`)
- Chat-stream MCP integration test (`chat_stream_tests.rs`)
- End-to-end test: SSE mock → MCP tool_call → mock server response

### Dependencies
- `rmcp` dev-dependency with `server`, `macros`, `schemars`, `transport-io` features
- `schemars` dev-dependency

## Testing
- `cargo check -p astra-cli` passes
- `cargo test -p astra-cli` passes (including new MCP integration tests)
