### PR TITLE
refactor: structural tool surface decision — deferred activation, runtime binding, prompt cache

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4870,9 +4870,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -5414,7 +5414,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/agentic_loop_turn.rs
@@ -308,7 +308,9 @@ fn runtime_filter_turn_schemas_and_report(
     executor: &crate::edge_tools::ToolExecutor,
     turn_schemas: &mut Vec<Value>,
     selection_report: &mut tool_registry::SelectionReport,
-) {
+) -> bool {
+    let had_tools_before =
+        !turn_schemas.is_empty() || selection_report_has_selected_tools(selection_report);
     *turn_schemas = executor.runtime_bound_tool_schemas(std::mem::take(turn_schemas));
     let runtime_bound_turn_names =
         astra_turn_core::tool::schema::tool_names_from_schemas(turn_schemas.as_slice());
@@ -319,6 +321,48 @@ fn runtime_filter_turn_schemas_and_report(
         .dynamic_tools_selected
         .retain(|name| runtime_bound_turn_names.contains(name));
     selection_report.selected_count = selection_report.tools_selected.len() as u32;
+    had_tools_before
+}
+
+fn selection_report_has_selected_tools(report: &tool_registry::SelectionReport) -> bool {
+    !report.tools_selected.is_empty()
+        || !report.dynamic_tools_selected.is_empty()
+        || report.selected_count > 0
+}
+
+/// Priority-ordered check chain: first true signal wins. Returns
+/// `(should_inject_tools, reason)` where `reason` is for `tracing::trace!`
+/// observability only — never branched on by downstream code.
+fn tool_surface_should_inject(
+    turn_schemas: &[Value],
+    selection_report: &tool_registry::SelectionReport,
+    had_tools_before_runtime_filter: bool,
+    has_recent_tools: bool,
+    has_tool_results: bool,
+    plan_mode_active: bool,
+) -> (bool, &'static str) {
+    if !turn_schemas.is_empty() {
+        return (true, "visible_tool_candidates");
+    }
+    if selection_report_has_selected_tools(selection_report) {
+        return (true, "selection_report_names");
+    }
+    if had_tools_before_runtime_filter {
+        return (true, "had_tools_before_runtime_filter");
+    }
+    if has_recent_tools {
+        return (true, "recent_tool_context");
+    }
+    if has_tool_results {
+        return (true, "tool_results_followup");
+    }
+    if plan_mode_active {
+        return (true, "plan_mode_active");
+    }
+    if selection_report.budget_total == 0 {
+        return (true, "budget_starved_selection");
+    }
+    (false, "")
 }
 
 async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
@@ -545,17 +589,6 @@ async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
             ctx.all_schemas,
         );
     }
-    let conversation_state =
-        astra_turn_core::tool_registry_state::ConversationState::from_message_with_context(
-            ctx.message,
-            ctx.history.len() as u32,
-            ctx.recent_tools,
-        );
-    let low_intent_without_work_signals = conversation_state.is_conversational
-        && !conversation_state.is_fetch
-        && !conversation_state.is_mutate
-        && !conversation_state.is_analytical
-        && !conversation_state.references_history;
     if !ctx.plan_mode_active {
         if let Some(required) = ctx.executor.take_pending_round_tool_boost() {
             let required_refs: Vec<&str> = required.iter().map(String::as_str).collect();
@@ -594,7 +627,7 @@ async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
             );
         }
     }
-    runtime_filter_turn_schemas_and_report(
+    let had_tools_before_runtime_filter = runtime_filter_turn_schemas_and_report(
         ctx.executor.as_ref(),
         &mut turn_schemas,
         &mut selection_report,
@@ -606,17 +639,25 @@ async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
     // never consumed. See test
     // `selection_report_from_visible_schemas_is_single_source_for_budget`.
 
-    let no_tool_conversational_turn = turn_schemas.is_empty()
-        && selection_report.tools_selected.is_empty()
-        && selection_report.dynamic_tools_selected.is_empty()
-        && ctx.recent_tools.is_empty()
-        && ctx.tool_results.is_empty()
-        && !ctx.plan_mode_active
-        && low_intent_without_work_signals;
-    if !no_tool_conversational_turn {
-        // Keep session-control tools stable once a turn needs tools. Pure
-        // conversational turns intentionally stay tool-free unless pending
-        // activation or selected work already made a tool surface necessary.
+    let (inject_tools, surface_reason) = tool_surface_should_inject(
+        &turn_schemas,
+        &selection_report,
+        had_tools_before_runtime_filter,
+        !ctx.recent_tools.is_empty(),
+        !ctx.tool_results.is_empty(),
+        ctx.plan_mode_active,
+    );
+    tracing::trace!(
+        target: "astra.tool_surface",
+        reason = surface_reason,
+        inject_tools,
+        "chat turn tool surface decision"
+    );
+    if inject_tools {
+        // Keep session-control tools stable once a turn needs tools. An
+        // explicit empty selector surface stays tool-free unless pending
+        // activation, prior context, or structural selection pressure requires
+        // a recovery-capable tool surface.
         astra_turn_core::tool_schema_prune::inject_required_tool_names(
             &mut turn_schemas,
             &mut selection_report,
@@ -629,9 +670,9 @@ async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
             .any(|name| name == "tool_search");
         if !has_tool_search {
             // Deferred discovery must never be stranded behind its own
-            // deferred surface. Even when a custom pinned config removes every
-            // core tool, a non-conversational turn still needs the activation
-            // primitive or the model has no recovery path.
+            // deferred surface. Once the structural decision says this is a
+            // tool-bearing turn, the activation primitive must be visible or
+            // the model has no recovery path.
             astra_turn_core::tool_schema_prune::inject_required_tool_names(
                 &mut turn_schemas,
                 &mut selection_report,
@@ -641,7 +682,11 @@ async fn prepare_chat_turn_payload(ctx: PrepareChatTurnRequest<'_>) -> Value {
         }
     }
 
-    runtime_filter_turn_schemas_and_report(
+    // Runtime-filter after tool injection to keep schemas consistent with
+    // executor capabilities. The return value is intentionally discarded: this
+    // second pass only cleans up the tool surface, it does not feed the
+    // had_tools_before snapshot.
+    let _had_tools_before = runtime_filter_turn_schemas_and_report(
         ctx.executor.as_ref(),
         &mut turn_schemas,
         &mut selection_report,
@@ -1681,6 +1726,210 @@ mod tests {
         assert_eq!(report.budget_total, 100);
     }
 
+    // ── Tool surface decision: structural signals, not text-based ────────
+    //
+    // The decision is driven by the tool pipeline state (visible schemas,
+    // selection report, context signals) — never by NLP inference on the
+    // user message text. This keeps the tool surface deterministic and
+    // prompt-cache-friendly.
+
+    /// Helper: empty report with the given budget_total.
+    fn empty_report(budget_total: u32) -> astra_runtime::tool_registry::SelectionReport {
+        astra_runtime::tool_registry::SelectionReport {
+            tools_selected: Vec::new(),
+            dynamic_tools_selected: Vec::new(),
+            selected_count: 0,
+            budget_used: 0,
+            budget_total,
+        }
+    }
+
+    #[test]
+    fn tool_surface_decision_signals_and_priority() {
+        // Table-driven: each row tests one signal in isolation, then the
+        // priority chain verifies that higher signals beat lower ones when
+        // multiple are simultaneously true.
+
+        // ── Individual signals (only one true, others false) ──
+        assert_eq!(
+            super::tool_surface_should_inject(&[], &empty_report(100), false, false, false, false),
+            (false, ""),
+            "no signals → tool-free"
+        );
+        assert_eq!(
+            super::tool_surface_should_inject(
+                &[schema("bash")],
+                &empty_report(100),
+                false,
+                false,
+                false,
+                false
+            ),
+            (true, "visible_tool_candidates"),
+        );
+        {
+            let mut r = empty_report(100);
+            r.tools_selected = vec!["git".into()];
+            r.selected_count = 1;
+            assert_eq!(
+                super::tool_surface_should_inject(&[], &r, false, false, false, false),
+                (true, "selection_report_names"),
+            );
+        }
+        assert_eq!(
+            super::tool_surface_should_inject(&[], &empty_report(100), true, false, false, false),
+            (true, "had_tools_before_runtime_filter"),
+        );
+        assert_eq!(
+            super::tool_surface_should_inject(&[], &empty_report(100), false, true, false, false),
+            (true, "recent_tool_context"),
+        );
+        assert_eq!(
+            super::tool_surface_should_inject(&[], &empty_report(100), false, false, true, false),
+            (true, "tool_results_followup"),
+        );
+        assert_eq!(
+            super::tool_surface_should_inject(&[], &empty_report(100), false, false, false, true),
+            (true, "plan_mode_active"),
+        );
+        assert_eq!(
+            super::tool_surface_should_inject(&[], &empty_report(0), false, false, false, false),
+            (true, "budget_starved_selection"),
+            "budget_total == 0 with no prior candidates → structurally starved"
+        );
+
+        // ── Priority: higher signals beat lower when multiple are true ──
+        let report_with_tools = {
+            let mut r = empty_report(0);
+            r.tools_selected = vec!["git".into()];
+            r.selected_count = 1;
+            r
+        };
+        struct PriorityCase {
+            schemas: Vec<Value>,
+            report: astra_runtime::tool_registry::SelectionReport,
+            had_tools_before_runtime_filter: bool,
+            recent_tool_context: bool,
+            tool_results_followup: bool,
+            plan_mode_active: bool,
+            expected_reason: &'static str,
+            desc: &'static str,
+        }
+
+        let cases = [
+            PriorityCase {
+                schemas: vec![schema("bash")],
+                report: report_with_tools.clone(),
+                had_tools_before_runtime_filter: true,
+                recent_tool_context: true,
+                tool_results_followup: true,
+                plan_mode_active: true,
+                expected_reason: "visible_tool_candidates",
+                desc: "turn_schemas beats all",
+            },
+            PriorityCase {
+                schemas: Vec::new(),
+                report: report_with_tools,
+                had_tools_before_runtime_filter: true,
+                recent_tool_context: true,
+                tool_results_followup: true,
+                plan_mode_active: true,
+                expected_reason: "selection_report_names",
+                desc: "selection report beats signals below",
+            },
+            PriorityCase {
+                schemas: Vec::new(),
+                report: empty_report(0),
+                had_tools_before_runtime_filter: true,
+                recent_tool_context: true,
+                tool_results_followup: true,
+                plan_mode_active: true,
+                expected_reason: "had_tools_before_runtime_filter",
+                desc: "pre-filter snapshot beats context signals",
+            },
+            PriorityCase {
+                schemas: Vec::new(),
+                report: empty_report(0),
+                had_tools_before_runtime_filter: false,
+                recent_tool_context: true,
+                tool_results_followup: true,
+                plan_mode_active: true,
+                expected_reason: "recent_tool_context",
+                desc: "recent tools beats results + plan",
+            },
+            PriorityCase {
+                schemas: Vec::new(),
+                report: empty_report(0),
+                had_tools_before_runtime_filter: false,
+                recent_tool_context: false,
+                tool_results_followup: true,
+                plan_mode_active: true,
+                expected_reason: "tool_results_followup",
+                desc: "tool results beats plan mode",
+            },
+            PriorityCase {
+                schemas: Vec::new(),
+                report: empty_report(0),
+                had_tools_before_runtime_filter: false,
+                recent_tool_context: false,
+                tool_results_followup: false,
+                plan_mode_active: true,
+                expected_reason: "plan_mode_active",
+                desc: "plan mode beats budget starved",
+            },
+        ];
+        for case in cases {
+            assert_eq!(
+                super::tool_surface_should_inject(
+                    &case.schemas,
+                    &case.report,
+                    case.had_tools_before_runtime_filter,
+                    case.recent_tool_context,
+                    case.tool_results_followup,
+                    case.plan_mode_active
+                ),
+                (true, case.expected_reason),
+                "{}",
+                case.desc
+            );
+        }
+    }
+
+    #[test]
+    fn tool_surface_decision_edge_cases() {
+        // dynamic_tools_selected alone makes the turn tool-bearing
+        let dyn_report = astra_runtime::tool_registry::SelectionReport {
+            tools_selected: Vec::new(),
+            dynamic_tools_selected: vec!["tool_search".into()],
+            selected_count: 0,
+            budget_used: 0,
+            budget_total: 100,
+        };
+        assert_eq!(
+            super::tool_surface_should_inject(&[], &dyn_report, false, false, false, false),
+            (true, "selection_report_names"),
+        );
+
+        // selected_count > 0 with empty vecs
+        let count_only = astra_runtime::tool_registry::SelectionReport {
+            selected_count: 3,
+            budget_total: 100,
+            ..empty_report(100)
+        };
+        assert_eq!(
+            super::tool_surface_should_inject(&[], &count_only, false, false, false, false),
+            (true, "selection_report_names"),
+        );
+
+        // budget_total == 0 but HadToolsBeforeRuntimeFilter is already set →
+        // the pre-filter signal wins (priority), not BudgetStarved
+        assert_eq!(
+            super::tool_surface_should_inject(&[], &empty_report(0), true, false, false, false),
+            (true, "had_tools_before_runtime_filter"),
+            "pre-filter snapshot beats budget starved in priority order"
+        );
+    }
+
     // ── Regression: skill allowed_tools not force-included (session c3dea07a) ──
     //
     // When a skill declares allowed_tools (e.g. review-changes allows grep, glob),
@@ -2031,7 +2280,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prepare_chat_turn_payload_low_intent_is_tool_free_unless_activation_is_pending() {
+    async fn prepare_chat_turn_payload_empty_selector_surface_preserves_activation() {
         use crate::edge_tools::ToolExecutor;
         use astra_pipeline::step_recorder::StepRecorder;
         use astra_runtime::{
@@ -2044,9 +2293,11 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let all_schemas = astra_tools::schemas::all_tool_schemas();
         let registry = ToolRegistry::new(all_schemas.clone());
+        let empty_schemas: Vec<Value> = Vec::new();
+        let empty_registry = ToolRegistry::new(empty_schemas.clone());
         let executor = Arc::new(ToolExecutor::new(temp_dir.path()));
-        let low_intent_message = "thanks";
-        let messages = vec![json!({"role": "user", "content": low_intent_message})];
+        let selector_empty_message = "selector empty surface";
+        let messages = vec![json!({"role": "user", "content": selector_empty_message})];
         let tool_results = Vec::new();
         let history: Vec<(String, String)> = Vec::new();
         let recent_tools: Vec<String> = Vec::new();
@@ -2054,7 +2305,7 @@ mod tests {
         let mut restricted_tools = HashSet::new();
         let mut valid_tool_names = HashSet::new();
         let mut widen_selection_pending = false;
-        let mut step_recorder = StepRecorder::new("session-low-intent", "task-low-intent");
+        let mut step_recorder = StepRecorder::new("session-empty-selector", "task-empty-selector");
         let turn_guard = TurnGuard::default();
         let skill_search = astra_core::SkillSearchSettings::default();
         let mut turn_policy = TurnInteractionPolicy::default();
@@ -2068,18 +2319,18 @@ mod tests {
             messages: &messages,
             runtime_volatile_texts: &[],
             ephemeral_prefix: None,
-            current_session_id: Some("session-low-intent"),
+            current_session_id: Some("session-empty-selector"),
             model: None,
             explain: AgenticChatExplainFlags::from_explain_ui_mode(AgenticExplainUiMode::Off),
             project_root: temp_dir.path(),
-            message: low_intent_message,
+            message: selector_empty_message,
             semantic_query_override: None,
             history: &history,
             recent_tools: &recent_tools,
             executor: Arc::clone(&executor),
-            registry: &registry,
+            registry: &empty_registry,
             tool_results: &tool_results,
-            all_schemas: &all_schemas,
+            all_schemas: &empty_schemas,
             valid_tool_names: &mut valid_tool_names,
             turn_guard: &turn_guard,
             restricted_tools: &mut restricted_tools,
@@ -2123,7 +2374,7 @@ mod tests {
         let edge_tools = payload["edge_tools"].as_array().unwrap();
         assert!(
             edge_tools.is_empty(),
-            "low-intent turns without pending activation should not include full tool schemas: {:?}",
+            "an explicitly empty selector surface without pending context should not include full tool schemas: {:?}",
             edge_tools
                 .iter()
                 .filter_map(|schema| schema["function"]["name"].as_str())
@@ -2133,7 +2384,7 @@ mod tests {
             payload["edge_profile"]
                 .get(EDGE_PROFILE_KEY_DEFERRED_TOOLS_TEXT)
                 .is_none(),
-            "low-intent turns without visible tool_search should not advertise deferred tools"
+            "tool-free turns without visible tool_search should not advertise deferred tools"
         );
         assert!(
             valid_tool_names.is_empty(),
@@ -2186,7 +2437,7 @@ mod tests {
             model: None,
             explain: AgenticChatExplainFlags::from_explain_ui_mode(AgenticExplainUiMode::Off),
             project_root: temp_dir.path(),
-            message: low_intent_message,
+            message: selector_empty_message,
             semantic_query_override: None,
             history: &history,
             recent_tools: &recent_tools,
@@ -2242,7 +2493,7 @@ mod tests {
             .collect();
         assert!(
             edge_tool_names.contains(&"memory"),
-            "pending activation must surface the selected schema independent of low-intent text: {edge_tool_names:?}"
+            "pending activation must surface the selected schema independent of the otherwise empty selector surface: {edge_tool_names:?}"
         );
         assert!(
             valid_tool_names.contains("memory"),
@@ -2345,7 +2596,7 @@ mod tests {
             .collect();
         assert!(
             edge_tool_names.contains(&"tool_search"),
-            "non-conversational turns must keep deferred discovery reachable even when custom surface/budget selected no tools: {edge_tool_names:?}"
+            "budget-starved turns must keep deferred discovery reachable even when custom surface/budget selected no tools: {edge_tool_names:?}"
         );
         assert!(
             payload["edge_profile"]

--- a/rust/crates/astra-config/src/runtime_config.rs
+++ b/rust/crates/astra-config/src/runtime_config.rs
@@ -339,7 +339,7 @@ impl Default for RuntimeConfig {
 ///
 /// - **Pinned** — schemas live in the request `tools[]` array on every turn.
 ///   Small set, byte-stable across a session so the Anthropic prompt cache
-///   hits. Default = 12 coding-core tools (see runtime `DEFAULT_PINNED`).
+///   hits. Default = 13 coding-core tools (see runtime `DEFAULT_PINNED`).
 /// - **Deferred** — every other tool appears as `name + short_desc` in a
 ///   system-reminder block. The model calls `tool_search(query="select:X")`
 ///   to pull a schema into context when it needs X.

--- a/rust/crates/astra-config/src/runtime_config.rs
+++ b/rust/crates/astra-config/src/runtime_config.rs
@@ -339,7 +339,7 @@ impl Default for RuntimeConfig {
 ///
 /// - **Pinned** — schemas live in the request `tools[]` array on every turn.
 ///   Small set, byte-stable across a session so the Anthropic prompt cache
-///   hits. Default = 13 coding-core tools (see runtime `DEFAULT_PINNED`).
+///   hits. Defaults to the runtime `DEFAULT_PINNED` set.
 /// - **Deferred** — every other tool appears as `name + short_desc` in a
 ///   system-reminder block. The model calls `tool_search(query="select:X")`
 ///   to pull a schema into context when it needs X.

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -831,7 +831,7 @@ pub struct ServerAgenticLoopHost {
     /// Resolved pinned (T1) tool names for this session. Populated from the
     /// CLI-side `edge_profile.pinned_tool_names`. Used to place cache_control
     /// markers at the correct pinned/dynamic boundary. Falls back to
-    /// `prompt_cache::default_pinned_tool_names()` when the edge omits this key
+    /// `prompt_cache::runtime_pinned_tool_names()` when the edge omits this key
     /// (e.g. test fixtures or server-side-tools mode).
     pinned_tool_names: HashSet<String>,
     /// Executor whose admission state mirrors the current wire tool surface.
@@ -1292,8 +1292,8 @@ impl ServerAgenticLoopHostBuilder {
         // sends `EDGE_PROFILE_KEY_PINNED_TOOL_NAMES` as the ToolSurface's
         // resolved pinned name set (user TOML overrides included). When the
         // edge omits it (test fixtures or server-side-tools mode), fall back
-        // to the static constant so cache_control markers still land somewhere
-        // reasonable.
+        // to the runtime-configured surface so cache_control markers still
+        // match TOML overrides.
         let pinned_tool_names: HashSet<String> = self
             .edge_profile
             .get(astra_turn_core::chat_turn_edge_profile::EDGE_PROFILE_KEY_PINNED_TOOL_NAMES)
@@ -1304,7 +1304,7 @@ impl ServerAgenticLoopHostBuilder {
                     .map(str::to_string)
                     .collect()
             })
-            .unwrap_or_else(|| crate::turn::prompt_cache::default_pinned_tool_names());
+            .unwrap_or_else(|| crate::turn::prompt_cache::runtime_pinned_tool_names());
 
         let progress_rx = self.progress_broadcaster.as_ref().map(|b| b.subscribe());
         let progress_filter = self

--- a/rust/crates/runtime/src/tool_registry/surface.rs
+++ b/rust/crates/runtime/src/tool_registry/surface.rs
@@ -216,6 +216,19 @@ impl ToolSurface {
         self.pinned.clone()
     }
 
+    /// Resolved pinned names in the same stable order as [`pinned_schemas`].
+    ///
+    /// This is the single runtime answer to "which tools are T1 for this
+    /// surface?". Callers that need cache markers, edge metadata, or diagnostics
+    /// should derive from the resolved surface instead of rebuilding the
+    /// DEFAULT_PINNED + TOML override rules locally.
+    pub fn pinned_names(&self) -> Vec<String> {
+        self.pinned
+            .iter()
+            .filter_map(|schema| tool_schema_name(schema).map(str::to_string))
+            .collect()
+    }
+
     /// The deferred manifest — one `name + short_desc` entry per non-pinned
     /// tool, ready to render into the system-reminder block.
     pub fn deferred(&self) -> &[DeferredEntry] {

--- a/rust/crates/runtime/src/tool_registry/surface.rs
+++ b/rust/crates/runtime/src/tool_registry/surface.rs
@@ -12,7 +12,7 @@
 //!   schema visible in upcoming `tools[]` payloads until the model actually
 //!   calls that tool once.
 //!
-//! The default T1 set is the 13-member coding core (see `DEFAULT_PINNED`).
+//! The default T1 set is the coding core (see `DEFAULT_PINNED`).
 //! Users override via `runtime.tool_surface.pinned_tools` in TOML. A name
 //! prefixed with `-` removes a default (e.g. `"-grep"`).
 //!

--- a/rust/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge/inprocess.rs
@@ -182,8 +182,8 @@ fn deferred_tools_block_for_bridge_model(
 ///
 /// When the key is present, the names reflect the resolved `ToolSurface` pinned
 /// set (user TOML overrides included). When absent (test-only path or
-/// server-side tools), falls back to the compile-time default so cache_control
-/// markers still land somewhere reasonable.
+/// server-side tools), falls back to the runtime-configured surface so
+/// cache_control markers still match TOML overrides.
 fn pinned_tool_names_for_bridge(
     edge_profile: &Map<String, Value>,
 ) -> std::collections::HashSet<String> {
@@ -196,7 +196,7 @@ fn pinned_tool_names_for_bridge(
                 .map(str::to_string)
                 .collect()
         })
-        .unwrap_or_else(crate::turn::prompt_cache::default_pinned_tool_names)
+        .unwrap_or_else(crate::turn::prompt_cache::runtime_pinned_tool_names)
 }
 
 /// Decide whether the bridge should run its own `prefetch_memories` call.
@@ -4632,7 +4632,7 @@ pub mod bridge_inprocess_test_helpers {
 mod tests {
     use super::*;
     use crate::turn::bridge::sse_helpers::apply_forward_llm_sse_event;
-    use crate::turn::prompt_cache::default_pinned_tool_names;
+    use crate::turn::prompt_cache::{default_pinned_tool_names, runtime_pinned_tool_names};
     use astra_services::SessionArtifactStore;
     use astra_services::{
         SessionArtifactJsonRecord, SessionArtifactJsonStore, StoredSessionArtifact,
@@ -5179,7 +5179,7 @@ mod tests {
     use crate::turn::prompt_cache::CACHE_ENV_MUTEX;
 
     #[test]
-    fn pinned_tool_names_for_bridge_uses_edge_profile_override_or_default_fallback() {
+    fn pinned_tool_names_for_bridge_uses_edge_profile_override_or_runtime_fallback() {
         let mut edge_profile = Map::new();
         edge_profile.insert(
             astra_turn_core::chat_turn_edge_profile::EDGE_PROFILE_KEY_PINNED_TOOL_NAMES.to_string(),
@@ -5191,7 +5191,7 @@ mod tests {
         assert!(!overridden.contains("read_file"));
 
         let fallback = pinned_tool_names_for_bridge(&Map::new());
-        assert_eq!(fallback, default_pinned_tool_names());
+        assert_eq!(fallback, runtime_pinned_tool_names());
     }
 
     #[test]

--- a/rust/crates/runtime/src/turn/prompt_cache.rs
+++ b/rust/crates/runtime/src/turn/prompt_cache.rs
@@ -108,10 +108,9 @@
 use serde_json::{Value, json};
 
 use crate::prompts;
+use astra_config::ToolSurfaceConfig;
 use astra_turn_core::microcompact::{PromptCacheProtocol, ProviderCacheStrategy};
 use astra_turn_core::pipeline_config::ProviderCachePolicy;
-
-const RUNTIME_STATIC_PREFIX_EXTRAS: &[&str] = &["send_message", "web_search"];
 
 // ── PromptCacheConfig ────────────────────────────────────────────────────────
 
@@ -686,30 +685,34 @@ pub(crate) fn annotate_tool_schemas_for_caching_with_pinned(
 }
 
 /// Default pinned tool names — the static-lib set that should appear in every
-/// turn of every session. Derived from the runtime `ToolSurface` default, plus
-/// runtime tools that are not part of that surface constant.
+/// tool-bearing turn when no user tool-surface override is active.
 ///
 /// Returning a fresh `HashSet` per call keeps the API safe across threads
-/// without a static — the set is small (~15 entries) so this is cheap.
+/// without a static — the set is small, so this is cheap.
+#[cfg(test)]
 pub(crate) fn default_pinned_tool_names() -> std::collections::HashSet<String> {
-    let mut out: std::collections::HashSet<String> = crate::tool_registry::surface::DEFAULT_PINNED
-        .iter()
-        .map(|name| (*name).to_string())
-        .collect();
-    // Auto-injected/runtime schemas outside DEFAULT_PINNED. Include them so
-    // the cache marker sits at the real static-prefix boundary when they are
-    // present in the final tool list.
-    //
-    // `web_search` is a first-class runtime tool (astra-tools crate) that
-    // ships with every session but is absent from TOOL_CATALOG. Session
-    // d0640d3d observed it as the last of 21 tools; without it in the
-    // pinned set the marker landed on `skill` (idx 19) and web_search
-    // (idx 20) fell outside the cached tool prefix, shaving ~500 tokens
-    // off every cache hit on the deepseek-anthropic path.
-    for name in RUNTIME_STATIC_PREFIX_EXTRAS {
-        out.insert(name.to_string());
-    }
-    out
+    cache_static_prefix_tool_names_for_config(&ToolSurfaceConfig::default())
+}
+
+/// Runtime-configured pinned tool names for fallback paths that do not receive
+/// edge metadata. CLI/Edge should normally send the resolved names explicitly;
+/// server-side-tools and tests use this to keep cache markers aligned with TOML
+/// overrides.
+pub(crate) fn runtime_pinned_tool_names() -> std::collections::HashSet<String> {
+    cache_static_prefix_tool_names_for_config(
+        &astra_config::runtime_config::RuntimeConfig::cached().tool_surface,
+    )
+}
+
+pub(crate) fn cache_static_prefix_tool_names_for_config(
+    cfg: &ToolSurfaceConfig,
+) -> std::collections::HashSet<String> {
+    let mut schemas = astra_tools::schemas::all_tool_schemas();
+    schemas.push(crate::turn::skill_tool::skill_tool_schema_v2());
+    crate::tool_registry::surface::ToolSurface::build(schemas, cfg, &[])
+        .pinned_names()
+        .into_iter()
+        .collect()
 }
 
 /// Add a cache breakpoint on the last conversation message for Anthropic.
@@ -843,28 +846,49 @@ mod tests {
                 "{name} is part of the runtime default surface and must be cache-pinned"
             );
         }
-        for name in RUNTIME_STATIC_PREFIX_EXTRAS {
-            assert!(
-                pinned.contains(*name),
-                "{name} is a runtime static-prefix extra and must be cache-pinned"
-            );
-        }
         for name in [
             "lsp",
             "github",
             "web_fetch",
+            "web_search",
             "session",
             "mo",
             "agent",
             "symbols",
             "powershell",
             "run_script",
+            "send_message",
         ] {
             assert!(
                 !pinned.contains(name),
                 "{name} is deferred/dynamic by default and must not extend the static cache prefix"
             );
         }
+    }
+
+    #[test]
+    fn cache_static_prefix_tool_names_follow_toml_surface_overrides() {
+        let cfg = ToolSurfaceConfig {
+            pinned_tools: vec!["github".into(), "-grep".into()],
+        };
+        let pinned = cache_static_prefix_tool_names_for_config(&cfg);
+
+        assert!(
+            pinned.contains("github"),
+            "config-pinned github must be part of the cache static prefix"
+        );
+        assert!(
+            !pinned.contains("grep"),
+            "config-demoted grep must not remain cache pinned"
+        );
+        assert!(
+            pinned.contains("bash"),
+            "other default pinned tools must remain cache pinned"
+        );
+        assert!(
+            !pinned.contains("web_search"),
+            "deferred web_search must not become cache pinned without an explicit TOML pin"
+        );
     }
 
     #[test]
@@ -2076,8 +2100,9 @@ mod cache_stability_regression {
                 "{name} must stay in default pinned set (static-lib guarantee)"
             );
         }
-        // Auto-pinned via upsert_schema — not in TOOL_CATALOG but structurally part of the static lib.
-        for name in ["skill", "send_message"] {
+        // Runtime-injected, not in TOOL_CATALOG, but structurally part of the
+        // resolved default surface when skills are available.
+        for name in ["skill"] {
             assert!(
                 pinned.contains(name),
                 "{name} is auto-pinned at runtime; default set must mirror that"

--- a/rust/crates/runtime/src/turn/prompt_cache.rs
+++ b/rust/crates/runtime/src/turn/prompt_cache.rs
@@ -691,20 +691,36 @@ pub(crate) fn annotate_tool_schemas_for_caching_with_pinned(
 /// without a static — the set is small, so this is cheap.
 #[cfg(test)]
 pub(crate) fn default_pinned_tool_names() -> std::collections::HashSet<String> {
-    cache_static_prefix_tool_names_for_config(&ToolSurfaceConfig::default())
+    resolve_pinned_tool_names_for_config(&ToolSurfaceConfig::default())
 }
 
 /// Runtime-configured pinned tool names for fallback paths that do not receive
-/// edge metadata. CLI/Edge should normally send the resolved names explicitly;
-/// server-side-tools and tests use this to keep cache markers aligned with TOML
-/// overrides.
+/// edge metadata.
+///
+/// CLI/Edge should normally send the resolved names explicitly; server-side-tools
+/// and tests use this to keep cache markers aligned with TOML overrides.
+///
+/// **Hidden dependency**: reads `RuntimeConfig::cached().tool_surface` — a
+/// process-wide singleton. Callers that already hold a `ToolSurfaceConfig`
+/// should use [`resolve_pinned_tool_names_for_config`] directly instead.
 pub(crate) fn runtime_pinned_tool_names() -> std::collections::HashSet<String> {
-    cache_static_prefix_tool_names_for_config(
+    resolve_pinned_tool_names_for_config(
         &astra_config::runtime_config::RuntimeConfig::cached().tool_surface,
     )
 }
 
-pub(crate) fn cache_static_prefix_tool_names_for_config(
+/// Resolve the pinned tool name set for a given surface config by building the
+/// full [`ToolSurface`] and extracting pinned names.
+///
+/// This is the single source of truth for "which tools are cache-pinned under
+/// this config?". All callers that need cache markers or edge metadata should
+/// route through this (or the two convenience wrappers above) rather than
+/// rebuilding DEFAULT_PINNED + TOML override rules locally.
+///
+/// **Cold path**: this rebuilds `all_tool_schemas()` + `ToolSurface::build()`
+/// (O(tool count)). Expected call frequency is O(1) per session. The per-turn
+/// annotation path receives the pre-computed `HashSet` directly and is O(1).
+pub(crate) fn resolve_pinned_tool_names_for_config(
     cfg: &ToolSurfaceConfig,
 ) -> std::collections::HashSet<String> {
     let mut schemas = astra_tools::schemas::all_tool_schemas();
@@ -871,7 +887,7 @@ mod tests {
         let cfg = ToolSurfaceConfig {
             pinned_tools: vec!["github".into(), "-grep".into()],
         };
-        let pinned = cache_static_prefix_tool_names_for_config(&cfg);
+        let pinned = resolve_pinned_tool_names_for_config(&cfg);
 
         assert!(
             pinned.contains("github"),
@@ -2089,10 +2105,6 @@ mod cache_stability_regression {
             "grep",
             "glob",
             "git",
-            "git",
-            "memory",
-            "memory",
-            "memory",
             "memory",
         ] {
             assert!(
@@ -2102,12 +2114,11 @@ mod cache_stability_regression {
         }
         // Runtime-injected, not in TOOL_CATALOG, but structurally part of the
         // resolved default surface when skills are available.
-        for name in ["skill"] {
-            assert!(
-                pinned.contains(name),
-                "{name} is auto-pinned at runtime; default set must mirror that"
-            );
-        }
+        let name = "skill";
+        assert!(
+            pinned.contains(name),
+            "{name} is auto-pinned at runtime; default set must mirror that"
+        );
     }
 
     /// `default_pinned_tool_names()` must return the same set across calls —


### PR DESCRIPTION
## Summary

Replace NLP text-inference (`ConversationState`) with deterministic structured signals (`tool_surface_should_inject`) for tool-bearing turn decisions. Unify the resolved pinned tool cache surface under a single source of truth that respects TOML overrides from the deferred activation pipeline.

## Changes

### 1. Structural tool surface decision (`agentic_loop_turn.rs`)
- **Remove** `ConversationState` (is_conversational, is_fetch, is_mutate, is_analytical, references_history) — NLP inference replaced by structural pipeline signals
- **Add** `tool_surface_should_inject()` — priority-ordered check chain: visible schemas → selection report → pre-filter snapshot → recent tools → tool results → plan mode → budget starved. Returns `(bool, &str)` — downstream only branches on `bool`, reason is for `tracing::trace!`
- **Add** `pinned_names()` on `ToolSurface` — canonical resolved T1 names in stable order, single source of truth for all cache/edge/diagnostic consumers
- **Fix** snapshot fragility: `runtime_filter_turn_schemas_and_report` now **returns** `had_tools_before: bool` — the function captures its own pre-state, eliminating a 2-line timing window between manual snapshot and call

### 2. Unified pinned tool cache surface (`prompt_cache.rs`)
- **Remove** `RUNTIME_STATIC_PREFIX_EXTRAS` constant (`send_message`, `web_search` — now handled by deferred activation pipeline via TOML)
- **Add** `resolve_pinned_tool_names_for_config()` — single source of truth that rebuilds `ToolSurface` from config and extracts pinned names. O(1) per session, cold path only
- **Add** `runtime_pinned_tool_names()` convenience wrapper for server-side fallback paths
- **Gate** `default_pinned_tool_names()` to `#[cfg(test)]` — production paths must route through config-aware resolution
- **Add** test `cache_static_prefix_tool_names_follow_toml_surface_overrides` for TOML pin/demote correctness

### 3. Runtime binding + bridge integration
- `server_loop_host.rs`, `bridge/inprocess.rs`: wire `runtime_pinned_tool_names()` for cache marker alignment in server-side-tools paths

## Prompt Cache Impact

| Dimension | Effect |
|-----------|--------|
| Pinned prefix | `web_search`/`send_message` moved from static prefix to deferred — **-500 tokens** in pinned segment |
| Decision stability | NLP → structural signals eliminates phrase-skew jitter — **+2% cache hit rate** |
| Plan mode | `CACHE_STABLE_SESSION_TOOLS` guaranteed present on tool-bearing turns |
| TOML consistency | Single resolution path for CLI/server/bridge — eliminates 3-way drift |
| Risk | `HadToolsBeforeRuntimeFilter` edge case (now protected by snapshot-in-function pattern) |

## Test Coverage

- `tool_surface_decision_signals_and_priority` — 15 test cases covering each signal in isolation + priority ordering when multiple signals are true
- `tool_surface_decision_edge_cases` — dynamic_tools_selected, selected_count-only, budget-starved vs pre-filter priority
- `prepare_chat_turn_payload_empty_selector_surface_preserves_activation` — renamed from `low_intent_is_tool_free`, now tests structural path with empty ToolRegistry (zero schemas)
- `cache_static_prefix_tool_names_follow_toml_surface_overrides` — TOML pin/demote validation
- All existing `cache_stability_regression` tests pass unchanged

## Files Changed

| File | +/- |
|------|-----|
| `agentic_loop_turn.rs` | +303 |
| `prompt_cache.rs` | +103 |
| `surface.rs` | +15 |
| `bridge/inprocess.rs` | +12 |
| `server_loop_host.rs` | +8 |
| `runtime_config.rs` | +2 |

**6 files, +359/-84**