### PR TITLE
refactor: permission hardening and sandbox security overhaul

### DIFF
--- a/rust/crates/astra-cli/src/cli/agent_runtime.rs
+++ b/rust/crates/astra-cli/src/cli/agent_runtime.rs
@@ -37,7 +37,6 @@ pub(crate) async fn build_one_shot_spawner(
     api: &astra_thin_client::ThinClient,
     token: String,
     unified_skill_registry: std::sync::Arc<astra_runtime::skills::UnifiedSkillRegistry>,
-    perm_mode: super::permission_manager::PermissionMode,
     skill_search: astra_core::SkillSearchSettings,
     session_id: Option<String>,
     default_model: Option<String>,
@@ -56,7 +55,7 @@ pub(crate) async fn build_one_shot_spawner(
         std::sync::Arc::new(astra_runtime::orchestration::ProgressBroadcaster::default());
 
     let mut spawn_executor =
-        spawn_subrun::CliSpawnAgentExecutor::new(api.clone(), token, project_root, perm_mode, None)
+        spawn_subrun::CliSpawnAgentExecutor::new(api.clone(), token, project_root, None)
             .with_default_model(default_model)
             .with_skill_resolver(skill_resolver)
             .with_skill_search(skill_search);
@@ -196,7 +195,7 @@ pub(crate) async fn initialize_multi_agent_runtime(
         token.clone(),
         state.model.clone(),
         project_root.clone(),
-        state.perm_manager.mode(),
+        state.perm_manager.inherited_permissions_for_child(true),
         None,
     )
     .with_skill_resolver(skill_resolver.clone())
@@ -226,18 +225,13 @@ pub(crate) async fn initialize_multi_agent_runtime(
     .with_prefix_store(prefix_store.clone());
     state.delegation_engine = Some(std::sync::Arc::new(engine));
 
-    let mut spawn_executor = spawn_subrun::CliSpawnAgentExecutor::new(
-        api.clone(),
-        token,
-        project_root,
-        state.perm_manager.mode(),
-        None,
-    )
-    .with_default_model(state.model.clone())
-    .with_skill_resolver(skill_resolver)
-    .with_skill_search(state.skill_search.clone())
-    .with_bg_task_commands(state.bg_task_commands.clone())
-    .with_bg_task_list_cache(state.bg_task_list_cache.clone());
+    let mut spawn_executor =
+        spawn_subrun::CliSpawnAgentExecutor::new(api.clone(), token, project_root, None)
+            .with_default_model(state.model.clone())
+            .with_skill_resolver(skill_resolver)
+            .with_skill_search(state.skill_search.clone())
+            .with_bg_task_commands(state.bg_task_commands.clone())
+            .with_bg_task_list_cache(state.bg_task_list_cache.clone());
     // Wire a token provider so each spawn reads the freshest access
     // token at execution time. Without this, sub-agents fail with 401
     // in long-running sessions after the parent's auth refresh

--- a/rust/crates/astra-cli/src/cli/app_server.rs
+++ b/rust/crates/astra-cli/src/cli/app_server.rs
@@ -405,7 +405,6 @@ async fn run_turn(
         &ctx.api,
         token.clone(),
         unified_skill_registry.clone(),
-        pm.mode(),
         skill_search.clone(),
         Some(thread_id.clone()),
         model.clone(),

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -34,6 +34,7 @@ use crate::{
 use crate::cli::chat_stream::sse_loop::agentic_loop_turn::{
     ChatTurnSseFetchRequest, PrepareTurnTelemetry, fetch_chat_turn_sse,
 };
+use crate::cli::chat_stream::sse_loop::refresh_root_permission_context;
 
 use astra_runtime::tool_sandbox::SandboxPolicy;
 
@@ -351,6 +352,7 @@ impl AgenticLoopHost for CliAgenticLoopHost<'_> {
         if let Some(new_mode) = self.executor.take_pending_permission_mode_change() {
             let old_mode = self.perm_manager.mode();
             self.perm_manager.set_mode(new_mode);
+            refresh_root_permission_context(&mut state.permission_context, self.perm_manager).await;
             append_permission_mode_change_audit(
                 state.current_session_id.as_deref(),
                 self.chat_turn_index,
@@ -376,6 +378,7 @@ impl AgenticLoopHost for CliAgenticLoopHost<'_> {
         self.perm_manager.pull_mode_from_mirror();
         let mode_after = self.perm_manager.mode();
         if mode_before != mode_after {
+            refresh_root_permission_context(&mut state.permission_context, self.perm_manager).await;
             append_permission_mode_change_audit(
                 state.current_session_id.as_deref(),
                 self.chat_turn_index,
@@ -599,6 +602,7 @@ impl AgenticLoopHost for CliAgenticLoopHost<'_> {
         // `turn_result?` below.
 
         // Sync latest approval overrides into state for checkpoint persistence.
+        refresh_root_permission_context(&mut state.permission_context, self.perm_manager).await;
         state.approval_overrides = self.perm_manager.export_session_overrides();
 
         let turn_result = turn_result?;

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -153,15 +153,12 @@ fn extend_restricted_with_blocked_tools(
     // callers don't need signature changes; add future block sources here.
 }
 
-type RootPermissionContextHandle =
-    Arc<tokio::sync::RwLock<astra_runtime::orchestration::PermissionSyncContext>>;
+type RootPermissionContextHandle = astra_runtime::orchestration::PermissionSyncHandle;
 
 fn root_permission_context_handle(
     perm_manager: &crate::cli::permission_manager::PermissionManager,
 ) -> RootPermissionContextHandle {
-    Arc::new(tokio::sync::RwLock::new(
-        perm_manager.runtime_permission_context(),
-    ))
+    perm_manager.runtime_permission_handle()
 }
 
 async fn refresh_root_permission_context(
@@ -172,7 +169,7 @@ async fn refresh_root_permission_context(
     if let Some(existing) = handle.as_ref() {
         *existing.write().await = latest;
     } else {
-        *handle = Some(Arc::new(tokio::sync::RwLock::new(latest)));
+        *handle = Some(latest.into_shared());
     }
 }
 

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -362,11 +362,20 @@ pub(crate) async fn stream_chat_sse(
     // --add-dir: expand sandbox to include additional directories
     if let Some(cli_context) = p.cli_context {
         for dir in &cli_context.add_dirs {
-            executor.expand_sandbox_path(dir.clone());
+            if let Err(e) = executor.expand_sandbox_path(dir.clone()) {
+                astra_core::agent_warn!("sandbox", "--add-dir {} rejected: {e}", dir.display());
+            }
         }
     } else if let Ok(dirs) = std::env::var("ASTRA_CLI_ADD_DIRS") {
         for dir in dirs.split(':').filter(|s| !s.is_empty()) {
-            executor.expand_sandbox_path(PathBuf::from(dir));
+            let dir = PathBuf::from(dir);
+            if let Err(e) = executor.expand_sandbox_path(dir.clone()) {
+                astra_core::agent_warn!(
+                    "sandbox",
+                    "ASTRA_CLI_ADD_DIRS {} rejected: {e}",
+                    dir.display()
+                );
+            }
         }
     }
     let messages = load_turn_messages(p.pre_loaded_messages.take(), p.history, p.message);

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -153,6 +153,29 @@ fn extend_restricted_with_blocked_tools(
     // callers don't need signature changes; add future block sources here.
 }
 
+type RootPermissionContextHandle =
+    Arc<tokio::sync::RwLock<astra_runtime::orchestration::PermissionSyncContext>>;
+
+fn root_permission_context_handle(
+    perm_manager: &crate::cli::permission_manager::PermissionManager,
+) -> RootPermissionContextHandle {
+    Arc::new(tokio::sync::RwLock::new(
+        perm_manager.runtime_permission_context(),
+    ))
+}
+
+async fn refresh_root_permission_context(
+    handle: &mut Option<RootPermissionContextHandle>,
+    perm_manager: &crate::cli::permission_manager::PermissionManager,
+) {
+    let latest = perm_manager.runtime_permission_context();
+    if let Some(existing) = handle.as_ref() {
+        *existing.write().await = latest;
+    } else {
+        *handle = Some(Arc::new(tokio::sync::RwLock::new(latest)));
+    }
+}
+
 pub(crate) async fn stream_chat_sse(
     mut p: ChatTurnParams<'_>,
 ) -> Result<StreamResult, crate::TurnFailure> {
@@ -505,9 +528,10 @@ pub(crate) async fn stream_chat_sse(
         None => std::mem::take(&mut local_discovered_skills),
     };
 
-    // Capture full permission mode before perm_manager is moved into the host.
-    let parent_perm_mode = p.perm_manager.mode();
+    // Capture the child permission envelope before perm_manager is moved into the host.
+    let child_permissions = p.perm_manager.inherited_permissions_for_child(true);
     let parent_cancel_token = p.cancel_token.clone();
+    let root_permission_context = root_permission_context_handle(p.perm_manager);
 
     // Snapshot approval overrides for checkpoint persistence.
     let initial_approval_overrides = p.perm_manager.export_session_overrides();
@@ -586,7 +610,7 @@ pub(crate) async fn stream_chat_sse(
             p.token.to_string(),
             p.model.map(|m| m.to_string()),
             project_root.clone(),
-            parent_perm_mode,
+            child_permissions,
             parent_cancel_token,
         )
         .with_skill_resolver(skill_resolver.clone())
@@ -815,7 +839,7 @@ pub(crate) async fn stream_chat_sse(
         max_cumulative_tokens: 0,
         thinking: astra_turn_core::thinking_config::ThinkingConfig::Off,
         recent_file_reads: Vec::new(),
-        permission_context: None,
+        permission_context: Some(root_permission_context),
         permission_handler: None,
         tactical_adapter: None,
         step_signal_collector: None,
@@ -1073,9 +1097,12 @@ mod tests {
     use super::{
         circuit_breaker_config_from_tool_selection, detect_turn_hook_sets,
         extend_restricted_with_blocked_tools, normalize_turn_model,
-        restored_compaction_effectiveness,
+        refresh_root_permission_context, restored_compaction_effectiveness,
+        root_permission_context_handle,
     };
+    use crate::cli::permission_manager::{PermissionManager, PermissionMode};
     use astra_runtime::observability::ObservabilityHub;
+    use astra_runtime::turn::permission_gate::{PermissionCheckResult, check_tool_permission};
     use astra_turn_core::chat_turn_heuristics::infer_task_execution_profile;
     use serde_json::json;
     use std::collections::HashSet;
@@ -1096,6 +1123,146 @@ mod tests {
         assert_eq!(cfg.max_introspect_emissions, 3);
         assert_eq!(cfg.half_open_patience, 2);
         assert_eq!(cfg.absolute_max_rounds, 200);
+    }
+
+    #[tokio::test]
+    async fn root_permission_context_auto_mode_allows_visible_tools() {
+        let mut manager = PermissionManager::new(false);
+        manager.set_mode(PermissionMode::Auto);
+        let ctx = root_permission_context_handle(&manager);
+
+        let result = check_tool_permission(
+            "git",
+            Some(r#"{"action":"status"}"#),
+            Some(&ctx),
+            None,
+            std::time::Duration::from_millis(1),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                PermissionCheckResult::Allowed | PermissionCheckResult::AllowedImplicit { .. }
+            ),
+            "auto mode must install a root permission context that allows visible tools, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_root_permission_context_updates_existing_handle() {
+        let mut manager = PermissionManager::new(false);
+        let mut handle = Some(root_permission_context_handle(&manager));
+        let original = handle.as_ref().unwrap().clone();
+
+        manager.set_mode(PermissionMode::Auto);
+        refresh_root_permission_context(&mut handle, &manager).await;
+
+        let refreshed = handle.as_ref().unwrap();
+        assert!(
+            Arc::ptr_eq(&original, refreshed),
+            "refresh must update the existing context so any permission handler keeps seeing the current policy"
+        );
+
+        let result = check_tool_permission(
+            "bash",
+            Some(r#"{"command":"git status"}"#),
+            Some(refreshed),
+            None,
+            std::time::Duration::from_millis(1),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                PermissionCheckResult::Allowed | PermissionCheckResult::AllowedImplicit { .. }
+            ),
+            "refreshed auto context should allow bash, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prompt_mode_approval_refresh_allows_same_tool_call() {
+        let mut manager = PermissionManager::new(false);
+        manager.set_mode(PermissionMode::Prompt);
+        let mut handle = Some(root_permission_context_handle(&manager));
+        let args = json!({"command": "cargo test"});
+        let args_str = serde_json::to_string(&args).unwrap();
+
+        let before = check_tool_permission(
+            "bash",
+            Some(&args_str),
+            handle.as_ref(),
+            None,
+            std::time::Duration::from_millis(1),
+        )
+        .await;
+        assert!(
+            matches!(before, PermissionCheckResult::Denied { .. }),
+            "prompt mode should require approval before a bash execution, got {before:?}"
+        );
+
+        manager.record_approval("bash", Some(&args), true);
+        refresh_root_permission_context(&mut handle, &manager).await;
+
+        let after = check_tool_permission(
+            "bash",
+            Some(&args_str),
+            handle.as_ref(),
+            None,
+            std::time::Duration::from_millis(1),
+        )
+        .await;
+        assert!(
+            matches!(
+                after,
+                PermissionCheckResult::Allowed | PermissionCheckResult::AllowedImplicit { .. }
+            ),
+            "prompt approval must refresh into the runtime permission context, got {after:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn accept_edits_root_context_allows_edits_but_not_bash() {
+        let mut manager = PermissionManager::new(false);
+        manager.set_mode(PermissionMode::AcceptEdits);
+        let handle = root_permission_context_handle(&manager);
+
+        let write_args = serde_json::to_string(&json!({
+            "path": "src/lib.rs",
+            "content": "pub fn demo() {}\n",
+        }))
+        .unwrap();
+        let write_result = check_tool_permission(
+            "write_file",
+            Some(&write_args),
+            Some(&handle),
+            None,
+            std::time::Duration::from_millis(1),
+        )
+        .await;
+        assert!(
+            matches!(
+                write_result,
+                PermissionCheckResult::Allowed | PermissionCheckResult::AllowedImplicit { .. }
+            ),
+            "accept_edits should allow workspace file edits, got {write_result:?}"
+        );
+
+        let bash_args = serde_json::to_string(&json!({"command": "cargo test"})).unwrap();
+        let bash_result = check_tool_permission(
+            "bash",
+            Some(&bash_args),
+            Some(&handle),
+            None,
+            std::time::Duration::from_millis(1),
+        )
+        .await;
+        assert!(
+            matches!(bash_result, PermissionCheckResult::Denied { .. }),
+            "accept_edits should still require approval for bash, got {bash_result:?}"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -102,7 +102,7 @@ fn maybe_wire_delegation_engine(
         token.to_string(),
         state.model.clone(),
         project_root.clone(),
-        state.perm_manager.mode(),
+        state.perm_manager.inherited_permissions_for_child(true),
         None,
     );
     let mut registry = astra_services::AgentProfileRegistry::new();
@@ -486,7 +486,6 @@ async fn execute_headless_task_body(
         api,
         token.clone(),
         pipeline_modules.unified_skill_registry.clone(),
-        pm.mode(),
         skill_search.clone(),
         session_id.clone(),
         effective_model.clone(),
@@ -1804,7 +1803,6 @@ async fn execute_cli_command_impl(
                 api,
                 token.clone(),
                 astra_runtime::skills::default_unified_registry().clone(),
-                pm.mode(),
                 skill_search.clone(),
                 session_id.clone(),
                 effective_model.clone(),

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -1037,11 +1037,10 @@ fn handle_permission_command(arg: &str, state: &mut SessionState) {
     match arg {
         "" => {
             let next = match state.perm_manager.mode() {
-                PermissionMode::Prompt => PermissionMode::Plan,
-                PermissionMode::Plan => PermissionMode::AcceptEdits,
-                PermissionMode::AcceptEdits => PermissionMode::Auto,
-                PermissionMode::Auto => PermissionMode::Deny,
-                PermissionMode::Deny => PermissionMode::Prompt,
+                PermissionMode::Prompt | PermissionMode::Deny => PermissionMode::AcceptEdits,
+                PermissionMode::AcceptEdits => PermissionMode::Plan,
+                PermissionMode::Plan => PermissionMode::Auto,
+                PermissionMode::Auto => PermissionMode::Prompt,
             };
             state.perm_manager.set_mode(next);
             eprintln!(
@@ -1146,13 +1145,7 @@ fn handle_permission_command(arg: &str, state: &mut SessionState) {
 }
 
 pub(crate) fn permission_mode_display_label(mode: PermissionMode) -> &'static str {
-    match mode {
-        PermissionMode::Prompt => "Ask",
-        PermissionMode::Auto => "Auto",
-        PermissionMode::AcceptEdits => "Edits",
-        PermissionMode::Plan => "Plan",
-        PermissionMode::Deny => "Deny",
-    }
+    mode.chip_text()
 }
 
 #[cfg(test)]
@@ -1166,7 +1159,7 @@ mod permission_mode_display_tests {
         assert_eq!(permission_mode_display_label(PermissionMode::Auto), "Auto");
         assert_eq!(
             permission_mode_display_label(PermissionMode::AcceptEdits),
-            "Edits"
+            "Accept"
         );
         assert_eq!(permission_mode_display_label(PermissionMode::Plan), "Plan");
         assert_eq!(permission_mode_display_label(PermissionMode::Deny), "Deny");

--- a/rust/crates/astra-cli/src/cli/delegate_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/delegate_subrun.rs
@@ -27,7 +27,6 @@ use astra_runtime::{
 };
 use astra_services::coordination::AgentResult;
 
-use super::permission_manager::PermissionMode;
 use super::skill_subrun::{SubRunHost, persist_failed_subrun};
 use crate::edge_tools;
 
@@ -92,14 +91,14 @@ fn resolve_worktree_path(
 /// Creates a fresh agentic loop host for each delegated sub-run, runs it to
 /// completion, and collects the result as [`AgentResult`].
 ///
-/// Inherits the parent session's permission mode so sub-agents enforce the
-/// same approval policy.
+/// Inherits the parent session's permission envelope so sub-agents enforce the
+/// same mode, rules, and session approvals.
 pub(crate) struct CliDelegateSubRunExecutor {
     api: astra_thin_client::ThinClient,
     token: String,
     default_model: Option<String>,
     project_root: PathBuf,
-    permission_mode: PermissionMode,
+    inherited_permissions: astra_runtime::orchestration::InheritedPermissions,
     cancel_token: Option<Arc<tokio_util::sync::CancellationToken>>,
     skill_resolver: Option<Arc<dyn astra_runtime::turn::skill_tool::SkillResolver>>,
     skill_search: SkillSearchSettings,
@@ -128,15 +127,16 @@ impl CliDelegateSubRunExecutor {
         token: String,
         default_model: Option<String>,
         project_root: PathBuf,
-        permission_mode: PermissionMode,
+        mut inherited_permissions: astra_runtime::orchestration::InheritedPermissions,
         cancel_token: Option<Arc<tokio_util::sync::CancellationToken>>,
     ) -> Self {
+        inherited_permissions.is_background = true;
         Self {
             api,
             token,
             default_model,
             project_root,
-            permission_mode,
+            inherited_permissions,
             cancel_token,
             skill_resolver: None,
             skill_search: SkillSearchSettings::default(),
@@ -244,11 +244,13 @@ impl SubRunExecutor for CliDelegateSubRunExecutor {
 
         // Issue #326 P5b: delegate sub-run is headless — strip project
         // allow rules but honour deny + user file.
-        let perm_manager = super::permission_manager::PermissionManager::with_load_policy(
-            self.permission_mode,
+        let perm_manager = super::permission_manager::PermissionManager::with_inherited(
             &self.project_root,
-            &super::permission_manager::PermissionLoadPolicy::HeadlessSafe,
+            self.inherited_permissions.clone(),
         );
+        let permission_context = std::sync::Arc::new(tokio::sync::RwLock::new(
+            perm_manager.runtime_permission_context(),
+        ));
 
         // T-9: Worktree CWD injection — when team isolation provides a per-agent
         // worktree path via context, use it as the working directory instead of
@@ -488,7 +490,7 @@ impl SubRunExecutor for CliDelegateSubRunExecutor {
             max_cumulative_tokens: 0,
             thinking: child_thinking,
             recent_file_reads: Vec::new(),
-            permission_context: None,
+            permission_context: Some(permission_context),
             permission_handler: None,
             tactical_adapter: None,
             step_signal_collector: None,
@@ -684,7 +686,11 @@ pub(crate) fn register_default_agents(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_restricted_tools, register_default_agents, resolve_worktree_path};
+    use super::{
+        CliDelegateSubRunExecutor, build_restricted_tools, register_default_agents,
+        resolve_worktree_path,
+    };
+    use crate::cli::permission_manager::PermissionMode;
     use std::collections::{HashMap, HashSet};
     use std::path::PathBuf;
 
@@ -715,6 +721,26 @@ mod tests {
             main.delegate_to.is_empty(),
             "empty delegate_to = all agents"
         );
+    }
+
+    #[test]
+    fn delegate_executor_constructor_marks_permissions_background() {
+        let inherited_permissions =
+            astra_runtime::orchestration::InheritedPermissions::new(PermissionMode::Auto);
+        let executor = CliDelegateSubRunExecutor::new(
+            astra_thin_client::ThinClient::new("http://unused", None).unwrap(),
+            "token".to_string(),
+            None,
+            PathBuf::from("."),
+            inherited_permissions,
+            None,
+        );
+
+        assert_eq!(
+            executor.inherited_permissions.mode,
+            astra_runtime::orchestration::PermissionMode::Auto
+        );
+        assert!(executor.inherited_permissions.is_background);
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/delegate_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/delegate_subrun.rs
@@ -248,9 +248,7 @@ impl SubRunExecutor for CliDelegateSubRunExecutor {
             &self.project_root,
             self.inherited_permissions.clone(),
         );
-        let permission_context = std::sync::Arc::new(tokio::sync::RwLock::new(
-            perm_manager.runtime_permission_context(),
-        ));
+        let permission_context = perm_manager.runtime_permission_handle();
 
         // T-9: Worktree CWD injection — when team isolation provides a per-agent
         // worktree path via context, use it as the working directory instead of

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -6,7 +6,8 @@ use crate::cli::workspace_trust::{
     evaluate_workspace_trust, project_permissions_hash,
 };
 use astra_runtime::tool_sandbox::{
-    CommandRisk, GitSafetyViolation, analyze_command_risks, validate_git_command,
+    CommandRisk, GitSafetyViolation, SandboxPolicy, analyze_command_risks, validate_git_command,
+    validate_path,
 };
 use astra_thin_client::ApprovalKind;
 use astra_turn_core::cloud_approval_policy::{
@@ -175,13 +176,46 @@ fn canonicalize_existing_or_parent(p: &Path) -> std::io::Result<PathBuf> {
 }
 
 /// Extract the `'{path}'` target from a sandbox-denied reason string.
-/// Returns the first single-quoted path (the one before the word "outside").
+/// Returns the first single-quoted path when the reason is an outside-project
+/// sandbox denial. This covers both `Path '...'` and `command references '...'`
+/// messages.
 fn parse_sandbox_target_path(reason: &str) -> Option<PathBuf> {
-    let needle = "Path '";
-    let start = reason.find(needle)? + needle.len();
+    if !reason.contains("outside the project") && !reason.contains("outside project") {
+        return None;
+    }
+
+    let start = reason.find('\'')? + 1;
     let rest = &reason[start..];
     let end = rest.find('\'')?;
     Some(PathBuf::from(&rest[..end]))
+}
+
+fn sandbox_expand_sensitive_target_denial(name: &str, args: &serde_json::Value) -> Option<String> {
+    if !name.starts_with("sandbox_expand:") {
+        return None;
+    }
+    let reason = args.get("reason").and_then(serde_json::Value::as_str)?;
+    let target = parse_sandbox_target_path(reason)?;
+    if !sandbox_expand_target_is_sensitive(&target) {
+        return None;
+    }
+    Some(format!(
+        "Sensitive path cannot be approved through sandbox expansion: {}",
+        target.display()
+    ))
+}
+
+fn sandbox_expand_target_is_sensitive(path: &Path) -> bool {
+    let path = path.to_string_lossy();
+    sensitive_path_match_for_request("read_file", &serde_json::json!({ "path": path.as_ref() }))
+        .is_some()
+        || validate_path(
+            &SandboxPolicy::permissive(
+                std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            ),
+            path.as_ref(),
+        )
+        .is_err()
 }
 
 fn trim_explicit_path_token(token: &str) -> &str {
@@ -3278,6 +3312,10 @@ impl PermissionManager {
             None,
         );
 
+        if let Some(reason) = sandbox_expand_sensitive_target_denial(name, args) {
+            return PermissionDecision::Deny(reason);
+        }
+
         if matches!(envelope.source, DecisionSource::SandboxExpansion)
             && matches!(envelope.decision, HardDecision::NeedExternal { .. })
         {
@@ -5053,6 +5091,72 @@ mod tests {
         let args = serde_json::json!({"reason": "path outside project"});
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
         assert!(matches!(decision, PermissionDecision::Allow));
+    }
+
+    #[test]
+    fn sandbox_expand_auto_mode_denies_sensitive_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
+        let args = serde_json::json!({
+            "reason": format!(
+                "Path '/etc/shadow' is outside the project directory '{}'.",
+                dir.path().display()
+            )
+        });
+
+        let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
+
+        match decision {
+            PermissionDecision::Deny(reason) => {
+                assert!(
+                    reason.contains("Sensitive path cannot be approved through sandbox expansion"),
+                    "unexpected denial reason: {reason}"
+                );
+            }
+            other => panic!("sensitive sandbox expansion must deny in Auto mode; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sandbox_expand_rejects_shell_reference_to_sensitive_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
+        let args = serde_json::json!({
+            "reason": format!(
+                "The command references '~/.ssh/id_rsa' which is outside the project directory '{}'.",
+                dir.path().display()
+            )
+        });
+
+        let decision = pm.check_nonblocking("sandbox_expand:bash", &args);
+
+        assert!(
+            matches!(decision, PermissionDecision::Deny(ref reason) if reason.contains("Sensitive path")),
+            "home-relative credential sandbox expansion must deny; got {decision:?}"
+        );
+    }
+
+    #[test]
+    fn sandbox_expand_allow_rule_cannot_bypass_sensitive_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+        pm.settings
+            .allow
+            .push("sandbox_expand:read_file".to_string());
+        pm.cached_allow = pm.settings.parsed_allow_rules();
+        let args = serde_json::json!({
+            "reason": format!(
+                "Path '/etc/shadow' is outside the project directory '{}'.",
+                dir.path().display()
+            )
+        });
+
+        let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
+
+        assert!(
+            matches!(decision, PermissionDecision::Deny(ref reason) if reason.contains("Sensitive path")),
+            "sandbox_expand allow rules must not unlock sensitive targets; got {decision:?}"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -414,9 +414,17 @@ fn content_aware_fingerprint(
         }
         Some(CloudGatedToolKind::Write) => {
             let path = path_hint_from_args(args);
-            ApprovalFingerprint::file_op(name, path.as_deref())
+            ApprovalFingerprint::file_op(file_write_fingerprint_tool(name), path.as_deref())
         }
         None => ApprovalFingerprint::bare(name),
+    }
+}
+
+fn file_write_fingerprint_tool(tool_name: &str) -> &str {
+    if astra_turn_core::tool_categories::registry().is_file_op(tool_name) {
+        "file_write"
+    } else {
+        tool_name
     }
 }
 
@@ -442,7 +450,7 @@ fn approval_lookup_fingerprint(
         }
         Some(CloudGatedToolKind::Write) => {
             if let Some(path) = path_hint_from_args(args) {
-                ApprovalFingerprint::file_op_exact(name, Some(&path))
+                ApprovalFingerprint::file_op_exact(file_write_fingerprint_tool(name), Some(&path))
             } else {
                 ApprovalFingerprint::bare(name)
             }
@@ -462,7 +470,7 @@ fn cloud_detail_lookup_fingerprint(
             ApprovalFingerprint::shell(tool, cmd, false)
         }
         (Some(CloudGatedToolKind::Write), Some(path)) => {
-            ApprovalFingerprint::file_op_exact(tool, Some(path))
+            ApprovalFingerprint::file_op_exact(file_write_fingerprint_tool(tool), Some(path))
         }
         _ => ApprovalFingerprint::bare(tool),
     }
@@ -484,7 +492,7 @@ fn approval_lookup_fingerprint_candidates(
         if astra_turn_core::tool_categories::registry().is_file_op(name) {
             push_unique_fingerprint(
                 &mut candidates,
-                ApprovalFingerprint::file_op_exact("edit", Some(&path)),
+                ApprovalFingerprint::file_op_exact("file_write", Some(&path)),
             );
         }
         if let Some(resolved) = resolved_write_path(&path) {
@@ -495,7 +503,7 @@ fn approval_lookup_fingerprint_candidates(
             if astra_turn_core::tool_categories::registry().is_file_op(name) {
                 push_unique_fingerprint(
                     &mut candidates,
-                    ApprovalFingerprint::file_op_exact("edit", Some(&resolved)),
+                    ApprovalFingerprint::file_op_exact("file_write", Some(&resolved)),
                 );
             }
         }
@@ -517,7 +525,7 @@ fn cloud_detail_lookup_fingerprint_candidates(
         if astra_turn_core::tool_categories::registry().is_file_op(tool) {
             push_unique_fingerprint(
                 &mut candidates,
-                ApprovalFingerprint::file_op_exact("edit", Some(path)),
+                ApprovalFingerprint::file_op_exact("file_write", Some(path)),
             );
         }
         if let Some(resolved) = resolved_write_path(path) {
@@ -528,7 +536,7 @@ fn cloud_detail_lookup_fingerprint_candidates(
             if astra_turn_core::tool_categories::registry().is_file_op(tool) {
                 push_unique_fingerprint(
                     &mut candidates,
-                    ApprovalFingerprint::file_op_exact("edit", Some(&resolved)),
+                    ApprovalFingerprint::file_op_exact("file_write", Some(&resolved)),
                 );
             }
         }
@@ -609,7 +617,7 @@ fn sensitive_path_match_for_request(tool_name: &str, args: &serde_json::Value) -
 // ─── Permission types: re-exports from astra-turn-core ──────────────
 //
 // Issue #326 P1 / R1 §1 / R2 Major 4: previously this file defined
-// its own `PermissionMode`, `PermissionRule`, and `PermissionDecision`
+// its own `PermissionMode`, `PermissionRule`, and decision type
 // alongside the ones in `astra-turn-core::permission_types`. Three
 // independent type names with overlapping semantics caused a string-
 // roundtrip wart at every crate boundary (`with_inherited` matched
@@ -618,9 +626,9 @@ fn sensitive_path_match_for_request(tool_name: &str, args: &serde_json::Value) -
 // We now use turn-core's types directly via type aliases; the rule
 // parser and matcher are identical (compared field-by-field) so this
 // is a pure rename + import change. The CLI keeps its own
-// `PermissionDecision` (renamed to `GateOutcome` in P1) because its
-// shape (Allow / Deny / NeedApproval) is genuinely different from
-// turn-core's `PermissionDecision` (Approve / Deny / Escalate).
+// `GateOutcome` because its shape (Allow / Deny / NeedApproval) is
+// genuinely different from turn-core's callback decision type
+// (Approve / Deny / Escalate).
 pub(crate) use astra_turn_core::permission::types::PermissionMode;
 pub(crate) use astra_turn_core::permission::types::PermissionRule;
 
@@ -710,15 +718,6 @@ pub(crate) struct PermissionSettings {
     /// unless the user sets this to `true` at project or user scope.
     #[serde(default)]
     pub allow_sensitive_path_writes: bool,
-    /// Issue #326 P1.5b / R2 Major 2: grammar version. Files
-    /// without this field (every file written by astra prior to
-    /// this PR) are treated as v1 and parsed leniently. New
-    /// saves stamp `grammar_version = 2` so future readers know
-    /// the file is in the structured-key form
-    /// (`Bash(argv_prefix="…")`). The grammar-v2 parser is
-    /// backward-compatible: v1 strings still parse correctly.
-    #[serde(default)]
-    pub grammar_version: u32,
 }
 
 /// Outcome of loading a `permissions.json` file.
@@ -751,7 +750,7 @@ pub enum PermissionSettingsLoadError {
     /// error). Stat-level errors (file simply not present) are *not*
     /// reported here — those are normal first-run conditions.
     Io { path: PathBuf, source: io::Error },
-    /// File parsed as JSON but contains a malformed v2 rule string.
+    /// File parsed as JSON but contains a malformed permission rule string.
     InvalidRule {
         path: PathBuf,
         rule: String,
@@ -994,7 +993,7 @@ impl PermissionSettings {
 
     fn validate_rules(&self, path: &Path) -> Result<(), PermissionSettingsLoadError> {
         for rule in self.allow.iter().chain(self.deny.iter()) {
-            if let Err(err) = astra_turn_core::permission::rule_grammar::parse_rule_v2(rule) {
+            if let Err(err) = astra_turn_core::permission::rule_grammar::parse_rule(rule) {
                 return Err(PermissionSettingsLoadError::InvalidRule {
                     path: path.to_path_buf(),
                     rule: rule.clone(),
@@ -1014,10 +1013,7 @@ impl PermissionSettings {
     fn save_to_file(&self, dir: &Path, path: &Path) -> io::Result<()> {
         fs::create_dir_all(dir)?;
 
-        let mut to_serialize = self.clone();
-        to_serialize.grammar_version = astra_turn_core::permission::rule_grammar::GRAMMAR_VERSION;
-
-        let json = serde_json::to_string_pretty(&to_serialize)?;
+        let json = serde_json::to_string_pretty(self)?;
 
         let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
         std::io::Write::write_all(&mut tmp, json.as_bytes())?;
@@ -1195,24 +1191,28 @@ impl PermissionSettings {
     fn parsed_allow_rules(&self) -> Vec<PermissionRule> {
         self.allow
             .iter()
-            .map(|s| parse_rule_with_grammar_v2(s))
+            .map(|s| parse_permission_rule(s))
             .collect()
     }
 
     fn parsed_deny_rules(&self) -> Vec<PermissionRule> {
-        self.deny
-            .iter()
-            .map(|s| parse_rule_with_grammar_v2(s))
-            .collect()
+        self.deny.iter().map(|s| parse_permission_rule(s)).collect()
     }
 }
 
-/// Issue #326 P1.5b: parse legacy and grammar-v2 rule strings into
-/// the shared turn-core enforcement type. Load-time validation has
-/// already made v2 parse failures loud; this helper keeps existing
-/// v1 strings backward-compatible.
-fn parse_rule_with_grammar_v2(s: &str) -> PermissionRule {
+fn parse_permission_rule(s: &str) -> PermissionRule {
     PermissionRule::parse(s)
+}
+
+fn normalize_permission_rule_text(rule: &str) -> String {
+    let trimmed = rule.trim();
+    if astra_turn_core::permission::rule_grammar::parse_rule(trimmed).is_ok() {
+        return trimmed.to_string();
+    }
+    if !trimmed.is_empty() && !trimmed.contains('(') {
+        return format!("{trimmed}()");
+    }
+    trimmed.to_string()
 }
 
 pub(crate) struct PermissionManager {
@@ -1721,8 +1721,9 @@ impl PermissionManager {
     /// Issue #326 P0 / R1 Major 10 / task #17: if the parent envelope
     /// carries a `fingerprinted_overrides` JSON blob, we deserialize
     /// it back into the child's `session_overrides` so the child
-    /// honours per-fingerprint decisions (`Bash(cargo test:*) → Allow`)
-    /// instead of relying on the legacy `tool_name → bool` collapse.
+    /// honours per-fingerprint decisions
+    /// (`Bash(argv_prefix="cargo test")` -> Allow) instead of relying
+    /// on a broad `tool_name -> bool` collapse.
     /// A deserialization failure logs a warning and leaves overrides
     /// empty rather than silently downgrading to a wider rule.
     pub(crate) fn with_inherited(
@@ -1868,8 +1869,8 @@ impl PermissionManager {
     /// Issue #326 P0 / R1 Major 10 / task #17: previously this method
     /// called `session_overrides.to_legacy_overrides()`, which collapses
     /// every fingerprinted decision into a `tool_name → bool` map. So
-    /// a parent who pressed "Always" on `Bash(cargo test:*)` would
-    /// hand the child a `Bash → Allow` envelope, and the child could
+    /// a parent who pressed "Always" on `Bash(argv_prefix="cargo test")`
+    /// would hand the child a `Bash -> Allow` envelope, and the child could
     /// then run `Bash(rm -rf …)` without ever asking. That is exactly
     /// the bypass review-r1 calls out.
     ///
@@ -1877,7 +1878,7 @@ impl PermissionManager {
     /// as JSON because runtime types can't depend on
     /// `approval_fingerprint`). The child is expected to consult those
     /// fingerprints first; only if no fingerprint matches does it fall
-    /// through to the legacy `allow_rules` / `deny_rules`. The
+    /// through to the inherited `allow_rules` / `deny_rules`. The
     /// `to_legacy_overrides()` helper still exists for telemetry /
     /// display but is **no longer wired into enforcement**.
     pub(crate) fn inherited_permissions_for_child(
@@ -2203,7 +2204,7 @@ impl PermissionManager {
         // The lookup fingerprint uses the tool-name-only classifier for
         // cloud details so read-only bash commands do not collapse to `bare`.
         // For path-shaped tools we probe both the raw detail and the
-        // workspace-resolved absolute path so legacy exact/prefix rules and
+        // workspace-resolved absolute path so exact/prefix rules and
         // workspace-scoped write memory can both match.
         let fps = cloud_detail_lookup_fingerprint_candidates(tool, detail);
         let sensitive_path = cloud_detail_is_sensitive(tool, detail);
@@ -2595,7 +2596,7 @@ impl PermissionManager {
                 // different things per kind: a shell command for
                 // Execute, a path for Write. Build the allow-rule arg
                 // shape to match so `make_allow_rule` produces the
-                // right pattern (`Bash(cargo:*)` vs `write_file`).
+                // right pattern (`Bash(argv_prefix="cargo")` vs `write_file`).
                 let kind = cloud_gated_tool_kind(tool);
                 let rule_args = match (kind, detail) {
                     (Some(CloudGatedToolKind::Execute), Some(cmd)) => {
@@ -2670,7 +2671,10 @@ impl PermissionManager {
                         )
                     }
                     (Some(CloudGatedToolKind::Write), d) => {
-                        astra_turn_core::approval_fingerprint::ApprovalFingerprint::file_op(tool, d)
+                        astra_turn_core::approval_fingerprint::ApprovalFingerprint::file_op(
+                            file_write_fingerprint_tool(tool),
+                            d,
+                        )
                     }
                     _ => astra_turn_core::approval_fingerprint::ApprovalFingerprint::bare(tool),
                 };
@@ -2861,7 +2865,7 @@ impl PermissionManager {
     pub(crate) fn add_allow_rule(&mut self, rule: &str) {
         use astra_turn_core::permission::audit::PersistTarget;
 
-        let rule_text = rule.to_string();
+        let rule_text = normalize_permission_rule_text(rule);
         if self.settings.allow.contains(&rule_text) {
             return;
         }
@@ -2877,7 +2881,7 @@ impl PermissionManager {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
-        let correlation_id = format!("rule-{}-{}", timestamp_ms, rule);
+        let correlation_id = format!("rule-{}-{}", timestamp_ms, rule_text);
         let save_result = PermissionSettings::modify(&root, |settings| -> Result<(), String> {
             if !settings.allow.contains(&rule_text) {
                 settings.allow.push(rule_text.clone());
@@ -2934,7 +2938,7 @@ impl PermissionManager {
     fn add_user_allow_rule_with_home(&mut self, rule: &str, home: Option<&Path>) {
         use astra_turn_core::permission::audit::PersistTarget;
 
-        let rule_text = rule.to_string();
+        let rule_text = normalize_permission_rule_text(rule);
         if self.user_settings.allow.contains(&rule_text) {
             return;
         }
@@ -2947,7 +2951,7 @@ impl PermissionManager {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
-        let correlation_id = format!("rule-{}-{}", timestamp_ms, rule);
+        let correlation_id = format!("rule-{}-{}", timestamp_ms, rule_text);
         let save_result = match home {
             Some(home) => {
                 PermissionSettings::modify_user_in_home(home, |settings| -> Result<(), String> {
@@ -3278,19 +3282,15 @@ impl PermissionManager {
         &mut self,
         name: &str,
         args: &serde_json::Value,
-    ) -> PermissionDecision {
+    ) -> GateOutcome {
         let decision = self.check_nonblocking_inner(name, args);
-        if let PermissionDecision::Deny(reason) = &decision {
+        if let GateOutcome::Deny(reason) = &decision {
             self.record_rejection(name, reason);
         }
         decision
     }
 
-    fn check_nonblocking_inner(
-        &mut self,
-        name: &str,
-        args: &serde_json::Value,
-    ) -> PermissionDecision {
+    fn check_nonblocking_inner(&mut self, name: &str, args: &serde_json::Value) -> GateOutcome {
         fn trim_sandbox_reason_for_ui(raw: &str) -> String {
             const INSTRUCTION: &str =
                 "Ask the user for permission before accessing files outside the project.";
@@ -3313,7 +3313,7 @@ impl PermissionManager {
         );
 
         if let Some(reason) = sandbox_expand_sensitive_target_denial(name, args) {
-            return PermissionDecision::Deny(reason);
+            return GateOutcome::Deny(reason);
         }
 
         if matches!(envelope.source, DecisionSource::SandboxExpansion)
@@ -3323,9 +3323,9 @@ impl PermissionManager {
                 self.check_overrides_any(&approval_lookup_fingerprint_candidates(name, args))
             {
                 return if allowed {
-                    PermissionDecision::Allow
+                    GateOutcome::Allow
                 } else {
-                    PermissionDecision::Deny("Sandbox expansion denied for session".into())
+                    GateOutcome::Deny("Sandbox expansion denied for session".into())
                 };
             }
             let reason = args
@@ -3335,10 +3335,10 @@ impl PermissionManager {
             if let Some(target) = parse_sandbox_target_path(reason)
                 && self.path_under_trusted_root(&target)
             {
-                return PermissionDecision::Allow;
+                return GateOutcome::Allow;
             }
             if self.check_allow_rules(name, args) {
-                return PermissionDecision::Allow;
+                return GateOutcome::Allow;
             }
         }
 
@@ -3350,9 +3350,9 @@ impl PermissionManager {
                 true,
             ) {
                 return if allowed {
-                    PermissionDecision::Allow
+                    GateOutcome::Allow
                 } else {
-                    PermissionDecision::Deny("Sensitive path denied for session".into())
+                    GateOutcome::Deny("Sensitive path denied for session".into())
                 };
             }
             if self.mode == PermissionMode::Auto
@@ -3363,24 +3363,24 @@ impl PermissionManager {
                     "permission",
                     "Auto mode allowed write to sensitive path (opt-in): tool={name}"
                 );
-                return PermissionDecision::Allow;
+                return GateOutcome::Allow;
             }
             if self.mode == PermissionMode::Auto {
-                return PermissionDecision::Deny(
+                return GateOutcome::Deny(
                     "Sensitive path requires explicit opt-in in Auto mode".to_string(),
                 );
             }
         }
 
         match envelope.decision {
-            HardDecision::Allow => PermissionDecision::Allow,
-            HardDecision::Deny { reason } => PermissionDecision::Deny(reason),
+            HardDecision::Allow => GateOutcome::Allow,
+            HardDecision::Deny { reason } => GateOutcome::Deny(reason),
             HardDecision::NeedExternal { prompt } => {
                 if matches!(envelope.source, DecisionSource::Mode { .. }) {
                     let fp = content_aware_fingerprint(name, args);
                     match self.denial_tracker.should_prompt(&fp) {
                         astra_turn_core::approval_fingerprint::DenialAction::SkipTool => {
-                            return PermissionDecision::Deny(format!(
+                            return GateOutcome::Deny(format!(
                                 "{name}: auto-denied (repeated denials)"
                             ));
                         }
@@ -3400,7 +3400,7 @@ impl PermissionManager {
                         let (header, detail) = Self::format_tool_display(name, args);
                         (header, detail, prompt.reason)
                     };
-                PermissionDecision::NeedApproval {
+                GateOutcome::NeedApproval {
                     tool: prompt.tool,
                     header,
                     detail,
@@ -3588,19 +3588,11 @@ impl PermissionManager {
     }
 }
 
-/// Outcome of a non-blocking permission gate evaluation.
+/// Outcome of the CLI permission gate.
 ///
-/// Issue #326 P1 / R1 §1: this used to be called `PermissionDecision`,
-/// which collided with `astra_turn_core::permission::types::PermissionDecision`
-/// (a different shape: Approve / Deny / Escalate). The CLI gate
-/// produces a different envelope (Allow / Deny / NeedApproval) — the
-/// turn-core type is for callbacks inside the runtime, this one is
-/// what the gate hands back to the stream host. We rename to
-/// `GateOutcome` so the two never get confused at a use site.
-///
-/// The legacy alias `PermissionDecision` is kept for one PR cycle
-/// to avoid churning every call site; new code should use
-/// `GateOutcome`.
+/// This is intentionally distinct from the turn-core callback decision
+/// type: the CLI gate returns Allow / Deny / NeedApproval for
+/// stream-host routing.
 #[derive(Debug)]
 pub(crate) enum GateOutcome {
     Allow,
@@ -3613,11 +3605,6 @@ pub(crate) enum GateOutcome {
         reason: String,
     },
 }
-
-/// Backwards-compatible alias for the previous name. Exists only so
-/// the existing call sites in `stream_render.rs` etc. keep compiling
-/// during the P1 type-merge transition. Will be removed in P2.
-pub(crate) type PermissionDecision = GateOutcome;
 
 #[cfg(test)]
 #[derive(Clone, Copy, Debug)]
@@ -3730,7 +3717,7 @@ fn is_read_only_allowlisted(lower_cmd: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApprovalPromptKind, ExecuteDecision, ModifyError, PermissionDecision, PermissionLoadPolicy,
+        ApprovalPromptKind, ExecuteDecision, GateOutcome, ModifyError, PermissionLoadPolicy,
         PermissionManager, PermissionMode, PermissionRule, PermissionSettings,
         PermissionSettingsLoadError, SideEffect, cloud_always_feedback_message,
         content_aware_fingerprint, decode_mode_for_mirror, encode_mode_for_mirror,
@@ -3949,20 +3936,20 @@ mod tests {
 
         assert!(matches!(
             pm.check_nonblocking("bash", &args),
-            PermissionDecision::NeedApproval { .. }
+            GateOutcome::NeedApproval { .. }
         ));
 
         pm.record_turn_approval("bash", Some(&args), true);
         assert!(matches!(
             pm.check_nonblocking("bash", &args),
-            PermissionDecision::Allow
+            GateOutcome::Allow
         ));
         assert!(pm.export_session_overrides().is_none());
 
         pm.clear_turn_overrides();
         assert!(matches!(
             pm.check_nonblocking("bash", &args),
-            PermissionDecision::NeedApproval { .. }
+            GateOutcome::NeedApproval { .. }
         ));
     }
 
@@ -3979,7 +3966,7 @@ mod tests {
 
         assert!(matches!(
             pm.check_nonblocking("write_file", &args),
-            PermissionDecision::NeedApproval { .. }
+            GateOutcome::NeedApproval { .. }
         ));
 
         let events = astra_services::session_journal::read_journal(&session_id).unwrap();
@@ -4335,29 +4322,29 @@ mod tests {
     // ── Permission rules ──────────────────────────────────────────────────────
 
     #[test]
-    fn rule_parse_bare_tool() {
-        let rule = PermissionRule::parse("Edit");
-        assert_eq!(rule.tool, "edit");
+    fn rule_parse_broad_tool() {
+        let rule = PermissionRule::parse("write_file()");
+        assert_eq!(rule.tool, "write_file");
         assert_eq!(rule.pattern, None);
     }
 
     #[test]
     fn rule_parse_with_prefix_pattern() {
-        let rule = PermissionRule::parse("Bash(git commit:*)");
+        let rule = PermissionRule::parse(r#"Bash(argv_prefix="git commit")"#);
         assert_eq!(rule.tool, "bash");
         assert_eq!(rule.pattern, Some("git commit".to_string()));
     }
 
     #[test]
     fn rule_matches_bare_tool() {
-        let rule = PermissionRule::parse("bash");
+        let rule = PermissionRule::parse("bash()");
         assert!(rule.matches("bash", Some("anything")));
         assert!(rule.matches("bash", None));
     }
 
     #[test]
     fn rule_matches_prefix() {
-        let rule = PermissionRule::parse("Bash(git commit:*)");
+        let rule = PermissionRule::parse(r#"Bash(argv_prefix="git commit")"#);
         assert!(rule.matches("bash", Some("git commit -m 'fix'")));
         assert!(!rule.matches("bash", Some("git push origin main")));
         assert!(!rule.matches("bash", None));
@@ -4366,7 +4353,9 @@ mod tests {
     #[test]
     fn deny_rules_block_matching_commands() {
         let mut pm = PermissionManager::new(true); // auto_approve=true
-        pm.settings.deny.push("Bash(rm:*)".to_string());
+        pm.settings
+            .deny
+            .push(r#"Bash(argv_prefix="rm")"#.to_string());
         pm.cached_deny = pm.settings.parsed_deny_rules();
         let args = serde_json::json!({"command": "rm -rf /tmp/test"});
         assert!(!pm.check("bash", &args));
@@ -4375,7 +4364,9 @@ mod tests {
     #[test]
     fn allow_rules_permit_matching_commands() {
         let mut pm = PermissionManager::new(false); // auto_approve=false
-        pm.settings.allow.push("Bash(cargo test:*)".to_string());
+        pm.settings
+            .allow
+            .push(r#"Bash(argv_prefix="cargo test")"#.to_string());
         pm.cached_allow = pm.settings.parsed_allow_rules();
         let args = serde_json::json!({"command": "cargo test --release"});
         // Allow rules skip the interactive prompt.
@@ -4385,7 +4376,7 @@ mod tests {
     #[test]
     fn allow_rules_ignore_dangerous_broad_bash_shapes() {
         let mut pm = PermissionManager::new(false);
-        pm.settings.allow.push("bash".to_string());
+        pm.settings.allow.push("bash()".to_string());
         pm.settings
             .allow
             .push(r#"Bash(argv_prefix="python", op="execute")"#.to_string());
@@ -4405,11 +4396,11 @@ mod tests {
     }
 
     #[test]
-    fn allow_rules_enforce_v2_op_and_path_context() {
+    fn allow_rules_enforce_op_and_path_context() {
         let mut pm = PermissionManager::new(false);
         pm.settings
             .allow
-            .push(r#"write_file(path_glob="src/**/*.rs", op="write")"#.to_string());
+            .push(r#"file_write(path_glob="src/**/*.rs", op="write")"#.to_string());
         pm.cached_allow = pm.settings.parsed_allow_rules();
 
         assert!(pm.check_allow_rules(
@@ -4420,7 +4411,7 @@ mod tests {
     }
 
     #[test]
-    fn allow_rules_enforce_v2_network_domain_context() {
+    fn allow_rules_enforce_network_domain_context() {
         let mut pm = PermissionManager::new(false);
         pm.settings
             .allow
@@ -4438,7 +4429,7 @@ mod tests {
     }
 
     #[test]
-    fn allow_rules_enforce_v2_mcp_capability_context() {
+    fn allow_rules_enforce_mcp_capability_context() {
         let mut pm = PermissionManager::new(false);
         pm.settings.allow.push(
             r#"MCP(tool="mcp_jira_create_issue", capability="destructive=false")"#.to_string(),
@@ -4459,13 +4450,17 @@ mod tests {
     fn settings_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let mut settings = PermissionSettings::default();
-        settings.allow.push("Bash(git:*)".to_string());
-        settings.deny.push("Bash(rm -rf:*)".to_string());
+        settings
+            .allow
+            .push(r#"Bash(argv_prefix="git")"#.to_string());
+        settings
+            .deny
+            .push(r#"Bash(argv_prefix="rm -rf")"#.to_string());
         settings.save(dir.path()).unwrap();
 
         let loaded = PermissionSettings::load(dir.path());
-        assert_eq!(loaded.allow, vec!["Bash(git:*)"]);
-        assert_eq!(loaded.deny, vec!["Bash(rm -rf:*)"]);
+        assert_eq!(loaded.allow, vec![r#"Bash(argv_prefix="git")"#]);
+        assert_eq!(loaded.deny, vec![r#"Bash(argv_prefix="rm -rf")"#]);
     }
 
     // ── Issue #326 P0: corrupt permissions.json must surface ────────────────
@@ -4496,7 +4491,7 @@ mod tests {
     }
 
     #[test]
-    fn try_load_returns_invalid_rule_for_unknown_v2_key() {
+    fn try_load_returns_invalid_rule_for_unknown_key() {
         let dir = tempfile::tempdir().unwrap();
         let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
@@ -4532,11 +4527,11 @@ mod tests {
     }
 
     #[test]
-    fn legacy_load_facade_still_returns_default_on_corrupt() {
-        // Backwards-compat: existing call sites that use `load()` get
-        // a defaulted settings struct (and a `tracing::warn` they may
-        // or may not be capturing). The new signal is on
-        // `PermissionManager::load_errors()`, not on `load()`.
+    fn load_facade_returns_default_on_corrupt() {
+        // Existing call sites that use `load()` get a defaulted
+        // settings struct (and a `tracing::warn` they may or may not
+        // be capturing). The structured signal is on
+        // `PermissionManager::load_errors()`.
         let dir = tempfile::tempdir().unwrap();
         let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
@@ -4554,16 +4549,16 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         let result = PermissionSettings::modify(dir.path(), |s| -> Result<(), &'static str> {
-            s.allow.push("Bash(npm test:*)".to_string());
+            s.allow.push(r#"Bash(argv_prefix="npm test")"#.to_string());
             Ok(())
         })
         .unwrap();
 
-        assert_eq!(result.allow, vec!["Bash(npm test:*)"]);
+        assert_eq!(result.allow, vec![r#"Bash(argv_prefix="npm test")"#]);
 
         // Re-load directly to confirm the change actually hit disk.
         let reloaded = PermissionSettings::load(dir.path());
-        assert_eq!(reloaded.allow, vec!["Bash(npm test:*)"]);
+        assert_eq!(reloaded.allow, vec![r#"Bash(argv_prefix="npm test")"#]);
     }
 
     #[test]
@@ -4575,21 +4570,24 @@ mod tests {
 
         // Process A: write a rule first.
         let mut a = PermissionSettings::default();
-        a.allow.push("Bash(rule-a:*)".to_string());
+        a.allow.push(r#"Bash(argv_prefix="rule-a")"#.to_string());
         a.save(dir.path()).unwrap();
 
         // Process B: open a stale baseline by NOT calling load.
         // Use modify to add a different rule — modify will re-load
         // under the flock and see rule-a, then add rule-b on top.
         let result = PermissionSettings::modify(dir.path(), |s| -> Result<(), &'static str> {
-            s.allow.push("Bash(rule-b:*)".to_string());
+            s.allow.push(r#"Bash(argv_prefix="rule-b")"#.to_string());
             Ok(())
         })
         .unwrap();
 
         assert_eq!(
             result.allow,
-            vec!["Bash(rule-a:*)", "Bash(rule-b:*)"],
+            vec![
+                r#"Bash(argv_prefix="rule-a")"#,
+                r#"Bash(argv_prefix="rule-b")"#
+            ],
             "modify must merge with the on-disk baseline, not overwrite"
         );
     }
@@ -4629,11 +4627,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         // Pre-write a baseline so we can detect any unexpected change.
         let mut baseline = PermissionSettings::default();
-        baseline.allow.push("Bash(baseline:*)".to_string());
+        baseline
+            .allow
+            .push(r#"Bash(argv_prefix="baseline")"#.to_string());
         baseline.save(dir.path()).unwrap();
 
         let err = PermissionSettings::modify(dir.path(), |s| -> Result<(), &'static str> {
-            s.allow.push("Bash(would-be:*)".to_string());
+            s.allow.push(r#"Bash(argv_prefix="would-be")"#.to_string());
             Err("user changed their mind")
         })
         .unwrap_err();
@@ -4641,7 +4641,7 @@ mod tests {
 
         // File on disk is unchanged.
         let reloaded = PermissionSettings::load(dir.path());
-        assert_eq!(reloaded.allow, vec!["Bash(baseline:*)"]);
+        assert_eq!(reloaded.allow, vec![r#"Bash(argv_prefix="baseline")"#]);
     }
 
     // ── Issue #326 P5b: PermissionLoadPolicy ──────────────────────────
@@ -4654,8 +4654,8 @@ mod tests {
         std::fs::write(
             kiro.join("permissions.json"),
             r#"{
-                "allow": ["Bash(curl:*)"],
-                "deny": ["Bash(rm -rf:*)"]
+                "allow": ["Bash(argv_prefix=\"curl\")"],
+                "deny": ["Bash(argv_prefix=\"rm -rf\")"]
             }"#,
         )
         .unwrap();
@@ -4673,7 +4673,7 @@ mod tests {
         );
         // Project deny rules preserved — a project can still tighten
         // sub-run restrictions.
-        assert_eq!(pm.settings.deny, vec!["Bash(rm -rf:*)"]);
+        assert_eq!(pm.settings.deny, vec![r#"Bash(argv_prefix="rm -rf")"#]);
     }
 
     #[test]
@@ -4684,8 +4684,8 @@ mod tests {
         std::fs::write(
             kiro.join("permissions.json"),
             r#"{
-                "allow": ["Bash(rm:*)"],
-                "deny": ["Edit(/etc/**)"],
+                "allow": ["Bash(argv_prefix=\"rm\")"],
+                "deny": ["file_write(path_glob=\"/etc/**\", op=\"write\")"],
                 "allow_sensitive_path_writes": true
             }"#,
         )
@@ -4697,7 +4697,10 @@ mod tests {
             &PermissionLoadPolicy::InteractiveUntrusted,
         );
         assert!(pm.settings.allow.is_empty());
-        assert_eq!(pm.settings.deny, vec!["Edit(/etc/**)"]);
+        assert_eq!(
+            pm.settings.deny,
+            vec![r#"file_write(path_glob="/etc/**", op="write")"#]
+        );
         assert!(
             !pm.settings.allow_sensitive_path_writes,
             "untrusted must zero allow_sensitive_path_writes"
@@ -4712,8 +4715,8 @@ mod tests {
         std::fs::write(
             kiro.join("permissions.json"),
             r#"{
-                "allow": ["Bash(npm test:*)"],
-                "deny": ["Bash(rm -rf:*)"],
+                "allow": ["Bash(argv_prefix=\"npm test\")"],
+                "deny": ["Bash(argv_prefix=\"rm -rf\")"],
                 "allow_sensitive_path_writes": true
             }"#,
         )
@@ -4724,8 +4727,8 @@ mod tests {
             dir.path(),
             &PermissionLoadPolicy::InteractiveTrusted,
         );
-        assert_eq!(pm.settings.allow, vec!["Bash(npm test:*)"]);
-        assert_eq!(pm.settings.deny, vec!["Bash(rm -rf:*)"]);
+        assert_eq!(pm.settings.allow, vec![r#"Bash(argv_prefix="npm test")"#]);
+        assert_eq!(pm.settings.deny, vec![r#"Bash(argv_prefix="rm -rf")"#]);
         assert!(pm.settings.allow_sensitive_path_writes);
     }
 
@@ -4755,8 +4758,8 @@ mod tests {
         std::fs::write(
             kiro.join("permissions.json"),
             r#"{
-                "allow": ["Bash(npm test:*)"],
-                "deny": ["Bash(rm:*)"]
+                "allow": ["Bash(argv_prefix=\"npm test\")"],
+                "deny": ["Bash(argv_prefix=\"rm\")"]
             }"#,
         )
         .unwrap();
@@ -4769,7 +4772,7 @@ mod tests {
         );
 
         assert!(pm.settings.allow.is_empty());
-        assert_eq!(pm.settings.deny, vec!["Bash(rm:*)"]);
+        assert_eq!(pm.settings.deny, vec![r#"Bash(argv_prefix="rm")"#]);
         assert!(matches!(
             pm.workspace_trust.as_ref().map(|t| &t.reason),
             Some(WorkspaceTrustReason::UnknownWorkspace)
@@ -4818,7 +4821,7 @@ mod tests {
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(
             kiro.join("permissions.json"),
-            r#"{"allow":["Bash(npm test:*)"],"deny":["Bash(rm:*)"]}"#,
+            r#"{"allow":["Bash(argv_prefix=\"npm test\")"],"deny":["Bash(argv_prefix=\"rm\")"]}"#,
         )
         .unwrap();
         let ledger_path = dir.path().join("trusted_workspaces.json");
@@ -4837,8 +4840,8 @@ mod tests {
             ledger_path,
         );
 
-        assert_eq!(pm.settings.allow, vec!["Bash(npm test:*)"]);
-        assert_eq!(pm.settings.deny, vec!["Bash(rm:*)"]);
+        assert_eq!(pm.settings.allow, vec![r#"Bash(argv_prefix="npm test")"#]);
+        assert_eq!(pm.settings.deny, vec![r#"Bash(argv_prefix="rm")"#]);
     }
 
     #[test]
@@ -4847,7 +4850,11 @@ mod tests {
         let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         let permissions_path = kiro.join("permissions.json");
-        std::fs::write(&permissions_path, r#"{"allow":["Bash(ls:*)"]}"#).unwrap();
+        std::fs::write(
+            &permissions_path,
+            r#"{"allow":["Bash(argv_prefix=\"ls\")"]}"#,
+        )
+        .unwrap();
         let trusted_hash = project_permissions_hash(dir.path()).unwrap();
 
         let ledger_path = dir.path().join("trusted_workspaces.json");
@@ -4860,7 +4867,11 @@ mod tests {
         );
         ledger.save().unwrap();
 
-        std::fs::write(&permissions_path, r#"{"allow":["Bash(cargo test:*)"]}"#).unwrap();
+        std::fs::write(
+            &permissions_path,
+            r#"{"allow":["Bash(argv_prefix=\"cargo test\")"]}"#,
+        )
+        .unwrap();
         let pm = PermissionManager::with_workspace_trust_mode_from_ledger_path(
             PermissionMode::Prompt,
             dir.path(),
@@ -5074,7 +5085,7 @@ mod tests {
     fn with_project_mode_loads_settings() {
         let dir = tempfile::tempdir().unwrap();
         let mut settings = PermissionSettings::default();
-        settings.deny.push("Bash(rm:*)".to_string());
+        settings.deny.push(r#"Bash(argv_prefix="rm")"#.to_string());
         settings.save(dir.path()).unwrap();
 
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
@@ -5090,7 +5101,7 @@ mod tests {
         let mut pm = PermissionManager::new(true);
         let args = serde_json::json!({"reason": "path outside project"});
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
-        assert!(matches!(decision, PermissionDecision::Allow));
+        assert!(matches!(decision, GateOutcome::Allow));
     }
 
     #[test]
@@ -5107,7 +5118,7 @@ mod tests {
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
 
         match decision {
-            PermissionDecision::Deny(reason) => {
+            GateOutcome::Deny(reason) => {
                 assert!(
                     reason.contains("Sensitive path cannot be approved through sandbox expansion"),
                     "unexpected denial reason: {reason}"
@@ -5131,7 +5142,7 @@ mod tests {
         let decision = pm.check_nonblocking("sandbox_expand:bash", &args);
 
         assert!(
-            matches!(decision, PermissionDecision::Deny(ref reason) if reason.contains("Sensitive path")),
+            matches!(decision, GateOutcome::Deny(ref reason) if reason.contains("Sensitive path")),
             "home-relative credential sandbox expansion must deny; got {decision:?}"
         );
     }
@@ -5142,7 +5153,7 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
         pm.settings
             .allow
-            .push("sandbox_expand:read_file".to_string());
+            .push("sandbox_expand:read_file()".to_string());
         pm.cached_allow = pm.settings.parsed_allow_rules();
         let args = serde_json::json!({
             "reason": format!(
@@ -5154,7 +5165,7 @@ mod tests {
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
 
         assert!(
-            matches!(decision, PermissionDecision::Deny(ref reason) if reason.contains("Sensitive path")),
+            matches!(decision, GateOutcome::Deny(ref reason) if reason.contains("Sensitive path")),
             "sandbox_expand allow rules must not unlock sensitive targets; got {decision:?}"
         );
     }
@@ -5165,21 +5176,20 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Deny, dir.path());
         let args = serde_json::json!({"reason": "path outside project"});
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
-        assert!(matches!(decision, PermissionDecision::Deny(_)));
+        assert!(matches!(decision, GateOutcome::Deny(_)));
     }
 
     #[test]
     fn sandbox_expand_prompt_mode_needs_approval() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
-        // Clear user settings so that ~/.astra/permissions.json allow rules (e.g.
-        // `sandbox_expand:bash` granted in a previous interactive session) do not
-        // bypass the prompt in this isolated unit test.
+        // Clear user settings so that ~/.astra/permissions.json allow rules granted
+        // in a previous interactive session do not bypass the prompt in this test.
         pm.replace_user_settings(PermissionSettings::default());
         let args = serde_json::json!({"reason": "path outside project"});
         let decision = pm.check_nonblocking("sandbox_expand:bash", &args);
         match decision {
-            PermissionDecision::NeedApproval { tool, header, .. } => {
+            GateOutcome::NeedApproval { tool, header, .. } => {
                 assert_eq!(tool, "sandbox_expand:bash");
                 assert!(header.contains("bash"));
             }
@@ -5199,7 +5209,7 @@ mod tests {
         let decision = pm.check_nonblocking("sandbox_expand:write_file", &args);
 
         match decision {
-            PermissionDecision::NeedApproval {
+            GateOutcome::NeedApproval {
                 tool,
                 header,
                 detail,
@@ -5227,7 +5237,7 @@ mod tests {
         let args = serde_json::json!({"reason": raw_fs_msg});
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
         match decision {
-            PermissionDecision::NeedApproval {
+            GateOutcome::NeedApproval {
                 header,
                 detail,
                 reason,
@@ -5255,7 +5265,7 @@ mod tests {
         pm.record_approval("sandbox_expand:read_file", None, true);
         let args = serde_json::json!({"reason": "path outside project"});
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
-        assert!(matches!(decision, PermissionDecision::Allow));
+        assert!(matches!(decision, GateOutcome::Allow));
     }
 
     #[test]
@@ -5297,7 +5307,7 @@ mod tests {
         });
         let decision = pm.check_nonblocking("sandbox_expand:glob", &args_b);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "glob on a sub-path of the trusted root should be auto-allowed; got {decision:?}"
         );
 
@@ -5313,7 +5323,7 @@ mod tests {
         });
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args_c);
         assert!(
-            matches!(decision, PermissionDecision::NeedApproval { .. }),
+            matches!(decision, GateOutcome::NeedApproval { .. }),
             "an unrelated outside path must still prompt; got {decision:?}"
         );
     }
@@ -5358,12 +5368,12 @@ mod tests {
 
             if *expect_allow {
                 assert!(
-                    matches!(decision, PermissionDecision::Allow),
+                    matches!(decision, GateOutcome::Allow),
                     "[{idx}] '{template}' — expected Allow, got {decision:?}"
                 );
             } else {
                 assert!(
-                    matches!(decision, PermissionDecision::NeedApproval { .. }),
+                    matches!(decision, GateOutcome::NeedApproval { .. }),
                     "[{idx}] '{template}' — expected NeedApproval, got {decision:?}"
                 );
             }
@@ -5390,7 +5400,7 @@ mod tests {
         });
         let decision = pm.check_nonblocking("sandbox_expand:write_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "missing descendants under a trusted existing directory should keep the Always UX"
         );
     }
@@ -5419,7 +5429,7 @@ mod tests {
         });
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::NeedApproval { .. }),
+            matches!(decision, GateOutcome::NeedApproval { .. }),
             "a non-existent approved path must not become trusted after it appears as a symlink"
         );
     }
@@ -5450,7 +5460,7 @@ mod tests {
         });
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::NeedApproval { .. }),
+            matches!(decision, GateOutcome::NeedApproval { .. }),
             "canonicalized candidate should point at the symlink target, not the trusted root"
         );
     }
@@ -5468,14 +5478,14 @@ mod tests {
         // "I never want this tool to widen the sandbox".
         pm.settings
             .deny
-            .push("sandbox_expand:read_file".to_string());
+            .push("sandbox_expand:read_file()".to_string());
         pm.cached_deny = pm.settings.parsed_deny_rules();
 
         let args = serde_json::json!({"reason": "/tmp/foo"});
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
 
         match decision {
-            PermissionDecision::Deny(reason) => {
+            GateOutcome::Deny(reason) => {
                 assert!(
                     reason.contains("rule") || reason.contains("Denied"),
                     "expected deny-by-rule message, got: {reason}"
@@ -5506,7 +5516,7 @@ mod tests {
             serde_json::json!({"reason": "Path '/b/deeper' is outside the project '/root'."});
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args_b);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "second sandbox_expand:read_file should be auto-allowed; got {decision:?}"
         );
     }
@@ -5518,7 +5528,7 @@ mod tests {
         pm.record_approval("sandbox_expand:read_file", None, false);
         let args = serde_json::json!({"reason": "path outside project"});
         let decision = pm.check_nonblocking("sandbox_expand:read_file", &args);
-        assert!(matches!(decision, PermissionDecision::Deny(_)));
+        assert!(matches!(decision, GateOutcome::Deny(_)));
     }
 
     #[test]
@@ -5530,7 +5540,7 @@ mod tests {
         let args = serde_json::json!({"path": "test.txt"});
         let decision = pm.check_nonblocking("read_file", &args);
         // read_file is classified as Read → always allowed
-        assert!(matches!(decision, PermissionDecision::Allow));
+        assert!(matches!(decision, GateOutcome::Allow));
     }
 
     #[test]
@@ -5540,7 +5550,7 @@ mod tests {
         let args = serde_json::json!({"path": "src/main.rs", "content": "fn main() {}"});
         let decision = pm.check_nonblocking("write_file", &args);
         match decision {
-            PermissionDecision::NeedApproval {
+            GateOutcome::NeedApproval {
                 detail: Some(detail),
                 ..
             } => {
@@ -5560,7 +5570,7 @@ mod tests {
         let args = serde_json::json!({"command": "cargo test -p astra-cli"});
         let decision = pm.check_nonblocking("bash", &args);
         match decision {
-            PermissionDecision::NeedApproval {
+            GateOutcome::NeedApproval {
                 detail: Some(detail),
                 reason,
                 ..
@@ -5590,7 +5600,7 @@ mod tests {
         let args = serde_json::json!({"action": "commit", "message": "ship it"});
         let decision = pm.check_nonblocking("git", &args);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "Auto mode should auto-allow explicit tools, got: {decision:?}"
         );
     }
@@ -5601,7 +5611,7 @@ mod tests {
         let args = serde_json::json!({"action": "commit", "message": "ship it"});
         let decision = pm.check_nonblocking("git", &args);
         assert!(
-            matches!(decision, PermissionDecision::NeedApproval { .. }),
+            matches!(decision, GateOutcome::NeedApproval { .. }),
             "Prompt mode should require approval for explicit tools, got: {decision:?}"
         );
     }
@@ -5615,7 +5625,7 @@ mod tests {
         let args = serde_json::json!({"path": "note.txt", "content": "hi"});
         let decision = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::Deny(_)),
+            matches!(decision, GateOutcome::Deny(_)),
             "expected Deny, got {decision:?}"
         );
         let recs = pm.recent_rejections();
@@ -5633,7 +5643,7 @@ mod tests {
         let mut pm = PermissionManager::new(true);
         let args = serde_json::json!({"command": "sudo rm -rf /"});
         let decision = pm.check_nonblocking("bash", &args);
-        assert!(matches!(decision, PermissionDecision::Deny(_)));
+        assert!(matches!(decision, GateOutcome::Deny(_)));
         let recs = pm.recent_rejections();
         assert_eq!(recs.len(), 1);
         assert_eq!(recs[0].0, "bash");
@@ -5645,7 +5655,7 @@ mod tests {
         let mut pm = PermissionManager::new(false);
         let args = serde_json::json!({"action": "commit", "message": "ship it"});
         let decision = pm.check_nonblocking("git", &args);
-        assert!(matches!(decision, PermissionDecision::NeedApproval { .. }));
+        assert!(matches!(decision, GateOutcome::NeedApproval { .. }));
         assert!(pm.recent_rejections().is_empty());
     }
 
@@ -5661,7 +5671,7 @@ mod tests {
         // Must NOT be Allow — git safety is bypass-immune
         let decision = pm.check_nonblocking("bash", &args);
         assert!(
-            matches!(decision, PermissionDecision::NeedApproval { .. }),
+            matches!(decision, GateOutcome::NeedApproval { .. }),
             "session override must not bypass git safety: got {decision:?}"
         );
     }
@@ -5674,7 +5684,7 @@ mod tests {
         let args = serde_json::json!({"command": "sudo rm -rf /"});
         let decision = pm.check_nonblocking("bash", &args);
         assert!(
-            matches!(decision, PermissionDecision::Deny(_)),
+            matches!(decision, GateOutcome::Deny(_)),
             "session override must not bypass dangerous command check: got {decision:?}"
         );
     }
@@ -5689,7 +5699,7 @@ mod tests {
         let args = serde_json::json!({"path": ".git/config", "content": "bad"});
         let decision = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::Deny(_)),
+            matches!(decision, GateOutcome::Deny(_)),
             "Auto mode must deny sensitive paths by default instead of prompting: got {decision:?}"
         );
 
@@ -5697,7 +5707,7 @@ mod tests {
         pm.settings.allow_sensitive_path_writes = true;
         let decision2 = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(decision2, PermissionDecision::Allow),
+            matches!(decision2, GateOutcome::Allow),
             "opt-in should unlock Auto mode sensitive writes: got {decision2:?}"
         );
     }
@@ -5710,7 +5720,7 @@ mod tests {
 
         let decision = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "content-specific sensitive path approval should be honored: got {decision:?}"
         );
     }
@@ -5725,7 +5735,7 @@ mod tests {
 
         let decision = pm.check_nonblocking("write_file", &sensitive);
         assert!(
-            matches!(decision, PermissionDecision::Deny(_)),
+            matches!(decision, GateOutcome::Deny(_)),
             "non-sensitive directory approval must not unlock sensitive sibling in Auto mode: got {decision:?}"
         );
     }
@@ -5744,7 +5754,7 @@ mod tests {
         let later = serde_json::json!({"path": ".git/hooks/pre-commit", "content": "hook"});
         let decision = pm.check_nonblocking("write_file", &later);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "sensitive prefix approval should cover matching sensitive path: got {decision:?}"
         );
     }
@@ -5757,7 +5767,7 @@ mod tests {
         let args = serde_json::json!({"command": "echo hello"});
         let decision = pm.check_nonblocking("bash", &args);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "session override should allow safe commands: got {decision:?}"
         );
     }
@@ -5769,7 +5779,7 @@ mod tests {
         let args = serde_json::json!({"path": ".git/config", "content": "bad"});
         let decision = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::NeedApproval { .. }),
+            matches!(decision, GateOutcome::NeedApproval { .. }),
             "Prompt mode should require approval for dangerous path: got {decision:?}"
         );
     }
@@ -5791,7 +5801,7 @@ mod tests {
     #[test]
     fn make_allow_rule_bash_keeps_subcommand() {
         // Issue #326 P1.5 / R1 Major 5: previously this saved
-        // `Bash(cargo:*)`, which would silently allow `cargo
+        // `Bash(argv_prefix="cargo")`, which would silently allow `cargo
         // uninstall --no-confirm`. We now keep the subcommand.
         let args = serde_json::json!({"command": "cargo test --release"});
         let rule = PermissionManager::make_allow_rule("bash", &args);
@@ -5891,7 +5901,7 @@ mod tests {
     fn make_allow_rule_file_write_uses_path_rule() {
         let args = serde_json::json!({"path": "/tmp/foo"});
         let rule = PermissionManager::make_allow_rule("write_file", &args);
-        assert_eq!(rule, r#"Edit(path_glob="/tmp/foo", op="write")"#);
+        assert_eq!(rule, r#"file_write(path_glob="/tmp/foo", op="write")"#);
 
         let parsed = PermissionRule::parse(&rule);
         assert!(parsed.matches_with_context(
@@ -5918,7 +5928,7 @@ mod tests {
     }
 
     #[test]
-    fn persisted_write_file_rule_covers_file_edit_family_inside_workspace() {
+    fn persisted_file_write_rule_covers_file_write_family_inside_workspace() {
         let mut pm = PermissionManager::new(false);
         let approved_args = serde_json::json!({"path": "zzzz3.md", "content": "# zzzz3"});
         let rule = PermissionManager::make_allow_rule("write_file", &approved_args);
@@ -5949,7 +5959,7 @@ mod tests {
         assert_eq!(
             rule,
             format!(
-                r#"Edit(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
+                r#"file_write(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
             )
         );
     }
@@ -5969,7 +5979,7 @@ mod tests {
         assert_eq!(rule, r#"Bash(argv_prefix="cargo test", op="execute")"#);
 
         // Single-word / flag-shaped commands fall back to exact rules instead
-        // of broad `Bash(ls:*)` or `Bash(true:*)` allow rules.
+        // of broad `Bash(argv_prefix="ls")` or `Bash(argv_prefix="true")` allow rules.
         let args = serde_json::json!({"command": "ls -la > /tmp/out"});
         let rule = PermissionManager::make_allow_rule("bash", &args);
         assert_eq!(
@@ -6006,7 +6016,7 @@ mod tests {
 
     #[test]
     fn rule_prefix_respects_word_boundary() {
-        let rule = PermissionRule::parse("Bash(git commit:*)");
+        let rule = PermissionRule::parse(r#"Bash(argv_prefix="git commit")"#);
         // Should match "git commit -m 'fix'"
         assert!(rule.matches("bash", Some("git commit -m 'fix'")));
         // Should NOT match "git commitizen" (different word)
@@ -6017,7 +6027,7 @@ mod tests {
 
     #[test]
     fn rule_prefix_allows_separators_after_match() {
-        let rule = PermissionRule::parse("Bash(cargo:*)");
+        let rule = PermissionRule::parse(r#"Bash(argv_prefix="cargo")"#);
         assert!(rule.matches("bash", Some("cargo test")));
         assert!(rule.matches("bash", Some("cargo-test"))); // false: '-' is a separator
         assert!(rule.matches("bash", Some("cargo=build")));
@@ -6030,7 +6040,9 @@ mod tests {
     fn user_level_allow_rule_permits_tool() {
         let mut pm = PermissionManager::new(false);
         // Simulate user-level allow rule
-        pm.user_settings.allow.push("Bash(cargo:*)".to_string());
+        pm.user_settings
+            .allow
+            .push(r#"Bash(argv_prefix="cargo")"#.to_string());
         pm.cached_user_allow = pm.user_settings.parsed_allow_rules();
 
         let args = serde_json::json!({"command": "cargo test"});
@@ -6041,10 +6053,12 @@ mod tests {
     fn user_level_deny_blocks_even_with_project_allow() {
         let mut pm = PermissionManager::new(false);
         // Project allows bash
-        pm.settings.allow.push("bash".to_string());
+        pm.settings.allow.push("bash()".to_string());
         pm.cached_allow = pm.settings.parsed_allow_rules();
-        // User denies bash(rm:*)
-        pm.user_settings.deny.push("Bash(rm:*)".to_string());
+        // User denies rm commands.
+        pm.user_settings
+            .deny
+            .push(r#"Bash(argv_prefix="rm")"#.to_string());
         pm.cached_user_deny = pm.user_settings.parsed_deny_rules();
 
         let args = serde_json::json!({"command": "rm -rf /tmp/foo"});
@@ -6055,11 +6069,15 @@ mod tests {
     #[test]
     fn project_deny_overrides_user_allow() {
         let mut pm = PermissionManager::new(false);
-        // User allows bash(git:*)
-        pm.user_settings.allow.push("Bash(git:*)".to_string());
+        // User allows git commands.
+        pm.user_settings
+            .allow
+            .push(r#"Bash(argv_prefix="git")"#.to_string());
         pm.cached_user_allow = pm.user_settings.parsed_allow_rules();
-        // Project denies bash(git push:*)
-        pm.settings.deny.push("Bash(git push:*)".to_string());
+        // Project denies git push commands.
+        pm.settings
+            .deny
+            .push(r#"Bash(argv_prefix="git push")"#.to_string());
         pm.cached_deny = pm.settings.parsed_deny_rules();
 
         let args = serde_json::json!({"command": "git push --force"});
@@ -6070,16 +6088,16 @@ mod tests {
     #[test]
     fn user_allow_does_not_override_project_deny() {
         let mut pm = PermissionManager::new(false);
-        // Project denies edit
-        pm.settings.deny.push("edit".to_string());
+        // Project denies write_file.
+        pm.settings.deny.push("write_file()".to_string());
         pm.cached_deny = pm.settings.parsed_deny_rules();
-        // User allows edit
-        pm.user_settings.allow.push("edit".to_string());
+        // User allows write_file.
+        pm.user_settings.allow.push("write_file()".to_string());
         pm.cached_user_allow = pm.user_settings.parsed_allow_rules();
 
         let args = serde_json::json!({});
-        // Deny from project level → blocks
-        assert!(pm.check_deny_rules("edit", &args));
+        // Deny from project level blocks.
+        assert!(pm.check_deny_rules("write_file", &args));
     }
 
     #[test]
@@ -6090,18 +6108,17 @@ mod tests {
         let path = dir.join("permissions.json");
 
         let settings = PermissionSettings {
-            allow: vec!["Bash(cargo:*)".to_string()],
-            deny: vec!["Bash(rm:*)".to_string()],
+            allow: vec![r#"Bash(argv_prefix="cargo")"#.to_string()],
+            deny: vec![r#"Bash(argv_prefix="rm")"#.to_string()],
             allow_sensitive_path_writes: false,
-            grammar_version: 0,
         };
         let json = serde_json::to_string_pretty(&settings).unwrap();
         fs::write(&path, json).unwrap();
 
         let loaded: PermissionSettings =
             serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(loaded.allow, vec!["Bash(cargo:*)"]);
-        assert_eq!(loaded.deny, vec!["Bash(rm:*)"]);
+        assert_eq!(loaded.allow, vec![r#"Bash(argv_prefix="cargo")"#]);
+        assert_eq!(loaded.deny, vec![r#"Bash(argv_prefix="rm")"#]);
     }
 
     #[test]
@@ -6113,8 +6130,8 @@ mod tests {
         fs::write(
             dir.join("permissions.json"),
             serde_json::json!({
-                "allow": ["Bash(cargo test:*)"],
-                "deny": ["Bash(rm:*)"]
+                "allow": ["Bash(argv_prefix=\"cargo test\")"],
+                "deny": ["Bash(argv_prefix=\"rm\")"]
             })
             .to_string(),
         )
@@ -6122,23 +6139,24 @@ mod tests {
 
         let updated =
             PermissionSettings::modify_user_in_home(home, |settings| -> Result<(), String> {
-                settings.allow.push("Bash(npm test:*)".to_string());
+                settings
+                    .allow
+                    .push(r#"Bash(argv_prefix="npm test")"#.to_string());
                 Ok(())
             })
             .unwrap();
 
         assert_eq!(
             updated.allow,
-            vec!["Bash(cargo test:*)", "Bash(npm test:*)"]
+            vec![
+                r#"Bash(argv_prefix="cargo test")"#,
+                r#"Bash(argv_prefix="npm test")"#
+            ]
         );
         let reloaded = PermissionSettings::try_load_inner(&dir.join("permissions.json"));
         assert!(reloaded.error.is_none());
         assert_eq!(reloaded.settings.allow, updated.allow);
-        assert_eq!(reloaded.settings.deny, vec!["Bash(rm:*)"]);
-        assert_eq!(
-            reloaded.settings.grammar_version,
-            astra_turn_core::permission::rule_grammar::GRAMMAR_VERSION
-        );
+        assert_eq!(reloaded.settings.deny, vec![r#"Bash(argv_prefix="rm")"#]);
     }
 
     #[test]
@@ -6147,7 +6165,7 @@ mod tests {
         let home = tmp.path();
         let mut pm = PermissionManager::new(false);
 
-        pm.add_user_allow_rule_with_home("Bash(npm test:*)", Some(home));
+        pm.add_user_allow_rule_with_home(r#"Bash(argv_prefix="npm test")"#, Some(home));
 
         assert!(pm.last_save_error().is_none());
         let args = serde_json::json!({"command": "npm test -- --grep auth"});
@@ -6155,7 +6173,10 @@ mod tests {
         let reloaded =
             PermissionSettings::try_load_inner(&home.join(".astra").join("permissions.json"));
         assert!(reloaded.error.is_none());
-        assert_eq!(reloaded.settings.allow, vec!["Bash(npm test:*)"]);
+        assert_eq!(
+            reloaded.settings.allow,
+            vec![r#"Bash(argv_prefix="npm test")"#]
+        );
     }
 
     #[test]
@@ -6163,7 +6184,7 @@ mod tests {
         let mut pm = PermissionManager::new(false);
         pm.user_settings
             .allow
-            .push("sandbox_expand:bash".to_string());
+            .push("sandbox_expand:bash()".to_string());
         pm.cached_user_allow = pm.user_settings.parsed_allow_rules();
         let args = serde_json::json!({
             "reason": "Path '/tmp/outside' is outside the project directory '/tmp/project'."
@@ -6171,7 +6192,7 @@ mod tests {
 
         let decision = pm.check_nonblocking("sandbox_expand:bash", &args);
 
-        assert!(matches!(decision, PermissionDecision::Allow));
+        assert!(matches!(decision, GateOutcome::Allow));
     }
 
     #[test]
@@ -6193,7 +6214,7 @@ mod tests {
         std::fs::create_dir_all(&kiro).unwrap();
         std::fs::write(
             kiro.join("permissions.json"),
-            r#"{"allow":["Bash(cargo:*)"],"deny":["Bash(rm:*)"]}"#,
+            r#"{"allow":["Bash(argv_prefix=\"cargo\")"],"deny":["Bash(argv_prefix=\"rm\")"]}"#,
         )
         .unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, root);
@@ -6210,14 +6231,14 @@ mod tests {
 
     #[test]
     fn display_permission_rule_bare() {
-        let rule = PermissionRule::parse("Edit");
-        assert_eq!(format!("{rule}"), "edit");
+        let rule = PermissionRule::parse("write_file()");
+        assert_eq!(format!("{rule}"), "write_file()");
     }
 
     #[test]
     fn display_permission_rule_with_pattern() {
-        let rule = PermissionRule::parse("Bash(git commit:*)");
-        assert_eq!(format!("{rule}"), "bash(git commit:*)");
+        let rule = PermissionRule::parse(r#"Bash(argv_prefix="git commit")"#);
+        assert_eq!(format!("{rule}"), r#"bash(argv_prefix="git commit")"#);
     }
 
     // ── inherited permissions ──────────────────────────────────────────────────
@@ -6238,7 +6259,7 @@ mod tests {
         };
 
         let mut inherited = InheritedPermissions::new(RuntimeMode::Prompt);
-        inherited.add_allow(RuntimeRule::parse("bash(git commit:*)"));
+        inherited.add_allow(RuntimeRule::parse(r#"Bash(argv_prefix="git commit")"#));
 
         let pm = PermissionManager::with_inherited(std::path::Path::new("/tmp"), inherited);
 
@@ -6255,7 +6276,7 @@ mod tests {
         };
 
         let mut inherited = InheritedPermissions::new(RuntimeMode::Prompt);
-        inherited.add_deny(RuntimeRule::parse("bash(rm -rf:*)"));
+        inherited.add_deny(RuntimeRule::parse(r#"Bash(argv_prefix="rm -rf")"#));
 
         let pm = PermissionManager::with_inherited(std::path::Path::new("/tmp"), inherited);
 
@@ -6275,7 +6296,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
         pm.session_overrides.insert(bare_fp("bash"), true);
-        pm.session_overrides.insert(bare_fp("edit"), false);
+        pm.session_overrides.insert(bare_fp("file_write"), false);
 
         let inherited = pm.inherited_permissions_for_child(true);
 
@@ -6293,8 +6314,8 @@ mod tests {
     #[test]
     fn child_inherits_fingerprinted_session_overrides_not_collapsed_to_tool_level() {
         // Contract test for issue #326 P0 / R1 Major 10 / task #17:
-        // parent allowed `Bash(cargo test:*)` via session override.
-        // The child must NOT see this as `Bash(*) → Allow` (which would
+        // parent allowed `Bash(argv_prefix="cargo test")` via session override.
+        // The child must NOT see this as `Bash() → Allow` (which would
         // let it run `Bash(rm -rf …)`); it must reconstruct the same
         // command-prefix-level fingerprint and only allow `cargo test`.
         use astra_runtime::orchestration::PermissionMode as RuntimeMode;
@@ -6305,7 +6326,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut parent = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
-        // Parent presses Always on `Bash(cargo test:*)` → session override.
+        // Parent presses Always on `Bash(argv_prefix="cargo test")` -> session override.
         let cargo_test_fp = ApprovalFingerprint {
             tool_name: "bash".to_string(),
             command_exact: None,
@@ -6521,7 +6542,7 @@ mod tests {
         let args = serde_json::json!({"path": "src/lib.rs", "content": "pub fn ok() {}\n"});
         let local = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(local, PermissionDecision::Allow),
+            matches!(local, GateOutcome::Allow),
             "local check must auto-allow after cloud 'always': got {local:?}"
         );
     }
@@ -6542,7 +6563,7 @@ mod tests {
         let write_args = serde_json::json!({"path": "foo.rs", "content": "hello"});
         let local = pm.check_nonblocking("write_file", &write_args);
         assert!(
-            matches!(local, PermissionDecision::Allow),
+            matches!(local, GateOutcome::Allow),
             "auto-run must allow write_file: got {local:?}"
         );
     }
@@ -6562,7 +6583,7 @@ mod tests {
         let args1 = serde_json::json!({"path": "src/lib.rs", "content": "pub fn one() {}\n"});
         assert!(matches!(
             pm.check_nonblocking("write_file", &args1),
-            PermissionDecision::Allow
+            GateOutcome::Allow
         ));
 
         // 2nd call: cloud approval must auto-allow (session override)
@@ -6581,7 +6602,7 @@ mod tests {
         let args2 = serde_json::json!({"path": "src/main.rs", "content": "fn main() {}\n"});
         assert!(matches!(
             pm.check_nonblocking("write_file", &args2),
-            PermissionDecision::Allow
+            GateOutcome::Allow
         ));
     }
 
@@ -6712,12 +6733,12 @@ mod tests {
         // causing approved tools to be re-prompted every call.
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
-        let args = serde_json::json!({"file_path": "src/main.rs", "content": "hello"});
+        let args = serde_json::json!({"path": "src/main.rs", "content": "hello"});
 
         // First call should need approval (no override yet).
         let decision = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::NeedApproval { .. }),
+            matches!(decision, GateOutcome::NeedApproval { .. }),
             "first call should need approval"
         );
 
@@ -6727,7 +6748,7 @@ mod tests {
         // Second call with same tool+path should be auto-approved via session override.
         let decision = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "second call should be auto-approved via session override, got: {decision:?}"
         );
     }
@@ -6744,7 +6765,7 @@ mod tests {
 
         let decision = pm.check_nonblocking("bash", &similar_args);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "workspace command-family approval should cover cd-wrapped cargo test; got {decision:?}"
         );
     }
@@ -6777,17 +6798,17 @@ mod tests {
         );
 
         let decision = pm.check_nonblocking("write_file", &args_a);
-        assert!(matches!(decision, PermissionDecision::Allow));
+        assert!(matches!(decision, GateOutcome::Allow));
 
         let decision = pm.check_nonblocking("write_file", &args_b);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "workspace write trust should cover later safe file edits anywhere in the workspace"
         );
 
         let decision = pm.check_nonblocking("str_replace", &replace_args);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "workspace write trust should cover sibling file-edit tools, got {decision:?}"
         );
     }
@@ -6803,13 +6824,13 @@ mod tests {
 
         let decision = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "exact path approval should match the same deep path: got {decision:?}"
         );
 
         let sibling_decision = pm.check_nonblocking("write_file", &sibling);
         assert!(
-            matches!(sibling_decision, PermissionDecision::NeedApproval { .. }),
+            matches!(sibling_decision, GateOutcome::NeedApproval { .. }),
             "exact path approval must not match a sibling path: got {sibling_decision:?}"
         );
     }
@@ -6825,7 +6846,7 @@ mod tests {
         let args = serde_json::json!({"path": "any/path.rs", "content": "x"});
         let decision = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "bare override should subsume any content-aware check"
         );
     }
@@ -6954,20 +6975,20 @@ mod tests {
         let args = serde_json::json!({"path": ".ssh/id_rsa", "content": "x"});
         let d = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(d, PermissionDecision::Deny(_)),
+            matches!(d, GateOutcome::Deny(_)),
             "Auto mode must deny sensitive paths by default instead of prompting, got {d:?}"
         );
 
         // Non-sensitive path still auto-allowed.
         let safe = serde_json::json!({"path": "src/foo.rs", "content": "x"});
         let d2 = pm.check_nonblocking("write_file", &safe);
-        assert!(matches!(d2, PermissionDecision::Allow));
+        assert!(matches!(d2, GateOutcome::Allow));
 
         // Opt-in via project settings flips it to Allow.
         pm.settings.allow_sensitive_path_writes = true;
         let d3 = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(d3, PermissionDecision::Allow),
+            matches!(d3, GateOutcome::Allow),
             "allow_sensitive_path_writes opt-in should let Auto mode proceed, got {d3:?}"
         );
     }
@@ -7015,7 +7036,7 @@ mod tests {
         );
         let decision = pm.check_nonblocking("grep", &args);
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "Auto mode should allow read-only session journal search without an opt-in prompt: {decision:?}"
         );
     }
@@ -7037,7 +7058,7 @@ mod tests {
 
         let decision = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(decision, PermissionDecision::Deny(_)),
+            matches!(decision, GateOutcome::Deny(_)),
             "session journals are internal read-only diagnostics, not writable state: {decision:?}"
         );
     }
@@ -7255,22 +7276,22 @@ mod tests {
 
         // Prompt mode → NeedApproval.
         let d1 = pm.check_nonblocking("write_file", &args);
-        assert!(matches!(d1, PermissionDecision::NeedApproval { .. }));
+        assert!(matches!(d1, GateOutcome::NeedApproval { .. }));
 
         // Switch to Auto → Allow.
         pm.set_mode(PermissionMode::Auto);
         let d2 = pm.check_nonblocking("write_file", &args);
-        assert!(matches!(d2, PermissionDecision::Allow));
+        assert!(matches!(d2, GateOutcome::Allow));
 
         // Also allows str_replace.
         let args2 = serde_json::json!({"path": "src/bar.rs", "old_str": "a", "new_str": "b"});
         let d3 = pm.check_nonblocking("str_replace", &args2);
-        assert!(matches!(d3, PermissionDecision::Allow));
+        assert!(matches!(d3, GateOutcome::Allow));
 
         // And bash.
         let args3 = serde_json::json!({"command": "cargo build"});
         let d4 = pm.check_nonblocking("bash", &args3);
-        assert!(matches!(d4, PermissionDecision::Allow));
+        assert!(matches!(d4, GateOutcome::Allow));
     }
 
     #[test]
@@ -7297,7 +7318,7 @@ mod tests {
         // Local check should also allow.
         let args = serde_json::json!({"path": "src/foo.rs", "old_str": "a", "new_str": "b"});
         let local_decision = pm.check_nonblocking("str_replace", &args);
-        assert!(matches!(local_decision, PermissionDecision::Allow));
+        assert!(matches!(local_decision, GateOutcome::Allow));
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -7328,24 +7349,24 @@ mod tests {
         let args = serde_json::json!({"path": "src/x.rs", "content": "x"});
         let d1 = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(d1, PermissionDecision::NeedApproval { .. }),
+            matches!(d1, GateOutcome::NeedApproval { .. }),
             "expected NeedApproval in Prompt mode, got {d1:?}",
         );
 
         // Mid-session: user types `/mode auto`. The decision for d1 (already
         // returned) is not retroactively mutated — that's structurally true
-        // because PermissionDecision is a value type with no back-reference
+        // because GateOutcome is a value type with no back-reference
         // to the manager. What we pin down is that the NEXT check sees the
         // new mode.
         pm.set_mode(PermissionMode::Auto);
         let d2 = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(d2, PermissionDecision::Allow),
+            matches!(d2, GateOutcome::Allow),
             "next check after set_mode(Auto) must Allow, got {d2:?}",
         );
 
         // And the old decision object is untouched.
-        assert!(matches!(d1, PermissionDecision::NeedApproval { .. }));
+        assert!(matches!(d1, GateOutcome::NeedApproval { .. }));
     }
 
     #[test]
@@ -7359,7 +7380,7 @@ mod tests {
         let args = serde_json::json!({"path": "src/foo.rs", "old_str": "a", "new_str": "b"});
         let d1 = pm.check_nonblocking("str_replace", &args);
         assert!(
-            matches!(d1, PermissionDecision::NeedApproval { .. }),
+            matches!(d1, GateOutcome::NeedApproval { .. }),
             "expected NeedApproval before rule add, got {d1:?}",
         );
 
@@ -7367,7 +7388,7 @@ mod tests {
 
         let d2 = pm.check_nonblocking("str_replace", &args);
         assert!(
-            matches!(d2, PermissionDecision::Allow),
+            matches!(d2, GateOutcome::Allow),
             "next str_replace check must Allow after add_allow_rule, got {d2:?}",
         );
     }
@@ -7377,9 +7398,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
-        pm.add_allow_rule("Bash(ls:*)");
+        pm.add_allow_rule(r#"Bash(argv_prefix="ls")"#);
         let first = pm.settings.allow.clone();
-        pm.add_allow_rule("Bash(ls:*)");
+        pm.add_allow_rule(r#"Bash(argv_prefix="ls")"#);
         let second = pm.settings.allow.clone();
         assert_eq!(
             first, second,
@@ -7397,20 +7418,28 @@ mod tests {
         // PermissionSettings::modify so it reads that fresh baseline
         // instead of saving its stale in-memory settings over it.
         let mut external = PermissionSettings::default();
-        external.allow.push("Bash(rule-a:*)".to_string());
+        external
+            .allow
+            .push(r#"Bash(argv_prefix="rule-a")"#.to_string());
         external.save(dir.path()).unwrap();
 
-        pm.add_allow_rule("Bash(rule-b:*)");
+        pm.add_allow_rule(r#"Bash(argv_prefix="rule-b")"#);
 
         let reloaded = PermissionSettings::load(dir.path());
         assert_eq!(
             reloaded.allow,
-            vec!["Bash(rule-a:*)", "Bash(rule-b:*)"],
+            vec![
+                r#"Bash(argv_prefix="rule-a")"#,
+                r#"Bash(argv_prefix="rule-b")"#
+            ],
             "add_allow_rule must preserve concurrent disk additions"
         );
         assert_eq!(
             pm.settings.allow,
-            vec!["Bash(rule-a:*)", "Bash(rule-b:*)"],
+            vec![
+                r#"Bash(argv_prefix="rule-a")"#,
+                r#"Bash(argv_prefix="rule-b")"#
+            ],
             "manager cache should refresh to the lock-merged settings"
         );
     }
@@ -7422,15 +7451,15 @@ mod tests {
 
         let args = serde_json::json!({"path": "secrets.env", "content": "x"});
         let d1 = pm.check_nonblocking("write_file", &args);
-        assert!(matches!(d1, PermissionDecision::NeedApproval { .. }));
+        assert!(matches!(d1, GateOutcome::NeedApproval { .. }));
 
         // Operator adds a deny rule mid-session.
-        pm.settings.deny.push("write_file".into());
+        pm.settings.deny.push("write_file()".into());
         pm.cached_deny = pm.settings.parsed_deny_rules();
 
         let d2 = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(d2, PermissionDecision::Deny(_)),
+            matches!(d2, GateOutcome::Deny(_)),
             "deny rule must win over pending NeedApproval, got {d2:?}",
         );
     }
@@ -7447,7 +7476,7 @@ mod tests {
 
         let d_bash = pm.check_nonblocking("bash", &bash_args);
         assert!(
-            matches!(d_bash, PermissionDecision::Allow),
+            matches!(d_bash, GateOutcome::Allow),
             "bash must allow after session override, got {d_bash:?}",
         );
 
@@ -7455,7 +7484,7 @@ mod tests {
         let write_args = serde_json::json!({"path": "a.txt", "content": "y"});
         let d_write = pm.check_nonblocking("write_file", &write_args);
         assert!(
-            matches!(d_write, PermissionDecision::NeedApproval { .. }),
+            matches!(d_write, GateOutcome::NeedApproval { .. }),
             "unrelated tool must still require approval, got {d_write:?}",
         );
     }
@@ -7468,27 +7497,27 @@ mod tests {
         let args = serde_json::json!({"path": "src/a.rs", "content": "x"});
         let d1 = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(d1, PermissionDecision::Allow),
+            matches!(d1, GateOutcome::Allow),
             "Auto mode must allow write_file, got {d1:?}",
         );
 
         pm.set_mode(PermissionMode::Deny);
         let d2 = pm.check_nonblocking("write_file", &args);
         assert!(
-            matches!(d2, PermissionDecision::Deny(_)),
+            matches!(d2, GateOutcome::Deny(_)),
             "Deny mode must reject write_file after flip, got {d2:?}",
         );
 
         // The earlier Allow decision is not retroactively mutated.
-        assert!(matches!(d1, PermissionDecision::Allow));
+        assert!(matches!(d1, GateOutcome::Allow));
     }
 
     #[test]
     fn phase_h_multiple_concurrent_in_flight_decisions_are_independent() {
         // Simulates two parallel NeedApproval decisions issued back-to-back
         // in Prompt mode. A mode change between them must only affect the
-        // second, not retroactively the first, and both PermissionDecision
-        // values are independent.
+        // second, not retroactively the first, and both decision values are
+        // independent.
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
@@ -7496,15 +7525,15 @@ mod tests {
         let b = serde_json::json!({"path": "b.txt", "content": "B"});
 
         let da = pm.check_nonblocking("write_file", &a);
-        assert!(matches!(da, PermissionDecision::NeedApproval { .. }));
+        assert!(matches!(da, GateOutcome::NeedApproval { .. }));
 
         pm.set_mode(PermissionMode::Auto);
 
         let db = pm.check_nonblocking("write_file", &b);
-        assert!(matches!(db, PermissionDecision::Allow));
+        assert!(matches!(db, GateOutcome::Allow));
 
         // `da` object remains NeedApproval — it's a snapshot by value.
-        assert!(matches!(da, PermissionDecision::NeedApproval { .. }));
+        assert!(matches!(da, GateOutcome::NeedApproval { .. }));
     }
 
     #[test]
@@ -7512,20 +7541,20 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
-        pm.add_allow_rule("Bash(rm:*)");
+        pm.add_allow_rule(r#"Bash(argv_prefix="rm")"#);
         // Operator realizes mistake, adds a specific deny for dangerous rm.
-        pm.settings.deny.push("Bash(rm:*)".into());
+        pm.settings.deny.push(r#"Bash(argv_prefix="rm")"#.into());
         pm.cached_deny = pm.settings.parsed_deny_rules();
 
         let args = serde_json::json!({"command": "rm -rf /tmp/foo"});
         let d = pm.check_nonblocking("bash", &args);
         assert!(
-            matches!(d, PermissionDecision::Deny(_)),
+            matches!(d, GateOutcome::Deny(_)),
             "deny rule must override prior allow rule, got {d:?}",
         );
     }
 
-    // ── Phase H v2 — REAL concurrency + reverse-order scenarios ──────────────
+    // ── Phase H concurrency + reverse-order scenarios ───────────────────────
     //
     // Addresses two review findings on the original Phase H:
     //   1. "Concurrent in-flight" test was actually serial `&mut pm` calls.
@@ -7561,9 +7590,9 @@ mod tests {
                 for i in 0..iterations {
                     let mut g = pm.lock_recover();
                     match i % 3 {
-                        0 => g.add_allow_rule("Bash(echo:*)"),
+                        0 => g.add_allow_rule(r#"Bash(argv_prefix="echo")"#),
                         1 => {
-                            g.settings.deny.push("Bash(rm:*)".into());
+                            g.settings.deny.push(r#"Bash(argv_prefix="rm")"#.into());
                             g.cached_deny = g.settings.parsed_deny_rules();
                         }
                         _ => g.set_mode(if i % 2 == 0 {
@@ -7603,7 +7632,7 @@ mod tests {
         let mut g = pm.lock_recover();
         let d = g.check_nonblocking("bash", &serde_json::json!({"command": "rm -rf /"}));
         assert!(
-            matches!(d, PermissionDecision::Deny(_)),
+            matches!(d, GateOutcome::Deny(_)),
             "deny rule survived concurrent churn → got {d:?}",
         );
     }
@@ -7625,19 +7654,19 @@ mod tests {
         let args = serde_json::json!({"path": "src/foo.rs", "old_str": "a", "new_str": "b"});
         let first = pm.check_nonblocking("str_replace", &args);
         assert!(
-            matches!(first, PermissionDecision::Allow),
+            matches!(first, GateOutcome::Allow),
             "first check with allow-rule installed must Allow, got {first:?}",
         );
 
         // Operator realizes mistake and bans str_replace at deny tier.
-        pm.settings.deny.push("str_replace".into());
+        pm.settings.deny.push("str_replace()".into());
         pm.cached_deny = pm.settings.parsed_deny_rules();
 
         // The very NEXT check must see the deny — no allow-cache, no stale
         // decision reuse.
         let second = pm.check_nonblocking("str_replace", &args);
         assert!(
-            matches!(second, PermissionDecision::Deny(_)),
+            matches!(second, GateOutcome::Deny(_)),
             "deny added after a prior allow must bite next check, got {second:?}",
         );
     }
@@ -7657,25 +7686,25 @@ mod tests {
 
         assert!(matches!(
             pm.check_nonblocking("str_replace", &sr_args),
-            PermissionDecision::Allow
+            GateOutcome::Allow
         ));
         assert!(matches!(
             pm.check_nonblocking("read_file", &rf_args),
-            PermissionDecision::Allow
+            GateOutcome::Allow
         ));
 
         // Ban str_replace only.
-        pm.settings.deny.push("str_replace".into());
+        pm.settings.deny.push("str_replace()".into());
         pm.cached_deny = pm.settings.parsed_deny_rules();
 
         let sr_decision = pm.check_nonblocking("str_replace", &sr_args);
         assert!(
-            matches!(sr_decision, PermissionDecision::Deny(_)),
+            matches!(sr_decision, GateOutcome::Deny(_)),
             "str_replace must be denied after rule added, got {sr_decision:?}"
         );
         let rf_decision = pm.check_nonblocking("read_file", &rf_args);
         assert!(
-            matches!(rf_decision, PermissionDecision::Allow),
+            matches!(rf_decision, GateOutcome::Allow),
             "read_file must still Allow, got {rf_decision:?}"
         );
     }
@@ -7760,7 +7789,7 @@ mod tests {
             &serde_json::json!({"path": "src/main.rs", "content": "hi"}),
         );
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "after restart, saved rule must still Allow; got {decision:?}"
         );
     }
@@ -7779,7 +7808,7 @@ mod tests {
             &serde_json::json!({"path": "tests/another.rs", "content": "hi"}),
         );
         assert!(
-            matches!(decision, PermissionDecision::Allow),
+            matches!(decision, GateOutcome::Allow),
             "workspace write trust should survive restart for later safe paths; got {decision:?}"
         );
     }
@@ -7797,7 +7826,7 @@ mod tests {
                 &serde_json::json!({"path": ".env", "content": "TOKEN=1"}),
             );
             assert!(
-                matches!(same_session, PermissionDecision::Allow),
+                matches!(same_session, GateOutcome::Allow),
                 "same-session sensitive override should still work; got {same_session:?}"
             );
         }

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -2351,6 +2351,12 @@ impl PermissionManager {
         self.evaluation_context()
     }
 
+    pub(crate) fn runtime_permission_handle(
+        &self,
+    ) -> astra_runtime::orchestration::PermissionSyncHandle {
+        self.runtime_permission_context().into_shared()
+    }
+
     fn evaluation_context(&self) -> astra_turn_core::permission::types::PermissionSyncContext {
         let mut inherited = self
             .inherited

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -2339,6 +2339,18 @@ impl PermissionManager {
         })
     }
 
+    /// Snapshot the current root-session policy for the runtime tool gate.
+    ///
+    /// The CLI permission manager is the source of truth for interactive
+    /// modes, persisted rules, and per-session approval fingerprints. Runtime
+    /// execution must receive the same policy instead of treating a root TUI
+    /// session as "no permission context configured".
+    pub(crate) fn runtime_permission_context(
+        &self,
+    ) -> astra_runtime::orchestration::PermissionSyncContext {
+        self.evaluation_context()
+    }
+
     fn evaluation_context(&self) -> astra_turn_core::permission::types::PermissionSyncContext {
         let mut inherited = self
             .inherited

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -5084,6 +5084,33 @@ mod tests {
     }
 
     #[test]
+    fn sandbox_expand_accept_edits_mode_still_needs_approval() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::AcceptEdits, dir.path());
+        pm.replace_user_settings(PermissionSettings::default());
+        let args = serde_json::json!({
+            "reason": "Path '/tmp/outside.md' is outside the project directory '/tmp/project'; sandbox approval is required for this external path."
+        });
+
+        let decision = pm.check_nonblocking("sandbox_expand:write_file", &args);
+
+        match decision {
+            PermissionDecision::NeedApproval {
+                tool,
+                header,
+                detail,
+                reason,
+            } => {
+                assert_eq!(tool, "sandbox_expand:write_file");
+                assert_eq!(header, "write_file wants to write outside the project");
+                assert_eq!(detail, None);
+                assert!(reason.contains("/tmp/outside.md"), "{reason}");
+            }
+            other => panic!("AcceptEdits must ask before expanding outside sandbox; got {other:?}"),
+        }
+    }
+
+    #[test]
     fn sandbox_expand_prompt_does_not_echo_reason_into_detail() {
         // Regression: the UI used to show the same sandbox message in
         // header, detail, and reason because both stream_render and

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -6,8 +6,7 @@ use crate::cli::workspace_trust::{
     evaluate_workspace_trust, project_permissions_hash,
 };
 use astra_runtime::tool_sandbox::{
-    CommandRisk, GitSafetyViolation, SandboxPolicy, analyze_command_risks, validate_git_command,
-    validate_path,
+    CommandRisk, GitSafetyViolation, analyze_command_risks, validate_git_command,
 };
 use astra_thin_client::ApprovalKind;
 use astra_turn_core::cloud_approval_policy::{
@@ -175,19 +174,38 @@ fn canonicalize_existing_or_parent(p: &Path) -> std::io::Result<PathBuf> {
     ))
 }
 
-/// Extract the `'{path}'` target from a sandbox-denied reason string.
-/// Returns the first single-quoted path when the reason is an outside-project
-/// sandbox denial. This covers both `Path '...'` and `command references '...'`
-/// messages.
+/// Extract the filesystem path target from a sandbox-denied reason string.
+///
+/// Scans all single-quoted segments and returns the first one that
+/// looks like an absolute or home-relative filesystem path. This is
+/// robust against reason strings that quote a tool name or project
+/// root before the target path — we never misidentify a bare token
+/// like `bash` as the path.
 fn parse_sandbox_target_path(reason: &str) -> Option<PathBuf> {
     if !reason.contains("outside the project") && !reason.contains("outside project") {
         return None;
     }
 
-    let start = reason.find('\'')? + 1;
-    let rest = &reason[start..];
-    let end = rest.find('\'')?;
-    Some(PathBuf::from(&rest[..end]))
+    let mut rest = reason;
+    while let Some(start) = rest.find('\'') {
+        let after = &rest[start + 1..];
+        let end = after.find('\'')?;
+        let token = &after[..end];
+        if is_pathlike_target(token) {
+            return Some(PathBuf::from(token));
+        }
+        rest = &after[end + 1..];
+    }
+    None
+}
+
+/// A quoted token is a path target if it is absolute or home-relative.
+/// Bare tool names (e.g. `bash`) and project roots that happen to be
+/// quoted are still accepted only when they look like real paths.
+fn is_pathlike_target(token: &str) -> bool {
+    token.starts_with('/')
+        || token.starts_with("~/")
+        || (token.contains('/') && !token.contains(' '))
 }
 
 fn sandbox_expand_sensitive_target_denial(name: &str, args: &serde_json::Value) -> Option<String> {
@@ -205,17 +223,13 @@ fn sandbox_expand_sensitive_target_denial(name: &str, args: &serde_json::Value) 
     ))
 }
 
+/// Check whether a sandbox-expansion target is a sensitive path
+/// that must never be approved. This is the single source of truth
+/// reusing `astra_sandbox::policy::is_never_readable_path`, which
+/// also gates permissive-mode path access — so the sandbox expansion
+/// flow and the sandbox path validator can never disagree.
 fn sandbox_expand_target_is_sensitive(path: &Path) -> bool {
-    let path = path.to_string_lossy();
-    sensitive_path_match_for_request("read_file", &serde_json::json!({ "path": path.as_ref() }))
-        .is_some()
-        || validate_path(
-            &SandboxPolicy::permissive(
-                std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-            ),
-            path.as_ref(),
-        )
-        .is_err()
+    astra_sandbox::is_never_readable_path(path)
 }
 
 fn trim_explicit_path_token(token: &str) -> &str {
@@ -3739,7 +3753,8 @@ mod tests {
         PermissionManager, PermissionMode, PermissionRule, PermissionSettings,
         PermissionSettingsLoadError, SideEffect, cloud_always_feedback_message,
         content_aware_fingerprint, decode_mode_for_mirror, encode_mode_for_mirror,
-        format_denied_message, is_read_only_allowlisted, safe_alternative_for,
+        format_denied_message, is_read_only_allowlisted, parse_sandbox_target_path,
+        safe_alternative_for,
     };
     use crate::cli::workspace_trust::{
         TrustState, WorkspaceTrustLedger, WorkspaceTrustReason, project_permissions_hash,
@@ -8060,5 +8075,40 @@ mod tests {
         let h2 = pm.mode_mirror_handle();
         h1.stage(PermissionMode::Auto);
         assert_eq!(h2.current(), PermissionMode::Auto);
+    }
+
+    // ── parse_sandbox_target_path must extract the filesystem path ──
+    // The reason string may contain multiple single-quoted tokens
+    // (e.g. a tool name AND a path). The parser must return the
+    // path, not the first quoted token it sees.
+
+    #[test]
+    fn parse_sandbox_target_path_extracts_path_not_tool_name() {
+        // When a tool name appears in quotes before the path, the
+        // first-quote heuristic returns the tool name. We want the
+        // last quoted segment (the filesystem path).
+        let reason =
+            "Tool 'bash' references '/etc/passwd' which is outside the project directory '/proj'.";
+        let parsed = parse_sandbox_target_path(reason);
+        assert_eq!(
+            parsed.as_ref().map(std::path::Path::new),
+            Some(std::path::Path::new("/etc/passwd")),
+            "must extract the filesystem path, not the tool name"
+        );
+    }
+
+    #[test]
+    fn parse_sandbox_target_path_handles_single_quoted_path() {
+        let reason = "Path '/home/user/.env' is outside the project directory '/proj'.";
+        let parsed = parse_sandbox_target_path(reason);
+        assert_eq!(
+            parsed.as_ref().map(std::path::Path::new),
+            Some(std::path::Path::new("/home/user/.env"))
+        );
+    }
+
+    #[test]
+    fn parse_sandbox_target_path_returns_none_for_unrelated_reason() {
+        assert!(parse_sandbox_target_path("some other error").is_none());
     }
 }

--- a/rust/crates/astra-cli/src/cli/skill_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/skill_subrun.rs
@@ -574,9 +574,7 @@ impl SkillSubRunExecutor for CliSkillSubRunExecutor {
             &self.project_root,
             self.inherited_permissions.clone(),
         );
-        let permission_context = std::sync::Arc::new(tokio::sync::RwLock::new(
-            perm_manager.runtime_permission_context(),
-        ));
+        let permission_context = perm_manager.runtime_permission_handle();
 
         let executor = edge_tools::ToolExecutor::new(&self.project_root)
             .with_cloud(self.api.api_origin(), &self.token);

--- a/rust/crates/astra-cli/src/cli/skill_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/skill_subrun.rs
@@ -35,7 +35,7 @@ use astra_skills::executor::isolated::{SkillSubRunExecutor, SubRunResult};
 use serde_json::{Value, json};
 
 use super::effects::ChatTurnPrepLineGuard;
-use super::permission_manager::{PermissionManager, PermissionMode};
+use super::permission_manager::PermissionManager;
 use crate::cli::chat_stream::turn_policy_from_payload_edge_tools;
 use crate::cli::stream::stream_render::{EdgeSseContext, RenderPolicy, consume_turn_sse};
 use crate::edge_tools;
@@ -468,15 +468,15 @@ impl AgenticLoopHost for SubRunHost {
 /// Creates a fresh [`SubRunHost`] and [`AgenticLoopState`] for each sub-run,
 /// then runs [`run_agentic_loop_with_host`] to completion.
 ///
-/// Inherits the parent session's full [`PermissionMode`] (Auto/Prompt/Deny)
-/// so that fork sub-runs enforce the same approval policy as the parent.
+/// Inherits the parent session's full permission envelope so that fork
+/// sub-runs enforce the same mode, rules, and session approvals as the parent.
 pub(crate) struct CliSkillSubRunExecutor {
     api: astra_thin_client::ThinClient,
     token: String,
     default_model: Option<String>,
     project_root: PathBuf,
-    /// Full permission mode inherited from the parent session.
-    permission_mode: PermissionMode,
+    /// Full permission envelope inherited from the parent session.
+    inherited_permissions: astra_runtime::orchestration::InheritedPermissions,
     /// Parent cancellation token — propagated so Ctrl+C / stop interrupts subruns.
     cancel_token: Option<std::sync::Arc<tokio_util::sync::CancellationToken>>,
     /// Skill resolver inherited from parent — enables nested skill invocations.
@@ -493,15 +493,16 @@ impl CliSkillSubRunExecutor {
         token: String,
         default_model: Option<String>,
         project_root: PathBuf,
-        permission_mode: PermissionMode,
+        mut inherited_permissions: astra_runtime::orchestration::InheritedPermissions,
         cancel_token: Option<std::sync::Arc<tokio_util::sync::CancellationToken>>,
     ) -> Self {
+        inherited_permissions.is_background = true;
         Self {
             api,
             token,
             default_model,
             project_root,
-            permission_mode,
+            inherited_permissions,
             cancel_token,
             skill_resolver: None,
             skill_search: SkillSearchSettings::default(),
@@ -569,11 +570,13 @@ impl SkillSubRunExecutor for CliSkillSubRunExecutor {
         // Issue #326 P5b: skill subruns are headless — never read
         // project allow rules. Deny rules and the user-level rule
         // file are still honoured (apply_load_policy(HeadlessSafe)).
-        let perm_manager = PermissionManager::with_load_policy(
-            self.permission_mode,
+        let perm_manager = PermissionManager::with_inherited(
             &self.project_root,
-            &super::permission_manager::PermissionLoadPolicy::HeadlessSafe,
+            self.inherited_permissions.clone(),
         );
+        let permission_context = std::sync::Arc::new(tokio::sync::RwLock::new(
+            perm_manager.runtime_permission_context(),
+        ));
 
         let executor = edge_tools::ToolExecutor::new(&self.project_root)
             .with_cloud(self.api.api_origin(), &self.token);
@@ -765,7 +768,7 @@ impl SkillSubRunExecutor for CliSkillSubRunExecutor {
             max_cumulative_tokens: SUBRUN_MAX_CUMULATIVE_TOKENS,
             thinking,
             recent_file_reads: Vec::new(),
-            permission_context: None,
+            permission_context: Some(permission_context),
             permission_handler: None,
             tactical_adapter: None,
             step_signal_collector: None,
@@ -992,12 +995,14 @@ mod tests {
 
     #[tokio::test]
     async fn cli_skill_subrun_rejects_when_recursion_depth_limit_reached() {
+        let inherited_permissions =
+            astra_runtime::orchestration::InheritedPermissions::new(PermissionMode::Deny);
         let executor = CliSkillSubRunExecutor::new(
             astra_thin_client::ThinClient::new("http://unused", None).unwrap(),
             "token".to_string(),
             Some("test-model".to_string()),
             PathBuf::from("."),
-            PermissionMode::Deny,
+            inherited_permissions,
             None,
         );
         let allowed_tools: Vec<String> = Vec::new();
@@ -1018,6 +1023,26 @@ mod tests {
             .unwrap_err();
 
         assert!(err.contains("recursion depth 3 reached maximum 3"));
+    }
+
+    #[test]
+    fn cli_skill_subrun_constructor_marks_permissions_background() {
+        let inherited_permissions =
+            astra_runtime::orchestration::InheritedPermissions::new(PermissionMode::Auto);
+        let executor = CliSkillSubRunExecutor::new(
+            astra_thin_client::ThinClient::new("http://unused", None).unwrap(),
+            "token".to_string(),
+            None,
+            PathBuf::from("."),
+            inherited_permissions,
+            None,
+        );
+
+        assert_eq!(
+            executor.inherited_permissions.mode,
+            astra_runtime::orchestration::PermissionMode::Auto
+        );
+        assert!(executor.inherited_permissions.is_background);
     }
 
     // ── Phase-R10 adversarial contract pins (CLI-side constants) ────────

--- a/rust/crates/astra-cli/src/cli/slash/slash_agent.rs
+++ b/rust/crates/astra-cli/src/cli/slash/slash_agent.rs
@@ -2553,7 +2553,8 @@ mod tests {
             parent_agent_id: "main".to_string(),
             recursion_depth: 0,
             parent_is_fork_child: false,
-            inherited_permissions: None,
+            inherited_permissions: astra_runtime::orchestration::InheritedPermissions::auto_approve(
+            ),
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
             live_event_sink: None,

--- a/rust/crates/astra-cli/src/cli/slash/slash_router.rs
+++ b/rust/crates/astra-cli/src/cli/slash/slash_router.rs
@@ -416,11 +416,12 @@ pub(crate) async fn handle_slash_command(
             match arg {
                 "" => {
                     let next = match state.perm_manager.mode() {
-                        PermissionMode::Prompt => PermissionMode::Plan,
-                        PermissionMode::Plan => PermissionMode::AcceptEdits,
-                        PermissionMode::AcceptEdits => PermissionMode::Auto,
-                        PermissionMode::Auto => PermissionMode::Deny,
-                        PermissionMode::Deny => PermissionMode::Prompt,
+                        PermissionMode::Prompt | PermissionMode::Deny => {
+                            PermissionMode::AcceptEdits
+                        }
+                        PermissionMode::AcceptEdits => PermissionMode::Plan,
+                        PermissionMode::Plan => PermissionMode::Auto,
+                        PermissionMode::Auto => PermissionMode::Prompt,
                     };
                     state.perm_manager.set_mode(next);
                     eprintln!(

--- a/rust/crates/astra-cli/src/cli/slash/slash_team.rs
+++ b/rust/crates/astra-cli/src/cli/slash/slash_team.rs
@@ -965,7 +965,7 @@ pub(crate) async fn handle_team_command(
                 token,
                 state.model.clone(),
                 project_root.clone(),
-                state.perm_manager.mode(),
+                state.perm_manager.inherited_permissions_for_child(true),
                 Some(cancel_token.clone()),
             )
             .with_progress_tx(progress_tx);

--- a/rust/crates/astra-cli/src/cli/spawn_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/spawn_subrun.rs
@@ -994,12 +994,10 @@ mod tests {
     use crate::cli::chat_stream::StreamEvent;
     fn test_permission_context() -> (
         InheritedPermissions,
-        Arc<tokio::sync::RwLock<PermissionSyncContext>>,
+        astra_runtime::orchestration::PermissionSyncHandle,
     ) {
         let inherited_permissions = InheritedPermissions::new(PermissionMode::Prompt);
-        let permission_context = Arc::new(tokio::sync::RwLock::new(PermissionSyncContext::new(
-            inherited_permissions.clone(),
-        )));
+        let permission_context = PermissionSyncContext::shared(inherited_permissions.clone());
         (inherited_permissions, permission_context)
     }
 

--- a/rust/crates/astra-cli/src/cli/spawn_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/spawn_subrun.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use astra_core::SkillSearchSettings;
 use astra_runtime::{
     orchestration::{
-        PermissionSummary, SpawnAgentExecutor, SpawnRunConfig, SpawnRunResult,
-        spawn_completion_status_from_finish_reason,
+        InheritedPermissions, PermissionSummary, SpawnAgentExecutor, SpawnRunConfig,
+        SpawnRunResult, spawn_completion_status_from_finish_reason,
     },
     pipeline::step_protocol::InMemoryIdempotencyCache,
     pipeline::step_recorder::StepRecorder,
@@ -29,7 +29,6 @@ use astra_turn_core::agent_live_event::SharedAgentLiveEventSink;
 use serde_json::{Value, json};
 
 use super::chat_stream::StreamEvent;
-use super::permission_manager::PermissionMode;
 use super::skill_subrun::SubRunHost;
 use crate::edge_tools;
 
@@ -56,7 +55,6 @@ pub struct CliSpawnAgentExecutor {
     /// falls back to `self.token` for parity with the pre-fix behaviour.
     token_provider: Option<TokenProvider>,
     project_root: PathBuf,
-    permission_mode: PermissionMode,
     cancel_token: Option<Arc<tokio_util::sync::CancellationToken>>,
     skill_resolver: Option<Arc<dyn astra_runtime::turn::skill_tool::SkillResolver>>,
     skill_search: SkillSearchSettings,
@@ -311,7 +309,6 @@ impl CliSpawnAgentExecutor {
         api: astra_thin_client::ThinClient,
         token: String,
         project_root: PathBuf,
-        permission_mode: PermissionMode,
         cancel_token: Option<Arc<tokio_util::sync::CancellationToken>>,
     ) -> Self {
         Self {
@@ -319,7 +316,6 @@ impl CliSpawnAgentExecutor {
             token,
             token_provider: None,
             project_root,
-            permission_mode,
             cancel_token,
             skill_resolver: None,
             skill_search: SkillSearchSettings::default(),
@@ -450,22 +446,11 @@ impl SpawnAgentExecutor for CliSpawnAgentExecutor {
         let agent_id_for_terminal = config.agent_id.clone();
         let started_at = std::time::Instant::now();
 
-        // Create permission manager - use inherited permissions if available
-        let perm_manager = if let Some(ref inherited) = config.inherited_permissions {
-            super::permission_manager::PermissionManager::with_inherited(
-                &self.project_root,
-                inherited.clone(),
-            )
-        } else {
-            // Issue #326 P5b: spawned agent sub-run is headless
-            // when no inherited permissions are provided either.
-            // Either way, project allow rules don't apply.
-            super::permission_manager::PermissionManager::with_load_policy(
-                self.permission_mode,
-                &self.project_root,
-                &super::permission_manager::PermissionLoadPolicy::HeadlessSafe,
-            )
-        };
+        let inherited_permissions: InheritedPermissions = config.inherited_permissions.clone();
+        let perm_manager = super::permission_manager::PermissionManager::with_inherited(
+            &self.project_root,
+            inherited_permissions,
+        );
 
         // Use the working directory from config (may be a worktree)
         let effective_root = config.working_dir.clone();
@@ -754,7 +739,7 @@ impl SpawnAgentExecutor for CliSpawnAgentExecutor {
             max_cumulative_tokens: 0,
             thinking: child_thinking,
             recent_file_reads: Vec::new(),
-            permission_context: config.permission_context,
+            permission_context: Some(config.permission_context),
             permission_handler: None,
             tactical_adapter: None,
             step_signal_collector: None,
@@ -790,34 +775,30 @@ impl SpawnAgentExecutor for CliSpawnAgentExecutor {
         let prompt_tokens = state.total_prompt;
         let completion_tokens = state.total_completion;
         let duration_ms = start_time.elapsed().as_millis() as u64;
-        let (permission_summary, permission_requests, permission_requests_approved, tools_blocked) =
-            if let Some(ctx) = state.permission_context.as_ref() {
-                let ctx_guard = ctx.read().await;
-                let telemetry = ctx_guard.telemetry();
-                let mode = match ctx_guard.mode() {
-                    astra_runtime::orchestration::PermissionMode::Auto => "auto".to_string(),
-                    astra_runtime::orchestration::PermissionMode::Plan => "plan".to_string(),
-                    astra_runtime::orchestration::PermissionMode::AcceptEdits => {
-                        "accept_edits".to_string()
-                    }
-                    astra_runtime::orchestration::PermissionMode::Prompt => "prompt".to_string(),
-                    astra_runtime::orchestration::PermissionMode::Deny => "deny".to_string(),
-                };
-                (
-                    Some(PermissionSummary {
-                        mode,
-                        allow_rules: ctx_guard.effective_allow_rule_count(),
-                        deny_rules: ctx_guard.effective_deny_rule_count(),
-                        has_parent: has_parent_permissions,
-                        recent_denials: telemetry.recent_denials.clone(),
-                    }),
-                    telemetry.permission_requests,
-                    telemetry.permission_requests_approved,
-                    telemetry.tools_blocked,
-                )
-            } else {
-                (None, 0, 0, 0)
-            };
+        let ctx = state
+            .permission_context
+            .as_ref()
+            .expect("spawned agent state must carry runtime permission context");
+        let ctx_guard = ctx.read().await;
+        let telemetry = ctx_guard.telemetry();
+        let mode = match ctx_guard.mode() {
+            astra_runtime::orchestration::PermissionMode::Auto => "auto".to_string(),
+            astra_runtime::orchestration::PermissionMode::Plan => "plan".to_string(),
+            astra_runtime::orchestration::PermissionMode::AcceptEdits => "accept_edits".to_string(),
+            astra_runtime::orchestration::PermissionMode::Prompt => "prompt".to_string(),
+            astra_runtime::orchestration::PermissionMode::Deny => "deny".to_string(),
+        };
+        let permission_summary = Some(PermissionSummary {
+            mode,
+            allow_rules: ctx_guard.effective_allow_rule_count(),
+            deny_rules: ctx_guard.effective_deny_rule_count(),
+            has_parent: has_parent_permissions,
+            recent_denials: telemetry.recent_denials.clone(),
+        });
+        let permission_requests = telemetry.permission_requests;
+        let permission_requests_approved = telemetry.permission_requests_approved;
+        let tools_blocked = telemetry.tools_blocked;
+        drop(ctx_guard);
 
         // Derive finish_reason from the structured interruption
         // record if present. This surfaces budget exhaustion /
@@ -999,7 +980,10 @@ mod tests {
         CliSpawnAgentExecutor, TokenProvider, agent_live_stream_event_sink, build_child_messages,
     };
     use crate::lock_recovery::LockRecovery;
-    use astra_runtime::orchestration::{SpawnAgentExecutor, SpawnRunConfig};
+    use astra_runtime::orchestration::{
+        InheritedPermissions, PermissionMode, PermissionSyncContext, SpawnAgentExecutor,
+        SpawnRunConfig,
+    };
     use astra_turn_core::agent_live_event::{
         AgentLiveEvent, AgentLiveEventKind, AgentLiveEventSink, AgentLiveSendError,
     };
@@ -1008,7 +992,16 @@ mod tests {
     use std::sync::Arc;
 
     use crate::cli::chat_stream::StreamEvent;
-    use crate::cli::permission_manager::PermissionMode;
+    fn test_permission_context() -> (
+        InheritedPermissions,
+        Arc<tokio::sync::RwLock<PermissionSyncContext>>,
+    ) {
+        let inherited_permissions = InheritedPermissions::new(PermissionMode::Prompt);
+        let permission_context = Arc::new(tokio::sync::RwLock::new(PermissionSyncContext::new(
+            inherited_permissions.clone(),
+        )));
+        (inherited_permissions, permission_context)
+    }
 
     #[derive(Debug, Default)]
     struct RecordingLiveSink(std::sync::Mutex<Vec<AgentLiveEvent>>);
@@ -1023,13 +1016,8 @@ mod tests {
     #[test]
     fn test_executor_creation() {
         let api = astra_thin_client::ThinClient::new("http://test", None).expect("test api");
-        let executor = CliSpawnAgentExecutor::new(
-            api,
-            "token".to_string(),
-            PathBuf::from("/tmp"),
-            PermissionMode::Prompt,
-            None,
-        );
+        let executor =
+            CliSpawnAgentExecutor::new(api, "token".to_string(), PathBuf::from("/tmp"), None);
         assert!(executor.skill_resolver.is_none());
         assert!(
             executor.token_provider.is_none(),
@@ -1042,14 +1030,9 @@ mod tests {
     #[test]
     fn resolve_effective_model_prefers_spawn_model_then_default() {
         let api = astra_thin_client::ThinClient::new("http://test", None).expect("test api");
-        let executor = CliSpawnAgentExecutor::new(
-            api,
-            "token".to_string(),
-            PathBuf::from("/tmp"),
-            PermissionMode::Prompt,
-            None,
-        )
-        .with_default_model(Some("session-default".to_string()));
+        let executor =
+            CliSpawnAgentExecutor::new(api, "token".to_string(), PathBuf::from("/tmp"), None)
+                .with_default_model(Some("session-default".to_string()));
 
         assert_eq!(
             executor
@@ -1106,7 +1089,6 @@ mod tests {
             api.clone(),
             "stale-token".to_string(),
             PathBuf::from("/tmp"),
-            PermissionMode::Prompt,
             None,
         );
         assert_eq!(
@@ -1124,7 +1106,6 @@ mod tests {
             api,
             "stale-frozen-fallback".to_string(),
             PathBuf::from("/tmp"),
-            PermissionMode::Prompt,
             None,
         )
         .with_token_provider(provider);
@@ -1155,7 +1136,6 @@ mod tests {
             api,
             "fallback-token".to_string(),
             PathBuf::from("/tmp"),
-            PermissionMode::Prompt,
             None,
         )
         .with_token_provider(provider);
@@ -1171,14 +1151,9 @@ mod tests {
     async fn async_token_provider_panic_surfaces_instead_of_using_stale_fallback() {
         let api = astra_thin_client::ThinClient::new("http://test", None).expect("test api");
         let provider: TokenProvider = std::sync::Arc::new(|| panic!("token store poisoned"));
-        let executor = CliSpawnAgentExecutor::new(
-            api,
-            "stale-token".to_string(),
-            PathBuf::from("/tmp"),
-            PermissionMode::Prompt,
-            None,
-        )
-        .with_token_provider(provider);
+        let executor =
+            CliSpawnAgentExecutor::new(api, "stale-token".to_string(), PathBuf::from("/tmp"), None)
+                .with_token_provider(provider);
 
         let err = executor.resolve_token_async().await.unwrap_err();
         assert!(
@@ -1192,14 +1167,10 @@ mod tests {
         let api = astra_thin_client::ThinClient::new("http://test", None).expect("test api");
         let provider: TokenProvider = std::sync::Arc::new(|| panic!("token store poisoned"));
         let live_sink = Arc::new(RecordingLiveSink::default());
-        let executor = CliSpawnAgentExecutor::new(
-            api,
-            "stale-token".to_string(),
-            PathBuf::from("/tmp"),
-            PermissionMode::Prompt,
-            None,
-        )
-        .with_token_provider(provider);
+        let (inherited_permissions, permission_context) = test_permission_context();
+        let executor =
+            CliSpawnAgentExecutor::new(api, "stale-token".to_string(), PathBuf::from("/tmp"), None)
+                .with_token_provider(provider);
 
         let err = executor
             .execute(SpawnRunConfig {
@@ -1217,9 +1188,9 @@ mod tests {
                 mailbox: None,
                 progress_emitter: None,
                 context_cache: None,
-                inherited_permissions: None,
+                inherited_permissions,
                 parent_address: None,
-                permission_context: None,
+                permission_context,
                 inherited_skills: Vec::new(),
                 live_event_sink: Some(live_sink.clone()),
                 inherited_prefix: None,

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -3236,180 +3236,179 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                 // authorization. On approval, temporarily expand the sandbox
                 // boundary and retry the tool.
                 if crate::sandbox_retry::is_sandbox_denied(&outcome.output) {
-                    if let Some(pm) = &mut self.perm_manager {
-                        let sandbox_msg =
-                            crate::sandbox_retry::sandbox_denied_message(&outcome.output)
-                                .unwrap_or("");
-                        let sandbox_tool_key = format!("sandbox_expand:{tool}");
-                        let guard_args = serde_json::json!({"reason": sandbox_msg});
-                        let decision = crate::tool_safety_guard::ToolSafetyGuard::check_request(
-                            Some(&mut **pm),
-                            &sandbox_tool_key,
-                            &guard_args,
-                        );
-                        let approved = match decision {
-                            crate::cli::permission_manager::PermissionDecision::Allow => true,
-                            crate::cli::permission_manager::PermissionDecision::Deny(_) => false,
-                            crate::cli::permission_manager::PermissionDecision::NeedApproval {
-                                header,
-                                detail,
-                                reason,
-                                ..
-                            } => {
-                                if let Some(tx) = &self.approval_request_tx {
-                                    use crate::cli::chat_stream::ApprovalResponse;
-                                    let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
-                                    // `🔒 ` prefix visually marks sandbox-escape
-                                    // prompts; header/detail/reason otherwise
-                                    // come straight from the permission manager
-                                    // so we don't echo the same text thrice.
-                                    let _ = tx.send(chat_stream::ApprovalRequest::bare(
-                                        sandbox_tool_key.clone(),
-                                        format!("🔒 {header}"),
-                                        detail,
-                                        reason,
-                                        args.clone(),
-                                        resp_tx,
-                                    ));
-                                    let response = if let Some(token) = self.cancel_token {
-                                        tokio::select! {
-                                            biased;
-                                            _ = token.cancelled() => ApprovalResponse::Deny,
-                                            r = resp_rx => r.unwrap_or(ApprovalResponse::Deny),
+                    let sandbox_msg = crate::sandbox_retry::sandbox_denied_message(&outcome.output)
+                        .map(|message| message.into_owned())
+                        .unwrap_or_default();
+                    if let Some(expand_dir) =
+                        crate::sandbox_retry::sandbox_expand_dir_from_denial(args, &sandbox_msg)
+                    {
+                        if let Some(pm) = &mut self.perm_manager {
+                            let sandbox_tool_key = format!("sandbox_expand:{tool}");
+                            let guard_args = serde_json::json!({"reason": sandbox_msg.clone()});
+                            let decision = crate::tool_safety_guard::ToolSafetyGuard::check_request(
+                                Some(&mut **pm),
+                                &sandbox_tool_key,
+                                &guard_args,
+                            );
+                            let approved = match decision {
+                                crate::cli::permission_manager::PermissionDecision::Allow => true,
+                                crate::cli::permission_manager::PermissionDecision::Deny(_) => false,
+                                crate::cli::permission_manager::PermissionDecision::NeedApproval {
+                                    header,
+                                    detail,
+                                    reason,
+                                    ..
+                                } => {
+                                    if let Some(tx) = &self.approval_request_tx {
+                                        use crate::cli::chat_stream::ApprovalResponse;
+                                        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+                                        // `🔒 ` prefix visually marks sandbox-escape
+                                        // prompts; header/detail/reason otherwise
+                                        // come straight from the permission manager
+                                        // so we don't echo the same text thrice.
+                                        let _ = tx.send(chat_stream::ApprovalRequest::bare(
+                                            sandbox_tool_key.clone(),
+                                            format!("🔒 {header}"),
+                                            detail,
+                                            reason,
+                                            args.clone(),
+                                            resp_tx,
+                                        ));
+                                        let response = if let Some(token) = self.cancel_token {
+                                            tokio::select! {
+                                                biased;
+                                                _ = token.cancelled() => ApprovalResponse::Deny,
+                                                r = resp_rx => r.unwrap_or(ApprovalResponse::Deny),
+                                            }
+                                        } else {
+                                            resp_rx.await.unwrap_or(ApprovalResponse::Deny)
+                                        };
+                                        let selected_scope = response.always_scope(
+                                            astra_turn_core::permission::scope::AllowScope::Project,
+                                        );
+                                        match selected_scope {
+                                            Some(astra_turn_core::permission::scope::AllowScope::Project) => {
+                                                // Persistent: writes a tool-level allow
+                                                // rule to settings for future sessions.
+                                                let rule = crate::cli::permission_manager::PermissionManager::make_allow_rule(&sandbox_tool_key, &guard_args);
+                                                let remember_preview =
+                                                    astra_turn_core::permission::match_target::remember_preview(
+                                                        &sandbox_tool_key,
+                                                        &guard_args,
+                                                        "in this workspace",
+                                                    );
+                                                pm.add_allow_rule(&rule);
+                                                if let Some(err) = pm.take_last_save_error() {
+                                                    astra_core::agent_warn!(
+                                                        "permission",
+                                                        "Always allow for {remember_preview} is session-only; failed to save rule {rule}: {err}"
+                                                    );
+                                                    if let Some(tx) = &self.stream_event_tx {
+                                                        let _ = tx.send(chat_stream::StreamEvent::StatusLine(
+                                                            format!(
+                                                                "Failed to save Always allow for {remember_preview}: {err}"
+                                                            ),
+                                                        ));
+                                                    }
+                                                }
+                                                pm.trust_sandbox_root_from_reason(&sandbox_msg);
+                                            }
+                                            Some(
+                                                astra_turn_core::permission::scope::AllowScope::RestOfSession,
+                                            ) => {
+                                                pm.trust_sandbox_root_from_reason(&sandbox_msg);
+                                            }
+                                            Some(
+                                                astra_turn_core::permission::scope::AllowScope::User,
+                                            ) => {
+                                                let rule = crate::cli::permission_manager::PermissionManager::make_allow_rule(&sandbox_tool_key, &guard_args);
+                                                let remember_preview =
+                                                    astra_turn_core::permission::match_target::remember_preview(
+                                                        &sandbox_tool_key,
+                                                        &guard_args,
+                                                        "for this user",
+                                                    );
+                                                pm.add_user_allow_rule(&rule);
+                                                if let Some(err) = pm.take_last_save_error() {
+                                                    astra_core::agent_warn!(
+                                                        "permission",
+                                                        "Always allow for {remember_preview} is session-only; failed to save user rule {rule}: {err}"
+                                                    );
+                                                    if let Some(tx) = &self.stream_event_tx {
+                                                        let _ = tx.send(chat_stream::StreamEvent::StatusLine(
+                                                            format!(
+                                                                "Failed to save Always allow for {remember_preview}: {err}"
+                                                            ),
+                                                        ));
+                                                    }
+                                                }
+                                                pm.trust_sandbox_root_from_reason(&sandbox_msg);
+                                            }
+                                            Some(
+                                                astra_turn_core::permission::scope::AllowScope::OnceThisCall
+                                                | astra_turn_core::permission::scope::AllowScope::RestOfTurn,
+                                            )
+                                            | None => {}
                                         }
+                                        if matches!(
+                                            selected_scope,
+                                            Some(
+                                                astra_turn_core::permission::scope::AllowScope::Project
+                                                    | astra_turn_core::permission::scope::AllowScope::RestOfSession
+                                                    | astra_turn_core::permission::scope::AllowScope::User
+                                            )
+                                        ) {
+                                            pm.record_approval(&sandbox_tool_key, Some(args), true);
+                                        }
+                                        response.is_approved()
+                                    } else if self.render_policy.is_silent() {
+                                        // Sub-run mode: auto-deny sandbox expansion
+                                        astra_core::agent_warn!(
+                                            "permission",
+                                            "Auto-denied sandbox expansion {sandbox_tool_key} in sub-run mode: {reason}"
+                                        );
+                                        pm.record_approval(&sandbox_tool_key, Some(args), false);
+                                        false
                                     } else {
-                                        resp_rx.await.unwrap_or(ApprovalResponse::Deny)
-                                    };
-                                    let selected_scope = response.always_scope(
-                                        astra_turn_core::permission::scope::AllowScope::Project,
-                                    );
-                                    match selected_scope {
-                                        Some(astra_turn_core::permission::scope::AllowScope::Project) => {
-                                            // Persistent: writes a tool-level allow
-                                            // rule to settings for future sessions.
-                                            let rule = crate::cli::permission_manager::PermissionManager::make_allow_rule(&sandbox_tool_key, &guard_args);
-                                            let remember_preview =
-                                                astra_turn_core::permission::match_target::remember_preview(
-                                                    &sandbox_tool_key,
-                                                    &guard_args,
-                                                    "in this workspace",
-                                                );
-                                            pm.add_allow_rule(&rule);
-                                            if let Some(err) = pm.take_last_save_error() {
-                                                astra_core::agent_warn!(
-                                                    "permission",
-                                                    "Always allow for {remember_preview} is session-only; failed to save rule {rule}: {err}"
-                                                );
-                                                if let Some(tx) = &self.stream_event_tx {
-                                                    let _ = tx.send(chat_stream::StreamEvent::StatusLine(
-                                                        format!(
-                                                            "Failed to save Always allow for {remember_preview}: {err}"
-                                                        ),
-                                                    ));
-                                                }
-                                            }
-                                            pm.trust_sandbox_root_from_reason(sandbox_msg);
-                                        }
-                                        Some(
-                                            astra_turn_core::permission::scope::AllowScope::RestOfSession,
-                                        ) => {
-                                            pm.trust_sandbox_root_from_reason(sandbox_msg);
-                                        }
-                                        Some(
-                                            astra_turn_core::permission::scope::AllowScope::User,
-                                        ) => {
-                                            let rule = crate::cli::permission_manager::PermissionManager::make_allow_rule(&sandbox_tool_key, &guard_args);
-                                            let remember_preview =
-                                                astra_turn_core::permission::match_target::remember_preview(
-                                                    &sandbox_tool_key,
-                                                    &guard_args,
-                                                    "for this user",
-                                                );
-                                            pm.add_user_allow_rule(&rule);
-                                            if let Some(err) = pm.take_last_save_error() {
-                                                astra_core::agent_warn!(
-                                                    "permission",
-                                                    "Always allow for {remember_preview} is session-only; failed to save user rule {rule}: {err}"
-                                                );
-                                                if let Some(tx) = &self.stream_event_tx {
-                                                    let _ = tx.send(chat_stream::StreamEvent::StatusLine(
-                                                        format!(
-                                                            "Failed to save Always allow for {remember_preview}: {err}"
-                                                        ),
-                                                    ));
-                                                }
-                                            }
-                                            pm.trust_sandbox_root_from_reason(sandbox_msg);
-                                        }
-                                        Some(
-                                            astra_turn_core::permission::scope::AllowScope::OnceThisCall
-                                            | astra_turn_core::permission::scope::AllowScope::RestOfTurn,
-                                        )
-                                        | None => {}
+                                        // Issue #326 P0 (tui-only) / #331:
+                                        // legacy interactive stdin path is dead
+                                        // code now that the REPL is gone. With
+                                        // no approval channel and not silent =
+                                        // configuration mismatch, fail closed.
+                                        astra_core::agent_warn!(
+                                            "permission",
+                                            "Auto-denied sandbox expansion {sandbox_tool_key}: \
+                                             no approval sink installed (no TUI, not silent). \
+                                             Pass --mode auto or attach to a TUI session. reason={reason}"
+                                        );
+                                        pm.record_approval(&sandbox_tool_key, Some(args), false);
+                                        false
                                     }
-                                    if matches!(
-                                        selected_scope,
-                                        Some(
-                                            astra_turn_core::permission::scope::AllowScope::Project
-                                                | astra_turn_core::permission::scope::AllowScope::RestOfSession
-                                                | astra_turn_core::permission::scope::AllowScope::User
-                                        )
-                                    ) {
-                                        pm.record_approval(&sandbox_tool_key, Some(args), true);
-                                    }
-                                    response.is_approved()
-                                } else if self.render_policy.is_silent() {
-                                    // Sub-run mode: auto-deny sandbox expansion
-                                    astra_core::agent_warn!(
-                                        "permission",
-                                        "Auto-denied sandbox expansion {sandbox_tool_key} in sub-run mode: {reason}"
-                                    );
-                                    pm.record_approval(&sandbox_tool_key, Some(args), false);
-                                    false
-                                } else {
-                                    // Issue #326 P0 (tui-only) / #331:
-                                    // legacy interactive stdin path is dead
-                                    // code now that the REPL is gone. With
-                                    // no approval channel and not silent =
-                                    // configuration mismatch, fail closed.
-                                    astra_core::agent_warn!(
-                                        "permission",
-                                        "Auto-denied sandbox expansion {sandbox_tool_key}: \
-                                         no approval sink installed (no TUI, not silent). \
-                                         Pass --mode auto or attach to a TUI session. reason={reason}"
-                                    );
-                                    pm.record_approval(&sandbox_tool_key, Some(args), false);
-                                    false
                                 }
+                            };
+                            if approved {
+                                self.executor.expand_sandbox_path(expand_dir);
+                                outcome = execute_with_metadata_responsive(
+                                    std::sync::Arc::clone(&self.executor),
+                                    tool.to_string(),
+                                    args.clone(),
+                                    self.cancel_token.cloned(),
+                                )
+                                .await;
+                                tool_result_fields = outcome.tool_result_fields;
+                                tool_execution_marked_error = outcome.is_error;
+                                outcome.output
+                            } else {
+                                tool_execution_marked_error = true;
+                                format!("Error: {sandbox_msg}")
                             }
-                        };
-                        if approved {
-                            // Single source of truth in `sandbox_retry` — both
-                            // the sequential path here and the parallel batch
-                            // path call the same derivation so their behaviour
-                            // stays byte-identical.
-                            if let Some(dir) =
-                                crate::sandbox_retry::sandbox_expand_dir_from_args(args)
-                            {
-                                self.executor.expand_sandbox_path(dir);
-                            }
-                            outcome = execute_with_metadata_responsive(
-                                std::sync::Arc::clone(&self.executor),
-                                tool.to_string(),
-                                args.clone(),
-                                self.cancel_token.cloned(),
-                            )
-                            .await;
-                            tool_result_fields = outcome.tool_result_fields;
+                        } else {
                             tool_execution_marked_error = outcome.is_error;
                             outcome.output
-                        } else {
-                            tool_execution_marked_error = true;
-                            format!("Error: {sandbox_msg}")
                         }
                     } else {
-                        tool_execution_marked_error = outcome.is_error;
-                        outcome.output
+                        tool_execution_marked_error = true;
+                        crate::sandbox_retry::sandbox_retry_no_expand_dir_output(tool, &sandbox_msg)
                     }
                 } else {
                     tool_result_fields = outcome.tool_result_fields;
@@ -4081,9 +4080,17 @@ impl SseStreamHost for CliSseStreamHost<'_> {
             let args = req.args.clone();
             let sandbox_tool_key = format!("sandbox_expand:{tool}");
             let sandbox_msg = crate::sandbox_retry::sandbox_denied_message(&outputs[pos].0.output)
-                .unwrap_or("")
-                .to_string();
-            let guard_args = serde_json::json!({"reason": sandbox_msg});
+                .map(|message| message.into_owned())
+                .unwrap_or_default();
+            let Some(expand_dir) =
+                crate::sandbox_retry::sandbox_expand_dir_from_denial(&args, &sandbox_msg)
+            else {
+                outputs[pos].0 = crate::edge_tools::ToolExecutionOutcome::error(
+                    crate::sandbox_retry::sandbox_retry_no_expand_dir_output(&tool, &sandbox_msg),
+                );
+                continue;
+            };
+            let guard_args = serde_json::json!({"reason": sandbox_msg.clone()});
             let decision = crate::tool_safety_guard::ToolSafetyGuard::check_request(
                 self.perm_manager.as_deref_mut(),
                 &sandbox_tool_key,
@@ -4178,9 +4185,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
             if !approved {
                 continue;
             }
-            if let Some(dir) = crate::sandbox_retry::sandbox_expand_dir_from_args(&args) {
-                self.executor.expand_sandbox_path(dir);
-            }
+            self.executor.expand_sandbox_path(expand_dir);
             if let Some(pm) = &mut self.perm_manager {
                 pm.record_approval(&sandbox_tool_key, Some(&args), true);
             }

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -405,11 +405,11 @@ fn persist_scoped_allow_rule(
         };
         astra_core::agent_warn!(
             "permission",
-            "Always allow for {remember_preview} is session-only; failed to save rule {rule} to {target_label}: {err}"
+            "Don't ask again for {remember_preview} is session-only; failed to save rule {rule} to {target_label}: {err}"
         );
         if let Some(tx) = save_warning_tx {
             let _ = tx.send(chat_stream::StreamEvent::StatusLine(format!(
-                "Failed to save Always allow for {remember_preview} to {target_label}: {err}"
+                "Failed to save don't-ask-again rule for {remember_preview} to {target_label}: {err}"
             )));
         }
     }
@@ -3301,12 +3301,12 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                                                 if let Some(err) = pm.take_last_save_error() {
                                                     astra_core::agent_warn!(
                                                         "permission",
-                                                        "Always allow for {remember_preview} is session-only; failed to save rule {rule}: {err}"
+                                                        "Don't ask again for {remember_preview} is session-only; failed to save rule {rule}: {err}"
                                                     );
                                                     if let Some(tx) = &self.stream_event_tx {
                                                         let _ = tx.send(chat_stream::StreamEvent::StatusLine(
                                                             format!(
-                                                                "Failed to save Always allow for {remember_preview}: {err}"
+                                                                "Failed to save don't-ask-again rule for {remember_preview}: {err}"
                                                             ),
                                                         ));
                                                     }
@@ -3332,12 +3332,12 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                                                 if let Some(err) = pm.take_last_save_error() {
                                                     astra_core::agent_warn!(
                                                         "permission",
-                                                        "Always allow for {remember_preview} is session-only; failed to save user rule {rule}: {err}"
+                                                        "Don't ask again for {remember_preview} is session-only; failed to save user rule {rule}: {err}"
                                                     );
                                                     if let Some(tx) = &self.stream_event_tx {
                                                         let _ = tx.send(chat_stream::StreamEvent::StatusLine(
                                                             format!(
-                                                                "Failed to save Always allow for {remember_preview}: {err}"
+                                                                "Failed to save don't-ask-again rule for {remember_preview}: {err}"
                                                             ),
                                                         ));
                                                     }

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -1411,11 +1411,11 @@ impl<'a> CliSseStreamHost<'a> {
         };
 
         match decision {
-            crate::cli::permission_manager::PermissionDecision::Allow => Ok(()),
-            crate::cli::permission_manager::PermissionDecision::Deny(reason) => Err(format!(
+            crate::cli::permission_manager::GateOutcome::Allow => Ok(()),
+            crate::cli::permission_manager::GateOutcome::Deny(reason) => Err(format!(
                 "Error: {sandbox_msg} (sandbox_expand:{tool} denied: {reason})"
             )),
-            crate::cli::permission_manager::PermissionDecision::NeedApproval {
+            crate::cli::permission_manager::GateOutcome::NeedApproval {
                 tool: approval_tool,
                 header,
                 detail,
@@ -2982,7 +2982,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
         let cloud_approved = self.cloud_pre_approved.remove(request_id);
 
         let decision = if cloud_approved {
-            crate::cli::permission_manager::PermissionDecision::Allow
+            crate::cli::permission_manager::GateOutcome::Allow
         } else {
             match self.perm_manager.as_mut() {
                 Some(pm) => crate::tool_safety_guard::ToolSafetyGuard::check_request(
@@ -2995,14 +2995,14 @@ impl SseStreamHost for CliSseStreamHost<'_> {
         };
         let mut denied_output = None;
         let mut allowed = match decision {
-            crate::cli::permission_manager::PermissionDecision::Allow => true,
-            crate::cli::permission_manager::PermissionDecision::Deny(reason) => {
+            crate::cli::permission_manager::GateOutcome::Allow => true,
+            crate::cli::permission_manager::GateOutcome::Deny(reason) => {
                 denied_output = Some(crate::cli::permission_manager::format_denied_message(
                     &reason,
                 ));
                 false
             }
-            crate::cli::permission_manager::PermissionDecision::NeedApproval {
+            crate::cli::permission_manager::GateOutcome::NeedApproval {
                 tool: t,
                 header,
                 detail,
@@ -3057,8 +3057,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     let always_scope = approval_default_always_scope(&scope_ctx);
                     // Show what Always will remember in product
                     // language. The persisted rule remains an internal
-                    // detail; the UI must not leak `Bash(...:*)` or
-                    // other permissions.json DSL.
+                    // detail; the UI must not leak permissions.json DSL.
                     if always_scope == astra_turn_core::permission::scope::AllowScope::Project {
                         // Include the package root when available so
                         // the user understands the memory boundary.
@@ -3414,9 +3413,9 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                                 &guard_args,
                             );
                             let approved = match decision {
-                                crate::cli::permission_manager::PermissionDecision::Allow => true,
-                                crate::cli::permission_manager::PermissionDecision::Deny(_) => false,
-                                crate::cli::permission_manager::PermissionDecision::NeedApproval {
+                                crate::cli::permission_manager::GateOutcome::Allow => true,
+                                crate::cli::permission_manager::GateOutcome::Deny(_) => false,
+                                crate::cli::permission_manager::GateOutcome::NeedApproval {
                                     header,
                                     detail,
                                     reason,
@@ -3974,10 +3973,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     None, &req.tool, &req.args,
                 ),
             };
-            let ok = matches!(
-                decision,
-                crate::cli::permission_manager::PermissionDecision::Allow
-            );
+            let ok = matches!(decision, crate::cli::permission_manager::GateOutcome::Allow);
             if !ok {
                 all_allowed = false;
                 break;
@@ -4282,8 +4278,8 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                 &guard_args,
             );
             let approved = match decision {
-                crate::cli::permission_manager::PermissionDecision::Allow => true,
-                crate::cli::permission_manager::PermissionDecision::Deny(reason) => {
+                crate::cli::permission_manager::GateOutcome::Allow => true,
+                crate::cli::permission_manager::GateOutcome::Deny(reason) => {
                     // Surface the deny reason so the LLM and user can
                     // see why the sandbox refused to widen, instead of
                     // silently continuing with the original
@@ -4293,7 +4289,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     outputs[pos].0.is_error = true;
                     false
                 }
-                crate::cli::permission_manager::PermissionDecision::NeedApproval {
+                crate::cli::permission_manager::GateOutcome::NeedApproval {
                     tool: approval_tool,
                     header,
                     detail,
@@ -7390,7 +7386,7 @@ mod tests {
             crate::cli::permission_manager::PermissionManager::with_project(false, temp.path());
         assert!(matches!(
             reloaded.check_nonblocking("write_file", &args),
-            crate::cli::permission_manager::PermissionDecision::Allow
+            crate::cli::permission_manager::GateOutcome::Allow
         ));
     }
 
@@ -7453,13 +7449,13 @@ mod tests {
         let args = serde_json::json!({"path": ".env"});
         assert!(matches!(
             pm.check_nonblocking("write_file", &args),
-            crate::cli::permission_manager::PermissionDecision::Allow
+            crate::cli::permission_manager::GateOutcome::Allow
         ));
         let mut reloaded =
             crate::cli::permission_manager::PermissionManager::with_project(false, temp.path());
         assert!(matches!(
             reloaded.check_nonblocking("write_file", &args),
-            crate::cli::permission_manager::PermissionDecision::NeedApproval { .. }
+            crate::cli::permission_manager::GateOutcome::NeedApproval { .. }
         ));
     }
 

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -1385,7 +1385,10 @@ impl<'a> CliSseStreamHost<'a> {
 
         self.resolve_sandbox_expansion_approval(tool, &sandbox_msg, &expand_dir)
             .await?;
-        self.executor.expand_sandbox_path(expand_dir);
+        if let Err(e) = self.executor.expand_sandbox_path(expand_dir) {
+            astra_core::agent_warn!("sandbox", "post-approval expansion rejected: {e}");
+            return Ok(false);
+        }
         Ok(true)
     }
 
@@ -3549,7 +3552,12 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                                 }
                             };
                             if approved {
-                                self.executor.expand_sandbox_path(expand_dir);
+                                if let Err(e) = self.executor.expand_sandbox_path(expand_dir) {
+                                    astra_core::agent_warn!(
+                                        "sandbox",
+                                        "post-approval expansion rejected: {e}"
+                                    );
+                                }
                                 outcome = execute_with_metadata_responsive(
                                     std::sync::Arc::clone(&self.executor),
                                     tool.to_string(),
@@ -4360,7 +4368,10 @@ impl SseStreamHost for CliSseStreamHost<'_> {
             if !approved {
                 continue;
             }
-            self.executor.expand_sandbox_path(expand_dir);
+            if let Err(e) = self.executor.expand_sandbox_path(expand_dir) {
+                astra_core::agent_warn!("sandbox", "post-approval expansion rejected: {e}");
+                continue;
+            }
             if let Some(pm) = &mut self.perm_manager {
                 pm.record_approval(&sandbox_tool_key, Some(&args), true);
             }

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -1400,7 +1400,7 @@ impl<'a> CliSseStreamHost<'a> {
         let decision = {
             let Some(pm) = self.perm_manager.as_mut() else {
                 return Err(format!(
-                    "Error: {sandbox_msg} (sandbox_expand:{tool} denied: no permission manager configured)"
+                    "Error: {sandbox_msg} (cannot ask to expand sandbox for {tool}: no permission manager configured)"
                 ));
             };
             crate::tool_safety_guard::ToolSafetyGuard::check_request(
@@ -1413,7 +1413,7 @@ impl<'a> CliSseStreamHost<'a> {
         match decision {
             crate::cli::permission_manager::GateOutcome::Allow => Ok(()),
             crate::cli::permission_manager::GateOutcome::Deny(reason) => Err(format!(
-                "Error: {sandbox_msg} (sandbox_expand:{tool} denied: {reason})"
+                "Error: {sandbox_msg} (sandbox expansion for {tool} denied: {reason})"
             )),
             crate::cli::permission_manager::GateOutcome::NeedApproval {
                 tool: approval_tool,
@@ -1437,7 +1437,7 @@ impl<'a> CliSseStreamHost<'a> {
                         "approval required for an external path, but no approval prompt is available in this interface"
                     };
                     return Err(format!(
-                        "Error: {sandbox_msg} (sandbox_expand:{tool} denied: {reason})"
+                        "Error: {sandbox_msg} (sandbox expansion for {tool} denied: {reason})"
                     ));
                 };
 
@@ -1497,7 +1497,7 @@ impl<'a> CliSseStreamHost<'a> {
                         pm.record_approval(&approval_tool, Some(&guard_args), false);
                     }
                     Err(format!(
-                        "Error: {sandbox_msg} (sandbox_expand:{tool} denied: user denied sandbox expansion)"
+                        "Error: {sandbox_msg} (sandbox expansion for {tool} denied: user denied)"
                     ))
                 }
             }
@@ -4284,8 +4284,9 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     // see why the sandbox refused to widen, instead of
                     // silently continuing with the original
                     // sandbox-denied output.
-                    outputs[pos].0.output =
-                        format!("Error: {sandbox_msg} (sandbox_expand:{tool} denied: {reason})");
+                    outputs[pos].0.output = format!(
+                        "Error: {sandbox_msg} (sandbox expansion for {tool} denied: {reason})"
+                    );
                     outputs[pos].0.is_error = true;
                     false
                 }
@@ -7169,7 +7170,10 @@ mod tests {
             !error.contains(crate::sandbox_retry::SANDBOX_DENIED_PREFIX),
             "{error}"
         );
-        assert!(error.contains("sandbox_expand:read_file denied"), "{error}");
+        assert!(
+            error.contains("sandbox expansion for read_file denied"),
+            "{error}"
+        );
         assert!(
             executor.resolve_checked(&target.to_string_lossy()).is_err(),
             "denied preflight must not expand the sandbox"

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -1345,6 +1345,164 @@ impl<'a> CliSseStreamHost<'a> {
         }
         result
     }
+
+    async fn preflight_explicit_path_sandbox_expansion(
+        &mut self,
+        tool: &str,
+        args: &serde_json::Value,
+    ) -> Result<bool, String> {
+        let mut expanded = false;
+        for target in crate::sandbox_retry::explicit_file_tool_path_targets(tool, args) {
+            expanded |= self
+                .preflight_explicit_path_sandbox_expansion_target(&target)
+                .await?;
+        }
+        Ok(expanded)
+    }
+
+    async fn preflight_explicit_path_sandbox_expansion_target(
+        &mut self,
+        target: &crate::sandbox_retry::ExplicitPathPreflightTarget,
+    ) -> Result<bool, String> {
+        let tool = target.tool.as_str();
+        let args = &target.args;
+        let Err(resolve_error) = self.executor.resolve_checked(&target.path) else {
+            return Ok(false);
+        };
+        let Some(sandbox_msg) = crate::sandbox_retry::sandbox_denied_message(&resolve_error)
+            .map(|message| message.into_owned())
+        else {
+            return Ok(false);
+        };
+        let Some(expand_dir) =
+            crate::sandbox_retry::sandbox_expand_dir_from_denial(args, &sandbox_msg)
+        else {
+            return Err(crate::sandbox_retry::sandbox_retry_no_expand_dir_output(
+                tool,
+                &sandbox_msg,
+            ));
+        };
+
+        self.resolve_sandbox_expansion_approval(tool, &sandbox_msg, &expand_dir)
+            .await?;
+        self.executor.expand_sandbox_path(expand_dir);
+        Ok(true)
+    }
+
+    async fn resolve_sandbox_expansion_approval(
+        &mut self,
+        tool: &str,
+        sandbox_msg: &str,
+        expand_dir: &Path,
+    ) -> Result<(), String> {
+        let sandbox_tool_key = format!("sandbox_expand:{tool}");
+        let guard_args = serde_json::json!({"reason": sandbox_msg});
+        let decision = {
+            let Some(pm) = self.perm_manager.as_mut() else {
+                return Err(format!(
+                    "Error: {sandbox_msg} (sandbox_expand:{tool} denied: no permission manager configured)"
+                ));
+            };
+            crate::tool_safety_guard::ToolSafetyGuard::check_request(
+                Some(&mut **pm),
+                &sandbox_tool_key,
+                &guard_args,
+            )
+        };
+
+        match decision {
+            crate::cli::permission_manager::PermissionDecision::Allow => Ok(()),
+            crate::cli::permission_manager::PermissionDecision::Deny(reason) => Err(format!(
+                "Error: {sandbox_msg} (sandbox_expand:{tool} denied: {reason})"
+            )),
+            crate::cli::permission_manager::PermissionDecision::NeedApproval {
+                tool: approval_tool,
+                header,
+                detail,
+                reason,
+            } => {
+                use crate::cli::chat_stream::ApprovalResponse;
+
+                let Some(tx) = &self.approval_request_tx else {
+                    astra_core::agent_warn!(
+                        "permission",
+                        "Denied sandbox expansion {sandbox_tool_key}: approval prompt unavailable. reason={reason}"
+                    );
+                    if let Some(pm) = self.perm_manager.as_mut() {
+                        pm.record_approval(&approval_tool, Some(&guard_args), false);
+                    }
+                    let reason = if self.render_policy.is_silent() {
+                        "approval required for an external path, but this run cannot ask for approvals in the current mode"
+                    } else {
+                        "approval required for an external path, but no approval prompt is available in this interface"
+                    };
+                    return Err(format!(
+                        "Error: {sandbox_msg} (sandbox_expand:{tool} denied: {reason})"
+                    ));
+                };
+
+                let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+                let _ = tx.send(chat_stream::ApprovalRequest::bare(
+                    approval_tool.clone(),
+                    format!("🔒 {header}"),
+                    detail,
+                    reason,
+                    guard_args.clone(),
+                    resp_tx,
+                ));
+                let response = if let Some(token) = self.cancel_token {
+                    tokio::select! {
+                        biased;
+                        _ = token.cancelled() => ApprovalResponse::Deny,
+                        r = resp_rx => r.unwrap_or(ApprovalResponse::Deny),
+                    }
+                } else {
+                    resp_rx.await.unwrap_or(ApprovalResponse::Deny)
+                };
+
+                if response.is_approved() {
+                    let save_warning_tx = self.stream_event_tx.clone();
+                    if let Some(pm) = self.perm_manager.as_mut() {
+                        let workspace_untrusted = !pm.project_allow_rules_active();
+                        let always_scope =
+                            approval_default_always_scope(&approval_scope_context_for_tool(
+                                &approval_tool,
+                                &guard_args,
+                                false,
+                                workspace_untrusted,
+                            ));
+                        let selected_scope = response.always_scope(always_scope);
+                        apply_approval_memory_action(
+                            pm,
+                            approval_memory_action(&response, always_scope, true),
+                            &approval_tool,
+                            &guard_args,
+                            response.match_target(),
+                            save_warning_tx.as_ref(),
+                        );
+                        if matches!(
+                            selected_scope,
+                            Some(
+                                astra_turn_core::permission::scope::AllowScope::Project
+                                    | astra_turn_core::permission::scope::AllowScope::RestOfSession
+                                    | astra_turn_core::permission::scope::AllowScope::User
+                            )
+                        ) {
+                            pm.trust_sandbox_root(expand_dir.to_path_buf());
+                        }
+                    }
+                    Ok(())
+                } else {
+                    if let Some(pm) = self.perm_manager.as_mut() {
+                        pm.record_approval(&approval_tool, Some(&guard_args), false);
+                    }
+                    Err(format!(
+                        "Error: {sandbox_msg} (sandbox_expand:{tool} denied: user denied sandbox expansion)"
+                    ))
+                }
+            }
+        }
+    }
 }
 
 impl<'a> CliSseStreamHost<'a> {
@@ -3152,6 +3310,14 @@ impl SseStreamHost for CliSseStreamHost<'_> {
             denied_output = Some(error);
             allowed = false;
         }
+        if allowed
+            && let Err(error) = self
+                .preflight_explicit_path_sandbox_expansion(tool, args)
+                .await
+        {
+            denied_output = Some(error);
+            allowed = false;
+        }
         let start = std::time::Instant::now();
         let mut tool_result_fields = None;
         let mut tool_execution_marked_error = false;
@@ -3924,6 +4090,26 @@ impl SseStreamHost for CliSseStreamHost<'_> {
         // speculative output. Journal/observability still fire exactly
         // once from the post-execution pass below.
         let speculative_by_id = self.harvest_speculation_for_batch(&conc_reqs).await;
+        let mut preflight_errors = std::collections::HashMap::new();
+        for (_, req) in &conc_reqs {
+            if reusable_speculative_output(speculative_by_id.get(&req.request_id).cloned())
+                .is_some()
+            {
+                continue;
+            }
+            if let Err(error) = self
+                .preflight_explicit_path_sandbox_expansion(&req.tool, &req.args)
+                .await
+            {
+                astra_core::agent_warn!(
+                    "permission",
+                    "Parallel sandbox preflight for {} failed before execution: {}",
+                    req.tool,
+                    error
+                );
+                preflight_errors.insert(req.request_id.clone(), error);
+            }
+        }
         let outputs: Vec<(crate::edge_tools::ToolExecutionOutcome, u64)> = join_all(
             conc_reqs
                 .iter()
@@ -3935,8 +4121,12 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     let executor = std::sync::Arc::clone(&executor);
                     let cancel_token_for_tool = self.cancel_token.cloned();
                     let speculative = speculative_by_id.get(&req.request_id).cloned();
+                    let preflight_error = preflight_errors.get(&req.request_id).cloned();
                     let cancel_token = self.cancel_token.cloned();
                     async move {
+                        if let Some(error) = preflight_error {
+                            return (crate::edge_tools::ToolExecutionOutcome::error(error), 0u64);
+                        }
                         if let Some(output) = reusable_speculative_output(speculative) {
                             return (
                                 crate::edge_tools::ToolExecutionOutcome {
@@ -6866,6 +7056,203 @@ mod tests {
         let (decision, ()) = tokio::join!(decision_fut, responder);
 
         assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
+    }
+
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn sandbox_preflight_auto_expands_explicit_external_path() {
+        let server = MockServer::start().await;
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).expect("thin client");
+        let base = tempfile::tempdir_in(std::env::current_dir().expect("cwd")).expect("tempdir");
+        let project = base.path().join("project");
+        let external = base.path().join("external");
+        std::fs::create_dir(&project).expect("project");
+        std::fs::create_dir(&external).expect("external");
+        let target = external.join("notes.md");
+        std::fs::write(&target, "outside\n").expect("target");
+        let executor = std::sync::Arc::new(crate::edge_tools::ToolExecutor::new(&project));
+        let before = executor
+            .resolve_checked(&target.to_string_lossy())
+            .expect_err("external path should start outside the sandbox");
+        assert!(crate::sandbox_retry::is_sandbox_denied(&before), "{before}");
+
+        let mut tool_cache = EdgeToolCache::new(8);
+        let mut pm =
+            crate::cli::permission_manager::PermissionManager::with_project(false, &project);
+        pm.set_mode(crate::cli::permission_manager::PermissionMode::Auto);
+        let mut host = CliSseStreamHost::from_edge_ctx(
+            EdgeSseContext {
+                api: &api,
+                token: "tok",
+                executor_id: "edge-test",
+                executor: std::sync::Arc::clone(&executor),
+                render_policy: RenderPolicy::Silent,
+                perm_manager: Some(&mut pm),
+                cancel_token: None,
+                stream_event_tx: None,
+                stream_event_sink: None,
+                approval_request_tx: None,
+                ask_user_request_tx: None,
+                skill_resolver: None,
+                skill_continuation: false,
+                turn_rollback_on_failure: false,
+                tool_cache: &mut tool_cache,
+                observability_hub: None,
+                incremental_state: None,
+            },
+            80,
+            false,
+        );
+
+        let expanded = host
+            .preflight_explicit_path_sandbox_expansion(
+                "read_file",
+                &serde_json::json!({"path": target.to_string_lossy()}),
+            )
+            .await
+            .expect("auto should approve sandbox expansion");
+
+        assert!(expanded);
+        executor
+            .resolve_checked(&target.to_string_lossy())
+            .expect("external path should be allowed after preflight");
+    }
+
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn sandbox_preflight_deny_mode_returns_clean_error_without_expanding() {
+        let server = MockServer::start().await;
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).expect("thin client");
+        let base = tempfile::tempdir_in(std::env::current_dir().expect("cwd")).expect("tempdir");
+        let project = base.path().join("project");
+        let external = base.path().join("external");
+        std::fs::create_dir(&project).expect("project");
+        std::fs::create_dir(&external).expect("external");
+        let target = external.join("notes.md");
+        std::fs::write(&target, "outside\n").expect("target");
+        let executor = std::sync::Arc::new(crate::edge_tools::ToolExecutor::new(&project));
+
+        let mut tool_cache = EdgeToolCache::new(8);
+        let mut pm =
+            crate::cli::permission_manager::PermissionManager::with_project(false, &project);
+        pm.set_mode(crate::cli::permission_manager::PermissionMode::Deny);
+        let mut host = CliSseStreamHost::from_edge_ctx(
+            EdgeSseContext {
+                api: &api,
+                token: "tok",
+                executor_id: "edge-test",
+                executor: std::sync::Arc::clone(&executor),
+                render_policy: RenderPolicy::Silent,
+                perm_manager: Some(&mut pm),
+                cancel_token: None,
+                stream_event_tx: None,
+                stream_event_sink: None,
+                approval_request_tx: None,
+                ask_user_request_tx: None,
+                skill_resolver: None,
+                skill_continuation: false,
+                turn_rollback_on_failure: false,
+                tool_cache: &mut tool_cache,
+                observability_hub: None,
+                incremental_state: None,
+            },
+            80,
+            false,
+        );
+
+        let error = host
+            .preflight_explicit_path_sandbox_expansion(
+                "read_file",
+                &serde_json::json!({"path": target.to_string_lossy()}),
+            )
+            .await
+            .expect_err("deny mode should reject sandbox expansion");
+
+        assert!(error.starts_with("Error: "), "{error}");
+        assert!(
+            !error.contains(crate::sandbox_retry::SANDBOX_DENIED_PREFIX),
+            "{error}"
+        );
+        assert!(error.contains("sandbox_expand:read_file denied"), "{error}");
+        assert!(
+            executor.resolve_checked(&target.to_string_lossy()).is_err(),
+            "denied preflight must not expand the sandbox"
+        );
+    }
+
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn parallel_batch_preflights_external_paths_in_auto_mode() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tools/result"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&server)
+            .await;
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).expect("thin client");
+        let base = tempfile::tempdir_in(std::env::current_dir().expect("cwd")).expect("tempdir");
+        let project = base.path().join("project");
+        let external = base.path().join("external");
+        std::fs::create_dir(&project).expect("project");
+        std::fs::create_dir(&external).expect("external");
+        let first = external.join("one.txt");
+        let second = external.join("two.txt");
+        std::fs::write(&first, "one\n").expect("first");
+        std::fs::write(&second, "two\n").expect("second");
+        let executor = std::sync::Arc::new(crate::edge_tools::ToolExecutor::new(&project));
+
+        let mut tool_cache = EdgeToolCache::new(8);
+        let mut pm =
+            crate::cli::permission_manager::PermissionManager::with_project(false, &project);
+        pm.set_mode(crate::cli::permission_manager::PermissionMode::Auto);
+        let mut host = CliSseStreamHost::from_edge_ctx(
+            EdgeSseContext {
+                api: &api,
+                token: "tok",
+                executor_id: "edge-test",
+                executor,
+                render_policy: RenderPolicy::Silent,
+                perm_manager: Some(&mut pm),
+                cancel_token: None,
+                stream_event_tx: None,
+                stream_event_sink: None,
+                approval_request_tx: None,
+                ask_user_request_tx: None,
+                skill_resolver: None,
+                skill_continuation: false,
+                turn_rollback_on_failure: false,
+                tool_cache: &mut tool_cache,
+                observability_hub: None,
+                incremental_state: None,
+            },
+            80,
+            false,
+        );
+
+        let results = host
+            .execute_tools_batch(vec![
+                ToolBatchRequest {
+                    request_id: "pf-1".to_string(),
+                    tool: "read_file".to_string(),
+                    args: serde_json::json!({"path": first.to_string_lossy()}),
+                },
+                ToolBatchRequest {
+                    request_id: "pf-2".to_string(),
+                    tool: "read_file".to_string(),
+                    args: serde_json::json!({"path": second.to_string_lossy()}),
+                },
+            ])
+            .await;
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|result| result.status == "success"));
+        assert!(results[0].output.contains("one"), "{}", results[0].output);
+        assert!(results[1].output.contains("two"), "{}", results[1].output);
+        assert!(results.iter().all(|result| {
+            !result
+                .output
+                .contains(crate::sandbox_retry::SANDBOX_DENIED_PREFIX)
+        }));
     }
 
     #[serial_test::serial]

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -3235,10 +3235,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                 // If the sandbox denied the operation, prompt the user for
                 // authorization. On approval, temporarily expand the sandbox
                 // boundary and retry the tool.
-                if crate::sandbox_retry::is_sandbox_denied(&outcome.output) {
-                    let sandbox_msg = crate::sandbox_retry::sandbox_denied_message(&outcome.output)
-                        .map(|message| message.into_owned())
-                        .unwrap_or_default();
+                if let Some(sandbox_msg) = normalize_sandbox_denied_outcome(&mut outcome) {
                     if let Some(expand_dir) =
                         crate::sandbox_retry::sandbox_expand_dir_from_denial(args, &sandbox_msg)
                     {
@@ -3395,6 +3392,7 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                                     self.cancel_token.cloned(),
                                 )
                                 .await;
+                                normalize_sandbox_denied_outcome(&mut outcome);
                                 tool_result_fields = outcome.tool_result_fields;
                                 tool_execution_marked_error = outcome.is_error;
                                 outcome.output
@@ -4072,16 +4070,13 @@ impl SseStreamHost for CliSseStreamHost<'_> {
         // we no longer assume the parallel batch was pre-approved.
         let mut outputs = outputs;
         for pos in 0..outputs.len() {
-            if !crate::sandbox_retry::is_sandbox_denied(&outputs[pos].0.output) {
+            let Some(sandbox_msg) = normalize_sandbox_denied_outcome(&mut outputs[pos].0) else {
                 continue;
-            }
+            };
             let (_, req) = conc_reqs[pos];
             let tool = req.tool.clone();
             let args = req.args.clone();
             let sandbox_tool_key = format!("sandbox_expand:{tool}");
-            let sandbox_msg = crate::sandbox_retry::sandbox_denied_message(&outputs[pos].0.output)
-                .map(|message| message.into_owned())
-                .unwrap_or_default();
             let Some(expand_dir) =
                 crate::sandbox_retry::sandbox_expand_dir_from_denial(&args, &sandbox_msg)
             else {
@@ -4102,17 +4097,10 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     // Surface the deny reason so the LLM and user can
                     // see why the sandbox refused to widen, instead of
                     // silently continuing with the original
-                    // SANDBOX_DENIED output.
-                    let prefix = "SANDBOX_DENIED: ";
-                    let suffix = format!(" (sandbox_expand:{tool} denied: {reason})");
-                    if !outputs[pos].0.output.contains(&suffix) {
-                        if outputs[pos].0.output.starts_with(prefix) {
-                            outputs[pos].0.output.push_str(&suffix);
-                        } else {
-                            outputs[pos].0.output =
-                                format!("{prefix}{}{suffix}", outputs[pos].0.output);
-                        }
-                    }
+                    // sandbox-denied output.
+                    outputs[pos].0.output =
+                        format!("Error: {sandbox_msg} (sandbox_expand:{tool} denied: {reason})");
+                    outputs[pos].0.is_error = true;
                     false
                 }
                 crate::cli::permission_manager::PermissionDecision::NeedApproval {
@@ -4172,12 +4160,12 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                         // forcing PermissionMode::Auto for headless
                         // entries; reaching this branch with no sink
                         // means a misconfiguration. Surface a clear
-                        // reason in the SANDBOX_DENIED output.
-                        let suffix = " (approval required for sandbox_expand but no TUI; \
-                                       pass --mode auto or add allow rule)";
-                        if !outputs[pos].0.output.contains(suffix) {
-                            outputs[pos].0.output.push_str(suffix);
-                        }
+                        // reason without exposing the sandbox-denied wire
+                        // prefix.
+                        outputs[pos].0.output = format!(
+                            "Error: {sandbox_msg} (approval required for sandbox_expand but no TUI; pass --mode auto or add allow rule)"
+                        );
+                        outputs[pos].0.is_error = true;
                         false
                     }
                 }
@@ -4197,6 +4185,8 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     self.cancel_token.cloned(),
                 ))
                 .await;
+            let mut retried = retried;
+            normalize_sandbox_denied_outcome(&mut retried);
             outputs[pos] = (retried, retry_dur);
         }
 
@@ -5746,6 +5736,25 @@ fn edge_tool_outcome_status(outcome: &crate::edge_tools::ToolExecutionOutcome) -
     }
 }
 
+fn normalize_sandbox_denied_outcome(
+    outcome: &mut crate::edge_tools::ToolExecutionOutcome,
+) -> Option<String> {
+    let message = crate::sandbox_retry::sandbox_denied_message_from_result(
+        &outcome.output,
+        outcome.tool_result_fields.as_ref(),
+    )?
+    .into_owned();
+    outcome.tool_result_fields = Some(
+        crate::sandbox_retry::merge_sandbox_denied_tool_result_fields(
+            outcome.tool_result_fields.take(),
+            &message,
+        ),
+    );
+    outcome.output = format!("Error: {message}");
+    outcome.is_error = true;
+    Some(message)
+}
+
 async fn catch_tool_execution_panic<F>(future: F) -> (crate::edge_tools::ToolExecutionOutcome, u64)
 where
     F: Future<Output = crate::edge_tools::ToolExecutionOutcome>,
@@ -6301,9 +6310,10 @@ mod tests {
         approval_stale_revalidation_error, catch_tool_execution_panic, dispatch_turn_event_block,
         edge_tool_is_cacheable_read, edge_tool_outcome_status, execute_with_metadata_responsive,
         extract_cli_diff_block, format_tool_display_from_preview, is_edge_auth_failure,
-        merge_edge_tool_rounds, path_mtime_ms, reusable_speculative_output, style_tool_description,
-        sync_incremental_accum_state, sync_incremental_tool_result_state, task_preview_from_args,
-        theme, tool_completion_icon, tool_dedup_signature,
+        merge_edge_tool_rounds, normalize_sandbox_denied_outcome, path_mtime_ms,
+        reusable_speculative_output, style_tool_description, sync_incremental_accum_state,
+        sync_incremental_tool_result_state, task_preview_from_args, theme, tool_completion_icon,
+        tool_dedup_signature,
     };
     use crate::cli::chat_stream;
     use crate::cli::cli_config::cli_utils::{CredentialsFile, Profile, save_credentials};
@@ -7535,6 +7545,54 @@ mod tests {
         assert!(
             s2.lines_written >= 2,
             "md mode should still track lines_written"
+        );
+    }
+
+    #[test]
+    fn sandbox_denied_outcome_normalizes_legacy_prefix() {
+        let mut outcome = crate::edge_tools::ToolExecutionOutcome::error(
+            "SANDBOX_DENIED: Path '/tmp/out.md' is outside the project directory '/tmp/project'; sandbox approval is required for this external path."
+                .to_string(),
+        );
+
+        let message = normalize_sandbox_denied_outcome(&mut outcome).expect("sandbox denial");
+
+        assert_eq!(
+            message,
+            "Path '/tmp/out.md' is outside the project directory '/tmp/project'; sandbox approval is required for this external path."
+        );
+        assert_eq!(outcome.output, format!("Error: {message}"));
+        let fields = outcome.tool_result_fields.expect("metadata fields");
+        assert_eq!(
+            fields.get("error_kind").and_then(Value::as_str),
+            Some(crate::sandbox_retry::SANDBOX_DENIED_ERROR_KIND)
+        );
+        assert!(
+            !outcome
+                .output
+                .contains(crate::sandbox_retry::SANDBOX_DENIED_PREFIX)
+        );
+    }
+
+    #[test]
+    fn sandbox_denied_outcome_normalizes_metadata_only_result() {
+        let mut outcome = crate::edge_tools::ToolExecutionOutcome {
+            output: "Error: operation blocked by local policy".to_string(),
+            tool_result_fields: Some(crate::sandbox_retry::sandbox_denied_tool_result_fields(
+                "Path '/tmp/out.md' is outside the project directory '/tmp/project'; sandbox approval is required for this external path.",
+            )),
+            is_error: true,
+        };
+
+        let message = normalize_sandbox_denied_outcome(&mut outcome).expect("sandbox denial");
+
+        assert_eq!(
+            outcome.output,
+            "Error: Path '/tmp/out.md' is outside the project directory '/tmp/project'; sandbox approval is required for this external path."
+        );
+        assert_eq!(
+            message,
+            "Path '/tmp/out.md' is outside the project directory '/tmp/project'; sandbox approval is required for this external path."
         );
     }
 

--- a/rust/crates/astra-cli/src/cli/workspace_trust.rs
+++ b/rust/crates/astra-cli/src/cli/workspace_trust.rs
@@ -639,9 +639,9 @@ mod tests {
         let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         let path = kiro.join("permissions.json");
-        std::fs::write(&path, br#"{"allow":["Bash(ls:*)"]}"#).unwrap();
+        std::fs::write(&path, br#"{"allow":["Bash(argv_prefix=\"ls\")"]}"#).unwrap();
         let first = project_permissions_hash(dir.path()).unwrap();
-        std::fs::write(&path, br#"{"allow":["Bash(cargo test:*)"]}"#).unwrap();
+        std::fs::write(&path, br#"{"allow":["Bash(argv_prefix=\"cargo test\")"]}"#).unwrap();
         let second = project_permissions_hash(dir.path()).unwrap();
         assert_ne!(first, second);
     }
@@ -652,7 +652,7 @@ mod tests {
         let kiro = dir.path().join(".astra");
         std::fs::create_dir_all(&kiro).unwrap();
         let path = kiro.join("permissions.json");
-        std::fs::write(&path, br#"{"allow":["Bash(ls:*)"]}"#).unwrap();
+        std::fs::write(&path, br#"{"allow":["Bash(argv_prefix=\"ls\")"]}"#).unwrap();
         let trusted_hash = project_permissions_hash(dir.path()).unwrap();
 
         let ledger_path = dir.path().join("trusted_workspaces.json");
@@ -668,7 +668,7 @@ mod tests {
         let trusted = evaluate_workspace_trust_from_path(dir.path(), ledger_path.clone());
         assert!(trusted.applies_project_allow());
 
-        std::fs::write(&path, br#"{"allow":["Bash(cargo test:*)"]}"#).unwrap();
+        std::fs::write(&path, br#"{"allow":["Bash(argv_prefix=\"cargo test\")"]}"#).unwrap();
         let changed = evaluate_workspace_trust_from_path(dir.path(), ledger_path);
         assert!(!changed.applies_project_allow());
         assert_eq!(changed.reason, WorkspaceTrustReason::RulesHashChanged);

--- a/rust/crates/astra-cli/src/edge_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools.rs
@@ -24,6 +24,30 @@ use astra_turn_core::sync_utils::{
 /// The agentic loop / permission manager can detect this to prompt the user
 /// for authorization instead of letting the model silently fall back to bash.
 pub const SANDBOX_DENIED_PREFIX: &str = "SANDBOX_DENIED: ";
+
+/// Error returned by [`ToolExecutor::expand_sandbox_path`] when a path is
+/// rejected by the validation gate.
+///
+/// Every variant maps to a concrete, auditable rejection reason so callers
+/// (CLI flag parsing, TUI approval flow) can surface a precise message
+/// instead of a generic "denied".
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SandboxExpansionError {
+    /// The path was not absolute. Only absolute, concrete paths are expandable.
+    #[error("sandbox expansion requires an absolute path")]
+    NotAbsolute,
+    /// The path is the filesystem root `/`, which would open the entire
+    /// filesystem to the sandbox — always rejected.
+    #[error("sandbox expansion cannot open the filesystem root")]
+    RootPath,
+    /// The path contains a `..` component that escapes the supplied directory.
+    #[error("sandbox expansion rejects parent-dir traversal escapes")]
+    TraversalEscape,
+    /// The path is a system-sensitive directory or credential store whose
+    /// children include secrets (e.g. `/etc`, `~/.ssh`, `/var/run/secrets`).
+    #[error("sandbox expansion rejects system-sensitive path")]
+    SystemSensitivePath,
+}
 use crossterm::style::Stylize;
 use reqwest::Client;
 use serde_json::{Value, json};
@@ -4259,12 +4283,42 @@ impl ToolExecutor {
 
     /// Expand the sandbox boundary to include an additional directory.
     /// Called when the user approves access to a path outside the project.
-    pub fn expand_sandbox_path(&self, dir: PathBuf) {
+    ///
+    /// Validates the path before mutating the policy. Rejects:
+    /// - non-absolute paths ([`SandboxExpansionError::NotAbsolute`])
+    /// - the filesystem root `/` ([`SandboxExpansionError::RootPath`])
+    /// - parent-dir (`..`) traversal escapes ([`SandboxExpansionError::TraversalEscape`])
+    /// - system-sensitive directories and credential paths
+    ///   ([`SandboxExpansionError::SystemSensitivePath`])
+    ///
+    /// This is defense-in-depth: most call paths pre-validate via
+    /// `sandbox_retry::checked_expand_path`, but this gate ensures
+    /// user-supplied inputs (e.g. `--add-dir`, `ASTRA_CLI_ADD_DIRS`)
+    /// cannot open `/` or `/etc`.
+    pub fn expand_sandbox_path(&self, dir: PathBuf) -> Result<PathBuf, SandboxExpansionError> {
+        if !dir.is_absolute() {
+            return Err(SandboxExpansionError::NotAbsolute);
+        }
+        if dir == Path::new("/") {
+            return Err(SandboxExpansionError::RootPath);
+        }
+        if dir
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(SandboxExpansionError::TraversalEscape);
+        }
+        if astra_sandbox::is_sensitive_system_dir(&dir)
+            || astra_sandbox::is_never_readable_path(&dir)
+        {
+            return Err(SandboxExpansionError::SystemSensitivePath);
+        }
         if let Ok(mut guard) = self.sandbox_policy.write() {
             if let Some(ref mut policy) = *guard {
-                policy.allowed_paths.push(dir);
+                policy.allowed_paths.push(dir.clone());
             }
         }
+        Ok(dir)
     }
 
     /// Run passive workspace checks (optional **rust-analyzer LSP**, `cargo`, `tsc`) after

--- a/rust/crates/astra-cli/src/edge_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools.rs
@@ -440,6 +440,28 @@ fn cli_tool_output_is_error(output: &str) -> bool {
 
 pub(crate) use astra_tools::git_gix::ToolExecutionOutcome;
 
+fn sandbox_denied_outcome_from_output(output: &str) -> Option<ToolExecutionOutcome> {
+    let message = crate::sandbox_retry::sandbox_denied_message(output)?.into_owned();
+    Some(ToolExecutionOutcome {
+        output: format!("Error: {message}"),
+        tool_result_fields: Some(crate::sandbox_retry::sandbox_denied_tool_result_fields(
+            &message,
+        )),
+        is_error: true,
+    })
+}
+
+fn tool_execution_outcome_from_output(output: String) -> ToolExecutionOutcome {
+    if let Some(outcome) = sandbox_denied_outcome_from_output(&output) {
+        return outcome;
+    }
+    if cli_tool_output_is_error(&output) {
+        ToolExecutionOutcome::error(output)
+    } else {
+        ToolExecutionOutcome::ok(output)
+    }
+}
+
 struct EdgeToolRun {
     output: String,
     error_kind: Option<astra_core::ErrorKind>,
@@ -468,6 +490,10 @@ impl EdgeToolRun {
     }
 
     fn into_outcome(self) -> ToolExecutionOutcome {
+        if let Some(outcome) = sandbox_denied_outcome_from_output(&self.output) {
+            return outcome;
+        }
+
         let mut outcome = if self.error_kind.is_some() || cli_tool_output_is_error(&self.output) {
             ToolExecutionOutcome::error(self.output)
         } else {
@@ -4397,22 +4423,14 @@ impl ToolExecutor {
         if name == "bash" {
             let output = self.finalize_tool_output(self.bash_with_cancel(args, cancel_token), name);
             self.record_output_size(output.len());
-            return Some(if cli_tool_output_is_error(&output) {
-                ToolExecutionOutcome::error(output)
-            } else {
-                ToolExecutionOutcome::ok(output)
-            });
+            return Some(tool_execution_outcome_from_output(output));
         }
         #[cfg(windows)]
         if name == "powershell" {
             let output =
                 self.finalize_tool_output(self.powershell_with_cancel(args, cancel_token), name);
             self.record_output_size(output.len());
-            return Some(if cli_tool_output_is_error(&output) {
-                ToolExecutionOutcome::error(output)
-            } else {
-                ToolExecutionOutcome::ok(output)
-            });
+            return Some(tool_execution_outcome_from_output(output));
         }
         #[cfg(not(windows))]
         let _ = cancel_token; // powershell branch is the only other cancel-aware tool

--- a/rust/crates/astra-cli/src/edge_tools/file_state.rs
+++ b/rust/crates/astra-cli/src/edge_tools/file_state.rs
@@ -183,6 +183,17 @@ impl ToolExecutor {
             .any(|root| path.starts_with(root))
     }
 
+    pub(super) fn is_within_sandbox_boundary(&self, path: &Path) -> bool {
+        let guard = self
+            .sandbox_policy
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match guard.as_ref() {
+            Some(policy) => policy.is_path_allowed(path),
+            None => true,
+        }
+    }
+
     /// Get the mtime of a file in milliseconds. Returns 0 on error.
     pub(super) fn file_mtime_ms(path: &Path) -> u128 {
         fs::metadata(path)

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -21,6 +21,17 @@ fn is_unc_path(path: &str) -> bool {
     path.starts_with("\\\\") || path.starts_with("//")
 }
 
+fn expand_home_path_arg(path: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    if matches!(path, "~" | "$HOME" | "${HOME}") {
+        return Some(home);
+    }
+    path.strip_prefix("~/")
+        .or_else(|| path.strip_prefix("$HOME/"))
+        .or_else(|| path.strip_prefix("${HOME}/"))
+        .map(|suffix| home.join(suffix))
+}
+
 /// Append the stable [`TOOL_SUCCESS_SENTINEL`] to a human-readable success body.
 ///
 /// Contract (see `tool::result::semantics`): file-mutation emitters MUST emit
@@ -115,7 +126,14 @@ impl ToolExecutor {
         if is_unc_path(path) {
             return Err("Error: UNC/network paths are not supported (security risk)".to_string());
         }
-        let p = Path::new(path);
+        let expanded_home_path = expand_home_path_arg(path);
+        let path_for_validation = expanded_home_path
+            .as_ref()
+            .map(|path| path.to_string_lossy().into_owned());
+        let validation_path = path_for_validation.as_deref().unwrap_or(path);
+        let p = expanded_home_path
+            .as_deref()
+            .unwrap_or_else(|| Path::new(path));
         let resolved = if p.is_absolute() {
             p.to_path_buf()
         } else {
@@ -145,16 +163,16 @@ impl ToolExecutor {
             if let Some(ref policy) = *sp_guard
                 && !matches!(policy.isolation, IsolationLevel::Permissive)
             {
-                return validate_path(policy, path).map_err(|e| {
+                return validate_path(policy, validation_path).map_err(|e| {
                     if e.is_boundary_violation() {
                         // Use structured prefix so the agentic loop can detect sandbox
                         // denials and prompt the user for authorization instead of
                         // letting the model silently fall back to bash.
                         format!(
-                            "{}Path '{}' is outside the project directory '{}'. \
-                             Ask the user for permission before accessing files outside the project.",
+                            "{}Path '{}' is outside the project directory '{}'; \
+                             sandbox approval is required for this external path.",
                             SANDBOX_DENIED_PREFIX,
-                            path,
+                            validation_path,
                             policy.project_root.display(),
                         )
                     } else {
@@ -828,11 +846,11 @@ impl ToolExecutor {
         // symlink swaps (TOCTOU) between the initial resolve_checked and now.
         if path.exists() {
             if let Ok(canonical) = path.canonicalize() {
-                if !self.is_within_project_root(&canonical) {
+                if !self.is_within_sandbox_boundary(&canonical) {
                     return json!({
                         "success": false,
                         "error": format!(
-                            "Security: path '{}' was replaced with a symlink pointing outside the project",
+                            "Security: path '{}' was replaced with a symlink pointing outside the approved sandbox boundary",
                             path.display()
                         )
                     }).to_string();

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -6,7 +6,7 @@ use super::{
     SANDBOX_DENIED_PREFIX, ToolExecutor, code_intel, fuzzy_replacer, tool_output_limit,
     truncate_output,
 };
-use astra_runtime::tool_sandbox::{IsolationLevel, validate_path};
+use astra_runtime::tool_sandbox::validate_path;
 use astra_sandbox::is_internal_safe_path;
 use astra_tools::fs_ops::{
     check_anchor_vs_replacement_size, read_to_string_lossy, str_replace_fail,
@@ -160,9 +160,7 @@ impl ToolExecutor {
                 .sandbox_policy
                 .read()
                 .unwrap_or_else(|e| e.into_inner());
-            if let Some(ref policy) = *sp_guard
-                && !matches!(policy.isolation, IsolationLevel::Permissive)
-            {
+            if let Some(ref policy) = *sp_guard {
                 return validate_path(policy, validation_path).map_err(|e| {
                     if e.is_boundary_violation() {
                         // Use structured prefix so the agentic loop can detect sandbox

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -448,6 +448,10 @@ fn check_bash_path_boundary_with_oldpwd(
     command: &str,
     oldpwd: Option<&std::path::Path>,
 ) -> Option<String> {
+    if matches!(policy.isolation, IsolationLevel::Permissive) {
+        return check_bash_sensitive_path_boundary(policy, command, oldpwd);
+    }
+
     if let Some(msg) = check_shell_compound_body_path_boundary(policy, command, oldpwd) {
         return Some(msg);
     }
@@ -542,16 +546,55 @@ fn check_powershell_path_boundary(
                 policy.project_root.join(trimmed)
             };
             let path_str = resolved.to_string_lossy();
-            if let Err(e) = validate_path(policy, &path_str)
-                && e.is_boundary_violation()
+            if let Err(error) = validate_path(policy, &path_str) {
+                if error.is_boundary_violation() {
+                    return Some(format!(
+                        "{}The command references '{}' which is outside the project directory '{}'. \
+                         Ask the user for permission before accessing files outside the project.",
+                        SANDBOX_DENIED_PREFIX,
+                        trimmed,
+                        policy.project_root.display(),
+                    ));
+                }
+                return Some(format!("Sandbox: {error}"));
+            }
+        }
+    }
+    None
+}
+
+fn check_bash_sensitive_path_boundary(
+    policy: &astra_runtime::tool_sandbox::SandboxPolicy,
+    command: &str,
+    oldpwd: Option<&std::path::Path>,
+) -> Option<String> {
+    for segment in bash_command_segments(command) {
+        for raw in shell_tokenize_like_bash(segment) {
+            let token = raw
+                .trim_matches(|c| c == '"' || c == '\'' || c == '`')
+                .trim_end_matches([';', '&', ')', ',']);
+            if token.is_empty()
+                || token.starts_with('-')
+                || token.starts_with("http://")
+                || token.starts_with("https://")
+                || token.contains('*')
+                || token.contains('?')
             {
-                return Some(format!(
-                    "{}The command references '{}' which is outside the project directory '{}'. \
-                     Ask the user for permission before accessing files outside the project.",
-                    SANDBOX_DENIED_PREFIX,
-                    trimmed,
-                    policy.project_root.display(),
-                ));
+                continue;
+            }
+            let literal = restore_escaped_shell_analysis_chars(token);
+            let resolved = if literal.starts_with('/') {
+                std::path::PathBuf::from(&literal)
+            } else if let Some(expanded) = expand_static_dir_reference(policy, token, oldpwd) {
+                expanded
+            } else {
+                policy.project_root.join(&literal)
+            };
+            let path_str = resolved.to_string_lossy();
+            if let Err(error) = validate_path(policy, &path_str)
+                && !error.is_boundary_violation()
+            {
+                return Some(format!("Sandbox: {error}"));
             }
         }
     }
@@ -876,16 +919,17 @@ fn validate_plain_command_path_arg(
         policy.project_root.join(&literal_arg)
     };
     let path_str = resolved.to_string_lossy();
-    if let Err(e) = validate_path(policy, &path_str)
-        && e.is_boundary_violation()
-    {
-        return Some(format!(
-            "{}The command references '{}' which is outside the project directory '{}'. \
-             Ask the user for permission before accessing files outside the project.",
-            SANDBOX_DENIED_PREFIX,
-            literal_arg,
-            policy.project_root.display(),
-        ));
+    if let Err(error) = validate_path(policy, &path_str) {
+        if error.is_boundary_violation() {
+            return Some(format!(
+                "{}The command references '{}' which is outside the project directory '{}'. \
+                 Ask the user for permission before accessing files outside the project.",
+                SANDBOX_DENIED_PREFIX,
+                literal_arg,
+                policy.project_root.display(),
+            ));
+        }
+        return Some(format!("Sandbox: {error}"));
     }
     None
 }
@@ -4157,9 +4201,7 @@ impl ToolExecutor {
                 .sandbox_policy
                 .read()
                 .unwrap_or_else(|e| e.into_inner());
-            if let Some(ref policy) = *sp_guard
-                && !matches!(policy.isolation, IsolationLevel::Permissive)
-            {
+            if let Some(ref policy) = *sp_guard {
                 if let Some(msg) = check_bash_path_boundary(policy, &command) {
                     return Err(msg);
                 }
@@ -4442,9 +4484,7 @@ impl ToolExecutor {
                 .sandbox_policy
                 .read()
                 .unwrap_or_else(|e| e.into_inner());
-            if let Some(ref policy) = *sp_guard
-                && !matches!(policy.isolation, IsolationLevel::Permissive)
-            {
+            if let Some(ref policy) = *sp_guard {
                 if let Some(msg) = check_powershell_path_boundary(policy, command) {
                     return msg;
                 }
@@ -5784,13 +5824,32 @@ mod tests {
     // ── resolve_checked sandbox ──────────────────────────────────────────────
 
     #[test]
-    fn resolve_checked_with_permissive_sandbox_allows_all() {
+    fn resolve_checked_with_permissive_sandbox_allows_ordinary_external_paths() {
         use astra_runtime::tool_sandbox::SandboxPolicy;
         let dir = tempfile::tempdir().unwrap();
         let executor = ToolExecutor::new(dir.path());
         *executor.sandbox_policy.write().unwrap() = Some(SandboxPolicy::permissive(dir.path()));
         let result = executor.resolve_checked("/etc/passwd");
         assert!(result.is_ok(), "should allow with permissive: {result:?}");
+    }
+
+    #[test]
+    fn resolve_checked_with_permissive_sandbox_blocks_sensitive_paths() {
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let dir = tempfile::tempdir().unwrap();
+        let sensitive_path = dir.path().join(".ssh/id_rsa");
+        let executor = ToolExecutor::new(dir.path());
+        *executor.sandbox_policy.write().unwrap() = Some(SandboxPolicy::permissive(dir.path()));
+
+        let err = executor
+            .resolve_checked(&sensitive_path.to_string_lossy())
+            .unwrap_err();
+
+        assert!(err.contains("sensitive credential path"), "{err}");
+        assert!(
+            !err.starts_with(super::SANDBOX_DENIED_PREFIX),
+            "sensitive paths are bypass-immune, not expandable sandbox boundaries: {err}"
+        );
     }
 
     #[test]
@@ -5876,11 +5935,26 @@ mod tests {
     }
 
     #[test]
-    fn bash_path_boundary_permissive_skips_check() {
+    fn bash_path_boundary_permissive_allows_ordinary_external_paths() {
         use astra_runtime::tool_sandbox::SandboxPolicy;
         let policy = SandboxPolicy::permissive("/home/user/project");
         let result = check_bash_path_boundary(&policy, "cat /etc/passwd");
         assert!(result.is_none(), "permissive mode should allow everything");
+    }
+
+    #[test]
+    fn bash_path_boundary_permissive_blocks_sensitive_paths() {
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let policy = SandboxPolicy::permissive("/home/user/project");
+
+        let result = check_bash_path_boundary(&policy, "cat /home/user/.ssh/id_rsa")
+            .expect("permissive should still block sensitive credential paths");
+
+        assert!(result.contains("sensitive credential path"), "{result}");
+        assert!(
+            !result.starts_with(super::SANDBOX_DENIED_PREFIX),
+            "sensitive paths are not expandable sandbox boundaries: {result}"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -556,7 +556,7 @@ fn check_powershell_path_boundary(
                         policy.project_root.display(),
                     ));
                 }
-                return Some(format!("Sandbox: {error}"));
+                return Some(format!("{SANDBOX_DENIED_PREFIX}Sandbox: {error}"));
             }
         }
     }
@@ -917,7 +917,7 @@ fn validate_plain_command_path_arg(
                 policy.project_root.display(),
             ));
         }
-        return Some(format!("Sandbox: {error}"));
+        return Some(format!("{SANDBOX_DENIED_PREFIX}Sandbox: {error}"));
     }
     None
 }
@@ -5813,8 +5813,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let executor = ToolExecutor::new(dir.path());
         *executor.sandbox_policy.write().unwrap() = Some(SandboxPolicy::permissive(dir.path()));
-        let result = executor.resolve_checked("/etc/passwd");
-        assert!(result.is_ok(), "should allow with permissive: {result:?}");
+        let result = executor.resolve_checked("/usr/bin/cat");
+        assert!(
+            result.is_ok(),
+            "should allow ordinary external path with permissive: {result:?}"
+        );
     }
 
     #[test]
@@ -5856,7 +5859,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let executor = ToolExecutor::new(dir.path());
         *executor.sandbox_policy.write().unwrap() = Some(SandboxPolicy::for_project(dir.path()));
-        let err = executor.resolve_checked("/etc/passwd").unwrap_err();
+        let err = executor.resolve_checked("/usr/bin/cat").unwrap_err();
         assert!(
             err.starts_with(super::SANDBOX_DENIED_PREFIX),
             "boundary violation should have SANDBOX_DENIED prefix: {err}"

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -4362,7 +4362,7 @@ impl ToolExecutor {
             Ok(invocation) => invocation,
             Err(message) => {
                 self.restore_bash_detach_handle(slot, handle).await;
-                return Some(super::ToolExecutionOutcome::error(message));
+                return Some(super::tool_execution_outcome_from_output(message));
             }
         };
         let config =
@@ -4376,11 +4376,7 @@ impl ToolExecutor {
                 let output =
                     self.finalize_tool_output(self.render_bash_output(&command, out), "bash");
                 self.record_output_size(output.len());
-                Some(if output.starts_with("Error") {
-                    super::ToolExecutionOutcome::error(output)
-                } else {
-                    super::ToolExecutionOutcome::ok(output)
-                })
+                Some(super::tool_execution_outcome_from_output(output))
             }
             Ok(DetachableShellOutput::Detached {
                 payload,

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -564,41 +564,29 @@ fn check_powershell_path_boundary(
 }
 
 fn check_bash_sensitive_path_boundary(
-    policy: &astra_runtime::tool_sandbox::SandboxPolicy,
+    _policy: &astra_runtime::tool_sandbox::SandboxPolicy,
     command: &str,
-    oldpwd: Option<&std::path::Path>,
+    _oldpwd: Option<&std::path::Path>,
 ) -> Option<String> {
-    for segment in bash_command_segments(command) {
-        for raw in shell_tokenize_like_bash(segment) {
-            let token = raw
-                .trim_matches(|c| c == '"' || c == '\'' || c == '`')
-                .trim_end_matches([';', '&', ')', ',']);
-            if token.is_empty()
-                || token.starts_with('-')
-                || token.starts_with("http://")
-                || token.starts_with("https://")
-                || token.contains('*')
-                || token.contains('?')
-            {
-                continue;
-            }
-            let literal = restore_escaped_shell_analysis_chars(token);
-            let resolved = if literal.starts_with('/') {
-                std::path::PathBuf::from(&literal)
-            } else if let Some(expanded) = expand_static_dir_reference(policy, token, oldpwd) {
-                expanded
-            } else {
-                policy.project_root.join(&literal)
-            };
-            let path_str = resolved.to_string_lossy();
-            if let Err(error) = validate_path(policy, &path_str)
-                && !error.is_boundary_violation()
-            {
-                return Some(format!("Sandbox: {error}"));
-            }
+    let args = serde_json::json!({ "command": command });
+    let hit = astra_turn_core::permission::path_sensitivity::sensitive_path_match_for_tool_args(
+        "bash", &args,
+    )?;
+    let kind = match hit.sensitivity {
+        astra_turn_core::permission::path_sensitivity::PathSensitivity::InternalArtifactReadOnly(
+            _,
+        ) => "internal runtime artifact path",
+        astra_turn_core::permission::path_sensitivity::PathSensitivity::Sensitive => {
+            "sensitive credential path"
         }
-    }
-    None
+        astra_turn_core::permission::path_sensitivity::PathSensitivity::Normal => {
+            "sensitive path"
+        }
+    };
+    Some(format!(
+        "Sandbox: Path '{}' is blocked as a {kind}",
+        hit.token
+    ))
 }
 
 fn shell_tokenize_like_bash(input: &str) -> Vec<String> {
@@ -5892,7 +5880,11 @@ mod tests {
         ] {
             let result = check_bash_path_boundary(&policy, cmd);
             assert!(result.is_some(), "{label}: should block: {cmd}");
-            assert!(result.unwrap().starts_with(super::SANDBOX_DENIED_PREFIX));
+            let msg = result.unwrap();
+            assert!(
+                msg.starts_with(super::SANDBOX_DENIED_PREFIX),
+                "{label}: expected SANDBOX_DENIED prefix, got: {msg}"
+            );
         }
     }
 
@@ -5945,6 +5937,35 @@ mod tests {
 
         let result = check_bash_path_boundary(&policy, "cat /home/user/.ssh/id_rsa")
             .expect("permissive should still block sensitive credential paths");
+
+        assert!(result.contains("sensitive credential path"), "{result}");
+        assert!(
+            !result.starts_with(super::SANDBOX_DENIED_PREFIX),
+            "sensitive paths are not expandable sandbox boundaries: {result}"
+        );
+    }
+
+    #[test]
+    fn bash_path_boundary_permissive_allows_grep_pattern_mentioning_sensitive_name() {
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let policy = SandboxPolicy::permissive("/home/user/project");
+        let result = check_bash_path_boundary(
+            &policy,
+            r#"grep -n "fn resolve_checked\|sensitive credential\|SANDBOX_DENIED_PREFIX\|\.ssh\|credentials.json" rust/crates/astra-cli/src/edge_tools/shell.rs"#,
+        );
+
+        assert!(
+            result.is_none(),
+            "grep search text is data, not a filesystem access: {result:?}"
+        );
+    }
+
+    #[test]
+    fn bash_path_boundary_permissive_blocks_grep_sensitive_file_operand() {
+        use astra_runtime::tool_sandbox::SandboxPolicy;
+        let policy = SandboxPolicy::permissive("/home/user/project");
+        let result = check_bash_path_boundary(&policy, "grep -n needle ~/.ssh/id_rsa")
+            .expect("permissive should still block sensitive grep operands");
 
         assert!(result.contains("sensitive credential path"), "{result}");
         assert!(

--- a/rust/crates/astra-cli/src/edge_tools/tests/sandbox_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/sandbox_tests.rs
@@ -54,3 +54,39 @@ fn expand_sandbox_to_root_opens_everything() {
     assert!(exe.resolve_checked("/etc/passwd").is_ok());
     assert!(exe.resolve_checked("/var/secret").is_ok());
 }
+
+#[test]
+fn write_file_existing_external_file_respects_expanded_sandbox_boundary() {
+    let base = tempfile::tempdir_in(std::env::current_dir().unwrap()).unwrap();
+    let project = base.path().join("project");
+    let external = base.path().join("external");
+    std::fs::create_dir(&project).unwrap();
+    std::fs::create_dir(&external).unwrap();
+    let target = external.join("notes.md");
+    std::fs::write(&target, "old\n").unwrap();
+
+    let exe = ToolExecutor::new(&project);
+    let before_expand = exe.read_file(&serde_json::json!({
+        "path": target.to_string_lossy()
+    }));
+    assert!(
+        crate::sandbox_retry::is_sandbox_denied(&before_expand),
+        "{before_expand}"
+    );
+
+    exe.expand_sandbox_path(external);
+
+    let read = exe.read_file(&serde_json::json!({
+        "path": target.to_string_lossy()
+    }));
+    assert!(read.contains("old"), "{read}");
+
+    let result = exe.write_file(&serde_json::json!({
+        "path": target.to_string_lossy(),
+        "content": "new\n"
+    }));
+    let parsed: serde_json::Value = serde_json::from_str(&result).expect("write_file json");
+
+    assert_eq!(parsed["success"].as_bool(), Some(true), "{result}");
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "new\n");
+}

--- a/rust/crates/astra-cli/src/edge_tools/tests/sandbox_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/sandbox_tests.rs
@@ -90,3 +90,56 @@ fn write_file_existing_external_file_respects_expanded_sandbox_boundary() {
     assert_eq!(parsed["success"].as_bool(), Some(true), "{result}");
     assert_eq!(std::fs::read_to_string(&target).unwrap(), "new\n");
 }
+
+#[tokio::test]
+async fn execute_with_metadata_sandbox_denial_is_structured_and_hides_wire_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = ToolExecutor::new(dir.path());
+
+    let outcome = exe
+        .execute_with_metadata("read_file", &serde_json::json!({"path": "/etc/passwd"}))
+        .await;
+
+    assert!(outcome.is_error);
+    assert!(
+        !outcome
+            .output
+            .contains(crate::sandbox_retry::SANDBOX_DENIED_PREFIX),
+        "{}",
+        outcome.output
+    );
+    assert!(outcome.output.starts_with("Error: "), "{}", outcome.output);
+    let fields = outcome.tool_result_fields.expect("metadata fields");
+    assert_eq!(
+        fields.get("error_kind").and_then(serde_json::Value::as_str),
+        Some(crate::sandbox_retry::SANDBOX_DENIED_ERROR_KIND)
+    );
+}
+
+#[tokio::test]
+async fn cancelable_bash_sandbox_denial_is_structured_and_hides_wire_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = ToolExecutor::new(dir.path());
+
+    let outcome = exe
+        .execute_with_metadata_cancelable(
+            "bash",
+            &serde_json::json!({"command": "cat /etc/passwd"}),
+            None,
+        )
+        .await;
+
+    assert!(outcome.is_error);
+    assert!(
+        !outcome
+            .output
+            .contains(crate::sandbox_retry::SANDBOX_DENIED_PREFIX),
+        "{}",
+        outcome.output
+    );
+    let fields = outcome.tool_result_fields.expect("metadata fields");
+    assert_eq!(
+        fields.get("error_kind").and_then(serde_json::Value::as_str),
+        Some(crate::sandbox_retry::SANDBOX_DENIED_ERROR_KIND)
+    );
+}

--- a/rust/crates/astra-cli/src/edge_tools/tests/sandbox_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/sandbox_tests.rs
@@ -6,33 +6,44 @@ use super::ToolExecutor;
 
 #[test]
 fn expand_sandbox_path_adds_and_resolves() {
-    let dir = tempfile::tempdir().unwrap();
-    let exe = ToolExecutor::new(dir.path());
+    // Use tempdir_in(CWD) so the external dir is NOT under std::env::temp_dir()
+    // (which is pre-allowed by default_temp_allowed_paths) — this isolates the
+    // test to the expansion behavior rather than the default temp allowance.
+    let base = tempfile::tempdir_in(std::env::current_dir().unwrap()).unwrap();
+    let project = base.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let exe = ToolExecutor::new(&project);
 
-    // Before expansion: /etc is not allowed
+    let external_path = base.path().join("external");
+    std::fs::create_dir(&external_path).unwrap();
+    let target = external_path.join("notes.md");
+    std::fs::write(&target, "old\n").unwrap();
+    let target_str = target.to_string_lossy().into_owned();
+
+    // Before expansion: external file is not allowed.
     assert!(
         !exe.sandbox_policy
             .read()
             .unwrap()
             .as_ref()
             .unwrap()
-            .is_path_allowed(std::path::Path::new("/etc/passwd"))
+            .is_path_allowed(&target)
     );
-    assert!(exe.resolve_checked("/etc/passwd").is_err());
+    assert!(exe.resolve_checked(&target_str).is_err());
 
     // Expand
-    exe.expand_sandbox_path(PathBuf::from("/etc"));
+    exe.expand_sandbox_path(external_path.clone()).unwrap();
 
-    // After expansion: /etc is allowed via both APIs
+    // After expansion: target is allowed via both APIs.
     assert!(
         exe.sandbox_policy
             .read()
             .unwrap()
             .as_ref()
             .unwrap()
-            .is_path_allowed(std::path::Path::new("/etc/passwd"))
+            .is_path_allowed(&target)
     );
-    assert!(exe.resolve_checked("/etc/passwd").is_ok());
+    assert!(exe.resolve_checked(&target_str).is_ok());
 }
 
 #[test]
@@ -40,19 +51,75 @@ fn expand_sandbox_path_noop_without_policy() {
     let dir = tempfile::tempdir().unwrap();
     let exe = ToolExecutor::new(dir.path());
     *exe.sandbox_policy.write().unwrap() = None;
-    // Should not panic
-    exe.expand_sandbox_path(PathBuf::from("/etc"));
+    let external = tempfile::tempdir().unwrap();
+    // Should not panic; returns Ok (no-op) when no policy is installed.
+    exe.expand_sandbox_path(external.path().to_path_buf())
+        .unwrap();
 }
 
 #[test]
-fn expand_sandbox_to_root_opens_everything() {
+fn expand_sandbox_path_rejects_root() {
     let dir = tempfile::tempdir().unwrap();
     let exe = ToolExecutor::new(dir.path());
-    // Expanding to "/" opens the entire filesystem — this is why
-    // stream_render.rs must never pass "/" to expand_sandbox_path.
-    exe.expand_sandbox_path(PathBuf::from("/"));
-    assert!(exe.resolve_checked("/etc/passwd").is_ok());
-    assert!(exe.resolve_checked("/var/secret").is_ok());
+    // Expanding to "/" would open the entire filesystem — reject.
+    let err = exe
+        .expand_sandbox_path(PathBuf::from("/"))
+        .expect_err("root must be rejected");
+    assert!(matches!(
+        err,
+        crate::edge_tools::SandboxExpansionError::RootPath
+    ));
+    // Filesystem must remain closed.
+    assert!(exe.resolve_checked("/etc/passwd").is_err());
+    assert!(exe.resolve_checked("/var/secret").is_err());
+}
+
+#[test]
+fn expand_sandbox_path_rejects_system_sensitive_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = ToolExecutor::new(dir.path());
+    for sys in ["/etc", "/etc/passwd", "/etc/ssh", "/var/run/secrets"] {
+        let err = exe
+            .expand_sandbox_path(PathBuf::from(sys))
+            .expect_err("system-sensitive path must be rejected");
+        assert!(
+            matches!(
+                err,
+                crate::edge_tools::SandboxExpansionError::SystemSensitivePath
+            ),
+            "expected SystemSensitivePath for {sys}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn expand_sandbox_path_rejects_parent_dir_traversal() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = ToolExecutor::new(dir.path());
+    // Absolute path with a `..` component — must be rejected as a traversal
+    // escape, not as NotAbsolute.
+    let traversal = dir.path().join("subdir/..");
+    let err = exe
+        .expand_sandbox_path(traversal)
+        .expect_err("parent-dir traversal must be rejected");
+    assert!(matches!(
+        err,
+        crate::edge_tools::SandboxExpansionError::TraversalEscape
+    ));
+}
+
+#[test]
+fn expand_sandbox_path_rejects_relative_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = ToolExecutor::new(dir.path());
+    // Only absolute, concrete paths are expandable.
+    let err = exe
+        .expand_sandbox_path(PathBuf::from("relative/path"))
+        .expect_err("relative path must be rejected");
+    assert!(matches!(
+        err,
+        crate::edge_tools::SandboxExpansionError::NotAbsolute
+    ));
 }
 
 #[test]
@@ -74,7 +141,7 @@ fn write_file_existing_external_file_respects_expanded_sandbox_boundary() {
         "{before_expand}"
     );
 
-    exe.expand_sandbox_path(external);
+    exe.expand_sandbox_path(external).unwrap();
 
     let read = exe.read_file(&serde_json::json!({
         "path": target.to_string_lossy()
@@ -96,8 +163,14 @@ async fn execute_with_metadata_sandbox_denial_is_structured_and_hides_wire_prefi
     let dir = tempfile::tempdir().unwrap();
     let exe = ToolExecutor::new(dir.path());
 
+    // Use a non-sensitive path outside the sandbox boundary so the denial
+    // routes through the structured sandbox-denial path (not the
+    // never-readable short-circuit which /etc/passwd now triggers).
     let outcome = exe
-        .execute_with_metadata("read_file", &serde_json::json!({"path": "/etc/passwd"}))
+        .execute_with_metadata(
+            "read_file",
+            &serde_json::json!({"path": "/var/astra-sandbox-test-nonexistent"}),
+        )
         .await;
 
     assert!(outcome.is_error);
@@ -124,7 +197,7 @@ async fn cancelable_bash_sandbox_denial_is_structured_and_hides_wire_prefix() {
     let outcome = exe
         .execute_with_metadata_cancelable(
             "bash",
-            &serde_json::json!({"command": "cat /etc/passwd"}),
+            &serde_json::json!({"command": "cat /var/astra-sandbox-test-nonexistent"}),
             None,
         )
         .await;

--- a/rust/crates/astra-cli/src/sandbox_retry.rs
+++ b/rust/crates/astra-cli/src/sandbox_retry.rs
@@ -57,7 +57,7 @@ pub(crate) fn explicit_file_tool_path_args<'a>(tool: &str, args: &'a Value) -> V
     let mut paths = Vec::new();
     match tool {
         "read_file" | "write_file" | "str_replace" | "multi_edit" | "delete_file" | "list_dir"
-        | "grep" => {
+        | "grep" | "apply_patch" => {
             push_explicit_arg_path(&mut paths, args, "path");
         }
         "notebook_edit" => {
@@ -1313,5 +1313,24 @@ mod tests {
         // Step 3: the message body survives stripping.
         let body = sandbox_denied_message(tool_output).expect("body");
         assert!(body.contains("outside the project directory"));
+    }
+
+    // ── apply_patch must participate in preflight path extraction ──
+    // (Review C1-sandbox). Without this arm, sandbox denials for
+    // apply_patch paths never trigger the expand/retry flow.
+
+    #[test]
+    fn explicit_file_tool_path_args_covers_apply_patch() {
+        let args = json!({
+            "path": "/home/user/external-workspace/src/lib.rs",
+            "patch": "--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new"
+        });
+        let paths = super::explicit_file_tool_path_args("apply_patch", &args);
+        assert!(
+            paths.iter().any(|p| p
+                .as_ref()
+                .contains("/home/user/external-workspace/src/lib.rs")),
+            "apply_patch must surface its path for preflight; got {paths:?}"
+        );
     }
 }

--- a/rust/crates/astra-cli/src/sandbox_retry.rs
+++ b/rust/crates/astra-cli/src/sandbox_retry.rs
@@ -20,6 +20,203 @@ use std::path::{Component, Path, PathBuf};
 
 use serde_json::{Map, Value};
 
+#[derive(Debug, Clone)]
+pub(crate) struct ExplicitPathPreflightTarget {
+    pub(crate) tool: String,
+    pub(crate) args: Value,
+    pub(crate) path: String,
+}
+
+impl ExplicitPathPreflightTarget {
+    fn new(tool: impl Into<String>, args: Value, path: impl Into<String>) -> Self {
+        Self {
+            tool: tool.into(),
+            args,
+            path: path.into(),
+        }
+    }
+}
+
+fn push_unique_explicit_path<'a>(paths: &mut Vec<Cow<'a, str>>, path: Cow<'a, str>) {
+    if !paths
+        .iter()
+        .any(|existing| existing.as_ref() == path.as_ref())
+    {
+        paths.push(path);
+    }
+}
+
+fn push_explicit_arg_path<'a>(paths: &mut Vec<Cow<'a, str>>, args: &'a Value, key: &str) {
+    if let Some(path) = args.get(key).and_then(Value::as_str) {
+        push_unique_explicit_path(paths, Cow::Borrowed(path));
+    }
+}
+
+#[must_use]
+pub(crate) fn explicit_file_tool_path_args<'a>(tool: &str, args: &'a Value) -> Vec<Cow<'a, str>> {
+    let mut paths = Vec::new();
+    match tool {
+        "read_file" | "write_file" | "str_replace" | "multi_edit" | "delete_file" | "list_dir"
+        | "grep" => {
+            push_explicit_arg_path(&mut paths, args, "path");
+        }
+        "notebook_edit" => {
+            push_explicit_arg_path(&mut paths, args, "notebook_path");
+            push_explicit_arg_path(&mut paths, args, "path");
+        }
+        "glob" => {
+            push_explicit_arg_path(&mut paths, args, "path");
+            if paths.is_empty()
+                && let Some(base) = args
+                    .get("pattern")
+                    .and_then(Value::as_str)
+                    .and_then(glob_preflight_base_from_absolute_pattern)
+            {
+                push_unique_explicit_path(&mut paths, Cow::Owned(base));
+            }
+        }
+        "symbols" | "find_references" | "symbol_search" | "dead_code" | "call_graph"
+        | "rename_symbol" => {
+            push_explicit_arg_path(&mut paths, args, "path");
+        }
+        "find_definition" => {
+            push_explicit_arg_path(&mut paths, args, "path");
+            push_explicit_arg_path(&mut paths, args, "file");
+        }
+        "lsp" | "hover_info" | "extract_members" => {
+            push_explicit_arg_path(&mut paths, args, "file");
+        }
+        "bash" => {
+            if args
+                .get("command")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .is_some_and(astra_turn_core::cloud_approval_policy::bash_command_is_read_only)
+                && let Some(path) = sandbox_expand_dir_from_args(args)
+            {
+                push_unique_explicit_path(
+                    &mut paths,
+                    Cow::Owned(path.to_string_lossy().into_owned()),
+                );
+            }
+        }
+        "git" => {
+            if args.get("action").and_then(Value::as_str) == Some("worktree") {
+                let worktree_sub_action = args.get("sub_action").and_then(Value::as_str);
+                if matches!(worktree_sub_action, Some("add" | "remove")) {
+                    push_explicit_arg_path(&mut paths, args, "path");
+                }
+            }
+        }
+        "rollback_file_edits" => {
+            push_explicit_arg_path(&mut paths, args, "path");
+        }
+        "session" => {
+            if args.get("action").and_then(Value::as_str) == Some("rollback_edits") {
+                push_explicit_arg_path(&mut paths, args, "path");
+            }
+        }
+        _ => {}
+    }
+    paths
+}
+
+#[must_use]
+pub(crate) fn explicit_file_tool_path_arg<'a>(tool: &str, args: &'a Value) -> Option<Cow<'a, str>> {
+    explicit_file_tool_path_args(tool, args).into_iter().next()
+}
+
+#[must_use]
+pub(crate) fn explicit_file_tool_path_targets(
+    tool: &str,
+    args: &Value,
+) -> Vec<ExplicitPathPreflightTarget> {
+    let mut targets = Vec::new();
+    for path in explicit_file_tool_path_args(tool, args) {
+        targets.push(ExplicitPathPreflightTarget::new(
+            tool,
+            args.clone(),
+            path.into_owned(),
+        ));
+    }
+    if tool == "agent" && args.get("action").and_then(Value::as_str) == Some("run_chain") {
+        targets.extend(agent_run_chain_explicit_path_targets(args));
+    }
+    targets
+}
+
+fn agent_run_chain_explicit_path_targets(args: &Value) -> Vec<ExplicitPathPreflightTarget> {
+    let Ok(chain) = serde_json::from_value::<astra_runtime::tool_registry::ToolChain>(args.clone())
+    else {
+        return Vec::new();
+    };
+    let input = args
+        .get("input")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+    let ctx = astra_turn_core::tool_registry_chain::ChainContext::new(input);
+    chain
+        .steps
+        .into_iter()
+        .filter(|step| step.skip_if_prev_contains.is_none())
+        .filter(|step| !value_contains_chain_output_reference(&step.args))
+        .flat_map(|step| {
+            let resolved_args =
+                astra_turn_core::tool_registry_chain::resolve_args(&step.args, &ctx);
+            let tool = step.tool;
+            let paths = explicit_file_tool_path_args(&tool, &resolved_args)
+                .into_iter()
+                .map(Cow::into_owned)
+                .collect::<Vec<_>>();
+            paths
+                .into_iter()
+                .map(move |path| {
+                    ExplicitPathPreflightTarget::new(tool.clone(), resolved_args.clone(), path)
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn value_contains_chain_output_reference(value: &Value) -> bool {
+    match value {
+        Value::String(value) => value.contains("$prev") || value.contains("$step."),
+        Value::Array(values) => values.iter().any(value_contains_chain_output_reference),
+        Value::Object(map) => map.values().any(value_contains_chain_output_reference),
+        _ => false,
+    }
+}
+
+#[must_use]
+pub(crate) fn glob_preflight_base_from_absolute_pattern(pattern: &str) -> Option<String> {
+    if !Path::new(pattern).is_absolute()
+        || pattern.contains("~/")
+        || pattern.split(['/', '\\']).any(|part| part == "..")
+    {
+        return None;
+    }
+
+    let normalized = pattern.replace('\\', "/");
+    let parts: Vec<&str> = normalized.split('/').skip(1).collect();
+    let first_glob = parts.iter().position(|part| {
+        part.contains('*') || part.contains('?') || part.contains('[') || part.contains('{')
+    });
+
+    match first_glob {
+        Some(0) => Some("/".to_string()),
+        Some(index) => Some(format!("/{}", parts[..index].join("/"))),
+        None => {
+            let path = Path::new(pattern);
+            Some(
+                path.parent()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .filter(|p| !p.is_empty())
+                    .unwrap_or_else(|| "/".to_string()),
+            )
+        }
+    }
+}
+
 /// Derive which directory should be added to the sandbox's allow-list
 /// when a tool returned SANDBOX_DENIED for the given arguments.
 ///
@@ -527,16 +724,160 @@ fn quote_aware_tokens(input: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        SANDBOX_DENIED_ERROR_KIND, SANDBOX_DENIED_PREFIX, extract_first_absolute_path,
-        is_sandbox_denied, is_sandbox_denied_result, sandbox_denied_message,
-        sandbox_denied_message_from_result, sandbox_denied_tool_result_fields,
-        sandbox_expand_dir_from_args, sandbox_expand_dir_from_denial,
-        sandbox_retry_no_expand_dir_output,
+        SANDBOX_DENIED_ERROR_KIND, SANDBOX_DENIED_PREFIX, explicit_file_tool_path_arg,
+        explicit_file_tool_path_targets, extract_first_absolute_path,
+        glob_preflight_base_from_absolute_pattern, is_sandbox_denied, is_sandbox_denied_result,
+        sandbox_denied_message, sandbox_denied_message_from_result,
+        sandbox_denied_tool_result_fields, sandbox_expand_dir_from_args,
+        sandbox_expand_dir_from_denial, sandbox_retry_no_expand_dir_output,
     };
     use serde_json::json;
     use std::path::PathBuf;
 
     // ── sandbox_expand_dir_from_args ─────────────────────────────────────
+
+    #[test]
+    fn glob_preflight_base_splits_absolute_pattern_like_glob_tool() {
+        assert_eq!(
+            glob_preflight_base_from_absolute_pattern("/home/user/external-workspace/**/*.ts"),
+            Some("/home/user/external-workspace".to_string())
+        );
+        assert_eq!(
+            glob_preflight_base_from_absolute_pattern("/home/user/external-workspace/package.json"),
+            Some("/home/user/external-workspace".to_string())
+        );
+        assert_eq!(
+            glob_preflight_base_from_absolute_pattern("src/**/*.rs"),
+            None
+        );
+        assert_eq!(
+            glob_preflight_base_from_absolute_pattern("/home/user/../secret/**/*.rs"),
+            None
+        );
+    }
+
+    #[test]
+    fn explicit_targets_cover_static_paths_without_false_positive_patterns() {
+        let file_args = json!({"path": "/home/user/external-workspace/file.rs"});
+        for tool in [
+            "read_file",
+            "write_file",
+            "str_replace",
+            "multi_edit",
+            "delete_file",
+            "list_dir",
+            "grep",
+        ] {
+            assert_eq!(
+                explicit_file_tool_path_arg(tool, &file_args).as_deref(),
+                Some("/home/user/external-workspace/file.rs"),
+                "{tool} should expose its path for sandbox preflight"
+            );
+        }
+
+        let grep_args = json!({"pattern": "/home/user/external-workspace/**/*.rs"});
+        assert!(
+            explicit_file_tool_path_targets("grep", &grep_args).is_empty(),
+            "grep pattern is search text, not a filesystem path"
+        );
+
+        let glob_args = json!({"pattern": "/home/user/external-workspace/**/*.rs"});
+        let glob_targets = explicit_file_tool_path_targets("glob", &glob_args);
+        assert_eq!(glob_targets.len(), 1);
+        assert_eq!(glob_targets[0].path, "/home/user/external-workspace");
+
+        let git_args = json!({
+            "action": "worktree",
+            "sub_action": "add",
+            "branch": "feature/review",
+            "path": "/home/user/external-workspace/astra-feature-review"
+        });
+        let git_targets = explicit_file_tool_path_targets("git", &git_args);
+        assert_eq!(git_targets.len(), 1);
+        assert_eq!(
+            git_targets[0].path,
+            "/home/user/external-workspace/astra-feature-review"
+        );
+
+        let session_config_args = json!({
+            "action": "set_config",
+            "path": "display.max_output_lines",
+            "value": 120
+        });
+        assert!(
+            explicit_file_tool_path_arg("session", &session_config_args).is_none(),
+            "session config path is a configuration key, not a filesystem path"
+        );
+    }
+
+    #[test]
+    fn explicit_targets_cover_agent_run_chain_static_paths_only() {
+        let chain_args = json!({
+            "action": "run_chain",
+            "name": "external-chain",
+            "description": "external chain",
+            "steps": [
+                {
+                    "id": "read-static",
+                    "tool": "read_file",
+                    "args": {
+                        "path": "/home/user/external-workspace/static.md"
+                    }
+                },
+                {
+                    "id": "read-input",
+                    "tool": "read_file",
+                    "args": {
+                        "path": "$input.read_path"
+                    }
+                }
+            ],
+            "input": {
+                "read_path": "/home/user/external-workspace/input.md"
+            }
+        });
+        let chain_targets = explicit_file_tool_path_targets("agent", &chain_args);
+        let target_paths: Vec<_> = chain_targets
+            .iter()
+            .map(|target| (target.tool.as_str(), target.path.as_str()))
+            .collect();
+        assert_eq!(
+            target_paths,
+            vec![
+                ("read_file", "/home/user/external-workspace/static.md"),
+                ("read_file", "/home/user/external-workspace/input.md"),
+            ]
+        );
+
+        let dynamic_chain_args = json!({
+            "action": "run_chain",
+            "name": "dynamic-chain",
+            "description": "dynamic chain",
+            "steps": [
+                {
+                    "id": "first",
+                    "tool": "read_file",
+                    "args": {
+                        "path": "/home/user/external-workspace/static.md"
+                    }
+                },
+                {
+                    "id": "second",
+                    "tool": "read_file",
+                    "args": {
+                        "path": "$prev.path"
+                    }
+                }
+            ],
+            "input": {}
+        });
+        let dynamic_targets = explicit_file_tool_path_targets("agent", &dynamic_chain_args);
+        assert_eq!(dynamic_targets.len(), 1);
+        assert_eq!(
+            dynamic_targets[0].path,
+            "/home/user/external-workspace/static.md"
+        );
+    }
 
     #[test]
     fn expand_dir_from_read_file_path() {

--- a/rust/crates/astra-cli/src/sandbox_retry.rs
+++ b/rust/crates/astra-cli/src/sandbox_retry.rs
@@ -15,7 +15,8 @@
 //! stdin, no async state) so they can be unit-tested and called from
 //! both paths.
 
-use std::path::{Path, PathBuf};
+use std::borrow::Cow;
+use std::path::{Component, Path, PathBuf};
 
 use serde_json::Value;
 
@@ -23,72 +24,78 @@ use serde_json::Value;
 /// when a tool returned SANDBOX_DENIED for the given arguments.
 ///
 /// Priority:
-/// 1. `args.path` or `args.file_path` (file-tool shape) — take parent,
-///    or the file itself when the parent would be `/`.
-/// 2. `args.command` (bash shape) — extract first absolute path token
-///    and apply the same parent logic.
+/// 1. Explicit file path-like argument fields (`path`, `file_path`, `file`,
+///    `notebook_path`) - take parent, the path itself when it is an existing
+///    directory, or the file itself when the parent would be `/`.
+/// 2. Explicit working-directory fields (`cwd`, `workdir`, `working_dir`) -
+///    take the directory itself.
+/// 3. `args.command` (bash shape) - extract the first concrete path token
+///    (`/abs/path`, `~/path`, `$HOME/path`, or `${HOME}/path`) and apply the
+///    same parent logic.
 ///
-/// Returns `None` when no concrete path can be derived (e.g. tool
-/// arguments carry only relative paths — those are already inside the
-/// project root per the sandbox contract).
+/// Returns `None` when no safe concrete path can be derived (e.g. relative
+/// paths, traversal, ambiguous shell syntax, or protected credential paths).
 ///
-/// **Never returns `/`** — widening to root would defeat the sandbox.
+/// **Never returns `/` or a protected sensitive path** - widening either would
+/// defeat the sandbox contract.
 #[must_use]
 pub fn sandbox_expand_dir_from_args(args: &Value) -> Option<PathBuf> {
-    // Only absolute paths are candidates for sandbox expansion: relative
-    // paths are already inside the project root per the sandbox
-    // contract, so a SANDBOX_DENIED on a relative path indicates a
-    // different issue (the relative path resolved to outside via `../`
-    // traversal etc.) and the conservative move is to NOT auto-widen.
-    //
-    // We also reject paths containing `..` components: `canonicalize()`
-    // isn't safe here because the target file may not yet exist (e.g. a
-    // write tool creating a new file), so we can't resolve traversal
-    // reliably. A token like `/allowed/../etc/passwd` would otherwise
-    // widen to `/allowed` — but Path::parent is purely lexical and the
-    // real parent after `..` resolution is `/etc`. Refusing to expand
-    // keeps the sandbox tight; the user sees the original denial and
-    // can resubmit with a clean absolute path.
-    let parent_or_self = |p: &str| -> Option<PathBuf> {
-        let path = Path::new(p);
-        if !path.is_absolute() {
-            return None;
-        }
-        // Reject `..` / `.` traversal tokens — see note above.
-        // We check the raw string rather than Path::components because
-        // components() silently drops `.` (so `/./etc` would normalize
-        // to `/etc`) while we want to refuse the whole non-canonical
-        // input rather than guess at the author's intent.
-        for segment in p.split('/') {
-            if segment == ".." || segment == "." {
-                return None;
-            }
-        }
-        let parent = path.parent()?;
-        // Defensive: after normalization above, `parent == /` means the
-        // file sits directly under root (e.g. `/passwd`). Expand exactly
-        // the file, never the root directory.
-        if parent == Path::new("/") || parent.as_os_str().is_empty() {
-            Some(PathBuf::from(p))
-        } else {
-            Some(parent.to_path_buf())
-        }
-    };
-
-    if let Some(p) = args
-        .get("path")
-        .or_else(|| args.get("file_path"))
-        .and_then(Value::as_str)
-        && let Some(dir) = parent_or_self(p)
-    {
+    if let Some(dir) = sandbox_expand_dir_from_path_args(args) {
         return Some(dir);
     }
 
     args.get("command")
         .and_then(Value::as_str)
-        .and_then(extract_first_absolute_path)
-        .and_then(|p| parent_or_self(&p))
+        .and_then(extract_first_sandbox_expand_path)
+        .and_then(|p| sandbox_expand_dir_from_pathish(&p))
 }
+
+/// Derive a sandbox expansion directory from tool arguments and, when the
+/// arguments are not enough, from the sandbox-denied message itself.
+///
+/// This covers bash commands such as `cat ~/repo/file`: the command argument
+/// may not carry a literal absolute path, but the denial is recoverable because
+/// home-directory references resolve deterministically for the local executor.
+#[must_use]
+pub fn sandbox_expand_dir_from_denial(args: &Value, sandbox_msg: &str) -> Option<PathBuf> {
+    if let Some(dir) = sandbox_expand_dir_from_path_args(args) {
+        return Some(dir);
+    }
+
+    if let Some(dir) = sandbox_expand_dir_from_denial_message(sandbox_msg) {
+        return Some(dir);
+    }
+
+    args.get("command")
+        .and_then(Value::as_str)
+        .and_then(extract_first_sandbox_expand_path)
+        .and_then(|p| sandbox_expand_dir_from_pathish(&p))
+}
+
+fn sandbox_expand_dir_from_path_args(args: &Value) -> Option<PathBuf> {
+    for key in SANDBOX_PATH_ARG_KEYS {
+        if let Some(dir) = args
+            .get(*key)
+            .and_then(Value::as_str)
+            .and_then(sandbox_expand_dir_from_pathish)
+        {
+            return Some(dir);
+        }
+    }
+    for key in SANDBOX_DIR_ARG_KEYS {
+        if let Some(dir) = args
+            .get(*key)
+            .and_then(Value::as_str)
+            .and_then(sandbox_expand_dir_from_dir_pathish)
+        {
+            return Some(dir);
+        }
+    }
+    None
+}
+
+const SANDBOX_PATH_ARG_KEYS: &[&str] = &["path", "file_path", "file", "notebook_path"];
+const SANDBOX_DIR_ARG_KEYS: &[&str] = &["cwd", "workdir", "working_dir"];
 
 /// Extract the first absolute-path token from a bash command.
 ///
@@ -115,7 +122,7 @@ pub fn extract_first_absolute_path(command: &str) -> Option<String> {
         // Strip trailing shell punctuation (`;`, `&`, `)`) — a path
         // token followed by `;` or `&` is still a concrete absolute
         // path to the sandbox; we must not hand back the punctuation.
-        let token = raw.trim_end_matches([';', '&', ')']).to_string();
+        let token = trim_shell_path_token(&raw);
         if token.is_empty() {
             continue;
         }
@@ -131,17 +138,203 @@ pub fn extract_first_absolute_path(command: &str) -> Option<String> {
             if token.contains('$') {
                 continue;
             }
-            return Some(token);
+            return Some(token.to_string());
         }
         // Windows absolute path: `C:\...`. Avoids indexing past the end
         // for short tokens (pre-fix bug: `&token[1..3]` panicked on any
         // 2-char or shorter token).
         let bytes = token.as_bytes();
         if bytes.len() >= 3 && bytes[1] == b':' && (bytes[2] == b'\\' || bytes[2] == b'/') {
-            return Some(token);
+            return Some(token.to_string());
         }
     }
     None
+}
+
+fn extract_first_sandbox_expand_path(command: &str) -> Option<String> {
+    let tokens = quote_aware_tokens(command);
+    for raw in tokens {
+        let token = trim_shell_path_token(&raw);
+        if token.is_empty() {
+            continue;
+        }
+        if token.starts_with('/') {
+            if token.starts_with("//") || token.contains('$') {
+                continue;
+            }
+            return Some(token.to_string());
+        }
+        if is_home_reference(token) {
+            return Some(token.to_string());
+        }
+        let bytes = token.as_bytes();
+        if bytes.len() >= 3 && bytes[1] == b':' && (bytes[2] == b'\\' || bytes[2] == b'/') {
+            return Some(token.to_string());
+        }
+    }
+    None
+}
+
+fn sandbox_expand_dir_from_denial_message(message: &str) -> Option<PathBuf> {
+    let mut segments = message.split('\'');
+    let mut before = segments.next().unwrap_or_default();
+    while let Some(segment) = segments.next() {
+        let after = segments.next().unwrap_or_default();
+        if !quoted_segment_names_sandbox_boundary(before) {
+            if quoted_segment_is_sensitive_path(segment) {
+                return None;
+            }
+            if let Some(dir) = sandbox_expand_dir_from_pathish(segment) {
+                return Some(dir);
+            }
+        }
+        before = after;
+    }
+    None
+}
+
+fn quoted_segment_names_sandbox_boundary(before_quote: &str) -> bool {
+    let before_quote = before_quote.trim_end().to_ascii_lowercase();
+    before_quote.ends_with("project directory")
+        || before_quote.ends_with("project root")
+        || before_quote.ends_with("workspace directory")
+        || before_quote.ends_with("workspace root")
+}
+
+fn quoted_segment_is_sensitive_path(segment: &str) -> bool {
+    let token = trim_shell_path_token(segment);
+    let Some(path) = expand_concrete_pathish(token) else {
+        return false;
+    };
+    path.is_absolute() && sandbox_expand_path_is_sensitive(&path)
+}
+
+fn sandbox_expand_dir_from_pathish(pathish: &str) -> Option<PathBuf> {
+    let token = trim_shell_path_token(pathish);
+    if pathish_has_forbidden_segment(token) {
+        return None;
+    }
+    let path = expand_concrete_pathish(token)?;
+    checked_expand_path(path, false)
+}
+
+fn sandbox_expand_dir_from_dir_pathish(pathish: &str) -> Option<PathBuf> {
+    let token = trim_shell_path_token(pathish);
+    if pathish_has_forbidden_segment(token) {
+        return None;
+    }
+    let path = expand_concrete_pathish(token)?;
+    checked_expand_path(path, true)
+}
+
+fn checked_expand_path(path: PathBuf, directory_arg: bool) -> Option<PathBuf> {
+    if !path.is_absolute() || path == Path::new("/") {
+        return None;
+    }
+    if has_forbidden_component(&path) || sandbox_expand_path_is_sensitive(&path) {
+        return None;
+    }
+    if directory_arg || path.is_dir() {
+        return Some(path);
+    }
+
+    let parent = path.parent()?;
+    if parent == Path::new("/") || parent.as_os_str().is_empty() {
+        Some(path)
+    } else {
+        Some(parent.to_path_buf())
+    }
+}
+
+fn expand_concrete_pathish(token: &str) -> Option<PathBuf> {
+    if token.is_empty() || token.contains('\0') {
+        return None;
+    }
+    if let Some(home_path) = expand_home_reference(token) {
+        return Some(home_path);
+    }
+    if token.contains('$') {
+        return None;
+    }
+    let path = PathBuf::from(token);
+    path.is_absolute().then_some(path)
+}
+
+fn expand_home_reference(token: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    if matches!(token, "~" | "$HOME" | "${HOME}") {
+        return Some(home);
+    }
+    let suffix = token
+        .strip_prefix("~/")
+        .or_else(|| token.strip_prefix("$HOME/"))
+        .or_else(|| token.strip_prefix("${HOME}/"))?;
+    (!suffix.contains('$')).then(|| home.join(suffix))
+}
+
+fn is_home_reference(token: &str) -> bool {
+    matches!(token, "~" | "$HOME" | "${HOME}")
+        || token.starts_with("~/")
+        || token.starts_with("$HOME/")
+        || token.starts_with("${HOME}/")
+}
+
+fn trim_shell_path_token(token: &str) -> &str {
+    token
+        .trim()
+        .trim_matches(['"', '\''])
+        .trim_end_matches([';', '&', ')', ','])
+        .trim_matches(['"', '\''])
+}
+
+fn has_forbidden_component(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
+}
+
+fn pathish_has_forbidden_segment(pathish: &str) -> bool {
+    pathish
+        .split(['/', '\\'])
+        .any(|segment| matches!(segment, "." | ".."))
+}
+
+fn sandbox_expand_path_is_sensitive(path: &Path) -> bool {
+    let lower = path.to_string_lossy().to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "/etc/shadow" | "/etc/sudoers" | "/etc/passwd"
+    ) {
+        return true;
+    }
+    if lower.starts_with("/etc/sudoers.d/") {
+        return true;
+    }
+    for marker in [
+        "/.ssh",
+        "/.aws",
+        "/.kube",
+        "/.gnupg",
+        "/.azure",
+        "/.config/gh",
+        "/.config/gcloud",
+        "/.docker/config.json",
+        "/.git-credentials",
+        "/.netrc",
+    ] {
+        if lower == marker.trim_start_matches('/')
+            || lower.ends_with(marker)
+            || lower.contains(&format!("{marker}/"))
+        {
+            return true;
+        }
+    }
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    matches!(
+        file_name,
+        "id_rsa" | "id_ed25519" | "id_ecdsa" | "id_ed25519_sk" | ".env"
+    )
 }
 
 /// Prefix emitted by tool executors when a call is blocked by the
@@ -155,15 +348,43 @@ pub const SANDBOX_DENIED_PREFIX: &str = "SANDBOX_DENIED: ";
 /// one consumer.
 #[must_use]
 pub fn is_sandbox_denied(output: &str) -> bool {
-    output.starts_with(SANDBOX_DENIED_PREFIX)
+    sandbox_denied_message(output).is_some()
 }
 
 /// Strip the SANDBOX_DENIED_PREFIX and return just the message body.
 ///
 /// Returns `None` if the string doesn't carry the prefix.
 #[must_use]
-pub fn sandbox_denied_message(output: &str) -> Option<&str> {
-    output.strip_prefix(SANDBOX_DENIED_PREFIX)
+pub fn sandbox_denied_message(output: &str) -> Option<Cow<'_, str>> {
+    if let Some(message) = output.strip_prefix(SANDBOX_DENIED_PREFIX) {
+        return Some(Cow::Borrowed(message));
+    }
+
+    if let Ok(value) = serde_json::from_str::<Value>(output)
+        && let Some(message) = value
+            .get("error")
+            .or_else(|| value.get("message"))
+            .and_then(Value::as_str)
+            .and_then(|message| message.strip_prefix(SANDBOX_DENIED_PREFIX))
+    {
+        return Some(Cow::Owned(message.to_string()));
+    }
+
+    let trimmed = output.strip_prefix("Error: ").unwrap_or(output);
+    if trimmed.contains("outside the project directory")
+        && (trimmed.contains("sandbox approval") || trimmed.contains("Ask the user"))
+    {
+        return Some(Cow::Borrowed(trimmed.trim_end_matches('.')));
+    }
+
+    None
+}
+
+#[must_use]
+pub fn sandbox_retry_no_expand_dir_output(tool: &str, sandbox_msg: &str) -> String {
+    format!(
+        "Error: {tool} was blocked by the sandbox, but Astra could not safely choose a concrete non-sensitive directory to approve.\nPath check: {sandbox_msg}"
+    )
 }
 
 /// Minimal quote-aware tokenizer: splits on whitespace unless it's
@@ -175,8 +396,17 @@ fn quote_aware_tokens(input: &str) -> Vec<String> {
     let mut current = String::new();
     let mut in_single = false;
     let mut in_double = false;
+    let mut escaped = false;
     for ch in input.chars() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            continue;
+        }
         match ch {
+            '\\' if !in_single => {
+                escaped = true;
+            }
             '\'' if !in_double => {
                 in_single = !in_single;
             }
@@ -191,6 +421,9 @@ fn quote_aware_tokens(input: &str) -> Vec<String> {
             c => current.push(c),
         }
     }
+    if escaped {
+        current.push('\\');
+    }
     if !current.is_empty() {
         tokens.push(current);
     }
@@ -201,7 +434,8 @@ fn quote_aware_tokens(input: &str) -> Vec<String> {
 mod tests {
     use super::{
         SANDBOX_DENIED_PREFIX, extract_first_absolute_path, is_sandbox_denied,
-        sandbox_denied_message, sandbox_expand_dir_from_args,
+        sandbox_denied_message, sandbox_expand_dir_from_args, sandbox_expand_dir_from_denial,
+        sandbox_retry_no_expand_dir_output,
     };
     use serde_json::json;
     use std::path::PathBuf;
@@ -237,6 +471,27 @@ mod tests {
         assert_eq!(
             sandbox_expand_dir_from_args(&args),
             Some(PathBuf::from("/home/user/outside"))
+        );
+    }
+
+    #[test]
+    fn expand_dir_from_home_reference_path_arg() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let args = json!({"path": "~/astra-review-guide.md"});
+        assert_eq!(sandbox_expand_dir_from_args(&args), Some(home));
+    }
+
+    #[test]
+    fn expand_dir_from_bash_home_env_reference() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let args = json!({"command": "cat ${HOME}/external-workspace/Tool.ts"});
+        assert_eq!(
+            sandbox_expand_dir_from_args(&args),
+            Some(home.join("external-workspace"))
         );
     }
 
@@ -300,6 +555,15 @@ mod tests {
     }
 
     #[test]
+    fn expand_dir_handles_shell_escaped_spaces_in_command_paths() {
+        let args = json!({"command": r#"cat /home/user/My\ Project/report.md"#});
+        assert_eq!(
+            sandbox_expand_dir_from_args(&args),
+            Some(PathBuf::from("/home/user/My Project"))
+        );
+    }
+
+    #[test]
     fn expand_dir_rejects_parent_traversal_in_path() {
         // `/allowed/../etc/passwd` lexically has parent `/allowed/..`, which
         // Path::parent reports as `/allowed` — but after `..` resolution the
@@ -322,6 +586,63 @@ mod tests {
         // simpler contract than trying to partially-normalize.
         let args = json!({"path": "/./etc/hosts"});
         assert_eq!(sandbox_expand_dir_from_args(&args), None);
+    }
+
+    #[test]
+    fn expand_dir_rejects_sensitive_path_args() {
+        for args in [
+            json!({"path": "/home/user/.ssh/id_rsa"}),
+            json!({"path": "/etc/shadow"}),
+            json!({"cwd": "/home/user/.ssh"}),
+        ] {
+            assert_eq!(
+                sandbox_expand_dir_from_args(&args),
+                None,
+                "sandbox expansion must not derive a directory for sensitive path args: {args}"
+            );
+        }
+    }
+
+    #[test]
+    fn expand_dir_from_denial_message_when_args_are_not_enough() {
+        let args = json!({"command": "custom_reader --target outside"});
+        let message = "The command references '/home/user/external-workspace/Tool.ts' which is outside the project directory '/home/user/project'.";
+        assert_eq!(
+            sandbox_expand_dir_from_denial(&args, message),
+            Some(PathBuf::from("/home/user/external-workspace"))
+        );
+    }
+
+    #[test]
+    fn expand_dir_from_denial_message_home_reference() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let args = json!({"command": "cat ~/external-workspace/Tool.ts"});
+        let message = "The command references '~/external-workspace/Tool.ts' which is outside the project directory '/project'.";
+        assert_eq!(
+            sandbox_expand_dir_from_denial(&args, message),
+            Some(home.join("external-workspace"))
+        );
+    }
+
+    #[test]
+    fn expand_dir_from_denial_message_does_not_use_project_root_fallback() {
+        let args = json!({"path": "../secret.txt"});
+        let message = "Path '../secret.txt' is outside the project directory '/home/user/project'; sandbox approval is required for this external path.";
+        assert_eq!(sandbox_expand_dir_from_denial(&args, message), None);
+    }
+
+    #[test]
+    fn expand_dir_from_denial_message_rejects_sensitive_target() {
+        let args = json!({"command": "external_reader --target secret"});
+        let message =
+            "Path '/home/user/.ssh/id_rsa' is outside the project directory '/home/user/project'.";
+        assert_eq!(
+            sandbox_expand_dir_from_denial(&args, message),
+            None,
+            "sandbox retry must fail closed if a denial names a sensitive path"
+        );
     }
 
     // ── extract_first_absolute_path ──────────────────────────────────────
@@ -361,6 +682,14 @@ mod tests {
             !extract_first_absolute_path("echo '/a/b'")
                 .unwrap()
                 .contains('\'')
+        );
+    }
+
+    #[test]
+    fn extract_path_handles_shell_escaped_spaces() {
+        assert_eq!(
+            extract_first_absolute_path(r#"cat /path\ with\ spaces/file"#),
+            Some("/path with spaces/file".to_string())
         );
     }
 
@@ -413,6 +742,17 @@ mod tests {
     }
 
     #[test]
+    fn is_sandbox_denied_detects_structured_write_file_error() {
+        let output = json!({
+            "success": false,
+            "error": "SANDBOX_DENIED: Path '/home/user/out.md' is outside the project directory '/home/user/project'; sandbox approval is required for this external path."
+        })
+        .to_string();
+
+        assert!(is_sandbox_denied(&output));
+    }
+
+    #[test]
     fn is_sandbox_denied_rejects_non_prefixed() {
         assert!(!is_sandbox_denied("ok: file contents…"));
         assert!(!is_sandbox_denied(
@@ -423,12 +763,40 @@ mod tests {
     #[test]
     fn sandbox_denied_message_strips_prefix() {
         let msg = sandbox_denied_message("SANDBOX_DENIED: path outside").unwrap();
-        assert_eq!(msg, "path outside");
+        assert_eq!(msg.as_ref(), "path outside");
+    }
+
+    #[test]
+    fn sandbox_denied_message_strips_structured_error_prefix() {
+        let output = json!({
+            "success": false,
+            "error": "SANDBOX_DENIED: Path '/home/user/out.md' is outside the project directory '/home/user/project'; sandbox approval is required for this external path."
+        })
+        .to_string();
+
+        let msg = sandbox_denied_message(&output).unwrap();
+        assert_eq!(
+            msg.as_ref(),
+            "Path '/home/user/out.md' is outside the project directory '/home/user/project'; sandbox approval is required for this external path."
+        );
     }
 
     #[test]
     fn sandbox_denied_message_none_for_non_prefixed() {
         assert!(sandbox_denied_message("ok: contents").is_none());
+    }
+
+    #[test]
+    fn sandbox_retry_no_expand_dir_output_is_not_retryable_denial() {
+        let output = sandbox_retry_no_expand_dir_output(
+            "read_file",
+            "Path '../secret.txt' is outside the project directory '/home/user/project'.",
+        );
+
+        assert!(!output.contains(SANDBOX_DENIED_PREFIX));
+        assert!(!is_sandbox_denied(&output));
+        assert!(output.contains("concrete non-sensitive directory"));
+        assert!(output.contains("Path check:"));
     }
 
     // ── Integration invariant (regression guard for session 3b7ac18f)

--- a/rust/crates/astra-cli/src/sandbox_retry.rs
+++ b/rust/crates/astra-cli/src/sandbox_retry.rs
@@ -18,7 +18,7 @@
 use std::borrow::Cow;
 use std::path::{Component, Path, PathBuf};
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 /// Derive which directory should be added to the sandbox's allow-list
 /// when a tool returned SANDBOX_DENIED for the given arguments.
@@ -343,6 +343,16 @@ fn sandbox_expand_path_is_sensitive(path: &Path) -> bool {
 /// executor tree.
 pub const SANDBOX_DENIED_PREFIX: &str = "SANDBOX_DENIED: ";
 
+/// Stable structured error kind for sandbox boundary denials.
+///
+/// The visible output should be a human-readable `Error: ...` message; this
+/// metadata is the machine-readable retry signal.
+pub const SANDBOX_DENIED_ERROR_KIND: &str = "sandbox_denied";
+
+const ERROR_KIND_FIELD: &str = "error_kind";
+const MESSAGE_FIELD: &str = "message";
+const SANDBOX_DENIED_MESSAGE_FIELD: &str = "sandbox_denied_message";
+
 /// True when `output` is a sandbox-denied result from one of the edge
 /// tools. Keep this the single check site so the prefix contract has
 /// one consumer.
@@ -378,6 +388,90 @@ pub fn sandbox_denied_message(output: &str) -> Option<Cow<'_, str>> {
     }
 
     None
+}
+
+/// True when a tool result is a sandbox denial.
+///
+/// Prefer structured metadata (`error_kind=sandbox_denied`) over visible text.
+/// The legacy text parser remains as a compatibility fallback for older edge
+/// tool emitters.
+#[must_use]
+pub fn is_sandbox_denied_result(
+    output: &str,
+    tool_result_fields: Option<&Map<String, Value>>,
+) -> bool {
+    sandbox_denied_message_from_result(output, tool_result_fields).is_some()
+}
+
+/// Return the human-readable sandbox denial message from a tool result.
+///
+/// This is the result-level equivalent of [`sandbox_denied_message`]: metadata
+/// wins when present; otherwise we parse legacy visible output.
+#[must_use]
+pub fn sandbox_denied_message_from_result<'a>(
+    output: &'a str,
+    tool_result_fields: Option<&'a Map<String, Value>>,
+) -> Option<Cow<'a, str>> {
+    if let Some(fields) = tool_result_fields
+        && fields.get(ERROR_KIND_FIELD).and_then(Value::as_str) == Some(SANDBOX_DENIED_ERROR_KIND)
+    {
+        if let Some(message) = fields
+            .get(MESSAGE_FIELD)
+            .or_else(|| fields.get(SANDBOX_DENIED_MESSAGE_FIELD))
+            .and_then(Value::as_str)
+        {
+            return Some(normalize_sandbox_denied_message(message));
+        }
+        if let Some(message) = sandbox_denied_message(output) {
+            return Some(message);
+        }
+        let trimmed = output
+            .strip_prefix("Error: ")
+            .unwrap_or(output)
+            .trim()
+            .trim_end_matches('.');
+        if !trimmed.is_empty() {
+            return Some(Cow::Borrowed(trimmed));
+        }
+        return Some(Cow::Borrowed(
+            "Sandbox approval is required for this external path",
+        ));
+    }
+
+    sandbox_denied_message(output)
+}
+
+/// Build canonical metadata for a sandbox-denied tool result.
+#[must_use]
+pub fn sandbox_denied_tool_result_fields(message: &str) -> Map<String, Value> {
+    merge_sandbox_denied_tool_result_fields(None, message)
+}
+
+/// Merge sandbox-denied metadata into an existing tool result field map.
+#[must_use]
+pub fn merge_sandbox_denied_tool_result_fields(
+    existing: Option<Map<String, Value>>,
+    message: &str,
+) -> Map<String, Value> {
+    let mut fields = existing.unwrap_or_default();
+    fields.insert(
+        ERROR_KIND_FIELD.to_string(),
+        Value::String(SANDBOX_DENIED_ERROR_KIND.to_string()),
+    );
+    fields.insert(
+        MESSAGE_FIELD.to_string(),
+        Value::String(normalize_sandbox_denied_message(message).into_owned()),
+    );
+    fields
+}
+
+fn normalize_sandbox_denied_message(message: &str) -> Cow<'_, str> {
+    let message = message.strip_prefix("Error: ").unwrap_or(message);
+    if let Some(message) = message.strip_prefix(SANDBOX_DENIED_PREFIX) {
+        Cow::Borrowed(message)
+    } else {
+        Cow::Borrowed(message)
+    }
 }
 
 #[must_use]
@@ -433,8 +527,10 @@ fn quote_aware_tokens(input: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        SANDBOX_DENIED_PREFIX, extract_first_absolute_path, is_sandbox_denied,
-        sandbox_denied_message, sandbox_expand_dir_from_args, sandbox_expand_dir_from_denial,
+        SANDBOX_DENIED_ERROR_KIND, SANDBOX_DENIED_PREFIX, extract_first_absolute_path,
+        is_sandbox_denied, is_sandbox_denied_result, sandbox_denied_message,
+        sandbox_denied_message_from_result, sandbox_denied_tool_result_fields,
+        sandbox_expand_dir_from_args, sandbox_expand_dir_from_denial,
         sandbox_retry_no_expand_dir_output,
     };
     use serde_json::json;
@@ -784,6 +880,45 @@ mod tests {
     #[test]
     fn sandbox_denied_message_none_for_non_prefixed() {
         assert!(sandbox_denied_message("ok: contents").is_none());
+    }
+
+    #[test]
+    fn sandbox_denied_result_detects_metadata_without_wire_prefix() {
+        let fields = sandbox_denied_tool_result_fields(
+            "Path '/home/user/out.md' is outside the project directory '/home/user/project'; sandbox approval is required for this external path.",
+        );
+        let output = "Error: operation blocked by local policy";
+
+        assert!(is_sandbox_denied_result(output, Some(&fields)));
+        assert!(!is_sandbox_denied(output));
+    }
+
+    #[test]
+    fn sandbox_denied_result_message_prefers_metadata() {
+        let fields = sandbox_denied_tool_result_fields(
+            "Path '/tmp/out.md' is outside the project directory '/tmp/project'; sandbox approval is required for this external path.",
+        );
+
+        let msg = sandbox_denied_message_from_result("Error: generic fallback", Some(&fields))
+            .expect("metadata message");
+        assert_eq!(
+            msg.as_ref(),
+            "Path '/tmp/out.md' is outside the project directory '/tmp/project'; sandbox approval is required for this external path."
+        );
+    }
+
+    #[test]
+    fn sandbox_denied_result_fields_are_stable() {
+        let fields = sandbox_denied_tool_result_fields("SANDBOX_DENIED: path outside");
+
+        assert_eq!(
+            fields.get("error_kind").and_then(|value| value.as_str()),
+            Some(SANDBOX_DENIED_ERROR_KIND)
+        );
+        assert_eq!(
+            fields.get("message").and_then(|value| value.as_str()),
+            Some("path outside")
+        );
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/sandbox_retry.rs
+++ b/rust/crates/astra-cli/src/sandbox_retry.rs
@@ -100,21 +100,20 @@ pub(crate) fn explicit_file_tool_path_args<'a>(tool: &str, args: &'a Value) -> V
                 );
             }
         }
-        "git" => {
-            if args.get("action").and_then(Value::as_str) == Some("worktree") {
-                let worktree_sub_action = args.get("sub_action").and_then(Value::as_str);
-                if matches!(worktree_sub_action, Some("add" | "remove")) {
-                    push_explicit_arg_path(&mut paths, args, "path");
-                }
-            }
+        "git"
+            if args.get("action").and_then(Value::as_str) == Some("worktree")
+                && matches!(
+                    args.get("sub_action").and_then(Value::as_str),
+                    Some("add" | "remove")
+                ) =>
+        {
+            push_explicit_arg_path(&mut paths, args, "path");
         }
         "rollback_file_edits" => {
             push_explicit_arg_path(&mut paths, args, "path");
         }
-        "session" => {
-            if args.get("action").and_then(Value::as_str) == Some("rollback_edits") {
-                push_explicit_arg_path(&mut paths, args, "path");
-            }
+        "session" if args.get("action").and_then(Value::as_str) == Some("rollback_edits") => {
+            push_explicit_arg_path(&mut paths, args, "path");
         }
         _ => {}
     }
@@ -403,7 +402,7 @@ fn quoted_segment_is_sensitive_path(segment: &str) -> bool {
     let Some(path) = expand_concrete_pathish(token) else {
         return false;
     };
-    path.is_absolute() && sandbox_expand_path_is_sensitive(&path)
+    path.is_absolute() && astra_sandbox::is_sensitive_path(&path)
 }
 
 fn sandbox_expand_dir_from_pathish(pathish: &str) -> Option<PathBuf> {
@@ -428,7 +427,7 @@ fn checked_expand_path(path: PathBuf, directory_arg: bool) -> Option<PathBuf> {
     if !path.is_absolute() || path == Path::new("/") {
         return None;
     }
-    if has_forbidden_component(&path) || sandbox_expand_path_is_sensitive(&path) {
+    if has_forbidden_component(&path) || astra_sandbox::is_sensitive_path(&path) {
         return None;
     }
     if directory_arg || path.is_dir() {
@@ -493,45 +492,6 @@ fn pathish_has_forbidden_segment(pathish: &str) -> bool {
     pathish
         .split(['/', '\\'])
         .any(|segment| matches!(segment, "." | ".."))
-}
-
-fn sandbox_expand_path_is_sensitive(path: &Path) -> bool {
-    let lower = path.to_string_lossy().to_ascii_lowercase();
-    if matches!(
-        lower.as_str(),
-        "/etc/shadow" | "/etc/sudoers" | "/etc/passwd"
-    ) {
-        return true;
-    }
-    if lower.starts_with("/etc/sudoers.d/") {
-        return true;
-    }
-    for marker in [
-        "/.ssh",
-        "/.aws",
-        "/.kube",
-        "/.gnupg",
-        "/.azure",
-        "/.config/gh",
-        "/.config/gcloud",
-        "/.docker/config.json",
-        "/.git-credentials",
-        "/.netrc",
-    ] {
-        if lower == marker.trim_start_matches('/')
-            || lower.ends_with(marker)
-            || lower.contains(&format!("{marker}/"))
-        {
-            return true;
-        }
-    }
-    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    matches!(
-        file_name,
-        "id_rsa" | "id_ed25519" | "id_ecdsa" | "id_ed25519_sk" | ".env"
-    )
 }
 
 /// Prefix emitted by tool executors when a call is blocked by the
@@ -936,10 +896,10 @@ mod tests {
     fn expand_dir_from_bash_with_flags_and_pipes() {
         // Scanner must pick the path token regardless of position — not
         // just `parts[1]`. Real commands have flags before the path.
-        let args = json!({"command": "head -n 50 /etc/hosts | grep localhost"});
+        let args = json!({"command": "head -n 50 /tmp/hosts | grep localhost"});
         assert_eq!(
             sandbox_expand_dir_from_args(&args),
-            Some(PathBuf::from("/etc"))
+            Some(PathBuf::from("/tmp"))
         );
     }
 
@@ -984,10 +944,10 @@ mod tests {
 
     #[test]
     fn expand_dir_handles_quoted_paths_in_command() {
-        let args = json!({"command": "cat \"/etc/hosts\""});
+        let args = json!({"command": "cat \"/tmp/hosts\""});
         assert_eq!(
             sandbox_expand_dir_from_args(&args),
-            Some(PathBuf::from("/etc"))
+            Some(PathBuf::from("/tmp"))
         );
     }
 

--- a/rust/crates/astra-cli/src/tool_safety_guard.rs
+++ b/rust/crates/astra-cli/src/tool_safety_guard.rs
@@ -20,13 +20,13 @@ impl ToolSafetyGuard {
         perm_manager: Option<&mut crate::cli::permission_manager::PermissionManager>,
         name: &str,
         args: &Value,
-    ) -> crate::cli::permission_manager::PermissionDecision {
+    ) -> crate::cli::permission_manager::GateOutcome {
         if let Err(error) = Self::check_dispatch(name, args) {
-            return crate::cli::permission_manager::PermissionDecision::Deny(error);
+            return crate::cli::permission_manager::GateOutcome::Deny(error);
         }
         match perm_manager {
             Some(pm) => pm.check_nonblocking(name, args),
-            None => crate::cli::permission_manager::PermissionDecision::Allow,
+            None => crate::cli::permission_manager::GateOutcome::Allow,
         }
     }
 
@@ -110,7 +110,7 @@ fn is_mutating_tool(name: &str, args: Option<&Value>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{MAX_RUN_CHAIN_MUTATING_STEPS, ToolSafetyGuard};
-    use crate::cli::permission_manager::{PermissionDecision, PermissionManager};
+    use crate::cli::permission_manager::{GateOutcome, PermissionManager};
     use astra_runtime::tool_registry::ToolChain;
     use serde_json::json;
 
@@ -184,7 +184,7 @@ mod tests {
         );
 
         match decision {
-            PermissionDecision::Deny(reason) => {
+            GateOutcome::Deny(reason) => {
                 assert!(reason.contains("blocked by default"));
             }
             other => panic!("expected deny, got: {other:?}"),
@@ -200,7 +200,7 @@ mod tests {
             &json!({"path": "file.txt", "content": "x"}),
         );
 
-        assert!(matches!(decision, PermissionDecision::NeedApproval { .. }));
+        assert!(matches!(decision, GateOutcome::NeedApproval { .. }));
     }
 
     #[test]
@@ -213,7 +213,7 @@ mod tests {
         );
 
         match decision {
-            PermissionDecision::Deny(reason) => {
+            GateOutcome::Deny(reason) => {
                 assert!(reason.contains("shell_obfuscation"));
                 assert!(reason.contains("eval"));
             }

--- a/rust/crates/astra-cli/src/tui/approval/button_row.rs
+++ b/rust/crates/astra-cli/src/tui/approval/button_row.rs
@@ -4,7 +4,7 @@
 //! keys shift focus; Enter resolves the approval.
 //!
 //! When the pending queue contains more than one entry we prepend two
-//! **batch buttons** (Accept all / Reject all). Those are surfaced
+//! **batch buttons** (Yes to all / No to all). Those are surfaced
 //! through a separate constructor so the cell widget can render them on
 //! a dedicated row.
 
@@ -31,15 +31,15 @@ pub(crate) struct Button {
 /// Primary approval buttons in presentation order.
 pub(crate) const PRIMARY_BUTTONS: &[Button] = &[
     Button {
-        label: "Allow once",
+        label: "Yes",
         action: ButtonAction::Respond(ApprovalResponse::AllowOnce),
     },
     Button {
-        label: "Always allow",
+        label: "Yes, and don't ask again",
         action: ButtonAction::Respond(ApprovalResponse::AlwaysAllow),
     },
     Button {
-        label: "Reject",
+        label: "No",
         action: ButtonAction::Respond(ApprovalResponse::Deny),
     },
 ];
@@ -47,12 +47,12 @@ pub(crate) const PRIMARY_BUTTONS: &[Button] = &[
 /// Batch buttons shown when multiple approvals are pending.
 pub(crate) const BATCH_BUTTONS: &[Button] = &[
     Button {
-        label: "Accept all",
+        label: "Yes to all",
         action: ButtonAction::RespondAll(ApprovalResponse::AllowOnce),
     },
-    // Same one-shot semantics as the single Reject (P5e).
+    // Same one-shot semantics as the single No (P5e).
     Button {
-        label: "Reject all",
+        label: "No to all",
         action: ButtonAction::RespondAll(ApprovalResponse::Deny),
     },
 ];
@@ -61,23 +61,23 @@ pub(crate) const BATCH_BUTTONS: &[Button] = &[
 /// cell when the queue has more than one entry.
 pub(crate) const PRIMARY_WITH_BATCH: &[Button] = &[
     Button {
-        label: "Allow once",
+        label: "Yes",
         action: ButtonAction::Respond(ApprovalResponse::AllowOnce),
     },
     Button {
-        label: "Always allow",
+        label: "Yes, and don't ask again",
         action: ButtonAction::Respond(ApprovalResponse::AlwaysAllow),
     },
     Button {
-        label: "Reject",
+        label: "No",
         action: ButtonAction::Respond(ApprovalResponse::Deny),
     },
     Button {
-        label: "Accept all",
+        label: "Yes to all",
         action: ButtonAction::RespondAll(ApprovalResponse::AllowOnce),
     },
     Button {
-        label: "Reject all",
+        label: "No to all",
         action: ButtonAction::RespondAll(ApprovalResponse::Deny),
     },
 ];
@@ -106,7 +106,7 @@ impl ButtonRow {
         }
     }
 
-    /// Primary row plus Accept-all/Reject-all, used on a focused cell
+    /// Primary row plus Yes-to-all/No-to-all, used on a focused cell
     /// when more than one approval is pending.
     pub fn primary_with_batch() -> Self {
         Self {
@@ -145,7 +145,7 @@ impl ButtonRow {
         self.focus = (self.focus + 1) % self.buttons.len();
     }
 
-    /// Jump focus to the `Reject` button so Esc-as-default-reject can
+    /// Jump focus to the `No` button so Esc-as-default-reject can
     /// still reuse the same activation path when we prefer to.
     pub fn focus_reject(&mut self) {
         if let Some(pos) = self

--- a/rust/crates/astra-cli/src/tui/approval/button_row_tests.rs
+++ b/rust/crates/astra-cli/src/tui/approval/button_row_tests.rs
@@ -11,7 +11,7 @@ use crate::cli::chat_stream::ApprovalResponse;
 fn primary_row_has_simple_ux_buttons_in_expected_order() {
     let row = ButtonRow::primary();
     let labels: Vec<&str> = row.buttons().iter().map(|b| b.label).collect();
-    assert_eq!(labels, vec!["Allow once", "Always allow", "Reject"]);
+    assert_eq!(labels, vec!["Yes", "Yes, and don't ask again", "No"]);
 }
 
 #[test]
@@ -19,7 +19,7 @@ fn primary_row_starts_with_accept_focused() {
     let row = ButtonRow::primary();
     assert_eq!(row.focus(), 0);
     let focused = row.focused().expect("focused button");
-    assert_eq!(focused.label, "Allow once");
+    assert_eq!(focused.label, "Yes");
 }
 
 #[test]
@@ -38,7 +38,7 @@ fn right_arrow_advances_focus() {
     let mut row = ButtonRow::primary();
     row.move_right();
     assert_eq!(row.focus(), 1);
-    assert_eq!(row.focused().unwrap().label, "Always allow");
+    assert_eq!(row.focused().unwrap().label, "Yes, and don't ask again");
 }
 
 #[test]
@@ -111,11 +111,11 @@ fn primary_row_does_not_expose_legacy_scope_or_match_target_labels() {
 fn focus_reject_jumps_to_reject_regardless_of_origin() {
     let mut row = ButtonRow::primary();
     row.focus_reject();
-    assert_eq!(row.focused().unwrap().label, "Reject");
+    assert_eq!(row.focused().unwrap().label, "No");
 
     row.move_left(); // now on Always
     row.focus_reject();
-    assert_eq!(row.focused().unwrap().label, "Reject");
+    assert_eq!(row.focused().unwrap().label, "No");
 }
 
 // ─── Batch row ────────────────────────────────────────────────────
@@ -124,7 +124,7 @@ fn focus_reject_jumps_to_reject_regardless_of_origin() {
 fn batch_row_has_two_buttons() {
     let row = ButtonRow::batch();
     let labels: Vec<&str> = row.buttons().iter().map(|b| b.label).collect();
-    assert_eq!(labels, vec!["Accept all", "Reject all"]);
+    assert_eq!(labels, vec!["Yes to all", "No to all"]);
 }
 
 #[test]

--- a/rust/crates/astra-cli/src/tui/approval/queue.rs
+++ b/rust/crates/astra-cli/src/tui/approval/queue.rs
@@ -214,7 +214,7 @@ impl ApprovalMetadata {
 
     /// Issue #326 P4 / R2 Major 1: attach the wide UI
     /// grouping key. Same-group entries can be batch-resolved
-    /// together; cross-group "Accept all" is rejected by
+    /// together; cross-group "Yes to all" is rejected by
     /// `ApprovalBatchGroupKey::allows_accept_all` for
     /// destructive groups.
     #[must_use]
@@ -354,7 +354,7 @@ impl PendingApproval {
     fn selection_hint(&self) -> Option<String> {
         if self.always_uses_session_fallback() {
             return Some(
-                "Always allow stays session-only until you trust this workspace. Choose Trust Workspace or run `/allow trust` to save workspace rules."
+                "Don't ask again stays session-only until you trust this workspace. Choose Trust Workspace or run `/allow trust` to save workspace rules."
                     .to_string(),
             );
         }
@@ -648,7 +648,7 @@ impl ApprovalQueue {
     /// `None` group keys are intentionally not batchable: pressing a
     /// batch button on a legacy/ungrouped queue resolves only the
     /// focused entry, never the whole queue. For grouped approvals,
-    /// `Accept all` is further gated by
+    /// `Yes to all` is further gated by
     /// [`ApprovalBatchGroupKey::allows_accept_all`]; destructive groups
     /// must be approved item-by-item.
     ///
@@ -1208,11 +1208,11 @@ mod tests {
         assert_eq!(q.len(), 2);
         assert!(
             rx_a.try_recv().is_err(),
-            "dangerous Accept all must not send"
+            "dangerous Yes to all must not send"
         );
         assert!(
             rx_b.try_recv().is_err(),
-            "dangerous Accept all must not send"
+            "dangerous Yes to all must not send"
         );
 
         assert_eq!(q.respond_focused_group(ApprovalResponse::Deny), 2);
@@ -1247,13 +1247,13 @@ mod tests {
             ApprovalMetadata::default().with_batch_group_key(group),
         );
 
-        // Move from Allow once to Accept all (index 3).
+        // Move from Yes to Yes to all (index 3).
         for _ in 0..3 {
             q.focused_button_move_right();
         }
         assert!(
             q.focused_button_action().is_none(),
-            "dangerous groups must not activate Accept all"
+            "dangerous groups must not activate Yes to all"
         );
 
         q.focused_button_move_right();
@@ -1262,7 +1262,7 @@ mod tests {
             Some(super::super::button_row::ButtonAction::RespondAll(
                 ApprovalResponse::Deny
             )),
-            "Reject all remains available for dangerous groups"
+            "No to all remains available for dangerous groups"
         );
     }
 
@@ -1280,14 +1280,14 @@ mod tests {
             ApprovalMetadata::default().with_workspace_untrusted(true),
         );
 
-        // Allow once -> Always.
+        // Yes -> don't ask again.
         q.focused_button_move_right();
         assert_eq!(
             q.focused_button_action(),
             Some(super::super::button_row::ButtonAction::Respond(
                 ApprovalResponse::AlwaysAllow
             )),
-            "benign untrusted-workspace request should keep Always available via session fallback"
+            "benign untrusted-workspace request should keep don't-ask-again available via session fallback"
         );
 
         q.focused_button_move_left();
@@ -1296,7 +1296,7 @@ mod tests {
             Some(super::super::button_row::ButtonAction::Respond(
                 ApprovalResponse::AllowOnce
             )),
-            "Allow once remains available for untrusted workspaces"
+            "Yes remains available for untrusted workspaces"
         );
     }
 
@@ -1364,7 +1364,7 @@ mod tests {
         assert_eq!(
             view.selection_hint.as_deref(),
             Some(
-                "Always allow stays session-only until you trust this workspace. Choose Trust Workspace or run `/allow trust` to save workspace rules."
+                "Don't ask again stays session-only until you trust this workspace. Choose Trust Workspace or run `/allow trust` to save workspace rules."
             )
         );
     }

--- a/rust/crates/astra-cli/src/tui/bottom_pane/approval_integration_tests.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/approval_integration_tests.rs
@@ -107,7 +107,7 @@ fn right_moves_focus_to_always_and_enter_remembers_workspace_default() {
     let mut bp = BottomPane::new();
     let rx = enqueue(&mut bp, "bash");
 
-    // Allow once -> Always
+    // Yes -> don't ask again
     let _ = bp.handle_key(special(KeyCode::Right));
     let _ = bp.handle_key(special(KeyCode::Enter));
     assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::AlwaysAllow);
@@ -390,7 +390,7 @@ fn activation_single_vs_batch_reports_correct_variant() {
 fn down_moves_focus_like_right() {
     let mut bp = BottomPane::new();
     let rx = enqueue(&mut bp, "bash");
-    // Down from Allow once -> Always.
+    // Down from Yes -> don't ask again.
     let _ = bp.handle_key(special(KeyCode::Down));
     let _ = bp.handle_key(special(KeyCode::Enter));
     assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::AlwaysAllow);
@@ -400,7 +400,7 @@ fn down_moves_focus_like_right() {
 fn up_moves_focus_like_left_wrapping_to_reject() {
     let mut bp = BottomPane::new();
     let rx = enqueue(&mut bp, "bash");
-    // Up from Allow once wraps to the last button (Reject).
+    // Up from Yes wraps to the last button (No).
     let _ = bp.handle_key(special(KeyCode::Up));
     let _ = bp.handle_key(special(KeyCode::Enter));
     assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::Deny);
@@ -410,7 +410,7 @@ fn up_moves_focus_like_left_wrapping_to_reject() {
 fn primary_always_resolves_without_second_match_target_step() {
     let mut bp = BottomPane::new();
     let rx = enqueue(&mut bp, "bash");
-    // From Allow once (index 0), Down once lands on Always.
+    // From Yes (index 0), Down once lands on don't ask again.
     let _ = bp.handle_key(special(KeyCode::Down));
     let _ = bp.handle_key(special(KeyCode::Enter));
     assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::AlwaysAllow);

--- a/rust/crates/astra-cli/src/tui/bottom_pane/keyboard_tests.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/keyboard_tests.rs
@@ -68,20 +68,16 @@ fn backtab_cycles_mode_when_composer_has_text() {
 
 #[test]
 fn next_mode_cycle_full_loop_skips_deny() {
-    // Prompt → Auto → AcceptEdits → Plan → Prompt (wrap).
-    // Deny → Auto (same as Prompt — both return to Auto).
+    // Prompt → AcceptEdits → Plan → Auto → Prompt (wrap).
+    // Deny → AcceptEdits (same as Prompt).
     // Deny is intentionally excluded from the Shift+Tab cycle;
-    // cycling past it lands on Auto.
+    // cycling past it lands on the next everyday interactive mode.
     assert_eq!(
         next_permission_mode_for_cycle(PermissionMode::Prompt),
-        PermissionMode::Auto
+        PermissionMode::AcceptEdits
     );
     assert_eq!(
         next_permission_mode_for_cycle(PermissionMode::Deny),
-        PermissionMode::Auto
-    );
-    assert_eq!(
-        next_permission_mode_for_cycle(PermissionMode::Auto),
         PermissionMode::AcceptEdits
     );
     assert_eq!(
@@ -90,6 +86,10 @@ fn next_mode_cycle_full_loop_skips_deny() {
     );
     assert_eq!(
         next_permission_mode_for_cycle(PermissionMode::Plan),
+        PermissionMode::Auto
+    );
+    assert_eq!(
+        next_permission_mode_for_cycle(PermissionMode::Auto),
         PermissionMode::Prompt
     );
 }
@@ -97,10 +97,10 @@ fn next_mode_cycle_full_loop_skips_deny() {
 #[test]
 fn next_mode_cycle_starting_from_default() {
     // Starting from Prompt (the default), verify the first Shift+Tab
-    // goes to Auto.
+    // goes to Accept.
     assert_eq!(
         next_permission_mode_for_cycle(PermissionMode::Prompt),
-        PermissionMode::Auto
+        PermissionMode::AcceptEdits
     );
 }
 

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -3943,7 +3943,8 @@ mod tests {
             recursion_depth: 0,
             parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
-            inherited_permissions: None,
+            inherited_permissions: astra_runtime::orchestration::InheritedPermissions::auto_approve(
+            ),
             inherited_skills: Vec::new(),
             live_event_sink: None,
             trace_context: None,

--- a/rust/crates/astra-cli/src/tui/history_cell/approval.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/approval.rs
@@ -7,7 +7,7 @@
 //!   rm -rf /tmp/scratch
 //!   destructive path outside cwd
 //!
-//! ▸ Allow once    Always allow    Reject
+//! ▸ Yes    Yes, and don't ask again    No
 //!   ← → move · Enter confirm · Esc close
 //! ```
 //!
@@ -1019,12 +1019,13 @@ mod tests {
             true,
         )
         .with_selection_hint(
-            "Always allow stays session-only until you trust this workspace. Run `astra permissions trust` to save workspace rules.",
+            "Don't ask again stays session-only until you trust this workspace. Run `astra permissions trust` to save workspace rules.",
         );
         let rendered = render(&cell);
         assert!(
-            rendered
-                .contains("Note · Always allow stays session-only until you trust this workspace."),
+            rendered.contains(
+                "Note · Don't ask again stays session-only until you trust this workspace."
+            ),
             "selection hints should render as a note, got:\n{rendered}"
         );
         assert!(

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_100.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_100.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/approval.rs
+assertion_line: 1080
 expression: "render_at(&fixture_full(), 100)"
 ---
 ╭─ Approval · Bash
@@ -8,5 +9,5 @@ expression: "render_at(&fixture_full(), 100)"
 │ Needs approval before it runs.
 │ Remember · similar `npm test` commands in this workspace
 │
-│  Allow once   Always allow   Reject
+│  Yes   Yes, and don't ask again   No
 ╰─ ←→ move · Enter select · Esc close

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_160.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_160.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/approval.rs
+assertion_line: 1088
 expression: "render_at(&fixture_full(), 160)"
 ---
 ╭─ Approval · Bash
@@ -8,5 +9,5 @@ expression: "render_at(&fixture_full(), 160)"
 │ Needs approval before it runs.
 │ Remember · similar `npm test` commands in this workspace
 │
-│  Allow once   Always allow   Reject
+│  Yes   Yes, and don't ask again   No
 ╰─ ←→ move · Enter select · Esc close

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_80.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_80.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/approval.rs
+assertion_line: 1072
 expression: "render_at(&fixture_full(), 80)"
 ---
 ╭─ Approval · Bash
@@ -8,5 +9,5 @@ expression: "render_at(&fixture_full(), 80)"
 │ Needs approval before it runs.
 │ Remember · similar `npm test` commands in this workspace
 │
-│  Allow once   Always allow   Reject
+│  Yes   Yes, and don't ask again   No
 ╰─ ←→ move · Enter select · Esc close

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_agent_and_host_80.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_agent_and_host_80.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/approval.rs
+assertion_line: 1101
 expression: "render_at(&cell, 80)"
 ---
 ╭─ Approval · Bash · agent review-subagent · ssh:bastion-prod
@@ -9,5 +10,5 @@ expression: "render_at(&cell, 80)"
 │ Remember · similar `npm test` commands in this workspace
 │ Can't remember · sub-agent request
 │
-│  Allow once   Always allow   Reject
+│  Yes   Yes, and don't ask again   No
 ╰─ ←→ move · Enter select · Esc close

--- a/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_destructive_80.snap
+++ b/rust/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__approval__tests__approval_card_destructive_80.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/approval.rs
+assertion_line: 1123
 expression: "render_at(&cell, 80)"
 ---
 ╭─ Approval · Edit File
@@ -9,5 +10,5 @@ expression: "render_at(&cell, 80)"
 │ writes outside workspace
 │ Can't remember · outside workspace
 │
-│  Allow once   Always allow   Reject
+│  Yes   Yes, and don't ask again   No
 ╰─ ←→ move · Enter select · Esc close

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -1219,12 +1219,7 @@ fn build_permission_mode_picker(
             is_current: current == crate::cli::permission_manager::PermissionMode::Prompt,
         },
         SelectionItem {
-            name: "Auto".into(),
-            description: Some("All tools auto-approved".into()),
-            is_current: current == crate::cli::permission_manager::PermissionMode::Auto,
-        },
-        SelectionItem {
-            name: "Edit".into(),
+            name: "Accept".into(),
             description: Some(
                 "Auto-approve workspace edits; still ask for shell and external writes".into(),
             ),
@@ -1238,13 +1233,18 @@ fn build_permission_mode_picker(
             is_current: current == crate::cli::permission_manager::PermissionMode::Plan,
         },
         SelectionItem {
+            name: "Auto".into(),
+            description: Some("All tools auto-approved".into()),
+            is_current: current == crate::cli::permission_manager::PermissionMode::Auto,
+        },
+        SelectionItem {
             name: "Deny".into(),
             description: Some("Deny all tool calls".into()),
             is_current: current == crate::cli::permission_manager::PermissionMode::Deny,
         },
     ];
     ListSelectionView::new(items, Some("Modes".into())).with_footer_hint(
-        "Shift+Tab cycles ask → auto → edit → plan · /allow rules · /allow trust · /allow trace",
+        "Shift+Tab cycles ask → accept → plan → auto · /allow rules · /allow trust · /allow trace",
     )
 }
 
@@ -1254,10 +1254,10 @@ pub(crate) fn next_permission_mode_for_cycle(
     use crate::cli::permission_manager::PermissionMode;
 
     match current {
-        PermissionMode::Prompt | PermissionMode::Deny => PermissionMode::Auto,
-        PermissionMode::Auto => PermissionMode::AcceptEdits,
+        PermissionMode::Prompt | PermissionMode::Deny => PermissionMode::AcceptEdits,
         PermissionMode::AcceptEdits => PermissionMode::Plan,
-        PermissionMode::Plan => PermissionMode::Prompt,
+        PermissionMode::Plan => PermissionMode::Auto,
+        PermissionMode::Auto => PermissionMode::Prompt,
     }
 }
 
@@ -1269,7 +1269,7 @@ pub(crate) fn permission_mode_feedback(
     match mode {
         PermissionMode::Prompt => "Mode → Ask",
         PermissionMode::Auto => "Mode → Auto",
-        PermissionMode::AcceptEdits => "Mode → Edits",
+        PermissionMode::AcceptEdits => "Mode → Accept",
         PermissionMode::Plan => "Mode → Plan",
         PermissionMode::Deny => "Mode → Deny",
     }
@@ -1481,7 +1481,7 @@ pub(crate) fn handle_view_result(
             );
             return;
         }
-        "Edit" => {
+        "Accept" => {
             apply_permission_mode_selection(
                 state,
                 chat_widget,
@@ -4018,17 +4018,17 @@ mod view_result_tests {
     }
 
     #[test]
-    fn edit_selection_updates_state_and_commits_feedback() {
+    fn accept_selection_updates_state_and_commits_feedback() {
         let mut state = SessionState::default();
         let mut bottom_pane = BottomPane::new();
         let mut chat_widget = ChatWidget::new("");
 
-        handle_view_result("Edit", &mut state, &mut bottom_pane, &mut chat_widget);
+        handle_view_result("Accept", &mut state, &mut bottom_pane, &mut chat_widget);
 
         assert_eq!(state.perm_manager.mode(), PermissionMode::AcceptEdits);
         assert_eq!(
             last_system_message(&chat_widget).as_deref(),
-            Some("Mode → Edits")
+            Some("Mode → Accept")
         );
     }
 
@@ -4067,10 +4067,6 @@ mod view_result_tests {
     fn permission_mode_cycle_skips_deny_and_wraps() {
         assert_eq!(
             next_permission_mode_for_cycle(PermissionMode::Prompt),
-            PermissionMode::Auto
-        );
-        assert_eq!(
-            next_permission_mode_for_cycle(PermissionMode::Auto),
             PermissionMode::AcceptEdits
         );
         assert_eq!(
@@ -4079,11 +4075,15 @@ mod view_result_tests {
         );
         assert_eq!(
             next_permission_mode_for_cycle(PermissionMode::Plan),
+            PermissionMode::Auto
+        );
+        assert_eq!(
+            next_permission_mode_for_cycle(PermissionMode::Auto),
             PermissionMode::Prompt
         );
         assert_eq!(
             next_permission_mode_for_cycle(PermissionMode::Deny),
-            PermissionMode::Auto
+            PermissionMode::AcceptEdits
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/status_line/line.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/line.rs
@@ -362,13 +362,7 @@ const CWD_MAX_WIDTH: usize = 26;
 const PRIMARY_LEFT_FLOOR_WIDTH: usize = 14;
 
 fn permission_mode_label(mode: PermissionMode) -> &'static str {
-    match mode {
-        PermissionMode::Prompt => "Ask",
-        PermissionMode::Auto => "Auto",
-        PermissionMode::Plan => "Plan",
-        PermissionMode::AcceptEdits => "Edits",
-        PermissionMode::Deny => "Deny",
-    }
+    mode.chip_text()
 }
 
 impl StatusLine {

--- a/rust/crates/astra-cli/src/tui/status_line/tests.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/tests.rs
@@ -213,7 +213,7 @@ fn accept_edits_mode_renders_cyan_chip() {
     let chip = s
         .left
         .iter()
-        .find(|seg| seg.text == "Edits")
+        .find(|seg| seg.text == "Accept")
         .expect("accept_edits chip segment");
     assert_eq!(chip.style.fg, Some(ratatui::style::Color::Cyan));
     assert!(

--- a/rust/crates/astra-sandbox/src/lib.rs
+++ b/rust/crates/astra-sandbox/src/lib.rs
@@ -27,7 +27,10 @@ pub use git_safety::{
     GitSafetyViolation, is_bare_git_repo, is_soft_violation, validate_git_command,
 };
 pub use path::{SandboxPathError, canonicalize_parent_and_append, normalize_path, validate_path};
-pub use policy::{IsolationLevel, SandboxPolicy, is_never_readable_path};
+pub use policy::{
+    IsolationLevel, SandboxPolicy, is_never_readable_path, is_sensitive_path,
+    is_sensitive_system_dir,
+};
 pub use process_isolation::{
     CgroupGuard, IsolatedOutput, IsolationConfig, apply_cgroup, execute_isolated,
 };

--- a/rust/crates/astra-sandbox/src/lib.rs
+++ b/rust/crates/astra-sandbox/src/lib.rs
@@ -27,7 +27,7 @@ pub use git_safety::{
     GitSafetyViolation, is_bare_git_repo, is_soft_violation, validate_git_command,
 };
 pub use path::{SandboxPathError, canonicalize_parent_and_append, normalize_path, validate_path};
-pub use policy::{IsolationLevel, SandboxPolicy};
+pub use policy::{IsolationLevel, SandboxPolicy, is_never_readable_path};
 pub use process_isolation::{
     CgroupGuard, IsolatedOutput, IsolationConfig, apply_cgroup, execute_isolated,
 };

--- a/rust/crates/astra-sandbox/src/path.rs
+++ b/rust/crates/astra-sandbox/src/path.rs
@@ -1,6 +1,6 @@
 //! Path validation and boundary enforcement.
 
-use super::policy::{IsolationLevel, SandboxPolicy};
+use super::policy::{IsolationLevel, SandboxPolicy, is_never_readable_path};
 use std::path::{Path, PathBuf};
 
 /// Error type for path validation failures.
@@ -16,6 +16,8 @@ pub enum SandboxPathError {
     SymlinkEscape { requested: String, target: String },
     /// Path could not be resolved (doesn't exist, permission denied, etc.).
     ResolutionFailed { requested: String, reason: String },
+    /// Path matches a credential-bearing location that is blocked at every isolation level.
+    SensitivePath { requested: String },
 }
 
 impl std::fmt::Display for SandboxPathError {
@@ -40,6 +42,12 @@ impl std::fmt::Display for SandboxPathError {
             Self::ResolutionFailed { requested, reason } => {
                 write!(f, "Cannot resolve path '{requested}': {reason}")
             }
+            Self::SensitivePath { requested } => {
+                write!(
+                    f,
+                    "Path '{requested}' is blocked as a sensitive credential path"
+                )
+            }
         }
     }
 }
@@ -59,7 +67,8 @@ impl SandboxPathError {
 
 /// Validate and resolve a path against the sandbox policy.
 ///
-/// For Permissive isolation, returns the path as-is.
+/// For Permissive isolation, returns the path as-is except for bypass-immune
+/// credential paths that are blocked at every isolation level.
 /// For Standard/Strict isolation:
 /// 1. Resolves the path (relative to project_root or absolute)
 /// 2. Canonicalizes to resolve symlinks and `..` components
@@ -69,16 +78,6 @@ impl SandboxPathError {
 ///
 /// Returns `SandboxPathError` if the path escapes the boundary or can't be resolved.
 pub fn validate_path(policy: &SandboxPolicy, path: &str) -> Result<PathBuf, SandboxPathError> {
-    // Permissive isolation: no validation.
-    if policy.isolation == IsolationLevel::Permissive {
-        let p = Path::new(path);
-        return Ok(if p.is_absolute() {
-            p.to_path_buf()
-        } else {
-            policy.project_root.join(p)
-        });
-    }
-
     // Resolve the raw path
     let raw = Path::new(path);
     let resolved = if raw.is_absolute() {
@@ -86,6 +85,16 @@ pub fn validate_path(policy: &SandboxPolicy, path: &str) -> Result<PathBuf, Sand
     } else {
         policy.project_root.join(raw)
     };
+
+    if policy.isolation == IsolationLevel::Permissive {
+        let sensitive_candidate = sensitive_check_path(&resolved);
+        if is_never_readable_path(&resolved) || is_never_readable_path(&sensitive_candidate) {
+            return Err(SandboxPathError::SensitivePath {
+                requested: path.to_string(),
+            });
+        }
+        return Ok(resolved);
+    }
 
     // Resolve symlinks safely: canonicalize what exists, normalize the rest.
     // This mitigates TOCTOU attacks where a symlink is created between exists() and
@@ -105,6 +114,12 @@ pub fn validate_path(policy: &SandboxPolicy, path: &str) -> Result<PathBuf, Sand
         canonicalize_parent_and_append(&resolved)?
     };
 
+    if is_never_readable_path(&canonical) {
+        return Err(SandboxPathError::SensitivePath {
+            requested: path.to_string(),
+        });
+    }
+
     // Check boundary
     if policy.is_path_allowed(&canonical) {
         Ok(canonical)
@@ -115,6 +130,15 @@ pub fn validate_path(policy: &SandboxPolicy, path: &str) -> Result<PathBuf, Sand
             project_root: policy.project_root.display().to_string(),
         })
     }
+}
+
+fn sensitive_check_path(path: &Path) -> PathBuf {
+    if path.exists()
+        && let Ok(canonical) = path.canonicalize()
+    {
+        return canonical;
+    }
+    canonicalize_parent_and_append(path).unwrap_or_else(|_| normalize_path(path))
 }
 
 /// Normalize path without filesystem access (for non-existent files).
@@ -223,6 +247,27 @@ mod tests {
         // Allows dotdot escape
         let result = validate_path(&p, "../../etc/passwd");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn permissive_isolation_blocks_sensitive_credential_paths() {
+        let p = SandboxPolicy::permissive("/home/user/project");
+
+        for path in [
+            "/home/user/.ssh/id_rsa",
+            "/home/user/.aws/credentials",
+            "/etc/shadow",
+        ] {
+            let result = validate_path(&p, path);
+            assert!(result.is_err(), "permissive must block {path}");
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("sensitive credential path"),
+                "denial should name sensitive path policy"
+            );
+        }
     }
 
     // ── Standard isolation ───────────────────────────────────────────────

--- a/rust/crates/astra-sandbox/src/path.rs
+++ b/rust/crates/astra-sandbox/src/path.rs
@@ -55,8 +55,10 @@ impl std::fmt::Display for SandboxPathError {
 impl std::error::Error for SandboxPathError {}
 
 impl SandboxPathError {
-    /// Returns `true` when the error is a boundary violation (not a resolution failure).
-    /// Callers can use this to distinguish "needs user authorization" from "path is broken".
+    /// Returns `true` when the error is an expandable sandbox boundary
+    /// violation (not a resolution failure or bypass-immune sensitive path).
+    /// Callers can use this to distinguish "needs user authorization" from
+    /// "path is broken" and "path is never readable".
     pub fn is_boundary_violation(&self) -> bool {
         matches!(
             self,
@@ -398,6 +400,10 @@ mod tests {
         // Classification
         assert!(boundary.is_boundary_violation());
         assert!(symlink.is_boundary_violation());
+        let sensitive = SandboxPathError::SensitivePath {
+            requested: "~/.ssh/id_rsa".into(),
+        };
+        assert!(!sensitive.is_boundary_violation());
         assert!(!resolution.is_boundary_violation());
     }
 }

--- a/rust/crates/astra-sandbox/src/path.rs
+++ b/rust/crates/astra-sandbox/src/path.rs
@@ -235,10 +235,10 @@ mod tests {
     #[test]
     fn permissive_isolation_path_validation() {
         let p = SandboxPolicy::permissive("/home/user/project");
-        // Allows absolute paths
-        let result = validate_path(&p, "/etc/passwd");
+        // Allows arbitrary absolute paths (non-sensitive).
+        let result = validate_path(&p, "/var/data/file");
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), PathBuf::from("/etc/passwd"));
+        assert_eq!(result.unwrap(), PathBuf::from("/var/data/file"));
         // Resolves relative
         let result = validate_path(&p, "src/main.rs");
         assert!(result.is_ok());
@@ -246,9 +246,16 @@ mod tests {
             result.unwrap(),
             PathBuf::from("/home/user/project/src/main.rs")
         );
-        // Allows dotdot escape
-        let result = validate_path(&p, "../../etc/passwd");
+        // Allows dotdot escape to non-sensitive paths
+        let result = validate_path(&p, "../../var/data");
         assert!(result.is_ok());
+        // System account files are blocked at every isolation level —
+        // /etc/passwd is no longer a valid permissive-mode target.
+        let result = validate_path(&p, "/etc/passwd");
+        assert!(
+            result.is_err(),
+            "/etc/passwd must be blocked in permissive mode"
+        );
     }
 
     #[test]

--- a/rust/crates/astra-sandbox/src/policy.rs
+++ b/rust/crates/astra-sandbox/src/policy.rs
@@ -135,7 +135,8 @@ const ALWAYS_DENIED_ENV_KEY_PATTERNS: &[&str] = &[
 
 /// Path substrings that identify credential files — NEVER readable,
 /// even in Permissive isolation. These are data-at-rest threats:
-/// secret keys, password databases, credential stores.
+/// secret keys, password databases, credential stores, environment
+/// files, and cloud SDK caches.
 const NEVER_READABLE_PATH_PATTERNS: &[&str] = &[
     "/etc/shadow",
     "/etc/gshadow",
@@ -148,10 +149,21 @@ const NEVER_READABLE_PATH_PATTERNS: &[&str] = &[
     ".docker/config.json",
     ".netrc",
     "/var/run/secrets",
+    // Environment files carry app secrets (DB URLs, API tokens).
+    ".env",
+    // Cloud SDK credential caches.
+    ".kube/config",
+    ".npmrc",
+    ".pypirc",
+    ".git-credentials",
+    ".config/gcloud/credentials",
+    // Generic credential file names.
+    "credentials.json",
+    "credentials.db",
 ];
 
 /// Check if a path matches any never-readable pattern.
-pub(crate) fn is_never_readable_path(path: &std::path::Path) -> bool {
+pub fn is_never_readable_path(path: &std::path::Path) -> bool {
     let path_str = path.to_string_lossy();
     NEVER_READABLE_PATH_PATTERNS
         .iter()
@@ -433,5 +445,49 @@ mod tests {
                 "{p:?}"
             );
         }
+    }
+
+    // ── Credential paths must be never-readable (review C2/H1) ──
+    // These are data-at-rest secrets. They must be blocked even in
+    // Permissive isolation, regardless of project root.
+
+    #[test]
+    fn never_readable_paths_block_dotenv() {
+        assert!(is_never_readable_path(std::path::Path::new(
+            "/home/user/.env"
+        )));
+        assert!(is_never_readable_path(std::path::Path::new("/proj/.env")));
+        assert!(is_never_readable_path(std::path::Path::new(".env.local")));
+    }
+
+    #[test]
+    fn never_readable_paths_block_cloud_and_pkg_credentials() {
+        assert!(is_never_readable_path(std::path::Path::new(
+            "/home/user/.kube/config"
+        )));
+        assert!(is_never_readable_path(std::path::Path::new(
+            "/home/user/.npmrc"
+        )));
+        assert!(is_never_readable_path(std::path::Path::new(
+            "/home/user/.pypirc"
+        )));
+        assert!(is_never_readable_path(std::path::Path::new(
+            "/home/user/.config/gcloud/credentials.db"
+        )));
+        assert!(is_never_readable_path(std::path::Path::new(
+            "/home/user/.git-credentials"
+        )));
+        assert!(is_never_readable_path(std::path::Path::new(
+            "/proj/credentials.json"
+        )));
+    }
+
+    #[test]
+    fn permissive_mode_blocks_never_readable_credential_paths() {
+        let p = SandboxPolicy::permissive("/proj");
+        assert!(p.is_path_allowed(std::path::Path::new("/anywhere")));
+        assert!(!p.is_path_allowed(std::path::Path::new("/home/u/.env")));
+        assert!(!p.is_path_allowed(std::path::Path::new("/home/u/.kube/config")));
+        assert!(!p.is_path_allowed(std::path::Path::new("/home/u/.npmrc")));
     }
 }

--- a/rust/crates/astra-sandbox/src/policy.rs
+++ b/rust/crates/astra-sandbox/src/policy.rs
@@ -151,7 +151,7 @@ const NEVER_READABLE_PATH_PATTERNS: &[&str] = &[
 ];
 
 /// Check if a path matches any never-readable pattern.
-fn is_never_readable_path(path: &std::path::Path) -> bool {
+pub(crate) fn is_never_readable_path(path: &std::path::Path) -> bool {
     let path_str = path.to_string_lossy();
     NEVER_READABLE_PATH_PATTERNS
         .iter()

--- a/rust/crates/astra-sandbox/src/policy.rs
+++ b/rust/crates/astra-sandbox/src/policy.rs
@@ -133,13 +133,19 @@ const ALWAYS_DENIED_ENV_KEY_PATTERNS: &[&str] = &[
     "PRIVATE_KEY",
 ];
 
-/// Path substrings that identify credential files — NEVER readable,
-/// even in Permissive isolation. These are data-at-rest threats:
-/// secret keys, password databases, credential stores, environment
-/// files, and cloud SDK caches.
-const NEVER_READABLE_PATH_PATTERNS: &[&str] = &[
+/// Credential path substrings — data-at-rest threats: secret keys, password
+/// databases, credential stores, environment files, cloud SDK caches. These
+/// are matched as substrings against the full path string, so `.env` matches
+/// both `/home/user/.env` and `/app/.env.local`-style variants intentionally
+/// (never readable, even in Permissive isolation).
+const SENSITIVE_PATH_SUBSTRINGS: &[&str] = &[
+    // System account/password files — leak account metadata and password hashes.
+    "/etc/passwd",
     "/etc/shadow",
     "/etc/gshadow",
+    "/etc/sudoers",
+    // SSH host private keys and config.
+    "/etc/ssh/",
     ".ssh/id_",
     ".ssh/authorized_keys",
     ".ssh/identity",
@@ -162,12 +168,118 @@ const NEVER_READABLE_PATH_PATTERNS: &[&str] = &[
     "credentials.db",
 ];
 
-/// Check if a path matches any never-readable pattern.
-pub fn is_never_readable_path(path: &std::path::Path) -> bool {
+/// System directories whose entire subtree is sensitive — expanding any of
+/// these to the sandbox exposes credentials, account metadata, sudo policy,
+/// or kernel/device state. A directory is sensitive if it equals one of these
+/// prefixes or is a direct child of one.
+const SENSITIVE_SYSTEM_DIR_PREFIXES: &[&str] = &[
+    "/etc",
+    "/var/run/secrets",
+    "/var/lib/secrets",
+    "/boot",
+    "/proc",
+    "/sys",
+    "/dev",
+];
+
+/// Home-directory credential markers — match the directory itself or any
+/// descendant path. These cover credential stores that live under a user's
+/// home directory.
+const SENSITIVE_CRED_DIR_MARKERS: &[&str] = &[
+    "/.ssh",
+    "/.aws",
+    "/.kube",
+    "/.gnupg",
+    "/.azure",
+    "/.config/gh",
+    "/.config/gcloud",
+    "/.docker",
+    "/.git-credentials",
+    "/.netrc",
+];
+
+/// Credential file names — matched by the final path component. These are
+/// private keys and secret-bearing files that must never be exposed regardless
+/// of their parent directory.
+const SENSITIVE_CRED_FILE_NAMES: &[&str] = &[
+    "id_rsa",
+    "id_ed25519",
+    "id_ecdsa",
+    "id_ed25519_sk",
+    "id_dsa",
+    ".env",
+];
+
+/// Device files under `/dev` that are universally safe — they are sinks or
+/// zero sources, never secret-bearing. All other `/dev/*` entries (block
+/// devices, character devices, USB endpoints) remain sensitive.
+const SAFE_DEVICE_FILES: &[&str] = &["/dev/null", "/dev/zero", "/dev/full"];
+
+/// True if `path` is a system-sensitive **directory** subtree (`/etc`, `/boot`,
+/// `/proc`, `/sys`, `/dev`, credential dirs under `$HOME`).
+///
+/// This is the directory-level gate used to reject sandbox expansion: opening
+/// any of these to the sandbox would expose entire subtrees of secrets or
+/// kernel state. Use [`is_sensitive_path`] for the file/credential-level check.
+pub fn is_sensitive_system_dir(path: &std::path::Path) -> bool {
+    let lower = path.to_string_lossy().to_ascii_lowercase();
+    // Carve out universally-safe device sinks before the /dev prefix check.
+    // /dev/null, /dev/zero, /dev/full are deterministic sinks/sources with no
+    // secret surface; all other /dev nodes (block devices, tty, usb) stay blocked.
+    if SAFE_DEVICE_FILES.contains(&lower.as_str()) {
+        return false;
+    }
+    for prefix in SENSITIVE_SYSTEM_DIR_PREFIXES {
+        if lower == *prefix || lower.starts_with(&format!("{prefix}/")) {
+            return true;
+        }
+    }
+    for marker in SENSITIVE_CRED_DIR_MARKERS {
+        if lower == marker.trim_start_matches('/')
+            || lower.ends_with(marker)
+            || lower.contains(&format!("{marker}/"))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// True if `path` is sensitive — a system file, credential, system directory,
+/// or credential-bearing path. This is the **single source of truth** for all
+/// path-sensitivity checks across the sandbox, shell-hardening, and permission
+/// layers.
+///
+/// Combines:
+/// - [`is_sensitive_system_dir`] (directory-subtree match)
+/// - [`SENSITIVE_PATH_SUBSTRINGS`] (broad credential-file substring match)
+/// - [`SENSITIVE_CRED_FILE_NAMES`] (exact file-name match)
+pub fn is_sensitive_path(path: &std::path::Path) -> bool {
+    if is_sensitive_system_dir(path) {
+        return true;
+    }
     let path_str = path.to_string_lossy();
-    NEVER_READABLE_PATH_PATTERNS
+    if SENSITIVE_PATH_SUBSTRINGS
         .iter()
-        .any(|pattern| path_str.contains(pattern))
+        .any(|p| path_str.contains(p))
+    {
+        return true;
+    }
+    if let Some(file_name) = path.file_name().and_then(|n| n.to_str())
+        && SENSITIVE_CRED_FILE_NAMES.contains(&file_name)
+    {
+        return true;
+    }
+    false
+}
+
+/// Check if a path matches any never-readable pattern.
+///
+/// Thin alias of [`is_sensitive_path`] retained as the canonical read-gating
+/// predicate name. A path that is sensitive is never readable, even in
+/// Permissive isolation.
+pub fn is_never_readable_path(path: &std::path::Path) -> bool {
+    is_sensitive_path(path)
 }
 
 /// Check if an env key matches any always-denied pattern.
@@ -356,9 +468,21 @@ mod tests {
             assert_eq!(p.isolation, isolation, "{tier:?}");
             assert_eq!(p.network_allowed, network, "{tier:?}");
             assert_eq!(p.max_execution_secs, max_secs, "{tier:?}");
-            // Permissive allows any path; others block outside
-            let passwd_ok = p.is_path_allowed(std::path::Path::new("/etc/passwd"));
-            assert_eq!(passwd_ok, tier == TrustTier::Bundled, "passwd for {tier:?}");
+            // Permissive allows arbitrary non-sensitive paths; others block
+            // outside the project root.
+            let arbitrary_ok = p.is_path_allowed(std::path::Path::new("/var/data"));
+            assert_eq!(
+                arbitrary_ok,
+                tier == TrustTier::Bundled,
+                "arbitrary path for {tier:?}"
+            );
+            // System account files are never-readable at every tier — the
+            // prior assertion that /etc/passwd was allowed in Permissive
+            // mode was the very bug fixed by review CRITICAL #1.
+            assert!(
+                !p.is_path_allowed(std::path::Path::new("/etc/passwd")),
+                "/etc/passwd must be blocked at every tier ({tier:?})"
+            );
             // Community has env allowlist
             if tier == TrustTier::Community {
                 assert!(p.env_allowlist.is_some());
@@ -417,11 +541,15 @@ mod tests {
     fn permissive_path_and_env_rules() {
         let p = SandboxPolicy::permissive("/proj");
         assert!(p.allowed_paths.is_empty());
-        // Permissive allows most paths except never-readable credential files.
+        // Permissive allows arbitrary non-sensitive paths.
         assert!(p.is_path_allowed(std::path::Path::new("/anywhere")));
-        assert!(p.is_path_allowed(std::path::Path::new("/etc/passwd")));
-        // Credential paths are always blocked.
+        assert!(p.is_path_allowed(std::path::Path::new("/var/data")));
+        // System account files and credential paths are always blocked,
+        // even in Permissive mode — review CRITICAL #1 closed the
+        // ReadShortCircuit bypass for /etc/passwd, /etc/shadow, /etc/sudoers.
+        assert!(!p.is_path_allowed(std::path::Path::new("/etc/passwd")));
         assert!(!p.is_path_allowed(std::path::Path::new("/etc/shadow")));
+        assert!(!p.is_path_allowed(std::path::Path::new("/etc/sudoers")));
         assert!(!p.is_path_allowed(std::path::Path::new("/home/user/.ssh/id_rsa")));
         // Credential env vars are always blocked, even in Permissive mode.
         assert!(!p.is_env_allowed("SECRET_KEY"));
@@ -480,6 +608,40 @@ mod tests {
         assert!(is_never_readable_path(std::path::Path::new(
             "/proj/credentials.json"
         )));
+    }
+
+    // ── System credential/account files must be never-readable (review CRITICAL #1) ──
+    // /etc/passwd, /etc/shadow, /etc/sudoers, and /etc/ssh/ contain account
+    // metadata, password hashes, and host keys. In Auto mode, read_file on
+    // these would otherwise be Allow via ReadShortCircuit unless listed here.
+
+    #[test]
+    fn never_readable_paths_block_system_account_files() {
+        assert!(is_never_readable_path(std::path::Path::new("/etc/passwd")));
+        assert!(is_never_readable_path(std::path::Path::new("/etc/shadow")));
+        assert!(is_never_readable_path(std::path::Path::new("/etc/gshadow")));
+        assert!(is_never_readable_path(std::path::Path::new("/etc/sudoers")));
+        assert!(is_never_readable_path(std::path::Path::new(
+            "/etc/sudoers.d/extra"
+        )));
+    }
+
+    #[test]
+    fn never_readable_paths_block_ssh_host_keys_directory() {
+        assert!(is_never_readable_path(std::path::Path::new(
+            "/etc/ssh/ssh_host_rsa_key"
+        )));
+        assert!(is_never_readable_path(std::path::Path::new(
+            "/etc/ssh/ssh_host_ed25519_key"
+        )));
+    }
+
+    #[test]
+    fn permissive_mode_blocks_never_readable_system_account_files() {
+        let p = SandboxPolicy::permissive("/proj");
+        assert!(!p.is_path_allowed(std::path::Path::new("/etc/passwd")));
+        assert!(!p.is_path_allowed(std::path::Path::new("/etc/shadow")));
+        assert!(!p.is_path_allowed(std::path::Path::new("/etc/sudoers")));
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/approval/request_key.rs
+++ b/rust/crates/astra-turn-core/src/approval/request_key.rs
@@ -6,7 +6,7 @@
 //! questions need OPPOSITE accuracy:
 //!
 //! - **Rule matching** (the existing fingerprint) wants to be GENEROUS.
-//!   A user-saved rule like `Bash(npm test:*)` should match any future
+//!   A user-saved rule like `Bash(argv_prefix="npm test")` should match any future
 //!   `npm test` call regardless of arguments. The fingerprint normalizes
 //!   path patterns (`approval_fingerprint.rs:185-197`) and tolerates wide
 //!   command matches (`approval_fingerprint.rs:99-130`). Generous = good.

--- a/rust/crates/astra-turn-core/src/permission/audit.rs
+++ b/rust/crates/astra-turn-core/src/permission/audit.rs
@@ -237,7 +237,7 @@ pub struct RulePersistedEvent {
     pub timestamp_ms: u64,
     pub correlation_id: String,
     pub target: PersistTarget,
-    /// The rule string we tried to persist, in v2 grammar form.
+    /// The rule string we tried to persist, in current grammar form.
     pub rule_text: String,
     /// True iff the on-disk save succeeded.
     pub saved: bool,
@@ -724,7 +724,7 @@ mod tests {
             timestamp_ms: 100,
             correlation_id: "c-0".into(),
             target: PersistTarget::Project,
-            rule_text: "Bash(npm test:*)".into(),
+            rule_text: r#"Bash(argv_prefix="npm test")"#.into(),
             saved: true,
             failure_reason: None,
         });

--- a/rust/crates/astra-turn-core/src/permission/engine.rs
+++ b/rust/crates/astra-turn-core/src/permission/engine.rs
@@ -170,7 +170,7 @@ pub enum TraceOutcome {
     Matched(HardDecision),
 }
 
-/// The 11 fixed evaluation slots. Plan v3 §P2 freezes the order:
+/// The fixed evaluation slots. Plan v3 §P2 freezes the order:
 /// any future change must update both this enum and the
 /// `evaluation_order_is_stable` pinning test, so the rule-precedence
 /// contract can't drift silently.
@@ -187,6 +187,7 @@ pub enum EvaluationStep {
     SensitivePath,
     ExecuteHardDeny,
     SandboxExpand,
+    ToolAllowlist,
     AskRules,
     ReadShortCircuit,
     SessionOverride,
@@ -197,7 +198,7 @@ pub enum EvaluationStep {
 
 /// Canonical ordering. Any reorder must change this constant AND
 /// flip the pinning test in `tests::evaluation_order_is_stable`.
-pub const EVALUATION_ORDER: [EvaluationStep; 13] = [
+pub const EVALUATION_ORDER: [EvaluationStep; 14] = [
     EvaluationStep::SchemaIdentity,
     EvaluationStep::DenyRules,
     EvaluationStep::SafetyMiddleware,
@@ -205,6 +206,7 @@ pub const EVALUATION_ORDER: [EvaluationStep; 13] = [
     EvaluationStep::SensitivePath,
     EvaluationStep::ExecuteHardDeny,
     EvaluationStep::SandboxExpand,
+    EvaluationStep::ToolAllowlist,
     EvaluationStep::AskRules,
     EvaluationStep::ReadShortCircuit,
     EvaluationStep::SessionOverride,
@@ -753,6 +755,40 @@ pub fn evaluate_permission(
         "not a sandbox expansion",
     );
 
+    if ctx.inherited.allowed_tools.is_some() {
+        if !ctx.inherited.is_tool_allowed_by_allowlist(tool_name) {
+            let decision = HardDecision::Deny {
+                reason: format!("Tool '{tool_name}' not in allowed tools list"),
+            };
+            push_matched(
+                &mut trace,
+                EvaluationStep::ToolAllowlist,
+                &decision,
+                "tool not in allowed_tools",
+            );
+            return envelope(
+                decision,
+                DecisionSource::Mode {
+                    mode: "agent policy allowlist".to_string(),
+                },
+                trace,
+                will_save,
+                risk_tags,
+            );
+        }
+        push_skipped(
+            &mut trace,
+            EvaluationStep::ToolAllowlist,
+            "tool in allowed_tools; continuing to permission mode",
+        );
+    } else {
+        push_skipped(
+            &mut trace,
+            EvaluationStep::ToolAllowlist,
+            "no tool allowlist",
+        );
+    }
+
     if let Some(rule) = ctx
         .inherited
         .ask_rule_with_context(tool_name, &rule_match_context)
@@ -1065,18 +1101,6 @@ pub fn evaluate_permission(
 
     let mode = ctx.mode();
     let (decision, mode_label) = match mode {
-        PermissionMode::Auto if ctx.inherited.allowed_tools.is_some() => {
-            if ctx.inherited.is_tool_allowed_by_allowlist(tool_name) {
-                (HardDecision::Allow, "agent policy allowlist".to_string())
-            } else {
-                (
-                    HardDecision::Deny {
-                        reason: format!("Tool '{tool_name}' not in allowed tools list"),
-                    },
-                    "agent policy allowlist".to_string(),
-                )
-            }
-        }
         PermissionMode::Auto => (HardDecision::Allow, mode.to_string()),
         PermissionMode::Plan => (
             HardDecision::Deny {
@@ -1084,30 +1108,6 @@ pub fn evaluate_permission(
             },
             mode.to_string(),
         ),
-        PermissionMode::AcceptEdits if ctx.inherited.allowed_tools.is_some() => {
-            if !ctx.inherited.is_tool_allowed_by_allowlist(tool_name) {
-                (
-                    HardDecision::Deny {
-                        reason: format!("Tool '{tool_name}' not in allowed tools list"),
-                    },
-                    "agent policy allowlist".to_string(),
-                )
-            } else if accept_edits_auto_allows(tool_name, args) {
-                (HardDecision::Allow, mode.to_string())
-            } else {
-                (
-                    HardDecision::NeedExternal {
-                        prompt: approval_prompt(
-                            tool_name,
-                            args,
-                            "Write/execute tool requires approval".to_string(),
-                            risk_tags.clone(),
-                        ),
-                    },
-                    mode.to_string(),
-                )
-            }
-        }
         PermissionMode::AcceptEdits => {
             if accept_edits_auto_allows(tool_name, args) {
                 (HardDecision::Allow, mode.to_string())
@@ -1131,18 +1131,6 @@ pub fn evaluate_permission(
             },
             mode.to_string(),
         ),
-        PermissionMode::Prompt if ctx.inherited.allowed_tools.is_some() => {
-            if ctx.inherited.is_tool_allowed_by_allowlist(tool_name) {
-                (HardDecision::Allow, "agent policy allowlist".to_string())
-            } else {
-                (
-                    HardDecision::Deny {
-                        reason: format!("Tool '{tool_name}' not in allowed tools list"),
-                    },
-                    "agent policy allowlist".to_string(),
-                )
-            }
-        }
         PermissionMode::Prompt => (
             HardDecision::NeedExternal {
                 prompt: approval_prompt(
@@ -1543,6 +1531,7 @@ mod tests {
                 EvaluationStep::SensitivePath,
                 EvaluationStep::ExecuteHardDeny,
                 EvaluationStep::SandboxExpand,
+                EvaluationStep::ToolAllowlist,
                 EvaluationStep::AskRules,
                 EvaluationStep::ReadShortCircuit,
                 EvaluationStep::SessionOverride,
@@ -1733,7 +1722,7 @@ mod tests {
     }
 
     #[test]
-    fn prompt_mode_allowlist_locally_allows_listed_non_explicit_tool() {
+    fn prompt_mode_allowlist_does_not_locally_allow_listed_write_tool() {
         let ctx = crate::permission::types::PermissionSyncContext::new(
             crate::permission::types::InheritedPermissions {
                 mode: crate::permission::types::PermissionMode::Prompt,
@@ -1747,17 +1736,21 @@ mod tests {
             &ctx,
         );
 
-        assert!(matches!(envelope.decision, HardDecision::Allow));
+        assert!(
+            matches!(envelope.decision, HardDecision::NeedExternal { .. }),
+            "allowed_tools restricts the child tool surface but must not approve writes in Prompt mode; got {:?}",
+            envelope.decision
+        );
         assert_eq!(
             envelope.source,
             DecisionSource::Mode {
-                mode: "agent policy allowlist".to_string()
+                mode: "prompt".to_string()
             }
         );
     }
 
     #[test]
-    fn prompt_mode_allowlist_blocks_unlisted_tool() {
+    fn prompt_mode_allowlist_blocks_unlisted_explicit_tool_before_prompting() {
         let ctx = crate::permission::types::PermissionSyncContext::new(
             crate::permission::types::InheritedPermissions {
                 mode: crate::permission::types::PermissionMode::Prompt,
@@ -1775,6 +1768,25 @@ mod tests {
                 mode: "agent policy allowlist".to_string()
             }
         );
+    }
+
+    #[test]
+    fn prompt_mode_allowlist_still_allows_listed_read_only_tool() {
+        let ctx = crate::permission::types::PermissionSyncContext::new(
+            crate::permission::types::InheritedPermissions {
+                mode: crate::permission::types::PermissionMode::Prompt,
+                allowed_tools: Some(std::collections::HashSet::from(["read_file".to_string()])),
+                ..Default::default()
+            },
+        );
+        let envelope = evaluate_permission(
+            "read_file",
+            &serde_json::json!({"path": "src/lib.rs"}),
+            &ctx,
+        );
+
+        assert!(matches!(envelope.decision, HardDecision::Allow));
+        assert_eq!(envelope.source, DecisionSource::ReadShortCircuit);
     }
 
     #[test]
@@ -2264,10 +2276,12 @@ mod tests {
         );
 
         assert!(matches!(envelope.decision, HardDecision::Deny { .. }));
-        assert!(matches!(
+        assert_eq!(
             envelope.source,
-            DecisionSource::ExplicitApprovalGate { .. }
-        ));
+            DecisionSource::Mode {
+                mode: "agent policy allowlist".to_string()
+            }
+        );
     }
 
     #[test]
@@ -2349,10 +2363,12 @@ mod tests {
             evaluate_permission("bash", &serde_json::json!({"command": "cargo test"}), &ctx);
 
         assert!(matches!(envelope.decision, HardDecision::Deny { .. }));
-        assert!(matches!(
+        assert_eq!(
             envelope.source,
-            DecisionSource::ExplicitApprovalGate { .. }
-        ));
+            DecisionSource::Mode {
+                mode: "agent policy allowlist".to_string()
+            }
+        );
     }
 
     // ── Issue #326 P5 / R2 Major 5: MCP capability metadata ──

--- a/rust/crates/astra-turn-core/src/permission/engine.rs
+++ b/rust/crates/astra-turn-core/src/permission/engine.rs
@@ -816,7 +816,6 @@ pub fn evaluate_permission(
         && ctx.mode() != PermissionMode::Deny
         && !(ctx.mode() == PermissionMode::Plan
             && is_plan_mode_unstructured_execute_tool(tool_name))
-        && ctx.inherited.is_tool_allowed_by_allowlist(tool_name)
     {
         let decision = HardDecision::Allow;
         push_matched(
@@ -993,15 +992,11 @@ pub fn evaluate_permission(
                 )
             }
             PermissionMode::Auto => {
-                let decision = if ctx.inherited.allowed_tools.is_some()
-                    && !ctx.inherited.is_tool_allowed_by_allowlist(tool_name)
-                {
-                    HardDecision::Deny {
-                        reason: format!("Tool '{tool_name}' not in allowed tools list"),
-                    }
-                } else {
-                    HardDecision::Allow
-                };
+                // ToolAllowlist step already denied unlisted tools, so
+                // anything reaching ExplicitApproval in Auto mode is
+                // allowed (it's an explicit-approval-gated tool that
+                // the mode auto-approves).
+                let decision = HardDecision::Allow;
                 push_matched(
                     &mut trace,
                     EvaluationStep::ExplicitApproval,
@@ -1019,16 +1014,9 @@ pub fn evaluate_permission(
                 )
             }
             PermissionMode::AcceptEdits => {
-                let decision = if ctx.inherited.allowed_tools.is_some()
-                    && !ctx.inherited.is_tool_allowed_by_allowlist(tool_name)
-                {
-                    HardDecision::Deny {
-                        reason: format!("Tool '{tool_name}' not in allowed tools list"),
-                    }
-                } else {
-                    HardDecision::NeedExternal {
-                        prompt: approval_prompt(tool_name, args, prompt_reason, risk_tags.clone()),
-                    }
+                // ToolAllowlist step already denied unlisted tools.
+                let decision = HardDecision::NeedExternal {
+                    prompt: approval_prompt(tool_name, args, prompt_reason, risk_tags.clone()),
                 };
                 push_matched(
                     &mut trace,
@@ -2122,6 +2110,46 @@ mod tests {
             bash_read.source,
             DecisionSource::SensitivePath { .. }
         ));
+    }
+
+    #[test]
+    fn evaluate_grep_pattern_mentioning_sensitive_name_is_not_sensitive_in_any_mode() {
+        let args = serde_json::json!({
+            "command": r#"grep -n "fn resolve_checked\|sensitive credential\|SANDBOX_DENIED_PREFIX\|\.ssh\|credentials.json" rust/crates/astra-cli/src/edge_tools/shell.rs"#
+        });
+
+        for mode in [
+            crate::permission::types::PermissionMode::Prompt,
+            crate::permission::types::PermissionMode::AcceptEdits,
+            crate::permission::types::PermissionMode::Auto,
+        ] {
+            let ctx = crate::permission::types::PermissionSyncContext::root(mode);
+            let envelope = evaluate_permission("bash", &args, &ctx);
+            assert!(
+                !matches!(envelope.source, DecisionSource::SensitivePath { .. }),
+                "{mode:?} must not treat grep search text as a sensitive path: {envelope:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn evaluate_grep_sensitive_file_operand_is_sensitive_in_any_mode() {
+        let args = serde_json::json!({
+            "command": "grep -n needle ~/.ssh/id_rsa"
+        });
+
+        for mode in [
+            crate::permission::types::PermissionMode::Prompt,
+            crate::permission::types::PermissionMode::AcceptEdits,
+            crate::permission::types::PermissionMode::Auto,
+        ] {
+            let ctx = crate::permission::types::PermissionSyncContext::root(mode);
+            let envelope = evaluate_permission("bash", &args, &ctx);
+            assert!(
+                matches!(envelope.source, DecisionSource::SensitivePath { .. }),
+                "{mode:?} must gate a real sensitive file operand: {envelope:?}"
+            );
+        }
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/permission/engine.rs
+++ b/rust/crates/astra-turn-core/src/permission/engine.rs
@@ -703,10 +703,11 @@ pub fn evaluate_permission(
                     .and_then(Value::as_str)
                     .unwrap_or("Access to path outside project boundary")
                     .to_string();
+                let action = sandbox_expand_action_label(inner_tool);
                 let decision = HardDecision::NeedExternal {
                     prompt: ApprovalPrompt {
                         tool: tool_name.to_string(),
-                        header: format!("{inner_tool} wants to read outside the project"),
+                        header: format!("{inner_tool} wants to {action} outside the project"),
                         detail: None,
                         reason,
                         risk_tags: risk_tags.clone(),
@@ -1225,6 +1226,30 @@ fn push_matched(
     });
 }
 
+fn sandbox_expand_action_label(inner_tool: &str) -> &'static str {
+    match cloud_gated_tool_kind(inner_tool) {
+        Some(CloudGatedToolKind::Write) => "write",
+        Some(CloudGatedToolKind::Execute) => "execute",
+        None if matches!(
+            inner_tool,
+            "read_file"
+                | "list_dir"
+                | "grep"
+                | "glob"
+                | "symbols"
+                | "find_definition"
+                | "find_references"
+                | "symbol_search"
+                | "hover_info"
+                | "extract_members"
+        ) =>
+        {
+            "read"
+        }
+        None => "access",
+    }
+}
+
 fn approval_prompt(
     tool_name: &str,
     args: &Value,
@@ -1549,6 +1574,56 @@ mod tests {
             deny_idx < sandbox_idx,
             "DenyRules ({deny_idx}) must run before SandboxExpand ({sandbox_idx})"
         );
+    }
+
+    #[test]
+    fn sandbox_expand_prompt_headers_describe_inner_tool_action() {
+        for mode in [
+            crate::permission::types::PermissionMode::Prompt,
+            crate::permission::types::PermissionMode::AcceptEdits,
+        ] {
+            let ctx = crate::permission::types::PermissionSyncContext::new(
+                crate::permission::types::InheritedPermissions {
+                    mode,
+                    ..Default::default()
+                },
+            );
+
+            for (tool, expected_header) in [
+                (
+                    "sandbox_expand:read_file",
+                    "read_file wants to read outside the project",
+                ),
+                (
+                    "sandbox_expand:write_file",
+                    "write_file wants to write outside the project",
+                ),
+                (
+                    "sandbox_expand:bash",
+                    "bash wants to execute outside the project",
+                ),
+            ] {
+                let envelope = evaluate_permission(
+                    tool,
+                    &serde_json::json!({
+                        "reason": "Path '/tmp/outside' is outside the project directory '/tmp/project'; sandbox approval is required for this external path."
+                    }),
+                    &ctx,
+                );
+
+                match envelope.decision {
+                    HardDecision::NeedExternal { prompt } => {
+                        assert_eq!(prompt.tool, tool);
+                        assert_eq!(prompt.header, expected_header);
+                        assert!(prompt.detail.is_none());
+                    }
+                    other => {
+                        panic!("{mode:?} sandbox expansion should prompt for {tool}; got {other:?}")
+                    }
+                }
+                assert_eq!(envelope.source, DecisionSource::SandboxExpansion);
+            }
+        }
     }
 
     /// Catastrophic-command checks (the `rm -rf /` circuit breaker)

--- a/rust/crates/astra-turn-core/src/permission/engine.rs
+++ b/rust/crates/astra-turn-core/src/permission/engine.rs
@@ -1398,10 +1398,23 @@ fn content_aware_fingerprint(tool_name: &str, args: &Value) -> ApprovalFingerpri
             let path = path_hint_from_args(args);
             path.map_or_else(
                 || ApprovalFingerprint::bare(tool_name),
-                |path| ApprovalFingerprint::file_op_exact(tool_name, Some(&path)),
+                |path| {
+                    ApprovalFingerprint::file_op_exact(
+                        file_write_fingerprint_tool(tool_name),
+                        Some(&path),
+                    )
+                },
             )
         }
         None => ApprovalFingerprint::bare(tool_name),
+    }
+}
+
+fn file_write_fingerprint_tool(tool_name: &str) -> &str {
+    if crate::tool::categories::registry().is_file_op(tool_name) {
+        "file_write"
+    } else {
+        tool_name
     }
 }
 
@@ -1416,7 +1429,7 @@ fn content_aware_fingerprint_candidates(tool_name: &str, args: &Value) -> Vec<Ap
         if crate::tool::categories::registry().is_file_op(tool_name) {
             push_unique_fingerprint(
                 &mut candidates,
-                ApprovalFingerprint::file_op_exact("edit", Some(&path)),
+                ApprovalFingerprint::file_op_exact("file_write", Some(&path)),
             );
         }
         if let Some(resolved) = resolved_write_path(&path) {
@@ -1427,7 +1440,7 @@ fn content_aware_fingerprint_candidates(tool_name: &str, args: &Value) -> Vec<Ap
             if crate::tool::categories::registry().is_file_op(tool_name) {
                 push_unique_fingerprint(
                     &mut candidates,
-                    ApprovalFingerprint::file_op_exact("edit", Some(&resolved)),
+                    ApprovalFingerprint::file_op_exact("file_write", Some(&resolved)),
                 );
             }
         }
@@ -1680,7 +1693,7 @@ mod tests {
             .into_owned();
         assert_eq!(
             rule,
-            format!(r#"Edit(path_prefix="{cwd}", op="write", cwd_root="{cwd}")"#)
+            format!(r#"file_write(path_prefix="{cwd}", op="write", cwd_root="{cwd}")"#)
         );
     }
 
@@ -1691,7 +1704,7 @@ mod tests {
             &serde_json::json!({"path": "/tmp/zzzz3.md", "content": "# zzzz3"}),
         );
 
-        assert_eq!(rule, r#"Edit(path_glob="/tmp/zzzz3.md", op="write")"#);
+        assert_eq!(rule, r#"file_write(path_glob="/tmp/zzzz3.md", op="write")"#);
     }
 
     #[test]
@@ -1913,7 +1926,7 @@ mod tests {
         let ctx = crate::permission::types::PermissionSyncContext::new(
             crate::permission::types::InheritedPermissions {
                 mode: crate::permission::types::PermissionMode::Prompt,
-                ask_rules: vec![crate::permission::types::PermissionRule::parse("bash(*)")],
+                ask_rules: vec![crate::permission::types::PermissionRule::parse("bash()")],
                 ..Default::default()
             },
         );

--- a/rust/crates/astra-turn-core/src/permission/match_target.rs
+++ b/rust/crates/astra-turn-core/src/permission/match_target.rs
@@ -15,7 +15,7 @@ use crate::cloud::approval_policy::{
 };
 use crate::parallel_tool_exec::is_read_only_tool_with_args;
 use crate::permission::memory_profile::{permission_memory_profile, workspace_write_prefix};
-use crate::permission::rule_grammar::{PermissionRuleV2, serialize_rule_v2};
+use crate::permission::rule_grammar::{PermissionRuleSpec, serialize_rule};
 use crate::permission::scope::AllowScope;
 use crate::tool::args::hints::{command_hint_from_args, path_hint_from_args};
 
@@ -59,12 +59,12 @@ pub fn allow_rule_for_match_target(
     target: &AllowMatchTarget,
 ) -> String {
     match target {
-        AllowMatchTarget::Tool => tool_name.to_string(),
+        AllowMatchTarget::Tool => broad_rule(tool_name),
         AllowMatchTarget::Exact => {
-            exact_rule(tool_name, args).unwrap_or_else(|| tool_name.to_string())
+            exact_rule(tool_name, args).unwrap_or_else(|| broad_rule(tool_name))
         }
         AllowMatchTarget::Prefix(prefix) => {
-            prefix_rule(tool_name, args, prefix).unwrap_or_else(|| tool_name.to_string())
+            prefix_rule(tool_name, args, prefix).unwrap_or_else(|| broad_rule(tool_name))
         }
     }
 }
@@ -196,7 +196,7 @@ fn exact_rule(tool_name: &str, args: &Value) -> Option<String> {
     match cloud_gated_tool_kind(tool_name)? {
         CloudGatedToolKind::Execute => {
             let cmd = command_hint_from_args(args)?;
-            Some(serialize_rule_v2(&PermissionRuleV2 {
+            Some(serialize_rule(&PermissionRuleSpec {
                 tool: display_tool_name(tool_name),
                 argv_exact: Some(cmd.to_string()),
                 argv_prefix: None,
@@ -213,7 +213,7 @@ fn exact_rule(tool_name: &str, args: &Value) -> Option<String> {
         CloudGatedToolKind::Write => {
             let path = path_hint_from_args(args)?;
             let rule_tool = file_write_rule_tool(tool_name);
-            Some(serialize_rule_v2(&PermissionRuleV2 {
+            Some(serialize_rule(&PermissionRuleSpec {
                 tool: rule_tool,
                 argv_exact: None,
                 argv_prefix: None,
@@ -235,7 +235,7 @@ fn prefix_rule(tool_name: &str, _args: &Value, prefix: &str) -> Option<String> {
         return None;
     }
     match cloud_gated_tool_kind(tool_name)? {
-        CloudGatedToolKind::Execute => Some(serialize_rule_v2(&PermissionRuleV2 {
+        CloudGatedToolKind::Execute => Some(serialize_rule(&PermissionRuleSpec {
             tool: display_tool_name(tool_name),
             argv_exact: None,
             argv_prefix: Some(prefix.to_string()),
@@ -253,7 +253,7 @@ fn prefix_rule(tool_name: &str, _args: &Value, prefix: &str) -> Option<String> {
                 .and_then(|path| workspace_write_prefix(&path))
                 .filter(|root| root == prefix);
             let rule_tool = file_write_rule_tool(tool_name);
-            Some(serialize_rule_v2(&PermissionRuleV2 {
+            Some(serialize_rule(&PermissionRuleSpec {
                 tool: rule_tool,
                 argv_exact: None,
                 argv_prefix: None,
@@ -272,7 +272,7 @@ fn prefix_rule(tool_name: &str, _args: &Value, prefix: &str) -> Option<String> {
 
 fn file_write_rule_tool(tool_name: &str) -> String {
     if crate::tool::categories::registry().is_file_op(tool_name) {
-        "Edit".to_string()
+        "file_write".to_string()
     } else {
         tool_name.to_string()
     }
@@ -280,7 +280,7 @@ fn file_write_rule_tool(tool_name: &str) -> String {
 
 fn file_write_fingerprint_tool(tool_name: &str) -> &str {
     if crate::tool::categories::registry().is_file_op(tool_name) {
-        "edit"
+        "file_write"
     } else {
         tool_name
     }
@@ -292,6 +292,26 @@ fn display_tool_name(tool_name: &str) -> String {
         None => tool_name.to_string(),
         Some(first) => first.to_uppercase().to_string() + chars.as_str(),
     }
+}
+
+fn broad_rule(tool_name: &str) -> String {
+    serialize_rule(&PermissionRuleSpec {
+        tool: if tool_name == "bash" {
+            display_tool_name(tool_name)
+        } else {
+            tool_name.to_string()
+        },
+        argv_exact: None,
+        argv_prefix: None,
+        path_glob: None,
+        path_prefix: None,
+        op: None,
+        cwd_root: None,
+        git_branch: None,
+        domain: None,
+        capability: None,
+        extra: Default::default(),
+    })
 }
 
 #[cfg(test)]
@@ -325,7 +345,7 @@ mod tests {
         let args = serde_json::json!({"path": "a.md"});
         assert_eq!(
             allow_rule_for_match_target("write_file", &args, &AllowMatchTarget::Tool),
-            "write_file"
+            "write_file()"
         );
     }
 
@@ -371,7 +391,7 @@ mod tests {
             &args,
             &AllowMatchTarget::Prefix("zzz".to_string()),
         );
-        assert_eq!(rule, r#"Edit(path_prefix="zzz", op="write")"#);
+        assert_eq!(rule, r#"file_write(path_prefix="zzz", op="write")"#);
 
         let parsed = PermissionRule::parse(&rule);
         assert!(parsed.matches_with_context(
@@ -402,15 +422,22 @@ mod tests {
             &args,
             &AllowMatchTarget::Prefix("zzz".into()),
         );
-        let later =
-            crate::approval_fingerprint::ApprovalFingerprint::file_op("edit", Some("zzz2.md"));
+        let later = crate::approval_fingerprint::ApprovalFingerprint::file_op(
+            "file_write",
+            Some("zzz2.md"),
+        );
         let other =
-            crate::approval_fingerprint::ApprovalFingerprint::file_op("edit", Some("abc.md"));
+            crate::approval_fingerprint::ApprovalFingerprint::file_op("file_write", Some("abc.md"));
+        let other_tool = crate::approval_fingerprint::ApprovalFingerprint::file_op(
+            "str_replace",
+            Some("zzz2.md"),
+        );
         let mut overrides = crate::approval_fingerprint::FingerprintedOverrides::default();
         overrides.insert(approved, true);
 
         assert_eq!(overrides.check(&later), Some(true));
         assert_eq!(overrides.check(&other), None);
+        assert_eq!(overrides.check(&other_tool), None);
     }
 
     #[test]
@@ -430,7 +457,7 @@ mod tests {
         assert_eq!(
             rule,
             format!(
-                r#"Edit(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
+                r#"file_write(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
             )
         );
         let parsed = PermissionRule::parse(&rule);
@@ -529,7 +556,7 @@ mod tests {
         assert_eq!(
             allow_rule_for_match_target("write_file", &args, &target),
             format!(
-                r#"Edit(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
+                r#"file_write(path_prefix="{workspace_root}", op="write", cwd_root="{workspace_root}")"#
             )
         );
     }

--- a/rust/crates/astra-turn-core/src/permission/path_glob.rs
+++ b/rust/crates/astra-turn-core/src/permission/path_glob.rs
@@ -13,8 +13,8 @@
 //!
 //! 1. The permission rule grammar is small — a few hundred globs at
 //!    most across user + project files. Performance isn't the issue.
-//! 2. We need *exact* compatibility with the v2 rule grammar's
-//!    quoting rules, so a hand-rolled matcher avoids the
+//! 2. We need *exact* compatibility with the permission rule
+//!    grammar's quoting rules, so a hand-rolled matcher avoids the
 //!    impedance-mismatch of "what does globset escape vs what does
 //!    permission_rule_grammar escape".
 //! 3. The glob alphabet here is intentionally a subset of gitignore;

--- a/rust/crates/astra-turn-core/src/permission/path_sensitivity.rs
+++ b/rust/crates/astra-turn-core/src/permission/path_sensitivity.rs
@@ -190,20 +190,9 @@ pub fn sensitive_path_match_for_tool_args(
     if let Some(command) = command_hint_from_args(args)
         && !command.is_empty()
     {
-        for token in shell_like_tokens(command) {
-            let extracted = shell_token_path_candidates(&token);
-            if extracted.is_empty() {
-                let access = classify_shell_token_access(command, &token);
-                if let Some(hit) = path_requires_sensitive_gate(&token, access) {
-                    return Some(hit);
-                }
-                continue;
-            }
-            for candidate in extracted {
-                let access = classify_shell_token_access(command, &candidate);
-                if let Some(hit) = path_requires_sensitive_gate(&candidate, access) {
-                    return Some(hit);
-                }
+        for candidate in shell_permission_path_candidates(command) {
+            if let Some(hit) = path_requires_sensitive_gate(&candidate.token, candidate.access) {
+                return Some(hit);
             }
         }
     }
@@ -213,6 +202,656 @@ pub fn sensitive_path_match_for_tool_args(
 
 pub fn sensitive_path_token_for_tool_args(tool_name: &str, args: &Value) -> Option<String> {
     sensitive_path_match_for_tool_args(tool_name, args).map(|hit| hit.token)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ShellPermissionPathCandidate {
+    token: String,
+    access: PathAccess,
+}
+
+fn shell_permission_path_candidates(command: &str) -> Vec<ShellPermissionPathCandidate> {
+    let mut candidates = redirection_path_candidates(command);
+
+    for segment in shell_command_segments(command) {
+        let tokens = shell_like_tokens(segment);
+        append_segment_path_candidates(command, &tokens, &mut candidates);
+    }
+
+    candidates
+}
+
+fn append_segment_path_candidates(
+    command: &str,
+    tokens: &[String],
+    candidates: &mut Vec<ShellPermissionPathCandidate>,
+) {
+    let Some(command_idx) = leading_shell_command_index(tokens) else {
+        return;
+    };
+    let base = tokens[command_idx]
+        .rsplit('/')
+        .next()
+        .unwrap_or(tokens[command_idx].as_str());
+
+    match base {
+        "grep" | "egrep" | "fgrep" | "rg" | "ag" => {
+            append_grep_like_path_candidates(command, tokens, command_idx + 1, candidates);
+        }
+        "sed" => append_sed_path_candidates(command, tokens, command_idx + 1, candidates),
+        "awk" => append_awk_path_candidates(command, tokens, command_idx + 1, candidates),
+        _ if is_shell_file_operand_command(base) => {
+            append_generic_file_operand_candidates(command, tokens, command_idx + 1, candidates);
+        }
+        _ => {}
+    }
+}
+
+fn push_permission_path_candidate(
+    candidates: &mut Vec<ShellPermissionPathCandidate>,
+    token: &str,
+    access: PathAccess,
+) {
+    let extracted = shell_token_path_candidates(token);
+    if extracted.is_empty() {
+        push_unique_permission_path_candidate(candidates, token.to_string(), access);
+    } else {
+        for candidate in extracted {
+            push_unique_permission_path_candidate(candidates, candidate, access);
+        }
+    }
+}
+
+fn push_unique_permission_path_candidate(
+    candidates: &mut Vec<ShellPermissionPathCandidate>,
+    token: String,
+    access: PathAccess,
+) {
+    if token.is_empty() || token == "-" {
+        return;
+    }
+    let candidate = ShellPermissionPathCandidate { token, access };
+    if !candidates.iter().any(|existing| existing == &candidate) {
+        candidates.push(candidate);
+    }
+}
+
+fn leading_shell_command_index(tokens: &[String]) -> Option<usize> {
+    let mut idx = 0usize;
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        let base = token.rsplit('/').next().unwrap_or(token);
+        if token.is_empty() || (token.contains('=') && !token.starts_with('=')) {
+            idx += 1;
+            continue;
+        }
+        if matches!(
+            base,
+            "sudo" | "doas" | "env" | "command" | "exec" | "nice" | "nohup" | "time" | "timeout"
+        ) {
+            idx += 1;
+            continue;
+        }
+        return Some(idx);
+    }
+    None
+}
+
+fn is_shell_file_operand_command(base: &str) -> bool {
+    matches!(
+        base,
+        "cat"
+            | "head"
+            | "tail"
+            | "less"
+            | "more"
+            | "tac"
+            | "nl"
+            | "wc"
+            | "stat"
+            | "file"
+            | "md5sum"
+            | "sha1sum"
+            | "sha256sum"
+            | "readlink"
+            | "realpath"
+            | "diff"
+            | "cmp"
+            | "comm"
+            | "join"
+            | "cut"
+            | "paste"
+            | "sort"
+            | "uniq"
+            | "cp"
+            | "mv"
+            | "rm"
+            | "rmdir"
+            | "ln"
+            | "truncate"
+            | "chmod"
+            | "chown"
+            | "chgrp"
+            | "unlink"
+            | "shred"
+            | "tee"
+            | "install"
+            | "dd"
+            | "mkdir"
+            | "mkfifo"
+            | "mknod"
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShellFlagValueKind {
+    Path,
+    Pattern,
+    Other,
+}
+
+fn append_grep_like_path_candidates(
+    command: &str,
+    tokens: &[String],
+    mut idx: usize,
+    candidates: &mut Vec<ShellPermissionPathCandidate>,
+) {
+    let mut pattern_seen = false;
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        if token == "--" {
+            idx += 1;
+            break;
+        }
+        if let Some((value, kind)) = grep_inline_flag_value(token) {
+            if matches!(kind, ShellFlagValueKind::Path) {
+                push_permission_path_candidate(
+                    candidates,
+                    value,
+                    classify_shell_token_access(command, value),
+                );
+            } else if matches!(kind, ShellFlagValueKind::Pattern) {
+                pattern_seen = true;
+            }
+            idx += 1;
+            continue;
+        }
+        if let Some(kind) = grep_flag_value_kind(token) {
+            if let Some(value) = tokens.get(idx + 1) {
+                if matches!(kind, ShellFlagValueKind::Path) {
+                    push_permission_path_candidate(
+                        candidates,
+                        value,
+                        classify_shell_token_access(command, value),
+                    );
+                } else if matches!(kind, ShellFlagValueKind::Pattern) {
+                    pattern_seen = true;
+                }
+                idx += 2;
+                continue;
+            }
+            idx += 1;
+            continue;
+        }
+        if token.starts_with('-') && token != "-" {
+            idx += 1;
+            continue;
+        }
+        if !pattern_seen {
+            pattern_seen = true;
+            idx += 1;
+            continue;
+        }
+        push_permission_path_candidate(
+            candidates,
+            token,
+            classify_shell_token_access(command, token),
+        );
+        idx += 1;
+    }
+
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        push_permission_path_candidate(
+            candidates,
+            token,
+            classify_shell_token_access(command, token),
+        );
+        idx += 1;
+    }
+}
+
+fn grep_flag_value_kind(flag: &str) -> Option<ShellFlagValueKind> {
+    match flag {
+        "-e" | "--regexp" => Some(ShellFlagValueKind::Pattern),
+        "-f" | "--file" => Some(ShellFlagValueKind::Path),
+        "-m"
+        | "--max-count"
+        | "-A"
+        | "--after-context"
+        | "-B"
+        | "--before-context"
+        | "-C"
+        | "--context"
+        | "--label"
+        | "--binary-files"
+        | "--include"
+        | "--exclude"
+        | "--exclude-dir"
+        | "--exclude-from"
+        | "-g"
+        | "--glob"
+        | "--iglob"
+        | "-t"
+        | "--type"
+        | "-T"
+        | "--type-not"
+        | "--colors"
+        | "--engine"
+        | "--sort"
+        | "--sortr"
+        | "--encoding"
+        | "--context-separator"
+        | "--path-separator" => Some(ShellFlagValueKind::Other),
+        _ => None,
+    }
+}
+
+fn grep_inline_flag_value(flag: &str) -> Option<(&str, ShellFlagValueKind)> {
+    flag.strip_prefix("--regexp=")
+        .map(|value| (value, ShellFlagValueKind::Pattern))
+        .or_else(|| {
+            flag.strip_prefix("--file=")
+                .map(|value| (value, ShellFlagValueKind::Path))
+        })
+        .or_else(|| {
+            flag.strip_prefix("--include=")
+                .map(|value| (value, ShellFlagValueKind::Other))
+        })
+        .or_else(|| {
+            flag.strip_prefix("--exclude=")
+                .map(|value| (value, ShellFlagValueKind::Other))
+        })
+        .or_else(|| {
+            flag.strip_prefix("--exclude-dir=")
+                .map(|value| (value, ShellFlagValueKind::Other))
+        })
+        .or_else(|| {
+            flag.strip_prefix("--exclude-from=")
+                .map(|value| (value, ShellFlagValueKind::Other))
+        })
+        .or_else(|| {
+            flag.strip_prefix("--glob=")
+                .map(|value| (value, ShellFlagValueKind::Other))
+        })
+        .or_else(|| {
+            flag.strip_prefix("--iglob=")
+                .map(|value| (value, ShellFlagValueKind::Other))
+        })
+        .or_else(|| {
+            flag.strip_prefix("--type=")
+                .map(|value| (value, ShellFlagValueKind::Other))
+        })
+        .or_else(|| {
+            flag.strip_prefix("--type-not=")
+                .map(|value| (value, ShellFlagValueKind::Other))
+        })
+        .or_else(|| {
+            flag.strip_prefix("-e")
+                .filter(|value| !value.is_empty())
+                .map(|value| (value, ShellFlagValueKind::Pattern))
+        })
+        .or_else(|| {
+            flag.strip_prefix("-f")
+                .filter(|value| !value.is_empty())
+                .map(|value| (value, ShellFlagValueKind::Path))
+        })
+        .or_else(|| {
+            flag.strip_prefix("-g")
+                .filter(|value| !value.is_empty())
+                .map(|value| (value, ShellFlagValueKind::Other))
+        })
+}
+
+fn append_sed_path_candidates(
+    command: &str,
+    tokens: &[String],
+    mut idx: usize,
+    candidates: &mut Vec<ShellPermissionPathCandidate>,
+) {
+    let mut script_seen = false;
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        if token == "--" {
+            idx += 1;
+            break;
+        }
+        if let Some(value) = token
+            .strip_prefix("-f")
+            .filter(|value| !value.is_empty())
+            .or_else(|| token.strip_prefix("--file="))
+        {
+            push_permission_path_candidate(
+                candidates,
+                value,
+                classify_shell_token_access(command, value),
+            );
+            idx += 1;
+            continue;
+        }
+        if token.starts_with("-e") && token.len() > 2 && !token.starts_with("--")
+            || token.starts_with("--expression=")
+        {
+            script_seen = true;
+            idx += 1;
+            continue;
+        }
+        if matches!(token, "-f" | "--file") {
+            if let Some(value) = tokens.get(idx + 1) {
+                push_permission_path_candidate(
+                    candidates,
+                    value,
+                    classify_shell_token_access(command, value),
+                );
+                idx += 2;
+                continue;
+            }
+        }
+        if matches!(token, "-e" | "--expression") {
+            script_seen = true;
+            idx += 2;
+            continue;
+        }
+        if token.starts_with('-') && token != "-" {
+            idx += 1;
+            continue;
+        }
+        if !script_seen {
+            script_seen = true;
+            idx += 1;
+            continue;
+        }
+        push_permission_path_candidate(
+            candidates,
+            token,
+            classify_shell_token_access(command, token),
+        );
+        idx += 1;
+    }
+
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        push_permission_path_candidate(
+            candidates,
+            token,
+            classify_shell_token_access(command, token),
+        );
+        idx += 1;
+    }
+}
+
+fn append_awk_path_candidates(
+    command: &str,
+    tokens: &[String],
+    mut idx: usize,
+    candidates: &mut Vec<ShellPermissionPathCandidate>,
+) {
+    let mut program_seen = false;
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        if token == "--" {
+            idx += 1;
+            break;
+        }
+        if let Some(value) = token
+            .strip_prefix("-f")
+            .filter(|value| !value.is_empty())
+            .or_else(|| token.strip_prefix("--file="))
+            .or_else(|| token.strip_prefix("-i").filter(|value| !value.is_empty()))
+            .or_else(|| token.strip_prefix("--include="))
+        {
+            push_permission_path_candidate(
+                candidates,
+                value,
+                classify_shell_token_access(command, value),
+            );
+            idx += 1;
+            continue;
+        }
+        if (token.starts_with("-F") || token.starts_with("-v")) && token.len() > 2
+            || token.starts_with("--field-separator=")
+            || token.starts_with("--assign=")
+        {
+            idx += 1;
+            continue;
+        }
+        if matches!(token, "-f" | "--file" | "-i" | "--include") {
+            if let Some(value) = tokens.get(idx + 1) {
+                push_permission_path_candidate(
+                    candidates,
+                    value,
+                    classify_shell_token_access(command, value),
+                );
+                idx += 2;
+                continue;
+            }
+        }
+        if matches!(token, "-F" | "--field-separator" | "-v" | "--assign") {
+            idx += 2;
+            continue;
+        }
+        if token.starts_with('-') && token != "-" {
+            idx += 1;
+            continue;
+        }
+        if !program_seen {
+            program_seen = true;
+            idx += 1;
+            continue;
+        }
+        push_permission_path_candidate(
+            candidates,
+            token,
+            classify_shell_token_access(command, token),
+        );
+        idx += 1;
+    }
+
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        push_permission_path_candidate(
+            candidates,
+            token,
+            classify_shell_token_access(command, token),
+        );
+        idx += 1;
+    }
+}
+
+fn append_generic_file_operand_candidates(
+    command: &str,
+    tokens: &[String],
+    mut idx: usize,
+    candidates: &mut Vec<ShellPermissionPathCandidate>,
+) {
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        if token == "--" {
+            idx += 1;
+            break;
+        }
+        if token.starts_with('-') && token != "-" {
+            idx += 1;
+            continue;
+        }
+        push_permission_path_candidate(
+            candidates,
+            token,
+            classify_shell_token_access(command, token),
+        );
+        idx += 1;
+    }
+
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        push_permission_path_candidate(
+            candidates,
+            token,
+            classify_shell_token_access(command, token),
+        );
+        idx += 1;
+    }
+}
+
+fn shell_command_segments(command: &str) -> Vec<&str> {
+    let chars: Vec<(usize, char)> = command.char_indices().collect();
+    let mut segments = Vec::new();
+    let mut segment_start = 0usize;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+    let mut idx = 0usize;
+
+    while idx < chars.len() {
+        let (byte_idx, ch) = chars[idx];
+        if escaped {
+            escaped = false;
+            idx += 1;
+            continue;
+        }
+        if ch == '\\' && !in_single_quote {
+            escaped = true;
+            idx += 1;
+            continue;
+        }
+        if ch == '\'' && !in_double_quote {
+            in_single_quote = !in_single_quote;
+            idx += 1;
+            continue;
+        }
+        if ch == '"' && !in_single_quote {
+            in_double_quote = !in_double_quote;
+            idx += 1;
+            continue;
+        }
+        if !in_single_quote && !in_double_quote {
+            let is_double_separator =
+                matches!(ch, '&' | '|') && chars.get(idx + 1).is_some_and(|(_, next)| *next == ch);
+            let is_single_separator = matches!(ch, '|' | ';' | '\n' | '\r');
+            if is_double_separator || is_single_separator {
+                let segment = command[segment_start..byte_idx].trim();
+                if !segment.is_empty() {
+                    segments.push(segment);
+                }
+                segment_start = if is_double_separator {
+                    let (next_idx, next_ch) = chars[idx + 1];
+                    idx += 2;
+                    next_idx + next_ch.len_utf8()
+                } else {
+                    idx += 1;
+                    byte_idx + ch.len_utf8()
+                };
+                continue;
+            }
+        }
+        idx += 1;
+    }
+
+    let segment = command[segment_start..].trim();
+    if !segment.is_empty() {
+        segments.push(segment);
+    }
+    segments
+}
+
+fn redirection_path_candidates(command: &str) -> Vec<ShellPermissionPathCandidate> {
+    let chars: Vec<(usize, char)> = command.char_indices().collect();
+    let mut candidates = Vec::new();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+    let mut idx = 0usize;
+
+    while idx < chars.len() {
+        let (_, ch) = chars[idx];
+        if escaped {
+            escaped = false;
+            idx += 1;
+            continue;
+        }
+        if ch == '\\' && !in_single_quote {
+            escaped = true;
+            idx += 1;
+            continue;
+        }
+        if ch == '\'' && !in_double_quote {
+            in_single_quote = !in_single_quote;
+            idx += 1;
+            continue;
+        }
+        if ch == '"' && !in_single_quote {
+            in_double_quote = !in_double_quote;
+            idx += 1;
+            continue;
+        }
+        if in_single_quote || in_double_quote || !matches!(ch, '<' | '>') {
+            idx += 1;
+            continue;
+        }
+
+        let access = if ch == '>' {
+            PathAccess::Write
+        } else {
+            PathAccess::Read
+        };
+        let mut target_idx = idx + 1;
+        if ch == '<'
+            && chars
+                .get(target_idx)
+                .is_some_and(|(_, next)| matches!(*next, '<'))
+        {
+            idx += 1;
+            continue;
+        }
+        while chars
+            .get(target_idx)
+            .is_some_and(|(_, next)| matches!(*next, '<' | '>' | '&') || next.is_ascii_digit())
+        {
+            target_idx += 1;
+        }
+        while chars
+            .get(target_idx)
+            .is_some_and(|(_, next)| next.is_whitespace())
+        {
+            target_idx += 1;
+        }
+        if chars
+            .get(target_idx)
+            .is_some_and(|(_, next)| *next == '&' || next.is_ascii_digit())
+        {
+            idx = target_idx + 1;
+            continue;
+        }
+        let Some((start, _)) = chars.get(target_idx).copied() else {
+            break;
+        };
+        let mut end = command.len();
+        let mut scan_idx = target_idx;
+        while scan_idx < chars.len() {
+            let (byte_idx, current) = chars[scan_idx];
+            if current.is_whitespace() || matches!(current, '|' | ';' | '&' | '<' | '>' | '(' | ')')
+            {
+                end = byte_idx;
+                break;
+            }
+            scan_idx += 1;
+        }
+        let target = command[start..end].trim_matches(|c| matches!(c, '\'' | '"' | '`'));
+        push_permission_path_candidate(&mut candidates, target, access);
+        idx = scan_idx;
+    }
+
+    candidates
 }
 
 /// Classify whether a path token extracted from a shell command is being read
@@ -703,6 +1342,31 @@ mod tests {
         let artifact_path = artifact_path.to_string_lossy();
         let args = serde_json::json!({
             "command": format!("cat {artifact_path} ~/.ssh/id_rsa")
+        });
+
+        let hit = sensitive_path_match_for_tool_args("bash", &args).expect("sensitive path");
+        assert_eq!(hit.token, "~/.ssh/id_rsa");
+        assert_eq!(hit.sensitivity, PathSensitivity::Sensitive);
+        assert_eq!(hit.access, PathAccess::Read);
+    }
+
+    #[test]
+    fn grep_pattern_mentioning_sensitive_name_is_not_a_sensitive_path_access() {
+        let args = serde_json::json!({
+            "command": r#"grep -n "fn resolve_checked\|sensitive credential\|SANDBOX_DENIED_PREFIX\|\.ssh\|credentials.json" rust/crates/astra-cli/src/edge_tools/shell.rs"#
+        });
+
+        assert_eq!(
+            sensitive_path_match_for_tool_args("bash", &args),
+            None,
+            "grep search text is data, not a filesystem access"
+        );
+    }
+
+    #[test]
+    fn grep_file_operand_with_sensitive_path_is_sensitive() {
+        let args = serde_json::json!({
+            "command": "grep -n needle ~/.ssh/id_rsa"
         });
 
         let hit = sensitive_path_match_for_tool_args("bash", &args).expect("sensitive path");

--- a/rust/crates/astra-turn-core/src/permission/rule_grammar.rs
+++ b/rust/crates/astra-turn-core/src/permission/rule_grammar.rs
@@ -1,77 +1,39 @@
-//! Issue #326 P1.5b / R2 Major 2: versioned rule grammar for
-//! `.astra/permissions.json` and `~/.astra/permissions.json`.
+//! Current permission rule grammar for `.astra/permissions.json` and
+//! `~/.astra/permissions.json`.
 //!
-//! ## Why version the grammar
+//! The grammar is intentionally explicit and fail-closed. Broad tool
+//! rules use `Tool()`, scoped rules use `Tool(key="value")`, and
+//! malformed or unsupported strings are rejected at settings-load time
+//! instead of being silently migrated.
 //!
-//! The legacy v1 grammar was a string with at most one optional
-//! pattern slot:
-//!
-//! - `Bash` (matches every bash call)
-//! - `Bash(git commit:*)` (matches any command starting with `git commit`)
-//! - `Edit` (matches every edit)
-//!
-//! That's all the existing parser ([`crate::permission::types::PermissionRule::parse`])
-//! can express. Plan v3 §P5 needs path globs, structured
-//! argument constraints, cwd_root scoping, git_branch scoping, and
-//! domain-level rules for network tools — none of which fit into a
-//! single `pattern` slot. Without a real grammar the implementer
-//! would either smuggle JSON into that one string (ad-hoc parser,
-//! silent-failure mode) or break backward compat. Both are bad.
-//!
-//! ## Compatibility contract
-//!
-//! - `permissions.json` files written by older astra versions have
-//!   no `grammar_version` field and use bare strings; we treat
-//!   them as v1 and parse with the legacy parser. They are
-//!   automatically read; nothing breaks for an existing user.
-//!
-//! - When the store next saves the file, it tags `grammar_version: 2`
-//!   and writes a `.v1.bak.json` sibling so the user can always
-//!   roll back. Migration is a one-shot per file.
-//!
-//! - The v2 parser is **strict** about unknown keys. A malformed
-//!   rule logs `tracing::warn` and is skipped — but the diagnostic
-//!   path is "loud, never silent". (Issue #326 P0 §load-error
-//!   already wired LoadError up to the TUI banner / headless
-//!   exit-1; corrupt rules surface there.)
-//!
-//! ## Examples (v2)
+//! ## Examples
 //!
 //! ```text
 //! Bash(argv_exact="npm test -- --watch")
 //! Bash(argv_prefix="npm test", cwd_root="packages/web")
 //! Bash(argv_prefix="cargo test")
-//! Edit(path_prefix="src/generated/", op="write")
-//! Edit(path_glob="src/**/*.rs", op="write")
-//! Edit(path_glob="src/auth/*.ts", op="read")
+//! file_write(path_prefix="src/generated/", op="write")
+//! file_write(path_glob="src/**/*.rs", op="write")
+//! read_file(path_glob="src/auth/*.ts", op="read")
 //! Network(tool="web_fetch", domain="api.github.com")
-//! Read(path_glob="**")
 //! MCP(tool="mcp_jira_create_issue", capability="destructive=false")
 //! deny: Bash(argv_prefix="rm -rf")
-//! deny: Edit(path_glob=".env*", op="write")
+//! deny: file_write(path_glob=".env*", op="write")
 //! ```
 //!
 //! Each rule serializes as `Tool(key="value", key="value")`. Keys
 //! are quoted to allow embedded commas/parens. Unknown keys produce
 //! a `RuleParseError::UnknownField` which the loader treats as a
-//! load error (NOT silently dropped — that's the failure mode R1
-//! Major 1 calls out).
+//! load error.
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-/// Current grammar version — written into `permissions.json` by the
-/// store layer. Older files (without a version tag) are migrated to
-/// this version on the next save.
-pub const GRAMMAR_VERSION: u32 = 2;
-
-/// A v2 permission rule. Carries the structured fields plan v3 §P5
-/// needs, plus a fallback `extra` map so the future can add fields
-/// without breaking older parsers.
+/// A parsed permission rule in the current structured grammar.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PermissionRuleV2 {
-    /// Required: tool family (`Bash`, `Edit`, `Read`, `Network`,
-    /// `MCP`, etc.). Stored verbatim; matchers lowercase-compare.
+pub struct PermissionRuleSpec {
+    /// Required: concrete tool or tool family (`Bash`, `Network`, `MCP`, etc.).
+    /// Stored verbatim; matchers lowercase-compare.
     pub tool: String,
 
     /// Bash class: exact command line. Unlike `argv_prefix`, this
@@ -84,24 +46,22 @@ pub struct PermissionRuleV2 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub argv_prefix: Option<String>,
 
-    /// Edit/Read class: gitignore-style path glob.
+    /// File class: gitignore-style path glob.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path_glob: Option<String>,
 
-    /// Edit/Read class: literal path prefix. Unlike `path_glob`, this
+    /// File class: literal path prefix. Unlike `path_glob`, this
     /// does not interpret `*`, `?`, or braces as metacharacters.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path_prefix: Option<String>,
 
-    /// Edit class: operation kind (`"read"` / `"write"`). For Read
-    /// this is implicit but P5 will allow restricting writes
-    /// independently of reads.
+    /// Operation kind (`"read"` / `"write"` / `"execute"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op: Option<String>,
 
     /// Scope: package/Cargo.toml/pkg.json directory the rule binds
-    /// to. P5 plan §cwd-fingerprint defaults this on for new rules
-    /// so `web/npm test` Always doesn't generalize to `api/npm test`.
+    /// to, so `web/npm test` Always doesn't generalize to
+    /// `api/npm test`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd_root: Option<String>,
 
@@ -119,16 +79,14 @@ pub struct PermissionRuleV2 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capability: Option<String>,
 
-    /// Forward-compat slot: anything we don't recognize today is
-    /// kept here so a newer astra writing v2-plus-extensions doesn't
-    /// silently lose them on round-trip. Unknown keys still error
-    /// at PARSE time (loud) — this map is for serializer round-trip
-    /// only.
+    /// Serializer-only extension slot. Unknown keys still error at
+    /// parse time; this map is for callers that already own a parsed
+    /// extension-aware spec.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, String>,
 }
 
-impl PermissionRuleV2 {
+impl PermissionRuleSpec {
     /// Bash rule with normalized argv prefix.
     #[must_use]
     pub fn bash(argv_prefix: impl Into<String>) -> Self {
@@ -147,11 +105,11 @@ impl PermissionRuleV2 {
         }
     }
 
-    /// Edit rule with path glob.
+    /// File write rule with path glob.
     #[must_use]
-    pub fn edit(path_glob: impl Into<String>, op: impl Into<String>) -> Self {
+    pub fn file_write(path_glob: impl Into<String>, op: impl Into<String>) -> Self {
         Self {
-            tool: "Edit".to_string(),
+            tool: "file_write".to_string(),
             argv_exact: None,
             argv_prefix: None,
             path_glob: Some(path_glob.into()),
@@ -188,7 +146,7 @@ impl PermissionRuleV2 {
     }
 }
 
-/// Errors that can occur while parsing a v2 rule string.
+/// Errors that can occur while parsing a permission rule string.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuleParseError {
     /// Empty / whitespace-only input.
@@ -199,13 +157,20 @@ pub enum RuleParseError {
     MalformedField { raw: String },
     /// A key appeared more than once (`argv_prefix=... argv_prefix=...`).
     DuplicateKey { key: String },
-    /// Recognized as v2 syntax but used a key the parser doesn't know.
-    /// We surface this loudly rather than silently dropping —
+    /// Recognized as current syntax but used a key the parser doesn't know.
+    /// We surface this loudly rather than silently dropping;
     /// otherwise typos like `cwd_roott="..."` would become a
-    /// non-firing rule. (Issue #326 P5b loud-load-errors policy.)
+    /// non-firing rule.
     UnknownField { tool: String, key: String },
     /// A required field (e.g. tool name) was empty.
     MissingTool,
+    /// Current rules must spell the argument list explicitly, even
+    /// for broad tool rules (`Tool()`).
+    MissingArgumentList { raw: String },
+    /// Abstract tool families are no longer accepted as persisted
+    /// rules. Persist `file_write` for file-write families or a
+    /// concrete tool such as `write_file` / `read_file` instead.
+    UnsupportedToolFamily { tool: String },
     /// Two fields that describe the same dimension were set together.
     ConflictingFields {
         first: &'static str,
@@ -226,6 +191,18 @@ impl std::fmt::Display for RuleParseError {
                 write!(f, "unknown key `{key}` for tool `{tool}`")
             }
             Self::MissingTool => write!(f, "rule has no tool name"),
+            Self::MissingArgumentList { raw } => {
+                write!(
+                    f,
+                    "permission rule must use Tool(key=\"value\") or Tool() form: {raw}"
+                )
+            }
+            Self::UnsupportedToolFamily { tool } => {
+                write!(
+                    f,
+                    "unsupported permission tool `{tool}`; use file_write or a current exact tool rule"
+                )
+            }
             Self::ConflictingFields { first, second } => {
                 write!(f, "`{first}` and `{second}` cannot be set together")
             }
@@ -235,42 +212,28 @@ impl std::fmt::Display for RuleParseError {
 
 impl std::error::Error for RuleParseError {}
 
-/// Parse a v2-style rule:
+/// Parse a current permission rule:
 ///
 /// ```text
 /// Bash(argv_prefix="npm test", cwd_root="packages/web")
-/// Edit(path_glob="src/**/*.rs", op="write")
+/// file_write(path_glob="src/**/*.rs", op="write")
 /// ```
-///
-/// Falls back to the legacy v1 parser for inputs that don't contain
-/// `=` or `"` (i.e. `Bash(npm:*)`, `Edit`). The fallback always
-/// succeeds — that's what makes the file format backward-compat.
-pub fn parse_rule_v2(s: &str) -> Result<PermissionRuleV2, RuleParseError> {
+pub fn parse_rule(s: &str) -> Result<PermissionRuleSpec, RuleParseError> {
     let s = s.trim();
     if s.is_empty() {
         return Err(RuleParseError::Empty);
     }
 
-    // No paren → bare tool, e.g. `Bash`.
     let Some(paren_start) = s.find('(') else {
-        return Ok(PermissionRuleV2 {
-            tool: s.to_string(),
-            argv_exact: None,
-            argv_prefix: None,
-            path_glob: None,
-            path_prefix: None,
-            op: None,
-            cwd_root: None,
-            git_branch: None,
-            domain: None,
-            capability: None,
-            extra: BTreeMap::new(),
-        });
+        return Err(RuleParseError::MissingArgumentList { raw: s.to_string() });
     };
 
     let tool = s[..paren_start].trim().to_string();
     if tool.is_empty() {
         return Err(RuleParseError::MissingTool);
+    }
+    if matches!(tool.to_ascii_lowercase().as_str(), "edit" | "read") {
+        return Err(RuleParseError::UnsupportedToolFamily { tool });
     }
 
     let Some(paren_end) = s.rfind(')') else {
@@ -279,45 +242,14 @@ pub fn parse_rule_v2(s: &str) -> Result<PermissionRuleV2, RuleParseError> {
     if paren_end <= paren_start {
         return Err(RuleParseError::UnterminatedParen);
     }
+    if !s[paren_end + 1..].trim().is_empty() {
+        return Err(RuleParseError::MalformedField {
+            raw: s[paren_end + 1..].trim().to_string(),
+        });
+    }
     let body = s[paren_start + 1..paren_end].trim();
 
-    // Detect v1 syntax: `pattern:*` with no `=` and no `"`.
-    if !body.contains('=') && !body.contains('"') {
-        // v1 fallback: treat the whole body as a command/path prefix.
-        let pattern = body.trim_end_matches(":*").trim_end_matches('*').trim();
-        let mut rule = PermissionRuleV2 {
-            tool: tool.clone(),
-            argv_exact: None,
-            argv_prefix: None,
-            path_glob: None,
-            path_prefix: None,
-            op: None,
-            cwd_root: None,
-            git_branch: None,
-            domain: None,
-            capability: None,
-            extra: BTreeMap::new(),
-        };
-        if !pattern.is_empty() {
-            // Choose the best-fit field for the legacy pattern by
-            // tool family. Bash → argv_prefix; Edit/Read → path_glob;
-            // anything else (Network, MCP, custom) → extra so we
-            // don't lose it.
-            let lower_tool = tool.to_lowercase();
-            if lower_tool == "bash" {
-                rule.argv_prefix = Some(pattern.to_string());
-            } else if lower_tool == "edit" || lower_tool == "read" || lower_tool == "view" {
-                rule.path_glob = Some(pattern.to_string());
-            } else {
-                rule.extra
-                    .insert("pattern".to_string(), pattern.to_string());
-            }
-        }
-        return Ok(rule);
-    }
-
-    // v2 path: parse comma-separated key="value" pairs.
-    let mut rule = PermissionRuleV2 {
+    let mut rule = PermissionRuleSpec {
         tool: tool.clone(),
         argv_exact: None,
         argv_prefix: None,
@@ -402,10 +334,10 @@ pub fn parse_rule_v2(s: &str) -> Result<PermissionRuleV2, RuleParseError> {
     Ok(rule)
 }
 
-/// Format a rule back into v2 string form. Stable: keys are emitted
+/// Format a rule back into current string form. Stable: keys are emitted
 /// in a fixed order so roundtrip-by-string is deterministic.
 #[must_use]
-pub fn serialize_rule_v2(rule: &PermissionRuleV2) -> String {
+pub fn serialize_rule(rule: &PermissionRuleSpec) -> String {
     let mut fields: Vec<(String, String)> = Vec::new();
     if let Some(v) = &rule.argv_exact {
         fields.push(("argv_exact".into(), v.clone()));
@@ -439,7 +371,7 @@ pub fn serialize_rule_v2(rule: &PermissionRuleV2) -> String {
     }
 
     if fields.is_empty() {
-        return rule.tool.clone();
+        return format!("{}()", rule.tool);
     }
 
     let body = fields
@@ -514,31 +446,29 @@ fn split_top_level_commas(s: &str) -> Vec<&str> {
 mod tests {
     use super::*;
 
-    // ── Roundtrip ──────────────────────────────────────────────────
-
     #[test]
-    fn v2_bash_argv_roundtrip() {
-        let rule = PermissionRuleV2::bash("npm test");
-        let s = serialize_rule_v2(&rule);
+    fn current_bash_argv_roundtrip() {
+        let rule = PermissionRuleSpec::bash("npm test");
+        let s = serialize_rule(&rule);
         assert_eq!(s, "Bash(argv_prefix=\"npm test\")");
-        let parsed = parse_rule_v2(&s).unwrap();
+        let parsed = parse_rule(&s).unwrap();
         assert_eq!(parsed, rule);
     }
 
     #[test]
-    fn v2_edit_path_glob_op_roundtrip() {
-        let rule = PermissionRuleV2::edit("src/**/*.rs", "write");
-        let s = serialize_rule_v2(&rule);
+    fn current_file_path_glob_op_roundtrip() {
+        let rule = PermissionRuleSpec::file_write("src/**/*.rs", "write");
+        let s = serialize_rule(&rule);
         assert!(s.contains("path_glob=\"src/**/*.rs\""));
         assert!(s.contains("op=\"write\""));
-        let parsed = parse_rule_v2(&s).unwrap();
+        let parsed = parse_rule(&s).unwrap();
         assert_eq!(parsed, rule);
     }
 
     #[test]
-    fn v2_edit_path_prefix_op_roundtrip() {
-        let rule = PermissionRuleV2 {
-            tool: "write_file".to_string(),
+    fn current_file_path_prefix_op_roundtrip() {
+        let rule = PermissionRuleSpec {
+            tool: "file_write".to_string(),
             argv_exact: None,
             argv_prefix: None,
             path_glob: None,
@@ -550,15 +480,15 @@ mod tests {
             capability: None,
             extra: BTreeMap::new(),
         };
-        let s = serialize_rule_v2(&rule);
-        assert_eq!(s, r#"write_file(path_prefix="zzz", op="write")"#);
-        let parsed = parse_rule_v2(&s).unwrap();
+        let s = serialize_rule(&rule);
+        assert_eq!(s, r#"file_write(path_prefix="zzz", op="write")"#);
+        let parsed = parse_rule(&s).unwrap();
         assert_eq!(parsed, rule);
     }
 
     #[test]
-    fn v2_full_field_roundtrip() {
-        let rule = PermissionRuleV2 {
+    fn current_full_field_roundtrip() {
+        let rule = PermissionRuleSpec {
             tool: "Bash".to_string(),
             argv_exact: None,
             argv_prefix: Some("cargo test".to_string()),
@@ -571,73 +501,74 @@ mod tests {
             capability: None,
             extra: BTreeMap::new(),
         };
-        let s = serialize_rule_v2(&rule);
-        let parsed = parse_rule_v2(&s).unwrap();
+        let s = serialize_rule(&rule);
+        let parsed = parse_rule(&s).unwrap();
         assert_eq!(parsed, rule);
     }
 
     #[test]
-    fn v2_value_with_comma_roundtrips_through_quoting() {
-        let rule = PermissionRuleV2::bash("echo a, b, c");
-        let s = serialize_rule_v2(&rule);
-        let parsed = parse_rule_v2(&s).unwrap();
+    fn current_value_with_comma_roundtrips_through_quoting() {
+        let rule = PermissionRuleSpec::bash("echo a, b, c");
+        let s = serialize_rule(&rule);
+        let parsed = parse_rule(&s).unwrap();
         assert_eq!(parsed.argv_prefix.as_deref(), Some("echo a, b, c"));
     }
 
     #[test]
-    fn v2_value_with_quotes_roundtrips() {
-        let rule = PermissionRuleV2::bash(r#"echo "hello""#);
-        let s = serialize_rule_v2(&rule);
-        let parsed = parse_rule_v2(&s).unwrap();
+    fn current_value_with_quotes_roundtrips() {
+        let rule = PermissionRuleSpec::bash(r#"echo "hello""#);
+        let s = serialize_rule(&rule);
+        let parsed = parse_rule(&s).unwrap();
         assert_eq!(parsed.argv_prefix.as_deref(), Some(r#"echo "hello""#));
     }
 
-    // ── v1 → v2 fallback ──────────────────────────────────────────
-
     #[test]
-    fn legacy_bash_pattern_migrates_to_argv_prefix() {
-        let rule = parse_rule_v2("Bash(npm:*)").unwrap();
-        assert_eq!(rule.tool, "Bash");
-        assert_eq!(rule.argv_prefix.as_deref(), Some("npm"));
-        assert!(rule.path_glob.is_none());
+    fn unsupported_bash_pattern_is_rejected() {
+        let err = parse_rule("Bash(npm:*)").unwrap_err();
+        assert!(matches!(err, RuleParseError::MalformedField { .. }));
     }
 
     #[test]
-    fn legacy_bash_with_command_and_args() {
-        let rule = parse_rule_v2("Bash(git commit:*)").unwrap();
-        assert_eq!(rule.argv_prefix.as_deref(), Some("git commit"));
+    fn unsupported_bash_with_command_and_args_is_rejected() {
+        let err = parse_rule("Bash(git commit:*)").unwrap_err();
+        assert!(matches!(err, RuleParseError::MalformedField { .. }));
     }
 
     #[test]
-    fn legacy_edit_pattern_migrates_to_path_glob() {
-        let rule = parse_rule_v2("Edit(src/lib.rs)").unwrap();
-        assert_eq!(rule.tool, "Edit");
-        assert_eq!(rule.path_glob.as_deref(), Some("src/lib.rs"));
+    fn unsupported_edit_family_is_rejected() {
+        let err = parse_rule("Edit(src/lib.rs)").unwrap_err();
+        assert!(matches!(err, RuleParseError::UnsupportedToolFamily { .. }));
     }
 
     #[test]
-    fn legacy_bare_tool_no_paren() {
-        let rule = parse_rule_v2("Bash").unwrap();
+    fn unsupported_read_family_is_rejected() {
+        let err = parse_rule(r#"Read(path_glob="**")"#).unwrap_err();
+        assert!(matches!(err, RuleParseError::UnsupportedToolFamily { .. }));
+    }
+
+    #[test]
+    fn unsupported_bare_tool_no_paren_is_rejected() {
+        let err = parse_rule("Bash").unwrap_err();
+        assert!(matches!(err, RuleParseError::MissingArgumentList { .. }));
+    }
+
+    #[test]
+    fn broad_rule_uses_explicit_empty_argument_list() {
+        let rule = parse_rule("Bash()").unwrap();
         assert_eq!(rule.tool, "Bash");
         assert!(rule.argv_prefix.is_none());
+        assert_eq!(serialize_rule(&rule), "Bash()");
     }
 
     #[test]
-    fn legacy_unknown_tool_keeps_pattern_in_extra() {
-        // For Network/MCP/etc the legacy `pattern` slot has no
-        // obvious mapping; we keep it in `extra` rather than
-        // silently dropping.
-        let rule = parse_rule_v2("CustomTool(some-pattern:*)").unwrap();
-        assert_eq!(rule.tool, "CustomTool");
-        assert_eq!(
-            rule.extra.get("pattern").map(String::as_str),
-            Some("some-pattern")
-        );
+    fn unsupported_unknown_tool_pattern_is_rejected() {
+        let err = parse_rule("CustomTool(some-pattern:*)").unwrap_err();
+        assert!(matches!(err, RuleParseError::MalformedField { .. }));
     }
 
     #[test]
     fn network_and_mcp_rules_accept_concrete_tool_key() {
-        let network = parse_rule_v2(r#"Network(tool="web_fetch", domain="github.com")"#).unwrap();
+        let network = parse_rule(r#"Network(tool="web_fetch", domain="github.com")"#).unwrap();
         assert_eq!(
             network.extra.get("tool").map(String::as_str),
             Some("web_fetch")
@@ -645,7 +576,7 @@ mod tests {
         assert_eq!(network.domain.as_deref(), Some("github.com"));
 
         let mcp =
-            parse_rule_v2(r#"MCP(tool="mcp_jira_create_issue", capability="destructive=false")"#)
+            parse_rule(r#"MCP(tool="mcp_jira_create_issue", capability="destructive=false")"#)
                 .unwrap();
         assert_eq!(
             mcp.extra.get("tool").map(String::as_str),
@@ -658,68 +589,66 @@ mod tests {
 
     #[test]
     fn unknown_field_errors_loudly() {
-        let err = parse_rule_v2(r#"Bash(cwd_roott="x")"#).unwrap_err();
+        let err = parse_rule(r#"Bash(cwd_roott="x")"#).unwrap_err();
         assert!(matches!(err, RuleParseError::UnknownField { .. }));
     }
 
     #[test]
     fn duplicate_field_errors_loudly() {
-        let err = parse_rule_v2(r#"Bash(argv_prefix="a", argv_prefix="b")"#).unwrap_err();
+        let err = parse_rule(r#"Bash(argv_prefix="a", argv_prefix="b")"#).unwrap_err();
         assert!(matches!(err, RuleParseError::DuplicateKey { .. }));
     }
 
     #[test]
     fn path_glob_and_path_prefix_conflict_loudly() {
         let err =
-            parse_rule_v2(r#"write_file(path_glob="src/**/*.rs", path_prefix="src/", op="write")"#)
+            parse_rule(r#"file_write(path_glob="src/**/*.rs", path_prefix="src/", op="write")"#)
                 .unwrap_err();
         assert!(matches!(err, RuleParseError::ConflictingFields { .. }));
     }
 
     #[test]
     fn unterminated_paren_errors() {
-        let err = parse_rule_v2("Bash(argv_prefix=\"a\"").unwrap_err();
+        let err = parse_rule("Bash(argv_prefix=\"a\"").unwrap_err();
         assert!(matches!(err, RuleParseError::UnterminatedParen));
     }
 
     #[test]
     fn empty_rule_errors() {
-        assert!(matches!(parse_rule_v2(""), Err(RuleParseError::Empty)));
-        assert!(matches!(parse_rule_v2("   "), Err(RuleParseError::Empty)));
+        assert!(matches!(parse_rule(""), Err(RuleParseError::Empty)));
+        assert!(matches!(parse_rule("   "), Err(RuleParseError::Empty)));
     }
 
     #[test]
     fn missing_tool_errors() {
-        let err = parse_rule_v2("(argv_prefix=\"x\")").unwrap_err();
+        let err = parse_rule("(argv_prefix=\"x\")").unwrap_err();
         assert!(matches!(err, RuleParseError::MissingTool));
     }
 
     #[test]
     fn malformed_field_no_eq_errors() {
-        let err = parse_rule_v2("Bash(argv_prefix\"x\")").unwrap_err();
+        let err = parse_rule("Bash(argv_prefix\"x\")").unwrap_err();
         assert!(matches!(err, RuleParseError::MalformedField { .. }));
     }
 
     #[test]
     fn malformed_field_unterminated_quote_errors() {
-        let err = parse_rule_v2(r#"Bash(argv_prefix="abc)"#).unwrap_err();
+        let err = parse_rule(r#"Bash(argv_prefix="abc)"#).unwrap_err();
         assert!(matches!(
             err,
             RuleParseError::MalformedField { .. } | RuleParseError::UnterminatedParen
         ));
     }
 
-    // ── Forward-compat ───────────────────────────────────────────
+    #[test]
+    fn trailing_content_after_rule_errors() {
+        let err = parse_rule(r#"Bash(argv_prefix="x") trailing"#).unwrap_err();
+        assert!(matches!(err, RuleParseError::MalformedField { .. }));
+    }
 
     #[test]
-    fn extra_fields_roundtrip_via_extra_map() {
-        // A future version writes `priority="high"`; today we don't
-        // know that key. The error path is loud (UnknownField), so
-        // a future-extensions reader is expected to use a more
-        // permissive parser. This test confirms that the *strict*
-        // parser surfaces the unknown key rather than silently
-        // dropping it.
-        let err = parse_rule_v2(r#"Bash(argv_prefix="x", priority="high")"#).unwrap_err();
+    fn unknown_extension_fields_error_loudly() {
+        let err = parse_rule(r#"Bash(argv_prefix="x", priority="high")"#).unwrap_err();
         assert!(matches!(err, RuleParseError::UnknownField { .. }));
     }
 }

--- a/rust/crates/astra-turn-core/src/permission/sync.rs
+++ b/rust/crates/astra-turn-core/src/permission/sync.rs
@@ -385,13 +385,7 @@ impl PermissionRequestHandler {
                         }
                     }
                 } else {
-                    // No callback: auto-approve for non-background, deny for background
-                    let ctx = self.sync_context.read().await;
-                    if ctx.inherited.is_background {
-                        PermissionResponse::deny("no permission handler configured")
-                    } else {
-                        PermissionResponse::approve()
-                    }
+                    PermissionResponse::deny("no permission handler configured")
                 }
             }
         }
@@ -571,6 +565,42 @@ mod handler_tests {
         assert_eq!(
             response.reason.as_deref(),
             Some("bash still needs approval")
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_prompt_without_callback_fails_closed_for_foreground_agent() {
+        let ctx = PermissionSyncContext::root(PermissionMode::Prompt);
+        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+
+        let request = PermissionRequest::new("write_file", serde_json::json!({"path": "out.txt"}));
+        let response = handler.handle_request(&request).await;
+
+        assert!(!response.approved);
+        assert!(
+            response
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("no permission handler configured")),
+            "missing callback should fail closed with an actionable reason, got {response:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_accept_edits_without_callback_fails_closed_for_mutation() {
+        let ctx = PermissionSyncContext::root(PermissionMode::AcceptEdits);
+        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+
+        let request = PermissionRequest::new("bash", serde_json::json!({"command": "npm test"}));
+        let response = handler.handle_request(&request).await;
+
+        assert!(!response.approved);
+        assert!(
+            response
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("no permission handler configured")),
+            "missing callback should fail closed with an actionable reason, got {response:?}"
         );
     }
 

--- a/rust/crates/astra-turn-core/src/permission/sync.rs
+++ b/rust/crates/astra-turn-core/src/permission/sync.rs
@@ -93,18 +93,18 @@ mod tests {
 
     #[test]
     fn test_permission_rule_parse() {
-        let rule = PermissionRule::parse("bash");
+        let rule = PermissionRule::parse("bash()");
         assert_eq!(rule.tool, "bash");
         assert!(rule.pattern.is_none());
 
-        let rule = PermissionRule::parse("Bash(git commit:*)");
+        let rule = PermissionRule::parse(r#"Bash(argv_prefix="git commit")"#);
         assert_eq!(rule.tool, "bash");
         assert_eq!(rule.pattern, Some("git commit".to_string()));
     }
 
     #[test]
     fn test_permission_rule_matches() {
-        let rule = PermissionRule::parse("bash(git commit:*)");
+        let rule = PermissionRule::parse(r#"Bash(argv_prefix="git commit")"#);
 
         assert!(rule.matches("bash", Some("git commit -m 'fix'")));
         assert!(rule.matches("Bash", Some("git commit --amend")));
@@ -116,8 +116,8 @@ mod tests {
     #[test]
     fn test_inherited_permissions() {
         let mut inherited = InheritedPermissions::default();
-        inherited.add_allow(PermissionRule::parse("bash(git:*)"));
-        inherited.add_deny(PermissionRule::parse("bash(rm -rf:*)"));
+        inherited.add_allow(PermissionRule::parse(r#"Bash(argv_prefix="git")"#));
+        inherited.add_deny(PermissionRule::parse(r#"Bash(argv_prefix="rm -rf")"#));
 
         assert!(inherited.is_allowed("bash", Some("git status")));
         assert!(!inherited.is_allowed("bash", Some("npm install")));
@@ -129,7 +129,7 @@ mod tests {
     fn test_permission_sync_context() {
         let inherited = InheritedPermissions {
             mode: PermissionMode::Prompt,
-            allow_rules: vec![PermissionRule::parse("bash(git:*)")],
+            allow_rules: vec![PermissionRule::parse(r#"Bash(argv_prefix="git")"#)],
             deny_rules: vec![],
             ..Default::default()
         };
@@ -140,7 +140,7 @@ mod tests {
         assert!(ctx.is_allowed("bash", Some("git status")));
 
         // Apply session override
-        let update = PermissionUpdate::allow(PermissionRule::parse("bash(npm:*)"));
+        let update = PermissionUpdate::allow(PermissionRule::parse(r#"Bash(argv_prefix="npm")"#));
         ctx.apply_update(&update);
         assert!(ctx.is_allowed("bash", Some("npm install")));
 
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn test_permission_response() {
         let response = PermissionResponse::approve()
-            .with_update(PermissionUpdate::allow(PermissionRule::tool("edit")).persistent());
+            .with_update(PermissionUpdate::allow(PermissionRule::tool("write_file")).persistent());
 
         assert!(response.approved);
         assert_eq!(response.updates.len(), 1);
@@ -206,7 +206,7 @@ mod tests {
     #[test]
     fn test_permission_response_to_message() {
         let response = PermissionResponse::approve().with_update(PermissionUpdate::allow(
-            PermissionRule::parse("bash(git:*)"),
+            PermissionRule::parse(r#"Bash(argv_prefix="git")"#),
         ));
         let from = AgentAddress::new("parent-run", "parent-agent");
         let to = AgentAddress::new("child-run", "child-agent");
@@ -607,7 +607,7 @@ mod handler_tests {
     #[tokio::test]
     async fn handler_respects_inherited_allow() {
         let mut inherited = InheritedPermissions::new(PermissionMode::Prompt);
-        inherited.add_allow(PermissionRule::parse("bash(git:*)"));
+        inherited.add_allow(PermissionRule::parse(r#"Bash(argv_prefix="git")"#));
         let ctx = PermissionSyncContext::new(inherited);
         let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
 
@@ -621,7 +621,7 @@ mod handler_tests {
     #[tokio::test]
     async fn handler_respects_inherited_deny() {
         let mut inherited = InheritedPermissions::new(PermissionMode::Auto);
-        inherited.add_deny(PermissionRule::parse("bash(rm -rf:*)"));
+        inherited.add_deny(PermissionRule::parse(r#"Bash(argv_prefix="rm -rf")"#));
         let ctx = PermissionSyncContext::new(inherited);
         let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
 
@@ -638,7 +638,9 @@ mod handler_tests {
         let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx))).with_callback(
             Box::new(|req, _ctx| {
                 if req.tool_name == "bash" {
-                    PermissionDecision::approve_with_rule(PermissionRule::parse("bash(git:*)"))
+                    PermissionDecision::approve_with_rule(PermissionRule::parse(
+                        r#"Bash(argv_prefix="git")"#,
+                    ))
                 } else {
                     PermissionDecision::deny("unknown tool")
                 }
@@ -659,7 +661,7 @@ mod handler_tests {
         let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
 
         let request = PermissionRequest::new("bash", serde_json::json!({"command": "git status"}))
-            .with_suggested_rule("bash(git:*)");
+            .with_suggested_rule(r#"Bash(argv_prefix="git")"#);
         let response = handler.handle_request(&request).await;
 
         assert!(response.approved);

--- a/rust/crates/astra-turn-core/src/permission/sync.rs
+++ b/rust/crates/astra-turn-core/src/permission/sync.rs
@@ -236,9 +236,6 @@ mod tests {
 
 // ─── Permission Request Handler ─────────────────────────────────────────────
 
-use std::sync::Arc;
-use tokio::sync::RwLock;
-
 fn accept_edits_auto_allows_request(request: &PermissionRequest) -> bool {
     matches!(
         (
@@ -256,14 +253,14 @@ fn accept_edits_auto_allows_request(request: &PermissionRequest) -> bool {
 /// sends responses back to the child.
 pub struct PermissionRequestHandler {
     /// The parent's permission context.
-    sync_context: Arc<RwLock<PermissionSyncContext>>,
+    sync_context: PermissionSyncHandle,
     /// Callback for making permission decisions.
     callback: Option<PermissionCallback>,
 }
 
 impl PermissionRequestHandler {
     /// Create a new handler with the given sync context.
-    pub fn new(sync_context: Arc<RwLock<PermissionSyncContext>>) -> Self {
+    pub fn new(sync_context: PermissionSyncHandle) -> Self {
         Self {
             sync_context,
             callback: None,
@@ -417,8 +414,8 @@ impl PermissionRequestHandler {
     }
 
     /// Get the sync context.
-    pub fn sync_context(&self) -> Arc<RwLock<PermissionSyncContext>> {
-        Arc::clone(&self.sync_context)
+    pub fn sync_context(&self) -> PermissionSyncHandle {
+        std::sync::Arc::clone(&self.sync_context)
     }
 }
 
@@ -432,8 +429,8 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_auto_mode_approves() {
-        let ctx = PermissionSyncContext::root(PermissionMode::Auto);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+        let handler =
+            PermissionRequestHandler::new(PermissionSyncContext::shared_root(PermissionMode::Auto));
 
         let request = PermissionRequest::new("bash", serde_json::json!({"command": "echo hello"}));
         let response = handler.handle_request(&request).await;
@@ -443,8 +440,8 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_deny_mode_denies() {
-        let ctx = PermissionSyncContext::root(PermissionMode::Deny);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+        let handler =
+            PermissionRequestHandler::new(PermissionSyncContext::shared_root(PermissionMode::Deny));
 
         let request = PermissionRequest::new("bash", serde_json::json!({"command": "rm -rf /"}));
         let response = handler.handle_request(&request).await;
@@ -455,8 +452,8 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_plan_mode_denies() {
-        let ctx = PermissionSyncContext::root(PermissionMode::Plan);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+        let handler =
+            PermissionRequestHandler::new(PermissionSyncContext::shared_root(PermissionMode::Plan));
 
         let request = PermissionRequest::new("write_file", serde_json::json!({"path": "plan.txt"}));
         let response = handler.handle_request(&request).await;
@@ -467,8 +464,8 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_plan_mode_allows_plan_control_tools() {
-        let ctx = PermissionSyncContext::root(PermissionMode::Plan);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+        let handler =
+            PermissionRequestHandler::new(PermissionSyncContext::shared_root(PermissionMode::Plan));
 
         let request =
             PermissionRequest::new("exit_plan_mode", serde_json::json!({"plan": "# plan"}));
@@ -479,8 +476,8 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_plan_mode_guides_legacy_aliases_to_exit_plan_mode() {
-        let ctx = PermissionSyncContext::root(PermissionMode::Plan);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+        let handler =
+            PermissionRequestHandler::new(PermissionSyncContext::shared_root(PermissionMode::Plan));
 
         let request =
             PermissionRequest::new("session", serde_json::json!({"action": "exit_plan_mode"}));
@@ -497,15 +494,15 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_accept_edits_auto_approves_workspace_write_without_callback() {
-        let ctx = PermissionSyncContext::root(PermissionMode::AcceptEdits);
         let callback_calls = StdArc::new(AtomicUsize::new(0));
         let seen = StdArc::clone(&callback_calls);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx))).with_callback(
-            Box::new(move |_req, _ctx| {
-                seen.fetch_add(1, Ordering::SeqCst);
-                PermissionDecision::deny("callback should not run for workspace edits")
-            }),
-        );
+        let handler = PermissionRequestHandler::new(PermissionSyncContext::shared_root(
+            PermissionMode::AcceptEdits,
+        ))
+        .with_callback(Box::new(move |_req, _ctx| {
+            seen.fetch_add(1, Ordering::SeqCst);
+            PermissionDecision::deny("callback should not run for workspace edits")
+        }));
 
         let request = PermissionRequest::new(
             "write_file",
@@ -521,15 +518,13 @@ mod handler_tests {
     async fn handler_accept_edits_background_denies_external_write_escalation() {
         let mut inherited = InheritedPermissions::new(PermissionMode::AcceptEdits);
         inherited.is_background = true;
-        let ctx = PermissionSyncContext::new(inherited);
         let callback_calls = StdArc::new(AtomicUsize::new(0));
         let seen = StdArc::clone(&callback_calls);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx))).with_callback(
-            Box::new(move |_req, _ctx| {
+        let handler = PermissionRequestHandler::new(PermissionSyncContext::shared(inherited))
+            .with_callback(Box::new(move |_req, _ctx| {
                 seen.fetch_add(1, Ordering::SeqCst);
                 PermissionDecision::Escalate
-            }),
-        );
+            }));
 
         let request = PermissionRequest::new(
             "write_file",
@@ -547,15 +542,15 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_accept_edits_still_asks_callback_for_bash() {
-        let ctx = PermissionSyncContext::root(PermissionMode::AcceptEdits);
         let callback_calls = StdArc::new(AtomicUsize::new(0));
         let seen = StdArc::clone(&callback_calls);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx))).with_callback(
-            Box::new(move |_req, _ctx| {
-                seen.fetch_add(1, Ordering::SeqCst);
-                PermissionDecision::deny("bash still needs approval")
-            }),
-        );
+        let handler = PermissionRequestHandler::new(PermissionSyncContext::shared_root(
+            PermissionMode::AcceptEdits,
+        ))
+        .with_callback(Box::new(move |_req, _ctx| {
+            seen.fetch_add(1, Ordering::SeqCst);
+            PermissionDecision::deny("bash still needs approval")
+        }));
 
         let request = PermissionRequest::new("bash", serde_json::json!({"command": "cargo test"}));
         let response = handler.handle_request(&request).await;
@@ -570,8 +565,9 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_prompt_without_callback_fails_closed_for_foreground_agent() {
-        let ctx = PermissionSyncContext::root(PermissionMode::Prompt);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+        let handler = PermissionRequestHandler::new(PermissionSyncContext::shared_root(
+            PermissionMode::Prompt,
+        ));
 
         let request = PermissionRequest::new("write_file", serde_json::json!({"path": "out.txt"}));
         let response = handler.handle_request(&request).await;
@@ -588,8 +584,9 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_accept_edits_without_callback_fails_closed_for_mutation() {
-        let ctx = PermissionSyncContext::root(PermissionMode::AcceptEdits);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+        let handler = PermissionRequestHandler::new(PermissionSyncContext::shared_root(
+            PermissionMode::AcceptEdits,
+        ));
 
         let request = PermissionRequest::new("bash", serde_json::json!({"command": "npm test"}));
         let response = handler.handle_request(&request).await;
@@ -608,8 +605,7 @@ mod handler_tests {
     async fn handler_respects_inherited_allow() {
         let mut inherited = InheritedPermissions::new(PermissionMode::Prompt);
         inherited.add_allow(PermissionRule::parse(r#"Bash(argv_prefix="git")"#));
-        let ctx = PermissionSyncContext::new(inherited);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+        let handler = PermissionRequestHandler::new(PermissionSyncContext::shared(inherited));
 
         let request = PermissionRequest::new("bash", serde_json::json!({"command": "git status"}))
             .with_hint("git status");
@@ -622,8 +618,7 @@ mod handler_tests {
     async fn handler_respects_inherited_deny() {
         let mut inherited = InheritedPermissions::new(PermissionMode::Auto);
         inherited.add_deny(PermissionRule::parse(r#"Bash(argv_prefix="rm -rf")"#));
-        let ctx = PermissionSyncContext::new(inherited);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+        let handler = PermissionRequestHandler::new(PermissionSyncContext::shared(inherited));
 
         let request = PermissionRequest::new("bash", serde_json::json!({"command": "rm -rf /"}))
             .with_hint("rm -rf /");
@@ -634,18 +629,18 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_uses_callback() {
-        let ctx = PermissionSyncContext::root(PermissionMode::Prompt);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx))).with_callback(
-            Box::new(|req, _ctx| {
-                if req.tool_name == "bash" {
-                    PermissionDecision::approve_with_rule(PermissionRule::parse(
-                        r#"Bash(argv_prefix="git")"#,
-                    ))
-                } else {
-                    PermissionDecision::deny("unknown tool")
-                }
-            }),
-        );
+        let handler = PermissionRequestHandler::new(PermissionSyncContext::shared_root(
+            PermissionMode::Prompt,
+        ))
+        .with_callback(Box::new(|req, _ctx| {
+            if req.tool_name == "bash" {
+                PermissionDecision::approve_with_rule(PermissionRule::parse(
+                    r#"Bash(argv_prefix="git")"#,
+                ))
+            } else {
+                PermissionDecision::deny("unknown tool")
+            }
+        }));
 
         let request = PermissionRequest::new("bash", serde_json::json!({"command": "git status"}));
         let response = handler.handle_request(&request).await;
@@ -657,8 +652,8 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_applies_suggested_rule_in_auto() {
-        let ctx = PermissionSyncContext::root(PermissionMode::Auto);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+        let handler =
+            PermissionRequestHandler::new(PermissionSyncContext::shared_root(PermissionMode::Auto));
 
         let request = PermissionRequest::new("bash", serde_json::json!({"command": "git status"}))
             .with_suggested_rule(r#"Bash(argv_prefix="git")"#);
@@ -675,8 +670,8 @@ mod handler_tests {
 
     #[tokio::test]
     async fn handler_process_message() {
-        let ctx = PermissionSyncContext::root(PermissionMode::Auto);
-        let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(ctx)));
+        let handler =
+            PermissionRequestHandler::new(PermissionSyncContext::shared_root(PermissionMode::Auto));
 
         let request = PermissionRequest::new("bash", serde_json::json!({"command": "ls"}));
         let from = AgentAddress::new("child-run", "child");

--- a/rust/crates/astra-turn-core/src/permission/types.rs
+++ b/rust/crates/astra-turn-core/src/permission/types.rs
@@ -917,6 +917,15 @@ pub struct PermissionSyncContext {
     telemetry: PermissionTelemetry,
 }
 
+/// Shared runtime permission context handle.
+///
+/// Runtime entrypoints should construct permission state through
+/// [`PermissionSyncContext::shared`] or [`PermissionSyncContext::shared_root`]
+/// instead of open-coding `Arc<RwLock<PermissionSyncContext>>`. Keeping the
+/// handle shape centralized prevents new CLI/server/edge entrypoints from
+/// silently reintroducing a missing-context path.
+pub type PermissionSyncHandle = std::sync::Arc<tokio::sync::RwLock<PermissionSyncContext>>;
+
 impl PermissionSyncContext {
     /// Create a new sync context with inherited permissions.
     pub fn new(inherited: InheritedPermissions) -> Self {
@@ -928,12 +937,28 @@ impl PermissionSyncContext {
         }
     }
 
+    /// Create a shared runtime permission context from an explicit inherited
+    /// permissions envelope.
+    pub fn shared(inherited: InheritedPermissions) -> PermissionSyncHandle {
+        Self::new(inherited).into_shared()
+    }
+
+    /// Convert an already-built context into a shared runtime handle.
+    pub fn into_shared(self) -> PermissionSyncHandle {
+        std::sync::Arc::new(tokio::sync::RwLock::new(self))
+    }
+
     /// Create a context with no inherited permissions (root agent).
     pub fn root(mode: PermissionMode) -> Self {
         Self::new(InheritedPermissions {
             mode,
             ..Default::default()
         })
+    }
+
+    /// Create a shared root runtime permission context.
+    pub fn shared_root(mode: PermissionMode) -> PermissionSyncHandle {
+        Self::shared(InheritedPermissions::new(mode))
     }
 
     /// Get the effective permission mode.
@@ -1411,6 +1436,45 @@ mod tests {
         assert!(child_perms.is_background);
         assert!(child_perms.is_allowed("bash", Some("git status")));
         assert!(child_perms.is_allowed("bash", Some("npm install")));
+    }
+
+    #[tokio::test]
+    async fn permission_sync_shared_handle_preserves_explicit_envelope() {
+        let inherited = InheritedPermissions {
+            mode: PermissionMode::Deny,
+            allowed_tools: Some(["read_file".to_string()].into_iter().collect()),
+            ..Default::default()
+        };
+
+        let handle = PermissionSyncContext::shared(inherited);
+        let ctx = handle.read().await;
+
+        assert_eq!(ctx.mode(), PermissionMode::Deny);
+        assert!(ctx.inherited.is_tool_allowed_by_allowlist("read_file"));
+        assert!(!ctx.inherited.is_tool_allowed_by_allowlist("bash"));
+    }
+
+    #[tokio::test]
+    async fn permission_sync_shared_root_uses_root_envelope() {
+        let handle = PermissionSyncContext::shared_root(PermissionMode::AcceptEdits);
+        let ctx = handle.read().await;
+
+        assert_eq!(ctx.mode(), PermissionMode::AcceptEdits);
+        assert!(ctx.inherited.allow_rules.is_empty());
+        assert!(ctx.inherited.deny_rules.is_empty());
+    }
+
+    #[tokio::test]
+    async fn permission_sync_into_shared_preserves_session_updates() {
+        let mut ctx = PermissionSyncContext::root(PermissionMode::Prompt);
+        ctx.apply_update(&PermissionUpdate::allow(PermissionRule::parse(
+            r#"Bash(argv_prefix="cargo test")"#,
+        )));
+
+        let handle = ctx.into_shared();
+        let shared = handle.read().await;
+
+        assert!(shared.is_allowed("bash", Some("cargo test -p astra-runtime")));
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/permission/types.rs
+++ b/rust/crates/astra-turn-core/src/permission/types.rs
@@ -110,11 +110,8 @@ impl PermissionPatternMatch {
 
 /// A permission rule that can be inherited or synchronized.
 ///
-/// Format: `tool_name` or `tool_name(pattern:*)` for prefix matching.
-/// Examples:
-/// - `bash` — matches all bash commands
-/// - `bash(git commit:*)` — matches bash commands starting with "git commit"
-/// - `edit` — matches all edit operations
+/// Persisted string form uses the current explicit grammar:
+/// `Tool()` for broad rules or `Tool(key="value")` for scoped rules.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PermissionRule {
     /// Tool name (lowercase).
@@ -122,8 +119,8 @@ pub struct PermissionRule {
     /// Optional command prefix for execute tools.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pattern: Option<String>,
-    /// Whether `pattern` is a legacy prefix/glob match or an exact
-    /// command/path match.
+    /// Whether `pattern` is a prefix/glob, exact command/path, or
+    /// literal path-prefix match.
     #[serde(default, skip_serializing_if = "PermissionPatternMatch::is_prefix")]
     pub pattern_match: PermissionPatternMatch,
     /// Optional operation kind constraint (`read`, `write`, `execute`).
@@ -172,9 +169,9 @@ impl PermissionRule {
         }
     }
 
-    /// Convert a parsed grammar-v2 rule into the enforcement shape.
+    /// Convert a parsed rule spec into the enforcement shape.
     #[must_use]
-    pub fn from_rule_v2(rule: crate::permission::rule_grammar::PermissionRuleV2) -> Self {
+    pub fn from_rule_spec(rule: crate::permission::rule_grammar::PermissionRuleSpec) -> Self {
         let lower_family = rule.tool.to_lowercase();
         let tool = if matches!(lower_family.as_str(), "network" | "mcp") {
             rule.extra
@@ -190,12 +187,6 @@ impl PermissionRule {
                 (Some(exact), PermissionPatternMatch::Exact)
             } else {
                 (rule.argv_prefix.clone(), PermissionPatternMatch::Prefix)
-            }
-        } else if matches!(lower_family.as_str(), "edit" | "read" | "view") {
-            if let Some(path_prefix) = rule.path_prefix.clone() {
-                (Some(path_prefix), PermissionPatternMatch::PathPrefix)
-            } else {
-                (rule.path_glob.clone(), PermissionPatternMatch::Prefix)
             }
         } else {
             (
@@ -226,30 +217,25 @@ impl PermissionRule {
         }
     }
 
-    /// Parse a rule from string format: `Tool` or `Tool(pattern:*)`.
+    /// Parse a rule from the current explicit string format.
+    pub fn try_parse(
+        rule_str: &str,
+    ) -> Result<Self, crate::permission::rule_grammar::RuleParseError> {
+        crate::permission::rule_grammar::parse_rule(rule_str).map(Self::from_rule_spec)
+    }
+
+    /// Parse a rule from the current explicit string format.
+    ///
+    /// Invalid inputs become a non-matching sentinel. Settings loading
+    /// validates rules first and surfaces the parse error to the user;
+    /// this fallback keeps direct internal callers fail-closed.
     pub fn parse(rule_str: &str) -> Self {
-        if let Ok(rule) = crate::permission::rule_grammar::parse_rule_v2(rule_str) {
-            return Self::from_rule_v2(rule);
-        }
-        if let Some(paren_start) = rule_str.find('(') {
-            if let Some(paren_end) = rule_str.rfind(')') {
-                let tool = rule_str[..paren_start].to_lowercase();
-                let inner = &rule_str[paren_start + 1..paren_end];
-                let pattern = inner.trim_end_matches(":*").trim_end_matches('*');
-                return Self {
-                    tool,
-                    pattern: Some(pattern.to_string()),
-                    pattern_match: PermissionPatternMatch::Prefix,
-                    op: None,
-                    cwd_root: None,
-                    git_branch: None,
-                    domain: None,
-                    capability: None,
-                };
-            }
-        }
+        Self::try_parse(rule_str).unwrap_or_else(|_| Self::invalid())
+    }
+
+    fn invalid() -> Self {
         Self {
-            tool: rule_str.to_lowercase(),
+            tool: "__invalid_permission_rule__".to_string(),
             pattern: None,
             pattern_match: PermissionPatternMatch::Prefix,
             op: None,
@@ -262,15 +248,13 @@ impl PermissionRule {
 
     /// Check if this rule matches a tool call.
     ///
-    /// Issue #326 P5 / R2 Major 2: a pattern that contains glob
-    /// metacharacters (`*` / `**` / `?` / `{a,b}`) is matched
-    /// against the command string via [`crate::permission::path_glob::glob_match`].
-    /// Patterns without metacharacters fall back to the legacy
-    /// word-boundary prefix match so existing rules continue to
-    /// behave the same way (`Bash(npm test:*)` still allows
-    /// `npm test --verbose`).
+    /// A pattern that contains glob metacharacters (`*` / `**` / `?` /
+    /// `{a,b}`) is matched against the command string via
+    /// [`crate::permission::path_glob::glob_match`]. Plain command
+    /// prefixes use word-boundary prefix matching so `npm test`
+    /// allows `npm test --verbose` but not `npm testify`.
     pub fn matches(&self, tool_name: &str, command: Option<&str>) -> bool {
-        self.matches_with_context(tool_name, &RuleMatchContext::legacy(command))
+        self.matches_with_context(tool_name, &RuleMatchContext::from_command_hint(command))
     }
 
     /// True when a bash allow rule is broad enough to bypass the safety
@@ -389,7 +373,7 @@ impl PermissionRule {
                     let lower_cmd = cmd.to_lowercase();
                     crate::permission::path_glob::glob_match(pattern, &lower_cmd)
                 } else {
-                    // Legacy word-boundary prefix path.
+                    // Word-boundary prefix path.
                     let lower_cmd = cmd.to_lowercase();
                     let lower_prefix = pattern.to_lowercase();
                     if !lower_cmd.starts_with(&lower_prefix) {
@@ -407,7 +391,7 @@ impl PermissionRule {
 }
 
 fn file_write_family_matches(rule_tool: &str, tool_name: &str, ctx: &RuleMatchContext) -> bool {
-    rule_tool == "edit"
+    rule_tool == "file_write"
         && matches!(
             crate::cloud::approval_policy::cloud_gated_tool_kind(tool_name),
             Some(crate::cloud::approval_policy::CloudGatedToolKind::Write)
@@ -420,7 +404,7 @@ fn file_write_family_matches(rule_tool: &str, tool_name: &str, ctx: &RuleMatchCo
         && crate::tool::categories::registry().is_file_op(tool_name)
 }
 
-/// Context for v2 permission-rule matching.
+/// Context for permission-rule matching.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RuleMatchContext {
     pub command: Option<String>,
@@ -434,7 +418,7 @@ pub struct RuleMatchContext {
 
 impl RuleMatchContext {
     #[must_use]
-    pub fn legacy(command: Option<&str>) -> Self {
+    pub fn from_command_hint(command: Option<&str>) -> Self {
         Self {
             command: command.map(ToOwned::to_owned),
             path: command.map(ToOwned::to_owned),
@@ -593,54 +577,42 @@ fn current_git_branch(cwd: &Path) -> Option<String> {
 
 /// Cheap predicate: does `pattern` contain any of the glob
 /// metacharacters [`crate::permission::path_glob`] recognizes?
-/// Used to decide between glob-match and legacy prefix-match.
+/// Used to decide between glob-match and prefix-match.
 fn pattern_contains_glob_metachars(pattern: &str) -> bool {
     pattern.contains('*') || pattern.contains('?') || pattern.contains('{')
 }
 
 impl std::fmt::Display for PermissionRule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let has_v2_constraints = self.op.is_some()
-            || self.cwd_root.is_some()
-            || self.git_branch.is_some()
-            || self.domain.is_some()
-            || self.capability.is_some();
-        if has_v2_constraints {
-            let mut rule = crate::permission::rule_grammar::PermissionRuleV2 {
-                tool: self.tool.clone(),
-                argv_exact: None,
-                argv_prefix: None,
-                path_glob: None,
-                path_prefix: None,
-                op: self.op.clone(),
-                cwd_root: self.cwd_root.clone(),
-                git_branch: self.git_branch.clone(),
-                domain: self.domain.clone(),
-                capability: self.capability.clone(),
-                extra: Default::default(),
-            };
-            if self.tool == "bash" {
-                if self.pattern_match == PermissionPatternMatch::Exact {
-                    rule.argv_exact = self.pattern.clone();
-                } else {
-                    rule.argv_prefix = self.pattern.clone();
-                }
-            } else if self.pattern_match == PermissionPatternMatch::PathPrefix {
-                rule.path_prefix = self.pattern.clone();
+        let mut rule = crate::permission::rule_grammar::PermissionRuleSpec {
+            tool: self.tool.clone(),
+            argv_exact: None,
+            argv_prefix: None,
+            path_glob: None,
+            path_prefix: None,
+            op: self.op.clone(),
+            cwd_root: self.cwd_root.clone(),
+            git_branch: self.git_branch.clone(),
+            domain: self.domain.clone(),
+            capability: self.capability.clone(),
+            extra: Default::default(),
+        };
+        if self.tool == "bash" {
+            if self.pattern_match == PermissionPatternMatch::Exact {
+                rule.argv_exact = self.pattern.clone();
             } else {
-                rule.path_glob = self.pattern.clone();
+                rule.argv_prefix = self.pattern.clone();
             }
-            write!(
-                f,
-                "{}",
-                crate::permission::rule_grammar::serialize_rule_v2(&rule)
-            )
+        } else if self.pattern_match == PermissionPatternMatch::PathPrefix {
+            rule.path_prefix = self.pattern.clone();
         } else {
-            match &self.pattern {
-                Some(pat) => write!(f, "{}({}:*)", self.tool, pat),
-                None => write!(f, "{}", self.tool),
-            }
+            rule.path_glob = self.pattern.clone();
         }
+        write!(
+            f,
+            "{}",
+            crate::permission::rule_grammar::serialize_rule(&rule)
+        )
     }
 }
 
@@ -670,11 +642,11 @@ pub struct InheritedPermissions {
     #[serde(default)]
     pub is_background: bool,
     /// Issue #326 P0 / R1 Major 10 / task #17:
-    /// Fingerprinted session overrides from the parent. The legacy
+    /// Fingerprinted session overrides from the parent. The
     /// `allow_rules` / `deny_rules` above carry **command-prefix-level**
     /// rules; this field carries **per-fingerprint** decisions
-    /// (`Bash(cargo test:*) → Allow` is **not** the same as
-    /// `Bash(*) → Allow`). Children must consult this BEFORE the legacy
+    /// (`Bash(argv_prefix="cargo test") → Allow` is **not** the same as
+    /// `Bash() → Allow`). Children must consult this BEFORE the inherited
     /// rules so a "user pressed Always on cargo test" decision doesn't
     /// get downgraded to "Bash is fully allowed".
     ///
@@ -684,8 +656,8 @@ pub struct InheritedPermissions {
     /// between `astra-turn-core::permission_types` and
     /// `astra-turn-core::approval_fingerprint`). The deserialization
     /// is best-effort: if a child receives a payload that fails to
-    /// parse, it falls back to the legacy allow/deny rules and logs a
-    /// warning — never silently downgrades.
+    /// parse, it falls back to the allow/deny rules and logs a
+    /// warning.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fingerprinted_overrides: Option<serde_json::Value>,
 }
@@ -708,7 +680,7 @@ impl InheritedPermissions {
     }
     /// Check if a tool is explicitly allowed by inherited rules.
     pub fn is_allowed(&self, tool_name: &str, command: Option<&str>) -> bool {
-        self.is_allowed_with_context(tool_name, &RuleMatchContext::legacy(command))
+        self.is_allowed_with_context(tool_name, &RuleMatchContext::from_command_hint(command))
     }
 
     /// Check if a tool is explicitly allowed by inherited rules.
@@ -720,7 +692,7 @@ impl InheritedPermissions {
 
     /// Check if a tool is explicitly denied by inherited rules.
     pub fn is_denied(&self, tool_name: &str, command: Option<&str>) -> bool {
-        self.is_denied_with_context(tool_name, &RuleMatchContext::legacy(command))
+        self.is_denied_with_context(tool_name, &RuleMatchContext::from_command_hint(command))
     }
 
     /// Check if a tool is explicitly denied by inherited rules.
@@ -779,7 +751,7 @@ pub struct PermissionRequest {
     pub hint: Option<String>,
     /// Full tool arguments (for parent to inspect).
     pub args: serde_json::Value,
-    /// Child's suggested rule if approved (e.g., "bash(git commit:*)").
+    /// Child's suggested rule if approved (e.g., `Bash(argv_prefix="git commit")`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_rule: Option<String>,
     /// Brief description of why the tool is needed.
@@ -971,7 +943,7 @@ impl PermissionSyncContext {
 
     /// Check if a tool is allowed (by inherited or session rules).
     pub fn is_allowed(&self, tool_name: &str, command: Option<&str>) -> bool {
-        self.is_allowed_with_context(tool_name, &RuleMatchContext::legacy(command))
+        self.is_allowed_with_context(tool_name, &RuleMatchContext::from_command_hint(command))
     }
 
     /// Check if a tool is allowed (by inherited or session rules).
@@ -990,7 +962,7 @@ impl PermissionSyncContext {
 
     /// Check if a tool is denied (by inherited or session rules).
     pub fn is_denied(&self, tool_name: &str, command: Option<&str>) -> bool {
-        self.is_denied_with_context(tool_name, &RuleMatchContext::legacy(command))
+        self.is_denied_with_context(tool_name, &RuleMatchContext::from_command_hint(command))
     }
 
     /// Check if a tool is denied (by inherited or session rules).
@@ -1162,17 +1134,22 @@ mod tests {
 
     #[test]
     fn test_permission_rule_parse() {
-        let rule = PermissionRule::parse("bash");
+        let rule = PermissionRule::parse("bash()");
         assert_eq!(rule.tool, "bash");
         assert!(rule.pattern.is_none());
 
-        let rule = PermissionRule::parse("Bash(git commit:*)");
+        let rule = PermissionRule::parse(r#"Bash(argv_prefix="git commit")"#);
         assert_eq!(rule.tool, "bash");
         assert_eq!(rule.pattern, Some("git commit".to_string()));
+
+        assert!(PermissionRule::try_parse("Bash(git commit:*)").is_err());
+        assert!(
+            !PermissionRule::parse("Bash(git commit:*)").matches("bash", Some("git commit -m fix"))
+        );
     }
 
     #[test]
-    fn permission_mode_rejects_legacy_aliases() {
+    fn permission_mode_rejects_removed_aliases() {
         for alias in ["yolo", "bypass-safety", "bypass_safety"] {
             assert!(alias.parse::<PermissionMode>().is_err());
         }
@@ -1180,7 +1157,7 @@ mod tests {
 
     #[test]
     fn test_permission_rule_matches() {
-        let rule = PermissionRule::parse("bash(git commit:*)");
+        let rule = PermissionRule::parse(r#"Bash(argv_prefix="git commit")"#);
 
         assert!(rule.matches("bash", Some("git commit -m 'fix'")));
         assert!(rule.matches("Bash", Some("git commit --amend")));
@@ -1192,14 +1169,14 @@ mod tests {
     #[test]
     fn dangerous_bash_allow_shapes_are_not_honored_as_allow_rules() {
         let mut inherited = InheritedPermissions::new(PermissionMode::Prompt);
-        inherited.add_allow(PermissionRule::parse("bash"));
+        inherited.add_allow(PermissionRule::parse("bash()"));
         inherited.add_allow(PermissionRule::parse(
             r#"Bash(argv_prefix="python", op="execute")"#,
         ));
         inherited.add_allow(PermissionRule::parse(
             r#"Bash(argv_prefix="npm test", op="execute")"#,
         ));
-        inherited.add_deny(PermissionRule::parse("Bash(python:*)"));
+        inherited.add_deny(PermissionRule::parse(r#"Bash(argv_prefix="python")"#));
 
         assert!(!inherited.is_allowed_with_context(
             "bash",
@@ -1223,36 +1200,32 @@ mod tests {
 
     #[test]
     fn rule_matches_with_glob_pattern() {
-        // Issue #326 P5 / R2 Major 2: glob metacharacters in
-        // the pattern switch from prefix-match to full glob.
-        let rule = PermissionRule::with_pattern("edit", "src/**/*.rs");
-        assert!(rule.matches("edit", Some("src/lib.rs")));
-        assert!(rule.matches("edit", Some("src/auth/login.rs")));
-        assert!(rule.matches("edit", Some("src/a/b/c/d.rs")));
-        assert!(!rule.matches("edit", Some("docs/readme.md")));
+        let rule = PermissionRule::with_pattern("file_write", "src/**/*.rs");
+        assert!(rule.matches("file_write", Some("src/lib.rs")));
+        assert!(rule.matches("file_write", Some("src/auth/login.rs")));
+        assert!(rule.matches("file_write", Some("src/a/b/c/d.rs")));
+        assert!(!rule.matches("file_write", Some("docs/readme.md")));
     }
 
     #[test]
     fn rule_matches_with_brace_alternatives() {
-        let rule = PermissionRule::with_pattern("edit", "**/*.{rs,ts,js}");
-        assert!(rule.matches("edit", Some("lib.rs")));
-        assert!(rule.matches("edit", Some("ui/component.ts")));
-        assert!(rule.matches("edit", Some("server.js")));
-        assert!(!rule.matches("edit", Some("config.toml")));
+        let rule = PermissionRule::with_pattern("file_write", "**/*.{rs,ts,js}");
+        assert!(rule.matches("file_write", Some("lib.rs")));
+        assert!(rule.matches("file_write", Some("ui/component.ts")));
+        assert!(rule.matches("file_write", Some("server.js")));
+        assert!(!rule.matches("file_write", Some("config.toml")));
     }
 
     #[test]
-    fn rule_matches_falls_back_to_prefix_when_no_metachars() {
-        // No * / ? / { → legacy word-boundary prefix path
-        // remains unchanged so existing v1 rules still work.
-        let rule = PermissionRule::parse("bash(npm test:*)");
+    fn rule_matches_plain_prefix_when_no_metachars() {
+        let rule = PermissionRule::parse(r#"Bash(argv_prefix="npm test")"#);
         assert!(rule.matches("bash", Some("npm test")));
         assert!(rule.matches("bash", Some("npm test --watch")));
         assert!(!rule.matches("bash", Some("npm run deploy")));
     }
 
     #[test]
-    fn v2_rule_enforces_cwd_root_constraint() {
+    fn current_rule_enforces_cwd_root_constraint() {
         let rule =
             PermissionRule::parse(r#"Bash(argv_prefix="npm test", cwd_root="packages/web")"#);
         let matching = RuleMatchContext {
@@ -1271,7 +1244,7 @@ mod tests {
     }
 
     #[test]
-    fn v2_rule_enforces_git_branch_constraint() {
+    fn current_rule_enforces_git_branch_constraint() {
         let rule = PermissionRule::parse(r#"Bash(argv_prefix="git push", git_branch="main")"#);
         let main_branch = RuleMatchContext {
             command: Some("git push origin main".into()),
@@ -1289,7 +1262,7 @@ mod tests {
     }
 
     #[test]
-    fn v2_rule_enforces_network_domain_constraint() {
+    fn current_rule_enforces_network_domain_constraint() {
         let rule = PermissionRule::parse(r#"Network(tool="web_fetch", domain="github.com")"#);
         let github = RuleMatchContext {
             domain: Some("api.github.com".into()),
@@ -1305,7 +1278,7 @@ mod tests {
     }
 
     #[test]
-    fn v2_rule_enforces_mcp_capability_constraint() {
+    fn current_rule_enforces_mcp_capability_constraint() {
         let rule = PermissionRule::parse(
             r#"MCP(tool="mcp_jira_create_issue", capability="destructive=false")"#,
         );
@@ -1323,8 +1296,8 @@ mod tests {
     }
 
     #[test]
-    fn v2_rule_enforces_op_constraint() {
-        let rule = PermissionRule::parse(r#"Edit(path_glob="src/**/*.rs", op="write")"#);
+    fn current_rule_enforces_op_constraint() {
+        let rule = PermissionRule::parse(r#"file_write(path_glob="src/**/*.rs", op="write")"#);
         let write_ctx = RuleMatchContext {
             path: Some("src/main.rs".into()),
             op: Some("write".into()),
@@ -1336,9 +1309,9 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(rule.matches_with_context("edit", &write_ctx));
         assert!(rule.matches_with_context("write_file", &write_ctx));
         assert!(rule.matches_with_context("str_replace", &write_ctx));
+        assert!(!rule.matches_with_context("edit", &write_ctx));
         assert!(!rule.matches_with_context("edit", &read_ctx));
         assert!(!rule.matches_with_context("read_file", &read_ctx));
         assert!(!rule.matches_with_context("read_file", &write_ctx));
@@ -1346,8 +1319,8 @@ mod tests {
     }
 
     #[test]
-    fn v2_path_rule_without_glob_matches_exact_path() {
-        let rule = PermissionRule::parse(r#"write_file(path_glob="zzzz3.md", op="write")"#);
+    fn current_path_rule_without_glob_matches_exact_path() {
+        let rule = PermissionRule::parse(r#"file_write(path_glob="zzzz3.md", op="write")"#);
         let approved = RuleMatchContext {
             path: Some("zzzz3.md".into()),
             op: Some("write".into()),
@@ -1364,8 +1337,8 @@ mod tests {
     }
 
     #[test]
-    fn v2_path_prefix_rule_matches_sibling_prefixes() {
-        let rule = PermissionRule::parse(r#"write_file(path_prefix="zzz", op="write")"#);
+    fn current_path_prefix_rule_matches_sibling_prefixes() {
+        let rule = PermissionRule::parse(r#"file_write(path_prefix="zzz", op="write")"#);
         let approved = RuleMatchContext {
             path: Some("zzz2.md".into()),
             op: Some("write".into()),
@@ -1382,7 +1355,7 @@ mod tests {
     }
 
     #[test]
-    fn sync_context_uses_v2_constraints_for_allow_rules() {
+    fn sync_context_uses_current_constraints_for_allow_rules() {
         let inherited = InheritedPermissions {
             mode: PermissionMode::Prompt,
             allow_rules: vec![PermissionRule::parse(
@@ -1409,8 +1382,8 @@ mod tests {
     #[test]
     fn test_inherited_permissions() {
         let mut inherited = InheritedPermissions::default();
-        inherited.add_allow(PermissionRule::parse("bash(git:*)"));
-        inherited.add_deny(PermissionRule::parse("bash(rm -rf:*)"));
+        inherited.add_allow(PermissionRule::parse(r#"Bash(argv_prefix="git")"#));
+        inherited.add_deny(PermissionRule::parse(r#"Bash(argv_prefix="rm -rf")"#));
 
         assert!(inherited.is_allowed("bash", Some("git status")));
         assert!(!inherited.is_allowed("bash", Some("npm install")));
@@ -1422,7 +1395,7 @@ mod tests {
     fn test_permission_sync_context() {
         let inherited = InheritedPermissions {
             mode: PermissionMode::Prompt,
-            allow_rules: vec![PermissionRule::parse("bash(git:*)")],
+            allow_rules: vec![PermissionRule::parse(r#"Bash(argv_prefix="git")"#)],
             deny_rules: vec![],
             ..Default::default()
         };
@@ -1430,7 +1403,7 @@ mod tests {
         let mut ctx = PermissionSyncContext::new(inherited);
         assert!(ctx.is_allowed("bash", Some("git status")));
 
-        let update = PermissionUpdate::allow(PermissionRule::parse("bash(npm:*)"));
+        let update = PermissionUpdate::allow(PermissionRule::parse(r#"Bash(argv_prefix="npm")"#));
         ctx.apply_update(&update);
         assert!(ctx.is_allowed("bash", Some("npm install")));
 
@@ -1443,7 +1416,7 @@ mod tests {
     #[test]
     fn test_permission_response() {
         let response = PermissionResponse::approve()
-            .with_update(PermissionUpdate::allow(PermissionRule::tool("edit")).persistent());
+            .with_update(PermissionUpdate::allow(PermissionRule::tool("write_file")).persistent());
 
         assert!(response.approved);
         assert_eq!(response.updates.len(), 1);

--- a/rust/crates/astra-turn-core/src/permission/types.rs
+++ b/rust/crates/astra-turn-core/src/permission/types.rs
@@ -721,6 +721,21 @@ impl InheritedPermissions {
         }
     }
 
+    /// Set the tool allowlist. When set, only these tools may execute.
+    /// Used by the spawner to carry an agent type's `allowed_tools`
+    /// into the permission engine so the `ToolAllowlist` evaluation
+    /// step enforces it. This is the single source of truth for
+    /// execution-time tool restriction.
+    pub fn with_allowed_tools(mut self, tools: impl IntoIterator<Item = String>) -> Self {
+        let set: HashSet<String> = tools
+            .into_iter()
+            .map(|t| t.trim().to_ascii_lowercase())
+            .filter(|t| !t.is_empty() && t != "*")
+            .collect();
+        self.allowed_tools = if set.is_empty() { None } else { Some(set) };
+        self
+    }
+
     /// Add an allow rule.
     pub fn add_allow(&mut self, rule: PermissionRule) {
         if !self.allow_rules.contains(&rule) {

--- a/rust/crates/astra-turn-core/src/permission/types.rs
+++ b/rust/crates/astra-turn-core/src/permission/types.rs
@@ -42,7 +42,7 @@ impl PermissionMode {
         match self {
             Self::Auto => "Auto",
             Self::Plan => "Plan",
-            Self::AcceptEdits => "Edits",
+            Self::AcceptEdits => "Accept",
             Self::Prompt => "Ask",
             Self::Deny => "Deny",
         }
@@ -1146,6 +1146,7 @@ mod tests {
         let parsed = "accept_edits".parse::<PermissionMode>().unwrap();
         assert_eq!(parsed, PermissionMode::AcceptEdits);
         assert_eq!(parsed.to_string(), "accept_edits");
+        assert_eq!(parsed.chip_text(), "Accept");
         assert_eq!(
             "accept-edits".parse::<PermissionMode>().unwrap(),
             PermissionMode::AcceptEdits

--- a/rust/crates/runtime/src/messaging/e2e_loop_tests.rs
+++ b/rust/crates/runtime/src/messaging/e2e_loop_tests.rs
@@ -605,9 +605,7 @@ mod tests {
         let mut host = MockHost::new(vec![text_result("Handled request.")]);
         let mut state = make_state();
         state.messaging.mailbox = Some(parent_mb);
-        state.permission_context = Some(Arc::new(tokio::sync::RwLock::new(
-            PermissionSyncContext::root(PermissionMode::Auto),
-        )));
+        state.permission_context = Some(PermissionSyncContext::shared_root(PermissionMode::Auto));
 
         let outcome = run_agentic_loop_with_host(&mut host, &mut state).await;
         assert!(outcome.is_ok());
@@ -646,17 +644,15 @@ mod tests {
             "arguments": r#"{"command": "echo hi"}"#
         })];
 
-        let permission_context = Arc::new(tokio::sync::RwLock::new(PermissionSyncContext::new(
-            InheritedPermissions {
-                mode: PermissionMode::Prompt,
-                allow_rules: vec![],
-                deny_rules: vec![],
-                ask_rules: vec![],
-                allowed_tools: Some(HashSet::from(["view".to_string()])),
-                is_background: false,
-                ..Default::default()
-            },
-        )));
+        let permission_context = PermissionSyncContext::shared(InheritedPermissions {
+            mode: PermissionMode::Prompt,
+            allow_rules: vec![],
+            deny_rules: vec![],
+            ask_rules: vec![],
+            allowed_tools: Some(HashSet::from(["view".to_string()])),
+            is_background: false,
+            ..Default::default()
+        });
         let mut messages = Vec::new();
         let mut tool_results = Vec::new();
         let valid_tool_names = HashSet::from(["bash".to_string()]);
@@ -1182,6 +1178,7 @@ mod tests {
 
         // Skill was pre-resolved; grep will be matched from edge_tool_round
         let pre_resolved = vec![("skill:0".to_string(), "Skill instructions".to_string())];
+        let permission_context = PermissionSyncContext::shared_root(PermissionMode::Auto);
 
         run_agentic_headless_tool_round(HeadlessToolRoundCtx {
             turn_index: 0,
@@ -1212,7 +1209,7 @@ mod tests {
             tool_event_hooks: &tool_event_hooks,
             term: &mut term,
             mailbox: None,
-            permission_context: None,
+            permission_context: Some(&permission_context),
             progress_emitter: None,
             pre_resolved_results: &pre_resolved,
             server_tool_executor: None,
@@ -1338,25 +1335,23 @@ mod tests {
 
         let (router, parent_mb, mut child_mb, _dt) = setup_two_agents().await;
 
-        // Parent has a handler that approves bash(git:*) requests
-        let parent_ctx = Arc::new(tokio::sync::RwLock::new(PermissionSyncContext::root(
-            PermissionMode::Prompt,
-        )));
+        // Parent has a handler that approves bash requests
+        let parent_ctx = PermissionSyncContext::shared_root(PermissionMode::Prompt);
         let handler = PermissionRequestHandler::new(parent_ctx.clone());
 
-        // Child has permission context that requires asking parent for bash
+        // Child has permission context that requires asking parent for bash.
+        // Use a bare ask rule so this test cannot be accidentally satisfied by
+        // the read-only shortcut before it reaches the mailbox.
         let child_inherited = InheritedPermissions {
             mode: PermissionMode::Prompt,
             allow_rules: vec![],
             deny_rules: vec![],
-            ask_rules: vec![PermissionRule::parse("bash(*)")],
+            ask_rules: vec![PermissionRule::parse("bash")],
             allowed_tools: None,
             is_background: false,
             ..Default::default()
         };
-        let child_permission_ctx = Arc::new(tokio::sync::RwLock::new(PermissionSyncContext::new(
-            child_inherited,
-        )));
+        let child_permission_ctx = PermissionSyncContext::shared(child_inherited);
 
         // Spawn parent handler task
         let parent_router = router.clone();
@@ -1374,7 +1369,7 @@ mod tests {
                 response
                     .updates
                     .push(PermissionUpdate::allow(PermissionRule::parse(
-                        "bash(git:*)",
+                        r#"Bash(argv_prefix="touch")"#,
                     )));
 
                 // Extract the target address from the Direct variant
@@ -1390,9 +1385,9 @@ mod tests {
 
         // Child sends tool call that requires permission
         let tool_calls = vec![json!({
-            "id": "call-bash-git",
+            "id": "call-bash-touch",
             "name": "bash",
-            "arguments": r#"{"command": "git status"}"#
+            "arguments": r#"{"command": "touch astra-permission-approved-test"}"#
         })];
 
         let mut messages = Vec::new();
@@ -1464,6 +1459,10 @@ mod tests {
             "tool should not be blocked by permission: {:?}",
             error
         );
+
+        let telemetry = child_permission_ctx.read().await.telemetry();
+        assert_eq!(telemetry.permission_requests, 1);
+        assert_eq!(telemetry.permission_requests_approved, 1);
     }
 
     /// Test: child requests permission but parent denies
@@ -1474,25 +1473,21 @@ mod tests {
         let (router, parent_mb, mut child_mb, _dt) = setup_two_agents().await;
 
         // Parent has deny mode - rejects all requests
-        let parent_ctx = Arc::new(tokio::sync::RwLock::new(PermissionSyncContext::root(
-            PermissionMode::Deny,
-        )));
+        let parent_ctx = PermissionSyncContext::shared_root(PermissionMode::Deny);
         let handler = PermissionRequestHandler::new(parent_ctx.clone());
 
-        // Child requires asking parent for bash. The ask rule pins the
-        // request-parent flow before the read-only shortcut can decide locally.
+        // Child requires asking parent for bash. The bare ask rule pins the
+        // request-parent flow before any local shortcut can decide.
         let child_inherited = InheritedPermissions {
             mode: PermissionMode::Prompt,
             allow_rules: vec![],
             deny_rules: vec![],
-            ask_rules: vec![PermissionRule::parse("bash(*)")],
+            ask_rules: vec![PermissionRule::parse("bash")],
             allowed_tools: None,
             is_background: false,
             ..Default::default()
         };
-        let child_permission_ctx = Arc::new(tokio::sync::RwLock::new(PermissionSyncContext::new(
-            child_inherited,
-        )));
+        let child_permission_ctx = PermissionSyncContext::shared(child_inherited);
 
         // Spawn parent handler that denies
         let parent_router = router.clone();
@@ -1592,6 +1587,10 @@ mod tests {
             "tool should be blocked by permission denial: {:?}",
             error
         );
+
+        let telemetry = child_permission_ctx.read().await.telemetry();
+        assert_eq!(telemetry.permission_requests, 1);
+        assert_eq!(telemetry.permission_requests_approved, 0);
     }
 
     /// Empty tool names (model bug) must be rejected before dedup counting

--- a/rust/crates/runtime/src/orchestration/agent_tool.rs
+++ b/rust/crates/runtime/src/orchestration/agent_tool.rs
@@ -1458,7 +1458,7 @@ pub async fn handle_agent_spawn_action(args: &Value, ctx: Option<&AgentToolConte
         recursion_depth: ctx.recursion_depth,
         parent_is_fork_child: ctx.is_fork_child,
         working_dir: ctx.working_dir.clone(),
-        inherited_permissions: Some(inherited_permissions),
+        inherited_permissions,
         inherited_skills: ctx.active_skills.clone(),
         live_event_sink: ctx.live_event_sink.clone(),
         trace_context: ctx.trace_context.clone(),

--- a/rust/crates/runtime/src/orchestration/mod.rs
+++ b/rust/crates/runtime/src/orchestration/mod.rs
@@ -46,7 +46,8 @@ pub use fork_cache_probe::{ForkCacheProbeState, maybe_emit_fork_cache_probe};
 pub use permission_sync::{
     InheritedPermissions, PermissionAction, PermissionCallback, PermissionDecision, PermissionMode,
     PermissionRequest, PermissionRequestHandler, PermissionRequestMessaging, PermissionResponse,
-    PermissionResponseMessaging, PermissionRule, PermissionSyncContext, PermissionUpdate,
+    PermissionResponseMessaging, PermissionRule, PermissionSyncContext, PermissionSyncHandle,
+    PermissionUpdate,
 };
 pub use spawner::{
     AgentHistoryRecord, AgentStatus, DynamicAgentSpawner, InheritedChildPrefix, PermissionSummary,

--- a/rust/crates/runtime/src/orchestration/spawner.rs
+++ b/rust/crates/runtime/src/orchestration/spawner.rs
@@ -1756,9 +1756,8 @@ impl DynamicAgentSpawner {
         // SpawnContext requires an envelope so a child cannot enter runtime
         // execution without an authorization context.
         let inherited_permissions = context.inherited_permissions.clone();
-        let permission_context = std::sync::Arc::new(tokio::sync::RwLock::new(
-            super::permission_sync::PermissionSyncContext::new(inherited_permissions.clone()),
-        ));
+        let permission_context =
+            super::permission_sync::PermissionSyncContext::shared(inherited_permissions.clone());
 
         // 8. Build run config
         let run_config = SpawnRunConfig {

--- a/rust/crates/runtime/src/orchestration/spawner.rs
+++ b/rust/crates/runtime/src/orchestration/spawner.rs
@@ -1755,7 +1755,19 @@ impl DynamicAgentSpawner {
         // 7b. Build permission context from explicit inherited permissions.
         // SpawnContext requires an envelope so a child cannot enter runtime
         // execution without an authorization context.
-        let inherited_permissions = context.inherited_permissions.clone();
+        //
+        // The agent type's `allowed_tools` is merged into
+        // `inherited_permissions` here so the permission engine's
+        // `ToolAllowlist` evaluation step enforces it as the single
+        // source of truth (review C1-arch). Previously
+        // `run_config.allowed_tools` carried the list for prompt
+        // pruning but the engine skipped the allowlist step when
+        // `inherited.allowed_tools` was `None` — letting spawned
+        // agents call tools outside their declared surface.
+        let inherited_permissions = context
+            .inherited_permissions
+            .clone()
+            .with_allowed_tools(agent_def.allowed_tools.iter().cloned());
         let permission_context =
             super::permission_sync::PermissionSyncContext::shared(inherited_permissions.clone());
 

--- a/rust/crates/runtime/src/orchestration/spawner.rs
+++ b/rust/crates/runtime/src/orchestration/spawner.rs
@@ -360,7 +360,7 @@ pub struct SpawnContext {
     /// Working directory for the spawned agent.
     pub working_dir: PathBuf,
     /// Permissions inherited from the parent agent.
-    pub inherited_permissions: Option<super::permission_sync::InheritedPermissions>,
+    pub inherited_permissions: super::permission_sync::InheritedPermissions,
     /// Skills inherited from the parent agent (subset of parent's active skills).
     pub inherited_skills: Vec<String>,
     /// Optional live-event sink for child token/tool/status mirroring.
@@ -490,13 +490,13 @@ pub struct SpawnRunConfig {
     /// Optional shared context cache for cross-agent knowledge sharing.
     pub context_cache: Option<Arc<SharedContextCache>>,
     /// Inherited permissions from parent agent.
-    pub inherited_permissions: Option<super::permission_sync::InheritedPermissions>,
+    pub inherited_permissions: super::permission_sync::InheritedPermissions,
     /// Parent agent address for permission requests (if this is a child agent).
     pub parent_address: Option<astra_messaging::types::AgentAddress>,
     /// Permission context for runtime permission management.
-    /// Created from inherited_permissions or as a fresh root context.
+    /// Created from the explicit inherited permissions envelope.
     pub permission_context:
-        Option<std::sync::Arc<tokio::sync::RwLock<super::permission_sync::PermissionSyncContext>>>,
+        std::sync::Arc<tokio::sync::RwLock<super::permission_sync::PermissionSyncContext>>,
     /// Skills inherited from parent agent.
     pub inherited_skills: Vec<String>,
     /// Optional live-event sink for child token/tool/status mirroring.
@@ -1752,11 +1752,13 @@ impl DynamicAgentSpawner {
             &context.parent_agent_id,
         );
 
-        // 7b. Build permission context from inherited permissions
-        let permission_context = context.inherited_permissions.as_ref().map(|inherited| {
-            let ctx = super::permission_sync::PermissionSyncContext::new(inherited.clone());
-            std::sync::Arc::new(tokio::sync::RwLock::new(ctx))
-        });
+        // 7b. Build permission context from explicit inherited permissions.
+        // SpawnContext requires an envelope so a child cannot enter runtime
+        // execution without an authorization context.
+        let inherited_permissions = context.inherited_permissions.clone();
+        let permission_context = std::sync::Arc::new(tokio::sync::RwLock::new(
+            super::permission_sync::PermissionSyncContext::new(inherited_permissions.clone()),
+        ));
 
         // 8. Build run config
         let run_config = SpawnRunConfig {
@@ -1775,7 +1777,7 @@ impl DynamicAgentSpawner {
             progress_emitter: Some(emitter.clone()),
             context_cache: Some(Arc::clone(&self.context_cache)),
             // Inherit permissions from parent context
-            inherited_permissions: context.inherited_permissions.clone(),
+            inherited_permissions,
             // Parent address for permission requests
             parent_address: Some(parent_address),
             // Permission context for runtime permission management
@@ -2782,24 +2784,18 @@ fn estimate_cache_read_tokens(prefix: &astra_turn_core::fork_prefix::ForkPrefix)
 fn build_permission_summary(context: &SpawnContext) -> PermissionSummary {
     let mut summary = PermissionSummary::default();
 
-    if let Some(ref inherited) = context.inherited_permissions {
-        summary.mode = match inherited.mode {
-            super::permission_sync::PermissionMode::Auto => "auto".to_string(),
-            super::permission_sync::PermissionMode::Plan => "plan".to_string(),
-            super::permission_sync::PermissionMode::AcceptEdits => "accept_edits".to_string(),
-            super::permission_sync::PermissionMode::Prompt => "prompt".to_string(),
-            super::permission_sync::PermissionMode::Deny => "deny".to_string(),
-        };
-        summary.allow_rules = inherited.allow_rules.len() as u32;
-        summary.deny_rules = inherited.deny_rules.len() as u32;
-        // Has parent if parent_run_id is not empty and not "root"
-        summary.has_parent =
-            !context.parent_run_id.is_empty() && context.parent_run_id != ROOT_RUN_ID;
-    } else {
-        summary.mode = "auto".to_string();
-        summary.has_parent =
-            !context.parent_run_id.is_empty() && context.parent_run_id != ROOT_RUN_ID;
-    }
+    let inherited = &context.inherited_permissions;
+    summary.mode = match inherited.mode {
+        super::permission_sync::PermissionMode::Auto => "auto".to_string(),
+        super::permission_sync::PermissionMode::Plan => "plan".to_string(),
+        super::permission_sync::PermissionMode::AcceptEdits => "accept_edits".to_string(),
+        super::permission_sync::PermissionMode::Prompt => "prompt".to_string(),
+        super::permission_sync::PermissionMode::Deny => "deny".to_string(),
+    };
+    summary.allow_rules = inherited.allow_rules.len() as u32;
+    summary.deny_rules = inherited.deny_rules.len() as u32;
+    // Has parent if parent_run_id is not empty and not "root"
+    summary.has_parent = !context.parent_run_id.is_empty() && context.parent_run_id != ROOT_RUN_ID;
 
     summary
 }
@@ -2919,7 +2915,7 @@ mod tests {
             recursion_depth: 0,
             parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             live_event_sink: None,
             trace_context: None,
@@ -2930,6 +2926,45 @@ mod tests {
 
         let result = spawner.spawn(input, &context).await.unwrap();
         assert!(matches!(result, SpawnAgentOutput::Launched { .. }));
+    }
+
+    #[tokio::test]
+    async fn spawn_builds_permission_context_from_explicit_inherited_permissions() {
+        let executor = Arc::new(CapturingPermissionExecutor::new());
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_executor(executor.clone() as Arc<dyn SpawnAgentExecutor>);
+        let input = SpawnAgentInput {
+            description: "Test agent".to_string(),
+            prompt: "Do a test".to_string(),
+            agent_type: "explore".to_string(),
+            run_in_background: false,
+            ..Default::default()
+        };
+        let context = SpawnContext {
+            parent_run_id: "parent-123".to_string(),
+            parent_agent_id: "parent".to_string(),
+            recursion_depth: 0,
+            parent_is_fork_child: false,
+            working_dir: PathBuf::from("/tmp"),
+            inherited_permissions: crate::orchestration::InheritedPermissions::new(
+                crate::orchestration::permission_sync::PermissionMode::Deny,
+            ),
+            inherited_skills: vec![],
+            live_event_sink: None,
+            trace_context: None,
+            spawn_tool_call_id: None,
+            execution_metadata: None,
+            delegation_chain: Vec::new(),
+        };
+
+        let result = spawner.spawn(input, &context).await.unwrap();
+        assert!(matches!(result, SpawnAgentOutput::Completed { .. }));
+
+        let mode = executor.take_captured().expect("executor captured config");
+        assert_eq!(
+            mode,
+            crate::orchestration::permission_sync::PermissionMode::Deny
+        );
     }
 
     #[tokio::test]
@@ -2985,7 +3020,7 @@ mod tests {
             recursion_depth: 0,
             parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             live_event_sink: None,
             trace_context: None,
@@ -3038,7 +3073,7 @@ mod tests {
             recursion_depth: 0,
             parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             live_event_sink: None,
             trace_context: None,
@@ -3092,7 +3127,7 @@ mod tests {
             recursion_depth: 0,
             parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             live_event_sink: None,
             trace_context: None,
@@ -3143,7 +3178,7 @@ mod tests {
             parent_agent_id: "main".to_string(),
             recursion_depth: 0,
             parent_is_fork_child: false,
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
             live_event_sink: None,
@@ -3209,11 +3244,27 @@ mod tests {
         captured_depth: std::sync::Mutex<Option<u8>>,
     }
 
+    struct CapturingPermissionExecutor {
+        captured: std::sync::Mutex<Option<crate::orchestration::permission_sync::PermissionMode>>,
+    }
+
     impl CapturingDepthExecutor {
         fn new() -> Self {
             Self {
                 captured_depth: std::sync::Mutex::new(None),
             }
+        }
+    }
+
+    impl CapturingPermissionExecutor {
+        fn new() -> Self {
+            Self {
+                captured: std::sync::Mutex::new(None),
+            }
+        }
+
+        fn take_captured(&self) -> Option<crate::orchestration::permission_sync::PermissionMode> {
+            self.captured.lock().unwrap().take()
         }
     }
 
@@ -3239,6 +3290,30 @@ mod tests {
     impl SpawnAgentExecutor for CapturingPrefixExecutor {
         async fn execute(&self, config: SpawnRunConfig) -> Result<SpawnRunResult, String> {
             *self.captured.lock().unwrap() = Some(config.inherited_prefix.clone());
+            Ok(SpawnRunResult {
+                agent_id: config.agent_id,
+                run_id: config.run_id,
+                status: "completed".into(),
+                finish_reason: "normal".into(),
+                cancelled_by_user: None,
+                output: Some("ok".into()),
+                error: None,
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                tool_calls: 0,
+                permission_summary: None,
+                permission_requests: 0,
+                permission_requests_approved: 0,
+                tools_blocked: 0,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl SpawnAgentExecutor for CapturingPermissionExecutor {
+        async fn execute(&self, config: SpawnRunConfig) -> Result<SpawnRunResult, String> {
+            let mode = config.permission_context.read().await.mode();
+            *self.captured.lock().unwrap() = Some(mode);
             Ok(SpawnRunResult {
                 agent_id: config.agent_id,
                 run_id: config.run_id,
@@ -3506,7 +3581,7 @@ mod tests {
             parent_agent_id: "main".to_string(),
             recursion_depth: 0,
             parent_is_fork_child: false,
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
             live_event_sink: None,
@@ -3554,7 +3629,7 @@ mod tests {
             parent_agent_id: "main".to_string(),
             recursion_depth: 2,
             parent_is_fork_child: false,
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
             live_event_sink: None,
@@ -3591,7 +3666,7 @@ mod tests {
             parent_agent_id: "main".to_string(),
             recursion_depth: 0,
             parent_is_fork_child: false,
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
             live_event_sink: None,
@@ -3627,7 +3702,7 @@ mod tests {
             parent_agent_id: "main".to_string(),
             recursion_depth: astra_turn_core::agentic_recursion_guard::MAX_AGENT_RECURSION_DEPTH,
             parent_is_fork_child: false,
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
             live_event_sink: None,
@@ -3662,7 +3737,7 @@ mod tests {
             parent_agent_id: "main".to_string(),
             recursion_depth: 0,
             parent_is_fork_child: false,
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
             live_event_sink: None,
@@ -3766,7 +3841,7 @@ mod tests {
             parent_agent_id: "main".to_string(),
             recursion_depth: 0,
             parent_is_fork_child: false,
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
             live_event_sink: None,
@@ -3806,7 +3881,7 @@ mod tests {
             parent_agent_id: "main".to_string(),
             recursion_depth: 0,
             parent_is_fork_child: false,
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp"),
             live_event_sink: None,
@@ -3861,7 +3936,7 @@ mod tests {
             recursion_depth: 0,
             parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec!["review-changes".to_string(), "analyze-session".to_string()],
             live_event_sink: None,
             trace_context: None,
@@ -3889,7 +3964,7 @@ mod tests {
             recursion_depth: 0,
             parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: Vec::new(),
             live_event_sink: None,
             trace_context: None,
@@ -3965,7 +4040,7 @@ mod tests {
             recursion_depth: 0,
             parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             live_event_sink: None,
             trace_context: None,
@@ -5712,7 +5787,7 @@ mod tests {
             recursion_depth: 0,
             parent_is_fork_child: false,
             working_dir: PathBuf::from("/tmp"),
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             live_event_sink: None,
             trace_context: None,

--- a/rust/crates/runtime/src/prompts/system.rs
+++ b/rust/crates/runtime/src/prompts/system.rs
@@ -685,18 +685,7 @@ fn output_format_section() -> &'static str {
      - **Explanations**: lead with the answer, then supporting detail.\n\
      - **Multiple findings**: use a list or table.\n\
      - **NEVER repeat a summary/report.** Stop cleanly when done.\n\
-     - **Ask the user only for real decisions.** Use `ask_user` only when visible or activated; otherwise ask in your normal response.\n\
-     \n\
-     ## Tool Precedence\n\
-     - Understand code: glob/list_dir → grep → targeted read_file. Use `symbols` only when it is visible in tools[] or after `tool_search(query=\"select:symbols\")`.\n\
-     - Navigate code: grep for names/usages, then read_file around exact matches.\n\
-     - Impact: grep callers/imports and read the call sites that matter.\n\
-     - Rename/refactor: use targeted reads and surgical str_replace; verify with project tests.\n\
-     - File search: glob → grep → log search\n\
-     - Code edit: read context → str_replace → project build/test command\n\
-     - Git: status → diff → log → show → blame\n\
-     - Build/test: run the repository's normal command → fix errors → repeat\n\
-     - GitHub: list → detail → CI status\n"
+     - **Ask the user only for real decisions.** Use `ask_user` only when visible or activated; otherwise ask in your normal response.\n"
 }
 
 /// Tool error recovery. Scenario-based: diagnose → fix → anti-pattern.
@@ -741,15 +730,42 @@ pub(crate) fn self_model_section(_tool_names: &[&str]) -> String {
     String::new()
 }
 
-/// Tool-conditional guidance. Removed — tool descriptions in the schema already
-/// contain usage guidance. This section was duplicating schema content and
-/// wasting ~1000 tokens per turn. Returns empty string.
+fn tool_visible(tool_names: &[&str], name: &str) -> bool {
+    tool_names.contains(&name)
+}
+
+/// Tool-conditional guidance.
+///
+/// Keep this section about the cross-tool admission protocol, not individual
+/// schemas. Schema docs explain arguments; this text prevents the model from
+/// calling structured tools that are known only through examples, memory, or
+/// `<deferred_tools>`.
 pub(crate) fn tool_conditional_section(
-    _tool_names: &[&str],
+    tool_names: &[&str],
     _profile_desc: &str,
     _selection_confidence: f64,
 ) -> String {
-    String::new()
+    if tool_names.is_empty() {
+        return String::new();
+    }
+
+    let mut body = String::from(
+        "\n## Tool Availability Protocol\n\
+         - Call a structured tool only if it is visible in this turn's `tools[]`.\n\
+         - Do not infer tool availability from examples, prior turns, pinned defaults, or local executor capability; the current `tools[]` is authoritative.\n",
+    );
+    if tool_visible(tool_names, "tool_search") {
+        body.push_str(
+            "         - A tool listed only in `<deferred_tools>` is not callable yet. Before first use, call `tool_search(query=\"select:NAME\")` and then follow the returned schema exactly.\n",
+        );
+    } else {
+        body.push_str(
+            "         - If a needed structured tool is not visible, use a visible alternative or ask in your normal response.\n",
+        );
+    }
+    body.push_str(&tool_precedence_section(tool_names));
+    body.push_str(&search_strategy_section(tool_names));
+    body
 }
 
 /// Per-turn advisory for tool-selector uncertainty.
@@ -765,142 +781,442 @@ pub(crate) fn low_confidence_tool_selection_section(selection_confidence: f64) -
     })
 }
 
-/// Task-type specific strategy. Session-scoped — depends on detected task type.
-fn task_type_section(task_type: Option<&str>) -> &'static str {
+fn symbols_guidance(tool_names: &[&str]) -> String {
+    if tool_visible(tool_names, "symbols") {
+        " Use `symbols` for symbol-aware navigation when appropriate.".to_string()
+    } else if tool_visible(tool_names, "tool_search") {
+        " Use `symbols` only if it appears in `<deferred_tools>` and after `tool_search(query=\"select:symbols\")`.".to_string()
+    } else {
+        String::new()
+    }
+}
+
+fn deferred_search_guidance(tool_names: &[&str]) -> &'static str {
+    if tool_visible(tool_names, "tool_search") {
+        "activate a deferred content-search tool with `tool_search(query=\"select:NAME\")` before use"
+    } else if tool_visible(tool_names, "bash") {
+        "use visible shell search through `bash` when appropriate"
+    } else {
+        "use only visible discovery/read tools"
+    }
+}
+
+fn tool_precedence_section(tool_names: &[&str]) -> String {
+    let has_glob = tool_visible(tool_names, "glob");
+    let has_list_dir = tool_visible(tool_names, "list_dir");
+    let has_grep = tool_visible(tool_names, "grep");
+    let has_read_file = tool_visible(tool_names, "read_file");
+    let has_log_search = tool_visible(tool_names, "log_search");
+    let has_str_replace = tool_visible(tool_names, "str_replace");
+    let has_write_file = tool_visible(tool_names, "write_file");
+    let has_bash = tool_visible(tool_names, "bash");
+    let has_git = tool_visible(tool_names, "git");
+    let has_github = tool_visible(tool_names, "github");
+
+    if !(has_glob
+        || has_list_dir
+        || has_grep
+        || has_read_file
+        || has_log_search
+        || has_str_replace
+        || has_write_file
+        || has_bash
+        || has_git
+        || has_github)
+    {
+        return String::new();
+    }
+
+    let mut body = String::from("\n## Tool Precedence\n");
+    if has_grep {
+        let layout = match (has_glob, has_list_dir) {
+            (true, true) => "glob/list_dir",
+            (true, false) => "glob",
+            (false, true) => "list_dir",
+            (false, false) => "known paths",
+        };
+        let read_suffix = if has_read_file {
+            " → targeted read_file"
+        } else {
+            ""
+        };
+        let navigate_suffix = if has_read_file {
+            ", then read_file around exact matches"
+        } else {
+            ""
+        };
+        let file_search_chain = if has_glob && has_log_search {
+            "glob → grep → log_search"
+        } else if has_glob {
+            "glob → grep"
+        } else if has_log_search {
+            "grep → log_search"
+        } else {
+            "grep"
+        };
+        body.push_str(&format!(
+            "     - Understand code: {layout} → grep{read_suffix}.{}\n\
+             - Navigate code: grep for names/usages{navigate_suffix}.\n\
+             - Impact: grep callers/imports and read the call sites that matter.\n\
+             - File search: {file_search_chain}\n",
+            symbols_guidance(tool_names)
+        ));
+    } else if has_glob || has_list_dir || has_read_file || tool_visible(tool_names, "tool_search") {
+        let layout = match (has_glob, has_list_dir) {
+            (true, true) => "glob/list_dir for layout",
+            (true, false) => "glob for filenames",
+            (false, true) => "list_dir for layout",
+            (false, false) => "available context",
+        };
+        body.push_str(&format!(
+            "     - Understand code: {layout}, then targeted read_file when visible.{}\n\
+             - Navigate code: {}; never call hidden structured tools directly.\n",
+            symbols_guidance(tool_names),
+            deferred_search_guidance(tool_names)
+        ));
+        if tool_visible(tool_names, "tool_search") {
+            body.push_str(
+                "     - Deferred search: if `grep` appears only in `<deferred_tools>`, select it before calling it; the name alone is not executable.\n",
+            );
+        }
+    }
+
+    if has_str_replace || has_write_file {
+        body.push_str(
+            "     - Code edit: read current context with visible tools → apply the smallest edit → run a visible build/test path.\n",
+        );
+    } else if has_read_file {
+        body.push_str(
+            "     - Code read: use targeted ranges or outlines; avoid whole large files unless necessary.\n",
+        );
+    }
+    if has_git {
+        body.push_str("     - Git: status → diff → log → show → blame\n");
+    } else if has_bash {
+        body.push_str(
+            "     - Git: use shell git commands through `bash` only when repository state is needed; do not call the structured `git` tool when it is absent.\n",
+        );
+    }
+    if has_bash {
+        body.push_str(
+            "     - Build/test: run the repository's normal command → fix errors → repeat\n",
+        );
+    }
+    if has_github {
+        body.push_str("     - GitHub: list → detail → CI status\n");
+    }
+    body
+}
+
+fn read_file_review_guidance(tool_names: &[&str]) -> &'static str {
+    if tool_visible(tool_names, "read_file") {
+        "call read_file with start_line/end_line for ~30 lines around the change, or outline=true for large files"
+    } else {
+        "use visible read/context tools for small, targeted slices around the change"
+    }
+}
+
+/// Task-type specific strategy. Session-scoped — depends on detected task type
+/// and the currently visible tool set.
+fn task_type_section(task_type: Option<&str>, tool_names: &[&str]) -> String {
     match task_type {
         Some("code_review") => {
-            "\n## Code Review Strategy\n\
-              ### CRITICAL: Evidence BEFORE conclusions\n\
-              You MUST gather evidence first, then form conclusions. NEVER write a summary or verdict \
-              before you have examined the diff. Do NOT output review text in the same turn as your \
-              first tool call — wait for tool results.\n\
-              \n\
-              ### Process\n\
-              1. **Get the diff**:\n\
-                 - **Working-tree / staged changes**: call git(action=\"status\") + git(action=\"diff\") in ONE parallel turn.\n\
+            let diff_guidance = if tool_visible(tool_names, "git") {
+                "- **Working-tree / staged changes**: call git(action=\"status\") + git(action=\"diff\") in ONE parallel turn.\n\
                  - **Specific commit review**: call git(action=\"log\") + git(action=\"show\") (or git(action=\"diff\") with ref) in ONE parallel turn.\n\
                  - **Efficient alternative**: use bash with `git log -1 --format='%H %s' && git diff HEAD~1` for a single-tool compound fetch.\n\
               ONLY use git(action=\"diff\") with `path` if the output shows \"[truncated]\". \
-              The first git(action=\"diff\") returns the COMPLETE diff — do NOT re-fetch the same content with path filters.\n\
-               2. **Identify scope**: list changed files and classify them (logic, test, config, formatting).\n\
-               Treat the diff as primary evidence — avoid whole-repo or file-by-file crawls unless a specific risk remains.\n\
-               3. **Read targeted context**: for files with non-trivial logic changes, call read_file with \
-               start_line/end_line for ~30 lines around the change, or outline=true for large files. \
-               Default budget: no more than 3 read_file calls for the review; only exceed that when an unresolved risk remains. \
-               NEVER read_file on a whole large file — if it fails with 'too large', retry with line ranges or outline=true.\n\
-               4. **Evaluate**: correctness → security → edge cases → performance → test coverage. Skip pure style nits.\n\
-               5. **If a read_file fails**: degrade your conclusion for that file. Say \"could not verify\" — do NOT claim it is fine.\n\
-              \n\
-              ### Output\n\
-              - Summary: 1–3 bullets on the change and risk.\n\
-              - Findings: 0–5 material issues only; label must-fix/should-fix/suggestion, cite file:line, and give the fix. If none, say \"None\".\n\
-              - Verification: say what you checked and what you could not verify\n\
-              - Verdict: LGTM or Needs changes. NEVER say LGTM if you had read_file errors on logic-changed files.\n\
-              \n\
-              ### Anti-patterns (NEVER do these)\n\
-               - Do NOT write a review summary in the same response where you call git(action=\"diff\").\n\
-               - Do NOT say \"tests look good\" without reading at least one test file.\n\
-               - Do NOT call git(action=\"log\") in one turn, wait, then call git(action=\"show\") — call BOTH in the first turn.\n\
-               - Do NOT keep calling read_file without a new, explicit risk question to resolve.\n\
-               - Do NOT output XML-like tags or claim full confidence when evidence is incomplete.\n"
+              The first git(action=\"diff\") returns the COMPLETE diff — do NOT re-fetch the same content with path filters."
+                    .to_string()
+            } else if tool_visible(tool_names, "bash") {
+                "- **Diff/source evidence**: use visible `bash` shell commands to inspect repository state when needed; do not call absent structured git tools.\n\
+                 - **Specific commit review**: fetch commit evidence through visible tools or ask for the commit/diff if the environment cannot expose it."
+                    .to_string()
+            } else {
+                "- **Diff/source evidence**: use the diff or files already provided by the user, visible tools, or ask for the missing diff before reviewing."
+                    .to_string()
+            };
+            let git_antipattern = if tool_visible(tool_names, "git") {
+                "- Do NOT write a review summary in the same response where you call git(action=\"diff\").\n\
+                 - Do NOT call git(action=\"log\") in one turn, wait, then call git(action=\"show\") — call BOTH in the first turn."
+                    .to_string()
+            } else {
+                "- Do NOT call structured git actions when `git` is not visible.\n\
+                 - Do NOT write review conclusions before gathering the available evidence."
+                    .to_string()
+            };
+            let read_budget = if tool_visible(tool_names, "read_file") {
+                "Default budget: no more than 3 read_file calls for the review; only exceed that when an unresolved risk remains. NEVER read_file on a whole large file — if it fails with 'too large', retry with line ranges or outline=true."
+            } else {
+                "Default budget: no more than 3 targeted reads for the review; only exceed that when an unresolved risk remains. Avoid whole large files; use visible ranges or outlines when supported."
+            };
+            format!(
+                "\n## Code Review Strategy\n\
+                  ### CRITICAL: Evidence BEFORE conclusions\n\
+                  You MUST gather evidence first, then form conclusions. NEVER write a summary or verdict \
+                  before you have examined the diff. Do NOT output review text in the same turn as your \
+                  first tool call — wait for tool results.\n\
+                  \n\
+                  ### Process\n\
+                  1. **Get the diff**:\n\
+                     {diff_guidance}\n\
+                   2. **Identify scope**: list changed files and classify them (logic, test, config, formatting).\n\
+                   Treat the diff as primary evidence — avoid whole-repo or file-by-file crawls unless a specific risk remains.\n\
+                   3. **Read targeted context**: {read_guidance}. \
+                   {read_budget}\n\
+                   4. **Evaluate**: correctness → security → edge cases → performance → test coverage. Skip pure style nits.\n\
+                   5. **If a read fails**: degrade your conclusion for that file. Say \"could not verify\" — do NOT claim it is fine.\n\
+                  \n\
+                  ### Output\n\
+                  - Summary: 1–3 bullets on the change and risk.\n\
+                  - Findings: 0–5 material issues only; label must-fix/should-fix/suggestion, cite file:line, and give the fix. If none, say \"None\".\n\
+                  - Verification: say what you checked and what you could not verify\n\
+                  - Verdict: LGTM or Needs changes. NEVER say LGTM if you had read errors on logic-changed files.\n\
+                  \n\
+                  ### Anti-patterns (NEVER do these)\n\
+                   {git_antipattern}\n\
+                   - Do NOT say \"tests look good\" without reading at least one test file.\n\
+                   - Do NOT keep calling read tools without a new, explicit risk question to resolve.\n\
+                   - Do NOT output XML-like tags or claim full confidence when evidence is incomplete.\n",
+                read_guidance = read_file_review_guidance(tool_names),
+            )
         }
         Some("debugging") => {
-            "\n## Debugging Strategy\n\
-             1. Start with the error message / stack trace — read it carefully before exploring.\n\
-             2. Form a hypothesis about the root cause.\n\
-             3. Verify with ONE targeted tool call (read the suspected file/function).\n\
-             4. If hypothesis is wrong, form a new one — don't shotgun search.\n\
-             5. Check recent git changes near the error site (git(action=\"log\"), git(action=\"blame\")).\n\
-             6. If a command fails, do NOT retry the exact same command — vary the approach.\n\
-             7. Once found: explain the root cause, show the fix, verify it compiles/passes.\n"
+            let history = if tool_visible(tool_names, "git") {
+                "Check recent git changes near the error site with git(action=\"log\") and git(action=\"blame\")."
+            } else if tool_visible(tool_names, "bash") {
+                "If recent history matters, use visible shell git commands through `bash`; do not call absent structured git tools."
+            } else {
+                "If recent history matters, use visible history/context tools or ask for the missing evidence."
+            };
+            format!(
+                "\n## Debugging Strategy\n\
+                 1. Start with the error message / stack trace — read it carefully before exploring.\n\
+                 2. Form a hypothesis about the root cause.\n\
+                 3. Verify with ONE targeted tool call using a visible tool.\n\
+                 4. If hypothesis is wrong, form a new one — don't shotgun search.\n\
+                 5. {history}\n\
+                 6. If a command fails, do NOT retry the exact same command — vary the approach.\n\
+                 7. Once found: explain the root cause, show the fix, verify it compiles/passes.\n"
+            )
         }
-        Some("exploration") => {
+        Some("exploration") => format!(
             "\n## Exploration Strategy\n\
-             1. Start broad: list_dir for project structure, then identify entry points.\n\
-             2. Narrow: grep for key terms, glob for file patterns.\n\
+             1. Start broad: use visible layout/file tools for project structure, then identify entry points.\n\
+             2. Narrow: {}.\n\
              3. Build a mental map: entry points → core modules → dependencies → patterns.\n\
              4. Read files with targeted ranges, not full files — scan structure first.\n\
-             5. Summarize architecture with concrete file paths and relationships.\n\
-             6. Note patterns: error handling style, naming conventions, test structure.\n"
-        }
+            5. Summarize architecture with concrete file paths and relationships.\n\
+             6. Note patterns: error handling style, naming conventions, test structure.\n",
+            if tool_visible(tool_names, "grep") {
+                if tool_visible(tool_names, "glob") {
+                    "grep for key terms, glob for file patterns"
+                } else {
+                    "grep for key terms"
+                }
+            } else {
+                deferred_search_guidance(tool_names)
+            }
+        ),
         Some("implementation") => {
-            "\n## Implementation Strategy\n\
-              1. **Understand structure**: glob/list_dir for layout, grep for names, read_file targeted sections. Use `symbols` only when visible or activated.\n\
-              2. **Find location**: glob → grep → read sections.\n\
-              3. **Check impact**: grep callers/imports and read the relevant call sites.\n\
-              4. **Implement surgically**: minimal changes, follow style. str_replace auto-formats.\n\
-              5. **Wire it up**: add imports, register modules, update exports.\n\
-              6. **Verify**: run the repository's normal build/test command, fix errors, repeat.\n\
-              7. **Commit**: git(action=\"commit\") with a clear message.\n"
+            let symbols = symbols_guidance(tool_names);
+            let edit_guidance = if tool_visible(tool_names, "str_replace") {
+                "minimal changes, follow style. str_replace auto-formats"
+            } else {
+                "minimal changes, follow style. use visible edit tools only"
+            };
+            let verify_guidance = if tool_visible(tool_names, "bash") {
+                "run the repository's normal build/test command, fix errors, repeat"
+            } else {
+                "run a visible build/test path when available, fix errors, repeat"
+            };
+            if tool_visible(tool_names, "grep") {
+                let layout = match (
+                    tool_visible(tool_names, "glob"),
+                    tool_visible(tool_names, "list_dir"),
+                ) {
+                    (true, true) => "glob/list_dir for layout",
+                    (true, false) => "glob for filenames",
+                    (false, true) => "list_dir for layout",
+                    (false, false) => "available context",
+                };
+                let read_suffix = if tool_visible(tool_names, "read_file") {
+                    ", read_file targeted sections"
+                } else {
+                    ""
+                };
+                let find_location = match (
+                    tool_visible(tool_names, "glob"),
+                    tool_visible(tool_names, "read_file"),
+                ) {
+                    (true, true) => "glob → grep → read sections",
+                    (true, false) => "glob → grep",
+                    (false, true) => "grep → read sections",
+                    (false, false) => "grep exact names/usages",
+                };
+                format!(
+                    "\n## Implementation Strategy\n\
+                      1. **Understand structure**: {layout}, grep for names{read_suffix}.{symbols}\n\
+                      2. **Find location**: {find_location}.\n\
+                      3. **Check impact**: grep callers/imports and read the relevant call sites.\n\
+                      4. **Implement surgically**: {edit_guidance}.\n\
+                      5. **Wire it up**: add imports, register modules, update exports.\n\
+                      6. **Verify**: {verify_guidance}.\n\
+                      7. **Commit**: {commit_guidance}.\n",
+                    commit_guidance = if tool_visible(tool_names, "git") {
+                        "git(action=\"commit\") with a clear message"
+                    } else if tool_visible(tool_names, "bash") {
+                        "use visible shell git commands only if the user asked for a commit"
+                    } else {
+                        "only if a visible git-capable tool exists and the user asked for it"
+                    }
+                )
+            } else {
+                format!(
+                    "\n## Implementation Strategy\n\
+                      1. **Understand structure**: use visible layout/file tools and targeted reads.{symbols}\n\
+                      2. **Find location**: {} before using any deferred search tool.\n\
+                      3. **Check impact**: find callers/imports with visible search/read tools; do not call hidden structured tools.\n\
+                      4. **Implement surgically**: {edit_guidance}.\n\
+                      5. **Wire it up**: add imports, register modules, update exports.\n\
+                      6. **Verify**: {verify_guidance}.\n\
+                      7. **Commit**: {}.\n",
+                    deferred_search_guidance(tool_names),
+                    if tool_visible(tool_names, "git") {
+                        "git(action=\"commit\") with a clear message"
+                    } else if tool_visible(tool_names, "bash") {
+                        "use visible shell git commands only if the user asked for a commit"
+                    } else {
+                        "only if a visible git-capable tool exists and the user asked for it"
+                    }
+                )
+            }
         }
-        Some("refactoring") => {
+        Some("refactoring") => format!(
             "\n## Refactoring Strategy\n\
              1. Run tests BEFORE refactoring to establish a passing baseline.\n\
-             2. Use grep/read_file to find callers before changing a signature; activate `symbols` first if you need symbol-aware navigation and it is deferred.\n\
-             3. For renames: preview with grep/read_file, then apply a targeted edit.\n\
+             2. Use {} to find callers before changing a signature.{}\n\
+             3. For renames: preview with visible search/read tools, then apply a targeted edit.\n\
              4. Make one logical change at a time — verify after each.\n\
              5. Preserve external behavior; focus on clarity and maintainability.\n\
-             6. Run tests AFTER to confirm nothing regressed.\n"
-        }
-        Some("testing") => {
-            "\n## Testing Strategy\n\
+             6. Run tests AFTER to confirm nothing regressed.\n",
+            if tool_visible(tool_names, "grep") && tool_visible(tool_names, "read_file") {
+                "grep/read_file"
+            } else if tool_visible(tool_names, "grep") {
+                "grep"
+            } else if tool_visible(tool_names, "read_file") {
+                "read_file"
+            } else {
+                "visible search/read tools"
+            },
+            symbols_guidance(tool_names)
+        ),
+        Some("testing") => "\n## Testing Strategy\n\
              1. Read the module under test to understand its behavior and edge cases.\n\
              2. Follow existing test patterns: naming, setup/teardown, assertion style.\n\
              3. Cover: happy path → edge cases → error conditions → boundary values.\n\
              4. Each test verifies ONE behavior with a clear, descriptive name.\n\
              5. Run the new tests to confirm they pass — fix failures before reporting.\n"
-        }
-        Some("documentation") => {
-            "\n## Documentation Strategy\n\
+            .to_string(),
+        Some("documentation") => "\n## Documentation Strategy\n\
              - Read the code first — document actual behavior, not assumptions.\n\
              - Include: purpose, usage examples, parameters, return values, error conditions.\n\
              - Keep docs close to the code they describe.\n\
              - Use the project's existing documentation style and format.\n"
-        }
-        Some("performance") => {
-            "\n## Performance Strategy\n\
+            .to_string(),
+        Some("performance") => "\n## Performance Strategy\n\
              1. Measure first — don't guess. Profile to locate the actual bottleneck.\n\
              2. Optimize the hottest path only; avoid premature optimization elsewhere.\n\
              3. Check: algorithm complexity, allocation patterns, I/O blocking, cache misses.\n\
              4. Verify improvement with before/after measurements.\n\
              5. Ensure optimization doesn't break correctness — run tests after.\n"
-        }
+            .to_string(),
         Some("analysis") => {
-            "\n## Analysis Strategy\n\
-             1. Gather data from multiple sources: code, git history, logs, docs.\n\
-             2. Form hypotheses, then verify — don't jump to conclusions from a single signal.\n\
-             3. Use git(action=\"blame\") + git(action=\"file_history\") for ownership/evolution questions.\n\
-             4. Summarize findings with concrete evidence (file paths, line numbers, commit SHAs).\n\
-             5. Present: root cause → impact → recommendation.\n"
+            let ownership = if tool_visible(tool_names, "git") {
+                "Use git(action=\"blame\") + git(action=\"file_history\") for ownership/evolution questions."
+            } else if tool_visible(tool_names, "bash") {
+                "Use visible shell git commands for ownership/evolution questions when repository history is needed."
+            } else {
+                "Use visible docs/history/context tools for ownership/evolution questions, or ask for the missing evidence."
+            };
+            format!(
+                "\n## Analysis Strategy\n\
+                 1. Gather data from multiple sources: code, history, logs, docs.\n\
+                 2. Form hypotheses, then verify — don't jump to conclusions from a single signal.\n\
+                 3. {ownership}\n\
+                 4. Summarize findings with concrete evidence (file paths, line numbers, commit SHAs).\n\
+                 5. Present: root cause → impact → recommendation.\n"
+            )
         }
         Some("deployment") => {
-            "\n## Deployment Strategy\n\
-             1. Check CI status FIRST — don't deploy if builds are failing.\n\
-             2. Review pending changes: git(action=\"status\") → git(action=\"diff\") → CI status.\n\
-             3. Verify config files (env vars, secrets) are correct for target environment.\n\
-             4. Prefer incremental rollout over big-bang deployments.\n"
+            let review = if tool_visible(tool_names, "git") {
+                "Review pending changes: git(action=\"status\") → git(action=\"diff\") → CI status."
+            } else if tool_visible(tool_names, "bash") {
+                "Review pending changes with visible shell git commands and CI status when available."
+            } else {
+                "Review pending changes and CI status using visible tools; ask if deployment evidence is unavailable."
+            };
+            format!(
+                "\n## Deployment Strategy\n\
+                 1. Check CI status FIRST — don't deploy if builds are failing.\n\
+                 2. {review}\n\
+                 3. Verify config files (env vars, secrets) are correct for target environment.\n\
+                 4. Prefer incremental rollout over big-bang deployments.\n"
+            )
         }
-        _ => "",
+        _ => String::new(),
     }
 }
 
-/// Search strategy. Session-scoped — only when search tools are available.
-fn search_strategy_section(tool_names: &[&str]) -> &'static str {
-    let has_glob = tool_names.contains(&"glob");
-    let has_grep = tool_names.contains(&"grep");
-    let has_read_file = tool_names.contains(&"read_file");
-    if has_glob || has_grep || has_read_file {
-        "\n## Search Strategy\n\
-         - Use glob first for filenames/dirs, then grep only that subset for content.\n\
-         - For broad exploration that clearly needs >3 searches, consider an explore agent if available.\n\
-         - Start narrow. Prefer likely roots first: src, crates, app, lib, packages, cmd, internal, tests.\n\
-         - For code review, search changed files or adjacent modules before the whole repo.\n\
-         - Skip generated or bulky trees unless the task explicitly targets them: build, dist, target, coverage, htmlcov, node_modules, vendor.\n\
-         - After grep finds candidates, switch to targeted reads instead of repeating more broad searches.\n\
-         - If a grep is slow or noisy, tighten path, extension, or literal term — do NOT repeat the same broad search.\n\
-         - Use `symbols` for code symbols only when it is visible or has been activated; keep grep for content searches.\n"
+/// Search strategy. Session-scoped — only when search/read tools are available.
+fn search_strategy_section(tool_names: &[&str]) -> String {
+    let has_glob = tool_visible(tool_names, "glob");
+    let has_grep = tool_visible(tool_names, "grep");
+    let has_read_file = tool_visible(tool_names, "read_file");
+    let has_list_dir = tool_visible(tool_names, "list_dir");
+    if !(has_glob || has_grep || has_read_file || has_list_dir) {
+        return String::new();
+    }
+
+    if has_grep {
+        let first_step = match (has_glob, has_list_dir) {
+            (true, true) => "Use glob/list_dir first",
+            (true, false) => "Use glob first",
+            (false, true) => "Use list_dir first",
+            (false, false) => "Start from known paths",
+        };
+        format!(
+            "\n## Search Strategy\n\
+             - {first_step} for filenames/dirs, then grep only that subset for content.\n\
+             - For broad exploration that clearly needs >3 searches, consider an explore agent if available.\n\
+             - Start narrow. Prefer likely roots first: src, crates, app, lib, packages, cmd, internal, tests.\n\
+             - For code review, search changed files or adjacent modules before the whole repo.\n\
+             - Skip generated or bulky trees unless the task explicitly targets them: build, dist, target, coverage, htmlcov, node_modules, vendor.\n\
+             - After grep finds candidates, switch to targeted reads instead of repeating more broad searches.\n\
+             - If grep is slow or noisy, tighten path, extension, or literal term — do NOT repeat the same broad search.\n\
+             - Use `symbols` for code symbols only when visible or activated; keep grep for content searches.\n"
+        )
     } else {
-        ""
+        let mut body = String::from(
+            "\n## Search Strategy\n\
+             - Use visible layout/file tools first for filenames/dirs, then targeted reads for exact context.\n\
+             - For broad exploration that clearly needs >3 searches, consider an explore agent if available.\n\
+             - Start narrow. Prefer likely roots first: src, crates, app, lib, packages, cmd, internal, tests.\n\
+             - For code review, inspect changed files or adjacent modules before the whole repo.\n\
+             - Skip generated or bulky trees unless the task explicitly targets them: build, dist, target, coverage, htmlcov, node_modules, vendor.\n\
+             - After locating candidates, switch to targeted reads instead of repeating broad searches.\n",
+        );
+        if tool_visible(tool_names, "tool_search") {
+            body.push_str(
+                "             - If content search is needed and appears in `<deferred_tools>`, activate it with `tool_search(query=\"select:NAME\")` before calling it.\n",
+            );
+        }
+        if tool_visible(tool_names, "bash") {
+            body.push_str(
+                "             - Shell commands inside `bash` are separate from structured tools; a hidden structured `grep` tool still requires visibility or activation.\n",
+            );
+        }
+        body
     }
 }
 
@@ -1049,24 +1365,13 @@ pub fn build_system_prompt_sections_with_style(
         ));
     }
 
-    let tt = task_type_section(task_type);
+    let tt = task_type_section(task_type, tool_names);
     if !tt.is_empty() {
         // The detected task type is recomputed each turn from the user
         // request — it's environmental signal, not part of the agent
         // persona. Bill to `Environment` so token accounting reflects
         // reality.
-        sections.push(PromptSection::dynamic(
-            tt.to_string(),
-            PromptTokenBucket::Environment,
-        ));
-    }
-
-    let ss = search_strategy_section(tool_names);
-    if !ss.is_empty() {
-        sections.push(PromptSection::dynamic(
-            ss.to_string(),
-            PromptTokenBucket::Environment,
-        ));
+        sections.push(PromptSection::dynamic(tt, PromptTokenBucket::Environment));
     }
 
     // ── Dynamic sections (change every turn) ──
@@ -1719,7 +2024,8 @@ mod tests {
 
     #[test]
     fn code_review_prompt_includes_commit_review_guidance() {
-        let p = build_main_system_prompt(&["git", "bash"], "", 1.0, Some("code_review"));
+        let p =
+            build_main_system_prompt(&["git", "bash", "read_file"], "", 1.0, Some("code_review"));
         assert!(
             p.contains("Specific commit review"),
             "should include commit review variant"
@@ -1735,6 +2041,13 @@ mod tests {
         assert!(
             p.contains("Default budget: no more than 3 read_file calls"),
             "should bound read_file fanout for review turns"
+        );
+
+        let p_no_read_file =
+            build_main_system_prompt(&["git", "bash"], "", 1.0, Some("code_review"));
+        assert!(
+            !p_no_read_file.contains("read_file calls"),
+            "review prompt must not mention structured read_file calls when read_file is hidden"
         );
     }
 
@@ -2143,9 +2456,58 @@ mod tests {
             );
         }
         assert!(
-            p_nav.contains("tool_search(query=\"select:symbols\")"),
-            "symbols guidance must require deferred activation"
+            !p_nav.contains("tool_search(query=\"select:symbols\")"),
+            "symbols activation guidance must not mention tool_search when tool_search is hidden"
         );
+        let p_nav_with_search =
+            build_main_system_prompt(&["glob", "grep", "read_file", "tool_search"], "", 0.5, None);
+        assert!(
+            p_nav_with_search.contains("tool_search(query=\"select:symbols\")"),
+            "symbols guidance must require deferred activation when tool_search is visible"
+        );
+
+        let p_no_grep = build_main_system_prompt(
+            &["bash", "read_file", "tool_search"],
+            "",
+            0.5,
+            Some("implementation"),
+        );
+        for direct_grep_phrase in [
+            "→ grep",
+            "grep for names/usages",
+            "grep for names",
+            "grep callers/imports",
+            "After grep finds",
+            "str_replace auto-formats",
+        ] {
+            assert!(
+                !p_no_grep.contains(direct_grep_phrase),
+                "prompt must not instruct direct structured grep when grep is not visible: {direct_grep_phrase}"
+            );
+        }
+        assert!(
+            p_no_grep.contains("Call a structured tool only if it is visible"),
+            "prompt should state the current tools[] admission boundary"
+        );
+        assert!(
+            p_no_grep.contains("tool_search(query=\"select:NAME\")"),
+            "prompt should route deferred tools through tool_search activation"
+        );
+
+        let p_no_git =
+            build_main_system_prompt(&["bash", "read_file"], "", 0.5, Some("code_review"));
+        for direct_git_phrase in [
+            "git(action=\"status\")",
+            "git(action=\"diff\")",
+            "git(action=\"log\")",
+            "git(action=\"show\")",
+            "git(action=\"blame\")",
+        ] {
+            assert!(
+                !p_no_git.contains(direct_git_phrase),
+                "prompt must not instruct direct structured git when git is not visible: {direct_git_phrase}"
+            );
+        }
 
         // Profile desc in prompt
         let p_prof = build_main_system_prompt(&["bash"], "\n## Project: TestProj\n", 0.5, None);
@@ -2325,7 +2687,7 @@ mod tests {
 
         // Implementation strategy stays grounded in surfaced tools.
         let p = build_main_system_prompt(
-            &["glob", "grep", "read_file", "git"],
+            &["glob", "grep", "read_file", "str_replace", "git"],
             "",
             0.5,
             Some("implementation"),

--- a/rust/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/rust/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -2664,9 +2664,7 @@ impl AgenticRunLifecycleService {
             Self::thinking_from_chat_context(&request.context, request.model.as_deref());
         let root_permissions =
             Self::inherited_permissions_from_request(request, &request_constraints);
-        let root_permission_context = Some(Arc::new(RwLock::new(PermissionSyncContext::new(
-            root_permissions.clone(),
-        ))));
+        let root_permission_context = Some(PermissionSyncContext::shared(root_permissions.clone()));
 
         // Create harness sink early so sub-run executors can share it.
         #[cfg(feature = "harness")]
@@ -6445,9 +6443,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
             .resolve_for_model(config.agent_profile.model_override.as_deref());
         let restricted_tools: std::collections::HashSet<String> =
             load_deployment_disabled_tools().into_iter().collect();
-        let permission_context = Arc::new(RwLock::new(PermissionSyncContext::new(
-            self.inherited_permissions.clone(),
-        )));
+        let permission_context = PermissionSyncContext::shared(self.inherited_permissions.clone());
 
         let mut loop_state = AgenticLoopState {
             messages: vec![user_message],
@@ -7751,9 +7747,8 @@ mod tests {
 
     fn test_spawn_run_config(allowed_tools: Vec<&str>, read_only: bool) -> SpawnRunConfig {
         let inherited_permissions = crate::orchestration::InheritedPermissions::auto_approve();
-        let permission_context = Arc::new(RwLock::new(
-            crate::orchestration::PermissionSyncContext::new(inherited_permissions.clone()),
-        ));
+        let permission_context =
+            crate::orchestration::PermissionSyncContext::shared(inherited_permissions.clone());
         SpawnRunConfig {
             run_id: "child-run".to_string(),
             agent_id: "child@1234".to_string(),

--- a/rust/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/rust/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -35,9 +35,9 @@ use astra_core::{ErrorResponse, SharedPool, connect_matrixone, error_response};
 use astra_services::coordination::{AgentProfile, AgentTier};
 use astra_services::runs::{
     CancelRunRecord, ChatRequestData, ChatRunRecord, ChatStreamRecord, DurableRunRecord,
-    DurableRunStatusKind, RunInputData, RunInputRecord, RunLifecycleService, RunListRecord,
-    RunMutationRecord, RunProjectionCheckpointRecord, RunProjectionRecord, RunStatusRecord,
-    durable_run_status_kind,
+    DurableRunStatusKind, RequestedTurnInteractionMode, RunInputData, RunInputRecord,
+    RunLifecycleService, RunListRecord, RunMutationRecord, RunProjectionCheckpointRecord,
+    RunProjectionRecord, RunStatusRecord, durable_run_status_kind,
 };
 use astra_services::session_audit::{RUNTIME_PROMOTION_EVENT_TYPE, RuntimePromotionEventData};
 use astra_services::skills::SkillService;
@@ -58,8 +58,8 @@ use crate::MatrixOneSettings;
 use crate::observability::ObservabilityHub;
 use crate::orchestration::{
     AgentProgressEvent, AgentToolContext, DynamicAgentSpawner, InheritedPermissions,
-    ProgressBroadcaster, ProgressEventType, SpawnAgentExecutor, SpawnRunConfig, SpawnRunResult,
-    SpawnedAgentState,
+    PermissionMode, PermissionSyncContext, ProgressBroadcaster, ProgressEventType,
+    SpawnAgentExecutor, SpawnRunConfig, SpawnRunResult, SpawnedAgentState,
 };
 use crate::server::run::cloud_workspace_provisioning::CloudWorkspaceProvisioner;
 use crate::server::run::workspace_provisioning::{
@@ -597,6 +597,7 @@ fn build_server_skill_executor(
     execution_bindings: Option<&ExecutionBindingSnapshot>,
     forward_headers: &HashMap<String, String>,
     request_constraints: RequestConstraints,
+    inherited_permissions: InheritedPermissions,
     skill_resolver: Option<Arc<dyn crate::turn::skill_tool::SkillResolver>>,
     session_id: &str,
     edge_connection_pool: Option<&astra_server_types::edge_connection_pool::EdgeConnectionPool>,
@@ -621,6 +622,7 @@ fn build_server_skill_executor(
     .with_edge_profile(edge_profile.clone())
     .with_forward_headers(forward_headers.clone())
     .with_request_constraints(request_constraints)
+    .with_inherited_permissions(inherited_permissions)
     .with_skill_resolver(skill_resolver)
     .with_cancel_token(cancel_token);
     if let Some(snapshot) = execution_bindings {
@@ -1796,10 +1798,19 @@ impl AgenticRunLifecycleService {
         ))
     }
 
-    fn inherited_permissions_from_constraints(
+    fn root_permission_mode_from_request(request: &ChatRequestData) -> PermissionMode {
+        match request.interaction_mode {
+            Some(RequestedTurnInteractionMode::Deny) => PermissionMode::Deny,
+            _ => PermissionMode::Auto,
+        }
+    }
+
+    fn inherited_permissions_from_request(
+        request: &ChatRequestData,
         constraints: &RequestConstraints,
     ) -> InheritedPermissions {
-        let mut inherited = InheritedPermissions::auto_approve();
+        let mut inherited =
+            InheritedPermissions::new(Self::root_permission_mode_from_request(request));
         inherited.allowed_tools = constraints.allowed_tools.clone();
         inherited
     }
@@ -1869,7 +1880,8 @@ impl AgenticRunLifecycleService {
             is_fork_child: false,
             working_dir: workspace.to_path_buf(),
             spawner: entry.spawner,
-            inherited_permissions: Self::inherited_permissions_from_constraints(
+            inherited_permissions: Self::inherited_permissions_from_request(
+                request,
                 &request_constraints,
             ),
             active_skills: Vec::new(),
@@ -2650,6 +2662,11 @@ impl AgenticRunLifecycleService {
             .unwrap_or_default();
         let thinking_config =
             Self::thinking_from_chat_context(&request.context, request.model.as_deref());
+        let root_permissions =
+            Self::inherited_permissions_from_request(request, &request_constraints);
+        let root_permission_context = Some(Arc::new(RwLock::new(PermissionSyncContext::new(
+            root_permissions.clone(),
+        ))));
 
         // Create harness sink early so sub-run executors can share it.
         #[cfg(feature = "harness")]
@@ -2686,6 +2703,7 @@ impl AgenticRunLifecycleService {
             execution_bindings,
             &request.forward_headers,
             request_constraints.clone(),
+            root_permissions.clone(),
             skill_resolver.clone(),
             session_id,
             self.edge_connection_pool.as_ref(),
@@ -2813,7 +2831,7 @@ impl AgenticRunLifecycleService {
             max_cumulative_tokens: 0,
             thinking: thinking_config,
             recent_file_reads: Vec::new(),
-            permission_context: None,
+            permission_context: root_permission_context,
             permission_handler: None,
             tactical_adapter: None,
             step_signal_collector: None,
@@ -5867,12 +5885,16 @@ impl ServerSpawnAgentExecutor {
             })
     }
 
-    fn build_subrun_executor(&self) -> ServerSubRunExecutor {
+    fn build_subrun_executor(
+        &self,
+        inherited_permissions: InheritedPermissions,
+    ) -> ServerSubRunExecutor {
         let mut executor = ServerSubRunExecutor::new(
             self.matrixone.clone(),
             Arc::clone(&self.encryptor),
             Arc::clone(&self.edge_callback_ledger),
         );
+        executor = executor.with_inherited_permissions(inherited_permissions);
         if let Some(pool) = self.shared_pool.clone() {
             executor = executor.with_pool(pool);
         }
@@ -6081,6 +6103,8 @@ impl SpawnAgentExecutor for ServerSpawnAgentExecutor {
 
         let request_constraints =
             spawn_child_request_constraints(&context.request_constraints, &config);
+        let mut child_permissions = config.inherited_permissions.clone();
+        child_permissions.allowed_tools = request_constraints.allowed_tools.clone();
         let subrun = SubRunConfig {
             run_id: config.run_id.clone(),
             agent_profile: profile,
@@ -6110,7 +6134,7 @@ impl SpawnAgentExecutor for ServerSpawnAgentExecutor {
             harness_sink: context.harness_sink.clone(),
         };
 
-        let executor = self.build_subrun_executor();
+        let executor = self.build_subrun_executor(child_permissions);
         #[cfg(feature = "bridge-e2e-hooks")]
         let executor = if !context.test_child_llm_rounds.is_empty() {
             executor.with_test_llm_rounds(context.test_child_llm_rounds.clone())
@@ -6153,6 +6177,7 @@ pub struct ServerSubRunExecutor {
     edge_registry_service: Option<Arc<dyn astra_services::multi_agent::EdgeRegistryService>>,
     skill_service: Option<Arc<dyn SkillService>>,
     memory_extraction_service: Option<Arc<crate::session_memory::MemoryExtractionService>>,
+    inherited_permissions: InheritedPermissions,
     /// Shared ToolExecutionService so executors share the same disabled_tools set.
     pub tool_execution_service: Option<ToolExecutionService>,
     #[cfg(feature = "bridge-e2e-hooks")]
@@ -6175,6 +6200,7 @@ impl ServerSubRunExecutor {
             edge_registry_service: None,
             skill_service: None,
             memory_extraction_service: None,
+            inherited_permissions: InheritedPermissions::auto_approve(),
             tool_execution_service: None,
             #[cfg(feature = "bridge-e2e-hooks")]
             test_llm_rounds: Vec::new(),
@@ -6191,6 +6217,14 @@ impl ServerSubRunExecutor {
         svc: Arc<crate::session_memory::MemoryExtractionService>,
     ) -> Self {
         self.memory_extraction_service = Some(svc);
+        self
+    }
+
+    pub fn with_inherited_permissions(
+        mut self,
+        inherited_permissions: InheritedPermissions,
+    ) -> Self {
+        self.inherited_permissions = inherited_permissions;
         self
     }
 
@@ -6411,6 +6445,9 @@ impl SubRunExecutor for ServerSubRunExecutor {
             .resolve_for_model(config.agent_profile.model_override.as_deref());
         let restricted_tools: std::collections::HashSet<String> =
             load_deployment_disabled_tools().into_iter().collect();
+        let permission_context = Arc::new(RwLock::new(PermissionSyncContext::new(
+            self.inherited_permissions.clone(),
+        )));
 
         let mut loop_state = AgenticLoopState {
             messages: vec![user_message],
@@ -6529,7 +6566,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
             max_cumulative_tokens: 0,
             thinking: astra_turn_core::thinking_config::ThinkingConfig::Off,
             recent_file_reads: Vec::new(),
-            permission_context: None,
+            permission_context: Some(permission_context),
             permission_handler: None,
             tactical_adapter: None,
             step_signal_collector: None,
@@ -7284,7 +7321,7 @@ mod tests {
             parent_agent_id: "root-agent".to_string(),
             recursion_depth: 0,
             parent_is_fork_child: false,
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp/astra"),
             live_event_sink: None,
@@ -7363,7 +7400,7 @@ mod tests {
             parent_agent_id: "root-agent".to_string(),
             recursion_depth: 0,
             parent_is_fork_child: false,
-            inherited_permissions: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
             inherited_skills: vec![],
             working_dir: PathBuf::from("/tmp/astra"),
             live_event_sink: None,
@@ -7713,6 +7750,10 @@ mod tests {
     }
 
     fn test_spawn_run_config(allowed_tools: Vec<&str>, read_only: bool) -> SpawnRunConfig {
+        let inherited_permissions = crate::orchestration::InheritedPermissions::auto_approve();
+        let permission_context = Arc::new(RwLock::new(
+            crate::orchestration::PermissionSyncContext::new(inherited_permissions.clone()),
+        ));
         SpawnRunConfig {
             run_id: "child-run".to_string(),
             agent_id: "child@1234".to_string(),
@@ -7728,9 +7769,9 @@ mod tests {
             mailbox: None,
             progress_emitter: None,
             context_cache: None,
-            inherited_permissions: None,
+            inherited_permissions,
             parent_address: None,
-            permission_context: None,
+            permission_context,
             inherited_skills: Vec::new(),
             live_event_sink: None,
             inherited_prefix: None,
@@ -8210,6 +8251,53 @@ mod tests {
             interaction_mode: None,
             interactive_client: false,
         }
+    }
+
+    #[test]
+    fn server_root_permissions_default_to_auto_for_server_approval_gate() {
+        let mut request = test_request("edit files");
+        request.interaction_mode = Some(RequestedTurnInteractionMode::Prompt);
+        let constraints = RequestConstraints::default();
+
+        let inherited =
+            AgenticRunLifecycleService::inherited_permissions_from_request(&request, &constraints);
+
+        assert_eq!(inherited.mode, PermissionMode::Auto);
+        assert!(inherited.allowed_tools.is_none());
+    }
+
+    #[test]
+    fn server_root_permissions_map_deny_and_preserve_tool_allowlist() {
+        let mut request = test_request("no tools");
+        request.interaction_mode = Some(RequestedTurnInteractionMode::Deny);
+        let constraints = RequestConstraints {
+            allowed_tools: Some(["read_file".to_string()].into_iter().collect()),
+            ..Default::default()
+        };
+
+        let inherited =
+            AgenticRunLifecycleService::inherited_permissions_from_request(&request, &constraints);
+
+        assert_eq!(inherited.mode, PermissionMode::Deny);
+        assert!(
+            inherited
+                .allowed_tools
+                .as_ref()
+                .is_some_and(|tools| tools.contains("read_file"))
+        );
+    }
+
+    #[test]
+    fn server_subrun_executor_keeps_inherited_permissions() {
+        let inherited_permissions = InheritedPermissions::new(PermissionMode::Deny);
+        let executor = ServerSubRunExecutor::new(
+            test_settings(),
+            test_encryptor(),
+            Arc::new(TokioMutex::new(HashMap::new())),
+        )
+        .with_inherited_permissions(inherited_permissions);
+
+        assert_eq!(executor.inherited_permissions.mode, PermissionMode::Deny);
     }
 
     struct FailingWorkspaceRecordStore;
@@ -11962,6 +12050,28 @@ mod tests {
         assert!(
             fn_body.contains("with_execution_binding_snapshot"),
             "build_server_skill_executor must pass execution bindings to server skill sub-runs"
+        );
+    }
+
+    #[test]
+    fn build_server_skill_executor_wires_inherited_permissions() {
+        let source = include_str!("mod.rs");
+        let fn_start = source
+            .find("fn build_server_skill_executor(")
+            .expect("build_server_skill_executor must exist");
+        let fn_end = source[fn_start..]
+            .find("\npub(crate) fn ")
+            .or_else(|| source[fn_start..].find("\nfn "))
+            .map(|p| fn_start + p)
+            .unwrap_or(source.len());
+        let fn_body = &source[fn_start..fn_end];
+        assert!(
+            fn_body.contains("inherited_permissions"),
+            "build_server_skill_executor must accept request-level permissions"
+        );
+        assert!(
+            fn_body.contains("with_inherited_permissions"),
+            "build_server_skill_executor must pass request-level permissions to server skill sub-runs"
         );
     }
 

--- a/rust/crates/runtime/src/server/server_skill_subrun.rs
+++ b/rust/crates/runtime/src/server/server_skill_subrun.rs
@@ -276,9 +276,8 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
         let compact_strategy = astra_turn_core::microcompact::CompactStrategy::from_provider_hint(
             effective_model.as_deref().unwrap_or(""),
         );
-        let permission_context = Arc::new(tokio::sync::RwLock::new(
-            crate::orchestration::PermissionSyncContext::new(self.inherited_permissions.clone()),
-        ));
+        let permission_context =
+            crate::orchestration::PermissionSyncContext::shared(self.inherited_permissions.clone());
 
         // Build a sub-run session ID for isolation.
         let safe_name = crate::skills::loader::sanitize_for_path(skill_name);

--- a/rust/crates/runtime/src/server/server_skill_subrun.rs
+++ b/rust/crates/runtime/src/server/server_skill_subrun.rs
@@ -88,6 +88,8 @@ pub struct ServerSkillSubRunExecutor {
     /// from the parent lifecycle service. `None` → no extraction in
     /// skill sub-runs (rarely surfaces user-relevant memory).
     memory_extraction_service: Option<Arc<crate::session_memory::MemoryExtractionService>>,
+    /// Request-level permissions inherited from the parent server run.
+    inherited_permissions: crate::orchestration::InheritedPermissions,
 }
 
 impl ServerSkillSubRunExecutor {
@@ -116,6 +118,7 @@ impl ServerSkillSubRunExecutor {
             #[cfg(feature = "harness")]
             harness_sink: None,
             memory_extraction_service: None,
+            inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
         }
     }
 
@@ -195,6 +198,14 @@ impl ServerSkillSubRunExecutor {
         self
     }
 
+    pub fn with_inherited_permissions(
+        mut self,
+        inherited_permissions: crate::orchestration::InheritedPermissions,
+    ) -> Self {
+        self.inherited_permissions = inherited_permissions;
+        self
+    }
+
     pub fn with_edge_connection_pool(
         mut self,
         pool: astra_server_types::edge_connection_pool::EdgeConnectionPool,
@@ -265,6 +276,9 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
         let compact_strategy = astra_turn_core::microcompact::CompactStrategy::from_provider_hint(
             effective_model.as_deref().unwrap_or(""),
         );
+        let permission_context = Arc::new(tokio::sync::RwLock::new(
+            crate::orchestration::PermissionSyncContext::new(self.inherited_permissions.clone()),
+        ));
 
         // Build a sub-run session ID for isolation.
         let safe_name = crate::skills::loader::sanitize_for_path(skill_name);
@@ -480,7 +494,7 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
             max_cumulative_tokens: SUBRUN_MAX_CUMULATIVE_TOKENS,
             thinking: astra_turn_core::thinking_config::ThinkingConfig::Off,
             recent_file_reads: Vec::new(),
-            permission_context: None,
+            permission_context: Some(permission_context),
             permission_handler: None,
             tactical_adapter: None,
             step_signal_collector: None,
@@ -608,6 +622,10 @@ mod tests {
         assert!(executor.cancel_token.is_none());
         assert!(executor.skill_resolver.is_none());
         assert!(executor.llm_token_service.is_none());
+        assert_eq!(
+            executor.inherited_permissions.mode,
+            crate::orchestration::PermissionMode::Auto
+        );
     }
 
     #[test]
@@ -631,6 +649,24 @@ mod tests {
         assert!(executor.llm_token_service.is_some());
         assert_eq!(executor.edge_tools.len(), 1);
         assert!(executor.cancel_token.is_some());
+    }
+
+    #[test]
+    fn server_skill_subrun_executor_keeps_inherited_permissions() {
+        let inherited_permissions = crate::orchestration::InheritedPermissions::new(
+            crate::orchestration::PermissionMode::Deny,
+        );
+        let executor = ServerSkillSubRunExecutor::new(
+            mock_matrixone(),
+            mock_encryptor(),
+            "test-session".to_string(),
+        )
+        .with_inherited_permissions(inherited_permissions);
+
+        assert_eq!(
+            executor.inherited_permissions.mode,
+            crate::orchestration::PermissionMode::Deny
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/agentic/headless_round.rs
+++ b/rust/crates/runtime/src/turn/agentic/headless_round.rs
@@ -26,9 +26,7 @@ pub use astra_turn_core::headless_tool_body_preview::{
     HeadlessRoundTerminal, HeadlessStderrStyle, NoopHeadlessTerminal,
 };
 
-pub(crate) type PermissionSyncHandle = std::sync::Arc<
-    tokio::sync::RwLock<crate::orchestration::permission_sync::PermissionSyncContext>,
->;
+use crate::orchestration::PermissionSyncHandle;
 
 /// Typed execution context for one headless tool round.
 pub struct HeadlessToolRoundCtx<'a, E: EdgeToolRoundRow> {

--- a/rust/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/host.rs
@@ -2742,6 +2742,9 @@ pub(crate) mod tests {
     // ── State builder ───────────────────────────────────────────────────────
 
     pub(crate) fn make_state() -> AgenticLoopState {
+        let tool_policy =
+            astra_config::runtime_config::ToolSelectionConfig::default().resolve_for_model(None);
+
         AgenticLoopState {
             messages: Vec::new(),
             volatile_pending: Vec::new(),
@@ -2779,14 +2782,10 @@ pub(crate) mod tests {
             idempotency_cache: InMemoryIdempotencyCache::new(),
             semantic_dedup: SemanticDedup::new(0.95),
             call_counts: HashMap::new(),
-            max_identical_tool_calls: astra_config::runtime_config::RuntimeConfig::load()
-                .tool_selection
-                .effective_max_identical_calls(),
-            max_tools_per_turn: astra_config::runtime_config::RuntimeConfig::load()
-                .tool_selection
-                .effective_max_tools_per_turn(),
-            repeated_cache_hit_suppression: 3,
-            max_consecutive_empty_name: 3,
+            max_identical_tool_calls: tool_policy.max_identical_tool_calls,
+            max_tools_per_turn: tool_policy.max_tools_per_turn,
+            repeated_cache_hit_suppression: tool_policy.repeated_cache_hit_suppression,
+            max_consecutive_empty_name: tool_policy.max_consecutive_empty_name,
             stall: Default::default(),
             telemetry: Default::default(),
             skills: SkillState {
@@ -2830,7 +2829,9 @@ pub(crate) mod tests {
             max_cumulative_tokens: 0,
             thinking: astra_turn_core::thinking_config::ThinkingConfig::Off,
             recent_file_reads: Vec::new(),
-            permission_context: None,
+            permission_context: Some(crate::orchestration::PermissionSyncContext::shared_root(
+                crate::orchestration::PermissionMode::Auto,
+            )),
             permission_handler: None,
             tactical_adapter: None,
             step_signal_collector: None,

--- a/rust/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/host.rs
@@ -1344,8 +1344,7 @@ pub struct AgenticLoopState {
     /// Optional permission sync context for runtime permission management.
     /// When set, tool execution checks permissions before running and can
     /// request permission from parent agent via mailbox if denied.
-    pub permission_context:
-        Option<std::sync::Arc<tokio::sync::RwLock<crate::orchestration::PermissionSyncContext>>>,
+    pub permission_context: Option<crate::orchestration::PermissionSyncHandle>,
 
     /// Optional permission request handler for processing child requests.
     /// When set, incoming PermissionRequest messages are handled automatically.

--- a/rust/crates/runtime/src/turn/context_pipeline_adapter.rs
+++ b/rust/crates/runtime/src/turn/context_pipeline_adapter.rs
@@ -137,7 +137,7 @@ pub(crate) fn build_external_sources(
     if let Some(ref text) = tool_conditional {
         extra_dynamic_sections.push(crate::prompts::PromptSection::dynamic(
             text.clone(),
-            crate::prompts::PromptTokenBucket::BasePersona,
+            crate::prompts::PromptTokenBucket::Environment,
         ));
     }
 
@@ -795,11 +795,56 @@ mod tests {
         );
     }
 
+    #[test]
+    fn tool_availability_protocol_is_visible_tool_scoped_in_pipeline_sources() {
+        let ep = serde_json::Map::new();
+        let state = make_state();
+        let sources = build_external_sources(
+            &ep,
+            &state,
+            "hi",
+            &["bash", "read_file", "tool_search"],
+            0.8,
+            None,
+            None,
+        );
+
+        let tool_section = sources
+            .extra_dynamic_sections
+            .iter()
+            .find(|section| section.text.contains("Tool Availability Protocol"))
+            .expect("tool availability protocol should be emitted for visible tools");
+        assert_eq!(
+            tool_section.token_bucket,
+            crate::prompts::PromptTokenBucket::Environment
+        );
+        assert!(
+            tool_section
+                .text
+                .contains("Call a structured tool only if it is visible")
+        );
+        assert!(
+            tool_section
+                .text
+                .contains("tool_search(query=\"select:NAME\")")
+        );
+        for direct_grep_phrase in [
+            "→ grep",
+            "grep for names/usages",
+            "grep callers/imports",
+            "After grep finds",
+        ] {
+            assert!(
+                !tool_section.text.contains(direct_grep_phrase),
+                "pipeline prompt must not instruct direct structured grep when grep is hidden: {direct_grep_phrase}"
+            );
+        }
+    }
+
     // `selected_tool_guidance_is_volatile` was deleted: it asserted on
-    // `## Self-Model` + `Explicit Tool Requests` strings that originated
-    // from the now-empty `self_model_section` / `tool_conditional_section`
-    // bodies (commit a1187f76). The volatile-lane routing contract is
-    // covered by the composite integration tests below.
+    // legacy `## Self-Model` + `Explicit Tool Requests` strings. The
+    // volatile-lane routing contract is covered by the composite integration
+    // tests below.
 
     #[test]
     fn external_sources_empty_memory_when_edge_profile_has_none() {

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
@@ -444,10 +444,12 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::sync::Arc;
 
     use super::*;
     use serde_json::json;
 
+    use crate::orchestration::{PermissionMode, PermissionSyncContext};
     use crate::skills::hooks::{HookAction, ToolEventHook, ToolEventHookRegistry, ToolEventKind};
     use crate::turn::agentic::headless_round::NoopHeadlessTerminal;
     use astra_pipeline::step_protocol::CachedToolResult;
@@ -558,6 +560,7 @@ mod tests {
         call_counts: HashMap<String, u32>,
         tool_call_records: Vec<ToolCallRecord>,
         tool_event_hooks: ToolEventHookRegistry,
+        permission_context: Option<Arc<tokio::sync::RwLock<PermissionSyncContext>>>,
         term: NoopHeadlessTerminal,
         repeated_cache_hit_suppression: u32,
         max_consecutive_empty_name: u32,
@@ -591,6 +594,9 @@ mod tests {
                 call_counts: HashMap::new(),
                 tool_call_records: Vec::new(),
                 tool_event_hooks: ToolEventHookRegistry::default(),
+                permission_context: Some(Arc::new(tokio::sync::RwLock::new(
+                    PermissionSyncContext::root(PermissionMode::Auto),
+                ))),
                 term: NoopHeadlessTerminal,
                 // Tests assume the legacy threshold of 2 unless they override.
                 // Production runs derive these from the per-model policy.
@@ -639,7 +645,7 @@ mod tests {
                     tool_event_hooks: &self.tool_event_hooks,
                     term: &mut self.term,
                     mailbox: None,
-                    permission_context: None,
+                    permission_context: self.permission_context.as_ref(),
                     progress_emitter: None,
                     effective_permission_timeout: Duration::from_secs(30),
                     server_tool_executor,
@@ -688,6 +694,32 @@ mod tests {
             }
             _ => panic!("expected permitted execution"),
         }
+    }
+
+    #[tokio::test]
+    async fn permit_execution_without_permission_context_denies() {
+        let mut harness = PipelineHarness::new();
+        harness.permission_context = None;
+        let mut pipeline = harness.pipeline();
+        let validated = match pipeline.validate_slot(HeadlessRoundToolIdx::SyntheticEdge(0)) {
+            HeadlessPipelineStage::Continue(validated) => validated,
+            _ => panic!("expected validated execution"),
+        };
+
+        match pipeline.permit_execution(validated).await {
+            HeadlessPipelineStage::ShortCircuit => {}
+            _ => panic!("missing permission context must fail closed"),
+        }
+
+        let error = harness
+            .tool_call_records
+            .last()
+            .and_then(|record| record.error.as_deref())
+            .unwrap_or("");
+        assert!(
+            error.contains("no permission context configured"),
+            "expected actionable missing-context denial, got {error:?}"
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline.rs
@@ -5,7 +5,8 @@ use astra_services::session_journal::ToolCallRecord;
 use astra_thin_client::ThinClient;
 use serde_json::{Map, Value};
 
-use super::agentic::headless_round::{HeadlessRoundTerminal, PermissionSyncHandle};
+use super::agentic::headless_round::HeadlessRoundTerminal;
+use crate::orchestration::PermissionSyncHandle;
 use astra_pipeline::step_protocol::{IdempotencyKey, InMemoryIdempotencyCache};
 use astra_pipeline::step_recorder::StepRecorder;
 use astra_text_utils::semantic_dedup::SemanticDedup;
@@ -444,12 +445,11 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
 #[cfg(test)]
 mod tests {
     use std::path::Path;
-    use std::sync::Arc;
 
     use super::*;
     use serde_json::json;
 
-    use crate::orchestration::{PermissionMode, PermissionSyncContext};
+    use crate::orchestration::{PermissionMode, PermissionSyncContext, PermissionSyncHandle};
     use crate::skills::hooks::{HookAction, ToolEventHook, ToolEventHookRegistry, ToolEventKind};
     use crate::turn::agentic::headless_round::NoopHeadlessTerminal;
     use astra_pipeline::step_protocol::CachedToolResult;
@@ -560,7 +560,7 @@ mod tests {
         call_counts: HashMap<String, u32>,
         tool_call_records: Vec<ToolCallRecord>,
         tool_event_hooks: ToolEventHookRegistry,
-        permission_context: Option<Arc<tokio::sync::RwLock<PermissionSyncContext>>>,
+        permission_context: Option<PermissionSyncHandle>,
         term: NoopHeadlessTerminal,
         repeated_cache_hit_suppression: u32,
         max_consecutive_empty_name: u32,
@@ -594,9 +594,7 @@ mod tests {
                 call_counts: HashMap::new(),
                 tool_call_records: Vec::new(),
                 tool_event_hooks: ToolEventHookRegistry::default(),
-                permission_context: Some(Arc::new(tokio::sync::RwLock::new(
-                    PermissionSyncContext::root(PermissionMode::Auto),
-                ))),
+                permission_context: Some(PermissionSyncContext::shared_root(PermissionMode::Auto)),
                 term: NoopHeadlessTerminal,
                 // Tests assume the legacy threshold of 2 unless they override.
                 // Production runs derive these from the per-model policy.

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
@@ -894,3 +894,38 @@ fn nonprogress_backoff_message(
         format!("  ⚠ Busy-poll backoff: {tool_name} (~{remaining_secs}s)"),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn names<const N: usize>(values: [&str; N]) -> HashSet<String> {
+        values.into_iter().map(str::to_string).collect()
+    }
+
+    #[test]
+    fn validator_denial_for_deferred_grep_uses_activation_hint() {
+        let valid = names(["tool_search", "bash"]);
+        let deferred = names(["grep"]);
+
+        let body = validator_denial_body("grep", &valid, &deferred);
+
+        assert!(body.contains("not available in this turn yet"));
+        assert!(body.contains("`<deferred_tools>`"));
+        assert!(body.contains("tool_search"));
+        assert!(body.contains("query=\"select:grep\""));
+        assert!(!body.contains("Unknown tool"));
+    }
+
+    #[test]
+    fn validator_denial_for_hidden_non_deferred_tool_stays_unknown() {
+        let valid = names(["tool_search", "bash"]);
+        let deferred = names(["agent"]);
+
+        let body = validator_denial_body("grep", &valid, &deferred);
+
+        assert!(body.contains("Unknown tool"));
+        assert!(!body.contains("query=\"select:grep\""));
+    }
+}

--- a/rust/crates/runtime/src/turn/permission_gate.rs
+++ b/rust/crates/runtime/src/turn/permission_gate.rs
@@ -698,7 +698,7 @@ mod tests {
                     let response =
                         crate::orchestration::permission_sync::PermissionResponse::approve()
                             .with_update(PermissionUpdate::allow(PermissionRule::parse(
-                                "Bash(touch:*)",
+                                r#"Bash(argv_prefix="touch")"#,
                             )));
                     router_clone
                         .send(response.to_message(

--- a/rust/crates/runtime/src/turn/permission_gate.rs
+++ b/rust/crates/runtime/src/turn/permission_gate.rs
@@ -35,7 +35,7 @@ pub enum PermissionCheckResult {
 /// Check permission for a tool call.
 ///
 /// Flow:
-/// 1. If no permission_context, always allow (legacy mode)
+/// 1. If no permission_context, fail closed
 /// 2. Check PermissionSyncContext.is_allowed()
 /// 3. If denied and have mailbox, request permission from the parent
 /// 4. Return result
@@ -44,8 +44,9 @@ pub enum PermissionCheckResult {
 ///
 /// * `tool_name` — Name of the tool being invoked (e.g. `"bash"`, `"edit_file"`).
 /// * `args` — Optional JSON string of tool arguments, used for rule matching.
-/// * `permission_context` — Shared permission rules for this agent. `None` means
-///   legacy/unrestricted mode (all tools allowed).
+/// * `permission_context` — Shared permission rules for this agent. `None`
+///   means the caller failed to provide an authorization context, so the gate
+///   denies the tool call.
 /// * `mailbox` — Agent's mailbox for requesting permission from the parent.
 ///   `None` when no parent is available (root agent or standalone mode).
 /// * `timeout` — Maximum time to wait for a parent permission response.
@@ -56,9 +57,10 @@ pub async fn check_tool_permission(
     mailbox: Option<&mut AgentMailbox>,
     timeout: Duration,
 ) -> PermissionCheckResult {
-    // No permission context = legacy mode, always allow
     let Some(ctx) = permission_context else {
-        return PermissionCheckResult::Allowed;
+        return PermissionCheckResult::Denied {
+            reason: "no permission context configured".to_string(),
+        };
     };
 
     let normalized_args = args
@@ -234,7 +236,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_context_always_allowed() {
+    async fn no_context_fails_closed() {
         let result = check_tool_permission(
             "edit",
             Some("src/main.rs"),
@@ -243,7 +245,12 @@ mod tests {
             Duration::from_secs(5),
         )
         .await;
-        assert!(is_allowed(&result));
+        match result {
+            PermissionCheckResult::Denied { reason } => {
+                assert!(reason.contains("no permission context"));
+            }
+            other => panic!("missing permission context must deny, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -378,27 +385,12 @@ mod tests {
         assert_eq!(telemetry.tools_blocked, 1);
     }
 
-    /// REGRESSION: a sub-agent in `Prompt` mode whose tool IS in the
-    /// agent_type's `allowed_tools` allowlist must be auto-approved
-    /// without trying to ask the parent. The user already authorized
-    /// the spawn action that created this sub-agent, knowing its
-    /// agent_type's tool surface (e.g. `code-review` ⇒ bash, grep,
-    /// glob, view). Asking them again per-tool-call is friction
-    /// without consent value.
-    ///
-    /// The pre-fix bug (session 2a98814b): sub-agents inherited
-    /// Prompt mode, fell through to the "request parent" branch, but
-    /// the orchestrator mailbox was never registered in
-    /// `initialize_multi_agent_runtime` — so `request_permission`
-    /// returned `MailboxError::AgentNotFound("orchestrator@run-...")`
-    /// and the tool call was denied. 4 review agents spawned, all
-    /// returned 0 tool calls, useless output.
-    ///
-    /// Fix: extend the local-approve fast path so it also fires when
-    /// `allowed_tools.is_some()` AND the tool is in the list,
-    /// regardless of mode. The allowlist IS the consent.
+    /// `allowed_tools` is a tool-surface boundary, not consent to run
+    /// mutating or executing tools. In Prompt mode, allowlisted bash
+    /// still needs a parent approval sink; without one, the gate denies
+    /// instead of silently executing.
     #[tokio::test]
-    async fn allowlisted_tool_auto_approves_in_prompt_mode_without_mailbox() {
+    async fn allowlisted_execute_tool_denies_in_prompt_mode_without_mailbox() {
         let inherited = InheritedPermissions {
             mode: PermissionMode::Prompt,
             allow_rules: vec![],
@@ -422,27 +414,25 @@ mod tests {
         // production state on a fresh REPL).
         let result = check_tool_permission(
             "bash",
-            Some(r#"{"command":"git show HEAD"}"#),
+            Some(r#"{"command":"touch prompt-mode-allowlist-denied.txt"}"#),
             Some(&ctx),
             None,
             Duration::from_secs(1),
         )
         .await;
         assert!(
-            is_allowed(&result),
-            "tool in agent_type allowlist must auto-approve in Prompt mode; \
-             got {result:?}. Pre-fix this would have hit the 'mailbox = None' \
-             branch and denied the call."
+            matches!(result, PermissionCheckResult::Denied { .. }),
+            "allowlisted execute tools must still require approval in Prompt mode; got {result:?}"
         );
 
         let telemetry = ctx.read().await.telemetry();
         assert_eq!(
             telemetry.permission_requests, 0,
-            "must NOT send a mailbox request — the allowlist is the consent"
+            "without a mailbox the gate should fail before sending a request"
         );
         assert_eq!(
-            telemetry.tools_blocked, 0,
-            "must NOT block the call — allowlisted tools bypass the prompt path"
+            telemetry.tools_blocked, 1,
+            "missing approval sink should be recorded as a blocked tool"
         );
     }
 
@@ -685,8 +675,8 @@ mod tests {
 
         // No allowlist set — Prompt mode falls through to the
         // request-parent flow that this test is exercising. (When an
-        // allowlist IS set, allowlisted tools auto-approve locally;
-        // see `allowlisted_tool_auto_approves_in_prompt_mode_without_mailbox`.)
+        // allowlist IS set, mutating/execute tools still need approval;
+        // see `allowlisted_execute_tool_denies_in_prompt_mode_without_mailbox`.)
         let inherited = InheritedPermissions {
             mode: PermissionMode::Prompt,
             allow_rules: vec![],

--- a/rust/crates/runtime/src/turn/permission_gate.rs
+++ b/rust/crates/runtime/src/turn/permission_gate.rs
@@ -4,12 +4,10 @@
 //! When a tool is blocked by permissions, it returns an error result
 //! instead of executing, or requests permission from the parent agent.
 
-use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::RwLock;
 
 use crate::orchestration::permission_sync::{
-    PermissionRequest, PermissionResponse, PermissionSyncContext, PermissionUpdate,
+    PermissionRequest, PermissionResponse, PermissionSyncHandle, PermissionUpdate,
 };
 use astra_messaging::router::AgentMailbox;
 use astra_turn_core::permission::engine::{DecisionSource, HardDecision, evaluate_permission};
@@ -53,7 +51,7 @@ pub enum PermissionCheckResult {
 pub async fn check_tool_permission(
     tool_name: &str,
     args: Option<&str>,
-    permission_context: Option<&Arc<RwLock<PermissionSyncContext>>>,
+    permission_context: Option<&PermissionSyncHandle>,
     mailbox: Option<&mut AgentMailbox>,
     timeout: Duration,
 ) -> PermissionCheckResult {
@@ -185,7 +183,7 @@ pub fn permission_denied_error_result(tool_name: &str, reason: &str) -> String {
 pub async fn check_tool_permission_in_plan_mode(
     tool_name: &str,
     args: Option<&str>,
-    permission_context: Option<&Arc<RwLock<PermissionSyncContext>>>,
+    permission_context: Option<&PermissionSyncHandle>,
     mailbox: Option<&mut AgentMailbox>,
     timeout: Duration,
     plan_mode_active: bool,
@@ -224,9 +222,11 @@ mod tests {
     use super::*;
     use crate::orchestration::permission_sync::{
         InheritedPermissions, PermissionMode, PermissionResponseMessaging, PermissionRule,
+        PermissionSyncContext,
     };
     use astra_turn_core::permission::types::RuleMatchContext;
     use std::collections::HashSet;
+    use std::sync::Arc;
 
     fn is_allowed(result: &PermissionCheckResult) -> bool {
         matches!(
@@ -264,7 +264,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         let result =
             check_tool_permission("edit", None, Some(&ctx), None, Duration::from_secs(5)).await;
@@ -282,7 +282,7 @@ mod tests {
             is_background: true,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         let result =
             check_tool_permission("edit", None, Some(&ctx), None, Duration::from_secs(5)).await;
@@ -300,7 +300,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         let result =
             check_tool_permission("edit", None, Some(&ctx), None, Duration::from_secs(5)).await;
@@ -327,7 +327,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         // Should approve without needing a mailbox
         let result = check_tool_permission(
@@ -362,7 +362,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         // "view" is in the allowlist — should approve
         let result =
@@ -408,7 +408,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         // No mailbox — orchestrator is not registered (the actual
         // production state on a fresh REPL).
@@ -458,7 +458,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         let result = check_tool_permission(
             "read_file",
@@ -492,7 +492,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         // `edit` is NOT in the code-review-style allowlist.
         let result = check_tool_permission(
@@ -520,7 +520,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         let result = check_tool_permission(
             "bash",
@@ -547,7 +547,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         let result = check_tool_permission(
             "git",
@@ -601,7 +601,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         let router_clone = router.clone();
         let parent_addr_clone = parent_addr.clone();
@@ -686,7 +686,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         let router_clone = router.clone();
         let parent_addr_clone = parent_addr.clone();
@@ -769,7 +769,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         // Pretend the session is mid-plan with active plan id present.
         let result = check_tool_permission_in_plan_mode(
@@ -803,7 +803,7 @@ mod tests {
             mode: PermissionMode::Auto,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         for (tool, args) in [
             ("str_replace", None),
@@ -841,7 +841,7 @@ mod tests {
             mode: PermissionMode::Auto,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         for command in ["git status --short", "ls src", "grep -R needle src"] {
             let args = serde_json::json!({ "command": command }).to_string();
@@ -867,7 +867,7 @@ mod tests {
             mode: PermissionMode::Auto,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         for tool in &[
             "read_file",
@@ -910,7 +910,7 @@ mod tests {
             mode: PermissionMode::Auto,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         let result = check_tool_permission_in_plan_mode(
             "bash",
@@ -936,7 +936,7 @@ mod tests {
             mode: PermissionMode::Auto,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         let result = check_tool_permission_in_plan_mode(
             "exit_plan_mode",
@@ -991,7 +991,7 @@ mod tests {
             is_background: false,
             ..Default::default()
         };
-        let ctx = Arc::new(RwLock::new(PermissionSyncContext::new(inherited)));
+        let ctx = PermissionSyncContext::shared(inherited);
 
         let result = check_tool_permission(
             "bash",

--- a/rust/crates/runtime/src/turn/prompt_cache.rs
+++ b/rust/crates/runtime/src/turn/prompt_cache.rs
@@ -384,7 +384,7 @@ pub(crate) fn assemble_bridge_pipeline_outcome(
     if let Some(ref text) = tool_conditional {
         volatile.push(prompts::PromptSection::dynamic(
             text.clone(),
-            prompts::PromptTokenBucket::BasePersona,
+            prompts::PromptTokenBucket::Environment,
         ));
     }
     let all_sections_for_trace = {

--- a/rust/crates/runtime/tests/permission_sync_e2e.rs
+++ b/rust/crates/runtime/tests/permission_sync_e2e.rs
@@ -85,7 +85,7 @@ async fn e2e_child_requests_permission_parent_approves() {
         // Create permission request
         let request = PermissionRequest::new("bash", serde_json::json!({"command": "git status"}))
             .with_hint("git status")
-            .with_suggested_rule("bash(git:*)");
+            .with_suggested_rule(r#"Bash(argv_prefix="git")"#);
 
         // Send and wait for response
         child_mailbox
@@ -148,7 +148,7 @@ async fn e2e_parent_denies_based_on_rules() {
 
     // Parent context with deny rule for dangerous commands
     let mut inherited = InheritedPermissions::new(PermissionMode::Auto);
-    inherited.add_deny(PermissionRule::parse("bash(rm -rf:*)"));
+    inherited.add_deny(PermissionRule::parse(r#"Bash(argv_prefix="rm -rf")"#));
     let parent_ctx = PermissionSyncContext::new(inherited);
     let handler = PermissionRequestHandler::new(Arc::new(RwLock::new(parent_ctx)));
 
@@ -263,7 +263,7 @@ async fn e2e_inherited_permissions_propagate() {
     let mut parent_ctx = PermissionSyncContext::root(PermissionMode::Prompt);
 
     // Add session allow rule
-    let update = PermissionUpdate::allow(PermissionRule::parse("bash(git:*)"));
+    let update = PermissionUpdate::allow(PermissionRule::parse(r#"Bash(argv_prefix="git")"#));
     parent_ctx.apply_update(&update);
 
     // Create child's inherited permissions
@@ -290,7 +290,7 @@ async fn e2e_permission_updates_persist() {
 
     // Request with suggested rule for bash git commands
     let request = PermissionRequest::new("bash", serde_json::json!({"command": "git status"}))
-        .with_suggested_rule("bash(git:*)");
+        .with_suggested_rule(r#"Bash(argv_prefix="git")"#);
 
     let response = handler.handle_request(&request).await;
     assert!(response.approved);
@@ -352,7 +352,7 @@ async fn e2e_multi_level_delegation() {
     // Add allow rule at root level
     let mut root_ctx = root_ctx;
     root_ctx.apply_update(&PermissionUpdate::allow(PermissionRule::parse(
-        "bash(git:*)",
+        r#"Bash(argv_prefix="git")"#,
     )));
 
     // Create child inherited
@@ -361,7 +361,7 @@ async fn e2e_multi_level_delegation() {
 
     // Child adds another rule
     child_ctx.apply_update(&PermissionUpdate::allow(PermissionRule::parse(
-        "bash(npm:*)",
+        r#"Bash(argv_prefix="npm")"#,
     )));
 
     // Create grandchild inherited


### PR DESCRIPTION
## Summary

Large-scale permission and sandbox security refactor — net simplification with fail-closed security posture.

## Changes

### Security Hardening
- `NEVER_READABLE_PATH_PATTERNS` expanded: `/etc/passwd`, `/etc/sudoers`, `/etc/ssh/`, `/boot`, `/proc`, `/sys`, `/dev`
- `ReadShortCircuit` in Permissive mode no longer bypasses sensitive path checks
- `expand_sandbox_path` now returns `Result` with `SandboxExpansionError` — root, traversal-escape, and system-sensitive paths rejected at API level
- Sensitive sandbox paths are now bypass-immune (no approval can override)

### Permission Context Architecture
- Centralized `PermissionSyncContext` handles across runtimes
- Sub-agents now correctly inherit permission context (was `None`)
- Tool allowlists enforced in sub-agent permission gates
- All 6 permission gates verified fail-closed

### Code Quality
- Legacy permission rule grammar removed
- 62 files changed, +5632 / -1795

## Verification
- `astra-sandbox`: 133 passed
- `astra-turn-core`: all tests passed
- `astra-cli edge_tools::tests`: 433 passed
- 23 approval keyboard integration tests pass
- E2E tests rewritten with stronger telemetry assertions

## Breaking Changes
- `expand_sandbox_path` signature changed: now returns `Result<PathBuf, SandboxExpansionError>`
- All 5 call sites updated (`stream_render.rs` ×3, `sse_loop/mod.rs` ×2)