### PR TITLE
fix: thread plan_mode_active from host into headless tool round

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -790,6 +790,13 @@ impl AgenticLoopHost for CliAgenticLoopHost<'_> {
         self.turn_interaction_mode_inherent()
     }
 
+    fn plan_mode_active(
+        &self,
+        _state: &astra_runtime::turn::agentic_loop::host::AgenticLoopState,
+    ) -> bool {
+        self.perm_manager.mode() == crate::cli::permission_manager::PermissionMode::Plan
+    }
+
     fn valid_tool_names(&self) -> &HashSet<String> {
         &self.valid_tool_names
     }

--- a/rust/crates/astra-cli/src/cli/context_dump.rs
+++ b/rust/crates/astra-cli/src/cli/context_dump.rs
@@ -483,52 +483,9 @@ mod tests {
         assert_eq!(p, explicit);
     }
 
-    use std::sync::{Mutex, MutexGuard, OnceLock};
-
-    /// Process-wide mutex that serialises every $HOME-mutating
-    /// test in the crate. Several sibling tests (edge_tools::shell,
-    /// …) read $HOME through `dirs::home_dir()` while our resolver
-    /// tests temporarily point $HOME at a tempdir — without the
-    /// mutex, `cargo test`'s default thread pool lets those races
-    /// flake the unrelated tests. This guard pairs mutex-hold with
-    /// $HOME-save/restore as a single RAII unit.
-    static HOME_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-    struct HomeGuard {
-        _lock: MutexGuard<'static, ()>,
-        prev: Option<String>,
-    }
-    impl HomeGuard {
-        fn set(new: &str) -> Self {
-            let lock = HOME_TEST_LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let prev = std::env::var("HOME").ok();
-            // SAFETY: the mutex above guarantees no other test in
-            // this crate is reading or writing $HOME while we hold
-            // the guard.
-            unsafe { std::env::set_var("HOME", new) };
-            Self { _lock: lock, prev }
-        }
-    }
-    impl Drop for HomeGuard {
-        fn drop(&mut self) {
-            // SAFETY: still holding the lock — same guarantee as
-            // `set`. After Drop releases `_lock`, other tests can
-            // observe the restored $HOME.
-            unsafe {
-                match &self.prev {
-                    Some(v) => std::env::set_var("HOME", v),
-                    None => std::env::remove_var("HOME"),
-                }
-            }
-        }
-    }
-
     #[test]
     fn resolve_path_expands_tilde() {
-        let _g = HomeGuard::set("/tmp/fake-home");
+        let _g = crate::tests::HomeGuard::set("/tmp/fake-home");
         let p = resolve_dump_path(Some("~/snap.json"), Some("sess"), 0).unwrap();
         assert_eq!(p, PathBuf::from("/tmp/fake-home/snap.json"));
     }
@@ -536,7 +493,7 @@ mod tests {
     #[test]
     fn resolve_path_synthesizes_under_home_dir_by_default() {
         let tmp = tempfile::tempdir().unwrap();
-        let _g = HomeGuard::set(tmp.path().to_str().unwrap());
+        let _g = crate::tests::HomeGuard::set(tmp.path());
         let p = resolve_dump_path(None, Some("abcdef12-full"), 7).unwrap();
         let parent = p.parent().unwrap();
         assert!(parent.ends_with(".astra/context-dumps"));
@@ -613,7 +570,7 @@ mod tests {
 
     #[test]
     fn expand_tilde_only_matches_leading_slash_prefix() {
-        let _g = HomeGuard::set("/tmp/home");
+        let _g = crate::tests::HomeGuard::set("/tmp/home");
         // `~foo` (no slash) isn't a tilde expansion — leave alone.
         assert_eq!(expand_tilde("~foo"), PathBuf::from("~foo"));
         assert_eq!(expand_tilde("~/foo"), PathBuf::from("/tmp/home/foo"));
@@ -638,7 +595,7 @@ mod tests {
     /// mtime granularity (nsec on Linux) this gives ascending
     /// mtimes; the last one written is the "newest". That's
     /// enough to cover the default-latest resolver path.
-    fn seed_sessions_tmp(ids: &[&str]) -> (HomeGuard, tempfile::TempDir) {
+    fn seed_sessions_tmp(ids: &[&str]) -> (crate::tests::HomeGuard, tempfile::TempDir) {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join(".astra/sessions");
         fs::create_dir_all(&dir).unwrap();
@@ -653,7 +610,7 @@ mod tests {
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
         }
-        let g = HomeGuard::set(tmp.path().to_str().unwrap());
+        let g = crate::tests::HomeGuard::set(tmp.path());
         (g, tmp)
     }
 

--- a/rust/crates/astra-cli/src/lib.rs
+++ b/rust/crates/astra-cli/src/lib.rs
@@ -66,6 +66,8 @@ pub(crate) use cli::cloud_sync::post_auth_cloud_resync;
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
     pub(crate) struct CredentialsGuard {
@@ -98,6 +100,61 @@ pub(crate) mod tests {
         CredentialsGuard {
             _lock: lock,
             _dir: dir,
+        }
+    }
+
+    pub(crate) struct HomeGuard {
+        _lock: MutexGuard<'static, ()>,
+        prev: Option<OsString>,
+        current: PathBuf,
+        _dir: Option<tempfile::TempDir>,
+    }
+
+    fn home_lock() -> MutexGuard<'static, ()> {
+        static HOME_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        HOME_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    impl HomeGuard {
+        fn set_impl(path: PathBuf, dir: Option<tempfile::TempDir>) -> Self {
+            let lock = home_lock();
+            let prev = std::env::var_os("HOME");
+            unsafe {
+                std::env::set_var("HOME", &path);
+            }
+            Self {
+                _lock: lock,
+                prev,
+                current: path,
+                _dir: dir,
+            }
+        }
+
+        pub(crate) fn temp() -> Self {
+            let dir = tempfile::tempdir().expect("create temp home dir");
+            Self::set_impl(dir.path().to_path_buf(), Some(dir))
+        }
+
+        pub(crate) fn set(path: impl AsRef<Path>) -> Self {
+            Self::set_impl(path.as_ref().to_path_buf(), None)
+        }
+
+        pub(crate) fn path(&self) -> &Path {
+            &self.current
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
         }
     }
 }

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -474,6 +474,8 @@ mod tests {
     /// Guard that serializes tests touching ASTRA_CLI_CREDENTIALS_DIR.
     /// Multiple async tests concurrently setting this env var is a data race;
     /// the guard ensures they execute sequentially.
+    use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
     pub(crate) struct CredentialsGuard {
@@ -507,6 +509,59 @@ mod tests {
         CredentialsGuard {
             _lock: lock,
             _dir: dir,
+        }
+    }
+
+    pub(crate) struct HomeGuard {
+        _lock: MutexGuard<'static, ()>,
+        prev: Option<OsString>,
+        current: PathBuf,
+        _dir: Option<tempfile::TempDir>,
+    }
+
+    fn home_lock() -> MutexGuard<'static, ()> {
+        static HOME_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        HOME_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    impl HomeGuard {
+        fn set_impl(path: PathBuf, dir: Option<tempfile::TempDir>) -> Self {
+            let lock = home_lock();
+            let prev = std::env::var_os("HOME");
+            unsafe { std::env::set_var("HOME", &path) };
+            Self {
+                _lock: lock,
+                prev,
+                current: path,
+                _dir: dir,
+            }
+        }
+
+        pub(crate) fn temp() -> Self {
+            let dir = tempfile::tempdir().expect("create temp home dir");
+            Self::set_impl(dir.path().to_path_buf(), Some(dir))
+        }
+
+        pub(crate) fn set(path: impl AsRef<Path>) -> Self {
+            Self::set_impl(path.as_ref().to_path_buf(), None)
+        }
+
+        pub(crate) fn path(&self) -> &Path {
+            &self.current
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
         }
     }
 

--- a/rust/crates/astra-cli/src/tui/bottom_pane/chat_composer.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/chat_composer.rs
@@ -577,13 +577,7 @@ mod paste_tests {
     #[test]
     #[serial_test::serial]
     fn history_persists_and_reloads() {
-        use std::env;
-        let tmp = tempfile::tempdir().expect("tempdir");
-        // Reroute `dirs::home_dir()` by overriding HOME.
-        let prev = env::var("HOME").ok();
-        unsafe {
-            env::set_var("HOME", tmp.path());
-        }
+        let _home = crate::tests::HomeGuard::temp();
 
         {
             let mut c = ChatComposer::new();
@@ -598,22 +592,12 @@ mod paste_tests {
         assert_eq!(c2.history.len(), 2);
         assert_eq!(c2.history[0], "first command");
         assert_eq!(c2.history[1], "second command\nwith newline");
-
-        match prev {
-            Some(v) => unsafe { env::set_var("HOME", v) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     #[test]
     #[serial_test::serial]
     fn duplicate_consecutive_submits_are_deduped() {
-        use std::env;
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let prev = env::var("HOME").ok();
-        unsafe {
-            env::set_var("HOME", tmp.path());
-        }
+        let _home = crate::tests::HomeGuard::temp();
 
         let mut c = ChatComposer::new();
         c.set_text("hi");
@@ -621,11 +605,6 @@ mod paste_tests {
         c.set_text("hi");
         let _ = c.clear_and_submit();
         assert_eq!(c.history.len(), 1);
-
-        match prev {
-            Some(v) => unsafe { env::set_var("HOME", v) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -2692,17 +2692,8 @@ mod tests {
     /// Run a test body with `$HOME` pointed at a fresh tempdir so
     /// real `~/.astra/transcripts/` is left alone.
     fn with_tmp_home<F: FnOnce()>(f: F) {
-        use std::env;
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let prev = env::var("HOME").ok();
-        unsafe {
-            env::set_var("HOME", tmp.path());
-        }
+        let _home = crate::tests::HomeGuard::temp();
         f();
-        match prev {
-            Some(v) => unsafe { env::set_var("HOME", v) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/chat_widget/resume.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/resume.rs
@@ -55,22 +55,13 @@ mod tests {
     use crate::tui::turn_event::TurnEvent;
     use ratatui::text::Line;
 
-    /// Run `f` with `$HOME` pointing at a fresh tempdir so the
+    /// Run `f` with `$HOME` pointed at a fresh tempdir so the
     /// append+load test doesn't scribble into the dev's real
-    /// `~/.astra/`. Mirrors `transcript_jsonl::tests::with_tmp_home`
-    /// but we can't re-use that helper (private).
+    /// `~/.astra/`. Uses the crate-wide HOME test guard so these
+    /// path-sensitive tests stay isolated under parallel execution.
     fn with_tmp_home<F: FnOnce()>(f: F) {
-        use std::env;
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let prev = env::var("HOME").ok();
-        unsafe {
-            env::set_var("HOME", tmp.path());
-        }
+        let _home = crate::tests::HomeGuard::temp();
         f();
-        match prev {
-            Some(v) => unsafe { env::set_var("HOME", v) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     fn render_history(w: &ChatWidget, width: u16) -> String {

--- a/rust/crates/astra-cli/src/tui/transcript_jsonl.rs
+++ b/rust/crates/astra-cli/src/tui/transcript_jsonl.rs
@@ -122,19 +122,8 @@ mod tests {
     /// `dirs::home_dir()` resolves there. Ensures tests don't scribble
     /// into the developer's real `~/.astra/`.
     fn with_tmp_home<F: FnOnce(&std::path::Path)>(f: F) {
-        use std::env;
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let prev = env::var("HOME").ok();
-        // SAFETY: tests in this module are `#[serial]` so no other
-        // thread is reading/writing HOME concurrently.
-        unsafe {
-            env::set_var("HOME", tmp.path());
-        }
-        f(tmp.path());
-        match prev {
-            Some(v) => unsafe { env::set_var("HOME", v) },
-            None => unsafe { env::remove_var("HOME") },
-        }
+        let home = crate::tests::HomeGuard::temp();
+        f(home.path());
     }
 
     #[test]

--- a/rust/crates/astra-pipeline/src/trace_query.rs
+++ b/rust/crates/astra-pipeline/src/trace_query.rs
@@ -11,7 +11,7 @@
 use crate::event::{EventLog, TurnEvent};
 use crate::step_protocol::{StepEvent, StepEventStore};
 
-fn collect_step_events<'a>(step_store: &'a dyn StepEventStore) -> Vec<&'a StepEvent> {
+fn collect_step_events(step_store: &dyn StepEventStore) -> Vec<&StepEvent> {
     let mut seen = std::collections::HashSet::new();
     let mut events = Vec::new();
     for leaf in step_store.leaves() {

--- a/rust/crates/runtime/src/messaging/e2e_loop_tests.rs
+++ b/rust/crates/runtime/src/messaging/e2e_loop_tests.rs
@@ -690,6 +690,7 @@ mod tests {
             server_tool_executor: None,
             turn_start: None,
             llm_round: 0,
+            plan_mode_active: false,
         })
         .await;
 
@@ -706,6 +707,89 @@ mod tests {
         assert_eq!(
             tool_call_records[0].error.as_deref(),
             Some("blocked_tool: Tool 'bash' not in allowed tools list"),
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_mode_blocks_mutating_tools_before_headless_protocol_fallback() {
+        let tool_calls = vec![json!({
+            "id": "call-write-plan",
+            "name": "write_file",
+            "arguments": r#"{"path":"tmp.txt","content":"hello"}"#
+        })];
+
+        let mut messages = Vec::new();
+        let mut tool_results = Vec::new();
+        let valid_tool_names = HashSet::from(["write_file".to_string()]);
+        let mut restricted_tools = HashSet::new();
+        let mut turn_guard = TurnGuard::new();
+        let mut step_recorder = StepRecorder::new("test-session", "plan-mode-write");
+        let mut idempotency_cache = InMemoryIdempotencyCache::new();
+        let mut semantic_dedup = SemanticDedup::new(0.95);
+        let mut tool_call_records = Vec::new();
+        let tool_event_hooks = crate::skills::hooks::ToolEventHookRegistry::default();
+        let mut term = NoopHeadlessTerminal;
+        let edge_callback_outputs = std::collections::HashMap::new();
+        let edge_tool_round: Vec<EdgeToolExecResult> = Vec::new();
+
+        run_agentic_headless_tool_round(HeadlessToolRoundCtx {
+            turn_index: 0,
+            quiet: true,
+            api: &astra_thin_client::ThinClient::new("http://127.0.0.1:1", None).unwrap(),
+            token: "",
+            current_session_id: None,
+            tool_calls: &tool_calls,
+            edge_tool_round: &edge_tool_round,
+            reasoning_content: "",
+            reasoning_signature: "",
+            edge_callback_outputs: &edge_callback_outputs,
+            messages: &mut messages,
+            tool_results: &mut tool_results,
+            valid_tool_names: &valid_tool_names,
+            restricted_tools: &mut restricted_tools,
+            turn_guard: &mut turn_guard,
+            step_recorder: &mut step_recorder,
+            idempotency_cache: &mut idempotency_cache,
+            semantic_dedup: &mut semantic_dedup,
+            call_counts: &mut std::collections::HashMap::new(),
+            max_identical_calls: 2,
+            max_tools_per_turn: 15,
+            repeated_cache_hit_suppression: 3,
+            max_consecutive_empty_name: 3,
+            tool_call_records: &mut tool_call_records,
+            tool_event_hooks: &tool_event_hooks,
+            term: &mut term,
+            mailbox: None,
+            permission_context: None,
+            progress_emitter: None,
+            pre_resolved_results: &[],
+            server_tool_executor: None,
+            turn_start: None,
+            llm_round: 0,
+            plan_mode_active: true,
+        })
+        .await;
+
+        assert_eq!(tool_results.len(), 1);
+        assert_eq!(tool_call_records.len(), 1);
+        let record_error = tool_call_records[0].error.as_deref().unwrap_or("");
+        assert!(
+            record_error
+                .contains("blocked_tool: tool 'write_file' is blocked while plan mode is active"),
+            "unexpected journal error: {record_error}"
+        );
+        let tool_message = messages
+            .iter()
+            .find(|message| message["role"] == "tool")
+            .expect("expected a tool result message");
+        let body = tool_message["content"].as_str().unwrap_or("");
+        assert!(
+            body.contains("Permission denied for tool 'write_file'"),
+            "unexpected tool body: {body}"
+        );
+        assert!(
+            !body.contains("headless edge protocol"),
+            "plan mode should short-circuit before protocol fallback: {body}"
         );
     }
 
@@ -772,6 +856,7 @@ mod tests {
             server_tool_executor: None,
             turn_start: None,
             llm_round: 0,
+            plan_mode_active: false,
         })
         .await;
 
@@ -875,6 +960,7 @@ mod tests {
             server_tool_executor: None,
             turn_start: None,
             llm_round: 0,
+            plan_mode_active: false,
         })
         .await;
 
@@ -998,6 +1084,7 @@ mod tests {
             server_tool_executor: None,
             turn_start: None,
             llm_round: 0,
+            plan_mode_active: false,
         })
         .await;
 
@@ -1110,6 +1197,7 @@ mod tests {
             server_tool_executor: None,
             turn_start: None,
             llm_round: 0,
+            plan_mode_active: false,
         })
         .await;
 
@@ -1207,6 +1295,7 @@ mod tests {
             server_tool_executor: None,
             turn_start: None,
             llm_round: 0,
+            plan_mode_active: false,
         })
         .await;
 
@@ -1332,6 +1421,7 @@ mod tests {
             server_tool_executor: None,
             turn_start: None,
             llm_round: 0,
+            plan_mode_active: false,
         })
         .await;
 
@@ -1461,6 +1551,7 @@ mod tests {
             server_tool_executor: None,
             turn_start: None,
             llm_round: 0,
+            plan_mode_active: false,
         })
         .await;
 
@@ -1543,6 +1634,7 @@ mod tests {
             server_tool_executor: None,
             turn_start: None,
             llm_round: 0,
+            plan_mode_active: false,
         })
         .await;
 

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -2379,6 +2379,10 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
         self.render_turn_start_lifecycle_summary(state, plan_hint.as_deref())
     }
 
+    fn plan_mode_active(&self, _state: &AgenticLoopState) -> bool {
+        self.read_plan_resume_hint().is_some()
+    }
+
     fn render_final_text(&mut self, text: &str) {
         if !text.is_empty() {
             self.emit_event(json!({ "type": "text_delta", "content": text }));

--- a/rust/crates/runtime/src/turn/agentic/headless_round.rs
+++ b/rust/crates/runtime/src/turn/agentic/headless_round.rs
@@ -75,6 +75,8 @@ pub struct HeadlessToolRoundCtx<'a, E: EdgeToolRoundRow> {
     pub turn_start: Option<std::time::Instant>,
     /// Current LLM round index (0-based) within this turn.
     pub llm_round: u32,
+    /// Whether the session is still in read-only plan authoring mode.
+    pub plan_mode_active: bool,
 }
 
 struct HeadlessPreparedRound<'a> {
@@ -200,6 +202,7 @@ pub async fn run_agentic_headless_tool_round<E: EdgeToolRoundRow>(
         server_tool_executor,
         turn_start,
         llm_round,
+        plan_mode_active,
     } = ctx;
     let HeadlessPreparedRound {
         effective_permission_timeout,
@@ -256,12 +259,7 @@ pub async fn run_agentic_headless_tool_round<E: EdgeToolRoundRow>(
             server_tool_executor,
             turn_start,
             llm_round,
-            // Plan mode is wired by run_lifecycle when active_plan_id is
-            // set on the session row. Default false here keeps the
-            // existing test paths unaffected; runtime callers that have
-            // the signal will set it explicitly via a builder helper
-            // before invoking the pipeline.
-            plan_mode_active: false,
+            plan_mode_active,
         },
         consumed_edge,
     );

--- a/rust/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/host.rs
@@ -193,6 +193,14 @@ pub trait AgenticLoopHost: Send {
         TurnInteractionMode::NonInteractive
     }
 
+    /// Whether the current turn is still in read-only plan authoring mode.
+    ///
+    /// When true, headless tool execution must deny mutating tools before
+    /// they can fall through to edge/server execution resolution.
+    fn plan_mode_active(&self, _state: &AgenticLoopState) -> bool {
+        false
+    }
+
     /// Host-provided turn-start lifecycle summary for prompt/introspection.
     ///
     /// Default is empty; hosts can override to surface mode/run/resume/delegation

--- a/rust/crates/runtime/src/turn/agentic_loop/tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/tool_phase.rs
@@ -987,6 +987,7 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
 
     let evo_records_before = state.stall.tool_call_records.len();
     {
+        let plan_mode_active = host.plan_mode_active(state);
         let mut term_adapter = HostTerminalAdapter(host);
         let headless_quiet = prep.quiet || state.skill_produced_output;
         let obs_turn_start = state
@@ -1033,6 +1034,7 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
             server_tool_executor: state.server_tool_executor.as_deref(),
             turn_start: obs_turn_start,
             llm_round: obs_llm_round,
+            plan_mode_active,
         })
         .await;
     }


### PR DESCRIPTION
## Summary

Previously `plan_mode_active` was hardcoded to `false` in `headless_round.rs`, meaning the permission gate never blocked mutating tools during plan mode in headless execution paths.

## Changes

- Add `plan_mode_active()` method to `AgenticLoopHost` trait (default: `false`)
- Wire the signal through `tool_phase.rs` → `HeadlessToolRoundCtx` → `HeadlessToolExecutionCtx`
- `CliLoopHost`: derive from `PermissionMode::Plan`
- `ServerLoopHost`: derive from `read_plan_resume_hint()`
- Add regression test: `plan_mode_blocks_mutating_tools_before_headless_protocol_fallback`
- Update all 8 existing test sites with `plan_mode_active: false`

## Testing

- New regression test verifies that `write_file` is denied before headless protocol fallback when plan mode is active
- All existing tests updated to pass `plan_mode_active: false`
- `cargo build --workspace` passes