### PR TITLE
fix: compaction engine quality improvements

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/params.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/params.rs
@@ -1,10 +1,10 @@
 use astra_runtime::pipeline::persistence::ToolHealthEntry;
 use std::collections::HashSet;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 use tokio::sync::mpsc;
 
-use crate::{ExplainMode, cli::permission_manager::PermissionManager};
+use crate::{cli::permission_manager::PermissionManager, ExplainMode};
 
 /// Atomic counter pair published by streaming tools (currently
 /// bash) while they run. Consumers read `lines` / `bytes` on a
@@ -141,6 +141,8 @@ pub enum StreamEvent {
     ExplainText(String),
     /// Verdict audit events from the turn.
     VerdictReport(Vec<crate::VerdictEvent>),
+    /// Structured compaction event for real-time UX feedback.
+    Compaction(astra_turn_core::compaction_types::CompactionEvent),
 }
 
 pub type StreamEventTx = mpsc::UnboundedSender<StreamEvent>;

--- a/rust/crates/astra-cli/src/cli/chat_stream/params.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/params.rs
@@ -1,10 +1,10 @@
 use astra_runtime::pipeline::persistence::ToolHealthEntry;
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::mpsc;
 
-use crate::{cli::permission_manager::PermissionManager, ExplainMode};
+use crate::{ExplainMode, cli::permission_manager::PermissionManager};
 
 /// Atomic counter pair published by streaming tools (currently
 /// bash) while they run. Consumers read `lines` / `bytes` on a

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -7,16 +7,16 @@
 use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 
 use astra_runtime::{
     tool_registry::ToolRegistry,
     turn::agentic::headless_round::HeadlessStderrStyle,
     turn::agentic_loop::host::{
-        interaction_scoped_tool_restrictions, AgenticLoopHost, AgenticLoopState, HostTurnResult,
-        TurnInteractionMode,
+        AgenticLoopHost, AgenticLoopState, HostTurnResult, TurnInteractionMode,
+        interaction_scoped_tool_restrictions,
     },
 };
 use astra_turn_core::compaction_types::CompactionEvent;
@@ -25,14 +25,14 @@ use crossterm::style::Stylize;
 use serde_json::Value;
 
 use crate::{
+    ExplainMode,
     cli::permission_manager::{PermissionManager, PermissionMode},
     cli::stream_render::RenderPolicy,
     edge_tools::ToolExecutor,
-    ExplainMode,
 };
 
 use crate::cli::chat_stream::sse_loop::agentic_loop_turn::{
-    fetch_chat_turn_sse, ChatTurnSseFetchRequest, PrepareTurnTelemetry,
+    ChatTurnSseFetchRequest, PrepareTurnTelemetry, fetch_chat_turn_sse,
 };
 
 use astra_runtime::tool_sandbox::SandboxPolicy;
@@ -1567,5 +1567,39 @@ mod tests {
             "plan-mode cleanup must not delete entries it never owned"
         );
         assert_eq!(restricted.len(), 1);
+    }
+
+    #[test]
+    fn on_compaction_forwards_via_channel() {
+        // Verify that compaction events forwarded through the stream channel
+        // arrive with correct kind and summary.
+        use crate::cli::chat_stream::StreamEvent;
+        use astra_turn_core::compaction_types::{CompactionEvent, CompactionKind};
+        use tokio::sync::mpsc;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let event = CompactionEvent {
+            kind: CompactionKind::ReactiveBudget,
+            pressure: 0.85,
+            tokens_freed: 12000,
+            tokens_before: 48000,
+            tokens_after: 36000,
+            max_tokens: 64000,
+            summary: "reactive budget compaction".into(),
+        };
+
+        // Same pattern used by CliAgenticLoopHost::on_compaction:
+        let _ = tx.send(StreamEvent::Compaction(event));
+
+        let received = rx.try_recv().expect("must receive compaction event");
+        match received {
+            StreamEvent::Compaction(e) => {
+                assert_eq!(e.kind, CompactionKind::ReactiveBudget);
+                assert_eq!(e.pressure, 0.85);
+                assert_eq!(e.tokens_freed, 12000);
+                assert_eq!(e.summary, "reactive budget compaction");
+            }
+            other => panic!("expected Compaction event, got {other:?}"),
+        }
     }
 }

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -7,31 +7,32 @@
 use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Instant;
 
 use astra_runtime::{
     tool_registry::ToolRegistry,
     turn::agentic::headless_round::HeadlessStderrStyle,
     turn::agentic_loop::host::{
-        AgenticLoopHost, AgenticLoopState, HostTurnResult, TurnInteractionMode,
-        interaction_scoped_tool_restrictions,
+        interaction_scoped_tool_restrictions, AgenticLoopHost, AgenticLoopState, HostTurnResult,
+        TurnInteractionMode,
     },
 };
+use astra_turn_core::compaction_types::CompactionEvent;
 use async_trait::async_trait;
 use crossterm::style::Stylize;
 use serde_json::Value;
 
 use crate::{
-    ExplainMode,
     cli::permission_manager::{PermissionManager, PermissionMode},
     cli::stream_render::RenderPolicy,
     edge_tools::ToolExecutor,
+    ExplainMode,
 };
 
 use crate::cli::chat_stream::sse_loop::agentic_loop_turn::{
-    ChatTurnSseFetchRequest, PrepareTurnTelemetry, fetch_chat_turn_sse,
+    fetch_chat_turn_sse, ChatTurnSseFetchRequest, PrepareTurnTelemetry,
 };
 
 use astra_runtime::tool_sandbox::SandboxPolicy;
@@ -780,6 +781,15 @@ impl AgenticLoopHost for CliAgenticLoopHost<'_> {
             HeadlessStderrStyle::Normal => eprintln!("{}", line),
         }
         self.pending_clear_lines += 1;
+    }
+
+    fn on_compaction(&mut self, event: CompactionEvent) {
+        // Stderr fallback (always visible).
+        self.emit_headless_line(HeadlessStderrStyle::Dim, event.summary.clone());
+        // Structured event for TUI / stream consumers.
+        if let Some(tx) = &self.stream_event_tx {
+            let _ = tx.send(crate::cli::StreamEvent::Compaction(event));
+        }
     }
 
     fn is_quiet(&self) -> bool {

--- a/rust/crates/astra-cli/src/cli/plan_monitor.rs
+++ b/rust/crates/astra-cli/src/cli/plan_monitor.rs
@@ -749,7 +749,8 @@ fn display_plan_updates_live(
                     | StreamEvent::AgentLive(_)
                     | StreamEvent::ExplainReport(_)
                     | StreamEvent::ExplainText(_)
-                    | StreamEvent::VerdictReport(_) => continue,
+                    | StreamEvent::VerdictReport(_)
+                    | StreamEvent::Compaction(_) => continue,
                 }
             }
             PlanUpdate::ApprovalNeeded {

--- a/rust/crates/astra-cli/src/cli/slash_info.rs
+++ b/rust/crates/astra-cli/src/cli/slash_info.rs
@@ -1588,7 +1588,7 @@ pub(crate) async fn handle_info_command(
                     pair
                 })
                 .collect();
-            let history_tokens = prompts::estimate_tokens(&est_messages);
+            let history_tokens = prompts::estimate_tokens(&est_messages, 0, 0);
             let budget = &state.context_budget;
             let limit = budget.model_limit;
             let usage_pct = if limit > 0 {

--- a/rust/crates/astra-cli/src/cli/spawn_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/spawn_subrun.rs
@@ -303,6 +303,7 @@ fn stream_event_to_agent_live_kind(
         )),
         StreamEvent::Thinking(_)
         | StreamEvent::AgentLive(_)
+        | StreamEvent::Compaction(_)
         | StreamEvent::ExplainReport(_)
         | StreamEvent::ExplainText(_)
         | StreamEvent::VerdictReport(_) => None,

--- a/rust/crates/astra-cli/src/cli/stream_events_writer.rs
+++ b/rust/crates/astra-cli/src/cli/stream_events_writer.rs
@@ -148,6 +148,18 @@ fn event_to_json(event: &StreamEvent) -> String {
         StreamEvent::ExplainReport(_) | StreamEvent::VerdictReport(_) => {
             serde_json::json!({"type": "ignored"})
         }
+        StreamEvent::Compaction(event) => {
+            serde_json::json!({
+                "type": "compaction",
+                "kind": event.kind,
+                "pressure": event.pressure,
+                "tokens_freed": event.tokens_freed,
+                "tokens_before": event.tokens_before,
+                "tokens_after": event.tokens_after,
+                "max_tokens": event.max_tokens,
+                "summary": event.summary,
+            })
+        }
     };
     serde_json::to_string(&value).unwrap_or_default()
 }

--- a/rust/crates/astra-cli/src/cli/stream_events_writer.rs
+++ b/rust/crates/astra-cli/src/cli/stream_events_writer.rs
@@ -167,6 +167,7 @@ fn event_to_json(event: &StreamEvent) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use astra_turn_core::compaction_types::{CompactionEvent, CompactionKind};
 
     #[test]
     fn token_event_serializes() {
@@ -306,6 +307,15 @@ mod tests {
             StreamEvent::WaitingForModel,
             StreamEvent::ModelResponding,
             StreamEvent::StatusLine("done".into()),
+            StreamEvent::Compaction(CompactionEvent {
+                kind: CompactionKind::Microcompact,
+                pressure: 0.5,
+                tokens_freed: 1000,
+                tokens_before: 30000,
+                tokens_after: 29000,
+                max_tokens: 64000,
+                summary: "test".into(),
+            }),
         ];
         for event in &events {
             let json = event_to_json(event);
@@ -373,6 +383,29 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["type"], "status");
         assert!(v["text"].as_str().unwrap().contains("clippy"));
+    }
+
+    #[test]
+    fn compaction_event_serializes() {
+        let event = CompactionEvent {
+            kind: CompactionKind::Microcompact,
+            pressure: 0.82,
+            tokens_freed: 4500,
+            tokens_before: 32000,
+            tokens_after: 27500,
+            max_tokens: 64000,
+            summary: "freed 4500 tokens".into(),
+        };
+        let json = event_to_json(&StreamEvent::Compaction(event));
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "compaction");
+        assert_eq!(v["kind"], "microcompact");
+        assert_eq!(v["pressure"], 0.82);
+        assert_eq!(v["tokens_freed"], 4500);
+        assert_eq!(v["tokens_before"], 32000);
+        assert_eq!(v["tokens_after"], 27500);
+        assert_eq!(v["max_tokens"], 64000);
+        assert_eq!(v["summary"], "freed 4500 tokens");
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/app_event.rs
+++ b/rust/crates/astra-cli/src/tui/app_event.rs
@@ -58,4 +58,7 @@ pub(crate) enum TuiAppEvent {
     TurnError(String),
     ExplainReport(Vec<serde_json::Value>),
     VerdictReport(Vec<crate::VerdictEvent>),
+
+    // ── Context compaction (real-time UX) ───────────────────────────────
+    Compaction(astra_turn_core::compaction_types::CompactionEvent),
 }

--- a/rust/crates/astra-cli/src/tui/chat_widget/bridge.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/bridge.rs
@@ -127,6 +127,7 @@ pub(crate) fn translate(ev: TuiAppEvent, ctx: TurnContext) -> Option<AppEvent> {
         TuiAppEvent::TurnError(msg) => Some(AppEvent::Wire(WireEvent::TurnError(msg))),
         TuiAppEvent::ExplainReport(items) => Some(AppEvent::Wire(WireEvent::ExplainReport(items))),
         TuiAppEvent::VerdictReport(items) => Some(AppEvent::Wire(WireEvent::VerdictReport(items))),
+        TuiAppEvent::Compaction(event) => Some(AppEvent::Wire(WireEvent::Compaction(event))),
         // Bottom-pane-only events — ChatWidget doesn't care.
         TuiAppEvent::ThinkingStarted
         | TuiAppEvent::WaitingForModel

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -40,6 +40,7 @@ use super::history_cell::{
     task::TaskCell, tool::ToolCell, turn_summary::TurnSummaryCell, user::UserCell,
 };
 use super::transcript_jsonl;
+use astra_turn_core::compaction_types::CompactionEvent;
 use super::turn_event::TurnEvent;
 use crate::VerdictEvent;
 
@@ -138,6 +139,9 @@ pub(crate) enum WireEvent {
     TurnError(String),
     ExplainReport(Vec<serde_json::Value>),
     VerdictReport(Vec<crate::VerdictEvent>),
+    /// Structured compaction event — renders as a system info cell
+    /// so the user sees live context-health feedback in scrollback.
+    Compaction(CompactionEvent),
 }
 
 /// Per-turn metrics the outer loop collects and hands to
@@ -859,6 +863,9 @@ impl ChatWidget {
             WireEvent::TurnError(msg) => self.on_turn_error(msg),
             WireEvent::ExplainReport(items) => self.on_explain_report(items),
             WireEvent::VerdictReport(items) => self.on_verdict_report(items),
+            WireEvent::Compaction(event) => {
+                self.commit_system(SystemCell::info(event.summary));
+            }
         }
     }
 

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -40,9 +40,9 @@ use super::history_cell::{
     task::TaskCell, tool::ToolCell, turn_summary::TurnSummaryCell, user::UserCell,
 };
 use super::transcript_jsonl;
-use astra_turn_core::compaction_types::CompactionEvent;
 use super::turn_event::TurnEvent;
 use crate::VerdictEvent;
+use astra_turn_core::compaction_types::CompactionEvent;
 
 /// Events the ChatWidget knows how to route. Grouped by origin so
 /// `handle_event` can scale to more variants without bloating a

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -3194,6 +3194,7 @@ fn handle_app_event(
         TuiAppEvent::AgentLive(_)
         | TuiAppEvent::AgentLiveBatch(_)
         | TuiAppEvent::StatusLine(_)
+        | TuiAppEvent::Compaction(_)
         | TuiAppEvent::ExplainReport(_)
         | TuiAppEvent::VerdictReport(_)
         | TuiAppEvent::PermissionAutoApproved { .. } => {}

--- a/rust/crates/astra-cli/src/tui/stream_bridge.rs
+++ b/rust/crates/astra-cli/src/tui/stream_bridge.rs
@@ -312,6 +312,10 @@ fn map_stream_event(event: StreamEvent) -> Option<TuiAppEvent> {
         StreamEvent::WaitingForModel => TuiAppEvent::WaitingForModel,
         StreamEvent::ModelResponding => TuiAppEvent::ModelResponding,
         StreamEvent::StatusLine(text) => TuiAppEvent::StatusLine(text),
+        StreamEvent::Compaction(event) => {
+            // Forward to both TUI and status line.
+            TuiAppEvent::Compaction(event)
+        }
         StreamEvent::AgentLive(event) => TuiAppEvent::AgentLive(event),
         StreamEvent::PermissionAutoApproved { tool, reason } => {
             TuiAppEvent::PermissionAutoApproved { tool, reason }

--- a/rust/crates/astra-turn-core/src/compaction_types.rs
+++ b/rust/crates/astra-turn-core/src/compaction_types.rs
@@ -103,6 +103,53 @@ impl CompactionTier {
     }
 }
 
+// ───────────────────────────── CompactionKind ─────────────────────────────
+
+/// Kinds of compaction events emitted by the compression pipeline.
+///
+/// Each variant maps to a specific compaction trigger or phase in the
+/// agentic loop lifecycle. The `Display` impl produces the stderr-formatted
+/// label and the `Serialize`/`Deserialize` impls use `snake_case` for JSON.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompactionKind {
+    /// Pre-turn pressure advisory (before compaction triggers).
+    PressureWarning,
+    /// Tool-result clearing microcompact.
+    Microcompact,
+    /// Default-tier proactive compression pipeline.
+    DefaultCompression,
+    /// Aggressive-tier proactive compression pipeline.
+    AggressiveCompression,
+    /// Compression on resume from checkpoint.
+    Resume,
+    /// Mid-turn reactive budget compaction.
+    ReactiveBudget,
+    /// Compaction before retrying a 413 error (default tier).
+    RetryDefault,
+    /// Compaction before retrying a 413 error (aggressive tier).
+    RetryAggressive,
+    /// Compaction before retrying a 413 error (emergency tier).
+    RetryEmergency,
+}
+
+impl std::fmt::Display for CompactionKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::PressureWarning => "pressure_warning",
+            Self::Microcompact => "microcompact",
+            Self::DefaultCompression => "default_compression",
+            Self::AggressiveCompression => "aggressive_compression",
+            Self::Resume => "resume",
+            Self::ReactiveBudget => "reactive_budget",
+            Self::RetryDefault => "retry_default",
+            Self::RetryAggressive => "retry_aggressive",
+            Self::RetryEmergency => "retry_emergency",
+        };
+        write!(f, "{}", s)
+    }
+}
+
 // ───────────────────────────── CompactionEvent ────────────────────────────
 
 /// Structured compaction event for real-time UX feedback.
@@ -113,9 +160,8 @@ impl CompactionTier {
 /// without parsing stderr heuristics.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CompactionEvent {
-    /// Human-readable label: "microcompact", "default_compression",
-    /// "aggressive_compression", "reactive_budget", "retry".
-    pub kind: String,
+    /// Compaction kind for type-safe event discrimination.
+    pub kind: CompactionKind,
     /// Pressure when compaction fired (0.0–1.0).
     pub pressure: f64,
     /// Tokens freed by this compaction round.
@@ -133,7 +179,7 @@ pub struct CompactionEvent {
 impl CompactionEvent {
     /// Build a compaction event from the raw numbers.
     pub fn new(
-        kind: &str,
+        kind: CompactionKind,
         pressure: f64,
         tokens_freed: u64,
         tokens_before: u64,
@@ -142,16 +188,16 @@ impl CompactionEvent {
         let tokens_after = tokens_before.saturating_sub(tokens_freed);
         // Dimmed prefix so the line is visually distinct from agent output.
         let summary = format!(
-            "  ♻ {}: freed ~{} tokens ({:.0}→{:.0} of {:.0}), pressure {:.0}%",
+            "  ♻ {}: freed ~{} tokens ({}→{} of {}), pressure {:.0}%",
             kind,
             tokens_freed,
             tokens_before,
             tokens_after,
-            max_tokens.try_into().unwrap_or(0),
+            max_tokens,
             pressure * 100.0,
         );
         Self {
-            kind: kind.to_string(),
+            kind,
             pressure,
             tokens_freed,
             tokens_before,
@@ -175,7 +221,13 @@ mod tests {
 
     #[test]
     fn compaction_event_summary_includes_before_after() {
-        let ev = CompactionEvent::new("reactive_budget", 0.88, 18_000, 185_000, 200_000);
+        let ev = CompactionEvent::new(
+            CompactionKind::ReactiveBudget,
+            0.88,
+            18_000,
+            185_000,
+            200_000,
+        );
         assert!(ev.summary.contains("♻"));
         assert!(ev.summary.contains("reactive_budget"));
         assert!(ev.summary.contains("185"));
@@ -187,15 +239,27 @@ mod tests {
 
     #[test]
     fn compaction_event_should_warn_at_70_percent() {
-        let low = CompactionEvent::new("default", 0.69, 1000, 50000, 100000);
-        let high = CompactionEvent::new("aggressive", 0.70, 2000, 70000, 100000);
+        let low = CompactionEvent::new(
+            CompactionKind::DefaultCompression,
+            0.69,
+            1000,
+            50000,
+            100000,
+        );
+        let high = CompactionEvent::new(
+            CompactionKind::AggressiveCompression,
+            0.70,
+            2000,
+            70000,
+            100000,
+        );
         assert!(!low.should_warn());
         assert!(high.should_warn());
     }
 
     #[test]
     fn compaction_event_tokens_after_saturates() {
-        let ev = CompactionEvent::new("test", 0.5, 500, 300, 500);
+        let ev = CompactionEvent::new(CompactionKind::DefaultCompression, 0.5, 500, 300, 500);
         assert_eq!(ev.tokens_after, 0);
     }
 
@@ -256,5 +320,47 @@ mod tests {
                 "aggressive={aggressive} must be above trigger={trigger} for {max_tokens}-token window"
             );
         }
+    }
+
+    #[test]
+    fn pre_turn_trigger_at_128k_boundary_is_correct() {
+        // 131071 (just below 128K) → 0.80 (standard window)
+        // 131072 (128K exactly) → 0.85 (large window)
+        let below = CompactionTier::pre_turn_trigger(131_071);
+        let at = CompactionTier::pre_turn_trigger(131_072);
+        let above = CompactionTier::pre_turn_trigger(131_073);
+
+        assert!(
+            (below - 0.80).abs() < 0.01,
+            "131071 should be ~0.80 (standard), got {below}"
+        );
+        assert!(
+            (at - 0.85).abs() < 0.01,
+            "131072 should be ~0.85 (large), got {at}"
+        );
+        assert!(
+            at > below,
+            "trigger must step up at 128K boundary: {below} → {at}"
+        );
+        assert!(
+            (above - 0.85).abs() < 0.01,
+            "131073 should stay at ~0.85 (large), got {above}"
+        );
+    }
+
+    #[test]
+    fn aggressive_trigger_at_128k_boundary() {
+        let below = CompactionTier::aggressive_trigger(131_071);
+        let at = CompactionTier::aggressive_trigger(131_072);
+
+        assert!(
+            at >= below,
+            "aggressive must not decrease at 128K: {below} → {at}"
+        );
+        // aggressive_trigger should be ≥ 0.90 for large windows.
+        assert!(
+            at >= 0.90,
+            "aggressive trigger at 128K must be at least 0.90, got {at}"
+        );
     }
 }

--- a/rust/crates/astra-turn-core/src/compaction_types.rs
+++ b/rust/crates/astra-turn-core/src/compaction_types.rs
@@ -2,15 +2,15 @@
 //!
 //! Extracted from `prompts::context` for cross-crate use.
 
+use serde::{Deserialize, Serialize};
+
 /// Token-budget compaction tier based on context window usage.
 ///
 /// Variants are declared in ascending order of aggressiveness. `PartialOrd`/`Ord`
 /// derive ordinal comparison from this order, so guards like
 /// `tier < CompactionTier::CompactHistory` and escalation via `tier.max(other)`
 /// rely on keeping new variants inserted at the correct position.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CompactionTier {
     /// < 60% of effective input limit — no action needed.
@@ -54,5 +54,207 @@ impl CompactionTier {
             _ => Self::AggressivePrune,
         };
         self.max(min_tier)
+    }
+
+    // ── Adaptive thresholds (context-window aware) ─────────────────
+
+    /// Pre-turn compaction trigger pressure, scaled to model context window.
+    ///
+    /// Smaller context windows need earlier compaction because the same
+    /// pressure ratio leaves less absolute token headroom. For example,
+    /// a 32 K model at 80% has only 6.4 K free — barely enough for one
+    /// tool output — while a 200 K model at 80% still has 40 K free.
+    #[must_use]
+    pub fn pre_turn_trigger(max_tokens: u64) -> f64 {
+        match max_tokens {
+            ..=32_767 => 0.70,        // ≤32 K: compact at 70%
+            32_768..=65_535 => 0.75,  // 32 K–65 K: compact at 75%
+            65_536..=131_071 => 0.80, // 65 K–128 K: compact at 80%
+            _ => 0.85,                // ≥128 K: compact at 85%
+        }
+    }
+
+    /// Pre-turn pressure-warning threshold, scaled to model context window.
+    ///
+    /// Always 10 points below the trigger so the user gets a heads-up
+    /// before compaction fires.
+    #[must_use]
+    pub fn pre_turn_warning(max_tokens: u64) -> f64 {
+        match max_tokens {
+            ..=32_767 => 0.60,
+            32_768..=65_535 => 0.65,
+            65_536..=131_071 => 0.70,
+            _ => 0.75,
+        }
+    }
+
+    /// Aggressive-compaction trigger pressure, scaled to model context window.
+    ///
+    /// When pressure exceeds this threshold, the aggressive pipeline
+    /// (summarising entire history) fires instead of the default pipeline.
+    /// Always above `pre_turn_trigger` by ~15 points, capped at 0.95.
+    #[must_use]
+    pub fn aggressive_trigger(max_tokens: u64) -> f64 {
+        match max_tokens {
+            ..=32_767 => 0.85,
+            32_768..=65_535 => 0.90,
+            _ => 0.95,
+        }
+    }
+}
+
+// ───────────────────────────── CompactionEvent ────────────────────────────
+
+/// Structured compaction event for real-time UX feedback.
+///
+/// Emitted by the agentic loop host whenever the compression pipeline
+/// fires — pre-turn, mid-turn, or on retry. Receivers (CLI scroller, TUI
+/// status line, context panel) use this to render live compaction feedback
+/// without parsing stderr heuristics.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CompactionEvent {
+    /// Human-readable label: "microcompact", "default_compression",
+    /// "aggressive_compression", "reactive_budget", "retry".
+    pub kind: String,
+    /// Pressure when compaction fired (0.0–1.0).
+    pub pressure: f64,
+    /// Tokens freed by this compaction round.
+    pub tokens_freed: u64,
+    /// Estimated tokens before compaction.
+    pub tokens_before: u64,
+    /// Estimated tokens after compaction.
+    pub tokens_after: u64,
+    /// Max context window tokens.
+    pub max_tokens: u64,
+    /// User-facing summary line.
+    pub summary: String,
+}
+
+impl CompactionEvent {
+    /// Build a compaction event from the raw numbers.
+    pub fn new(
+        kind: &str,
+        pressure: f64,
+        tokens_freed: u64,
+        tokens_before: u64,
+        max_tokens: u64,
+    ) -> Self {
+        let tokens_after = tokens_before.saturating_sub(tokens_freed);
+        // Dimmed prefix so the line is visually distinct from agent output.
+        let summary = format!(
+            "  ♻ {}: freed ~{} tokens ({:.0}→{:.0} of {:.0}), pressure {:.0}%",
+            kind,
+            tokens_freed,
+            tokens_before,
+            tokens_after,
+            max_tokens.try_into().unwrap_or(0),
+            pressure * 100.0,
+        );
+        Self {
+            kind: kind.to_string(),
+            pressure,
+            tokens_freed,
+            tokens_before,
+            tokens_after,
+            max_tokens,
+            summary,
+        }
+    }
+
+    /// Pressure is high enough to warrant a pre-turn warning
+    /// (before compaction triggers). Uses the event's max_tokens
+    /// for adaptive thresholding.
+    pub fn should_warn(&self) -> bool {
+        self.pressure >= CompactionTier::pre_turn_warning(self.max_tokens)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compaction_event_summary_includes_before_after() {
+        let ev = CompactionEvent::new("reactive_budget", 0.88, 18_000, 185_000, 200_000);
+        assert!(ev.summary.contains("♻"));
+        assert!(ev.summary.contains("reactive_budget"));
+        assert!(ev.summary.contains("185"));
+        assert!(ev.summary.contains("167"));
+        assert!(ev.summary.contains("200"));
+        assert!(ev.summary.contains("88%"));
+        assert_eq!(ev.tokens_after, 167_000);
+    }
+
+    #[test]
+    fn compaction_event_should_warn_at_70_percent() {
+        let low = CompactionEvent::new("default", 0.69, 1000, 50000, 100000);
+        let high = CompactionEvent::new("aggressive", 0.70, 2000, 70000, 100000);
+        assert!(!low.should_warn());
+        assert!(high.should_warn());
+    }
+
+    #[test]
+    fn compaction_event_tokens_after_saturates() {
+        let ev = CompactionEvent::new("test", 0.5, 500, 300, 500);
+        assert_eq!(ev.tokens_after, 0);
+    }
+
+    // ── Adaptive thresholds ────────────────────────────────────────
+
+    #[test]
+    fn pre_turn_trigger_decreases_for_small_windows() {
+        // 16 K window = tiny → compact at 70%
+        assert!((CompactionTier::pre_turn_trigger(16_000) - 0.70).abs() < 0.01);
+        // 32 K window = small → compact at 70%
+        assert!((CompactionTier::pre_turn_trigger(32_000) - 0.70).abs() < 0.01);
+        // 48 K window = medium → compact at 75%
+        assert!((CompactionTier::pre_turn_trigger(48_000) - 0.75).abs() < 0.01);
+        // 65 K window = standard → compact at 80%
+        assert!((CompactionTier::pre_turn_trigger(65_536) - 0.80).abs() < 0.01);
+        // 132 K window = large (128 K model) → compact at 85%
+        assert!((CompactionTier::pre_turn_trigger(131_072) - 0.85).abs() < 0.01);
+        // 200 K window = huge → compact at 85%
+        assert!((CompactionTier::pre_turn_trigger(200_000) - 0.85).abs() < 0.01);
+    }
+
+    #[test]
+    fn pre_turn_warning_is_below_trigger() {
+        for max_tokens in [16_000u64, 32_000, 48_000, 65_536, 128_000, 200_000] {
+            let trigger = CompactionTier::pre_turn_trigger(max_tokens);
+            let warning = CompactionTier::pre_turn_warning(max_tokens);
+            assert!(
+                warning < trigger,
+                "warning={warning} must be below trigger={trigger} for {max_tokens}-token window"
+            );
+        }
+    }
+
+    #[test]
+    fn pre_turn_thresholds_are_stable_at_boundaries() {
+        // Just below and just above each boundary should produce similar triggers.
+        // f64 representation of 0.05 may overshoot due to binary rounding —
+        // using 0.055 epsilon accounts for this.
+        assert!(
+            (CompactionTier::pre_turn_trigger(32_767) - CompactionTier::pre_turn_trigger(32_768))
+                .abs()
+                <= 0.055
+        );
+        assert!(
+            (CompactionTier::pre_turn_trigger(65_535) - CompactionTier::pre_turn_trigger(65_536))
+                .abs()
+                <= 0.055
+        );
+    }
+
+    #[test]
+    fn aggressive_trigger_above_pre_turn_trigger() {
+        for max_tokens in [16_000u64, 32_000, 48_000, 65_536, 131_072, 200_000] {
+            let trigger = CompactionTier::pre_turn_trigger(max_tokens);
+            let aggressive = CompactionTier::aggressive_trigger(max_tokens);
+            assert!(
+                aggressive > trigger,
+                "aggressive={aggressive} must be above trigger={trigger} for {max_tokens}-token window"
+            );
+        }
     }
 }

--- a/rust/crates/runtime/benches/hot_paths.rs
+++ b/rust/crates/runtime/benches/hot_paths.rs
@@ -2,18 +2,18 @@
 //!
 //! Run: `cargo bench -p astra-runtime --bench hot_paths`
 
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use serde_json::json;
 
 use astra_runtime::bridge::sse_events::{find_sse_frame_end, parse_sse_json_frame};
-use astra_runtime::prompts::{CompactionTier, estimate_str_tokens, estimate_tokens};
+use astra_runtime::prompts::{estimate_str_tokens, estimate_tokens, CompactionTier};
 use astra_runtime::text_tokenize::{build_tf, tokenize};
-use astra_runtime::tool_registry::ConversationState;
-use astra_runtime::tool_registry::TOOL_CATALOG;
 use astra_runtime::tool_registry::scoring::pre_filter_dynamic;
 use astra_runtime::tool_registry::tool_pool::{
-    SearchableToolMeta, ToolDenyPredicate, ToolPool, ToolSearchConfig, ToolSource, select_two_phase,
+    select_two_phase, SearchableToolMeta, ToolDenyPredicate, ToolPool, ToolSearchConfig, ToolSource,
 };
+use astra_runtime::tool_registry::ConversationState;
+use astra_runtime::tool_registry::TOOL_CATALOG;
 use astra_runtime::turn::cloud::compaction::compact_tiered;
 
 // ── Token Estimation ───────────────────────────────────────────────
@@ -58,12 +58,12 @@ fn bench_estimate_tokens_messages(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("estimate_tokens");
     group.bench_with_input(BenchmarkId::new("2_messages", 2), &small_msgs, |b, msgs| {
-        b.iter(|| estimate_tokens(black_box(msgs)))
+        b.iter(|| estimate_tokens(black_box(msgs), 0, 0))
     });
     group.bench_with_input(
         BenchmarkId::new("20_messages", 20),
         &large_msgs,
-        |b, msgs| b.iter(|| estimate_tokens(black_box(msgs))),
+        |b, msgs| b.iter(|| estimate_tokens(black_box(msgs), 0, 0)),
     );
     group.finish();
 }

--- a/rust/crates/runtime/benches/hot_paths.rs
+++ b/rust/crates/runtime/benches/hot_paths.rs
@@ -2,18 +2,18 @@
 //!
 //! Run: `cargo bench -p astra-runtime --bench hot_paths`
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use serde_json::json;
 
 use astra_runtime::bridge::sse_events::{find_sse_frame_end, parse_sse_json_frame};
-use astra_runtime::prompts::{estimate_str_tokens, estimate_tokens, CompactionTier};
+use astra_runtime::prompts::{CompactionTier, estimate_str_tokens, estimate_tokens};
 use astra_runtime::text_tokenize::{build_tf, tokenize};
-use astra_runtime::tool_registry::scoring::pre_filter_dynamic;
-use astra_runtime::tool_registry::tool_pool::{
-    select_two_phase, SearchableToolMeta, ToolDenyPredicate, ToolPool, ToolSearchConfig, ToolSource,
-};
 use astra_runtime::tool_registry::ConversationState;
 use astra_runtime::tool_registry::TOOL_CATALOG;
+use astra_runtime::tool_registry::scoring::pre_filter_dynamic;
+use astra_runtime::tool_registry::tool_pool::{
+    SearchableToolMeta, ToolDenyPredicate, ToolPool, ToolSearchConfig, ToolSource, select_two_phase,
+};
 use astra_runtime::turn::cloud::compaction::compact_tiered;
 
 // ── Token Estimation ───────────────────────────────────────────────

--- a/rust/crates/runtime/src/prompts/context.rs
+++ b/rust/crates/runtime/src/prompts/context.rs
@@ -38,34 +38,19 @@ pub fn estimate_str_tokens(s: &str) -> usize {
 }
 
 /// Approximate token count with CJK-aware estimation.
-/// Adds overhead per message for role/formatting tokens, plus estimated
-/// system prompt and tool schema overhead that the LLM API counts but
-/// we don't see in the messages array.
-pub fn estimate_tokens(messages: &[serde_json::Value]) -> usize {
-    const PER_MESSAGE_OVERHEAD: usize = 4; // role + separators
-    // System prompt (~1.2K tokens) + tool schemas (~1.5K tokens avg) + model framing
-    const FIXED_OVERHEAD: usize = 3000;
-    let message_tokens: usize = messages
-        .iter()
-        .map(|m| estimate_single_message_tokens(m) + PER_MESSAGE_OVERHEAD)
-        .sum();
-    message_tokens + FIXED_OVERHEAD
-}
-
-/// Precise token estimation using actual overhead measurements instead of the
-/// hardcoded 3,000-token `FIXED_OVERHEAD`.
+/// Adds overhead per message for role/formatting tokens, plus system prompt
+/// and tool schema overhead that the LLM API counts but we don't see in the
+/// messages array.
 ///
 /// * `schema_token_total` — sum of measured token costs for all selected tool
-///   schemas (from `ToolRegistry::token_cost`).
+///   schemas (from `ToolRegistry::token_cost`). Pass 0 if unavailable.
 /// * `system_prompt_tokens` — estimated tokens of the system prompt, or 0 to
-///   use the default 1,200 estimate.
+///   use the default 14,000 estimate.
 ///
-/// This produces more accurate compaction-tier decisions, especially under
-/// CJK-heavy conversations where the old estimate was 50% too low.
-/// Calibrated default: the full system prompt (~52 KB) is approximately 14 000 tokens.
+/// Calibrated default: the full system prompt (~52 KB) is approximately 14,000 tokens.
 pub const DEFAULT_SYSTEM_PROMPT_TOKENS: usize = 14_000;
 
-pub fn estimate_tokens_precise(
+pub fn estimate_tokens(
     messages: &[serde_json::Value],
     schema_token_total: usize,
     system_prompt_tokens: usize,
@@ -755,29 +740,10 @@ mod tests {
     }
 
     #[test]
-    fn estimate_tokens_unchanged_behavior() {
-        let messages = vec![msg(&"x".repeat(400))];
-        // 400/4 = 100 + 4 overhead + 3000 fixed = 3104
-        assert_eq!(estimate_tokens(&messages), 3104);
-    }
-
-    #[test]
-    fn estimate_tokens_with_tool_calls_unchanged() {
-        let messages = vec![tool_msg(&"y".repeat(200))];
-        // 200/4 = 50 args + 15 structural overhead + 4 msg overhead + 3000 fixed = 3069
-        assert_eq!(estimate_tokens(&messages), 3069);
-    }
-
-    #[test]
-    fn estimate_tokens_empty() {
-        assert_eq!(estimate_tokens(&[]), 3000);
-    }
-
-    #[test]
-    fn estimate_tokens_precise_includes_schema_tokens() {
+    fn estimate_tokens_includes_schema_tokens() {
         let msgs = vec![msg(&"x".repeat(400))];
-        let without_schema = estimate_tokens_precise(&msgs, 0, 0);
-        let with_schema = estimate_tokens_precise(&msgs, 50_000, 0);
+        let without_schema = estimate_tokens(&msgs, 0, 0);
+        let with_schema = estimate_tokens(&msgs, 50_000, 0);
         assert!(
             with_schema > without_schema + 40_000,
             "schema_token_total must be included: without={without_schema}, with={with_schema}",
@@ -819,6 +785,76 @@ mod tests {
         );
     }
 
+    /// Regression test for session 540c37d1:
+    /// Without schema token accounting, CJK-heavy conversations are severely
+    /// underestimated (pressure ~0.61 when real was ~0.89), so compaction
+    /// never triggered.
+    ///
+    /// `estimate_tokens` with schema tokens must produce a substantially
+    /// higher estimate than without, ensuring compaction gates fire.
+    #[test]
+    fn estimate_with_schema_dwarfs_estimate_without_schema_for_cjk() {
+        // Simulate session 540c37d1: ~50 CJK-heavy messages + tool results
+        let mut messages = Vec::new();
+        for i in 0..25 {
+            messages.push(msg(&format!(
+                "第{i}个回合：请帮我深入分析这段代码的问题，包括错误处理、性能瓶颈和可维护性"
+            )));
+            messages.push(msg(&format!(
+                "好的，让我详细分析第{i}个回合的问题。首先从错误处理的角度来看..."
+            )));
+        }
+        // Add some tool result messages (simulating file reads / greps)
+        for i in 0..10 {
+            messages.push(msg(&format!(
+                "{{\"result\": \"文件 file_{i}.rs 读取完成，共 200 行，发现以下潜在问题：...\", \"success\": true}}"
+            )));
+        }
+
+        let without_schema = estimate_tokens(&messages, 0, 0);
+        let with_schema = estimate_tokens(&messages, 50_000, 0);
+
+        // Schema-aware estimate must be at least 50% higher
+        let ratio = with_schema as f64 / without_schema as f64;
+        assert!(
+            ratio > 1.5,
+            "with schema ({with_schema}) must be >1.5× without schema ({without_schema}) for CJK-heavy sessions; got {ratio:.2}x"
+        );
+    }
+
+    /// `estimate_tokens` with schema tokens must produce estimates
+    /// that push past compaction thresholds when the session is truly large.
+    /// With a 128K model and 0.75 compact_threshold, the trim-start is at
+    /// 0.75 * 0.80 * 0.85 * 128K ≈ 65K effective tokens.
+    #[test]
+    fn estimate_crosses_compact_threshold_for_large_cjk_session() {
+        let mut messages = Vec::new();
+        // Build a large CJK conversation with tool results
+        for i in 0..40 {
+            messages.push(msg(&format!(
+                "请继续分析和修复第{i}个文件中的问题代码，关注性能和安全"
+            )));
+            messages.push(msg(&format!(
+                "正在分析第{i}个文件。发现错误处理缺失、循环内有分配、SQL注入风险等问题。建议：1. 引入Result类型 2. 预分配vector 3. 使用参数化查询..."
+            )));
+            if i < 25 {
+                messages.push(msg(&format!(
+                    "{{\"lines\": \"// file_{i}.rs 原始文件内容\\nfn main() {{\\n    let x = 1;\\n}}\", \"matches\": 3, \"path\": \"src/file_{i}.rs\"}}"
+                )));
+            }
+        }
+
+        let estimated = estimate_tokens(&messages, 50_000, 0);
+        // With 40 user + 40 assistant + 25 tool msgs (~105 total), CJK content,
+        // 50K schema + 14K system prompt, the estimate should exceed 65K,
+        // the TrimSchemas trigger for the default 128K model.
+        assert!(
+            estimated > 65_000,
+            "CJK session ({count} msgs) with schema tokens should cross TrimSchemas trigger: got {estimated}",
+            count = messages.len(),
+        );
+    }
+
     #[test]
     fn estimate_str_tokens_cjk_punctuation() {
         // CJK punctuation (U+3000-303F, FF00-FFEF) counts as CJK tokens
@@ -834,9 +870,14 @@ mod tests {
 
     #[test]
     fn estimate_tokens_cjk_message() {
-        // CJK message: "分析一下这个文件" = 8 CJK chars × 1.5 = 12 tokens + 4 overhead + 3000 fixed
+        // CJK message: "分析一下这个文件" = 8 CJK chars × 1.5 = 12 tokens
+        // + 4 overhead + 14_000 sys + 300 framing = 14_316
         let messages = vec![msg("分析一下这个文件")];
-        assert_eq!(estimate_tokens(&messages), 12 + 4 + 3000);
+        let est = estimate_tokens(&messages, 0, 0);
+        assert!(
+            est > 14_000,
+            "CJK message should estimate > 14K tokens, got {est}"
+        );
     }
 
     // ── Phase 6.1: Mixed EN/CN regression tests ──
@@ -983,21 +1024,21 @@ mod tests {
     #[test]
     fn capped_output_tokens_default_16k() {
         let b = budget_for_model(None); // 128K, 0.15
-        // full_reserve = 128_000 * 0.15 = 19_200 → capped to 16_384 (large model)
+                                        // full_reserve = 128_000 * 0.15 = 19_200 → capped to 16_384 (large model)
         assert_eq!(capped_output_tokens(&b), 16_384);
     }
 
     #[test]
     fn capped_output_tokens_scales_for_small_model() {
         let b = budget_for_model(Some("gpt-3.5")); // 16K, 0.12
-        // full_reserve = 16_000 * 0.12 = 1_920 → min(1920, 8192) = 1920 (small model cap)
+                                                   // full_reserve = 16_000 * 0.12 = 1_920 → min(1920, 8192) = 1920 (small model cap)
         assert_eq!(capped_output_tokens(&b), 1920);
     }
 
     #[test]
     fn capped_output_tokens_claude_16k() {
         let b = budget_for_model(Some("claude-3.5-sonnet")); // 200K, 0.20
-        // full_reserve = 200_000 * 0.20 = 40_000 → capped to 16_384 (large model)
+                                                             // full_reserve = 200_000 * 0.20 = 40_000 → capped to 16_384 (large model)
         assert_eq!(capped_output_tokens(&b), 16_384);
     }
 
@@ -1063,17 +1104,21 @@ mod tests {
     }
 
     #[test]
-    fn estimate_tokens_empty_messages_has_fixed_overhead() {
-        let tokens = estimate_tokens(&[]);
-        // Just FIXED_OVERHEAD (3000) with no messages
-        assert_eq!(tokens, 3000);
+    fn estimate_tokens_empty_messages_has_base_overhead() {
+        // Empty messages still account for system prompt + model framing.
+        // DEFAULT_SYSTEM_PROMPT_TOKENS (14_000) + MODEL_FRAMING (300) = 14_300
+        let tokens = estimate_tokens(&[], 0, 0);
+        assert!(
+            tokens >= 14_000,
+            "empty messages should have base overhead, got {tokens}"
+        );
     }
 
     #[test]
     fn estimate_tokens_message_without_content() {
-        let tokens = estimate_tokens(&[json!({"role": "user"})]);
+        let tokens = estimate_tokens(&[json!({"role": "user"})], 0, 0);
         // Should not panic on missing content
-        assert!(tokens > 3000); // overhead + per-message overhead
+        assert!(tokens > 14_000); // overhead + per-message overhead
     }
 
     #[test]
@@ -1416,7 +1461,7 @@ mod tests {
         // Should use default values
         assert!((b.compact_threshold - 0.8).abs() < f64::EPSILON);
         assert_eq!(b.keep_recent_turns, 3); // default preserve_recent_turns
-        // 4000 tokens * 4 chars = 16000 chars
+                                            // 4000 tokens * 4 chars = 16000 chars
         assert_eq!(b.memory_budget_chars, 16000);
     }
 

--- a/rust/crates/runtime/src/prompts/context.rs
+++ b/rust/crates/runtime/src/prompts/context.rs
@@ -55,7 +55,6 @@ pub fn estimate_tokens(
     schema_token_total: usize,
     system_prompt_tokens: usize,
 ) -> usize {
-    const PER_MESSAGE_OVERHEAD: usize = 4;
     const MODEL_FRAMING: usize = 300; // JSON wrappers, role tokens, separators
 
     let sys_tokens = if system_prompt_tokens > 0 {
@@ -71,8 +70,10 @@ pub fn estimate_tokens(
     message_tokens + sys_tokens + schema_token_total + MODEL_FRAMING
 }
 
+pub(crate) const PER_MESSAGE_OVERHEAD: usize = 4;
+
 /// Estimate tokens for a single message (content + tool_calls arguments).
-fn estimate_single_message_tokens(m: &serde_json::Value) -> usize {
+pub(crate) fn estimate_single_message_tokens(m: &serde_json::Value) -> usize {
     let content_tokens = m
         .get("content")
         .and_then(|v| v.as_str())
@@ -119,7 +120,6 @@ pub struct CacheAwareEstimate {
 }
 
 fn estimate_message_batch_tokens(messages: &[serde_json::Value]) -> usize {
-    const PER_MESSAGE_OVERHEAD: usize = 4;
     messages
         .iter()
         .map(|m| estimate_single_message_tokens(m) + PER_MESSAGE_OVERHEAD)
@@ -1024,21 +1024,21 @@ mod tests {
     #[test]
     fn capped_output_tokens_default_16k() {
         let b = budget_for_model(None); // 128K, 0.15
-                                        // full_reserve = 128_000 * 0.15 = 19_200 → capped to 16_384 (large model)
+        // full_reserve = 128_000 * 0.15 = 19_200 → capped to 16_384 (large model)
         assert_eq!(capped_output_tokens(&b), 16_384);
     }
 
     #[test]
     fn capped_output_tokens_scales_for_small_model() {
         let b = budget_for_model(Some("gpt-3.5")); // 16K, 0.12
-                                                   // full_reserve = 16_000 * 0.12 = 1_920 → min(1920, 8192) = 1920 (small model cap)
+        // full_reserve = 16_000 * 0.12 = 1_920 → min(1920, 8192) = 1920 (small model cap)
         assert_eq!(capped_output_tokens(&b), 1920);
     }
 
     #[test]
     fn capped_output_tokens_claude_16k() {
         let b = budget_for_model(Some("claude-3.5-sonnet")); // 200K, 0.20
-                                                             // full_reserve = 200_000 * 0.20 = 40_000 → capped to 16_384 (large model)
+        // full_reserve = 200_000 * 0.20 = 40_000 → capped to 16_384 (large model)
         assert_eq!(capped_output_tokens(&b), 16_384);
     }
 
@@ -1461,7 +1461,7 @@ mod tests {
         // Should use default values
         assert!((b.compact_threshold - 0.8).abs() < f64::EPSILON);
         assert_eq!(b.keep_recent_turns, 3); // default preserve_recent_turns
-                                            // 4000 tokens * 4 chars = 16000 chars
+        // 4000 tokens * 4 chars = 16000 chars
         assert_eq!(b.memory_budget_chars, 16000);
     }
 

--- a/rust/crates/runtime/src/prompts/mod.rs
+++ b/rust/crates/runtime/src/prompts/mod.rs
@@ -19,6 +19,7 @@ pub use context::{
     budget_for_model, budget_for_model_with_override, capped_output_tokens, estimate_str_tokens,
     estimate_tokens, estimate_tokens_cache_aware, estimate_tokens_cache_aware_split,
 };
+pub(crate) use context::{PER_MESSAGE_OVERHEAD, estimate_single_message_tokens};
 pub use system::{
     CacheScope, LOW_CONFIDENCE_THRESHOLD, PARALLEL_BATCHING_NUDGE_THRESHOLD, PromptOverrides,
     PromptSection, PromptTokenBucket, ROUND_BUDGET_HARD_LIMIT, ROUND_BUDGET_THRESHOLD, STALL_NUDGE,

--- a/rust/crates/runtime/src/prompts/mod.rs
+++ b/rust/crates/runtime/src/prompts/mod.rs
@@ -18,7 +18,6 @@ pub use context::{
     CacheAwareEstimate, CompactConfig, CompactionTier, ContextBudget, DEFAULT_SYSTEM_PROMPT_TOKENS,
     budget_for_model, budget_for_model_with_override, capped_output_tokens, estimate_str_tokens,
     estimate_tokens, estimate_tokens_cache_aware, estimate_tokens_cache_aware_split,
-    estimate_tokens_precise,
 };
 pub use system::{
     CacheScope, LOW_CONFIDENCE_THRESHOLD, PARALLEL_BATCHING_NUDGE_THRESHOLD, PromptOverrides,
@@ -322,15 +321,16 @@ mod tests {
     #[test]
     fn estimate_tokens_empty() {
         // Empty messages still have fixed overhead (system prompt + tools)
-        assert_eq!(estimate_tokens(&[]), 3000);
+        let est = estimate_tokens(&[], 0, 0);
+        assert!(est >= 14_000, "should have base overhead, got {est}");
     }
 
     #[test]
     fn estimate_tokens_basic() {
         let msgs = vec![serde_json::json!({"role": "user", "content": "hello world"})];
-        let est = estimate_tokens(&msgs);
-        // "hello world" = 11 chars → 11/4 = 2 tokens + 4 overhead + 3000 fixed ≈ 3006
-        assert!(est > 3000 && est < 3020, "got {est}");
+        let est = estimate_tokens(&msgs, 0, 0);
+        // "hello world" = 11 chars → 11/4 = 2 tokens + 4 overhead + 14_000 + 300 ≈ 14_306
+        assert!(est > 14_000 && est < 14_500, "got {est}");
     }
 
     #[test]
@@ -338,7 +338,7 @@ mod tests {
         let short = vec![serde_json::json!({"role": "user", "content": "hi"})];
         let long = vec![serde_json::json!({"role": "user", "content": "a".repeat(4000)})];
         // Long should be significantly more than short (not just overhead)
-        assert!(estimate_tokens(&long) > estimate_tokens(&short) + 500);
+        assert!(estimate_tokens(&long, 0, 0) > estimate_tokens(&short, 0, 0) + 500);
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -15,7 +15,7 @@ use astra_turn_core::agentic_turn_ingest::{
     agentic_turn_stream_snapshot_with_kind, ingest_agentic_turn_stream,
     map_ingest_outcome_to_iteration_control,
 };
-use astra_turn_core::compaction_types::CompactionTier;
+use astra_turn_core::compaction_types::{CompactionEvent, CompactionTier};
 use astra_turn_core::interaction_types::TurnInteractionMode;
 use astra_turn_core::interruption::{InterruptionKind, InterruptionRecord, ResumeAction};
 use uuid::Uuid;
@@ -1078,20 +1078,23 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                             sess.recovery.record_reactive_compact();
                             sess.stats.record_compaction(result.tokens_freed);
                         }
-                        let summary = super::super::compaction_replay::compaction_summary(&result);
+                        let tokens_freed = result.pipeline_outcome.total_tokens_freed;
                         if !prep.quiet {
-                            host.emit_headless_line(
-                                HeadlessStderrStyle::Yellow,
-                                format!(
-                                    "♻ Context overflow — {} pipeline: {}; retrying turn…",
-                                    tier_label, summary,
-                                ),
+                            let pressure = state.last_measured_prompt_tokens
+                                .unwrap_or(0) as f64
+                                / state.max_turn_input_tokens as f64;
+                            let event = CompactionEvent::new(
+                                &format!("retry_{}", tier_label),
+                                pressure,
+                                tokens_freed,
+                                state.last_measured_prompt_tokens.unwrap_or(0),
+                                state.max_turn_input_tokens,
                             );
+                            host.on_compaction(event);
                         }
 
                         // Emit structured compaction telemetry for observability.
                         if let Some(sid) = state.current_session_id.as_deref() {
-                            let tokens_freed = result.pipeline_outcome.total_tokens_freed;
                             let budget_likely_satisfied = result.budget_likely_satisfied;
                             let layers: Vec<(String, u64)> = result
                                 .pipeline_outcome
@@ -2538,7 +2541,7 @@ async fn handle_token_budget<H: AgenticLoopHost>(
     if !state.budget_wrapup_injected
         && state.compaction_effectiveness.attempt_count < MAX_REACTIVE_BUDGET_COMPACTION_ATTEMPTS
     {
-        let budget = super::super::context_compression::TokenBudget {
+        let budget = super::super::cloud::compaction_engine::TokenBudget {
             max_prompt_tokens: state.max_turn_input_tokens,
             last_measured_tokens: measured,
             current_round_index: Some(state.current_round_index),
@@ -2546,7 +2549,7 @@ async fn handle_token_budget<H: AgenticLoopHost>(
         let mut total_freed = 0;
         if state.compact_tier_applied < CompactionTier::CompactHistory {
             let pipeline =
-                super::super::context_compression::CompressionPipeline::aggressive_pipeline();
+                super::super::cloud::compaction_engine::CompactionEngine::aggressive_pipeline();
             let outcome = pipeline.compress_if_needed(&mut state.messages, &budget);
             total_freed = outcome.total_tokens_freed;
         }
@@ -2570,13 +2573,15 @@ async fn handle_token_budget<H: AgenticLoopHost>(
 
         if total_freed > 0 {
             if !prep.quiet {
-                host.emit_headless_line(
-                    HeadlessStderrStyle::Yellow,
-                    format!(
-                        "♻ Context pressure {measured}/{} tokens — freed ~{} tokens (compact+spill), continuing.",
-                        state.max_turn_input_tokens, total_freed,
-                    ),
+                let pressure = measured as f64 / state.max_turn_input_tokens as f64;
+                let event = CompactionEvent::new(
+                    "reactive_budget",
+                    pressure,
+                    total_freed,
+                    measured,
+                    state.max_turn_input_tokens,
                 );
+                host.on_compaction(event);
             }
             if let Some(ref mut sess) = state.pipeline_session {
                 sess.recovery.record_reactive_compact();

--- a/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -15,7 +15,7 @@ use astra_turn_core::agentic_turn_ingest::{
     agentic_turn_stream_snapshot_with_kind, ingest_agentic_turn_stream,
     map_ingest_outcome_to_iteration_control,
 };
-use astra_turn_core::compaction_types::{CompactionEvent, CompactionTier};
+use astra_turn_core::compaction_types::{CompactionEvent, CompactionKind, CompactionTier};
 use astra_turn_core::interaction_types::TurnInteractionMode;
 use astra_turn_core::interruption::{InterruptionKind, InterruptionRecord, ResumeAction};
 use uuid::Uuid;
@@ -1072,7 +1072,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                 );
                 match outcome {
                     super::super::compaction_replay::CompactionReplayOutcome::Compacted(result) => {
-                        let tier_label = result.tier.label();
+                        let tier_label = result.tier.to_string();
                         // Feed compaction stats into pipeline for reserve estimation.
                         if let Some(ref mut sess) = state.pipeline_session {
                             sess.recovery.record_reactive_compact();
@@ -1080,14 +1080,23 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                         }
                         let tokens_freed = result.pipeline_outcome.total_tokens_freed;
                         if !prep.quiet {
-                            let pressure = state.last_measured_prompt_tokens
-                                .unwrap_or(0) as f64
-                                / state.max_turn_input_tokens as f64;
+                            // In a retry context we know we overflowed the
+                            // context window, so use max_turn_input_tokens as
+                            // the floor for tokens_before when measured value
+                            // is unavailable (rather than 0, which is misleading).
+                            let tokens_before = state
+                                .last_measured_prompt_tokens
+                                .unwrap_or(state.max_turn_input_tokens);
+                            let pressure = if state.max_turn_input_tokens == 0 {
+                                0.0
+                            } else {
+                                (tokens_before as f64 / state.max_turn_input_tokens as f64).min(1.0)
+                            };
                             let event = CompactionEvent::new(
-                                &format!("retry_{}", tier_label),
+                                result.tier,
                                 pressure,
                                 tokens_freed,
-                                state.last_measured_prompt_tokens.unwrap_or(0),
+                                tokens_before,
                                 state.max_turn_input_tokens,
                             );
                             host.on_compaction(event);
@@ -1106,7 +1115,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                                 astra_services::session_journal::JournalEvent::compaction_retry(
                                     Some(sid),
                                     session_turn_number(state),
-                                    tier_label,
+                                    &tier_label,
                                     tokens_freed,
                                     budget_likely_satisfied,
                                     state.consecutive_context_window_errors,
@@ -2575,7 +2584,7 @@ async fn handle_token_budget<H: AgenticLoopHost>(
             if !prep.quiet {
                 let pressure = measured as f64 / state.max_turn_input_tokens as f64;
                 let event = CompactionEvent::new(
-                    "reactive_budget",
+                    CompactionKind::ReactiveBudget,
                     pressure,
                     total_freed,
                     measured,

--- a/rust/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/host.rs
@@ -49,8 +49,8 @@
 //! which wraps this loop with consistent outcome mapping.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use astra_services::session_audit::RuntimePromotionEventData;
@@ -133,8 +133,8 @@ pub struct HostTurnResult {
 }
 
 pub use astra_turn_core::interaction_types::{
-    interaction_scoped_tool_restrictions, tool_counts_as_factual_evidence, TurnInteractionMode,
-    TurnInteractionPolicy, ASK_USER_TOOL_NAME,
+    ASK_USER_TOOL_NAME, TurnInteractionMode, TurnInteractionPolicy,
+    interaction_scoped_tool_restrictions, tool_counts_as_factual_evidence,
 };
 
 // ─── Host trait ──────────────────────────────────────────────────────────────
@@ -200,7 +200,10 @@ pub trait AgenticLoopHost: Send {
     /// have a UI layer (CLI / TUI) should override to emit a structured
     /// event (e.g. `StreamEvent::Compaction`) for richer rendering.
     fn on_compaction(&mut self, event: CompactionEvent) {
-        self.emit_headless_line(HeadlessStderrStyle::Dim, event.summary);
+        // Clone to avoid moving event.summary — subclasses overriding this
+        // method receive the full event by value and may inspect all fields.
+        let summary = event.summary.clone();
+        self.emit_headless_line(HeadlessStderrStyle::Dim, summary);
     }
 
     /// Whether the current turn is still in read-only plan authoring mode.
@@ -1608,9 +1611,9 @@ fn apply_harness_pause_recovery_threshold(
 
 #[allow(unused_imports)]
 pub(crate) use super::super::agentic::adaptive_tuning::{
-    apply_adaptive_execution_profile, apply_per_turn_adaptation, apply_tactical_actions,
-    maybe_run_tuning_cycle, record_loop_completion_feedback, should_emit_adaptive_scenario_event,
-    DEFAULT_TUNING_CYCLE_INTERVAL,
+    DEFAULT_TUNING_CYCLE_INTERVAL, apply_adaptive_execution_profile, apply_per_turn_adaptation,
+    apply_tactical_actions, maybe_run_tuning_cycle, record_loop_completion_feedback,
+    should_emit_adaptive_scenario_event,
 };
 #[cfg(test)]
 pub(crate) use super::tool_support::delegate_tool_schema;
@@ -1644,20 +1647,20 @@ pub const DELEGATE_TOOL_NAME: &str =
 
 #[allow(unused_imports)]
 pub(crate) use super::super::agentic::delegate_interception::{
-    coordination_pattern_name, delegation_adaptive_context, delegation_final_output_preview,
-    format_delegation_result, format_delegation_terminal_preview, is_delegation_call,
-    merge_workspace_hint_into_delegation_request, parse_coordination_pattern,
+    DelegationAdaptiveContext, DelegationExecutionResult, DelegationFinalOutputSource,
+    DelegationOutcomeMetadata, coordination_pattern_name, delegation_adaptive_context,
+    delegation_final_output_preview, format_delegation_result, format_delegation_terminal_preview,
+    is_delegation_call, merge_workspace_hint_into_delegation_request, parse_coordination_pattern,
     parse_delegate_agents, parse_delegation_request, partition_and_execute_delegations,
     pattern_from_name, select_default_coordination_pattern, task_needs_review,
-    tool_call_arguments_value, tool_call_name, DelegationAdaptiveContext,
-    DelegationExecutionResult, DelegationFinalOutputSource, DelegationOutcomeMetadata,
+    tool_call_arguments_value, tool_call_name,
 };
 
 #[allow(unused_imports)]
 use super::super::harness_adapter::harness_at;
 #[allow(unused_imports)]
 pub(crate) use super::execution_phase::{
-    execute_turn_and_ingest_phase, TurnExecutionControl, TurnExecutionPhase,
+    TurnExecutionControl, TurnExecutionPhase, execute_turn_and_ingest_phase,
 };
 #[allow(unused_imports)]
 pub(crate) use super::finalization::{
@@ -1666,10 +1669,10 @@ pub(crate) use super::finalization::{
 };
 #[allow(unused_imports)]
 pub(crate) use super::lifecycle::{
-    prepare_turn_iteration, run_loop_preamble, PreparedTurnIteration, TurnIterationPrep,
+    PreparedTurnIteration, TurnIterationPrep, prepare_turn_iteration, run_loop_preamble,
 };
 #[allow(unused_imports)]
-pub(crate) use super::tool_phase::{execute_tool_phase, TurnToolPhaseControl};
+pub(crate) use super::tool_phase::{TurnToolPhaseControl, execute_tool_phase};
 
 #[cfg(feature = "harness")]
 pub(crate) fn set_harness_interruption(
@@ -2839,7 +2842,7 @@ pub(crate) mod tests {
         // Tokens accumulate across turns (+=)
         assert_eq!(state.total_prompt, 35); // 20 + 15
         assert_eq!(state.total_completion, 15); // 10 + 5
-                                                // Edge tool counted
+        // Edge tool counted
         assert!(state.total_tool_calls >= 1);
         // Messages accumulated: assistant + tool from turn 1, at minimum
         assert!(state.messages.len() >= 2);
@@ -3019,7 +3022,7 @@ pub(crate) mod tests {
         assert_eq!(host.current_turn, 0); // No turns executed
         assert!(state.final_text.contains("without a final answer")); // EmptyCompletion message
         assert_eq!(state.remaining_turns, 10); // Unchanged
-                                               // EmptyCompletion interruption recorded
+        // EmptyCompletion interruption recorded
         let interruption = state
             .interruption
             .as_ref()
@@ -3191,11 +3194,13 @@ pub(crate) mod tests {
         assert!(outcome.is_ok());
         assert_eq!(host.current_turn, 2);
         assert!(state.final_text.contains("Turn budget exhausted"));
-        assert!(!state
-            .messages
-            .iter()
-            .filter_map(|message| message.get("content").and_then(Value::as_str))
-            .any(|content| content.contains("Budget review")));
+        assert!(
+            !state
+                .messages
+                .iter()
+                .filter_map(|message| message.get("content").and_then(Value::as_str))
+                .any(|content| content.contains("Budget review"))
+        );
     }
 
     #[tokio::test]
@@ -3300,14 +3305,18 @@ pub(crate) mod tests {
             !state.final_text.contains("changes look good"),
             "budget exhaustion must overwrite stale success-shaped text"
         );
-        assert!(state
-            .final_text
-            .contains("Turn budget exhausted after 2 agentic turn(s)"));
-        assert!(!state
-            .messages
-            .iter()
-            .filter_map(|message| message.get("content").and_then(Value::as_str))
-            .any(|content| content.contains("Budget review")));
+        assert!(
+            state
+                .final_text
+                .contains("Turn budget exhausted after 2 agentic turn(s)")
+        );
+        assert!(
+            !state
+                .messages
+                .iter()
+                .filter_map(|message| message.get("content").and_then(Value::as_str))
+                .any(|content| content.contains("Budget review"))
+        );
     }
 
     #[tokio::test]
@@ -3922,14 +3931,14 @@ pub(crate) mod tests {
     // ── E2E delegation round-trip tests ─────────────────────────────────────
 
     /// Helper to build a DelegationEngine with StubSubRunExecutor for tests.
-    pub(crate) fn make_test_delegation_engine(
-    ) -> Arc<crate::server::delegation::engine::DelegationEngine> {
+    pub(crate) fn make_test_delegation_engine()
+    -> Arc<crate::server::delegation::engine::DelegationEngine> {
         use crate::server::delegation::engine::{
             DelegationEngine, DelegationTracker, StubSubRunExecutor,
         };
         use crate::server::run::engine::RunEngine;
-        use astra_services::coordination::{AgentProfile, AgentTier};
         use astra_services::AgentProfileRegistry;
+        use astra_services::coordination::{AgentProfile, AgentTier};
 
         let mut registry = AgentProfileRegistry::new();
         let _ = registry.register(AgentProfile::new(
@@ -4933,14 +4942,18 @@ pub(crate) mod tests {
             .filter(|m| m.get("tool_call_id").and_then(Value::as_str) == Some("call_1"))
             .collect();
         assert_eq!(msg1.len(), 1);
-        assert!(msg1[0]["content"]
-            .as_str()
-            .unwrap()
-            .contains("# Skill: test-skill"));
-        assert!(msg1[0]["content"]
-            .as_str()
-            .unwrap()
-            .contains("Follow these instructions carefully."));
+        assert!(
+            msg1[0]["content"]
+                .as_str()
+                .unwrap()
+                .contains("# Skill: test-skill")
+        );
+        assert!(
+            msg1[0]["content"]
+                .as_str()
+                .unwrap()
+                .contains("Follow these instructions carefully.")
+        );
 
         // Second call: replay loaded content + dedup note.
         let msg2: Vec<&Value> = state
@@ -5000,20 +5013,24 @@ pub(crate) mod tests {
             .iter()
             .filter(|m| m.get("tool_call_id").and_then(Value::as_str) == Some("call_1"))
             .collect();
-        assert!(msg1[0]["content"]
-            .as_str()
-            .unwrap()
-            .contains("# Skill: test-skill"));
+        assert!(
+            msg1[0]["content"]
+                .as_str()
+                .unwrap()
+                .contains("# Skill: test-skill")
+        );
 
         let msg2: Vec<&Value> = state
             .messages
             .iter()
             .filter(|m| m.get("tool_call_id").and_then(Value::as_str) == Some("call_2"))
             .collect();
-        assert!(msg2[0]["content"]
-            .as_str()
-            .unwrap()
-            .contains("# Skill: other-skill"));
+        assert!(
+            msg2[0]["content"]
+                .as_str()
+                .unwrap()
+                .contains("# Skill: other-skill")
+        );
 
         // Both tracked
         assert_eq!(state.skills.invoked.len(), 2);
@@ -5148,10 +5165,12 @@ pub(crate) mod tests {
             .filter(|m| m.get("tool_call_id").and_then(Value::as_str) == Some("call_skill"))
             .collect();
         assert_eq!(skill_msgs.len(), 1);
-        assert!(skill_msgs[0]["content"]
-            .as_str()
-            .unwrap()
-            .contains("# Skill: test-skill"));
+        assert!(
+            skill_msgs[0]["content"]
+                .as_str()
+                .unwrap()
+                .contains("# Skill: test-skill")
+        );
 
         // Skill exclusivity drop is now a debug log, not a user-facing headless line.
         // Verify the host did NOT receive any deferred notice (it goes to tracing now).
@@ -6398,8 +6417,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
         }
     }
 
-    fn make_session(
-    ) -> std::sync::Arc<std::sync::RwLock<crate::observability::ObservabilitySession>> {
+    fn make_session()
+    -> std::sync::Arc<std::sync::RwLock<crate::observability::ObservabilitySession>> {
         std::sync::Arc::new(std::sync::RwLock::new(
             crate::observability::ObservabilitySession::new_simple("test-session"),
         ))
@@ -7870,7 +7889,7 @@ print(json.dumps({'context': 'user said: ' + msg}))
 
     #[test]
     fn stress_all_8_default_rules_fire() {
-        use astra_learning::auto_tuning::{default_rules, FeedbackSignal, SignalType};
+        use astra_learning::auto_tuning::{FeedbackSignal, SignalType, default_rules};
 
         let hub = make_hub();
         // Load default evolution rules so the tuning engine has something to evaluate
@@ -9325,7 +9344,7 @@ mod parallel_execution_tests {
     /// Unit test for partition_tool_batches.
     #[test]
     fn partition_tool_batches_groups_correctly() {
-        use crate::turn::agentic::headless_round::{partition_tool_batches, ToolBatch};
+        use crate::turn::agentic::headless_round::{ToolBatch, partition_tool_batches};
         use astra_turn_core::headless_tool_assembly::HeadlessRoundToolIdx;
 
         let tool_calls = vec![

--- a/rust/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/host.rs
@@ -49,8 +49,8 @@
 //! which wraps this loop with consistent outcome mapping.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use astra_services::session_audit::RuntimePromotionEventData;
@@ -65,7 +65,7 @@ use astra_text_utils::semantic_dedup::SemanticDedup;
 use astra_tools::task_mgmt::{SessionTask, TaskManager};
 use astra_turn_core::chat_turn_heuristics::TaskExecutionProfile;
 use astra_turn_core::chat_turn_sse_dispatch::ChatTurnSseAccum;
-use astra_turn_core::compaction_types::CompactionTier;
+use astra_turn_core::compaction_types::{CompactionEvent, CompactionTier};
 use astra_turn_core::guardrails::turn_guard::TurnGuard;
 use astra_turn_core::guardrails::verdict_audit::AgenticVerdictAuditEvent;
 use astra_turn_core::headless_tool_body_preview::HeadlessStderrStyle;
@@ -133,8 +133,8 @@ pub struct HostTurnResult {
 }
 
 pub use astra_turn_core::interaction_types::{
-    ASK_USER_TOOL_NAME, TurnInteractionMode, TurnInteractionPolicy,
-    interaction_scoped_tool_restrictions, tool_counts_as_factual_evidence,
+    interaction_scoped_tool_restrictions, tool_counts_as_factual_evidence, TurnInteractionMode,
+    TurnInteractionPolicy, ASK_USER_TOOL_NAME,
 };
 
 // ─── Host trait ──────────────────────────────────────────────────────────────
@@ -191,6 +191,16 @@ pub trait AgenticLoopHost: Send {
     /// hasn't been updated yet.
     fn turn_interaction_mode(&self) -> TurnInteractionMode {
         TurnInteractionMode::NonInteractive
+    }
+
+    /// Emit a structured compaction event for real-time UX feedback.
+    ///
+    /// Default implementation falls back to [`emit_headless_line`] so
+    /// existing hosts get stderr output without changes. Hosts that
+    /// have a UI layer (CLI / TUI) should override to emit a structured
+    /// event (e.g. `StreamEvent::Compaction`) for richer rendering.
+    fn on_compaction(&mut self, event: CompactionEvent) {
+        self.emit_headless_line(HeadlessStderrStyle::Dim, event.summary);
     }
 
     /// Whether the current turn is still in read-only plan authoring mode.
@@ -1125,7 +1135,7 @@ pub struct AgenticLoopState {
     pub compaction_effectiveness: super::super::compaction_replay::CompactionEffectivenessTracker,
 
     /// Measured token cost of the tool schemas injected into the LLM request.
-    /// Passed to `estimate_tokens_precise` so pressure estimates include the
+    /// Passed to `estimate_tokens` so pressure estimates include the
     /// schema overhead the API will count. 0 = unknown (legacy / sub-runs).
     pub pinned_tool_schema_tokens: u64,
     /// Cache-sensitive sticky tool schema set for the current user turn.
@@ -1598,9 +1608,9 @@ fn apply_harness_pause_recovery_threshold(
 
 #[allow(unused_imports)]
 pub(crate) use super::super::agentic::adaptive_tuning::{
-    DEFAULT_TUNING_CYCLE_INTERVAL, apply_adaptive_execution_profile, apply_per_turn_adaptation,
-    apply_tactical_actions, maybe_run_tuning_cycle, record_loop_completion_feedback,
-    should_emit_adaptive_scenario_event,
+    apply_adaptive_execution_profile, apply_per_turn_adaptation, apply_tactical_actions,
+    maybe_run_tuning_cycle, record_loop_completion_feedback, should_emit_adaptive_scenario_event,
+    DEFAULT_TUNING_CYCLE_INTERVAL,
 };
 #[cfg(test)]
 pub(crate) use super::tool_support::delegate_tool_schema;
@@ -1634,20 +1644,20 @@ pub const DELEGATE_TOOL_NAME: &str =
 
 #[allow(unused_imports)]
 pub(crate) use super::super::agentic::delegate_interception::{
-    DelegationAdaptiveContext, DelegationExecutionResult, DelegationFinalOutputSource,
-    DelegationOutcomeMetadata, coordination_pattern_name, delegation_adaptive_context,
-    delegation_final_output_preview, format_delegation_result, format_delegation_terminal_preview,
-    is_delegation_call, merge_workspace_hint_into_delegation_request, parse_coordination_pattern,
+    coordination_pattern_name, delegation_adaptive_context, delegation_final_output_preview,
+    format_delegation_result, format_delegation_terminal_preview, is_delegation_call,
+    merge_workspace_hint_into_delegation_request, parse_coordination_pattern,
     parse_delegate_agents, parse_delegation_request, partition_and_execute_delegations,
     pattern_from_name, select_default_coordination_pattern, task_needs_review,
-    tool_call_arguments_value, tool_call_name,
+    tool_call_arguments_value, tool_call_name, DelegationAdaptiveContext,
+    DelegationExecutionResult, DelegationFinalOutputSource, DelegationOutcomeMetadata,
 };
 
 #[allow(unused_imports)]
 use super::super::harness_adapter::harness_at;
 #[allow(unused_imports)]
 pub(crate) use super::execution_phase::{
-    TurnExecutionControl, TurnExecutionPhase, execute_turn_and_ingest_phase,
+    execute_turn_and_ingest_phase, TurnExecutionControl, TurnExecutionPhase,
 };
 #[allow(unused_imports)]
 pub(crate) use super::finalization::{
@@ -1656,10 +1666,10 @@ pub(crate) use super::finalization::{
 };
 #[allow(unused_imports)]
 pub(crate) use super::lifecycle::{
-    PreparedTurnIteration, TurnIterationPrep, prepare_turn_iteration, run_loop_preamble,
+    prepare_turn_iteration, run_loop_preamble, PreparedTurnIteration, TurnIterationPrep,
 };
 #[allow(unused_imports)]
-pub(crate) use super::tool_phase::{TurnToolPhaseControl, execute_tool_phase};
+pub(crate) use super::tool_phase::{execute_tool_phase, TurnToolPhaseControl};
 
 #[cfg(feature = "harness")]
 pub(crate) fn set_harness_interruption(
@@ -2829,7 +2839,7 @@ pub(crate) mod tests {
         // Tokens accumulate across turns (+=)
         assert_eq!(state.total_prompt, 35); // 20 + 15
         assert_eq!(state.total_completion, 15); // 10 + 5
-        // Edge tool counted
+                                                // Edge tool counted
         assert!(state.total_tool_calls >= 1);
         // Messages accumulated: assistant + tool from turn 1, at minimum
         assert!(state.messages.len() >= 2);
@@ -3009,7 +3019,7 @@ pub(crate) mod tests {
         assert_eq!(host.current_turn, 0); // No turns executed
         assert!(state.final_text.contains("without a final answer")); // EmptyCompletion message
         assert_eq!(state.remaining_turns, 10); // Unchanged
-        // EmptyCompletion interruption recorded
+                                               // EmptyCompletion interruption recorded
         let interruption = state
             .interruption
             .as_ref()
@@ -3181,13 +3191,11 @@ pub(crate) mod tests {
         assert!(outcome.is_ok());
         assert_eq!(host.current_turn, 2);
         assert!(state.final_text.contains("Turn budget exhausted"));
-        assert!(
-            !state
-                .messages
-                .iter()
-                .filter_map(|message| message.get("content").and_then(Value::as_str))
-                .any(|content| content.contains("Budget review"))
-        );
+        assert!(!state
+            .messages
+            .iter()
+            .filter_map(|message| message.get("content").and_then(Value::as_str))
+            .any(|content| content.contains("Budget review")));
     }
 
     #[tokio::test]
@@ -3292,18 +3300,14 @@ pub(crate) mod tests {
             !state.final_text.contains("changes look good"),
             "budget exhaustion must overwrite stale success-shaped text"
         );
-        assert!(
-            state
-                .final_text
-                .contains("Turn budget exhausted after 2 agentic turn(s)")
-        );
-        assert!(
-            !state
-                .messages
-                .iter()
-                .filter_map(|message| message.get("content").and_then(Value::as_str))
-                .any(|content| content.contains("Budget review"))
-        );
+        assert!(state
+            .final_text
+            .contains("Turn budget exhausted after 2 agentic turn(s)"));
+        assert!(!state
+            .messages
+            .iter()
+            .filter_map(|message| message.get("content").and_then(Value::as_str))
+            .any(|content| content.contains("Budget review")));
     }
 
     #[tokio::test]
@@ -3918,14 +3922,14 @@ pub(crate) mod tests {
     // ── E2E delegation round-trip tests ─────────────────────────────────────
 
     /// Helper to build a DelegationEngine with StubSubRunExecutor for tests.
-    pub(crate) fn make_test_delegation_engine()
-    -> Arc<crate::server::delegation::engine::DelegationEngine> {
+    pub(crate) fn make_test_delegation_engine(
+    ) -> Arc<crate::server::delegation::engine::DelegationEngine> {
         use crate::server::delegation::engine::{
             DelegationEngine, DelegationTracker, StubSubRunExecutor,
         };
         use crate::server::run::engine::RunEngine;
-        use astra_services::AgentProfileRegistry;
         use astra_services::coordination::{AgentProfile, AgentTier};
+        use astra_services::AgentProfileRegistry;
 
         let mut registry = AgentProfileRegistry::new();
         let _ = registry.register(AgentProfile::new(
@@ -4929,18 +4933,14 @@ pub(crate) mod tests {
             .filter(|m| m.get("tool_call_id").and_then(Value::as_str) == Some("call_1"))
             .collect();
         assert_eq!(msg1.len(), 1);
-        assert!(
-            msg1[0]["content"]
-                .as_str()
-                .unwrap()
-                .contains("# Skill: test-skill")
-        );
-        assert!(
-            msg1[0]["content"]
-                .as_str()
-                .unwrap()
-                .contains("Follow these instructions carefully.")
-        );
+        assert!(msg1[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("# Skill: test-skill"));
+        assert!(msg1[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("Follow these instructions carefully."));
 
         // Second call: replay loaded content + dedup note.
         let msg2: Vec<&Value> = state
@@ -5000,24 +5000,20 @@ pub(crate) mod tests {
             .iter()
             .filter(|m| m.get("tool_call_id").and_then(Value::as_str) == Some("call_1"))
             .collect();
-        assert!(
-            msg1[0]["content"]
-                .as_str()
-                .unwrap()
-                .contains("# Skill: test-skill")
-        );
+        assert!(msg1[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("# Skill: test-skill"));
 
         let msg2: Vec<&Value> = state
             .messages
             .iter()
             .filter(|m| m.get("tool_call_id").and_then(Value::as_str) == Some("call_2"))
             .collect();
-        assert!(
-            msg2[0]["content"]
-                .as_str()
-                .unwrap()
-                .contains("# Skill: other-skill")
-        );
+        assert!(msg2[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("# Skill: other-skill"));
 
         // Both tracked
         assert_eq!(state.skills.invoked.len(), 2);
@@ -5152,12 +5148,10 @@ pub(crate) mod tests {
             .filter(|m| m.get("tool_call_id").and_then(Value::as_str) == Some("call_skill"))
             .collect();
         assert_eq!(skill_msgs.len(), 1);
-        assert!(
-            skill_msgs[0]["content"]
-                .as_str()
-                .unwrap()
-                .contains("# Skill: test-skill")
-        );
+        assert!(skill_msgs[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("# Skill: test-skill"));
 
         // Skill exclusivity drop is now a debug log, not a user-facing headless line.
         // Verify the host did NOT receive any deferred notice (it goes to tracing now).
@@ -5798,9 +5792,9 @@ pub(crate) mod tests {
     async fn compact_tier_gate_skips_mechanical_compression() {
         // When compact_tier_applied >= CompactHistory (e.g. after a pre-turn LLM
         // summary), handle_token_budget must NOT run the tier-1 mechanical
-        // CompressionPipeline again. We verify this by populating the history
+        // CompactionEngine again. We verify this by populating the history
         // with otherwise-compressible tool_result payloads: if the guard is
-        // broken, CompressionPipeline would rewrite them to `[Cleared]` and the
+        // broken, CompactionEngine would rewrite them to `[Cleared]` and the
         // original text would disappear. With the guard honoured the messages
         // stay intact and spill-to-disk (an independent tier-2 recovery) runs.
         let session_id = format!(
@@ -6404,8 +6398,8 @@ print(json.dumps({'context': 'user said: ' + msg}))
         }
     }
 
-    fn make_session()
-    -> std::sync::Arc<std::sync::RwLock<crate::observability::ObservabilitySession>> {
+    fn make_session(
+    ) -> std::sync::Arc<std::sync::RwLock<crate::observability::ObservabilitySession>> {
         std::sync::Arc::new(std::sync::RwLock::new(
             crate::observability::ObservabilitySession::new_simple("test-session"),
         ))
@@ -7876,7 +7870,7 @@ print(json.dumps({'context': 'user said: ' + msg}))
 
     #[test]
     fn stress_all_8_default_rules_fire() {
-        use astra_learning::auto_tuning::{FeedbackSignal, SignalType, default_rules};
+        use astra_learning::auto_tuning::{default_rules, FeedbackSignal, SignalType};
 
         let hub = make_hub();
         // Load default evolution rules so the tuning engine has something to evaluate
@@ -9331,7 +9325,7 @@ mod parallel_execution_tests {
     /// Unit test for partition_tool_batches.
     #[test]
     fn partition_tool_batches_groups_correctly() {
-        use crate::turn::agentic::headless_round::{ToolBatch, partition_tool_batches};
+        use crate::turn::agentic::headless_round::{partition_tool_batches, ToolBatch};
         use astra_turn_core::headless_tool_assembly::HeadlessRoundToolIdx;
 
         let tool_calls = vec![

--- a/rust/crates/runtime/src/turn/agentic_loop/lifecycle.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/lifecycle.rs
@@ -13,7 +13,7 @@ use super::host::{
 };
 use crate::orchestration::permission_sync::PermissionResponseMessaging;
 use astra_services::SessionArtifactStore;
-use astra_turn_core::compaction_types::CompactionTier;
+use astra_turn_core::compaction_types::{CompactionEvent, CompactionTier};
 use astra_turn_core::interruption::{
     InterruptionKind, InterruptionRecord, InterruptionStateSummary, ResumeAction,
 };
@@ -1111,6 +1111,25 @@ pub(crate) async fn run_loop_preamble<H: AgenticLoopHost>(
     // See `context_pipeline_adapter::build_session_context` + `bind_project_context`.
 }
 
+/// Estimate context pressure from raw message token count.
+///
+/// Returns `(pressure, estimated_tokens)` where pressure is a 0.0–1.0
+/// ratio against `max_turn_input_tokens`. When no limit is configured
+/// (`max_turn_input_tokens == 0`) returns `(0.0, 0)`.
+#[inline]
+fn estimate_context_pressure(
+    messages: &[serde_json::Value],
+    pinned_tool_schema_tokens: usize,
+    max_turn_input_tokens: u64,
+) -> (f64, u64) {
+    if max_turn_input_tokens == 0 {
+        return (0.0, 0);
+    }
+    let tokens =
+        crate::prompts::estimate_tokens(messages, pinned_tool_schema_tokens, 0) as u64;
+    (tokens as f64 / max_turn_input_tokens as f64, tokens)
+}
+
 pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
     host: &mut H,
     state: &mut AgenticLoopState,
@@ -1688,28 +1707,31 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
         // When pipeline_session is active, use its pressure model (predictive
         // with reserves) and cascade-aware limits. Otherwise fall back to
         // legacy inline estimation.
-        let pressure = if state.max_turn_input_tokens > 0 {
-            let fresh_estimate = crate::prompts::estimate_tokens_precise(
-                &state.messages,
-                state.pinned_tool_schema_tokens as usize,
-                0,
-            ) as u64;
-            fresh_estimate as f64 / state.max_turn_input_tokens as f64
-        } else {
-            0.0
-        };
+        let (pressure, pressure_estimate_tokens) =
+            estimate_context_pressure(&state.messages, state.pinned_tool_schema_tokens as usize, state.max_turn_input_tokens);
 
-        // Pre-turn LLM compact: if pressure exceeds 80%, let the host run an
-        // optional cache-friendly inline-summary pass before the next LLM call.
-        // Server hosts can build the exact system prompt + history prefix;
-        // generic hosts keep the default no-op behavior. When it succeeds the
-        // host bumps `state.compact_tier_applied` so the later budget guard
-        // won't re-run mechanical compression.
-        if pressure >= 0.80
+        // Pre-turn LLM compact: if pressure exceeds the model-adaptive
+        // trigger, let the host run an optional cache-friendly inline-summary
+        // pass before the next LLM call.
+        if pressure >= CompactionTier::pre_turn_trigger(state.max_turn_input_tokens)
             && state.compact_tier_applied < CompactionTier::CompactHistory
             && state.messages.len() > 10
         {
             host.maybe_pre_turn_compact(state, pressure, quiet).await;
+        }
+
+        // Pre-turn pressure warning: when context is near the model-adaptive
+        // warning threshold, emit a non-intrusive advisory so the user knows
+        // compaction is imminent.
+        if pressure >= CompactionTier::pre_turn_warning(state.max_turn_input_tokens) && !quiet {
+            let warning = CompactionEvent::new(
+                "pressure_warning",
+                pressure,
+                0, // no tokens freed yet
+                pressure_estimate_tokens,
+                state.max_turn_input_tokens,
+            );
+            host.on_compaction(warning);
         }
 
         // Adaptive microcompact: scale aggressiveness with context pressure.
@@ -1751,15 +1773,14 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
         };
         if mc.results_compacted > 0 {
             if !quiet {
-                host.emit_headless_line(
-                    HeadlessStderrStyle::Dim,
-                    format!(
-                        "  ♻ Compacted {} old tool result(s), ~{} tokens saved (pressure {:.0}%)",
-                        mc.results_compacted,
-                        mc.tokens_saved,
-                        pressure * 100.0,
-                    ),
+                let event = CompactionEvent::new(
+                    "microcompact",
+                    pressure,
+                    mc.tokens_saved as u64,
+                    pressure_estimate_tokens,
+                    state.max_turn_input_tokens,
                 );
+                host.on_compaction(event);
             }
             state.step_recorder.record_compaction(
                 mc.results_compacted as u32,
@@ -1777,51 +1798,47 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
         }
 
         // Re-estimate pressure after microcompact (messages may have shrunk).
-        let post_mc_tokens = crate::prompts::estimate_tokens(&state.messages) as u64;
-        let post_mc_pressure = if state.max_turn_input_tokens > 0 {
-            post_mc_tokens as f64 / state.max_turn_input_tokens as f64
-        } else {
-            0.0
-        };
+        // Use the same precise estimation as the pre-microcompact check
+        // above so that pinned tool schema tokens are included — without
+        // them, the guard under-estimates pressure and skips compaction
+        // (observed in session 540c37d1 where budget_pressure=0.887 but
+        // post_mc_pressure was ~0.61 and never crossed the 0.75 threshold).
+        let (post_mc_pressure, post_mc_tokens) =
+            estimate_context_pressure(&state.messages, state.pinned_tool_schema_tokens as usize, state.max_turn_input_tokens);
 
         // Proactive compression gate: if pressure is still high after
         // microcompact, run the full compression pipeline *before* calling
         // the LLM, preventing 413 errors instead of reacting to them.
-        if post_mc_pressure >= 0.75 {
-            let budget = super::super::context_compression::TokenBudget {
+        if post_mc_pressure >= CompactionTier::pre_turn_trigger(state.max_turn_input_tokens) {
+            let budget = super::super::cloud::compaction_engine::TokenBudget {
                 max_prompt_tokens: state.max_turn_input_tokens,
                 last_measured_tokens: post_mc_tokens,
                 current_round_index: Some(state.current_round_index),
             };
-            let pipeline = if post_mc_pressure >= 0.90 {
-                super::super::context_compression::CompressionPipeline::aggressive_pipeline()
+            let pipeline = if post_mc_pressure >= CompactionTier::aggressive_trigger(state.max_turn_input_tokens) {
+                super::super::cloud::compaction_engine::CompactionEngine::aggressive_pipeline()
             } else {
-                super::super::context_compression::CompressionPipeline::default_pipeline()
+                super::super::cloud::compaction_engine::CompactionEngine::default_pipeline()
             };
             let outcome = pipeline.compress_if_needed(&mut state.messages, &budget);
             if outcome.total_tokens_freed > 0 && !quiet {
-                let tier = if post_mc_pressure >= 0.90 {
-                    "aggressive"
+                let tier = if post_mc_pressure >= CompactionTier::aggressive_trigger(state.max_turn_input_tokens) {
+                    "aggressive_compression"
                 } else {
-                    "default"
+                    "default_compression"
                 };
-                host.emit_headless_line(
-                    HeadlessStderrStyle::Yellow,
-                    format!(
-                        "  ⚡ Proactive {} compression: freed ~{} tokens at {:.0}% pressure",
-                        tier,
-                        outcome.total_tokens_freed,
-                        post_mc_pressure * 100.0,
-                    ),
+                let event = CompactionEvent::new(
+                    tier,
+                    post_mc_pressure,
+                    outcome.total_tokens_freed,
+                    post_mc_tokens,
+                    state.max_turn_input_tokens,
                 );
+                host.on_compaction(event);
                 // Record compression audit for pipeline journal
                 if let Some(ref mut sess) = state.pipeline_session {
                     sess.record_compaction_audit(
-                        if post_mc_pressure >= 0.90 {
-                            "aggressive_compression"
-                        } else {
-                            "default_compression"
-                        },
+                        tier,
                         outcome.layer_results.len() as u32,
                         outcome.total_tokens_freed.min(u32::MAX as u64) as u32,
                     );
@@ -1836,35 +1853,29 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
     // proactively compress before the first LLM call.  This prevents an
     // immediate 413 when resuming from a CompactAndRetry interruption.
     if turn_index == 0 && state.messages.len() > 10 && state.max_turn_input_tokens > 0 {
-        let estimated_tokens = crate::prompts::estimate_tokens(&state.messages) as f64;
-        let estimated_pressure = estimated_tokens / state.max_turn_input_tokens as f64;
-        if estimated_pressure >= 0.75 {
-            let budget = super::super::context_compression::TokenBudget {
+        let (estimated_pressure, estimated_tokens) =
+            estimate_context_pressure(&state.messages, state.pinned_tool_schema_tokens as usize, state.max_turn_input_tokens);
+        if estimated_pressure >= CompactionTier::pre_turn_trigger(state.max_turn_input_tokens) {
+            let budget = super::super::cloud::compaction_engine::TokenBudget {
                 max_prompt_tokens: state.max_turn_input_tokens,
-                last_measured_tokens: estimated_tokens as u64,
+                last_measured_tokens: estimated_tokens,
                 current_round_index: Some(state.current_round_index),
             };
-            let pipeline = if estimated_pressure >= 0.90 {
-                super::super::context_compression::CompressionPipeline::aggressive_pipeline()
+            let pipeline = if estimated_pressure >= CompactionTier::aggressive_trigger(state.max_turn_input_tokens) {
+                super::super::cloud::compaction_engine::CompactionEngine::aggressive_pipeline()
             } else {
-                super::super::context_compression::CompressionPipeline::default_pipeline()
+                super::super::cloud::compaction_engine::CompactionEngine::default_pipeline()
             };
             let outcome = pipeline.compress_if_needed(&mut state.messages, &budget);
             if outcome.total_tokens_freed > 0 && !quiet {
-                let tier = if estimated_pressure >= 0.90 {
-                    "aggressive"
-                } else {
-                    "default"
-                };
-                host.emit_headless_line(
-                    HeadlessStderrStyle::Yellow,
-                    format!(
-                        "  ⚡ Resume {} compression: freed ~{} tokens at ~{:.0}% est. pressure",
-                        tier,
-                        outcome.total_tokens_freed,
-                        estimated_pressure * 100.0,
-                    ),
+                let event = CompactionEvent::new(
+                    "resume",
+                    estimated_pressure,
+                    outcome.total_tokens_freed,
+                    estimated_tokens,
+                    state.max_turn_input_tokens,
                 );
+                host.on_compaction(event);
             }
         }
     }

--- a/rust/crates/runtime/src/turn/agentic_loop/lifecycle.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/lifecycle.rs
@@ -7,13 +7,14 @@ use serde_json::Value;
 
 use super::super::agentic::adaptive_tuning::apply_adaptive_execution_profile;
 use super::super::agentic::headless_round::HeadlessStderrStyle;
+use super::super::cloud::compaction_engine::{CompactionEngine, TokenBudget};
 use super::host::{
     AgenticLoopHost, AgenticLoopOutcome, AgenticLoopState, RunControlStatus,
     try_write_heavy_checkpoint,
 };
 use crate::orchestration::permission_sync::PermissionResponseMessaging;
 use astra_services::SessionArtifactStore;
-use astra_turn_core::compaction_types::{CompactionEvent, CompactionTier};
+use astra_turn_core::compaction_types::{CompactionEvent, CompactionKind, CompactionTier};
 use astra_turn_core::interruption::{
     InterruptionKind, InterruptionRecord, InterruptionStateSummary, ResumeAction,
 };
@@ -1117,7 +1118,7 @@ pub(crate) async fn run_loop_preamble<H: AgenticLoopHost>(
 /// ratio against `max_turn_input_tokens`. When no limit is configured
 /// (`max_turn_input_tokens == 0`) returns `(0.0, 0)`.
 #[inline]
-fn estimate_context_pressure(
+pub(crate) fn estimate_context_pressure(
     messages: &[serde_json::Value],
     pinned_tool_schema_tokens: usize,
     max_turn_input_tokens: u64,
@@ -1125,9 +1126,54 @@ fn estimate_context_pressure(
     if max_turn_input_tokens == 0 {
         return (0.0, 0);
     }
-    let tokens =
-        crate::prompts::estimate_tokens(messages, pinned_tool_schema_tokens, 0) as u64;
+    let tokens = crate::prompts::estimate_tokens(messages, pinned_tool_schema_tokens, 0) as u64;
     (tokens as f64 / max_turn_input_tokens as f64, tokens)
+}
+
+/// Run the compaction pipeline and record results (event + audit).
+///
+/// Shared by pre-turn proactive compression and resume-time compression to
+/// avoid ~30 lines of duplicated TokenBudget → pipeline selection → compress →
+/// event → audit logic.
+fn run_proactive_compaction<H: AgenticLoopHost>(
+    pressure: f64,
+    tokens_measured: u64,
+    state: &mut AgenticLoopState,
+    quiet: bool,
+    host: &mut H,
+    kind: CompactionKind,
+    audit_label: &str,
+) {
+    let max_tokens = state.max_turn_input_tokens;
+    let budget = TokenBudget {
+        max_prompt_tokens: max_tokens,
+        last_measured_tokens: tokens_measured,
+        current_round_index: Some(state.current_round_index),
+    };
+    let pipeline = if pressure >= CompactionTier::aggressive_trigger(max_tokens) {
+        CompactionEngine::aggressive_pipeline()
+    } else {
+        CompactionEngine::default_pipeline_for(max_tokens)
+    };
+    let outcome = pipeline.compress_if_needed(&mut state.messages, &budget);
+    if outcome.total_tokens_freed > 0 && !quiet {
+        let event = CompactionEvent::new(
+            kind,
+            pressure,
+            outcome.total_tokens_freed,
+            tokens_measured,
+            max_tokens,
+        );
+        host.on_compaction(event);
+        if let Some(ref mut sess) = state.pipeline_session {
+            sess.record_compaction_audit(
+                audit_label,
+                outcome.layer_results.len() as u32,
+                outcome.total_tokens_freed.min(u32::MAX as u64) as u32,
+            );
+            sess.stats.record_compaction(outcome.total_tokens_freed);
+        }
+    }
 }
 
 pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
@@ -1707,8 +1753,11 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
         // When pipeline_session is active, use its pressure model (predictive
         // with reserves) and cascade-aware limits. Otherwise fall back to
         // legacy inline estimation.
-        let (pressure, pressure_estimate_tokens) =
-            estimate_context_pressure(&state.messages, state.pinned_tool_schema_tokens as usize, state.max_turn_input_tokens);
+        let (pressure, pressure_estimate_tokens) = estimate_context_pressure(
+            &state.messages,
+            state.pinned_tool_schema_tokens as usize,
+            state.max_turn_input_tokens,
+        );
 
         // Pre-turn LLM compact: if pressure exceeds the model-adaptive
         // trigger, let the host run an optional cache-friendly inline-summary
@@ -1725,7 +1774,7 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
         // compaction is imminent.
         if pressure >= CompactionTier::pre_turn_warning(state.max_turn_input_tokens) && !quiet {
             let warning = CompactionEvent::new(
-                "pressure_warning",
+                CompactionKind::PressureWarning,
                 pressure,
                 0, // no tokens freed yet
                 pressure_estimate_tokens,
@@ -1774,7 +1823,7 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
         if mc.results_compacted > 0 {
             if !quiet {
                 let event = CompactionEvent::new(
-                    "microcompact",
+                    CompactionKind::Microcompact,
                     pressure,
                     mc.tokens_saved as u64,
                     pressure_estimate_tokens,
@@ -1803,48 +1852,32 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
         // them, the guard under-estimates pressure and skips compaction
         // (observed in session 540c37d1 where budget_pressure=0.887 but
         // post_mc_pressure was ~0.61 and never crossed the 0.75 threshold).
-        let (post_mc_pressure, post_mc_tokens) =
-            estimate_context_pressure(&state.messages, state.pinned_tool_schema_tokens as usize, state.max_turn_input_tokens);
+        let (post_mc_pressure, post_mc_tokens) = estimate_context_pressure(
+            &state.messages,
+            state.pinned_tool_schema_tokens as usize,
+            state.max_turn_input_tokens,
+        );
 
         // Proactive compression gate: if pressure is still high after
         // microcompact, run the full compression pipeline *before* calling
         // the LLM, preventing 413 errors instead of reacting to them.
         if post_mc_pressure >= CompactionTier::pre_turn_trigger(state.max_turn_input_tokens) {
-            let budget = super::super::cloud::compaction_engine::TokenBudget {
-                max_prompt_tokens: state.max_turn_input_tokens,
-                last_measured_tokens: post_mc_tokens,
-                current_round_index: Some(state.current_round_index),
-            };
-            let pipeline = if post_mc_pressure >= CompactionTier::aggressive_trigger(state.max_turn_input_tokens) {
-                super::super::cloud::compaction_engine::CompactionEngine::aggressive_pipeline()
+            let is_aggressive =
+                post_mc_pressure >= CompactionTier::aggressive_trigger(state.max_turn_input_tokens);
+            let (kind, label) = if is_aggressive {
+                (CompactionKind::AggressiveCompression, "aggressive")
             } else {
-                super::super::cloud::compaction_engine::CompactionEngine::default_pipeline()
+                (CompactionKind::DefaultCompression, "default")
             };
-            let outcome = pipeline.compress_if_needed(&mut state.messages, &budget);
-            if outcome.total_tokens_freed > 0 && !quiet {
-                let tier = if post_mc_pressure >= CompactionTier::aggressive_trigger(state.max_turn_input_tokens) {
-                    "aggressive_compression"
-                } else {
-                    "default_compression"
-                };
-                let event = CompactionEvent::new(
-                    tier,
-                    post_mc_pressure,
-                    outcome.total_tokens_freed,
-                    post_mc_tokens,
-                    state.max_turn_input_tokens,
-                );
-                host.on_compaction(event);
-                // Record compression audit for pipeline journal
-                if let Some(ref mut sess) = state.pipeline_session {
-                    sess.record_compaction_audit(
-                        tier,
-                        outcome.layer_results.len() as u32,
-                        outcome.total_tokens_freed.min(u32::MAX as u64) as u32,
-                    );
-                    sess.stats.record_compaction(outcome.total_tokens_freed);
-                }
-            }
+            run_proactive_compaction(
+                post_mc_pressure,
+                post_mc_tokens,
+                state,
+                quiet,
+                host,
+                kind,
+                label,
+            );
         }
     }
 
@@ -1853,30 +1886,21 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
     // proactively compress before the first LLM call.  This prevents an
     // immediate 413 when resuming from a CompactAndRetry interruption.
     if turn_index == 0 && state.messages.len() > 10 && state.max_turn_input_tokens > 0 {
-        let (estimated_pressure, estimated_tokens) =
-            estimate_context_pressure(&state.messages, state.pinned_tool_schema_tokens as usize, state.max_turn_input_tokens);
+        let (estimated_pressure, estimated_tokens) = estimate_context_pressure(
+            &state.messages,
+            state.pinned_tool_schema_tokens as usize,
+            state.max_turn_input_tokens,
+        );
         if estimated_pressure >= CompactionTier::pre_turn_trigger(state.max_turn_input_tokens) {
-            let budget = super::super::cloud::compaction_engine::TokenBudget {
-                max_prompt_tokens: state.max_turn_input_tokens,
-                last_measured_tokens: estimated_tokens,
-                current_round_index: Some(state.current_round_index),
-            };
-            let pipeline = if estimated_pressure >= CompactionTier::aggressive_trigger(state.max_turn_input_tokens) {
-                super::super::cloud::compaction_engine::CompactionEngine::aggressive_pipeline()
-            } else {
-                super::super::cloud::compaction_engine::CompactionEngine::default_pipeline()
-            };
-            let outcome = pipeline.compress_if_needed(&mut state.messages, &budget);
-            if outcome.total_tokens_freed > 0 && !quiet {
-                let event = CompactionEvent::new(
-                    "resume",
-                    estimated_pressure,
-                    outcome.total_tokens_freed,
-                    estimated_tokens,
-                    state.max_turn_input_tokens,
-                );
-                host.on_compaction(event);
-            }
+            run_proactive_compaction(
+                estimated_pressure,
+                estimated_tokens,
+                state,
+                quiet,
+                host,
+                CompactionKind::Resume,
+                "resume",
+            );
         }
     }
 
@@ -2751,6 +2775,205 @@ mod tests {
         assert!(
             !ir.user_message.is_empty(),
             "interruption user_message must be non-empty for resume guidance"
+        );
+    }
+
+    // ── estimate_context_pressure tests ────────────────────────────
+    //
+    // Session 540c37d1: the old estimate_tokens (without schema tokens)
+    // underestimated CJK tokens by ~50%, causing pressure to read 0.61
+    // when it was actually 0.89. These tests ensure the unified function
+    // returns correct pressure across all scenarios.
+
+    #[test]
+    fn estimate_context_pressure_zero_max_tokens() {
+        let messages = vec![json!({"role": "user", "content": "hello"})];
+        let (pressure, tokens) = estimate_context_pressure(&messages, 0, 0);
+        assert_eq!(pressure, 0.0, "zero max_tokens → zero pressure");
+        assert_eq!(tokens, 0, "zero max_tokens → zero token count");
+    }
+
+    #[test]
+    fn estimate_context_pressure_empty_messages() {
+        let messages: Vec<serde_json::Value> = vec![];
+        let (pressure, _tokens) = estimate_context_pressure(&messages, 0, 100_000);
+        // estimate_tokens has a base overhead even for empty messages,
+        // so pressure is non-zero. What matters: it's well below warning.
+        assert!(pressure < 0.2, "empty messages pressure stays low");
+
+        // With zero max_tokens: returns (0.0, 0) via guard.
+        let (pressure_zero, tokens_zero) = estimate_context_pressure(&messages, 0, 0);
+        assert_eq!(pressure_zero, 0.0);
+        assert_eq!(tokens_zero, 0);
+    }
+
+    #[test]
+    fn estimate_context_pressure_normal_ascii() {
+        let messages = vec![
+            json!({"role": "system", "content": "You are a helpful assistant."}),
+            json!({"role": "user", "content": "What is 2+2?"}),
+        ];
+        let (pressure, tokens) = estimate_context_pressure(&messages, 5_000, 100_000);
+        assert!(
+            pressure > 0.0,
+            "non-empty messages produce non-zero pressure"
+        );
+        assert!(
+            pressure < 0.3,
+            "short messages with schema well under budget; got {pressure}"
+        );
+        assert!(tokens > 0, "tokens must be > 0");
+    }
+
+    #[test]
+    fn estimate_context_pressure_schema_tokens_raise_pressure() {
+        let messages: Vec<serde_json::Value> = (0..10)
+            .map(|i| json!({"role": "user", "content": format!("message {}", i)}))
+            .collect();
+        let (p_without, _) = estimate_context_pressure(&messages, 0, 100_000);
+        let (p_with, _) = estimate_context_pressure(&messages, 50_000, 100_000);
+        assert!(
+            p_with > p_without,
+            "50K schema tokens must raise pressure above baseline"
+        );
+    }
+
+    #[test]
+    fn estimate_context_pressure_cjk_messages_count_tokens() {
+        let messages: Vec<serde_json::Value> = (0..50)
+            .map(|i| {
+                json!({"role": "user", "content": format!("这是第{}条中文消息，包含较多的中文字符以确保token估算准确。", i)})
+            })
+            .collect();
+        let (pressure, tokens) = estimate_context_pressure(&messages, 10_000, 100_000);
+        assert!(tokens > 5_000, "50 CJK messages produce substantial tokens");
+        assert!(
+            pressure > 0.05,
+            "50 CJK messages produce measurable pressure"
+        );
+    }
+
+    #[test]
+    fn estimate_context_pressure_scales_with_message_count() {
+        let make_messages = |n: usize| -> Vec<serde_json::Value> {
+            (0..n)
+                .map(|i| json!({"role": "user", "content": format!("message number {}", i)}))
+                .collect()
+        };
+        let (p10, _) = estimate_context_pressure(&make_messages(10), 0, 100_000);
+        let (p50, _) = estimate_context_pressure(&make_messages(50), 0, 100_000);
+        let (p100, _) = estimate_context_pressure(&make_messages(100), 0, 100_000);
+        assert!(p100 > p50, "100 msgs > 50 msgs pressure");
+        assert!(p50 > p10, "50 msgs > 10 msgs pressure");
+        assert!(p100 > p10, "100 msgs > 10 msgs pressure");
+    }
+
+    // ── Full pipeline integration test ─────────────────────────────
+    //
+    // Verifies that prepare_turn_iteration runs the complete compaction
+    // pipeline — pressure estimation → warning emission → microcompact
+    // → re-estimation → proactive compression — without panicking.
+
+    fn high_pressure_cjk_state(max_tokens: u64, schema_tokens: usize) -> AgenticLoopState {
+        let mut state = make_state();
+        state.max_turn_input_tokens = max_tokens;
+        state.pinned_tool_schema_tokens = schema_tokens as u64;
+        state.messages = (0..150)
+            .map(|i| {
+                json!({"role": "user", "content": format!("这是第{}条测试消息，用于模拟高压力场景，包含足够多的中文字符来产生真实的token估算。会话540c37d1显示CJK文本的token估算往往被低估，这个测试确保修复后不会退化。", i)})
+            })
+            .collect();
+        state
+    }
+
+    #[tokio::test]
+    async fn prepare_turn_with_cjk_pressure_runs_full_pipeline() {
+        // Small context window (32K) + CJK messages + schema tokens
+        // pushes pressure well above the 0.70 trigger for ≤32K windows.
+        let mut host = MockHost::new(Vec::new());
+        let mut state = high_pressure_cjk_state(32_000, 10_000);
+
+        let result = prepare_turn_iteration(&mut host, &mut state, 1).await;
+        assert!(
+            result.is_ok(),
+            "prepare_turn_iteration must not fail under high pressure: {:?}",
+            result.err()
+        );
+
+        // Messages should have been compacted (count reduced from 150).
+        assert!(
+            state.messages.len() < 150,
+            "messages must be compacted under high pressure; got {}",
+            state.messages.len()
+        );
+        // CJK + schema tokens at 32K window must trigger at least
+        // CompactHistory-level compaction (significant reduction).
+        assert!(
+            state.messages.len() <= 100,
+            "CJK session must be significantly compacted (≤100 from 150); got {}",
+            state.messages.len()
+        );
+
+        // Verify a compaction boundary marker was inserted.
+        let has_boundary = state
+            .messages
+            .iter()
+            .any(|m| m.get("_compact_boundary").is_some());
+        assert!(
+            has_boundary,
+            "compaction must insert a boundary marker in the message list"
+        );
+
+        // Emissions are suppressed when quiet=true, but the pipeline
+        // itself must execute without panicking — that's the contract.
+    }
+
+    /// Resume-time compaction: when turn_index==0 and there are >10
+    /// messages (e.g. restored from checkpoint), pressure estimation
+    /// should trigger proactive compression before the first LLM call.
+    #[tokio::test]
+    async fn prepare_turn_resume_compacts_high_pressure() {
+        let mut host = MockHost::new(Vec::new());
+        let mut state = make_state();
+        state.max_turn_input_tokens = 32_000;
+        state.pinned_tool_schema_tokens = 10_000;
+        state.messages = (0..100)
+            .map(|i| {
+                json!({"role": "user", "content": format!("CJK压力测试第{}条消息——确保恢复路径也能正常压缩上下文窗口。", i)})
+            })
+            .collect();
+
+        // turn_index == 0 triggers resume compaction path
+        let result = prepare_turn_iteration(&mut host, &mut state, 0).await;
+        assert!(
+            result.is_ok(),
+            "resume compaction must not fail: {:?}",
+            result.err()
+        );
+        assert!(
+            state.messages.len() < 100,
+            "resume compaction must reduce message count from 100; got {}",
+            state.messages.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_turn_with_low_pressure_skips_compaction() {
+        let mut host = MockHost::new(Vec::new());
+        let mut state = make_state();
+        state.max_turn_input_tokens = 200_000; // large window
+        state.messages = (0..5)
+            .map(|i| json!({"role": "user", "content": format!("msg {}", i)}))
+            .collect();
+
+        let result = prepare_turn_iteration(&mut host, &mut state, 1).await;
+        assert!(result.is_ok());
+
+        // Low pressure should leave all 5 messages intact.
+        assert_eq!(
+            state.messages.len(),
+            5,
+            "low-pressure messages must not be compacted"
         );
     }
 }

--- a/rust/crates/runtime/src/turn/agentic_loop/tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/tool_phase.rs
@@ -1648,7 +1648,7 @@ fn introspect_token_pressure(state: &super::host::AgenticLoopState) -> f64 {
     if state.max_turn_input_tokens == 0 {
         return 0.0;
     }
-    let fresh_estimate = crate::prompts::estimate_tokens_precise(
+    let fresh_estimate = crate::prompts::estimate_tokens(
         &state.messages,
         state.pinned_tool_schema_tokens as usize,
         0,
@@ -1784,7 +1784,7 @@ mod tests {
             json!({"role": "user", "content": "hello world"}),
         ];
         state.pinned_tool_schema_tokens = 120;
-        let expected = crate::prompts::estimate_tokens_precise(
+        let expected = crate::prompts::estimate_tokens(
             &state.messages,
             state.pinned_tool_schema_tokens as usize,
             0,

--- a/rust/crates/runtime/src/turn/chat_turn_budget_pressure.rs
+++ b/rust/crates/runtime/src/turn/chat_turn_budget_pressure.rs
@@ -11,7 +11,7 @@ pub fn budget_pressure_for_chat_turn(
     model: Option<&str>,
     pinned_schema_tokens: usize,
 ) -> f64 {
-    let estimated = prompts::estimate_tokens_precise(messages, pinned_schema_tokens, 0);
+    let estimated = prompts::estimate_tokens(messages, pinned_schema_tokens, 0);
     let budget = prompts::budget_for_model(model);
     let tier = budget.compaction_tier(estimated);
     tier.budget_pressure()
@@ -26,5 +26,103 @@ mod tests {
     fn budget_pressure_is_finite_for_minimal_messages() {
         let p = budget_pressure_for_chat_turn(&[json!({"role":"user","content":"hi"})], None, 0);
         assert!(p.is_finite());
+    }
+
+    /// Regression: without schema tokens, CJK-heavy conversations were
+    /// underestimated by 50-60%, causing compaction to never trigger.
+    /// Session 540c37d1: budget_pressure=0.887 but post_mc_pressure was
+    /// ~0.61 because schema tokens were omitted from the estimate.
+    #[test]
+    fn cjk_with_schema_tokens_produces_higher_pressure() {
+        // Simulate 40 messages of CJK conversation (user + assistant turns)
+        let mut messages = Vec::new();
+        for i in 0..20 {
+            messages.push(json!({"role":"user","content": format!("第{i}个问题：请帮我分析一下这个问题应该怎么解决？")}));
+            messages.push(json!({"role":"assistant","content": format!("好的，我来帮你分析第{i}个问题。根据代码审查的结果，问题出在以下几个方面...")}));
+        }
+
+        let pressure_without_schema = budget_pressure_for_chat_turn(&messages, None, 0);
+        let pressure_with_schema = budget_pressure_for_chat_turn(&messages, None, 50_000);
+
+        assert!(
+            pressure_with_schema > pressure_without_schema,
+            "schema tokens must increase pressure: without={pressure_without_schema}, with={pressure_with_schema}"
+        );
+    }
+
+    /// Realistic scenario from session 540c37d1: ~130 messages (50+ turns
+    /// with tool results), CJK content, ~50K tool schema tokens.
+    /// Total estimated tokens should exceed ~81K (Compact trigger for
+    /// default 128K model) and cross TrimSchemas (pressure >= 0.3).
+    #[test]
+    fn realistic_cjk_session_reaches_compact_pressure() {
+        let mut messages = Vec::new();
+        // Simulate a long conversation: 50 user turns + 50 assistant turns + 30 tool results
+        for i in 0..50 {
+            messages.push(json!({"role":"user","content": format!(
+                "请继续分析第{i}个文件的问题，包括代码结构、错误处理、性能优化和安全性审查"
+            )}));
+            messages.push(json!({"role":"assistant","content": format!(
+                "已分析第{i}个文件，发现以下问题：\n1. 错误处理不完善——缺少Result类型传播\n2. 性能瓶颈在第42行的嵌套循环中——建议使用HashMap索引\n3. 需要重构以提高可维护性——函数过长超过80行\n4. 安全风险：用户输入未做SQL注入防护\n5. 并发问题：Arc<Mutex<T>>可能导致死锁"
+            )}));
+            if i < 30 {
+                // Simulated tool call results (file reads / greps / symbols)
+                messages.push(json!({"role":"tool","content": format!(
+                    "{{\"result\": \"文件 file_{i}.rs 分析完成：共 350 行，发现 5 个主要问题和 12 个优化建议\", \"success\": true}}"
+                )}));
+            }
+        }
+
+        let pressure = budget_pressure_for_chat_turn(&messages, None, 50_000);
+
+        assert!(
+            pressure >= 0.3,
+            "CJK-heavy session ({count} msgs) with schema tokens should reach at least TrimSchemas: got {pressure}",
+            count = messages.len(),
+        );
+    }
+
+    /// Messages that grow from 10 to 60 should monotonically increase pressure.
+    #[test]
+    fn pressure_grows_with_message_count() {
+        let mut pressures = Vec::new();
+        for count in [10, 20, 40, 60, 80] {
+            let messages: Vec<_> = (0..count)
+                .map(|i| {
+                    json!({"role":"user","content": format!("请帮我分析和修复第{i}个代码问题")})
+                })
+                .collect();
+            pressures.push(budget_pressure_for_chat_turn(&messages, None, 40_000));
+        }
+
+        for i in 1..pressures.len() {
+            assert!(
+                pressures[i] >= pressures[i - 1],
+                "pressure must not decrease with more messages: index {i}: {} < {}",
+                pressures[i],
+                pressures[i - 1]
+            );
+        }
+    }
+
+    /// Empty messages + no schema = Normal tier (0.0)
+    #[test]
+    fn empty_messages_zero_schema_is_normal() {
+        let p = budget_pressure_for_chat_turn(&[], None, 0);
+        assert_eq!(p, 0.0);
+    }
+
+    /// Even with many messages, if they're all short and no schema tokens,
+    /// pressure should stay reasonable.
+    #[test]
+    fn short_ascii_messages_dont_spike_pressure() {
+        let messages: Vec<_> = (0..100)
+            .map(|i| json!({"role":"user","content": format!("msg{i}")}))
+            .collect();
+        let p = budget_pressure_for_chat_turn(&messages, Some("gpt-4o"), 0);
+        assert!(
+            p < 0.6,
+            "100 short ASCII messages with no schema should be below CompactHistory threshold: {p}"
+        );
     }
 }

--- a/rust/crates/runtime/src/turn/chat_turn_budget_pressure.rs
+++ b/rust/crates/runtime/src/turn/chat_turn_budget_pressure.rs
@@ -48,6 +48,19 @@ mod tests {
             pressure_with_schema > pressure_without_schema,
             "schema tokens must increase pressure: without={pressure_without_schema}, with={pressure_with_schema}"
         );
+        // 50K schema tokens in a 128K window produce at least a tier jump
+        // (Normal→TrimSchemas = +0.3). Without schema the 40 CJK messages
+        // alone land in Normal (0.0), so the delta must be meaningful.
+        assert!(
+            pressure_with_schema - pressure_without_schema >= 0.15,
+            "50K schema tokens must increase pressure by at least 0.15: delta={}",
+            pressure_with_schema - pressure_without_schema
+        );
+        // With schema tokens, must at least reach TrimSchemas (0.3).
+        assert!(
+            pressure_with_schema >= 0.3,
+            "40 CJK messages + 50K schema tokens must reach at least TrimSchemas: got {pressure_with_schema}"
+        );
     }
 
     /// Realistic scenario from session 540c37d1: ~130 messages (50+ turns
@@ -75,10 +88,24 @@ mod tests {
 
         let pressure = budget_pressure_for_chat_turn(&messages, None, 50_000);
 
+        // At minimum must trigger TrimSchemas (0.3).
         assert!(
             pressure >= 0.3,
-            "CJK-heavy session ({count} msgs) with schema tokens should reach at least TrimSchemas: got {pressure}",
+            "CJK-heavy session ({count} msgs) with schema tokens must reach at least TrimSchemas: got {pressure}",
             count = messages.len(),
+        );
+
+        // The continuous pressure estimate (ratio of estimated tokens to
+        // effective input limit) must exceed 0.6 — this is the real
+        // regression guard for session 540c37d1 where CJK underestimation
+        // kept pressure artificially low.
+        let (continuous_pressure, _) =
+            crate::turn::agentic_loop::lifecycle::estimate_context_pressure(
+                &messages, 50_000, 128_000,
+            );
+        assert!(
+            continuous_pressure >= 0.6,
+            "continuous CJK pressure must reach CompactHistory (≥0.6), got {continuous_pressure}"
         );
     }
 
@@ -86,6 +113,7 @@ mod tests {
     #[test]
     fn pressure_grows_with_message_count() {
         let mut pressures = Vec::new();
+        let mut continuous_pressures = Vec::new();
         for count in [10, 20, 40, 60, 80] {
             let messages: Vec<_> = (0..count)
                 .map(|i| {
@@ -93,6 +121,10 @@ mod tests {
                 })
                 .collect();
             pressures.push(budget_pressure_for_chat_turn(&messages, None, 40_000));
+            let (cp, _) = crate::turn::agentic_loop::lifecycle::estimate_context_pressure(
+                &messages, 0, 40_000,
+            );
+            continuous_pressures.push(cp);
         }
 
         for i in 1..pressures.len() {
@@ -103,6 +135,14 @@ mod tests {
                 pressures[i - 1]
             );
         }
+        // 80 CJK messages must produce noticeably higher continuous
+        // pressure than 10.  Tiered pressure can stay flat within a band
+        // (both in Normal=0.0), but the continuous estimator must grow.
+        assert!(
+            continuous_pressures[4] - continuous_pressures[0] >= 0.01,
+            "80 CJK messages must be at least +0.01 continuous pressure over 10: delta={}",
+            continuous_pressures[4] - continuous_pressures[0]
+        );
     }
 
     /// Empty messages + no schema = Normal tier (0.0)

--- a/rust/crates/runtime/src/turn/cloud/compaction.rs
+++ b/rust/crates/runtime/src/turn/cloud/compaction.rs
@@ -1267,7 +1267,7 @@ mod tests {
         assert!(micro_cleared > 0);
 
         // Step 2: estimate tokens and determine tier
-        let est = crate::prompts::estimate_tokens(&after_micro);
+        let est = crate::prompts::estimate_tokens(&after_micro, 0, 0);
         let tier = budget.compaction_tier(est);
 
         // Step 3: tiered compaction
@@ -1280,7 +1280,7 @@ mod tests {
         );
 
         // Verify: output is bounded
-        let final_tokens = crate::prompts::estimate_tokens(&result.messages);
+        let final_tokens = crate::prompts::estimate_tokens(&result.messages, 0, 0);
         let effective_limit = budget.effective_input_limit();
         assert!(
             final_tokens < effective_limit,

--- a/rust/crates/runtime/src/turn/cloud/compaction_engine.rs
+++ b/rust/crates/runtime/src/turn/cloud/compaction_engine.rs
@@ -23,17 +23,17 @@ use std::time::{Duration, SystemTime};
 // ───────────────────────────── Pipeline ──────────────────────────────────
 
 /// Ordered pipeline of compression layers.
-pub struct CompressionPipeline {
+pub struct CompactionEngine {
     layers: Vec<Box<dyn CompressionLayer>>,
 }
 
-impl Default for CompressionPipeline {
+impl Default for CompactionEngine {
     fn default() -> Self {
         Self::default_pipeline()
     }
 }
 
-impl CompressionPipeline {
+impl CompactionEngine {
     pub fn new() -> Self {
         Self { layers: Vec::new() }
     }
@@ -995,7 +995,7 @@ mod tests {
         let mut msgs = make_agentic_session(6, 3, 3000);
         let b = budget(100_000, 85_000); // 85% pressure
 
-        let mut pipeline = CompressionPipeline::new();
+        let mut pipeline = CompactionEngine::new();
         pipeline.add_layer(Box::new(ToolResultTruncation::new(
             Duration::from_secs(0),
             200,
@@ -1021,7 +1021,7 @@ mod tests {
         // Pressure just above L1's trigger but well within L1's ability to resolve
         let b = budget(100_000, 70_000); // 70% pressure
 
-        let mut pipeline = CompressionPipeline::new();
+        let mut pipeline = CompactionEngine::new();
         pipeline.add_layer(Box::new(ToolResultTruncation::new(
             Duration::from_secs(0),
             128,
@@ -1055,7 +1055,7 @@ mod tests {
         // Low pressure — no layer should fire
         let mut msgs = make_agentic_session(3, 2, 500);
         let b = budget(200_000, 30_000); // 15% pressure
-        let outcome = CompressionPipeline::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let outcome = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
         assert!(outcome.layer_results.is_empty());
         assert!(outcome.budget_satisfied);
     }
@@ -1066,7 +1066,7 @@ mod tests {
     fn pipeline_empty_messages_no_panic() {
         let mut msgs: Vec<Value> = vec![];
         let b = budget(80_000, 90_000);
-        let outcome = CompressionPipeline::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let outcome = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
         assert!(msgs.is_empty());
         assert_eq!(outcome.total_tokens_freed, 0);
     }
@@ -1075,7 +1075,7 @@ mod tests {
     fn pipeline_system_only_no_panic() {
         let mut msgs = vec![json!({"role": "system", "content": "sys"})];
         let b = budget(80_000, 90_000);
-        let outcome = CompressionPipeline::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let outcome = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
         assert_eq!(msgs.len(), 1);
         assert_eq!(outcome.total_tokens_freed, 0);
     }
@@ -1087,7 +1087,7 @@ mod tests {
             json!({"role": "user", "content": "next"}),
         ];
         let b = budget(80_000, 40_000);
-        let outcome = CompressionPipeline::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let outcome = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
         assert!(msgs[0].get("tool_calls").is_none());
         assert!(outcome.budget_satisfied);
     }
@@ -1985,7 +1985,7 @@ mod tests {
     fn from_config_default_preserves_correct_turn_count() {
         // Default config: preserve_recent_turns=3, compression_threshold=0.8.
         // from_config should create TieredCompaction that keeps 3 turn pairs.
-        let pipeline = CompressionPipeline::default_pipeline();
+        let pipeline = CompactionEngine::default_pipeline();
 
         let mut msgs = vec![
             json!({"role": "system", "content": "sys"}),
@@ -2163,7 +2163,7 @@ mod tests {
 
         // Context is at 90% — default pipeline should fire L1 and possibly L3
         let b = budget(100_000, 90_000);
-        let outcome = CompressionPipeline::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let outcome = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
 
         assert!(outcome.total_tokens_freed > 0);
 
@@ -2202,9 +2202,9 @@ mod tests {
         // Very high pressure — both pipelines should fire
         let b = budget(80_000, 120_000); // 150% pressure
 
-        let out_default = CompressionPipeline::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let out_default = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
         let out_aggressive =
-            CompressionPipeline::aggressive_pipeline().compress_if_needed(&mut msgs_aggressive, &b);
+            CompactionEngine::aggressive_pipeline().compress_if_needed(&mut msgs_aggressive, &b);
 
         // Aggressive should free at least as much
         assert!(
@@ -2220,7 +2220,7 @@ mod tests {
         let mut msgs = make_agentic_session(20, 4, 3000);
         let b = budget(50_000, 200_000); // massively over budget
 
-        let outcome = CompressionPipeline::emergency_pipeline().compress_if_needed(&mut msgs, &b);
+        let outcome = CompactionEngine::emergency_pipeline().compress_if_needed(&mut msgs, &b);
 
         assert!(outcome.total_tokens_freed > 0);
         // Must have system + first user + at least boundary + tail

--- a/rust/crates/runtime/src/turn/cloud/compaction_engine.rs
+++ b/rust/crates/runtime/src/turn/cloud/compaction_engine.rs
@@ -10,6 +10,7 @@
 //! 3. **TieredCompaction** — drop middle messages, keep system + first user + recent.
 //! 4. **ReactiveCompact** — emergency: keep system + first user + last 4.
 
+use astra_turn_core::compaction_types::CompactionTier;
 pub use astra_turn_core::compression_types::{
     CompressionLayer, CompressionResult, PipelineOutcome, TokenBudget,
 };
@@ -29,7 +30,7 @@ pub struct CompactionEngine {
 
 impl Default for CompactionEngine {
     fn default() -> Self {
-        Self::default_pipeline()
+        Self::default_pipeline_for(64_000)
     }
 }
 
@@ -95,52 +96,69 @@ impl CompactionEngine {
     }
 
     /// Build a pipeline from RuntimeConfig's CompressionConfig.
-    pub fn from_config(config: &CompressionConfig) -> Self {
+    ///
+    /// `max_tokens` is the model's context-window limit, used to compute
+    /// adaptive thresholds via `CompactionTier` so that large-window models
+    /// aren't over-compressed.
+    pub fn from_config(config: &CompressionConfig, max_tokens: u64) -> Self {
+        let base = CompactionTier::pre_turn_trigger(max_tokens);
         let mut p = Self::new();
+        // Layer cascade (light → heavy) with CompactionTier-derived base.
+        // Trigger thresholds increase with layer weight (lower threshold =
+        // earlier activation). Each multiplier is a fraction of the
+        // adaptive trigger level derived from the model's context window:
+        //
+        //   0.625 × base   DuplicateReadElimination  (lightest — just stubs)
+        //   0.750 × base   ToolResultTruncation       (truncates old results)
+        //   0.9375 × base  TieredCompaction            (drops old turns)
+        //   0.95  fixed    ReactiveCompact             (absolute last resort)
+        p.add_layer(Box::new(DuplicateReadElimination::new(
+            (base * 0.625).clamp(0.0, 1.0),
+        )));
         p.add_layer(Box::new(ToolResultTruncation::new(
             Duration::from_secs(3600),
             config.max_tool_result_length as usize,
-            config.compression_threshold * 0.75,
-        )));
-        p.add_layer(Box::new(DuplicateReadElimination::new(
-            config.compression_threshold * 0.625,
+            (base * 0.75).clamp(0.0, 1.0),
         )));
         p.add_layer(Box::new(TieredCompaction::new(
             config.preserve_recent_turns as usize,
-            config.compression_threshold * 0.9375,
+            (base * 0.9375).clamp(0.0, 1.0),
         )));
         p.add_layer(Box::new(ReactiveCompact::new(0.95)));
         p
     }
 
-    /// Default pipeline (balanced thresholds from default config).
-    pub fn default_pipeline() -> Self {
-        Self::from_config(&CompressionConfig::default())
+    /// Default pipeline for the given context window size.
+    /// Uses CompactionTier-derived adaptive thresholds.
+    pub fn default_pipeline_for(max_tokens: u64) -> Self {
+        Self::from_config(&CompressionConfig::default(), max_tokens)
     }
 
     /// Aggressive pipeline for second-chance compaction retries.
+    /// All thresholds set to 0.0 so every layer fires unconditionally.
     pub fn aggressive_pipeline() -> Self {
         let mut p = Self::new();
+        p.add_layer(Box::new(DuplicateReadElimination::new(0.0)));
         p.add_layer(Box::new(ToolResultTruncation::new(
             Duration::from_secs(300),
             512,
             0.0,
         )));
-        p.add_layer(Box::new(DuplicateReadElimination::new(0.0)));
         p.add_layer(Box::new(TieredCompaction::new(2, 0.0)));
         p.add_layer(Box::new(ReactiveCompact::new(0.0)));
         p
     }
 
     /// Emergency pipeline — absolute last resort before propagating error.
+    /// All thresholds set to 0.0 so every layer fires unconditionally.
     pub fn emergency_pipeline() -> Self {
         let mut p = Self::new();
+        p.add_layer(Box::new(DuplicateReadElimination::new(0.0)));
         p.add_layer(Box::new(ToolResultTruncation::new(
             Duration::from_secs(0),
             128,
             0.0,
         )));
-        p.add_layer(Box::new(DuplicateReadElimination::new(0.0)));
         p.add_layer(Box::new(TieredCompaction::new(1, 0.0)));
         p.add_layer(Box::new(ReactiveCompact::new(0.0)));
         p
@@ -600,8 +618,10 @@ impl CompressionLayer for TieredCompaction {
 
         let freed_tokens: usize = dropped
             .iter()
-            .filter_map(|m| m.get("content").and_then(Value::as_str))
-            .map(|s| crate::prompts::estimate_str_tokens(s))
+            .map(|m| {
+                crate::prompts::estimate_single_message_tokens(m)
+                    + crate::prompts::PER_MESSAGE_OVERHEAD
+            })
             .sum();
 
         let user_queries: Vec<&str> = dropped
@@ -770,8 +790,10 @@ impl CompressionLayer for ReactiveCompact {
 
         let freed_tokens: usize = dropped
             .iter()
-            .filter_map(|m| m.get("content").and_then(Value::as_str))
-            .map(|s| crate::prompts::estimate_str_tokens(s))
+            .map(|m| {
+                crate::prompts::estimate_single_message_tokens(m)
+                    + crate::prompts::PER_MESSAGE_OVERHEAD
+            })
             .sum();
 
         let boundary = serde_json::json!({
@@ -818,25 +840,7 @@ impl CompressionLayer for ReactiveCompact {
 
 // ───────────────────────────── Proactive Context Folding (disabled) ─────
 
-/// Result of proactive folding.
-#[derive(Debug, Clone)]
-pub struct FoldingResult {
-    pub folded_count: usize,
-    pub tokens_freed_estimate: u64,
-}
-
-/// No-op. Previously folded read-only tool results to 200 chars after 2 rounds,
-/// which destroyed content the model needed for edits. All context compaction is
-/// now handled by the single unified pass in `compact_tool_results_adaptive`.
-pub fn fold_old_read_only_results(_messages: &mut [Value], _current_round: u32) -> FoldingResult {
-    FoldingResult {
-        folded_count: 0,
-        tokens_freed_estimate: 0,
-    }
-}
-
 // ───────────────────────────── Tests ─────────────────────────────────────
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1055,7 +1059,8 @@ mod tests {
         // Low pressure — no layer should fire
         let mut msgs = make_agentic_session(3, 2, 500);
         let b = budget(200_000, 30_000); // 15% pressure
-        let outcome = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let outcome =
+            CompactionEngine::default_pipeline_for(64_000).compress_if_needed(&mut msgs, &b);
         assert!(outcome.layer_results.is_empty());
         assert!(outcome.budget_satisfied);
     }
@@ -1066,7 +1071,8 @@ mod tests {
     fn pipeline_empty_messages_no_panic() {
         let mut msgs: Vec<Value> = vec![];
         let b = budget(80_000, 90_000);
-        let outcome = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let outcome =
+            CompactionEngine::default_pipeline_for(64_000).compress_if_needed(&mut msgs, &b);
         assert!(msgs.is_empty());
         assert_eq!(outcome.total_tokens_freed, 0);
     }
@@ -1075,7 +1081,8 @@ mod tests {
     fn pipeline_system_only_no_panic() {
         let mut msgs = vec![json!({"role": "system", "content": "sys"})];
         let b = budget(80_000, 90_000);
-        let outcome = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let outcome =
+            CompactionEngine::default_pipeline_for(64_000).compress_if_needed(&mut msgs, &b);
         assert_eq!(msgs.len(), 1);
         assert_eq!(outcome.total_tokens_freed, 0);
     }
@@ -1087,7 +1094,8 @@ mod tests {
             json!({"role": "user", "content": "next"}),
         ];
         let b = budget(80_000, 40_000);
-        let outcome = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let outcome =
+            CompactionEngine::default_pipeline_for(64_000).compress_if_needed(&mut msgs, &b);
         assert!(msgs[0].get("tool_calls").is_none());
         assert!(outcome.budget_satisfied);
     }
@@ -1985,7 +1993,7 @@ mod tests {
     fn from_config_default_preserves_correct_turn_count() {
         // Default config: preserve_recent_turns=3, compression_threshold=0.8.
         // from_config should create TieredCompaction that keeps 3 turn pairs.
-        let pipeline = CompactionEngine::default_pipeline();
+        let pipeline = CompactionEngine::default_pipeline_for(64_000);
 
         let mut msgs = vec![
             json!({"role": "system", "content": "sys"}),
@@ -2163,7 +2171,8 @@ mod tests {
 
         // Context is at 90% — default pipeline should fire L1 and possibly L3
         let b = budget(100_000, 90_000);
-        let outcome = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let outcome =
+            CompactionEngine::default_pipeline_for(64_000).compress_if_needed(&mut msgs, &b);
 
         assert!(outcome.total_tokens_freed > 0);
 
@@ -2202,7 +2211,8 @@ mod tests {
         // Very high pressure — both pipelines should fire
         let b = budget(80_000, 120_000); // 150% pressure
 
-        let out_default = CompactionEngine::default_pipeline().compress_if_needed(&mut msgs, &b);
+        let out_default =
+            CompactionEngine::default_pipeline_for(64_000).compress_if_needed(&mut msgs, &b);
         let out_aggressive =
             CompactionEngine::aggressive_pipeline().compress_if_needed(&mut msgs_aggressive, &b);
 
@@ -2275,40 +2285,6 @@ mod tests {
     }
 
     // ── Proactive Folding ──────────────────────────────────────────────
-
-    #[test]
-    fn fold_is_noop_preserves_all_content() {
-        let long_content = "x".repeat(500);
-        let mut msgs = vec![json!({
-            "role": "tool",
-            "tool_call_id": "call-1",
-            "content": &long_content,
-            "_tool_name": "read_file",
-            "_round_index": 0
-        })];
-
-        let result = fold_old_read_only_results(&mut msgs, 10);
-
-        assert_eq!(result.folded_count, 0);
-        assert_eq!(result.tokens_freed_estimate, 0);
-        assert_eq!(msgs[0]["content"].as_str().unwrap(), long_content);
-    }
-
-    #[test]
-    fn fold_noop_never_truncates_regardless_of_round_distance() {
-        let long_content = "x".repeat(5000);
-        let mut msgs = vec![
-            json!({"role": "tool", "content": &long_content, "_tool_name": "read_file", "_round_index": 0}),
-            json!({"role": "tool", "content": &long_content, "_tool_name": "grep", "_round_index": 0}),
-            json!({"role": "tool", "content": &long_content, "_tool_name": "git_show", "_round_index": 1}),
-        ];
-
-        let result = fold_old_read_only_results(&mut msgs, 100);
-        assert_eq!(result.folded_count, 0);
-        for msg in &msgs {
-            assert_eq!(msg["content"].as_str().unwrap().len(), 5000);
-        }
-    }
 
     #[test]
     fn tool_truncation_skips_results_in_protected_head() {

--- a/rust/crates/runtime/src/turn/cloud/mod.rs
+++ b/rust/crates/runtime/src/turn/cloud/mod.rs
@@ -1,5 +1,6 @@
 pub mod analytics;
 pub mod compaction;
+pub mod compaction_engine;
 pub mod memoria_compact;
 pub mod memory_orchestrator;
 pub mod session_end_governance;

--- a/rust/crates/runtime/src/turn/compaction_replay.rs
+++ b/rust/crates/runtime/src/turn/compaction_replay.rs
@@ -9,8 +9,8 @@
 //! which handles prompt-level work: schema pruning, section reduction).
 //! This module handles message-level compaction — removing old turns,
 //! summarizing tool results, truncating large outputs — and only triggers
-//! AFTER a 413 has been observed. The local [`RetryTier`] below is NOT
-//! the same enum as the pipeline's `CompactionTier`; it represents
+//! AFTER a 413 has been observed. The [`CompactionKind`] variants
+//! `RetryDefault`/`RetryAggressive`/`RetryEmergency` represent
 //! escalation across retry attempts, not preemptive pressure bands.
 //!
 //! The pipeline's `RecoveryState` is informed of PTL errors and compaction
@@ -24,6 +24,7 @@
 //! `ResumeAction::CompactAndRetry` (for cross-session resume).
 
 use super::cloud::compaction_engine::{CompactionEngine, PipelineOutcome, TokenBudget};
+use astra_turn_core::compaction_types::CompactionKind;
 use serde_json::Value;
 
 /// Maximum number of automatic compact-and-retry cycles per turn.
@@ -63,32 +64,10 @@ pub struct CompactionReplayResult {
     /// Full pipeline outcome (for trace/journal).
     pub pipeline_outcome: PipelineOutcome,
     /// Which compaction tier was used.
-    pub tier: RetryTier,
+    pub tier: CompactionKind,
 }
 
-/// Retry-attempt escalation tier for telemetry — NOT the same as the
-/// pipeline's [`astra_turn_core::compaction_types::CompactionTier`].
-/// These three levels map to the three `CompactionEngine` variants
-/// (default / aggressive / emergency) and escalate with each consecutive
-/// context-window error.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RetryTier {
-    Default,
-    Aggressive,
-    Emergency,
-}
-
-impl RetryTier {
-    pub(crate) fn label(self) -> &'static str {
-        match self {
-            Self::Default => "default",
-            Self::Aggressive => "aggressive",
-            Self::Emergency => "emergency",
-        }
-    }
-}
-
-/// Tracks compaction effectiveness across retries within a turn.
+/// Outcome of a compaction-replay attempt.
 ///
 /// When compaction frees tokens but the next LLM call still fails with a
 /// context-window error, this indicates "insufficient compaction" — the freed
@@ -234,16 +213,19 @@ pub(crate) fn try_compact_for_retry_tiered(
 
     // Tiered escalation: default → aggressive → emergency.
     let (pipeline, tier) = if retry_count <= 1 {
-        (CompactionEngine::default_pipeline(), RetryTier::Default)
+        (
+            CompactionEngine::default_pipeline_for(max_tokens),
+            CompactionKind::RetryDefault,
+        )
     } else if retry_count == 2 {
         (
             CompactionEngine::aggressive_pipeline(),
-            RetryTier::Aggressive,
+            CompactionKind::RetryAggressive,
         )
     } else {
         (
             CompactionEngine::emergency_pipeline(),
-            RetryTier::Emergency,
+            CompactionKind::RetryEmergency,
         )
     };
     let outcome = pipeline.compress_if_needed(messages, &budget);
@@ -442,8 +424,8 @@ mod tests {
 
         let r1 = r1.unwrap();
         let r2 = r2.unwrap();
-        assert_eq!(r1.tier, RetryTier::Default);
-        assert_eq!(r2.tier, RetryTier::Aggressive);
+        assert_eq!(r1.tier, CompactionKind::RetryDefault);
+        assert_eq!(r2.tier, CompactionKind::RetryAggressive);
 
         // Aggressive pipeline should free at least as many tokens
         assert!(
@@ -460,7 +442,7 @@ mod tests {
         let r = try_compact_for_retry_tiered(&mut msgs, Some(200_000), 100_000, 3);
         assert!(r.is_some(), "emergency tier should compact");
         let r = r.unwrap();
-        assert_eq!(r.tier, RetryTier::Emergency);
+        assert_eq!(r.tier, CompactionKind::RetryEmergency);
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/compaction_replay.rs
+++ b/rust/crates/runtime/src/turn/compaction_replay.rs
@@ -23,7 +23,7 @@
 //! propagates as a structured `InterruptionRecord` with
 //! `ResumeAction::CompactAndRetry` (for cross-session resume).
 
-use super::context_compression::{CompressionPipeline, PipelineOutcome, TokenBudget};
+use super::cloud::compaction_engine::{CompactionEngine, PipelineOutcome, TokenBudget};
 use serde_json::Value;
 
 /// Maximum number of automatic compact-and-retry cycles per turn.
@@ -68,7 +68,7 @@ pub struct CompactionReplayResult {
 
 /// Retry-attempt escalation tier for telemetry — NOT the same as the
 /// pipeline's [`astra_turn_core::compaction_types::CompactionTier`].
-/// These three levels map to the three `CompressionPipeline` variants
+/// These three levels map to the three `CompactionEngine` variants
 /// (default / aggressive / emergency) and escalate with each consecutive
 /// context-window error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -213,8 +213,8 @@ pub(crate) fn try_compact_for_retry_tiered(
     // pre-request pressure estimate in `agentic_loop::lifecycle` so a
     // CompactAndRetry triggered precisely by large tool_calls is not
     // silently skipped.
-    let measured =
-        last_measured_tokens.unwrap_or_else(|| crate::prompts::estimate_tokens(messages) as u64);
+    let measured = last_measured_tokens
+        .unwrap_or_else(|| crate::prompts::estimate_tokens(messages, 0, 0) as u64);
 
     let max_tokens = if model_context_limit > 0 {
         model_context_limit
@@ -234,15 +234,15 @@ pub(crate) fn try_compact_for_retry_tiered(
 
     // Tiered escalation: default → aggressive → emergency.
     let (pipeline, tier) = if retry_count <= 1 {
-        (CompressionPipeline::default_pipeline(), RetryTier::Default)
+        (CompactionEngine::default_pipeline(), RetryTier::Default)
     } else if retry_count == 2 {
         (
-            CompressionPipeline::aggressive_pipeline(),
+            CompactionEngine::aggressive_pipeline(),
             RetryTier::Aggressive,
         )
     } else {
         (
-            CompressionPipeline::emergency_pipeline(),
+            CompactionEngine::emergency_pipeline(),
             RetryTier::Emergency,
         )
     };
@@ -343,21 +343,6 @@ pub fn try_compact_for_retry_checked(
 }
 
 /// Build a concise summary string for the compaction event (for logs/journal).
-pub(crate) fn compaction_summary(result: &CompactionReplayResult) -> String {
-    let layers = result.layer_descriptions.join(", ");
-    format!(
-        "compacted ~{} tokens ({} messages removed) via [{}]; budget {}",
-        result.tokens_freed,
-        result.messages_removed,
-        layers,
-        if result.budget_likely_satisfied {
-            "likely satisfied"
-        } else {
-            "still pressured"
-        }
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -436,26 +421,6 @@ mod tests {
             result.is_some(),
             "expected compaction to run with estimated tokens"
         );
-    }
-
-    #[test]
-    fn compaction_summary_format() {
-        let result = CompactionReplayResult {
-            tokens_freed: 5000,
-            messages_removed: 12,
-            layer_descriptions: vec!["ToolResultTruncation: ~2000 tokens".into()],
-            budget_likely_satisfied: true,
-            tier: RetryTier::Default,
-            pipeline_outcome: PipelineOutcome {
-                layer_results: Vec::new(),
-                total_tokens_freed: 5000,
-                budget_satisfied: true,
-            },
-        };
-        let s = compaction_summary(&result);
-        assert!(s.contains("5000"));
-        assert!(s.contains("12 messages"));
-        assert!(s.contains("likely satisfied"));
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
@@ -326,8 +326,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
             }
             let (mut tool_msg, tr) =
                 headless_idempotency_hit_openai_pair(&slot.id, &slot.name, &cached.output);
-            // Add folding metadata so fold_old_read_only_results can decay
-            // cache-hit results the same way it decays fresh tool results.
+            // Add round-index metadata for cache-hit result tracking.
             if let Some(obj) = tool_msg.as_object_mut() {
                 obj.insert(
                     "_round_index".to_string(),

--- a/rust/crates/runtime/src/turn/mod.rs
+++ b/rust/crates/runtime/src/turn/mod.rs
@@ -6,7 +6,6 @@ pub mod budget_messaging;
 pub mod chat_turn_budget_pressure;
 pub mod cloud;
 pub mod compaction_replay;
-pub mod context_compression;
 pub(crate) mod context_pipeline_adapter;
 pub mod harness_adapter;
 pub mod headless_tool_pipeline;

--- a/rust/crates/runtime/tests/compaction_survival.rs
+++ b/rust/crates/runtime/tests/compaction_survival.rs
@@ -2,13 +2,12 @@
 //! realistic multi-round agentic workflows.
 //!
 //! Context compaction is now a single unified pass (compact_tool_results_adaptive)
-//! running before each LLM call. fold_old_read_only_results is a no-op and
-//! run_micro_compact has been removed.
+//! running before each LLM call.
 //!
 //! These tests encode the invariant: **within a single user turn, tool results
 //! must survive long enough for the model to act on them.**
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 // ─── Helpers ────────────────────────────────────────────────────────────
 
@@ -121,8 +120,6 @@ fn read_results_survive_through_edit_round() {
     ));
 
     // Now simulate what happens before round 4 (the edit round):
-    // The system runs fold_old_read_only_results with current_round=4.
-    astra_runtime::turn::cloud::compaction_engine::fold_old_read_only_results(&mut messages, 4);
 
     // INVARIANT: The round-0 file reads must still be usable.
     // The model needs the full code content to craft a str_replace.
@@ -169,8 +166,6 @@ fn no_partial_content_folding_ever() {
             "grep",
         ));
     }
-
-    astra_runtime::turn::cloud::compaction_engine::fold_old_read_only_results(&mut messages, 9);
 
     let content = messages[2]["content"].as_str().unwrap();
 
@@ -227,10 +222,7 @@ fn fold_then_microcompact_no_useless_stubs() {
         tool_result_with_round("c8", &big_content, 3, "read_file"),
     ];
 
-    // Step 1: fold runs (round 5)
-    astra_runtime::turn::cloud::compaction_engine::fold_old_read_only_results(&mut messages, 5);
-
-    // Step 2: microcompact runs at low pressure
+    // microcompact runs at low pressure
     astra_turn_core::microcompact::compact_tool_results_adaptive(
         &mut messages,
         0.3,
@@ -360,8 +352,7 @@ fn mutation_evidence_survives_all_compaction_stages() {
         ));
     }
 
-    // Run both compaction stages (fold is a no-op, unified adaptive is the real pass)
-    astra_runtime::turn::cloud::compaction_engine::fold_old_read_only_results(&mut messages, 7);
+    // Run compaction
     astra_turn_core::microcompact::compact_tool_results_adaptive(
         &mut messages,
         0.85,

--- a/rust/crates/runtime/tests/compaction_survival.rs
+++ b/rust/crates/runtime/tests/compaction_survival.rs
@@ -8,7 +8,7 @@
 //! These tests encode the invariant: **within a single user turn, tool results
 //! must survive long enough for the model to act on them.**
 
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 // ─── Helpers ────────────────────────────────────────────────────────────
 
@@ -122,7 +122,7 @@ fn read_results_survive_through_edit_round() {
 
     // Now simulate what happens before round 4 (the edit round):
     // The system runs fold_old_read_only_results with current_round=4.
-    astra_runtime::turn::context_compression::fold_old_read_only_results(&mut messages, 4);
+    astra_runtime::turn::cloud::compaction_engine::fold_old_read_only_results(&mut messages, 4);
 
     // INVARIANT: The round-0 file reads must still be usable.
     // The model needs the full code content to craft a str_replace.
@@ -170,7 +170,7 @@ fn no_partial_content_folding_ever() {
         ));
     }
 
-    astra_runtime::turn::context_compression::fold_old_read_only_results(&mut messages, 9);
+    astra_runtime::turn::cloud::compaction_engine::fold_old_read_only_results(&mut messages, 9);
 
     let content = messages[2]["content"].as_str().unwrap();
 
@@ -228,7 +228,7 @@ fn fold_then_microcompact_no_useless_stubs() {
     ];
 
     // Step 1: fold runs (round 5)
-    astra_runtime::turn::context_compression::fold_old_read_only_results(&mut messages, 5);
+    astra_runtime::turn::cloud::compaction_engine::fold_old_read_only_results(&mut messages, 5);
 
     // Step 2: microcompact runs at low pressure
     astra_turn_core::microcompact::compact_tool_results_adaptive(
@@ -361,7 +361,7 @@ fn mutation_evidence_survives_all_compaction_stages() {
     }
 
     // Run both compaction stages (fold is a no-op, unified adaptive is the real pass)
-    astra_runtime::turn::context_compression::fold_old_read_only_results(&mut messages, 7);
+    astra_runtime::turn::cloud::compaction_engine::fold_old_read_only_results(&mut messages, 7);
     astra_turn_core::microcompact::compact_tool_results_adaptive(
         &mut messages,
         0.85,


### PR DESCRIPTION
## Summary

Comprehensive fix-all from a three-angle code review (first-principles, test coverage, code quality) of the compaction engine on branch `fix_0601_04`.

## Changes

### First-Principles Fixes
- **Layer ordering**: `DuplicateReadElimination` now runs before `ToolResultTruncation` (cheapest-first principle)
- **Token estimation**: `tokens_freed` now includes `PER_MESSAGE_OVERHEAD` for accurate pipeline exit checks
- **Retry compaction**: `tokens_before` uses `max_turn_input_tokens` instead of `0` when `last_measured_prompt_tokens` is `None`
- **`aggressive_trigger` docs**: fixed doc comment claiming +15 points when actually +10

### Code Quality
- **DRY extraction**: `run_proactive_compaction()` helper unified ~30 lines of duplicate code for pre-turn and resume compaction paths
- **Dead code removal**: `fold_old_read_only_results` removed; `RetryTier` enum deleted in favor of `CompactionKind`
- **Import hygiene**: full-qualified paths replaced with top-level imports in `lifecycle.rs`
- **`try_into().unwrap_or(0)`** on `u64` → simpler direct usage

### Resume Compaction
- Resume compaction path now calls `record_compaction_audit()` (was silently invisible to pipeline stats)
- Added boundary marker insertion after resume compaction

### UI Integration
- `CompactionEvent` propagated as structured `StreamEvent::Compaction` for TUI/cli consumers
- Stderr dim-line fallback for headless mode

### Test Coverage
- CJK regression tests strengthened: `pressure >= 0.6` for CompactHistory tier, delta assertions
- 128K boundary tests added: `pre_turn_trigger_at_128k_boundary` / `aggressive_trigger_at_128k_boundary`
- Resume compaction path test: `prepare_turn_resume_compacts_high_pressure`
- `pressure_grows_with_message_count` now checks monotonic growth per-step
- `CompactionKind` enum used in tests instead of raw strings

## Test Results
```
astra-runtime lib:   3242 passed, 0 failed, 16 skipped
astra-turn-core:     6 passed, 0 failed
compaction_survival: 6 passed, 0 failed
clippy:              clean (-D warnings)
```

## Files Changed
27 files, +1141 −366 lines