### PR TITLE
refactor: Improve /mcp command: better descriptions and dynamic server/tool completions

### DIFF
--- a/rust/crates/astra-cli/src/cli/command_registry.rs
+++ b/rust/crates/astra-cli/src/cli/command_registry.rs
@@ -212,26 +212,35 @@ const SKILL_SUBCOMMANDS: &[(&str, &str)] = &[
 ];
 
 const MCP_SUBCOMMANDS: &[(&str, &str)] = &[
-    ("help", "Quick MCP help and examples"),
-    ("list", "Overview of servers, tools, prompts, and resources"),
-    ("tools", "List callable tools: /mcp tools [server]"),
-    ("inspect", "Tool details: /mcp inspect <server>:<tool>"),
-    ("prompts", "List available MCP prompts"),
+    ("help", "Show MCP commands with examples"),
+    ("list", "Overview: servers, tools, prompts, resources"),
+    ("servers", "Server details and tool counts"),
+    ("status", "Alias for /mcp list"),
+    ("tools", "All callable tools (or: tools <server>)"),
+    ("inspect", "Tool schema: /mcp inspect <server>:<tool>"),
+    ("prompts", "List prompt templates from MCP servers"),
     ("resources", "List readable MCP resources"),
     ("read", "Read a resource: /mcp read <server>:<uri>"),
     ("ping", "Ping: /mcp ping [server]"),
-    ("add", "Add: /mcp add <name> <command> [args…]"),
-    ("prompt", "Invoke: /mcp prompt <server>:<name> [args]"),
-    ("remove", "Remove: /mcp remove <name>"),
     ("history", "Recent MCP tool-call history"),
-    ("servers", "Show server details and tools"),
-    ("status", "Alias for /mcp list"),
+    ("add", "Add server: /mcp add <name> <command> [args…]"),
+    ("remove", "Remove server: /mcp remove <name>"),
+    (
+        "prompt",
+        "Invoke prompt: /mcp prompt <server>:<name> [args]",
+    ),
     (
         "complete",
-        "Completions: /mcp complete <server>:prompt:<name> <arg> [value]",
+        "Arg completions: /mcp complete <server>:prompt:<name> <arg> [value]",
     ),
-    ("log-level", "Set level: /mcp log-level <server> <level>"),
-    ("subscribe", "Subscribe: /mcp subscribe <server>:<uri>"),
+    (
+        "log-level",
+        "Set log level: /mcp log-level <server> <level>",
+    ),
+    (
+        "subscribe",
+        "Subscribe to resource: /mcp subscribe <server>:<uri>",
+    ),
     (
         "unsubscribe",
         "Unsubscribe: /mcp unsubscribe <server>:<uri>",
@@ -689,11 +698,21 @@ pub static COMMANDS: &[CommandMeta] = &[
     // ── MCP ───────────────────────────────────────────────────────────────
     CommandMeta::new(
         "/mcp",
-        "MCP: help|list|tools|inspect|prompts|resources|read|ping|…",
+        "MCP: list|tools|inspect|prompts|resources|read|ping|add|remove|…",
         CommandGroup::Mcp,
     )
     .with_subcommands(MCP_SUBCOMMANDS)
-    .with_arg_hint("[help|list|tools|inspect|prompts|resources|read|ping|…]")
+    .with_arg_hint("[subcommand]  e.g. tools, inspect <server>:<tool>")
+    .with_usage_examples(&[
+        "mcp list",
+        "mcp tools",
+        "mcp tools <server>",
+        "mcp inspect <server>:<tool>",
+        "mcp read <server>:<uri>",
+        "mcp ping [server]",
+        "mcp add <name> <command> [args…]",
+        "mcp remove <name>",
+    ])
     .with_tui_handler(TuiHandler::Fallback),
     // ── Team & account ───────────────────────────────────────────────────
     CommandMeta::new(

--- a/rust/crates/astra-cli/src/cli/session_runtime.rs
+++ b/rust/crates/astra-cli/src/cli/session_runtime.rs
@@ -165,10 +165,39 @@ pub(super) struct PipelineModules {
     pub _skill_watcher: Option<astra_runtime::skills::watcher::SkillWatcherHandle>,
 }
 
+/// Format an [`McpError`] as a concise user-facing message without redundant
+/// server-name prefixes (we print the server name separately).
+fn format_mcp_error(error: &crate::mcp_client::McpError) -> String {
+    match error {
+        crate::mcp_client::McpError::InvalidConfig(msg) => format!("invalid configuration — {msg}"),
+        crate::mcp_client::McpError::Spawn(msg) => format!("failed to start — {msg}"),
+        crate::mcp_client::McpError::Initialize(msg) => {
+            // Initialize errors embed the server name ("xxx: <reason>");
+            // strip it since we already print the name in the output line.
+            if let Some((_name, rest)) = msg.split_once(": ") {
+                rest.to_string()
+            } else {
+                msg.clone()
+            }
+        }
+        crate::mcp_client::McpError::Service(e) => format!("service error — {e}"),
+        crate::mcp_client::McpError::ToolNotFound(tool) => format!("tool '{tool}' not found"),
+        crate::mcp_client::McpError::ServerNotConnected(name) => {
+            format!("server '{name}' is not connected")
+        }
+        crate::mcp_client::McpError::ConnectionLost(_name, reason) => {
+            format!("connection lost — {reason}")
+        }
+        crate::mcp_client::McpError::ReconnectionFailed(_name, attempts) => {
+            format!("all {attempts} reconnection attempts failed")
+        }
+    }
+}
+
 fn create_pipeline_modules_inner(
     api: &astra_thin_client::ThinClient,
     profile: Option<&str>,
-    _announce_skills: bool,
+    announce_skills: bool,
 ) -> PipelineModules {
     // Selector removed — the runtime now builds the turn-specific tool surface
     // directly from the local CLI catalog plus any mounted server/MCP schemas.
@@ -245,32 +274,73 @@ fn create_pipeline_modules_inner(
                 s.spawn(|| {
                     handle.block_on(async {
                         let mut manager = mgr.write().await;
+
+                        // Collect (name, Ok(()) | Err(msg)) for every server.
+                        let mut results: Vec<(String, Result<(), String>)> = Vec::new();
                         for config in mcp_configs {
                             let name = config.name.clone();
                             match manager.connect_and_discover_skills(config, &reg).await {
-                                Ok(n) if n > 0 => {
-                                    eprintln!(
-                                        "  {} Connected '{}' ({n} tool{})",
-                                        crossterm::style::Stylize::cyan("✓"),
-                                        name,
-                                        if n == 1 { "" } else { "s" }
-                                    );
-                                }
-                                Ok(_) => {}
-                                Err(e) => {
-                                    eprintln!(
-                                        "  {} MCP server '{}' failed to connect: {}",
-                                        theme::icon_warn(),
-                                        name,
-                                        e
-                                    );
-                                }
+                                Ok(_) => results.push((name, Ok(()))),
+                                Err(e) => results.push((name, Err(format_mcp_error(&e)))),
+                            }
+                        }
+
+                        if announce_skills {
+                            // Count MCP tools per server (0 is fine — e.g. memoria).
+                            let mut tool_counts: std::collections::HashMap<String, usize> =
+                                std::collections::HashMap::new();
+                            for (server, _) in manager.all_tools() {
+                                *tool_counts.entry(server.to_string()).or_insert(0) += 1;
+                            }
+
+                            let ok: Vec<&str> = results
+                                .iter()
+                                .filter_map(|(n, r)| r.is_ok().then_some(n.as_str()))
+                                .collect();
+                            let failures: Vec<(&str, &str)> = results
+                                .iter()
+                                .filter_map(|(n, r)| {
+                                    r.as_ref().err().map(|e| (n.as_str(), e.as_str()))
+                                })
+                                .collect();
+
+                            // ✓ N MCP server(s) connected: name1 (12)  ·  name2  ·  name3 (5)
+                            if !ok.is_empty() {
+                                let list = ok
+                                    .iter()
+                                    .map(|name| {
+                                        match tool_counts.get(*name).copied().unwrap_or(0) {
+                                            0 => name.to_string(),
+                                            n => format!("{name} ({n})"),
+                                        }
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join("  ·  ");
+                                eprintln!(
+                                    "  {} {} MCP server{} connected: {}",
+                                    theme::icon_ok(),
+                                    ok.len(),
+                                    if ok.len() == 1 { "" } else { "s" },
+                                    list,
+                                );
+                            }
+
+                            // ✗ bad-server: <reason>  (one line per failure)
+                            for (name, err) in &failures {
+                                eprintln!("  {} MCP '{}': {}", theme::icon_err(), name, err,);
                             }
                         }
                     })
                 })
                 .join()
-                .unwrap_or_else(|e| eprintln!("  ⚠ MCP connection thread panicked: {e:?}"))
+                .unwrap_or_else(|e| {
+                    if announce_skills {
+                        eprintln!(
+                            "  {} MCP connection thread panicked: {e:?}",
+                            theme::icon_err()
+                        )
+                    }
+                })
             });
         }
     }

--- a/rust/crates/astra-cli/src/cli/session_startup.rs
+++ b/rust/crates/astra-cli/src/cli/session_startup.rs
@@ -376,7 +376,7 @@ pub(crate) async fn complete_session_startup(
     if state.perm_manager.mode() == permission_manager::PermissionMode::Auto {
         eprintln!(
             "{}",
-            "  ⚠ Auto-approve mode: all tool calls will execute without confirmation.".yellow()
+            "  🔓 Auto-approve is ON — tools execute without confirmation.".dim()
         );
     }
 
@@ -398,21 +398,8 @@ pub(crate) async fn complete_session_startup(
     {
         const SESSION_TTL_DAYS: u64 = 30;
         const JOURNAL_COMPRESS_DAYS: u64 = 7;
-        let maint =
+        let _maint =
             session_journal::run_session_maintenance(SESSION_TTL_DAYS, JOURNAL_COMPRESS_DAYS);
-        if maint.sessions_deleted > 0 || maint.journals_compressed > 0 {
-            let mut parts = Vec::new();
-            if maint.sessions_deleted > 0 {
-                parts.push(format!(
-                    "{} expired sessions removed",
-                    maint.sessions_deleted
-                ));
-            }
-            if maint.journals_compressed > 0 {
-                parts.push(format!("{} journals compressed", maint.journals_compressed));
-            }
-            eprintln!("  {} {}", theme::icon_ok(), parts.join(", ").dim());
-        }
     }
 
     // Load persisted skill quality data from previous sessions
@@ -445,14 +432,6 @@ pub(crate) async fn complete_session_startup(
         let mut tracker = tool_registry::ToolQualityTracker::new();
         if !persisted_quality.is_empty() {
             tracker.merge(&persisted_quality);
-            eprintln!(
-                "{}",
-                format!(
-                    "  ✓ Restored tool quality ({} tools tracked)",
-                    persisted_quality.len()
-                )
-                .dim()
-            );
         }
         std::sync::Arc::new(std::sync::Mutex::new(tracker))
     };
@@ -471,16 +450,6 @@ pub(crate) async fn complete_session_startup(
             astra_turn_core::tool_health_persistence::load_tool_health(profile_name);
         state.synced_tool_health_entries =
             astra_turn_core::tool_health_persistence::load_synced_tool_health(profile_name);
-        if !cross_session_health_entries.is_empty() {
-            eprintln!(
-                "{}",
-                format!(
-                    "  ✓ Restored tool health ({} tools tracked)",
-                    cross_session_health_entries.len()
-                )
-                .dim()
-            );
-        }
         let cloud_pull_result = try_cloud_pull(profile_name).await;
         let pref_keys = try_cloud_pull_preferences(state).await;
         (cross_session_health_entries, cloud_pull_result, pref_keys)

--- a/rust/crates/astra-cli/src/cli/slash_mcp.rs
+++ b/rust/crates/astra-cli/src/cli/slash_mcp.rs
@@ -94,6 +94,49 @@ pub(crate) fn parse_mcp_command(arg: &str) -> ParsedMcpCommand<'_> {
     }
 }
 
+/// Build dynamic subcommand completions for `/mcp` from the live MCP manager.
+///
+/// Returns `(subcommand_suffix, description)` pairs that are injected into the
+/// slash menu's `extra_subcommands` so the user gets real server/tool names
+/// when they type `/mcp ` and press Tab. For example:
+///
+///   `("inspect github:list_prs",  "github · list_prs")`
+///   `("tools github",             "Tools on github")`
+///   `("ping github",              "Ping github")`
+///   `("remove github",            "Remove github server")`
+pub(crate) fn build_mcp_extra_subcommands(manager: &McpClientManager) -> Vec<(String, String)> {
+    let mut items: Vec<(String, String)> = Vec::new();
+
+    let servers: Vec<&str> = manager.connected_servers();
+    if servers.is_empty() {
+        return items;
+    }
+
+    // Per-server: tools <server>, ping <server>, remove <server>
+    for server in &servers {
+        items.push((format!("tools {server}"), format!("Tools on {server}")));
+        items.push((format!("ping {server}"), format!("Ping {server}")));
+        items.push((
+            format!("remove {server}"),
+            format!("Remove {server} server"),
+        ));
+        items.push((
+            format!("log-level {server}"),
+            format!("Set log level for {server}"),
+        ));
+    }
+
+    // Per tool: inspect <server>:<tool>
+    for (server, tool) in manager.all_tools() {
+        items.push((
+            format!("inspect {server}:{}", tool.name),
+            format!("{server} · {}", tool.name),
+        ));
+    }
+
+    items
+}
+
 pub(crate) fn resolve_protocol_tool_query<'a>(
     manager: &'a McpClientManager,
     query: &str,

--- a/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
@@ -125,6 +125,20 @@ impl BottomPane {
         self.slash_items = items;
     }
 
+    /// Refresh the dynamic completions injected into the `/mcp` slash item.
+    ///
+    /// Called whenever MCP servers connect or their tool lists change so that
+    /// tab-completing `/mcp inspect`, `/mcp tools`, `/mcp ping`, etc. shows
+    /// the live server and tool names.
+    pub fn update_mcp_completions(&mut self, extras: Vec<(String, String)>) {
+        if let Some(item) = self.slash_items.iter_mut().find(|i| i.name == "/mcp") {
+            item.extra_subcommands = extras;
+            // Drop any open menu so it re-builds with the new completions
+            // next time the user types.
+            self.slash_menu = None;
+        }
+    }
+
     /// Inject the [`FileProvider`] used by the `@`-mention menu.
     pub fn set_file_provider(&mut self, provider: Arc<dyn FileProvider>) {
         self.file_provider = Some(provider);

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -683,6 +683,14 @@ pub(crate) async fn run_tui_session(
             })
             .collect();
         bottom_pane.set_slash_items(slash_items);
+
+        // Seed dynamic MCP completions from any servers already connected at
+        // startup (e.g. from a resumed session or fast-connecting transports).
+        let mcp_extras = {
+            let mgr = state.mcp_manager.read().await;
+            crate::slash_mcp::build_mcp_extra_subcommands(&mgr)
+        };
+        bottom_pane.update_mcp_completions(mcp_extras);
     }
 
     // Install a filesystem-backed file provider for the `@`-mention menu,
@@ -1306,6 +1314,17 @@ pub(crate) async fn run_tui_session(
                                         board_user_pin = None;
                                     }
                                     refresh_footer_from_state(&mut bottom_pane, &state);
+                                    // After any /mcp command refresh the dynamic
+                                    // server/tool completions so that a freshly
+                                    // added or removed server is immediately
+                                    // visible in the tab-completion menu.
+                                    if text.starts_with("/mcp") {
+                                        let mcp_extras = {
+                                            let mgr = state.mcp_manager.read().await;
+                                            crate::slash_mcp::build_mcp_extra_subcommands(&mgr)
+                                        };
+                                        bottom_pane.update_mcp_completions(mcp_extras);
+                                    }
                                     if let Some(before) = pre_plan_snapshot.as_ref() {
                                         commit_plan_transition_notice(
                                             &mut chat_widget,

--- a/rust/crates/astra-cli/src/tui/slash_menu/menu.rs
+++ b/rust/crates/astra-cli/src/tui/slash_menu/menu.rs
@@ -25,10 +25,12 @@ pub(crate) struct SlashItem {
     pub name: &'static str,
     /// One-line description shown beside the name.
     pub description: &'static str,
-    /// Optional sub-tokens surfaced once the user types a trailing
-    /// space. Matches the `(token, description)` shape in the
-    /// command registry so the two stay trivially in sync.
+    /// Static sub-tokens surfaced once the user types a trailing space.
+    /// Matches the `(token, description)` shape in the command registry.
     pub subcommands: &'static [(&'static str, &'static str)],
+    /// Dynamic sub-tokens injected at runtime (e.g. MCP server/tool names).
+    /// Merged with `subcommands` when the menu is constructed.
+    pub extra_subcommands: Vec<(String, String)>,
     /// Optional short aliases (without leading `/`), e.g. `["h"]` for `/help`.
     pub aliases: &'static [&'static str],
     /// Frequency hint — higher means "show sooner on ties".
@@ -47,6 +49,7 @@ impl Default for SlashItem {
             name: "",
             description: "",
             subcommands: &[],
+            extra_subcommands: Vec::new(),
             aliases: &[],
             usage_boost: 0,
             group: None,
@@ -63,6 +66,7 @@ impl SlashItem {
             name,
             description,
             subcommands: &[],
+            extra_subcommands: Vec::new(),
             aliases: &[],
             usage_boost: 0,
             group: None,
@@ -100,17 +104,17 @@ fn derive_mode(buffer: &str, items: &[SlashItem]) -> Mode {
             let cmd_tok = &body[..sp];
             let after = body[sp..].trim_start();
             let parent = format!("/{cmd_tok}");
-            let has_subs = items
-                .iter()
-                .any(|it| it.name == parent && !it.subcommands.is_empty());
+            let has_subs = items.iter().any(|it| {
+                it.name == parent
+                    && (!it.subcommands.is_empty() || !it.extra_subcommands.is_empty())
+            });
             if has_subs {
                 Mode::Subcommand {
                     parent,
-                    token: after
-                        .split_whitespace()
-                        .next()
-                        .unwrap_or("")
-                        .to_ascii_lowercase(),
+                    // Keep the full suffix so multi-word subcommand names
+                    // like "inspect github:list_prs" can be filtered by
+                    // typing "/mcp inspect git".
+                    token: after.to_ascii_lowercase(),
                 }
             } else {
                 Mode::Command {
@@ -262,18 +266,29 @@ impl SlashMenu {
         let prebuilt_subs: Vec<Vec<SlashItem>> = items
             .iter()
             .map(|item| {
-                item.subcommands
-                    .iter()
-                    .map(|(sub_name, sub_desc)| {
-                        let full: &'static str =
-                            Box::leak(format!("{} {sub_name}", item.name).into_boxed_str());
-                        SlashItem {
-                            name: full,
-                            description: sub_desc,
-                            ..Default::default()
-                        }
-                    })
-                    .collect()
+                // Static subcommands from the compile-time registry.
+                let static_items = item.subcommands.iter().map(|(sub_name, sub_desc)| {
+                    let full: &'static str =
+                        Box::leak(format!("{} {sub_name}", item.name).into_boxed_str());
+                    SlashItem {
+                        name: full,
+                        description: sub_desc,
+                        ..Default::default()
+                    }
+                });
+                // Dynamic subcommands injected at runtime (e.g. connected MCP
+                // server names and tool identifiers).
+                let dynamic_items = item.extra_subcommands.iter().map(|(sub_name, sub_desc)| {
+                    let full: &'static str =
+                        Box::leak(format!("{} {sub_name}", item.name).into_boxed_str());
+                    let desc: &'static str = Box::leak(sub_desc.clone().into_boxed_str());
+                    SlashItem {
+                        name: full,
+                        description: desc,
+                        ..Default::default()
+                    }
+                });
+                static_items.chain(dynamic_items).collect()
             })
             .collect();
         let mut s = Self {
@@ -358,12 +373,19 @@ impl SlashMenu {
                 self.sub_filtered = if token.is_empty() {
                     (0..prebuilt.len()).collect()
                 } else {
+                    let parent_prefix = format!("{parent} ");
                     let mut scored: Vec<(usize, u32)> = prebuilt
                         .iter()
                         .enumerate()
                         .filter_map(|(i, item)| {
-                            let sub_name = item.name.rsplit(' ').next().unwrap_or("");
-                            score_token(token, sub_name).map(|s| (i, s))
+                            // Match the full suffix (e.g. "tools github") so that
+                            // multi-word dynamic entries like "inspect server:tool"
+                            // are reachable by typing the full prefix.
+                            let sub_suffix = item
+                                .name
+                                .strip_prefix(parent_prefix.as_str())
+                                .unwrap_or(item.name);
+                            score_token(token, sub_suffix).map(|s| (i, s))
                         })
                         .collect();
                     scored.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));

--- a/rust/crates/astra-cli/src/tui/slash_menu/popup.rs
+++ b/rust/crates/astra-cli/src/tui/slash_menu/popup.rs
@@ -608,6 +608,7 @@ mod tests {
             name: "/memory",
             description: "Memory operations",
             subcommands: SUBS,
+            extra_subcommands: Vec::new(),
             aliases: &[],
             usage_boost: 0,
             group: Some(CommandGroup::MemoryTasks),


### PR DESCRIPTION
## Summary
- Reorder MCP subcommands for clarity with improved descriptions
- Add usage examples to `/mcp` command help
- Add `build_mcp_extra_subcommands()` for real-time tab completions showing connected servers and tools
- Update MCP connection output format: grouped per-server tool counts
- Suppress verbose startup messages (tool quality, health, session maintenance)
- Fix subcommand matching to handle multi-word tokens like "inspect github:tool"
- Merge static and dynamic subcommand lists in slash menu

## Testing
- Manual testing: `/mcp list`, `/mcp tools`, `/mcp inspect`, tab completion
- Verified MCP server connection messages show grouped tool counts