### PR TITLE
fix: model context_window now dynamically loaded from config instead of hardcoded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,9 @@ rust/.cargo/*
 !rust/.cargo/audit.toml
 
 
+# Benchmarks (local SWE-bench workspaces, runs, reports)
+benchmarks/
+
 # insta-rs runtime artifacts (only the canonical .snap is tracked)
 *.snap.new
 .insta/

--- a/rust/crates/core/src/runtime_limits.rs
+++ b/rust/crates/core/src/runtime_limits.rs
@@ -142,7 +142,28 @@ impl RuntimeLimits {
 ///
 /// Returns the full context window in tokens. The caller should
 /// apply a reserve (e.g., 80% for input, 20% for output).
+/// Convenience wrapper around [`context_window_for_model_with_override`].
 pub fn context_window_for_model(model: &str) -> Option<u64> {
+    context_window_for_model_with_override(model, None)
+}
+
+/// Known context window sizes for common models.
+///
+/// When `config_override` is provided (from `.models.yaml` or the DB),
+/// it takes precedence over the hardcoded lookup table. When `None`, falls
+/// back to the static lookup table keyed by model name.
+///
+/// Returns the full context window in tokens. The caller should
+/// apply a reserve (e.g., 80% for input, 20% for output).
+pub fn context_window_for_model_with_override(
+    model: &str,
+    config_override: Option<u32>,
+) -> Option<u64> {
+    // Dynamic override from model config — always wins.
+    if let Some(cw) = config_override {
+        return Some(cw as u64);
+    }
+
     let lower = model.to_lowercase();
     // Anthropic 4.6+ generation: 1M context window.
     // The 4.6 generation (Opus 4.6, Sonnet 4.6, Haiku 4.6) advertises a 1M
@@ -158,17 +179,25 @@ pub fn context_window_for_model(model: &str) -> Option<u64> {
         return Some(1_000_000);
     }
     if lower.contains("opus-4") || lower.contains("claude-opus") {
-        return Some(200_000);
+        return Some(128_000);
     }
     if lower.contains("sonnet-4") || lower.contains("claude-sonnet") {
-        return Some(200_000);
+        return Some(128_000);
     }
     if lower.contains("haiku-4") || lower.contains("claude-haiku") {
-        return Some(200_000);
-    }
-    // DeepSeek
-    if lower.contains("deepseek") {
         return Some(128_000);
+    }
+    // DeepSeek V4 (1M context) — must precede generic deepseek arm
+    if lower.contains("deepseek-v4") {
+        return Some(1_000_000);
+    }
+    // DeepSeek V3 / R1 (64K context)
+    if lower.contains("deepseek") {
+        return Some(64_000);
+    }
+    // Google — Gemini (1M context)
+    if lower.contains("gemini") {
+        return Some(1_000_000);
     }
     // Qwen (most have 1M but practical limit is lower)
     if lower.contains("qwen") {

--- a/rust/crates/runtime/src/prompts/context.rs
+++ b/rust/crates/runtime/src/prompts/context.rs
@@ -475,8 +475,8 @@ mod tests {
     #[test]
     fn effective_input_limit_claude() {
         let b = budget_for_model(Some("claude-3.5-sonnet"));
-        // 200_000 * (1 - 0.20) = 160_000
-        assert_eq!(b.effective_input_limit(), 160_000);
+        // 128_000 * (1 - 0.15) = 108_800
+        assert_eq!(b.effective_input_limit(), 108_800);
     }
 
     #[test]
@@ -655,10 +655,30 @@ mod tests {
     }
 
     #[test]
-    fn model_claude() {
+    fn model_claude_legacy() {
         let b = budget_for_model(Some("claude-3-opus"));
-        assert_eq!(b.model_limit, 200_000);
-        assert!((b.output_reserve_ratio - 0.20).abs() < f64::EPSILON);
+        assert_eq!(b.model_limit, 128_000);
+        assert!((b.output_reserve_ratio - 0.15).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn model_claude_4_6_gets_1m() {
+        let b = budget_for_model(Some("claude-sonnet-4-6"));
+        assert_eq!(b.model_limit, 1_000_000);
+        assert!((b.output_reserve_ratio - 0.10).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn model_claude_4_7_gets_1m() {
+        let b = budget_for_model(Some("claude-opus-4-7"));
+        assert_eq!(b.model_limit, 1_000_000);
+    }
+
+    #[test]
+    fn model_deepseek_v4_gets_1m() {
+        let b = budget_for_model(Some("deepseek-v4-pro"));
+        assert_eq!(b.model_limit, 1_000_000);
+        assert!((b.output_reserve_ratio - 0.10).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -671,6 +691,44 @@ mod tests {
     #[test]
     fn model_qwen() {
         let b = budget_for_model(Some("qwen-turbo"));
+        assert_eq!(b.model_limit, 128_000);
+    }
+
+    // ---------------------------------------------------------------
+    // 4b. Dynamic override from model config
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn override_wins_over_hardcoded() {
+        // deepseek-chat is hardcoded at 64K, override should win
+        let b = budget_for_model_with_override(Some("deepseek-chat"), Some(1_000_000));
+        assert_eq!(b.model_limit, 1_000_000);
+        assert!((b.output_reserve_ratio - 0.10).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn override_for_unknown_model() {
+        let b = budget_for_model_with_override(Some("my-custom-model"), Some(256_000));
+        assert_eq!(b.model_limit, 256_000);
+        assert!((b.output_reserve_ratio - 0.10).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn override_small_window_gets_small_reserve() {
+        let b = budget_for_model_with_override(Some("small-model"), Some(32_000));
+        assert_eq!(b.model_limit, 32_000);
+        assert!((b.output_reserve_ratio - 0.15).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn no_override_falls_back_to_hardcoded() {
+        let b = budget_for_model_with_override(Some("deepseek-chat"), None);
+        assert_eq!(b.model_limit, 64_000);
+    }
+
+    #[test]
+    fn no_override_unknown_falls_back_to_default() {
+        let b = budget_for_model_with_override(Some("totally-unknown-model"), None);
         assert_eq!(b.model_limit, 128_000);
     }
 
@@ -1346,8 +1404,8 @@ mod tests {
         let b = ContextBudget::from_runtime_config(&config, Some("claude-3.5-sonnet"));
 
         // Model-specific values should be applied
-        assert_eq!(b.model_limit, 200_000); // Claude
-        assert!((b.output_reserve_ratio - 0.20).abs() < f64::EPSILON);
+        assert_eq!(b.model_limit, 128_000); // Claude
+        assert!((b.output_reserve_ratio - 0.15).abs() < f64::EPSILON);
 
         // RuntimeConfig values should be applied
         assert!((b.compact_threshold - 0.6).abs() < f64::EPSILON);

--- a/rust/crates/runtime/src/prompts/context.rs
+++ b/rust/crates/runtime/src/prompts/context.rs
@@ -387,9 +387,15 @@ pub fn budget_for_model_with_override(
         // OpenAI — o1/o3 reasoning models (200K context)
         m if m.contains("o1") || m.contains("o3") => (200_000, 0.15),
         // Anthropic — Claude 4.6+ generation (1M context)
-        m if m.contains("opus-4-6") || m.contains("sonnet-4-6") || m.contains("haiku-4-6")
-            || m.contains("opus-4-7") || m.contains("sonnet-4-7") || m.contains("haiku-4-7")
-            => (1_000_000, 0.10),
+        m if m.contains("opus-4-6")
+            || m.contains("sonnet-4-6")
+            || m.contains("haiku-4-6")
+            || m.contains("opus-4-7")
+            || m.contains("sonnet-4-7")
+            || m.contains("haiku-4-7") =>
+        {
+            (1_000_000, 0.10)
+        }
         // Anthropic — Claude older (128K context default)
         m if m.contains("claude") => (128_000, 0.15),
         // Google — Gemini (1M context)

--- a/rust/crates/runtime/src/prompts/context.rs
+++ b/rust/crates/runtime/src/prompts/context.rs
@@ -351,7 +351,30 @@ impl Default for ContextBudget {
 }
 
 /// Return a ContextBudget tuned for a known model name.
+/// Convenience wrapper around [`budget_for_model_with_override`].
 pub fn budget_for_model(model: Option<&str>) -> ContextBudget {
+    budget_for_model_with_override(model, None)
+}
+
+/// Return a ContextBudget tuned for a known model name.
+///
+/// When `config_context_window` is provided (from `.models.yaml` or the DB),
+/// it takes precedence over the hardcoded lookup table. When `None`, falls
+/// back to the static lookup table keyed by model name.
+pub fn budget_for_model_with_override(
+    model: Option<&str>,
+    config_context_window: Option<u32>,
+) -> ContextBudget {
+    // Dynamic override from model config — always wins.
+    if let Some(cw) = config_context_window {
+        let cw = cw as usize;
+        return ContextBudget {
+            model_limit: cw,
+            output_reserve_ratio: if cw >= 128_000 { 0.10 } else { 0.15 },
+            ..Default::default()
+        };
+    }
+
     let name = model.unwrap_or("");
 
     let (limit, reserve) = match name {
@@ -363,11 +386,17 @@ pub fn budget_for_model(model: Option<&str>) -> ContextBudget {
         m if m.contains("gpt-3.5") => (16_000, 0.12),
         // OpenAI — o1/o3 reasoning models (200K context)
         m if m.contains("o1") || m.contains("o3") => (200_000, 0.15),
-        // Anthropic — Claude (200K context, large output window)
-        m if m.contains("claude") => (200_000, 0.20),
+        // Anthropic — Claude 4.6+ generation (1M context)
+        m if m.contains("opus-4-6") || m.contains("sonnet-4-6") || m.contains("haiku-4-6")
+            || m.contains("opus-4-7") || m.contains("sonnet-4-7") || m.contains("haiku-4-7")
+            => (1_000_000, 0.10),
+        // Anthropic — Claude older (128K context default)
+        m if m.contains("claude") => (128_000, 0.15),
         // Google — Gemini (1M context)
         m if m.contains("gemini") => (1_000_000, 0.10),
-        // DeepSeek (64K context)
+        // DeepSeek V4 (1M context) — must precede generic deepseek arm
+        m if m.contains("deepseek-v4") => (1_000_000, 0.10),
+        // DeepSeek V3 / R1 (64K context)
         m if m.contains("deepseek") => (64_000, 0.15),
         // Moonshot / Kimi
         m if m.contains("kimi") || m.contains("moonshot") => (128_000, 0.15),

--- a/rust/crates/runtime/src/prompts/mod.rs
+++ b/rust/crates/runtime/src/prompts/mod.rs
@@ -362,7 +362,7 @@ mod tests {
     #[test]
     fn budget_for_model_claude() {
         let b = budget_for_model(Some("claude-3.5-sonnet"));
-        assert_eq!(b.model_limit, 200_000);
+        assert_eq!(b.model_limit, 128_000);
     }
 
     #[test]

--- a/rust/crates/runtime/src/prompts/mod.rs
+++ b/rust/crates/runtime/src/prompts/mod.rs
@@ -16,8 +16,9 @@ pub use astra_prompts::skills::{
 };
 pub use context::{
     CacheAwareEstimate, CompactConfig, CompactionTier, ContextBudget, DEFAULT_SYSTEM_PROMPT_TOKENS,
-    budget_for_model, budget_for_model_with_override, capped_output_tokens, estimate_str_tokens, estimate_tokens,
-    estimate_tokens_cache_aware, estimate_tokens_cache_aware_split, estimate_tokens_precise,
+    budget_for_model, budget_for_model_with_override, capped_output_tokens, estimate_str_tokens,
+    estimate_tokens, estimate_tokens_cache_aware, estimate_tokens_cache_aware_split,
+    estimate_tokens_precise,
 };
 pub use system::{
     CacheScope, LOW_CONFIDENCE_THRESHOLD, PARALLEL_BATCHING_NUDGE_THRESHOLD, PromptOverrides,

--- a/rust/crates/runtime/src/prompts/mod.rs
+++ b/rust/crates/runtime/src/prompts/mod.rs
@@ -16,7 +16,7 @@ pub use astra_prompts::skills::{
 };
 pub use context::{
     CacheAwareEstimate, CompactConfig, CompactionTier, ContextBudget, DEFAULT_SYSTEM_PROMPT_TOKENS,
-    budget_for_model, capped_output_tokens, estimate_str_tokens, estimate_tokens,
+    budget_for_model, budget_for_model_with_override, capped_output_tokens, estimate_str_tokens, estimate_tokens,
     estimate_tokens_cache_aware, estimate_tokens_cache_aware_split, estimate_tokens_precise,
 };
 pub use system::{

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -276,6 +276,8 @@ struct ResolvedTurnLlmConfig {
     request_body_overrides: Option<Map<String, Value>>,
     completions_url_override: Option<String>,
     request_timeout: Option<Duration>,
+    /// Context window from model config. Falls back to hardcoded table when `None`.
+    context_window: Option<u32>,
 }
 
 type PipelineTurnOutcome = crate::turn::llm::context::LlmContextAssemblyOutput;
@@ -363,6 +365,7 @@ async fn resolve_llm_model_for_turn(
             request_body_overrides: None,
             completions_url_override: Some(config.url.clone()),
             request_timeout: config.timeout_ms.map(Duration::from_millis),
+            context_window: None,
         });
     }
     let resolved =
@@ -382,6 +385,7 @@ async fn resolve_llm_model_for_turn(
         request_body_overrides: resolved.request_body_overrides,
         completions_url_override: None,
         request_timeout: None,
+        context_window: resolved.context_window,
     })
 }
 
@@ -1484,6 +1488,7 @@ impl ServerAgenticLoopHost {
             request_body_overrides: None,
             completions_url_override: None,
             request_timeout: None,
+            context_window: None,
         };
         let wire_messages = self.assemble_llm_messages(
             system_msgs.clone(),
@@ -2629,7 +2634,10 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
         );
 
         // ── 3. Call LLM ─────────────────────────────────────────────────
-        let budget = crate::prompts::budget_for_model(Some(&llm_cfg.model_name));
+        let budget = crate::prompts::budget_for_model_with_override(
+            Some(&llm_cfg.model_name),
+            llm_cfg.context_window,
+        );
         let max_output_tokens = crate::prompts::capped_output_tokens(&budget);
 
         let cache_cap =
@@ -4131,6 +4139,7 @@ mod tests {
             request_body_overrides: None,
             completions_url_override: None,
             request_timeout: None,
+            context_window: None,
         };
         let msgs = host.assemble_llm_messages(
             vec![json!({"role": "system", "content": "system prompt text"})],

--- a/rust/crates/services/src/durable_task.rs
+++ b/rust/crates/services/src/durable_task.rs
@@ -5731,6 +5731,7 @@ mod tests {
             request_body_overrides: None,
             prompt_cache_capability: None,
             thinking_capability: None,
+            context_window: None,
         };
         let config = CloudLlmConfig::from_resolved(resolved);
         assert_eq!(config.model, "gpt-4o-mini");

--- a/rust/crates/services/src/models.rs
+++ b/rust/crates/services/src/models.rs
@@ -356,6 +356,9 @@ pub struct ResolvedActiveLlmModel {
     pub prompt_cache_capability: Option<PromptCacheCapabilityData>,
     /// Probe-determined thinking capability. NULL if unprobed.
     pub thinking_capability: Option<ThinkingCapability>,
+    /// Context window size from model config (`.models.yaml` or DB).
+    /// `None` means use the hardcoded fallback table.
+    pub context_window: Option<u32>,
 }
 
 impl std::fmt::Debug for ResolvedActiveLlmModel {
@@ -371,6 +374,7 @@ impl std::fmt::Debug for ResolvedActiveLlmModel {
             .field("request_body_overrides", &self.request_body_overrides)
             .field("prompt_cache_capability", &self.prompt_cache_capability)
             .field("thinking_capability", &self.thinking_capability)
+            .field("context_window", &self.context_window)
             .finish()
     }
 }
@@ -474,6 +478,8 @@ fn build_resolved_active_llm_from_row(
     let prompt_cache_capability = quirks.prompt_cache_capability;
     let request_body_overrides = quirks.request_body_overrides;
 
+    let context_window: Option<i32> = row.try_get("context_window").ok().flatten();
+
     Ok(ResolvedActiveLlmModel {
         model_name,
         wire_model_name,
@@ -485,6 +491,7 @@ fn build_resolved_active_llm_from_row(
         request_body_overrides,
         prompt_cache_capability,
         thinking_capability,
+        context_window: context_window.map(|cw| cw as u32),
     })
 }
 
@@ -2841,6 +2848,7 @@ mod tests {
             request_body_overrides: None,
             prompt_cache_capability: None,
             thinking_capability: None,
+            context_window: None,
         };
         assert_eq!(r.upstream_model_name(), "deepseek-v4-pro");
         // The local name is still reachable for routing / metrics.
@@ -2860,6 +2868,7 @@ mod tests {
             request_body_overrides: None,
             prompt_cache_capability: None,
             thinking_capability: None,
+            context_window: None,
         };
         assert_eq!(r.upstream_model_name(), "claude-sonnet-4-6");
     }


### PR DESCRIPTION
## Summary

修复了 Astra agent loop 中模型上下文窗口的硬编码问题——`.models.yaml` 里的 `context_window` 字段此前完全没有被 agent loop 使用。

## 问题

Agent loop 通过两个独立的硬编码字符串匹配表来确定模型的上下文窗口大小：

| 函数 | 文件 | 问题 |
|---|---|---|
| `budget_for_model()` | `prompts/context.rs` | deepseek 64K (低于实际) |
| `context_window_for_model()` | `core/src/runtime_limits.rs` | deepseek 128K (与另一处不一致) |

两表数值不一致，且 `.models.yaml` 的 `context_window` 字段被完全忽略。加新模型必须改 Rust 源码并重新编译。

## 修改

1. **两表对齐**：修正不一致值（deepseek V3/R1 统一为 64K、新增 gemini→1M、claude 默认统一为 128K、新增 deepseek-v4→1M、claude 4.6/4.7→1M 精确匹配）
2. **动态覆盖**：新增 `budget_for_model_with_override()` 和 `context_window_for_model_with_override()`，接受来自模型配置的可选 `context_window` 参数，有配置值时优先使用
3. **数据穿透**：`ResolvedActiveLlmModel` → `ResolvedTurnLlmConfig` → `budget_for_model_with_override()` 全链路贯通，DB 中已存储的 `context_window` 列现在能真正影响 agent 行为
4. **向后兼容**：原函数签名不变，所有现有调用点无需修改，未提供配置值时回退到硬编码表

## Test plan

- [x] `cargo check --workspace` 通过
- [x] 切换不同模型后 `ContextBudget.model_limit` 反映 `.models.yaml` 中的实际值
- [x] 未在配置中的模型仍走硬编码 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)