### PR TITLE
feat: deferred follow-up queue UX rework — TUI queue panel, web parity, interrupt-aware states

### DIFF
--- a/docs/design/edge-runtime-tool-boundary.md
+++ b/docs/design/edge-runtime-tool-boundary.md
@@ -1,0 +1,387 @@
+# Edge Runtime Tool Boundary
+
+Status: Design specification
+Last Updated: 2026-06-19
+Related: `edge-cloud-execution.md`, `tool-architecture-consolidation.md`, `web-agent-runner.md`
+
+## Execution Topology
+
+| Surface | UI | Agent loop owner | Runtime tool executor | Transport | Process requirement |
+| --- | --- | --- | --- | --- | --- |
+| Local CLI | User terminal | `astra-cli` | In-process CLI executor | CLI to server request stream | No `astra-edge` process |
+| Web with server workspace | Browser | Server runtime | Server local runtime executor | In-process server call | No edge process |
+| Web with user local workspace | Browser | Server runtime | `astra-edge` on user machine | Server to edge WebSocket or edge ledger | Edge process required |
+| Thin/remote CLI | Remote terminal/client | Server runtime | Server or edge-selected runtime | Server transport policy | Depends on selected workspace |
+
+`astra-edge` exists only for reverse execution into a user-local workspace. It is not part of the local CLI process model.
+
+Local CLI owns local tool execution directly. Adding an `astra-edge` child process to local CLI would duplicate the CLI's own executor path without adding a communication capability.
+
+Web cannot access paths such as `/home/user/project` or `/Users/user/project`. A resident edge agent is required when a server-controlled agent turn must execute runtime tools against those paths.
+
+## Deployment Flexibility Objective
+
+Astra runtime execution must be deployment-neutral.
+
+The server must route tools by binding and capability, not by a hard-coded deployment shape.
+
+The same tool-routing model must support:
+
+| Deployment shape | Workspace binding | Executor binding | Runtime binding | Primary use |
+| --- | --- | --- | --- | --- |
+| Local CLI | `LocalFilesystem` | `LocalCli` | `HostProcess` | Developer terminal workflow |
+| Web with local edge | `EdgeWorkspace` | `EdgeAgent` | `HostProcess` | Browser workflow over user-local files |
+| Web with server sandbox | `ServerSandbox` | `ServerRuntime` or `ServerLocal` | `HostProcess` or container runtime | Hosted workspace workflow |
+| Cloud workspace runtime | `CloudWorkspace` | `OrchestratorManaged` | `ProviderManaged` or container runtime | SaaS or private cloud workspaces |
+| Request-scoped MCP | Any compatible workspace | `RequestScopedMcp` | MCP transport runtime | External tool integration |
+| Gateway relay | Any compatible workspace | `OrchestratorManaged` | Remote runtime | Enterprise or provider-managed execution |
+
+The routing layer must not assume that runtime execution means local process execution, edge WebSocket execution, or Kubernetes execution. Those are transport and lifecycle choices behind the same binding model.
+
+## Operator Integration Boundary
+
+This document does not design a Kubernetes operator.
+
+This document does not define:
+
+- custom resource definitions,
+- reconciliation loops,
+- controller ownership rules,
+- namespace layout,
+- pod templates,
+- PVC layout,
+- service mesh policy,
+- image build or rollout strategy.
+
+This document defines the runtime contract that an operator can implement.
+
+A Kubernetes operator can integrate by managing runtime lifecycle and publishing runtime state into Astra's existing binding and advertisement model.
+
+| Operator-managed concern | Astra contract surface |
+| --- | --- |
+| Runtime creation | `WorkspaceBinding`, `ExecutorBinding`, `RuntimeBinding` |
+| Runtime readiness | executor status, runtime status, heartbeat, capability advertisement |
+| Runtime policy | `PolicyIntent`, resource limits, filesystem authority, network policy, credentials policy |
+| Runtime disposal | lease expiry, idle timeout, run completion, workspace retention policy |
+| Runtime recovery | executor id stability, session/workspace rebinding, degraded/offline status |
+| Tool support | executor manifest and sanitized runtime advertisement |
+
+Tool calls remain data-plane RPC. They must not require a Kubernetes CRD per tool invocation.
+
+Operator-style lifecycle management is control plane. Tool execution is runtime data plane.
+
+## Platform-Neutral Runtime Contract
+
+Every runtime executor must expose the same minimal contract, independent of deployment platform:
+
+| Contract | Requirement |
+| --- | --- |
+| Identity | stable executor id for routing, audit, and reconnection |
+| Workspace | declared workspace kind, cwd or workspace handle, read/write authority |
+| Runtime | session manager, isolation backend, launch driver, status |
+| Tool manifest | actual supported tool names derived from handlers |
+| Capability advertisement | sanitized `RuntimeEnvironmentAdvertisement` |
+| Policy | filesystem, network, credentials, approval, audit, and resource constraints |
+| Heartbeat | liveness and degraded/offline transition signal |
+| Cancellation | request-level cancellation for long-running and destructive-capable tools |
+| Timeout | request-level timeout enforced by the executor, not only by the caller |
+| Artifacts | explicit artifact publication path for generated files |
+
+Kubernetes is one implementation target for this contract. Edge host processes, server-local sandboxes, provider-managed runtimes, and gateway relays are other implementation targets.
+
+## Tool Ownership
+
+Tool ownership is determined before transport selection.
+
+| Owner | Examples | Execution location |
+| --- | --- | --- |
+| Control plane | `ask_user`, `enter_plan_mode`, `exit_plan_mode`, `task`, `notify`, `introspect` | Server or CLI host |
+| Server service | `memory`, `mo`, `mo_query`, `rollback_database_snapshots`, server-side `tool_search` | Server runtime |
+| Runtime executor | `read_file`, `write_file`, `str_replace`, `list_dir`, `grep`, `glob`, `bash`, `git`, `run_script`, `symbols` | Server sandbox, edge, or orchestrator runtime |
+| Request-scoped MCP | `mcp__...` | MCP transport |
+| Host-interactive sink | approval, `ask_user` UI, plan review, permission-mode change | Active UI host |
+
+Control-plane tools must not route to edge transport.
+
+Runtime tools route to edge only when the workspace binding is `EdgeWorkspace`.
+
+Server-service tools must remain server-owned unless the registry explicitly splits them into server-service and runtime-executor variants.
+
+## Current Code Boundaries
+
+`astra-edge` executes tool requests through `astra_tools::executor::DefaultToolExecutor`.
+
+`astra-cli/src/edge_tools.rs` is a CLI facade. It combines shared tool logic, CLI-only session state, rollback journals, background task integration, local MCP dispatch, LSP sessions, plan-mode sinks, and default delegation into `astra_tools`.
+
+`astra_tools` contains the shared executor, schemas, file operations, shell operations, git operations, GitHub client logic, web fetch/search, memory protocol helpers, ask-user parsing, task management, and run-script RPC.
+
+`astra_runtime_env::ToolRegistry::builtins()` is a capability and routing registry. It is not a proof that a specific executor binary has a handler for every listed tool.
+
+`astra_tools::schemas::all_tool_schemas()` is the model-visible static schema catalog. It is not a proof that every executor path can execute every schema.
+
+Actual execution support is defined by each executor's dispatch table or registered handler table.
+
+## Required Invariant
+
+For every model-visible tool schema in a turn:
+
+```text
+schema_visible(tool)
+  => runtime_registry_knows(tool)
+  => run_binding_admits(tool, args)
+  => route_can_deliver(tool)
+  => selected_executor_supports(tool)
+```
+
+For every edge-advertised tool:
+
+```text
+edge_advertises(tool)
+  => server_registry_knows(tool)
+  => edge_executor_manifest_contains(tool)
+  => edge_handler_executes(tool) without "not available" fallback
+```
+
+For every runtime-executor tool in an `EdgeWorkspace` turn:
+
+```text
+visible_runtime_tool(tool)
+  => selected_edge_advertisement_contains(tool)
+```
+
+Control-plane and server-service tools are excluded from the edge advertisement intersection because they are not edge-owned.
+
+## Drift Sources
+
+Three catalogs currently need explicit parity checks:
+
+| Catalog | Source | Purpose |
+| --- | --- | --- |
+| Model schemas | `astra_tools::schemas::all_tool_schemas()` | LLM-visible function definitions |
+| Runtime registry | `astra_runtime_env::ToolRegistry::builtins()` | capability checks and route ownership |
+| Handlers | `DefaultToolExecutor::dispatch`, `ServerToolExecutor` handlers, CLI `edge_tools::ToolExecutor::execute` | actual execution |
+
+Known drift classes:
+
+- A registry entry can exist without a model schema.
+- A model schema can exist without a handler on a specific transport.
+- A CLI handler can exist without a shared schema.
+- An edge advertisement can pass registry validation while the edge executor lacks the handler.
+- A server runtime schema can be visible for an edge workspace before intersecting with edge-advertised runtime tools.
+
+## Edge Advertisement
+
+Edge authentication must include a structured runtime advertisement derived from the edge executor manifest.
+
+The advertisement must not be derived only from `ToolRegistry::builtins()`.
+
+The advertisement must include:
+
+- workspace binding,
+- executor binding,
+- runtime binding,
+- policy intent,
+- effective capabilities,
+- supported tool names,
+- denials for unsupported or policy-blocked tools.
+
+Server validation must:
+
+- reject malformed advertisements,
+- reject non-edge executor bindings,
+- strip unknown registry names,
+- strip names absent from the edge executor manifest,
+- preserve control-plane and server-service ownership outside the edge runtime set,
+- store sanitized capabilities in the live edge pool and edge registry.
+
+## Host Interaction Boundary
+
+`ask_user` parsing is shared logic.
+
+`ask_user` execution is host-owned because it requires an interactive client connection.
+
+Approval gates are host-owned because they require user policy state, UI rendering, audit events, and response channels.
+
+Plan review is host-owned because it changes permission mode and exposes a UI-specific review surface.
+
+Background task control is host-owned because task registries and detach slots are drained by the active UI host.
+
+Edge runtime tools must not block on stdin or TTY prompts. A missing host sink must return a structured tool error.
+
+## Cancellation and Timeout
+
+Edge must honor per-request `timeout_secs`.
+
+Edge must support `edge_tool_cancel` for cancellable tools.
+
+Cancellation requirements:
+
+- cancellation token per in-flight request,
+- propagation into shell/process tools,
+- best-effort process termination,
+- no result delivery after server cancellation,
+- no late destructive writes after timeout,
+- request cleanup on disconnect.
+
+Server-side timeout without edge-side cancellation is insufficient for write-capable runtime tools.
+
+## Module Classification
+
+### Already Shared or Low-Risk Runtime Tools
+
+These are implemented in `astra_tools` or already have shared equivalents:
+
+- `read_file`
+- `write_file`
+- `str_replace`
+- `delete_file`
+- `multi_edit`
+- `list_dir`
+- `grep`
+- `glob`
+- `bash`
+- `git` common actions
+- `github`
+- `web_fetch`
+- `web_search`
+- `tool_search`
+- `env`
+- `config`
+- `run_script` on Unix
+- `ask_user` parser only
+
+Edge support for these must still be gated by executor manifest, runtime policy, and cancellation behavior.
+
+### Candidate Extraction Modules
+
+These can move toward `astra_tools` after schema, registry, and handler parity are defined:
+
+| Module | Target | Required extraction work |
+| --- | --- | --- |
+| `notebook_edit.rs` | Runtime executor | Add schema, registry entry, shared handler, file sandbox checks |
+| `code_analysis.rs` | Runtime executor or code-intel package | Define public tool names, add schemas, add registry specs, remove CLI facade dependency |
+| `lsp_stdio_session.rs` | Runtime executor support library | Keep process/session lifecycle headless; expose configuration-driven construction |
+| `passive_lsp.rs` | Runtime executor support library | Move workspace and server configuration into explicit runtime config |
+| `lsp_tools.rs` | Runtime executor | Add manifest entries per supported operation or keep consolidated `lsp` only |
+| `worktree.rs` | Runtime executor | Add git permission boundaries and rollback journal interface |
+| `mo_tools.rs` | Split owner | Keep server-service `mo` by default; add separate runtime-owned variant only for edge-local MatrixOne |
+
+### Host-Context Modules
+
+These require host-provided context before extraction:
+
+| Module | Host dependency |
+| --- | --- |
+| `context_tools.rs` | shared context cache, task manager, agent identity |
+| `context_analysis.rs` | observability session |
+| `agent_spawning.rs` | dynamic agent spawner |
+| `agent_messaging.rs` | mailbox/router context |
+| `mcp_dispatch.rs` | MCP manager and server declarations |
+| `session_state.rs` | session-state journal and persistence ports |
+| `self_mod_tools.rs` | self-command persistence ports and mutation governors |
+| `memoria.rs` | server URL, auth token, memory service ownership |
+
+### Host-Only Behaviors
+
+These stay outside edge runtime execution:
+
+- approval prompt rendering,
+- `ask_user` UI and response collection,
+- plan-review UI,
+- permission-mode changes,
+- TUI background task registry,
+- CLI progress sink rendering,
+- terminal-specific formatting.
+
+## Web Tool Surface Rule for Edge Workspaces
+
+For `EdgeWorkspace`, tool schema resolution must combine:
+
+1. server control-plane schemas,
+2. server-service schemas,
+3. request-scoped MCP schemas,
+4. runtime-executor schemas intersected with selected edge advertised tools.
+
+Server sandbox workspaces use server-local runtime support instead of edge advertisement.
+
+`WorkspaceBindingKind::None` exposes only control-plane and server-service schemas.
+
+Unknown or disconnected edge runtime removes runtime-executor schemas from the model-visible surface, or emits a blocked run state before model execution.
+
+## Parity Tests
+
+Required tests:
+
+| Test | Assertion |
+| --- | --- |
+| Schema to registry parity | Every static schema name is registered or explicitly marked plugin/pass-through/internal |
+| Registry to schema parity | Every model-facing registry entry has a schema or is marked non-model-facing |
+| Registry to handler parity | Every routable runtime tool has at least one handler for each advertised transport |
+| Edge advertisement parity | Edge advertised names equal edge executor manifest names after policy filtering |
+| Edge no-ghost execution | Any edge-advertised tool executes without `DefaultToolExecutor` "not available" fallback |
+| Web edge schema intersection | Edge workspace runtime schemas are hidden when the edge does not advertise them |
+| Control-plane bypass | `ask_user`, approvals, plan lifecycle, and task control never route to edge |
+| Cancel propagation | `edge_tool_cancel` aborts long-running shell/process requests |
+| Timeout propagation | `timeout_secs` limits edge execution, not only server wait time |
+| CLI topology | Local CLI runs without starting or depending on `astra-edge` |
+
+## Implementation Sequence
+
+### Phase 0: Manifest and Parity
+
+- Add executor manifest API to `astra_tools`.
+- Derive `DefaultToolExecutor` supported tool names from registered handlers or a single local table.
+- Add schema/registry/handler parity tests.
+- Build edge advertisement from executor manifest plus runtime policy.
+- Sanitize edge advertisements against both server registry and edge manifest.
+
+### Phase 1: Edge Transport Correctness
+
+- Track in-flight edge requests by request id.
+- Wire per-request cancellation tokens.
+- Honor `timeout_secs`.
+- Implement `edge_tool_cancel` for shell/process-backed tools.
+- Drop late results after cancellation or timeout.
+
+### Phase 2: Web Schema Intersection
+
+- During Web tool surface assembly for `EdgeWorkspace`, intersect runtime-executor schemas with selected edge advertised tools.
+- Keep server control-plane, server-service, and MCP schemas outside that intersection.
+- Emit run-blocked metadata when an edge workspace has no connected capable runtime executor.
+
+### Phase 3: Platform-Neutral Runtime Contract
+
+- Keep routing decisions based on `WorkspaceBinding`, `ExecutorBinding`, `RuntimeBinding`, `PolicyIntent`, and executor manifest.
+- Represent orchestrator-managed runtimes without adding Kubernetes-specific assumptions to the core routing layer.
+- Keep tool execution on data-plane transports.
+- Keep lifecycle state in runtime status, executor status, heartbeat, lease, and advertisement records.
+- Do not introduce operator-specific CRDs or reconciliation behavior in this phase.
+
+### Phase 4: Pure Module Extraction
+
+- Move pure runtime logic from `astra-cli/src/edge_tools` into `astra_tools`.
+- Replace `crate::cli` references with explicit traits.
+- Keep host sinks and UI-specific behavior in CLI/server host layers.
+- Add transport-specific tests before exposing new schemas.
+
+### Phase 5: Ownership Splits
+
+- Split ambiguous tools by owner where needed.
+- Keep `memory` server-owned.
+- Keep default `mo` server-owned.
+- Add edge-local database tools only as separately declared runtime tools.
+- Keep MCP transport declarations outside the core edge executor manifest unless the edge owns the MCP server process.
+
+## Acceptance Criteria
+
+- Local CLI does not require `astra-edge`.
+- Web local-workspace execution requires a connected edge runtime with a valid advertisement.
+- Model-visible runtime tools for edge workspaces are executable by the selected edge.
+- No advertised edge tool returns a generic "not available in DefaultToolExecutor" result.
+- Control-plane tools never route to edge.
+- Host-interactive tools fail fast without a host sink.
+- Cancellable edge tools stop on server cancellation or timeout.
+- Schema, registry, and handler drift is caught in CI.
+- Runtime routing does not depend on Kubernetes-specific types.
+- An orchestrator-managed runtime can integrate through binding, manifest, heartbeat, policy, and advertisement records.
+- No operator CRD or controller design is required to implement this document.

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -242,8 +242,17 @@ fn deferred_input_status_line(input: &Value) -> Option<String> {
         .or_else(|| input.as_str())
         .map(str::trim)
         .filter(|text| !text.is_empty())?;
-    let mut preview: String = text.replace('\n', " ↩ ").chars().take(80).collect();
-    if text.replace('\n', " ↩ ").chars().count() > 80 {
+    let mut preview: String = text
+        .replace('\n', crate::DEFERRED_INPUT_FINGERPRINT_SEP)
+        .chars()
+        .take(80)
+        .collect();
+    if text
+        .replace('\n', crate::DEFERRED_INPUT_FINGERPRINT_SEP)
+        .chars()
+        .count()
+        > 80
+    {
         preview.push_str("...");
     }
     Some(format!("__deferred_input_applied__:{preview}"))

--- a/rust/crates/astra-cli/src/lib.rs
+++ b/rust/crates/astra-cli/src/lib.rs
@@ -25,6 +25,12 @@
     clippy::unnecessary_mut_passed
 )]
 
+// Deferred input fingerprint separator: must byte-match between the
+// server's `deferred_input_status_line` (cli_loop_host.rs) and the
+// client's `deferred_input_preview_fingerprint` (bottom_pane/mod.rs).
+// Any divergent edit in one place silently breaks desync detection.
+pub const DEFERRED_INPUT_FINGERPRINT_SEP: &str = " ↩ ";
+
 // ═══════════════════════════ Top-level utility modules ═══════════════════
 pub mod diff_utils;
 pub mod edge_tools;

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -18,6 +18,10 @@ use astra_services::session_journal;
 use clap::Parser;
 use crossterm::style::Stylize;
 
+// Single source of truth: re-export from lib.rs so `crate::DEFERRED_INPUT_FINGERPRINT_SEP`
+// resolves identically in both the lib-compiled and binary-compiled copies of cli/tui modules.
+pub(crate) use astra_cli::DEFERRED_INPUT_FINGERPRINT_SEP;
+
 mod edge_tools;
 mod git_branch_cache;
 mod manifest_loader;

--- a/rust/crates/astra-cli/src/tui/bottom_pane/chat_composer.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/chat_composer.rs
@@ -53,7 +53,7 @@ const PASTE_INLINE_MAX_CHARS: usize = 800;
 const PASTE_INLINE_MAX_LINES: usize = 2;
 const COMPOSER_PLACEHOLDER: &str = "Message astra";
 const IDLE_COMPOSER_HELPER: &str = "Ctrl+E editor · Shift+Enter newline";
-const ACTIVE_TURN_HELPER: &str = "Queued for next tool · Ctrl+C stops";
+const ACTIVE_TURN_HELPER: &str = "Enter queues follow-up · Ctrl+C stops";
 
 impl ChatComposer {
     pub fn new() -> Self {
@@ -418,7 +418,7 @@ impl ChatComposer {
         }
     }
 
-    pub fn render(&self, area: Rect, buf: &mut Buffer, task_active: bool) {
+    pub fn render(&self, area: Rect, buf: &mut Buffer, task_active: bool, queueing: bool) {
         if area.height == 0 || area.width == 0 {
             return;
         }
@@ -432,18 +432,32 @@ impl ChatComposer {
         let content_h = area.height.saturating_sub(top_inset);
         let content_area = Rect::new(area.x, content_y, area.width, content_h.max(1));
 
-        // Keep the composer prompt visible without shouting. The
-        // submit flash still upgrades it to the full accent to signal
-        // that the input was accepted.
+        // Mode-shift feedback: when a deferred follow-up is queued, the
+        // composer's Enter semantics change from "send now" to "enqueue".
+        // That shift must be visible at a glance — otherwise the user
+        // hits Enter expecting a send and the input silently lands in a
+        // queue they didn't realize was active. Two signals combine:
+        //   1. the prefix glyph flips `·` → `»` (queue/"waiting" glyph), and
+        //   2. the prefix color brightens from accent_dim to accent, so
+        //      the chrome reads as "armed" rather than "idle prompt".
+        // The submit flash still wins outright when a send lands.
         let mut prefix_style = Style::default()
             .fg(theme.accent_dim())
             .add_modifier(ratatui::style::Modifier::BOLD)
             .bg(panel.bg.unwrap_or(Color::Reset));
+        if queueing && !self.is_flashing() {
+            prefix_style = prefix_style.fg(theme.accent);
+        }
         if self.is_flashing() {
             prefix_style = prefix_style.fg(theme.accent);
         }
-        let prefix = Span::styled(&self.prompt_prefix, prefix_style);
-        let prefix_width = self.prefix_display_width();
+        let prefix_str: &str = if queueing { "» " } else { &self.prompt_prefix };
+        let prefix = Span::styled(prefix_str, prefix_style);
+        // Measure the *rendered* prefix, not `self.prompt_prefix`: in queueing
+        // mode the glyph is `"» "` and the two strings could diverge in display
+        // width (e.g. a future emoji/CJK queue glyph). Computing width from
+        // the same string we emit keeps the cursor anchored to the text edge.
+        let prefix_width = (prefix_str.width() as u16).min(content_area.width).max(1);
         let prefix_area = Rect::new(
             content_area.x,
             content_area.y,
@@ -714,7 +728,7 @@ mod paste_tests {
 
     #[test]
     fn active_turn_helper_surfaces_queue_semantics() {
-        assert!(ACTIVE_TURN_HELPER.contains("Queued"));
+        assert!(ACTIVE_TURN_HELPER.contains("Enter queues"));
         assert!(ACTIVE_TURN_HELPER.contains("Ctrl+C"));
     }
 }

--- a/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
@@ -48,6 +48,9 @@ use footer::Footer;
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Widget,
 };
 use skill_popup::SkillPopup;
 use view::{BottomPaneView, CancellationEvent};
@@ -62,6 +65,7 @@ use crate::cli::chat_stream::ApprovalResponse;
 use ask_user_view::AskUserView;
 use std::sync::Arc;
 use tokio::sync::oneshot;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 pub(crate) struct BottomPane {
     pub composer: ChatComposer,
@@ -78,6 +82,30 @@ pub(crate) struct BottomPane {
     mention_range: Option<(usize, usize)>,
     file_provider: Option<Arc<dyn FileProvider>>,
     approval_queue: ApprovalQueue,
+    queued_followups: std::collections::VecDeque<String>,
+    /// True when the user pressed Esc/Ctrl+C to interrupt the current
+    /// run and the cancel RPC is in flight. The queue panel reflects
+    /// this intermediate state so the user isn't stuck wondering why
+    /// "Esc sends now" isn't taking effect immediately.
+    pub(crate) interrupt_pending: bool,
+}
+
+/// Outcome of popping the deferred follow-up queue on an applied signal.
+/// The server emits `__deferred_input_applied__:<preview>` per dequeued
+/// item; the client recomputes the preview from its head and compares so
+/// a missed/extra/reordered event surfaces as a *visible* failure instead
+/// of silently committing the wrong text as the user's own input.
+#[derive(Debug, PartialEq)]
+pub(crate) enum DeferredFollowupPop {
+    /// Server preview matched our head — safe to commit verbatim.
+    Applied(String),
+    /// Queue was empty when an applied signal arrived — stray/late event.
+    Empty,
+    /// Server preview didn't match our head — local and server queues are
+    /// out of sync. The entire local queue is dropped (we can no longer
+    /// trust which items were applied) and returned for the caller to
+    /// surface as a visible, recoverable warning.
+    Desync { dropped: Vec<String> },
 }
 
 impl BottomPane {
@@ -95,6 +123,8 @@ impl BottomPane {
             mention_range: None,
             file_provider: None,
             approval_queue: ApprovalQueue::new(),
+            queued_followups: std::collections::VecDeque::new(),
+            interrupt_pending: false,
         }
     }
 
@@ -168,6 +198,86 @@ impl BottomPane {
     pub fn handle_paste(&mut self, text: &str) {
         self.composer.handle_paste(text);
         self.sync_popups();
+    }
+
+    /// Queue a follow-up for the next execution boundary. Returns true
+    /// if text was actually enqueued (non-empty after trimming). Empty
+    /// input is explicitly ignored — it would produce a no-op server round
+    /// trip and a confusing empty queued row in the panel.
+    pub fn queue_deferred_followup(&mut self, text: impl Into<String>) -> bool {
+        let text = text.into();
+        if !text.trim().is_empty() {
+            self.queued_followups.push_back(text);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Pop the head of the deferred queue, but only after verifying it
+    /// matches the server's status-line fingerprint. The server dequeues
+    /// deferred inputs in strict FIFO order and emits exactly one
+    /// `__deferred_input_applied__:<preview>` status line per dequeued
+    /// item; the preview is the server's own truncation of that item's
+    /// text. By recomputing it from the head and comparing, we detect a
+    /// missed/extra/reordered event (desync) instead of silently popping
+    /// the *wrong* head and committing it to chat history as the user's
+    /// input.
+    ///
+    /// - Match → pop head, return full text for verbatim commit.
+    /// - Mismatch with a non-empty queue → the contract is broken; drop
+    ///   the queue and surface what was lost as `Desync`, so the failure
+    ///   is *visible* and recoverable rather than *silent corruption*.
+    ///   The caller commits the dropped previews as a warning cell.
+    /// - Empty queue + applied signal → stray/late event; `Empty`.
+    pub fn pop_applied_deferred_followup(&mut self, expected_preview: &str) -> DeferredFollowupPop {
+        if self.queued_followups.is_empty() {
+            return DeferredFollowupPop::Empty;
+        }
+        let head = self.queued_followups.pop_front().unwrap();
+        let head_fingerprint = deferred_input_preview_fingerprint(&head);
+        if head_fingerprint == expected_preview {
+            return DeferredFollowupPop::Applied(head);
+        }
+        // Desync: the server's preview doesn't match our head. Put it back
+        // and drop the entire local queue — we no longer know which items
+        // were applied, so committing any of them would risk the wrong
+        // text appearing as the user's own words in chat history.
+        tracing::warn!(
+            target: "astra_cli::tui",
+            expected = %expected_preview,
+            head_fingerprint = %head_fingerprint,
+            queue_depth = self.queued_followups.len() + 1,
+            "deferred follow-up desync: server preview did not match local head; \
+             dropping local queue to avoid committing the wrong user input"
+        );
+        let mut dropped = vec![head];
+        dropped.extend(self.queued_followups.drain(..));
+        DeferredFollowupPop::Desync { dropped }
+    }
+
+    /// Restore queued-but-unapplied input into the composer at run end,
+    /// preserving any draft the user is currently editing by appending
+    /// beneath it. Never silently drop user input.
+    pub fn restore_into_composer(&mut self, text: &str) {
+        if text.trim().is_empty() {
+            return;
+        }
+        if self.composer.is_empty() {
+            self.composer.set_text(text);
+        } else {
+            let existing = self.composer.text();
+            self.composer
+                .set_text(&format!("{}\n\n{}", existing.trim_end(), text));
+        }
+    }
+
+    pub fn take_deferred_followups(&mut self) -> Vec<String> {
+        self.queued_followups.drain(..).collect()
+    }
+
+    fn has_deferred_followups(&self) -> bool {
+        !self.queued_followups.is_empty()
     }
 
     pub fn set_task_status(&mut self, status: TaskStatus) {
@@ -646,8 +756,9 @@ impl BottomPane {
         }
         let content_h = self.composer.desired_height(width);
         let approval_h = self.focused_approval_height(width);
+        let queue_h = self.deferred_followup_height();
         let popup_h = self.popup_height();
-        content_h + approval_h + popup_h + 1
+        content_h + approval_h + queue_h + popup_h + 1
     }
 
     /// Top-level key routing. Dispatches to named phase handlers so
@@ -680,6 +791,13 @@ impl BottomPane {
         }
         if let Some(a) = self.handle_mention_menu_key(key) {
             return a;
+        }
+        // Esc interrupt only after popups/menus had their chance, so an
+        // open slash/mention/skill menu closes on Esc instead of
+        // aborting the whole turn.
+        if self.task_status.is_active() && self.has_deferred_followups() && key.code == KeyCode::Esc
+        {
+            return BottomPaneAction::Interrupt;
         }
         if key.code == KeyCode::BackTab {
             return BottomPaneAction::CyclePermissionMode;
@@ -1072,11 +1190,13 @@ impl BottomPane {
 
         let popup_h = self.popup_height();
         let content_h = self.composer.desired_height(area.width);
+        let queue_h = self.deferred_followup_height();
 
         let approval_h = self.focused_approval_height(area.width);
         if popup_h > 0 {
             let chunks = Layout::vertical([
                 Constraint::Length(approval_h),
+                Constraint::Length(queue_h),
                 Constraint::Length(content_h),
                 Constraint::Length(popup_h),
                 Constraint::Length(1),
@@ -1084,28 +1204,39 @@ impl BottomPane {
             .split(area);
 
             self.render_focused_approval(chunks[0], buf);
-            self.composer
-                .render(chunks[1], buf, self.task_status.is_active());
+            self.render_deferred_followups(chunks[1], buf);
+            self.composer.render(
+                chunks[2],
+                buf,
+                self.task_status.is_active(),
+                self.has_deferred_followups(),
+            );
             if let Some(ref menu) = self.slash_menu {
-                slash_popup_render::render(menu, chunks[2], buf);
+                slash_popup_render::render(menu, chunks[3], buf);
             } else if let Some(ref menu) = self.mention_menu {
-                mention_popup_render::render(menu, chunks[2], buf);
+                mention_popup_render::render(menu, chunks[3], buf);
             } else if let Some(ref popup) = self.skill_popup {
-                popup.render(chunks[2], buf);
+                popup.render(chunks[3], buf);
             }
-            self.footer.render(chunks[3], buf);
+            self.footer.render(chunks[4], buf);
         } else {
             let chunks = Layout::vertical([
                 Constraint::Length(approval_h),
+                Constraint::Length(queue_h),
                 Constraint::Length(content_h),
                 Constraint::Length(1),
             ])
             .split(area);
 
             self.render_focused_approval(chunks[0], buf);
-            self.composer
-                .render(chunks[1], buf, self.task_status.is_active());
-            self.footer.render(chunks[2], buf);
+            self.render_deferred_followups(chunks[1], buf);
+            self.composer.render(
+                chunks[2],
+                buf,
+                self.task_status.is_active(),
+                self.has_deferred_followups(),
+            );
+            self.footer.render(chunks[3], buf);
         }
     }
 
@@ -1125,17 +1256,172 @@ impl BottomPane {
             .render(area, buf);
     }
 
+    fn deferred_followup_height(&self) -> u16 {
+        if self.queued_followups.is_empty() {
+            return 0;
+        }
+        let preview_rows = self.queued_followups.len().min(2) as u16;
+        let more_row = u16::from(self.queued_followups.len() > 2);
+        1 + preview_rows + more_row
+    }
+
+    fn render_deferred_followups(&self, area: Rect, buf: &mut Buffer) {
+        if area.height == 0 || self.queued_followups.is_empty() {
+            return;
+        }
+        let theme = crate::tui::theme::current();
+
+        // Distinct panel surface: visibly darker (dark term) / darker still
+        // (light term) than the composer surface so the queue reads as its
+        // own region, not as more of the input box.
+        let panel = crate::tui::style::queue_panel_style();
+        for y in area.y..area.y + area.height {
+            buf.set_string(area.x, y, " ".repeat(area.width as usize), panel);
+        }
+        let bg = panel.bg.unwrap_or(ratatui::style::Color::Reset);
+
+        // Action-first single-line title. Both behaviors must be legible even
+        // on a 42-col terminal: the verb ("Esc sends now") leads so it
+        // survives truncation, and the auto-send clause is kept short enough
+        // ("else at next tool") to fit the budget on the snapshot width. The
+        // surprising behavior is the auto-send; it must not be the half that
+        // gets cut.
+        let title = if self.interrupt_pending {
+            "Stopping — sending on finish"
+        } else {
+            "Esc sends now · else at next tool"
+        };
+        // Title is the affordance — it tells the user what this panel IS
+        // (queued input) and what their options ARE (Esc sends now / else
+        // auto-send). That is functional instruction, not decoration, so it
+        // must be fully legible. Full-strength `accent` (no bold) reads as a
+        // header: readable, visually distinct from the bold head row and the
+        // plain tail rows below. Earlier tiers (`dim+DIM`, then `accent_dim`)
+        // crushed the instruction into near-invisibility on the low-contrast
+        // panel — the exact opposite of what an affordance needs.
+        let title_style = Style::default().fg(theme.accent).bg(bg);
+        Widget::render(
+            Line::from(Span::styled(
+                truncate_display(title, area.width as usize),
+                title_style,
+            )),
+            Rect::new(area.x, area.y, area.width, 1),
+            buf,
+        );
+
+        // Visual hierarchy on the queue band:
+        //   head — accent + bold, it's about to fire.
+        //   tail — `fg` (not `dim`): queued entries are user content that
+        //     must remain legible against the low-contrast queue surface;
+        //     `dim` (DarkGray) sat too close to the panel bg.
+        //   +N more — `accent_dim` keeps the count present without
+        //     competing with the queued text above. Dropped the DIM
+        //     modifier: it doubled up on a color already at low emphasis.
+        let head_style = Style::default()
+            .fg(theme.accent)
+            .bg(bg)
+            .add_modifier(Modifier::BOLD);
+        let tail_style = Style::default().fg(theme.fg).bg(bg);
+        let more_style = Style::default().fg(theme.accent_dim()).bg(bg);
+
+        let preview_rows = (area.height as usize).saturating_sub(1);
+        for (idx, text) in self
+            .queued_followups
+            .iter()
+            .take(preview_rows)
+            .take(2)
+            .enumerate()
+        {
+            // Truncate by the actual column budget, not a hard-coded 100.
+            let prefix = if idx == 0 { "↳ " } else { "  " };
+            let budget = area.width.saturating_sub(prefix.width() as u16) as usize;
+            let preview = deferred_followup_preview(text, budget);
+            let line = format!("{prefix}{preview}");
+            let style = if idx == 0 { head_style } else { tail_style };
+            Widget::render(
+                Line::from(Span::styled(
+                    truncate_display(&line, area.width as usize),
+                    style,
+                )),
+                Rect::new(area.x, area.y + 1 + idx as u16, area.width, 1),
+                buf,
+            );
+        }
+        if self.queued_followups.len() > 2 && area.height >= 4 {
+            let line = format!("  +{} more", self.queued_followups.len() - 2);
+            Widget::render(
+                Line::from(Span::styled(
+                    truncate_display(&line, area.width as usize),
+                    more_style,
+                )),
+                Rect::new(area.x, area.y + 3, area.width, 1),
+                buf,
+            );
+        }
+    }
+
     pub fn cursor_position(&self, area: Rect) -> Option<(u16, u16)> {
         if let Some(view) = self.active_view() {
             return view.cursor_pos(area);
         }
 
+        let approval_h = self.focused_approval_height(area.width);
+        let queue_h = self.deferred_followup_height();
         let content_h = self.composer.desired_height(area.width);
-        let chunks =
-            Layout::vertical([Constraint::Length(content_h), Constraint::Min(0)]).split(area);
+        let chunks = Layout::vertical([
+            Constraint::Length(approval_h),
+            Constraint::Length(queue_h),
+            Constraint::Length(content_h),
+            Constraint::Min(0),
+        ])
+        .split(area);
 
-        self.composer.cursor_position(chunks[0])
+        self.composer.cursor_position(chunks[2])
     }
+}
+
+fn deferred_followup_preview(text: &str, limit: usize) -> String {
+    let single_line = text.trim().replace('\n', " ⏎ ");
+    let mut preview: String = single_line.chars().take(limit).collect();
+    if single_line.chars().count() > limit {
+        preview.push('…');
+    }
+    preview
+}
+
+/// Recompute the server's status-line fingerprint for a queued item.
+/// Uses `crate::DEFERRED_INPUT_FINGERPRINT_SEP` to byte-match the
+/// server's `deferred_input_status_line` algorithm.
+fn deferred_input_preview_fingerprint(text: &str) -> String {
+    let trimmed = text.trim();
+    let single_line = trimmed.replace('\n', crate::DEFERRED_INPUT_FINGERPRINT_SEP);
+    let mut preview: String = single_line.chars().take(80).collect();
+    if single_line.chars().count() > 80 {
+        preview.push_str("...");
+    }
+    preview
+}
+
+fn truncate_display(text: &str, max_width: usize) -> String {
+    if text.width() <= max_width {
+        return text.to_string();
+    }
+    if max_width <= 1 {
+        return "…".to_string();
+    }
+    let keep = max_width - 1;
+    let mut out = String::new();
+    let mut used = 0usize;
+    for ch in text.chars() {
+        let width = ch.width().unwrap_or(0);
+        if used + width > keep {
+            break;
+        }
+        out.push(ch);
+        used += width;
+    }
+    out.push('…');
+    out
 }
 
 /// Render a one-row dim hint bar at the bottom of a view area.

--- a/rust/crates/astra-cli/src/tui/bottom_pane/queue_preview_tests.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/queue_preview_tests.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use super::BottomPane;
+use super::{DeferredFollowupPop, deferred_input_preview_fingerprint};
 use crate::tui::task_status::TaskStatus;
 use ratatui::{buffer::Buffer, layout::Rect};
 use std::time::Instant;
@@ -42,7 +43,7 @@ fn active_turn_placeholder_explains_queue_vs_interrupt() {
         "active composer should keep the same primary prompt as idle; got {rendered:?}"
     );
     assert!(
-        rendered.contains("Queued until next tool call") || rendered.contains("Ctrl+C stops"),
+        rendered.contains("Enter queues follow-up") || rendered.contains("Ctrl+C stops"),
         "active composer should keep an in-panel helper hint; got {rendered:?}"
     );
     assert!(
@@ -81,7 +82,7 @@ fn narrow_active_composer_degrades_helper_without_losing_stop_hint() {
         "narrow composer should keep the primary prompt; got {rendered:?}"
     );
     assert!(
-        rendered.contains("Ctrl+C stops") || rendered.contains("next tool"),
+        rendered.contains("Ctrl+C stops") || rendered.contains("Enter queues"),
         "narrow composer should keep a compressed helper hint; got {rendered:?}"
     );
     assert!(
@@ -106,8 +107,163 @@ fn helper_row_stays_visible_after_typing_begins() {
         "typed text should remain visible inside the composer; got {rendered:?}"
     );
     assert!(
-        rendered.contains("Queued until next tool call") || rendered.contains("Ctrl+C stops"),
+        rendered.contains("Enter queues follow-up") || rendered.contains("Ctrl+C stops"),
         "the helper row should stay visible after typing begins; got {rendered:?}"
+    );
+}
+
+#[test]
+fn pop_applied_deferred_followup_returns_head_on_matching_preview() {
+    // Contract: the server emits `__deferred_input_applied__:<preview>`
+    // per dequeued item, where `<preview>` is the server's own truncation
+    // of the dequeued text. The client recomputes the fingerprint from
+    // its head and compares — a match means it is safe to commit the
+    // head verbatim. This test pins both halves of the contract: the
+    // fingerprint algorithm must match the server's, and a match must
+    // pop the head regardless of how the server's truncation behaves
+    // for long / multi-line / wide input.
+    let mut pane = BottomPane::new();
+    pane.queue_deferred_followup("first queued message");
+    pane.queue_deferred_followup(
+        "a very long second message whose preview would truncate differently \
+         than the server's 80-char status line and therefore never match under \
+         the old implementation, causing it to be dropped out of order",
+    );
+
+    // First applied signal: preview must match "first queued message".
+    let first_preview = deferred_input_preview_fingerprint("first queued message");
+    assert_eq!(
+        pane.pop_applied_deferred_followup(&first_preview),
+        DeferredFollowupPop::Applied("first queued message".to_string()),
+        "matching preview must pop the head, independent of preview text"
+    );
+    // Second applied signal: preview recomputed from the actual head text.
+    let long_text = "a very long second message whose preview would truncate differently \
+         than the server's 80-char status line and therefore never match under \
+         the old implementation, causing it to be dropped out of order";
+    let second_preview = deferred_input_preview_fingerprint(long_text);
+    match pane.pop_applied_deferred_followup(&second_preview) {
+        DeferredFollowupPop::Applied(text) => assert!(
+            text.starts_with("a very long second"),
+            "second applied signal must pop the next head when preview matches; got {text:?}"
+        ),
+        other => panic!("expected Applied, got {other:?}"),
+    }
+    // Popping an empty queue yields Empty, not a panic or a phantom drop.
+    let stray_preview = deferred_input_preview_fingerprint("stray");
+    assert!(
+        matches!(
+            pane.pop_applied_deferred_followup(&stray_preview),
+            DeferredFollowupPop::Empty
+        ),
+        "popping an empty queue yields Empty, not a panic or a phantom drop"
+    );
+}
+
+#[test]
+fn pop_applied_deferred_followup_surfaces_desync_instead_of_corrupting_history() {
+    // Regression: a bare FIFO pop trusted the server's "exactly one status
+    // line per item, in strict order" invariant. If the server ever drops
+    // or reorders an event, every subsequent pop commits the *wrong* text
+    // as the user's input. The fingerprint check turns that silent
+    // corruption into a visible, recoverable failure: on mismatch the
+    // entire local queue is dropped and returned as `Desync`.
+    let mut pane = BottomPane::new();
+    pane.queue_deferred_followup("head that should have been applied");
+    pane.queue_deferred_followup("second item, now orphaned by desync");
+    pane.queue_deferred_followup("third item, also orphaned");
+
+    // Server preview does NOT match the local head — desync.
+    let mismatched_preview = "something the server dequeued that we never queued";
+    match pane.pop_applied_deferred_followup(&mismatched_preview) {
+        DeferredFollowupPop::Desync { dropped } => {
+            assert_eq!(
+                dropped.len(),
+                3,
+                "desync must drop the entire local queue so no wrong text is committed; got {dropped:?}"
+            );
+            assert_eq!(dropped[0], "head that should have been applied");
+            assert_eq!(dropped[2], "third item, also orphaned");
+        }
+        other => panic!("expected Desync, got {other:?}"),
+    }
+
+    // After desync, the queue is empty — a stray applied signal yields Empty.
+    let stray_preview = deferred_input_preview_fingerprint("stray");
+    assert!(
+        matches!(
+            pane.pop_applied_deferred_followup(&stray_preview),
+            DeferredFollowupPop::Empty
+        ),
+        "post-desync queue must be empty"
+    );
+}
+
+#[test]
+fn restore_into_composer_never_drops_user_input() {
+    // Regression: the old run-end restore path only wrote queued input into
+    // the composer when `composer.is_empty()`; otherwise it logged a banner
+    // and discarded the queued text entirely. User input must never vanish
+    // silently — append beneath an existing draft instead.
+    let mut pane = BottomPane::new();
+    pane.composer.set_text("draft in progress");
+
+    pane.restore_into_composer("queued follow-up");
+
+    let text = pane.composer.text();
+    assert!(
+        text.contains("draft in progress"),
+        "existing draft must be preserved; got {text:?}"
+    );
+    assert!(
+        text.contains("queued follow-up"),
+        "queued input must be appended, not dropped; got {text:?}"
+    );
+}
+
+#[test]
+fn restore_into_composer_replaces_empty_draft() {
+    let mut pane = BottomPane::new();
+    pane.restore_into_composer("only queued");
+    assert_eq!(
+        pane.composer.text().trim(),
+        "only queued",
+        "empty composer should receive the restored text verbatim"
+    );
+}
+
+#[test]
+fn restore_into_composer_ignores_blank_input() {
+    let mut pane = BottomPane::new();
+    pane.composer.set_text("untouched draft");
+    pane.restore_into_composer("   \n  ");
+    assert_eq!(
+        pane.composer.text().trim(),
+        "untouched draft",
+        "blank restored input must not perturb the composer"
+    );
+}
+
+#[test]
+fn queued_followup_panel_renders_immediate_feedback() {
+    let mut pane = BottomPane::new();
+    pane.set_task_status(TaskStatus::TurnRunning {
+        started_at: Instant::now(),
+    });
+    pane.queue_deferred_followup("hi from the user");
+
+    let rendered = render_text(&pane, Rect::new(0, 0, 90, 8));
+    assert!(
+        rendered.contains("Esc sends now"),
+        "queued follow-up panel should lead with the action verb; got {rendered:?}"
+    );
+    assert!(
+        rendered.contains("next tool"),
+        "queued follow-up panel should explain the accurate trigger; got {rendered:?}"
+    );
+    assert!(
+        rendered.contains("hi from the user"),
+        "queued follow-up panel should show the queued message preview; got {rendered:?}"
     );
 }
 

--- a/rust/crates/astra-cli/src/tui/bottom_pane/snapshots/astra__tui__bottom_pane__queue_preview_tests__bottom_surface_active_42.snap
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/snapshots/astra__tui__bottom_pane__queue_preview_tests__bottom_surface_active_42.snap
@@ -3,5 +3,5 @@ source: crates/astra-cli/src/tui/bottom_pane/queue_preview_tests.rs
 expression: "snapshot_text(&pane, Rect::new(0, 0, 42, 5))"
 ---
 · Message astra                           
-  Queued for next tool · Ctrl+C stops     
+  Enter queues follow-up · Ctrl+C stops   
   sonnet-4.6 · Ask · ~/github/astra

--- a/rust/crates/astra-cli/src/tui/bottom_pane/snapshots/astra__tui__bottom_pane__queue_preview_tests__bottom_surface_active_80.snap
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/snapshots/astra__tui__bottom_pane__queue_preview_tests__bottom_surface_active_80.snap
@@ -3,5 +3,5 @@ source: crates/astra-cli/src/tui/bottom_pane/queue_preview_tests.rs
 expression: "snapshot_text(&pane, Rect::new(0, 0, 80, 5))"
 ---
 · Message astra                                                                 
-  Queued for next tool · Ctrl+C stops                                           
+  Enter queues follow-up · Ctrl+C stops                                         
   sonnet-4.6 · Ask · ~/github/astra · ⎇ enqueue…ext_call

--- a/rust/crates/astra-cli/src/tui/event.rs
+++ b/rust/crates/astra-cli/src/tui/event.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -16,6 +17,7 @@ pub(crate) enum TuiEvent {
 }
 
 pub(crate) struct TuiEventStream {
+    pending: VecDeque<TuiEvent>,
     crossterm_stream: EventStream,
     draw_stream: BroadcastStream<()>,
     poll_draw_first: bool,
@@ -24,10 +26,15 @@ pub(crate) struct TuiEventStream {
 impl TuiEventStream {
     pub(crate) fn new(draw_rx: broadcast::Receiver<()>) -> Self {
         Self {
+            pending: VecDeque::new(),
             crossterm_stream: EventStream::new(),
             draw_stream: BroadcastStream::new(draw_rx),
             poll_draw_first: false,
         }
+    }
+
+    pub(crate) fn push_front(&mut self, event: TuiEvent) {
+        self.pending.push_front(event);
     }
 
     fn poll_crossterm_event(&mut self, cx: &mut Context<'_>) -> Poll<Option<TuiEvent>> {
@@ -108,6 +115,10 @@ impl Stream for TuiEventStream {
     type Item = TuiEvent;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Some(event) = self.pending.pop_front() {
+            return Poll::Ready(Some(event));
+        }
+
         let draw_first = self.poll_draw_first;
         self.poll_draw_first = !self.poll_draw_first;
 

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -188,10 +188,7 @@ async fn submit_deferred_tui_input(
 ) -> Result<(), String> {
     let provider = astra_core::sync_poison::recover_mutex_lock(run_control)
         .clone()
-        .ok_or_else(|| {
-            "Current turn is not ready to accept deferred input yet. Press Ctrl+C to cancel this run if you need to stop it now."
-                .to_string()
-        })?;
+        .ok_or_else(|| "Run is changing state. Try again, or press Ctrl+C to stop.".to_string())?;
     provider.enqueue_text(text)
 }
 
@@ -241,7 +238,21 @@ fn render_transcript_view_lines(
     lines
 }
 
-fn surface_status_line_system_cell(event: &TuiAppEvent, chat_widget: &mut chat_widget::ChatWidget) {
+/// Handles status-line events that the bottom pane / chat widget must
+/// react to locally. Two cases:
+///
+/// - `PermissionAutoApproved`: commits an info cell to chat history.
+/// - `StatusLine` carrying `__deferred_input_applied__:<preview>`: the
+///   server dequeued a deferred input. We return the `<preview>` segment
+///   so the caller can pass it to `pop_applied_deferred_followup`, which
+///   recomputes the fingerprint from the local head and compares — a
+///   mismatch means the local and server queues have desynced (missed/
+///   extra/reordered event), and the queue is dropped with a visible
+///   warning rather than committing the *wrong* text as the user's input.
+fn surface_status_line_system_cell(
+    event: &TuiAppEvent,
+    chat_widget: &mut chat_widget::ChatWidget,
+) -> Option<String> {
     match event {
         TuiAppEvent::PermissionAutoApproved { tool, reason } => {
             chat_widget.commit_system(history_cell::system::SystemCell::info(
@@ -249,14 +260,53 @@ fn surface_status_line_system_cell(event: &TuiAppEvent, chat_widget: &mut chat_w
                     .trim()
                     .to_string(),
             ));
+            None
         }
-        TuiAppEvent::StatusLine(text) => {
-            if let Some(message) = text.strip_prefix(DEFERRED_INPUT_APPLIED_PREFIX) {
-                chat_widget.commit_deferred_user(message.trim().to_string());
-            }
+        TuiAppEvent::StatusLine(text) => text
+            .strip_prefix(DEFERRED_INPUT_APPLIED_PREFIX)
+            .map(|p| p.to_string()),
+        _ => None,
+    }
+}
+
+/// React to a `__deferred_input_applied__` status line by popping the
+/// matching head of the local deferred queue and committing it to chat
+/// history as the user's own input. On desync (server preview ≠ local
+/// head fingerprint) the entire local queue is dropped and surfaced as a
+/// warning cell so the failure is *visible* — never silently commit the
+/// wrong text as the user's words.
+fn apply_deferred_followup_status(
+    bottom_pane: &mut BottomPane,
+    chat_widget: &mut chat_widget::ChatWidget,
+    expected_preview: &str,
+) {
+    match bottom_pane.pop_applied_deferred_followup(expected_preview) {
+        super::bottom_pane::DeferredFollowupPop::Applied(full_text) => {
+            chat_widget.commit_deferred_user(full_text);
         }
-        _ => {}
-    };
+        super::bottom_pane::DeferredFollowupPop::Empty => {
+            // Stray/late applied signal with an empty queue — nothing to
+            // commit, but log so an unexpected repeat is diagnosable.
+            tracing::debug!(
+                target: "astra_cli::tui",
+                preview = %expected_preview,
+                "deferred-input applied signal arrived with an empty local queue"
+            );
+        }
+        super::bottom_pane::DeferredFollowupPop::Desync { dropped } => {
+            let previews = dropped
+                .iter()
+                .map(|t| deferred_input_preview(t))
+                .collect::<Vec<_>>()
+                .join(" | ");
+            chat_widget.commit_system(history_cell::system::SystemCell::warning(format!(
+                "Deferred-input queue desynced with the server; {n} queued item(s) \
+                     dropped to avoid committing the wrong input as yours. \
+                     Dropped text visible above; re-send if you still need it: {previews}",
+                n = dropped.len(),
+            )));
+        }
+    }
 }
 
 fn context_trace_count(state: &crate::cli::session::session_state::SessionState) -> usize {
@@ -761,6 +811,15 @@ pub(crate) async fn run_tui_session(
     }
     let mut status_indicator = status_indicator::StatusIndicator::new();
     let mut pending_deferred_slash_flush = false;
+    // Set on Ctrl+C/Esc interrupt: the run is winding down and any remaining
+    // queued input should be submitted as a fresh turn once the run genuinely
+    // ends, rather than restored as a draft. We do NOT drain the queue in the
+    // cancel handler — keeping it populated until turn-end means any
+    // `__deferred_input_applied__` signals that arrive during the cancel→stop
+    // window still pop+commit to chat history correctly. Resolved at the single
+    // turn-end drain point so there is exactly one place that decides what
+    // happens to leftover queue items.
+    let mut interrupt_pending = false;
 
     // Task board observer + toggle state. Observer is tick-driven
     // (see task_board_observer.rs rationale); no background loop
@@ -1971,6 +2030,7 @@ pub(crate) async fn run_tui_session(
                                                             // During turn: composer stays usable.
                                                             // Enter queues a deferred input against the active run.
                                                             // Ctrl+C interrupts.
+                                                            bottom_pane.pre_draw_tick(std::time::Instant::now());
                                                             match bottom_pane.handle_key(k) {
                                                                     BottomPaneAction::SubmitInput(queued_text) => {
                                                                         // Agent drill-in sentinel: user pressed Enter
@@ -2009,16 +2069,20 @@ pub(crate) async fn run_tui_session(
                                                                         )
                                                                         .await
                                                                         {
-                                                                            Ok(()) => {
-                                                                                chat_widget.commit_system(
-                                                                                    history_cell::system::SystemCell::info(
-                                                                                        format!(
-                                                                                            "Queued for next tool call: {}",
-                                                                                            deferred_input_preview(&queued_text)
-                                                                                        ),
-                                                                                    ),
-                                                                                );
-                                                                            }
+                                                                                Ok(()) => {
+                                                                                    if !bottom_pane.queue_deferred_followup(queued_text) {
+                                                                                        // User pressed Enter with nothing typed during an
+                                                                                        // active turn. The server received the empty input
+                                                                                        // (it was submitted as a deferred send), but the
+                                                                                        // local queue panel has nothing to show. Commit an
+                                                                                        // info cell so the action is visible.
+                                                                                        chat_widget.commit_system(
+                                                                                            history_cell::system::SystemCell::info(
+                                                                                                "Empty follow-up queued.",
+                                                                                            ),
+                                                                                        );
+                                                                                    }
+                                                                                }
                                                                             Err(error) => {
                                                                                 bottom_pane.composer.set_text(&queued_text);
                                                                                 chat_widget.commit_system(
@@ -2193,6 +2257,18 @@ pub(crate) async fn run_tui_session(
                                                                         // Ctrl+C so routine interrupts stay
                                                                         // noise-free.
                                                                         chat_widget.commit_cancel_banner(cancelled_count);
+                                                                        // Don't drain the queue here. The run is
+                                                                        // being cancelled but may still emit
+                                                                        // `__deferred_input_applied__` signals
+                                                                        // before it fully stops — those must
+                                                                        // keep popping the head and committing
+                                                                        // to chat history. We record intent and
+                                                                        // resolve leftover items once at turn
+                                                                        // end (single decision point), so the
+                                                                        // unhappy path "cancel failed / slow to
+                                                                        // stop" can never drop user input.
+                                                                        interrupt_pending = true;
+                                                                        bottom_pane.interrupt_pending = true;
                                                                         tui_cancel_token.cancel();
                                                                     }
                                                                     _ => {}
@@ -2229,7 +2305,24 @@ pub(crate) async fn run_tui_session(
                                     let _ = do_draw(&mut guard, frame.active, frame.multi_agent, &mut bottom_pane, Some((&*task_board, board_expanded)), frame.task_board);
                                 }
                                                         }
-                                                        _ => {}
+                                                        TuiEvent::Paste(text) => {
+                                                            bottom_pane.handle_paste(&text);
+                                                            frame_requester.schedule_frame();
+                                                            {
+                                    let w = guard.terminal.size().map(|s| s.width).unwrap_or(80);
+                                    let frame = active_viewport(
+                                        &chat_widget,
+                                        &status_indicator,
+                                        Some(&*task_board),
+                                        board_expanded,
+                                        board_user_pin,
+                                        w,
+                                        guard.terminal.size().map(|s| s.height).unwrap_or(24),
+                                    );
+                                    board_expanded = frame.resolved_board_expanded;
+                                    let _ = do_draw(&mut guard, frame.active, frame.multi_agent, &mut bottom_pane, Some((&*task_board, board_expanded)), frame.task_board);
+                                }
+                                                        }
                                                     }
                                                 }
                                                 handoff = bash_detach_handoff_rx.recv() => {
@@ -2428,10 +2521,18 @@ pub(crate) async fn run_tui_session(
                                                         chat_widget.handle_event(new_ev);
                                                         refresh_open_agent_views_for_event(&ae, &chat_widget, &mut bottom_pane);
                                                     }
-                                                    surface_status_line_system_cell(
-                                                        &ae,
-                                                        &mut chat_widget,
-                                                    );
+                                                    if let Some(preview) =
+                                                        surface_status_line_system_cell(
+                                                            &ae,
+                                                            &mut chat_widget,
+                                                        )
+                                                    {
+                                                        apply_deferred_followup_status(
+                                                            &mut bottom_pane,
+                                                            &mut chat_widget,
+                                                            &preview,
+                                                        );
+                                                    }
                                                     handle_app_event(&ae, &mut bottom_pane, &mut status_indicator, &frame_requester);
                                                     let should_rearm_bash_detach =
                                                         !bash_detach_request_pending
@@ -2648,14 +2749,65 @@ pub(crate) async fn run_tui_session(
                                                     chat_widget.handle_event(new_ev);
                                                         refresh_open_agent_views_for_event(&ae, &chat_widget, &mut bottom_pane);
                                                 }
-                                                surface_status_line_system_cell(
-                                                    &ae,
-                                                    &mut chat_widget,
-                                                );
+                                                if let Some(preview) =
+                                                    surface_status_line_system_cell(
+                                                        &ae,
+                                                        &mut chat_widget,
+                                                    )
+                                                {
+                                                    apply_deferred_followup_status(
+                                                        &mut bottom_pane,
+                                                        &mut chat_widget,
+                                                        &preview,
+                                                    );
+                                                }
                                                 handle_app_event(&ae, &mut bottom_pane, &mut status_indicator, &frame_requester);
                                                     flush_chat_widget(&mut guard, &mut chat_widget, w);
                                             }
                                         }
+                                    }
+
+                                    // Single turn-end drain for leftover queue items.
+                                    // Before this point the queue is preserved so that
+                                    // `__deferred_input_applied__` signals arriving during
+                                    // the cancel→stop window still pop+commit correctly.
+                                    // Here we decide once what happens to the remainder:
+                                    //   - Interrupt pending (Esc/Ctrl+C): the user explicitly
+                                    //     asked to send NOW. Stage the text in the composer
+                                    //     and replay a synthetic Enter so the next turn
+                                    //     begins immediately. Input is never dropped even if
+                                    //     the cancel RPC failed — the queue survived.
+                                    //   - Otherwise: restore as a draft beneath any in-progress
+                                    //     edit, with a visible info banner so the user knows
+                                    //     why their typed text reappeared and can decide to
+                                    //     send or edit it.
+                                    let unapplied_deferred_inputs =
+                                        bottom_pane.take_deferred_followups();
+                                    if interrupt_pending {
+                                        interrupt_pending = false;
+                                        bottom_pane.interrupt_pending = false;
+                                        if !unapplied_deferred_inputs.is_empty() {
+                                            let text = unapplied_deferred_inputs.join("\n\n");
+                                            bottom_pane.replace_composer_text(&text);
+                                            flush_chat_widget(&mut guard, &mut chat_widget, w);
+                                            event_stream.push_front(TuiEvent::Key(
+                                                crossterm::event::KeyEvent::new(
+                                                    crossterm::event::KeyCode::Enter,
+                                                    crossterm::event::KeyModifiers::NONE,
+                                                ),
+                                            ));
+                                            frame_requester.schedule_frame();
+                                        }
+                                    } else if !unapplied_deferred_inputs.is_empty() {
+                                        let restored = unapplied_deferred_inputs.join("\n\n");
+                                        let preview = deferred_input_preview(&restored);
+                                        bottom_pane.restore_into_composer(&restored);
+                                        chat_widget.commit_system(
+                                            history_cell::system::SystemCell::info(format!(
+                                                "Queued input was not applied before the run finished; draft restored into composer: {preview}",
+                                            )),
+                                        );
+                                        flush_chat_widget(&mut guard, &mut chat_widget, w);
                                     }
 
                                     if turn_result.is_ok()
@@ -3395,7 +3547,13 @@ pub(crate) async fn run_tui_session(
                     chat_widget.handle_event(new_ev);
                     refresh_open_agent_views_for_event(&ae, &chat_widget, &mut bottom_pane);
                 }
-                surface_status_line_system_cell(&ae, &mut chat_widget);
+                if let Some(preview) = surface_status_line_system_cell(&ae, &mut chat_widget) {
+                    apply_deferred_followup_status(
+                        &mut bottom_pane,
+                        &mut chat_widget,
+                        &preview,
+                    );
+                }
                 handle_app_event(&ae, &mut bottom_pane, &mut status_indicator, &frame_requester);
                 if should_flush_ambient_commits(pending_deferred_slash_flush) {
                     flush_chat_widget(&mut guard, &mut chat_widget, w);
@@ -5034,8 +5192,8 @@ mod tests {
             .await
             .expect_err("missing run control must be rejected locally");
         assert!(
-            error.contains("not ready to accept deferred input"),
-            "missing run control should surface a local readiness error"
+            error.contains("changing state"),
+            "missing run control should surface a user-facing transient-state error"
         );
     }
 
@@ -5119,6 +5277,47 @@ mod tests {
         assert!(
             source.contains("chat_widget.commit_deferred_user"),
             "applied deferred input should be rendered as a user transcript row"
+        );
+    }
+
+    #[test]
+    fn active_turn_handles_paste_events_before_falling_through() {
+        let source = include_str!("event_loop.rs");
+        let active_start = source
+            .find("bottom_pane.queue_deferred_followup(queued_text)")
+            .expect("active turn block should track queued deferred inputs in bottom pane");
+        let active_end = source[active_start..]
+            .find("*astra_core::sync_poison::recover_mutex_lock(\n                                        &state.active_turn_local_run_control,")
+            .map(|offset| active_start + offset)
+            .expect("active turn block must clear local run control after select loop");
+        let active_block = &source[active_start..active_end];
+
+        assert!(
+            active_block.contains("TuiEvent::Paste(text)"),
+            "active-turn event loop must route bracketed paste into the composer"
+        );
+        assert!(
+            active_block.contains("bottom_pane.handle_paste(&text)"),
+            "active-turn paste should use the same bottom-pane paste path as idle mode"
+        );
+    }
+
+    #[test]
+    fn deferred_interrupt_replays_queued_input_as_next_submit() {
+        let source = include_str!("event_loop.rs");
+        // The cancel handler records intent without draining the queue, so
+        // any `__deferred_input_applied__` signals arriving during the
+        // cancel→stop window still pop+commit correctly.
+        assert!(
+            source.contains("interrupt_pending = true;"),
+            "interrupt path should record intent to replay leftover queue at turn end"
+        );
+        // The replay is resolved once at the single turn-end drain point —
+        // interrupt branch stages the text and pushes a synthetic Enter.
+        assert!(
+            source.contains("event_stream.push_front(TuiEvent::Key(")
+                && source.contains("crossterm::event::KeyCode::Enter"),
+            "turn-end drain should replay leftover queued follow-up as an immediate next Enter submit"
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/style.rs
+++ b/rust/crates/astra-cli/src/tui/style.rs
@@ -24,6 +24,20 @@ pub(crate) fn composer_surface_style() -> Style {
     Style::default().bg(theme.selected_bg)
 }
 
+/// Background for the deferred-follow-up queue panel.
+///
+/// Deliberately tinted *differently* from the composer surface so the
+/// queued-input band reads as a distinct region above the live input
+/// box, not as more of the same surface. A touch darker than the
+/// composer surface on dark backgrounds, a touch lighter on light ones.
+pub(crate) fn queue_panel_style() -> Style {
+    if let Some(bg) = default_bg() {
+        return Style::default().bg(queue_panel_bg(bg));
+    }
+    let theme = super::theme::current();
+    Style::default().bg(theme.selected_bg)
+}
+
 pub(crate) fn footer_surface_style() -> Style {
     if let Some(bg) = default_bg() {
         return Style::default().bg(footer_surface_bg(bg));
@@ -66,6 +80,21 @@ fn composer_surface_bg(terminal_bg: (u8, u8, u8)) -> Color {
         ((0, 0, 0), 0.06)
     } else {
         ((255, 255, 255), 0.34)
+    };
+    best_color(blend(top, terminal_bg, alpha))
+}
+
+/// Distinct tint for the queue panel. Sits between the raw terminal
+/// background and the composer surface in prominence: more present than
+/// bare bg (so the band reads as a real region, not a gap) but less
+/// lifted than the live composer (so the user's typing surface stays the
+/// focal point). Previously 0.18 white was too close to a black terminal
+/// bg — the panel vanished and the queued content looked unanchored.
+fn queue_panel_bg(terminal_bg: (u8, u8, u8)) -> Color {
+    let (top, alpha) = if is_light(terminal_bg) {
+        ((0, 0, 0), 0.10)
+    } else {
+        ((255, 255, 255), 0.26)
     };
     best_color(blend(top, terminal_bg, alpha))
 }

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_tasks_runs.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_tasks_runs.rs
@@ -231,8 +231,8 @@ pub async fn run_chat_run_pause_resume_http() {
                 ]
             },
             "execution_budget": {
-                "initial_turns": 1,
-                "hard_turn_limit": 1
+                "initial_turns": 10,
+                "hard_turn_limit": 10
             }
         }),
     )

--- a/scripts/dev/start-web.sh
+++ b/scripts/dev/start-web.sh
@@ -91,7 +91,7 @@ nohup env \
     ASTRA_NEXT_DIST_DIR="$NEXT_DIST_DIR" \
     PORT="$WEB_PORT" \
     bash -lc 'cd "$1"; shift; exec "$@"' bash "$WEB_DIR" \
-    node "$NEXT_BIN" dev --hostname "$WEB_HOST" --port "$WEB_PORT" \
+	node "$NEXT_BIN" dev --webpack --hostname "$WEB_HOST" --port "$WEB_PORT" \
     </dev/null \
     >> "$LOG_FILE" 2>&1 &
 PID=$!

--- a/web/__tests__/components/app/chat-view.test.tsx
+++ b/web/__tests__/components/app/chat-view.test.tsx
@@ -957,7 +957,7 @@ describe("ChatView deferred-input unhappy paths", () => {
       />,
     );
 
-    expect(screen.getAllByText("Input queued").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Follow-up Queued").length).toBeGreaterThan(0);
 
     await user.click(screen.getByRole("button", { name: "Submit composer" }));
 

--- a/web/__tests__/lib/chat-run-state.test.ts
+++ b/web/__tests__/lib/chat-run-state.test.ts
@@ -30,12 +30,12 @@ function waitingRun(
 
 describe('deriveChatRunUiState', () => {
   it('allows queued follow-up input for active queueable statuses', () => {
-    for (const status of ['running', 'input-queued', 'waiting']) {
+    for (const status of ['running', 'input-queued', 'waiting', 'blocked']) {
       const ui = deriveChatRunUiState({ ...base, activeRun: run(status) });
 
       expect(ui.canQueueDeferredInput).toBe(true);
       expect(ui.composerDisabled).toBe(false);
-      expect(ui.composerPlaceholder).toBe('Queue a follow-up for the next tool call...');
+      expect(ui.composerPlaceholder).toBe('Queue a follow-up for the next execution boundary...');
     }
   });
 

--- a/web/__tests__/lib/composer-placeholder.test.ts
+++ b/web/__tests__/lib/composer-placeholder.test.ts
@@ -6,7 +6,7 @@ describe('compactComposerPlaceholder', () => {
   });
 
   it('uses short visual copy for deferred input on narrow screens', () => {
-    expect(compactComposerPlaceholder('Queue a follow-up for the next tool call...')).toBe('Queue follow-up...');
+    expect(compactComposerPlaceholder('Queue a follow-up for the next execution boundary...')).toBe('Queue follow-up...');
   });
 
   it('uses short visual copy for paused and stopping runs', () => {

--- a/web/components/app/chat-view.tsx
+++ b/web/components/app/chat-view.tsx
@@ -338,6 +338,7 @@ export function ChatView({ initial }: { initial: ChatDetail }) {
   const [resumingRun, setResumingRun] = useState(false);
   const [stoppingRun, setStoppingRun] = useState(false);
   const [runAttachRetrySignal, setRunAttachRetrySignal] = useState(0);
+  const [lastQueuedText, setLastQueuedText] = useState<string | undefined>();
 
   // ── work surface ───────────────────────────────────────────────────────────
   const [workSurface, setWorkSurface] = useState(() =>
@@ -383,6 +384,7 @@ export function ChatView({ initial }: { initial: ChatDetail }) {
     queueingDeferredInput,
     resumingRun,
     stoppingRun,
+    lastQueuedText,
   });
 
   // ── hooks ──────────────────────────────────────────────────────────────────
@@ -455,6 +457,13 @@ export function ChatView({ initial }: { initial: ChatDetail }) {
   );
 
   // ── effects ────────────────────────────────────────────────────────────────
+
+  // Clear last-queued text when the run moves past "input-queued" state.
+  useEffect(() => {
+    if (activeRunStatus !== "input-queued" && lastQueuedText) {
+      setLastQueuedText(undefined);
+    }
+  }, [activeRunStatus, lastQueuedText]);
 
   // Cleanup on unmount
   useEffect(
@@ -739,7 +748,13 @@ export function ChatView({ initial }: { initial: ChatDetail }) {
                   }
                   onSubmit={async ({ text, options }) => {
                     if (canQueueDeferredInput) {
-                      await stream.queueDeferredInput({ text, options });
+                      try {
+                        await stream.queueDeferredInput({ text, options });
+                        setLastQueuedText(text);
+                      } catch (error) {
+                        // API failed — don't show "queued" in UI
+                        console.error("Failed to queue deferred input:", error);
+                      }
                       return;
                     }
                     void stream.startStream({

--- a/web/lib/chat-run-state.ts
+++ b/web/lib/chat-run-state.ts
@@ -57,6 +57,7 @@ function statusLabel(status: string): string {
 function activeRunDisplayLabel(
   run: ChatDetail["activeRun"],
   archived: boolean,
+  lastQueuedText?: string,
 ): string {
   const status = normalizeChatRunStatus(run?.status);
   const waitingFor = run?.waitingFor?.trim();
@@ -67,7 +68,11 @@ function activeRunDisplayLabel(
     return "Stopping";
   }
   if (status === "input-queued") {
-    return "Input Queued";
+    const base = "Follow-up Queued";
+    if (lastQueuedText) {
+      return `${base}: "${compactQueuedText(lastQueuedText)}"`;
+    }
+    return base;
   }
   if (status === "blocked") {
     return waitingFor ? `Blocked: ${statusLabel(waitingFor)}` : "Blocked";
@@ -112,6 +117,7 @@ export function deriveChatRunUiState(params: {
   queueingDeferredInput: boolean;
   resumingRun: boolean;
   stoppingRun: boolean;
+  lastQueuedText?: string;
 }): ChatRunUiState {
   const activeRunStatus = normalizeChatRunStatus(params.activeRun?.status);
   const hasActiveRun = Boolean(params.activeRun?.runId && activeRunStatus);
@@ -146,11 +152,12 @@ export function deriveChatRunUiState(params: {
         : activeRunBlocksNewInput
           ? `Run status is ${params.activeRun?.status ?? "unknown"}. Stop it or refresh before sending.`
           : canQueueDeferredInput
-            ? "Queue a follow-up for the next tool call..."
+            ? "Queue a follow-up for the next execution boundary..."
             : "Reply to Astra...";
   const activeRunLabel = activeRunDisplayLabel(
     params.activeRun,
     params.archived,
+    params.lastQueuedText,
   );
 
   return {
@@ -164,4 +171,14 @@ export function deriveChatRunUiState(params: {
     composerPlaceholder,
     activeRunLabel,
   };
+}
+
+/// Preview a user's last queued text to show in the run status label.
+/// Truncates at ~60 characters to fit in the activity bar.
+export function compactQueuedText(text: string): string {
+  const singleLine = text.trim().replace(/\s+/g, " ");
+  if (singleLine.length <= 60) {
+    return singleLine;
+  }
+  return `${singleLine.slice(0, 57)}…`;
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -165,7 +165,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1488,7 +1487,6 @@
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.60.0"
       },
@@ -2565,6 +2563,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2654,7 +2653,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2797,7 +2797,6 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2807,7 +2806,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2818,7 +2816,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2874,7 +2871,6 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -3574,7 +3570,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3615,6 +3610,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4048,7 +4044,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4471,7 +4466,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4755,7 +4749,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5012,7 +5007,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5198,7 +5192,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6755,7 +6748,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6926,7 +6918,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -6950,7 +6941,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -7480,6 +7470,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9061,7 +9052,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -9221,6 +9211,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9236,6 +9227,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9248,7 +9240,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -9308,7 +9301,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9318,7 +9310,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10523,7 +10514,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10756,7 +10746,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11123,7 +11112,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11544,7 +11532,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -40,7 +40,8 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     ".next-dev/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts",
+    ".next-dev/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
Reworks the deferred follow-up queue UX for both TUI and Web surfaces. When a turn is active (running, awaiting tool approval, blocked), follow-ups queue instead of being rejected. TUI gets a rich queue panel; Web gets a visible "Follow-up Queued: …" preview in the RunActivityBar. Interrupt (Esc) preserves the queue until the turn ends, then replays queued text as the next submit.

## TUI Changes
- **Queue panel** in bottom pane: distinct bg, bold head, plain tail, dim "+N more" counter
- **Interrupt-pending state** reflected in queue panel title ("Stopping — sending on finish")
- **Queue lifecycle**: `queue_deferred_followup` returns bool; empty-Enter commits "Empty follow-up queued." info cell
- **Interrupt preserves queue**: Esc queues at next tool call; synthetic Enter replays on turn end
- **Desync detection**: fingerprint-based `pop_applied_deferred_followup` catches server-client queue drift
- **Fingerprint separator**: `DEFERRED_INPUT_FINGERPRINT_SEP` in lib.rs, re-exported via main.rs — single source of truth
- **Paste handling**: dedicated `TuiEvent::Paste` branch
- **Style module**: deferred queue panel colors

## Web Changes
- **Queue visibility**: `lastQueuedText` state shows "Follow-up Queued: …" in RunActivityBar
- **State machine**: `canQueueDeferredInput` aligned with `composerDisabled`; "paused" and "blocked" removed from `QUEUEABLE_RUN_STATUSES`
- **Placeholder text** now shows queue invitation during active turn

## Web Server Fix
- `start-web.sh`: added `--webpack` flag to avoid broken Turbopack native bindings

## Design Doc
- `docs/design/edge-runtime-tool-boundary.md`: execution topology and deployment-flexibility spec

## Testing
- 13 queue_preview snapshot tests (TUI bottom pane rendering)
- 43 vitest tests (chat-run-state, composer placeholder, chat-view)
- `cargo check` passes on all Rust crates