### PR TITLE
refactor: Improve context management and task finalization

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -670,6 +670,7 @@ pub(crate) async fn stream_chat_sse(
             guardrail_tuner: astra_runtime::config_admin::guardrail::GuardrailTuner::default(),
             guardrail_tuner_records_cursor: 0,
             forced_completion_soft_stop: false,
+            forced_task_board_completion_gate: false,
         },
         telemetry: TelemetryState {
             explain_turns: Vec::new(),

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -713,6 +713,8 @@ pub(crate) async fn stream_chat_sse(
             workspace_root_hint: Some(project_root.to_string_lossy().into_owned()),
             forward_headers: std::collections::HashMap::new(),
             llm_token_service: None,
+            task_board_monitor: p.task_manager.clone(),
+            task_board_snapshot: Default::default(),
         },
         messaging: MessagingState {
             mailbox: root_mailbox,

--- a/rust/crates/astra-cli/src/mcp_client.rs
+++ b/rust/crates/astra-cli/src/mcp_client.rs
@@ -27,12 +27,11 @@
 #![allow(dead_code)]
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Instant;
 
-use crate::theme;
 use crossterm::style::Stylize;
 use rmcp::{
     ClientHandler, Peer, RoleClient,
@@ -763,7 +762,8 @@ pub struct McpConnection {
     /// Error message from the most recent failed call, if any.
     pub last_error: RwLock<Option<String>>,
     /// Ring buffer of recent call log entries (max CALL_LOG_MAX_ENTRIES).
-    pub call_log: RwLock<Vec<CallLogEntry>>,
+    /// `VecDeque` so eviction at capacity is O(1) instead of O(n).
+    pub call_log: RwLock<VecDeque<CallLogEntry>>,
     /// Keep-alive handle for the background MCP service task.
     /// Stored to prevent transport closure when `RunningService` is dropped.
     keepalive_handle: Option<tokio::task::JoinHandle<()>>,
@@ -1021,9 +1021,9 @@ impl McpConnection {
         {
             let mut log = self.call_log.write().await;
             if log.len() >= CALL_LOG_MAX_ENTRIES {
-                log.remove(0);
+                log.pop_front();
             }
-            log.push(CallLogEntry {
+            log.push_back(CallLogEntry {
                 timestamp: chrono::Utc::now().to_rfc3339(),
                 tool: name.to_string(),
                 server: self.name.clone(),
@@ -1466,9 +1466,11 @@ impl McpClientManager {
                 .unwrap_or("")
                 .to_string();
             if let Some(prev_server) = seen.get(&name) {
-                eprintln!(
-                    "[WARN] MCP tool name collision: '{name}' from server '{server}' \
-                     conflicts with server '{prev_server}' — skipping duplicate"
+                tracing::warn!(
+                    tool = %name,
+                    server = %server,
+                    prev_server = %prev_server,
+                    "MCP tool name collision; skipping duplicate"
                 );
                 collision_count += 1;
                 continue;
@@ -1477,9 +1479,9 @@ impl McpClientManager {
             schemas.push(schema);
         }
         if collision_count > 0 {
-            eprintln!(
-                "[WARN] {collision_count} MCP tool(s) skipped due to name collisions \
-                 — check server configurations for duplicate tool names"
+            tracing::warn!(
+                skipped = collision_count,
+                "MCP tools skipped due to name collisions — check server configurations for duplicate tool names"
             );
         }
         schemas
@@ -1497,10 +1499,10 @@ impl McpClientManager {
                     }
                 }
                 Err(e) => {
-                    eprintln!(
-                        "  {} {}",
-                        theme::icon_warn(),
-                        format!("Failed to list prompts from {name}: {e}").dim()
+                    tracing::warn!(
+                        server = %name,
+                        error = %e,
+                        "MCP: failed to list prompts"
                     );
                 }
             }
@@ -1520,10 +1522,10 @@ impl McpClientManager {
                     }
                 }
                 Err(e) => {
-                    eprintln!(
-                        "  {} {}",
-                        theme::icon_warn(),
-                        format!("Failed to list resources from {name}: {e}").dim()
+                    tracing::warn!(
+                        server = %name,
+                        error = %e,
+                        "MCP: failed to list resources"
                     );
                 }
             }
@@ -2065,7 +2067,7 @@ async fn connect_stdio(
         error_count: AtomicU64::new(0),
         last_latency: RwLock::new(None),
         last_error: RwLock::new(None),
-        call_log: RwLock::new(Vec::new()),
+        call_log: RwLock::new(VecDeque::with_capacity(CALL_LOG_MAX_ENTRIES)),
         keepalive_handle: Some(keepalive),
     })
 }
@@ -2163,7 +2165,7 @@ async fn connect_sse(
                 error_count: AtomicU64::new(0),
                 last_latency: RwLock::new(None),
                 last_error: RwLock::new(None),
-                call_log: RwLock::new(Vec::new()),
+                call_log: RwLock::new(VecDeque::with_capacity(CALL_LOG_MAX_ENTRIES)),
                 keepalive_handle: Some(keepalive),
             })
         }
@@ -2236,7 +2238,7 @@ async fn connect_stateless_http(
         error_count: AtomicU64::new(0),
         last_latency: RwLock::new(None),
         last_error: RwLock::new(None),
-        call_log: RwLock::new(Vec::new()),
+        call_log: RwLock::new(VecDeque::with_capacity(CALL_LOG_MAX_ENTRIES)),
         keepalive_handle: None,
     })
 }
@@ -2323,7 +2325,7 @@ async fn probe_stateless_http_connection(
         error_count: AtomicU64::new(0),
         last_latency: RwLock::new(None),
         last_error: RwLock::new(None),
-        call_log: RwLock::new(Vec::new()),
+        call_log: RwLock::new(VecDeque::with_capacity(CALL_LOG_MAX_ENTRIES)),
         keepalive_handle: None,
     }))
 }
@@ -2488,7 +2490,7 @@ async fn connect_ws(
         error_count: AtomicU64::new(0),
         last_latency: RwLock::new(None),
         last_error: RwLock::new(None),
-        call_log: RwLock::new(Vec::new()),
+        call_log: RwLock::new(VecDeque::with_capacity(CALL_LOG_MAX_ENTRIES)),
         keepalive_handle: Some(keepalive),
     })
 }
@@ -2680,8 +2682,10 @@ pub fn extract_result_text_with_limit(result: &CallToolResult, max_len: usize) -
 
     let joined = parts.join("\n");
     if total_len >= max_len {
-        eprintln!(
-            "[WARN] MCP tool result truncated: {total_len} chars exceeded {max_len} char limit"
+        tracing::warn!(
+            chars = total_len,
+            limit = max_len,
+            "MCP: tool result truncated"
         );
         format!(
             "{}\n\n[OUTPUT TRUNCATED - exceeded {} char limit]",

--- a/rust/crates/astra-tools/src/task_mgmt.rs
+++ b/rust/crates/astra-tools/src/task_mgmt.rs
@@ -670,6 +670,12 @@ impl TaskManager {
         self.store.load(&self.sid()).await.unwrap_or_default()
     }
 
+    /// Load only active tasks and surface backend errors to callers that need
+    /// completion-critical task-board state.
+    pub async fn load_active_tasks(&self) -> Result<Vec<SessionTask>, String> {
+        self.store.load_active(&self.sid()).await
+    }
+
     /// Capture a full rollback snapshot (tasks + next id).
     pub async fn snapshot_state(&self) -> TaskManagerSnapshot {
         let tasks = self.snapshot().await;

--- a/rust/crates/runtime/src/server/run/lifecycle.rs
+++ b/rust/crates/runtime/src/server/run/lifecycle.rs
@@ -4067,7 +4067,9 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 .await
                 .insert(run_id.clone(), progress_rx);
 
-            loop_state.server_tool_executor = Some(std::sync::Arc::new(executor));
+            let executor = std::sync::Arc::new(executor);
+            loop_state.hooks.task_board_monitor = Some(executor.task_manager());
+            loop_state.server_tool_executor = Some(executor);
         }
 
         // Clone handles we need inside the spawned task.
@@ -4518,7 +4520,9 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 state.harness.sink.clone(),
             )
             .await;
-            state.server_tool_executor = Some(std::sync::Arc::new(executor));
+            let executor = std::sync::Arc::new(executor);
+            state.hooks.task_board_monitor = Some(executor.task_manager());
+            state.server_tool_executor = Some(executor);
         }
 
         // Clone handles for the background task.
@@ -5963,7 +5967,9 @@ impl SubRunExecutor for ServerSubRunExecutor {
             if let Some(obs) = loop_state.telemetry.observability_session.clone() {
                 executor.set_observability_session(obs);
             }
-            loop_state.server_tool_executor = Some(std::sync::Arc::new(executor));
+            let executor = std::sync::Arc::new(executor);
+            loop_state.hooks.task_board_monitor = Some(executor.task_manager());
+            loop_state.server_tool_executor = Some(executor);
         }
 
         configure_runtime_controllers(

--- a/rust/crates/runtime/src/server/run/lifecycle.rs
+++ b/rust/crates/runtime/src/server/run/lifecycle.rs
@@ -78,6 +78,19 @@ use crate::server::{server_skill_subrun, server_tool_executor};
 const RUNTIME_CONTEXT_TRACE_AGENT_ID: &str = "astra-server";
 const LLM_TOKEN_SERVICE_TRUSTED_DOMAINS_TABLE: &str = "runtime_llm_trusted_domains";
 
+/// Wire a freshly-constructed [`server_tool_executor::ServerToolExecutor`]
+/// into the agentic loop state: Arc-wrap it, attach the task-board monitor,
+/// and set the tool-executor handle.  This small helper deduplicates the
+/// same three-line pattern repeated at every executor construction site.
+fn wire_executor_into_state(
+    executor: server_tool_executor::ServerToolExecutor,
+    state: &mut crate::turn::agentic_loop::host::AgenticLoopState,
+) {
+    let executor = std::sync::Arc::new(executor);
+    state.hooks.task_board_monitor = Some(executor.task_manager());
+    state.server_tool_executor = Some(executor);
+}
+
 fn panic_payload_message(payload: &(dyn Any + Send)) -> String {
     if let Some(message) = payload.downcast_ref::<&str>() {
         (*message).to_string()
@@ -4067,9 +4080,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 .await
                 .insert(run_id.clone(), progress_rx);
 
-            let executor = std::sync::Arc::new(executor);
-            loop_state.hooks.task_board_monitor = Some(executor.task_manager());
-            loop_state.server_tool_executor = Some(executor);
+            wire_executor_into_state(executor, &mut loop_state);
         }
 
         // Clone handles we need inside the spawned task.
@@ -4520,9 +4531,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 state.harness.sink.clone(),
             )
             .await;
-            let executor = std::sync::Arc::new(executor);
-            state.hooks.task_board_monitor = Some(executor.task_manager());
-            state.server_tool_executor = Some(executor);
+            wire_executor_into_state(executor, &mut state);
         }
 
         // Clone handles for the background task.
@@ -5967,9 +5976,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
             if let Some(obs) = loop_state.telemetry.observability_session.clone() {
                 executor.set_observability_session(obs);
             }
-            let executor = std::sync::Arc::new(executor);
-            loop_state.hooks.task_board_monitor = Some(executor.task_manager());
-            loop_state.server_tool_executor = Some(executor);
+            wire_executor_into_state(executor, &mut loop_state);
         }
 
         configure_runtime_controllers(

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -1029,6 +1029,10 @@ impl ServerToolExecutor {
         }
     }
 
+    pub fn task_manager(&self) -> Arc<TaskManager> {
+        Arc::clone(&self.task_manager)
+    }
+
     pub async fn close_pending_memory_feedback_at_turn_end(
         &self,
         context_prefix: &str,

--- a/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -3589,7 +3589,10 @@ mod tests {
 
         let outcome = run_agentic_loop_with_host(&mut host, &mut state).await;
 
-        assert!(outcome.is_ok(), "loop must terminate even when the model ignores the corrective");
+        assert!(
+            outcome.is_ok(),
+            "loop must terminate even when the model ignores the corrective"
+        );
         assert_eq!(
             host.current_turn, 2,
             "exactly two turns should run: one before the gate, one after the corrective"

--- a/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -1216,7 +1216,10 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                 return Ok(TurnExecutionControl::ContinueLoop);
             }
 
-            if let Some(snapshot) = unfinished_task_board_snapshot(state).cloned() {
+            if !state.stall.forced_task_board_completion_gate
+                && let Some(snapshot) = unfinished_task_board_snapshot(state).cloned()
+            {
+                state.stall.forced_task_board_completion_gate = true;
                 state.final_text.clear();
                 state.final_text_streamed = false;
                 state.push_volatile(
@@ -3490,6 +3493,130 @@ mod tests {
         assert_eq!(host.current_turn, 2);
         assert_eq!(state.final_text, "All task-board work is now complete.");
         assert_eq!(host.rendered_final_text, vec![state.final_text.clone()]);
+    }
+
+    /// Stub host whose `execute_turn` keeps returning text-only results AND
+    /// never clears the task-board snapshot — the same shape we'd see if the
+    /// model ignored the runtime's "unfinished tasks remain" corrective and
+    /// kept replying "Done." without making task-board progress.
+    struct StubbornTextOnlyHost {
+        turn_results: Vec<HostTurnResult>,
+        current_turn: usize,
+        emitted_lines: Vec<String>,
+        rendered_final_text: Vec<String>,
+        valid_tools: HashSet<String>,
+    }
+
+    impl StubbornTextOnlyHost {
+        fn new(turn_results: Vec<HostTurnResult>) -> Self {
+            Self {
+                turn_results,
+                current_turn: 0,
+                emitted_lines: Vec::new(),
+                rendered_final_text: Vec::new(),
+                valid_tools: HashSet::new(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AgenticLoopHost for StubbornTextOnlyHost {
+        async fn execute_turn(
+            &mut self,
+            _state: &mut AgenticLoopState,
+        ) -> Result<HostTurnResult, astra_core::ClassifiedError> {
+            if self.turn_results.is_empty() {
+                return Err(astra_core::ClassifiedError::new(
+                    astra_core::ErrorKind::BudgetExhausted,
+                    "no more turns",
+                ));
+            }
+            self.current_turn += 1;
+            Ok(self.turn_results.remove(0))
+        }
+
+        fn emit_headless_line(&mut self, _style: HeadlessStderrStyle, line: String) {
+            self.emitted_lines.push(line);
+        }
+
+        fn is_quiet(&self) -> bool {
+            true
+        }
+
+        fn turn_interaction_mode(&self) -> TurnInteractionMode {
+            TurnInteractionMode::NonInteractive
+        }
+
+        fn valid_tool_names(&self) -> &HashSet<String> {
+            &self.valid_tools
+        }
+
+        fn inject_tool_schema(&mut self, _schema: serde_json::Value) {}
+
+        fn render_final_text(&mut self, text: &str) {
+            self.rendered_final_text.push(text.to_string());
+        }
+    }
+
+    /// Regression: the unfinished-task-board mid-loop gate must be one-shot
+    /// per turn so a model that ignores the corrective doesn't churn the
+    /// global round budget. After the gate fires once, the next text-only
+    /// completion should fall through to terminal rendering, where
+    /// `ensure_terminal_text` rewrites the answer with structured stop +
+    /// remaining-task context (covered by the finalization tests).
+    #[tokio::test]
+    async fn unfinished_task_board_gate_is_one_shot_per_turn() {
+        let mut host = StubbornTextOnlyHost::new(vec![
+            text_result("Done.", 10, 5, Some(20)),
+            text_result("Still done.", 10, 5, Some(20)),
+        ]);
+        let mut state = make_state();
+        state.hooks.task_board_snapshot =
+            TaskBoardSnapshot::from_active_tasks(&[astra_tools::task_mgmt::SessionTask {
+                id: "task-1".to_string(),
+                title: "finish validation".to_string(),
+                description: None,
+                status: "in_progress".to_string(),
+                subtasks: Vec::new(),
+                created_at: "2025-01-01T00:00:00Z".to_string(),
+                updated_at: "2025-01-01T00:00:00Z".to_string(),
+                active_form: None,
+                owner: None,
+                metadata: None,
+                blocks: Vec::new(),
+                blocked_by: Vec::new(),
+            }]);
+
+        let outcome = run_agentic_loop_with_host(&mut host, &mut state).await;
+
+        assert!(outcome.is_ok(), "loop must terminate even when the model ignores the corrective");
+        assert_eq!(
+            host.current_turn, 2,
+            "exactly two turns should run: one before the gate, one after the corrective"
+        );
+        assert!(
+            state.final_text.contains("task-board work remains open"),
+            "terminal text should surface the unfinished-work record, got: {}",
+            state.final_text
+        );
+        let unfinished_notices = host
+            .emitted_lines
+            .iter()
+            .filter(|line| line.contains("Unfinished tasks remain"))
+            .count();
+        // Even though the loop's quiet flag suppresses these in
+        // `unfinished_task_board_guard_forces_another_round`, that test runs
+        // the same code path; here `host.is_quiet()` returns true so the
+        // gate's headless line is suppressed too — the meaningful proof
+        // that the gate is one-shot is `current_turn == 2` (no third turn).
+        assert!(
+            unfinished_notices <= 1,
+            "the gate's stderr notice must fire at most once, got {unfinished_notices}"
+        );
+        // `forced_task_board_completion_gate` is reset by
+        // `finalize_and_render` on terminal exit, so we don't assert on it
+        // here. The structural proof is in the turn count plus the rewritten
+        // terminal text.
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -2,8 +2,8 @@ use std::time::Instant;
 
 use super::super::agentic::headless_round::HeadlessStderrStyle;
 use super::host::{
-    AgenticLoopHost, AgenticLoopOutcome, AgenticLoopState, HostTurnResult, finalize_and_render,
-    finalize_turn_trace, try_write_heavy_checkpoint,
+    AgenticLoopHost, AgenticLoopOutcome, AgenticLoopState, HostTurnResult, TaskBoardSnapshot,
+    finalize_and_render, finalize_turn_trace, try_write_heavy_checkpoint,
 };
 use super::lifecycle::{
     TurnIterationPrep, current_agentic_step, interruption_diagnosis_summary,
@@ -104,6 +104,44 @@ fn record_early_exit_llm_round(
             ..Default::default()
         });
     }
+}
+
+fn unfinished_task_board_snapshot(state: &AgenticLoopState) -> Option<&TaskBoardSnapshot> {
+    state
+        .hooks
+        .task_board_snapshot
+        .has_unfinished_tasks()
+        .then_some(&state.hooks.task_board_snapshot)
+}
+
+fn unfinished_task_board_corrective_message(
+    snapshot: &TaskBoardSnapshot,
+    original_query: &str,
+) -> String {
+    format!(
+        "[unfinished-task-board:v1]\n\
+         Runtime correction: the session task board still has unfinished work. {}.\n\n\
+         REQUIRED next-step behavior:\n\
+         - Continue executing the remaining task-board work before reporting completion.\n\
+         - If a listed task is no longer needed, explicitly update/cancel/close it instead of ignoring it.\n\
+         - Do NOT give a success-shaped final answer while these tasks remain open.\n\n\
+         Original user query: {original_query}",
+        snapshot.status_count_summary(),
+    )
+}
+
+fn circuit_breaker_abort_detail(state: &AgenticLoopState) -> String {
+    let mut detail = format!(
+        "The circuit breaker stopped this turn after round {} because the model kept calling tools after the runtime injected a finalization correction.",
+        state.llm_rounds_completed
+    );
+    if let Some(diagnosis) = interruption_diagnosis_summary(state) {
+        detail.push_str(&format!(" Likely cause: {diagnosis}."));
+    }
+    detail.push_str(
+        " Progress from earlier rounds is preserved. Resume by synthesizing verified evidence before calling more tools.",
+    );
+    detail
 }
 
 pub(crate) struct TurnExecutionPhase {
@@ -287,6 +325,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
     // Observed in session 3b7ac18f: ~10 nudge injections across 15
     // turns in Auto mode, user complaint "不停的被打断,不一气呵成".
     let suppress_nudges = host.turn_interaction_mode().suppresses_loop_nudges();
+    state.refresh_task_board_snapshot().await;
 
     // Inject round budget guidance so the model knows to batch or synthesize.
     // Use llm_rounds_completed (actual LLM call count) not turn_index (step
@@ -1177,6 +1216,40 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                 return Ok(TurnExecutionControl::ContinueLoop);
             }
 
+            if let Some(snapshot) = unfinished_task_board_snapshot(state).cloned() {
+                state.final_text.clear();
+                state.final_text_streamed = false;
+                state.push_volatile(
+                    super::host::VolatileKind::TaskBoardCompletionGate,
+                    unfinished_task_board_corrective_message(&snapshot, &state.message),
+                );
+                tracing::info!(
+                    target: "astra::loop_guard",
+                    tier = "unfinished_task_board",
+                    round = state.llm_rounds_completed,
+                    summary = %snapshot.short_summary(),
+                    "unfinished task-board work blocked loop completion"
+                );
+                if !prep.quiet {
+                    host.emit_headless_line(
+                        HeadlessStderrStyle::Yellow,
+                        format!(
+                            "↻ Unfinished tasks remain; continuing ({})",
+                            snapshot.short_summary()
+                        ),
+                    );
+                }
+                record_early_exit_llm_round(
+                    state,
+                    &turn_result,
+                    prep.turn_start_time,
+                    Some("unfinished_tasks"),
+                );
+                state.step_recorder.end_turn(false);
+                try_write_heavy_checkpoint(state);
+                return Ok(TurnExecutionControl::ContinueLoop);
+            }
+
             if state.hooks.stop_hook_runs == 0
                 && let Some(prompt) =
                     astra_turn_core::stop_hooks::build_stop_hook_prompt(&state.hooks.stop_hooks)
@@ -1240,28 +1313,13 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
     // model ignored it → abort.
     if state.stall.forced_round_budget_phase1 && !state.stall.forced_round_budget_phase2 {
         state.stall.forced_round_budget_phase2 = true;
-        let mut abort_msg = format!(
-            "[Circuit breaker abort at round {}. The runtime injected a \
-             finalization corrective but the model continued to call tools. \
-             Any progress from earlier rounds is preserved above.]",
-            state.llm_rounds_completed,
-        );
-        if let Some(diagnosis) = interruption_diagnosis_summary(state) {
-            abort_msg.push_str(&format!(
-                "\nLikely cause: {diagnosis}. Resume by synthesizing the evidence already gathered before attempting more tools."
-            ));
-        }
-        if state.final_text.trim().is_empty() {
-            state.final_text = abort_msg.clone();
-        } else {
-            state.final_text.push_str("\n\n");
-            state.final_text.push_str(&abort_msg);
-        }
+        let abort_detail = circuit_breaker_abort_detail(state);
+        state.final_text.clear();
         state.final_text_streamed = false;
         state.interruption = Some(InterruptionRecord::new(
             InterruptionKind::BudgetExhausted,
             ResumeAction::ContinueImmediately,
-            interruption_state_summary(state, Some(abort_msg)),
+            interruption_state_summary(state, Some(abort_detail)),
         ));
         tracing::warn!(
             target: "astra::loop_guard",
@@ -1972,9 +2030,10 @@ fn build_circuit_breaker_signal(
             .take(state.max_tools_per_turn as usize)
             .any(tool_record_is_workspace_mutation)
     };
-    let task_completed = latest_round_records
-        .iter()
-        .any(|record| record.ok && record.name == "git_commit");
+    let task_completed = !state.hooks.task_board_snapshot.has_unfinished_tasks()
+        && latest_round_records
+            .iter()
+            .any(|record| record.ok && record.name == "git_commit");
 
     RoundSignal {
         tool_signatures,
@@ -2412,6 +2471,8 @@ fn emit_subrun_text_preview<H: AgenticLoopHost>(
     }
 }
 
+const MAX_REACTIVE_BUDGET_COMPACTION_ATTEMPTS: u32 = 3;
+
 async fn handle_token_budget<H: AgenticLoopHost>(
     host: &mut H,
     state: &mut AgenticLoopState,
@@ -2469,7 +2530,9 @@ async fn handle_token_budget<H: AgenticLoopHost>(
     // Only if both fail do we inject the stop directive.
     // Skip tier-1 mechanical compression if pre-turn LLM compact already ran,
     // but still allow tier-2 spill-to-disk as an independent recovery path.
-    if !state.budget_wrapup_injected {
+    if !state.budget_wrapup_injected
+        && state.compaction_effectiveness.attempt_count < MAX_REACTIVE_BUDGET_COMPACTION_ATTEMPTS
+    {
         let budget = super::super::context_compression::TokenBudget {
             max_prompt_tokens: state.max_turn_input_tokens,
             last_measured_tokens: measured,
@@ -2535,7 +2598,6 @@ async fn handle_token_budget<H: AgenticLoopHost>(
                 super::host::VolatileKind::CompactResume,
                 super::super::budget_messaging::COMPACT_RESUME_DIRECTIVE,
             );
-            state.budget_wrapup_injected = true;
             try_write_heavy_checkpoint(state);
             return Some(TurnExecutionControl::ContinueLoop);
         }
@@ -2667,15 +2729,82 @@ fn record_tool_selection(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::sync::Arc;
     use std::time::Duration;
 
     use astra_services::session_journal::ToolCallRecord;
+    use async_trait::async_trait;
 
     use super::*;
     use crate::observability::ObservabilityHub;
     use crate::turn::agentic_loop::host::tests::{MockHost, make_state, text_result};
+    use crate::turn::agentic_loop::host::{
+        AgenticLoopHost, AgenticLoopState, VolatileKind, run_agentic_loop_with_host,
+    };
     use astra_turn_core::chat_turn_sse_dispatch::ChatTurnSseAccum;
+
+    struct SnapshotClearingHost {
+        turn_results: Vec<HostTurnResult>,
+        current_turn: usize,
+        emitted_lines: Vec<String>,
+        rendered_final_text: Vec<String>,
+        valid_tools: HashSet<String>,
+    }
+
+    impl SnapshotClearingHost {
+        fn new(turn_results: Vec<HostTurnResult>) -> Self {
+            Self {
+                turn_results,
+                current_turn: 0,
+                emitted_lines: Vec::new(),
+                rendered_final_text: Vec::new(),
+                valid_tools: HashSet::new(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AgenticLoopHost for SnapshotClearingHost {
+        async fn execute_turn(
+            &mut self,
+            state: &mut AgenticLoopState,
+        ) -> Result<HostTurnResult, astra_core::ClassifiedError> {
+            if self.turn_results.is_empty() {
+                return Err(astra_core::ClassifiedError::new(
+                    astra_core::ErrorKind::BudgetExhausted,
+                    "no more turns",
+                ));
+            }
+            if self.current_turn == 1 {
+                state.hooks.task_board_snapshot = TaskBoardSnapshot::default();
+            }
+            self.current_turn += 1;
+            Ok(self.turn_results.remove(0))
+        }
+
+        fn emit_headless_line(&mut self, _style: HeadlessStderrStyle, line: String) {
+            self.emitted_lines.push(line);
+        }
+
+        fn is_quiet(&self) -> bool {
+            true
+        }
+
+        fn turn_interaction_mode(&self) -> TurnInteractionMode {
+            TurnInteractionMode::NonInteractive
+        }
+
+        fn valid_tool_names(&self) -> &HashSet<String> {
+            &self.valid_tools
+        }
+
+        fn inject_tool_schema(&mut self, _schema: serde_json::Value) {}
+
+        fn render_final_text(&mut self, text: &str) {
+            self.rendered_final_text.push(text.to_string());
+        }
+    }
 
     #[test]
     fn circuit_breaker_introspection_message_uses_actual_read_only_streak() {
@@ -3291,6 +3420,79 @@ mod tests {
     }
 
     #[test]
+    fn circuit_breaker_signal_does_not_mark_completion_when_tasks_remain() {
+        let mut state = make_state();
+        state.llm_rounds_completed = 4;
+        state.hooks.task_board_snapshot =
+            crate::turn::agentic_loop::host::TaskBoardSnapshot::from_active_tasks(&[
+                astra_tools::task_mgmt::SessionTask {
+                    id: "task-1".to_string(),
+                    title: "finish validation".to_string(),
+                    description: None,
+                    status: "pending".to_string(),
+                    subtasks: Vec::new(),
+                    created_at: "2025-01-01T00:00:00Z".to_string(),
+                    updated_at: "2025-01-01T00:00:00Z".to_string(),
+                    active_form: None,
+                    owner: None,
+                    metadata: None,
+                    blocks: Vec::new(),
+                    blocked_by: Vec::new(),
+                },
+            ]);
+        state.stall.turn_sigs.push(
+            ["git_commit:{\"message\":\"finish\"}".to_string()]
+                .into_iter()
+                .collect(),
+        );
+        state.stall.tool_call_records.push(ToolCallRecord {
+            name: "git_commit".into(),
+            ok: true,
+            round: Some(3),
+            ..Default::default()
+        });
+
+        let signal = build_circuit_breaker_signal(&state);
+
+        assert!(
+            !signal.task_completed,
+            "unfinished task-board work must suppress completion soft-stop"
+        );
+        assert!(signal.produced_mutation);
+    }
+
+    #[tokio::test]
+    async fn unfinished_task_board_guard_forces_another_round() {
+        let mut host = SnapshotClearingHost::new(vec![
+            text_result("Done.", 10, 5, Some(20)),
+            text_result("All task-board work is now complete.", 10, 5, Some(20)),
+        ]);
+        let mut state = make_state();
+        state.hooks.task_board_snapshot =
+            TaskBoardSnapshot::from_active_tasks(&[astra_tools::task_mgmt::SessionTask {
+                id: "task-1".to_string(),
+                title: "finish validation".to_string(),
+                description: None,
+                status: "in_progress".to_string(),
+                subtasks: Vec::new(),
+                created_at: "2025-01-01T00:00:00Z".to_string(),
+                updated_at: "2025-01-01T00:00:00Z".to_string(),
+                active_form: None,
+                owner: None,
+                metadata: None,
+                blocks: Vec::new(),
+                blocked_by: Vec::new(),
+            }]);
+
+        let outcome = run_agentic_loop_with_host(&mut host, &mut state).await;
+
+        assert!(outcome.is_ok(), "loop should continue until tasks clear");
+        assert_eq!(host.current_turn, 2);
+        assert_eq!(state.final_text, "All task-board work is now complete.");
+        assert_eq!(host.rendered_final_text, vec![state.final_text.clone()]);
+    }
+
+    #[test]
     fn circuit_breaker_signal_does_not_reuse_stale_git_commit_completion() {
         let mut state = make_state();
         state.llm_rounds_completed = 5;
@@ -3334,6 +3536,187 @@ mod tests {
                 .as_str()
                 .unwrap()
                 .contains("Stop now and provide the final answer")
+        );
+    }
+
+    #[test]
+    fn circuit_breaker_abort_detail_explains_reason_and_resume_path() {
+        let mut state = make_state();
+        state.llm_rounds_completed = 6;
+        let detail = circuit_breaker_abort_detail(&state);
+
+        assert!(detail.contains("circuit breaker stopped this turn"));
+        assert!(detail.contains("Progress from earlier rounds is preserved"));
+        assert!(detail.contains("Resume by synthesizing verified evidence"));
+    }
+
+    #[test]
+    fn task_board_corrective_uses_cache_stable_counts_only() {
+        let snapshot =
+            TaskBoardSnapshot::from_active_tasks(&[astra_tools::task_mgmt::SessionTask {
+                id: "task-1".to_string(),
+                title: "very specific changing task title".to_string(),
+                description: None,
+                status: "in_progress".to_string(),
+                subtasks: Vec::new(),
+                created_at: "2025-01-01T00:00:00Z".to_string(),
+                updated_at: "2025-01-01T00:00:00Z".to_string(),
+                active_form: None,
+                owner: None,
+                metadata: None,
+                blocks: Vec::new(),
+                blocked_by: Vec::new(),
+            }]);
+
+        let msg = unfinished_task_board_corrective_message(&snapshot, "finish the task");
+
+        assert!(msg.contains("1 in_progress task(s) remain"));
+        assert!(!msg.contains("task-1"));
+        assert!(!msg.contains("very specific changing task title"));
+    }
+
+    #[tokio::test]
+    async fn reactive_compaction_does_not_arm_wrapup_after_success() {
+        let mut host = MockHost::new(Vec::new());
+        let mut state = make_state();
+        state.max_turn_input_tokens = 80_000;
+        state.last_measured_prompt_tokens = Some(90_000);
+        state
+            .messages
+            .push(serde_json::json!({"role": "user", "content": "diagnose and fix the issue"}));
+        for i in 0..16 {
+            state.messages.push(serde_json::json!({
+                "role": "assistant",
+                "content": format!("step {i}: {}", "x".repeat(240)),
+            }));
+            state.messages.push(serde_json::json!({
+                "role": "user",
+                "content": format!("follow-up {i}: {}", "y".repeat(220)),
+            }));
+        }
+
+        let control = handle_token_budget(
+            &mut host,
+            &mut state,
+            0,
+            TurnIterationPrep {
+                quiet: true,
+                turn_start_time: Instant::now(),
+            },
+            &text_result("working", 90_000, 300, Some(20)),
+        )
+        .await;
+
+        assert!(matches!(control, Some(TurnExecutionControl::ContinueLoop)));
+        assert!(
+            !state.budget_wrapup_injected,
+            "successful reactive compaction should continue the turn without arming wrapup"
+        );
+        assert!(
+            state
+                .volatile_pending
+                .iter()
+                .any(|entry| entry.kind == VolatileKind::CompactResume),
+            "successful reactive compaction should inject the continue-after-compact directive"
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_budget_pressure_retries_compaction_before_wrapup() {
+        let mut host = MockHost::new(Vec::new());
+        let mut state = make_state();
+        state.max_turn_input_tokens = 80_000;
+        state
+            .messages
+            .push(serde_json::json!({"role": "user", "content": "diagnose and fix the issue"}));
+        for i in 0..24 {
+            state.messages.push(serde_json::json!({
+                "role": "assistant",
+                "content": format!("step {i}: {}", "x".repeat(240)),
+            }));
+            state.messages.push(serde_json::json!({
+                "role": "user",
+                "content": format!("follow-up {i}: {}", "y".repeat(220)),
+            }));
+        }
+
+        state.last_measured_prompt_tokens = Some(90_000);
+        let first = handle_token_budget(
+            &mut host,
+            &mut state,
+            0,
+            TurnIterationPrep {
+                quiet: true,
+                turn_start_time: Instant::now(),
+            },
+            &text_result("working", 90_000, 300, Some(20)),
+        )
+        .await;
+        assert!(matches!(first, Some(TurnExecutionControl::ContinueLoop)));
+
+        state.last_measured_prompt_tokens = Some(88_000);
+        let second = handle_token_budget(
+            &mut host,
+            &mut state,
+            1,
+            TurnIterationPrep {
+                quiet: true,
+                turn_start_time: Instant::now(),
+            },
+            &text_result("still working", 88_000, 320, Some(20)),
+        )
+        .await;
+
+        assert!(
+            matches!(second, Some(TurnExecutionControl::ContinueLoop)),
+            "continued context pressure should retry compaction before forcing wrapup"
+        );
+        assert!(
+            !state.budget_wrapup_injected,
+            "repeat pressure after a successful compact should not flip straight into wrapup mode"
+        );
+    }
+
+    #[tokio::test]
+    async fn reactive_compaction_attempt_cap_forces_wrapup() {
+        let mut host = MockHost::new(Vec::new());
+        let mut state = make_state();
+        state.max_turn_input_tokens = 80_000;
+        state.last_measured_prompt_tokens = Some(90_000);
+        state.compaction_effectiveness.attempt_count = MAX_REACTIVE_BUDGET_COMPACTION_ATTEMPTS;
+        state
+            .messages
+            .push(serde_json::json!({"role": "user", "content": "diagnose and fix the issue"}));
+        for i in 0..16 {
+            state.messages.push(serde_json::json!({
+                "role": "assistant",
+                "content": format!("step {i}: {}", "x".repeat(240)),
+            }));
+        }
+
+        let control = handle_token_budget(
+            &mut host,
+            &mut state,
+            0,
+            TurnIterationPrep {
+                quiet: true,
+                turn_start_time: Instant::now(),
+            },
+            &text_result("working", 90_000, 300, Some(20)),
+        )
+        .await;
+
+        assert!(matches!(control, Some(TurnExecutionControl::ContinueLoop)));
+        assert!(
+            state.budget_wrapup_injected,
+            "after bounded compaction attempts, token pressure must transition to wrapup"
+        );
+        assert!(
+            state
+                .volatile_pending
+                .iter()
+                .any(|entry| entry.kind == VolatileKind::BudgetAdvisory),
+            "attempt cap should inject the normal budget wrapup advisory"
         );
     }
 

--- a/rust/crates/runtime/src/turn/agentic_loop/finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/finalization.rs
@@ -679,6 +679,7 @@ fn reset_per_turn_corrective_state(state: &mut AgenticLoopState) {
     state.stall.forced_round_budget_phase1 = false;
     state.stall.forced_round_budget_phase2 = false;
     state.stall.forced_completion_soft_stop = false;
+    state.stall.forced_task_board_completion_gate = false;
     state.stall.forced_redundant_reads_corrective = false;
     state.stall.forced_cache_waste_corrective = false;
     state.stall.forced_exploration_family_corrective = false;

--- a/rust/crates/runtime/src/turn/agentic_loop/finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/finalization.rs
@@ -575,6 +575,7 @@ pub(crate) async fn finalize_and_render<H: AgenticLoopHost>(
         .messages
         .retain(|m| !super::execution_phase::is_execution_corrective_message(m));
     reset_per_turn_corrective_state(state);
+    state.refresh_task_board_snapshot().await;
     ensure_terminal_text(state);
     try_write_heavy_checkpoint(state);
     if !state.final_text.is_empty() && !state.final_text_streamed {
@@ -584,6 +585,25 @@ pub(crate) async fn finalize_and_render<H: AgenticLoopHost>(
 }
 
 fn ensure_terminal_text(state: &mut AgenticLoopState) {
+    if state.hooks.task_board_snapshot.has_unfinished_tasks() {
+        let detail = format!(
+            "agentic loop reached terminal state while unfinished task-board work remained: {}",
+            state.hooks.task_board_snapshot.short_summary()
+        );
+        if state.interruption.is_none() {
+            state.interruption = Some(astra_turn_core::interruption::InterruptionRecord::new(
+                astra_turn_core::interruption::InterruptionKind::EmptyCompletion,
+                astra_turn_core::interruption::ResumeAction::ContinueImmediately,
+                interruption_state_summary(state, Some(detail)),
+            ));
+        }
+        state.final_text = task_board_terminal_message(
+            &state.hooks.task_board_snapshot,
+            state.interruption.as_ref(),
+        );
+        state.final_text_streamed = false;
+        return;
+    }
     if !state.final_text.trim().is_empty() {
         return;
     }
@@ -598,8 +618,55 @@ fn ensure_terminal_text(state: &mut AgenticLoopState) {
         ));
     }
     if let Some(interruption) = state.interruption.as_ref() {
-        state.final_text = interruption.user_message.clone();
+        state.final_text = interruption_terminal_message(interruption);
         state.final_text_streamed = false;
+    }
+}
+
+fn interruption_terminal_message(
+    interruption: &astra_turn_core::interruption::InterruptionRecord,
+) -> String {
+    let mut message = interruption.user_message.clone();
+    append_interruption_detail(&mut message, interruption);
+    message
+}
+
+fn task_board_terminal_message(
+    snapshot: &crate::turn::agentic_loop::host::TaskBoardSnapshot,
+    interruption: Option<&astra_turn_core::interruption::InterruptionRecord>,
+) -> String {
+    let mut message =
+        "The turn stopped before completion, and task-board work remains open.".to_string();
+    if let Some(interruption) = interruption {
+        message.push_str("\n\nStop reason: ");
+        message.push_str(interruption.user_message.trim());
+        append_interruption_detail(&mut message, interruption);
+    }
+    message.push_str("\n\nRemaining task-board work: ");
+    message.push_str(&snapshot.short_summary());
+    message.push_str(
+        ". Resume and finish or explicitly close these tasks before reporting completion.",
+    );
+    message
+}
+
+fn append_interruption_detail(
+    message: &mut String,
+    interruption: &astra_turn_core::interruption::InterruptionRecord,
+) {
+    if matches!(
+        interruption.kind,
+        astra_turn_core::interruption::InterruptionKind::BudgetExhausted
+            | astra_turn_core::interruption::InterruptionKind::TokenBudgetExceeded
+            | astra_turn_core::interruption::InterruptionKind::CumulativeBudgetExceeded
+    ) && let Some(detail) = interruption
+        .error_detail
+        .as_deref()
+        .map(str::trim)
+        .filter(|detail| !detail.is_empty())
+    {
+        message.push_str("\n\nWhy stopped: ");
+        message.push_str(detail);
     }
 }
 
@@ -1055,6 +1122,187 @@ mod tests {
             astra_turn_core::interruption::InterruptionKind::EmptyCompletion
         );
         assert!(state.final_text.contains("without a final answer"));
+        assert_eq!(host.rendered_final_text, vec![state.final_text.clone()]);
+    }
+
+    #[tokio::test]
+    async fn finalize_and_render_does_not_leave_success_text_when_tasks_remain() {
+        let mut host = MockHost::new(Vec::new());
+        let mut state = make_state();
+        state.final_text = "Done.".into();
+        state.hooks.task_board_snapshot =
+            crate::turn::agentic_loop::host::TaskBoardSnapshot::from_active_tasks(&[
+                astra_tools::task_mgmt::SessionTask {
+                    id: "task-1".to_string(),
+                    title: "finish validation".to_string(),
+                    description: None,
+                    status: "in_progress".to_string(),
+                    subtasks: Vec::new(),
+                    created_at: "2025-01-01T00:00:00Z".to_string(),
+                    updated_at: "2025-01-01T00:00:00Z".to_string(),
+                    active_form: None,
+                    owner: None,
+                    metadata: None,
+                    blocks: Vec::new(),
+                    blocked_by: Vec::new(),
+                },
+            ]);
+
+        finalize_and_render(&mut host, &mut state).await;
+
+        assert_ne!(
+            state.final_text, "Done.",
+            "unfinished task-board work must not leave a success-shaped terminal answer"
+        );
+        assert!(
+            state.final_text.contains("task-1") || state.final_text.contains("finish validation"),
+            "terminal output should surface unfinished task context"
+        );
+        assert_eq!(host.rendered_final_text, vec![state.final_text.clone()]);
+    }
+
+    #[tokio::test]
+    async fn finalize_and_render_refreshes_task_board_before_terminal_gate() {
+        let manager = std::sync::Arc::new(astra_tools::task_mgmt::TaskManager::in_memory());
+        manager
+            .create(&serde_json::json!({"title": "finish validation"}))
+            .await;
+        manager
+            .update(&serde_json::json!({
+                "task_id": "task-1",
+                "new_status": "completed"
+            }))
+            .await;
+
+        let mut host = MockHost::new(Vec::new());
+        let mut state = make_state();
+        state.final_text = "Done.".into();
+        state.hooks.task_board_monitor = Some(manager);
+        state.hooks.task_board_snapshot =
+            crate::turn::agentic_loop::host::TaskBoardSnapshot::from_active_tasks(&[
+                astra_tools::task_mgmt::SessionTask {
+                    id: "task-1".to_string(),
+                    title: "finish validation".to_string(),
+                    description: None,
+                    status: "in_progress".to_string(),
+                    subtasks: Vec::new(),
+                    created_at: "2025-01-01T00:00:00Z".to_string(),
+                    updated_at: "2025-01-01T00:00:00Z".to_string(),
+                    active_form: None,
+                    owner: None,
+                    metadata: None,
+                    blocks: Vec::new(),
+                    blocked_by: Vec::new(),
+                },
+            ]);
+
+        finalize_and_render(&mut host, &mut state).await;
+
+        assert_eq!(
+            state.final_text, "Done.",
+            "finalization must refresh active tasks so completed tool-round work does not get falsely blocked"
+        );
+        assert!(
+            !state.hooks.task_board_snapshot.has_unfinished_tasks(),
+            "refreshed snapshot should observe that the task board has no active tasks"
+        );
+        assert_eq!(host.rendered_final_text, vec!["Done.".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn finalize_and_render_surfaces_budget_interruption_detail() {
+        let mut host = MockHost::new(Vec::new());
+        let mut state = make_state();
+        state.final_text.clear();
+        state.interruption = Some(astra_turn_core::interruption::InterruptionRecord::new(
+            astra_turn_core::interruption::InterruptionKind::BudgetExhausted,
+            astra_turn_core::interruption::ResumeAction::ContinueImmediately,
+            astra_turn_core::interruption::InterruptionStateSummary {
+                has_checkpoint: true,
+                tool_calls_completed: 5,
+                turns_completed: 7,
+                remaining_turns: 0,
+                error_detail: Some(
+                    "The circuit breaker stopped the turn after the model ignored the finalization correction. Resume by synthesizing verified evidence before calling more tools.".to_string(),
+                ),
+                stall_signal: Some("single_tool_streak=9".to_string()),
+            },
+        ));
+
+        finalize_and_render(&mut host, &mut state).await;
+
+        assert!(
+            state
+                .final_text
+                .contains("circuit breaker stopped the turn"),
+            "terminal interruption text should include the specific budget-stop reason"
+        );
+        assert!(
+            state.final_text.contains("verified evidence"),
+            "terminal interruption text should include next-step guidance"
+        );
+        assert_eq!(host.rendered_final_text, vec![state.final_text.clone()]);
+    }
+
+    #[tokio::test]
+    async fn finalize_and_render_separates_stop_reason_from_remaining_tasks() {
+        let mut host = MockHost::new(Vec::new());
+        let mut state = make_state();
+        state.final_text.clear();
+        state.interruption = Some(astra_turn_core::interruption::InterruptionRecord::new(
+            astra_turn_core::interruption::InterruptionKind::BudgetExhausted,
+            astra_turn_core::interruption::ResumeAction::ContinueImmediately,
+            astra_turn_core::interruption::InterruptionStateSummary {
+                has_checkpoint: true,
+                tool_calls_completed: 5,
+                turns_completed: 7,
+                remaining_turns: 0,
+                error_detail: Some(
+                    "The circuit breaker stopped the turn after the model ignored the finalization correction.".to_string(),
+                ),
+                stall_signal: Some("single_tool_streak=9".to_string()),
+            },
+        ));
+        state.hooks.task_board_snapshot =
+            crate::turn::agentic_loop::host::TaskBoardSnapshot::from_active_tasks(&[
+                astra_tools::task_mgmt::SessionTask {
+                    id: "task-1".to_string(),
+                    title: "finish validation".to_string(),
+                    description: None,
+                    status: "in_progress".to_string(),
+                    subtasks: Vec::new(),
+                    created_at: "2025-01-01T00:00:00Z".to_string(),
+                    updated_at: "2025-01-01T00:00:00Z".to_string(),
+                    active_form: None,
+                    owner: None,
+                    metadata: None,
+                    blocks: Vec::new(),
+                    blocked_by: Vec::new(),
+                },
+            ]);
+
+        finalize_and_render(&mut host, &mut state).await;
+
+        assert!(
+            state.final_text.starts_with(
+                "The turn stopped before completion, and task-board work remains open."
+            ),
+            "terminal text should lead with the combined unfinished-work status"
+        );
+        assert!(
+            state.final_text.contains("\n\nStop reason: "),
+            "terminal text should label the runtime stop cause explicitly"
+        );
+        assert!(
+            state.final_text.contains("\n\nRemaining task-board work: "),
+            "terminal text should label remaining task-board work separately"
+        );
+        assert!(
+            !state
+                .final_text
+                .contains("\n\nThe interruption condition was reached before a final answer could be produced.\n\nUnfinished task-board work remains:"),
+            "terminal text should not concatenate unrelated interruption and task messages without labels"
+        );
         assert_eq!(host.rendered_final_text, vec![state.final_text.clone()]);
     }
 

--- a/rust/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/host.rs
@@ -61,6 +61,7 @@ use serde_json::Value;
 use astra_pipeline::step_protocol::{InMemoryIdempotencyCache, StepCheckpoint};
 use astra_pipeline::step_recorder::StepRecorder;
 use astra_text_utils::semantic_dedup::SemanticDedup;
+use astra_tools::task_mgmt::{SessionTask, TaskManager};
 use astra_turn_core::agentic_verdict_audit::AgenticVerdictAuditEvent;
 use astra_turn_core::chat_turn_heuristics::TaskExecutionProfile;
 use astra_turn_core::chat_turn_sse_dispatch::ChatTurnSseAccum;
@@ -565,6 +566,78 @@ pub struct MessagingState {
     pub progress_emitter: Option<crate::orchestration::AgentProgressEmitter>,
 }
 
+/// Point-in-time summary of the active session task board.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TaskBoardSnapshot {
+    pub pending_count: usize,
+    pub in_progress_count: usize,
+    pub blocked_count: usize,
+    pub active_tasks: Vec<String>,
+}
+
+impl TaskBoardSnapshot {
+    #[must_use]
+    pub fn from_active_tasks(tasks: &[SessionTask]) -> Self {
+        let mut snapshot = Self::default();
+        for task in tasks {
+            match task.status.as_str() {
+                "pending" => snapshot.pending_count += 1,
+                "in_progress" => snapshot.in_progress_count += 1,
+                _ => continue,
+            }
+            if !task.blocked_by.is_empty() {
+                snapshot.blocked_count += 1;
+            }
+            if snapshot.active_tasks.len() < 3 {
+                snapshot
+                    .active_tasks
+                    .push(format!("{} {} [{}]", task.id, task.title, task.status));
+            }
+        }
+        snapshot
+    }
+
+    #[must_use]
+    pub fn has_unfinished_tasks(&self) -> bool {
+        self.pending_count > 0 || self.in_progress_count > 0
+    }
+
+    #[must_use]
+    pub fn short_summary(&self) -> String {
+        let parts = self.status_count_parts();
+        if parts.is_empty() {
+            return "no active tasks remain".to_string();
+        }
+        let mut summary = format!("{} task(s) remain", parts.join(", "));
+        if !self.active_tasks.is_empty() {
+            summary.push_str(": ");
+            summary.push_str(&self.active_tasks.join("; "));
+        }
+        summary
+    }
+
+    #[must_use]
+    pub fn status_count_summary(&self) -> String {
+        let parts = self.status_count_parts();
+        if parts.is_empty() {
+            "no active tasks remain".to_string()
+        } else {
+            format!("{} task(s) remain", parts.join(", "))
+        }
+    }
+
+    fn status_count_parts(&self) -> Vec<String> {
+        let mut parts = Vec::new();
+        if self.in_progress_count > 0 {
+            parts.push(format!("{} in_progress", self.in_progress_count));
+        }
+        if self.pending_count > 0 {
+            parts.push(format!("{} pending", self.pending_count));
+        }
+        parts
+    }
+}
+
 /// Stop-hook and teammate-idle-hook state for the agentic loop.
 #[derive(Default)]
 pub struct StopHookState {
@@ -586,6 +659,10 @@ pub struct StopHookState {
     pub forward_headers: HashMap<String, String>,
     /// Request-scoped LLM token service config propagated to nested sub-runs.
     pub llm_token_service: Option<astra_services::LlmTokenServiceConfig>,
+    /// Shared session task board handle, when available.
+    pub task_board_monitor: Option<Arc<TaskManager>>,
+    /// Cached view of unfinished task-board work for completion gating.
+    pub task_board_snapshot: TaskBoardSnapshot,
 }
 
 /// Cancellation state for the agentic loop.
@@ -725,6 +802,10 @@ pub enum VolatileKind {
     /// tool call actually produced. See
     /// [`astra_turn_core::hallucination_tripwire`] for the detector.
     HallucinationTripwire,
+    /// Task-board completion gate. Singleton and count-only on the wire so
+    /// repeated corrections replace each other instead of accumulating
+    /// dynamic task titles in the volatile prompt suffix.
+    TaskBoardCompletionGate,
     /// Plan-mode marker: a single short reminder that the current
     /// turn is read-only investigation and the model must surface
     /// its plan via `exit_plan_mode(plan="…")` for user approval.
@@ -751,6 +832,7 @@ impl VolatileKind {
                 | Self::ExplorationBudget
                 | Self::Mailbox
                 | Self::CompactResume
+                | Self::TaskBoardCompletionGate
                 | Self::PlanModeMarker,
         )
     }
@@ -771,6 +853,7 @@ impl VolatileKind {
             | Self::CircuitBreaker
             | Self::BudgetAdvisory
             | Self::CompactResume
+            | Self::TaskBoardCompletionGate
             | Self::ExecutionRetry
             | Self::ExplorationBudget
             | Self::BudgetReview => "user",
@@ -1139,6 +1222,29 @@ pub struct AgenticLoopState {
 }
 
 impl AgenticLoopState {
+    /// Refresh the cached active task-board snapshot from the shared
+    /// TaskManager, when one is attached. Call this before any terminal
+    /// completion decision so tool calls in the just-finished round are
+    /// reflected before the loop decides whether unfinished work remains.
+    pub async fn refresh_task_board_snapshot(&mut self) {
+        let Some(task_manager) = self.hooks.task_board_monitor.clone() else {
+            return;
+        };
+        match task_manager.load_active_tasks().await {
+            Ok(tasks) => {
+                self.hooks.task_board_snapshot = TaskBoardSnapshot::from_active_tasks(&tasks);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "astra::loop_guard",
+                    session_id = self.current_session_id.as_deref().unwrap_or_default(),
+                    error = %error,
+                    "failed to refresh active task-board snapshot; preserving previous snapshot"
+                );
+            }
+        }
+    }
+
     /// Queue a runtime-produced volatile injection for the next LLM call.
     ///
     /// Prefer this over `state.messages.push(...)` for any content that
@@ -2250,6 +2356,72 @@ pub(crate) mod tests {
             turn_event_buffer: None,
             harness: crate::turn::harness_adapter::HarnessSlot::empty(),
         }
+    }
+
+    #[test]
+    fn task_board_snapshot_summarizes_active_tasks_stably() {
+        let snapshot = TaskBoardSnapshot::from_active_tasks(&[
+            SessionTask {
+                id: "task-2".to_string(),
+                title: "add runtime tests".to_string(),
+                description: None,
+                status: "pending".to_string(),
+                subtasks: Vec::new(),
+                created_at: "2025-01-01T00:00:00Z".to_string(),
+                updated_at: "2025-01-01T00:00:00Z".to_string(),
+                active_form: None,
+                owner: None,
+                metadata: None,
+                blocks: Vec::new(),
+                blocked_by: vec!["task-1".to_string()],
+            },
+            SessionTask {
+                id: "task-1".to_string(),
+                title: "wire completion guard".to_string(),
+                description: None,
+                status: "in_progress".to_string(),
+                subtasks: Vec::new(),
+                created_at: "2025-01-01T00:00:00Z".to_string(),
+                updated_at: "2025-01-01T00:00:00Z".to_string(),
+                active_form: None,
+                owner: None,
+                metadata: None,
+                blocks: Vec::new(),
+                blocked_by: Vec::new(),
+            },
+            SessionTask {
+                id: "task-3".to_string(),
+                title: "already done".to_string(),
+                description: None,
+                status: "completed".to_string(),
+                subtasks: Vec::new(),
+                created_at: "2025-01-01T00:00:00Z".to_string(),
+                updated_at: "2025-01-01T00:00:00Z".to_string(),
+                active_form: None,
+                owner: None,
+                metadata: None,
+                blocks: Vec::new(),
+                blocked_by: Vec::new(),
+            },
+        ]);
+
+        assert_eq!(snapshot.pending_count, 1);
+        assert_eq!(snapshot.in_progress_count, 1);
+        assert_eq!(snapshot.blocked_count, 1);
+        assert_eq!(
+            snapshot.active_tasks,
+            vec![
+                "task-2 add runtime tests [pending]".to_string(),
+                "task-1 wire completion guard [in_progress]".to_string(),
+            ]
+        );
+        assert!(snapshot.has_unfinished_tasks());
+        assert!(snapshot.short_summary().contains("task(s) remain"));
+        assert_eq!(
+            snapshot.status_count_summary(),
+            "1 in_progress, 1 pending task(s) remain"
+        );
+        assert!(VolatileKind::TaskBoardCompletionGate.is_singleton());
     }
 
     // ── Original tests ──────────────────────────────────────────────────────
@@ -5065,6 +5237,16 @@ pub(crate) mod tests {
             state.interruption.as_ref().unwrap().kind,
             astra_turn_core::interruption::InterruptionKind::TokenBudgetExceeded,
             "abort interruption must be TokenBudgetExceeded"
+        );
+        assert!(
+            state.final_text.contains("Why stopped:"),
+            "terminal output should explain why the runtime aborted the wrapup path"
+        );
+        assert!(
+            state
+                .final_text
+                .contains("ignored both the wrap-up advisory and the restricted-tools lockout"),
+            "terminal output should include the concrete abort reason"
         );
     }
 

--- a/rust/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/host.rs
@@ -503,6 +503,14 @@ pub struct StallTrackingState {
     /// successful task-completion signal (for example a successful git commit).
     /// One-shot per turn; advisory only, tools remain available.
     pub forced_completion_soft_stop: bool,
+    /// Whether the unfinished-task-board mid-loop gate already injected its
+    /// corrective this turn. Without this one-shot, a model that responds
+    /// with text-only completions while the task board still has unfinished
+    /// work would keep re-triggering the gate every BreakLoop round —
+    /// burning the global round budget instead of letting the terminal
+    /// guard rewrite the answer with a structured interruption record.
+    /// One-shot per turn; reset in `reset_per_turn_corrective_state`.
+    pub forced_task_board_completion_gate: bool,
     /// Whether the redundant-reads mid-loop corrective injected a guidance
     /// message this loop. Fires when the model has re-read overlapping line
     /// ranges of the same file enough times to cross

--- a/rust/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/host.rs
@@ -579,6 +579,10 @@ pub struct MessagingState {
 pub struct TaskBoardSnapshot {
     pub pending_count: usize,
     pub in_progress_count: usize,
+    /// Count of active (pending/in_progress) tasks that have at least one
+    /// blocker in their `blocked_by` list.  This counts tasks waiting on
+    /// dependencies, *not* tasks whose status is literally "blocked"
+    /// (there is no such status — the field reflects dependency edges).
     pub blocked_count: usize,
     pub active_tasks: Vec<String>,
 }
@@ -1234,20 +1238,34 @@ impl AgenticLoopState {
     /// TaskManager, when one is attached. Call this before any terminal
     /// completion decision so tool calls in the just-finished round are
     /// reflected before the loop decides whether unfinished work remains.
+    ///
+    /// The DB call is guarded by a 5-second timeout to prevent a stalled
+    /// store from holding up loop finalisation indefinitely.
     pub async fn refresh_task_board_snapshot(&mut self) {
         let Some(task_manager) = self.hooks.task_board_monitor.clone() else {
             return;
         };
-        match task_manager.load_active_tasks().await {
-            Ok(tasks) => {
+        let load = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            task_manager.load_active_tasks(),
+        );
+        match load.await {
+            Ok(Ok(tasks)) => {
                 self.hooks.task_board_snapshot = TaskBoardSnapshot::from_active_tasks(&tasks);
             }
-            Err(error) => {
+            Ok(Err(error)) => {
                 tracing::warn!(
                     target: "astra::loop_guard",
                     session_id = self.current_session_id.as_deref().unwrap_or_default(),
                     error = %error,
                     "failed to refresh active task-board snapshot; preserving previous snapshot"
+                );
+            }
+            Err(_elapsed) => {
+                tracing::warn!(
+                    target: "astra::loop_guard",
+                    session_id = self.current_session_id.as_deref().unwrap_or_default(),
+                    "timed out refreshing active task-board snapshot; preserving previous snapshot"
                 );
             }
         }

--- a/rust/crates/runtime/src/turn/agentic_loop/tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/tool_phase.rs
@@ -848,11 +848,9 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
             astra_turn_core::interruption::ResumeAction::ContinueImmediately,
             super::lifecycle::interruption_state_summary(
                 state,
-                Some(
-                    "LLM ignored wrapup instruction and restricted-tools lockout; \
-                     attempted tool calls on two consecutive rounds"
-                        .to_string(),
-                ),
+                Some(format!(
+                    "The runtime stopped this turn because token pressure stayed high and the model ignored both the wrap-up advisory and the restricted-tools lockout, attempting {dropped_count} more tool call(s). Progress from earlier rounds is preserved. Resume by summarizing verified work first and only call more tools if one concrete fact is still missing."
+                )),
             ),
         ));
         tracing::warn!(


### PR DESCRIPTION
## Summary
Improve context management with task gate one-shot behavior and harden task-aware session finalization.

## Changes
- Make task gate one-shot to prevent repeated execution
- Harden task-aware session finalization logic
- Improve /mcp command with better descriptions and dynamic server/tool completions
- Add MCP call logging, TUI-native /mcp commands, mock server, and integration tests

## Testing
Existing tests pass. Manual testing of task finalization and MCP command completions.