### PR TITLE
feat(admin): add taas token key binding

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -115,8 +115,13 @@ astra-admin model delete gpt-4
 astra-admin model load .models.yaml
 
 # Token management
-astra-admin token list [--token-type llm] [--scope global]
-astra-admin token create --type llm --provider openai --scope global [--scope-id acme] [--token-value "$OPENAI_API_KEY"]
+astra-admin token list [--token-type llm] [--provider openai] [--scope global] [--scope-id USER_OR_REPO]
+astra-admin token create --type llm --provider openai --scope global [--token-value "$OPENAI_API_KEY"]
+astra-admin token create --type api_key --provider github --scope user --scope-id USER_ID [--token-value "$API_KEY"]
+
+# TAAS token key binding
+astra-admin taas list-keys [--user-id ASTRA_USER_ID]
+astra-admin taas bind-key --user-id ASTRA_USER_ID --token-value "$TAAS_TOKEN_KEY"
 
 # Skill management
 astra-admin skill list [--limit 50] [--offset 0]

--- a/rust/crates/astra-admin/src/cli_args.rs
+++ b/rust/crates/astra-admin/src/cli_args.rs
@@ -30,6 +30,8 @@ pub(crate) enum Command {
     #[command(subcommand)]
     Token(TokenCmd),
     #[command(subcommand)]
+    Taas(TaasCmd),
+    #[command(subcommand)]
     Skill(SkillCmd),
     #[command(subcommand)]
     Prompt(PromptCmd),
@@ -175,7 +177,11 @@ pub(crate) struct TokenListArgs {
     #[arg(long)]
     pub token_type: Option<String>,
     #[arg(long)]
+    pub provider: Option<String>,
+    #[arg(long)]
     pub scope: Option<String>,
+    #[arg(long)]
+    pub scope_id: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -190,6 +196,26 @@ pub(crate) struct TokenCreateArgs {
     pub scope_id: Option<String>,
     #[arg(long)]
     pub token_value: Option<String>,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum TaasCmd {
+    ListKeys(TaasListKeysArgs),
+    BindKey(TaasBindKeyArgs),
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct TaasListKeysArgs {
+    #[arg(long)]
+    pub user_id: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct TaasBindKeyArgs {
+    #[arg(long)]
+    pub user_id: String,
+    #[arg(long)]
+    pub token_value: String,
 }
 
 #[derive(Subcommand, Debug)]
@@ -305,5 +331,65 @@ mod tests {
     fn default_api_url() {
         let cli = Cli::try_parse_from(["astra-admin", "init"]).unwrap();
         assert_eq!(cli.api_url, None);
+    }
+
+    #[test]
+    fn parse_token_list_filters() {
+        let cli = Cli::try_parse_from([
+            "astra-admin",
+            "token",
+            "list",
+            "--token-type",
+            "api_key",
+            "--provider",
+            "taas",
+            "--scope",
+            "user",
+            "--scope-id",
+            "u123",
+        ])
+        .unwrap();
+        if let Some(Command::Token(TokenCmd::List(args))) = cli.command {
+            assert_eq!(args.token_type.as_deref(), Some("api_key"));
+            assert_eq!(args.provider.as_deref(), Some("taas"));
+            assert_eq!(args.scope.as_deref(), Some("user"));
+            assert_eq!(args.scope_id.as_deref(), Some("u123"));
+        } else {
+            panic!("expected token list command");
+        }
+    }
+
+    #[test]
+    fn parse_taas_bind_key_requires_token_value() {
+        let result = Cli::try_parse_from(["astra-admin", "taas", "bind-key", "--user-id", "u123"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_taas_commands() {
+        let bind = Cli::try_parse_from([
+            "astra-admin",
+            "taas",
+            "bind-key",
+            "--user-id",
+            "u123",
+            "--token-value",
+            "taas-key",
+        ])
+        .unwrap();
+        if let Some(Command::Taas(TaasCmd::BindKey(args))) = bind.command {
+            assert_eq!(args.user_id, "u123");
+            assert_eq!(args.token_value, "taas-key");
+        } else {
+            panic!("expected taas bind-key command");
+        }
+
+        let list =
+            Cli::try_parse_from(["astra-admin", "taas", "list-keys", "--user-id", "u123"]).unwrap();
+        if let Some(Command::Taas(TaasCmd::ListKeys(args))) = list.command {
+            assert_eq!(args.user_id.as_deref(), Some("u123"));
+        } else {
+            panic!("expected taas list-keys command");
+        }
     }
 }

--- a/rust/crates/astra-admin/src/main.rs
+++ b/rust/crates/astra-admin/src/main.rs
@@ -18,6 +18,10 @@ use http_helpers::*;
 use input::*;
 use interactive::run_interactive;
 
+const TAAS_TOKEN_TYPE: &str = "api_key";
+const TAAS_TOKEN_PROVIDER: &str = "taas";
+const TAAS_TOKEN_SCOPE: &str = "user";
+
 /// Parse `POST /models` or `PUT /models/{name}` JSON and print `is_active` / `connectivity`.
 fn print_model_load_server_result(body: &str, model_name: &str) {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
@@ -606,8 +610,14 @@ async fn main() -> Result<(), String> {
             if let Some(token_type) = args.token_type {
                 q.push(("token_type", token_type));
             }
+            if let Some(provider) = args.provider {
+                q.push(("provider", provider));
+            }
             if let Some(scope) = args.scope {
                 q.push(("scope", scope));
+            }
+            if let Some(scope_id) = args.scope_id {
+                q.push(("scope_id", scope_id));
             }
             let body = api
                 .get_bearer_path_query_text(&token, paths::ADMIN_TOKENS, &q)
@@ -627,6 +637,42 @@ async fn main() -> Result<(), String> {
                         "provider": args.provider,
                         "scope": args.scope,
                         "scope_id": args.scope_id,
+                        "token_value": args.token_value
+                    }),
+                )
+                .await
+                .map_err(map_thin_err)?;
+            print_json_or_raw(&body);
+            Ok(())
+        }
+        Command::Taas(TaasCmd::ListKeys(args)) => {
+            let (_, _, _, token) = get_profile_and_token(cli.profile.as_deref())?;
+            let mut q = vec![
+                ("token_type", TAAS_TOKEN_TYPE.to_string()),
+                ("provider", TAAS_TOKEN_PROVIDER.to_string()),
+                ("scope", TAAS_TOKEN_SCOPE.to_string()),
+            ];
+            if let Some(user_id) = args.user_id {
+                q.push(("scope_id", user_id));
+            }
+            let body = api
+                .get_bearer_path_query_text(&token, paths::ADMIN_TOKENS, &q)
+                .await
+                .map_err(map_thin_err)?;
+            print_json_or_raw(&body);
+            Ok(())
+        }
+        Command::Taas(TaasCmd::BindKey(args)) => {
+            let (_, _, _, token) = get_profile_and_token(cli.profile.as_deref())?;
+            let body = api
+                .post_bearer_path_json_text(
+                    &token,
+                    paths::ADMIN_TOKENS,
+                    &serde_json::json!({
+                        "token_type": TAAS_TOKEN_TYPE,
+                        "provider": TAAS_TOKEN_PROVIDER,
+                        "scope": TAAS_TOKEN_SCOPE,
+                        "scope_id": args.user_id,
                         "token_value": args.token_value
                     }),
                 )

--- a/rust/crates/astra-server-types/src/http_type_tests.rs
+++ b/rust/crates/astra-server-types/src/http_type_tests.rs
@@ -97,6 +97,21 @@ fn admin_token_create_request_defaults_applied() {
 }
 
 #[test]
+fn admin_token_list_query_all_fields() {
+    let input = json!({
+        "token_type": "api_key",
+        "provider": "taas",
+        "scope": "user",
+        "scope_id": "u123"
+    });
+    let q: AdminTokenListQuery = serde_json::from_value(input).unwrap();
+    assert_eq!(q.token_type.as_deref(), Some("api_key"));
+    assert_eq!(q.provider.as_deref(), Some("taas"));
+    assert_eq!(q.scope.as_deref(), Some("user"));
+    assert_eq!(q.scope_id.as_deref(), Some("u123"));
+}
+
+#[test]
 fn admin_audit_list_query_defaults_applied() {
     let q: AdminAuditListQuery = serde_json::from_str("{}").unwrap();
     assert_eq!(q.limit, 100);

--- a/rust/crates/astra-server-types/src/lib.rs
+++ b/rust/crates/astra-server-types/src/lib.rs
@@ -415,7 +415,9 @@ pub struct LearningTriggerResponse {
 #[derive(Deserialize, Default)]
 pub struct AdminTokenListQuery {
     pub token_type: Option<String>,
+    pub provider: Option<String>,
     pub scope: Option<String>,
+    pub scope_id: Option<String>,
 }
 
 #[cfg(feature = "server")]

--- a/rust/crates/runtime/src/server/admin_handlers.rs
+++ b/rust/crates/runtime/src/server/admin_handlers.rs
@@ -20,7 +20,9 @@ pub(super) async fn admin_list_tokens_handler(
         .token_reader
         .list_tokens(AdminTokenFilter {
             token_type: query.token_type,
+            provider: query.provider,
             scope: query.scope,
+            scope_id: query.scope_id,
         })
         .await?;
 
@@ -35,17 +37,17 @@ pub(super) async fn admin_create_token_handler(
     Json(request): Json<AdminTokenCreateRequest>,
 ) -> Result<(StatusCode, Json<AdminTokenResponse>), (StatusCode, Json<ErrorResponse>)> {
     state.admin.authorizer.require_admin(&headers).await?;
-    let created = state
-        .admin
-        .token_writer
-        .create_token(AdminTokenCreateRequestData {
-            token_type: request.token_type,
-            provider: request.provider,
-            scope: request.scope,
-            scope_id: request.scope_id,
-            token_value: request.token_value,
-        })
-        .await?;
+    let request_data = AdminTokenCreateRequestData {
+        token_type: request.token_type,
+        provider: request.provider,
+        scope: request.scope,
+        scope_id: request.scope_id,
+        token_value: request.token_value,
+    };
+    request_data
+        .validate()
+        .map_err(|message| error_response(StatusCode::BAD_REQUEST, message))?;
+    let created = state.admin.token_writer.create_token(request_data).await?;
 
     Ok((StatusCode::CREATED, Json(AdminTokenResponse::from(created))))
 }

--- a/rust/crates/runtime/tests/admin_contract.rs
+++ b/rust/crates/runtime/tests/admin_contract.rs
@@ -131,11 +131,17 @@ impl AdminTokenReader for StubAdminTokenReader {
         if let Some(token_type) = filter.token_type {
             tokens.retain(|token| token.token_type == token_type);
         }
+        if let Some(provider) = filter.provider {
+            tokens.retain(|token| token.provider.as_deref() == Some(provider.as_str()));
+        }
         if let Some(scope) = filter.scope {
             match scope.as_str() {
                 "user" | "repo" | "global" => tokens.retain(|token| token.scope == scope),
                 _ => {}
             }
+        }
+        if let Some(scope_id) = filter.scope_id {
+            tokens.retain(|token| token.scope_id.as_deref() == Some(scope_id.as_str()));
         }
 
         Ok(tokens)
@@ -539,6 +545,44 @@ async fn admin_token_create_matches_shared_contract() {
 }
 
 #[tokio::test]
+async fn admin_token_create_rejects_invalid_taas_binding() {
+    let (status, json) = post_json(
+        build_app_with_admin(),
+        "/admin/tokens",
+        &[("authorization", "Bearer admin-token")],
+        serde_json::json!({
+            "token_type": "api_key",
+            "provider": "taas",
+            "scope": "user",
+            "scope_id": "contract-user-123"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["detail"], "TAAS token bindings require token_value");
+}
+
+#[tokio::test]
+async fn admin_token_create_rejects_invalid_scope_shape() {
+    let (status, json) = post_json(
+        build_app_with_admin(),
+        "/admin/tokens",
+        &[("authorization", "Bearer admin-token")],
+        serde_json::json!({
+            "token_type": "llm",
+            "provider": "openai",
+            "scope": "global",
+            "scope_id": "contract-user-123"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["detail"], "scope_id must be omitted for global tokens");
+}
+
+#[tokio::test]
 async fn admin_async_jobs_match_shared_contract() {
     let contract = load_contract();
     let app = build_app_with_admin();
@@ -671,6 +715,39 @@ async fn admin_tokens_variants_match_shared_contract() {
         assert_eq!(status.as_u16(), expected.status, "{label}");
         assert_contract_json(&json, &expected.json, label);
     }
+
+    let (status, json) = read_json(
+        app.clone(),
+        "/admin/tokens?provider=github&scope=user&scope_id=contract-user-123",
+        auth,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        json,
+        serde_json::json!([{
+            "token_id": "contract-user-token",
+            "token_type": "api",
+            "provider": "github",
+            "scope": "user",
+            "scope_id": "contract-user-123",
+            "created_at": "2026-01-02T09:30:00"
+        }])
+    );
+
+    let (status, json) = read_json(app, "/admin/tokens?scope_id=contract-user-123", auth).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        json,
+        serde_json::json!([{
+            "token_id": "contract-user-token",
+            "token_type": "api",
+            "provider": "github",
+            "scope": "user",
+            "scope_id": "contract-user-123",
+            "created_at": "2026-01-02T09:30:00"
+        }])
+    );
 }
 
 #[tokio::test]

--- a/rust/crates/services/src/admin.rs
+++ b/rust/crates/services/src/admin.rs
@@ -5,6 +5,12 @@ use axum::{
     http::{HeaderMap, StatusCode},
 };
 
+pub const ADMIN_TOKEN_SCOPE_GLOBAL: &str = "global";
+pub const ADMIN_TOKEN_SCOPE_REPO: &str = "repo";
+pub const ADMIN_TOKEN_SCOPE_USER: &str = "user";
+pub const ADMIN_TOKEN_TYPE_API_KEY: &str = "api_key";
+pub const ADMIN_TOKEN_PROVIDER_TAAS: &str = "taas";
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AuthenticatedUser {
     pub user_id: String,
@@ -14,7 +20,20 @@ pub struct AuthenticatedUser {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AdminTokenFilter {
     pub token_type: Option<String>,
+    pub provider: Option<String>,
     pub scope: Option<String>,
+    pub scope_id: Option<String>,
+}
+
+impl AdminTokenFilter {
+    pub fn taas_user_key(scope_id: Option<String>) -> Self {
+        Self {
+            token_type: Some(ADMIN_TOKEN_TYPE_API_KEY.to_string()),
+            provider: Some(ADMIN_TOKEN_PROVIDER_TAAS.to_string()),
+            scope: Some(ADMIN_TOKEN_SCOPE_USER.to_string()),
+            scope_id,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -34,6 +53,63 @@ pub struct AdminTokenCreateRequestData {
     pub scope: String,
     pub scope_id: Option<String>,
     pub token_value: Option<String>,
+}
+
+impl AdminTokenCreateRequestData {
+    pub fn taas_user_key(user_id: String, token_value: String) -> Self {
+        Self {
+            token_type: ADMIN_TOKEN_TYPE_API_KEY.to_string(),
+            provider: Some(ADMIN_TOKEN_PROVIDER_TAAS.to_string()),
+            scope: ADMIN_TOKEN_SCOPE_USER.to_string(),
+            scope_id: Some(user_id),
+            token_value: Some(token_value),
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.token_type.trim().is_empty() {
+            return Err("token_type is required".to_string());
+        }
+
+        match self.scope.as_str() {
+            ADMIN_TOKEN_SCOPE_GLOBAL => {
+                if match self.scope_id.as_deref() {
+                    Some(scope_id) => !scope_id.trim().is_empty(),
+                    None => false,
+                } {
+                    return Err("scope_id must be omitted for global tokens".to_string());
+                }
+            }
+            ADMIN_TOKEN_SCOPE_USER | ADMIN_TOKEN_SCOPE_REPO => {
+                if match self.scope_id.as_deref() {
+                    Some(scope_id) => scope_id.trim().is_empty(),
+                    None => true,
+                } {
+                    return Err(format!("scope_id is required for {} tokens", self.scope));
+                }
+            }
+            _ => {
+                return Err("scope must be one of global, user, or repo".to_string());
+            }
+        }
+
+        if self.provider.as_deref() == Some(ADMIN_TOKEN_PROVIDER_TAAS) {
+            if self.token_type != ADMIN_TOKEN_TYPE_API_KEY {
+                return Err("TAAS token bindings must use token_type api_key".to_string());
+            }
+            if self.scope != ADMIN_TOKEN_SCOPE_USER {
+                return Err("TAAS token bindings must use user scope".to_string());
+            }
+            if match self.token_value.as_deref() {
+                Some(token_value) => token_value.trim().is_empty(),
+                None => true,
+            } {
+                return Err("TAAS token bindings require token_value".to_string());
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -144,4 +220,104 @@ pub trait AdminUserRoleManager: Send + Sync {
         &self,
         request: AdminUserRoleRequestData,
     ) -> Result<AdminUserRoleRecord, (StatusCode, Json<ErrorResponse>)>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn taas_user_key_filter_uses_binding_convention() {
+        let filter = AdminTokenFilter::taas_user_key(Some("u123".to_string()));
+
+        assert_eq!(filter.token_type.as_deref(), Some(ADMIN_TOKEN_TYPE_API_KEY));
+        assert_eq!(filter.provider.as_deref(), Some(ADMIN_TOKEN_PROVIDER_TAAS));
+        assert_eq!(filter.scope.as_deref(), Some(ADMIN_TOKEN_SCOPE_USER));
+        assert_eq!(filter.scope_id.as_deref(), Some("u123"));
+    }
+
+    #[test]
+    fn taas_user_key_request_is_valid() {
+        let request =
+            AdminTokenCreateRequestData::taas_user_key("u123".to_string(), "taas-key".to_string());
+
+        assert_eq!(request.token_type, ADMIN_TOKEN_TYPE_API_KEY);
+        assert_eq!(request.provider.as_deref(), Some(ADMIN_TOKEN_PROVIDER_TAAS));
+        assert_eq!(request.scope, ADMIN_TOKEN_SCOPE_USER);
+        assert_eq!(request.scope_id.as_deref(), Some("u123"));
+        assert_eq!(request.token_value.as_deref(), Some("taas-key"));
+        assert!(request.validate().is_ok());
+    }
+
+    #[test]
+    fn global_token_without_scope_id_is_valid() {
+        let request = AdminTokenCreateRequestData {
+            token_type: "llm".to_string(),
+            provider: Some("openai".to_string()),
+            scope: ADMIN_TOKEN_SCOPE_GLOBAL.to_string(),
+            scope_id: None,
+            token_value: None,
+        };
+
+        assert!(request.validate().is_ok());
+    }
+
+    #[test]
+    fn user_token_requires_scope_id() {
+        let request = AdminTokenCreateRequestData {
+            token_type: "api_key".to_string(),
+            provider: Some("github".to_string()),
+            scope: ADMIN_TOKEN_SCOPE_USER.to_string(),
+            scope_id: None,
+            token_value: Some("key".to_string()),
+        };
+
+        assert_eq!(
+            request.validate().unwrap_err(),
+            "scope_id is required for user tokens"
+        );
+    }
+
+    #[test]
+    fn global_token_rejects_scope_id() {
+        let request = AdminTokenCreateRequestData {
+            token_type: "llm".to_string(),
+            provider: Some("openai".to_string()),
+            scope: ADMIN_TOKEN_SCOPE_GLOBAL.to_string(),
+            scope_id: Some("u123".to_string()),
+            token_value: None,
+        };
+
+        assert_eq!(
+            request.validate().unwrap_err(),
+            "scope_id must be omitted for global tokens"
+        );
+    }
+
+    #[test]
+    fn taas_token_requires_user_scope_and_value() {
+        let missing_value = AdminTokenCreateRequestData {
+            token_type: ADMIN_TOKEN_TYPE_API_KEY.to_string(),
+            provider: Some(ADMIN_TOKEN_PROVIDER_TAAS.to_string()),
+            scope: ADMIN_TOKEN_SCOPE_USER.to_string(),
+            scope_id: Some("u123".to_string()),
+            token_value: None,
+        };
+        assert_eq!(
+            missing_value.validate().unwrap_err(),
+            "TAAS token bindings require token_value"
+        );
+
+        let repo_scoped = AdminTokenCreateRequestData {
+            token_type: ADMIN_TOKEN_TYPE_API_KEY.to_string(),
+            provider: Some(ADMIN_TOKEN_PROVIDER_TAAS.to_string()),
+            scope: ADMIN_TOKEN_SCOPE_REPO.to_string(),
+            scope_id: Some("repo".to_string()),
+            token_value: Some("key".to_string()),
+        };
+        assert_eq!(
+            repo_scoped.validate().unwrap_err(),
+            "TAAS token bindings must use user scope"
+        );
+    }
 }

--- a/rust/crates/services/src/auth/admin.rs
+++ b/rust/crates/services/src/auth/admin.rs
@@ -1,11 +1,12 @@
 use super::encryption::FernetTokenEncryptor;
 use super::jwt::decode_jwt_claims;
 use crate::admin::{
-    AdminAuditFilter, AdminAuditReader, AdminAuditRecord, AdminAuthorizer,
-    AdminFeedbackStatsFilter, AdminFeedbackStatsReader, AdminFeedbackStatsRecord, AdminInitRecord,
-    AdminInitializer, AdminTokenCreateRequestData, AdminTokenFilter, AdminTokenReader,
-    AdminTokenRecord, AdminTokenWriter, AdminUserRoleManager, AdminUserRoleRecord,
-    AdminUserRoleRequestData, AuthenticatedUser,
+    ADMIN_TOKEN_SCOPE_GLOBAL, ADMIN_TOKEN_SCOPE_REPO, ADMIN_TOKEN_SCOPE_USER, AdminAuditFilter,
+    AdminAuditReader, AdminAuditRecord, AdminAuthorizer, AdminFeedbackStatsFilter,
+    AdminFeedbackStatsReader, AdminFeedbackStatsRecord, AdminInitRecord, AdminInitializer,
+    AdminTokenCreateRequestData, AdminTokenFilter, AdminTokenReader, AdminTokenRecord,
+    AdminTokenWriter, AdminUserRoleManager, AdminUserRoleRecord, AdminUserRoleRequestData,
+    AuthenticatedUser,
 };
 use crate::pagination::clamp_admin_audit_limit;
 use astra_core::{
@@ -367,16 +368,48 @@ impl AdminTokenReader for DatabaseAdminTokenReader {
             has_where = true;
         }
 
+        if let Some(provider) = filter.provider {
+            query_builder.push(if has_where { " AND " } else { " WHERE " });
+            query_builder.push("provider = ");
+            query_builder.push_bind(provider);
+            has_where = true;
+        }
+
         if let Some(scope) = filter.scope.as_deref() {
             let clause = match scope {
-                "user" => Some("scope_user_id IS NOT NULL"),
-                "repo" => Some("scope_repo IS NOT NULL"),
-                "global" => Some("scope_user_id IS NULL AND scope_repo IS NULL"),
+                ADMIN_TOKEN_SCOPE_USER => Some("scope_user_id IS NOT NULL"),
+                ADMIN_TOKEN_SCOPE_REPO => Some("scope_repo IS NOT NULL"),
+                ADMIN_TOKEN_SCOPE_GLOBAL => Some("scope_user_id IS NULL AND scope_repo IS NULL"),
                 _ => None,
             };
             if let Some(clause) = clause {
                 query_builder.push(if has_where { " AND " } else { " WHERE " });
                 query_builder.push(clause);
+                has_where = true;
+            }
+        }
+
+        if let Some(scope_id) = filter.scope_id {
+            query_builder.push(if has_where { " AND " } else { " WHERE " });
+            match filter.scope.as_deref() {
+                Some(ADMIN_TOKEN_SCOPE_REPO) => {
+                    query_builder.push("scope_repo = ");
+                    query_builder.push_bind(scope_id);
+                }
+                Some(ADMIN_TOKEN_SCOPE_GLOBAL) => {
+                    query_builder.push("1 = 0");
+                }
+                Some(ADMIN_TOKEN_SCOPE_USER) => {
+                    query_builder.push("scope_user_id = ");
+                    query_builder.push_bind(scope_id);
+                }
+                _ => {
+                    query_builder.push("(scope_user_id = ");
+                    query_builder.push_bind(scope_id.clone());
+                    query_builder.push(" OR scope_repo = ");
+                    query_builder.push_bind(scope_id);
+                    query_builder.push(")");
+                }
             }
         }
 
@@ -417,6 +450,9 @@ impl AdminTokenWriter for DatabaseAdminTokenWriter {
         &self,
         request: AdminTokenCreateRequestData,
     ) -> Result<AdminTokenRecord, (StatusCode, Json<ErrorResponse>)> {
+        request
+            .validate()
+            .map_err(|message| error_response(StatusCode::BAD_REQUEST, message))?;
         let token_id = Uuid::new_v4().to_string();
         let provider = request.provider.unwrap_or_else(|| "unknown".to_string());
         let encrypted_value = request
@@ -425,12 +461,12 @@ impl AdminTokenWriter for DatabaseAdminTokenWriter {
             .map(|value| self.encryptor.encrypt(value))
             .transpose()
             .map_err(internal_error)?;
-        let scope_user_id = if request.scope == "user" {
+        let scope_user_id = if request.scope == ADMIN_TOKEN_SCOPE_USER {
             request.scope_id.clone()
         } else {
             None
         };
-        let scope_repo = if request.scope == "repo" {
+        let scope_repo = if request.scope == ADMIN_TOKEN_SCOPE_REPO {
             request.scope_id.clone()
         } else {
             None


### PR DESCRIPTION
## What type of PR is this?

- [x] feat (new feature)
- [ ] fix (bug fix)
- [x] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [x] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes #

## What this PR does / why we need it

This PR adds an ASTRA-side TAAS token key binding base without introducing a runtime dependency on TAAS. It keeps ASTRA registration/login unchanged and uses the existing encrypted `auth_tokens` storage to bind a TAAS token key to an ASTRA local user with the convention `token_type=api_key`, `provider=taas`, `scope=user`, and `scope_id=<astra_user_id>`.

The intent is to support manual admin backfill now, while providing the storage/API/CLI base for the upcoming TAAS enterprise plan integration. Once TAAS provides the enterprise-account flow for one account with multiple keys, ASTRA can replace the manual bind step with automatic key creation and store the returned key in the same format.

Changes included:

- Extend `/admin/tokens` filtering with `provider` and `scope_id`.
- Add `astra-admin taas bind-key --user-id <ASTRA_USER_ID> --token-value <TAAS_TOKEN_KEY>`.
- Add `astra-admin taas list-keys [--user-id <ASTRA_USER_ID>]`.
- Keep TAAS key storage encrypted through existing `auth_tokens.encrypted_value`.
- Update CLI docs and add focused request/contract/CLI parsing tests.

Local verification:

```bash
make format-check
cargo fmt --manifest-path rust/Cargo.toml --all
cargo test --manifest-path rust/Cargo.toml -p astra-admin-cli cli_args::tests
cargo test --manifest-path rust/Cargo.toml -p astra-runtime --test admin_contract admin_tokens_variants_match_shared_contract
cargo test --manifest-path rust/Cargo.toml -p astra-server-types admin_token --features server
cargo check --manifest-path rust/Cargo.toml -p astra-admin-cli
```