### PR TITLE
chore: rename .kiro/ to .astra/ in permissions/config subsystem

### DIFF
--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -43,7 +43,7 @@ pub(crate) fn safe_alternative_for(reason: &str) -> Option<&'static str> {
     if lower.contains("sensitive path") {
         Some(
             "Write to a workspace-local path instead (e.g. under the current project tree), \
-             or set allow_sensitive_path_writes=true in .kiro/permissions.json to opt in.",
+             or set allow_sensitive_path_writes=true in .astra/permissions.json to opt in.",
         )
     } else if lower.contains("git safety") || lower.contains("force push") {
         Some(
@@ -93,7 +93,7 @@ fn cloud_always_feedback_message(
     if sensitive_path {
         return format!(
             "  ✓ {remember_preview}: allowed for this session only. \
-To auto-allow sensitive paths across sessions, set allow_sensitive_path_writes=true in .kiro/permissions.json."
+To auto-allow sensitive paths across sessions, set allow_sensitive_path_writes=true in .astra/permissions.json."
         );
     }
     if let Some(err) = persist_error {
@@ -864,7 +864,7 @@ fn now_rfc3339() -> String {
 }
 
 impl PermissionSettings {
-    /// Load from the project-level settings file (`.kiro/permissions.json`).
+    /// Load from the project-level settings file (`.astra/permissions.json`).
     ///
     /// Backwards-compatible facade: returns the parsed settings, falling
     /// back to `default()` on any error and emitting a `tracing::warn`.
@@ -882,7 +882,7 @@ impl PermissionSettings {
     /// settings (always defaulted on error so the agent stays usable)
     /// and a structured error for the UI to surface.
     pub fn try_load(project_root: &Path) -> PermissionSettingsLoadOutcome {
-        let path = project_root.join(".kiro").join("permissions.json");
+        let path = project_root.join(".astra").join("permissions.json");
         Self::try_load_inner(&path)
     }
 
@@ -989,7 +989,7 @@ impl PermissionSettings {
     /// Writes atomically via temp file + rename. Use `modify` (preferred) when
     /// correctness across concurrent processes matters.
     pub fn save(&self, project_root: &Path) -> io::Result<()> {
-        let dir = project_root.join(".kiro");
+        let dir = project_root.join(".astra");
         let path = dir.join("permissions.json");
         self.save_to_file(&dir, &path)
     }
@@ -1027,7 +1027,7 @@ impl PermissionSettings {
     ///
     /// `modify` closes that gap by:
     ///
-    /// 1. Acquiring an exclusive flock on `.kiro/permissions.lock`
+    /// 1. Acquiring an exclusive flock on `.astra/permissions.lock`
     ///    (blocks until any other process releases).
     /// 2. Re-reading the JSON file from disk so the closure sees
     ///    the freshest baseline.
@@ -1106,14 +1106,14 @@ impl PermissionSettings {
     where
         F: FnOnce(&mut Self) -> Result<(), E>,
     {
-        let dir = project_root.join(".kiro");
+        let dir = project_root.join(".astra");
         let path = dir.join("permissions.json");
         let lock_path = dir.join("permissions.lock");
         Self::modify_file(
             &dir,
             &path,
             &lock_path,
-            "create .kiro/",
+            "create .astra/",
             mutate,
             |settings| settings.save(project_root),
         )
@@ -1524,7 +1524,7 @@ impl PermissionManager {
     }
 
     /// Create with settings loaded from a project directory.
-    /// Loads `.kiro/permissions.json` if it exists, applying persistent allow/deny rules.
+    /// Loads `.astra/permissions.json` if it exists, applying persistent allow/deny rules.
     pub(crate) fn with_project(auto_approve: bool, project_root: &Path) -> Self {
         let mode = if auto_approve {
             PermissionMode::Auto
@@ -2529,7 +2529,7 @@ impl PermissionManager {
                 //   1. In-session override, keyed on the approval
                 //      fingerprint — the same process won't re-prompt.
                 //   2. Persistent allow rule, written to
-                //      `.kiro/permissions.json` — survives restart.
+                //      `.astra/permissions.json` — survives restart.
                 // Before this branch was fixed, only (1) fired for the
                 // cloud path while the local path did both. Symptom:
                 // next `astra` invocation re-prompts the same tool.
@@ -2816,7 +2816,7 @@ impl PermissionManager {
             return;
         };
 
-        let target_path = root.join(".kiro/permissions.json");
+        let target_path = root.join(".astra/permissions.json");
         let timestamp_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
@@ -4413,7 +4413,7 @@ mod tests {
     #[test]
     fn try_load_returns_corrupt_for_invalid_json() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         let path = kiro.join("permissions.json");
         std::fs::write(&path, "{ this is not json").unwrap();
@@ -4438,7 +4438,7 @@ mod tests {
     #[test]
     fn try_load_returns_invalid_rule_for_unknown_v2_key() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(
             kiro.join("permissions.json"),
@@ -4457,7 +4457,7 @@ mod tests {
     #[test]
     fn permission_manager_with_corrupt_project_records_load_error() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(kiro.join("permissions.json"), "not valid json").unwrap();
 
@@ -4478,7 +4478,7 @@ mod tests {
         // or may not be capturing). The new signal is on
         // `PermissionManager::load_errors()`, not on `load()`.
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(kiro.join("permissions.json"), "garbage").unwrap();
 
@@ -4541,7 +4541,7 @@ mod tests {
         // trying to fix by hand. modify surfaces the error so the
         // caller (TUI banner / headless exit-1) can deal with it.
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(kiro.join("permissions.json"), "{ not json").unwrap();
 
@@ -4589,7 +4589,7 @@ mod tests {
     #[test]
     fn load_policy_headless_safe_drops_project_allow_keeps_deny() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(
             kiro.join("permissions.json"),
@@ -4619,7 +4619,7 @@ mod tests {
     #[test]
     fn load_policy_interactive_untrusted_drops_allow_keeps_deny() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(
             kiro.join("permissions.json"),
@@ -4647,7 +4647,7 @@ mod tests {
     #[test]
     fn load_policy_interactive_trusted_loads_everything() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(
             kiro.join("permissions.json"),
@@ -4672,7 +4672,7 @@ mod tests {
     #[test]
     fn load_policy_corrupt_file_still_surfaces_through_headless_safe() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(kiro.join("permissions.json"), "{ bad").unwrap();
 
@@ -4690,7 +4690,7 @@ mod tests {
     #[test]
     fn workspace_trust_unknown_drops_allow_keeps_deny() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(
             kiro.join("permissions.json"),
@@ -4754,7 +4754,7 @@ mod tests {
     #[test]
     fn workspace_trust_matching_hash_loads_project_allow() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(
             kiro.join("permissions.json"),
@@ -4784,7 +4784,7 @@ mod tests {
     #[test]
     fn workspace_trust_hash_mismatch_drops_project_allow() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         let permissions_path = kiro.join("permissions.json");
         std::fs::write(&permissions_path, r#"{"allow":["Bash(ls:*)"]}"#).unwrap();
@@ -6207,7 +6207,7 @@ mod tests {
     fn rules_summary_shows_mode_and_rules() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
-        let kiro = root.join(".kiro");
+        let kiro = root.join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(
             kiro.join("permissions.json"),
@@ -7646,8 +7646,8 @@ mod tests {
         );
 
         // And persisted to disk — `PermissionSettings::save` writes to
-        // `<project>/.kiro/permissions.json` (see impl).
-        let settings_path = dir.path().join(".kiro").join("permissions.json");
+        // `<project>/.astra/permissions.json` (see impl).
+        let settings_path = dir.path().join(".astra").join("permissions.json");
         assert!(
             settings_path.exists(),
             "permissions.json must be written to disk at {}",
@@ -7730,7 +7730,7 @@ mod tests {
             );
         }
 
-        let settings_path = dir.path().join(".kiro").join("permissions.json");
+        let settings_path = dir.path().join(".astra").join("permissions.json");
         if settings_path.exists() {
             let on_disk = std::fs::read_to_string(&settings_path).unwrap();
             let saved: PermissionSettings = serde_json::from_str(&on_disk).unwrap();

--- a/rust/crates/astra-cli/src/cli/plan/plan_executor.rs
+++ b/rust/crates/astra-cli/src/cli/plan/plan_executor.rs
@@ -1190,7 +1190,7 @@ async fn plan_executor_task(
         emit_event(&update_tx, event);
     }
     // Issue #326 P5b: plan_executor is a headless sub-run; project
-    // allow rules from .kiro/permissions.json must NOT escalate the
+    // allow rules from .astra/permissions.json must NOT escalate the
     // sub-run's capabilities, but project deny rules are kept so the
     // user's restrictions still bind. apply_load_policy(HeadlessSafe)
     // strips allow_*/allow_sensitive_path_writes while preserving deny.

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -380,7 +380,7 @@ fn persist_scoped_allow_rule(
     }
     if let Some(err) = pm.take_last_save_error() {
         let target_label = match target {
-            astra_turn_core::permission::audit::PersistTarget::Project => ".kiro/permissions.json",
+            astra_turn_core::permission::audit::PersistTarget::Project => ".astra/permissions.json",
             astra_turn_core::permission::audit::PersistTarget::User => "~/.astra/permissions.json",
         };
         astra_core::agent_warn!(

--- a/rust/crates/astra-cli/src/cli/workspace_trust.rs
+++ b/rust/crates/astra-cli/src/cli/workspace_trust.rs
@@ -514,8 +514,8 @@ pub fn project_permissions_hash(workspace: &Path) -> Result<Option<String>, Work
 #[cfg(test)]
 mod tests {
     use super::{
-        evaluate_workspace_trust_from_path, project_permissions_hash, TrustState,
-        WorkspaceTrustError, WorkspaceTrustLedger, WorkspaceTrustReason,
+        TrustState, WorkspaceTrustError, WorkspaceTrustLedger, WorkspaceTrustReason,
+        evaluate_workspace_trust_from_path, project_permissions_hash,
     };
     use std::path::Path;
 

--- a/rust/crates/astra-cli/src/cli/workspace_trust.rs
+++ b/rust/crates/astra-cli/src/cli/workspace_trust.rs
@@ -3,7 +3,7 @@
 //!
 //! ## Why
 //!
-//! `.kiro/permissions.json` is a project-level file that ends up
+//! `.astra/permissions.json` is a project-level file that ends up
 //! committed to git. If a user clones a hostile repo (or just an
 //! unfamiliar one) and starts astra, the project file can grant
 //! the agent capabilities the user didn't intend — the
@@ -44,7 +44,7 @@
 //! }
 //! ```
 //!
-//! `rules_hash` is the SHA-256 of `.kiro/permissions.json` at the
+//! `rules_hash` is the SHA-256 of `.astra/permissions.json` at the
 //! moment trust was granted. If the project file later changes
 //! (team adds rules), the next session sees a hash mismatch and
 //! can prompt the user "N rules changed — re-review?".
@@ -152,7 +152,7 @@ pub struct WorkspaceTrustEntry {
     /// `None` for `Ask`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trusted_at: Option<String>,
-    /// SHA-256 of `.kiro/permissions.json` at the moment the trust
+    /// SHA-256 of `.astra/permissions.json` at the moment the trust
     /// decision was made. `None` when there was no project file
     /// yet (a brand-new workspace) or when the trust state is
     /// `Ask`.
@@ -490,15 +490,15 @@ fn canonicalize_key(workspace: &Path) -> String {
         .unwrap_or_else(|_| workspace.to_string_lossy().into_owned())
 }
 
-/// SHA-256 of `<workspace>/.kiro/permissions.json`, if it exists.
+/// SHA-256 of `<workspace>/.astra/permissions.json`, if it exists.
 pub fn project_permissions_hash(workspace: &Path) -> Result<Option<String>, WorkspaceTrustError> {
-    let path = workspace.join(".kiro").join("permissions.json");
+    let path = workspace.join(".astra").join("permissions.json");
     let bytes = match std::fs::read(&path) {
         Ok(bytes) => bytes,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => {
             return Err(WorkspaceTrustError::Io {
-                stage: "read .kiro/permissions.json",
+                stage: "read .astra/permissions.json",
                 source: e,
             });
         }
@@ -514,8 +514,8 @@ pub fn project_permissions_hash(workspace: &Path) -> Result<Option<String>, Work
 #[cfg(test)]
 mod tests {
     use super::{
-        TrustState, WorkspaceTrustError, WorkspaceTrustLedger, WorkspaceTrustReason,
-        evaluate_workspace_trust_from_path, project_permissions_hash,
+        evaluate_workspace_trust_from_path, project_permissions_hash, TrustState,
+        WorkspaceTrustError, WorkspaceTrustLedger, WorkspaceTrustReason,
     };
     use std::path::Path;
 
@@ -619,7 +619,7 @@ mod tests {
     #[test]
     fn project_permissions_hash_returns_sha256_when_file_exists() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(kiro.join("permissions.json"), b"{}").unwrap();
         let hash = project_permissions_hash(dir.path()).unwrap().unwrap();
@@ -636,7 +636,7 @@ mod tests {
     #[test]
     fn project_permissions_hash_changes_when_rules_change() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         let path = kiro.join("permissions.json");
         std::fs::write(&path, br#"{"allow":["Bash(ls:*)"]}"#).unwrap();
@@ -649,7 +649,7 @@ mod tests {
     #[test]
     fn evaluate_workspace_trust_requires_matching_rules_hash() {
         let dir = tempfile::tempdir().unwrap();
-        let kiro = dir.path().join(".kiro");
+        let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         let path = kiro.join("permissions.json");
         std::fs::write(&path, br#"{"allow":["Bash(ls:*)"]}"#).unwrap();

--- a/rust/crates/astra-cli/src/tui/history_cell/approval.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/approval.rs
@@ -119,7 +119,7 @@ pub(crate) struct ApprovalCell {
     ///
     ///   None        -> not yet attempted (or no Always pressed)
     ///   Some("…")   -> save outcome, e.g.
-    ///                  "Saved to .kiro/permissions.json" or
+    ///                  "Saved to .astra/permissions.json" or
     ///                  "Failed to save rule: <reason>"
     pub save_outcome: Option<String>,
     pub selection_hint: Option<String>,
@@ -776,10 +776,10 @@ mod tests {
             "execute".into(),
             true,
         )
-        .with_save_outcome("Saved to .kiro/permissions.json");
+        .with_save_outcome("Saved to .astra/permissions.json");
         let rendered = render(&cell);
         assert!(
-            rendered.contains("Saved to .kiro/permissions.json"),
+            rendered.contains("Saved to .astra/permissions.json"),
             "save outcome should render verbatim, got:\n{rendered}"
         );
     }

--- a/rust/crates/astra-sandbox/src/shell_hardening.rs
+++ b/rust/crates/astra-sandbox/src/shell_hardening.rs
@@ -28,7 +28,7 @@ pub const DANGEROUS_FILE_PATHS: &[&str] = &[
     ".idea/",
     // Agent configs
     ".claude/",
-    ".kiro/",
+    ".astra/",
     // SSH keys
     ".ssh/",
     // Ripgrep config (can alter search behavior)

--- a/rust/crates/astra-turn-core/src/permission/audit.rs
+++ b/rust/crates/astra-turn-core/src/permission/audit.rs
@@ -15,7 +15,7 @@
 //! question. R2 Major 4 specifically calls this out as a gap:
 //! exporting the audit log shouldn't say "Yes, it was approved"
 //! without saying "by user X, choosing Always-Project-User-Trusted,
-//! saved to .kiro/permissions.json successfully".
+//! saved to .astra/permissions.json successfully".
 //!
 //! The three events:
 //!
@@ -29,7 +29,7 @@
 //!    which scope (if AlwaysAllow).
 //!
 //! 3. [`RulePersistedEvent`] — fires when a rule is written to
-//!    `.kiro/permissions.json` or `~/.astra/permissions.json`.
+//!    `.astra/permissions.json` or `~/.astra/permissions.json`.
 //!    Payload includes the file, the new rule, and whether the
 //!    save succeeded.
 //!
@@ -76,7 +76,7 @@ pub enum AllowScope {
     /// Auto-approve identical fingerprints until the session ends.
     /// Per-fingerprint, NOT a global mode change.
     RestOfSession,
-    /// Persist a rule to `.kiro/permissions.json` (project file).
+    /// Persist a rule to `.astra/permissions.json` (project file).
     Project,
     /// Persist a rule to `~/.astra/permissions.json` (user file).
     User,

--- a/rust/crates/astra-turn-core/src/permission/engine.rs
+++ b/rust/crates/astra-turn-core/src/permission/engine.rs
@@ -139,7 +139,7 @@ pub enum DecisionSource {
 }
 
 /// Where a rule originally came from. UI uses this for the
-/// "Saved to .kiro/permissions.json" line in the approval card.
+/// "Saved to .astra/permissions.json" line in the approval card.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RuleOrigin {
     Project,
@@ -252,7 +252,7 @@ pub enum RiskTag {
     /// know what it does.
     MCPUnknownCapability,
     /// Workspace not in the trust ledger; persistent rules from
-    /// `.kiro/permissions.json` are downgraded to allow-only-once.
+    /// `.astra/permissions.json` are downgraded to allow-only-once.
     WorkspaceUntrusted,
     /// `sandbox_expand:*` request — the agent is asking us to widen
     /// the sandbox, not run a tool.

--- a/rust/crates/astra-turn-core/src/permission/rule_grammar.rs
+++ b/rust/crates/astra-turn-core/src/permission/rule_grammar.rs
@@ -1,5 +1,5 @@
 //! Issue #326 P1.5b / R2 Major 2: versioned rule grammar for
-//! `.kiro/permissions.json` and `~/.astra/permissions.json`.
+//! `.astra/permissions.json` and `~/.astra/permissions.json`.
 //!
 //! ## Why version the grammar
 //!

--- a/rust/crates/astra-turn-core/src/permission/scope.rs
+++ b/rust/crates/astra-turn-core/src/permission/scope.rs
@@ -9,7 +9,7 @@
 //!   this LLM round only
 //! - `RestOfSession`  — auto-approve until the session ends
 //!   (per-fingerprint, NOT a global mode flip)
-//! - `Project`        — write to .kiro/permissions.json
+//! - `Project`        — write to .astra/permissions.json
 //! - `User`           — write to ~/.astra/permissions.json
 //!
 //! Plan v3 §P3 also says destructive risk tags
@@ -35,7 +35,7 @@ pub enum AllowScope {
     RestOfTurn,
     /// Until session ends; per-fingerprint, not a global Auto flip.
     RestOfSession,
-    /// Persist to .kiro/permissions.json (project-shared).
+    /// Persist to .astra/permissions.json (project-shared).
     Project,
     /// Persist to ~/.astra/permissions.json (per-user).
     User,


### PR DESCRIPTION
## Summary

Rename all remaining `.kiro/` references to `.astra/` across the permissions and configuration subsystem.

## Changes

- **`permission_manager.rs`**: string literals, docstrings, test paths — 27 replacements
- **`workspace_trust.rs`**: comments, docstrings, error messages, test paths — 12 replacements  
- **`plan_executor.rs`**: comment — 1 replacement
- **`stream_render.rs`**: permission target label — 1 replacement
- **`approval.rs`**: save outcome messages in TUI history cell — 2 replacements
- **`shell_hardening.rs`**: dangerous path list entry — 1 replacement
- **`audit.rs`**: docstrings — 3 replacements
- **`engine.rs`**: docstring — 1 replacement
- **`rule_grammar.rs`**: module docstring — 1 replacement
- **`scope.rs`**: docstrings — 3 replacements

## Scope

Comments, docstrings, string literals, and test code only. No functional changes — this is the final pass of the kiro→astra rename in the permissions subsystem.