### PR TITLE
feat: optimize release workflows — pin macOS runners, split Docker build into multi-arch digest jobs

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -72,12 +72,12 @@ jobs:
             suffix: linux-arm64
             use-cross: true
             features: --features release-vendored-openssl
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             suffix: darwin-amd64
             use-cross: false
             features: ""
-          - os: macos-latest
+          - os: macos-15
             target: aarch64-apple-darwin
             suffix: darwin-arm64
             use-cross: false

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -15,22 +15,15 @@ env:
   IMAGE_NAME: matrixorigin/astra
 
 jobs:
-  docker:
-    name: Build & Push Docker Image
+  version:
+    name: Resolve Version
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      image_version: ${{ steps.release.outputs.image_version }}
+      latest: ${{ steps.release.outputs.latest }}
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Resolve release version
         id: release
         shell: bash
@@ -61,28 +54,131 @@ jobs:
           echo "image_version=${image_version}" >> "${GITHUB_OUTPUT}"
           echo "latest=${latest}" >> "${GITHUB_OUTPUT}"
 
+  build:
+    name: Build ${{ matrix.platform }}
+    needs: version
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            slug: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            slug: linux-arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - uses: docker/metadata-action@v5
         id: meta
         with:
           images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.release.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release.outputs.version }},enable=${{ steps.release.outputs.latest == 'true' }}
-            type=raw,value=latest,enable=${{ steps.release.outputs.latest == 'true' }}
+            type=semver,pattern={{version}},value=${{ needs.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.latest == 'true' }}
+            type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
 
       - uses: docker/build-push-action@v6
+        id: build
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            IMAGE_VERSION=${{ steps.release.outputs.image_version }}
+            IMAGE_VERSION=${{ needs.version.outputs.image_version }}
             IMAGE_REVISION=${{ github.sha }}
             IMAGE_BRANCH=${{ github.ref_name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-${{ matrix.slug }}
+          cache-to: type=gha,scope=docker-${{ matrix.slug }},mode=max
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           provenance: mode=max
           sbom: true
+
+      - name: Export digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge & Push Docker Manifest
+    needs:
+      - version
+      - build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.latest == 'true' }}
+            type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
+
+      - name: Create manifest list
+        shell: bash
+        working-directory: /tmp/digests
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          METADATA_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          mapfile -t tag_args < <(jq -r '.tags[] | "-t", .' <<< "${METADATA_JSON}")
+          if [ "${#tag_args[@]}" -eq 0 ]; then
+            echo "No Docker tags were generated" >&2
+            exit 1
+          fi
+
+          sources=()
+          for digest in *; do
+            sources+=("${IMAGE_NAME}@sha256:${digest}")
+          done
+          if [ "${#sources[@]}" -eq 0 ]; then
+            echo "No platform image digests were downloaded" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"


### PR DESCRIPTION
## Summary
Optimize the release CI workflows for reliability and faster builds:

1. **Pin macOS runners** (`release-binaries.yml`): Replace `macos-13` → `macos-15-intel` and `macos-latest` → `macos-15` for deterministic builds.
2. **Split Docker build into digest-based multi-arch jobs** (`release-docker.yml`): Replace the single monolithic `docker` job with three jobs — `version` (resolve semver), `build` (matrix: linux/amd64 + linux/arm64, each producing a digest artifact), and `merge` (create a multi-arch manifest from digests). Uses per-platform `gha` cache scopes and digest pinning for reproducibility.

## Changes
- `.github/workflows/release-binaries.yml`: Pin macos-13 → macos-15-intel, macos-latest → macos-15
- `.github/workflows/release-docker.yml`: Split into `version` / `build` (matrix) / `merge` jobs with digest-based manifest creation

## Testing
- Workflow syntax validated; will be exercised on the next release tag push.