### PR TITLE
fix: add SWE-bench benchmark profile

### DIFF
--- a/rust/crates/astra-cli/src/cli/app_server.rs
+++ b/rust/crates/astra-cli/src/cli/app_server.rs
@@ -443,6 +443,8 @@ async fn run_turn(
         harness_sink: None,
         #[cfg(feature = "harness")]
         harness_trace: None,
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     };
     let append_system_prompt = params
         .get("developerInstructions")

--- a/rust/crates/astra-cli/src/cli/chat_stream/params.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/params.rs
@@ -455,6 +455,9 @@ pub(crate) struct ChatTurnParams<'a> {
     #[cfg(feature = "harness")]
     pub(crate) harness_trace:
         Option<std::sync::Arc<std::sync::RwLock<astra_harness::SessionTrace>>>,
+    /// Optional benchmark profile for one-shot/headless runs.
+    #[cfg(feature = "harness")]
+    pub(crate) benchmark_profile: Option<astra_harness::HarnessProfile>,
 }
 
 /// Bundle of "basic CLI" fields shared across one-shot CLI chat invocations
@@ -509,6 +512,9 @@ pub(crate) struct BasicCliChatContext<'a> {
     /// Shared harness trace for /inspect trace command (non-REPL one-shot paths).
     #[cfg(feature = "harness")]
     pub harness_trace: Option<std::sync::Arc<std::sync::RwLock<astra_harness::SessionTrace>>>,
+    /// Optional benchmark profile for one-shot/headless runs.
+    #[cfg(feature = "harness")]
+    pub benchmark_profile: Option<astra_harness::HarnessProfile>,
 }
 
 impl<'a> ChatTurnParams<'a> {
@@ -586,6 +592,8 @@ impl<'a> ChatTurnParams<'a> {
             harness_sink: ctx.harness_sink.clone(),
             #[cfg(feature = "harness")]
             harness_trace: ctx.harness_trace.clone(),
+            #[cfg(feature = "harness")]
+            benchmark_profile: ctx.benchmark_profile,
         }
     }
 }

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -816,11 +816,17 @@ pub(crate) async fn stream_chat_sse(
             {
                 match p.harness_sink.as_ref() {
                     Some(sink) => {
-                        let base_kernel = std::sync::Arc::new(
-                            astra_harness::StandardKernel::with_default_verifiers(
-                                sink.clone() as std::sync::Arc<dyn astra_harness::SnapshotSink>
+                        let sink_for_kernel =
+                            sink.clone() as std::sync::Arc<dyn astra_harness::SnapshotSink>;
+                        let base_kernel = std::sync::Arc::new(match p.benchmark_profile {
+                            Some(profile) => astra_harness::StandardKernel::with_profile(
+                                sink_for_kernel,
+                                profile,
                             ),
-                        );
+                            None => astra_harness::StandardKernel::with_default_verifiers(
+                                sink_for_kernel,
+                            ),
+                        });
                         let session_id = p.session_id.map(|s| s.to_string());
                         let recording = if let Some(ref trace_arc) = p.harness_trace {
                             // Share SessionState's trace Arc so /inspect reads live data

--- a/rust/crates/astra-cli/src/cli/chat_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_turn.rs
@@ -1287,6 +1287,8 @@ async fn run_chat_turn(
             harness_sink: Some(state.harness_sink.clone()),
             #[cfg(feature = "harness")]
             harness_trace: Some(state.harness_trace.clone()),
+            #[cfg(feature = "harness")]
+            benchmark_profile: None,
         });
         tokio::pin!(stream_fut);
 

--- a/rust/crates/astra-cli/src/cli/cli_args.rs
+++ b/rust/crates/astra-cli/src/cli/cli_args.rs
@@ -37,6 +37,11 @@ fn parse_explain_mode_arg(value: &str) -> Result<crate::ExplainMode, String> {
     }
 }
 
+#[cfg(feature = "harness")]
+fn parse_benchmark_profile_arg(value: &str) -> Result<astra_harness::HarnessProfile, String> {
+    value.parse()
+}
+
 #[derive(Parser, Debug)]
 #[command(name = "astra")]
 #[command(about = "AI agent CLI — run `astra` for interactive chat")]
@@ -355,6 +360,10 @@ pub(crate) struct ChatArgs {
     /// Model override
     #[arg(long)]
     pub model: Option<String>,
+    /// Benchmark execution profile. Currently supports `swebench`.
+    #[cfg(feature = "harness")]
+    #[arg(long = "benchmark-profile", value_parser = parse_benchmark_profile_arg)]
+    pub benchmark_profile: Option<astra_harness::HarnessProfile>,
     /// Enable explain mode (`--explain` => on, `--explain verbose` => verbose)
     #[arg(
         long,

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -295,6 +295,8 @@ async fn execute_headless_task_body(
         harness_trace: Some(std::sync::Arc::new(std::sync::RwLock::new(
             astra_harness::SessionTrace::new(None),
         ))),
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     };
 
     let turn_options = crate::cli::turn_facade::BasicCliTurnOptions::default();
@@ -1664,6 +1666,8 @@ pub(crate) async fn execute_cli_command(
                 harness_trace: Some(std::sync::Arc::new(std::sync::RwLock::new(
                     astra_harness::SessionTrace::new(None),
                 ))),
+                #[cfg(feature = "harness")]
+                benchmark_profile: None,
             };
             let turn_options = crate::cli::turn_facade::BasicCliTurnOptions {
                 pre_loaded_messages: continuation_messages.take(),
@@ -2224,6 +2228,8 @@ pub(crate) async fn execute_cli_command(
                 harness_sink: Some(harness_sink.clone()),
                 #[cfg(feature = "harness")]
                 harness_trace: Some(harness_trace),
+                #[cfg(feature = "harness")]
+                benchmark_profile: args.benchmark_profile,
             };
             let turn_options = crate::cli::turn_facade::BasicCliTurnOptions {
                 pre_loaded_messages: continuation_messages.take(),
@@ -3050,6 +3056,8 @@ pub(crate) async fn run_print_mode(
         harness_trace: Some(std::sync::Arc::new(std::sync::RwLock::new(
             astra_harness::SessionTrace::new(None),
         ))),
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     };
 
     let turn_options = crate::cli::turn_facade::BasicCliTurnOptions {

--- a/rust/crates/astra-cli/src/cli/plan_executor.rs
+++ b/rust/crates/astra-cli/src/cli/plan_executor.rs
@@ -1553,6 +1553,8 @@ async fn plan_executor_task(
                     harness_sink: ctx.harness_sink.clone(),
                     #[cfg(feature = "harness")]
                     harness_trace: ctx.harness_trace.clone(),
+                    #[cfg(feature = "harness")]
+                    benchmark_profile: None,
                 })
                 .await;
 

--- a/rust/crates/astra-cli/src/cli/slash_info.rs
+++ b/rust/crates/astra-cli/src/cli/slash_info.rs
@@ -1290,6 +1290,8 @@ pub(crate) async fn handle_info_command(
                 harness_sink: Some(state.harness_sink.clone()),
                 #[cfg(feature = "harness")]
                 harness_trace: Some(state.harness_trace.clone()),
+                #[cfg(feature = "harness")]
+                benchmark_profile: None,
             })
             .await
             .map_err(|f| f.error)?;

--- a/rust/crates/astra-cli/src/cli/slash_state.rs
+++ b/rust/crates/astra-cli/src/cli/slash_state.rs
@@ -97,6 +97,8 @@ impl<'a> CompactCtx<'a> {
             harness_sink: Some(self.state.harness_sink.clone()),
             #[cfg(feature = "harness")]
             harness_trace: Some(self.state.harness_trace.clone()),
+            #[cfg(feature = "harness")]
+            benchmark_profile: None,
         }
     }
 }

--- a/rust/crates/astra-cli/src/cli/slash_task.rs
+++ b/rust/crates/astra-cli/src/cli/slash_task.rs
@@ -346,6 +346,8 @@ pub(crate) async fn handle_task_command(
                     harness_sink: Some(bg_harness_sink.clone()),
                     #[cfg(feature = "harness")]
                     harness_trace: Some(bg_harness_trace.clone()),
+                    #[cfg(feature = "harness")]
+                    benchmark_profile: None,
                 })
                 .await;
 

--- a/rust/crates/astra-cli/src/tests/chat_stream_tests.rs
+++ b/rust/crates/astra-cli/src/tests/chat_stream_tests.rs
@@ -103,6 +103,8 @@ async fn stream_chat_sse_persists_first_turn_step_events_under_adopted_session_i
         harness_sink: None,
         #[cfg(feature = "harness")]
         harness_trace: None,
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     })
     .await
     .unwrap();
@@ -214,6 +216,8 @@ async fn stream_chat_sse_simple_text_response() {
         harness_sink: None,
         #[cfg(feature = "harness")]
         harness_trace: None,
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     })
     .await
     .unwrap();
@@ -318,6 +322,8 @@ async fn stream_chat_sse_preserves_existing_session_id_for_server_scoped_trace()
         harness_sink: None,
         #[cfg(feature = "harness")]
         harness_trace: None,
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     })
     .await
     .unwrap();
@@ -426,6 +432,8 @@ async fn stream_chat_sse_reuses_persistent_root_mailbox_across_turns() {
             harness_sink: None,
             #[cfg(feature = "harness")]
             harness_trace: None,
+            #[cfg(feature = "harness")]
+            benchmark_profile: None,
         })
         .await
         .unwrap();
@@ -526,6 +534,8 @@ async fn stream_chat_sse_unregisters_ephemeral_root_mailbox() {
         harness_sink: None,
         #[cfg(feature = "harness")]
         harness_trace: None,
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     })
     .await
     .unwrap();
@@ -654,6 +664,8 @@ async fn stream_chat_sse_api_error_propagated() {
         harness_sink: None,
         #[cfg(feature = "harness")]
         harness_trace: None,
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     })
     .await;
     assert!(result.is_err());
@@ -758,6 +770,8 @@ async fn stream_chat_sse_with_tool_call_loop() {
         harness_sink: None,
         #[cfg(feature = "harness")]
         harness_trace: None,
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     })
     .await
     .unwrap();
@@ -885,6 +899,8 @@ async fn stream_chat_sse_journals_transaction_boundaries_end_to_end() {
         harness_sink: None,
         #[cfg(feature = "harness")]
         harness_trace: None,
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     })
     .await
     .unwrap();
@@ -1055,6 +1071,8 @@ async fn stream_chat_sse_reuses_authoritative_turn_identity_across_chat_turn_ret
         harness_sink: None,
         #[cfg(feature = "harness")]
         harness_trace: None,
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     })
     .await
     .unwrap();
@@ -1208,6 +1226,8 @@ async fn stream_chat_sse_dispatches_mcp_tool_call() {
         harness_sink: None,
         #[cfg(feature = "harness")]
         harness_trace: None,
+        #[cfg(feature = "harness")]
+        benchmark_profile: None,
     })
     .await
     .unwrap();

--- a/rust/crates/astra-harness/src/kernel.rs
+++ b/rust/crates/astra-harness/src/kernel.rs
@@ -1,6 +1,7 @@
 use crate::{
     DecisionRecord, HarnessKernel, HookVerdict, RuntimeSnapshot, Severity, SnapshotSink, Verifier,
 };
+use std::str::FromStr;
 use std::sync::Arc;
 
 pub struct StandardKernel {
@@ -22,6 +23,11 @@ impl StandardKernel {
         Self::configured(sink, HarnessLimits::default())
     }
 
+    /// Create a kernel with verifiers configured for a named execution profile.
+    pub fn with_profile(sink: Arc<dyn SnapshotSink>, profile: HarnessProfile) -> Self {
+        Self::configured(sink, profile.limits())
+    }
+
     /// Create a kernel with verifiers configured from explicit limits.
     pub fn configured(sink: Arc<dyn SnapshotSink>, limits: HarnessLimits) -> Self {
         let mut verifiers: Vec<Box<dyn Verifier>> = vec![
@@ -33,7 +39,11 @@ impl StandardKernel {
             Box::new(crate::verifiers::TurnGuardVerifierAdapter::default()),
             Box::new(crate::verifiers::DelegationVerifier::default()),
             Box::new(crate::verifiers::ConfidenceVerifier::default()),
-            Box::new(crate::verifiers::ProgressVerifier::default()),
+            Box::new(crate::verifiers::ProgressVerifier {
+                max_read_only_round_streak: limits.max_read_only_round_streak,
+                max_redundant_read_count: limits.max_redundant_read_count,
+                ..Default::default()
+            }),
             Box::new(crate::verifiers::CompletionVerifier),
         ];
         if let Some(max_cost) = limits.max_session_cost_usd {
@@ -55,8 +65,39 @@ impl StandardKernel {
     }
 }
 
+/// Named verifier profiles for different execution modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HarnessProfile {
+    #[default]
+    Default,
+    Swebench,
+}
+
+impl HarnessProfile {
+    pub fn limits(self) -> HarnessLimits {
+        match self {
+            Self::Default => HarnessLimits::default(),
+            Self::Swebench => HarnessLimits::swebench(),
+        }
+    }
+}
+
+impl FromStr for HarnessProfile {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "default" => Ok(Self::Default),
+            "swebench" | "swe-bench" => Ok(Self::Swebench),
+            other => Err(format!(
+                "invalid benchmark profile `{other}` (expected swebench)"
+            )),
+        }
+    }
+}
+
 /// Production limits for harness verifiers.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct HarnessLimits {
     pub max_turns: Option<u32>,
     pub max_tokens: Option<u64>,
@@ -68,6 +109,41 @@ pub struct HarnessLimits {
     pub cache_creation_cost_per_mtok: Option<f64>,
     pub max_tool_calls_per_session: Option<u32>,
     pub sensitive_tools: Vec<String>,
+    pub max_read_only_round_streak: u32,
+    pub max_redundant_read_count: u32,
+}
+
+impl Default for HarnessLimits {
+    fn default() -> Self {
+        let progress = crate::verifiers::ProgressVerifier::default();
+        Self {
+            max_turns: None,
+            max_tokens: None,
+            max_duration_millis: None,
+            max_session_cost_usd: None,
+            prompt_cost_per_mtok: None,
+            completion_cost_per_mtok: None,
+            cache_read_cost_per_mtok: None,
+            cache_creation_cost_per_mtok: None,
+            max_tool_calls_per_session: None,
+            sensitive_tools: Vec::new(),
+            max_read_only_round_streak: progress.max_read_only_round_streak,
+            max_redundant_read_count: progress.max_redundant_read_count,
+        }
+    }
+}
+
+impl HarnessLimits {
+    /// SWE-bench runs are offline/headless and should continue until they
+    /// produce a patch, finish, or hit the runner timeout. Disable the
+    /// interactive read-only checkpoint while keeping the other verifiers.
+    pub fn swebench() -> Self {
+        Self {
+            max_read_only_round_streak: 0,
+            max_redundant_read_count: 0,
+            ..Self::default()
+        }
+    }
 }
 
 impl StandardKernel {
@@ -224,6 +300,31 @@ mod tests {
             }
             other => panic!("expected pause verdict, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn swebench_profile_disables_progress_pause() {
+        let sink = InMemorySnapshotSink::arc();
+        let kernel = StandardKernel::with_profile(sink.clone(), HarnessProfile::Swebench);
+        let mut record = make_record(HookPoint::PostTurn, 1, 0);
+        record.snapshot.final_state = Some("empty".into());
+        record.snapshot.read_only_round_streak = 100;
+        record.snapshot.redundant_read_count = 100;
+
+        assert!(matches!(kernel.on_record(&record), HookVerdict::Continue));
+    }
+
+    #[test]
+    fn benchmark_profile_parser_accepts_only_known_profiles() {
+        assert_eq!(
+            "swebench".parse::<HarnessProfile>(),
+            Ok(HarnessProfile::Swebench)
+        );
+        assert_eq!(
+            "swe-bench".parse::<HarnessProfile>(),
+            Ok(HarnessProfile::Swebench)
+        );
+        assert!("unknown".parse::<HarnessProfile>().is_err());
     }
 
     #[test]

--- a/rust/crates/astra-harness/src/lib.rs
+++ b/rust/crates/astra-harness/src/lib.rs
@@ -11,7 +11,7 @@ pub mod verifiers;
 
 pub use adjust::{AdjustCommand, AdjustSender, adjust_channel};
 pub use debug::{Breakpoint, DebugKernel};
-pub use kernel::{HarnessLimits, StandardKernel};
+pub use kernel::{HarnessLimits, HarnessProfile, StandardKernel};
 pub use query::{HarnessQueryReceiver, HarnessQuerySender, query_channel};
 pub use rollback::RollbackAssessment;
 pub use snapshot_diff::SnapshotDiff;


### PR DESCRIPTION
## Summary

- Add `--benchmark-profile` for one-shot/headless Astra CLI runs.
- Add `HarnessProfile::Swebench`, accepting `swebench` / `swe-bench`.
- Disable the interactive read-only checkpoint for SWE-bench profile while keeping the rest of the harness guardrails.
- Thread the optional benchmark profile through the CLI chat parameter plumbing.

This isolates the runtime/profile fix used by the SWE-bench evaluation without adding the local experimental runner script to the main repository.

## Validation

- `cargo fmt --check`
- `cargo clippy -p astra-harness -- -D warnings`
- `cargo test -p astra-harness profile`
- `cargo test -p astra-cli --no-run`
- `cargo check -p astra-cli --features harness`
