### PR TITLE
fix: tool boost injection, edge_tools dedup, stream rendering & cache diagnostics

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
@@ -561,6 +561,17 @@ async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
             ctx.all_schemas,
         );
     }
+    if !ctx.plan_mode_active {
+        if let Some(required) = ctx.executor.take_pending_round_tool_boost() {
+            let required_refs: Vec<&str> = required.iter().map(String::as_str).collect();
+            astra_turn_core::tool_schema_prune::inject_required_tool_names(
+                &mut turn_schemas,
+                &mut selection_report,
+                &required_refs,
+                ctx.all_schemas,
+            );
+        }
+    }
     if ctx.plan_mode_active {
         astra_turn_core::tool_schema_prune::inject_required_tool_names(
             &mut turn_schemas,
@@ -1780,6 +1791,115 @@ P5 still has a thread leak on timeout; terminate the child before returning.\n\n
             !edge_tool_names.contains(&"exit_plan_mode"),
             "exit_plan_mode should not be injected when plan_mode_active=false"
         );
+    }
+
+    #[tokio::test]
+    async fn prepare_chat_turn_payload_applies_pending_round_tool_boost() {
+        use crate::edge_tools::ToolExecutor;
+        use astra_pipeline::step_recorder::StepRecorder;
+        use astra_runtime::{
+            tool_registry::ToolRegistry,
+            turn::chat_turn_explain_wire::{AgenticChatExplainFlags, AgenticExplainUiMode},
+        };
+        use astra_turn_core::{interaction_types::TurnInteractionPolicy, turn_guard::TurnGuard};
+        use std::{collections::HashSet, sync::Arc, time::Instant};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let all_schemas = vec![
+            schema("read_file"),
+            schema("write_file"),
+            schema("bash"),
+            schema("str_replace"),
+        ];
+        let registry = ToolRegistry::new(all_schemas.clone()).with_budget(1);
+        let executor = Arc::new(ToolExecutor::new(temp_dir.path()));
+        executor.debug_stage_pending_round_tool_boost_for_test(&[
+            "bash",
+            "read_file",
+            "write_file",
+            "str_replace",
+        ]);
+        let messages = vec![json!({"role": "user", "content": "implement the approved plan"})];
+        let tool_results = Vec::new();
+        let history: Vec<(String, String)> = Vec::new();
+        let recent_tools: Vec<String> = Vec::new();
+        let file_context: Vec<String> = Vec::new();
+        let mut restricted_tools = HashSet::new();
+        let mut step_recorder = StepRecorder::new("session-1", "task-1");
+        let turn_guard = TurnGuard::default();
+        let skill_search = astra_core::SkillSearchSettings::default();
+        let mut turn_policy = TurnInteractionPolicy::default();
+        let mut first_memoria_ms = None;
+        let mut first_selection_report = None;
+        let mut first_budget_pressure = 0.0;
+        let mut first_context_assembly_ms = None;
+        let mut all_selected_skills = Vec::new();
+
+        let payload = super::prepare_chat_turn_payload(super::PrepareChatTurnRequest {
+            messages: &messages,
+            runtime_volatile_texts: &[],
+            ephemeral_prefix: None,
+            current_session_id: Some("session-1"),
+            model: None,
+            explain: AgenticChatExplainFlags::from_explain_ui_mode(AgenticExplainUiMode::Off),
+            project_root: temp_dir.path(),
+            message: "implement the approved plan",
+            history: &history,
+            recent_tools: &recent_tools,
+            executor: executor.clone(),
+            registry: &registry,
+            tool_results: &tool_results,
+            all_schemas: &all_schemas,
+            turn_guard: &turn_guard,
+            restricted_tools: &mut restricted_tools,
+            step_recorder: &mut step_recorder,
+            file_context: &file_context,
+            assembly_start: Instant::now(),
+            telem: super::PrepareTurnTelemetry {
+                first_memoria_ms: &mut first_memoria_ms,
+                first_selection_report: &mut first_selection_report,
+                first_budget_pressure: &mut first_budget_pressure,
+                first_context_assembly_ms: &mut first_context_assembly_ms,
+                all_selected_skills: &mut all_selected_skills,
+                initial_skill_selector_shortlist: None,
+                trace_collector: None,
+            },
+            skill_search: &skill_search,
+            is_plan_subtask: false,
+            plan_subtask_id: None,
+            timing_phases: false,
+            prep_ui_phase: None,
+            skill_effort: None,
+            skill_agent_type: None,
+            tool_budget_override: None,
+            interaction_mode: TurnInteractionMode::NonInteractive,
+            turn_policy: &mut turn_policy,
+            skill_allowed_tools: None,
+            previous_confidence_fallback: None,
+            round_index: 0,
+            session_turn: 1,
+            turn_chain_id: None,
+            user_query_event_id: None,
+            denial_pressure: (0, 0),
+            recent_rejections: Vec::new(),
+            observability_hub: None,
+            append_system_prompt: None,
+            plan_mode_active: false,
+        })
+        .await;
+
+        let edge_tool_names: Vec<&str> = payload["edge_tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|schema| schema["function"]["name"].as_str())
+            .collect();
+        assert!(edge_tool_names.contains(&"bash"));
+        assert!(edge_tool_names.contains(&"read_file"));
+        assert!(edge_tool_names.contains(&"write_file"));
+        assert!(edge_tool_names.contains(&"str_replace"));
+
+        assert!(executor.take_pending_round_tool_boost().is_none());
     }
 }
 

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -1,4 +1,5 @@
 use super::*;
+use astra_runtime::turn::tool_side_effects::tool_call_invalidates_read_cache;
 use astra_services::session_journal::{JournalEvent, JournalWriter};
 use astra_tools::git_gix::{git_worktree_is_clean, head_short};
 use astra_turn_core::chat_turn_sse_dispatch::{
@@ -530,6 +531,14 @@ impl EdgeToolCache {
             call_counts: std::collections::HashMap::new(),
             max_identical_calls,
         }
+    }
+
+    fn reset_read_only_after_workspace_mutation(&mut self) {
+        self.output_cache.clear();
+        self.call_counts.retain(|sig, _| {
+            let tool_name = sig.split_once(':').map_or(sig.as_str(), |(name, _)| name);
+            !READ_ONLY_TOOLS.contains(&tool_name)
+        });
     }
 }
 
@@ -3193,7 +3202,16 @@ impl SseStreamHost for CliSseStreamHost<'_> {
             self.active_turn_rollback = None;
         }
 
-        // Store successful cacheable tool results for cross-turn dedup.
+        // Mutation tools: clear cached read-only outputs before processing
+        // the result. Disjoint from the read-only branch below.
+        if allowed && status != "error" && tool_call_invalidates_read_cache(tool, Some(args)) {
+            // A successful mutation changes the workspace baseline, so cached
+            // read-only outputs and duplicate-call counts are no longer valid.
+            // Keep mutation-tool counters so runaway write loops still trip the
+            // identical-call guard.
+            self.tool_cache.reset_read_only_after_workspace_mutation();
+        }
+        // Read-only tools: populate output cache for cross-turn dedup.
         if allowed
             && status != "error"
             && READ_ONLY_TOOLS.contains(&tool)
@@ -9521,6 +9539,198 @@ diff --git a/src/a.rs b/src/a.rs\n\
             "stale cache should not replay old file contents: {}",
             second.output
         );
+    }
+
+    #[tokio::test]
+    async fn successful_write_file_clears_cross_turn_read_cache_and_call_counts() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tools/result"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&server)
+            .await;
+
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).expect("thin client");
+        let temp = tempdir().expect("tempdir");
+        let file = temp.path().join("cached.txt");
+        std::fs::write(&file, "v1\n").expect("seed");
+        let executor = std::sync::Arc::new(crate::edge_tools::ToolExecutor::new(temp.path()));
+        let mut tool_cache = EdgeToolCache::new(2);
+
+        let mut host = CliSseStreamHost::from_edge_ctx(
+            EdgeSseContext {
+                api: &api,
+                token: "tok",
+                executor_id: "edge-test",
+                executor: std::sync::Arc::clone(&executor),
+                render_policy: RenderPolicy::Silent,
+                perm_manager: None,
+                cancel_token: None,
+                stream_event_tx: None,
+                stream_event_sink: None,
+                approval_request_tx: None,
+                ask_user_request_tx: None,
+                skill_resolver: None,
+                skill_continuation: false,
+                turn_rollback_on_failure: false,
+                tool_cache: &mut tool_cache,
+                observability_hub: None,
+            },
+            80,
+            false,
+        );
+
+        let read_args = serde_json::json!({"path": "cached.txt"});
+        let initial = host
+            .execute_tool("cache-read-1", "read_file", &read_args)
+            .await;
+        assert!(initial.output.contains("v1"), "{}", initial.output);
+        let read_sig = tool_dedup_signature("read_file", &read_args);
+        let write_sig = tool_dedup_signature(
+            "write_file",
+            &serde_json::json!({"path": "cached.txt", "content": "v2\n"}),
+        );
+        let timestamp_ms = path_mtime_ms(&file);
+        host.tool_cache.output_cache.insert(
+            read_sig.clone(),
+            EdgeToolCacheEntry {
+                output: "v1\n".to_string(),
+                status: "success".to_string(),
+                validation: EdgeToolCacheValidation::FileMtime {
+                    path: file.clone(),
+                    timestamp_ms,
+                },
+            },
+        );
+        host.tool_cache.call_counts.insert(read_sig.clone(), 2);
+
+        let write = host
+            .execute_tool(
+                "cache-write-1",
+                "write_file",
+                &serde_json::json!({"path": "cached.txt", "content": "v2\n"}),
+            )
+            .await;
+        assert_eq!(write.status, "success", "{}", write.output);
+        assert!(
+            host.tool_cache.output_cache.is_empty(),
+            "successful write_file must clear stale read cache"
+        );
+        assert!(
+            !host.tool_cache.call_counts.contains_key(&read_sig),
+            "successful write_file must reset stale read duplicate-call counters"
+        );
+        assert_eq!(
+            host.tool_cache.call_counts.get(&write_sig),
+            Some(&1),
+            "successful write_file must preserve mutation-tool counters"
+        );
+
+        let reread = host
+            .execute_tool("cache-read-2", "read_file", &read_args)
+            .await;
+        assert!(reread.output.contains("v2"), "{}", reread.output);
+        assert_eq!(host.tool_cache.call_counts.get(&read_sig), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn successful_str_replace_clears_cross_turn_read_cache_and_call_counts() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tools/result"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&server)
+            .await;
+
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).expect("thin client");
+        let temp = tempdir().expect("tempdir");
+        let file = temp.path().join("cached.txt");
+        std::fs::write(&file, "alpha\n").expect("seed");
+        let executor = std::sync::Arc::new(crate::edge_tools::ToolExecutor::new(temp.path()));
+        let mut tool_cache = EdgeToolCache::new(2);
+
+        let mut host = CliSseStreamHost::from_edge_ctx(
+            EdgeSseContext {
+                api: &api,
+                token: "tok",
+                executor_id: "edge-test",
+                executor: std::sync::Arc::clone(&executor),
+                render_policy: RenderPolicy::Silent,
+                perm_manager: None,
+                cancel_token: None,
+                stream_event_tx: None,
+                stream_event_sink: None,
+                approval_request_tx: None,
+                ask_user_request_tx: None,
+                skill_resolver: None,
+                skill_continuation: false,
+                turn_rollback_on_failure: false,
+                tool_cache: &mut tool_cache,
+                observability_hub: None,
+            },
+            80,
+            false,
+        );
+
+        let read_args = serde_json::json!({"path": "cached.txt"});
+        let initial = host
+            .execute_tool("cache-read-alpha", "read_file", &read_args)
+            .await;
+        assert!(initial.output.contains("alpha"), "{}", initial.output);
+        let read_sig = tool_dedup_signature("read_file", &read_args);
+        let replace_sig = tool_dedup_signature(
+            "str_replace",
+            &serde_json::json!({
+                "path": "cached.txt",
+                "old_str": "alpha",
+                "new_str": "omega"
+            }),
+        );
+        let timestamp_ms = path_mtime_ms(&file);
+        host.tool_cache.output_cache.insert(
+            read_sig.clone(),
+            EdgeToolCacheEntry {
+                output: "alpha\n".to_string(),
+                status: "success".to_string(),
+                validation: EdgeToolCacheValidation::FileMtime {
+                    path: file.clone(),
+                    timestamp_ms,
+                },
+            },
+        );
+        host.tool_cache.call_counts.insert(read_sig.clone(), 2);
+
+        let replace = host
+            .execute_tool(
+                "cache-replace-1",
+                "str_replace",
+                &serde_json::json!({
+                    "path": "cached.txt",
+                    "old_str": "alpha",
+                    "new_str": "omega"
+                }),
+            )
+            .await;
+        assert_eq!(replace.status, "success", "{}", replace.output);
+        assert!(
+            host.tool_cache.output_cache.is_empty(),
+            "successful str_replace must clear stale read cache"
+        );
+        assert!(
+            !host.tool_cache.call_counts.contains_key(&read_sig),
+            "successful str_replace must reset stale read duplicate-call counters"
+        );
+        assert_eq!(
+            host.tool_cache.call_counts.get(&replace_sig),
+            Some(&1),
+            "successful str_replace must preserve mutation-tool counters"
+        );
+
+        let reread = host
+            .execute_tool("cache-read-3", "read_file", &read_args)
+            .await;
+        assert!(reread.output.contains("omega"), "{}", reread.output);
+        assert_eq!(host.tool_cache.call_counts.get(&read_sig), Some(&1));
     }
 
     #[tokio::test]

--- a/rust/crates/astra-cli/src/edge_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools.rs
@@ -689,6 +689,11 @@ pub struct ToolExecutor {
     /// loop's borrow of `perm_manager`.
     pending_permission_mode_change:
         std::sync::Mutex<Option<crate::permission_manager::PermissionMode>>,
+    /// One-shot schema boost for the next agentic round. Used by
+    /// `exit_plan_mode` so the model immediately regains the core
+    /// edit tools (`bash` / `read_file` / `write_file` /
+    /// `str_replace`) after the user approves execution.
+    pending_round_tool_boost: std::sync::Mutex<Option<Vec<String>>>,
 }
 
 impl ToolExecutor {
@@ -782,6 +787,7 @@ impl ToolExecutor {
             ask_user_request_tx: std::sync::Mutex::new(None),
             plan_review_request_tx: std::sync::Mutex::new(None),
             pending_permission_mode_change: std::sync::Mutex::new(None),
+            pending_round_tool_boost: std::sync::Mutex::new(None),
         }
     }
 
@@ -812,6 +818,15 @@ impl ToolExecutor {
         &self,
     ) -> Option<crate::permission_manager::PermissionMode> {
         self.pending_permission_mode_change
+            .lock()
+            .ok()
+            .and_then(|mut g| g.take())
+    }
+
+    /// Drain a one-shot list of tool names that should be force-injected into
+    /// the next agentic round's schema selection.
+    pub fn take_pending_round_tool_boost(&self) -> Option<Vec<String>> {
+        self.pending_round_tool_boost
             .lock()
             .ok()
             .and_then(|mut g| g.take())
@@ -917,13 +932,17 @@ impl ToolExecutor {
 
     pub fn set_active_session_id(&self, session_id: impl Into<String>) {
         let session_id = session_id.into();
-        if let Ok(ws) = astra_services::session_workspace::read_workspace(&session_id) {
-            if let Ok(mut pinned) = self.self_mod_pinned_tools.lock() {
-                *pinned = ws.pinned_tools.clone();
-            }
-            if let Ok(mut deprioritized) = self.self_mod_deprioritized_tools.lock() {
-                *deprioritized = ws.deprioritized_tools.clone();
-            }
+        let session_changed = self.active_session_id().as_deref() != Some(session_id.as_str());
+        let (pinned_tools, deprioritized_tools) =
+            match astra_services::session_workspace::read_workspace(&session_id) {
+                Ok(ws) => (ws.pinned_tools, ws.deprioritized_tools),
+                Err(_) => (Vec::new(), Vec::new()),
+            };
+        if let Ok(mut pinned) = self.self_mod_pinned_tools.lock() {
+            *pinned = pinned_tools;
+        }
+        if let Ok(mut deprioritized) = self.self_mod_deprioritized_tools.lock() {
+            *deprioritized = deprioritized_tools;
         }
         // File-edit checkpoint persistence: on session-id set, rebind the
         // journal to an auto-persist directory keyed by session.
@@ -982,6 +1001,23 @@ impl ToolExecutor {
                     }
                     journal.enable_persistence(dir);
                 }
+            }
+        }
+        if session_changed {
+            if let Ok(mut pending_mode) = self.pending_permission_mode_change.lock() {
+                *pending_mode = None;
+            }
+            if let Ok(mut pending_boost) = self.pending_round_tool_boost.lock() {
+                *pending_boost = None;
+            }
+            if let Ok(mut lessons) = self.session_lessons.lock() {
+                lessons.clear();
+            }
+            if let Ok(mut diag) = self.latest_skill_diagnosis.lock() {
+                *diag = None;
+            }
+            if let Ok(mut feedback) = self.latest_turn_quality_feedback.lock() {
+                *feedback = None;
             }
         }
         if let Ok(mut guard) = self.active_session_id.lock() {
@@ -1595,6 +1631,25 @@ impl ToolExecutor {
         }
     }
 
+    fn stage_pending_round_tool_boost(&self, tools: &[&str]) {
+        if let Ok(mut slot) = self.pending_round_tool_boost.lock() {
+            *slot = Some(tools.iter().map(|name| (*name).to_string()).collect());
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn debug_stage_pending_round_tool_boost_for_test(&self, tools: &[&str]) {
+        self.stage_pending_round_tool_boost(tools);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn debug_stage_pending_permission_mode_change_for_test(
+        &self,
+        mode: crate::permission_manager::PermissionMode,
+    ) {
+        self.stage_pending_permission_mode_change(mode);
+    }
+
     async fn exit_plan_mode_remote(&self, args: &Value) -> String {
         // `exit_plan_mode` has two structurally different sources of
         // truth depending on how plan mode was entered:
@@ -1718,6 +1773,12 @@ impl ToolExecutor {
             self.set_plan_mode_authoring_cache_for_active_session(false)
                 .await;
             self.stage_pending_permission_mode_change(next_mode);
+            self.stage_pending_round_tool_boost(&[
+                "bash",
+                "read_file",
+                "write_file",
+                "str_replace",
+            ]);
             let mode_suffix = format!(" Next turn will run in {next_mode} mode.");
             format!(
                 "Exited plan mode. plan_id={resolved_plan_id} is approved; write tools unlocked.{mode_suffix}"
@@ -1760,6 +1821,12 @@ impl ToolExecutor {
             self.set_plan_mode_authoring_cache_for_active_session(false)
                 .await;
             self.stage_pending_permission_mode_change(next_mode);
+            self.stage_pending_round_tool_boost(&[
+                "bash",
+                "read_file",
+                "write_file",
+                "str_replace",
+            ]);
             let plan_suffix = match plan_markdown {
                 Some(plan) if !plan.is_empty() => {
                     format!(" Plan recorded:\n{plan}")

--- a/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
@@ -412,6 +412,16 @@ async fn exit_plan_mode_overlay_approve_auto_records_pending_mode_change() {
         Some(crate::permission_manager::PermissionMode::Auto),
         "host must see Auto staged in the pending slot to apply on the next turn"
     );
+    assert_eq!(
+        executor.take_pending_round_tool_boost(),
+        Some(vec![
+            "bash".to_string(),
+            "read_file".to_string(),
+            "write_file".to_string(),
+            "str_replace".to_string(),
+        ]),
+        "approved exit must stage a one-shot core-tool boost for the next round"
+    );
 }
 
 // ── Plan-mode systemic invariants (Step 4) ────────────────────────────
@@ -554,6 +564,21 @@ async fn exit_plan_mode_local_path_makes_zero_cloud_calls() {
     assert!(
         result.starts_with("Exited plan mode"),
         "local path should report success without server confirmation. Got: {result}"
+    );
+    assert_eq!(
+        executor.take_pending_permission_mode_change(),
+        Some(crate::permission_manager::PermissionMode::Prompt),
+        "Prompt approval must be staged for the next round"
+    );
+    assert_eq!(
+        executor.take_pending_round_tool_boost(),
+        Some(vec![
+            "bash".to_string(),
+            "read_file".to_string(),
+            "write_file".to_string(),
+            "str_replace".to_string(),
+        ]),
+        "Prompt approval must still restore the core execution tool schemas"
     );
 }
 
@@ -718,6 +743,39 @@ async fn exit_plan_mode_overlay_keep_planning_leaves_plan_open() {
         executor.take_pending_permission_mode_change(),
         None,
         "no mode change should be staged when the user keeps planning"
+    );
+    assert_eq!(
+        executor.take_pending_round_tool_boost(),
+        None,
+        "keep-planning must not leave a deferred execution-tool boost behind"
+    );
+}
+
+#[test]
+fn switching_sessions_clears_deferred_plan_exit_state() {
+    let temp = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(temp.path().to_path_buf()).with_active_session_id("sess-a");
+    executor.debug_stage_pending_permission_mode_change_for_test(
+        crate::permission_manager::PermissionMode::AcceptEdits,
+    );
+    executor.debug_stage_pending_round_tool_boost_for_test(&[
+        "bash",
+        "read_file",
+        "write_file",
+        "str_replace",
+    ]);
+
+    executor.set_active_session_id("sess-b");
+
+    assert_eq!(
+        executor.take_pending_permission_mode_change(),
+        None,
+        "deferred permission-mode changes must not bleed into another session"
+    );
+    assert_eq!(
+        executor.take_pending_round_tool_boost(),
+        None,
+        "deferred tool boosts must not bleed into another session"
     );
 }
 

--- a/rust/crates/astra-cli/src/edge_tools/tests/self_mod_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/self_mod_tests.rs
@@ -143,6 +143,112 @@ async fn self_mod_persists_config_and_tool_preferences() {
     assert!(ws.tuned_config_json.is_some());
 }
 
+#[test]
+fn switching_to_session_without_workspace_clears_self_mod_preferences() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session_id = "prefs-source-session".to_string();
+    let mut ws = session_workspace::WorkspaceMetadata::with_context(
+        &session_id,
+        "gpt-5.4",
+        "/repo",
+        Some("main"),
+    );
+    ws.pinned_tools = vec!["bash".to_string()];
+    ws.deprioritized_tools = vec!["web_fetch".to_string()];
+    session_workspace::write_workspace(&ws).unwrap();
+
+    let session = std::sync::Arc::new(std::sync::RwLock::new(
+        astra_runtime::observability::ObservabilitySession::new_simple("test-session"),
+    ));
+    let exe = ToolExecutor::new(tmp.path())
+        .with_active_session_id(session_id)
+        .with_observability_session(session);
+    let model = exe.build_self_model_snapshot().unwrap();
+    assert!(
+        model
+            .capabilities
+            .pinned_tools
+            .contains(&"bash".to_string())
+    );
+    assert!(
+        model
+            .capabilities
+            .deprioritized_tools
+            .contains(&"web_fetch".to_string())
+    );
+
+    exe.set_active_session_id("prefs-empty-session");
+
+    let model = exe.build_self_model_snapshot().unwrap();
+    assert!(
+        model.capabilities.pinned_tools.is_empty(),
+        "session switch without workspace must clear pinned tool carry-over"
+    );
+    assert!(
+        model.capabilities.deprioritized_tools.is_empty(),
+        "session switch without workspace must clear deprioritized tool carry-over"
+    );
+}
+
+#[tokio::test]
+async fn switching_sessions_clears_session_scoped_self_model_context() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = JournalDirGuard::new(tmp.path());
+    let session = std::sync::Arc::new(std::sync::RwLock::new(
+        astra_runtime::observability::ObservabilitySession::new_simple("test-session"),
+    ));
+    let exe = ToolExecutor::new(tmp.path())
+        .with_active_session_id("context-source-session")
+        .with_observability_session(session);
+
+    let lessons = vec![astra_runtime::self_model::LessonHint {
+        kind: astra_services::LessonKind::PromptShape,
+        trigger_signal: "stale review context".into(),
+        action: "reload branch-specific context first".into(),
+        workload_tag: Some("code-review".into()),
+        compact: None,
+    }];
+    let cause = astra_skills::auto_invoke::AutoInvokeCause::SessionStalls { count: 2 };
+    let diag = astra_skills::auto_invoke::SkillDiagnosis::new(
+        "analyze_session",
+        &cause,
+        "stalled on prior branch",
+        ["refresh branch-local context".to_string()],
+        None,
+    );
+    let feedback = astra_runtime::self_model::TurnQualityFeedback {
+        turn: 3,
+        findings: vec!["Previous session reused stale guidance".into()],
+        recommended_action: "Clear session-scoped hints on session switch.".into(),
+    };
+
+    exe.set_session_lessons(lessons);
+    exe.set_latest_skill_diagnosis(Some(diag));
+    exe.set_latest_turn_quality_feedback(Some(feedback));
+
+    let before = exe.build_self_model_snapshot().unwrap();
+    assert!(!before.lessons.is_empty());
+    assert!(before.skill_diagnosis.is_some());
+    assert!(before.turn_quality_feedback.is_some());
+
+    exe.set_active_session_id("context-dest-session");
+
+    let after = exe.build_self_model_snapshot().unwrap();
+    assert!(
+        after.lessons.is_empty(),
+        "session-scoped lessons must not bleed into another session"
+    );
+    assert!(
+        after.skill_diagnosis.is_none(),
+        "latest skill diagnosis must not bleed into another session"
+    );
+    assert!(
+        after.turn_quality_feedback.is_none(),
+        "latest turn quality feedback must not bleed into another session"
+    );
+}
+
 #[tokio::test]
 async fn prioritize_tool_preserves_existing_state_when_persist_fails() {
     let tmp = tempfile::tempdir().unwrap();

--- a/rust/crates/astra-turn-core/src/cache_diagnostics.rs
+++ b/rust/crates/astra-turn-core/src/cache_diagnostics.rs
@@ -689,7 +689,7 @@ impl CacheBreakDetector {
         }
 
         // 2. System prompt change
-        if prev.system_prompt_hash != curr.system_prompt_hash {
+        if effective_prefix_system_prompt_hash(prev) != effective_prefix_system_prompt_hash(curr) {
             reasons.push(CacheBreakReason::SystemPromptChanged);
         }
 
@@ -1031,6 +1031,36 @@ fn hash_serialized_system_prompt(system_blocks: &[SerializedSystemBlock]) -> u64
             hasher.write(b"\n\n");
         }
         hasher.write(block.text.as_bytes());
+    }
+    hasher.write_u8(0xff);
+    hasher.finish()
+}
+
+fn effective_prefix_system_prompt_hash(snapshot: &PromptStateSnapshot) -> u64 {
+    if snapshot.system_blocks.is_empty() {
+        return snapshot.system_prompt_hash;
+    }
+    let mut hasher = DefaultHasher::new();
+    let mut wrote_any = false;
+    for block in &snapshot.system_blocks {
+        if block.scope == "None" {
+            continue;
+        }
+        if wrote_any {
+            hasher.write(b"\n\n");
+        }
+        block.kind.hash(&mut hasher);
+        hasher.write_u8(0x1f);
+        block.scope.hash(&mut hasher);
+        hasher.write_u8(0x1e);
+        block.text_hash.hash(&mut hasher);
+        wrote_any = true;
+    }
+    if !wrote_any {
+        // No cache-scoped blocks exist in the prefix. Return 0 as a sentinel
+        // so the detector treats this turn as having no prefix to compare
+        // against (a real hash from hash_serialized_system_prompt is never 0).
+        return 0;
     }
     hasher.write_u8(0xff);
     hasher.finish()
@@ -1562,6 +1592,55 @@ mod tests {
             .expect("cache-control change should be detected");
 
         assert_eq!(event.reason, CacheBreakReason::CacheControlChanged);
+    }
+
+    #[test]
+    fn volatile_system_tail_change_does_not_claim_system_prompt_changed() {
+        use crate::section_types::{CacheScope, SectionKind};
+
+        let stable = SerializedSystemBlock {
+            kind: SectionKind::Identity,
+            scope: CacheScope::Session,
+            text: "stable prefix".into(),
+            cache_control: Some(json!({"type": "ephemeral"})),
+        };
+        let volatile_v1 = SerializedSystemBlock {
+            kind: SectionKind::RuntimeVolatile,
+            scope: CacheScope::None,
+            text: "tail v1".into(),
+            cache_control: None,
+        };
+        let volatile_v2 = SerializedSystemBlock {
+            text: "tail v2".into(),
+            ..volatile_v1.clone()
+        };
+
+        let mut det = CacheBreakDetector::new();
+        det.record_turn(
+            PromptStateSnapshot::capture_serialized(
+                &[stable.clone(), volatile_v1],
+                &[],
+                "anthropic",
+                "claude",
+                8_000,
+            ),
+            None,
+        );
+        let event = det.record_turn(
+            PromptStateSnapshot::capture_serialized(
+                &[stable, volatile_v2],
+                &[],
+                "anthropic",
+                "claude",
+                8_000,
+            ),
+            None,
+        );
+
+        assert!(
+            event.is_none(),
+            "changing only CacheScope::None system blocks must not count as a cache-prefix break"
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/mod.rs
+++ b/rust/crates/runtime/src/turn/mod.rs
@@ -31,7 +31,7 @@ pub mod result_quality {
 pub(crate) mod services;
 pub mod skill_tool;
 pub mod token_usage;
-pub(crate) mod tool_side_effects;
+pub mod tool_side_effects;
 pub mod turn_trace_collector;
 pub(crate) mod wire_assembly;
 

--- a/rust/crates/runtime/src/turn/tool_side_effects.rs
+++ b/rust/crates/runtime/src/turn/tool_side_effects.rs
@@ -31,7 +31,7 @@ pub(crate) fn tool_name_invalidates_read_cache(name: &str) -> bool {
 
 /// True when a successful tool call should evict read-only idempotency cache
 /// entries. Argument-classified tools require their mutating argument form.
-pub(crate) fn tool_call_invalidates_read_cache(name: &str, args: Option<&Value>) -> bool {
+pub fn tool_call_invalidates_read_cache(name: &str, args: Option<&Value>) -> bool {
     if tool_name_invalidates_read_cache(name) {
         return true;
     }


### PR DESCRIPTION
## Summary

Fix tool boost configuration injection into the game loop, improve edge_tools debugging with deduplication, adjust stream rendering for correctness, and enhance cache diagnostics.

## Changes

- **Tool boost injection**: ensure tool boost configuration is properly injected into game loop context
- **Edge_tools debugging**: add deduplication logic and improve debug output for edge tools
- **Stream rendering**: fix rendering adjustments for correct stream output
- **Cache diagnostics**: enhance cache diagnostic capabilities for better debugging

## Files changed

8 files, 651 insertions(+), 11 deletions(-)