### PR TITLE
fix: gate ctrl-b bash detach on active command

### DIFF
--- a/rust/crates/astra-cli/src/cli/slash/slash_agent.rs
+++ b/rust/crates/astra-cli/src/cli/slash/slash_agent.rs
@@ -1943,6 +1943,19 @@ mod tests {
     use std::sync::Arc;
     use std::time::SystemTime;
 
+    struct PendingWatchExecutor;
+
+    #[async_trait::async_trait]
+    impl astra_runtime::orchestration::SpawnAgentExecutor for PendingWatchExecutor {
+        async fn execute(
+            &self,
+            _config: astra_runtime::orchestration::SpawnRunConfig,
+        ) -> Result<astra_runtime::orchestration::SpawnRunResult, String> {
+            std::future::pending::<Result<astra_runtime::orchestration::SpawnRunResult, String>>()
+                .await
+        }
+    }
+
     fn make_agent(agent_id: &str, run_id: &str, status: AgentStatus) -> SpawnedAgentInfo {
         SpawnedAgentInfo {
             agent_id: agent_id.to_string(),
@@ -2525,7 +2538,9 @@ mod tests {
         let transport = Arc::new(InProcessTransport::new());
         let tracker = Arc::new(DelegationTracker::new());
         let router = Arc::new(AgentMailboxRouter::new(transport, tracker));
-        let spawner = Arc::new(DynamicAgentSpawner::new(router));
+        let spawner = Arc::new(
+            DynamicAgentSpawner::new(router).with_executor(Arc::new(PendingWatchExecutor)),
+        );
         let mut rx = Some(spawner.subscribe_progress());
         let last_snapshot = build_watch_snapshot(&[], &[]);
         let context = SpawnContext {
@@ -2544,6 +2559,7 @@ mod tests {
             description: "watch test agent".to_string(),
             prompt: "do nothing".to_string(),
             agent_type: "task".to_string(),
+            run_in_background: true,
             ..Default::default()
         };
 
@@ -2568,6 +2584,10 @@ mod tests {
 
         assert!(snapshot.contains("Spawned agents (1)"));
         assert!(snapshot.contains(agent_id.split('@').next().unwrap_or("watch")));
+
+        spawner
+            .shutdown_and_wait(std::time::Duration::from_millis(1))
+            .await;
     }
 
     #[tokio::test]

--- a/rust/crates/astra-cli/src/tui/ARCHITECTURE.md
+++ b/rust/crates/astra-cli/src/tui/ARCHITECTURE.md
@@ -198,7 +198,7 @@ slash_dispatch::dispatch("/model", ctx)
 | `Enter` | Composer | Submit text / dispatch slash command |
 | `Shift+Enter` | Composer | Insert newline (multi-line input) |
 | `Ctrl+C` | Turn active | Cancel/interrupt turn |
-| `Ctrl+B` | Foreground bash running | Promote running bash command to a background shell task |
+| `Ctrl+B` | Turn active with foreground bash/agent | Promote active bash to a background shell task; otherwise promote a foreground sync agent |
 | `Ctrl+C` | Composer non-empty | Clear draft |
 | `Ctrl+C` | Idle | Quit |
 | `Ctrl+D` | Composer empty | Quit |

--- a/rust/crates/astra-cli/src/tui/bg_task_proxy.rs
+++ b/rust/crates/astra-cli/src/tui/bg_task_proxy.rs
@@ -464,18 +464,63 @@ pub(crate) fn format_background_task_output_system_message(
     total_lines: u64,
     output: &str,
 ) -> String {
+    format_background_task_output_system_message_for_kind(
+        "shell",
+        BackgroundTaskOutputSystemMessage {
+            task_id,
+            title,
+            status,
+            offset,
+            total_bytes,
+            total_lines,
+            output,
+        },
+    )
+}
+
+pub(crate) struct BackgroundTaskOutputSystemMessage<'a> {
+    pub task_id: &'a str,
+    pub title: &'a str,
+    pub status: &'a str,
+    pub offset: u64,
+    pub total_bytes: u64,
+    pub total_lines: u64,
+    pub output: &'a str,
+}
+
+pub(crate) fn format_background_task_output_system_message_for_kind(
+    kind: &str,
+    message: BackgroundTaskOutputSystemMessage<'_>,
+) -> String {
+    let BackgroundTaskOutputSystemMessage {
+        task_id,
+        title,
+        status,
+        offset,
+        total_bytes,
+        total_lines,
+        output,
+    } = message;
     let label = background_shell_notification_label(task_id, title);
+    let read_label = match kind.trim() {
+        "" | "shell" => "Read shell output".to_string(),
+        "local agent" => "Read local agent output".to_string(),
+        "cloud session" => "Read cloud session output".to_string(),
+        "main session" => "Read main session output".to_string(),
+        "monitor" => "Read monitor output".to_string(),
+        other => format!("Read {other} output"),
+    };
     let tail = output.trim_end();
     if tail.is_empty() {
         return format!(
-            "Read shell output {task_id} · {label}\n{} · offset {offset} -> {total_bytes} · total {total_bytes} bytes · {total_lines} total lines",
+            "{read_label} {task_id} · {label}\n{} · offset {offset} -> {total_bytes} · total {total_bytes} bytes · {total_lines} total lines",
             background_task_empty_output_state(status)
         );
     }
 
     let line_count = tail.lines().count();
     format!(
-        "Read shell output {task_id} · {label}\n{line_count} new {} · offset {offset} -> {total_bytes} · total {total_bytes} bytes · {total_lines} total lines · {}\nOutput chunk:\n{tail}",
+        "{read_label} {task_id} · {label}\n{line_count} new {} · offset {offset} -> {total_bytes} · total {total_bytes} bytes · {total_lines} total lines · {}\nOutput chunk:\n{tail}",
         if line_count == 1 { "line" } else { "lines" },
         background_task_status_label(status)
     )

--- a/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
+++ b/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
@@ -5,10 +5,12 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use super::bg_task_proxy::{
-    background_task_output_snapshot, background_task_output_snapshot_for_local_agent,
+    BackgroundTaskOutputSystemMessage, background_task_output_snapshot,
+    background_task_output_snapshot_for_local_agent,
     background_task_output_snapshot_for_local_agent_projection,
     background_task_rejected_fanout_slot_id, background_task_rejected_fanout_slot_label,
     format_background_task_output_read_error, format_background_task_output_system_message,
+    format_background_task_output_system_message_for_kind,
     format_background_task_stop_error_system_message, is_background_task_terminal_race_error,
 };
 use super::bottom_pane::BottomPane;
@@ -590,9 +592,11 @@ pub(crate) async fn stop_background_task_with_agents(
     }
 }
 
-pub(crate) fn try_dispatch_background_task_output_sentinel(
+pub(crate) async fn try_dispatch_background_task_output_sentinel(
     sentinel: &str,
     background_registry: &mut super::background_tasks::BackgroundTaskRegistry,
+    agent_spawner: Option<Arc<astra_runtime::orchestration::DynamicAgentSpawner>>,
+    restored_local_agents: &[astra_services::session_workspace::BackgroundLocalAgentTaskProjection],
     chat_widget: &mut super::chat_widget::ChatWidget,
     bottom_pane: &mut BottomPane,
     frame_requester: &FrameRequester,
@@ -602,32 +606,71 @@ pub(crate) fn try_dispatch_background_task_output_sentinel(
         return false;
     };
     let task_id = task_id.to_string();
-    let (title, status) = background_registry
-        .get(&task_id)
-        .map(|handle| (handle.description.clone(), handle.projected_status()))
-        .unwrap_or_else(|| (task_id.clone(), "unknown"));
-    match background_registry.get_combined_output_stats(&task_id, 8192) {
-        Ok((output, total_bytes, total_lines)) => {
-            let offset = total_bytes.saturating_sub(output.len() as u64);
-            chat_widget.commit_system(super::history_cell::system::SystemCell::info(
-                format_background_task_output_system_message(
-                    &task_id,
-                    &title,
-                    status,
-                    offset,
-                    total_bytes,
-                    total_lines,
-                    &output,
-                ),
-            ));
+
+    if let Some(handle) = background_registry.get(&task_id) {
+        let title = handle.description.clone();
+        let status = handle.projected_status();
+        match background_registry.get_combined_output_stats(&task_id, 8192) {
+            Ok((output, total_bytes, total_lines)) => {
+                let offset = total_bytes.saturating_sub(output.len() as u64);
+                chat_widget.commit_system(super::history_cell::system::SystemCell::info(
+                    format_background_task_output_system_message(
+                        &task_id,
+                        &title,
+                        status,
+                        offset,
+                        total_bytes,
+                        total_lines,
+                        &output,
+                    ),
+                ));
+            }
+            Err(error) => {
+                chat_widget.commit_system(super::history_cell::system::SystemCell::error(
+                    format_background_task_output_read_error(&task_id, &error),
+                ));
+            }
         }
-        Err(error) => {
-            chat_widget.commit_system(super::history_cell::system::SystemCell::error(
-                format_background_task_output_read_error(&task_id, &error),
-            ));
+    } else {
+        match background_task_output_snapshot_with_agents(
+            background_registry,
+            agent_spawner.as_ref(),
+            restored_local_agents,
+            &task_id,
+            0,
+            8192,
+        )
+        .await
+        {
+            Ok(snapshot) => {
+                chat_widget.commit_system(super::history_cell::system::SystemCell::info(
+                    format_background_task_output_system_message_for_kind(
+                        &snapshot.kind,
+                        BackgroundTaskOutputSystemMessage {
+                            task_id: &task_id,
+                            title: snapshot.title.as_deref().unwrap_or(&task_id),
+                            status: &snapshot.status,
+                            offset: 0,
+                            total_bytes: snapshot.total_bytes,
+                            total_lines: snapshot.total_lines,
+                            output: &snapshot.output,
+                        },
+                    ),
+                ));
+            }
+            Err(error) => {
+                chat_widget.commit_system(super::history_cell::system::SystemCell::error(
+                    format_background_task_output_read_error(&task_id, &error),
+                ));
+            }
         }
     }
-    let rows = background_task_rows(background_registry);
+    let rows = background_task_rows_with_agents(
+        background_registry,
+        agent_spawner.as_ref(),
+        restored_local_agents,
+    )
+    .await;
     bottom_pane.refresh_background_task_rows(rows);
     bottom_pane.sync_popups();
     frame_requester.schedule_frame();

--- a/rust/crates/astra-cli/src/tui/bottom_pane/background_task_view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/background_task_view.rs
@@ -57,7 +57,7 @@ impl BackgroundTaskKind {
     }
 
     fn supports_output_action(self) -> bool {
-        matches!(self, Self::Shell)
+        matches!(self, Self::Shell | Self::LocalAgent)
     }
 }
 
@@ -743,6 +743,13 @@ impl BackgroundTaskView {
         }
         timing_parts.push(format!("elapsed {}", format_elapsed(row.elapsed_ms)));
 
+        let title_label = match row.kind {
+            BackgroundTaskKind::Shell => "  command ",
+            BackgroundTaskKind::LocalAgent => "  task ",
+            BackgroundTaskKind::CloudSession
+            | BackgroundTaskKind::MainSession
+            | BackgroundTaskKind::Monitor => "  title ",
+        };
         let mut lines = vec![
             Line::from(Span::styled(
                 format!("  {} · {}", row.id, row.status.label()),
@@ -755,7 +762,7 @@ impl BackgroundTaskView {
                 Span::raw(timing_parts.join(" · ")),
             ]),
             Line::from(vec![
-                Span::styled("  command ", dim),
+                Span::styled(title_label, dim),
                 Span::raw(row.title.clone()),
             ]),
         ];
@@ -1562,7 +1569,7 @@ mod tests {
     }
 
     #[test]
-    fn local_agent_detail_does_not_offer_shell_output_action() {
+    fn local_agent_detail_offers_typed_output_action() {
         let mut view = BackgroundTaskView::new(vec![typed_row(
             "agent-1",
             BackgroundTaskKind::LocalAgent,
@@ -1572,13 +1579,19 @@ mod tests {
         view.handle_key(key(KeyCode::Enter));
 
         let detail = render(&view, 80, 12);
-        assert!(detail.contains("actions: stop · return"), "{detail}");
-        assert!(!detail.contains("actions: output"), "{detail}");
+        assert!(
+            detail.contains("actions: output · stop · return"),
+            "{detail}"
+        );
+        assert!(detail.contains("task review auth flow"), "{detail}");
 
         view.handle_key(key(KeyCode::Char('o')));
         assert!(
-            view.take_pending_action().is_none(),
-            "local agent output must not emit shell task_output sentinel"
+            matches!(
+                view.take_pending_action().as_deref(),
+                Some("__background_task_output__\nagent-1")
+            ),
+            "local agent output should emit typed task_output sentinel"
         );
 
         view.handle_key(key(KeyCode::Char('s')));

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -1712,128 +1712,143 @@ pub(crate) async fn run_tui_session(
                                                             {
                                                                 let listener = bash_detach_listener.take();
                                                                 if let Some(listener) = listener {
-                                                                    if !background_registry.can_spawn_shell_task() {
-                                                                        bash_detach_listener = Some(listener);
-                                                                        chat_widget.commit_system(
-                                                                            history_cell::system::SystemCell::error(
-                                                                                "⏎ Backgrounding unavailable: background shell task limit reached."
-                                                                            ),
-                                                                        );
-                                                                        frame_requester.schedule_frame();
-                                                                        continue;
-                                                                    }
-                                                                    // Fire the watch signal to request detach.
-                                                                    // If the runner already completed, send
-                                                                    // fails silently — the handler moves on.
-                                                                    let _ = listener.signal_tx.send(true);
-                                                                    // Wait briefly for the runner to ship
-                                                                    // the live child + streams payload.
-                                                                    // 500ms is comfortably more than the
-                                                                    // bash runner's 25ms idle-poll tick;
-                                                                    // longer waits indicate bash wasn't
-                                                                    // actually running when the user hit
-                                                                    // Ctrl+B.
-                                                                    let payload = tokio::time::timeout(
-                                                                        std::time::Duration::from_millis(500),
-                                                                        listener.payload_rx,
-                                                                    )
-                                                                    .await;
-                                                                    match payload {
-                                                                        Ok(Ok(p)) => {
-                                                                            // Drop the bash runner straight
-                                                                            // into the registry. The
-                                                                            // adopt_detached_shell API
-                                                                            // takes the live child + streams
-                                                                            // and emits Started/Completed
-                                                                            // events like a normal bg task.
-                                                                            let id = match background_registry.adopt_detached_shell(
-                                                                                p.child,
-                                                                                p.stdout,
-                                                                                p.stderr,
-                                                                                &p.command,
-                                                                                p.partial_stdout,
-                                                                                p.partial_stderr,
-                                                                            ) {
-                                                                                Ok(id) => id,
-                                                                                Err(error) => {
-                                                                                    chat_widget.commit_system(
-                                                                                        history_cell::system::SystemCell::error(
-                                                                                            format!("⏎ Backgrounding failed: {error}")
-                                                                                        ),
-                                                                                    );
-                                                                                    frame_requester.schedule_frame();
-                                                                                    continue;
-                                                                                }
-                                                                            };
+                                                                    if listener.is_active() {
+                                                                        if !background_registry.can_spawn_shell_task() {
+                                                                            bash_detach_listener = Some(listener);
                                                                             chat_widget.commit_system(
-                                                                                history_cell::system::SystemCell::info(
-                                                                                    format!("⏎ Backgrounded as {id}. Opened background tasks; Enter details, S stop.")
+                                                                                history_cell::system::SystemCell::error(
+                                                                                    "⏎ Backgrounding unavailable: background shell task limit reached."
                                                                                 ),
                                                                             );
-                                                                            ctrl_b_promoted_task_id = Some(id);
-                                                                            persist_background_task_projections_if_changed(
-                                                                                &mut background_registry,
-                                                                                background_registry_turn_session_id.as_deref(),
-                                                                                background_registry_turn_model.as_deref(),
-                                                                                &mut background_task_projection_cache,
-                                                                            );
-                                                                            let selected_id = ctrl_b_promoted_task_id.as_deref();
-                                                                            let _ = reveal_background_task_view(
-                                                                                &mut background_registry,
-                                                                                agent_spawner_for_cancel.as_ref(),
-                                                                                &restored_local_agent_task_projections,
-                                                                                &mut bottom_pane,
-                                                                                &frame_requester,
-                                                                                selected_id,
-                                                                            )
-                                                                            .await;
-                                                                            // The turn is over from the
-                                                                            // model's perspective; cancel
-                                                                            // gracefully so it sees the
-                                                                            // <bash_detached> marker
-                                                                            // already returned by the bash
-                                                                            // tool and ends cleanly.
-                                                                            tui_cancel_token.cancel();
                                                                             frame_requester.schedule_frame();
                                                                             continue;
                                                                         }
-                                                                        // No payload — bash wasn't running,
-                                                                        // or completed normally before
-                                                                        // detach landed.
-                                                                        _ => {
+                                                                        // Fire the watch signal to request detach.
+                                                                        // Once signalled, this listener is single-use:
+                                                                        // the payload receiver is consumed below, so the
+                                                                        // runner must not restore the paired handle for a
+                                                                        // later bash invocation if handoff loses a race.
+                                                                        if listener.signal_tx.send(true).is_err() {
+                                                                            listener.retire();
                                                                             if let Ok(mut slot) = bash_detach_slot_for_ctrl_b.try_lock() {
                                                                                 *slot = None;
                                                                             }
+                                                                        } else {
+                                                                            listener.retire();
+                                                                        // Wait briefly for the runner to ship
+                                                                        // the live child + streams payload.
+                                                                        // 500ms is comfortably more than the
+                                                                        // bash runner's 25ms idle-poll tick;
+                                                                        // longer waits indicate bash wasn't
+                                                                        // actually running when the user hit
+                                                                        // Ctrl+B.
+                                                                        let payload = tokio::time::timeout(
+                                                                            std::time::Duration::from_millis(500),
+                                                                            listener.payload_rx,
+                                                                        )
+                                                                        .await;
+                                                                        match payload {
+                                                                            Ok(Ok(p)) => {
+                                                                                // Drop the bash runner straight
+                                                                                // into the registry. The
+                                                                                // adopt_detached_shell API
+                                                                                // takes the live child + streams
+                                                                                // and emits Started/Completed
+                                                                                // events like a normal bg task.
+                                                                                let id = match background_registry.adopt_detached_shell(
+                                                                                    p.child,
+                                                                                    p.stdout,
+                                                                                    p.stderr,
+                                                                                    &p.command,
+                                                                                    p.partial_stdout,
+                                                                                    p.partial_stderr,
+                                                                                ) {
+                                                                                    Ok(id) => id,
+                                                                                    Err(error) => {
+                                                                                        chat_widget.commit_system(
+                                                                                            history_cell::system::SystemCell::error(
+                                                                                                format!("⏎ Backgrounding failed: {error}")
+                                                                                            ),
+                                                                                        );
+                                                                                        frame_requester.schedule_frame();
+                                                                                        continue;
+                                                                                    }
+                                                                                };
+                                                                                chat_widget.commit_system(
+                                                                                    history_cell::system::SystemCell::info(
+                                                                                        format!("⏎ Backgrounded as {id}. Opened background tasks; Enter details, S stop.")
+                                                                                    ),
+                                                                                );
+                                                                                ctrl_b_promoted_task_id = Some(id);
+                                                                                persist_background_task_projections_if_changed(
+                                                                                    &mut background_registry,
+                                                                                    background_registry_turn_session_id.as_deref(),
+                                                                                    background_registry_turn_model.as_deref(),
+                                                                                    &mut background_task_projection_cache,
+                                                                                );
+                                                                                let selected_id = ctrl_b_promoted_task_id.as_deref();
+                                                                                let _ = reveal_background_task_view(
+                                                                                    &mut background_registry,
+                                                                                    agent_spawner_for_cancel.as_ref(),
+                                                                                    &restored_local_agent_task_projections,
+                                                                                    &mut bottom_pane,
+                                                                                    &frame_requester,
+                                                                                    selected_id,
+                                                                                )
+                                                                                .await;
+                                                                                // The turn is over from the
+                                                                                // model's perspective; cancel
+                                                                                // gracefully so it sees the
+                                                                                // <bash_detached> marker
+                                                                                // already returned by the bash
+                                                                                // tool and ends cleanly.
+                                                                                tui_cancel_token.cancel();
+                                                                                frame_requester.schedule_frame();
+                                                                                continue;
+                                                                            }
+                                                                            // No payload — bash completed or
+                                                                            // could not hand off after it had
+                                                                            // advertised an active detach window.
+                                                                            _ => {
+                                                                                if let Ok(mut slot) = bash_detach_slot_for_ctrl_b.try_lock() {
+                                                                                    *slot = None;
+                                                                                }
+                                                                            }
                                                                         }
+                                                                        }
+                                                                    } else {
+                                                                        bash_detach_listener = Some(listener);
                                                                     }
                                                                 }
-                                                                    if let Some(spawner) = agent_spawner_for_cancel.as_ref() {
-                                                                        if let Some(agent) = spawner
-                                                                            .promote_foreground_agent_to_background(None)
-                                                                            .await
-                                                                        {
-                                                                            chat_widget.commit_system(
-                                                                                history_cell::system::SystemCell::info(
-                                                                                    ctrl_b_promoted_agent_message(
-                                                                                        &agent.agent_id,
-                                                                                        &agent.description,
-                                                                                    ),
+                                                                if let Some(spawner) =
+                                                                    agent_spawner_for_cancel.as_ref()
+                                                                {
+                                                                    if let Some(agent) = spawner
+                                                                        .promote_foreground_agent_to_background(None)
+                                                                        .await
+                                                                    {
+                                                                        chat_widget.commit_system(
+                                                                            history_cell::system::SystemCell::info(
+                                                                                ctrl_b_promoted_agent_message(
+                                                                                    &agent.agent_id,
+                                                                                    &agent.description,
                                                                                 ),
-                                                                            );
-                                                                            let _ = reveal_background_task_view(
-                                                                                &mut background_registry,
-                                                                                agent_spawner_for_cancel.as_ref(),
-                                                                                &restored_local_agent_task_projections,
-                                                                                &mut bottom_pane,
-                                                                                &frame_requester,
-                                                                                Some(&agent.agent_id),
-                                                                            )
-                                                                            .await;
-                                                                            tui_cancel_token.cancel();
-                                                                            frame_requester.schedule_frame();
-                                                                            continue;
-                                                                        }
+                                                                            ),
+                                                                        );
+                                                                        let _ = reveal_background_task_view(
+                                                                            &mut background_registry,
+                                                                            agent_spawner_for_cancel.as_ref(),
+                                                                            &restored_local_agent_task_projections,
+                                                                            &mut bottom_pane,
+                                                                            &frame_requester,
+                                                                            Some(&agent.agent_id),
+                                                                        )
+                                                                        .await;
+                                                                        tui_cancel_token.cancel();
+                                                                        frame_requester.schedule_frame();
+                                                                        continue;
                                                                     }
+                                                                }
                                                                 chat_widget.commit_system(
                                                                     history_cell::system::SystemCell::info(
                                                                         "⏎ Backgrounding unavailable: no active bash or agent can be promoted right now."
@@ -1994,10 +2009,14 @@ pub(crate) async fn run_tui_session(
                                                                         if try_dispatch_background_task_output_sentinel(
                                                                             &result,
                                                                             &mut background_registry,
+                                                                            agent_spawner_for_cancel.clone(),
+                                                                            &restored_local_agent_task_projections,
                                                                             &mut chat_widget,
                                                                             &mut bottom_pane,
                                                                             &frame_requester,
-                                                                        ) {
+                                                                        )
+                                                                        .await
+                                                                        {
                                                                             continue;
                                                                         }
                                                                         let _ = try_dispatch_agent_kill_sentinel(
@@ -2029,10 +2048,14 @@ pub(crate) async fn run_tui_session(
                                                                         if try_dispatch_background_task_output_sentinel(
                                                                             &name,
                                                                             &mut background_registry,
+                                                                            agent_spawner_for_cancel.clone(),
+                                                                            &restored_local_agent_task_projections,
                                                                             &mut chat_widget,
                                                                             &mut bottom_pane,
                                                                             &frame_requester,
-                                                                        ) {
+                                                                        )
+                                                                        .await
+                                                                        {
                                                                             continue;
                                                                         }
                                                                         if try_dispatch_agent_kill_sentinel(
@@ -2557,10 +2580,14 @@ pub(crate) async fn run_tui_session(
                                 if try_dispatch_background_task_output_sentinel(
                                     &result,
                                     &mut background_registry,
+                                    state.agent_spawner.clone(),
+                                    &restored_local_agent_task_projections,
                                     &mut chat_widget,
                                     &mut bottom_pane,
                                     &frame_requester,
-                                ) {
+                                )
+                                .await
+                                {
                                     continue;
                                 }
                                 let _ = try_dispatch_agent_kill_sentinel(
@@ -2596,10 +2623,14 @@ pub(crate) async fn run_tui_session(
                                     if try_dispatch_background_task_output_sentinel(
                                         &name,
                                         &mut background_registry,
+                                        state.agent_spawner.clone(),
+                                        &restored_local_agent_task_projections,
                                         &mut chat_widget,
                                         &mut bottom_pane,
                                         &frame_requester,
-                                    ) {
+                                    )
+                                    .await
+                                    {
                                         continue;
                                     }
                                     // Kill sentinel: route to the spawner / task service before
@@ -4046,6 +4077,71 @@ mod tests {
         assert_eq!(snapshot.kind, "local agent");
         assert_eq!(snapshot.title.as_deref(), Some("review auth flow"));
         assert_ne!(snapshot.output_ref, "");
+
+        spawner
+            .shutdown_and_wait(std::time::Duration::from_millis(1))
+            .await;
+    }
+
+    #[tokio::test]
+    async fn background_task_output_sentinel_projects_local_agent() {
+        let spawner = test_agent_spawner(Arc::new(PendingAgentExecutor));
+        let input = SpawnAgentInput {
+            description: "review auth flow".to_string(),
+            prompt: "review auth flow".to_string(),
+            agent_type: "explore".to_string(),
+            run_in_background: true,
+            ..Default::default()
+        };
+        let spawned = spawner.spawn(input, &test_spawn_context()).await.unwrap();
+        let agent_id = match spawned {
+            SpawnAgentOutput::Launched { agent_id, .. } => agent_id,
+            other => panic!("expected launched background agent, got {other:?}"),
+        };
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut registry =
+            crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
+        let mut chat_widget = chat_widget::ChatWidget::new("");
+        let mut bottom_pane = BottomPane::new();
+        let sentinel = format!(
+            "{}{}",
+            bottom_pane::background_task_view::BACKGROUND_TASK_OUTPUT_SENTINEL,
+            agent_id
+        );
+
+        assert!(
+            try_dispatch_background_task_output_sentinel(
+                &sentinel,
+                &mut registry,
+                Some(spawner.clone()),
+                &[],
+                &mut chat_widget,
+                &mut bottom_pane,
+                &FrameRequester::test_dummy(),
+            )
+            .await,
+            "background task output sentinel should be consumed for local agents"
+        );
+
+        let last_system = chat_widget
+            .history()
+            .last()
+            .and_then(|cell| {
+                cell.as_any_ref()
+                    .downcast_ref::<history_cell::system::SystemCell>()
+            })
+            .expect("output sentinel should commit a system message");
+        assert!(
+            last_system.message().contains("Read local agent output"),
+            "local agent output should be rendered as local-agent output, got: {}",
+            last_system.message()
+        );
+        assert!(
+            last_system.message().contains("review auth flow"),
+            "local agent output should include the task title, got: {}",
+            last_system.message()
+        );
 
         spawner
             .shutdown_and_wait(std::time::Duration::from_millis(1))

--- a/rust/crates/astra-tools/src/detach.rs
+++ b/rust/crates/astra-tools/src/detach.rs
@@ -20,6 +20,7 @@
 //! boundary without lifetime gymnastics.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::Mutex;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
@@ -53,6 +54,23 @@ pub struct DetachShellHandle {
     /// One-shot reply channel for the runner to transfer the live
     /// child + streams back to the TUI.
     pub payload_tx: Arc<Mutex<Option<oneshot::Sender<DetachedShellPayload>>>>,
+    /// True only while a bash invocation is actively running with
+    /// this handle. The TUI uses this to avoid treating an idle
+    /// preloaded handle as a foreground bash task.
+    active: Arc<AtomicBool>,
+    /// Set once the TUI has consumed or abandoned the listener side.
+    /// A retired handle must not be restored to the reusable slot.
+    retired: Arc<AtomicBool>,
+}
+
+impl DetachShellHandle {
+    pub fn mark_active(&self, active: bool) {
+        self.active.store(active, Ordering::Release);
+    }
+
+    pub fn is_retired(&self) -> bool {
+        self.retired.load(Ordering::Acquire)
+    }
 }
 
 /// TUI-side end of the detach plumbing. Writes `true` to `signal_tx`
@@ -62,6 +80,19 @@ pub struct DetachShellListener {
     pub signal_tx: watch::Sender<bool>,
     /// Receive the detached child + streams from the runner.
     pub payload_rx: oneshot::Receiver<DetachedShellPayload>,
+    active: Arc<AtomicBool>,
+    retired: Arc<AtomicBool>,
+}
+
+impl DetachShellListener {
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
+
+    pub fn retire(&self) {
+        self.retired.store(true, Ordering::Release);
+        self.active.store(false, Ordering::Release);
+    }
 }
 
 /// Renewable slot the TUI installs on `ToolContext`. The bash runner
@@ -88,13 +119,19 @@ pub fn new_slot_with_handle() -> (DetachShellSlot, DetachShellListener) {
 pub fn new_detach_pair() -> (DetachShellHandle, DetachShellListener) {
     let (payload_tx, payload_rx) = oneshot::channel::<DetachedShellPayload>();
     let (signal_tx, signal_rx) = watch::channel(false);
+    let active = Arc::new(AtomicBool::new(false));
+    let retired = Arc::new(AtomicBool::new(false));
     let handle = DetachShellHandle {
         signal_rx: Arc::new(Mutex::new(Some(signal_rx))),
         payload_tx: Arc::new(Mutex::new(Some(payload_tx))),
+        active: active.clone(),
+        retired: retired.clone(),
     };
     let listener = DetachShellListener {
         signal_tx,
         payload_rx,
+        active,
+        retired,
     };
     (handle, listener)
 }
@@ -119,6 +156,21 @@ mod tests {
             result.is_err(),
             "with no detach the receiver must observe a closed channel"
         );
+    }
+
+    #[test]
+    fn listener_reports_active_window_and_retirement() {
+        let (handle, listener) = new_detach_pair();
+
+        assert!(!listener.is_active());
+        assert!(!handle.is_retired());
+
+        handle.mark_active(true);
+        assert!(listener.is_active());
+
+        listener.retire();
+        assert!(!listener.is_active());
+        assert!(handle.is_retired());
     }
 
     /// Round-trip: when the runner side takes the sender and

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -64,7 +64,10 @@ impl<'a> DetachHandleGuard<'a> {
     /// Consumes self and restores the handle to the slot for reuse.
     async fn restore(mut self) {
         if let (Some(slot), Some(handle)) = (self.slot.as_ref(), self.handle.take()) {
-            *slot.lock().await = Some(handle);
+            handle.mark_active(false);
+            if !handle.is_retired() {
+                *slot.lock().await = Some(handle);
+            }
         }
     }
 }
@@ -820,6 +823,7 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
 
     let output = if detach_handle_guard.has_handle() {
         let handle_ref = detach_handle_guard.get_ref().unwrap();
+        handle_ref.mark_active(true);
         match run_bash_with_detach(
             &mut cmd,
             timeout,
@@ -843,6 +847,7 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
                 // BackgroundTaskRegistry::adopt_detached_shell.
                 let detach_handle = detach_handle_guard.take().unwrap();
                 let Some(sender) = detach_handle.payload_tx.lock().await.take() else {
+                    detach_handle.mark_active(false);
                     terminate_detached_payload(payload).await;
                     return ToolResult::error(
                         "Error: bash detach failed: host payload channel was not available"
@@ -850,6 +855,7 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
                     );
                 };
                 if let Err(payload) = sender.send(*payload) {
+                    detach_handle.mark_active(false);
                     terminate_detached_payload(Box::new(payload)).await;
                     return ToolResult::error(
                         "Error: bash detach failed: host listener dropped before payload arrived"
@@ -5396,11 +5402,8 @@ printf 'probe.txt:1:needle\n'
         let dir = tempdir().unwrap();
         let mut ctx = crate::ToolContext::test(dir.path());
         let (slot, listener) = crate::detach::new_slot_with_handle();
-        let crate::detach::DetachShellListener {
-            signal_tx,
-            payload_rx,
-        } = listener;
-        drop(payload_rx);
+        let signal_tx = listener.signal_tx.clone();
+        drop(listener.payload_rx);
         ctx.detach_shell_handle = Some(slot);
 
         let bash_fut = tokio::spawn({
@@ -5512,6 +5515,23 @@ printf 'probe.txt:1:needle\n'
 
         let second = second.await.expect("second bash task");
         assert!(second.output.contains("bash_detached"), "{}", second.output);
+    }
+
+    #[tokio::test]
+    async fn retired_detach_slot_is_not_restored_after_normal_completion() {
+        let dir = tempdir().unwrap();
+        let mut ctx = crate::ToolContext::test(dir.path());
+        let (slot, listener) = crate::detach::new_slot_with_handle();
+        ctx.detach_shell_handle = Some(slot.clone());
+
+        listener.retire();
+
+        let result = execute_bash(&ctx, &serde_json::json!({"command": "printf 'done\\n'"})).await;
+        assert!(result.output.contains("done"), "{}", result.output);
+        assert!(
+            slot.lock().await.is_none(),
+            "retired detach handles must not be restored with a consumed or abandoned listener"
+        );
     }
 
     /// Sanity: when no detach handle is wired, the bash tool falls

--- a/rust/crates/runtime/src/orchestration/spawner.rs
+++ b/rust/crates/runtime/src/orchestration/spawner.rs
@@ -17,9 +17,11 @@ use astra_turn_core::orchestration_progress::{
 };
 use astra_turn_core::orchestration_spawn_tool::{SpawnAgentInput, SpawnAgentOutput};
 use astra_turn_core::trace_event::{TraceContext, TraceEvent, TraceEventWriter};
+use futures_util::FutureExt;
 
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
+use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -1271,6 +1273,9 @@ impl DynamicAgentSpawner {
                 reason: format!("{reason:?}"),
             });
         }
+        let Some(executor) = self.executor.as_ref().cloned() else {
+            return Err(SpawnError::ExecutorUnavailable);
+        };
 
         // 4. Reserve active-agent capacity under the same write lock that
         // inserts the agent. This closes the read-check/write-insert TOCTOU
@@ -1522,15 +1527,6 @@ impl DynamicAgentSpawner {
         // foreground sync spawns run through the same task/finalization
         // pipe. Sync mode simply waits for the terminal oneshot unless
         // Ctrl+B promotes the wait into a background `Launched` result.
-        let Some(ref executor) = self.executor else {
-            // No executor available - return as launched (degraded mode)
-            return Ok(SpawnAgentOutput::Launched {
-                agent_id,
-                description: input.description,
-                messaging_address: messaging_address.map(|a| a.to_string()),
-            });
-        };
-
         self.update_status(
             &agent_id,
             AgentStatus::Running {
@@ -1555,7 +1551,7 @@ impl DynamicAgentSpawner {
             .insert(agent_id.clone(), Arc::clone(&notify));
 
         let (terminal_tx, mut terminal_rx) = tokio::sync::oneshot::channel();
-        let executor = Arc::clone(executor);
+        let executor = Arc::clone(&executor);
         let spawner = self.clone_for_task();
         let agent_id_for_task = agent_id.clone();
         let agent_id_for_output = agent_id.clone();
@@ -1569,9 +1565,11 @@ impl DynamicAgentSpawner {
                 }
             }
             let guard = NotifyOnDrop(notify_guard);
-            let result = executor.execute(run_config).await;
+            let result = AssertUnwindSafe(executor.execute(run_config))
+                .catch_unwind()
+                .await;
             let output = match result {
-                Ok(run_result) => {
+                Ok(Ok(run_result)) => {
                     let status = spawn_run_result_to_agent_status(&run_result);
                     spawner
                         .finalize_background_agent(
@@ -1590,7 +1588,7 @@ impl DynamicAgentSpawner {
                         .unwrap_or(0);
                     spawn_run_result_to_sync_output(agent_id_for_output, run_result, duration_ms)
                 }
-                Err(error) => {
+                Ok(Err(error)) => {
                     spawner
                         .finalize_background_agent(
                             &agent_id_for_task,
@@ -1600,6 +1598,30 @@ impl DynamicAgentSpawner {
                             },
                             "failed",
                             None,
+                            None,
+                            None,
+                            Some(error.as_str()),
+                        )
+                        .await;
+                    SpawnAgentOutput::Failed {
+                        error,
+                        duration_ms: 0,
+                    }
+                }
+                Err(panic) => {
+                    let error = format!(
+                        "agent executor panicked: {}",
+                        panic_payload_message(panic.as_ref())
+                    );
+                    spawner
+                        .finalize_background_agent(
+                            &agent_id_for_task,
+                            AgentStatus::Failed {
+                                error: error.clone(),
+                                finish_reason: Some("panic".to_string()),
+                            },
+                            "failed",
+                            Some("panic"),
                             None,
                             None,
                             Some(error.as_str()),
@@ -2234,6 +2256,9 @@ pub enum SpawnError {
     #[error("Delegation failed: {0}")]
     DelegationFailed(String),
 
+    #[error("Agent executor unavailable: spawned agents cannot run in this context")]
+    ExecutorUnavailable,
+
     /// Fork children are allowed to spawn normal children, but not
     /// another inherit-prefix fork. This mirrors Claude Code's
     /// `isInForkChild()` guard and prevents recursive cache-key drift.
@@ -2267,6 +2292,16 @@ pub enum SpawnError {
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        return (*message).to_string();
+    }
+    if let Some(message) = payload.downcast_ref::<String>() {
+        return message.clone();
+    }
+    "unknown panic payload".to_string()
+}
 
 /// Build the [`InheritedChildPrefix`] payload handed to the executor.
 ///
@@ -2417,7 +2452,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_basic() {
-        let spawner = DynamicAgentSpawner::new(mock_router());
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_executor(Arc::new(ImmediateSuccessExecutor) as Arc<dyn SpawnAgentExecutor>);
         let input = SpawnAgentInput {
             description: "Test agent".to_string(),
             prompt: "Do a test".to_string(),
@@ -2440,6 +2476,44 @@ mod tests {
 
         let result = spawner.spawn(input, &context).await.unwrap();
         assert!(matches!(result, SpawnAgentOutput::Launched { .. }));
+    }
+
+    #[tokio::test]
+    async fn spawn_without_executor_fails_without_reserving_state() {
+        let spawner = DynamicAgentSpawner::new(mock_router());
+        let input = SpawnAgentInput {
+            description: "Test agent".to_string(),
+            prompt: "Do a test".to_string(),
+            agent_type: "explore".to_string(),
+            run_in_background: true,
+            fanout_group_id: Some("review-1".to_string()),
+            fanout_target_count: Some(2),
+            fanout_slot_index: Some(0),
+            ..Default::default()
+        };
+
+        let result = spawner.spawn(input, &make_bg_context()).await;
+        assert!(
+            matches!(result, Err(SpawnError::ExecutorUnavailable)),
+            "missing executor must fail explicitly, got {result:?}"
+        );
+        assert!(
+            spawner.active_agents.read().await.is_empty(),
+            "missing executor must not leave fake active agents"
+        );
+        assert!(
+            spawner.completion_notifiers.read().await.is_empty(),
+            "missing executor must not leave completion notifiers"
+        );
+        assert_eq!(
+            spawner.background_task_count(),
+            0,
+            "missing executor must not enqueue a background task"
+        );
+        assert!(
+            spawner.list_fanout_groups().await.is_empty(),
+            "missing executor must not leave fanout rows for a child that never ran"
+        );
     }
 
     #[tokio::test]
@@ -2499,7 +2573,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_agents() {
-        let spawner = DynamicAgentSpawner::new(mock_router());
+        let factory = BlockingExecutorFactory::new();
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_executor(factory.clone() as Arc<dyn SpawnAgentExecutor>);
         let context = SpawnContext {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "parent".to_string(),
@@ -2513,19 +2589,22 @@ mod tests {
             spawn_tool_call_id: None,
         };
 
-        // Spawn two agents
-        for i in 0..2 {
-            let input = SpawnAgentInput {
-                description: format!("Agent {}", i),
-                prompt: "Test".to_string(),
-                agent_type: "explore".to_string(),
-                ..Default::default()
-            };
-            let _ = spawner.spawn(input, &context).await;
-        }
+        let input = SpawnAgentInput {
+            description: "Agent 1".to_string(),
+            prompt: "Test".to_string(),
+            agent_type: "explore".to_string(),
+            run_in_background: true,
+            ..Default::default()
+        };
+        let _ = spawner.spawn(input, &context).await.unwrap();
 
         let agents = spawner.list_agents("parent-123").await;
-        assert_eq!(agents.len(), 2);
+        assert_eq!(agents.len(), 1);
+
+        factory.unblock();
+        spawner
+            .shutdown_and_wait(std::time::Duration::from_secs(2))
+            .await;
     }
 
     #[tokio::test]
@@ -2536,7 +2615,8 @@ mod tests {
         let cache = Arc::new(SharedContextCache::default());
 
         // Create spawner with custom cache
-        let spawner = DynamicAgentSpawner::with_context_cache(mock_router(), Arc::clone(&cache));
+        let spawner = DynamicAgentSpawner::with_context_cache(mock_router(), Arc::clone(&cache))
+            .with_executor(Arc::new(ImmediateSuccessExecutor) as Arc<dyn SpawnAgentExecutor>);
 
         // Verify spawner has the same cache
         assert!(Arc::ptr_eq(&cache, spawner.context_cache()));
@@ -2591,7 +2671,9 @@ mod tests {
     #[tokio::test]
     async fn test_named_spawn_records_parent_routing() {
         let router = mock_router();
-        let spawner = DynamicAgentSpawner::new(router.clone());
+        let factory = BlockingExecutorFactory::new();
+        let spawner = DynamicAgentSpawner::new(router.clone())
+            .with_executor(factory.clone() as Arc<dyn SpawnAgentExecutor>);
         let mut parent_mailbox = router
             .register(AgentAddress::new("parent-123", "main"), None)
             .await
@@ -2645,6 +2727,11 @@ mod tests {
             MessagePayload::Text { content, .. } => assert_eq!(content, "done"),
             other => panic!("expected text payload, got {other:?}"),
         }
+
+        factory.unblock();
+        spawner
+            .shutdown_and_wait(std::time::Duration::from_secs(2))
+            .await;
     }
 
     struct ImmediateSuccessExecutor;
@@ -3165,7 +3252,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_inherited_skills_passed_to_run_config() {
-        let spawner = DynamicAgentSpawner::new(mock_router());
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_executor(Arc::new(ImmediateSuccessExecutor) as Arc<dyn SpawnAgentExecutor>);
         let context = SpawnContext {
             parent_run_id: "parent-123".to_string(),
             parent_agent_id: "parent".to_string(),
@@ -3417,7 +3505,9 @@ mod tests {
 
     #[tokio::test]
     async fn spawned_agent_state_preserves_fanout_slot_identity() {
-        let spawner = DynamicAgentSpawner::new(mock_router());
+        let factory = BlockingExecutorFactory::new();
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_executor(factory.clone() as Arc<dyn SpawnAgentExecutor>);
         let mut input = make_bg_input();
         input.fanout_group_id = Some("review-1".to_string());
         input.fanout_group_title = Some("review fanout".to_string());
@@ -3436,7 +3526,7 @@ mod tests {
         let state = spawner
             .get_agent_state(&agent_id)
             .await
-            .expect("spawned agent should remain active without an executor");
+            .expect("spawned agent should remain active while executor is running");
         let slot = state
             .fanout_slot
             .as_ref()
@@ -3451,6 +3541,11 @@ mod tests {
             .find(|info| info.agent_id == agent_id)
             .expect("list projection should include spawned agent");
         assert_eq!(projected.fanout_slot, state.fanout_slot);
+
+        factory.unblock();
+        spawner
+            .shutdown_and_wait(std::time::Duration::from_secs(2))
+            .await;
     }
 
     #[tokio::test]
@@ -3474,7 +3569,9 @@ mod tests {
 
     #[tokio::test]
     async fn fanout_group_tracks_acceptance_and_rejects_duplicate_slot() {
-        let spawner = DynamicAgentSpawner::new(mock_router());
+        let factory = BlockingExecutorFactory::new();
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_executor(factory.clone() as Arc<dyn SpawnAgentExecutor>);
         let mut input = make_bg_input();
         input.fanout_group_id = Some("review-1".to_string());
         input.fanout_group_title = Some("review fanout".to_string());
@@ -3501,6 +3598,11 @@ mod tests {
         assert_eq!(summary.accepted, 1);
         assert_eq!(summary.active, 1);
         assert_eq!(groups[0].slots[1].requested_description, "bg test");
+
+        factory.unblock();
+        spawner
+            .shutdown_and_wait(std::time::Duration::from_secs(2))
+            .await;
     }
 
     #[tokio::test]
@@ -4396,19 +4498,41 @@ mod tests {
         );
     }
 
-    /// HIGH #5: background agent that panics does not leave a zombie in the JoinSet.
+    /// HIGH #5: background agent that panics must still finalize like a
+    /// normal failed child, not just disappear from the JoinSet.
     #[tokio::test]
-    async fn background_agent_panic_does_not_leave_zombie() {
+    async fn background_agent_panic_finalizes_failed_state() {
         let spawner = DynamicAgentSpawner::new(mock_router())
             .with_executor(Arc::new(PanicExecutor) as Arc<dyn SpawnAgentExecutor>);
 
-        let _ = spawner
+        let result = spawner
             .spawn(make_bg_input(), &make_bg_context())
             .await
             .unwrap();
+        let agent_id = match result {
+            SpawnAgentOutput::Launched { agent_id, .. } => agent_id,
+            other => panic!("expected Launched, got {other:?}"),
+        };
 
-        // Give the panic time to propagate; shutdown_and_wait catches the JoinError.
-        spawner
+        let status = spawner
+            .wait_for_agent(&agent_id, std::time::Duration::from_secs(2))
+            .await;
+        assert!(
+            matches!(status, Some(AgentStatus::Failed { ref error, .. }) if error.contains("executor panicked")),
+            "panic must surface as failed agent status, got {status:?}"
+        );
+
+        let archived = spawner
+            .get_agent_state_any(&agent_id)
+            .await
+            .expect("panicked agent should remain queryable as archived failed state");
+        assert!(
+            matches!(archived.status, AgentStatus::Failed { .. }),
+            "archived status must be failed: {:?}",
+            archived.status
+        );
+
+        let _ = spawner
             .shutdown_and_wait(std::time::Duration::from_secs(2))
             .await;
 
@@ -4416,6 +4540,59 @@ mod tests {
             spawner.background_task_count(),
             0,
             "panicked background task must not leave zombie in JoinSet"
+        );
+        assert!(
+            spawner.active_agents.read().await.is_empty(),
+            "panicked background task must not remain active"
+        );
+        assert!(
+            spawner.completion_notifiers.read().await.is_empty(),
+            "panicked background task must not leave completion notifiers"
+        );
+        assert!(
+            spawner
+                .background_agent_ids
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_empty(),
+            "panicked background task must not remain in background ids"
+        );
+    }
+
+    #[tokio::test]
+    async fn foreground_agent_panic_returns_failed_and_archives() {
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_executor(Arc::new(PanicExecutor) as Arc<dyn SpawnAgentExecutor>);
+        let mut input = make_bg_input();
+        input.run_in_background = false;
+
+        let result = spawner.spawn(input, &make_bg_context()).await.unwrap();
+        let agent_id = match result {
+            SpawnAgentOutput::Failed { ref error, .. } if error.contains("executor panicked") => {
+                spawner
+                    .completed_agents
+                    .read()
+                    .await
+                    .last()
+                    .expect("foreground panic should archive failed state")
+                    .agent_id
+                    .clone()
+            }
+            other => panic!("expected foreground Failed output for panic, got {other:?}"),
+        };
+
+        let archived = spawner
+            .get_agent_state_any(&agent_id)
+            .await
+            .expect("foreground panic should remain queryable");
+        assert!(
+            matches!(archived.status, AgentStatus::Failed { .. }),
+            "archived status must be failed: {:?}",
+            archived.status
+        );
+        assert!(
+            spawner.active_agents.read().await.is_empty(),
+            "foreground panic must not leave active agent state"
         );
     }
 
@@ -4640,12 +4817,13 @@ mod tests {
         // additive-only property. Even with inherit_prefix set in
         // the input, spawn must succeed (prefix request silently
         // has no effect without a store).
-        let spawner = DynamicAgentSpawner::new(mock_router());
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_executor(Arc::new(ImmediateSuccessExecutor) as Arc<dyn SpawnAgentExecutor>);
         let input = child_with_inherit(false);
         let ctx = parent_context("parent-unused");
         let result = spawner.spawn(input, &ctx).await;
         assert!(
-            matches!(result, Ok(SpawnAgentOutput::Launched { .. })),
+            result.is_ok(),
             "spawn must succeed without store even when inherit_prefix is set, got {result:?}"
         );
     }
@@ -4653,15 +4831,19 @@ mod tests {
     #[tokio::test]
     async fn spawn_resolves_matching_captured_prefix() {
         let store: Arc<dyn PrefixCaptureSink> = Arc::new(InMemoryPrefixStore::new());
-        let spawner = DynamicAgentSpawner::new(mock_router()).with_prefix_store(store.clone());
+        let exec = Arc::new(CapturingPrefixExecutor::new());
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_prefix_store(store.clone())
+            .with_executor(exec as Arc<dyn SpawnAgentExecutor>);
         capture_parent_for(&*store, "run-parent-A", TEST_CHILD_MODEL);
 
         let input = child_with_inherit(false);
         let ctx = parent_context("run-parent-A");
         let out = spawner.spawn(input, &ctx).await.unwrap();
         let agent_id = match out {
+            SpawnAgentOutput::Completed { agent_id, .. } => agent_id,
             SpawnAgentOutput::Launched { agent_id, .. } => agent_id,
-            other => panic!("expected Launched, got {other:?}"),
+            other => panic!("expected successful spawn output, got {other:?}"),
         };
         let outcome = spawner
             .last_prefix_resolve(&agent_id)
@@ -4690,13 +4872,16 @@ mod tests {
     #[tokio::test]
     async fn spawn_with_optional_and_missing_prefix_falls_back() {
         let store: Arc<dyn PrefixCaptureSink> = Arc::new(InMemoryPrefixStore::new());
-        let spawner = DynamicAgentSpawner::new(mock_router()).with_prefix_store(store);
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_prefix_store(store)
+            .with_executor(Arc::new(ImmediateSuccessExecutor) as Arc<dyn SpawnAgentExecutor>);
         let input = child_with_inherit(false); // not required
         let ctx = parent_context("run-no-capture");
         let out = spawner.spawn(input, &ctx).await.unwrap();
         let agent_id = match out {
+            SpawnAgentOutput::Completed { agent_id, .. } => agent_id,
             SpawnAgentOutput::Launched { agent_id, .. } => agent_id,
-            other => panic!("expected Launched, got {other:?}"),
+            other => panic!("expected successful spawn output, got {other:?}"),
         };
         let outcome = spawner.last_prefix_resolve(&agent_id).await.unwrap();
         assert!(
@@ -4710,7 +4895,9 @@ mod tests {
         // inherit_prefix=None → outcome should be Disabled, regardless
         // of whether a store is configured or the flag is on.
         let store: Arc<dyn PrefixCaptureSink> = Arc::new(InMemoryPrefixStore::new());
-        let spawner = DynamicAgentSpawner::new(mock_router()).with_prefix_store(store);
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_prefix_store(store)
+            .with_executor(Arc::new(ImmediateSuccessExecutor) as Arc<dyn SpawnAgentExecutor>);
         let input = SpawnAgentInput {
             description: "child".into(),
             prompt: "work".into(),
@@ -4721,8 +4908,9 @@ mod tests {
         let ctx = parent_context("run-parent");
         let out = spawner.spawn(input, &ctx).await.unwrap();
         let agent_id = match out {
+            SpawnAgentOutput::Completed { agent_id, .. } => agent_id,
             SpawnAgentOutput::Launched { agent_id, .. } => agent_id,
-            other => panic!("expected Launched, got {other:?}"),
+            other => panic!("expected successful spawn output, got {other:?}"),
         };
         let outcome = spawner.last_prefix_resolve(&agent_id).await.unwrap();
         assert!(
@@ -4875,7 +5063,8 @@ mod tests {
 
     #[tokio::test]
     async fn fork_child_can_still_spawn_fresh_child_without_inheritance() {
-        let spawner = DynamicAgentSpawner::new(mock_router());
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_executor(Arc::new(ImmediateSuccessExecutor) as Arc<dyn SpawnAgentExecutor>);
         let mut ctx = parent_context("run-fork-parent");
         ctx.parent_is_fork_child = true;
         let input = SpawnAgentInput {
@@ -4887,7 +5076,7 @@ mod tests {
 
         let result = spawner.spawn(input, &ctx).await;
         assert!(
-            matches!(result, Ok(SpawnAgentOutput::Launched { .. })),
+            result.is_ok(),
             "fork children must still be able to spawn ordinary non-inheriting children: {result:?}"
         );
     }


### PR DESCRIPTION
## Summary
- Track whether the detach handle is attached to an active bash invocation before Ctrl+B tries bash handoff
- Retire signalled detach handles so timeout/drop races cannot restore a stale one-shot sender for later bash calls
- Let foreground agent promotion proceed immediately when Ctrl+B is pressed without an active bash command
- Let background local-agent detail rows expose typed output, not only stop
- Render local-agent background output as local-agent output instead of shell output
- Route background-task output sentinels through the typed shell/local-agent/restored projection path
- Finalize executor panics as failed subagent lifecycle states instead of leaving active/background bookkeeping behind
- Fail agent spawn explicitly when no executor is installed, before reserving active state or fanout rows
- Update tests that intentionally spawn agents to install explicit fake executors instead of relying on no-executor degraded mode
- Update TUI shortcut docs for the bash/agent Ctrl+B behavior

## Coverage
- Added detach active/retired state coverage
- Added a retired-handle regression test so abandoned listeners are not restored after normal bash completion
- Added local-agent output sentinel coverage for the background task UI path
- Added foreground/background subagent executor-panic coverage for cleanup, notifier, archive, and active-state invariants
- Added no-executor coverage proving no fake active agent, notifier, JoinSet task, or fanout group is left behind
- Strengthened prefix/watch tests so successful spawn paths require a real fake executor

## Testing
- cargo fmt
- git diff --check
- Local tests/compile not run per prior request