### PR TITLE
fix: refine exit semantics — signal detection, detach robustness, and error classification

### DIFF
--- a/rust/crates/astra-cli/src/cli/task/task_result_projection.rs
+++ b/rust/crates/astra-cli/src/cli/task/task_result_projection.rs
@@ -97,7 +97,12 @@ pub(crate) fn stream_result_exit_code(sr: &StreamResult) -> crate::cli::exit_cod
                 | astra_tools::exit_semantics::ExitSemantics::DomainNegative,
             ) => false,
             None => !r.ok,
-            Some(astra_tools::exit_semantics::ExitSemantics::ExecutionError) => true,
+            Some(
+                astra_tools::exit_semantics::ExitSemantics::TimedOut
+                | astra_tools::exit_semantics::ExitSemantics::Cancelled
+                | astra_tools::exit_semantics::ExitSemantics::Signaled
+                | astra_tools::exit_semantics::ExitSemantics::ExecutionError,
+            ) => true,
         }
     };
 
@@ -217,6 +222,48 @@ mod tests {
         assert_eq!(stream_result_exit_code(&result), ExitCode::PersistenceError);
         result.session_persistence_error = None;
         assert_eq!(stream_result_exit_code(&result), ExitCode::Partial);
+    }
+
+    #[test]
+    fn stream_result_exit_code_treats_terminal_exit_semantics_as_tool_failure() {
+        for semantics in ["timed_out", "cancelled", "signaled", "execution_error"] {
+            let result = StreamResult {
+                tool_call_records: vec![astra_services::session_journal::ToolCallRecord {
+                    name: "bash".into(),
+                    ok: false,
+                    exit_semantics: Some(semantics.into()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+
+            assert_eq!(
+                stream_result_exit_code(&result),
+                ExitCode::ToolFailure,
+                "{semantics}"
+            );
+        }
+    }
+
+    #[test]
+    fn stream_result_exit_code_treats_domain_negative_exit_semantics_as_success() {
+        for semantics in ["success", "informational_failure", "domain_negative"] {
+            let result = StreamResult {
+                tool_call_records: vec![astra_services::session_journal::ToolCallRecord {
+                    name: "bash".into(),
+                    ok: false,
+                    exit_semantics: Some(semantics.into()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+
+            assert_eq!(
+                stream_result_exit_code(&result),
+                ExitCode::Success,
+                "{semantics}"
+            );
+        }
     }
 
     #[test]

--- a/rust/crates/astra-tools/src/exit_semantics.rs
+++ b/rust/crates/astra-tools/src/exit_semantics.rs
@@ -18,6 +18,13 @@ pub enum ExitSemantics {
     /// Command completed normally and found a negative/different
     /// domain state (e.g. `diff` found differences, `test` false).
     DomainNegative,
+    /// Command was terminated because the tool timeout elapsed.
+    TimedOut,
+    /// Command was terminated because the user/run cancellation token fired.
+    Cancelled,
+    /// Command was terminated by a signal. POSIX shells conventionally surface
+    /// this as exit status `128 + signal`.
+    Signaled,
     /// Command failed to execute, crashed, was denied, or returned a
     /// tool-specific real error.
     ExecutionError,
@@ -26,7 +33,10 @@ pub enum ExitSemantics {
 impl ExitSemantics {
     #[must_use]
     pub fn is_tool_error(self) -> bool {
-        matches!(self, Self::ExecutionError)
+        matches!(
+            self,
+            Self::TimedOut | Self::Cancelled | Self::Signaled | Self::ExecutionError
+        )
     }
 }
 
@@ -65,6 +75,9 @@ pub fn classify_exit(command: &str, exit_code: i32) -> ExitSemantics {
     if exit_code == 0 {
         return ExitSemantics::Success;
     }
+    if (128..256).contains(&exit_code) {
+        return ExitSemantics::Signaled;
+    }
     if matches!(exit_code, 126 | 127) || !(0..128).contains(&exit_code) {
         return ExitSemantics::ExecutionError;
     }
@@ -73,6 +86,7 @@ pub fn classify_exit(command: &str, exit_code: i32) -> ExitSemantics {
     match (family.as_deref(), exit_code) {
         (Some("grep" | "rg" | "ripgrep" | "ag"), 1) => ExitSemantics::InformationalFailure,
         (Some("diff" | "cmp"), 1) => ExitSemantics::DomainNegative,
+        (Some("false"), 1) => ExitSemantics::DomainNegative,
         (Some("test" | "["), 1) => ExitSemantics::DomainNegative,
         (Some("pytest" | "nose2" | "tox" | "unittest" | "jest" | "vitest" | "mocha"), 1) => {
             ExitSemantics::DomainNegative
@@ -116,6 +130,9 @@ pub fn classify_command_result(
                 } else {
                     CommandResultClass::DomainNegative
                 }
+            }
+            ExitSemantics::TimedOut | ExitSemantics::Cancelled | ExitSemantics::Signaled => {
+                CommandResultClass::ExecutionError
             }
             ExitSemantics::ExecutionError => {
                 if is_build_test_or_lint_command(command)
@@ -327,12 +344,13 @@ mod tests {
     }
 
     #[test]
-    fn diff_and_test_false_are_domain_negative() {
+    fn diff_test_false_and_false_are_domain_negative() {
         for command in [
             "diff a b",
             "git diff --quiet",
             "test -f missing",
             "[ -f missing ]",
+            "false",
             "cargo test",
             "go test ./...",
             "npm test",
@@ -347,10 +365,19 @@ mod tests {
     }
 
     #[test]
-    fn command_not_found_and_signal_are_execution_errors() {
-        for code in [2, 126, 127, 130, -1] {
+    fn command_not_found_is_execution_error() {
+        for code in [2, 126, 127, -1] {
             let semantics = classify_exit("grep bad[", code);
             assert_eq!(semantics, ExitSemantics::ExecutionError, "{code}");
+            assert!(semantics.is_tool_error(), "{code}");
+        }
+    }
+
+    #[test]
+    fn signal_encoded_exit_is_signaled() {
+        for code in [129, 130, 137, 143] {
+            let semantics = classify_exit("sleep 999", code);
+            assert_eq!(semantics, ExitSemantics::Signaled, "{code}");
             assert!(semantics.is_tool_error(), "{code}");
         }
     }

--- a/rust/crates/astra-tools/src/lib.rs
+++ b/rust/crates/astra-tools/src/lib.rs
@@ -124,13 +124,11 @@ impl ToolResult {
 
     /// Convert a legacy `String` output into a `ToolResult`.
     ///
-    /// Heuristic: strings starting with `"Error"` are treated as errors.
+    /// A string payload has no reliable error semantics. Callers that know the
+    /// result is an error must use [`ToolResult::error`] instead of relying on
+    /// output text.
     pub fn from_string(output: String) -> Self {
-        if output.starts_with("Error") {
-            Self::error(output)
-        } else {
-            Self::text(output)
-        }
+        Self::text(output)
     }
 }
 
@@ -720,6 +718,13 @@ mod tests {
         let r = ToolResult::error("boom".into());
         assert_eq!(r.output, "boom");
         assert!(r.is_error);
+    }
+
+    #[test]
+    fn tool_result_from_string_does_not_infer_error_from_text() {
+        let r = ToolResult::from_string("Error count: 0".into());
+        assert_eq!(r.output, "Error count: 0");
+        assert!(!r.is_error);
     }
 
     #[test]

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -1,7 +1,7 @@
 //! Shell operations: bash execution, grep, glob.
 
 use std::path::{Path, PathBuf};
-use std::process::{Command as StdCommand, Stdio};
+use std::process::{Command as StdCommand, ExitStatus, Stdio};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
@@ -832,14 +832,19 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
                 // it in its event-loop tick and calls
                 // BackgroundTaskRegistry::adopt_detached_shell.
                 let detach_handle = detach_handle_guard.take().unwrap();
-                if let Some(sender) = detach_handle.payload_tx.lock().await.take() {
-                    let send_failed = sender.send(*payload).is_err();
-                    if send_failed {
-                        return ToolResult::error(
-                            "Error: bash detach: TUI listener dropped before payload arrived"
-                                .to_string(),
-                        );
-                    }
+                let Some(sender) = detach_handle.payload_tx.lock().await.take() else {
+                    terminate_detached_payload(payload).await;
+                    return ToolResult::error(
+                        "Error: bash detach failed: host payload channel was not available"
+                            .to_string(),
+                    );
+                };
+                if let Err(payload) = sender.send(*payload) {
+                    terminate_detached_payload(Box::new(payload)).await;
+                    return ToolResult::error(
+                        "Error: bash detach failed: host listener dropped before payload arrived"
+                            .to_string(),
+                    );
                 }
                 let mut result = ToolResult::text(
                     "<bash_detached>The bash command was promoted to a background task. \
@@ -924,7 +929,8 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
         } else {
             result = format!("Error: bash timed out after {timeout_secs}s with no captured output");
         }
-        return ToolResult::error(truncate_output(result, output_limit));
+        return ToolResult::error(truncate_output(result, output_limit))
+            .with_exit_semantics(ExitSemantics::TimedOut);
     }
 
     if output.cancelled {
@@ -933,7 +939,8 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
         } else {
             result = "Error: bash cancelled before any output was captured".into();
         }
-        return ToolResult::error(truncate_output(result, output_limit));
+        return ToolResult::error(truncate_output(result, output_limit))
+            .with_exit_semantics(ExitSemantics::Cancelled);
     }
 
     let exit_semantics = classify_exit(command, output.exit_code);
@@ -2120,7 +2127,7 @@ async fn load_gitignored_search_paths(
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let exit_code = output.status.code().unwrap_or(-1);
+    let exit_code = exit_code_from_status(&output.status);
     if exit_code == 0 {
         return Ok(stdout.lines().map(strip_current_dir_prefix).collect());
     }
@@ -2908,6 +2915,24 @@ async fn sigkill_process_group(child: &mut tokio::process::Child) {
     let _ = child.wait().await;
 }
 
+fn exit_code_from_status(status: &ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            return 128 + signal;
+        }
+    }
+    -1
+}
+
+async fn terminate_detached_payload(mut payload: Box<crate::detach::DetachedShellPayload>) {
+    sigkill_process_group(&mut payload.child).await;
+}
+
 async fn run_readonly_command_with_partial(
     cmd: &mut Command,
     timeout: Duration,
@@ -2963,7 +2988,7 @@ async fn run_readonly_command_with_partial(
 
         match child.try_wait() {
             Ok(Some(status)) => {
-                exit_code = Some(status.code().unwrap_or(-1));
+                exit_code = Some(exit_code_from_status(&status));
                 break;
             }
             Ok(None) => {
@@ -3116,7 +3141,7 @@ pub(crate) async fn run_bash_with_detach(
 
         match child.try_wait() {
             Ok(Some(status)) => {
-                exit_code = Some(status.code().unwrap_or(-1));
+                exit_code = Some(exit_code_from_status(&status));
                 break;
             }
             Ok(None) => {
@@ -3226,21 +3251,13 @@ pub(crate) async fn run_bash_with_detach(
             });
             return Ok(BashRunOutcome::Detached(payload));
         }
-        // Streams already drained — fall back to Completed shape.
-        let exit_code = child
-            .wait()
-            .await
-            .map(|s| s.code().unwrap_or(-1))
-            .unwrap_or(-1);
-        return Ok(BashRunOutcome::Completed(ReadOnlyCommandOutput {
-            stdout: stdout_text,
-            stderr: stderr_text,
-            exit_code,
-            timed_out: false,
-            cancelled: false,
-            stdout_capped,
-            stderr_capped,
-        }));
+        // Detach is an ownership transfer. If either stream is already gone,
+        // the host cannot safely adopt the live process, so terminate it
+        // instead of leaving an orphan or blocking the foreground tool.
+        sigkill_process_group(&mut child).await;
+        return Err(
+            "Error: bash detach failed: child stream closed before handoff completed".to_string(),
+        );
     }
 
     // Normal completion path: drain remaining bytes and assemble
@@ -4695,6 +4712,75 @@ printf 'probe.txt:1:needle\n'
     }
 
     #[tokio::test]
+    async fn bash_grep_no_match_is_not_tool_error() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("haystack.txt"), "hay\n").unwrap();
+        let ctx = crate::ToolContext::test(dir.path());
+
+        let result = execute_bash(
+            &ctx,
+            &serde_json::json!({
+                "command": "grep needle haystack.txt"
+            }),
+        )
+        .await;
+
+        assert!(
+            !result.is_error,
+            "grep no-match is informational, not a tool error: {}",
+            result.output
+        );
+        assert_eq!(
+            result.exit_semantics,
+            Some(crate::exit_semantics::ExitSemantics::InformationalFailure)
+        );
+    }
+
+    #[tokio::test]
+    async fn bash_diff_difference_is_not_tool_error() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "a\n").unwrap();
+        std::fs::write(dir.path().join("b.txt"), "b\n").unwrap();
+        let ctx = crate::ToolContext::test(dir.path());
+
+        let result = execute_bash(
+            &ctx,
+            &serde_json::json!({
+                "command": "diff a.txt b.txt"
+            }),
+        )
+        .await;
+
+        assert!(
+            !result.is_error,
+            "diff differences are domain-negative, not a tool error: {}",
+            result.output
+        );
+        assert_eq!(
+            result.exit_semantics,
+            Some(crate::exit_semantics::ExitSemantics::DomainNegative)
+        );
+    }
+
+    #[tokio::test]
+    async fn bash_false_is_not_tool_error() {
+        let dir = tempdir().unwrap();
+        let ctx = crate::ToolContext::test(dir.path());
+
+        let result = execute_bash(&ctx, &serde_json::json!({"command": "false"})).await;
+
+        assert!(
+            !result.is_error,
+            "false is a domain-negative shell predicate, not a tool error: {}",
+            result.output
+        );
+        assert_eq!(
+            result.exit_semantics,
+            Some(crate::exit_semantics::ExitSemantics::DomainNegative)
+        );
+    }
+
+    #[tokio::test]
     async fn bash_masked_missing_command_is_env_failure() {
         let dir = tempdir().unwrap();
         let ctx = crate::ToolContext::test(dir.path());
@@ -4746,6 +4832,10 @@ printf 'probe.txt:1:needle\n'
             "got: {}",
             result.output
         );
+        assert_eq!(
+            result.exit_semantics,
+            Some(crate::exit_semantics::ExitSemantics::TimedOut)
+        );
         assert!(!result.output.contains("done"), "got: {}", result.output);
     }
 
@@ -4790,6 +4880,27 @@ printf 'probe.txt:1:needle\n'
             result.output.contains("bash cancelled"),
             "got: {}",
             result.output
+        );
+        assert_eq!(
+            result.exit_semantics,
+            Some(crate::exit_semantics::ExitSemantics::Cancelled)
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn exit_status_signal_is_not_encoded_as_minus_one() {
+        let status = Command::new("bash")
+            .arg("-c")
+            .arg("kill -TERM $$")
+            .status()
+            .await
+            .expect("spawn signal test");
+
+        assert_eq!(exit_code_from_status(&status), 143);
+        assert_eq!(
+            classify_exit("bash -c 'kill -TERM $$'", exit_code_from_status(&status)),
+            crate::exit_semantics::ExitSemantics::Signaled
         );
     }
 
@@ -5227,6 +5338,124 @@ printf 'probe.txt:1:needle\n'
         // The child is still alive in the payload; clean up so the
         // test doesn't leak a sleeping shell.
         drop(payload);
+    }
+
+    #[tokio::test]
+    async fn bash_detach_without_payload_channel_kills_child_and_errors() {
+        let dir = tempdir().unwrap();
+        let mut ctx = crate::ToolContext::test(dir.path());
+        let (handle, listener) = crate::detach::new_detach_pair();
+        *handle.payload_tx.lock().await = None;
+        let slot = Arc::new(Mutex::new(Some(handle)));
+        ctx.detach_shell_handle = Some(slot);
+
+        let bash_fut = tokio::spawn({
+            let ctx = ctx.clone();
+            async move {
+                execute_bash(
+                    &ctx,
+                    &serde_json::json!({
+                        "command": "printf 'before\\n'; sleep 30; printf 'after\\n'"
+                    }),
+                )
+                .await
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        listener.signal_tx.send(true).expect("detach signal send");
+
+        let result = tokio::time::timeout(Duration::from_secs(2), bash_fut)
+            .await
+            .expect("detach failure should not hang")
+            .expect("bash task");
+        assert!(result.is_error, "{result:?}");
+        assert!(
+            result
+                .output
+                .contains("host payload channel was not available"),
+            "{}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn bash_detach_when_listener_dropped_kills_child_and_errors() {
+        let dir = tempdir().unwrap();
+        let mut ctx = crate::ToolContext::test(dir.path());
+        let (slot, listener) = crate::detach::new_slot_with_handle();
+        let crate::detach::DetachShellListener {
+            signal_tx,
+            payload_rx,
+        } = listener;
+        drop(payload_rx);
+        ctx.detach_shell_handle = Some(slot);
+
+        let bash_fut = tokio::spawn({
+            let ctx = ctx.clone();
+            async move {
+                execute_bash(
+                    &ctx,
+                    &serde_json::json!({
+                        "command": "printf 'before\\n'; sleep 30; printf 'after\\n'"
+                    }),
+                )
+                .await
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        signal_tx.send(true).expect("detach signal send");
+
+        let result = tokio::time::timeout(Duration::from_secs(2), bash_fut)
+            .await
+            .expect("detach failure should not hang")
+            .expect("bash task");
+        assert!(result.is_error, "{result:?}");
+        assert!(
+            result
+                .output
+                .contains("host listener dropped before payload arrived"),
+            "{}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn bash_detach_after_stream_eof_kills_child_and_errors() {
+        let dir = tempdir().unwrap();
+        let mut ctx = crate::ToolContext::test(dir.path());
+        let (slot, listener) = crate::detach::new_slot_with_handle();
+        ctx.detach_shell_handle = Some(slot);
+
+        let bash_fut = tokio::spawn({
+            let ctx = ctx.clone();
+            async move {
+                execute_bash(
+                    &ctx,
+                    &serde_json::json!({
+                        "command": "exec 1>&-; sleep 30"
+                    }),
+                )
+                .await
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        listener.signal_tx.send(true).expect("detach signal send");
+
+        let result = tokio::time::timeout(Duration::from_secs(2), bash_fut)
+            .await
+            .expect("detach failure should not hang")
+            .expect("bash task");
+        assert!(result.is_error, "{result:?}");
+        assert!(
+            result
+                .output
+                .contains("child stream closed before handoff completed"),
+            "{}",
+            result.output
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Refines exit semantics classification across the tool layer to better distinguish terminal vs. informational failures, and hardens the bash detach path.

## Changes

### ExitSemantics
- Add `TimedOut`, `Cancelled`, `Signaled` variants
- Detect signal-encoded exits (128-255 range) in `classify_exit()`
- Classify `false` as `DomainNegative`
- `is_tool_error()` now covers all terminal variants

### ToolResult
- `from_string()` no longer infers errors from "Error" prefix — callers must use `ToolResult::error()` explicitly
- Bash timeout/cancel results now carry explicit exit semantics

### Bash detach
- Kill child process when stream closed before handoff completes (prevents orphans)
- Clean up error messaging for detach failures
- Add `terminate_detached_payload()` and `exit_code_from_status()` helpers

### Projection
- `stream_result_exit_code()` treats `TimedOut`/`Cancelled`/`Signaled` as `ToolFailure`

## Tests
- Signal detection tests (129, 130, 137, 143)
- `false` / `grep` no-match / `diff` difference are not tool errors
- Detach edge case: child stream closed before handoff
- Result projection tests for all exit semantics variants