### PR TITLE
fix: exit_semantics propagation, OpenAI tool pairing repair for all providers, session-start memory cache

### DIFF
--- a/rust/crates/astra-cli/src/cli/execution_state_summary.rs
+++ b/rust/crates/astra-cli/src/cli/execution_state_summary.rs
@@ -20,6 +20,7 @@ use astra_tools::task_mgmt::SessionTask;
 pub(crate) struct ExecutionStateSummaryInput<'a> {
     pub model: Option<&'a str>,
     pub last_turn_interrupted: bool,
+    pub plan_mode_active: bool,
     pub plan_mode: Option<&'a PlanModeState>,
     pub executing_plan: Option<&'a TaskPlan>,
     pub executing_plan_goal: Option<&'a str>,
@@ -37,6 +38,7 @@ pub(crate) fn format_for_session_state(
     format_summary(ExecutionStateSummaryInput {
         model: state.model.as_deref(),
         last_turn_interrupted: state.last_turn_interrupted,
+        plan_mode_active: state.plan_mode_active(),
         plan_mode: state.cloud_plan_mirror.as_ref(),
         executing_plan: state.executing_plan.as_ref(),
         executing_plan_goal: state.executing_plan_goal.as_deref(),
@@ -59,7 +61,7 @@ pub(crate) fn format_summary(input: ExecutionStateSummaryInput<'_>) -> Option<St
             "turn state: last turn was interrupted; inspect partial work before resuming".into(),
         );
     }
-    if let Some(plan_mode) = input.plan_mode {
+    if let Some(plan_mode) = input.plan_mode.filter(|_| input.plan_mode_active) {
         let mut line = format!(
             "plan authoring: {}",
             plan_resume_digest(plan_mode)
@@ -398,6 +400,7 @@ mod tests {
         let out = format_summary(ExecutionStateSummaryInput {
             model: Some("gpt-5.4"),
             last_turn_interrupted: true,
+            plan_mode_active: true,
             plan_mode: Some(&plan_mode),
             executing_plan: Some(&executing_plan),
             executing_plan_goal: Some("Ship auth flow"),
@@ -447,6 +450,7 @@ mod tests {
         let out = format_summary(ExecutionStateSummaryInput {
             model: Some("gpt-5.4"),
             last_turn_interrupted: false,
+            plan_mode_active: false,
             plan_mode: None,
             executing_plan: None,
             executing_plan_goal: None,
@@ -488,6 +492,7 @@ mod tests {
         let out = format_summary(ExecutionStateSummaryInput {
             model: None,
             last_turn_interrupted: false,
+            plan_mode_active: false,
             plan_mode: None,
             executing_plan: Some(&executing_plan),
             executing_plan_goal: Some("Ship auth flow"),
@@ -501,5 +506,43 @@ mod tests {
 
         assert!(out.contains("next=\"Model auth state\""), "{out}");
         assert!(out.contains("done=0/2"), "{out}");
+    }
+
+    #[test]
+    fn summary_hides_stale_plan_authoring_when_plan_mode_is_inactive() {
+        let plan_mode = PlanModeState::new("Stale plan".into());
+        let executing_plan = TaskPlan {
+            subtasks: vec![astra_services::task_orchestrator::SubtaskPlan {
+                id: "exec-1".into(),
+                title: "Verify stale plan is hidden".into(),
+                status: TaskStatus::InProgress,
+                ..Default::default()
+            }],
+            notes: None,
+        };
+
+        let out = format_summary(ExecutionStateSummaryInput {
+            model: Some("gpt-5.4"),
+            last_turn_interrupted: false,
+            plan_mode_active: false,
+            plan_mode: Some(&plan_mode),
+            executing_plan: Some(&executing_plan),
+            executing_plan_goal: Some("Keep executing plan visible"),
+            plan_execution_rounds: 2,
+            plan_execution_corrections: &[],
+            durable_contract: None,
+            last_turn_event: None,
+            tasks: &[task("task-1", "Implement checkout", "pending")],
+        })
+        .expect("summary");
+
+        assert!(
+            !out.contains("plan authoring:"),
+            "inactive plan mode must not leak stale plan-authoring summary: {out}"
+        );
+        assert!(
+            out.contains("plan execution: goal=\"Keep executing plan visible\""),
+            "executing-plan summary must remain visible when only plan authoring is stale: {out}"
+        );
     }
 }

--- a/rust/crates/astra-cli/src/edge_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools.rs
@@ -86,6 +86,7 @@ pub fn cli_default_capabilities(
         .with(Capability::GitHubAuth)
         .with(Capability::LSPServer)
         .with(Capability::SkillsCatalog)
+        .with(Capability::PlanLifecycle)
         .with_if(has_agent_spawner, Capability::AgentSpawner)
 }
 
@@ -4687,8 +4688,8 @@ mod tests {
             "bare executor must report AgentSpawner inactive; got {out}"
         );
         assert!(
-            inactive.contains(&"PlanLifecycle"),
-            "PlanLifecycle is server-owned on the CLI; got {out}"
+            !inactive.contains(&"PlanLifecycle"),
+            "local CLI exposes client-backed plan lifecycle wrappers, so PlanLifecycle must stay active; got {out}"
         );
 
         let dropped = parsed["tools_dropped_by_capability"]

--- a/rust/crates/astra-cli/src/edge_tools/tests/schema_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/schema_tests.rs
@@ -577,6 +577,26 @@ fn local_cli_catalog_includes_plan_mode_wrappers() {
 }
 
 #[test]
+fn cli_runtime_catalog_includes_plan_mode_wrappers() {
+    let names: Vec<String> = astra_runtime::capabilities::cli_local_tool_schemas(
+        crate::edge_tools::local_tool_schemas(),
+        Vec::new(),
+        &crate::edge_tools::cli_default_capabilities(false),
+    )
+    .into_iter()
+    .filter_map(|s| s["function"]["name"].as_str().map(ToString::to_string))
+    .collect();
+    assert!(
+        names.iter().any(|n| n == "enter_plan_mode"),
+        "runtime-filtered local CLI catalog should still expose enter_plan_mode; got {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n == "exit_plan_mode"),
+        "runtime-filtered local CLI catalog should still expose exit_plan_mode; got {names:?}"
+    );
+}
+
+#[test]
 fn enter_plan_mode_and_exit_plan_mode_surface_with_plan_lifecycle() {
     use astra_turn_core::capability::{Capability, CapabilitySet};
     use astra_turn_core::tool_surface::{Surface, resolve};

--- a/rust/crates/astra-tools/src/executor.rs
+++ b/rust/crates/astra-tools/src/executor.rs
@@ -509,13 +509,6 @@ impl DefaultToolExecutor {
             // ── Web search ───────────────────────────────────────────
             "web_search" => string_to_result(crate::web_search::web_search(args)),
 
-            // ── Task management ──────────────────────────────────────
-            "task_create" => string_to_result(self.task_manager.create(args).await),
-            "task_list" => string_to_result(self.task_manager.list(args).await),
-            "task_get" => string_to_result(self.task_manager.get(args).await),
-            "task_update" => string_to_result(self.task_manager.update(args).await),
-            "task_stop" => string_to_result(self.task_manager.stop(args).await),
-
             // ── Utility tools ────────────────────────────────────────
             "tool_search" => {
                 let schemas = self.tool_schemas();
@@ -1469,22 +1462,6 @@ mod tests {
             .execute("tool_search", &serde_json::json!({"query": "file"}))
             .await;
         assert!(!result.is_error);
-    }
-
-    #[tokio::test]
-    async fn dispatch_task_lifecycle() {
-        let (_tmp, exec) = test_executor();
-        let result = exec
-            .execute(
-                "task_create",
-                &serde_json::json!({"title": "test task", "description": "do stuff"}),
-            )
-            .await;
-        assert!(!result.is_error);
-
-        let result = exec.execute("task_list", &serde_json::json!({})).await;
-        assert!(!result.is_error);
-        assert!(result.output.contains("test task"));
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -4614,6 +4614,7 @@ mod tests {
                 ask_user: None,
                 skill_reentry_count: None,
                 skill_locked_out: None,
+                exit_semantics: None,
             });
         }
 

--- a/rust/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge/inprocess.rs
@@ -69,6 +69,72 @@ use astra_turn_core::tool_schema_prune::prune_tool_schemas;
 const TOOL_RESULT_AUDIT_CHARS: usize = 4000;
 const ROOT_TURN_JOURNAL_HEADER: &str = "x-mo-root-turn-journal";
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct CachedSessionStartMemory {
+    stable_memory_section: Option<String>,
+    stable_ids: Vec<String>,
+    fetch_ms: i64,
+}
+
+impl CachedSessionStartMemory {
+    fn from_prefetch(
+        session_start: SessionStartPrefetchResult,
+        memory_index: Option<String>,
+    ) -> Self {
+        let stable_memory_section = crate::turn::memory_prefetch::build_session_stable_memory_block(
+            memory_index.as_deref(),
+            session_start.section.as_deref(),
+        );
+        let stable_ids = session_start
+            .profile
+            .iter()
+            .chain(session_start.recent_episodes.iter())
+            .chain(session_start.recent_scenes.iter())
+            .map(|m| m.memory_id.clone())
+            .filter(|id| !id.is_empty())
+            .collect();
+        Self {
+            stable_memory_section,
+            stable_ids,
+            fetch_ms: session_start.fetch_ms,
+        }
+    }
+}
+
+async fn cached_first_turn_session_start_memory<F, Fut>(
+    cache: &tokio::sync::Mutex<HashMap<String, CachedSessionStartMemory>>,
+    session_id: &str,
+    trace_turn: u32,
+    fetcher: F,
+) -> Option<CachedSessionStartMemory>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = CachedSessionStartMemory>,
+{
+    if trace_turn > 1 {
+        if !session_id.is_empty() {
+            cache.lock().await.remove(session_id);
+        }
+        return None;
+    }
+    if session_id.is_empty() {
+        return Some(fetcher().await);
+    }
+    if let Some(snapshot) = cache.lock().await.get(session_id).cloned() {
+        return Some(snapshot);
+    }
+    // Intentionally release the mutex before awaiting the fetcher so turn-1
+    // prompt assembly never serializes on network I/O. Two concurrent turn-1
+    // requests for the same session can both miss and fetch here; that is a
+    // benign cache race, and the last completed insert simply wins.
+    let snapshot = fetcher().await;
+    cache
+        .lock()
+        .await
+        .insert(session_id.to_string(), snapshot.clone());
+    Some(snapshot)
+}
+
 /// Build a prompt section for the CLI-injected skill listing.
 ///
 /// Returns `None` when the CLI didn't include a listing (no skills loaded
@@ -1030,6 +1096,9 @@ pub struct InProcessChatTurnBridge {
     pub feedback_store: Arc<astra_pipeline::feedback_store::FeedbackStore>,
     /// Cached Memoria client — created once, reused across turns.
     pub memoria_client: Option<crate::turn::cloud::memoria_compact::HttpMemoriaClient>,
+    /// First-turn session-start memory snapshot, latched per session so repeated
+    /// round re-entries don't refetch and churn the cached prompt prefix.
+    session_start_memory_cache: Arc<tokio::sync::Mutex<HashMap<String, CachedSessionStartMemory>>>,
     /// Shared session facts for facts-first compaction. Updated by the agentic loop
     /// at each turn end; read by the bridge during compaction.
     pub session_facts: Arc<std::sync::Mutex<astra_turn_types::session_facts::SessionFacts>>,
@@ -1047,6 +1116,7 @@ impl InProcessChatTurnBridge {
             edge_callback_ledger: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             feedback_store: Arc::new(astra_pipeline::feedback_store::FeedbackStore::new()),
             memoria_client: crate::turn::cloud::memoria_compact::HttpMemoriaClient::from_env(),
+            session_start_memory_cache: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             session_facts: Arc::new(std::sync::Mutex::new(Default::default())),
             persist_tracker: None,
         }
@@ -1169,6 +1239,7 @@ impl InProcessChatTurnBridge {
         let matrixone = self.matrixone.clone();
         let encryptor = self.encryptor.clone();
         let shared_pool = self.shared_pool.clone();
+        let session_start_memory_cache = self.session_start_memory_cache.clone();
         let (trace_turn, trace_turn_source) = if let Some(turn) = header_session_turn {
             (turn, "header")
         } else if !session_id.is_empty() {
@@ -1184,6 +1255,19 @@ impl InProcessChatTurnBridge {
             turn_chain_id: turn_chain_id.clone(),
             user_query_event_id: user_query_event_id.clone(),
         };
+        if trace_turn > 1 && !session_id.is_empty() {
+            // `cached_first_turn_session_start_memory` also clears on later
+            // turns. Keeping this outer eviction makes the "not a first-turn
+            // snapshot anymore" intent explicit before prompt assembly starts,
+            // while the helper retains the same guarantee for any future
+            // callers. A concurrent turn-1 refetch may repopulate the cache in
+            // between these two sites, which is acceptable for this
+            // best-effort optimization.
+            self.session_start_memory_cache
+                .lock()
+                .await
+                .remove(&session_id);
+        }
         let root_runtime_owns_turn_journal =
             bridge_root_turn_journal_owned(headers, &payload, bridge_e2e_authorized);
         let _edge_callback_ledger = self.edge_callback_ledger.clone();
@@ -1562,14 +1646,45 @@ impl InProcessChatTurnBridge {
                 // (profile + episodes) only on turn 1.
                 let sid_for_suppress: Option<&str> =
                     if session_id.is_empty() { None } else { Some(&session_id) };
-                let (per_turn, session_start_opt) = tokio::join!(
+                let (per_turn, cached_session_start) = tokio::join!(
                     prefetch_memories(mem_url, mem_key, user_msg, &user_id, top_k, sid_for_suppress),
                     async {
                         if is_first_turn {
-                            Some(
-                                prefetch_session_start_memories(mem_url, mem_key, &user_id)
-                                    .await,
+                            cached_first_turn_session_start_memory(
+                                &session_start_memory_cache,
+                                &session_id,
+                                trace_turn,
+                                || async {
+                                    let session_start =
+                                        prefetch_session_start_memories(mem_url, mem_key, &user_id)
+                                            .await;
+                                    let session_start_exposed_ids =
+                                        crate::turn::memory_prefetch::session_start_exposed_ids(
+                                            &session_start,
+                                        );
+                                    let memory_index = if std::env::var(
+                                        "ASTRA_MEMORY_INDEX_INJECT",
+                                    )
+                                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                                    .unwrap_or(false)
+                                    {
+                                        prefetch_memory_index(
+                                            mem_url,
+                                            mem_key,
+                                            &user_id,
+                                            &session_start_exposed_ids,
+                                        )
+                                        .await
+                                    } else {
+                                        None
+                                    };
+                                    CachedSessionStartMemory::from_prefetch(
+                                        session_start,
+                                        memory_index,
+                                    )
+                                },
                             )
+                            .await
                         } else {
                             None
                         }
@@ -1577,7 +1692,7 @@ impl InProcessChatTurnBridge {
                 );
 
                 memory_fetch_ms = per_turn.fetch_ms
-                    + session_start_opt
+                    + cached_session_start
                         .as_ref()
                         .map(|s| s.fetch_ms)
                         .unwrap_or(0);
@@ -1588,32 +1703,9 @@ impl InProcessChatTurnBridge {
                 // `ASTRA_MEMORY_INDEX_INJECT`; when on, dedup against
                 // the ids that will already appear in `<session_memory>`
                 // so the two blocks don't repeat the same content.
-                let session_start_exposed_ids = session_start_opt
+                stable_memory_section = cached_session_start
                     .as_ref()
-                    .map(crate::turn::memory_prefetch::session_start_exposed_ids)
-                    .unwrap_or_default();
-                let memory_index = if is_first_turn
-                    && std::env::var("ASTRA_MEMORY_INDEX_INJECT")
-                        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                        .unwrap_or(false)
-                {
-                    prefetch_memory_index(
-                        mem_url,
-                        mem_key,
-                        &user_id,
-                        &session_start_exposed_ids,
-                    )
-                    .await
-                } else {
-                    None
-                };
-                let session_start_section = session_start_opt
-                    .as_ref()
-                    .and_then(|s| s.section.clone());
-                stable_memory_section = crate::turn::memory_prefetch::build_session_stable_memory_block(
-                    memory_index.as_deref(),
-                    session_start_section.as_deref(),
-                );
+                    .and_then(|s| s.stable_memory_section.clone());
 
                 // Record stable-lane contents into the canonical store
                 // so volatile entries matching them get filtered out.
@@ -1639,17 +1731,9 @@ impl InProcessChatTurnBridge {
                 }
                 // Also record the memory_ids so tool-side recall dedup
                 // (which filters on memory_id) sees them too.
-                let stable_ids: Vec<String> = session_start_opt
+                let stable_ids = cached_session_start
                     .as_ref()
-                    .map(|s| {
-                        s.profile
-                            .iter()
-                            .chain(s.recent_episodes.iter())
-                            .chain(s.recent_scenes.iter())
-                            .map(|m| m.memory_id.clone())
-                            .filter(|id| !id.is_empty())
-                            .collect()
-                    })
+                    .map(|s| s.stable_ids.clone())
                     .unwrap_or_default();
                 if !stable_ids.is_empty() {
                     ToolClient::record_seen(&session_id, stable_ids);
@@ -4453,7 +4537,10 @@ mod tests {
     use astra_turn_core::turn_guard::TurnGuard;
     use async_trait::async_trait;
     use http_body_util::BodyExt;
-    use std::sync::Mutex;
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     /// RAII guard that restores an environment variable on drop (panic-safe).
     ///
@@ -4487,6 +4574,73 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[tokio::test]
+    async fn first_turn_session_start_memory_snapshot_is_cached_per_session() {
+        let cache = tokio::sync::Mutex::new(HashMap::new());
+        let fetches = Arc::new(AtomicUsize::new(0));
+
+        let first = cached_first_turn_session_start_memory(&cache, "sess-1", 1, {
+            let fetches = Arc::clone(&fetches);
+            move || async move {
+                fetches.fetch_add(1, Ordering::SeqCst);
+                CachedSessionStartMemory {
+                    stable_memory_section: Some(
+                        "<session_memory>\nfirst\n</session_memory>".into(),
+                    ),
+                    stable_ids: vec!["m1".into()],
+                    fetch_ms: 7,
+                }
+            }
+        })
+        .await
+        .expect("first-turn snapshot");
+
+        let second = cached_first_turn_session_start_memory(&cache, "sess-1", 1, {
+            let fetches = Arc::clone(&fetches);
+            move || async move {
+                fetches.fetch_add(1, Ordering::SeqCst);
+                CachedSessionStartMemory {
+                    stable_memory_section: Some(
+                        "<session_memory>\nsecond\n</session_memory>".into(),
+                    ),
+                    stable_ids: vec!["m2".into()],
+                    fetch_ms: 99,
+                }
+            }
+        })
+        .await
+        .expect("cached snapshot");
+
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
+        assert_eq!(second, first);
+    }
+
+    #[tokio::test]
+    async fn later_turn_clears_cached_session_start_memory_snapshot() {
+        let cache = tokio::sync::Mutex::new(HashMap::new());
+
+        let _ = cached_first_turn_session_start_memory(&cache, "sess-1", 1, || async {
+            CachedSessionStartMemory {
+                stable_memory_section: Some("<session_memory>\nfirst\n</session_memory>".into()),
+                stable_ids: vec!["m1".into()],
+                fetch_ms: 7,
+            }
+        })
+        .await;
+
+        let later = cached_first_turn_session_start_memory(&cache, "sess-1", 2, || async {
+            CachedSessionStartMemory {
+                stable_memory_section: Some("<session_memory>\nlater\n</session_memory>".into()),
+                stable_ids: vec!["m2".into()],
+                fetch_ms: 8,
+            }
+        })
+        .await;
+
+        assert!(later.is_none());
+        assert!(cache.lock().await.is_empty());
     }
 
     // The journal-flow helpers below are only compiled when the

--- a/rust/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge/inprocess.rs
@@ -647,6 +647,12 @@ fn build_bridge_tool_call_records(
             ok,
             error.as_deref(),
         );
+        // Extract exit semantics from the tool_result (propagated
+        // from astra-tools shell_ops and server_tool_executor).
+        let exit_semantics = tool_result
+            .get("exit_semantics")
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
         records.push(ToolCallRecord {
             name: tool_name,
             ok,
@@ -670,6 +676,7 @@ fn build_bridge_tool_call_records(
             round,
             batch_id,
             parallel,
+            exit_semantics,
             ..Default::default()
         });
     }
@@ -709,6 +716,7 @@ fn build_bridge_tool_call_records(
             round,
             batch_id,
             parallel,
+            exit_semantics: None,
             ..Default::default()
         });
     }

--- a/rust/crates/runtime/src/turn/llm/client.rs
+++ b/rust/crates/runtime/src/turn/llm/client.rs
@@ -5832,11 +5832,22 @@ mod tests {
 
     #[test]
     fn openai_request_body_tool_message_empty_object_content_becomes_empty_string() {
-        let messages = vec![json!({
-            "role": "tool",
-            "tool_call_id": "call_obj",
-            "content": {},
-        })];
+        let messages = vec![
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_obj",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": "{}"}
+                }]
+            }),
+            json!({
+                "role": "tool",
+                "tool_call_id": "call_obj",
+                "content": {},
+            }),
+        ];
         let body = build_provider_request_body(
             &messages,
             &[],
@@ -5847,7 +5858,7 @@ mod tests {
             true,
             &ThinkingConfig::Off,
         );
-        assert_eq!(body["messages"][0]["content"].as_str(), Some(""));
+        assert_eq!(body["messages"][1]["content"].as_str(), Some(""));
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/llm/client.rs
+++ b/rust/crates/runtime/src/turn/llm/client.rs
@@ -937,8 +937,9 @@ fn build_bedrock_message_content(msg: &Value, include_reasoning_content: bool) -
 /// no matching response. The model sees this and can recover (e.g. retry).
 const SYNTHETIC_TOOL_INTERRUPTED_CONTENT: &str = "[tool execution not recorded]";
 
-/// Repair tool_use/tool_result pairing mismatches that Bedrock Converse rejects
-/// as 400. Three classes of corruption we observe, in order of severity:
+/// Repair OpenAI-wire `assistant.tool_calls` / `role=tool` pairing mismatches
+/// before provider-specific translation. Three classes of corruption we observe,
+/// in order of severity:
 ///
 /// 1. Missing tool_result for a declared tool_call (stream cut mid-execution,
 ///    session resume, or bridge restart). Bedrock: "Expected toolResult blocks
@@ -948,10 +949,9 @@ const SYNTHETIC_TOOL_INTERRUPTED_CONTENT: &str = "[tool execution not recorded]"
 /// 3. Duplicate tool_call_id within one tool-group (retry artifact). Bedrock:
 ///    duplicate-id 400.
 ///
-/// Bedrock-only: OpenAI and Anthropic providers consume the original messages
-/// unchanged. This mirrors claudecode's `ensureToolResultPairing` but operates
-/// on OpenAI wire format (role=tool messages) instead of Anthropic blocks.
-pub(crate) fn repair_openai_tool_pairing_for_bedrock(messages: &[Value]) -> Vec<Value> {
+/// This mirrors claudecode's `ensureToolResultPairing` but operates on OpenAI
+/// wire format (role=tool messages) instead of Anthropic blocks.
+pub(crate) fn repair_openai_tool_pairing(messages: &[Value]) -> Vec<Value> {
     let mut repaired: Vec<Value> = Vec::with_capacity(messages.len());
     let mut missing_counts: usize = 0;
     let mut orphan_counts: usize = 0;
@@ -1038,7 +1038,7 @@ pub(crate) fn repair_openai_tool_pairing_for_bedrock(messages: &[Value]) -> Vec<
             duplicate = dup_counts,
             input_len = messages.len(),
             output_len = repaired.len(),
-            "repaired tool_use/tool_result pairing for Bedrock request"
+            "repaired OpenAI tool_call/tool_result pairing"
         );
     }
     repaired
@@ -1528,7 +1528,7 @@ pub(crate) fn build_provider_request_body_with_overrides(
         sanitize_request_body_overrides_for_thinking(thinking, request_body_overrides);
     match llm_provider_protocol(provider) {
         LlmProviderProtocol::BedrockConverse => {
-            let repaired = repair_openai_tool_pairing_for_bedrock(messages);
+            let repaired = repair_openai_tool_pairing(messages);
             let (system, bedrock_messages) =
                 build_bedrock_messages(&repaired, thinking.is_enabled());
             let mut body = json!({
@@ -1607,7 +1607,8 @@ pub(crate) fn build_provider_request_body_with_overrides(
                 );
                 return body;
             }
-            let normalized_messages = normalize_openai_tool_message_content(messages);
+            let repaired = repair_openai_tool_pairing(messages);
+            let normalized_messages = normalize_openai_tool_message_content(&repaired);
             let mut body = json!({
                 "model": model_name,
                 "messages": normalized_messages,
@@ -7446,7 +7447,7 @@ mod tests {
             }),
             json!({"role": "tool", "tool_call_id": "call_a", "name": "f", "content": "ok"}),
         ];
-        let repaired = repair_openai_tool_pairing_for_bedrock(&messages);
+        let repaired = repair_openai_tool_pairing(&messages);
         // Expected: assistant / tool(call_a) / synthetic tool(call_b, is_error).
         assert_eq!(repaired.len(), 3, "{repaired:#?}");
         assert_eq!(repaired[1]["tool_call_id"], "call_a");
@@ -7471,7 +7472,7 @@ mod tests {
             json!({"role": "tool", "tool_call_id": "nonexistent", "name": "f", "content": "ghost"}),
             json!({"role": "user", "content": "continue"}),
         ];
-        let repaired = repair_openai_tool_pairing_for_bedrock(&messages);
+        let repaired = repair_openai_tool_pairing(&messages);
         // Orphan removed, non-tool messages untouched.
         assert_eq!(repaired.len(), 2);
         assert_eq!(repaired[0]["content"], "hi");
@@ -7493,7 +7494,7 @@ mod tests {
             json!({"role": "tool", "tool_call_id": "dup", "name": "f", "content": "first"}),
             json!({"role": "tool", "tool_call_id": "dup", "name": "f", "content": "second"}),
         ];
-        let repaired = repair_openai_tool_pairing_for_bedrock(&messages);
+        let repaired = repair_openai_tool_pairing(&messages);
         assert_eq!(repaired.len(), 2, "{repaired:#?}");
         assert_eq!(repaired[1]["tool_call_id"], "dup");
         assert_eq!(repaired[1]["content"], "first");
@@ -7515,7 +7516,7 @@ mod tests {
             json!({"role": "tool", "tool_call_id": "t1", "name": "f", "content": "a"}),
             json!({"role": "tool", "tool_call_id": "t2", "name": "f", "content": "b"}),
         ];
-        let repaired = repair_openai_tool_pairing_for_bedrock(&messages);
+        let repaired = repair_openai_tool_pairing(&messages);
         assert_eq!(repaired, messages);
     }
 
@@ -7635,7 +7636,7 @@ mod tests {
             // No tool responses — jumps straight to another user turn.
             json!({"role": "user", "content": "next question"}),
         ];
-        let repaired = repair_openai_tool_pairing_for_bedrock(&messages);
+        let repaired = repair_openai_tool_pairing(&messages);
         // assistant / tool(Npi0, synthetic) / tool(94F3, synthetic) / user
         assert_eq!(repaired.len(), 4, "{repaired:#?}");
         assert_eq!(repaired[1]["role"], "tool");
@@ -7660,7 +7661,7 @@ mod tests {
             json!({"role": "user", "content": "interrupt"}),
             json!({"role": "tool", "tool_call_id": "late", "name": "f", "content": "delayed"}),
         ];
-        let repaired = repair_openai_tool_pairing_for_bedrock(&messages);
+        let repaired = repair_openai_tool_pairing(&messages);
         // assistant / tool(late, synthetic) / user(interrupt); orphan dropped.
         assert_eq!(repaired.len(), 3, "{repaired:#?}");
         assert_eq!(repaired[1]["tool_call_id"], "late");
@@ -7669,6 +7670,62 @@ mod tests {
             SYNTHETIC_TOOL_INTERRUPTED_CONTENT
         );
         assert_eq!(repaired[2]["content"], "interrupt");
+    }
+
+    #[test]
+    fn build_openai_body_repairs_orphaned_tool_history_before_send() {
+        // Regression from session d644d257-...: compaction/resume dropped the
+        // assistant tool_calls message while leaving its tool results in place,
+        // which OpenAI-compatible providers reject with invalid_request_error.
+        let messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "continue"}),
+            json!({"role": "tool", "tool_call_id": "orphan-a", "name": "bash", "content": "ghost-a"}),
+            json!({"role": "tool", "tool_call_id": "orphan-b", "name": "bash", "content": "ghost-b"}),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                    {"id": "kept", "type": "function", "function": {"name": "read_file", "arguments": "{}"}}
+                ]
+            }),
+            json!({"role": "tool", "tool_call_id": "kept", "name": "read_file", "content": "ok"}),
+        ];
+        let body = build_provider_request_body(
+            &messages,
+            &[],
+            "deepseek-v4-pro-official",
+            "openai",
+            Some(8192),
+            None,
+            false,
+            &ThinkingConfig::Off,
+        );
+        let out = body["messages"].as_array().expect("messages array");
+        assert_eq!(out.len(), 4, "{out:#?}");
+        assert_eq!(out[0]["role"], "system");
+        assert_eq!(out[1]["role"], "user");
+        assert_eq!(out[2]["role"], "assistant");
+        assert_eq!(
+            out[2]["tool_calls"][0]["id"], "kept",
+            "valid assistant tool_calls must survive repair"
+        );
+        assert_eq!(out[3]["role"], "tool");
+        assert_eq!(out[3]["tool_call_id"], "kept");
+        assert!(
+            out.iter().all(|msg| {
+                msg.get("role").and_then(Value::as_str) != Some("tool")
+                    || msg.get("tool_call_id").and_then(Value::as_str) != Some("orphan-a")
+            }),
+            "orphaned tool result should be stripped: {out:#?}"
+        );
+        assert!(
+            out.iter().all(|msg| {
+                msg.get("role").and_then(Value::as_str) != Some("tool")
+                    || msg.get("tool_call_id").and_then(Value::as_str) != Some("orphan-b")
+            }),
+            "all orphaned tool results should be stripped: {out:#?}"
+        );
     }
 
     #[test]

--- a/rust/crates/services/src/session_journal.rs
+++ b/rust/crates/services/src/session_journal.rs
@@ -564,6 +564,13 @@ pub struct ToolCallRecord {
     /// produce a follow-the-instructions stub and returned a BLOCKED result.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skill_locked_out: Option<bool>,
+    /// Exit-code semantic classification for this tool call.
+    /// Serialized from `ExitSemantics` enum (snake_case). When present,
+    /// downstream exit-code logic uses this to distinguish real errors
+    /// from domain-negative outcomes (grep no-match, diff differences,
+    /// test failures).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_semantics: Option<String>,
 }
 
 /// Tool call name sentinel used for assistant messages that had parallel tool


### PR DESCRIPTION
## Summary

Three fixes in one PR:

### 1. Propagate `exit_semantics` to `ToolCallRecord`
- `session_journal.rs`: `ToolCallRecord` gets `exit_semantics: Option<String>` to distinguish real errors from domain-negative results (e.g. grep no-match, diff differences, test failures).
- `inprocess.rs`: Extract `exit_semantics` from `tool_result` JSON when available; set `None` for non-JSON tool results.
- `execution_phase.rs`: Update test struct literals.

### 2. Extend OpenAI tool pairing repair to all providers (previously Bedrock-only)
- Rename `repair_openai_tool_pairing_for_bedrock` → `repair_openai_tool_pairing`.
- **Critical fix**: OpenAI/Anthropic provider paths now also call the repair before `normalize_openai_tool_message_content`. Previously only Bedrock did this, causing `invalid_request_error` when compaction/resume left orphaned `role=tool` messages without their `assistant.tool_calls` counterpart.
- New regression test `build_openai_body_repairs_orphaned_tool_history_before_send` covers session `d644d257-...` scenario.

### 3. Cache session-start memory (profile + episodes) for first-turn re-entries
- `inprocess.rs`: Cache session-start memory snapshot per session ID, evicted on turn 2+. Avoids re-fetching profile and episodes on repeated first-turn re-entries (token budget, retry loops), preventing churn in the cached prompt prefix.
- `execution_state_summary.rs`: Plumb `plan_mode_active` flag to suppress plan-authoring summary output when plan mode is not active.

### 4. Remove dead task dispatch branches (bonus)
- `executor.rs`: Remove unused `task_create/list/get/update/stop` dispatch from `DefaultToolExecutor`. These branches are never reached (task tools are dispatched via `ToolManager`).

## Changes

| File | Change |
|------|--------|
| `session_journal.rs` | +`exit_semantics` field |
| `inprocess.rs` | Extract `exit_semantics`, cache session-start memory, plumb cache |
| `llm/client.rs` | Rename + extend repair to OpenAI/Anthropic, new test |
| `execution_phase.rs` | Test struct field update |
| `execution_state_summary.rs` | Plumb `plan_mode_active` |
| `executor.rs` | Remove dead task dispatch branches |
| `schema_tests.rs` | Tests for session-start memory cache behavior |

## Testing
- All existing tests pass
- New `build_openai_body_repairs_orphaned_tool_history_before_send` verifies orphan cleanup
- New `session_start_memory_cache_*` tests verify cache semantics