### PR TITLE
fix: TUI ANSI sanitization, diff preview redesign, edge-tool recovery, and code review fixes

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_turn.rs
@@ -4744,10 +4744,16 @@ mod tests {
 
     #[test]
     fn build_effective_line_skill_dev_picks_up_external_edits() {
+        const OLD_BODY: &str = "skill body version one";
+        const NEW_BODY: &str = "skill body version two rewritten";
         let tmp = tempfile::tempdir().unwrap();
         let skill_dir = tmp.path().join("evolving");
         std::fs::create_dir_all(&skill_dir).unwrap();
-        std::fs::write(skill_dir.join("SKILL.md"), "---\nname: evolving\n---\nV1").unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: evolving\n---\n{OLD_BODY}"),
+        )
+        .unwrap();
 
         let state = SessionState {
             skill_dev: Some(super::super::SkillDevState {
@@ -4758,19 +4764,22 @@ mod tests {
         };
 
         let turn1 = build_effective_line("check", &state, &mut crate::ui_adapter::LineUiAdapter);
-        assert!(turn1.contains("V1"));
+        assert!(turn1.contains(OLD_BODY));
 
         // Simulate external edit between turns
         std::fs::write(
             skill_dir.join("SKILL.md"),
-            "---\nname: evolving\n---\nV2 rewritten",
+            format!("---\nname: evolving\n---\n{NEW_BODY}"),
         )
         .unwrap();
 
         let turn2 =
             build_effective_line("check again", &state, &mut crate::ui_adapter::LineUiAdapter);
-        assert!(!turn2.contains("V1"), "should not contain old content");
-        assert!(turn2.contains("V2 rewritten"), "should contain new content");
+        assert!(
+            !turn2.contains(OLD_BODY),
+            "should not contain old skill body"
+        );
+        assert!(turn2.contains(NEW_BODY), "should contain new content");
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/cli_formatting.rs
+++ b/rust/crates/astra-cli/src/cli/cli_formatting.rs
@@ -1,11 +1,13 @@
 //! CLI output formatting utilities.
 //!
 //! Helper functions for formatting CLI output: truncation, path shortening,
-//! byte sizes, durations, and diff colorization.
+//! byte sizes, durations, and diff previews/colorization.
 
-use crossterm::style::Stylize;
+use crossterm::style::{Color, Stylize, style};
 use serde_json::Value;
 use std::borrow::Cow;
+
+use crate::diff_utils::parse_hunk_header;
 
 pub use astra_text_utils::str_preview::{github_repo_display, shorten_path, truncate_line};
 
@@ -29,66 +31,160 @@ pub fn extract_cli_diff_block(output: &str) -> Option<Cow<'_, str>> {
     Some(Cow::Owned(diff.to_string()))
 }
 
+const MAX_COLORIZED_DIFF_LINES: usize = 500;
+const MAX_COLORIZED_DIFF_CHANGED_LINES: usize = 200;
+
 /// Colorize a unified diff into a compact summary with green +lines and red -lines.
 /// Shows context around changes for better understanding.
-pub fn colorize_diff_summary(diff: &str, max_lines: usize) -> String {
+pub fn colorize_diff_summary(diff: &str) -> String {
+    let owned_preview;
+    let diff = if diff.lines().count() > MAX_COLORIZED_DIFF_LINES {
+        owned_preview = compact_unified_diff_preview(diff, MAX_COLORIZED_DIFF_CHANGED_LINES);
+        owned_preview.as_str()
+    } else {
+        diff
+    };
+
     let mut parts = Vec::new();
-    let mut shown = 0usize;
-    let mut total_add = 0usize;
-    let mut total_del = 0usize;
-
-    // Extract the file path from diff header
-    let mut file_path: Option<&str> = None;
-    for line in diff.lines() {
-        if let Some(path) = line.strip_prefix("+++ b/") {
-            file_path = Some(path);
-            break;
-        }
-    }
-
-    // Add file header if found
-    if let Some(path) = file_path {
-        let short = shorten_path(path, 50);
-        parts.push(format!("{}", short.dim()));
-    }
+    let mut old_line = 0u32;
+    let mut new_line = 0u32;
 
     for line in diff.lines() {
-        if line.starts_with('+') && !line.starts_with("+++ ") {
-            total_add += 1;
-            if shown < max_lines {
-                // Green + with highlighted code
-                let code = &line[1..]; // Skip the '+' prefix
-                let highlighted = highlight_code_line(code);
-                parts.push(format!("{}{}", "+".green(), highlighted));
-                shown += 1;
+        if line.starts_with("@@") {
+            if let Some((old_start, new_start)) = parse_hunk_header(line) {
+                old_line = old_start;
+                new_line = new_start;
             }
-        } else if line.starts_with('-') && !line.starts_with("--- ") {
-            total_del += 1;
-            if shown < max_lines {
-                // Red - with dimmed code (deleted)
-                let code = &line[1..]; // Skip the '-' prefix
-                parts.push(format!("{}{}", "-".red(), code.dim()));
-                shown += 1;
-            }
+            parts.push(format!("{}", line.cyan()));
+            continue;
         }
+        if line.starts_with("--- ") || line.starts_with("+++ ") {
+            let rendered = line
+                .strip_prefix("--- a/")
+                .or_else(|| line.strip_prefix("+++ b/"))
+                .map(|path| shorten_path(path, 60))
+                .unwrap_or_else(|| line.to_string());
+            parts.push(format!("{}", rendered.dim().bold()));
+            continue;
+        }
+        if let Some(code) = line.strip_prefix('+') {
+            new_line += 1;
+            let prefix = format!("{:>4} + ", new_line);
+            let body = format!("{prefix}{code}");
+            parts.push(format!(
+                "{}",
+                style(body).with(Color::Black).on(Color::DarkGreen)
+            ));
+            continue;
+        }
+        if let Some(code) = line.strip_prefix('-') {
+            old_line += 1;
+            let prefix = format!("{:>4} - ", old_line);
+            let body = format!("{prefix}{code}");
+            parts.push(format!(
+                "{}",
+                style(body).with(Color::White).on(Color::DarkRed)
+            ));
+            continue;
+        }
+        if line.starts_with(' ') {
+            old_line += 1;
+            new_line += 1;
+            let prefix = format!("{:>4}   ", new_line);
+            parts.push(format!("{}{}", prefix.dim(), &line[1..].dim()));
+            continue;
+        }
+        parts.push(format!("{}", line.dim()));
     }
-    let remaining = (total_add + total_del).saturating_sub(max_lines);
-    if remaining > 0 {
-        parts.push(format!(
-            "{}",
-            format!("… +{remaining} more ({total_add}+ {total_del}-)").dim(),
-        ));
-    } else if total_add > 0 || total_del > 0 {
-        // Show total counts on the last line
-        parts.push(format!("{}", format!("{total_add}+ {total_del}-").dim(),));
-    }
-    if parts.is_empty() {
-        return String::new();
-    }
-    parts.join("\n    ")
+
+    parts.join("\n")
 }
 
-/// Format byte size as human-friendly string.
+fn is_diff_change_line(line: &str) -> bool {
+    (line.starts_with('+') && !line.starts_with("+++ "))
+        || (line.starts_with('-') && !line.starts_with("--- "))
+}
+
+/// Build a compact unified-diff preview that keeps file/hunk headers plus the
+/// first N changed lines, then appends an accurate folded-count marker.
+pub fn compact_unified_diff_preview(diff: &str, max_changed_lines: usize) -> String {
+    if max_changed_lines == 0 {
+        return String::new();
+    }
+
+    let total_changed = diff
+        .lines()
+        .filter(|line| is_diff_change_line(line))
+        .count();
+    if total_changed == 0 {
+        return String::new();
+    }
+
+    let mut preview = Vec::new();
+    let mut pending_file_headers: Vec<&str> = Vec::new();
+    let mut pending_hunk_header: Option<&str> = None;
+    let mut file_headers_emitted = false;
+    let mut hunk_header_emitted = false;
+    let mut shown_changed = 0usize;
+
+    for line in diff.lines() {
+        if line.starts_with("diff --git ") || line.starts_with("index ") {
+            continue;
+        }
+
+        if line.starts_with("--- ") {
+            pending_file_headers.clear();
+            pending_file_headers.push(line);
+            pending_hunk_header = None;
+            file_headers_emitted = false;
+            hunk_header_emitted = false;
+            continue;
+        }
+
+        if line.starts_with("+++ ") {
+            pending_file_headers.push(line);
+            file_headers_emitted = false;
+            continue;
+        }
+
+        if line.starts_with("@@") {
+            pending_hunk_header = Some(line);
+            hunk_header_emitted = false;
+            continue;
+        }
+
+        if !is_diff_change_line(line) {
+            continue;
+        }
+
+        if shown_changed >= max_changed_lines {
+            continue;
+        }
+
+        if !file_headers_emitted {
+            preview.extend(pending_file_headers.iter().map(|line| (*line).to_string()));
+            file_headers_emitted = true;
+        }
+        if !hunk_header_emitted {
+            if let Some(header) = pending_hunk_header {
+                preview.push(header.to_string());
+            }
+            hunk_header_emitted = true;
+        }
+
+        preview.push(line.to_string());
+        shown_changed += 1;
+    }
+
+    let remaining = total_changed.saturating_sub(shown_changed);
+    if remaining > 0 {
+        preview.push(format!("… +{remaining} more changed lines"));
+    }
+
+    preview.join("\n")
+}
+
+/// Format a byte count at human scale (B, KiB, MiB, GiB).
 pub fn format_byte_size(bytes: usize) -> String {
     if bytes < 1024 {
         format!("{bytes}B")
@@ -360,6 +456,86 @@ mod tests {
         .to_string();
         let got = extract_cli_diff_block(&out).expect("diff");
         assert_eq!(got.as_ref(), diff_body);
+    }
+
+    #[test]
+    fn compact_unified_diff_preview_keeps_headers_and_correct_fold_count() {
+        let diff = "\
+diff --git a/src/a.rs b/src/a.rs\n\
+--- a/src/a.rs\n\
++++ b/src/a.rs\n\
+@@ -10,3 +10,4 @@\n\
+-old1\n\
++new1\n\
+-old2\n\
++new2\n\
++new3\n";
+        let preview = compact_unified_diff_preview(diff, 3);
+        assert_eq!(
+            preview,
+            "\
+--- a/src/a.rs\n\
++++ b/src/a.rs\n\
+@@ -10,3 +10,4 @@\n\
+-old1\n\
++new1\n\
+-old2\n\
+… +2 more changed lines"
+        );
+    }
+
+    #[test]
+    fn colorize_diff_summary_renders_line_numbers_from_hunks() {
+        let preview = "\
+--- a/src/a.rs\n\
++++ b/src/a.rs\n\
+@@ -41,2 +41,2 @@\n\
+-old\n\
++new";
+        let rendered = colorize_diff_summary(preview);
+        let stripped = strip_ansi(&rendered);
+        assert!(stripped.contains("src/a.rs"));
+        assert!(stripped.contains("@@ -41,2 +41,2 @@"));
+        assert!(stripped.contains("  41 - old"), "{stripped}");
+        assert!(stripped.contains("  41 + new"), "{stripped}");
+    }
+
+    #[test]
+    fn colorize_diff_summary_hard_caps_large_input_in_release_builds() {
+        let mut diff = String::from("--- a/src/a.rs\n+++ b/src/a.rs\n@@ -1,1 +1,300 @@\n");
+        for i in 0..600 {
+            diff.push_str(&format!("+line-{i}\n"));
+        }
+
+        let rendered = colorize_diff_summary(&diff);
+        let stripped = strip_ansi(&rendered);
+        assert!(stripped.contains("… +400 more changed lines"), "{stripped}");
+        assert!(!stripped.contains("line-599"), "{stripped}");
+    }
+
+    #[test]
+    fn compact_unified_diff_preview_handles_multiple_files() {
+        let diff = "\
+diff --git a/src/a.rs b/src/a.rs\n\
+--- a/src/a.rs\n\
++++ b/src/a.rs\n\
+@@ -1,1 +1,1 @@\n\
+-old-a\n\
++new-a\n\
+diff --git a/src/b.rs b/src/b.rs\n\
+--- a/src/b.rs\n\
++++ b/src/b.rs\n\
+@@ -10,1 +10,2 @@\n\
+-old-b\n\
++new-b\n\
++new-b2\n";
+        let preview = compact_unified_diff_preview(diff, 3);
+        assert!(preview.contains("--- a/src/a.rs"));
+        assert!(preview.contains("+++ b/src/a.rs"));
+        assert!(preview.contains("--- a/src/b.rs"));
+        assert!(preview.contains("+++ b/src/b.rs"));
+        assert!(preview.contains("-old-b"));
+        assert!(preview.contains("… +2 more changed lines"));
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream_render.rs
@@ -77,8 +77,8 @@ fn tool_output_event_text(tool: &str, output: &str) -> String {
 
 // CLI formatting utilities
 use super::cli_formatting::{
-    colorize_diff_summary, extract_cli_diff_block, format_byte_size, format_duration_suffix,
-    github_repo_display, shorten_path, truncate_line,
+    colorize_diff_summary, compact_unified_diff_preview, extract_cli_diff_block, format_byte_size,
+    format_duration_suffix, github_repo_display, shorten_path, truncate_line,
 };
 
 // Effects module types
@@ -4200,6 +4200,7 @@ pub(super) struct StreamRenderState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ToolOutputSummaryKind {
     Error,
+    Diff,
     Structural,
     Preview,
 }
@@ -4208,6 +4209,32 @@ enum ToolOutputSummaryKind {
 struct ToolOutputSummary {
     kind: ToolOutputSummaryKind,
     text: String,
+}
+
+fn format_terminal_tool_summary(tool: &str, summary: &ToolOutputSummary, warning: bool) -> String {
+    let rendered = if matches!(summary.kind, ToolOutputSummaryKind::Diff)
+        && matches!(tool, "write_file" | "str_replace" | "multi_edit")
+    {
+        colorize_diff_summary(&summary.text)
+    } else {
+        match summary.kind {
+            ToolOutputSummaryKind::Diff => summary.text.clone(),
+            ToolOutputSummaryKind::Preview | ToolOutputSummaryKind::Structural => {
+                if warning {
+                    format!("{}", summary.text.as_str().yellow())
+                } else {
+                    format!("{}", summary.text.as_str().dim())
+                }
+            }
+            ToolOutputSummaryKind::Error => format!("{}", summary.text.as_str().red()),
+        }
+    };
+
+    rendered
+        .lines()
+        .map(|line| format!("    {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 // ── Tool completion icon + output-summary sentinels (shared by `format_output_summary`) ──
@@ -5235,24 +5262,15 @@ impl StreamRenderState {
                 .unwrap_or_else(|| "failed".to_string());
             format!("    {}", err_msg.red())
         } else if is_warning {
-            // Show warning context in yellow.
-            match output_summary {
-                Some(summary) => match summary.kind {
-                    ToolOutputSummaryKind::Preview
-                    | ToolOutputSummaryKind::Structural
-                    | ToolOutputSummaryKind::Error => format!("    {}", summary.text.yellow()),
-                },
-                None => String::new(),
-            }
+            output_summary
+                .as_ref()
+                .map(|summary| format_terminal_tool_summary(tool, summary, true))
+                .unwrap_or_default()
         } else {
-            match output_summary {
-                Some(summary) => match summary.kind {
-                    ToolOutputSummaryKind::Preview
-                    | ToolOutputSummaryKind::Structural
-                    | ToolOutputSummaryKind::Error => format!("    {}", summary.text.dim()),
-                },
-                None => String::new(),
-            }
+            output_summary
+                .as_ref()
+                .map(|summary| format_terminal_tool_summary(tool, summary, false))
+                .unwrap_or_default()
         };
         if self.md.is_some() {
             self.stop_tool_stderr_running();
@@ -5321,23 +5339,15 @@ impl StreamRenderState {
                 .unwrap_or_else(|| "failed".to_string());
             format!("    {}", err_msg.red())
         } else if is_warning {
-            match output_summary {
-                Some(summary) => match summary.kind {
-                    ToolOutputSummaryKind::Preview
-                    | ToolOutputSummaryKind::Structural
-                    | ToolOutputSummaryKind::Error => format!("    {}", summary.text.yellow()),
-                },
-                None => String::new(),
-            }
+            output_summary
+                .as_ref()
+                .map(|summary| format_terminal_tool_summary(tool, summary, true))
+                .unwrap_or_default()
         } else {
-            match output_summary {
-                Some(summary) => match summary.kind {
-                    ToolOutputSummaryKind::Preview
-                    | ToolOutputSummaryKind::Structural
-                    | ToolOutputSummaryKind::Error => format!("    {}", summary.text.dim()),
-                },
-                None => String::new(),
-            }
+            output_summary
+                .as_ref()
+                .map(|summary| format_terminal_tool_summary(tool, summary, false))
+                .unwrap_or_default()
         };
 
         let mut out_lines = 1usize;
@@ -5366,6 +5376,10 @@ impl StreamRenderState {
     ) -> Option<ToolOutputSummary> {
         let structural = |text: String| ToolOutputSummary {
             kind: ToolOutputSummaryKind::Structural,
+            text,
+        };
+        let diff_summary = |text: String| ToolOutputSummary {
+            kind: ToolOutputSummaryKind::Diff,
             text,
         };
         let preview = |text: String| ToolOutputSummary {
@@ -5514,9 +5528,9 @@ impl StreamRenderState {
                 // str_replace: sentinel-wrapped diff; write_file: JSON `_cli_unified_diff` (same as headless preview).
                 let diff_block = extract_cli_diff_block(output);
                 if let Some(ref diff) = diff_block {
-                    let colored = colorize_diff_summary(diff.as_ref(), 5);
-                    if !colored.is_empty() {
-                        return Some(structural(colored));
+                    let preview = compact_unified_diff_preview(diff.as_ref(), 5);
+                    if !preview.is_empty() {
+                        return Some(diff_summary(preview));
                     }
                 }
                 // Fallback: check if output itself looks like a diff
@@ -5524,9 +5538,9 @@ impl StreamRenderState {
                     .lines()
                     .any(|l| l.starts_with("+++ ") || l.starts_with("--- "))
                 {
-                    let colored = colorize_diff_summary(output, 5);
-                    if !colored.is_empty() {
-                        return Some(structural(colored));
+                    let preview = compact_unified_diff_preview(output, 5);
+                    if !preview.is_empty() {
+                        return Some(diff_summary(preview));
                     }
                 }
                 if tool == "write_file"
@@ -6464,7 +6478,7 @@ pub(super) async fn consume_turn_sse(
     let idle = stream_idle_timeout();
     let (
         mut sse_result,
-        edge_tool_round,
+        host_edge_tool_round,
         mut md_renderer,
         lines_written,
         _pending_xml_buffer,
@@ -6517,6 +6531,7 @@ pub(super) async fn consume_turn_sse(
         (result, Vec::new(), md, lw, String::new(), false, None)
     };
     apply_edge_auth_failure_result(&mut sse_result.accum, auth_failure);
+    let edge_tool_round = merge_edge_tool_rounds(host_edge_tool_round, &sse_result.tool_results);
 
     let mut result = TurnResult {
         core: sse_result.accum,
@@ -6583,6 +6598,33 @@ pub(super) fn dispatch_turn_event_block(
 ) {
     let effects = dispatch_chat_turn_sse_event_block(block, &mut result.core, pending_edge);
     apply_sse_render_effects(effects, render, policy);
+}
+
+fn merge_edge_tool_rounds(
+    host_round: Vec<EdgeToolExecResult>,
+    consumed_tool_results: &[EdgeToolExecResult],
+) -> Vec<EdgeToolExecResult> {
+    if consumed_tool_results.is_empty() {
+        return host_round;
+    }
+
+    let mut merged = host_round;
+    let mut seen_request_ids: std::collections::HashSet<String> = merged
+        .iter()
+        .map(|result| result.request_id.clone())
+        .collect();
+
+    // Host wins on duplicate request_id; if consumed has the same id
+    // multiple times (unlikely but not enforced upstream), only the
+    // first unseen occurrence is appended — later duplicates are
+    // silently dropped.
+    for result in consumed_tool_results {
+        if seen_request_ids.insert(result.request_id.clone()) {
+            merged.push(result.clone());
+        }
+    }
+
+    merged
 }
 
 /// Append `<skill-loaded name="..."/>` to a successful skill result.
@@ -8222,6 +8264,29 @@ diff --git a/src/a.rs b/src/a.rs\n\
         assert!(summary.text.contains("+1"));
         assert!(summary.text.contains("-1"));
         assert!(summary.text.contains("src/a.rs"));
+    }
+
+    #[test]
+    fn str_replace_output_summary_keeps_raw_diff_preview_for_tui_rendering() {
+        let r = StreamRenderState::new();
+        let output = "\
+<<<ASTRA_UNIFIED_DIFF>>>\n\
+--- a/src/hello.py\n\
++++ b/src/hello.py\n\
+@@ -1,2 +1,3 @@\n\
+-print(\"old\")\n\
++print(\"new\")\n\
++print(\"more\")\n\
+<<<END_ASTRA_UNIFIED_DIFF>>>";
+        let summary = r
+            .format_output_summary("str_replace", output, "ok")
+            .expect("summary");
+        assert_eq!(summary.kind, ToolOutputSummaryKind::Diff);
+        assert!(summary.text.contains("--- a/src/hello.py"));
+        assert!(summary.text.contains("+++ b/src/hello.py"));
+        assert!(summary.text.contains("@@ -1,2 +1,3 @@"));
+        assert!(summary.text.contains("+print(\"new\")"));
+        assert!(!summary.text.contains('\x1b'));
     }
 
     #[test]
@@ -10055,6 +10120,59 @@ diff --git a/src/a.rs b/src/a.rs\n\
             "{}",
             result.output
         );
+    }
+
+    #[test]
+    fn merge_edge_tool_rounds_recovers_missing_host_result() {
+        let consumed = vec![EdgeToolExecResult {
+            request_id: "call-exit".to_string(),
+            tool: "exit_plan_mode".to_string(),
+            args: serde_json::json!({"approved": true}),
+            output: "Exited plan mode; user approved. Next turn will run in auto mode.".to_string(),
+            tool_result_fields: None,
+            status: "ok".to_string(),
+            duration_ms: 12,
+        }];
+
+        let merged = merge_edge_tool_rounds(Vec::new(), &consumed);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].request_id, consumed[0].request_id);
+        assert_eq!(merged[0].tool, consumed[0].tool);
+        assert_eq!(merged[0].args, consumed[0].args);
+        assert_eq!(merged[0].output, consumed[0].output);
+        assert_eq!(merged[0].status, consumed[0].status);
+        assert_eq!(merged[0].duration_ms, consumed[0].duration_ms);
+    }
+
+    #[test]
+    fn merge_edge_tool_rounds_deduplicates_by_request_id() {
+        let host = vec![EdgeToolExecResult {
+            request_id: "call-exit".to_string(),
+            tool: "exit_plan_mode".to_string(),
+            args: serde_json::json!({"approved": true}),
+            output: "host output".to_string(),
+            tool_result_fields: None,
+            status: "ok".to_string(),
+            duration_ms: 8,
+        }];
+        let consumed = vec![EdgeToolExecResult {
+            request_id: "call-exit".to_string(),
+            tool: "exit_plan_mode".to_string(),
+            args: serde_json::json!({"approved": true}),
+            output: "consumer output".to_string(),
+            tool_result_fields: None,
+            status: "ok".to_string(),
+            duration_ms: 9,
+        }];
+
+        let merged = merge_edge_tool_rounds(host.clone(), &consumed);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].request_id, host[0].request_id);
+        assert_eq!(merged[0].tool, host[0].tool);
+        assert_eq!(merged[0].args, host[0].args);
+        assert_eq!(merged[0].output, host[0].output);
+        assert_eq!(merged[0].status, host[0].status);
+        assert_eq!(merged[0].duration_ms, host[0].duration_ms);
     }
 
     #[tokio::test]

--- a/rust/crates/astra-cli/src/diff_utils.rs
+++ b/rust/crates/astra-cli/src/diff_utils.rs
@@ -1,0 +1,32 @@
+/// Parse a unified diff hunk header `@@ -old_start,old_count +new_start,new_count @@`
+/// Returns (old_start-1, new_start-1) — the line *before* the first changed line,
+/// so callers can increment before rendering each line.
+pub(crate) fn parse_hunk_header(header: &str) -> Option<(u32, u32)> {
+    let mut old_start: Option<u32> = None;
+    let mut new_start: Option<u32> = None;
+    for part in header.split_whitespace() {
+        if let Some(s) = part.strip_prefix('-') {
+            old_start = s.split(',').next()?.parse().ok();
+        } else if let Some(s) = part.strip_prefix('+') {
+            new_start = s.split(',').next()?.parse().ok();
+        }
+    }
+    Some((old_start?.saturating_sub(1), new_start?.saturating_sub(1)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_hunk_header;
+
+    #[test]
+    fn parse_hunk_header_returns_pre_change_line_numbers() {
+        assert_eq!(parse_hunk_header("@@ -41,2 +99,3 @@"), Some((40, 98)));
+    }
+
+    #[test]
+    fn parse_hunk_header_rejects_invalid_headers() {
+        assert_eq!(parse_hunk_header("@@ malformed @@"), None);
+        assert_eq!(parse_hunk_header("@@ -41,2 @@"), None);
+        assert_eq!(parse_hunk_header("@@ +99,3 @@"), None);
+    }
+}

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -81,6 +81,7 @@ mod delegate_subrun;
 mod diagnostic_log;
 #[path = "cli/diff_presenter.rs"]
 mod diff_presenter;
+mod diff_utils;
 #[path = "cli/durable_bridge.rs"]
 mod durable_bridge;
 #[path = "cli/edge_lifecycle.rs"]

--- a/rust/crates/astra-cli/src/tui/diff_render.rs
+++ b/rust/crates/astra-cli/src/tui/diff_render.rs
@@ -7,6 +7,8 @@
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
+use crate::diff_utils::parse_hunk_header;
+
 use super::color::is_light;
 use super::render::highlight::highlight_code_to_lines;
 use super::terminal_palette::default_bg;
@@ -32,7 +34,7 @@ fn add_style() -> Style {
     if is_light_bg() {
         Style::default().fg(LIGHT_ADD_FG).bg(LIGHT_ADD_BG)
     } else {
-        Style::default().fg(DARK_ADD_FG)
+        Style::default().fg(DARK_ADD_FG).bg(DARK_ADD_BG)
     }
 }
 
@@ -41,7 +43,7 @@ fn del_style() -> Style {
     if is_light_bg() {
         Style::default().fg(LIGHT_DEL_FG).bg(LIGHT_DEL_BG)
     } else {
-        Style::default().fg(DARK_DEL_FG)
+        Style::default().fg(DARK_DEL_FG).bg(DARK_DEL_BG)
     }
 }
 
@@ -195,21 +197,6 @@ fn diff_header_language(header: &str) -> Option<String> {
         .extension()
         .and_then(|ext| ext.to_str())
         .map(ToOwned::to_owned)
-}
-
-/// Parse hunk header `@@ -old_start,old_count +new_start,new_count @@`
-fn parse_hunk_header(header: &str) -> Option<(u32, u32)> {
-    let parts: Vec<&str> = header.split_whitespace().collect();
-    let mut old_start = 0u32;
-    let mut new_start = 0u32;
-    for part in &parts {
-        if let Some(s) = part.strip_prefix('-') {
-            old_start = s.split(',').next()?.parse().ok()?;
-        } else if let Some(s) = part.strip_prefix('+') {
-            new_start = s.split(',').next()?.parse().ok()?;
-        }
-    }
-    Some((old_start.saturating_sub(1), new_start.saturating_sub(1)))
 }
 
 #[cfg(test)]

--- a/rust/crates/astra-cli/src/tui/history_cell/tool.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/tool.rs
@@ -28,6 +28,7 @@ use ratatui::text::{Line, Span};
 use unicode_width::UnicodeWidthStr;
 
 use super::HistoryCell;
+use crate::tui::render::line_utils::sanitize_terminal_text;
 use crate::tui::turn_event::{ToolStatus as PersistStatus, TurnEvent};
 
 /// Live status. `Running` is intentionally separate from the
@@ -330,7 +331,8 @@ impl HistoryCell for ToolCell {
         // `│ <description>` — the command, path, or summary line.
         if !self.description.is_empty() {
             let max_w = w.saturating_sub(4);
-            for dl in self.description.lines().take(2) {
+            let description = sanitize_terminal_text(&self.description);
+            for dl in description.lines().take(2) {
                 lines.push(Line::from(vec![
                     Span::styled("  │ ", dim),
                     Span::raw(truncate_by_width(dl, max_w)),
@@ -341,11 +343,12 @@ impl HistoryCell for ToolCell {
         // `└ <output summary>` — diff renderer for +/- content,
         // plain truncated preview otherwise.
         if let Some(ref summary) = self.output_summary {
+            let summary = sanitize_terminal_text(summary);
             let has_diff = summary
                 .lines()
                 .any(|l| l.starts_with('+') || l.starts_with('-'));
             if has_diff {
-                let diff_lines = crate::tui::diff_render::render_diff_lines(summary, 8);
+                let diff_lines = crate::tui::diff_render::render_diff_lines(&summary, 10);
                 for (i, dl) in diff_lines.into_iter().enumerate() {
                     if i == 0 {
                         let mut spans = vec![Span::styled("  └ ", dim)];
@@ -587,13 +590,56 @@ mod tests {
         t.output_summary = Some("line-1\x1b[2J\nline-2\u{009b}1m".into());
 
         let out = render(&t, 100, 6);
-        assert!(out.contains("bash[31m"));
+        assert!(out.contains("bash"));
         assert!(out.contains("boom\tok"));
-        assert!(out.contains("line-1[2J"));
-        assert!(out.contains("line-21m"));
+        assert!(out.contains("line-1"));
+        assert!(out.contains("line-2"));
+        assert!(!out.contains("[2J"));
+        assert!(!out.contains("[31m"));
+        assert!(!out.contains("1m"));
         assert!(!out.contains('\x1b'));
         assert!(!out.contains('\r'));
         assert!(!out.contains('\u{9b}'));
+    }
+
+    #[test]
+    fn ansi_wrapped_diff_summary_still_uses_diff_renderer() {
+        let mut t = ok_tool("write_file", "/tmp/hello.py", 7);
+        t.output_summary = Some(
+            "\x1b[2mhello.py\x1b[0m\n\x1b[38;5;10m+\x1b[39m\x1b[38;5;10m#!/usr/bin/env python3\x1b[0m\n\x1b[38;5;10m+\x1b[39mprint(\"hello\")".into(),
+        );
+
+        let out = render(&t, 100, 8);
+        assert!(out.contains("hello.py"));
+        assert!(out.contains("   1 + #!/usr/bin/env python3"), "{out}");
+        assert!(out.contains("   2 + print(\"hello\")"), "{out}");
+        assert!(!out.contains("[38;5;10m"));
+        assert!(!out.contains("[2m"));
+    }
+
+    #[test]
+    fn raw_diff_preview_preserves_folded_change_count() {
+        let mut t = ok_tool("str_replace", "src/hello.py", 7);
+        t.output_summary = Some(
+            "\
+--- a/src/hello.py\n\
++++ b/src/hello.py\n\
+@@ -1,2 +1,7 @@\n\
+-print(\"old\")\n\
++print(\"new1\")\n\
++print(\"new2\")\n\
++print(\"new3\")\n\
++print(\"new4\")\n\
++print(\"new5\")\n\
+… +1 more changed lines"
+                .into(),
+        );
+
+        let out = render(&t, 100, 12);
+        assert!(out.contains("   1 - print(\"old\")"), "{out}");
+        assert!(out.contains("   1 + print(\"new1\")"), "{out}");
+        assert!(out.contains("   5 + print(\"new5\")"), "{out}");
+        assert!(out.contains("… +1 more changed lines"), "{out}");
     }
 
     // ── Progress signals ─────────────────────────────────────────

--- a/rust/crates/astra-cli/src/tui/render/line_utils.rs
+++ b/rust/crates/astra-cli/src/tui/render/line_utils.rs
@@ -1,20 +1,105 @@
 use std::borrow::Cow;
+use std::iter::Peekable;
+use std::str::Chars;
 
 use ratatui::text::{Line, Span};
+
+const MAX_STRING_ESCAPE_SCAN_CHARS: usize = 256;
 
 fn is_unsafe_terminal_control(ch: char) -> bool {
     ch.is_control() && ch != '\n' && ch != '\t'
 }
 
+fn skip_csi(chars: &mut Peekable<Chars<'_>>) {
+    for ch in chars.by_ref() {
+        if ('@'..='~').contains(&ch) {
+            break;
+        }
+    }
+}
+
+fn skip_string_escape(chars: &mut Peekable<Chars<'_>>, allow_bel: bool) -> Option<char> {
+    let mut scanned = 0usize;
+    while let Some(ch) = chars.next() {
+        scanned += 1;
+        if allow_bel && ch == '\x07' {
+            return None;
+        }
+        if ch == '\u{009c}' {
+            return None;
+        }
+        if ch == '\x1b' && matches!(chars.peek(), Some('\\')) {
+            chars.next();
+            return None;
+        }
+        if ch == '\n' {
+            return Some('\n');
+        }
+        if scanned >= MAX_STRING_ESCAPE_SCAN_CHARS {
+            return (!is_unsafe_terminal_control(ch)).then_some(ch);
+        }
+    }
+    None
+}
+
 pub(crate) fn sanitize_terminal_text(text: &str) -> Cow<'_, str> {
-    if !text.chars().any(is_unsafe_terminal_control) {
+    if !text.chars().any(|ch| {
+        is_unsafe_terminal_control(ch)
+            || matches!(
+                ch,
+                '\x1b'
+                    | '\u{0090}'
+                    | '\u{0098}'
+                    | '\u{009b}'
+                    | '\u{009c}'
+                    | '\u{009d}'
+                    | '\u{009e}'
+                    | '\u{009f}'
+            )
+    }) {
         return Cow::Borrowed(text);
     }
 
     let mut sanitized = String::with_capacity(text.len());
-    for ch in text.chars() {
-        if !is_unsafe_terminal_control(ch) {
-            sanitized.push(ch);
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\x1b' => match chars.peek() {
+                Some('[') => {
+                    chars.next();
+                    skip_csi(&mut chars);
+                }
+                Some(']') => {
+                    chars.next();
+                    if let Some(ch) = skip_string_escape(&mut chars, true) {
+                        sanitized.push(ch);
+                    }
+                }
+                Some('P' | 'X' | '^' | '_') => {
+                    chars.next();
+                    if let Some(ch) = skip_string_escape(&mut chars, false) {
+                        sanitized.push(ch);
+                    }
+                }
+                Some(next) if ('@'..='_').contains(next) => {
+                    chars.next();
+                }
+                _ => {}
+            },
+            '\u{009b}' => skip_csi(&mut chars),
+            '\u{009d}' => {
+                if let Some(ch) = skip_string_escape(&mut chars, true) {
+                    sanitized.push(ch);
+                }
+            }
+            '\u{0090}' | '\u{0098}' | '\u{009e}' | '\u{009f}' => {
+                if let Some(ch) = skip_string_escape(&mut chars, false) {
+                    sanitized.push(ch);
+                }
+            }
+            '\u{009c}' => {}
+            _ if !is_unsafe_terminal_control(ch) => sanitized.push(ch),
+            _ => {}
         }
     }
     Cow::Owned(sanitized)
@@ -82,8 +167,8 @@ mod tests {
 
     #[test]
     fn sanitize_terminal_text_strips_control_sequences_but_keeps_newlines_and_tabs() {
-        let text = "ok\x1b[31m\tstill\nfine\r\u{009b}1m";
-        assert_eq!(sanitize_terminal_text(text), "ok[31m\tstill\nfine1m");
+        let text = "ok\x1b[31m\tstill\nfine\r\u{009b}1m\x1b]0;title\x07";
+        assert_eq!(sanitize_terminal_text(text), "ok\tstill\nfine");
     }
 
     #[test]
@@ -97,7 +182,7 @@ mod tests {
 
         let sanitized = sanitize_line_for_terminal(&line);
         assert_eq!(sanitized.spans.len(), 2);
-        assert_eq!(sanitized.spans[0].content.as_ref(), "safe[31m");
+        assert_eq!(sanitized.spans[0].content.as_ref(), "safe");
         assert_eq!(sanitized.spans[1].content.as_ref(), "\tb\t");
         assert_eq!(sanitized.spans[0].style, Style::default().fg(Color::Green));
         assert_eq!(sanitized.style, Style::default().bg(Color::Black));
@@ -105,5 +190,19 @@ mod tests {
             sanitized.alignment,
             Some(ratatui::layout::Alignment::Center)
         );
+    }
+
+    #[test]
+    fn sanitize_terminal_text_limits_unterminated_string_escape_damage() {
+        let text = format!("prefix\x1b]0;{}tail", "x".repeat(300));
+        let sanitized = sanitize_terminal_text(&text);
+        assert!(sanitized.starts_with("prefix"));
+        assert!(sanitized.ends_with("tail"));
+    }
+
+    #[test]
+    fn sanitize_terminal_text_preserves_newline_after_unterminated_string_escape() {
+        let text = "prefix\x1b]0;title\nvisible";
+        assert_eq!(sanitize_terminal_text(text), "prefix\nvisible");
     }
 }

--- a/rust/crates/astra-cli/src/tui/session_picker/discovery.rs
+++ b/rust/crates/astra-cli/src/tui/session_picker/discovery.rs
@@ -282,18 +282,13 @@ mod tests {
     use super::*;
     use astra_services::{session_journal::JournalDirGuard, session_workspace};
 
-    fn with_tmp_home<F: FnOnce(&std::path::Path)>(f: F) {
-        use std::env;
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let prev = env::var("HOME").ok();
-        unsafe {
-            env::set_var("HOME", tmp.path());
-        }
+    fn with_tmp_sessions_dir<F: FnOnce(&std::path::Path)>(f: F) {
+        let cwd = std::env::current_dir().expect("current dir");
+        let tmp = tempfile::Builder::new()
+            .prefix("session-picker-discovery-")
+            .tempdir_in(&cwd)
+            .expect("tempdir in cwd");
         f(tmp.path());
-        match prev {
-            Some(v) => unsafe { env::set_var("HOME", v) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     fn write_picker_session(
@@ -316,9 +311,8 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn fs_source_reads_cost_from_latest_transcript_turn_summary() {
-        with_tmp_home(|home| {
-            let sessions_dir = home.join(".astra").join("sessions");
-            let _guard = JournalDirGuard::new(&sessions_dir);
+        with_tmp_sessions_dir(|sessions_dir| {
+            let _guard = JournalDirGuard::new(sessions_dir);
             let sid = "sessmeta123";
             let _ws = write_picker_session(&sessions_dir, sid);
 
@@ -349,9 +343,8 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn fs_source_uses_last_non_empty_transcript_cost() {
-        with_tmp_home(|home| {
-            let sessions_dir = home.join(".astra").join("sessions");
-            let _guard = JournalDirGuard::new(&sessions_dir);
+        with_tmp_sessions_dir(|sessions_dir| {
+            let _guard = JournalDirGuard::new(sessions_dir);
             let sid = "sessmeta456";
             let _ws = write_picker_session(&sessions_dir, sid);
 

--- a/rust/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge/inprocess.rs
@@ -514,6 +514,30 @@ fn normalize_exit_semantics_tag(tag: &str) -> Option<String> {
         .map(ToString::to_string)
 }
 
+#[cfg(test)]
+mod exit_semantics_tests {
+    use super::normalize_exit_semantics_tag;
+
+    #[test]
+    fn normalize_exit_semantics_tag_accepts_canonical_values() {
+        assert_eq!(
+            normalize_exit_semantics_tag("execution_error"),
+            Some("execution_error".to_string())
+        );
+        assert_eq!(
+            normalize_exit_semantics_tag("domain_negative"),
+            Some("domain_negative".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_exit_semantics_tag_rejects_unknown_values() {
+        assert_eq!(normalize_exit_semantics_tag("made_up"), None);
+        assert_eq!(normalize_exit_semantics_tag("ExecutionError"), None);
+        assert_eq!(normalize_exit_semantics_tag("domain-negative"), None);
+    }
+}
+
 fn build_bridge_tool_call_records(
     tool_calls: &[Value],
     tool_results: &[Value],


### PR DESCRIPTION
## Summary
Hardens terminal output sanitization, redesigns diff preview rendering, adds edge-tool recovery logic, and addresses code review findings.

## Changes
- **ANSI sanitization rewrite** (`line_utils.rs`): Full CSI/OSC/DCS/SOS/PM/APC sequence parsing with escape guard, replacing the old `is_control()`-only approach
- **Diff preview redesign** (`cli_formatting.rs`): New `compact_unified_diff_preview` for truncated diffs and `colorize_diff_summary` with hunk-header line numbers
- **Shared `parse_hunk_header`** (`diff_utils.rs`): Extracted from `cli_formatting.rs`/`diff_render.rs` into a single pub(crate) function
- **Dark-theme diff backgrounds** (`diff_render.rs`): Add/del lines now have tinted backgrounds in dark mode
- **TUI tool sanitization** (`history_cell/tool.rs`): `sanitize_terminal_text` applied to tool descriptions and output summaries
- **Edge-tool recovery** (`stream_render.rs`): `merge_edge_tool_rounds` recovers consumed tool results not captured by the host
- **Hook hardening**: Shell hook policy blocking now propagates errors properly
- **Context window consolidation**: Model name matching uses token-boundary `has_model_token` for robustness

## Testing
- All new functions have dedicated unit tests (ANSI parser, hunk header parsing, diff preview, edge recovery)
- `cargo check` and `cargo test` pass in `rust/crates/astra-cli`