### PR TITLE
fix: open background tasks from ctrl-b fallback

### DIFF
--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
@@ -56,6 +56,8 @@ use crate::{
 
 use crate::cli::chat_stream::edge_executor::edge_executor_instance_id;
 
+const BASH_BACKGROUND_TASK_CONTROL_TOOLS: &[&str] = &["task_output", "task_list", "task_stop"];
+
 /// Per-phase stderr timings for `/chat/turn`. Disabled — use `RUST_LOG=debug` instead.
 pub(crate) fn chat_turn_timing_stderr_enabled() -> bool {
     false
@@ -494,6 +496,18 @@ async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
                 &mut turn_schemas,
                 &mut selection_report,
                 &required_refs,
+                ctx.all_schemas,
+            );
+        }
+        if selection_report
+            .tools_selected
+            .iter()
+            .any(|name| name == "bash")
+        {
+            astra_turn_core::tool_schema_prune::inject_required_tool_names(
+                &mut turn_schemas,
+                &mut selection_report,
+                BASH_BACKGROUND_TASK_CONTROL_TOOLS,
                 ctx.all_schemas,
             );
         }
@@ -1704,6 +1718,117 @@ mod tests {
             !edge_tool_names.contains(&"exit_plan_mode"),
             "exit_plan_mode should not be injected when plan_mode_active=false"
         );
+    }
+
+    #[tokio::test]
+    async fn prepare_chat_turn_payload_injects_background_controls_when_bash_selected() {
+        use crate::edge_tools::ToolExecutor;
+        use astra_pipeline::step_recorder::StepRecorder;
+        use astra_runtime::{
+            tool_registry::ToolRegistry,
+            turn::chat_turn_explain_wire::{AgenticChatExplainFlags, AgenticExplainUiMode},
+        };
+        use astra_turn_core::{interaction_types::TurnInteractionPolicy, turn_guard::TurnGuard};
+        use std::{collections::HashSet, sync::Arc, time::Instant};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let all_schemas = vec![
+            schema("bash"),
+            schema("task_output"),
+            schema("task_list"),
+            schema("task_stop"),
+            schema("read_file"),
+        ];
+        let registry = ToolRegistry::new(all_schemas.clone()).with_budget(1);
+        let executor = Arc::new(ToolExecutor::new(temp_dir.path()));
+        let messages = vec![json!({"role": "user", "content": "run make check"})];
+        let tool_results = Vec::new();
+        let history: Vec<(String, String)> = Vec::new();
+        let recent_tools: Vec<String> = Vec::new();
+        let file_context: Vec<String> = Vec::new();
+        let mut restricted_tools = HashSet::new();
+        let mut widen_selection_pending = false;
+        let mut step_recorder = StepRecorder::new("session-1", "task-1");
+        let turn_guard = TurnGuard::default();
+        let skill_search = astra_core::SkillSearchSettings::default();
+        let mut turn_policy = TurnInteractionPolicy::default();
+        let mut first_memoria_ms = None;
+        let mut first_selection_report = None;
+        let mut first_budget_pressure = 0.0;
+        let mut first_context_assembly_ms = None;
+        let mut all_selected_skills = Vec::new();
+
+        let payload = prepare_chat_turn_payload(PrepareChatTurnRequest {
+            messages: &messages,
+            runtime_volatile_texts: &[],
+            ephemeral_prefix: None,
+            current_session_id: Some("session-1"),
+            model: None,
+            explain: AgenticChatExplainFlags::from_explain_ui_mode(AgenticExplainUiMode::Off),
+            project_root: temp_dir.path(),
+            message: "run make check",
+            semantic_query_override: None,
+            history: &history,
+            recent_tools: &recent_tools,
+            executor,
+            registry: &registry,
+            tool_results: &tool_results,
+            all_schemas: &all_schemas,
+            turn_guard: &turn_guard,
+            restricted_tools: &mut restricted_tools,
+            widen_selection_pending: &mut widen_selection_pending,
+            step_recorder: &mut step_recorder,
+            file_context: &file_context,
+            assembly_start: Instant::now(),
+            telem: PrepareTurnTelemetry {
+                first_memoria_ms: &mut first_memoria_ms,
+                first_selection_report: &mut first_selection_report,
+                first_budget_pressure: &mut first_budget_pressure,
+                first_context_assembly_ms: &mut first_context_assembly_ms,
+                all_selected_skills: &mut all_selected_skills,
+                initial_skill_selector_shortlist: None,
+                trace_collector: None,
+            },
+            skill_search: &skill_search,
+            is_plan_subtask: false,
+            plan_subtask_id: None,
+            timing_phases: false,
+            prep_ui_phase: None,
+            skill_effort: None,
+            skill_agent_type: None,
+            tool_budget_override: None,
+            interaction_mode: TurnInteractionMode::NonInteractive,
+            turn_policy: &mut turn_policy,
+            skill_allowed_tools: None,
+            previous_confidence_fallback: None,
+            round_index: 0,
+            session_turn: 1,
+            turn_chain_id: None,
+            user_query_event_id: None,
+            denial_pressure: (0, 0),
+            recent_rejections: Vec::new(),
+            observability_hub: None,
+            append_system_prompt: None,
+            plan_mode_active: false,
+        })
+        .await;
+
+        let edge_tool_names: Vec<&str> = payload["edge_tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|schema| schema["function"]["name"].as_str())
+            .collect();
+        assert!(
+            edge_tool_names.contains(&"bash"),
+            "test requires bash to be selected: {edge_tool_names:?}"
+        );
+        for name in ["task_output", "task_list", "task_stop"] {
+            assert!(
+                edge_tool_names.contains(&name),
+                "Bash selection must force-inject {name} for same-turn Ctrl+B follow-up: {edge_tool_names:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -7002,6 +7002,29 @@ mod tests {
             "{}",
             outcome.output
         );
+        assert!(
+            outcome.output.contains("call the `task_output` tool"),
+            "{}",
+            outcome.output
+        );
+        assert!(
+            outcome
+                .output
+                .contains("Do not run these tool names through Bash"),
+            "{}",
+            outcome.output
+        );
+        assert!(
+            !outcome.output.contains("task_output("),
+            "{}",
+            outcome.output
+        );
+        assert!(
+            !outcome.output.contains("task_list()"),
+            "{}",
+            outcome.output
+        );
+        assert!(!outcome.output.contains("task_stop("), "{}", outcome.output);
         assert_eq!(
             outcome
                 .tool_result_fields

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -6364,6 +6364,14 @@ pub(crate) async fn execute_with_metadata_responsive(
     args: Value,
     cancel_token: Option<tokio_util::sync::CancellationToken>,
 ) -> crate::edge_tools::ToolExecutionOutcome {
+    if tool_name == "bash"
+        && let Some(outcome) = executor
+            .bash_detachable_with_metadata(&args, cancel_token.as_ref())
+            .await
+    {
+        return outcome;
+    }
+
     if !should_offload_blocking_tool(&tool_name) {
         return executor
             .execute_with_metadata_cancelable(&tool_name, &args, cancel_token.as_ref())
@@ -6929,6 +6937,79 @@ mod tests {
 
         let outcome = execution.await;
         assert!(outcome.output.contains("responsive"), "{}", outcome.output);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn responsive_bash_uses_real_detach_slot_for_ctrl_b_handoff() {
+        let dir = tempdir().expect("tempdir");
+        let (slot, listener) = astra_tools::detach::new_slot_with_handle();
+        let executor = std::sync::Arc::new(
+            crate::edge_tools::ToolExecutor::new(dir.path()).with_bash_detach_slot(slot),
+        );
+
+        let execution = tokio::spawn(execute_with_metadata_responsive(
+            executor,
+            "bash".to_string(),
+            serde_json::json!({
+                "command": "printf 'before\\n'; sleep 5; printf 'after\\n'",
+                "timeout": 30.0,
+            }),
+            None,
+        ));
+
+        for _ in 0..100 {
+            if listener.is_active() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            listener.is_active(),
+            "foreground edge bash must activate the TUI detach listener"
+        );
+
+        listener.signal_tx.send(true).expect("signal detach");
+        let payload = tokio::time::timeout(std::time::Duration::from_secs(2), listener.payload_rx)
+            .await
+            .expect("edge bash should hand off promptly after Ctrl+B")
+            .expect("payload");
+        assert_eq!(
+            payload.command,
+            "printf 'before\\n'; sleep 5; printf 'after\\n'"
+        );
+        assert!(
+            payload.partial_stdout.contains("before"),
+            "partial stdout should include foreground bytes: {:?}",
+            payload.partial_stdout
+        );
+        payload
+            .adoption_tx
+            .send(Ok("bg-shell-edge".to_string()))
+            .expect("ack adoption");
+
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(2), execution)
+            .await
+            .expect("detached edge bash should finish the tool call")
+            .expect("join");
+        assert!(!outcome.is_error, "{outcome:?}");
+        assert!(
+            outcome.output.contains("bash_detached"),
+            "{}",
+            outcome.output
+        );
+        assert!(
+            outcome.output.contains("bg-shell-edge"),
+            "{}",
+            outcome.output
+        );
+        assert_eq!(
+            outcome
+                .tool_result_fields
+                .as_ref()
+                .and_then(|fields| fields.get("background_task_id"))
+                .and_then(Value::as_str),
+            Some("bg-shell-edge")
+        );
     }
 
     // ── D-9 regression: speculative success flag must gate reuse ──

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -7003,14 +7003,20 @@ mod tests {
             outcome.output
         );
         assert!(
-            outcome.output.contains("call the `task_output` tool"),
+            outcome.output.contains("end your turn now"),
+            "{}",
+            outcome.output
+        );
+        assert!(outcome.output.contains("Do NOT poll"), "{}", outcome.output);
+        assert!(
+            outcome
+                .output
+                .contains("call `task_output` ONCE with block=false"),
             "{}",
             outcome.output
         );
         assert!(
-            outcome
-                .output
-                .contains("Do not run these tool names through Bash"),
+            outcome.output.contains("tail/cat/head/less are denied"),
             "{}",
             outcome.output
         );

--- a/rust/crates/astra-cli/src/edge_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools.rs
@@ -2287,7 +2287,15 @@ impl ToolExecutor {
             Err(error) => return error.to_string(),
             Ok(None) => return "Task id is required".to_string(),
         };
-        let block = args.get("block").and_then(Value::as_bool).unwrap_or(true);
+        // Default to snapshot-now. The block-until-terminal mode is opt-in
+        // because polling-with-output-coalescing actively misleads the model:
+        // a long-running cargo build emits new bytes every few hundred ms, so
+        // a "wait for new output" loop returns immediately every iteration
+        // with status=running, training the model to keep polling instead
+        // of ending the turn and trusting the <task_notification>. block=true
+        // here means "wait for the task to TERMINATE", not "wait for the
+        // next chunk".
+        let block = args.get("block").and_then(Value::as_bool).unwrap_or(false);
         let offset = args.get("offset").and_then(Value::as_u64).unwrap_or(0);
         let max_bytes = args
             .get("max_bytes")
@@ -2316,9 +2324,14 @@ impl ToolExecutor {
                 }
                 match rx.await {
                     Ok(Ok(snapshot)) => {
+                        // Only exit on true terminal status (completed/failed/
+                        // killed/unavailable) or waiting_for_input. Non-shell
+                        // tasks (local agents) still return immediately because
+                        // they don't have streaming output. New-bytes-arrived
+                        // is NOT an exit condition any more — that was the
+                        // old reverse-incentive trap.
                         if snapshot.kind != "shell"
                             || background_task_status_should_return_immediately(&snapshot.status)
-                            || !snapshot.output.is_empty()
                             || tokio::time::Instant::now() >= deadline
                         {
                             return format_background_task_output(&task_id, offset, &snapshot);

--- a/rust/crates/astra-cli/src/edge_tools/self_mod_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools/self_mod_tools.rs
@@ -63,7 +63,7 @@ impl ToolExecutor {
                     return json!({"error": "compression.compression_threshold must be within [0.5, 0.98]"}).to_string();
                 }
                 let old = session.config.compression.compression_threshold;
-                if let Some(d) = normalized_drift(old, new) {
+                if let Some(d) = bounded_drift(old, new, 0.5, 0.98) {
                     if !force && d > ceiling {
                         return json!({
                             "error": "config_drift_ceiling_exceeded",
@@ -90,7 +90,7 @@ impl ToolExecutor {
                         .to_string();
                 }
                 let old = session.config.memory.retrieval_top_k;
-                if let Some(d) = normalized_drift(old as f64, new as f64) {
+                if let Some(d) = bounded_drift(old as f64, new as f64, 1.0, 20.0) {
                     if !force && d > ceiling {
                         return json!({
                             "error": "config_drift_ceiling_exceeded",
@@ -117,7 +117,7 @@ impl ToolExecutor {
                         .to_string();
                 }
                 let old = session.config.tool_selection.max_tools;
-                if let Some(d) = normalized_drift(old as f64, new as f64) {
+                if let Some(d) = bounded_drift(old as f64, new as f64, 5.0, 80.0) {
                     if !force && d > ceiling {
                         return json!({
                             "error": "config_drift_ceiling_exceeded",
@@ -143,7 +143,7 @@ impl ToolExecutor {
                     return json!({"error": "tool_selection.tool_budget_tokens must be within [0, 40000]"}).to_string();
                 }
                 let old = session.config.tool_selection.tool_budget_tokens;
-                if let Some(d) = normalized_drift(old as f64, new as f64) {
+                if let Some(d) = bounded_drift(old as f64, new as f64, 0.0, 40_000.0) {
                     if !force && d > ceiling {
                         return json!({
                             "error": "config_drift_ceiling_exceeded",
@@ -169,7 +169,7 @@ impl ToolExecutor {
                     return json!({"error": "token_budget.max_turn_input_tokens must be within [8000, 200000]"}).to_string();
                 }
                 let old = session.config.token_budget.max_turn_input_tokens;
-                if let Some(d) = normalized_drift(old as f64, new as f64) {
+                if let Some(d) = bounded_drift(old as f64, new as f64, 8_000.0, 200_000.0) {
                     if !force && d > ceiling {
                         return json!({
                             "error": "config_drift_ceiling_exceeded",
@@ -195,7 +195,7 @@ impl ToolExecutor {
                     return json!({"error": "token_budget.tools_reserve must be within [1000, 40000]"}).to_string();
                 }
                 let old = session.config.token_budget.tools_reserve;
-                if let Some(d) = normalized_drift(old as f64, new as f64) {
+                if let Some(d) = bounded_drift(old as f64, new as f64, 1_000.0, 40_000.0) {
                     if !force && d > ceiling {
                         return json!({
                             "error": "config_drift_ceiling_exceeded",
@@ -222,7 +222,7 @@ impl ToolExecutor {
                         .to_string();
                 }
                 let old = session.config.verification.strictness;
-                if let Some(d) = normalized_drift(old, new) {
+                if let Some(d) = bounded_drift(old, new, 0.2, 0.95) {
                     if !force && d > ceiling {
                         return json!({
                             "error": "config_drift_ceiling_exceeded",
@@ -468,12 +468,12 @@ impl ToolExecutor {
     }
 }
 
-fn normalized_drift(old: f64, new: f64) -> Option<f64> {
-    let denom = old.abs();
-    if denom < f64::EPSILON {
+fn bounded_drift(old: f64, new: f64, min: f64, max: f64) -> Option<f64> {
+    let span = max - min;
+    if span <= f64::EPSILON {
         return None;
     }
-    Some((new - old).abs() / denom)
+    Some((new - old).abs() / span)
 }
 
 fn extract_tool_name(args: &Value) -> Option<String> {

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -6,8 +6,12 @@ use super::{
     SANDBOX_DENIED_PREFIX, ToolExecutor, apply_env_overlay, build_test, code_intel,
     sandbox_command, validate_path, wrap_command_with_limits,
 };
-use astra_runtime::tool_sandbox::{SandboxMode, SandboxPolicy};
+use astra_runtime::tool_sandbox::{SandboxMode, SandboxPolicy, filter_environment};
 use serde_json::Value;
+use tokio::io::AsyncReadExt;
+use tokio::process::Command as TokioCommand;
+
+const BASH_DETACH_ADOPTION_ACK_WAIT: Duration = Duration::from_secs(5);
 
 pub(crate) fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
@@ -2941,8 +2945,16 @@ struct ShellRunConfig {
     cancel_token: Option<tokio_util::sync::CancellationToken>,
 }
 
-fn run_shell_output_with_config(config: ShellRunConfig) -> Result<std::process::Output, String> {
-    let effective_command = if config.harden_command {
+enum DetachableShellOutput {
+    Completed(std::process::Output),
+    Detached {
+        payload: Box<astra_tools::detach::DetachedShellPayload>,
+        adoption_rx: tokio::sync::oneshot::Receiver<Result<String, String>>,
+    },
+}
+
+fn effective_shell_command(config: &ShellRunConfig) -> String {
+    if config.harden_command {
         if let Some(ref policy) = config.sandbox_policy {
             if !matches!(policy.mode, SandboxMode::Permissive) {
                 wrap_command_with_limits(policy, &config.command)
@@ -2954,7 +2966,11 @@ fn run_shell_output_with_config(config: ShellRunConfig) -> Result<std::process::
         }
     } else {
         config.command.clone()
-    };
+    }
+}
+
+fn run_shell_output_with_config(config: ShellRunConfig) -> Result<std::process::Output, String> {
+    let effective_command = effective_shell_command(&config);
 
     let mut child_cmd = Command::new(&config.program);
     child_cmd
@@ -3064,6 +3080,345 @@ fn run_shell_output_with_config(config: ShellRunConfig) -> Result<std::process::
         stdout: stdout_buf,
         stderr: stderr_buf,
     })
+}
+
+fn detach_signal_observed(signal_rx: &mut Option<tokio::sync::watch::Receiver<bool>>) -> bool {
+    enum SignalState {
+        Observed,
+        NotObserved,
+        Disconnected,
+    }
+
+    let state = if let Some(rx) = signal_rx.as_mut() {
+        match rx.has_changed() {
+            Ok(true) if *rx.borrow_and_update() => SignalState::Observed,
+            Ok(_) => SignalState::NotObserved,
+            Err(_) => SignalState::Disconnected,
+        }
+    } else {
+        return false;
+    };
+
+    match state {
+        SignalState::Observed => true,
+        SignalState::NotObserved => false,
+        SignalState::Disconnected => {
+            *signal_rx = None;
+            false
+        }
+    }
+}
+
+async fn restore_detach_signal_receiver(
+    detach: &astra_tools::detach::DetachShellHandle,
+    signal_rx: Option<tokio::sync::watch::Receiver<bool>>,
+) {
+    if let Some(signal_rx) = signal_rx {
+        *detach.signal_rx.lock().await = Some(signal_rx);
+    }
+}
+
+fn apply_overlay_to_tokio_command(cmd: &mut TokioCommand) {
+    cmd.env_clear();
+    for (key, value) in astra_core::session_env_overlay::merged_pairs() {
+        cmd.env(key, value);
+    }
+}
+
+fn configure_detachable_tokio_command(config: &ShellRunConfig) -> TokioCommand {
+    let effective_command = effective_shell_command(config);
+    let mut child_cmd = TokioCommand::new(&config.program);
+    child_cmd
+        .arg(&config.shell_flag)
+        .arg(&effective_command)
+        .current_dir(&config.effective_project_root)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    apply_overlay_to_tokio_command(&mut child_cmd);
+
+    #[cfg(unix)]
+    child_cmd.process_group(0);
+
+    if let Some(ref policy) = config.sandbox_policy
+        && !matches!(policy.mode, SandboxMode::Permissive)
+    {
+        child_cmd.current_dir(&policy.project_root);
+        child_cmd.env_clear();
+        for (key, value) in filter_environment(policy) {
+            child_cmd.env(key, value);
+        }
+    }
+
+    child_cmd
+}
+
+fn record_async_bash_chunk(
+    sink: &Option<std::sync::Arc<crate::cli::chat_stream::ToolProgressSink>>,
+    bytes: &[u8],
+) {
+    if let Some(sink) = sink {
+        sink.record_chunk(bytes);
+    }
+}
+
+async fn drain_tokio_stdout(
+    stdout: &mut tokio::process::ChildStdout,
+    output: &mut Vec<u8>,
+    sink: &Option<std::sync::Arc<crate::cli::chat_stream::ToolProgressSink>>,
+    timeout: Duration,
+) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut buf = [0u8; 8192];
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep_until(deadline) => break,
+            read = stdout.read(&mut buf) => {
+                match read {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        record_async_bash_chunk(sink, &buf[..n]);
+                        output.extend_from_slice(&buf[..n]);
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+    }
+}
+
+async fn drain_tokio_stderr(
+    stderr: &mut tokio::process::ChildStderr,
+    output: &mut Vec<u8>,
+    sink: &Option<std::sync::Arc<crate::cli::chat_stream::ToolProgressSink>>,
+    timeout: Duration,
+) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut buf = [0u8; 8192];
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep_until(deadline) => break,
+            read = stderr.read(&mut buf) => {
+                match read {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        record_async_bash_chunk(sink, &buf[..n]);
+                        output.extend_from_slice(&buf[..n]);
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+    }
+}
+
+async fn kill_tokio_process_group(child: &mut tokio::process::Child) {
+    #[cfg(unix)]
+    {
+        if let Some(pid) = child.id()
+            && let Ok(raw) = i32::try_from(pid)
+        {
+            let pgid = nix::unistd::Pid::from_raw(raw);
+            let _ = nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGKILL);
+            let _ = child.wait().await;
+            return;
+        }
+    }
+    let _ = child.kill().await;
+}
+
+async fn terminate_detached_shell_payload(
+    mut payload: Box<astra_tools::detach::DetachedShellPayload>,
+) {
+    kill_tokio_process_group(&mut payload.child).await;
+}
+
+async fn run_shell_output_with_detach_config(
+    config: ShellRunConfig,
+    detach: &astra_tools::detach::DetachShellHandle,
+    command_label: &str,
+) -> Result<DetachableShellOutput, String> {
+    let mut child_cmd = configure_detachable_tokio_command(&config);
+    let mut child = child_cmd.spawn().map_err(|e| format!("Error: {e}"))?;
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Error: failed to capture stdout".to_string())?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Error: failed to capture stderr".to_string())?;
+
+    let mut signal_rx = detach.signal_rx.lock().await.take();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs_f64(config.timeout_secs);
+    let mut stdout_buf: Vec<u8> = Vec::new();
+    let mut stderr_buf: Vec<u8> = Vec::new();
+    let mut stdout_open = true;
+    let mut stderr_open = true;
+    let mut stdout_read_buf = [0u8; 8192];
+    let mut stderr_read_buf = [0u8; 8192];
+    let mut exit_status = None;
+    let mut detached = false;
+
+    loop {
+        if detach_signal_observed(&mut signal_rx) {
+            detached = true;
+            break;
+        }
+
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                exit_status = Some(status);
+                break;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                kill_tokio_process_group(&mut child).await;
+                restore_detach_signal_receiver(detach, signal_rx).await;
+                return Err(format!("Error: {e}"));
+            }
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            kill_tokio_process_group(&mut child).await;
+            restore_detach_signal_receiver(detach, signal_rx).await;
+            return Err(format!(
+                "Error: command timed out after {}s",
+                config.timeout_secs
+            ));
+        }
+
+        if let Some(rx) = signal_rx.as_mut() {
+            tokio::select! {
+                biased;
+                res = rx.changed() => {
+                    match res {
+                        Ok(()) if *rx.borrow_and_update() => {
+                            detached = true;
+                            break;
+                        }
+                        Ok(()) => {}
+                        Err(_) => signal_rx = None,
+                    }
+                }
+                _ = async {
+                    if let Some(token) = config.cancel_token.as_ref() {
+                        token.cancelled().await;
+                    } else {
+                        std::future::pending::<()>().await;
+                    }
+                } => {
+                    kill_tokio_process_group(&mut child).await;
+                    restore_detach_signal_receiver(detach, signal_rx).await;
+                    return Err("Error: command cancelled by user".to_string());
+                }
+                read = stdout.read(&mut stdout_read_buf), if stdout_open => {
+                    match read {
+                        Ok(0) => stdout_open = false,
+                        Ok(n) => {
+                            record_async_bash_chunk(&config.progress_sink, &stdout_read_buf[..n]);
+                            stdout_buf.extend_from_slice(&stdout_read_buf[..n]);
+                        }
+                        Err(_) => stdout_open = false,
+                    }
+                }
+                read = stderr.read(&mut stderr_read_buf), if stderr_open => {
+                    match read {
+                        Ok(0) => stderr_open = false,
+                        Ok(n) => {
+                            record_async_bash_chunk(&config.progress_sink, &stderr_read_buf[..n]);
+                            stderr_buf.extend_from_slice(&stderr_read_buf[..n]);
+                        }
+                        Err(_) => stderr_open = false,
+                    }
+                }
+                _ = tokio::time::sleep(Duration::from_millis(25)) => {}
+            }
+        } else {
+            tokio::select! {
+                biased;
+                _ = async {
+                    if let Some(token) = config.cancel_token.as_ref() {
+                        token.cancelled().await;
+                    } else {
+                        std::future::pending::<()>().await;
+                    }
+                } => {
+                    kill_tokio_process_group(&mut child).await;
+                    restore_detach_signal_receiver(detach, signal_rx).await;
+                    return Err("Error: command cancelled by user".to_string());
+                }
+                read = stdout.read(&mut stdout_read_buf), if stdout_open => {
+                    match read {
+                        Ok(0) => stdout_open = false,
+                        Ok(n) => {
+                            record_async_bash_chunk(&config.progress_sink, &stdout_read_buf[..n]);
+                            stdout_buf.extend_from_slice(&stdout_read_buf[..n]);
+                        }
+                        Err(_) => stdout_open = false,
+                    }
+                }
+                read = stderr.read(&mut stderr_read_buf), if stderr_open => {
+                    match read {
+                        Ok(0) => stderr_open = false,
+                        Ok(n) => {
+                            record_async_bash_chunk(&config.progress_sink, &stderr_read_buf[..n]);
+                            stderr_buf.extend_from_slice(&stderr_read_buf[..n]);
+                        }
+                        Err(_) => stderr_open = false,
+                    }
+                }
+                _ = tokio::time::sleep(Duration::from_millis(25)) => {}
+            }
+        }
+    }
+
+    if detached {
+        let (adoption_tx, adoption_rx) = tokio::sync::oneshot::channel();
+        let payload = Box::new(astra_tools::detach::DetachedShellPayload {
+            child,
+            stdout,
+            stderr,
+            command: command_label.to_string(),
+            partial_stdout: String::from_utf8_lossy(&stdout_buf).into_owned(),
+            partial_stderr: String::from_utf8_lossy(&stderr_buf).into_owned(),
+            adoption_tx,
+        });
+        return Ok(DetachableShellOutput::Detached {
+            payload,
+            adoption_rx,
+        });
+    }
+
+    let read_timeout = bash_pipe_read_timeout();
+    drain_tokio_stdout(
+        &mut stdout,
+        &mut stdout_buf,
+        &config.progress_sink,
+        read_timeout,
+    )
+    .await;
+    drain_tokio_stderr(
+        &mut stderr,
+        &mut stderr_buf,
+        &config.progress_sink,
+        read_timeout,
+    )
+    .await;
+
+    restore_detach_signal_receiver(detach, signal_rx).await;
+    Ok(DetachableShellOutput::Completed(std::process::Output {
+        status: exit_status.unwrap_or_else(|| {
+            child
+                .try_wait()
+                .ok()
+                .flatten()
+                .expect("bash child should have exited before normal completion")
+        }),
+        stdout: stdout_buf,
+        stderr: stderr_buf,
+    }))
 }
 
 /// Adaptive default bash timeout by command kind. Used when the caller
@@ -4040,6 +4395,114 @@ impl ToolExecutor {
             Ok(Ok(out)) => self.render_bash_output(&command, out),
             Ok(Err(error)) => error,
             Err(error) => format!("Error: bash worker failed: {error}"),
+        }
+    }
+
+    async fn restore_bash_detach_handle(
+        &self,
+        slot: astra_tools::detach::DetachShellSlot,
+        handle: astra_tools::detach::DetachShellHandle,
+    ) {
+        handle.mark_active(false);
+        if !handle.is_retired() {
+            *slot.lock().await = Some(handle);
+        }
+    }
+
+    pub(crate) async fn bash_detachable_with_metadata(
+        &self,
+        args: &Value,
+        cancel_token: Option<&tokio_util::sync::CancellationToken>,
+    ) -> Option<super::ToolExecutionOutcome> {
+        let slot = self.bash_detach_slot.as_ref()?.clone();
+        let handle = slot.lock().await.take()?;
+
+        let (command, timeout_secs) = match self.prepare_bash_invocation(args) {
+            Ok(invocation) => invocation,
+            Err(message) => {
+                self.restore_bash_detach_handle(slot, handle).await;
+                return Some(super::ToolExecutionOutcome::error(message));
+            }
+        };
+        let config =
+            self.shell_run_config("bash", "-c", &command, timeout_secs, true, cancel_token);
+
+        handle.mark_active(true);
+        let outcome = run_shell_output_with_detach_config(config, &handle, &command).await;
+        match outcome {
+            Ok(DetachableShellOutput::Completed(out)) => {
+                self.restore_bash_detach_handle(slot, handle).await;
+                let output =
+                    self.finalize_tool_output(self.render_bash_output(&command, out), "bash");
+                self.record_output_size(output.len());
+                Some(if output.starts_with("Error") {
+                    super::ToolExecutionOutcome::error(output)
+                } else {
+                    super::ToolExecutionOutcome::ok(output)
+                })
+            }
+            Ok(DetachableShellOutput::Detached {
+                payload,
+                adoption_rx,
+            }) => {
+                handle.mark_active(false);
+                let Some(sender) = handle.payload_tx.lock().await.take() else {
+                    terminate_detached_shell_payload(payload).await;
+                    return Some(super::ToolExecutionOutcome::error(
+                        "Error: bash detach failed: host payload channel was not available"
+                            .to_string(),
+                    ));
+                };
+                if let Err(payload) = sender.send(*payload) {
+                    terminate_detached_shell_payload(Box::new(payload)).await;
+                    return Some(super::ToolExecutionOutcome::error(
+                        "Error: bash detach failed: host listener dropped before payload arrived"
+                            .to_string(),
+                    ));
+                }
+
+                let task_id =
+                    match tokio::time::timeout(BASH_DETACH_ADOPTION_ACK_WAIT, adoption_rx).await {
+                        Ok(Ok(Ok(task_id))) => task_id,
+                        Ok(Ok(Err(error))) => {
+                            return Some(super::ToolExecutionOutcome::error(format!(
+                                "Error: bash detach failed: host could not adopt process: {error}"
+                            )));
+                        }
+                        Ok(Err(_)) => {
+                            return Some(super::ToolExecutionOutcome::error(
+                                "Error: bash detach failed: host dropped adoption acknowledgement"
+                                    .to_string(),
+                            ));
+                        }
+                        Err(_) => {
+                            return Some(super::ToolExecutionOutcome::error(
+                            "Error: bash detach failed: host did not acknowledge adoption in time"
+                                .to_string(),
+                        ));
+                        }
+                    };
+
+                let output = format!(
+                    "<bash_detached>The bash command was promoted to background task {task_id}. \
+                     Output continues in the BackgroundTaskRegistry; \
+                     poll progress with `task_output(task_id='{task_id}')`, inspect tasks with `task_list()`, \
+                     or stop it with `task_stop(task_id='{task_id}')`.\
+                     </bash_detached>"
+                );
+                let mut tool_result_fields = serde_json::Map::new();
+                tool_result_fields.insert("bash_detached".to_string(), Value::Bool(true));
+                tool_result_fields.insert("background_task_id".to_string(), Value::String(task_id));
+                Some(super::ToolExecutionOutcome {
+                    output,
+                    tool_result_fields: Some(tool_result_fields),
+                    is_error: false,
+                })
+            }
+            Err(error) => {
+                self.restore_bash_detach_handle(slot, handle).await;
+                Some(super::ToolExecutionOutcome::error(error))
+            }
         }
     }
 

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -7,11 +7,13 @@ use super::{
     sandbox_command, validate_path, wrap_command_with_limits,
 };
 use astra_runtime::tool_sandbox::{SandboxMode, SandboxPolicy, filter_environment};
+use astra_tools::detach::{
+    AdoptionAckOutcome, await_adoption_ack, detach_signal_observed, render_bash_detached_marker,
+    restore_detach_signal_receiver, sigkill_process_group, terminate_detached_payload,
+};
 use serde_json::Value;
 use tokio::io::AsyncReadExt;
 use tokio::process::Command as TokioCommand;
-
-const BASH_DETACH_ADOPTION_ACK_WAIT: Duration = Duration::from_secs(5);
 
 pub(crate) fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
@@ -2820,7 +2822,7 @@ fn run_command_with_cleanup(
             Ok(None) => {
                 if std::time::Instant::now() > deadline {
                     // Kill entire process group (command + all children)
-                    sigkill_process_group(&mut child);
+                    sync_sigkill_process_group(&mut child);
                     // Reap the zombie process to prevent resource leak
                     let _ = child.wait();
                     return Err(format!("Error: command timed out after {timeout_secs}s"));
@@ -2828,7 +2830,7 @@ fn run_command_with_cleanup(
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => {
-                sigkill_process_group(&mut child);
+                sync_sigkill_process_group(&mut child);
                 let _ = child.wait();
                 return Err(format!("Error: {e}"));
             }
@@ -2861,7 +2863,7 @@ const BASH_PIPE_READ_TIMEOUT: Duration = Duration::from_millis(500);
 ///
 /// Failures are silently ignored because the child may already have been
 /// reaped by the caller in a race; this helper is strictly best-effort.
-fn sigkill_process_group(child: &mut std::process::Child) {
+fn sync_sigkill_process_group(child: &mut std::process::Child) {
     #[cfg(unix)]
     {
         let pid = child.id();
@@ -2871,7 +2873,7 @@ fn sigkill_process_group(child: &mut std::process::Child) {
         } else {
             tracing::warn!(
                 pid,
-                "sigkill_process_group: PID exceeds i32::MAX, skipping killpg"
+                "sync_sigkill_process_group: PID exceeds i32::MAX, skipping killpg"
             );
         }
     }
@@ -3040,13 +3042,13 @@ fn run_shell_output_with_config(config: ShellRunConfig) -> Result<std::process::
                     .as_ref()
                     .is_some_and(|token| token.is_cancelled())
                 {
-                    sigkill_process_group(&mut child);
+                    sync_sigkill_process_group(&mut child);
                     let _ = child.wait();
                     return Err("Error: command cancelled by user".to_string());
                 }
                 if std::time::Instant::now() > deadline {
                     // Kill entire process group (bash + all children)
-                    sigkill_process_group(&mut child);
+                    sync_sigkill_process_group(&mut child);
                     // Reap the zombie process to prevent resource leak
                     let _ = child.wait();
                     return Err(format!(
@@ -3057,7 +3059,7 @@ fn run_shell_output_with_config(config: ShellRunConfig) -> Result<std::process::
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => {
-                sigkill_process_group(&mut child);
+                sync_sigkill_process_group(&mut child);
                 let _ = child.wait();
                 return Err(format!("Error: {e}"));
             }
@@ -3080,42 +3082,6 @@ fn run_shell_output_with_config(config: ShellRunConfig) -> Result<std::process::
         stdout: stdout_buf,
         stderr: stderr_buf,
     })
-}
-
-fn detach_signal_observed(signal_rx: &mut Option<tokio::sync::watch::Receiver<bool>>) -> bool {
-    enum SignalState {
-        Observed,
-        NotObserved,
-        Disconnected,
-    }
-
-    let state = if let Some(rx) = signal_rx.as_mut() {
-        match rx.has_changed() {
-            Ok(true) if *rx.borrow_and_update() => SignalState::Observed,
-            Ok(_) => SignalState::NotObserved,
-            Err(_) => SignalState::Disconnected,
-        }
-    } else {
-        return false;
-    };
-
-    match state {
-        SignalState::Observed => true,
-        SignalState::NotObserved => false,
-        SignalState::Disconnected => {
-            *signal_rx = None;
-            false
-        }
-    }
-}
-
-async fn restore_detach_signal_receiver(
-    detach: &astra_tools::detach::DetachShellHandle,
-    signal_rx: Option<tokio::sync::watch::Receiver<bool>>,
-) {
-    if let Some(signal_rx) = signal_rx {
-        *detach.signal_rx.lock().await = Some(signal_rx);
-    }
 }
 
 fn apply_overlay_to_tokio_command(cmd: &mut TokioCommand) {
@@ -3213,27 +3179,6 @@ async fn drain_tokio_stderr(
     }
 }
 
-async fn kill_tokio_process_group(child: &mut tokio::process::Child) {
-    #[cfg(unix)]
-    {
-        if let Some(pid) = child.id()
-            && let Ok(raw) = i32::try_from(pid)
-        {
-            let pgid = nix::unistd::Pid::from_raw(raw);
-            let _ = nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGKILL);
-            let _ = child.wait().await;
-            return;
-        }
-    }
-    let _ = child.kill().await;
-}
-
-async fn terminate_detached_shell_payload(
-    mut payload: Box<astra_tools::detach::DetachedShellPayload>,
-) {
-    kill_tokio_process_group(&mut payload.child).await;
-}
-
 async fn run_shell_output_with_detach_config(
     config: ShellRunConfig,
     detach: &astra_tools::detach::DetachShellHandle,
@@ -3274,14 +3219,14 @@ async fn run_shell_output_with_detach_config(
             }
             Ok(None) => {}
             Err(e) => {
-                kill_tokio_process_group(&mut child).await;
+                sigkill_process_group(&mut child).await;
                 restore_detach_signal_receiver(detach, signal_rx).await;
                 return Err(format!("Error: {e}"));
             }
         }
 
         if tokio::time::Instant::now() >= deadline {
-            kill_tokio_process_group(&mut child).await;
+            sigkill_process_group(&mut child).await;
             restore_detach_signal_receiver(detach, signal_rx).await;
             return Err(format!(
                 "Error: command timed out after {}s",
@@ -3309,7 +3254,7 @@ async fn run_shell_output_with_detach_config(
                         std::future::pending::<()>().await;
                     }
                 } => {
-                    kill_tokio_process_group(&mut child).await;
+                    sigkill_process_group(&mut child).await;
                     restore_detach_signal_receiver(detach, signal_rx).await;
                     return Err("Error: command cancelled by user".to_string());
                 }
@@ -3345,7 +3290,7 @@ async fn run_shell_output_with_detach_config(
                         std::future::pending::<()>().await;
                     }
                 } => {
-                    kill_tokio_process_group(&mut child).await;
+                    sigkill_process_group(&mut child).await;
                     restore_detach_signal_receiver(detach, signal_rx).await;
                     return Err("Error: command cancelled by user".to_string());
                 }
@@ -3787,7 +3732,7 @@ fn run_command_streaming(
                         });
                     } else {
                         // Hard kill.
-                        sigkill_process_group(&mut child);
+                        sync_sigkill_process_group(&mut child);
                         let _ = child.wait();
                         let _ = stdout_thread.join();
                         let _ = stderr_thread.join();
@@ -3803,7 +3748,7 @@ fn run_command_streaming(
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => {
-                sigkill_process_group(&mut child);
+                sync_sigkill_process_group(&mut child);
                 let _ = child.wait();
                 let _ = stdout_thread.join();
                 let _ = stderr_thread.join();
@@ -3844,7 +3789,7 @@ fn size_watchdog(
             Ok(Some(_)) => break,
             Ok(None) => {}
             Err(_) => {
-                sigkill_process_group(&mut child);
+                sync_sigkill_process_group(&mut child);
                 let _ = child.wait();
                 break;
             }
@@ -3852,7 +3797,7 @@ fn size_watchdog(
 
         // Kill if running too long.
         if start.elapsed() > max_duration {
-            sigkill_process_group(&mut child);
+            sync_sigkill_process_group(&mut child);
             let _ = child.wait();
             break;
         }
@@ -3945,7 +3890,7 @@ fn run_readonly_command_with_partial(
                 if std::time::Instant::now() > deadline {
                     // Kill the entire process group (catches child processes).
                     // Fall back to direct kill so child.wait() never blocks forever.
-                    sigkill_process_group(&mut child);
+                    sync_sigkill_process_group(&mut child);
                     let _ = child.wait();
                     let _ = reader.join();
                     let _ = stderr_reader.join();
@@ -3964,7 +3909,7 @@ fn run_readonly_command_with_partial(
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => {
-                sigkill_process_group(&mut child);
+                sync_sigkill_process_group(&mut child);
                 let _ = child.wait();
                 let _ = reader.join();
                 let _ = stderr_reader.join();
@@ -4181,10 +4126,7 @@ impl ToolExecutor {
             Some(c) => c,
             None => return Err("Error: missing 'command'".to_string()),
         };
-        if let Some(error) = astra_tools::shell_ops::background_task_tool_pseudo_call_error(command)
-        {
-            return Err(error);
-        }
+        astra_tools::shell_ops::validate_bash_background_task_contract(command)?;
 
         // Block pure sleep commands — they waste time with no useful output.
         // Only when no explicit timeout is set (explicit timeout = intentional test usage).
@@ -4451,43 +4393,42 @@ impl ToolExecutor {
             }) => {
                 handle.mark_active(false);
                 let Some(sender) = handle.payload_tx.lock().await.take() else {
-                    terminate_detached_shell_payload(payload).await;
+                    terminate_detached_payload(payload).await;
                     return Some(super::ToolExecutionOutcome::error(
                         "Error: bash detach failed: host payload channel was not available"
                             .to_string(),
                     ));
                 };
                 if let Err(payload) = sender.send(*payload) {
-                    terminate_detached_shell_payload(Box::new(payload)).await;
+                    terminate_detached_payload(Box::new(payload)).await;
                     return Some(super::ToolExecutionOutcome::error(
                         "Error: bash detach failed: host listener dropped before payload arrived"
                             .to_string(),
                     ));
                 }
 
-                let task_id =
-                    match tokio::time::timeout(BASH_DETACH_ADOPTION_ACK_WAIT, adoption_rx).await {
-                        Ok(Ok(Ok(task_id))) => task_id,
-                        Ok(Ok(Err(error))) => {
-                            return Some(super::ToolExecutionOutcome::error(format!(
-                                "Error: bash detach failed: host could not adopt process: {error}"
-                            )));
-                        }
-                        Ok(Err(_)) => {
-                            return Some(super::ToolExecutionOutcome::error(
-                                "Error: bash detach failed: host dropped adoption acknowledgement"
-                                    .to_string(),
-                            ));
-                        }
-                        Err(_) => {
-                            return Some(super::ToolExecutionOutcome::error(
+                let task_id = match await_adoption_ack(adoption_rx).await {
+                    AdoptionAckOutcome::Adopted { task_id, .. } => task_id,
+                    AdoptionAckOutcome::Refused(error) => {
+                        return Some(super::ToolExecutionOutcome::error(format!(
+                            "Error: bash detach failed: host could not adopt process: {error}"
+                        )));
+                    }
+                    AdoptionAckOutcome::SenderDropped => {
+                        return Some(super::ToolExecutionOutcome::error(
+                            "Error: bash detach failed: host dropped adoption acknowledgement"
+                                .to_string(),
+                        ));
+                    }
+                    AdoptionAckOutcome::TimedOut => {
+                        return Some(super::ToolExecutionOutcome::error(
                             "Error: bash detach failed: host did not acknowledge adoption in time"
                                 .to_string(),
                         ));
-                        }
-                    };
+                    }
+                };
 
-                let output = astra_tools::shell_ops::render_bash_detached_marker(&task_id);
+                let output = render_bash_detached_marker(&task_id);
                 let mut tool_result_fields = serde_json::Map::new();
                 tool_result_fields.insert("bash_detached".to_string(), Value::Bool(true));
                 tool_result_fields.insert("background_task_id".to_string(), Value::String(task_id));
@@ -5284,6 +5225,37 @@ mod tests {
         assert!(
             !result.contains("syntax error"),
             "pseudo task tool call must not reach bash: {result}"
+        );
+    }
+
+    /// The edge bash entry point must refuse direct disk reads of the
+    /// background-task output directory — the same denial the in-tools
+    /// `validate_execute_bash_command` enforces. Without this, the hot-path
+    /// edge bash silently bypasses the canonical validator and the model
+    /// can still `tail /tmp/astra/bg_tasks/...` to poll task output, which
+    /// is the canonical 12-LLM-round trace this contract was designed
+    /// to defeat.
+    #[test]
+    fn bash_rejects_background_task_output_dir_disk_read() {
+        let executor = test_executor();
+        for command in [
+            "tail -20 /tmp/astra/bg_tasks/default/bg-shell-1.stderr",
+            "cat /tmp/astra/bg_tasks/default/bg-shell-1.stdout",
+            "tail -f /var/folders/abc/T/astra/bg_tasks/sess/bg-shell-2.stdout",
+            "grep error /tmp/astra/bg_tasks/sess/bg-shell-3.stderr",
+        ] {
+            let result = executor.bash(&serde_json::json!({"command": command}));
+            assert!(
+                result.contains("background task output files"),
+                "{command} -> {result}"
+            );
+            assert!(result.contains("task_output"), "{command} -> {result}");
+        }
+        assert!(
+            executor
+                .bash(&serde_json::json!({"command": "echo bg_tasks is unrelated here"}))
+                .contains("bg_tasks is unrelated here"),
+            "literal word 'bg_tasks' without the astra path prefix must not trigger"
         );
     }
 
@@ -8407,7 +8379,7 @@ mod tests {
         // Process should be alive.
         assert!(child.try_wait().unwrap().is_none());
         // Kill it.
-        super::sigkill_process_group(&mut child);
+        super::sync_sigkill_process_group(&mut child);
         // Wait should complete immediately.
         let status = child.wait().expect("wait after sigkill");
         assert!(!status.success(), "process should have been killed");

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -4181,6 +4181,10 @@ impl ToolExecutor {
             Some(c) => c,
             None => return Err("Error: missing 'command'".to_string()),
         };
+        if let Some(error) = astra_tools::shell_ops::background_task_tool_pseudo_call_error(command)
+        {
+            return Err(error);
+        }
 
         // Block pure sleep commands — they waste time with no useful output.
         // Only when no explicit timeout is set (explicit timeout = intentional test usage).
@@ -4483,13 +4487,7 @@ impl ToolExecutor {
                         }
                     };
 
-                let output = format!(
-                    "<bash_detached>The bash command was promoted to background task {task_id}. \
-                     Output continues in the BackgroundTaskRegistry; \
-                     poll progress with `task_output(task_id='{task_id}')`, inspect tasks with `task_list()`, \
-                     or stop it with `task_stop(task_id='{task_id}')`.\
-                     </bash_detached>"
-                );
+                let output = astra_tools::shell_ops::render_bash_detached_marker(&task_id);
                 let mut tool_result_fields = serde_json::Map::new();
                 tool_result_fields.insert("bash_detached".to_string(), Value::Bool(true));
                 tool_result_fields.insert("background_task_id".to_string(), Value::String(task_id));
@@ -5273,6 +5271,20 @@ mod tests {
         let executor = test_executor();
         let result = executor.bash(&serde_json::json!({"command": "echo hello"}));
         assert!(result.trim().contains("hello"), "got: {result}");
+    }
+
+    #[test]
+    fn bash_rejects_background_task_pseudo_tool_call() {
+        let executor = test_executor();
+        let result =
+            executor.bash(&serde_json::json!({"command": "task_output(task_id='bg-shell-1')"}));
+        assert!(result.contains("background-task tool"), "got: {result}");
+        assert!(result.contains("not a bash command"), "got: {result}");
+        assert!(result.contains("Do not rerun"), "got: {result}");
+        assert!(
+            !result.contains("syntax error"),
+            "pseudo task tool call must not reach bash: {result}"
+        );
     }
 
     /// Regression for the c49bc4a3 inspection-loop deadlock: a model that

--- a/rust/crates/astra-cli/src/tui/ARCHITECTURE.md
+++ b/rust/crates/astra-cli/src/tui/ARCHITECTURE.md
@@ -198,7 +198,7 @@ slash_dispatch::dispatch("/model", ctx)
 | `Enter` | Composer | Submit text / dispatch slash command |
 | `Shift+Enter` | Composer | Insert newline (multi-line input) |
 | `Ctrl+C` | Turn active | Cancel/interrupt turn |
-| `Ctrl+B` | Turn active with foreground bash/agent | Promote active bash to a background shell task; otherwise promote a foreground sync agent |
+| `Ctrl+B` | Turn active with foreground bash/agent or existing background tasks | Promote active bash to a background shell task; otherwise promote a foreground sync agent; otherwise open Background tasks when tasks exist |
 | `Ctrl+C` | Composer non-empty | Clear draft |
 | `Ctrl+C` | Idle | Quit |
 | `Ctrl+D` | Composer empty | Quit |

--- a/rust/crates/astra-cli/src/tui/background_shortcut.rs
+++ b/rust/crates/astra-cli/src/tui/background_shortcut.rs
@@ -1,0 +1,56 @@
+pub(crate) fn ctrl_b_background_shortcut() -> &'static str {
+    ctrl_b_background_shortcut_for_tmux(is_tmux_session())
+}
+
+pub(crate) fn background_task_open_hint() -> String {
+    format!(
+        "{} open",
+        background_task_open_shortcuts_for_tmux(is_tmux_session())
+    )
+}
+
+pub(crate) fn ctrl_b_background_shortcut_for_tmux(is_tmux: bool) -> &'static str {
+    if is_tmux {
+        "Ctrl+B Ctrl+B (twice)"
+    } else {
+        "Ctrl+B"
+    }
+}
+
+pub(crate) fn background_task_open_shortcuts_for_tmux(is_tmux: bool) -> &'static str {
+    if is_tmux {
+        "Ctrl+B Ctrl+B/Ctrl+T"
+    } else {
+        "Ctrl+B/Ctrl+T"
+    }
+}
+
+fn is_tmux_session() -> bool {
+    std::env::var_os("TMUX").is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn foreground_background_shortcut_matches_tmux_prefix_behavior() {
+        assert_eq!(ctrl_b_background_shortcut_for_tmux(false), "Ctrl+B");
+        assert_eq!(
+            ctrl_b_background_shortcut_for_tmux(true),
+            "Ctrl+B Ctrl+B (twice)"
+        );
+    }
+
+    #[test]
+    fn background_task_open_shortcuts_stay_compact_in_tmux() {
+        assert_eq!(
+            background_task_open_shortcuts_for_tmux(false),
+            "Ctrl+B/Ctrl+T"
+        );
+        assert_eq!(
+            background_task_open_shortcuts_for_tmux(true),
+            "Ctrl+B Ctrl+B/Ctrl+T"
+        );
+    }
+}

--- a/rust/crates/astra-cli/src/tui/background_shortcut.rs
+++ b/rust/crates/astra-cli/src/tui/background_shortcut.rs
@@ -2,11 +2,8 @@ pub(crate) fn ctrl_b_background_shortcut() -> &'static str {
     ctrl_b_background_shortcut_for_tmux(is_tmux_session())
 }
 
-pub(crate) fn background_task_open_hint() -> String {
-    format!(
-        "{} open",
-        background_task_open_shortcuts_for_tmux(is_tmux_session())
-    )
+pub(crate) fn background_task_open_hint() -> &'static str {
+    "Shift+↓ manage"
 }
 
 pub(crate) fn ctrl_b_background_shortcut_for_tmux(is_tmux: bool) -> &'static str {
@@ -14,14 +11,6 @@ pub(crate) fn ctrl_b_background_shortcut_for_tmux(is_tmux: bool) -> &'static str
         "Ctrl+B Ctrl+B (twice)"
     } else {
         "Ctrl+B"
-    }
-}
-
-pub(crate) fn background_task_open_shortcuts_for_tmux(is_tmux: bool) -> &'static str {
-    if is_tmux {
-        "Ctrl+B Ctrl+B/Ctrl+T"
-    } else {
-        "Ctrl+B/Ctrl+T"
     }
 }
 
@@ -43,14 +32,7 @@ mod tests {
     }
 
     #[test]
-    fn background_task_open_shortcuts_stay_compact_in_tmux() {
-        assert_eq!(
-            background_task_open_shortcuts_for_tmux(false),
-            "Ctrl+B/Ctrl+T"
-        );
-        assert_eq!(
-            background_task_open_shortcuts_for_tmux(true),
-            "Ctrl+B Ctrl+B/Ctrl+T"
-        );
+    fn background_task_open_hint_uses_navigation_manage_shortcut() {
+        assert_eq!(background_task_open_hint(), "Shift+↓ manage");
     }
 }

--- a/rust/crates/astra-cli/src/tui/background_tasks.rs
+++ b/rust/crates/astra-cli/src/tui/background_tasks.rs
@@ -206,6 +206,13 @@ const MAX_OUTPUT_BYTES: u64 = 64 * 1024;
 /// beyond this limit are soft-rejected (return an empty id) to prevent
 /// unbounded resource consumption.  The LLM can retry or re-plan.
 const MAX_CONCURRENT_TASKS: usize = 32;
+/// Maximum number of *terminal* (completed/failed/killed) tasks retained
+/// in-memory after they finish. Terminal tasks must remain queryable so
+/// the model can answer "how did make check go?" in the next user turn —
+/// CC's TaskList keeps completed tasks visible until the user dismisses
+/// them; this cap is the equivalent for our HashMap-backed registry. When
+/// the cap is exceeded, the oldest-ended terminal entries are LRU-evicted.
+const MAX_TERMINAL_TASKS_RETAINED: usize = 64;
 const STALL_THRESHOLD: Duration = Duration::from_secs(45);
 const STALL_TAIL_RECHECK_COOLDOWN: Duration = Duration::from_secs(2);
 const PROMPT_PATTERNS: &[&str] = &[
@@ -237,6 +244,14 @@ impl BackgroundTaskRegistry {
             output_dir,
             pending_completions: Vec::new(),
         }
+    }
+
+    /// Rebind the directory used for future background shell output files.
+    /// Existing handles keep their original stdout/stderr paths because live
+    /// runners may still be appending to those files.
+    pub fn rebind_output_dir(&mut self, output_dir: PathBuf) {
+        std::fs::create_dir_all(&output_dir).ok();
+        self.output_dir = output_dir;
     }
 
     /// Spawn a shell command in the background. Returns the task ID.
@@ -552,10 +567,40 @@ impl BackgroundTaskRegistry {
 
     /// Prune terminated tasks from the registry to prevent unbounded
     /// memory growth in long-running sessions.  Tasks that have reached a
-    /// terminal state (completed / failed / killed) are removed from the
-    /// in-memory map; their output files remain on disk.
+    /// LRU-evict terminal tasks once the retained set exceeds
+    /// [`MAX_TERMINAL_TASKS_RETAINED`]. Running tasks are never touched.
+    /// Called from `poll_completions` so the cap is enforced exactly once
+    /// per tick rather than from every read path.
+    ///
+    /// Pre-fix this method dropped *every* terminal task on each tick,
+    /// which made `task_output("bg-shell-1")` start replying "not found"
+    /// the moment a make-check completed — even within the same session,
+    /// even seconds after the task notification fired. Models couldn't
+    /// answer "how did it go?" in the next turn without re-running the
+    /// command. The CC equivalent (`BackgroundTasksDialog`) keeps
+    /// completed entries visible until the user dismisses them; this cap
+    /// gives us the same semantics with a fixed memory ceiling.
     pub fn prune_terminated(&mut self) {
-        self.tasks.retain(|_, h| !h.status().is_terminal());
+        let mut terminal: Vec<(&str, u64)> = self
+            .tasks
+            .iter()
+            .filter(|(_, h)| h.status().is_terminal())
+            .map(|(id, h)| (id.as_str(), h.ended_at_ms.unwrap_or(h.started_at_ms)))
+            .collect();
+        if terminal.len() <= MAX_TERMINAL_TASKS_RETAINED {
+            return;
+        }
+        // Oldest-ended first; evict from the front of the sorted list.
+        terminal.sort_by_key(|(_, ended)| *ended);
+        let to_evict = terminal.len() - MAX_TERMINAL_TASKS_RETAINED;
+        let victims: Vec<String> = terminal
+            .into_iter()
+            .take(to_evict)
+            .map(|(id, _)| id.to_string())
+            .collect();
+        for id in victims {
+            self.tasks.remove(&id);
+        }
     }
 
     /// Kill all running tasks. Returns IDs of killed tasks.
@@ -675,8 +720,10 @@ impl BackgroundTaskRegistry {
 
     /// Poll for completed tasks. Call from the TUI tick.
     /// Returns events for tasks that finished since last poll.
-    /// Also prunes tasks that were terminal on entry, ensuring one
-    /// full tick of display + persist before removal.
+    /// Also LRU-trims the terminal-task pool when it exceeds
+    /// [`MAX_TERMINAL_TASKS_RETAINED`]; recently-finished entries
+    /// remain queryable across user turns so `task_output(id)` can
+    /// answer "how did it go?" instead of "not found".
     pub fn poll_completions(&mut self) -> Vec<BgTaskEvent> {
         self.prune_terminated();
         self.drain_join_set();
@@ -1510,6 +1557,32 @@ mod tests {
             last_tail_probe_at: None,
         };
         (handle, dir)
+    }
+
+    #[tokio::test]
+    async fn rebind_output_dir_keeps_existing_handles_and_routes_future_spawns() {
+        let tmp = TempDir::new().unwrap();
+        let old_dir = tmp.path().join("default");
+        let new_dir = tmp.path().join("session");
+        let mut reg = BackgroundTaskRegistry::new(old_dir.clone());
+
+        let old_id = reg.spawn_shell("true", "first turn task");
+        let old_stdout_path = reg.get(&old_id).unwrap().stdout_path.clone();
+        assert_eq!(old_stdout_path.parent(), Some(old_dir.as_path()));
+
+        reg.rebind_output_dir(new_dir.clone());
+
+        assert_eq!(
+            reg.get(&old_id).unwrap().stdout_path,
+            old_stdout_path,
+            "live tasks must keep the paths their runner is still writing"
+        );
+        let new_id = reg.spawn_shell("true", "next turn task");
+        assert_eq!(
+            reg.get(&new_id).unwrap().stdout_path.parent(),
+            Some(new_dir.as_path()),
+            "future tasks should use the rebound session output directory"
+        );
     }
 
     async fn wait_for_task_status(
@@ -2400,6 +2473,87 @@ mod tests {
         assert_eq!(
             killed_count, 1,
             "expected exactly 1 Killed event for {id}, got {killed_count}: {events:?}"
+        );
+    }
+
+    /// Regression for the trace where `task_output("bg-shell-1")` returned
+    /// "Background task not found" right after a successful completion
+    /// in the *previous* user turn. Pre-fix `prune_terminated` removed
+    /// every terminal entry on every `poll_completions`, so the next user
+    /// turn (a few hundred ms later) lost the ability to read the task's
+    /// final output. The fix retains terminal tasks up to a fixed cap.
+    #[tokio::test]
+    async fn terminal_tasks_remain_queryable_across_polls() {
+        let tmp = TempDir::new().unwrap();
+        let mut reg = BackgroundTaskRegistry::new(tmp.path().to_path_buf());
+        let id = reg.spawn_shell("true", "completed task");
+
+        // Wait for completion + drive the poll cycle a few times,
+        // mirroring the outer-tick loop that runs many times per second.
+        wait_until(Duration::from_secs(2), Duration::from_millis(20), || {
+            let _ = reg.poll_completions();
+            reg.get(&id).is_some_and(|h| h.status().is_terminal())
+        })
+        .await
+        .expect("task should complete and stay queryable");
+
+        // Three more ticks: pre-fix this would prune the task. Now it must
+        // remain queryable so the next user turn can `task_output(id)`.
+        for _ in 0..3 {
+            let _ = reg.poll_completions();
+        }
+        let handle = reg
+            .get(&id)
+            .expect("terminal task must remain queryable after multiple poll_completions ticks");
+        assert!(
+            handle.status().is_terminal(),
+            "retained handle must report terminal status, got {:?}",
+            handle.status()
+        );
+    }
+
+    /// Past `MAX_TERMINAL_TASKS_RETAINED` terminal entries the registry
+    /// LRU-evicts the oldest-ended ones so the in-memory map can't grow
+    /// without bound during a long session. Spawn one at a time and wait
+    /// for terminal — `MAX_CONCURRENT_TASKS` caps in-flight runners, but
+    /// retained terminals (after they finish) are bounded by a separate
+    /// cap which this test exercises.
+    #[tokio::test]
+    async fn terminal_tasks_lru_evict_when_over_cap() {
+        let tmp = TempDir::new().unwrap();
+        let mut reg = BackgroundTaskRegistry::new(tmp.path().to_path_buf());
+        let mut ids = Vec::new();
+        let total = MAX_TERMINAL_TASKS_RETAINED + 5;
+        for _ in 0..total {
+            let id = reg.spawn_shell("true", "tiny");
+            wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+                let _ = reg.poll_completions();
+                reg.get(&id).is_some_and(|h| h.status().is_terminal())
+            })
+            .await
+            .expect("each spawned task must reach terminal before the next spawn");
+            ids.push(id);
+        }
+        // One final poll to enforce the cap once we know everyone is terminal.
+        let _ = reg.poll_completions();
+
+        let retained = ids.iter().filter(|id| reg.get(id).is_some()).count();
+        assert_eq!(
+            retained, MAX_TERMINAL_TASKS_RETAINED,
+            "retained must equal cap exactly after spawning {total} terminal tasks"
+        );
+        // Newest entries are kept. The most recent task id we spawned must
+        // still be reachable — LRU eviction targets oldest-ended first.
+        let last = ids.last().unwrap();
+        assert!(
+            reg.get(last).is_some(),
+            "newest terminal task must survive LRU eviction"
+        );
+        // Oldest must be evicted.
+        let first = ids.first().unwrap();
+        assert!(
+            reg.get(first).is_none(),
+            "oldest terminal task must be evicted under LRU policy"
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/background_tasks.rs
+++ b/rust/crates/astra-cli/src/tui/background_tasks.rs
@@ -138,6 +138,10 @@ pub(crate) struct BackgroundTaskHandle {
     last_output_size: u64,
     last_activity: Instant,
     last_tail_probe_at: Option<Instant>,
+    /// Set after `prune_terminated` deletes this task's output files.
+    /// The handle stays in the map so callers get "output expired"
+    /// instead of "not found".
+    pub(crate) output_files_deleted: bool,
 }
 
 impl BackgroundTaskHandle {
@@ -249,16 +253,28 @@ impl BackgroundTaskRegistry {
     /// Rebind the directory used for future background shell output files.
     /// Existing handles keep their original stdout/stderr paths because live
     /// runners may still be appending to those files.
-    pub fn rebind_output_dir(&mut self, output_dir: PathBuf) {
-        std::fs::create_dir_all(&output_dir).ok();
+    ///
+    /// Returns an error if the directory cannot be created. Callers must
+    /// surface the failure — a silently-failed mkdir would surface much
+    /// later as `try_spawn_shell` "No such file or directory" with no link
+    /// back to this rebind, defeating traceability.
+    pub fn rebind_output_dir(&mut self, output_dir: PathBuf) -> Result<(), String> {
+        std::fs::create_dir_all(&output_dir).map_err(|e| {
+            format!(
+                "background task output directory could not be created at {}: {e}",
+                output_dir.display()
+            )
+        })?;
         self.output_dir = output_dir;
+        Ok(())
     }
 
     /// Spawn a shell command in the background. Returns the task ID.
     pub fn try_spawn_shell(&mut self, command: &str, description: &str) -> Result<String, String> {
-        if self.running_count() >= MAX_CONCURRENT_TASKS {
+        // Use active_count (includes stalled) to prevent capacity bypass
+        if self.active_count() >= MAX_CONCURRENT_TASKS {
             return Err(format!(
-                "background shell task limit reached ({MAX_CONCURRENT_TASKS} running)"
+                "background shell task limit reached ({MAX_CONCURRENT_TASKS} active)"
             ));
         }
         let id = format!("bg-shell-{}", NEXT_BG_ID.fetch_add(1, Ordering::Relaxed));
@@ -283,6 +299,7 @@ impl BackgroundTaskRegistry {
             last_output_size: 0,
             last_activity: Instant::now(),
             last_tail_probe_at: None,
+            output_files_deleted: false,
         };
         self.tasks.insert(id.clone(), handle);
 
@@ -335,7 +352,7 @@ impl BackgroundTaskRegistry {
     /// `command_label` is rendered as the task description. Cancel
     /// behaviour matches `spawn_shell`: `kill(id)` will SIGKILL the
     /// process group via the existing kill_on_drop guard.
-    pub fn adopt_detached_shell(
+    pub async fn adopt_detached_shell(
         &mut self,
         child: tokio::process::Child,
         stdout: tokio::process::ChildStdout,
@@ -344,11 +361,6 @@ impl BackgroundTaskRegistry {
         partial_stdout: String,
         partial_stderr: String,
     ) -> Result<String, String> {
-        if self.running_count() >= MAX_CONCURRENT_TASKS {
-            return Err(format!(
-                "background shell task limit reached ({MAX_CONCURRENT_TASKS} running)"
-            ));
-        }
         let id = format!("bg-shell-{}", NEXT_BG_ID.fetch_add(1, Ordering::Relaxed));
         let cancel = CancellationToken::new();
         let stdout_path = self.output_dir.join(format!("{id}.stdout"));
@@ -357,19 +369,39 @@ impl BackgroundTaskRegistry {
 
         // Seed output files with partial bytes the foreground runner
         // already showed. The LLM and user must see one continuous
-        // stream, not a jump-cut at the detach point. Errors are
-        // non-fatal: the streamer will append regardless.
+        // stream, not a jump-cut at the detach point.
+        // CRITICAL FIX: File creation errors block spawn to prevent orphan processes
         if !partial_stdout.is_empty() {
-            let _ = std::fs::write(&stdout_path, &partial_stdout);
+            if let Err(e) = tokio::fs::write(&stdout_path, &partial_stdout).await {
+                return Err(format!(
+                    "adopted shell: cannot seed stdout file {}: {e}",
+                    stdout_path.display()
+                ));
+            }
         } else {
             // Touch the file so get_output() on a not-yet-flushed
             // adopted task doesn't return ENOENT.
-            let _ = std::fs::File::create(&stdout_path);
+            if let Err(e) = tokio::fs::File::create(&stdout_path).await {
+                return Err(format!(
+                    "adopted shell: cannot create stdout file {}: {e}",
+                    stdout_path.display()
+                ));
+            }
         }
         if !partial_stderr.is_empty() {
-            let _ = std::fs::write(&stderr_path, &partial_stderr);
+            if let Err(e) = tokio::fs::write(&stderr_path, &partial_stderr).await {
+                return Err(format!(
+                    "adopted shell: cannot seed stderr file {}: {e}",
+                    stderr_path.display()
+                ));
+            }
         } else {
-            let _ = std::fs::File::create(&stderr_path);
+            if let Err(e) = tokio::fs::File::create(&stderr_path).await {
+                return Err(format!(
+                    "adopted shell: cannot create stderr file {}: {e}",
+                    stderr_path.display()
+                ));
+            }
         }
 
         let handle = BackgroundTaskHandle {
@@ -388,6 +420,7 @@ impl BackgroundTaskRegistry {
             last_output_size: partial_stdout.len() as u64 + partial_stderr.len() as u64,
             last_activity: Instant::now(),
             last_tail_probe_at: None,
+            output_files_deleted: false,
         };
         self.tasks.insert(id.clone(), handle);
 
@@ -459,6 +492,7 @@ impl BackgroundTaskRegistry {
             last_output_size,
             last_activity: Instant::now(),
             last_tail_probe_at: None,
+            output_files_deleted: false,
         };
         self.tasks.insert(id.to_string(), handle);
         Ok(())
@@ -491,12 +525,17 @@ impl BackgroundTaskRegistry {
         if handle.status().is_terminal() {
             return Err(format!("background shell '{id}' already terminated"));
         }
-        // Only signal cancellation. The runner observes this via
+        // Signal cancellation. The runner observes this via
         // `cancel.cancelled()`, kills the child, and emits its own
         // terminal `TaskCompletion`. `poll_completions` then translates
         // that to a single `Killed` event. No premature status-set,
         // no duplicate event.
+        // Note: kill() is best-effort and returns before the child
+        // process actually terminates. The process will be killed
+        // shortly and the completion will be processed in the next
+        // drain_join_set() or poll_completions() call.
         handle.cancel_token.cancel();
+        self.drain_join_set();
         Ok(())
     }
 
@@ -599,7 +638,16 @@ impl BackgroundTaskRegistry {
             .map(|(id, _)| id.to_string())
             .collect();
         for id in victims {
-            self.tasks.remove(&id);
+            if let Some(handle) = self.tasks.get_mut(&id) {
+                // Clean up output files on disk to prevent unbounded
+                // disk usage. Each task can produce up to MAX_OUTPUT_BYTES
+                // per stream; without cleanup, N tasks = N*2*cap bytes.
+                // Keep the handle in the map so get_output returns
+                // "output expired" instead of "not found".
+                let _ = std::fs::remove_file(&handle.stdout_path);
+                let _ = std::fs::remove_file(&handle.stderr_path);
+                handle.output_files_deleted = true;
+            }
         }
     }
 
@@ -624,6 +672,11 @@ impl BackgroundTaskRegistry {
             .tasks
             .get(id)
             .ok_or_else(|| format!("no background shell with id '{id}'"))?;
+        if handle.output_files_deleted {
+            return Err(format!(
+                "output for '{id}' was evicted (too many completed tasks); rerun if needed"
+            ));
+        }
         if handle.status().is_terminal() && !handle.stdout_path.exists() {
             return Err(missing_output_artifact_error(&handle.stdout_path));
         }
@@ -642,6 +695,11 @@ impl BackgroundTaskRegistry {
             .tasks
             .get(id)
             .ok_or_else(|| format!("no background shell with id '{id}'"))?;
+        if handle.output_files_deleted {
+            return Err(format!(
+                "output for '{id}' was evicted (too many completed tasks); rerun if needed"
+            ));
+        }
         if handle.status().is_terminal() && !handle.stdout_path.exists() {
             return Err(missing_output_artifact_error(&handle.stdout_path));
         }
@@ -660,6 +718,11 @@ impl BackgroundTaskRegistry {
             .tasks
             .get(id)
             .ok_or_else(|| format!("no background shell with id '{id}'"))?;
+        if handle.output_files_deleted {
+            return Err(format!(
+                "output for '{id}' was evicted (too many completed tasks); rerun if needed"
+            ));
+        }
         let stdout_missing = !handle.stdout_path.exists();
         let stderr_has_output = file_len(&handle.stderr_path) > 0;
         if handle.status().is_terminal() && stdout_missing && !stderr_has_output {
@@ -674,6 +737,11 @@ impl BackgroundTaskRegistry {
             .tasks
             .get(id)
             .ok_or_else(|| format!("no background shell with id '{id}'"))?;
+        if handle.output_files_deleted {
+            return Err(format!(
+                "output for '{id}' was evicted (too many completed tasks); rerun if needed"
+            ));
+        }
         read_tail_str(&handle.stderr_path, tail_bytes)
     }
 
@@ -731,7 +799,7 @@ impl BackgroundTaskRegistry {
     }
 
     /// Check all running shell tasks for stalls (no output growth for STALL_THRESHOLD).
-    pub fn stall_check(&mut self) {
+    pub async fn stall_check(&mut self) {
         self.drain_join_set();
         let mut stall_events = Vec::new();
         for handle in self.tasks.values_mut() {
@@ -744,10 +812,12 @@ impl BackgroundTaskRegistry {
             if handle.status() == BgTaskStatus::Stalled {
                 continue; // already reported
             }
-            let stdout_size = std::fs::metadata(&handle.stdout_path)
+            let stdout_size = tokio::fs::metadata(&handle.stdout_path)
+                .await
                 .map(|m| m.len())
                 .unwrap_or(0);
-            let stderr_size = std::fs::metadata(&handle.stderr_path)
+            let stderr_size = tokio::fs::metadata(&handle.stderr_path)
+                .await
                 .map(|m| m.len())
                 .unwrap_or(0);
             let current_size = stdout_size.saturating_add(stderr_size);
@@ -821,8 +891,21 @@ impl BackgroundTaskRegistry {
             .count()
     }
 
+    /// Number of active tasks consuming resources (including stalled).
+    /// Used for capacity checks to prevent bypassing MAX_CONCURRENT_TASKS
+    /// when stalled tasks accumulate.
+    pub fn active_count(&self) -> usize {
+        self.tasks
+            .values()
+            .filter(|h| {
+                let s = h.status();
+                h.live_control.is_available() && !s.is_terminal()
+            })
+            .count()
+    }
+
     pub fn can_spawn_shell_task(&self) -> bool {
-        self.running_count() < MAX_CONCURRENT_TASKS
+        self.active_count() < MAX_CONCURRENT_TASKS
     }
 
     /// Number of stalled tasks — surfaced separately on the status
@@ -952,7 +1035,15 @@ async fn run_shell_task(
         exit = child.wait() => {
             match exit {
                 Ok(exit_status) => {
+                    // CRITICAL FIX: On unix, read signal() for SIGKILL/OOM detection
+                    #[cfg(unix)]
+                    let code = exit_status.code().or_else(|| {
+                        use std::os::unix::process::ExitStatusExt;
+                        exit_status.signal().map(|sig| 128 + sig)
+                    });
+                    #[cfg(not(unix))]
                     let code = exit_status.code();
+
                     let success = exit_status.success()
                         || code
                             .map(|code| {
@@ -1016,12 +1107,16 @@ async fn run_shell_task(
 /// Reader for an adopted detached shell. Streams remaining bytes
 /// from a live `ChildStdout` (or stderr) into the registry's per-task
 /// file, appending after any partial-output prefix that
-/// `adopt_detached_shell` already wrote. Stops on stream EOF or
-/// channel error. Cap-handling: the file may pass `MAX_OUTPUT_BYTES`
-/// here; `stall_check` is the enforcement point for size cap because
-/// the streamer can't synchronously kill the child without racing
-/// with `wait()`.
-async fn drain_stream_to_file<R>(mut reader: R, path: std::path::PathBuf)
+/// `adopt_detached_shell` already wrote. Stops on stream EOF,
+/// channel error, or when total written exceeds MAX_OUTPUT_BYTES.
+/// The latter prevents unbounded disk writes from fast-outputting
+/// processes between stall_check polling intervals.
+async fn drain_stream_to_file<R>(
+    mut reader: R,
+    path: std::path::PathBuf,
+    initial_bytes: u64,
+    cancel: CancellationToken,
+) -> Result<u64, String>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
@@ -1035,30 +1130,54 @@ where
     {
         Ok(f) => f,
         Err(e) => {
-            tracing::warn!(
-                "adopted shell stream: failed to open {}: {e}",
-                path.display()
-            );
-            return;
+            let msg = format!("failed to open {}: {e}", path.display());
+            tracing::warn!("adopted shell stream: {msg}");
+            return Err(msg);
         }
     };
     let mut file = BufWriter::new(file);
     let mut buf = [0u8; 8192];
+    let mut written = initial_bytes;
     loop {
         match reader.read(&mut buf).await {
             Ok(0) => break,
             Ok(n) => {
+                written += n as u64;
+                if written > MAX_OUTPUT_BYTES {
+                    tracing::warn!(
+                        "adopted shell stream: output exceeded {} bytes, stopping write",
+                        MAX_OUTPUT_BYTES
+                    );
+                    break;
+                }
                 if let Err(e) = file.write_all(&buf[..n]).await {
-                    tracing::warn!("adopted shell stream: write error: {e}");
-                    return;
+                    let msg = format!("write error on {}: {e}", path.display());
+                    tracing::warn!("adopted shell stream: {msg}");
+                    // Cancel the task to kill the child process.
+                    // Without this, the child blocks on its stdout/stderr
+                    // pipe buffer (typically 64KB) waiting for a reader
+                    // that will never come — a silent deadlock.
+                    cancel.cancel();
+                    // Flush whatever made it into BufWriter before returning.
+                    let _ = file.flush().await;
+                    return Err(msg);
                 }
             }
-            Err(_) => return,
+            Err(e) => {
+                let msg = format!("read error on {}: {e}", path.display());
+                tracing::warn!("adopted shell stream: {msg}");
+                cancel.cancel();
+                let _ = file.flush().await;
+                return Err(msg);
+            }
         }
     }
     if let Err(e) = file.flush().await {
-        tracing::warn!("adopted shell stream: flush error: {e}");
+        let msg = format!("flush error on {}: {e}", path.display());
+        tracing::warn!("adopted shell stream: {msg}");
+        return Err(msg);
     }
+    Ok(written)
 }
 
 /// Adopted-shell runner: drains both streams concurrently and waits
@@ -1089,17 +1208,46 @@ async fn run_adopted_shell(run: AdoptedShellRun) -> TaskCompletion {
         command_label,
     } = run;
 
-    let stdout_drain = tokio::spawn(drain_stream_to_file(stdout, stdout_path.clone()));
-    let stderr_drain = tokio::spawn(drain_stream_to_file(stderr, stderr_path.clone()));
+    let stdout_initial = std::fs::metadata(&stdout_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let stderr_initial = std::fs::metadata(&stderr_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let stdout_drain = tokio::spawn(drain_stream_to_file(
+        stdout,
+        stdout_path.clone(),
+        stdout_initial,
+        cancel.clone(),
+    ));
+    let stderr_drain = tokio::spawn(drain_stream_to_file(
+        stderr,
+        stderr_path.clone(),
+        stderr_initial,
+        cancel.clone(),
+    ));
 
     let result = tokio::select! {
         exit = child.wait() => {
             // Drain remaining buffered output before reporting status.
-            let _ = stdout_drain.await;
-            let _ = stderr_drain.await;
+            let stdout_err = stdout_drain.await.ok().and_then(|r| r.err());
+            let stderr_err = stderr_drain.await.ok().and_then(|r| r.err());
+            // Collect drain errors — if output capture failed, the
+            // stall_check would otherwise misdiagnose it as "waiting
+            // for input" instead of reporting the real failure.
+            let drain_error = stdout_err.as_ref()
+                .or(stderr_err.as_ref());
             match exit {
                 Ok(exit_status) => {
+                    // CRITICAL FIX: On unix, read signal() for SIGKILL/OOM detection
+                    #[cfg(unix)]
+                    let code = exit_status.code().or_else(|| {
+                        use std::os::unix::process::ExitStatusExt;
+                        exit_status.signal().map(|sig| 128 + sig)
+                    });
+                    #[cfg(not(unix))]
                     let code = exit_status.code();
+
                     let success = exit_status.success()
                         || code
                             .map(|code| {
@@ -1108,7 +1256,18 @@ async fn run_adopted_shell(run: AdoptedShellRun) -> TaskCompletion {
                             })
                             .unwrap_or(false);
                     let summary = make_summary(&stdout_path, code);
-                    if success {
+                    if let Some(err) = drain_error {
+                        // Output capture failed — report as error
+                        // regardless of exit code so the LLM knows
+                        // the output file may be incomplete.
+                        TaskCompletion {
+                            id: task_id.clone(),
+                            status: BgTaskStatus::Failed,
+                            exit_code: code,
+                            summary: String::new(),
+                            error: Some(format!("output capture failed: {err}")),
+                        }
+                    } else if success {
                         TaskCompletion {
                             id: task_id.clone(),
                             status: BgTaskStatus::Completed,
@@ -1555,6 +1714,7 @@ mod tests {
             last_output_size: 0,
             last_activity: Instant::now(),
             last_tail_probe_at: None,
+            output_files_deleted: false,
         };
         (handle, dir)
     }
@@ -1570,7 +1730,7 @@ mod tests {
         let old_stdout_path = reg.get(&old_id).unwrap().stdout_path.clone();
         assert_eq!(old_stdout_path.parent(), Some(old_dir.as_path()));
 
-        reg.rebind_output_dir(new_dir.clone());
+        reg.rebind_output_dir(new_dir.clone()).expect("rebind ok");
 
         assert_eq!(
             reg.get(&old_id).unwrap().stdout_path,
@@ -1582,6 +1742,30 @@ mod tests {
             reg.get(&new_id).unwrap().stdout_path.parent(),
             Some(new_dir.as_path()),
             "future tasks should use the rebound session output directory"
+        );
+    }
+
+    /// `rebind_output_dir` must surface mkdir errors instead of swallowing
+    /// them — callers depend on the error to render a system message; a
+    /// silent failure would surface much later as cryptic "No such file or
+    /// directory" errors from `try_spawn_shell`.
+    #[tokio::test]
+    async fn rebind_output_dir_reports_mkdir_error_when_path_unwritable() {
+        let tmp = TempDir::new().unwrap();
+        let blocker = tmp.path().join("blocker");
+        std::fs::write(&blocker, b"").unwrap();
+        let unwritable = blocker.join("nested");
+        let mut reg = BackgroundTaskRegistry::new(tmp.path().to_path_buf());
+
+        let result = reg.rebind_output_dir(unwritable);
+        assert!(
+            result.is_err(),
+            "rebind must fail when the target path cannot be created"
+        );
+        let error = result.unwrap_err();
+        assert!(
+            error.contains("background task output directory could not be created"),
+            "error must name the failed operation: {error}"
         );
     }
 
@@ -1667,7 +1851,7 @@ mod tests {
         let source = include_str!("background_tasks.rs");
         // Find the body of stall_check.
         let start = source
-            .find("pub fn stall_check(&mut self) {")
+            .find("pub async fn stall_check(&mut self) {")
             .expect("stall_check must exist");
         // Body ends at the closing brace of the for-loop completion;
         // a sentinel from the function tail keeps us from over-reading.
@@ -2272,7 +2456,7 @@ mod tests {
         })
         .await
         .expect("background shell should exceed output cap");
-        reg.stall_check();
+        reg.stall_check().await;
 
         let events = reg.poll_completions();
         assert!(
@@ -2285,8 +2469,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn stall_check_throttles_same_size_tail_rechecks() {
+    #[tokio::test]
+    async fn stall_check_throttles_same_size_tail_rechecks() {
         let tmp = TempDir::new().unwrap();
         let mut reg = BackgroundTaskRegistry::new(tmp.path().to_path_buf());
         let (mut handle, _dir) = test_handle_with_status(BgTaskStatus::Running);
@@ -2298,14 +2482,14 @@ mod tests {
         handle.last_activity = Instant::now() - STALL_THRESHOLD - Duration::from_secs(1);
         reg.tasks.insert(handle.id.clone(), handle);
 
-        reg.stall_check();
+        reg.stall_check().await;
         assert!(
             reg.poll_completions().is_empty(),
             "first non-prompt tail probe should not emit a stall event"
         );
 
         std::fs::write(tmp.path().join("stdout.log"), "Continue? [y/N]\n").unwrap();
-        reg.stall_check();
+        reg.stall_check().await;
         assert!(
             reg.poll_completions().is_empty(),
             "immediate same-size reread must be throttled to avoid repeated tail I/O"
@@ -2313,7 +2497,7 @@ mod tests {
 
         let handle = reg.tasks.get_mut("bg-throttle").unwrap();
         handle.last_tail_probe_at = Some(Instant::now() - STALL_TAIL_RECHECK_COOLDOWN);
-        reg.stall_check();
+        reg.stall_check().await;
         assert!(reg.poll_completions().iter().any(|event| matches!(
             event,
             BgTaskEvent::Stalled { id, last_output_tail, .. }
@@ -2537,23 +2721,37 @@ mod tests {
         // One final poll to enforce the cap once we know everyone is terminal.
         let _ = reg.poll_completions();
 
+        // All tasks remain in the map (metadata preserved), but the
+        // oldest ones have their output files deleted.
         let retained = ids.iter().filter(|id| reg.get(id).is_some()).count();
         assert_eq!(
-            retained, MAX_TERMINAL_TASKS_RETAINED,
-            "retained must equal cap exactly after spawning {total} terminal tasks"
+            retained, total,
+            "all tasks must remain in the map after LRU eviction (metadata preserved)"
         );
-        // Newest entries are kept. The most recent task id we spawned must
-        // still be reachable — LRU eviction targets oldest-ended first.
+
+        let evicted = ids
+            .iter()
+            .filter(|id| reg.get(id).is_some_and(|h| h.output_files_deleted))
+            .count();
+        assert_eq!(
+            evicted,
+            total - MAX_TERMINAL_TASKS_RETAINED,
+            "oldest tasks must have output files marked as deleted"
+        );
+
+        // Newest entries are kept with output files intact. The most
+        // recent task id we spawned must still be reachable — LRU
+        // eviction targets oldest-ended first.
         let last = ids.last().unwrap();
         assert!(
-            reg.get(last).is_some(),
-            "newest terminal task must survive LRU eviction"
+            reg.get(last).is_some_and(|h| !h.output_files_deleted),
+            "newest terminal task must survive LRU eviction with output intact"
         );
-        // Oldest must be evicted.
+        // Oldest must have output files deleted.
         let first = ids.first().unwrap();
         assert!(
-            reg.get(first).is_none(),
-            "oldest terminal task must be evicted under LRU policy"
+            reg.get(first).is_some_and(|h| h.output_files_deleted),
+            "oldest terminal task must have output files evicted under LRU policy"
         );
     }
 
@@ -2629,6 +2827,7 @@ mod tests {
                 partial_stdout,
                 partial_stderr,
             )
+            .await
             .expect("adopt detached shell");
         assert!(
             id.starts_with("bg-shell-"),
@@ -2668,13 +2867,20 @@ mod tests {
 
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("adopted.stdout");
-        std::fs::write(&path, "before-detach\n").expect("seed output");
+        let seed = "before-detach\n";
+        std::fs::write(&path, seed).expect("seed output");
 
         let (mut tx, rx) = tokio::io::duplex(64);
-        let drain = tokio::spawn(drain_stream_to_file(rx, path.clone()));
+        let drain = tokio::spawn(drain_stream_to_file(
+            rx,
+            path.clone(),
+            seed.len() as u64,
+            CancellationToken::new(),
+        ));
         tx.write_all(b"after-detach\n").await.expect("write stream");
         drop(tx);
-        drain.await.expect("drain join");
+        let written = drain.await.expect("drain join").expect("drain ok");
+        assert_eq!(written, seed.len() as u64 + b"after-detach\n".len() as u64);
 
         let output = std::fs::read_to_string(&path).expect("read appended output");
         assert_eq!(output, "before-detach\nafter-detach\n");

--- a/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
+++ b/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
@@ -462,6 +462,25 @@ pub(crate) async fn reveal_background_task_view(
     frame_requester: &FrameRequester,
     selected_id: Option<&str>,
 ) -> bool {
+    reveal_background_task_view_with_selected(
+        background_registry,
+        agent_spawner,
+        restored_local_agents,
+        bottom_pane,
+        frame_requester,
+        selected_id,
+    )
+    .await
+}
+
+async fn reveal_background_task_view_with_selected(
+    background_registry: &mut super::background_tasks::BackgroundTaskRegistry,
+    agent_spawner: Option<&Arc<astra_runtime::orchestration::DynamicAgentSpawner>>,
+    restored_local_agents: &[astra_services::session_workspace::BackgroundLocalAgentTaskProjection],
+    bottom_pane: &mut BottomPane,
+    frame_requester: &FrameRequester,
+    selected_id: Option<&str>,
+) -> bool {
     let rows =
         background_task_rows_with_agents(background_registry, agent_spawner, restored_local_agents)
             .await;

--- a/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
+++ b/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
@@ -887,6 +887,71 @@ pub(crate) async fn background_task_output_snapshot_with_agents(
     }
 }
 
+/// Drain pending [`crate::edge_tools::BgTaskCommand`] entries posted by the
+/// tool-side `task_output` / `task_list` / `task_stop` calls and reply
+/// synchronously. **Must be invoked from any tick that holds the
+/// [`super::background_tasks::BackgroundTaskRegistry`]**, including the
+/// inner per-turn select loop — otherwise a tool calling `task_output` with
+/// `block=true` deadlocks against the outer-tick drainer (the turn future
+/// owns `&mut state`, the outer loop is parked on it, no one drains).
+///
+/// Replies use synchronous `oneshot::Sender::send` so the tool side wakes
+/// on the next poll. Errors during a snapshot/list/stop are propagated to
+/// the tool caller, never silently swallowed.
+pub(crate) async fn drain_bg_task_commands(
+    bg_task_commands: &std::sync::Arc<std::sync::Mutex<Vec<crate::edge_tools::BgTaskCommand>>>,
+    background_registry: &mut super::background_tasks::BackgroundTaskRegistry,
+    agent_spawner: Option<&Arc<astra_runtime::orchestration::DynamicAgentSpawner>>,
+    restored_local_agents: &[astra_services::session_workspace::BackgroundLocalAgentTaskProjection],
+) {
+    let cmds: Vec<_> = astra_core::sync_poison::recover_mutex_lock(bg_task_commands)
+        .drain(..)
+        .collect();
+    for cmd in cmds {
+        match cmd {
+            crate::edge_tools::BgTaskCommand::Kill { task_id, reply } => {
+                let _ = reply.send(
+                    stop_background_task_with_agents(
+                        background_registry,
+                        agent_spawner,
+                        restored_local_agents,
+                        &task_id,
+                    )
+                    .await,
+                );
+            }
+            crate::edge_tools::BgTaskCommand::GetOutputSince {
+                task_id,
+                offset,
+                max_bytes,
+                reply,
+            } => {
+                let _ = reply.send(
+                    background_task_output_snapshot_with_agents(
+                        background_registry,
+                        agent_spawner,
+                        restored_local_agents,
+                        &task_id,
+                        offset,
+                        max_bytes,
+                    )
+                    .await,
+                );
+            }
+            crate::edge_tools::BgTaskCommand::List { reply } => {
+                let _ = reply.send(
+                    render_background_task_list_xml_with_agents(
+                        background_registry,
+                        agent_spawner,
+                        restored_local_agents,
+                    )
+                    .await,
+                );
+            }
+        }
+    }
+}
+
 // ── XML rendering ──
 
 pub(crate) fn xml_escape_attr(value: &str) -> String {

--- a/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
+++ b/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
@@ -562,39 +562,84 @@ async fn reveal_background_task_view_rows(
     extra_rows: Vec<super::bottom_pane::background_task_view::BackgroundTaskRow>,
     selected_id: Option<&str>,
 ) -> bool {
+    reveal_background_task_view_rows_inner(
+        background_registry,
+        agent_spawner,
+        restored_local_agents,
+        bottom_pane,
+        frame_requester,
+        extra_rows,
+        selected_id,
+        false,
+    )
+    .await
+}
+
+/// Always open the background task panel, even if the registry is empty.
+/// Used by Ctrl+B so the user always lands in a panel they can navigate or
+/// dismiss. Empty-state rendering ("No background tasks.") lives in
+/// [`BackgroundTaskView::render_list`].
+pub(crate) async fn force_open_background_task_view(
+    background_registry: &mut super::background_tasks::BackgroundTaskRegistry,
+    agent_spawner: Option<&Arc<astra_runtime::orchestration::DynamicAgentSpawner>>,
+    restored_local_agents: &[astra_services::session_workspace::BackgroundLocalAgentTaskProjection],
+    bottom_pane: &mut BottomPane,
+    frame_requester: &FrameRequester,
+) -> bool {
+    reveal_background_task_view_rows_inner(
+        background_registry,
+        agent_spawner,
+        restored_local_agents,
+        bottom_pane,
+        frame_requester,
+        Vec::new(),
+        None,
+        true,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn reveal_background_task_view_rows_inner(
+    background_registry: &mut super::background_tasks::BackgroundTaskRegistry,
+    agent_spawner: Option<&Arc<astra_runtime::orchestration::DynamicAgentSpawner>>,
+    restored_local_agents: &[astra_services::session_workspace::BackgroundLocalAgentTaskProjection],
+    bottom_pane: &mut BottomPane,
+    frame_requester: &FrameRequester,
+    extra_rows: Vec<super::bottom_pane::background_task_view::BackgroundTaskRow>,
+    selected_id: Option<&str>,
+    force_open: bool,
+) -> bool {
     let mut rows =
         background_task_rows_with_agents(background_registry, agent_spawner, restored_local_agents)
             .await;
     rows.extend(extra_rows);
-    if rows.is_empty() {
-        sync_background_task_footer_from_rows(bottom_pane, &rows);
-        if bottom_pane.accepts_background_task_rows() {
-            bottom_pane.refresh_background_task_rows(rows);
-            bottom_pane.sync_popups();
-            frame_requester.schedule_frame();
-        }
-        return false;
-    }
-    let counts = super::status_line::BackgroundTaskCounts::from_rows(&rows);
-    if counts.is_empty() {
-        sync_background_task_footer_from_rows(bottom_pane, &rows);
-        if bottom_pane.accepts_background_task_rows() {
-            bottom_pane.refresh_background_task_rows(rows);
-            bottom_pane.sync_popups();
-            frame_requester.schedule_frame();
-        }
-        return false;
-    }
     sync_background_task_footer_from_rows(bottom_pane, &rows);
     use super::bottom_pane::background_task_view::BackgroundTaskView;
     if bottom_pane.accepts_background_task_rows() {
         bottom_pane.refresh_background_task_rows_selecting(rows, selected_id);
-    } else {
-        bottom_pane.push_view(Box::new(BackgroundTaskView::new_with_selected(
-            rows,
-            selected_id,
-        )));
+        bottom_pane.sync_popups();
+        frame_requester.schedule_frame();
+        return true;
     }
+    // Non-force callers (Ctrl+T, Shift+Down) only want to surface the panel
+    // when there's something actionable: running, waiting-for-input, or
+    // failed tasks. Completed-only or empty registries fall through so the
+    // caller can route the key elsewhere (Ctrl+T toggles task board, etc.).
+    // Ctrl+B forces open regardless: it's the user's "show me background
+    // state" verb, and they get a panel to navigate or dismiss.
+    if !force_open {
+        let counts = super::status_line::BackgroundTaskCounts::from_rows(&rows);
+        if counts.is_empty() {
+            bottom_pane.sync_popups();
+            frame_requester.schedule_frame();
+            return false;
+        }
+    }
+    bottom_pane.push_view(Box::new(BackgroundTaskView::new_with_selected(
+        rows,
+        selected_id,
+    )));
     bottom_pane.sync_popups();
     frame_requester.schedule_frame();
     true

--- a/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
+++ b/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
@@ -97,6 +97,31 @@ pub(crate) fn background_task_rows(
         .collect()
 }
 
+pub(crate) const PENDING_BASH_HANDOFF_TASK_ID: &str = "bg-shell-handoff";
+
+pub(crate) fn pending_bash_handoff_row(
+    title: &str,
+    elapsed_ms: u64,
+) -> super::bottom_pane::background_task_view::BackgroundTaskRow {
+    let title = title.trim();
+    let title = if title.is_empty() {
+        "Bash handoff"
+    } else {
+        title
+    };
+    let tail = "Waiting for foreground Bash to hand off its process.".to_string();
+    super::bottom_pane::background_task_view::BackgroundTaskRow::shell(
+        PENDING_BASH_HANDOFF_TASK_ID,
+        "pending",
+        elapsed_ms,
+        title,
+        None,
+        Some(tail.clone()),
+        Some(tail.len() as u64),
+    )
+    .with_output_stats(None, Some(1))
+}
+
 pub(crate) fn background_task_fanout_membership(
     slot: &astra_turn_core::orchestration_fanout_group::AgentFanoutSlotIdentity,
     group_title: Option<&str>,
@@ -487,6 +512,27 @@ pub(crate) async fn reveal_background_task_view(
     .await
 }
 
+pub(crate) async fn reveal_background_task_view_with_extra_rows(
+    background_registry: &mut super::background_tasks::BackgroundTaskRegistry,
+    agent_spawner: Option<&Arc<astra_runtime::orchestration::DynamicAgentSpawner>>,
+    restored_local_agents: &[astra_services::session_workspace::BackgroundLocalAgentTaskProjection],
+    bottom_pane: &mut BottomPane,
+    frame_requester: &FrameRequester,
+    extra_rows: Vec<super::bottom_pane::background_task_view::BackgroundTaskRow>,
+    selected_id: Option<&str>,
+) -> bool {
+    reveal_background_task_view_rows(
+        background_registry,
+        agent_spawner,
+        restored_local_agents,
+        bottom_pane,
+        frame_requester,
+        extra_rows,
+        selected_id,
+    )
+    .await
+}
+
 async fn reveal_background_task_view_with_selected(
     background_registry: &mut super::background_tasks::BackgroundTaskRegistry,
     agent_spawner: Option<&Arc<astra_runtime::orchestration::DynamicAgentSpawner>>,
@@ -495,14 +541,48 @@ async fn reveal_background_task_view_with_selected(
     frame_requester: &FrameRequester,
     selected_id: Option<&str>,
 ) -> bool {
-    let rows =
+    reveal_background_task_view_rows(
+        background_registry,
+        agent_spawner,
+        restored_local_agents,
+        bottom_pane,
+        frame_requester,
+        Vec::new(),
+        selected_id,
+    )
+    .await
+}
+
+async fn reveal_background_task_view_rows(
+    background_registry: &mut super::background_tasks::BackgroundTaskRegistry,
+    agent_spawner: Option<&Arc<astra_runtime::orchestration::DynamicAgentSpawner>>,
+    restored_local_agents: &[astra_services::session_workspace::BackgroundLocalAgentTaskProjection],
+    bottom_pane: &mut BottomPane,
+    frame_requester: &FrameRequester,
+    extra_rows: Vec<super::bottom_pane::background_task_view::BackgroundTaskRow>,
+    selected_id: Option<&str>,
+) -> bool {
+    let mut rows =
         background_task_rows_with_agents(background_registry, agent_spawner, restored_local_agents)
             .await;
+    rows.extend(extra_rows);
     if rows.is_empty() {
+        sync_background_task_footer_from_rows(bottom_pane, &rows);
+        if bottom_pane.accepts_background_task_rows() {
+            bottom_pane.refresh_background_task_rows(rows);
+            bottom_pane.sync_popups();
+            frame_requester.schedule_frame();
+        }
         return false;
     }
     let counts = super::status_line::BackgroundTaskCounts::from_rows(&rows);
     if counts.is_empty() {
+        sync_background_task_footer_from_rows(bottom_pane, &rows);
+        if bottom_pane.accepts_background_task_rows() {
+            bottom_pane.refresh_background_task_rows(rows);
+            bottom_pane.sync_popups();
+            frame_requester.schedule_frame();
+        }
         return false;
     }
     sync_background_task_footer_from_rows(bottom_pane, &rows);

--- a/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
+++ b/rust/crates/astra-cli/src/tui/bg_task_rendering.rs
@@ -423,6 +423,20 @@ pub(crate) async fn render_background_task_list_xml_with_agents(
     render_background_task_rows_xml(&rows)
 }
 
+pub(crate) fn sync_background_task_footer_from_rows(
+    bottom_pane: &mut BottomPane,
+    rows: &[super::bottom_pane::background_task_view::BackgroundTaskRow],
+) {
+    let counts = super::status_line::BackgroundTaskCounts::from_rows(rows);
+    bottom_pane.footer.bg_task_counts = if counts.is_empty() {
+        None
+    } else {
+        Some(counts)
+    };
+    bottom_pane.footer.bg_fanout_summaries =
+        super::status_line::BackgroundTaskFanoutSummary::from_rows(rows);
+}
+
 pub(crate) fn background_task_live_control_state(
     live_control: super::background_tasks::BgTaskLiveControl,
 ) -> super::bottom_pane::background_task_view::LiveControlState {
@@ -491,6 +505,7 @@ async fn reveal_background_task_view_with_selected(
     if counts.is_empty() {
         return false;
     }
+    sync_background_task_footer_from_rows(bottom_pane, &rows);
     use super::bottom_pane::background_task_view::BackgroundTaskView;
     if bottom_pane.accepts_background_task_rows() {
         bottom_pane.refresh_background_task_rows_selecting(rows, selected_id);
@@ -564,6 +579,7 @@ pub(crate) async fn try_dispatch_background_task_stop_sentinel(
         restored_local_agents,
     )
     .await;
+    sync_background_task_footer_from_rows(bottom_pane, &rows);
     bottom_pane.refresh_background_task_rows(rows);
     bottom_pane.sync_popups();
     frame_requester.schedule_frame();
@@ -690,6 +706,7 @@ pub(crate) async fn try_dispatch_background_task_output_sentinel(
         restored_local_agents,
     )
     .await;
+    sync_background_task_footer_from_rows(bottom_pane, &rows);
     bottom_pane.refresh_background_task_rows(rows);
     bottom_pane.sync_popups();
     frame_requester.schedule_frame();

--- a/rust/crates/astra-cli/src/tui/bottom_pane/background_task_view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/background_task_view.rs
@@ -593,7 +593,7 @@ impl BackgroundTaskView {
 
     fn request_output(&mut self) {
         if let Some(row) = self.selected_row()
-            && row.kind.supports_output_action()
+            && row_can_open_output(row)
         {
             self.pending_action = Some(format!("{BACKGROUND_TASK_OUTPUT_SENTINEL}{}", row.id));
         }
@@ -815,20 +815,17 @@ impl BackgroundTaskView {
         for line in tail.lines().take(DETAIL_TAIL_LINES) {
             lines.push(Line::from(format!("  {}", line)));
         }
+        let can_output = row_can_open_output(row);
         if row.status.is_killable() && row.live_control.can_stop() {
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
-                detail_actions_label(row.kind.supports_output_action(), true, area.width as usize),
+                detail_actions_label(can_output, true, area.width as usize),
                 dim,
             )));
         } else {
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
-                detail_actions_label(
-                    row.kind.supports_output_action(),
-                    false,
-                    area.width as usize,
-                ),
+                detail_actions_label(can_output, false, area.width as usize),
                 dim,
             )));
         }
@@ -1037,6 +1034,10 @@ fn detail_actions_label(can_output: bool, can_stop: bool, width: usize) -> &'sta
     }
 }
 
+fn row_can_open_output(row: &BackgroundTaskRow) -> bool {
+    row.kind.supports_output_action() && row.output_ref.is_some()
+}
+
 fn pluralize_with_count(count: usize, singular: &str, plural: &str) -> String {
     if count == 1 {
         format!("1 {singular}")
@@ -1161,6 +1162,30 @@ mod tests {
         assert_eq!(view.rows[1].id, "fail");
         assert_eq!(view.rows[2].id, "run");
         assert_eq!(view.rows[3].id, "done");
+    }
+
+    #[test]
+    fn pending_shell_without_output_ref_does_not_emit_output_action() {
+        let mut view = BackgroundTaskView::new(vec![BackgroundTaskRow::shell(
+            "bg-shell-handoff",
+            "pending",
+            0,
+            "make build",
+            None,
+            Some("Waiting for foreground Bash to hand off its process.".to_string()),
+            Some(51),
+        )]);
+
+        view.handle_key(key(KeyCode::Enter));
+        view.handle_key(key(KeyCode::Enter));
+
+        assert!(
+            view.take_pending_action().is_none(),
+            "pending handoff rows do not have a readable output artifact yet"
+        );
+        let text = render(&view, 80, 10);
+        assert!(text.contains("actions: return"), "{text}");
+        assert!(!text.contains("actions: output"), "{text}");
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/bottom_pane/background_task_view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/background_task_view.rs
@@ -510,6 +510,7 @@ impl BackgroundTaskView {
         if explicit_selection_found {
             self.mode = Mode::Detail;
         }
+        // CRITICAL FIX: Always clamp after mutation to prevent OOB panic
         self.clamp_selection();
     }
 

--- a/rust/crates/astra-cli/src/tui/bottom_pane/background_task_view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/background_task_view.rs
@@ -473,10 +473,15 @@ impl BackgroundTaskView {
         selected_id: Option<&str>,
     ) -> Self {
         let mut view = Self::new(rows);
+        let mut selected = false;
         if let Some(selected_id) = selected_id
             && let Some(idx) = view.rows.iter().position(|row| row.id == selected_id)
         {
             view.selected = idx;
+            selected = true;
+        }
+        if selected || view.rows.len() == 1 {
+            view.mode = Mode::Detail;
         }
         view
     }
@@ -496,11 +501,15 @@ impl BackgroundTaskView {
         let fallback_idx = current_selected_id
             .and_then(|id| rows.iter().position(|row| row.id == id))
             .or_else(|| rows.first().map(|_| 0));
+        let explicit_selection_found = selected_idx.is_some();
         self.selected = selected_idx
             .or(fallback_idx)
             .unwrap_or(0)
             .min(rows.len().saturating_sub(1));
         self.rows = rows;
+        if explicit_selection_found {
+            self.mode = Mode::Detail;
+        }
         self.clamp_selection();
     }
 
@@ -1200,6 +1209,71 @@ mod tests {
         );
 
         assert_eq!(view.selected_row().map(|row| row.id.as_str()), Some("run"));
+    }
+
+    #[test]
+    fn open_view_enters_detail_for_single_background_task() {
+        let view = BackgroundTaskView::new_with_selected(
+            vec![row("bg-shell-1", "running", "cargo test")],
+            None,
+        );
+
+        let text = render(&view, 90, 12);
+        assert!(text.contains("bg-shell-1 · running"), "{text}");
+        assert!(text.contains("command cargo test"), "{text}");
+        assert!(text.contains("Tail"), "{text}");
+        assert_eq!(
+            view.hint_keys().as_deref(),
+            Some("S stop · Esc list · Q close")
+        );
+    }
+
+    #[test]
+    fn open_view_enters_detail_for_explicit_selected_task() {
+        let view = BackgroundTaskView::new_with_selected(
+            vec![
+                row("first", "running", "first command"),
+                row("second", "running", "second command"),
+            ],
+            Some("second"),
+        );
+
+        let text = render(&view, 90, 12);
+        assert!(text.contains("second · running"), "{text}");
+        assert!(text.contains("command second command"), "{text}");
+        assert_eq!(
+            view.hint_keys().as_deref(),
+            Some("S stop · Esc list · Q close")
+        );
+    }
+
+    #[test]
+    fn explicit_refresh_keeps_adopted_handoff_in_detail() {
+        let mut view = BackgroundTaskView::new_with_selected(
+            vec![BackgroundTaskRow::shell(
+                "bg-shell-handoff",
+                "pending",
+                0,
+                "make build",
+                None,
+                Some("Waiting for foreground Bash to hand off its process.".to_string()),
+                Some(51),
+            )],
+            Some("bg-shell-handoff"),
+        );
+        assert!(
+            render(&view, 90, 12).contains("bg-shell-handoff · pending"),
+            "pending handoff should open in detail"
+        );
+
+        view.replace_rows_with_selected(
+            vec![row("bg-shell-7", "running", "make build")],
+            Some("bg-shell-7"),
+        );
+
+        let text = render(&view, 90, 12);
+        assert!(text.contains("bg-shell-7 · running"), "{text}");
+        assert!(text.contains("command make build"), "{text}");
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/bottom_pane/background_task_view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/background_task_view.rs
@@ -613,11 +613,6 @@ impl BackgroundTaskView {
         let title_style = Style::default()
             .fg(Color::Cyan)
             .add_modifier(Modifier::BOLD);
-        let running = self
-            .rows
-            .iter()
-            .filter(|row| row.status == BackgroundTaskStatus::Running)
-            .count();
         let waiting = self
             .rows
             .iter()
@@ -632,9 +627,7 @@ impl BackgroundTaskView {
             "  Background tasks".to_string()
         } else {
             let mut parts = vec![format!("{} total", self.rows.len())];
-            if running > 0 {
-                parts.push(format!("{running} running"));
-            }
+            parts.extend(background_task_active_count_parts(&self.rows));
             if waiting > 0 {
                 parts.push(pluralize_with_count(waiting, "needs input", "need input"));
             }
@@ -939,8 +932,8 @@ impl BottomPaneView for BackgroundTaskView {
 
     fn hint_keys(&self) -> Option<String> {
         match self.mode {
-            Mode::List => Some("↑↓ move · Enter details · S stop · Esc close".into()),
-            Mode::Detail => Some("S stop · Esc list · Q close".into()),
+            Mode::List => Some("↑↓ select · Enter details · O output · S stop · Esc close".into()),
+            Mode::Detail => Some("O output · S stop · Esc list · Q close".into()),
         }
     }
 
@@ -994,6 +987,45 @@ fn fanout_slot_title(row: &BackgroundTaskRow) -> String {
         fanout.slot_label.as_str()
     };
     format!("slot {}: {}", fanout.slot_index + 1, label)
+}
+
+fn background_task_active_count_parts(rows: &[BackgroundTaskRow]) -> Vec<String> {
+    let mut shells = 0usize;
+    let mut local_agents = 0usize;
+    let mut cloud_sessions = 0usize;
+    let mut main_sessions = 0usize;
+    let mut monitors = 0usize;
+
+    for row in rows.iter().filter(|row| {
+        matches!(
+            row.status,
+            BackgroundTaskStatus::Pending | BackgroundTaskStatus::Running
+        )
+    }) {
+        match row.kind {
+            BackgroundTaskKind::Shell => shells += 1,
+            BackgroundTaskKind::LocalAgent => local_agents += 1,
+            BackgroundTaskKind::CloudSession => cloud_sessions += 1,
+            BackgroundTaskKind::MainSession => main_sessions += 1,
+            BackgroundTaskKind::Monitor => monitors += 1,
+        }
+    }
+
+    [
+        (shells, "active shell", "active shells"),
+        (local_agents, "active local agent", "active local agents"),
+        (
+            cloud_sessions,
+            "active cloud session",
+            "active cloud sessions",
+        ),
+        (main_sessions, "active main session", "active main sessions"),
+        (monitors, "active monitor", "active monitors"),
+    ]
+    .into_iter()
+    .filter(|(count, _, _)| *count > 0)
+    .map(|(count, singular, plural)| pluralize_with_count(count, singular, plural))
+    .collect()
 }
 
 fn compact_list_row_text(
@@ -1174,6 +1206,37 @@ mod tests {
     }
 
     #[test]
+    fn list_header_summarizes_active_background_task_kinds() {
+        let view = BackgroundTaskView::new(vec![
+            typed_row("shell", BackgroundTaskKind::Shell, "running", "make check"),
+            typed_row(
+                "agent",
+                BackgroundTaskKind::LocalAgent,
+                "running",
+                "review auth",
+            ),
+            typed_row(
+                "cloud",
+                BackgroundTaskKind::CloudSession,
+                "pending",
+                "remote review",
+            ),
+            typed_row("done", BackgroundTaskKind::Shell, "completed", "old build"),
+        ]);
+
+        let text = render(&view, 140, 5);
+
+        assert!(text.contains("4 total"), "{text}");
+        assert!(text.contains("1 active shell"), "{text}");
+        assert!(text.contains("1 active local agent"), "{text}");
+        assert!(text.contains("1 active cloud session"), "{text}");
+        assert!(
+            !text.contains("3 running"),
+            "header should describe active background kinds instead of a vague running count: {text}"
+        );
+    }
+
+    #[test]
     fn pending_shell_without_output_ref_does_not_emit_output_action() {
         let mut view = BackgroundTaskView::new(vec![BackgroundTaskRow::shell(
             "bg-shell-handoff",
@@ -1224,7 +1287,7 @@ mod tests {
         assert!(text.contains("Tail"), "{text}");
         assert_eq!(
             view.hint_keys().as_deref(),
-            Some("S stop · Esc list · Q close")
+            Some("O output · S stop · Esc list · Q close")
         );
     }
 
@@ -1243,7 +1306,7 @@ mod tests {
         assert!(text.contains("command second command"), "{text}");
         assert_eq!(
             view.hint_keys().as_deref(),
-            Some("S stop · Esc list · Q close")
+            Some("O output · S stop · Esc list · Q close")
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/bottom_pane/help_view.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/help_view.rs
@@ -11,8 +11,13 @@ use super::view::{BottomPaneView, CancellationEvent, ViewCompletion};
 use crate::cli::command_registry::{self, CommandGroup, CommandMeta};
 
 const MAX_CMD_ROWS: usize = 10;
-const HELP_HINT: &str =
-    "←/→ switch group  ↑/↓ browse  Enter select  Ctrl+B background bash/agent  Esc close";
+
+fn help_hint() -> String {
+    format!(
+        "←/→ switch group  ↑/↓ browse  Enter select  {} background bash/agent  Esc close",
+        crate::tui::background_shortcut::ctrl_b_background_shortcut()
+    )
+}
 
 struct GroupData {
     group: CommandGroup,
@@ -151,7 +156,7 @@ impl BottomPaneView for HelpView {
             y += 1;
         }
         if y < area.bottom() {
-            let hint = Line::from(Span::styled(format!("  {HELP_HINT}"), dim));
+            let hint = Line::from(Span::styled(format!("  {}", help_hint()), dim));
             Widget::render(hint, Rect::new(area.x, y, area.width, 1), buf);
         }
     }
@@ -227,6 +232,6 @@ impl BottomPaneView for HelpView {
     }
 
     fn hint_keys(&self) -> Option<String> {
-        Some(HELP_HINT.to_string())
+        Some(help_hint())
     }
 }

--- a/rust/crates/astra-cli/src/tui/bottom_pane/hint_tests.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/hint_tests.rs
@@ -50,7 +50,14 @@ fn context_panel_hint_mentions_close() {
 fn help_hint_mentions_ctrl_b_backgrounding() {
     use super::help_view::HelpView;
     let v = HelpView::new();
-    hint_contains(&v, &["Ctrl+B", "background", "Esc"]);
+    hint_contains(
+        &v,
+        &[
+            crate::tui::background_shortcut::ctrl_b_background_shortcut(),
+            "background",
+            "Esc",
+        ],
+    );
 }
 
 // ─── Timeline ─────────────────────────────────────────────────────

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -524,17 +524,20 @@ impl ChatWidget {
         let Some(cell) = self.active_cell.as_mut() else {
             return false;
         };
-        let Some(tool) = cell.as_any_mut().downcast_mut::<ToolCell>() else {
-            return false;
-        };
-        if tool.name != "bash" {
-            return false;
+        {
+            let Some(tool) = cell.as_any_mut().downcast_mut::<ToolCell>() else {
+                return false;
+            };
+            if tool.name != "bash" {
+                return false;
+            }
+            tool.complete_bash_backgrounded(task_id);
         }
-        tool.complete_bash_backgrounded(task_id);
         if let Some(tool_use_id) = tool_use_id {
             self.backgrounded_bash_tool_use_ids
                 .insert(tool_use_id.to_string());
         }
+        self.commit_active();
         true
     }
 
@@ -916,6 +919,10 @@ impl ChatWidget {
     /// as well as the `Session expired` / "token refreshed" banners.
     pub fn commit_system(&mut self, cell: SystemCell) {
         self.commit_active(); // finalise anything live first
+        self.commit_cell(Box::new(cell));
+    }
+
+    pub fn commit_system_preserving_active(&mut self, cell: SystemCell) {
         self.commit_cell(Box::new(cell));
     }
 
@@ -2306,6 +2313,38 @@ mod tests {
             .and_then(|cell| cell.as_any_ref().downcast_ref::<ToolCell>())
             .unwrap();
         assert!(!cell.ctrl_b_background_hint);
+    }
+
+    #[test]
+    fn backgrounding_note_does_not_finalize_active_bash() {
+        let mut w = fresh();
+        w.handle_event(AppEvent::Wire(tool_started("bash", "$ make check")));
+
+        w.commit_system_preserving_active(SystemCell::info(
+            "⏎ Backgrounding Bash... waiting for handoff.",
+        ));
+
+        assert_eq!(w.history.len(), 1);
+        let active = w
+            .active_cell
+            .as_deref()
+            .and_then(|cell| cell.as_any_ref().downcast_ref::<ToolCell>())
+            .expect("Bash must remain active while waiting for detach handoff");
+        assert_eq!(active.status, ToolStatus::Running);
+        assert!(active.output_summary.is_none());
+
+        assert!(w.mark_active_bash_backgrounded(Some("tu_test"), "bg-shell-1"));
+        assert_eq!(w.history.len(), 2);
+        let tool = w.history[1]
+            .as_any_ref()
+            .downcast_ref::<ToolCell>()
+            .expect("backgrounded Bash should be committed after the handoff note");
+        assert_eq!(tool.status, ToolStatus::Success);
+        let summary = tool.output_summary.as_deref().unwrap_or_default();
+        assert!(
+            !summary.contains("failed before returning output"),
+            "backgrounded Bash must not carry the failure placeholder: {summary}"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -493,6 +493,12 @@ impl ChatWidget {
 
     pub fn set_bash_background_hint_enabled(&mut self, enabled: bool) {
         self.bash_background_hint_enabled = enabled;
+        if let Some(cell) = self.active_cell.as_mut()
+            && let Some(tool) = cell.as_any_mut().downcast_mut::<ToolCell>()
+            && tool.name == "bash"
+        {
+            tool.set_ctrl_b_background_hint(enabled);
+        }
     }
 
     /// IDs of currently-live parallel TaskCells in spawn order.
@@ -2228,6 +2234,28 @@ mod tests {
             .and_then(|cell| cell.as_any_ref().downcast_ref::<ToolCell>())
             .unwrap();
         assert!(cell.ctrl_b_background_hint);
+    }
+
+    #[test]
+    fn bash_ctrl_b_hint_updates_existing_active_cell() {
+        let mut w = fresh();
+        w.handle_event(AppEvent::Wire(tool_started("bash", "sleep 60")));
+
+        w.set_bash_background_hint_enabled(true);
+        let cell = w
+            .active_cell
+            .as_deref()
+            .and_then(|cell| cell.as_any_ref().downcast_ref::<ToolCell>())
+            .unwrap();
+        assert!(cell.ctrl_b_background_hint);
+
+        w.set_bash_background_hint_enabled(false);
+        let cell = w
+            .active_cell
+            .as_deref()
+            .and_then(|cell| cell.as_any_ref().downcast_ref::<ToolCell>())
+            .unwrap();
+        assert!(!cell.ctrl_b_background_hint);
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -420,6 +420,7 @@ pub(crate) struct ChatWidget {
     session_id: String,
     history: Vec<Arc<dyn HistoryCell>>,
     active_cell: Option<Box<dyn HistoryCell>>,
+    active_tool_use_id: Option<String>,
     /// Live parallel TaskCells, keyed by their `tool_use_id`.
     /// Mutating directly (no `Arc`) so child events can attach.
     live_tasks: std::collections::HashMap<String, Box<TaskCell>>,
@@ -465,6 +466,11 @@ pub(crate) struct ChatWidget {
     /// Control tool ids cleared at a turn boundary. Used to detect
     /// late `AgentControlCompleted` arrivals after the row was dropped.
     cleared_agent_tool_use_ids: std::collections::HashSet<String>,
+    /// Top-level Bash tool ids already rendered as "running in the
+    /// background" after a Ctrl+B handoff. If their server-side
+    /// ToolCompleted arrives after TurnError has committed the active
+    /// cell, drop it instead of synthesizing a duplicate ToolCell.
+    backgrounded_bash_tool_use_ids: std::collections::HashSet<String>,
     /// Current-turn UI capability for foreground bash promotion.
     /// Enabled by the interactive event loop only after it installs a
     /// detach handle that Ctrl+B can signal.
@@ -477,6 +483,7 @@ impl ChatWidget {
             session_id: session_id.into(),
             history: Vec::new(),
             active_cell: None,
+            active_tool_use_id: None,
             live_tasks: std::collections::HashMap::new(),
             live_task_order: Vec::new(),
             agent_runs: AgentRunRegistry::default(),
@@ -487,6 +494,7 @@ impl ChatWidget {
             cancelled_task_ids: std::collections::HashSet::new(),
             cleared_agent_run_ids: std::collections::HashSet::new(),
             cleared_agent_tool_use_ids: std::collections::HashSet::new(),
+            backgrounded_bash_tool_use_ids: std::collections::HashSet::new(),
             bash_background_hint_enabled: false,
         }
     }
@@ -499,6 +507,35 @@ impl ChatWidget {
         {
             tool.set_ctrl_b_background_hint(enabled);
         }
+    }
+
+    pub fn mark_active_bash_backgrounded(
+        &mut self,
+        tool_use_id: Option<&str>,
+        task_id: &str,
+    ) -> bool {
+        if let (Some(active_id), Some(tool_use_id)) =
+            (self.active_tool_use_id.as_deref(), tool_use_id)
+            && active_id != tool_use_id
+        {
+            return false;
+        }
+
+        let Some(cell) = self.active_cell.as_mut() else {
+            return false;
+        };
+        let Some(tool) = cell.as_any_mut().downcast_mut::<ToolCell>() else {
+            return false;
+        };
+        if tool.name != "bash" {
+            return false;
+        }
+        tool.complete_bash_backgrounded(task_id);
+        if let Some(tool_use_id) = tool_use_id {
+            self.backgrounded_bash_tool_use_ids
+                .insert(tool_use_id.to_string());
+        }
+        true
     }
 
     /// IDs of currently-live parallel TaskCells in spawn order.
@@ -1203,6 +1240,7 @@ impl ChatWidget {
             if cell.name == "bash" && self.bash_background_hint_enabled {
                 cell.set_ctrl_b_background_hint(true);
             }
+            self.active_tool_use_id = Some(tool_use_id);
             self.active_cell = Some(Box::new(cell));
         }
     }
@@ -1635,6 +1673,16 @@ impl ChatWidget {
         // synthesize a new completed cell (happens when the model
         // emits a ToolCompleted without a paired ToolStarted —
         // e.g. replayed from journal mid-turn).
+        if self.backgrounded_bash_tool_use_ids.contains(&tool_use_id) {
+            if self.active_tool_use_id.as_deref() == Some(tool_use_id.as_str()) {
+                self.backgrounded_bash_tool_use_ids.remove(&tool_use_id);
+                self.commit_active();
+                return;
+            }
+            self.backgrounded_bash_tool_use_ids.remove(&tool_use_id);
+            return;
+        }
+
         if let Some(cell) = self.active_cell.as_mut()
             && let Some(tc) = cell.as_any_mut().downcast_mut::<ToolCell>()
         {
@@ -1818,8 +1866,10 @@ impl ChatWidget {
     /// history, and persist. No-op when `active_cell` is None.
     fn commit_active(&mut self) {
         let Some(mut cell) = self.active_cell.take() else {
+            self.active_tool_use_id = None;
             return;
         };
+        self.active_tool_use_id = None;
         cell.finalize();
         // Box → Arc: the scrollback index shares cells with
         // long-lived render paths (e.g. Ctrl+O overlay) without
@@ -2825,6 +2875,50 @@ mod tests {
             .expect("last cell should be SystemCell");
         // Humanisation strips the tag.
         assert_eq!(err.message(), "rate limited");
+    }
+
+    #[test]
+    fn backgrounded_bash_survives_turn_error_and_drops_late_completion() {
+        let mut w = fresh();
+        w.handle_event(AppEvent::Wire(tool_started("bash", "$ make check")));
+        assert!(w.mark_active_bash_backgrounded(Some("tu_test"), "bg-shell-1"));
+
+        w.handle_event(AppEvent::Wire(WireEvent::TurnError("TUI cancel".into())));
+        assert_eq!(w.history.len(), 2);
+        let tool = w.history[0]
+            .as_any_ref()
+            .downcast_ref::<ToolCell>()
+            .expect("first cell should be the backgrounded bash tool");
+        assert_eq!(tool.status, ToolStatus::Success);
+        assert_eq!(
+            tool.output_summary.as_deref(),
+            Some("Running in the background as bg-shell-1 · Ctrl+B/Ctrl+T open")
+        );
+
+        w.handle_event(AppEvent::Wire(WireEvent::ToolStarted {
+            name: "read_file".into(),
+            description: "Reading: Cargo.toml".into(),
+            tool_use_id: "tu_next".into(),
+            parent_tool_use_id: None,
+        }));
+        w.handle_event(AppEvent::Wire(tool_completed(
+            "bash",
+            "$ make check",
+            "ok",
+            1200,
+            Some("<bash_detached>The bash command was promoted.</bash_detached>"),
+        )));
+        assert_eq!(
+            w.history.len(),
+            2,
+            "late bash ToolCompleted must not synthesize a duplicate ToolCell or commit the next active tool"
+        );
+        let active = w
+            .active_cell
+            .as_deref()
+            .and_then(|cell| cell.as_any_ref().downcast_ref::<ToolCell>())
+            .expect("next active tool should remain live");
+        assert_eq!(active.name, "read_file");
     }
 
     // ── Invariant: at most one live cell ─────────────────────────

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -533,9 +533,11 @@ impl ChatWidget {
             }
             tool.complete_bash_backgrounded(task_id);
         }
-        if let Some(tool_use_id) = tool_use_id {
-            self.backgrounded_bash_tool_use_ids
-                .insert(tool_use_id.to_string());
+        let suppress_tool_use_id = tool_use_id
+            .map(str::to_string)
+            .or_else(|| self.active_tool_use_id.clone());
+        if let Some(tool_use_id) = suppress_tool_use_id {
+            self.backgrounded_bash_tool_use_ids.insert(tool_use_id);
         }
         self.commit_active();
         true
@@ -2989,6 +2991,43 @@ mod tests {
         assert!(
             w.backgrounded_bash_tool_use_ids.is_empty(),
             "detached ToolCompleted should retire the suppression marker"
+        );
+        let tool = w.history[0]
+            .as_any_ref()
+            .downcast_ref::<ToolCell>()
+            .expect("history should contain the backgrounded Bash tool");
+        assert_eq!(tool.status, ToolStatus::Success);
+        let expected = format!(
+            "Running in the background as bg-shell-1 · {}",
+            crate::tui::background_shortcut::background_task_open_hint()
+        );
+        assert_eq!(tool.output_summary.as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn backgrounded_bash_without_explicit_tool_use_id_suppresses_late_completion() {
+        let mut w = fresh();
+        w.handle_event(AppEvent::Wire(tool_started("bash", "$ make check")));
+        assert!(w.mark_active_bash_backgrounded(None, "bg-shell-1"));
+
+        w.handle_event(AppEvent::Wire(tool_completed(
+            "bash",
+            "$ make check",
+            "success",
+            1200,
+            Some(
+                "<bash_detached>The bash command was promoted to background task bg-shell-1.</bash_detached>",
+            ),
+        )));
+
+        assert_eq!(
+            w.history.len(),
+            1,
+            "late detached ToolCompleted must not synthesize a duplicate Bash cell"
+        );
+        assert!(
+            w.backgrounded_bash_tool_use_ids.is_empty(),
+            "late detached ToolCompleted should retire the inferred suppression marker"
         );
         let tool = w.history[0]
             .as_any_ref()

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -152,6 +152,42 @@ pub(crate) enum WireEvent {
     Compaction(CompactionEvent),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackgroundTaskOutputInfoKind {
+    Other,
+    RunningSnapshot,
+    Snapshot,
+}
+
+fn background_task_output_info_kind(msg: &str) -> BackgroundTaskOutputInfoKind {
+    let first_line = msg.lines().next().unwrap_or_default().trim_start();
+    let is_background_output = [
+        "Read shell output ",
+        "Read local agent output ",
+        "Read cloud session output ",
+        "Read main session output ",
+        "Read monitor output ",
+    ]
+    .iter()
+    .any(|prefix| first_line.starts_with(prefix));
+    if !is_background_output {
+        return BackgroundTaskOutputInfoKind::Other;
+    }
+
+    let metadata = msg.split("\nOutput chunk:").next().unwrap_or(msg);
+    if metadata.contains("still running")
+        || metadata.contains("Pending ·")
+        || metadata.contains(" · pending")
+        || metadata.contains("needs input")
+        || metadata.contains("Waiting for input")
+        || metadata.contains("No result yet")
+    {
+        BackgroundTaskOutputInfoKind::RunningSnapshot
+    } else {
+        BackgroundTaskOutputInfoKind::Snapshot
+    }
+}
+
 /// Per-turn metrics the outer loop collects and hands to
 /// `TurnComplete` for the summary band. Boxed in the event enum
 /// so the enum stays small (clippy::large_enum_variant guard).
@@ -1790,7 +1826,15 @@ impl ChatWidget {
     }
 
     fn on_turn_info(&mut self, msg: String) {
-        self.commit_cell(Box::new(SystemCell::info(msg)));
+        match background_task_output_info_kind(&msg) {
+            BackgroundTaskOutputInfoKind::RunningSnapshot => {}
+            BackgroundTaskOutputInfoKind::Snapshot => {
+                self.commit_cell(Box::new(SystemCell::background_task(msg)));
+            }
+            BackgroundTaskOutputInfoKind::Other => {
+                self.commit_cell(Box::new(SystemCell::info(msg)));
+            }
+        }
     }
 
     fn on_explain_report(&mut self, items: Vec<serde_json::Value>) {
@@ -2347,6 +2391,65 @@ mod tests {
             .live_task_cell("tu_test")
             .expect("agent get_result should render as a live TaskCell");
         assert!(!get_result_cell.ctrl_b_background_hint);
+    }
+
+    #[test]
+    fn turn_info_suppresses_running_background_output_snapshot() {
+        let mut w = fresh();
+
+        w.handle_event(AppEvent::Wire(WireEvent::TurnInfo(
+            "Read shell output bg-shell-1 · \"make check\"\n\
+             9 new lines · offset 0 -> 178 · total 178 bytes · 5 total lines · still running\n\
+             Output chunk:\n\
+             Running clippy..."
+                .into(),
+        )));
+
+        assert!(
+            w.history().is_empty(),
+            "running background output snapshots belong in the background detail view, not scrollback"
+        );
+    }
+
+    #[test]
+    fn turn_info_keeps_terminal_background_output_as_background_cell() {
+        let mut w = fresh();
+
+        w.handle_event(AppEvent::Wire(WireEvent::TurnInfo(
+            "Read shell output bg-shell-1 · \"make check\"\n\
+             1 new line · offset 178 -> 210 · total 210 bytes · 6 total lines · completed\n\
+             Output chunk:\n\
+             All checks passed"
+                .into(),
+        )));
+
+        assert_eq!(w.history().len(), 1);
+        let cell = w
+            .history()
+            .last()
+            .and_then(|cell| {
+                cell.as_any_ref()
+                    .downcast_ref::<crate::tui::history_cell::system::SystemCell>()
+            })
+            .expect("terminal background output should render as a system cell");
+        let first = cell
+            .display_lines(100)
+            .first()
+            .map(|line| line.to_string())
+            .unwrap_or_default();
+        assert!(first.starts_with("↳ Background · "), "{first}");
+        assert!(!first.contains("Note ·"), "{first}");
+    }
+
+    #[test]
+    fn turn_info_keeps_non_background_info() {
+        let mut w = fresh();
+
+        w.handle_event(AppEvent::Wire(WireEvent::TurnInfo(
+            "token refreshed".into(),
+        )));
+
+        assert_eq!(w.history().len(), 1);
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -2890,10 +2890,11 @@ mod tests {
             .downcast_ref::<ToolCell>()
             .expect("first cell should be the backgrounded bash tool");
         assert_eq!(tool.status, ToolStatus::Success);
-        assert_eq!(
-            tool.output_summary.as_deref(),
-            Some("Running in the background as bg-shell-1 · Ctrl+B/Ctrl+T open")
+        let expected = format!(
+            "Running in the background as bg-shell-1 · {}",
+            crate::tui::background_shortcut::background_task_open_hint()
         );
+        assert_eq!(tool.output_summary.as_deref(), Some(expected.as_str()));
 
         w.handle_event(AppEvent::Wire(WireEvent::ToolStarted {
             name: "read_file".into(),

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -2922,6 +2922,47 @@ mod tests {
         assert_eq!(active.name, "read_file");
     }
 
+    #[test]
+    fn backgrounded_bash_normal_completion_commits_once_with_task_id() {
+        let mut w = fresh();
+        w.handle_event(AppEvent::Wire(tool_started("bash", "$ make check")));
+        assert!(w.mark_active_bash_backgrounded(Some("tu_test"), "bg-shell-1"));
+
+        w.handle_event(AppEvent::Wire(tool_completed(
+            "bash",
+            "$ make check",
+            "success",
+            1200,
+            Some(
+                "<bash_detached>The bash command was promoted to background task bg-shell-1.</bash_detached>",
+            ),
+        )));
+
+        assert!(
+            w.active_cell.is_none(),
+            "normal detached ToolCompleted should finish the foreground Bash cell"
+        );
+        assert_eq!(
+            w.history.len(),
+            1,
+            "detached ToolCompleted must not synthesize a duplicate Bash cell"
+        );
+        assert!(
+            w.backgrounded_bash_tool_use_ids.is_empty(),
+            "detached ToolCompleted should retire the suppression marker"
+        );
+        let tool = w.history[0]
+            .as_any_ref()
+            .downcast_ref::<ToolCell>()
+            .expect("history should contain the backgrounded Bash tool");
+        assert_eq!(tool.status, ToolStatus::Success);
+        let expected = format!(
+            "Running in the background as bg-shell-1 · {}",
+            crate::tui::background_shortcut::background_task_open_hint()
+        );
+        assert_eq!(tool.output_summary.as_deref(), Some(expected.as_str()));
+    }
+
     // ── Invariant: at most one live cell ─────────────────────────
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/rust/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -924,10 +924,6 @@ impl ChatWidget {
         self.commit_cell(Box::new(cell));
     }
 
-    pub fn commit_system_preserving_active(&mut self, cell: SystemCell) {
-        self.commit_cell(Box::new(cell));
-    }
-
     /// Commit a user message directly into history without opening a new turn
     /// or draining the current live tool/assistant state.
     ///
@@ -2315,38 +2311,6 @@ mod tests {
             .and_then(|cell| cell.as_any_ref().downcast_ref::<ToolCell>())
             .unwrap();
         assert!(!cell.ctrl_b_background_hint);
-    }
-
-    #[test]
-    fn backgrounding_note_does_not_finalize_active_bash() {
-        let mut w = fresh();
-        w.handle_event(AppEvent::Wire(tool_started("bash", "$ make check")));
-
-        w.commit_system_preserving_active(SystemCell::info(
-            "⏎ Backgrounding Bash... waiting for handoff.",
-        ));
-
-        assert_eq!(w.history.len(), 1);
-        let active = w
-            .active_cell
-            .as_deref()
-            .and_then(|cell| cell.as_any_ref().downcast_ref::<ToolCell>())
-            .expect("Bash must remain active while waiting for detach handoff");
-        assert_eq!(active.status, ToolStatus::Running);
-        assert!(active.output_summary.is_none());
-
-        assert!(w.mark_active_bash_backgrounded(Some("tu_test"), "bg-shell-1"));
-        assert_eq!(w.history.len(), 2);
-        let tool = w.history[1]
-            .as_any_ref()
-            .downcast_ref::<ToolCell>()
-            .expect("backgrounded Bash should be committed after the handoff note");
-        assert_eq!(tool.status, ToolStatus::Success);
-        let summary = tool.output_summary.as_deref().unwrap_or_default();
-        assert!(
-            !summary.contains("failed before returning output"),
-            "backgrounded Bash must not carry the failure placeholder: {summary}"
-        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -56,12 +56,6 @@ const WORKSPACE_TRUST_SENTINEL: &str = "__workspace_trust__\n";
 const DEFERRED_INPUT_APPLIED_PREFIX: &str = "__deferred_input_applied__:";
 const BASH_DETACH_HANDOFF_WAIT: Duration = Duration::from_secs(5);
 
-fn ctrl_b_promoted_notification(task_id: &str) -> String {
-    format!(
-        "<background_task_notification>\n<status>promoted</status>\n<task_id>{task_id}</task_id>\n<hint>The user pressed Ctrl+B and the running bash command was promoted to a background shell task. Continue normally; use task_output(task_id='{task_id}') for this task, task_list() to inspect tasks, or task_stop(task_id='{task_id}') to stop it.</hint>\n</background_task_notification>"
-    )
-}
-
 fn ctrl_b_promoted_agent_message(agent_id: &str, description: &str) -> String {
     let description = description.trim();
     if description.is_empty() {
@@ -1633,7 +1627,6 @@ pub(crate) async fn run_tui_session(
                                     let mut turn_tool_count: u32 = 0;
                                     let mut turn_ttft: Option<std::time::Instant> = None;
                                     let mut explain_items: Vec<serde_json::Value> = Vec::new();
-                                    let mut ctrl_b_promoted_task_id: Option<String> = None;
                                     // Phase 3b.3c: prime the bash detach slot for this
                                     // turn. The bash runner takes the handle on entry;
                                     // we keep the listener so a Ctrl+B keypress can
@@ -1754,9 +1747,10 @@ pub(crate) async fn run_tui_session(
                                                             // listening on the detach signal, fire it: the
                                                             // runner transfers child + live streams to the
                                                             // BackgroundTaskRegistry without kill, output
-                                                            // continues uninterrupted, the turn ends with a
-                                                            // <bash_detached> marker the LLM can reason
-                                                            // about. Otherwise, try to promote a foreground
+                                                            // continues uninterrupted, and the bash tool
+                                                            // returns a <bash_detached> marker with the
+                                                            // concrete background task id. Otherwise, try
+                                                            // to promote a foreground
                                                             // synchronous agent wait into a normal background
                                                             // agent. If neither path is available, the key is
                                                             // explicitly unavailable and does not cancel the
@@ -2254,16 +2248,29 @@ pub(crate) async fn run_tui_session(
                                                     bash_detach_request_pending = false;
                                                     match handoff {
                                                         Ok(p) => {
+                                                            let astra_tools::detach::DetachedShellPayload {
+                                                                child,
+                                                                stdout,
+                                                                stderr,
+                                                                command,
+                                                                partial_stdout,
+                                                                partial_stderr,
+                                                                adoption_tx,
+                                                            } = p;
                                                             let id = match background_registry.adopt_detached_shell(
-                                                                p.child,
-                                                                p.stdout,
-                                                                p.stderr,
-                                                                &p.command,
-                                                                p.partial_stdout,
-                                                                p.partial_stderr,
+                                                                child,
+                                                                stdout,
+                                                                stderr,
+                                                                &command,
+                                                                partial_stdout,
+                                                                partial_stderr,
                                                             ) {
-                                                                Ok(id) => id,
+                                                                Ok(id) => {
+                                                                    let _ = adoption_tx.send(Ok(id.clone()));
+                                                                    id
+                                                                },
                                                                 Err(error) => {
+                                                                    let _ = adoption_tx.send(Err(error.clone()));
                                                                     chat_widget.commit_system(
                                                                         history_cell::system::SystemCell::error(
                                                                             format!("⏎ Backgrounding failed: {error}")
@@ -2289,7 +2296,6 @@ pub(crate) async fn run_tui_session(
                                                                 ),
                                                             );
                                                             let selected_id = id.clone();
-                                                            ctrl_b_promoted_task_id = Some(id);
                                                             let _ = chat_widget.mark_active_bash_backgrounded(
                                                                 active_bash_tool_use_id.as_deref(),
                                                                 selected_id.as_str(),
@@ -2314,7 +2320,6 @@ pub(crate) async fn run_tui_session(
                                                                 Some(selected_id.as_str()),
                                                             )
                                                             .await;
-                                                            tui_cancel_token.cancel();
                                                         }
                                                         Err(error) => {
                                                             *bash_detach_slot_for_ctrl_b.lock().await = None;
@@ -2638,16 +2643,6 @@ pub(crate) async fn run_tui_session(
                                         ) {
                                             chat_widget.handle_event(ev);
                                         }
-                                    }
-
-                                    // Ctrl+B notification: tell the next turn
-                                    // about true promotions. Unavailable
-                                    // keypresses are UI-only and must not
-                                    // perturb model context.
-                                    if let Some(task_id) = ctrl_b_promoted_task_id {
-                                        state
-                                            .pending_bg_notifications
-                                            .push(ctrl_b_promoted_notification(&task_id));
                                     }
 
                                     // Update footer
@@ -3763,20 +3758,6 @@ mod tests {
             let decoded = ReopenTarget::parse(encoded).expect("known variant must round-trip");
             assert_eq!(decoded, target, "variant {encoded} did not round-trip");
         }
-    }
-
-    #[test]
-    fn ctrl_b_promoted_notification_guides_output_without_rerun() {
-        let notification = ctrl_b_promoted_notification("bg-shell-7");
-
-        assert!(notification.contains("<status>promoted</status>"));
-        assert!(notification.contains("<task_id>bg-shell-7</task_id>"));
-        assert!(notification.contains("task_output(task_id='bg-shell-7')"));
-        assert!(notification.contains("task_list()"));
-        assert!(
-            !notification.contains("job(action='shell'"),
-            "true Ctrl+B promotion must not tell the model to re-run a side-effecting command: {notification}"
-        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -2313,7 +2313,7 @@ pub(crate) async fn run_tui_session(
                                                             };
                                                             chat_widget.commit_system(
                                                                 history_cell::system::SystemCell::info(
-                                                                    format!("⏎ Backgrounded as {id}. Opened background tasks; ↑↓ move, Enter details, S stop, Esc close.")
+                                                                    format!("⏎ Backgrounded as {id}. Opened background task details; S stop, Esc list, Q close.")
                                                                 ),
                                                             );
                                                             let selected_id = id.clone();

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -1657,6 +1657,7 @@ pub(crate) async fn run_tui_session(
                                         BashDetachHandoffResult,
                                     >();
                                     let mut bash_detach_request_pending = false;
+                                    let mut active_bash_tool_use_id: Option<String> = None;
 
                                     let turn_tx = stream_bridge::create_per_turn_bridge(tui_tx.clone());
                                     let live_sink = stream_bridge::create_agent_live_sink(tui_tx.clone());
@@ -2284,11 +2285,15 @@ pub(crate) async fn run_tui_session(
                                                             };
                                                             chat_widget.commit_system(
                                                                 history_cell::system::SystemCell::info(
-                                                                    format!("⏎ Backgrounded as {id}. Opened background tasks; Enter details, S stop.")
+                                                                    format!("⏎ Backgrounded as {id}. Opened background tasks; ↑↓ move, Enter details, S stop, Esc close.")
                                                                 ),
                                                             );
                                                             let selected_id = id.clone();
                                                             ctrl_b_promoted_task_id = Some(id);
+                                                            let _ = chat_widget.mark_active_bash_backgrounded(
+                                                                active_bash_tool_use_id.as_deref(),
+                                                                selected_id.as_str(),
+                                                            );
                                                             set_bash_background_hint_enabled(
                                                                 &mut chat_widget,
                                                                 &mut status_indicator,
@@ -2370,11 +2375,24 @@ pub(crate) async fn run_tui_session(
                                                             && match &ae {
                                                                 TuiAppEvent::ToolStarted {
                                                                     name,
+                                                                    tool_use_id,
+                                                                    parent_tool_use_id,
                                                                     ..
-                                                                } => name == "bash",
+                                                                } => {
+                                                                    if name == "bash" && parent_tool_use_id.is_none() {
+                                                                        active_bash_tool_use_id = Some(tool_use_id.clone());
+                                                                    }
+                                                                    name == "bash"
+                                                                }
                                                                 TuiAppEvent::ToolCompleted {
+                                                                    tool_use_id,
                                                                     ..
-                                                                } => true,
+                                                                } => {
+                                                                    if active_bash_tool_use_id.as_deref() == Some(tool_use_id.as_str()) {
+                                                                        active_bash_tool_use_id = None;
+                                                                    }
+                                                                    true
+                                                                }
                                                                 _ => false,
                                                             };
                                                     if should_rearm_bash_detach {

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -18,7 +18,6 @@
 
 use std::{sync::Arc, time::Duration};
 
-use crate::lock_recovery::LockRecovery;
 #[cfg(test)]
 use astra_services::session_journal::ToolCallRecord;
 use astra_services::session_journal::{JournalEvent, JournalEventType};
@@ -1692,6 +1691,13 @@ pub(crate) async fn run_tui_session(
                                         let background_registry_turn_session_id =
                                             state.session_id.clone();
                                         let background_registry_turn_model = state.model.clone();
+                                        // Snapshot the bg-task command queue so the inner-tick
+                                        // drainer below can serve `task_output(block=true)` calls
+                                        // mid-turn. Without this, the tool side awaits a reply
+                                        // that the outer-tick drainer can't deliver — the outer
+                                        // loop is parked on this turn future.
+                                        let bg_task_commands_for_tick = state.bg_task_commands.clone();
+                                        let agent_spawner_for_tick = state.agent_spawner.clone();
                                         let ctx = crate::cli::turn::turn_entry::TurnContext { api, profile };
                                         let token = crate::cli::session::session_runtime::fresh_access_token(api, profile).await;
                                         let mut tui_ui = ui_adapter::TuiUiAdapter::new(tui_tx.clone());
@@ -2558,6 +2564,28 @@ pub(crate) async fn run_tui_session(
                                                     {
                                                         bottom_pane.footer.permission_mode = Some(live_mode);
                                                     }
+                                                    // Drain the bg-task command queue so a
+                                                    // tool-side `task_output(block=true)` waiting
+                                                    // for a snapshot reply makes progress while
+                                                    // this turn is still in flight. The outer
+                                                    // tick is parked on `&mut fut`, so without
+                                                    // this drainer the tool waits forever.
+                                                    drain_bg_task_commands(
+                                                        &bg_task_commands_for_tick,
+                                                        &mut background_registry,
+                                                        agent_spawner_for_tick.as_ref(),
+                                                        &restored_local_agent_task_projections,
+                                                    )
+                                                    .await;
+                                                    // Move terminal completions onto the handle
+                                                    // status so the next snapshot reply names
+                                                    // the task as completed/failed/killed.
+                                                    // Inner-tick poll yields events we drop:
+                                                    // the outer tick will pick up the next
+                                                    // `poll_completions()` (events stay queued
+                                                    // until consumed there) and emit the system
+                                                    // message + task_notification.
+                                                    background_registry.drain_join_set();
                                                     let bash_hint_enabled =
                                                         bash_detach_hint_enabled(
                                                             bash_detach_listener.as_ref(),
@@ -3434,69 +3462,44 @@ pub(crate) async fn run_tui_session(
                         &mut background_local_agent_projection_cache,
                     )
                     .await;
-                    background_registry.kill_all();
-                    background_registry = super::background_tasks::BackgroundTaskRegistry::new(
-                        background_task_output_dir(state.session_id.as_deref()),
-                    );
-                    restored_local_agent_task_projections = restore_background_task_projections(
-                        &mut background_registry,
-                        state.session_id.as_deref(),
-                    );
-                    background_task_projection_cache =
-                        background_registry.export_shell_task_projections();
-                    background_local_agent_projection_cache =
-                        restored_local_agent_task_projections.clone();
-                    background_registry_session_id = state.session_id.clone();
-                }
-                // Drain background shell commands from the tool executor.
-                {
-                    let cmds: Vec<_> = {
-                        state.bg_task_commands.lock_recover().drain(..).collect()
-                    };
-                    for cmd in cmds {
-                        match cmd {
-                            crate::edge_tools::BgTaskCommand::Kill { task_id, reply } => {
-                                let _ = reply.send(
-                                    stop_background_task_with_agents(
-                                        &mut background_registry,
-                                        state.agent_spawner.as_ref(),
-                                        &restored_local_agent_task_projections,
-                                        &task_id,
-                                    )
-                                    .await,
-                                );
-                            }
-                            crate::edge_tools::BgTaskCommand::GetOutputSince {
-                                task_id,
-                                offset,
-                                max_bytes,
-                                reply,
-                            } => {
-                                let _ = reply.send(
-                                    background_task_output_snapshot_with_agents(
-                                        &mut background_registry,
-                                        state.agent_spawner.as_ref(),
-                                        &restored_local_agent_task_projections,
-                                        &task_id,
-                                        offset,
-                                        max_bytes,
-                                    )
-                                    .await,
-                                );
-                            }
-                            crate::edge_tools::BgTaskCommand::List { reply } => {
-                                let _ = reply.send(
-                                    render_background_task_list_xml_with_agents(
-                                        &mut background_registry,
-                                        state.agent_spawner.as_ref(),
-                                        &restored_local_agent_task_projections,
-                                    )
-                                    .await,
-                                );
-                            }
-                        }
+                    let old_session_was_unbound = background_registry_session_id
+                        .as_deref()
+                        .is_none_or(|sid| sid.is_empty());
+                    let new_session_is_bound = state
+                        .session_id
+                        .as_deref()
+                        .is_some_and(|sid| !sid.is_empty());
+                    if old_session_was_unbound && new_session_is_bound {
+                        background_registry
+                            .rebind_output_dir(background_task_output_dir(state.session_id.as_deref()));
+                        background_task_projection_cache = Vec::new();
+                        background_local_agent_projection_cache = Vec::new();
+                        background_registry_session_id = state.session_id.clone();
+                    } else {
+                        background_registry.kill_all();
+                        background_registry = super::background_tasks::BackgroundTaskRegistry::new(
+                            background_task_output_dir(state.session_id.as_deref()),
+                        );
+                        restored_local_agent_task_projections =
+                            restore_background_task_projections(
+                                &mut background_registry,
+                                state.session_id.as_deref(),
+                            );
+                        background_task_projection_cache =
+                            background_registry.export_shell_task_projections();
+                        background_local_agent_projection_cache =
+                            restored_local_agent_task_projections.clone();
+                        background_registry_session_id = state.session_id.clone();
                     }
                 }
+                // Drain background shell commands from the tool executor.
+                drain_bg_task_commands(
+                    &state.bg_task_commands,
+                    &mut background_registry,
+                    state.agent_spawner.as_ref(),
+                    &restored_local_agent_task_projections,
+                )
+                .await;
 
                 // Poll background shell completions.
                 let bg_events = background_registry.poll_completions();
@@ -4917,6 +4920,51 @@ mod tests {
         assert!(
             bottom_pane.has_active_view(),
             "force-open must push the view onto the bottom pane stack"
+        );
+    }
+
+    /// Regression: `drain_bg_task_commands` must serve a queued
+    /// `GetOutputSince` so a tool-side `task_output(block=true)` waiting on
+    /// the reply makes progress mid-turn. Pre-fix the drain only ran on the
+    /// outer tick, which was parked on `&mut fut`, hanging tasks for
+    /// minutes (you saw 324s).
+    #[tokio::test]
+    async fn drain_bg_task_commands_serves_get_output_since_synchronously() {
+        use crate::edge_tools::BgTaskCommand;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut registry =
+            crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("drain"));
+        let id = registry.spawn_shell("true", "drain test");
+        for _ in 0..50 {
+            registry.poll_completions();
+            if registry
+                .get(&id)
+                .is_some_and(|h| h.projected_status() == "completed")
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let queue: std::sync::Arc<std::sync::Mutex<Vec<BgTaskCommand>>> = Default::default();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        queue.lock().unwrap().push(BgTaskCommand::GetOutputSince {
+            task_id: id.clone(),
+            offset: 0,
+            max_bytes: 4096,
+            reply: tx,
+        });
+
+        drain_bg_task_commands(&queue, &mut registry, None, &[]).await;
+
+        let snapshot = rx
+            .await
+            .expect("drain must reply on the oneshot channel")
+            .expect("snapshot must succeed for a known task id");
+        assert!(
+            snapshot.terminal,
+            "completed task must be reported as terminal so task_output(block=true) can return: {snapshot:?}",
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -3815,6 +3815,23 @@ mod tests {
     };
     use std::path::PathBuf;
 
+    fn unique_test_session_id(prefix: &str) -> String {
+        static NEXT_TEST_SESSION_ID: std::sync::atomic::AtomicU64 =
+            std::sync::atomic::AtomicU64::new(1);
+        let n = NEXT_TEST_SESSION_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        format!("{prefix}-{}-{n}", std::process::id())
+    }
+
+    fn event_loop_test_tempdir() -> tempfile::TempDir {
+        let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../target/tmp/astra-cli-event-loop-tests");
+        std::fs::create_dir_all(&base).expect("create event loop test temp root");
+        tempfile::Builder::new()
+            .prefix("event-loop-")
+            .tempdir_in(&base)
+            .expect("create event loop test tempdir")
+    }
+
     async fn wait_for_background_shell_terminal(
         registry: &mut crate::tui::background_tasks::BackgroundTaskRegistry,
         id: &str,
@@ -4185,7 +4202,7 @@ mod tests {
 
     #[tokio::test]
     async fn restored_local_agent_projects_as_unavailable_stale_task() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
         let restored = vec![restored_local_agent_projection("running")];
@@ -4220,7 +4237,7 @@ mod tests {
 
     #[tokio::test]
     async fn background_task_list_xml_includes_restored_local_agent_without_spawner() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
         let restored = vec![restored_local_agent_projection("running")];
@@ -4241,7 +4258,7 @@ mod tests {
 
     #[tokio::test]
     async fn restored_local_agent_keeps_fanout_group_metadata_for_resume_footer() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
         let restored = vec![restored_fanout_local_agent_projection("running")];
@@ -4274,7 +4291,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_output_command_reads_restored_local_agent_projection() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
         let restored = vec![restored_local_agent_projection("running")];
@@ -4299,7 +4316,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_stop_command_reports_stale_handle_for_restored_local_agent() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
         let restored = vec![restored_local_agent_projection("running")];
@@ -4325,7 +4342,7 @@ mod tests {
         let spawned = spawner.spawn(input, &test_spawn_context()).await.unwrap();
         assert!(matches!(spawned, SpawnAgentOutput::Launched { .. }));
 
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
 
@@ -4359,7 +4376,7 @@ mod tests {
             other => panic!("expected launched background agent, got {other:?}"),
         };
 
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
 
@@ -4393,7 +4410,7 @@ mod tests {
             other => panic!("expected launched background agent, got {other:?}"),
         };
 
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
 
@@ -4433,7 +4450,7 @@ mod tests {
             other => panic!("expected launched background agent, got {other:?}"),
         };
 
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
         let mut chat_widget = chat_widget::ChatWidget::new("");
@@ -4498,7 +4515,7 @@ mod tests {
             other => panic!("expected launched background agent, got {other:?}"),
         };
 
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
         let mut chat_widget = chat_widget::ChatWidget::new("");
@@ -4546,7 +4563,7 @@ mod tests {
         let spawned = spawner.spawn(input, &test_spawn_context()).await.unwrap();
         assert!(matches!(spawned, SpawnAgentOutput::Launched { .. }));
 
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
         let mut bottom_pane = BottomPane::new();
@@ -4669,19 +4686,13 @@ mod tests {
 
     #[tokio::test]
     async fn background_task_rows_include_typed_status_and_combined_tail() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry = crate::tui::background_tasks::BackgroundTaskRegistry::new(
             temp.path().join("bg-task-row-projection"),
         );
         let id = registry.spawn_shell("printf 'stdout-line'; printf 'stderr-line' >&2", "demo");
 
-        for _ in 0..50 {
-            registry.poll_completions();
-            if registry.get(&id).unwrap().status().as_str() == "completed" {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
+        wait_for_background_shell_terminal(&mut registry, &id).await;
 
         let rows = background_task_rows(&mut registry);
         let row = rows
@@ -4704,19 +4715,13 @@ mod tests {
 
     #[tokio::test]
     async fn background_task_rows_surface_missing_output_artifact() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry = crate::tui::background_tasks::BackgroundTaskRegistry::new(
             temp.path().join("bg-task-missing-output"),
         );
         let id = registry.spawn_shell("printf 'done'", "missing output artifact");
 
-        for _ in 0..50 {
-            registry.poll_completions();
-            if registry.get(&id).unwrap().status().as_str() == "completed" {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
+        wait_for_background_shell_terminal(&mut registry, &id).await;
         let stdout_path = registry.get(&id).unwrap().stdout_path.clone();
         std::fs::remove_file(&stdout_path).expect("remove captured stdout artifact");
 
@@ -4735,7 +4740,7 @@ mod tests {
 
     #[test]
     fn background_task_rows_project_restored_running_as_unavailable_stale() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let stdout = temp.path().join("restored.stdout");
         let stderr = temp.path().join("restored.stderr");
         std::fs::write(&stdout, "line from previous session\n").unwrap();
@@ -4781,11 +4786,11 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn background_task_projection_persistence_round_trips_workspace() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let _guard = astra_services::session_journal::JournalDirGuard::new(temp.path());
-        let session_id = "bg-projection-session";
+        let session_id = unique_test_session_id("bg-projection-session");
         let mut workspace = astra_services::session_workspace::WorkspaceMetadata::with_context(
-            session_id,
+            &session_id,
             "gpt-5",
             "/tmp",
             Some("main"),
@@ -4818,11 +4823,11 @@ mod tests {
         let mut cache = Vec::new();
         persist_background_task_projections_if_changed(
             &mut registry,
-            Some(session_id),
+            Some(&session_id),
             Some("gpt-5"),
             &mut cache,
         );
-        workspace = astra_services::session_workspace::read_workspace(session_id).unwrap();
+        workspace = astra_services::session_workspace::read_workspace(&session_id).unwrap();
 
         assert_eq!(workspace.background_shell_tasks.len(), 1);
         assert_eq!(workspace.background_shell_tasks[0].id, "bg-shell-persist");
@@ -4835,11 +4840,11 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn background_local_agent_projection_persistence_round_trips_workspace() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let _guard = astra_services::session_journal::JournalDirGuard::new(temp.path());
-        let session_id = "bg-local-agent-projection-session";
+        let session_id = unique_test_session_id("bg-local-agent-projection-session");
         let workspace = astra_services::session_workspace::WorkspaceMetadata::with_context(
-            session_id,
+            &session_id,
             "gpt-5",
             "/tmp",
             Some("main"),
@@ -4864,12 +4869,12 @@ mod tests {
         let projections = persist_background_local_agent_task_projections_if_changed(
             Some(&spawner),
             &[],
-            Some(session_id),
+            Some(&session_id),
             Some("gpt-5"),
             &mut cache,
         )
         .await;
-        let workspace = astra_services::session_workspace::read_workspace(session_id).unwrap();
+        let workspace = astra_services::session_workspace::read_workspace(&session_id).unwrap();
 
         assert_eq!(workspace.background_local_agent_tasks.len(), 1);
         assert_eq!(workspace.background_local_agent_tasks[0].id, agent_id);
@@ -4887,7 +4892,7 @@ mod tests {
 
     #[tokio::test]
     async fn background_task_output_snapshot_drains_completion_before_status() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry = crate::tui::background_tasks::BackgroundTaskRegistry::new(
             temp.path().join("bg-task-output-snapshot"),
         );
@@ -4906,7 +4911,7 @@ mod tests {
 
     #[tokio::test]
     async fn background_task_output_snapshot_includes_stderr_only_shell_output() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry = crate::tui::background_tasks::BackgroundTaskRegistry::new(
             temp.path().join("bg-task-output-stderr"),
         );
@@ -4926,7 +4931,7 @@ mod tests {
 
     #[test]
     fn background_task_output_snapshot_projects_restored_running_as_unavailable() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let stdout = temp.path().join("restored.stdout");
         let stderr = temp.path().join("restored.stderr");
         std::fs::write(&stdout, "old output\n").unwrap();
@@ -4960,7 +4965,7 @@ mod tests {
 
     #[tokio::test]
     async fn background_task_switcher_opens_for_failed_but_not_completed_only() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut completed_registry = crate::tui::background_tasks::BackgroundTaskRegistry::new(
             temp.path().join("completed-only"),
         );
@@ -5018,7 +5023,7 @@ mod tests {
 
     #[tokio::test]
     async fn background_task_switcher_opens_for_pending_bash_handoff() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("pending"));
         let mut bottom_pane = BottomPane::new();
@@ -5053,7 +5058,7 @@ mod tests {
     /// inside the view, so the user always has a navigable surface.
     #[tokio::test]
     async fn force_open_background_task_view_opens_panel_on_empty_registry() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("empty"));
         let mut bottom_pane = BottomPane::new();
@@ -5093,7 +5098,7 @@ mod tests {
 
     #[tokio::test]
     async fn force_open_background_task_view_preempts_existing_bottom_pane() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("overlay"));
         let mut bottom_pane = BottomPane::new();
@@ -5137,7 +5142,7 @@ mod tests {
     async fn drain_bg_task_commands_serves_get_output_since_synchronously() {
         use crate::edge_tools::BgTaskCommand;
 
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("drain"));
         let id = registry.spawn_shell("true", "drain test");
@@ -5177,7 +5182,7 @@ mod tests {
     /// so Ctrl+T can route to the task board instead of stealing the key.
     #[tokio::test]
     async fn open_background_task_view_falls_through_on_empty_registry() {
-        let temp = tempfile::TempDir::new().unwrap();
+        let temp = event_loop_test_tempdir();
         let mut registry =
             crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("empty2"));
         let mut bottom_pane = BottomPane::new();

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -52,6 +52,7 @@ use super::{
 const AGENT_DRILLDOWN_RECENT_COMPLETED: usize = 5;
 const WORKSPACE_TRUST_SENTINEL: &str = "__workspace_trust__\n";
 const DEFERRED_INPUT_APPLIED_PREFIX: &str = "__deferred_input_applied__:";
+const BASH_DETACH_HANDOFF_WAIT: Duration = Duration::from_secs(5);
 
 fn ctrl_b_promoted_notification(task_id: &str) -> String {
     format!(
@@ -71,6 +72,45 @@ fn ctrl_b_promoted_agent_message(agent_id: &str, description: &str) -> String {
 fn should_show_ctrl_b_background_hint(detach_ready: bool) -> bool {
     detach_ready
 }
+
+fn visible_bash_tool_is_running(status_indicator: &status_indicator::StatusIndicator) -> bool {
+    matches!(
+        status_indicator.state(),
+        status_indicator::IndicatorState::Tool { name, .. } if name == "bash"
+    )
+}
+
+fn set_bash_background_hint_enabled(
+    chat_widget: &mut chat_widget::ChatWidget,
+    status_indicator: &mut status_indicator::StatusIndicator,
+    enabled: bool,
+) {
+    chat_widget.set_bash_background_hint_enabled(enabled);
+    status_indicator.set_bash_background_hint_enabled(enabled);
+}
+
+async fn install_bash_detach_listener(
+    slot: &astra_tools::detach::DetachShellSlot,
+    chat_widget: &mut chat_widget::ChatWidget,
+    status_indicator: &mut status_indicator::StatusIndicator,
+) -> astra_tools::detach::DetachShellListener {
+    let (handle, listener) = astra_tools::detach::new_detach_pair();
+    *slot.lock().await = Some(handle);
+    set_bash_background_hint_enabled(chat_widget, status_indicator, false);
+    listener
+}
+
+fn bash_detach_hint_enabled(
+    listener: Option<&astra_tools::detach::DetachShellListener>,
+    _status_indicator: &status_indicator::StatusIndicator,
+) -> bool {
+    let Some(listener) = listener else {
+        return false;
+    };
+    should_show_ctrl_b_background_hint(listener.is_active())
+}
+
+type BashDetachHandoffResult = Result<astra_tools::detach::DetachedShellPayload, String>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ReopenTarget {
@@ -1599,18 +1639,22 @@ pub(crate) async fn run_tui_session(
                                     // payload back. Replaces any stale handle from a
                                     // prior turn that was never consumed (e.g. the model
                                     // didn't run bash last turn).
-                                    let mut bash_detach_listener = {
-                                            let (handle, listener) = astra_tools::detach::new_detach_pair();
-                                            if let Ok(mut slot) = state.bash_detach_slot.try_lock() {
-                                                *slot = Some(handle);
-                                                chat_widget.set_bash_background_hint_enabled(
-                                                    should_show_ctrl_b_background_hint(true),
-                                                );
-                                            } else {
-                                                chat_widget.set_bash_background_hint_enabled(false);
-                                            }
-                                        Some(listener)
-                                    };
+                                    let mut bash_detach_listener =
+                                        Some(
+                                            install_bash_detach_listener(
+                                                &state.bash_detach_slot,
+                                                &mut chat_widget,
+                                                &mut status_indicator,
+                                            )
+                                            .await,
+                                        );
+                                    let (
+                                        bash_detach_handoff_tx,
+                                        mut bash_detach_handoff_rx,
+                                    ) = tokio::sync::mpsc::unbounded_channel::<
+                                        BashDetachHandoffResult,
+                                    >();
+                                    let mut bash_detach_request_pending = false;
 
                                     let turn_tx = stream_bridge::create_per_turn_bridge(tui_tx.clone());
                                     let live_sink = stream_bridge::create_agent_live_sink(tui_tx.clone());
@@ -1639,6 +1683,7 @@ pub(crate) async fn run_tui_session(
                                         let fut = crate::cli::turn::turn_entry::handle_chat_input_with_ui(submit_text, token.as_deref(), &mut state, ctx, &mut tui_ui);
                                         tokio::pin!(fut);
 
+                                        let mut turn_result_ready: Option<Result<(), String>> = None;
                                         let r: Result<(), String> = loop {
                                             if let Err(e) = guard.ensure_tui_modes() {
                                                 break Err(format!(
@@ -1648,7 +1693,13 @@ pub(crate) async fn run_tui_session(
                                             let itick = tokio::time::sleep(Duration::from_millis(80));
                                             tokio::pin!(itick);
                                             tokio::select! {
-                                                result = &mut fut => { break result; }
+                                                result = &mut fut, if turn_result_ready.is_none() => {
+                                                    if bash_detach_request_pending {
+                                                        turn_result_ready = Some(result);
+                                                        continue;
+                                                    }
+                                                    break result;
+                                                }
                                                 Some(tev) = event_stream.next() => {
                                                     match tev {
                                                         TuiEvent::Key(k) => {
@@ -1710,6 +1761,19 @@ pub(crate) async fn run_tui_session(
                                                             if k.code == crossterm::event::KeyCode::Char('b')
                                                                 && k.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
                                                             {
+                                                                if bash_detach_request_pending {
+                                                                    chat_widget.commit_system(
+                                                                        history_cell::system::SystemCell::info(
+                                                                            "⏎ Backgrounding Bash... waiting for handoff."
+                                                                        ),
+                                                                    );
+                                                                    frame_requester.schedule_frame();
+                                                                    continue;
+                                                                }
+                                                                let visible_bash_is_running =
+                                                                    visible_bash_tool_is_running(
+                                                                        &status_indicator,
+                                                                    );
                                                                 let listener = bash_detach_listener.take();
                                                                 if let Some(listener) = listener {
                                                                     if listener.is_active() {
@@ -1730,92 +1794,54 @@ pub(crate) async fn run_tui_session(
                                                                         // later bash invocation if handoff loses a race.
                                                                         if listener.signal_tx.send(true).is_err() {
                                                                             listener.retire();
-                                                                            if let Ok(mut slot) = bash_detach_slot_for_ctrl_b.try_lock() {
-                                                                                *slot = None;
-                                                                            }
-                                                                        } else {
-                                                                            listener.retire();
-                                                                        // Wait briefly for the runner to ship
-                                                                        // the live child + streams payload.
-                                                                        // 500ms is comfortably more than the
-                                                                        // bash runner's 25ms idle-poll tick;
-                                                                        // longer waits indicate bash wasn't
-                                                                        // actually running when the user hit
-                                                                        // Ctrl+B.
-                                                                        let payload = tokio::time::timeout(
-                                                                            std::time::Duration::from_millis(500),
-                                                                            listener.payload_rx,
-                                                                        )
-                                                                        .await;
-                                                                        match payload {
-                                                                            Ok(Ok(p)) => {
-                                                                                // Drop the bash runner straight
-                                                                                // into the registry. The
-                                                                                // adopt_detached_shell API
-                                                                                // takes the live child + streams
-                                                                                // and emits Started/Completed
-                                                                                // events like a normal bg task.
-                                                                                let id = match background_registry.adopt_detached_shell(
-                                                                                    p.child,
-                                                                                    p.stdout,
-                                                                                    p.stderr,
-                                                                                    &p.command,
-                                                                                    p.partial_stdout,
-                                                                                    p.partial_stderr,
-                                                                                ) {
-                                                                                    Ok(id) => id,
-                                                                                    Err(error) => {
-                                                                                        chat_widget.commit_system(
-                                                                                            history_cell::system::SystemCell::error(
-                                                                                                format!("⏎ Backgrounding failed: {error}")
-                                                                                            ),
-                                                                                        );
-                                                                                        frame_requester.schedule_frame();
-                                                                                        continue;
-                                                                                    }
-                                                                                };
-                                                                                chat_widget.commit_system(
-                                                                                    history_cell::system::SystemCell::info(
-                                                                                        format!("⏎ Backgrounded as {id}. Opened background tasks; Enter details, S stop.")
-                                                                                    ),
-                                                                                );
-                                                                                ctrl_b_promoted_task_id = Some(id);
-                                                                                persist_background_task_projections_if_changed(
-                                                                                    &mut background_registry,
-                                                                                    background_registry_turn_session_id.as_deref(),
-                                                                                    background_registry_turn_model.as_deref(),
-                                                                                    &mut background_task_projection_cache,
-                                                                                );
-                                                                                let selected_id = ctrl_b_promoted_task_id.as_deref();
-                                                                                let _ = reveal_background_task_view(
-                                                                                    &mut background_registry,
-                                                                                    agent_spawner_for_cancel.as_ref(),
-                                                                                    &restored_local_agent_task_projections,
-                                                                                    &mut bottom_pane,
-                                                                                    &frame_requester,
-                                                                                    selected_id,
-                                                                                )
-                                                                                .await;
-                                                                                // The turn is over from the
-                                                                                // model's perspective; cancel
-                                                                                // gracefully so it sees the
-                                                                                // <bash_detached> marker
-                                                                                // already returned by the bash
-                                                                                // tool and ends cleanly.
-                                                                                tui_cancel_token.cancel();
-                                                                                frame_requester.schedule_frame();
-                                                                                continue;
-                                                                            }
-                                                                            // No payload — bash completed or
-                                                                            // could not hand off after it had
-                                                                            // advertised an active detach window.
-                                                                            _ => {
-                                                                                if let Ok(mut slot) = bash_detach_slot_for_ctrl_b.try_lock() {
-                                                                                    *slot = None;
-                                                                                }
-                                                                            }
+                                                                            *bash_detach_slot_for_ctrl_b.lock().await = None;
+                                                                            chat_widget.commit_system(
+                                                                                history_cell::system::SystemCell::error(
+                                                                                    "⏎ Backgrounding failed: active bash detach signal channel closed."
+                                                                                ),
+                                                                            );
+                                                                            set_bash_background_hint_enabled(
+                                                                                &mut chat_widget,
+                                                                                &mut status_indicator,
+                                                                                false,
+                                                                            );
+                                                                            frame_requester.schedule_frame();
+                                                                            continue;
                                                                         }
-                                                                        }
+                                                                        listener.retire();
+                                                                        bash_detach_request_pending = true;
+                                                                        set_bash_background_hint_enabled(
+                                                                            &mut chat_widget,
+                                                                            &mut status_indicator,
+                                                                            false,
+                                                                        );
+                                                                        chat_widget.commit_system(
+                                                                            history_cell::system::SystemCell::info(
+                                                                                "⏎ Backgrounding Bash... waiting for handoff."
+                                                                            ),
+                                                                        );
+                                                                        let handoff_tx = bash_detach_handoff_tx.clone();
+                                                                        tokio::spawn(async move {
+                                                                            let handoff = tokio::time::timeout(
+                                                                                BASH_DETACH_HANDOFF_WAIT,
+                                                                                listener.payload_rx,
+                                                                            )
+                                                                            .await;
+                                                                            let result = match handoff {
+                                                                                Ok(Ok(payload)) => Ok(payload),
+                                                                                Ok(Err(_)) => Err(
+                                                                                    "bash runner ended before handing off the process."
+                                                                                        .to_string(),
+                                                                                ),
+                                                                                Err(_) => Err(
+                                                                                    "bash did not hand off the process in time."
+                                                                                        .to_string(),
+                                                                                ),
+                                                                            };
+                                                                            let _ = handoff_tx.send(result);
+                                                                        });
+                                                                        frame_requester.schedule_frame();
+                                                                        continue;
                                                                     } else {
                                                                         bash_detach_listener = Some(listener);
                                                                     }
@@ -1849,11 +1875,35 @@ pub(crate) async fn run_tui_session(
                                                                         continue;
                                                                     }
                                                                 }
-                                                                chat_widget.commit_system(
-                                                                    history_cell::system::SystemCell::info(
-                                                                        "⏎ Backgrounding unavailable: no active bash or agent can be promoted right now."
-                                                                    ),
-                                                                );
+                                                                if !bottom_pane.has_active_view()
+                                                                    && open_background_task_view(
+                                                                        &mut background_registry,
+                                                                        agent_spawner_for_cancel.as_ref(),
+                                                                        &restored_local_agent_task_projections,
+                                                                        &mut bottom_pane,
+                                                                        &frame_requester,
+                                                                    )
+                                                                    .await
+                                                                {
+                                                                    continue;
+                                                                }
+                                                                if bottom_pane.has_active_view() {
+                                                                    frame_requester.schedule_frame();
+                                                                    continue;
+                                                                }
+                                                                if visible_bash_is_running {
+                                                                    chat_widget.commit_system(
+                                                                        history_cell::system::SystemCell::info(
+                                                                            "⏎ Backgrounding unavailable: this Bash command is not attached to a backgroundable runner; Esc can stop it."
+                                                                        ),
+                                                                    );
+                                                                } else {
+                                                                    chat_widget.commit_system(
+                                                                        history_cell::system::SystemCell::info(
+                                                                            "⏎ Backgrounding unavailable: no active foreground bash or agent, and no background tasks to show."
+                                                                        ),
+                                                                    );
+                                                                }
                                                                 frame_requester.schedule_frame();
                                                                 continue;
                                                             }
@@ -2197,6 +2247,90 @@ pub(crate) async fn run_tui_session(
                                                         _ => {}
                                                     }
                                                 }
+                                                Some(handoff) = bash_detach_handoff_rx.recv() => {
+                                                    bash_detach_request_pending = false;
+                                                    match handoff {
+                                                        Ok(p) => {
+                                                            let id = match background_registry.adopt_detached_shell(
+                                                                p.child,
+                                                                p.stdout,
+                                                                p.stderr,
+                                                                &p.command,
+                                                                p.partial_stdout,
+                                                                p.partial_stderr,
+                                                            ) {
+                                                                Ok(id) => id,
+                                                                Err(error) => {
+                                                                    chat_widget.commit_system(
+                                                                        history_cell::system::SystemCell::error(
+                                                                            format!("⏎ Backgrounding failed: {error}")
+                                                                        ),
+                                                                    );
+                                                                    set_bash_background_hint_enabled(
+                                                                        &mut chat_widget,
+                                                                        &mut status_indicator,
+                                                                        false,
+                                                                    );
+                                                                    let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
+                                                                    flush_chat_widget(&mut guard, &mut chat_widget, w);
+                                                                    frame_requester.schedule_frame();
+                                                                    if let Some(result) = turn_result_ready.take() {
+                                                                        break result;
+                                                                    }
+                                                                    continue;
+                                                                }
+                                                            };
+                                                            chat_widget.commit_system(
+                                                                history_cell::system::SystemCell::info(
+                                                                    format!("⏎ Backgrounded as {id}. Opened background tasks; Enter details, S stop.")
+                                                                ),
+                                                            );
+                                                            let selected_id = id.clone();
+                                                            ctrl_b_promoted_task_id = Some(id);
+                                                            set_bash_background_hint_enabled(
+                                                                &mut chat_widget,
+                                                                &mut status_indicator,
+                                                                false,
+                                                            );
+                                                            persist_background_task_projections_if_changed(
+                                                                &mut background_registry,
+                                                                background_registry_turn_session_id.as_deref(),
+                                                                background_registry_turn_model.as_deref(),
+                                                                &mut background_task_projection_cache,
+                                                            );
+                                                            let _ = reveal_background_task_view(
+                                                                &mut background_registry,
+                                                                agent_spawner_for_cancel.as_ref(),
+                                                                &restored_local_agent_task_projections,
+                                                                &mut bottom_pane,
+                                                                &frame_requester,
+                                                                Some(selected_id.as_str()),
+                                                            )
+                                                            .await;
+                                                            tui_cancel_token.cancel();
+                                                        }
+                                                        Err(error) => {
+                                                            *bash_detach_slot_for_ctrl_b.lock().await = None;
+                                                            chat_widget.commit_system(
+                                                                history_cell::system::SystemCell::error(
+                                                                    format!("⏎ Backgrounding failed: {error}")
+                                                                ),
+                                                            );
+                                                            set_bash_background_hint_enabled(
+                                                                &mut chat_widget,
+                                                                &mut status_indicator,
+                                                                false,
+                                                            );
+                                                        }
+                                                    }
+                                                    let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
+                                                    flush_chat_widget(&mut guard, &mut chat_widget, w);
+                                                    frame_requester.schedule_frame();
+                                                    if let Some(result) = turn_result_ready.take() {
+                                                        break result;
+                                                    }
+                                                    continue;
+                                                }
                                                 Some(ae) = tui_rx.recv() => {
                                                     // Track per-turn metrics
                                                     match &ae {
@@ -2229,6 +2363,38 @@ pub(crate) async fn run_tui_session(
                                                         &mut chat_widget,
                                                     );
                                                     handle_app_event(&ae, &mut bottom_pane, &mut status_indicator, &frame_requester);
+                                                    let should_rearm_bash_detach =
+                                                        bash_detach_listener.is_none()
+                                                            && match &ae {
+                                                                TuiAppEvent::ToolStarted {
+                                                                    name,
+                                                                    ..
+                                                                } => name == "bash",
+                                                                TuiAppEvent::ToolCompleted {
+                                                                    ..
+                                                                } => true,
+                                                                _ => false,
+                                                            };
+                                                    if should_rearm_bash_detach {
+                                                        bash_detach_listener = Some(
+                                                            install_bash_detach_listener(
+                                                                &bash_detach_slot_for_ctrl_b,
+                                                                &mut chat_widget,
+                                                                &mut status_indicator,
+                                                            )
+                                                            .await,
+                                                        );
+                                                    }
+                                                    let bash_hint_enabled =
+                                                        bash_detach_hint_enabled(
+                                                            bash_detach_listener.as_ref(),
+                                                            &status_indicator,
+                                                        );
+                                                    set_bash_background_hint_enabled(
+                                                        &mut chat_widget,
+                                                        &mut status_indicator,
+                                                        bash_hint_enabled,
+                                                    );
                                                     flush_chat_widget(&mut guard, &mut chat_widget, w);
                                                     {
                                     let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
@@ -2342,6 +2508,16 @@ pub(crate) async fn run_tui_session(
                                                     {
                                                         bottom_pane.footer.permission_mode = Some(live_mode);
                                                     }
+                                                    let bash_hint_enabled =
+                                                        bash_detach_hint_enabled(
+                                                            bash_detach_listener.as_ref(),
+                                                            &status_indicator,
+                                                        );
+                                                    set_bash_background_hint_enabled(
+                                                        &mut chat_widget,
+                                                        &mut status_indicator,
+                                                        bash_hint_enabled,
+                                                    );
                                                     let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
                                                     let frame = active_viewport(
                                         &chat_widget,
@@ -2414,7 +2590,11 @@ pub(crate) async fn run_tui_session(
                                     // Turn end — ChatWidget handles any
                                     // remaining live cell on TurnComplete.
                                     let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
-                                    chat_widget.set_bash_background_hint_enabled(false);
+                                    set_bash_background_hint_enabled(
+                                        &mut chat_widget,
+                                        &mut status_indicator,
+                                        false,
+                                    );
 
                                     bottom_pane.set_task_status(TaskStatus::Idle);
                                     status_indicator.set_state(

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -54,7 +54,6 @@ use super::{
 const AGENT_DRILLDOWN_RECENT_COMPLETED: usize = 5;
 const WORKSPACE_TRUST_SENTINEL: &str = "__workspace_trust__\n";
 const DEFERRED_INPUT_APPLIED_PREFIX: &str = "__deferred_input_applied__:";
-const BASH_DETACH_HANDOFF_WAIT: Duration = Duration::from_secs(5);
 
 fn ctrl_b_promoted_agent_message(agent_id: &str, description: &str) -> String {
     let description = description.trim();
@@ -1651,6 +1650,7 @@ pub(crate) async fn run_tui_session(
                                     >();
                                     let mut bash_detach_request_pending = false;
                                     let mut active_bash_tool_use_id: Option<String> = None;
+                                    let mut active_bash_description: Option<String> = None;
 
                                     let turn_tx = stream_bridge::create_per_turn_bridge(tui_tx.clone());
                                     let live_sink = stream_bridge::create_agent_live_sink(tui_tx.clone());
@@ -1807,6 +1807,10 @@ pub(crate) async fn run_tui_session(
                                                                         }
                                                                         listener.retire();
                                                                         bash_detach_request_pending = true;
+                                                                        let pending_title =
+                                                                            active_bash_description
+                                                                                .as_deref()
+                                                                                .unwrap_or("Bash");
                                                                         set_bash_background_hint_enabled(
                                                                             &mut chat_widget,
                                                                             &mut status_indicator,
@@ -1817,21 +1821,28 @@ pub(crate) async fn run_tui_session(
                                                                                 "⏎ Backgrounding Bash... waiting for handoff."
                                                                             ),
                                                                         );
+                                                                        let pending_rows = vec![
+                                                                            pending_bash_handoff_row(
+                                                                                pending_title,
+                                                                                0,
+                                                                            ),
+                                                                        ];
+                                                                        let _ = reveal_background_task_view_with_extra_rows(
+                                                                            &mut background_registry,
+                                                                            agent_spawner_for_cancel.as_ref(),
+                                                                            &restored_local_agent_task_projections,
+                                                                            &mut bottom_pane,
+                                                                            &frame_requester,
+                                                                            pending_rows,
+                                                                            Some(PENDING_BASH_HANDOFF_TASK_ID),
+                                                                        )
+                                                                        .await;
                                                                         let handoff_tx = bash_detach_handoff_tx.clone();
                                                                         tokio::spawn(async move {
-                                                                            let handoff = tokio::time::timeout(
-                                                                                BASH_DETACH_HANDOFF_WAIT,
-                                                                                listener.payload_rx,
-                                                                            )
-                                                                            .await;
-                                                                            let result = match handoff {
-                                                                                Ok(Ok(payload)) => Ok(payload),
-                                                                                Ok(Err(_)) => Err(
-                                                                                    "bash runner ended before handing off the process."
-                                                                                        .to_string(),
-                                                                                ),
+                                                                            let result = match listener.payload_rx.await {
+                                                                                Ok(payload) => Ok(payload),
                                                                                 Err(_) => Err(
-                                                                                    "bash did not hand off the process in time."
+                                                                                    "bash runner ended before handing off the process."
                                                                                         .to_string(),
                                                                                 ),
                                                                             };
@@ -2281,6 +2292,16 @@ pub(crate) async fn run_tui_session(
                                                                         &mut status_indicator,
                                                                         false,
                                                                     );
+                                                                    let _ = reveal_background_task_view_with_extra_rows(
+                                                                        &mut background_registry,
+                                                                        agent_spawner_for_cancel.as_ref(),
+                                                                        &restored_local_agent_task_projections,
+                                                                        &mut bottom_pane,
+                                                                        &frame_requester,
+                                                                        Vec::new(),
+                                                                        None,
+                                                                    )
+                                                                    .await;
                                                                     let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
                                                                     flush_chat_widget(&mut guard, &mut chat_widget, w);
                                                                     frame_requester.schedule_frame();
@@ -2333,6 +2354,16 @@ pub(crate) async fn run_tui_session(
                                                                 &mut status_indicator,
                                                                 false,
                                                             );
+                                                            let _ = reveal_background_task_view_with_extra_rows(
+                                                                &mut background_registry,
+                                                                agent_spawner_for_cancel.as_ref(),
+                                                                &restored_local_agent_task_projections,
+                                                                &mut bottom_pane,
+                                                                &frame_requester,
+                                                                Vec::new(),
+                                                                None,
+                                                            )
+                                                            .await;
                                                         }
                                                     }
                                                     let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
@@ -2380,12 +2411,14 @@ pub(crate) async fn run_tui_session(
                                                             && match &ae {
                                                                 TuiAppEvent::ToolStarted {
                                                                     name,
+                                                                    description,
                                                                     tool_use_id,
                                                                     parent_tool_use_id,
                                                                     ..
                                                                 } => {
                                                                     if name == "bash" && parent_tool_use_id.is_none() {
                                                                         active_bash_tool_use_id = Some(tool_use_id.clone());
+                                                                        active_bash_description = Some(description.clone());
                                                                     }
                                                                     name == "bash"
                                                                 }
@@ -2395,6 +2428,7 @@ pub(crate) async fn run_tui_session(
                                                                 } => {
                                                                     if active_bash_tool_use_id.as_deref() == Some(tool_use_id.as_str()) {
                                                                         active_bash_tool_use_id = None;
+                                                                        active_bash_description = None;
                                                                     }
                                                                     true
                                                                 }
@@ -4415,6 +4449,58 @@ mod tests {
         assert!(!should_show_ctrl_b_background_hint(false));
     }
 
+    #[test]
+    fn bash_tool_completed_returns_foreground_status_to_thinking() {
+        let mut bottom_pane = BottomPane::new();
+        let mut status_indicator = status_indicator::StatusIndicator::new();
+
+        handle_app_event(
+            &TuiAppEvent::ToolStarted {
+                name: "bash".to_string(),
+                description: "$ make check".to_string(),
+                tool_use_id: "tu_bash".to_string(),
+                parent_tool_use_id: None,
+            },
+            &mut bottom_pane,
+            &mut status_indicator,
+            &FrameRequester::test_dummy(),
+        );
+        status_indicator.set_bash_background_hint_enabled(true);
+        assert!(matches!(
+            status_indicator.state(),
+            status_indicator::IndicatorState::Tool { name, .. } if name == "bash"
+        ));
+        assert!(visible_bash_tool_is_running(&status_indicator));
+
+        handle_app_event(
+            &TuiAppEvent::ToolCompleted {
+                name: "bash".to_string(),
+                description: "$ make check".to_string(),
+                status: "success".to_string(),
+                duration_ms: 1200,
+                output_summary: Some(
+                    "<bash_detached>The bash command was promoted to background task bg-shell-1.</bash_detached>"
+                        .to_string(),
+                ),
+                output: None,
+                tool_use_id: "tu_bash".to_string(),
+                parent_tool_use_id: None,
+            },
+            &mut bottom_pane,
+            &mut status_indicator,
+            &FrameRequester::test_dummy(),
+        );
+
+        assert!(matches!(
+            status_indicator.state(),
+            status_indicator::IndicatorState::Thinking { .. }
+        ));
+        assert!(
+            !visible_bash_tool_is_running(&status_indicator),
+            "backgrounded Bash must no longer be the foreground activity after ToolCompleted"
+        );
+    }
+
     #[tokio::test]
     async fn background_task_rows_include_typed_status_and_combined_tail() {
         let temp = tempfile::TempDir::new().unwrap();
@@ -4762,6 +4848,35 @@ mod tests {
             "failed background tasks must remain reachable from Ctrl+T"
         );
         assert!(bottom_pane.has_active_view());
+    }
+
+    #[tokio::test]
+    async fn background_task_switcher_opens_for_pending_bash_handoff() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut registry =
+            crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("pending"));
+        let mut bottom_pane = BottomPane::new();
+
+        assert!(
+            reveal_background_task_view_with_extra_rows(
+                &mut registry,
+                None,
+                &[],
+                &mut bottom_pane,
+                &FrameRequester::test_dummy(),
+                vec![pending_bash_handoff_row("$ make build", 0)],
+                Some(PENDING_BASH_HANDOFF_TASK_ID),
+            )
+            .await,
+            "Ctrl+B should open background tasks immediately while Bash handoff is pending"
+        );
+
+        assert!(bottom_pane.has_active_view());
+        let counts = bottom_pane
+            .footer
+            .bg_task_counts
+            .expect("pending handoff row should surface footer counts");
+        assert_eq!(counts.running, 1);
     }
 
     #[tokio::test]

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -75,6 +75,13 @@ fn visible_bash_tool_is_running(status_indicator: &status_indicator::StatusIndic
     )
 }
 
+fn is_background_task_manage_key(key: &crossterm::event::KeyEvent) -> bool {
+    key.code == crossterm::event::KeyCode::Down
+        && key
+            .modifiers
+            .contains(crossterm::event::KeyModifiers::SHIFT)
+}
+
 fn set_bash_background_hint_enabled(
     chat_widget: &mut chat_widget::ChatWidget,
     status_indicator: &mut status_indicator::StatusIndicator,
@@ -811,6 +818,24 @@ pub(crate) async fn run_tui_session(
                         {
                             let _ = guard.terminal.clear();
                             guard.terminal.invalidate_viewport();
+                            frame_requester.schedule_frame();
+                            continue;
+                        }
+                        if is_background_task_manage_key(&key) && !bottom_pane.has_active_view() {
+                            if open_background_task_view(
+                                &mut background_registry,
+                                state.agent_spawner.as_ref(),
+                                &restored_local_agent_task_projections,
+                                &mut bottom_pane,
+                                &frame_requester,
+                            )
+                            .await
+                            {
+                                continue;
+                            }
+                            chat_widget.commit_system(history_cell::system::SystemCell::info(
+                                "No background tasks to manage.",
+                            ));
                             frame_requester.schedule_frame();
                             continue;
                         }
@@ -1737,6 +1762,28 @@ pub(crate) async fn run_tui_session(
                                                                 chat_widget.commit_system(
                                                                     history_cell::system::SystemCell::response(
                                                                         slash_dispatch::permission_mode_feedback(next_mode),
+                                                                    ),
+                                                                );
+                                                                frame_requester.schedule_frame();
+                                                                continue;
+                                                            }
+                                                            if is_background_task_manage_key(&k)
+                                                                && !bottom_pane.has_active_view()
+                                                            {
+                                                                if open_background_task_view(
+                                                                    &mut background_registry,
+                                                                    agent_spawner_for_cancel.as_ref(),
+                                                                    &restored_local_agent_task_projections,
+                                                                    &mut bottom_pane,
+                                                                    &frame_requester,
+                                                                )
+                                                                .await
+                                                                {
+                                                                    continue;
+                                                                }
+                                                                chat_widget.commit_system(
+                                                                    history_cell::system::SystemCell::info(
+                                                                        "No background tasks to manage."
                                                                     ),
                                                                 );
                                                                 frame_requester.schedule_frame();
@@ -4447,6 +4494,26 @@ mod tests {
     fn ctrl_b_background_hint_requires_detach() {
         assert!(should_show_ctrl_b_background_hint(true));
         assert!(!should_show_ctrl_b_background_hint(false));
+    }
+
+    #[test]
+    fn shift_down_is_background_task_manage_key() {
+        let shift_down = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Down,
+            crossterm::event::KeyModifiers::SHIFT,
+        );
+        let plain_down = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Down,
+            crossterm::event::KeyModifiers::NONE,
+        );
+        let ctrl_b = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('b'),
+            crossterm::event::KeyModifiers::CONTROL,
+        );
+
+        assert!(is_background_task_manage_key(&shift_down));
+        assert!(!is_background_task_manage_key(&plain_down));
+        assert!(!is_background_task_manage_key(&ctrl_b));
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -81,6 +81,13 @@ fn is_background_task_manage_key(key: &crossterm::event::KeyEvent) -> bool {
             .contains(crossterm::event::KeyModifiers::SHIFT)
 }
 
+fn is_ctrl_b_background_key(key: &crossterm::event::KeyEvent) -> bool {
+    key.code == crossterm::event::KeyCode::Char('b')
+        && key
+            .modifiers
+            .contains(crossterm::event::KeyModifiers::CONTROL)
+}
+
 fn set_bash_background_hint_enabled(
     chat_widget: &mut chat_widget::ChatWidget,
     status_indicator: &mut status_indicator::StatusIndicator,
@@ -820,7 +827,7 @@ pub(crate) async fn run_tui_session(
                             frame_requester.schedule_frame();
                             continue;
                         }
-                        if is_background_task_manage_key(&key) && !bottom_pane.has_active_view() {
+                        if is_background_task_manage_key(&key) || is_ctrl_b_background_key(&key) {
                             let _ = force_open_background_task_view(
                                 &mut background_registry,
                                 state.agent_spawner.as_ref(),
@@ -1669,6 +1676,16 @@ pub(crate) async fn run_tui_session(
                                     let mut bash_detach_request_pending = false;
                                     let mut active_bash_tool_use_id: Option<String> = None;
                                     let mut active_bash_description: Option<String> = None;
+                                    // Notifications for tasks that completed mid-turn. We
+                                    // surface the user-visible system message immediately on
+                                    // the inner tick (so the user sees "Background task
+                                    // bg-shell-N completed" while the model is still working),
+                                    // but we hold the model-facing <task_notification> XML
+                                    // here and forward it to `state.pending_bg_notifications`
+                                    // once the turn future releases its `&mut state` borrow.
+                                    // This guarantees a completion mid-turn shows up in the
+                                    // *next* turn's prompt instead of being lost.
+                                    let mut deferred_bg_notifications: Vec<String> = Vec::new();
 
                                     let turn_tx = stream_bridge::create_per_turn_bridge(tui_tx.clone());
                                     let live_sink = stream_bridge::create_agent_live_sink(tui_tx.clone());
@@ -1773,9 +1790,7 @@ pub(crate) async fn run_tui_session(
                                                             // empty (e.g. during bash detach handoff or while
                                                             // task_output is blocking on stdout). Empty state
                                                             // renders as "No background tasks." inside the view.
-                                                            if is_background_task_manage_key(&k)
-                                                                && !bottom_pane.has_active_view()
-                                                            {
+                                                            if is_background_task_manage_key(&k) {
                                                                 let _ = force_open_background_task_view(
                                                                     &mut background_registry,
                                                                     agent_spawner_for_cancel.as_ref(),
@@ -1807,9 +1822,7 @@ pub(crate) async fn run_tui_session(
                                                             // registry is empty in this instant — so the user has
                                                             // a stable surface to land on. There is no "unavailable"
                                                             // path: any state is a renderable panel state.
-                                                            if k.code == crossterm::event::KeyCode::Char('b')
-                                                                && k.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
-                                                            {
+                                                            if is_ctrl_b_background_key(&k) {
                                                                 // Side-effect 1: detach an in-flight backgroundable bash.
                                                                 // Skipped if a detach is already mid-flight (handoff
                                                                 // pending) or if the registry is at the shell-task cap.
@@ -1900,6 +1913,13 @@ pub(crate) async fn run_tui_session(
                                                                     )
                                                                     .await;
                                                                 } else {
+                                                                    // CRITICAL FIX: User feedback when Ctrl+B
+                                                                    // cannot detach bash or promote an agent.
+                                                                    chat_widget.commit_system(
+                                                                        history_cell::system::SystemCell::info(
+                                                                            "Ctrl+B: Nothing to background. Opening task panel.",
+                                                                        ),
+                                                                    );
                                                                     let _ = force_open_background_task_view(
                                                                         &mut background_registry,
                                                                         agent_spawner_for_cancel.as_ref(),
@@ -2252,10 +2272,66 @@ pub(crate) async fn run_tui_session(
                                                         _ => {}
                                                     }
                                                 }
-                                                Some(handoff) = bash_detach_handoff_rx.recv() => {
+                                                handoff = bash_detach_handoff_rx.recv() => {
                                                     bash_detach_request_pending = false;
+                                                    let handoff = match handoff {
+                                                        Some(h) => h,
+                                                        None => {
+                                                            // Channel closed — bash runner panicked or
+                                                            // was dropped before sending. Clean up
+                                                            // detach state so the UI doesn't wait
+                                                            // forever for a handoff that will never
+                                                            // arrive.
+                                                            tracing::warn!(
+                                                                "bash detach handoff channel closed without payload"
+                                                            );
+                                                            chat_widget.commit_system(
+                                                                history_cell::system::SystemCell::error(
+                                                                    "⏎ Backgrounding failed: runner disconnected",
+                                                                ),
+                                                            );
+                                                            set_bash_background_hint_enabled(
+                                                                &mut chat_widget,
+                                                                &mut status_indicator,
+                                                                false,
+                                                            );
+                                                            frame_requester.schedule_frame();
+                                                            if let Some(result) = turn_result_ready.take() {
+                                                                break result;
+                                                            }
+                                                            continue;
+                                                        }
+                                                    };
                                                     match handoff {
                                                         Ok(p) => {
+                                                            // Cap check before transferring child ownership.
+                                                            // If at capacity, reject adoption gracefully — the
+                                                            // bash runner already returned Detached and will
+                                                            // receive the error on adoption_rx.
+                                                            if !background_registry.can_spawn_shell_task() {
+                                                                let astra_tools::detach::DetachedShellPayload {
+                                                                    adoption_tx, ..
+                                                                } = p;
+                                                                let _ = adoption_tx.send(Err(format!(
+                                                                    "background shell task limit reached ({} running)",
+                                                                    background_registry.running_count()
+                                                                )));
+                                                                chat_widget.commit_system(
+                                                                    history_cell::system::SystemCell::error(
+                                                                        "⏎ Backgrounding failed: task limit reached",
+                                                                    ),
+                                                                );
+                                                                set_bash_background_hint_enabled(
+                                                                    &mut chat_widget,
+                                                                    &mut status_indicator,
+                                                                    false,
+                                                                );
+                                                                frame_requester.schedule_frame();
+                                                                if let Some(result) = turn_result_ready.take() {
+                                                                    break result;
+                                                                }
+                                                                continue;
+                                                            }
                                                             let astra_tools::detach::DetachedShellPayload {
                                                                 child,
                                                                 stdout,
@@ -2272,7 +2348,7 @@ pub(crate) async fn run_tui_session(
                                                                 &command,
                                                                 partial_stdout,
                                                                 partial_stderr,
-                                                            ) {
+                                                            ).await {
                                                                 Ok(id) => {
                                                                     let _ = adoption_tx.send(Ok(id.clone()));
                                                                     id
@@ -2577,15 +2653,33 @@ pub(crate) async fn run_tui_session(
                                                         &restored_local_agent_task_projections,
                                                     )
                                                     .await;
-                                                    // Move terminal completions onto the handle
-                                                    // status so the next snapshot reply names
-                                                    // the task as completed/failed/killed.
-                                                    // Inner-tick poll yields events we drop:
-                                                    // the outer tick will pick up the next
-                                                    // `poll_completions()` (events stay queued
-                                                    // until consumed there) and emit the system
-                                                    // message + task_notification.
-                                                    background_registry.drain_join_set();
+                                                    // Surface terminal background-task completions
+                                                    // mid-turn so the user sees "Background task
+                                                    // bg-shell-N completed" immediately, not only
+                                                    // at turn-end. `poll_completions()` consumes
+                                                    // each event exactly once, so we capture the
+                                                    // model-facing <task_notification> XML into
+                                                    // `deferred_bg_notifications` here and forward
+                                                    // it into `state.pending_bg_notifications`
+                                                    // once the turn future releases the `&mut
+                                                    // state` borrow — that way a completion that
+                                                    // fires mid-turn is still delivered to the
+                                                    // model on its next turn rather than lost.
+                                                    let bg_events = background_registry.poll_completions();
+                                                    for ev in &bg_events {
+                                                        let notification = super::background_tasks::format_notification_xml(ev);
+                                                        if !notification.is_empty() {
+                                                            deferred_bg_notifications.push(notification);
+                                                        }
+                                                    }
+                                                    for msg in background_task_event_system_messages(&bg_events) {
+                                                        chat_widget.commit_system(
+                                                            history_cell::system::SystemCell::info(&msg),
+                                                        );
+                                                    }
+                                                    if !bg_events.is_empty() {
+                                                        frame_requester.schedule_frame();
+                                                    }
                                                     let bash_hint_enabled =
                                                         bash_detach_hint_enabled(
                                                             bash_detach_listener.as_ref(),
@@ -2667,6 +2761,17 @@ pub(crate) async fn run_tui_session(
 
                                     // Turn end — ChatWidget handles any
                                     // remaining live cell on TurnComplete.
+                                    // The turn future has resolved, so the &mut state
+                                    // borrow is released — forward any background-task
+                                    // notifications captured mid-turn into the next-turn
+                                    // prompt channel. poll_completions() consumes events
+                                    // exactly once, so without this hand-off a task that
+                                    // finishes mid-turn would never reach the model.
+                                    if !deferred_bg_notifications.is_empty() {
+                                        state
+                                            .pending_bg_notifications
+                                            .append(&mut deferred_bg_notifications);
+                                    }
                                     let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
                                     set_bash_background_hint_enabled(
                                         &mut chat_widget,
@@ -3470,13 +3575,40 @@ pub(crate) async fn run_tui_session(
                         .as_deref()
                         .is_some_and(|sid| !sid.is_empty());
                     if old_session_was_unbound && new_session_is_bound {
-                        background_registry
-                            .rebind_output_dir(background_task_output_dir(state.session_id.as_deref()));
+                        if let Err(error) = background_registry
+                            .rebind_output_dir(background_task_output_dir(state.session_id.as_deref()))
+                        {
+                            chat_widget.commit_system(
+                                history_cell::system::SystemCell::error(format!(
+                                    "⚠ Background task storage unavailable: {error}. \
+                                     Background tasks may fail to spawn until this is fixed."
+                                )),
+                            );
+                            frame_requester.schedule_frame();
+                        }
                         background_task_projection_cache = Vec::new();
                         background_local_agent_projection_cache = Vec::new();
                         background_registry_session_id = state.session_id.clone();
                     } else {
-                        background_registry.kill_all();
+                        // Bound→bound (or bound→unbound) session change: tasks
+                        // from the prior session cannot meaningfully follow the
+                        // user across sessions because their projections are
+                        // session-scoped and a new session has its own tasks.
+                        // Kill them — but surface the kill list so the user
+                        // isn't surprised by silently terminated work.
+                        let killed = background_registry.kill_all();
+                        if !killed.is_empty() {
+                            let kind = if killed.len() == 1 { "task" } else { "tasks" };
+                            chat_widget.commit_system(history_cell::system::SystemCell::warning(
+                                format!(
+                                    "⚠ Session changed; cancelled {} background {} from the previous session: {}",
+                                    killed.len(),
+                                    kind,
+                                    killed.join(", ")
+                                ),
+                            ));
+                            frame_requester.schedule_frame();
+                        }
                         background_registry = super::background_tasks::BackgroundTaskRegistry::new(
                             background_task_output_dir(state.session_id.as_deref()),
                         );
@@ -3516,7 +3648,7 @@ pub(crate) async fn run_tui_session(
                     frame_requester.schedule_frame();
                 }
                 // Stall check every tick (internal timer gates at 5s intervals).
-                background_registry.stall_check();
+                background_registry.stall_check().await;
                 persist_background_task_projections_if_changed(
                     &mut background_registry,
                     state.session_id.as_deref(),
@@ -4464,6 +4596,26 @@ mod tests {
     }
 
     #[test]
+    fn ctrl_b_is_background_key() {
+        let ctrl_b = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('b'),
+            crossterm::event::KeyModifiers::CONTROL,
+        );
+        let plain_b = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('b'),
+            crossterm::event::KeyModifiers::NONE,
+        );
+        let ctrl_c = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('c'),
+            crossterm::event::KeyModifiers::CONTROL,
+        );
+
+        assert!(is_ctrl_b_background_key(&ctrl_b));
+        assert!(!is_ctrl_b_background_key(&plain_b));
+        assert!(!is_ctrl_b_background_key(&ctrl_c));
+    }
+
+    #[test]
     fn bash_tool_completed_returns_foreground_status_to_thinking() {
         let mut bottom_pane = BottomPane::new();
         let mut status_indicator = status_indicator::StatusIndicator::new();
@@ -4920,6 +5072,59 @@ mod tests {
         assert!(
             bottom_pane.has_active_view(),
             "force-open must push the view onto the bottom pane stack"
+        );
+    }
+
+    struct NonBackgroundPane;
+
+    impl bottom_pane::view::BottomPaneView for NonBackgroundPane {
+        fn render(&self, _area: ratatui::layout::Rect, _buf: &mut ratatui::buffer::Buffer) {}
+
+        fn desired_height(&self, _width: u16) -> u16 {
+            1
+        }
+
+        fn handle_key(&mut self, _key: crossterm::event::KeyEvent) {}
+
+        fn cursor_pos(&self, _area: ratatui::layout::Rect) -> Option<(u16, u16)> {
+            None
+        }
+    }
+
+    #[tokio::test]
+    async fn force_open_background_task_view_preempts_existing_bottom_pane() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut registry =
+            crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("overlay"));
+        let mut bottom_pane = BottomPane::new();
+        bottom_pane.push_view(Box::new(NonBackgroundPane));
+
+        assert!(
+            !bottom_pane.accepts_background_task_rows(),
+            "test pane must model a non-background active pane"
+        );
+        assert!(
+            force_open_background_task_view(
+                &mut registry,
+                None,
+                &[],
+                &mut bottom_pane,
+                &FrameRequester::test_dummy(),
+            )
+            .await,
+            "background manager must open even when another bottom pane is active"
+        );
+        assert!(
+            bottom_pane.accepts_background_task_rows(),
+            "background manager must become the active pane"
+        );
+        assert!(
+            bottom_pane.close_active_view(),
+            "background manager should close normally"
+        );
+        assert!(
+            bottom_pane.has_active_view(),
+            "the previous pane should still be underneath the background manager"
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -822,20 +822,14 @@ pub(crate) async fn run_tui_session(
                             continue;
                         }
                         if is_background_task_manage_key(&key) && !bottom_pane.has_active_view() {
-                            if open_background_task_view(
+                            let _ = force_open_background_task_view(
                                 &mut background_registry,
                                 state.agent_spawner.as_ref(),
                                 &restored_local_agent_task_projections,
                                 &mut bottom_pane,
                                 &frame_requester,
                             )
-                            .await
-                            {
-                                continue;
-                            }
-                            chat_widget.commit_system(history_cell::system::SystemCell::info(
-                                "No background tasks to manage.",
-                            ));
+                            .await;
                             frame_requester.schedule_frame();
                             continue;
                         }
@@ -1767,25 +1761,23 @@ pub(crate) async fn run_tui_session(
                                                                 frame_requester.schedule_frame();
                                                                 continue;
                                                             }
+                                                            // Shift+↓ shares Ctrl+B's verb: "show me the background
+                                                            // panel". Always force-open so the user has a stable
+                                                            // surface to land on, even when the registry is briefly
+                                                            // empty (e.g. during bash detach handoff or while
+                                                            // task_output is blocking on stdout). Empty state
+                                                            // renders as "No background tasks." inside the view.
                                                             if is_background_task_manage_key(&k)
                                                                 && !bottom_pane.has_active_view()
                                                             {
-                                                                if open_background_task_view(
+                                                                let _ = force_open_background_task_view(
                                                                     &mut background_registry,
                                                                     agent_spawner_for_cancel.as_ref(),
                                                                     &restored_local_agent_task_projections,
                                                                     &mut bottom_pane,
                                                                     &frame_requester,
                                                                 )
-                                                                .await
-                                                                {
-                                                                    continue;
-                                                                }
-                                                                chat_widget.commit_system(
-                                                                    history_cell::system::SystemCell::info(
-                                                                        "No background tasks to manage."
-                                                                    ),
-                                                                );
+                                                                .await;
                                                                 frame_requester.schedule_frame();
                                                                 continue;
                                                             }
@@ -1802,88 +1794,31 @@ pub(crate) async fn run_tui_session(
                                                             // agent. If neither path is available, the key is
                                                             // explicitly unavailable and does not cancel the
                                                             // parent turn.
+                                                            // Ctrl+B is a single verb: "show me the background panel".
+                                                            // Side-effects (promote a backgroundable bash, promote a
+                                                            // foreground agent) compose with that verb; they never
+                                                            // replace it. The panel is always opened — even if the
+                                                            // registry is empty in this instant — so the user has
+                                                            // a stable surface to land on. There is no "unavailable"
+                                                            // path: any state is a renderable panel state.
                                                             if k.code == crossterm::event::KeyCode::Char('b')
                                                                 && k.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
                                                             {
-                                                                if bash_detach_request_pending {
-                                                                    chat_widget.commit_system(
-                                                                        history_cell::system::SystemCell::info(
-                                                                            "⏎ Backgrounding Bash... waiting for handoff."
-                                                                        ),
-                                                                    );
-                                                                    frame_requester.schedule_frame();
-                                                                    continue;
-                                                                }
-                                                                let visible_bash_is_running =
-                                                                    visible_bash_tool_is_running(
-                                                                        &status_indicator,
-                                                                    );
-                                                                let listener = bash_detach_listener.take();
-                                                                if let Some(listener) = listener {
-                                                                    if listener.is_active() {
-                                                                        if !background_registry.can_spawn_shell_task() {
-                                                                            bash_detach_listener = Some(listener);
-                                                                            chat_widget.commit_system(
-                                                                                history_cell::system::SystemCell::error(
-                                                                                    "⏎ Backgrounding unavailable: background shell task limit reached."
-                                                                                ),
-                                                                            );
-                                                                            frame_requester.schedule_frame();
-                                                                            continue;
-                                                                        }
-                                                                        // Fire the watch signal to request detach.
-                                                                        // Once signalled, this listener is single-use:
-                                                                        // the payload receiver is consumed below, so the
-                                                                        // runner must not restore the paired handle for a
-                                                                        // later bash invocation if handoff loses a race.
-                                                                        if listener.signal_tx.send(true).is_err() {
-                                                                            listener.retire();
-                                                                            *bash_detach_slot_for_ctrl_b.lock().await = None;
-                                                                            chat_widget.commit_system(
-                                                                                history_cell::system::SystemCell::error(
-                                                                                    "⏎ Backgrounding failed: active bash detach signal channel closed."
-                                                                                ),
-                                                                            );
-                                                                            set_bash_background_hint_enabled(
-                                                                                &mut chat_widget,
-                                                                                &mut status_indicator,
-                                                                                false,
-                                                                            );
-                                                                            frame_requester.schedule_frame();
-                                                                            continue;
-                                                                        }
+                                                                // Side-effect 1: detach an in-flight backgroundable bash.
+                                                                // Skipped if a detach is already mid-flight (handoff
+                                                                // pending) or if the registry is at the shell-task cap.
+                                                                let detach_fired = if !bash_detach_request_pending
+                                                                    && background_registry.can_spawn_shell_task()
+                                                                    && let Some(listener) = bash_detach_listener.take()
+                                                                {
+                                                                    if listener.is_active() && listener.signal_tx.send(true).is_ok() {
                                                                         listener.retire();
                                                                         bash_detach_request_pending = true;
-                                                                        let pending_title =
-                                                                            active_bash_description
-                                                                                .as_deref()
-                                                                                .unwrap_or("Bash");
                                                                         set_bash_background_hint_enabled(
                                                                             &mut chat_widget,
                                                                             &mut status_indicator,
                                                                             false,
                                                                         );
-                                                                        chat_widget.commit_system(
-                                                                            history_cell::system::SystemCell::info(
-                                                                                "⏎ Backgrounding Bash... waiting for handoff."
-                                                                            ),
-                                                                        );
-                                                                        let pending_rows = vec![
-                                                                            pending_bash_handoff_row(
-                                                                                pending_title,
-                                                                                0,
-                                                                            ),
-                                                                        ];
-                                                                        let _ = reveal_background_task_view_with_extra_rows(
-                                                                            &mut background_registry,
-                                                                            agent_spawner_for_cancel.as_ref(),
-                                                                            &restored_local_agent_task_projections,
-                                                                            &mut bottom_pane,
-                                                                            &frame_requester,
-                                                                            pending_rows,
-                                                                            Some(PENDING_BASH_HANDOFF_TASK_ID),
-                                                                        )
-                                                                        .await;
                                                                         let handoff_tx = bash_detach_handoff_tx.clone();
                                                                         tokio::spawn(async move {
                                                                             let result = match listener.payload_rx.await {
@@ -1895,69 +1830,78 @@ pub(crate) async fn run_tui_session(
                                                                             };
                                                                             let _ = handoff_tx.send(result);
                                                                         });
-                                                                        frame_requester.schedule_frame();
-                                                                        continue;
+                                                                        true
                                                                     } else {
+                                                                        // Inactive listener or closed signal channel:
+                                                                        // restore so a later bash can pick it up.
                                                                         bash_detach_listener = Some(listener);
+                                                                        false
                                                                     }
-                                                                }
-                                                                if let Some(spawner) =
-                                                                    agent_spawner_for_cancel.as_ref()
-                                                                {
-                                                                    if let Some(agent) = spawner
+                                                                } else {
+                                                                    false
+                                                                };
+
+                                                                // Side-effect 2: promote a foreground agent. Only
+                                                                // fires if no bash detach was triggered this press
+                                                                // (one promotion per Ctrl+B, never both).
+                                                                let mut promoted_agent_id: Option<String> = None;
+                                                                if !detach_fired
+                                                                    && let Some(spawner) = agent_spawner_for_cancel.as_ref()
+                                                                    && let Some(agent) = spawner
                                                                         .promote_foreground_agent_to_background(None)
                                                                         .await
-                                                                    {
-                                                                        chat_widget.commit_system(
-                                                                            history_cell::system::SystemCell::info(
-                                                                                ctrl_b_promoted_agent_message(
-                                                                                    &agent.agent_id,
-                                                                                    &agent.description,
-                                                                                ),
+                                                                {
+                                                                    chat_widget.commit_system(
+                                                                        history_cell::system::SystemCell::info(
+                                                                            ctrl_b_promoted_agent_message(
+                                                                                &agent.agent_id,
+                                                                                &agent.description,
                                                                             ),
-                                                                        );
-                                                                        let _ = reveal_background_task_view(
-                                                                            &mut background_registry,
-                                                                            agent_spawner_for_cancel.as_ref(),
-                                                                            &restored_local_agent_task_projections,
-                                                                            &mut bottom_pane,
-                                                                            &frame_requester,
-                                                                            Some(&agent.agent_id),
-                                                                        )
-                                                                        .await;
-                                                                        tui_cancel_token.cancel();
-                                                                        frame_requester.schedule_frame();
-                                                                        continue;
-                                                                    }
+                                                                        ),
+                                                                    );
+                                                                    promoted_agent_id = Some(agent.agent_id);
+                                                                    tui_cancel_token.cancel();
                                                                 }
-                                                                if !bottom_pane.has_active_view()
-                                                                    && open_background_task_view(
+
+                                                                // Always: open the panel. Empty registry renders as
+                                                                // "No background tasks." inside the view; a pending
+                                                                // bash handoff renders as a ghost row pinned to top.
+                                                                if detach_fired {
+                                                                    let pending_title = active_bash_description
+                                                                        .as_deref()
+                                                                        .unwrap_or("Bash");
+                                                                    let pending_rows = vec![
+                                                                        pending_bash_handoff_row(pending_title, 0),
+                                                                    ];
+                                                                    let _ = reveal_background_task_view_with_extra_rows(
+                                                                        &mut background_registry,
+                                                                        agent_spawner_for_cancel.as_ref(),
+                                                                        &restored_local_agent_task_projections,
+                                                                        &mut bottom_pane,
+                                                                        &frame_requester,
+                                                                        pending_rows,
+                                                                        Some(PENDING_BASH_HANDOFF_TASK_ID),
+                                                                    )
+                                                                    .await;
+                                                                } else if let Some(agent_id) = promoted_agent_id.as_deref() {
+                                                                    let _ = reveal_background_task_view(
+                                                                        &mut background_registry,
+                                                                        agent_spawner_for_cancel.as_ref(),
+                                                                        &restored_local_agent_task_projections,
+                                                                        &mut bottom_pane,
+                                                                        &frame_requester,
+                                                                        Some(agent_id),
+                                                                    )
+                                                                    .await;
+                                                                } else {
+                                                                    let _ = force_open_background_task_view(
                                                                         &mut background_registry,
                                                                         agent_spawner_for_cancel.as_ref(),
                                                                         &restored_local_agent_task_projections,
                                                                         &mut bottom_pane,
                                                                         &frame_requester,
                                                                     )
-                                                                    .await
-                                                                {
-                                                                    continue;
-                                                                }
-                                                                if bottom_pane.has_active_view() {
-                                                                    frame_requester.schedule_frame();
-                                                                    continue;
-                                                                }
-                                                                if visible_bash_is_running {
-                                                                    chat_widget.commit_system(
-                                                                        history_cell::system::SystemCell::info(
-                                                                            "⏎ Backgrounding unavailable: this Bash command is not attached to a backgroundable runner; Esc can stop it."
-                                                                        ),
-                                                                    );
-                                                                } else {
-                                                                    chat_widget.commit_system(
-                                                                        history_cell::system::SystemCell::info(
-                                                                            "⏎ Backgrounding unavailable: no active foreground bash or agent, and no background tasks to show."
-                                                                        ),
-                                                                    );
+                                                                    .await;
                                                                 }
                                                                 frame_requester.schedule_frame();
                                                                 continue;
@@ -2358,15 +2302,15 @@ pub(crate) async fn run_tui_session(
                                                                     continue;
                                                                 }
                                                             };
-                                                            chat_widget.commit_system(
-                                                                history_cell::system::SystemCell::info(
-                                                                    format!("⏎ Backgrounded as {id}. Opened background task details; S stop, Esc list, Q close.")
-                                                                ),
-                                                            );
                                                             let selected_id = id.clone();
                                                             let _ = chat_widget.mark_active_bash_backgrounded(
                                                                 active_bash_tool_use_id.as_deref(),
                                                                 selected_id.as_str(),
+                                                            );
+                                                            chat_widget.commit_system(
+                                                                history_cell::system::SystemCell::info(
+                                                                    format!("⏎ Backgrounded as {id}. Opened background task details; S stop, Esc list, Q close.")
+                                                                ),
                                                             );
                                                             set_bash_background_hint_enabled(
                                                                 &mut chat_widget,
@@ -4944,6 +4888,62 @@ mod tests {
             .bg_task_counts
             .expect("pending handoff row should surface footer counts");
         assert_eq!(counts.running, 1);
+    }
+
+    /// Regression: Ctrl+B must always land the user in the background panel,
+    /// even when the registry is empty in this instant. The trace this guards
+    /// against: bash detached → task_output blocking on stdout for ~30s →
+    /// user presses Ctrl+B → previously hit "Backgrounding unavailable" with
+    /// no escape hatch. Now an empty registry renders as "No background tasks."
+    /// inside the view, so the user always has a navigable surface.
+    #[tokio::test]
+    async fn force_open_background_task_view_opens_panel_on_empty_registry() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut registry =
+            crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("empty"));
+        let mut bottom_pane = BottomPane::new();
+
+        assert!(
+            force_open_background_task_view(
+                &mut registry,
+                None,
+                &[],
+                &mut bottom_pane,
+                &FrameRequester::test_dummy(),
+            )
+            .await,
+            "Ctrl+B must open the background panel even on an empty registry"
+        );
+        assert!(
+            bottom_pane.has_active_view(),
+            "force-open must push the view onto the bottom pane stack"
+        );
+    }
+
+    /// The non-force entrypoint must still fall through on an empty registry
+    /// so Ctrl+T can route to the task board instead of stealing the key.
+    #[tokio::test]
+    async fn open_background_task_view_falls_through_on_empty_registry() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut registry =
+            crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("empty2"));
+        let mut bottom_pane = BottomPane::new();
+
+        assert!(
+            !open_background_task_view(
+                &mut registry,
+                None,
+                &[],
+                &mut bottom_pane,
+                &FrameRequester::test_dummy(),
+            )
+            .await,
+            "Ctrl+T must yield when no actionable background tasks exist"
+        );
+        assert!(
+            !bottom_pane.has_active_view(),
+            "non-force open must not push the view on empty registries"
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -57,9 +57,9 @@ const DEFERRED_INPUT_APPLIED_PREFIX: &str = "__deferred_input_applied__:";
 fn ctrl_b_promoted_agent_message(agent_id: &str, description: &str) -> String {
     let description = description.trim();
     if description.is_empty() {
-        format!("Backgrounded agent {agent_id}. Opened background tasks.")
+        format!("Opened agent {agent_id} details")
     } else {
-        format!("Backgrounded agent {agent_id} ({description}). Opened background tasks.")
+        format!("Opened agent {agent_id} ({description}) details")
     }
 }
 
@@ -1871,7 +1871,7 @@ pub(crate) async fn run_tui_session(
                                                                         .await
                                                                 {
                                                                     chat_widget.commit_system(
-                                                                        history_cell::system::SystemCell::info(
+                                                                        history_cell::system::SystemCell::background_task(
                                                                             ctrl_b_promoted_agent_message(
                                                                                 &agent.agent_id,
                                                                                 &agent.description,
@@ -2390,8 +2390,8 @@ pub(crate) async fn run_tui_session(
                                                                 selected_id.as_str(),
                                                             );
                                                             chat_widget.commit_system(
-                                                                history_cell::system::SystemCell::info(
-                                                                    format!("⏎ Backgrounded as {id}. Opened background task details; S stop, Esc list, Q close.")
+                                                                history_cell::system::SystemCell::background_task(
+                                                                    format!("Opened {id} details · S stop · Esc list · Q close")
                                                                 ),
                                                             );
                                                             set_bash_background_hint_enabled(
@@ -3924,9 +3924,9 @@ mod tests {
     fn ctrl_b_promoted_agent_message_is_user_facing() {
         let message = ctrl_b_promoted_agent_message("reviewer@run-1", "review auth");
 
-        assert!(message.contains("Backgrounded agent reviewer@run-1"));
+        assert!(message.contains("Opened agent reviewer@run-1"));
         assert!(message.contains("review auth"));
-        assert!(message.contains("Opened background tasks"));
+        assert!(message.contains("details"));
         assert!(!message.contains("agent(action="), "{message}");
         assert!(!message.contains("task_output"), "{message}");
         assert!(!message.contains("job("), "{message}");

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -44,9 +44,11 @@ use super::agent_view::*;
 use super::bg_task_proxy::*;
 use super::bg_task_rendering::*;
 use super::plan_mode::*;
+#[cfg(test)]
+use super::status_line;
 use super::{
     bottom_pane, chat_widget, history_cell, mention_menu, resume_summary, slash_dispatch,
-    slash_menu, status_indicator, status_line, stream_bridge, task_board_observer, ui_adapter,
+    slash_menu, status_indicator, stream_bridge, task_board_observer, ui_adapter,
 };
 
 const AGENT_DRILLDOWN_RECENT_COMPLETED: usize = 5;
@@ -3505,14 +3507,7 @@ pub(crate) async fn run_tui_session(
                 // same typed rows used by the switcher. That keeps
                 // footer and list projection in lock-step as more
                 // task kinds land.
-                let bg_counts = status_line::BackgroundTaskCounts::from_rows(&rows_for_footer);
-                bottom_pane.footer.bg_task_counts = if bg_counts.is_empty() {
-                    None
-                } else {
-                    Some(bg_counts)
-                };
-                bottom_pane.footer.bg_fanout_summaries =
-                    status_line::BackgroundTaskFanoutSummary::from_rows(&rows_for_footer);
+                sync_background_task_footer_from_rows(&mut bottom_pane, &rows_for_footer);
 
                 task_board.maybe_refresh();
                 let snap = task_board.snapshot();

--- a/rust/crates/astra-cli/src/tui/history_cell/system.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/system.rs
@@ -20,7 +20,14 @@ use crate::tui::turn_event::{SystemLevel, TurnEvent};
 pub(crate) struct SystemCell {
     message: String,
     level: SystemLevel,
+    presentation: SystemPresentation,
     ts: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SystemPresentation {
+    Standard,
+    BackgroundTask,
 }
 
 impl SystemCell {
@@ -28,6 +35,16 @@ impl SystemCell {
         Self {
             message: message.into(),
             level: SystemLevel::Info,
+            presentation: SystemPresentation::Standard,
+            ts: None,
+        }
+    }
+
+    pub fn background_task(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            level: SystemLevel::Info,
+            presentation: SystemPresentation::BackgroundTask,
             ts: None,
         }
     }
@@ -43,6 +60,7 @@ impl SystemCell {
         Self {
             message: message.into(),
             level: SystemLevel::Response,
+            presentation: SystemPresentation::Standard,
             ts: None,
         }
     }
@@ -52,6 +70,7 @@ impl SystemCell {
         Self {
             message: message.into(),
             level: SystemLevel::Warning,
+            presentation: SystemPresentation::Standard,
             ts: None,
         }
     }
@@ -67,6 +86,7 @@ impl SystemCell {
         Self {
             message: humanize_error(raw.as_ref()),
             level: SystemLevel::Error,
+            presentation: SystemPresentation::Standard,
             ts: None,
         }
     }
@@ -84,6 +104,7 @@ impl SystemCell {
             TurnEvent::System { ts, level, text } => Some(Self {
                 message: text,
                 level,
+                presentation: SystemPresentation::Standard,
                 ts,
             }),
             _ => None,
@@ -101,31 +122,38 @@ impl SystemCell {
 
 impl HistoryCell for SystemCell {
     fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
-        let (prefix, label_style, body_style) = match self.level {
-            SystemLevel::Info => (
-                "ℹ Note · ",
-                Style::default()
-                    .fg(crate::tui::theme::current().dim)
-                    .add_modifier(ratatui::style::Modifier::DIM),
-                Style::default().fg(Color::Gray),
-            ),
-            SystemLevel::Response => (
-                "Result · ",
-                Style::default()
-                    .fg(crate::tui::theme::current().dim)
-                    .add_modifier(ratatui::style::Modifier::DIM),
+        let (prefix, label_style, body_style) = match self.presentation {
+            SystemPresentation::BackgroundTask => (
+                "↳ Background · ",
+                Style::default().cyan().bold(),
                 Style::default().fg(Color::White),
             ),
-            SystemLevel::Warning => (
-                "⚠ Warning · ",
-                Style::default().yellow().bold(),
-                Style::default().yellow(),
-            ),
-            SystemLevel::Error => (
-                "✖ Error · ",
-                Style::default().red().bold(),
-                Style::default().red(),
-            ),
+            SystemPresentation::Standard => match self.level {
+                SystemLevel::Info => (
+                    "ℹ Note · ",
+                    Style::default()
+                        .fg(crate::tui::theme::current().dim)
+                        .add_modifier(ratatui::style::Modifier::DIM),
+                    Style::default().fg(Color::Gray),
+                ),
+                SystemLevel::Response => (
+                    "Result · ",
+                    Style::default()
+                        .fg(crate::tui::theme::current().dim)
+                        .add_modifier(ratatui::style::Modifier::DIM),
+                    Style::default().fg(Color::White),
+                ),
+                SystemLevel::Warning => (
+                    "⚠ Warning · ",
+                    Style::default().yellow().bold(),
+                    Style::default().yellow(),
+                ),
+                SystemLevel::Error => (
+                    "✖ Error · ",
+                    Style::default().red().bold(),
+                    Style::default().red(),
+                ),
+            },
         };
         let continuation = "  ".to_string();
         self.message
@@ -244,6 +272,17 @@ mod tests {
     }
 
     #[test]
+    fn background_task_renders_dedicated_label() {
+        let cell =
+            SystemCell::background_task("Opened bg-shell-1 details · S stop · Esc list · Q close");
+        let out = render(&cell, 90, 1);
+
+        assert!(out.starts_with("↳ Background · "), "label missing: {out:?}");
+        assert!(out.contains("Opened bg-shell-1 details"), "{out}");
+        assert!(!out.contains("Note ·"), "{out}");
+    }
+
+    #[test]
     fn response_continuation_lines_hang_indent() {
         // Multi-line responses must keep the label only on row 0 and
         // align continuation lines under the body so the block reads
@@ -282,6 +321,7 @@ mod tests {
     fn persist_roundtrip_for_each_level() {
         for (mk, lv) in [
             (SystemCell::info("a") as SystemCell, SystemLevel::Info),
+            (SystemCell::background_task("bg"), SystemLevel::Info),
             (SystemCell::response("d"), SystemLevel::Response),
             (SystemCell::warning("b"), SystemLevel::Warning),
             (SystemCell::error("c"), SystemLevel::Error),

--- a/rust/crates/astra-cli/src/tui/history_cell/task.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/task.rs
@@ -227,9 +227,12 @@ impl HistoryCell for TaskCell {
         // Header.
         let task_label = "Task";
         let background_hint = if self.status == TaskStatus::Running && self.ctrl_b_background_hint {
-            " · Ctrl+B to background"
+            format!(
+                " · {} to background",
+                crate::tui::background_shortcut::ctrl_b_background_shortcut()
+            )
         } else {
-            ""
+            String::new()
         };
         let header = if self.status == TaskStatus::Running {
             let meta = format!(" · {}{}", self.elapsed_str(), background_hint);
@@ -592,7 +595,13 @@ mod tests {
         t.set_ctrl_b_background_hint(true);
         let out = render(&t, 48, 2);
 
-        assert!(out.contains("Ctrl+B to background"), "{out}");
+        assert!(
+            out.contains(&format!(
+                "{} to background",
+                crate::tui::background_shortcut::ctrl_b_background_shortcut()
+            )),
+            "{out}"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/history_cell/tool.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/tool.rs
@@ -96,6 +96,18 @@ impl ToolCell {
         self.ctrl_b_background_hint = enabled;
     }
 
+    pub fn complete_bash_backgrounded(&mut self, task_id: &str) {
+        if self.name != "bash" {
+            return;
+        }
+        self.status = ToolStatus::Success;
+        self.duration_ms = Some(self.started_at.elapsed().as_millis() as u64);
+        self.output_summary = Some(bash_backgrounded_summary(Some(task_id)));
+        self.output = None;
+        self.ctrl_b_background_hint = false;
+        self.frozen_at.stamp_now();
+    }
+
     /// Update mid-flight progress counters from a `ToolOutput`
     /// event. Monotonic by contract — callers pass cumulative
     /// values, so we clamp against regressions that could otherwise
@@ -120,7 +132,9 @@ impl ToolCell {
         output_summary: Option<String>,
         output: Option<String>,
     ) {
-        self.status = if tool_result_status_is_success(status_str) {
+        let bash_detached = self.name == "bash"
+            && bash_detached_marker_present(output_summary.as_deref(), output.as_deref());
+        self.status = if bash_detached || tool_result_status_is_success(status_str) {
             ToolStatus::Success
         } else {
             ToolStatus::Failed
@@ -129,8 +143,14 @@ impl ToolCell {
         if !description.is_empty() {
             self.description = description;
         }
-        self.output_summary = non_empty_tool_text(output_summary);
-        self.output = non_empty_tool_text(output);
+        if bash_detached {
+            self.output_summary = Some(bash_backgrounded_summary(None));
+            self.output = None;
+            self.ctrl_b_background_hint = false;
+        } else {
+            self.output_summary = non_empty_tool_text(output_summary);
+            self.output = non_empty_tool_text(output);
+        }
         self.ensure_failure_details();
         self.frozen_at.stamp_now();
     }
@@ -866,6 +886,22 @@ fn failure_detail_fallback(name: &str, description: &str) -> String {
     }
 }
 
+fn bash_detached_marker_present(output_summary: Option<&str>, output: Option<&str>) -> bool {
+    output_summary
+        .into_iter()
+        .chain(output)
+        .any(|text| text.contains("<bash_detached>"))
+}
+
+fn bash_backgrounded_summary(task_id: Option<&str>) -> String {
+    match task_id {
+        Some(task_id) if !task_id.trim().is_empty() => {
+            format!("Running in the background as {task_id} · Ctrl+B/Ctrl+T open")
+        }
+        _ => "Running in the background · Ctrl+B/Ctrl+T open".to_string(),
+    }
+}
+
 fn friendly_tool_display_name_for_context(name: &str, _description: &str) -> String {
     friendly_tool_display_name(name)
 }
@@ -1181,6 +1217,38 @@ mod tests {
         let out = render(&t, 100, 4);
         assert!(out.contains("Bash failed before returning output"), "{out}");
         assert!(!out.contains("No details returned"), "{out}");
+    }
+
+    #[test]
+    fn bash_detached_marker_renders_backgrounded_success() {
+        let mut t = ToolCell::new_running("bash", "$ make check");
+        t.complete(
+            "failed",
+            1200,
+            String::new(),
+            None,
+            Some("<bash_detached>The bash command was promoted.</bash_detached>".into()),
+        );
+        assert_eq!(t.status, ToolStatus::Success);
+        assert_eq!(
+            t.output_summary.as_deref(),
+            Some("Running in the background · Ctrl+B/Ctrl+T open")
+        );
+        let out = render(&t, 100, 4);
+        assert!(out.contains("Running in the background"), "{out}");
+        assert!(out.contains("Ctrl+B/Ctrl+T open"), "{out}");
+        assert!(!out.contains("failed before returning output"), "{out}");
+    }
+
+    #[test]
+    fn explicit_bash_backgrounded_summary_keeps_task_id() {
+        let mut t = ToolCell::new_running("bash", "$ make check");
+        t.complete_bash_backgrounded("bg-shell-7");
+        assert_eq!(t.status, ToolStatus::Success);
+        assert_eq!(
+            t.output_summary.as_deref(),
+            Some("Running in the background as bg-shell-7 · Ctrl+B/Ctrl+T open")
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/history_cell/tool.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/tool.rs
@@ -132,8 +132,12 @@ impl ToolCell {
         output_summary: Option<String>,
         output: Option<String>,
     ) {
+        let bash_detached_task_id = (self.name == "bash")
+            .then(|| bash_detached_task_id(output_summary.as_deref(), output.as_deref()))
+            .flatten();
         let bash_detached = self.name == "bash"
-            && bash_detached_marker_present(output_summary.as_deref(), output.as_deref());
+            && (bash_detached_task_id.is_some()
+                || bash_detached_marker_present(output_summary.as_deref(), output.as_deref()));
         self.status = if bash_detached || tool_result_status_is_success(status_str) {
             ToolStatus::Success
         } else {
@@ -144,7 +148,7 @@ impl ToolCell {
             self.description = description;
         }
         if bash_detached {
-            self.output_summary = Some(bash_backgrounded_summary(None));
+            self.output_summary = Some(bash_backgrounded_summary(bash_detached_task_id.as_deref()));
             self.output = None;
             self.ctrl_b_background_hint = false;
         } else {
@@ -896,6 +900,18 @@ fn bash_detached_marker_present(output_summary: Option<&str>, output: Option<&st
         .any(|text| text.contains("<bash_detached>"))
 }
 
+fn bash_detached_task_id(output_summary: Option<&str>, output: Option<&str>) -> Option<String> {
+    output_summary
+        .into_iter()
+        .chain(output)
+        .filter(|text| text.contains("<bash_detached>"))
+        .flat_map(|text| {
+            text.split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '-' || ch == '_'))
+        })
+        .find(|token| token.starts_with("bg-shell-"))
+        .map(str::to_string)
+}
+
 fn bash_backgrounded_summary(task_id: Option<&str>) -> String {
     let open_hint = crate::tui::background_shortcut::background_task_open_hint();
     match task_id {
@@ -1246,6 +1262,29 @@ mod tests {
             "{out}"
         );
         assert!(!out.contains("failed before returning output"), "{out}");
+    }
+
+    #[test]
+    fn bash_detached_marker_with_task_id_renders_task_id() {
+        let mut t = ToolCell::new_running("bash", "$ make check");
+        t.complete(
+            "success",
+            1200,
+            String::new(),
+            None,
+            Some(
+                "<bash_detached>The bash command was promoted to background task bg-shell-9.</bash_detached>"
+                    .into(),
+            ),
+        );
+        assert_eq!(t.status, ToolStatus::Success);
+        let expected = format!(
+            "Running in the background as bg-shell-9 · {}",
+            crate::tui::background_shortcut::background_task_open_hint()
+        );
+        assert_eq!(t.output_summary.as_deref(), Some(expected.as_str()));
+        let out = render(&t, 100, 4);
+        assert!(out.contains("bg-shell-9"), "{out}");
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/history_cell/tool.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/tool.rs
@@ -1258,7 +1258,7 @@ mod tests {
         let out = render(&t, 100, 4);
         assert!(out.contains("Running in the background"), "{out}");
         assert!(
-            out.contains(&crate::tui::background_shortcut::background_task_open_hint()),
+            out.contains(crate::tui::background_shortcut::background_task_open_hint()),
             "{out}"
         );
         assert!(!out.contains("failed before returning output"), "{out}");

--- a/rust/crates/astra-cli/src/tui/history_cell/tool.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/tool.rs
@@ -377,9 +377,12 @@ impl ToolCell {
         // Signal mode: show real counters when the tool actually
         // streamed something.
         let background_hint = if self.name == "bash" && self.ctrl_b_background_hint {
-            " · Ctrl+B to background"
+            format!(
+                " · {} to background",
+                crate::tui::background_shortcut::ctrl_b_background_shortcut()
+            )
         } else {
-            ""
+            String::new()
         };
         if self.progress_lines > 0 || self.progress_bytes > 0 {
             let body = format!(
@@ -894,11 +897,12 @@ fn bash_detached_marker_present(output_summary: Option<&str>, output: Option<&st
 }
 
 fn bash_backgrounded_summary(task_id: Option<&str>) -> String {
+    let open_hint = crate::tui::background_shortcut::background_task_open_hint();
     match task_id {
         Some(task_id) if !task_id.trim().is_empty() => {
-            format!("Running in the background as {task_id} · Ctrl+B/Ctrl+T open")
+            format!("Running in the background as {task_id} · {open_hint}")
         }
-        _ => "Running in the background · Ctrl+B/Ctrl+T open".to_string(),
+        _ => format!("Running in the background · {open_hint}"),
     }
 }
 
@@ -1230,13 +1234,17 @@ mod tests {
             Some("<bash_detached>The bash command was promoted.</bash_detached>".into()),
         );
         assert_eq!(t.status, ToolStatus::Success);
-        assert_eq!(
-            t.output_summary.as_deref(),
-            Some("Running in the background · Ctrl+B/Ctrl+T open")
+        let expected = format!(
+            "Running in the background · {}",
+            crate::tui::background_shortcut::background_task_open_hint()
         );
+        assert_eq!(t.output_summary.as_deref(), Some(expected.as_str()));
         let out = render(&t, 100, 4);
         assert!(out.contains("Running in the background"), "{out}");
-        assert!(out.contains("Ctrl+B/Ctrl+T open"), "{out}");
+        assert!(
+            out.contains(&crate::tui::background_shortcut::background_task_open_hint()),
+            "{out}"
+        );
         assert!(!out.contains("failed before returning output"), "{out}");
     }
 
@@ -1245,10 +1253,11 @@ mod tests {
         let mut t = ToolCell::new_running("bash", "$ make check");
         t.complete_bash_backgrounded("bg-shell-7");
         assert_eq!(t.status, ToolStatus::Success);
-        assert_eq!(
-            t.output_summary.as_deref(),
-            Some("Running in the background as bg-shell-7 · Ctrl+B/Ctrl+T open")
+        let expected = format!(
+            "Running in the background as bg-shell-7 · {}",
+            crate::tui::background_shortcut::background_task_open_hint()
         );
+        assert_eq!(t.output_summary.as_deref(), Some(expected.as_str()));
     }
 
     #[test]
@@ -1654,7 +1663,13 @@ mod tests {
         t.set_ctrl_b_background_hint(true);
         t.started_at = Instant::now() - std::time::Duration::from_secs(4);
         let out = render(&t, 100, 4);
-        assert!(out.contains("Ctrl+B to background"), "{out}");
+        assert!(
+            out.contains(&format!(
+                "{} to background",
+                crate::tui::background_shortcut::ctrl_b_background_shortcut()
+            )),
+            "{out}"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/mod.rs
+++ b/rust/crates/astra-cli/src/tui/mod.rs
@@ -7,6 +7,7 @@ mod agent_control_status;
 mod agent_view;
 mod app_event;
 pub(crate) mod approval;
+mod background_shortcut;
 pub(crate) mod background_tasks;
 mod bg_task_proxy;
 mod bg_task_rendering;

--- a/rust/crates/astra-cli/src/tui/status_indicator.rs
+++ b/rust/crates/astra-cli/src/tui/status_indicator.rs
@@ -74,6 +74,7 @@ impl Default for IndicatorState {
 #[derive(Debug, Default)]
 pub(crate) struct StatusIndicator {
     state: IndicatorState,
+    bash_background_hint_enabled: bool,
     /// Per-turn streamed-char count (for the `↓ 5.1k tokens`
     /// counter). Reset on each new turn.
     stream_chars: u64,
@@ -107,6 +108,10 @@ impl StatusIndicator {
         &self.state
     }
 
+    pub fn set_bash_background_hint_enabled(&mut self, enabled: bool) {
+        self.bash_background_hint_enabled = enabled;
+    }
+
     pub fn set_state(&mut self, state: IndicatorState) {
         // The stream counter resets across state changes only when
         // entering a *brand new turn*. Within a turn, tool ↔ thinking
@@ -117,6 +122,7 @@ impl StatusIndicator {
             self.stream_chars = 0;
             self.turn_started_at = None;
             self.turn_label = None;
+            self.bash_background_hint_enabled = false;
         } else if self.turn_started_at.is_none() {
             // Auto-start a turn when transitioning out of Idle. Lets
             // existing callers that drive `set_state(Thinking{...})`
@@ -159,12 +165,13 @@ impl StatusIndicator {
     /// clock without mocking `Instant`. Production callers use
     /// `render()`.
     pub fn render_at(&self, now: Instant) -> Option<Line<'static>> {
-        render_for(
+        render_for_with_bash_hint(
             &self.state,
             self.stream_chars,
             self.turn_started_at,
             self.turn_label,
             now,
+            self.bash_background_hint_enabled,
         )
     }
 }
@@ -179,6 +186,17 @@ fn render_for(
     turn_started_at: Option<Instant>,
     turn_label: Option<&'static str>,
     now: Instant,
+) -> Option<Line<'static>> {
+    render_for_with_bash_hint(state, stream_chars, turn_started_at, turn_label, now, false)
+}
+
+fn render_for_with_bash_hint(
+    state: &IndicatorState,
+    stream_chars: u64,
+    turn_started_at: Option<Instant>,
+    turn_label: Option<&'static str>,
+    now: Instant,
+    bash_background_hint_enabled: bool,
 ) -> Option<Line<'static>> {
     if !state.is_active() {
         return None;
@@ -220,7 +238,14 @@ fn render_for(
 
     let mut spans = vec![Span::styled(format!("{} ", star_frame(now)), star_style)];
     spans.extend(label_spans(label, label_style, now));
-    let suffix = suffix(state, elapsed, stream_chars, thought_for, activity);
+    let suffix = suffix(
+        state,
+        elapsed,
+        stream_chars,
+        thought_for,
+        activity,
+        bash_background_hint_enabled,
+    );
     if !suffix.is_empty() {
         spans.push(Span::styled(format!(" {suffix}"), dim));
     }
@@ -295,6 +320,7 @@ fn suffix(
     stream_chars: u64,
     thought_for: Option<Duration>,
     activity: Option<&str>,
+    bash_background_hint_enabled: bool,
 ) -> String {
     let mut parts: Vec<String> = Vec::new();
     if let Some(activity) = activity {
@@ -313,6 +339,11 @@ fn suffix(
         && streamed_tokens >= TOKEN_COUNT_VISIBILITY_THRESHOLD
     {
         parts.push(format!("{} tokens", fmt_tokens(streamed_tokens)));
+    }
+    if bash_background_hint_enabled
+        && matches!(state, IndicatorState::Tool { name, .. } if name == "bash")
+    {
+        parts.push("Ctrl+B to background".into());
     }
     parts.push("Esc to stop".into());
     parts.join(" · ")
@@ -521,6 +552,28 @@ mod tests {
         let line = render_for(&state, 0, None, None, t0 + Duration::from_secs(1)).unwrap();
         let text = text_of(&line);
         assert!(text.contains("Bash"));
+    }
+
+    #[test]
+    fn bash_tool_can_surface_ctrl_b_hint() {
+        let t0 = Instant::now();
+        let mut s = StatusIndicator::new();
+        s.set_state(IndicatorState::Tool {
+            name: "bash".into(),
+            started_at: t0,
+        });
+        s.set_bash_background_hint_enabled(true);
+
+        let text = text_of(&s.render_at(t0 + Duration::from_secs(18)).unwrap());
+        assert!(text.contains("Bash"), "{text}");
+        assert!(text.contains("Ctrl+B to background"), "{text}");
+        assert!(text.contains("Esc to stop"), "{text}");
+
+        s.set_state(IndicatorState::Idle);
+        assert!(
+            !s.bash_background_hint_enabled,
+            "idle transition must clear stale Ctrl+B affordance"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/tui/status_indicator.rs
+++ b/rust/crates/astra-cli/src/tui/status_indicator.rs
@@ -118,11 +118,20 @@ impl StatusIndicator {
         // transitions preserve `stream_chars` so `↓ Nk tokens` keeps
         // climbing instead of flashing back to 0 each time the model
         // fires a tool. `begin_turn` is the explicit reset point.
+        // The Ctrl+B hint is bash-tool-scoped — drop it on any state
+        // that isn't a bash tool so a stale flag can't render under
+        // a different tool or thinking state.
+        let entering_bash_tool = matches!(
+            &state,
+            IndicatorState::Tool { name, .. } if name == "bash"
+        );
+        if !entering_bash_tool {
+            self.bash_background_hint_enabled = false;
+        }
         if matches!(state, IndicatorState::Idle) {
             self.stream_chars = 0;
             self.turn_started_at = None;
             self.turn_label = None;
-            self.bash_background_hint_enabled = false;
         } else if self.turn_started_at.is_none() {
             // Auto-start a turn when transitioning out of Idle. Lets
             // existing callers that drive `set_state(Thinking{...})`
@@ -582,6 +591,47 @@ mod tests {
         assert!(
             !s.bash_background_hint_enabled,
             "idle transition must clear stale Ctrl+B affordance"
+        );
+    }
+
+    /// Bash-only hint state must not survive a transition to any other
+    /// indicator state — even within the same turn. Without this guard,
+    /// a bash → read_file transition would leave `bash_background_hint`
+    /// flipped to true, and any future renderer that forgets to gate on
+    /// `IndicatorState::Tool { name == "bash" }` would draw the Ctrl+B
+    /// affordance under an unrelated tool. Better to drop the flag at
+    /// the source.
+    #[test]
+    fn non_bash_state_transition_clears_ctrl_b_hint() {
+        let t0 = Instant::now();
+        let mut s = StatusIndicator::new();
+        s.set_state(IndicatorState::Tool {
+            name: "bash".into(),
+            started_at: t0,
+        });
+        s.set_bash_background_hint_enabled(true);
+        assert!(s.bash_background_hint_enabled);
+
+        // bash → another tool: hint must drop.
+        s.set_state(IndicatorState::Tool {
+            name: "read_file".into(),
+            started_at: t0,
+        });
+        assert!(
+            !s.bash_background_hint_enabled,
+            "non-bash tool transition must clear stale Ctrl+B affordance"
+        );
+
+        // re-arming, then bash → thinking must also drop.
+        s.set_state(IndicatorState::Tool {
+            name: "bash".into(),
+            started_at: t0,
+        });
+        s.set_bash_background_hint_enabled(true);
+        s.set_state(IndicatorState::Thinking { started_at: t0 });
+        assert!(
+            !s.bash_background_hint_enabled,
+            "bash → thinking must clear stale Ctrl+B affordance"
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/status_indicator.rs
+++ b/rust/crates/astra-cli/src/tui/status_indicator.rs
@@ -343,7 +343,10 @@ fn suffix(
     if bash_background_hint_enabled
         && matches!(state, IndicatorState::Tool { name, .. } if name == "bash")
     {
-        parts.push("Ctrl+B to background".into());
+        parts.push(format!(
+            "{} to background",
+            crate::tui::background_shortcut::ctrl_b_background_shortcut()
+        ));
     }
     parts.push("Esc to stop".into());
     parts.join(" · ")
@@ -566,7 +569,13 @@ mod tests {
 
         let text = text_of(&s.render_at(t0 + Duration::from_secs(18)).unwrap());
         assert!(text.contains("Bash"), "{text}");
-        assert!(text.contains("Ctrl+B to background"), "{text}");
+        assert!(
+            text.contains(&format!(
+                "{} to background",
+                crate::tui::background_shortcut::ctrl_b_background_shortcut()
+            )),
+            "{text}"
+        );
         assert!(text.contains("Esc to stop"), "{text}");
 
         s.set_state(IndicatorState::Idle);

--- a/rust/crates/astra-cli/src/tui/status_line/line.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/line.rs
@@ -354,8 +354,9 @@ fn background_task_count_parts(counts: BackgroundTaskCounts) -> Vec<String> {
 
 fn background_task_chip_text(counts: BackgroundTaskCounts) -> String {
     format!(
-        "BG {} · Ctrl+B/Ctrl+T open",
-        background_task_count_parts(counts).join(" · ")
+        "BG {} · {}",
+        background_task_count_parts(counts).join(" · "),
+        crate::tui::background_shortcut::background_task_open_hint()
     )
 }
 

--- a/rust/crates/astra-cli/src/tui/status_line/line.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/line.rs
@@ -354,10 +354,22 @@ fn background_task_count_parts(counts: BackgroundTaskCounts) -> Vec<String> {
 
 fn background_task_chip_text(counts: BackgroundTaskCounts) -> String {
     format!(
-        "BG {} · {}",
+        "Background · {} · {}",
         background_task_count_parts(counts).join(" · "),
         crate::tui::background_shortcut::background_task_open_hint()
     )
+}
+
+fn background_task_chip_style(counts: BackgroundTaskCounts) -> Style {
+    if counts.failed_total() > 0 {
+        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+    } else if counts.waiting > 0 || counts.unavailable_total() > 0 {
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Cyan)
+    }
 }
 
 /// Threshold below which the budget chip is dim, above which it warns.
@@ -440,15 +452,10 @@ impl StatusLine {
         if let Some(counts) = ctx.bg_task_counts
             && !counts.is_empty()
         {
-            let style = if counts.failed_total() > 0 {
-                Style::default().fg(Color::Red)
-            } else if counts.waiting > 0 {
-                Style::default().fg(Color::Yellow)
-            } else {
-                muted
-            };
-            out.left
-                .push(Segment::styled(background_task_chip_text(counts), style));
+            out.left.push(Segment::styled(
+                background_task_chip_text(counts),
+                background_task_chip_style(counts),
+            ));
         }
 
         for summary in &ctx.bg_fanout_summaries {

--- a/rust/crates/astra-cli/src/tui/status_line/line.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/line.rs
@@ -434,6 +434,36 @@ impl StatusLine {
             }
         }
 
+        // Background tasks are active work the user may need to revisit while
+        // the foreground turn continues. Keep this before lower-priority
+        // per-turn chips so standard-width terminals do not hide it first.
+        if let Some(counts) = ctx.bg_task_counts
+            && !counts.is_empty()
+        {
+            let style = if counts.failed_total() > 0 {
+                Style::default().fg(Color::Red)
+            } else if counts.waiting > 0 {
+                Style::default().fg(Color::Yellow)
+            } else {
+                muted
+            };
+            out.left
+                .push(Segment::styled(background_task_chip_text(counts), style));
+        }
+
+        for summary in &ctx.bg_fanout_summaries {
+            out.left.push(Segment::styled(
+                summary.text(),
+                Style::default().fg(if summary.failed > 0 {
+                    Color::Red
+                } else if summary.unavailable > 0 {
+                    Color::Yellow
+                } else {
+                    Color::Magenta
+                }),
+            ));
+        }
+
         if ctx.pending_approvals > 0 {
             let text = if ctx.pending_approvals == 1 {
                 "⏸ 1 pending".to_string()
@@ -464,36 +494,6 @@ impl StatusLine {
                 };
                 out.left.push(Segment::styled(text, style));
             }
-        }
-
-        for summary in &ctx.bg_fanout_summaries {
-            out.left.push(Segment::styled(
-                summary.text(),
-                Style::default().fg(if summary.failed > 0 {
-                    Color::Red
-                } else if summary.unavailable > 0 {
-                    Color::Yellow
-                } else {
-                    Color::Magenta
-                }),
-            ));
-        }
-
-        // BackgroundTaskRegistry chip. Running tasks are informational;
-        // needs-input/failed tasks are attention states and stay visible
-        // even after no shell is making forward progress.
-        if let Some(counts) = ctx.bg_task_counts
-            && !counts.is_empty()
-        {
-            let style = if counts.failed_total() > 0 {
-                Style::default().fg(Color::Red)
-            } else if counts.waiting > 0 {
-                Style::default().fg(Color::Yellow)
-            } else {
-                muted
-            };
-            out.left
-                .push(Segment::styled(background_task_chip_text(counts), style));
         }
 
         // ── Right: cwd · budget · branch · cost ────────────────────

--- a/rust/crates/astra-cli/src/tui/status_line/line.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/line.rs
@@ -352,6 +352,13 @@ fn background_task_count_parts(counts: BackgroundTaskCounts) -> Vec<String> {
     parts
 }
 
+fn background_task_chip_text(counts: BackgroundTaskCounts) -> String {
+    format!(
+        "BG {} · Ctrl+B/Ctrl+T open",
+        background_task_count_parts(counts).join(" · ")
+    )
+}
+
 /// Threshold below which the budget chip is dim, above which it warns.
 const BUDGET_WARN_PERCENT: f32 = 75.0;
 const BUDGET_ERROR_PERCENT: f32 = 90.0;
@@ -477,7 +484,6 @@ impl StatusLine {
         if let Some(counts) = ctx.bg_task_counts
             && !counts.is_empty()
         {
-            let parts = background_task_count_parts(counts);
             let style = if counts.failed_total() > 0 {
                 Style::default().fg(Color::Red)
             } else if counts.waiting > 0 {
@@ -485,7 +491,8 @@ impl StatusLine {
             } else {
                 muted
             };
-            out.left.push(Segment::styled(parts.join(" · "), style));
+            out.left
+                .push(Segment::styled(background_task_chip_text(counts), style));
         }
 
         // ── Right: cwd · budget · branch · cost ────────────────────

--- a/rust/crates/astra-cli/src/tui/status_line/tests.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/tests.rs
@@ -582,6 +582,12 @@ fn bg_running_only_renders_count() {
         !plain.contains("needs input"),
         "needs-input segment must hide when 0; got {plain:?}"
     );
+    let chip = StatusLine::from_context(&c)
+        .left
+        .into_iter()
+        .find(|seg| seg.text.contains("Background"))
+        .expect("running background chip must render");
+    assert_eq!(chip.style.fg, Some(ratatui::style::Color::Cyan));
 }
 
 #[test]
@@ -641,7 +647,7 @@ fn bg_stalled_only_chip_uses_yellow_for_attention() {
     assert_eq!(
         chip.text,
         format!(
-            "BG 2 need input · {}",
+            "Background · 2 need input · {}",
             crate::tui::background_shortcut::background_task_open_hint()
         ),
         "stalled-only chip should be an attention state, not a vague background label"
@@ -673,7 +679,7 @@ fn bg_failed_only_chip_uses_red_attention() {
     assert_eq!(
         chip.text,
         format!(
-            "BG 1 shell failed · {}",
+            "Background · 1 shell failed · {}",
             crate::tui::background_shortcut::background_task_open_hint()
         )
     );
@@ -749,7 +755,7 @@ fn bg_footer_stays_discoverable_during_active_foreground_turn() {
     let plain = StatusLine::from_context(&c).plain();
     let open_hint = crate::tui::background_shortcut::background_task_open_hint();
     assert!(
-        plain.contains("BG 1 shell"),
+        plain.contains("Background · 1 shell"),
         "foreground activity must not hide running background tasks; got {plain:?}"
     );
     assert!(
@@ -784,7 +790,7 @@ fn bg_footer_survives_standard_width_compaction() {
         .map(|x| buf[(x, 0)].symbol().to_string())
         .collect();
     assert!(
-        rendered.contains("BG 1 shell"),
+        rendered.contains("Background"),
         "standard-width footer must keep background tasks discoverable; got {rendered:?}"
     );
 }

--- a/rust/crates/astra-cli/src/tui/status_line/tests.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/tests.rs
@@ -571,6 +571,10 @@ fn bg_running_only_renders_count() {
         "running-only chip must show count; got {plain:?}"
     );
     assert!(
+        plain.contains("Ctrl+B/Ctrl+T open"),
+        "running background tasks must expose the foreground switcher shortcut; got {plain:?}"
+    );
+    assert!(
         !plain.contains("background commands"),
         "chip must use typed task vocabulary; got {plain:?}"
     );
@@ -635,7 +639,7 @@ fn bg_stalled_only_chip_uses_yellow_for_attention() {
         .find(|seg| seg.text.contains("need input"))
         .expect("bg chip must render even when only stalled (the model needs to know)");
     assert_eq!(
-        chip.text, "2 need input",
+        chip.text, "BG 2 need input · Ctrl+B/Ctrl+T open",
         "stalled-only chip should be an attention state, not a vague background label"
     );
     assert_eq!(
@@ -662,7 +666,7 @@ fn bg_failed_only_chip_uses_red_attention() {
         .iter()
         .find(|seg| seg.text.contains("failed"))
         .expect("failed bg shell must stay visible as an attention state");
-    assert_eq!(chip.text, "1 shell failed");
+    assert_eq!(chip.text, "BG 1 shell failed · Ctrl+B/Ctrl+T open");
     assert_eq!(chip.style.fg, Some(ratatui::style::Color::Red));
 }
 

--- a/rust/crates/astra-cli/src/tui/status_line/tests.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/tests.rs
@@ -571,7 +571,7 @@ fn bg_running_only_renders_count() {
         "running-only chip must show count; got {plain:?}"
     );
     assert!(
-        plain.contains(&crate::tui::background_shortcut::background_task_open_hint()),
+        plain.contains(crate::tui::background_shortcut::background_task_open_hint()),
         "running background tasks must expose the foreground switcher shortcut; got {plain:?}"
     );
     assert!(
@@ -753,7 +753,7 @@ fn bg_footer_stays_discoverable_during_active_foreground_turn() {
         "foreground activity must not hide running background tasks; got {plain:?}"
     );
     assert!(
-        plain.contains(&open_hint),
+        plain.contains(open_hint),
         "footer must tell the user how to open/switch to background tasks; got {plain:?}"
     );
 }

--- a/rust/crates/astra-cli/src/tui/status_line/tests.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/tests.rs
@@ -571,7 +571,7 @@ fn bg_running_only_renders_count() {
         "running-only chip must show count; got {plain:?}"
     );
     assert!(
-        plain.contains("Ctrl+B/Ctrl+T open"),
+        plain.contains(&crate::tui::background_shortcut::background_task_open_hint()),
         "running background tasks must expose the foreground switcher shortcut; got {plain:?}"
     );
     assert!(
@@ -639,7 +639,11 @@ fn bg_stalled_only_chip_uses_yellow_for_attention() {
         .find(|seg| seg.text.contains("need input"))
         .expect("bg chip must render even when only stalled (the model needs to know)");
     assert_eq!(
-        chip.text, "BG 2 need input · Ctrl+B/Ctrl+T open",
+        chip.text,
+        format!(
+            "BG 2 need input · {}",
+            crate::tui::background_shortcut::background_task_open_hint()
+        ),
         "stalled-only chip should be an attention state, not a vague background label"
     );
     assert_eq!(
@@ -666,7 +670,13 @@ fn bg_failed_only_chip_uses_red_attention() {
         .iter()
         .find(|seg| seg.text.contains("failed"))
         .expect("failed bg shell must stay visible as an attention state");
-    assert_eq!(chip.text, "BG 1 shell failed · Ctrl+B/Ctrl+T open");
+    assert_eq!(
+        chip.text,
+        format!(
+            "BG 1 shell failed · {}",
+            crate::tui::background_shortcut::background_task_open_hint()
+        )
+    );
     assert_eq!(chip.style.fg, Some(ratatui::style::Color::Red));
 }
 

--- a/rust/crates/astra-cli/src/tui/status_line/tests.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/tests.rs
@@ -736,6 +736,29 @@ fn bg_footer_names_two_task_kinds_explicitly() {
 }
 
 #[test]
+fn bg_footer_stays_discoverable_during_active_foreground_turn() {
+    let c = StatusContext {
+        turn_active: true,
+        current_objective: Some("Waiting for next tool".into()),
+        bg_task_counts: Some(BackgroundTaskCounts {
+            running: 1,
+            ..BackgroundTaskCounts::default()
+        }),
+        ..ctx()
+    };
+    let plain = StatusLine::from_context(&c).plain();
+    let open_hint = crate::tui::background_shortcut::background_task_open_hint();
+    assert!(
+        plain.contains("BG 1 shell"),
+        "foreground activity must not hide running background tasks; got {plain:?}"
+    );
+    assert!(
+        plain.contains(&open_hint),
+        "footer must tell the user how to open/switch to background tasks; got {plain:?}"
+    );
+}
+
+#[test]
 fn bg_footer_collapses_three_or_more_task_kinds() {
     let c = StatusContext {
         bg_task_counts: Some(BackgroundTaskCounts {

--- a/rust/crates/astra-cli/src/tui/status_line/tests.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/tests.rs
@@ -759,6 +759,37 @@ fn bg_footer_stays_discoverable_during_active_foreground_turn() {
 }
 
 #[test]
+fn bg_footer_survives_standard_width_compaction() {
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+
+    let c = StatusContext {
+        model: Some("deepseek-v4-pro-overlong-thinking-model".into()),
+        permission_mode: PermissionMode::Auto,
+        pending_approvals: 2,
+        task_counts: Some((3, 5)),
+        bg_task_counts: Some(BackgroundTaskCounts {
+            running: 1,
+            ..BackgroundTaskCounts::default()
+        }),
+        cwd: Some("~/github/astra".into()),
+        git_branch: Some("fix-ctrl-b-background-fallback".into()),
+        ..ctx()
+    };
+    let status = StatusLine::from_context(&c);
+    let area = Rect::new(0, 0, 80, 1);
+    let mut buf = Buffer::empty(area);
+    status.render(area, &mut buf);
+    let rendered: String = (0..area.width)
+        .map(|x| buf[(x, 0)].symbol().to_string())
+        .collect();
+    assert!(
+        rendered.contains("BG 1 shell"),
+        "standard-width footer must keep background tasks discoverable; got {rendered:?}"
+    );
+}
+
+#[test]
 fn bg_footer_collapses_three_or_more_task_kinds() {
     let c = StatusContext {
         bg_task_counts: Some(BackgroundTaskCounts {

--- a/rust/crates/astra-tools/src/detach.rs
+++ b/rust/crates/astra-tools/src/detach.rs
@@ -12,9 +12,12 @@
 //! Single-shot semantics: each bash invocation gets at most one
 //! detach signal. The signal carries no data; the bash runner sends
 //! the payload back through the [`tokio::sync::oneshot`] reply
-//! channel embedded in [`DetachShellHandle`]. After detach the bash
-//! runner returns a marker `ToolResult` so the LLM sees the
-//! invocation ended via background promotion rather than completion.
+//! channel embedded in [`DetachShellHandle`]. The TUI adopts the
+//! payload into its background registry, then acknowledges the
+//! concrete task id through the payload's adoption channel. After
+//! detach the bash runner returns a marker `ToolResult` with that
+//! concrete task id so the LLM sees the invocation ended via
+//! background promotion rather than completion.
 //!
 //! All types are `Send + 'static` so they cross the runtime/tool
 //! boundary without lifetime gymnastics.
@@ -40,6 +43,10 @@ pub struct DetachedShellPayload {
     pub command: String,
     pub partial_stdout: String,
     pub partial_stderr: String,
+    /// TUI adoption acknowledgement. The bash runner waits for this
+    /// after handing off the child so its ToolResult can include the
+    /// real background task id in the current turn.
+    pub adoption_tx: oneshot::Sender<Result<String, String>>,
 }
 
 /// One-shot handle the bash runner uses to observe a detach request
@@ -201,6 +208,7 @@ mod tests {
             .take()
             .expect("sender available");
 
+        let (adoption_tx, adoption_rx) = tokio::sync::oneshot::channel();
         let payload = DetachedShellPayload {
             child,
             stdout,
@@ -208,6 +216,7 @@ mod tests {
             command: "printf hello; sleep 0.1".into(),
             partial_stdout: "hel".into(),
             partial_stderr: String::new(),
+            adoption_tx,
         };
         if sender.send(payload).is_err() {
             panic!("send payload failed");
@@ -216,5 +225,13 @@ mod tests {
         let received = listener.payload_rx.await.expect("recv payload");
         assert_eq!(received.command, "printf hello; sleep 0.1");
         assert_eq!(received.partial_stdout, "hel");
+        received
+            .adoption_tx
+            .send(Ok("bg-shell-test".into()))
+            .expect("ack adoption");
+        assert_eq!(
+            adoption_rx.await.expect("adoption rx"),
+            Ok("bg-shell-test".into())
+        );
     }
 }

--- a/rust/crates/astra-tools/src/detach.rs
+++ b/rust/crates/astra-tools/src/detach.rs
@@ -24,9 +24,162 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
+
+/// Maximum wall-clock the bash runner waits for the TUI to acknowledge
+/// adoption of a detached child after the payload has been handed off
+/// through `payload_tx`. Adoption is in-process and normally completes
+/// in well under 100 ms, but the TUI may be parked draining a backlog
+/// of events. 30 s gives enough headroom that a transient stall does
+/// not surface as a "host did not acknowledge adoption in time" error
+/// while still bounding the bash tool call so it cannot hang forever.
+pub const ADOPTION_ACK_WAIT: Duration = Duration::from_secs(30);
+
+/// Soft threshold above which the bash runner emits a warning that the
+/// TUI took longer than expected to acknowledge adoption. Useful as a
+/// canary for inner-tick starvation; below the [`ADOPTION_ACK_WAIT`]
+/// hard ceiling, no error is raised.
+pub const ADOPTION_ACK_SLOW_WARN: Duration = Duration::from_secs(1);
+
+/// Render the model-facing marker the bash tool returns after a
+/// successful detach. Encodes the anti-polling contract: the runtime
+/// will deliver a `<task_notification>` when the task terminates, and
+/// the model must end its turn instead of polling `task_output` or
+/// rerunning the command.
+pub fn render_bash_detached_marker(task_id: &str) -> String {
+    format!(
+        "<bash_detached>The bash command was promoted to background task {task_id}. \
+         The runtime will deliver a <task_notification> when the task terminates — \
+         end your turn now and let the user drive next steps. \
+         Do NOT poll: do not call `task_output`, do not rerun the bash command, \
+         and do not read the on-disk output files via bash (tail/cat/head/less are denied). \
+         If the user explicitly asks for partial progress, call `task_output` ONCE with \
+         block=false; if they ask you to wait, use `task_output` with block=true. \
+         Use `task_stop` only when the user wants the task cancelled.\
+         </bash_detached>"
+    )
+}
+
+/// Race-free check for the watch::Receiver that observes the TUI's
+/// `signal_tx.send(true)`. Returns `true` exactly once when the
+/// detach signal has been observed, drops the receiver if the
+/// sender has been closed, and is a no-op otherwise. Both bash
+/// runners share this so their detach windows agree byte-for-byte
+/// on what counts as "the user pressed Ctrl+B during this command".
+pub fn detach_signal_observed(signal_rx: &mut Option<watch::Receiver<bool>>) -> bool {
+    enum SignalState {
+        Observed,
+        NotObserved,
+        Disconnected,
+    }
+
+    let state = if let Some(rx) = signal_rx.as_mut() {
+        match rx.has_changed() {
+            Ok(true) if *rx.borrow_and_update() => SignalState::Observed,
+            Ok(_) => SignalState::NotObserved,
+            Err(_) => SignalState::Disconnected,
+        }
+    } else {
+        return false;
+    };
+
+    match state {
+        SignalState::Observed => true,
+        SignalState::NotObserved => false,
+        SignalState::Disconnected => {
+            *signal_rx = None;
+            false
+        }
+    }
+}
+
+/// Restore a watch::Receiver back into the handle so a later bash in
+/// the same turn can observe a fresh detach signal. Idempotent: a
+/// `None` receiver is a no-op.
+pub async fn restore_detach_signal_receiver(
+    detach: &DetachShellHandle,
+    signal_rx: Option<watch::Receiver<bool>>,
+) {
+    if let Some(signal_rx) = signal_rx {
+        *detach.signal_rx.lock().await = Some(signal_rx);
+    }
+}
+
+/// SIGKILL a child's process group (when spawned with `process_group(0)`)
+/// and reap. Best-effort on Unix; falls back to `child.kill()` elsewhere.
+/// Centralized here so both bash runners terminate detached payloads
+/// the same way on adoption failure.
+pub async fn sigkill_process_group(child: &mut tokio::process::Child) {
+    #[cfg(unix)]
+    {
+        if let Some(pid) = child.id() {
+            if let Ok(raw) = i32::try_from(pid) {
+                let pgid = nix::unistd::Pid::from_raw(raw);
+                let _ = nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGKILL);
+            } else {
+                tracing::warn!(
+                    pid,
+                    "sigkill_process_group: PID exceeds i32::MAX, skipping killpg"
+                );
+            }
+        }
+    }
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
+
+/// SIGKILL the live child carried in a [`DetachedShellPayload`]. Used
+/// when the TUI dropped the listener or the registry refused adoption,
+/// so the runtime cannot leave an orphaned process behind.
+pub async fn terminate_detached_payload(mut payload: Box<DetachedShellPayload>) {
+    sigkill_process_group(&mut payload.child).await;
+}
+
+/// Outcome of waiting for the TUI's adoption acknowledgement on the
+/// `adoption_tx` channel inside [`DetachedShellPayload`]. The runner
+/// turns these into ToolResult variants.
+pub enum AdoptionAckOutcome {
+    /// TUI returned a concrete background task id (`bg-shell-N`).
+    Adopted { task_id: String, waited: Duration },
+    /// TUI tried to adopt but the registry refused (e.g. cap reached).
+    Refused(String),
+    /// TUI dropped the ack sender without responding.
+    SenderDropped,
+    /// `ADOPTION_ACK_WAIT` elapsed without a reply.
+    TimedOut,
+}
+
+/// Wait for the TUI's adoption acknowledgement. Bounded by
+/// [`ADOPTION_ACK_WAIT`]; logs a `tracing::warn!` if the wait crossed
+/// [`ADOPTION_ACK_SLOW_WARN`] so a starved inner-tick is observable
+/// in production logs without surfacing as a user-visible error.
+pub async fn await_adoption_ack(
+    adoption_rx: oneshot::Receiver<Result<String, String>>,
+) -> AdoptionAckOutcome {
+    let started = tokio::time::Instant::now();
+    let outcome = match tokio::time::timeout(ADOPTION_ACK_WAIT, adoption_rx).await {
+        Ok(Ok(Ok(task_id))) => AdoptionAckOutcome::Adopted {
+            task_id,
+            waited: started.elapsed(),
+        },
+        Ok(Ok(Err(error))) => AdoptionAckOutcome::Refused(error),
+        Ok(Err(_)) => AdoptionAckOutcome::SenderDropped,
+        Err(_) => AdoptionAckOutcome::TimedOut,
+    };
+    if let AdoptionAckOutcome::Adopted { waited, task_id } = &outcome
+        && *waited > ADOPTION_ACK_SLOW_WARN
+    {
+        tracing::warn!(
+            task_id = task_id.as_str(),
+            waited_ms = waited.as_millis() as u64,
+            "bash detach adoption ack took longer than expected — TUI inner tick may be starved"
+        );
+    }
+    outcome
+}
 
 /// Live child + streams transferred from the bash runner to the
 /// background registry on Ctrl+B promotion. `partial_stdout` /

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -978,7 +978,7 @@ fn all_tool_schemas_core() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "task_output",
-                "description": "Read output for a specific typed background task. Use this after a background task notification or task_list entry. This is a tool call, not a Bash command; never invoke it through bash and never rerun the original command just to check progress. Returns explicit task kind, status, byte offsets, total bytes, and the requested output chunk when available. Requires the exact task_id so the model and UI refer to the same background task.",
+                "description": "Read the CURRENT tail of a typed background task's output. Returns immediately with whatever is buffered now (task kind, status, byte offsets, total bytes, chunk) — empty output is normal for tasks that just started. Do NOT poll this tool to track progress: the runtime emits a <task_notification> when the task reaches a terminal state. If you need to wait for terminal completion before continuing, set block=true; this returns only when the task is completed, failed, or killed (or the timeout elapses). This is a tool call, not a Bash command; never invoke it through bash and never read the on-disk task output files directly. Requires the exact task_id so the model and UI refer to the same background task.",
                 "parameters": {
                     "type": "object",
                     "additionalProperties": false,
@@ -989,7 +989,7 @@ fn all_tool_schemas_core() -> Vec<Value> {
                         },
                         "block": {
                             "type": "boolean",
-                            "description": "Wait for new output or terminal status before returning. Default true."
+                            "description": "If true, wait for the task to reach a terminal status (completed/failed/killed) before returning. Default false (snapshot-now). Only set true when the model genuinely cannot continue without the result."
                         },
                         "offset": {
                             "type": "integer",
@@ -1342,9 +1342,10 @@ mod tests {
         assert!(
             output_desc.contains("background task")
                 && output_desc.contains("not a Bash command")
-                && output_desc.contains("never rerun the original command")
+                && output_desc.contains("never read the on-disk task output files directly")
+                && output_desc.contains("Do NOT poll")
                 && !output_desc.contains("job(action"),
-            "task_output description must teach typed background task vocabulary"
+            "task_output description must teach snapshot-now semantics + forbid bash polling"
         );
         for tool_name in ["task_output", "task_stop", "task_list"] {
             let description = find_schema(&schemas, tool_name)

--- a/rust/crates/astra-tools/src/schemas.rs
+++ b/rust/crates/astra-tools/src/schemas.rs
@@ -978,7 +978,7 @@ fn all_tool_schemas_core() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "task_output",
-                "description": "Read output for a specific typed background task. Use this after a background task notification or task_list entry. Returns explicit task kind, status, byte offsets, total bytes, and the requested output chunk when available. Requires the exact task_id so the model and UI refer to the same background task.",
+                "description": "Read output for a specific typed background task. Use this after a background task notification or task_list entry. This is a tool call, not a Bash command; never invoke it through bash and never rerun the original command just to check progress. Returns explicit task kind, status, byte offsets, total bytes, and the requested output chunk when available. Requires the exact task_id so the model and UI refer to the same background task.",
                 "parameters": {
                     "type": "object",
                     "additionalProperties": false,
@@ -1014,7 +1014,7 @@ fn all_tool_schemas_core() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "task_stop",
-                "description": "Stop a running typed background task by id. Use for stuck shell tasks, waiting-for-input tasks, local agents, or tasks the user explicitly wants cancelled. Requires an exact task_id; does not stop the most recent task implicitly.",
+                "description": "Stop a running typed background task by id. This is a tool call, not a Bash command; never invoke it through bash. Use for stuck shell tasks, waiting-for-input tasks, local agents, or tasks the user explicitly wants cancelled. Requires an exact task_id; does not stop the most recent task implicitly.",
                 "parameters": {
                     "type": "object",
                     "additionalProperties": false,
@@ -1032,7 +1032,7 @@ fn all_tool_schemas_core() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "task_list",
-                "description": "List known typed background tasks for this session with kind, status, and ids. Use when you need to discover which background task to inspect or stop.",
+                "description": "List known typed background tasks for this session with kind, status, and ids. This is a tool call, not a Bash command; never invoke it through bash. Use when you need to discover which background task to inspect or stop.",
                 "parameters": {
                     "type": "object",
                     "additionalProperties": false,
@@ -1340,9 +1340,27 @@ mod tests {
             })
             .unwrap_or_default();
         assert!(
-            output_desc.contains("background task") && !output_desc.contains("job(action"),
+            output_desc.contains("background task")
+                && output_desc.contains("not a Bash command")
+                && output_desc.contains("never rerun the original command")
+                && !output_desc.contains("job(action"),
             "task_output description must teach typed background task vocabulary"
         );
+        for tool_name in ["task_output", "task_stop", "task_list"] {
+            let description = find_schema(&schemas, tool_name)
+                .and_then(|schema| {
+                    schema
+                        .get("function")
+                        .and_then(|f| f.get("description"))
+                        .and_then(Value::as_str)
+                })
+                .unwrap_or_default();
+            assert!(
+                description.contains("not a Bash command")
+                    && description.contains("never invoke it through bash"),
+                "{tool_name} description must forbid shell pseudo-calls: {description}"
+            );
+        }
         assert!(
             find_schema(&schemas, "agent_job").is_none(),
             "agent_job must not remain in the model-facing schema"

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -27,11 +27,13 @@ const BASH_DETACH_ADOPTION_ACK_WAIT: Duration = Duration::from_secs(5);
 pub fn render_bash_detached_marker(task_id: &str) -> String {
     format!(
         "<bash_detached>The bash command was promoted to background task {task_id}. \
-         Output continues in the BackgroundTaskRegistry. \
-         To inspect it, call the `task_output` tool with `task_id` set to `{task_id}`; \
-         call the `task_list` tool to see background tasks; \
-         call the `task_stop` tool with `task_id` set to `{task_id}` to stop it. \
-         Do not run these tool names through Bash, and do not rerun the original bash command just to check progress.\
+         The runtime will deliver a <task_notification> when the task terminates — \
+         end your turn now and let the user drive next steps. \
+         Do NOT poll: do not call `task_output`, do not rerun the bash command, \
+         and do not read the on-disk output files via bash (tail/cat/head/less are denied). \
+         If the user explicitly asks for partial progress, call `task_output` ONCE with \
+         block=false; if they ask you to wait, use `task_output` with block=true. \
+         Use `task_stop` only when the user wants the task cancelled.\
          </bash_detached>"
     )
 }
@@ -46,6 +48,32 @@ fn is_background_task_tool_shell_invocation(command: &str, tool: &str) -> bool {
             .is_none_or(|c| c.is_whitespace() || matches!(c, '(' | ';' | '|' | '&' | '<' | '>'));
         command_position && command_end
     })
+}
+
+/// Reject bash commands that try to read background-task output files
+/// directly off disk (`/tmp/astra/bg_tasks/...` or `${TMPDIR}/astra/bg_tasks/...`).
+/// The model must use `task_output` for this — disk reads bypass the
+/// snapshot protocol, return stale partial bytes mid-write, and miss
+/// the registry's terminal-status accounting. Reading these files via
+/// bash is the canonical "I'm polling" anti-pattern from the trace
+/// where a model burned 12 LLM rounds tail'ing the stderr file.
+pub fn background_task_output_dir_read_error(command: &str) -> Option<String> {
+    if !command.contains("bg_tasks") {
+        return None;
+    }
+    let lower = command.to_ascii_lowercase();
+    let bg_path_marker = "/astra/bg_tasks/";
+    if !lower.contains(bg_path_marker) {
+        return None;
+    }
+    Some(
+        "Error: bash cannot read background task output files directly. \
+         Call the `task_output` tool with the task_id (e.g. `bg-shell-1`) instead. \
+         The runtime delivers a <task_notification> when the task terminates; \
+         polling the on-disk files via bash returns stale partial bytes and \
+         bypasses terminal-status reporting."
+            .into(),
+    )
 }
 
 pub fn background_task_tool_pseudo_call_error(command: &str) -> Option<String> {
@@ -712,6 +740,9 @@ pub fn validate_execute_bash_command(command: &str) -> Result<(), String> {
         return Err("Error: empty bash command".into());
     }
     if let Some(error) = background_task_tool_pseudo_call_error(cmd) {
+        return Err(error);
+    }
+    if let Some(error) = background_task_output_dir_read_error(cmd) {
         return Err(error);
     }
     let lower = cmd.to_ascii_lowercase();
@@ -4682,6 +4713,42 @@ printf 'probe.txt:1:needle\n'
         assert!(
             validate_execute_bash_command("echo task_output").is_ok(),
             "plain text arguments should not be mistaken for shell tool invocations"
+        );
+    }
+
+    /// Regression: bash must refuse to read background task stdout/stderr
+    /// files directly off disk. The trace this guards against had a model
+    /// burn 12 LLM rounds running `tail /tmp/astra/bg_tasks/default/bg-shell-1.stderr`
+    /// instead of calling `task_output` — that's the canonical polling
+    /// anti-pattern. The denial is path-aware (it allows unrelated
+    /// commands that happen to mention "bg_tasks") and unconditional on
+    /// the read tool (tail/cat/head/less/grep all fail equivalently
+    /// because the validator doesn't care HOW you'd read it).
+    #[test]
+    fn validate_execute_bash_rejects_background_task_output_dir_reads() {
+        for command in [
+            "tail -20 /tmp/astra/bg_tasks/default/bg-shell-1.stderr",
+            "cat /tmp/astra/bg_tasks/default/bg-shell-1.stdout",
+            "head -50 /tmp/astra/bg_tasks/some-session/bg-shell-2.stderr",
+            "less /tmp/astra/bg_tasks/default/bg-shell-1.stdout",
+            "wc -l /tmp/astra/bg_tasks/default/bg-shell-1.stderr",
+            "grep error /tmp/astra/bg_tasks/default/bg-shell-1.stderr",
+            "tail -f /var/folders/abc/T/astra/bg_tasks/sess-1/bg-shell-1.stdout",
+        ] {
+            let error = validate_execute_bash_command(command).expect_err(command);
+            assert!(
+                error.contains("background task output files"),
+                "{command}: {error}"
+            );
+            assert!(error.contains("task_output"), "{command}: {error}");
+        }
+        assert!(
+            validate_execute_bash_command("echo bg_tasks is not a path here").is_ok(),
+            "the literal word 'bg_tasks' without the astra path prefix must not trigger"
+        );
+        assert!(
+            validate_execute_bash_command("ls /tmp/astra/").is_ok(),
+            "directories above bg_tasks/ remain freely listable"
         );
     }
 

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -3239,6 +3239,19 @@ pub(crate) async fn run_bash_with_detach(
     }
 
     if detached {
+        while !stdout_task.is_finished() || !stderr_task.is_finished() {
+            drain_command_chunks(
+                &mut rx,
+                &mut stdout_text,
+                &mut stderr_text,
+                max_stdout_bytes,
+                &mut stdout_capped,
+                max_stderr_bytes,
+                &mut stderr_capped,
+            );
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
         // Recover the live streams from the reader tasks. If a task
         // observed EOF before the detach notify (i.e. the stream
         // ended right at the signal moment) the stream is gone and
@@ -3361,10 +3374,14 @@ where
     let mut buffer = [0u8; 8192];
     loop {
         tokio::select! {
-            // Bias toward the read so a fast EOF doesn't lose data
-            // to a stale detach notification. The detach branch only
-            // wins when the read is actually pending.
+            // Ctrl+B is a job-control signal, so it must win even
+            // while a command is producing continuous output. Any
+            // unread bytes remain on the returned stream and are
+            // drained by the background registry after adoption.
             biased;
+            _ = detach.notified() => {
+                return Some(stream);
+            }
             res = stream.read(&mut buffer) => match res {
                 Ok(0) => return None,
                 Ok(read) => {
@@ -3379,9 +3396,6 @@ where
                     }
                 }
                 Err(_) => return None,
-            },
-            _ = detach.notified() => {
-                return Some(stream);
             }
         }
     }
@@ -5356,6 +5370,56 @@ printf 'probe.txt:1:needle\n'
         // The child is still alive in the payload; clean up so the
         // test doesn't leak a sleeping shell.
         drop(payload);
+    }
+
+    #[tokio::test]
+    async fn bash_detach_signal_wins_for_noisy_output() {
+        let dir = tempdir().unwrap();
+        let mut ctx = crate::ToolContext::test(dir.path());
+        let (slot, listener) = crate::detach::new_slot_with_handle();
+        ctx.detach_shell_handle = Some(slot);
+
+        let bash_fut = tokio::spawn({
+            let ctx = ctx.clone();
+            async move {
+                execute_bash(
+                    &ctx,
+                    &serde_json::json!({
+                        "command": "i=0; while true; do printf 'line-%s\\n' \"$i\"; i=$((i+1)); done"
+                    }),
+                )
+                .await
+            }
+        });
+
+        for _ in 0..50 {
+            if listener.is_active() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            listener.is_active(),
+            "detach listener should become active for running bash"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        listener.signal_tx.send(true).expect("detach signal send");
+
+        let payload = tokio::time::timeout(Duration::from_secs(1), listener.payload_rx)
+            .await
+            .expect("noisy bash must hand off promptly after Ctrl+B")
+            .expect("listener must receive noisy bash payload");
+        assert!(
+            payload.partial_stdout.contains("line-"),
+            "partial stdout should include noisy command output"
+        );
+        drop(payload);
+
+        let result = tokio::time::timeout(Duration::from_secs(1), bash_fut)
+            .await
+            .expect("detached noisy bash should return promptly")
+            .expect("bash task");
+        assert!(result.output.contains("bash_detached"), "{}", result.output);
     }
 
     #[tokio::test]

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -24,6 +24,39 @@ use crate::{ToolResult, per_tool_output_limit, truncate_output};
 const GREP_TIMEOUT: Duration = Duration::from_secs(20);
 const BASH_DETACH_ADOPTION_ACK_WAIT: Duration = Duration::from_secs(5);
 
+pub fn render_bash_detached_marker(task_id: &str) -> String {
+    format!(
+        "<bash_detached>The bash command was promoted to background task {task_id}. \
+         Output continues in the BackgroundTaskRegistry. \
+         To inspect it, call the `task_output` tool with `task_id` set to `{task_id}`; \
+         call the `task_list` tool to see background tasks; \
+         call the `task_stop` tool with `task_id` set to `{task_id}` to stop it. \
+         Do not run these tool names through Bash, and do not rerun the original bash command just to check progress.\
+         </bash_detached>"
+    )
+}
+
+fn is_function_style_tool_call(command: &str, tool: &str) -> bool {
+    let lower = command.trim().to_ascii_lowercase();
+    let Some(rest) = lower.strip_prefix(tool) else {
+        return false;
+    };
+    rest.trim_start().starts_with('(')
+}
+
+pub fn background_task_tool_pseudo_call_error(command: &str) -> Option<String> {
+    let tool = ["task_output", "task_list", "task_stop"]
+        .into_iter()
+        .find(|tool| is_function_style_tool_call(command, tool))?;
+    Some(format!(
+        "Error: `{tool}` is a background-task tool, not a bash command. \
+         Call the `{tool}` tool directly through the tool interface. \
+         Use `task_output` with the background task id, for example `bg-shell-1`, \
+         as the `task_id` argument when you need output. \
+         Do not rerun the original bash command just to check background progress."
+    ))
+}
+
 /// RAII guard for detach handle lifecycle. Takes ownership on creation,
 /// automatically restores to slot on drop unless explicitly consumed.
 /// This prevents handle leaks on early-return paths (errors, validation failures).
@@ -674,6 +707,9 @@ pub fn validate_execute_bash_command(command: &str) -> Result<(), String> {
     if cmd.is_empty() {
         return Err("Error: empty bash command".into());
     }
+    if let Some(error) = background_task_tool_pseudo_call_error(cmd) {
+        return Err(error);
+    }
     let lower = cmd.to_ascii_lowercase();
     let blocked_substrings = [
         "mkfs",
@@ -917,13 +953,7 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
                         );
                         }
                     };
-                let mut result = ToolResult::text(format!(
-                    "<bash_detached>The bash command was promoted to background task {task_id}. \
-                     Output continues in the BackgroundTaskRegistry; \
-                     poll progress with `task_output(task_id='{task_id}')`, inspect tasks with `task_list()`, \
-                     or stop it with `task_stop(task_id='{task_id}')`.\
-                     </bash_detached>"
-                ));
+                let mut result = ToolResult::text(render_bash_detached_marker(&task_id));
                 let mut metadata = serde_json::Map::new();
                 metadata.insert("bash_detached".to_string(), serde_json::Value::Bool(true));
                 metadata.insert("background_task_id".to_string(), task_id.into());
@@ -4629,6 +4659,21 @@ printf 'probe.txt:1:needle\n'
         assert!(validate_execute_bash_command("  \t").is_err());
     }
 
+    #[test]
+    fn validate_execute_bash_rejects_background_task_pseudo_tool_calls() {
+        for command in [
+            "task_output(task_id='bg-shell-1')",
+            "task_list()",
+            "task_stop(task_id=\"bg-shell-1\")",
+            " task_output ( task_id = 'bg-shell-1' ) ",
+        ] {
+            let error = validate_execute_bash_command(command).expect_err(command);
+            assert!(error.contains("background-task tool"), "{command}: {error}");
+            assert!(error.contains("not a bash command"), "{command}: {error}");
+            assert!(error.contains("Do not rerun"), "{command}: {error}");
+        }
+    }
+
     // ── rm path-aware validation ──────────────────────────────────────────────
 
     // --- Bug #6: kill variants all blocked via ProcessControl ---
@@ -5450,6 +5495,33 @@ printf 'probe.txt:1:needle\n'
         assert!(
             result.output.contains("bg-shell-test"),
             "result must include concrete task id: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("call the `task_output` tool"),
+            "result must point the LLM at the real task_output tool: {}",
+            result.output
+        );
+        assert!(
+            result
+                .output
+                .contains("Do not run these tool names through Bash"),
+            "result must tell the LLM not to execute tool names as shell: {}",
+            result.output
+        );
+        assert!(
+            !result.output.contains("task_output("),
+            "result must not use misleading pseudo-tool syntax: {}",
+            result.output
+        );
+        assert!(
+            !result.output.contains("task_list()"),
+            "result must not use misleading pseudo-tool syntax: {}",
+            result.output
+        );
+        assert!(
+            !result.output.contains("task_stop("),
+            "result must not use misleading pseudo-tool syntax: {}",
             result.output
         );
         assert_eq!(

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -22,7 +22,6 @@ use crate::exit_semantics::{ExitSemantics, classify_command_result, classify_exi
 use crate::{ToolResult, per_tool_output_limit, truncate_output};
 
 const GREP_TIMEOUT: Duration = Duration::from_secs(20);
-const COMMAND_DRAIN_CHUNK_BUDGET: usize = 64;
 
 /// RAII guard for detach handle lifecycle. Takes ownership on creation,
 /// automatically restores to slot on drop unless explicitly consumed.
@@ -3102,11 +3101,13 @@ async fn run_readonly_command_with_partial(
 }
 
 /// Detach-aware bash runner. Same shape as
-/// [`run_readonly_command_with_partial`] but the readers can yield
-/// the streams back when `detach.signal.notified()` fires. Detach
-/// wins over normal completion only while the child is still running
-/// — a child that exits before the user presses Ctrl+B still flows
-/// through the `Completed` path.
+/// [`run_readonly_command_with_partial`] but the runner owns stdout
+/// and stderr directly in its `select!` loop. When Ctrl+B arrives,
+/// it can hand the live child and streams to the host immediately
+/// instead of waiting for helper reader tasks to return ownership.
+/// Detach wins over normal completion only while the child is still
+/// running — a child that exits before the user presses Ctrl+B still
+/// flows through the `Completed` path.
 ///
 /// Returns `Detached(payload)` when the signal fires during reading;
 /// `Completed(output)` otherwise. The caller (bash tool) must
@@ -3120,8 +3121,6 @@ pub(crate) async fn run_bash_with_detach(
     detach: &crate::detach::DetachShellHandle,
     command_label: &str,
 ) -> Result<BashRunOutcome, String> {
-    use std::sync::Arc;
-
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     #[cfg(unix)]
     cmd.process_group(0);
@@ -3137,25 +3136,8 @@ pub(crate) async fn run_bash_with_detach(
         .stderr
         .take()
         .ok_or_else(|| "Error: failed to capture bash command stderr".to_string())?;
-
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<(StreamKind, String)>(256);
-    // Two private notify halves so the outer detach signal fans out
-    // to both reader tasks without losing notifications. We trip
-    // both manually after observing the shared oneshot signal.
-    let stdout_detach = Arc::new(tokio::sync::Notify::new());
-    let stderr_detach = Arc::new(tokio::sync::Notify::new());
-    let stdout_task = tokio::spawn(read_stream_until_detach(
-        stdout,
-        StreamKind::Stdout,
-        tx.clone(),
-        stdout_detach.clone(),
-    ));
-    let stderr_task = tokio::spawn(read_stream_until_detach(
-        stderr,
-        StreamKind::Stderr,
-        tx,
-        stderr_detach.clone(),
-    ));
+    let mut stdout = stdout;
+    let mut stderr = stderr;
 
     // Take the watch receiver for detach. If absent, the command
     // cannot be promoted. The watch receiver is borrowed in select!
@@ -3171,29 +3153,14 @@ pub(crate) async fn run_bash_with_detach(
     let mut timed_out = false;
     let mut cancelled = false;
     let mut detached = false;
+    let mut stdout_open = true;
+    let mut stderr_open = true;
+    let mut stdout_buffer = [0u8; 8192];
+    let mut stderr_buffer = [0u8; 8192];
 
     loop {
         if detach_signal_observed(&mut signal_rx) {
             detached = true;
-            stdout_detach.notify_one();
-            stderr_detach.notify_one();
-            break;
-        }
-
-        drain_command_chunks_budgeted(
-            &mut rx,
-            &mut stdout_text,
-            &mut stderr_text,
-            max_stdout_bytes,
-            &mut stdout_capped,
-            max_stderr_bytes,
-            &mut stderr_capped,
-        );
-
-        if detach_signal_observed(&mut signal_rx) {
-            detached = true;
-            stdout_detach.notify_one();
-            stderr_detach.notify_one();
             break;
         }
 
@@ -3208,82 +3175,119 @@ pub(crate) async fn run_bash_with_detach(
                     sigkill_process_group(&mut child).await;
                     break;
                 }
-                // Race: detach signal vs cancel vs idle tick.
-                // Watch receiver's `changed()` borrows `&mut self` so it
-                // plays nicely with select! without ownership transfer.
-                if let Some(ref mut rx) = signal_rx {
-                    if let Some(token) = cancel_token {
-                        tokio::select! {
-                            _ = token.cancelled() => {
-                                cancelled = true;
-                                sigkill_process_group(&mut child).await;
-                                break;
-                            }
-                            res = rx.changed() => {
-                                match res {
-                                    Ok(()) if *rx.borrow_and_update() => {
-                                        detached = true;
-                                        stdout_detach.notify_one();
-                                        stderr_detach.notify_one();
-                                        break;
-                                    }
-                                    Ok(()) => {}
-                                    Err(_) => {
-                                        // Sender dropped -> no detach possible.
-                                        signal_rx = None;
-                                    }
-                                }
-                            }
-                            _ = tokio::time::sleep(Duration::from_millis(25)) => {}
-                        }
-                    } else {
-                        tokio::select! {
-                            res = rx.changed() => {
-                                match res {
-                                    Ok(()) if *rx.borrow_and_update() => {
-                                        detached = true;
-                                        stdout_detach.notify_one();
-                                        stderr_detach.notify_one();
-                                        break;
-                                    }
-                                    Ok(()) => {}
-                                    Err(_) => {
-                                        signal_rx = None;
-                                    }
-                                }
-                            }
-                            _ = tokio::time::sleep(Duration::from_millis(25)) => {}
-                        }
-                    }
-                } else if let Some(token) = cancel_token {
-                    // No detach signal available, but cancel is wired.
+
+                if let Some(rx) = signal_rx.as_mut() {
                     tokio::select! {
-                        _ = token.cancelled() => {
+                        biased;
+                        res = rx.changed() => {
+                            match res {
+                                Ok(()) if *rx.borrow_and_update() => {
+                                    detached = true;
+                                    break;
+                                }
+                                Ok(()) => {}
+                                Err(_) => {
+                                    signal_rx = None;
+                                }
+                            }
+                        }
+                        _ = async {
+                            if let Some(token) = cancel_token {
+                                token.cancelled().await;
+                            } else {
+                                std::future::pending::<()>().await;
+                            }
+                        } => {
                             cancelled = true;
                             sigkill_process_group(&mut child).await;
                             break;
                         }
+                        read = stdout.read(&mut stdout_buffer), if stdout_open => {
+                            match read {
+                                Ok(0) => stdout_open = false,
+                                Ok(read) => append_command_bytes(
+                                    &mut stdout_text,
+                                    &stdout_buffer[..read],
+                                    max_stdout_bytes,
+                                    &mut stdout_capped,
+                                ),
+                                Err(_) => stdout_open = false,
+                            }
+                        }
+                        read = stderr.read(&mut stderr_buffer), if stderr_open => {
+                            match read {
+                                Ok(0) => stderr_open = false,
+                                Ok(read) => append_command_bytes(
+                                    &mut stderr_text,
+                                    &stderr_buffer[..read],
+                                    max_stderr_bytes,
+                                    &mut stderr_capped,
+                                ),
+                                Err(_) => stderr_open = false,
+                            }
+                        }
                         _ = tokio::time::sleep(Duration::from_millis(25)) => {}
                     }
                 } else {
-                    // Neither detach nor cancel: plain tick.
-                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    tokio::select! {
+                        biased;
+                        _ = async {
+                            if let Some(token) = cancel_token {
+                                token.cancelled().await;
+                            } else {
+                                std::future::pending::<()>().await;
+                            }
+                        } => {
+                            cancelled = true;
+                            sigkill_process_group(&mut child).await;
+                            break;
+                        }
+                        read = stdout.read(&mut stdout_buffer), if stdout_open => {
+                            match read {
+                                Ok(0) => stdout_open = false,
+                                Ok(read) => append_command_bytes(
+                                    &mut stdout_text,
+                                    &stdout_buffer[..read],
+                                    max_stdout_bytes,
+                                    &mut stdout_capped,
+                                ),
+                                Err(_) => stdout_open = false,
+                            }
+                        }
+                        read = stderr.read(&mut stderr_buffer), if stderr_open => {
+                            match read {
+                                Ok(0) => stderr_open = false,
+                                Ok(read) => append_command_bytes(
+                                    &mut stderr_text,
+                                    &stderr_buffer[..read],
+                                    max_stderr_bytes,
+                                    &mut stderr_capped,
+                                ),
+                                Err(_) => stderr_open = false,
+                            }
+                        }
+                        _ = tokio::time::sleep(Duration::from_millis(25)) => {}
+                    }
                 }
             }
             Err(e) => {
                 let error_msg = format!("Error: bash command failed: {e}");
                 sigkill_process_group(&mut child).await;
-                let _ = stdout_task.await;
-                let _ = stderr_task.await;
-                drain_command_chunks(
-                    &mut rx,
-                    &mut stdout_text,
-                    &mut stderr_text,
-                    max_stdout_bytes,
-                    &mut stdout_capped,
-                    max_stderr_bytes,
-                    &mut stderr_capped,
-                );
+                drain_remaining_command_streams(
+                    &mut stdout,
+                    &mut stderr,
+                    CommandStreamDrainState {
+                        stdout_open: &mut stdout_open,
+                        stderr_open: &mut stderr_open,
+                        stdout_text: &mut stdout_text,
+                        stderr_text: &mut stderr_text,
+                        stdout_capped: &mut stdout_capped,
+                        stderr_capped: &mut stderr_capped,
+                        max_stdout_bytes,
+                        max_stderr_bytes,
+                    },
+                )
+                .await;
                 restore_detach_signal_receiver(detach, signal_rx).await;
                 return Err(error_msg);
             }
@@ -3291,70 +3295,34 @@ pub(crate) async fn run_bash_with_detach(
     }
 
     if detached {
-        while !stdout_task.is_finished() || !stderr_task.is_finished() {
-            drain_command_chunks_budgeted(
-                &mut rx,
-                &mut stdout_text,
-                &mut stderr_text,
-                max_stdout_bytes,
-                &mut stdout_capped,
-                max_stderr_bytes,
-                &mut stderr_capped,
-            );
-            tokio::time::sleep(Duration::from_millis(1)).await;
-        }
-
-        // Recover the live streams from the reader tasks. If a task
-        // observed EOF before the detach notify (i.e. the stream
-        // ended right at the signal moment) the stream is gone and
-        // we can't include it in the payload — drop back to
-        // Completed for that branch.
-        let stdout_back = stdout_task.await.ok().flatten();
-        let stderr_back = stderr_task.await.ok().flatten();
-        // Final drain so partial state is accurate.
-        drain_command_chunks(
-            &mut rx,
-            &mut stdout_text,
-            &mut stderr_text,
-            max_stdout_bytes,
-            &mut stdout_capped,
-            max_stderr_bytes,
-            &mut stderr_capped,
-        );
-
-        if let (Some(stdout), Some(stderr)) = (stdout_back, stderr_back) {
-            let payload = Box::new(crate::detach::DetachedShellPayload {
-                child,
-                stdout,
-                stderr,
-                command: command_label.to_string(),
-                partial_stdout: stdout_text,
-                partial_stderr: stderr_text,
-            });
-            return Ok(BashRunOutcome::Detached(payload));
-        }
-        // Detach is an ownership transfer. If either stream is already gone,
-        // the host cannot safely adopt the live process, so terminate it
-        // instead of leaving an orphan or blocking the foreground tool.
-        sigkill_process_group(&mut child).await;
-        return Err(
-            "Error: bash detach failed: child stream closed before handoff completed".to_string(),
-        );
+        let payload = Box::new(crate::detach::DetachedShellPayload {
+            child,
+            stdout,
+            stderr,
+            command: command_label.to_string(),
+            partial_stdout: stdout_text,
+            partial_stderr: stderr_text,
+        });
+        return Ok(BashRunOutcome::Detached(payload));
     }
 
     // Normal completion path: drain remaining bytes and assemble
     // output exactly like the legacy runner.
-    let _ = stdout_task.await;
-    let _ = stderr_task.await;
-    drain_command_chunks(
-        &mut rx,
-        &mut stdout_text,
-        &mut stderr_text,
-        max_stdout_bytes,
-        &mut stdout_capped,
-        max_stderr_bytes,
-        &mut stderr_capped,
-    );
+    drain_remaining_command_streams(
+        &mut stdout,
+        &mut stderr,
+        CommandStreamDrainState {
+            stdout_open: &mut stdout_open,
+            stderr_open: &mut stderr_open,
+            stdout_text: &mut stdout_text,
+            stderr_text: &mut stderr_text,
+            stdout_capped: &mut stdout_capped,
+            stderr_capped: &mut stderr_capped,
+            max_stdout_bytes,
+            max_stderr_bytes,
+        },
+    )
+    .await;
 
     if timed_out || cancelled {
         truncate_partial_line(&mut stdout_text);
@@ -3400,59 +3368,6 @@ async fn read_stream<R>(
     }
 }
 
-/// Detach-aware variant of [`read_stream`] used by the bash tool when
-/// a `DetachShellHandle` is wired in `ToolContext`. On normal stream
-/// EOF returns `None` (legacy behaviour); when the embedded
-/// `Notify::notified()` fires it returns `Some(stream)` so the caller
-/// can hand the live stream off to the BackgroundTaskRegistry without
-/// reading further bytes (preserving exact byte-stream continuity for
-/// the adopted task).
-///
-/// This is a sibling rather than a parameterized version because:
-///   1. Adding the notify branch to the hot-path `read_stream` would
-///      compile in `tokio::select!` overhead for every bash call
-///      whether or not detach is wired.
-///   2. The return type changes (`()` → `Option<R>`), and changing
-///      `read_stream`'s signature would touch every caller.
-async fn read_stream_until_detach<R>(
-    mut stream: R,
-    kind: StreamKind,
-    tx: tokio::sync::mpsc::Sender<(StreamKind, String)>,
-    detach: std::sync::Arc<tokio::sync::Notify>,
-) -> Option<R>
-where
-    R: tokio::io::AsyncRead + Unpin,
-{
-    let mut buffer = [0u8; 8192];
-    loop {
-        tokio::select! {
-            // Ctrl+B is a job-control signal, so it must win even
-            // while a command is producing continuous output. Any
-            // unread bytes remain on the returned stream and are
-            // drained by the background registry after adoption.
-            biased;
-            _ = detach.notified() => {
-                return Some(stream);
-            }
-            res = stream.read(&mut buffer) => match res {
-                Ok(0) => return None,
-                Ok(read) => {
-                    let text = String::from_utf8_lossy(&buffer[..read]).into_owned();
-                    if tx.send((kind, text)).await.is_err() {
-                        tracing::warn!(
-                            stream_kind = ?kind,
-                            "detach command output channel closed; {} bytes lost",
-                            read
-                        );
-                        return None;
-                    }
-                }
-                Err(_) => return None,
-            }
-        }
-    }
-}
-
 fn drain_command_chunks(
     rx: &mut tokio::sync::mpsc::Receiver<(StreamKind, String)>,
     stdout_text: &mut String,
@@ -3471,30 +3386,6 @@ fn drain_command_chunks(
         max_stderr_bytes,
         stderr_capped,
     ) {}
-}
-
-fn drain_command_chunks_budgeted(
-    rx: &mut tokio::sync::mpsc::Receiver<(StreamKind, String)>,
-    stdout_text: &mut String,
-    stderr_text: &mut String,
-    max_stdout_bytes: usize,
-    stdout_capped: &mut bool,
-    max_stderr_bytes: usize,
-    stderr_capped: &mut bool,
-) {
-    for _ in 0..COMMAND_DRAIN_CHUNK_BUDGET {
-        if !drain_one_command_chunk(
-            rx,
-            stdout_text,
-            stderr_text,
-            max_stdout_bytes,
-            stdout_capped,
-            max_stderr_bytes,
-            stderr_capped,
-        ) {
-            break;
-        }
-    }
 }
 
 fn drain_one_command_chunk(
@@ -3536,6 +3427,73 @@ fn append_capped(output: &mut String, chunk: &str, max_bytes: usize, capped: &mu
         return;
     }
     output.push_str(chunk);
+}
+
+fn append_command_bytes(output: &mut String, bytes: &[u8], max_bytes: usize, capped: &mut bool) {
+    let text = String::from_utf8_lossy(bytes);
+    append_capped(output, &text, max_bytes, capped);
+}
+
+struct CommandStreamDrainState<'a> {
+    stdout_open: &'a mut bool,
+    stderr_open: &'a mut bool,
+    stdout_text: &'a mut String,
+    stderr_text: &'a mut String,
+    stdout_capped: &'a mut bool,
+    stderr_capped: &'a mut bool,
+    max_stdout_bytes: usize,
+    max_stderr_bytes: usize,
+}
+
+async fn drain_remaining_command_streams<O, E>(
+    stdout: &mut O,
+    stderr: &mut E,
+    state: CommandStreamDrainState<'_>,
+) where
+    O: tokio::io::AsyncRead + Unpin,
+    E: tokio::io::AsyncRead + Unpin,
+{
+    let CommandStreamDrainState {
+        stdout_open,
+        stderr_open,
+        stdout_text,
+        stderr_text,
+        stdout_capped,
+        stderr_capped,
+        max_stdout_bytes,
+        max_stderr_bytes,
+    } = state;
+    let mut stdout_buffer = [0u8; 8192];
+    let mut stderr_buffer = [0u8; 8192];
+
+    while *stdout_open || *stderr_open {
+        tokio::select! {
+            read = stdout.read(&mut stdout_buffer), if *stdout_open => {
+                match read {
+                    Ok(0) => *stdout_open = false,
+                    Ok(read) => append_command_bytes(
+                        stdout_text,
+                        &stdout_buffer[..read],
+                        max_stdout_bytes,
+                        stdout_capped,
+                    ),
+                    Err(_) => *stdout_open = false,
+                }
+            }
+            read = stderr.read(&mut stderr_buffer), if *stderr_open => {
+                match read {
+                    Ok(0) => *stderr_open = false,
+                    Ok(read) => append_command_bytes(
+                        stderr_text,
+                        &stderr_buffer[..read],
+                        max_stderr_bytes,
+                        stderr_capped,
+                    ),
+                    Err(_) => *stderr_open = false,
+                }
+            }
+        }
+    }
 }
 
 fn annotate_grep_with_scope(grep_output: &str, workspace_root: &Path) -> String {
@@ -5595,7 +5553,7 @@ printf 'probe.txt:1:needle\n'
     }
 
     #[tokio::test]
-    async fn bash_detach_after_stream_eof_kills_child_and_errors() {
+    async fn bash_detach_after_stdout_eof_still_hands_off_child() {
         let dir = tempdir().unwrap();
         let mut ctx = crate::ToolContext::test(dir.path());
         let (slot, listener) = crate::detach::new_slot_with_handle();
@@ -5617,18 +5575,19 @@ printf 'probe.txt:1:needle\n'
         tokio::time::sleep(Duration::from_millis(200)).await;
         listener.signal_tx.send(true).expect("detach signal send");
 
-        let result = tokio::time::timeout(Duration::from_secs(2), bash_fut)
+        let payload = tokio::time::timeout(Duration::from_secs(1), listener.payload_rx)
             .await
-            .expect("detach failure should not hang")
+            .expect("stdout-closed bash must still hand off promptly")
+            .expect("listener must receive payload for stdout-closed bash");
+        assert_eq!(payload.command, "exec 1>&-; sleep 30");
+        drop(payload);
+
+        let result = tokio::time::timeout(Duration::from_secs(1), bash_fut)
+            .await
+            .expect("detached stdout-closed bash should return promptly")
             .expect("bash task");
-        assert!(result.is_error, "{result:?}");
-        assert!(
-            result
-                .output
-                .contains("child stream closed before handoff completed"),
-            "{}",
-            result.output
-        );
+        assert!(!result.is_error, "{result:?}");
+        assert!(result.output.contains("bash_detached"), "{}", result.output);
     }
 
     #[tokio::test]

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -22,21 +22,8 @@ use crate::exit_semantics::{ExitSemantics, classify_command_result, classify_exi
 use crate::{ToolResult, per_tool_output_limit, truncate_output};
 
 const GREP_TIMEOUT: Duration = Duration::from_secs(20);
-const BASH_DETACH_ADOPTION_ACK_WAIT: Duration = Duration::from_secs(5);
 
-pub fn render_bash_detached_marker(task_id: &str) -> String {
-    format!(
-        "<bash_detached>The bash command was promoted to background task {task_id}. \
-         The runtime will deliver a <task_notification> when the task terminates — \
-         end your turn now and let the user drive next steps. \
-         Do NOT poll: do not call `task_output`, do not rerun the bash command, \
-         and do not read the on-disk output files via bash (tail/cat/head/less are denied). \
-         If the user explicitly asks for partial progress, call `task_output` ONCE with \
-         block=false; if they ask you to wait, use `task_output` with block=true. \
-         Use `task_stop` only when the user wants the task cancelled.\
-         </bash_detached>"
-    )
-}
+pub use crate::detach::render_bash_detached_marker;
 
 fn is_background_task_tool_shell_invocation(command: &str, tool: &str) -> bool {
     let lower = command.trim().to_ascii_lowercase();
@@ -89,6 +76,32 @@ pub fn background_task_tool_pseudo_call_error(command: &str) -> Option<String> {
     ))
 }
 
+/// Canonical bash pre-execution validator for the background-task contract.
+///
+/// Returns `Err(message)` for the two anti-patterns that *must* be blocked
+/// at the validator layer in every bash entry point:
+///
+/// 1. Pseudo-tool invocations (`task_output(...)`, `task_list`, `task_stop ...`)
+///    — the model thinks these are shell programs. Blocking here turns the
+///    mistake into an immediate corrective error instead of a `command not
+///    found` round-trip.
+/// 2. Direct disk reads of background-task stdout/stderr files
+///    (`tail /tmp/astra/bg_tasks/...`). The trace this guards against had a
+///    model burn 12 LLM rounds tail'ing a stderr file instead of calling
+///    `task_output`.
+///
+/// All bash entry points (in-process and edge) MUST funnel through this
+/// helper. Adding a new check requires editing one place, not two.
+pub fn validate_bash_background_task_contract(command: &str) -> Result<(), String> {
+    if let Some(err) = background_task_tool_pseudo_call_error(command) {
+        return Err(err);
+    }
+    if let Some(err) = background_task_output_dir_read_error(command) {
+        return Err(err);
+    }
+    Ok(())
+}
+
 /// RAII guard for detach handle lifecycle. Takes ownership on creation,
 /// automatically restores to slot on drop unless explicitly consumed.
 /// This prevents handle leaks on early-return paths (errors, validation failures).
@@ -122,10 +135,6 @@ impl<'a> DetachHandleGuard<'a> {
         self.handle.take()
     }
 
-    fn has_handle(&self) -> bool {
-        self.handle.is_some()
-    }
-
     /// Restore handle to slot. Call this on error/completed paths.
     /// Consumes self and restores the handle to the slot for reuse.
     async fn restore(mut self) {
@@ -152,41 +161,10 @@ impl<'a> Drop for DetachHandleGuard<'a> {
     }
 }
 
-async fn restore_detach_signal_receiver(
-    detach: &DetachShellHandle,
-    signal_rx: Option<tokio::sync::watch::Receiver<bool>>,
-) {
-    if let Some(signal_rx) = signal_rx {
-        *detach.signal_rx.lock().await = Some(signal_rx);
-    }
-}
-
-fn detach_signal_observed(signal_rx: &mut Option<tokio::sync::watch::Receiver<bool>>) -> bool {
-    enum SignalState {
-        Observed,
-        NotObserved,
-        Disconnected,
-    }
-
-    let state = if let Some(rx) = signal_rx.as_mut() {
-        match rx.has_changed() {
-            Ok(true) if *rx.borrow_and_update() => SignalState::Observed,
-            Ok(_) => SignalState::NotObserved,
-            Err(_) => SignalState::Disconnected,
-        }
-    } else {
-        return false;
-    };
-
-    match state {
-        SignalState::Observed => true,
-        SignalState::NotObserved => false,
-        SignalState::Disconnected => {
-            *signal_rx = None;
-            false
-        }
-    }
-}
+use crate::detach::{
+    detach_signal_observed, restore_detach_signal_receiver, sigkill_process_group,
+    terminate_detached_payload,
+};
 
 const GLOB_TIMEOUT: Duration = Duration::from_secs(15);
 /// Fallback `bash` timeout when the caller omits `timeout` AND the classifier
@@ -739,12 +717,7 @@ pub fn validate_execute_bash_command(command: &str) -> Result<(), String> {
     if cmd.is_empty() {
         return Err("Error: empty bash command".into());
     }
-    if let Some(error) = background_task_tool_pseudo_call_error(cmd) {
-        return Err(error);
-    }
-    if let Some(error) = background_task_output_dir_read_error(cmd) {
-        return Err(error);
-    }
+    validate_bash_background_task_contract(cmd)?;
     let lower = cmd.to_ascii_lowercase();
     let blocked_substrings = [
         "mkfs",
@@ -923,8 +896,7 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
         },
     );
 
-    let output = if detach_handle_guard.has_handle() {
-        let handle_ref = detach_handle_guard.get_ref().unwrap();
+    let output = if let Some(handle_ref) = detach_handle_guard.get_ref() {
         handle_ref.mark_active(true);
         match run_bash_with_detach(
             &mut cmd,
@@ -950,7 +922,14 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
                 // through the one-shot reply channel. The host drains
                 // it in its event-loop tick and calls
                 // BackgroundTaskRegistry::adopt_detached_shell.
-                let detach_handle = detach_handle_guard.take().unwrap();
+                let Some(detach_handle) = detach_handle_guard.take() else {
+                    // Handle was somehow consumed between get_ref and take —
+                    // this should not happen, but handle gracefully.
+                    terminate_detached_payload(payload).await;
+                    return ToolResult::error(
+                        "Error: bash detach failed: handle was already consumed".to_string(),
+                    );
+                };
                 let Some(sender) = detach_handle.payload_tx.lock().await.take() else {
                     detach_handle.mark_active(false);
                     terminate_detached_payload(payload).await;
@@ -967,27 +946,31 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
                             .to_string(),
                     );
                 }
-                let task_id =
-                    match tokio::time::timeout(BASH_DETACH_ADOPTION_ACK_WAIT, adoption_rx).await {
-                        Ok(Ok(Ok(task_id))) => task_id,
-                        Ok(Ok(Err(error))) => {
-                            return ToolResult::error(format!(
-                                "Error: bash detach failed: host could not adopt process: {error}"
-                            ));
-                        }
-                        Ok(Err(_)) => {
-                            return ToolResult::error(
-                                "Error: bash detach failed: host dropped adoption acknowledgement"
-                                    .to_string(),
-                            );
-                        }
-                        Err(_) => {
-                            return ToolResult::error(
+                use crate::detach::AdoptionAckOutcome;
+                let task_id = match crate::detach::await_adoption_ack(adoption_rx).await {
+                    AdoptionAckOutcome::Adopted { task_id, .. } => task_id,
+                    AdoptionAckOutcome::Refused(error) => {
+                        return ToolResult::error(format!(
+                            "Error: bash detach failed: host could not adopt process: {error}"
+                        ));
+                    }
+                    AdoptionAckOutcome::SenderDropped => {
+                        return ToolResult::error(
+                            "Error: bash detach failed: host dropped adoption acknowledgement"
+                                .to_string(),
+                        );
+                    }
+                    AdoptionAckOutcome::TimedOut => {
+                        // Child was already sent to the host; if adoption timed out,
+                        // the host is responsible for cleanup or the child may have
+                        // already terminated. We cannot access payload.child here
+                        // because *payload was moved into sender.send().
+                        return ToolResult::error(
                             "Error: bash detach failed: host did not acknowledge adoption in time"
                                 .to_string(),
                         );
-                        }
-                    };
+                    }
+                };
                 let mut result = ToolResult::text(render_bash_detached_marker(&task_id));
                 let mut metadata = serde_json::Map::new();
                 metadata.insert("bash_detached".to_string(), serde_json::Value::Bool(true));
@@ -3027,31 +3010,7 @@ fn append_context_flags(cmd: &mut Command, before: Option<usize>, after: Option<
 
 /// Kill the child's entire process group (SIGKILL via `killpg(2)`) then
 /// reap. Needed so orphaned grandchildren don't hold the stdio pipes open
-/// past the kill — the child must have been spawned with
-/// `process_group(0)` for the pgid to equal its PID.
-///
-/// Uses a direct syscall (best-effort; failures are ignored because the
-/// child may already have exited and been reaped, in which case the pgid
-/// is gone). Falls back to `child.kill()` on non-unix platforms.
-async fn sigkill_process_group(child: &mut tokio::process::Child) {
-    #[cfg(unix)]
-    {
-        if let Some(pid) = child.id() {
-            if let Ok(raw) = i32::try_from(pid) {
-                let pgid = nix::unistd::Pid::from_raw(raw);
-                let _ = nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGKILL);
-            } else {
-                tracing::warn!(
-                    pid,
-                    "sigkill_process_group: PID exceeds i32::MAX, skipping killpg"
-                );
-            }
-        }
-    }
-    let _ = child.kill().await;
-    let _ = child.wait().await;
-}
-
+/// past the kill.
 fn exit_code_from_status(status: &ExitStatus) -> i32 {
     if let Some(code) = status.code() {
         return code;
@@ -3064,10 +3023,6 @@ fn exit_code_from_status(status: &ExitStatus) -> i32 {
         }
     }
     -1
-}
-
-async fn terminate_detached_payload(mut payload: Box<crate::detach::DetachedShellPayload>) {
-    sigkill_process_group(&mut payload.child).await;
 }
 
 async fn run_readonly_command_with_partial(
@@ -5576,15 +5531,25 @@ printf 'probe.txt:1:needle\n'
             result.output
         );
         assert!(
-            result.output.contains("call the `task_output` tool"),
-            "result must point the LLM at the real task_output tool: {}",
+            result.output.contains("Do NOT poll"),
+            "result must tell the LLM not to poll task_output: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("do not rerun the bash command"),
+            "result must forbid the rerun anti-pattern: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("tail/cat/head/less are denied"),
+            "result must close the on-disk read escape hatch: {}",
             result.output
         );
         assert!(
             result
                 .output
-                .contains("Do not run these tool names through Bash"),
-            "result must tell the LLM not to execute tool names as shell: {}",
+                .contains("call `task_output` ONCE with block=false"),
+            "result must show the user-asked-for-progress escape hatch: {}",
             result.output
         );
         assert!(

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -36,18 +36,22 @@ pub fn render_bash_detached_marker(task_id: &str) -> String {
     )
 }
 
-fn is_function_style_tool_call(command: &str, tool: &str) -> bool {
+fn is_background_task_tool_shell_invocation(command: &str, tool: &str) -> bool {
     let lower = command.trim().to_ascii_lowercase();
-    let Some(rest) = lower.strip_prefix(tool) else {
-        return false;
-    };
-    rest.trim_start().starts_with('(')
+    lower.match_indices(tool).any(|(idx, _)| {
+        let before = lower[..idx].chars().rev().find(|c| !c.is_whitespace());
+        let after = lower[idx + tool.len()..].chars().next();
+        let command_position = before.is_none_or(|c| matches!(c, ';' | '|' | '&' | '('));
+        let command_end = after
+            .is_none_or(|c| c.is_whitespace() || matches!(c, '(' | ';' | '|' | '&' | '<' | '>'));
+        command_position && command_end
+    })
 }
 
 pub fn background_task_tool_pseudo_call_error(command: &str) -> Option<String> {
     let tool = ["task_output", "task_list", "task_stop"]
         .into_iter()
-        .find(|tool| is_function_style_tool_call(command, tool))?;
+        .find(|tool| is_background_task_tool_shell_invocation(command, tool))?;
     Some(format!(
         "Error: `{tool}` is a background-task tool, not a bash command. \
          Call the `{tool}` tool directly through the tool interface. \
@@ -4663,8 +4667,11 @@ printf 'probe.txt:1:needle\n'
     fn validate_execute_bash_rejects_background_task_pseudo_tool_calls() {
         for command in [
             "task_output(task_id='bg-shell-1')",
+            "task_output bg-shell-1",
             "task_list()",
+            "task_list 2>/dev/null; echo status",
             "task_stop(task_id=\"bg-shell-1\")",
+            "true && task_stop bg-shell-1",
             " task_output ( task_id = 'bg-shell-1' ) ",
         ] {
             let error = validate_execute_bash_command(command).expect_err(command);
@@ -4672,6 +4679,10 @@ printf 'probe.txt:1:needle\n'
             assert!(error.contains("not a bash command"), "{command}: {error}");
             assert!(error.contains("Do not rerun"), "{command}: {error}");
         }
+        assert!(
+            validate_execute_bash_command("echo task_output").is_ok(),
+            "plain text arguments should not be mistaken for shell tool invocations"
+        );
     }
 
     // ── rm path-aware validation ──────────────────────────────────────────────

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -22,6 +22,7 @@ use crate::exit_semantics::{ExitSemantics, classify_command_result, classify_exi
 use crate::{ToolResult, per_tool_output_limit, truncate_output};
 
 const GREP_TIMEOUT: Duration = Duration::from_secs(20);
+const BASH_DETACH_ADOPTION_ACK_WAIT: Duration = Duration::from_secs(5);
 
 /// RAII guard for detach handle lifecycle. Takes ownership on creation,
 /// automatically restores to slot on drop unless explicitly consumed.
@@ -462,7 +463,10 @@ pub(crate) enum BashRunOutcome {
     // The detached variant carries a live `tokio::process::Child` plus
     // two `ChildStdout`/`ChildStderr` handles that are large; box it
     // so the enum stays small for the dominant `Completed` path.
-    Detached(Box<crate::detach::DetachedShellPayload>),
+    Detached {
+        payload: Box<crate::detach::DetachedShellPayload>,
+        adoption_rx: tokio::sync::oneshot::Receiver<Result<String, String>>,
+    },
 }
 
 pub(crate) struct ReadOnlyCommandOutput {
@@ -867,7 +871,10 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
                 detach_handle_guard.restore().await;
                 output
             }
-            Ok(BashRunOutcome::Detached(payload)) => {
+            Ok(BashRunOutcome::Detached {
+                payload,
+                adoption_rx,
+            }) => {
                 // Hand the live child + streams back to the host
                 // through the one-shot reply channel. The host drains
                 // it in its event-loop tick and calls
@@ -889,15 +896,37 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
                             .to_string(),
                     );
                 }
-                let mut result = ToolResult::text(
-                    "<bash_detached>The bash command was promoted to a background task. \
-                     The host will resume reading its output via the BackgroundTaskRegistry; \
-                     poll progress with `task_output(task_id=<bg-shell-N>)` or inspect tasks with `task_list()`.\
+                let task_id =
+                    match tokio::time::timeout(BASH_DETACH_ADOPTION_ACK_WAIT, adoption_rx).await {
+                        Ok(Ok(Ok(task_id))) => task_id,
+                        Ok(Ok(Err(error))) => {
+                            return ToolResult::error(format!(
+                                "Error: bash detach failed: host could not adopt process: {error}"
+                            ));
+                        }
+                        Ok(Err(_)) => {
+                            return ToolResult::error(
+                                "Error: bash detach failed: host dropped adoption acknowledgement"
+                                    .to_string(),
+                            );
+                        }
+                        Err(_) => {
+                            return ToolResult::error(
+                            "Error: bash detach failed: host did not acknowledge adoption in time"
+                                .to_string(),
+                        );
+                        }
+                    };
+                let mut result = ToolResult::text(format!(
+                    "<bash_detached>The bash command was promoted to background task {task_id}. \
+                     Output continues in the BackgroundTaskRegistry; \
+                     poll progress with `task_output(task_id='{task_id}')`, inspect tasks with `task_list()`, \
+                     or stop it with `task_stop(task_id='{task_id}')`.\
                      </bash_detached>"
-                        .to_string(),
-                );
+                ));
                 let mut metadata = serde_json::Map::new();
                 metadata.insert("bash_detached".to_string(), serde_json::Value::Bool(true));
+                metadata.insert("background_task_id".to_string(), task_id.into());
                 result.metadata = Some(metadata);
                 return result;
             }
@@ -3295,6 +3324,7 @@ pub(crate) async fn run_bash_with_detach(
     }
 
     if detached {
+        let (adoption_tx, adoption_rx) = tokio::sync::oneshot::channel();
         let payload = Box::new(crate::detach::DetachedShellPayload {
             child,
             stdout,
@@ -3302,8 +3332,12 @@ pub(crate) async fn run_bash_with_detach(
             command: command_label.to_string(),
             partial_stdout: stdout_text,
             partial_stderr: stderr_text,
+            adoption_tx,
         });
-        return Ok(BashRunOutcome::Detached(payload));
+        return Ok(BashRunOutcome::Detached {
+            payload,
+            adoption_rx,
+        });
     }
 
     // Normal completion path: drain remaining bytes and assemble
@@ -5399,6 +5433,10 @@ printf 'probe.txt:1:needle\n'
             "partial stdout must include the bytes consumed before detach: {:?}",
             payload.partial_stdout
         );
+        payload
+            .adoption_tx
+            .send(Ok("bg-shell-test".into()))
+            .expect("ack adoption");
 
         // The bash invocation must have returned a marker result
         // (not killed, not a normal output) so the LLM sees the
@@ -5407,6 +5445,11 @@ printf 'probe.txt:1:needle\n'
         assert!(
             result.output.contains("bash_detached"),
             "result must announce detach to the LLM: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("bg-shell-test"),
+            "result must include concrete task id: {}",
             result.output
         );
         assert_eq!(
@@ -5418,10 +5461,14 @@ printf 'probe.txt:1:needle\n'
             Some(true),
             "metadata.bash_detached flag must be set so downstream wiring can route correctly"
         );
-
-        // The child is still alive in the payload; clean up so the
-        // test doesn't leak a sleeping shell.
-        drop(payload);
+        assert_eq!(
+            result
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get("background_task_id"))
+                .and_then(|v| v.as_str()),
+            Some("bg-shell-test")
+        );
     }
 
     #[tokio::test]
@@ -5465,13 +5512,21 @@ printf 'probe.txt:1:needle\n'
             payload.partial_stdout.contains("line-"),
             "partial stdout should include noisy command output"
         );
-        drop(payload);
+        payload
+            .adoption_tx
+            .send(Ok("bg-shell-noisy".into()))
+            .expect("ack noisy adoption");
 
         let result = tokio::time::timeout(Duration::from_secs(1), bash_fut)
             .await
             .expect("detached noisy bash should return promptly")
             .expect("bash task");
         assert!(result.output.contains("bash_detached"), "{}", result.output);
+        assert!(
+            result.output.contains("bg-shell-noisy"),
+            "{}",
+            result.output
+        );
     }
 
     #[tokio::test]
@@ -5553,6 +5608,51 @@ printf 'probe.txt:1:needle\n'
     }
 
     #[tokio::test]
+    async fn bash_detach_adoption_error_returns_tool_error() {
+        let dir = tempdir().unwrap();
+        let mut ctx = crate::ToolContext::test(dir.path());
+        let (slot, listener) = crate::detach::new_slot_with_handle();
+        ctx.detach_shell_handle = Some(slot);
+
+        let bash_fut = tokio::spawn({
+            let ctx = ctx.clone();
+            async move {
+                execute_bash(
+                    &ctx,
+                    &serde_json::json!({
+                        "command": "printf 'before\\n'; sleep 30; printf 'after\\n'"
+                    }),
+                )
+                .await
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        listener.signal_tx.send(true).expect("detach signal send");
+        let payload = tokio::time::timeout(Duration::from_secs(1), listener.payload_rx)
+            .await
+            .expect("payload should arrive")
+            .expect("listener must receive payload");
+        payload
+            .adoption_tx
+            .send(Err("background shell task limit reached".into()))
+            .expect("ack adoption failure");
+
+        let result = tokio::time::timeout(Duration::from_secs(1), bash_fut)
+            .await
+            .expect("adoption failure should not hang")
+            .expect("bash task");
+        assert!(result.is_error, "{result:?}");
+        assert!(
+            result
+                .output
+                .contains("host could not adopt process: background shell task limit reached"),
+            "{}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
     async fn bash_detach_after_stdout_eof_still_hands_off_child() {
         let dir = tempdir().unwrap();
         let mut ctx = crate::ToolContext::test(dir.path());
@@ -5580,7 +5680,10 @@ printf 'probe.txt:1:needle\n'
             .expect("stdout-closed bash must still hand off promptly")
             .expect("listener must receive payload for stdout-closed bash");
         assert_eq!(payload.command, "exec 1>&-; sleep 30");
-        drop(payload);
+        payload
+            .adoption_tx
+            .send(Ok("bg-shell-stdout-eof".into()))
+            .expect("ack stdout-eof adoption");
 
         let result = tokio::time::timeout(Duration::from_secs(1), bash_fut)
             .await
@@ -5588,6 +5691,11 @@ printf 'probe.txt:1:needle\n'
             .expect("bash task");
         assert!(!result.is_error, "{result:?}");
         assert!(result.output.contains("bash_detached"), "{}", result.output);
+        assert!(
+            result.output.contains("bg-shell-stdout-eof"),
+            "{}",
+            result.output
+        );
     }
 
     #[tokio::test]
@@ -5628,10 +5736,18 @@ printf 'probe.txt:1:needle\n'
             "second bash must still observe Ctrl+B after first normal completion: {:?}",
             payload.partial_stdout
         );
-        drop(payload);
+        payload
+            .adoption_tx
+            .send(Ok("bg-shell-second".into()))
+            .expect("ack second adoption");
 
         let second = second.await.expect("second bash task");
         assert!(second.output.contains("bash_detached"), "{}", second.output);
+        assert!(
+            second.output.contains("bg-shell-second"),
+            "{}",
+            second.output
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/astra-tools/src/shell_ops.rs
+++ b/rust/crates/astra-tools/src/shell_ops.rs
@@ -22,6 +22,7 @@ use crate::exit_semantics::{ExitSemantics, classify_command_result, classify_exi
 use crate::{ToolResult, per_tool_output_limit, truncate_output};
 
 const GREP_TIMEOUT: Duration = Duration::from_secs(20);
+const COMMAND_DRAIN_CHUNK_BUDGET: usize = 64;
 
 /// RAII guard for detach handle lifecycle. Takes ownership on creation,
 /// automatically restores to slot on drop unless explicitly consumed.
@@ -92,6 +93,33 @@ async fn restore_detach_signal_receiver(
 ) {
     if let Some(signal_rx) = signal_rx {
         *detach.signal_rx.lock().await = Some(signal_rx);
+    }
+}
+
+fn detach_signal_observed(signal_rx: &mut Option<tokio::sync::watch::Receiver<bool>>) -> bool {
+    enum SignalState {
+        Observed,
+        NotObserved,
+        Disconnected,
+    }
+
+    let state = if let Some(rx) = signal_rx.as_mut() {
+        match rx.has_changed() {
+            Ok(true) if *rx.borrow_and_update() => SignalState::Observed,
+            Ok(_) => SignalState::NotObserved,
+            Err(_) => SignalState::Disconnected,
+        }
+    } else {
+        return false;
+    };
+
+    match state {
+        SignalState::Observed => true,
+        SignalState::NotObserved => false,
+        SignalState::Disconnected => {
+            *signal_rx = None;
+            false
+        }
     }
 }
 
@@ -3145,7 +3173,14 @@ pub(crate) async fn run_bash_with_detach(
     let mut detached = false;
 
     loop {
-        drain_command_chunks(
+        if detach_signal_observed(&mut signal_rx) {
+            detached = true;
+            stdout_detach.notify_one();
+            stderr_detach.notify_one();
+            break;
+        }
+
+        drain_command_chunks_budgeted(
             &mut rx,
             &mut stdout_text,
             &mut stderr_text,
@@ -3154,6 +3189,13 @@ pub(crate) async fn run_bash_with_detach(
             max_stderr_bytes,
             &mut stderr_capped,
         );
+
+        if detach_signal_observed(&mut signal_rx) {
+            detached = true;
+            stdout_detach.notify_one();
+            stderr_detach.notify_one();
+            break;
+        }
 
         match child.try_wait() {
             Ok(Some(status)) => {
@@ -3178,27 +3220,37 @@ pub(crate) async fn run_bash_with_detach(
                                 break;
                             }
                             res = rx.changed() => {
-                                if res.is_ok() {
-                                    detached = true;
-                                    stdout_detach.notify_one();
-                                    stderr_detach.notify_one();
-                                    break;
+                                match res {
+                                    Ok(()) if *rx.borrow_and_update() => {
+                                        detached = true;
+                                        stdout_detach.notify_one();
+                                        stderr_detach.notify_one();
+                                        break;
+                                    }
+                                    Ok(()) => {}
+                                    Err(_) => {
+                                        // Sender dropped -> no detach possible.
+                                        signal_rx = None;
+                                    }
                                 }
-                                // Sender dropped → no detach possible.
-                                signal_rx = None;
                             }
                             _ = tokio::time::sleep(Duration::from_millis(25)) => {}
                         }
                     } else {
                         tokio::select! {
                             res = rx.changed() => {
-                                if res.is_ok() {
-                                    detached = true;
-                                    stdout_detach.notify_one();
-                                    stderr_detach.notify_one();
-                                    break;
+                                match res {
+                                    Ok(()) if *rx.borrow_and_update() => {
+                                        detached = true;
+                                        stdout_detach.notify_one();
+                                        stderr_detach.notify_one();
+                                        break;
+                                    }
+                                    Ok(()) => {}
+                                    Err(_) => {
+                                        signal_rx = None;
+                                    }
                                 }
-                                signal_rx = None;
                             }
                             _ = tokio::time::sleep(Duration::from_millis(25)) => {}
                         }
@@ -3240,7 +3292,7 @@ pub(crate) async fn run_bash_with_detach(
 
     if detached {
         while !stdout_task.is_finished() || !stderr_task.is_finished() {
-            drain_command_chunks(
+            drain_command_chunks_budgeted(
                 &mut rx,
                 &mut stdout_text,
                 &mut stderr_text,
@@ -3410,16 +3462,58 @@ fn drain_command_chunks(
     max_stderr_bytes: usize,
     stderr_capped: &mut bool,
 ) {
-    while let Ok((kind, chunk)) = rx.try_recv() {
-        match kind {
-            StreamKind::Stdout => {
-                append_capped(stdout_text, &chunk, max_stdout_bytes, stdout_capped)
-            }
-            StreamKind::Stderr => {
-                append_capped(stderr_text, &chunk, max_stderr_bytes, stderr_capped)
-            }
+    while drain_one_command_chunk(
+        rx,
+        stdout_text,
+        stderr_text,
+        max_stdout_bytes,
+        stdout_capped,
+        max_stderr_bytes,
+        stderr_capped,
+    ) {}
+}
+
+fn drain_command_chunks_budgeted(
+    rx: &mut tokio::sync::mpsc::Receiver<(StreamKind, String)>,
+    stdout_text: &mut String,
+    stderr_text: &mut String,
+    max_stdout_bytes: usize,
+    stdout_capped: &mut bool,
+    max_stderr_bytes: usize,
+    stderr_capped: &mut bool,
+) {
+    for _ in 0..COMMAND_DRAIN_CHUNK_BUDGET {
+        if !drain_one_command_chunk(
+            rx,
+            stdout_text,
+            stderr_text,
+            max_stdout_bytes,
+            stdout_capped,
+            max_stderr_bytes,
+            stderr_capped,
+        ) {
+            break;
         }
     }
+}
+
+fn drain_one_command_chunk(
+    rx: &mut tokio::sync::mpsc::Receiver<(StreamKind, String)>,
+    stdout_text: &mut String,
+    stderr_text: &mut String,
+    max_stdout_bytes: usize,
+    stdout_capped: &mut bool,
+    max_stderr_bytes: usize,
+    stderr_capped: &mut bool,
+) -> bool {
+    let Ok((kind, chunk)) = rx.try_recv() else {
+        return false;
+    };
+    match kind {
+        StreamKind::Stdout => append_capped(stdout_text, &chunk, max_stdout_bytes, stdout_capped),
+        StreamKind::Stderr => append_capped(stderr_text, &chunk, max_stderr_bytes, stderr_capped),
+    }
+    true
 }
 
 fn truncate_partial_line(output: &mut String) {

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -390,12 +390,12 @@ fn action_kind(action: &SessionStateRollbackAction) -> &'static str {
     }
 }
 
-fn normalized_drift(old: f64, new: f64) -> Option<f64> {
-    let denom = old.abs();
-    if denom < f64::EPSILON {
+fn bounded_drift(old: f64, new: f64, min: f64, max: f64) -> Option<f64> {
+    let span = max - min;
+    if span <= f64::EPSILON {
         return None;
     }
-    Some((new - old).abs() / denom)
+    Some((new - old).abs() / span)
 }
 
 fn extract_tool_name(args: &Value) -> Option<String> {
@@ -3685,7 +3685,7 @@ impl ServerToolExecutor {
                     return json!({"error": "compression.compression_threshold must be within [0.5, 0.98]"}).to_string();
                 }
                 let old = session.config.compression.compression_threshold;
-                let drift = normalized_drift(old, new);
+                let drift = bounded_drift(old, new, 0.5, 0.98);
                 if let Some(drift_value) = drift
                     && !force
                     && drift_value > ceiling
@@ -3712,7 +3712,7 @@ impl ServerToolExecutor {
                         .to_string();
                 }
                 let old = session.config.memory.retrieval_top_k;
-                let drift = normalized_drift(old as f64, new as f64);
+                let drift = bounded_drift(old as f64, new as f64, 1.0, 20.0);
                 if let Some(drift_value) = drift
                     && !force
                     && drift_value > ceiling
@@ -3739,7 +3739,7 @@ impl ServerToolExecutor {
                         .to_string();
                 }
                 let old = session.config.tool_selection.max_tools;
-                let drift = normalized_drift(old as f64, new as f64);
+                let drift = bounded_drift(old as f64, new as f64, 5.0, 80.0);
                 if let Some(drift_value) = drift
                     && !force
                     && drift_value > ceiling
@@ -3765,7 +3765,7 @@ impl ServerToolExecutor {
                     return json!({"error": "tool_selection.tool_budget_tokens must be within [0, 40000]"}).to_string();
                 }
                 let old = session.config.tool_selection.tool_budget_tokens;
-                let drift = normalized_drift(old as f64, new as f64);
+                let drift = bounded_drift(old as f64, new as f64, 0.0, 40_000.0);
                 if let Some(drift_value) = drift
                     && !force
                     && drift_value > ceiling
@@ -3791,7 +3791,7 @@ impl ServerToolExecutor {
                     return json!({"error": "token_budget.max_turn_input_tokens must be within [8000, 200000]"}).to_string();
                 }
                 let old = session.config.token_budget.max_turn_input_tokens;
-                let drift = normalized_drift(old as f64, new as f64);
+                let drift = bounded_drift(old as f64, new as f64, 8_000.0, 200_000.0);
                 if let Some(drift_value) = drift
                     && !force
                     && drift_value > ceiling
@@ -3817,7 +3817,7 @@ impl ServerToolExecutor {
                     return json!({"error": "token_budget.tools_reserve must be within [1000, 40000]"}).to_string();
                 }
                 let old = session.config.token_budget.tools_reserve;
-                let drift = normalized_drift(old as f64, new as f64);
+                let drift = bounded_drift(old as f64, new as f64, 1_000.0, 40_000.0);
                 if let Some(drift_value) = drift
                     && !force
                     && drift_value > ceiling
@@ -3844,7 +3844,7 @@ impl ServerToolExecutor {
                         .to_string();
                 }
                 let old = session.config.verification.strictness;
-                let drift = normalized_drift(old, new);
+                let drift = bounded_drift(old, new, 0.2, 0.95);
                 if let Some(drift_value) = drift
                     && !force
                     && drift_value > ceiling

--- a/rust/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/host.rs
@@ -2646,6 +2646,23 @@ pub(crate) mod tests {
         }
     }
 
+    fn make_detached_bash_edge_tool(task_id: &str) -> EdgeToolExecResult {
+        EdgeToolExecResult {
+            request_id: "req-bash".to_string(),
+            tool: "bash".to_string(),
+            args: json!({"command": "make check 2>&1"}),
+            output: format!(
+                "<bash_detached>The bash command was promoted to background task {task_id}.</bash_detached>"
+            ),
+            tool_result_fields: Some(serde_json::Map::from_iter([
+                ("bash_detached".to_string(), json!(true)),
+                ("background_task_id".to_string(), json!(task_id)),
+            ])),
+            status: "ok".to_string(),
+            duration_ms: 10,
+        }
+    }
+
     fn make_edge_tool_with_args(name: &str, args: Value, output: &str) -> EdgeToolExecResult {
         EdgeToolExecResult {
             request_id: format!("req-{name}"),
@@ -3838,6 +3855,45 @@ pub(crate) mod tests {
             state.messages.len() >= 2,
             "expected >=2 messages from headless round, got {}",
             state.messages.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn detached_bash_edge_tool_stops_without_followup_poll_round() {
+        let mut host = MockHost::new(vec![
+            edge_tool_result(
+                vec![make_detached_bash_edge_tool("bg-shell-1")],
+                10,
+                5,
+                None,
+            ),
+            edge_tool_result(
+                vec![make_edge_tool("task_output", "should not run")],
+                10,
+                5,
+                None,
+            ),
+        ])
+        .with_valid_tools(&["bash", "task_output"]);
+        let mut state = make_state();
+
+        let outcome = run_agentic_loop_with_host(&mut host, &mut state).await;
+
+        assert!(matches!(outcome, Ok(AgenticLoopOutcome::Completed)));
+        assert_eq!(
+            host.turn_count(),
+            1,
+            "detached bash should end the user turn instead of letting the model poll task_output"
+        );
+        assert_eq!(state.total_tool_calls, 1);
+        assert!(state.telemetry.all_tools_used.contains("bash"));
+        assert!(!state.telemetry.all_tools_used.contains("task_output"));
+        assert!(
+            state
+                .messages
+                .iter()
+                .any(|message| message.to_string().contains("bg-shell-1")),
+            "background task id must remain visible in the tool result messages"
         );
     }
 

--- a/rust/crates/runtime/src/turn/agentic_loop/tool_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/tool_phase.rs
@@ -40,6 +40,18 @@ pub(crate) enum TurnToolPhaseControl {
     Return(AgenticLoopOutcome),
 }
 
+fn edge_round_contains_detached_bash(turn_result: &super::host::HostTurnResult) -> bool {
+    turn_result.edge_tool_round.iter().any(|edge_result| {
+        edge_result.tool == "bash"
+            && edge_result
+                .tool_result_fields
+                .as_ref()
+                .and_then(|fields| fields.get("bash_detached"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+    })
+}
+
 fn build_runtime_session_quality_assessment(
     session_id: &str,
     quality: f64,
@@ -1272,6 +1284,17 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
     }
 
     record_edge_tool_observability(state, &turn_result.edge_tool_round);
+
+    if edge_round_contains_detached_bash(&turn_result) {
+        state.step_recorder.end_turn(false);
+        finalize_turn_trace(state).await;
+        refresh_runtime_promotion_signals_from_db(state).await;
+        state.telemetry.completed_turns_for_tuning += 1;
+        maybe_run_tuning_cycle(state);
+        let turn_tokens = state.last_measured_prompt_tokens.unwrap_or(0);
+        apply_per_turn_adaptation(state, turn_tokens);
+        return Ok(TurnToolPhaseControl::Return(AgenticLoopOutcome::Completed));
+    }
 
     if let Some(ref registry) = state.skills.registry_for_activation {
         let mut any_newly_activated = false;


### PR DESCRIPTION
## Summary
- Wire Ctrl+B to the Bash runner the TUI actually uses (`edge_tools`), not only the secondary `astra_tools` bash implementation. Foreground Bash now runs with a detach-aware tokio child/pipe owner, so Ctrl+B can hand the live process and stdout/stderr to `BackgroundTaskRegistry`.
- Open Background tasks immediately on Ctrl+B with a pending `bg-shell-handoff` row, then replace it with the adopted `bg-shell-N` detail after the payload is accepted.
- Keep background work visible while foreground work continues: footer/history now use `Shift+↓ manage`, and `Shift+↓` opens the background task switcher in idle and mid-turn states.
- Make the background task view more inspectable: the header summarizes active shells/local agents/cloud sessions by kind, rows stay selectable, and hints call out output/stop/list navigation actions.
- Preserve the foreground/background contract: foreground bash/agents are promoted before they count as background tasks; completed-only background rows do not steal the switcher.
- Render promoted Bash as a successful backgrounded result instead of `Bash failed before returning output`, and return foreground status to thinking after detached ToolCompleted.
- Removed stale Ctrl+B/Ctrl+T-only background-open hint plumbing; Ctrl+B/Ctrl+T still work as behavior, but the primary management affordance is the claudecode-style down-navigation path.

## Testing
- `cargo fmt --all`
- `git diff --check`
- `cargo check --manifest-path rust/Cargo.toml -p astra-cli`
- `cargo clippy --manifest-path rust/Cargo.toml -p astra-cli --all-targets -- -D warnings`
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli responsive_bash_uses_real_detach_slot_for_ctrl_b_handoff -- --nocapture`
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli tui::background_shortcut -- --nocapture`
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli tui::bottom_pane::background_task_view -- --nocapture`
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli tui::status_line -- --nocapture`
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli shift_down_is_background_task_manage_key -- --nocapture`
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli background_task_switcher -- --nocapture`
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli bash_tool_completed_returns_foreground_status_to_thinking -- --nocapture`
- `cargo test --manifest-path rust/Cargo.toml -p astra-cli bash_detach -- --nocapture`
- `make build`