### PR TITLE
fix: add bypass permission mode

### DIFF
--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -10,6 +10,14 @@ inputs:
     description: "Whether to save cache (true/false)"
     required: false
     default: "false"
+  use-sccache:
+    description: "Enable sccache with the GitHub Actions cache backend"
+    required: false
+    default: "true"
+  use-mold:
+    description: "Use mold as the Linux linker"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -30,6 +38,33 @@ runs:
     - uses: dtolnay/rust-toolchain@stable
 
     - uses: taiki-e/install-action@nextest
+
+    - name: Install mold linker
+      if: ${{ inputs.use-mold == 'true' && runner.os == 'Linux' }}
+      shell: bash
+      run: |
+        set -euxo pipefail
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends mold
+        if [[ -n "${RUSTFLAGS:-}" ]]; then
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold ${RUSTFLAGS}" >> "$GITHUB_ENV"
+        else
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold" >> "$GITHUB_ENV"
+        fi
+
+    - name: Install sccache
+      if: ${{ inputs.use-sccache == 'true' }}
+      uses: mozilla-actions/sccache-action@v0.0.10
+
+    - name: Configure sccache
+      if: ${{ inputs.use-sccache == 'true' }}
+      shell: bash
+      run: |
+        {
+          echo "SCCACHE_GHA_ENABLED=true"
+          echo "SCCACHE_CACHE_SIZE=5G"
+          echo "RUSTC_WRAPPER=sccache"
+        } >> "$GITHUB_ENV"
 
     - uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
         run: |
           cargo nextest run --manifest-path rust/Cargo.toml --workspace --no-run
           cargo nextest run --manifest-path rust/Cargo.toml -p astra-runtime --features bridge-e2e-hooks --no-run
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
 
   # ── Stage 2: parallel offline test shards (all need: build) ────────
   #

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ astra chat -m "summarize recent changes" --quiet
 # Continue an existing session
 astra chat -m "follow up" --session-id <id>
 
-# Auto-approve normal tool risk; hard prompts may still apply
+# Auto-approve normal tool risk; some git/sensitive gates may still stop
 astra chat -m "run tests and fix failures" --permission-mode auto
 
-# Skip approval prompts while keeping hard denies
+# Skip approval prompts; catastrophic and policy hard-denies still apply
 astra chat -m "run tests and fix failures" --permission-mode bypass
 
 # Session management

--- a/README.md
+++ b/README.md
@@ -94,8 +94,11 @@ astra chat -m "summarize recent changes" --quiet
 # Continue an existing session
 astra chat -m "follow up" --session-id <id>
 
-# Auto-approve all tool calls (CI mode)
+# Auto-approve normal tool risk; hard prompts may still apply
 astra chat -m "run tests and fix failures" --permission-mode auto
+
+# Skip approval prompts while keeping hard denies
+astra chat -m "run tests and fix failures" --permission-mode bypass
 
 # Session management
 astra session list

--- a/deployment/all-in-one/.env.example
+++ b/deployment/all-in-one/.env.example
@@ -14,7 +14,7 @@
 # --- Docker images -----------------------------------------------------------
 ASTRA_IMAGE=matrixorigin/astra:latest
 MEMORIA_IMAGE=matrixorigin/memoria:latest
-MATRIXONE_IMAGE=matrixorigin/matrixone:latest
+MATRIXONE_IMAGE=matrixorigin/matrixone:4.0.0-rc3
 
 # --- Host ports --------------------------------------------------------------
 # ASTRA_API_PORT controls the host-facing published port; the API container

--- a/deployment/all-in-one/README.md
+++ b/deployment/all-in-one/README.md
@@ -92,12 +92,12 @@ docker compose up -d
 
 ## Services
 
-| Service | Host port | Description |
-| --- | --- | --- |
-| `api` | `17001` | `astra-server` HTTP API |
-| `memoria` | `8100` | Memoria memory service |
-| `matrixone` | `26001` | MatrixOne MySQL-compatible endpoint |
-| `matrixone` debug | `26060` | MatrixOne debug/health endpoint |
+| Service           | Host port | Description                         |
+| ----------------- | --------- | ----------------------------------- |
+| `api`             | `17001`   | `astra-server` HTTP API             |
+| `memoria`         | `8100`    | Memoria memory service              |
+| `matrixone`       | `26001`   | MatrixOne MySQL-compatible endpoint |
+| `matrixone` debug | `26060`   | MatrixOne debug/health endpoint     |
 
 `ASTRA_API_PORT` in `.env` controls the host-facing published port. The API container itself listens on `17001`.
 
@@ -107,7 +107,7 @@ By default the stack pulls:
 
 - `matrixorigin/astra:latest`
 - `matrixorigin/memoria:latest`
-- `matrixorigin/matrixone:latest`
+- `matrixorigin/matrixone:4.0.0-rc3`
 
 Override image tags in `.env`, for example:
 

--- a/deployment/all-in-one/docker-compose.deps.yml
+++ b/deployment/all-in-one/docker-compose.deps.yml
@@ -7,11 +7,15 @@
 #   make dev-deps
 
 services:
-
   matrixone-init:
-    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:latest}
+    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:4.0.0-rc3}
     user: root
-    entrypoint: ["sh", "-c", "chown -R ${UID:-1000}:${GID:-1000} /mo-data && mkdir -p /mo-logs && chown -R ${UID:-1000}:${GID:-1000} /mo-logs"]
+    entrypoint:
+      [
+        "sh",
+        "-c",
+        "chown -R ${UID:-1000}:${GID:-1000} /mo-data && mkdir -p /mo-logs && chown -R ${UID:-1000}:${GID:-1000} /mo-logs",
+      ]
     volumes:
       - matrixone-data:/mo-data
       - ${MATRIXONE_LOG_DIR:-./data/matrixone/logs}:/mo-logs
@@ -19,7 +23,7 @@ services:
       - mo-net
 
   matrixone:
-    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:latest}
+    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:4.0.0-rc3}
     hostname: matrixone
     user: "${UID:-1000}:${GID:-1000}"
     depends_on:

--- a/deployment/all-in-one/docker-compose.memoria.yml
+++ b/deployment/all-in-one/docker-compose.memoria.yml
@@ -4,11 +4,10 @@
 #   docker-compose -f docker-compose.memoria.yml up -d
 
 services:
-
   # ─── Infrastructure ─────────────────────────────────────────
 
   matrixone:
-    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:latest}
+    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:4.0.0-rc3}
     hostname: matrixone
     entrypoint: /entrypoint.sh
     command: []

--- a/deployment/all-in-one/docker-compose.prod.yml
+++ b/deployment/all-in-one/docker-compose.prod.yml
@@ -11,14 +11,13 @@
 #   docker-compose -f docker-compose.prod.yml up -d
 #   docker-compose -f docker-compose.prod.yml up -d --scale api=3
 
-version: '3.8'
+version: "3.8"
 
 services:
-
   # ─── Database ─────────────────────────────────────────────
 
   matrixone:
-    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:latest}
+    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:4.0.0-rc3}
     hostname: matrixone
     command: ["/mo-service", "-launch", "/etc/quickstart/launch.toml"]
     ports:
@@ -39,10 +38,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '4'
+          cpus: "4"
           memory: 8G
         reservations:
-          cpus: '2'
+          cpus: "2"
           memory: 4G
     logging:
       driver: "json-file"
@@ -116,10 +115,10 @@ services:
       replicas: 3
       resources:
         limits:
-          cpus: '2'
+          cpus: "2"
           memory: 4G
         reservations:
-          cpus: '1'
+          cpus: "1"
           memory: 2G
 
     logging:

--- a/deployment/all-in-one/docker-compose.yml
+++ b/deployment/all-in-one/docker-compose.yml
@@ -9,7 +9,7 @@ x-env-files: &astra-env-files
 
 services:
   matrixone-init:
-    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:latest}
+    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:4.0.0-rc3}
     user: root
     entrypoint:
       - sh
@@ -31,7 +31,7 @@ services:
     restart: "no"
 
   matrixone:
-    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:latest}
+    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:4.0.0-rc3}
     hostname: matrixone
     user: "${UID:-1000}:${GID:-1000}"
     depends_on:

--- a/deployment/examples/aws/README.md
+++ b/deployment/examples/aws/README.md
@@ -71,6 +71,7 @@ aws ecr get-login-password --region us-east-1 | \
 ### 2. Database (RDS or Self-Managed)
 
 **Option A: Self-managed MatrixOne on EC2**
+
 ```bash
 # Launch EC2 instance
 aws ec2 run-instances \
@@ -82,10 +83,11 @@ aws ec2 run-instances \
 
 # Install MatrixOne
 ssh ec2-user@<instance-ip>
-docker run -d -p 6001:6001 matrixorigin/matrixone:latest
+docker run -d -p 6001:6001 matrixorigin/matrixone:4.0.0-rc3
 ```
 
 **Option B: RDS MySQL (compatible)**
+
 ```bash
 # Create RDS instance
 aws rds create-db-instance \
@@ -151,12 +153,13 @@ Store in ECS task definition or use Secrets Manager:
 
 ```json
 {
-  "environment": [
-    {"name": "MATRIXONE_HOST", "value": "db.internal"}
-  ],
+  "environment": [{ "name": "MATRIXONE_HOST", "value": "db.internal" }],
   "secrets": [
-    {"name": "ASTRA_TOKEN_ENCRYPTION_KEY", "valueFrom": "arn:aws:secretsmanager:..."},
-    {"name": "ASTRA_JWT_SECRET", "valueFrom": "arn:aws:secretsmanager:..."}
+    {
+      "name": "ASTRA_TOKEN_ENCRYPTION_KEY",
+      "valueFrom": "arn:aws:secretsmanager:..."
+    },
+    { "name": "ASTRA_JWT_SECRET", "valueFrom": "arn:aws:secretsmanager:..." }
   ]
 }
 ```

--- a/deployment/examples/on-premise/README.md
+++ b/deployment/examples/on-premise/README.md
@@ -110,7 +110,7 @@ docker run -d \
   --name matrixone \
   -p 6001:6001 \
   -v /data/matrixone:/mo-data \
-  matrixorigin/matrixone:latest
+  matrixorigin/matrixone:4.0.0-rc3
 
 # Server 2, 3 (Replicas)
 # Configure replication as needed

--- a/deployment/kubernetes/chart/values.yaml
+++ b/deployment/kubernetes/chart/values.yaml
@@ -28,7 +28,7 @@ matrixone:
   enabled: true
   image:
     repository: matrixorigin/matrixone
-    tag: latest
+    tag: 4.0.0-rc3
   port: 6001
   storage:
     size: 100Gi

--- a/docs/design/plan-mode.md
+++ b/docs/design/plan-mode.md
@@ -118,19 +118,20 @@ asynchronously.
 
 ## Permission modes
 
-Five permission modes exist underneath. The TUI cycles through four of
+Six permission modes exist underneath. The TUI cycles through five of
 them; `Deny` is reserved for headless / CI use and never appears in the
 Shift+Tab cycle to prevent accidental entry.
 
 | Permission mode (enum) | TUI label    | Cycle position | Behaviour                                          |
 |------------------------|--------------|----------------|----------------------------------------------------|
 | `Prompt`               | **Default**  | 1              | Each write/execute tool prompts the user           |
-| `Auto`                 | **Auto**     | 2              | Everything auto-approved                           |
-| `AcceptEdits`          | **Edit**     | 3              | Workspace edits auto-approved; shell still prompts |
-| `Plan`                 | **Plan**     | 4              | Read-only schema + exit_plan_mode                  |
+| `AcceptEdits`          | **Edit**     | 2              | Workspace edits auto-approved; shell still prompts |
+| `Plan`                 | **Plan**     | 3              | Read-only schema + exit_plan_mode                  |
+| `Auto`                 | **Auto**     | 4              | Normal tool risk auto-approved; hard prompts may remain |
+| `Bypass`               | **Bypass**   | 5              | Approval prompts skipped; hard denies still apply  |
 | `Deny`                 | (hidden)     | —              | All tools denied (CI / harness only)               |
 
-`Shift+Tab` cycles `Default → Auto → Edit → Plan → Default`.
+`Shift+Tab` cycles `Default → Edit → Plan → Auto → Bypass → Default`.
 
 ## Invariants
 

--- a/docs/design/plan-mode.md
+++ b/docs/design/plan-mode.md
@@ -128,10 +128,13 @@ Shift+Tab cycle to prevent accidental entry.
 | `AcceptEdits`          | **Edit**     | 2              | Workspace edits auto-approved; shell still prompts |
 | `Plan`                 | **Plan**     | 3              | Read-only schema + exit_plan_mode                  |
 | `Auto`                 | **Auto**     | 4              | Normal tool risk auto-approved; hard prompts may remain |
-| `Bypass`               | **Bypass**   | 5              | Approval prompts skipped; hard denies still apply  |
+| `Bypass`               | **Bypass**   | explicit       | Approval prompts skipped; hard denies still apply  |
 | `Deny`                 | (hidden)     | —              | All tools denied (CI / harness only)               |
 
-`Shift+Tab` cycles `Default → Edit → Plan → Auto → Bypass → Default`.
+`Shift+Tab` cycles `Default → Edit → Plan → Auto → Default`. `Bypass`
+requires an explicit `/allow bypass` or CLI `--permission-mode bypass` so a
+fast cycle cannot accidentally jump from Auto into the most permissive
+approval-interaction mode.
 
 ## Invariants
 

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -538,6 +538,9 @@ Set permission mode for tool execution.
 /allow rules     # Show rules
 ```
 
+Bare `/allow` and Shift+Tab cycle `prompt → accept_edits → plan → auto → prompt`.
+Use `/allow bypass` explicitly when you want to skip approval prompts.
+
 ### `/instructions [subcommand]`
 
 Project instructions from `.astra/instructions.md`.

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -523,8 +523,9 @@ Set permission mode for tool execution.
 
 | Mode                                     | Description                   |
 | ---------------------------------------- | ----------------------------- |
-| `auto`                                   | Auto-approve all tool use     |
+| `auto`                                   | Auto-approve normal tool risk |
 | `all`                                    | Alias for auto                |
+| `bypass` / `skip`                        | Skip approval prompts; hard denies still apply |
 | `plan`                                   | Read-only investigation mode  |
 | `accept_edits` / `accept-edits` / `edit` | Auto-approve local file edits |
 | `prompt`                                 | Prompt before each tool       |
@@ -532,7 +533,8 @@ Set permission mode for tool execution.
 | `rules`                                  | Show current permission rules |
 
 ```
-/allow auto      # Trust all tools
+/allow auto      # Auto-approve normal tool risk
+/allow bypass    # Skip approval prompts
 /allow prompt    # Ask before each
 /allow rules     # Show rules
 ```

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -523,14 +523,13 @@ Set permission mode for tool execution.
 
 | Mode                                     | Description                   |
 | ---------------------------------------- | ----------------------------- |
-| `auto`                                   | Auto-approve normal tool risk |
-| `all`                                    | Alias for auto                |
-| `bypass` / `skip`                        | Skip approval prompts; hard denies still apply |
-| `plan`                                   | Read-only investigation mode  |
-| `accept_edits` / `accept-edits` / `edit` | Auto-approve local file edits |
-| `prompt`                                 | Prompt before each tool       |
-| `deny`                                   | Deny all tool use             |
-| `rules`                                  | Show current permission rules |
+| `auto`            | Auto-approve normal tool risk; some git/sensitive gates may still stop |
+| `bypass` / `skip` | Skip approval prompts; catastrophic and policy hard-denies still apply |
+| `plan`            | Read-only investigation mode  |
+| `accept_edits`    | Auto-approve local file edits |
+| `prompt`          | Prompt before each tool       |
+| `deny`            | Deny all tool use             |
+| `rules`           | Show current permission rules |
 
 ```
 /allow auto      # Auto-approve normal tool risk

--- a/rust/crates/astra-cli/src/cli/app_server.rs
+++ b/rust/crates/astra-cli/src/cli/app_server.rs
@@ -1023,6 +1023,20 @@ mod tests {
     }
 
     #[test]
+    fn permission_mode_accepts_bypass() {
+        assert_eq!(
+            permission_mode_from_params(&serde_json::json!({"permissionMode": "bypass"}), false)
+                .unwrap(),
+            PermissionMode::Bypass
+        );
+        assert_eq!(
+            permission_mode_from_params(&serde_json::json!({"permission_mode": "skip"}), false)
+                .unwrap(),
+            PermissionMode::Bypass
+        );
+    }
+
+    #[test]
     fn permission_mode_validates_before_auto_approve_override() {
         assert!(
             permission_mode_from_params(&serde_json::json!({"permissionMode": "oops"}), true)

--- a/rust/crates/astra-cli/src/cli/arg_render.rs
+++ b/rust/crates/astra-cli/src/cli/arg_render.rs
@@ -137,6 +137,7 @@ pub(crate) fn render_permissions_args(args: &PermissionsArgs) -> String {
     match &args.command {
         None => String::new(),
         Some(PermissionsSubcommand::Auto) => "auto".to_string(),
+        Some(PermissionsSubcommand::Bypass) => "bypass".to_string(),
         Some(PermissionsSubcommand::AcceptEdits) => "accept_edits".to_string(),
         Some(PermissionsSubcommand::Plan) => "plan".to_string(),
         Some(PermissionsSubcommand::Prompt) => "prompt".to_string(),
@@ -257,6 +258,14 @@ mod arg_render_tests {
             command: Some(PermissionsSubcommand::Untrust),
         };
         assert_eq!(render_permissions_args(&untrust), "untrust");
+    }
+
+    #[test]
+    fn permissions_bypass_renders_mode_arg() {
+        let args = PermissionsArgs {
+            command: Some(PermissionsSubcommand::Bypass),
+        };
+        assert_eq!(render_permissions_args(&args), "bypass");
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/chat_stream/params.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/params.rs
@@ -208,7 +208,7 @@ impl ApprovalResponse {
 }
 
 /// Approval request sent from the SSE stream host to the plan executor / REPL
-/// when a tool requires interactive approval (bypass-immune check).
+/// when a tool requires interactive approval.
 ///
 /// Issue #326 P3: optional `metadata` carries the source-agent /
 /// host / risk-tag / will-save-preview / base-digest fields the
@@ -381,7 +381,7 @@ pub(crate) struct ChatTurnParams<'a> {
     pub(crate) agent_live_event_sink:
         Option<astra_turn_core::agent_live_event::SharedAgentLiveEventSink>,
     /// Optional channel for async tool approval during plan execution.
-    /// When a bypass-immune permission check triggers, the approval request is sent
+    /// When an interactive permission check triggers, the approval request is sent
     /// through this channel instead of blocking on stdin.
     pub(crate) approval_request_tx: Option<ApprovalRequestTx>,
     /// Optional channel for native TUI ask_user prompts.

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -207,11 +207,11 @@ fn derive_turn_interaction_mode(
         return TurnInteractionMode::NonInteractive;
     }
 
-    // Auto-resolving modes are the user's explicit opt-in to "run
-    // uninterrupted" — they stay Auto regardless of stdin /
-    // approval-channel / silent render. All of those signals only
-    // matter for Prompt (which needs stdin to ask the user), and
-    // auto-resolving modes already short-circuit prompts anyway.
+    // Auto-resolving modes are the user's explicit opt-in to suppress
+    // ordinary interaction nudges and ask_user prompts. Keep this as
+    // TurnInteractionMode::Auto regardless of stdin / approval-channel /
+    // silent render; hard permission gates are evaluated separately by
+    // the permission engine and may still require review or deny.
     // Regression for session c6e18730 where piped or silent contexts
     // silently demoted Auto → NonInteractive, which disabled the
     // nudge-suppression gate the user opted into.
@@ -1365,13 +1365,14 @@ mod tests {
 
     // ── Auto mode preservation under non-interactive contexts ─────────
     //
-    // The user's Auto-mode intent is "don't interrupt me, trust the
-    // model". This must NOT be silently demoted to NonInteractive just
-    // because the turn is happening in a piped-stdin / silent-render /
-    // approval-channel context — those only matter for Prompt mode (no
-    // stdin to prompt on → fall back to NonInteractive so nothing
-    // blocks on a human). In Auto, there's nothing to prompt anyway,
-    // so the structural non-interactivity is orthogonal.
+    // The user's Auto-mode intent is "suppress ordinary interaction
+    // nudges and ask_user prompts". This must NOT be silently demoted
+    // to NonInteractive just because the turn is happening in a
+    // piped-stdin / silent-render / approval-channel context — those
+    // only matter for Prompt mode (no stdin to prompt on → fall back
+    // to NonInteractive so nothing blocks on a human). Hard permission
+    // gates remain the permission engine's job, not this interaction
+    // classifier's job.
     //
     // Regression for session c6e18730: Auto-mode user saw `## ⚠
     // Sequential Tool Calls Detected` nudges injected into message
@@ -1404,8 +1405,7 @@ mod tests {
         assert_eq!(
             derive_turn_interaction_mode(PermissionMode::Auto, false, true, false, false, true),
             TurnInteractionMode::Auto,
-            "approval-tx (e.g. web-approval flow) is irrelevant to Auto — Auto short-\
-             circuits approvals anyway"
+            "approval-tx (e.g. web-approval flow) must not demote Auto interaction mode"
         );
     }
 

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -216,7 +216,7 @@ fn derive_turn_interaction_mode(
         // or silent contexts silently demoted Auto → NonInteractive,
         // which in turn disabled the nudge-suppression gate the user
         // opted into.
-        PermissionMode::Auto => TurnInteractionMode::Auto,
+        PermissionMode::Auto | PermissionMode::Bypass => TurnInteractionMode::Auto,
         PermissionMode::Plan => {
             if has_approval_request_tx || render_is_silent || !stdin_is_terminal {
                 TurnInteractionMode::NonInteractive
@@ -1309,6 +1309,10 @@ mod tests {
         );
         assert_eq!(
             derive_turn_interaction_mode(PermissionMode::Auto, false, false, false, false, true),
+            TurnInteractionMode::Auto
+        );
+        assert_eq!(
+            derive_turn_interaction_mode(PermissionMode::Bypass, false, false, false, false, true),
             TurnInteractionMode::Auto
         );
         assert_eq!(

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -207,16 +207,19 @@ fn derive_turn_interaction_mode(
         return TurnInteractionMode::NonInteractive;
     }
 
+    // Auto-resolving modes are the user's explicit opt-in to "run
+    // uninterrupted" — they stay Auto regardless of stdin /
+    // approval-channel / silent render. All of those signals only
+    // matter for Prompt (which needs stdin to ask the user), and
+    // auto-resolving modes already short-circuit prompts anyway.
+    // Regression for session c6e18730 where piped or silent contexts
+    // silently demoted Auto → NonInteractive, which disabled the
+    // nudge-suppression gate the user opted into.
+    if permission_mode.auto_resolves_approval_prompts() {
+        return TurnInteractionMode::Auto;
+    }
+
     match permission_mode {
-        // Auto is the user's explicit opt-in to "run uninterrupted" —
-        // it stays Auto regardless of stdin/approval-channel/silent
-        // render. All of those signals only matter for Prompt (which
-        // needs stdin to ask the user), and Auto already short-circuits
-        // prompts anyway. Regression for session c6e18730 where piped
-        // or silent contexts silently demoted Auto → NonInteractive,
-        // which in turn disabled the nudge-suppression gate the user
-        // opted into.
-        PermissionMode::Auto | PermissionMode::Bypass => TurnInteractionMode::Auto,
         PermissionMode::Plan => {
             if has_approval_request_tx || render_is_silent || !stdin_is_terminal {
                 TurnInteractionMode::NonInteractive
@@ -260,6 +263,7 @@ fn derive_turn_interaction_mode(
                 TurnInteractionMode::Deny
             }
         }
+        mode => unreachable!("auto-resolving permission mode returned before match: {mode:?}"),
     }
 }
 

--- a/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/rust/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -759,6 +759,7 @@ pub(crate) async fn stream_chat_sse(
             last_heavy_checkpoint: None,
             tool_call_records: Vec::new(),
             forced_factual_retry: false,
+            factual_retry_fallback_text: None,
             forced_execution_retry: false,
             forced_execution_escalation: false,
             forced_parallel_batching: false,

--- a/rust/crates/astra-cli/src/cli/cli_config/cli_args.rs
+++ b/rust/crates/astra-cli/src/cli/cli_config/cli_args.rs
@@ -732,7 +732,7 @@ pub(crate) struct PermissionsArgs {
 pub(crate) enum PermissionsSubcommand {
     /// Auto-approve allowed tool calls
     Auto,
-    /// Skip approval prompts; hard denies still apply
+    /// Skip approval prompts; catastrophic and policy hard-denies still apply
     Bypass,
     /// Auto-approve workspace-local edits while still prompting for shell and external writes
     #[command(name = "accept_edits")]

--- a/rust/crates/astra-cli/src/cli/cli_config/cli_args.rs
+++ b/rust/crates/astra-cli/src/cli/cli_config/cli_args.rs
@@ -721,7 +721,7 @@ pub(crate) struct GrepPatternArgs {
 
 #[derive(Args, Debug)]
 #[command(
-    after_help = "Examples:\n  astra permissions rules\n  astra permissions auto\n  astra permissions plan\n  astra permissions accept_edits\n  astra permissions prompt\n  astra permissions trust\n  astra permissions trace"
+    after_help = "Examples:\n  astra permissions rules\n  astra permissions auto\n  astra permissions bypass\n  astra permissions plan\n  astra permissions accept_edits\n  astra permissions prompt\n  astra permissions trust\n  astra permissions trace"
 )]
 pub(crate) struct PermissionsArgs {
     #[command(subcommand)]
@@ -732,6 +732,8 @@ pub(crate) struct PermissionsArgs {
 pub(crate) enum PermissionsSubcommand {
     /// Auto-approve allowed tool calls
     Auto,
+    /// Skip approval prompts; hard denies still apply
+    Bypass,
     /// Auto-approve workspace-local edits while still prompting for shell and external writes
     #[command(name = "accept_edits")]
     AcceptEdits,

--- a/rust/crates/astra-cli/src/cli/cli_config/cli_args.rs
+++ b/rust/crates/astra-cli/src/cli/cli_config/cli_args.rs
@@ -75,7 +75,7 @@ pub(crate) struct Cli {
     /// Resume a specific session by ID (or prefix)
     #[arg(short = 'r', long = "resume")]
     pub resume: Option<String>,
-    /// Auto-approve tool calls without prompting
+    /// Skip approval prompts; hard safety denies still apply
     #[arg(short = 'y', long = "yes")]
     pub yes: bool,
     /// System prompt to prepend (useful with --print for scripting)
@@ -378,7 +378,7 @@ pub(crate) struct ChatArgs {
         value_parser = parse_explain_mode_arg
     )]
     pub explain: Option<crate::cli::session::session_state::ExplainMode>,
-    /// Auto-approve tool calls
+    /// Skip approval prompts; hard safety denies still apply
     #[arg(short = 'y', long = "auto-approve", default_value_t = false)]
     pub auto_approve: bool,
     /// Permission mode: auto, bypass, plan, accept_edits, prompt (interactive, default), or deny.

--- a/rust/crates/astra-cli/src/cli/cli_config/cli_args.rs
+++ b/rust/crates/astra-cli/src/cli/cli_config/cli_args.rs
@@ -381,7 +381,7 @@ pub(crate) struct ChatArgs {
     /// Auto-approve tool calls
     #[arg(short = 'y', long = "auto-approve", default_value_t = false)]
     pub auto_approve: bool,
-    /// Permission mode: auto, plan, accept_edits, prompt (interactive, default), or deny.
+    /// Permission mode: auto, bypass, plan, accept_edits, prompt (interactive, default), or deny.
     #[arg(long = "permission-mode", value_parser = parse_permission_mode_arg)]
     pub permission_mode: Option<String>,
     /// Suppress spinner and progress output (result still printed)

--- a/rust/crates/astra-cli/src/cli/cli_config/cli_context.rs
+++ b/rust/crates/astra-cli/src/cli/cli_config/cli_context.rs
@@ -144,17 +144,28 @@ mod tests {
 
     #[test]
     fn from_launch_options_normalizes_tool_lists() {
-        let ctx = CliContext::from_launch_options(
-            false,
-            Some(12),
-            &["bash, view".into(), "rg".into()],
-            &["read_file edit_file".into()],
-            &[],
-            false,
-            None,
-            None,
-        )
-        .expect("cli context");
+        let ctx = temp_env::with_vars(
+            [
+                ("ASTRA_CLI_MAX_TURNS", None::<&str>),
+                ("ASTRA_CLI_SESSION_ID", None::<&str>),
+                ("ASTRA_CLI_SESSION_NAME", None::<&str>),
+                ("ASTRA_CLI_ALLOWED_TOOLS", None::<&str>),
+                ("ASTRA_CLI_DISALLOWED_TOOLS", None::<&str>),
+            ],
+            || {
+                CliContext::from_launch_options(
+                    false,
+                    Some(12),
+                    &["bash, view".into(), "rg".into()],
+                    &["read_file edit_file".into()],
+                    &[],
+                    false,
+                    None,
+                    None,
+                )
+                .expect("cli context")
+            },
+        );
 
         assert_eq!(ctx.max_turns, Some(12));
         assert_eq!(ctx.allowed_tools, vec!["bash", "view", "rg"]);

--- a/rust/crates/astra-cli/src/cli/command_registry.rs
+++ b/rust/crates/astra-cli/src/cli/command_registry.rs
@@ -322,9 +322,12 @@ const DIFF_SUBCOMMANDS: &[(&str, &str)] = &[
 const ALLOW_SUBCOMMANDS: &[(&str, &str)] = &[
     (
         "auto",
-        "Auto-approve normal tool risk; hard prompts may still apply",
+        "Auto-approve normal tool risk; some git/sensitive gates may still stop",
     ),
-    ("bypass", "Skip approval prompts; hard denies still apply"),
+    (
+        "bypass",
+        "Skip approval prompts; catastrophic and policy hard-denies still apply",
+    ),
     ("plan", "Read-only investigation mode; mutations are denied"),
     (
         "accept_edits",

--- a/rust/crates/astra-cli/src/cli/command_registry.rs
+++ b/rust/crates/astra-cli/src/cli/command_registry.rs
@@ -320,7 +320,11 @@ const DIFF_SUBCOMMANDS: &[(&str, &str)] = &[
 // EXPERIMENT_SUBCOMMANDS removed — /experiment is dead code
 
 const ALLOW_SUBCOMMANDS: &[(&str, &str)] = &[
-    ("auto", "Auto-approve all tool use"),
+    (
+        "auto",
+        "Auto-approve normal tool risk; hard prompts may still apply",
+    ),
+    ("bypass", "Skip approval prompts; hard denies still apply"),
     ("plan", "Read-only investigation mode; mutations are denied"),
     (
         "accept_edits",
@@ -779,11 +783,11 @@ pub static COMMANDS: &[CommandMeta] = &[
     // ── System ────────────────────────────────────────────────────────────
     CommandMeta::new(
         "/allow",
-        "Permission mode: /allow [auto|plan|accept_edits|prompt|deny|rules|trust|untrust|trace]",
+        "Permission mode: /allow [auto|bypass|plan|accept_edits|prompt|deny|rules|trust|untrust|trace]",
         CommandGroup::System,
     )
     .with_subcommands(ALLOW_SUBCOMMANDS)
-    .with_arg_hint("[auto|accept_edits|plan|prompt|deny|rules|trust|untrust|trace]")
+    .with_arg_hint("[auto|bypass|accept_edits|plan|prompt|deny|rules|trust|untrust|trace]")
     .with_tui_handler(TuiHandler::Inline),
     CommandMeta::new(
         "/instructions",
@@ -1105,10 +1109,11 @@ mod tests {
         assert!(allow.description.contains("plan"));
         assert_eq!(
             allow.arg_hint,
-            Some("[auto|accept_edits|plan|prompt|deny|rules|trust|untrust|trace]")
+            Some("[auto|bypass|accept_edits|plan|prompt|deny|rules|trust|untrust|trace]")
         );
 
         let subs = subcommand_completions("/allow").expect("/allow subcommands");
+        assert!(subs.iter().any(|(tok, _)| *tok == "bypass"));
         assert!(subs.iter().any(|(tok, _)| *tok == "accept_edits"));
         assert!(!subs.iter().any(|(tok, _)| *tok == "accept-edits"));
         assert!(!subs.iter().any(|(tok, _)| *tok == "default"));

--- a/rust/crates/astra-cli/src/cli/command_router.rs
+++ b/rust/crates/astra-cli/src/cli/command_router.rs
@@ -1097,6 +1097,10 @@ mod permission_mode_display_tests {
         assert_eq!(permission_mode_display_label(PermissionMode::Prompt), "Ask");
         assert_eq!(permission_mode_display_label(PermissionMode::Auto), "Auto");
         assert_eq!(
+            permission_mode_display_label(PermissionMode::Bypass),
+            "Bypass"
+        );
+        assert_eq!(
             permission_mode_display_label(PermissionMode::AcceptEdits),
             "Edits"
         );
@@ -3372,6 +3376,10 @@ mod one_shot_effective_settings_tests {
             effective_one_shot_permission_mode(Some("plan"), true, Some("accept_edits"), false)
                 .unwrap(),
             PermissionMode::Plan
+        );
+        assert_eq!(
+            effective_one_shot_permission_mode(Some("bypass"), false, Some("plan"), false).unwrap(),
+            PermissionMode::Bypass
         );
         assert_eq!(
             effective_one_shot_permission_mode(None, true, Some("plan"), false).unwrap(),

--- a/rust/crates/astra-cli/src/cli/durable_bridge.rs
+++ b/rust/crates/astra-cli/src/cli/durable_bridge.rs
@@ -844,12 +844,12 @@ impl astra_services::LlmJudge for ServerProxyLlmJudge {
 /// `/v1/chat/completions` proxy.
 ///
 /// Mirrors [`ServerProxyLlmJudge`] (verification): same auth, same model
-/// resolution, no extra credentials. Hosts wire this into
-/// `ServerAgenticLoopHost::set_turn_intent_judge` so the agentic loop's
-/// per-turn intent classification uses the LLM rather than only a
-/// keyword-matching fallback. On any error (transport, malformed output,
-/// rejection), the host falls back to the deterministic classifier so a
-/// transient outage never blocks the user's session.
+/// resolution, no extra credentials. It can be injected through
+/// `ServerAgenticLoopHost::set_turn_intent_judge` when a caller wants an
+/// explicit proxy-backed judge instead of the host's built-in summary-client
+/// judge path. On any error (transport, malformed output, rejection), the host
+/// proceeds without explicit turn intent so a transient outage never blocks
+/// the user's session.
 pub struct ServerProxyTurnIntentJudge {
     api: astra_thin_client::ThinClient,
     token: String,
@@ -868,18 +868,8 @@ impl astra_services::TurnIntentJudge for ServerProxyTurnIntentJudge {
         &self,
         ctx: &astra_services::TurnIntentJudgeContext,
     ) -> Result<astra_config::user_profile::TurnIntent, astra_services::TurnIntentJudgeError> {
-        let prompt = astra_services::build_turn_intent_prompt(ctx);
-        let system_msg = serde_json::json!({
-            "role": "system",
-            "content": "You output ONLY a JSON object as described in the user message. No prose. No markdown fences."
-        });
-        let user_msg = serde_json::json!({
-            "role": "user",
-            "content": prompt,
-        });
-
         let mut body = serde_json::json!({
-            "messages": [system_msg, user_msg],
+            "messages": astra_services::turn_intent_judge_messages(ctx),
             // Keep judge replies tight — the schema is fixed and small.
             "max_tokens": 256,
             // Low temperature for deterministic classification.

--- a/rust/crates/astra-cli/src/cli/journal_digest.rs
+++ b/rust/crates/astra-cli/src/cli/journal_digest.rs
@@ -99,6 +99,12 @@ pub struct Aggregates {
     pub total_tokens_out: u64,
     pub total_duration_ms: u64,
     pub total_tool_calls: u64,
+    /// Tool records that produced fresh observations, excluding cache hits,
+    /// duplicate suppressions, synthetic placeholders, and failures.
+    pub total_fresh_tool_calls: u64,
+    /// Tool records that did not execute fresh work because the runtime reused
+    /// or pointed back to an already-known result.
+    pub total_noop_or_cached_tool_calls: u64,
     pub tool_calls_failed: u64,
     /// Tool calls blocked by a safety guard (shell_obfuscation, dangerous command, etc.).
     /// Subset of `tool_calls_failed`. Non-zero means the agent hit safety walls.
@@ -144,6 +150,10 @@ pub struct TurnRow {
     pub selected_skills: Vec<String>,
     pub tool_calls_ok: u32,
     pub tool_calls_fail: u32,
+    #[serde(skip_serializing_if = "is_zero_u32")]
+    pub tool_calls_fresh: u32,
+    #[serde(skip_serializing_if = "is_zero_u32")]
+    pub tool_calls_noop_or_cached: u32,
     /// Number of short-circuited skill re-entries in this turn (reentry_count ≥ 1).
     /// Surfaces "model called `skill(X)` again after already loading X" waste.
     #[serde(skip_serializing_if = "is_zero_u32")]
@@ -271,20 +281,38 @@ fn preview(s: Option<&String>, max: usize) -> String {
     out
 }
 
-fn tool_call_counts(calls: Option<&Vec<session_journal::ToolCallRecord>>) -> (u32, u32) {
+#[derive(Debug, Default, Clone, Copy)]
+struct ToolCallStats {
+    ok: u32,
+    fail: u32,
+    fresh: u32,
+    noop_or_cached: u32,
+}
+
+impl ToolCallStats {
+    fn total(self) -> u32 {
+        self.ok + self.fail
+    }
+}
+
+fn tool_call_stats(calls: Option<&Vec<session_journal::ToolCallRecord>>) -> ToolCallStats {
     let Some(calls) = calls else {
-        return (0, 0);
+        return ToolCallStats::default();
     };
-    let mut ok = 0u32;
-    let mut fail = 0u32;
+    let mut stats = ToolCallStats::default();
     for c in calls {
         if is_effective_failure(c) {
-            fail += 1;
+            stats.fail += 1;
         } else {
-            ok += 1;
+            stats.ok += 1;
+            if c.is_structured_noop_or_cached_result() {
+                stats.noop_or_cached += 1;
+            } else {
+                stats.fresh += 1;
+            }
         }
     }
-    (ok, fail)
+    stats
 }
 
 /// Treat a tool call as a failure when either:
@@ -513,6 +541,8 @@ pub fn build_digest(session_id: &str, focus: DigestFocus) -> Result<JournalDiges
     let mut total_tokens_out: u64 = 0;
     let mut total_duration_ms: u64 = 0;
     let mut total_tool_calls: u64 = 0;
+    let mut total_fresh_tool_calls: u64 = 0;
+    let mut total_noop_or_cached_tool_calls: u64 = 0;
     let mut tool_calls_failed: u64 = 0;
     let mut safety_guard_blocks: u64 = 0;
     let mut turn_error_count = 0usize;
@@ -542,16 +572,22 @@ pub fn build_digest(session_id: &str, focus: DigestFocus) -> Result<JournalDiges
                     Vec::new()
                 };
                 let pending_attempt_run_id = attempt_run_id(&pending_rounds);
-                let (ok_c, fail_c) = tool_call_counts(ev.tool_calls.as_ref());
+                let stats = tool_call_stats(ev.tool_calls.as_ref());
                 let (reentry_c, locked_out_c) = skill_reentry_counts(ev.tool_calls.as_ref());
                 // Fallback: if tool_calls Vec is absent, use tool_count scalar.
-                let effective_total = if ok_c + fail_c > 0 {
-                    u64::from(ok_c + fail_c)
+                let effective_total = if stats.total() > 0 {
+                    u64::from(stats.total())
                 } else {
                     u64::from(ev.tool_count.unwrap_or(0))
                 };
                 total_tool_calls += effective_total;
-                tool_calls_failed += u64::from(fail_c);
+                total_fresh_tool_calls += if stats.total() > 0 {
+                    u64::from(stats.fresh)
+                } else {
+                    u64::from(ev.tool_count.unwrap_or(0))
+                };
+                total_noop_or_cached_tool_calls += u64::from(stats.noop_or_cached);
+                tool_calls_failed += u64::from(stats.fail);
                 // Count safety guard blocks regardless of focus level.
                 //
                 // Include `ok=true but result body encodes failure`
@@ -644,13 +680,19 @@ pub fn build_digest(session_id: &str, focus: DigestFocus) -> Result<JournalDiges
                         Vec::new()
                     },
                     // When tool_calls Vec is absent, treat tool_count as all-ok
-                    // (fail_c is necessarily 0 in this branch).
-                    tool_calls_ok: if ok_c + fail_c > 0 {
-                        ok_c
+                    // and fresh because no per-call semantics are available.
+                    tool_calls_ok: if stats.total() > 0 {
+                        stats.ok
                     } else {
                         ev.tool_count.unwrap_or(0)
                     },
-                    tool_calls_fail: fail_c,
+                    tool_calls_fail: stats.fail,
+                    tool_calls_fresh: if stats.total() > 0 {
+                        stats.fresh
+                    } else {
+                        ev.tool_count.unwrap_or(0)
+                    },
+                    tool_calls_noop_or_cached: stats.noop_or_cached,
                     skill_reentry_calls: reentry_c,
                     skill_locked_out_calls: locked_out_c,
                     user_input_preview,
@@ -804,6 +846,8 @@ pub fn build_digest(session_id: &str, focus: DigestFocus) -> Result<JournalDiges
             total_tokens_out,
             total_duration_ms,
             total_tool_calls,
+            total_fresh_tool_calls,
+            total_noop_or_cached_tool_calls,
             tool_calls_failed,
             safety_guard_blocks,
             avg_tokens_in,
@@ -868,11 +912,13 @@ pub fn print_text(d: &JournalDigest) {
         a.error_event_count
     );
     println!(
-        "  tokens_in={} tokens_out={} duration_ms={} tool_calls={} tool_failures={}",
+        "  tokens_in={} tokens_out={} duration_ms={} tool_calls={} fresh={} noop_or_cached={} tool_failures={}",
         a.total_tokens_in.to_string().magenta(),
         a.total_tokens_out.to_string().magenta(),
         a.total_duration_ms,
         a.total_tool_calls,
+        a.total_fresh_tool_calls,
+        a.total_noop_or_cached_tool_calls,
         a.tool_calls_failed
     );
     println!("\n  {}", "Averages (per turn)".bold().magenta());
@@ -1727,6 +1773,17 @@ mod tests {
         .expect("write journal");
 
         let d = build_digest(sid, DigestFocus::All).expect("digest");
+        assert_eq!(d.aggregates.total_tool_calls, 2);
+        assert_eq!(
+            d.aggregates.total_fresh_tool_calls, 1,
+            "only the real bash call should count as fresh evidence"
+        );
+        assert_eq!(
+            d.aggregates.total_noop_or_cached_tool_calls, 1,
+            "cache hits should be visible as no-op/cache calls"
+        );
+        assert_eq!(d.turns[0].tool_calls_fresh, 1);
+        assert_eq!(d.turns[0].tool_calls_noop_or_cached, 1);
         assert_eq!(
             d.aggregates.tool_calls_failed, 0,
             "cross-turn cache hits must not count as failures"

--- a/rust/crates/astra-cli/src/cli/permission_command.rs
+++ b/rust/crates/astra-cli/src/cli/permission_command.rs
@@ -51,19 +51,18 @@ pub(crate) fn parse_permission_command(arg: &str) -> PermissionCommandAction<'_>
 
 /// Next mode when cycling `/allow` with no argument.
 ///
-/// `Deny` is intentionally sticky under the cycle: it is the most restrictive
-/// mode and must only be exited by an explicit `/allow prompt` (or another
-/// named mode). Cycling must never silently move a session out of `Deny`,
-/// because that would widen permissions without an explicit user action.
-/// `Deny` is likewise never a cycle *target* — it is reachable only via
-/// `/allow deny`.
+/// `Deny` and `Bypass` are intentionally not cycle targets. `Deny` is sticky:
+/// it must only be exited by an explicit `/allow prompt` (or another named
+/// mode). `Bypass` is reachable only via explicit `/allow bypass` / CLI flag;
+/// cycling from it returns to Prompt. This keeps Shift+Tab from adjacent
+/// Auto → Bypass escalation.
 pub(crate) fn next_permission_mode_for_cycle(current: PermissionMode) -> PermissionMode {
     match current {
         PermissionMode::Deny => PermissionMode::Deny,
         PermissionMode::Prompt => PermissionMode::AcceptEdits,
         PermissionMode::AcceptEdits => PermissionMode::Plan,
         PermissionMode::Plan => PermissionMode::Auto,
-        PermissionMode::Auto => PermissionMode::Bypass,
+        PermissionMode::Auto => PermissionMode::Prompt,
         PermissionMode::Bypass => PermissionMode::Prompt,
     }
 }
@@ -253,14 +252,14 @@ mod tests {
         );
         assert_eq!(
             next_permission_mode_for_cycle(PermissionMode::Auto),
-            PermissionMode::Bypass
+            PermissionMode::Prompt
         );
         assert_eq!(
             next_permission_mode_for_cycle(PermissionMode::Bypass),
             PermissionMode::Prompt
         );
-        // `Deny` is sticky under the cycle: it must only be exited by an
-        // explicit `/allow <mode>`, never by a bare `/allow`.
+        // `Bypass` is explicit-only, and `Deny` is sticky under the cycle:
+        // neither can be reached by a bare `/allow`.
         assert_eq!(
             next_permission_mode_for_cycle(PermissionMode::Deny),
             PermissionMode::Deny

--- a/rust/crates/astra-cli/src/cli/permission_command.rs
+++ b/rust/crates/astra-cli/src/cli/permission_command.rs
@@ -4,7 +4,7 @@ use crate::cli::theme;
 use crossterm::style::Stylize;
 
 pub(crate) const PERMISSION_COMMAND_USAGE: &str =
-    "auto, plan, accept_edits, prompt, deny, rules, trust, untrust, trace";
+    "auto, bypass, plan, accept_edits, prompt, deny, rules, trust, untrust, trace";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PermissionCommandAction<'a> {
@@ -63,7 +63,8 @@ pub(crate) fn next_permission_mode_for_cycle(current: PermissionMode) -> Permiss
         PermissionMode::Prompt => PermissionMode::AcceptEdits,
         PermissionMode::AcceptEdits => PermissionMode::Plan,
         PermissionMode::Plan => PermissionMode::Auto,
-        PermissionMode::Auto => PermissionMode::Prompt,
+        PermissionMode::Auto => PermissionMode::Bypass,
+        PermissionMode::Bypass => PermissionMode::Prompt,
     }
 }
 
@@ -74,6 +75,7 @@ pub(crate) fn permission_mode_display_label(mode: PermissionMode) -> &'static st
 pub(crate) fn permission_mode_cli_detail(mode: PermissionMode) -> Option<&'static str> {
     match mode {
         PermissionMode::Auto => Some("all tools auto-approved"),
+        PermissionMode::Bypass => Some("skip approval prompts; hard denies still apply"),
         PermissionMode::Plan => Some("read-only investigation mode"),
         PermissionMode::AcceptEdits => Some("workspace-local edits auto-approved"),
         PermissionMode::Prompt | PermissionMode::Deny => None,
@@ -174,6 +176,8 @@ mod tests {
     fn parser_accepts_only_canonical_permission_modes() {
         let cases = [
             ("auto", PermissionMode::Auto),
+            ("bypass", PermissionMode::Bypass),
+            ("skip", PermissionMode::Bypass),
             ("plan", PermissionMode::Plan),
             ("accept_edits", PermissionMode::AcceptEdits),
             ("prompt", PermissionMode::Prompt),
@@ -245,6 +249,10 @@ mod tests {
         );
         assert_eq!(
             next_permission_mode_for_cycle(PermissionMode::Auto),
+            PermissionMode::Bypass
+        );
+        assert_eq!(
+            next_permission_mode_for_cycle(PermissionMode::Bypass),
             PermissionMode::Prompt
         );
         // `Deny` is sticky under the cycle: it must only be exited by an

--- a/rust/crates/astra-cli/src/cli/permission_command.rs
+++ b/rust/crates/astra-cli/src/cli/permission_command.rs
@@ -74,8 +74,12 @@ pub(crate) fn permission_mode_display_label(mode: PermissionMode) -> &'static st
 
 pub(crate) fn permission_mode_cli_detail(mode: PermissionMode) -> Option<&'static str> {
     match mode {
-        PermissionMode::Auto => Some("normal tool risk auto-approved; hard prompts may remain"),
-        PermissionMode::Bypass => Some("skip approval prompts; hard denies still apply"),
+        PermissionMode::Auto => {
+            Some("normal tool risk auto-approved; some git/sensitive gates may still stop")
+        }
+        PermissionMode::Bypass => {
+            Some("skip approval prompts; catastrophic and policy hard-denies still apply")
+        }
         PermissionMode::Plan => Some("read-only investigation mode"),
         PermissionMode::AcceptEdits => Some("workspace-local edits auto-approved"),
         PermissionMode::Prompt | PermissionMode::Deny => None,

--- a/rust/crates/astra-cli/src/cli/permission_command.rs
+++ b/rust/crates/astra-cli/src/cli/permission_command.rs
@@ -74,7 +74,7 @@ pub(crate) fn permission_mode_display_label(mode: PermissionMode) -> &'static st
 
 pub(crate) fn permission_mode_cli_detail(mode: PermissionMode) -> Option<&'static str> {
     match mode {
-        PermissionMode::Auto => Some("all tools auto-approved"),
+        PermissionMode::Auto => Some("normal tool risk auto-approved; hard prompts may remain"),
         PermissionMode::Bypass => Some("skip approval prompts; hard denies still apply"),
         PermissionMode::Plan => Some("read-only investigation mode"),
         PermissionMode::AcceptEdits => Some("workspace-local edits auto-approved"),

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -483,11 +483,8 @@ fn stored_override_allows_sensitive_path(
         return false;
     };
 
-    if stored.path_match == astra_turn_core::approval_fingerprint::PathMatchKind::Exact {
-        return true;
-    }
-
-    sensitive_path_match(&serde_json::json!({ "path": path })).is_some()
+    sensitive_path_match_for_request(&stored.tool_name, &serde_json::json!({ "path": path }))
+        .is_some()
 }
 
 fn sensitive_path_match(args: &serde_json::Value) -> Option<String> {
@@ -513,32 +510,18 @@ fn sensitive_path_match_for_request(tool_name: &str, args: &serde_json::Value) -
 // `GateOutcome` because its shape (Allow / Deny / NeedApproval) is
 // genuinely different from turn-core's callback decision type
 // (Approve / Deny / Escalate).
-pub(crate) use astra_turn_core::permission::types::PermissionMode;
 pub(crate) use astra_turn_core::permission::types::PermissionRule;
+pub(crate) use astra_turn_core::permission::types::{ManualApprovalPolicy, PermissionMode};
 
 /// Atomic encoding of [`PermissionMode`] for the lock-free mirror
 /// the TUI inner-tick path consumes. Keeps the mapping local and
 /// stable; widening the enum requires updating both directions.
 fn encode_mode_for_mirror(mode: PermissionMode) -> u8 {
-    match mode {
-        PermissionMode::Prompt => 0,
-        PermissionMode::Auto => 1,
-        PermissionMode::Plan => 2,
-        PermissionMode::AcceptEdits => 3,
-        PermissionMode::Deny => 4,
-        PermissionMode::Bypass => 5,
-    }
+    mode.mirror_code()
 }
 
 fn decode_mode_for_mirror(value: u8) -> PermissionMode {
-    match value {
-        1 => PermissionMode::Auto,
-        2 => PermissionMode::Plan,
-        3 => PermissionMode::AcceptEdits,
-        4 => PermissionMode::Deny,
-        5 => PermissionMode::Bypass,
-        _ => PermissionMode::Prompt,
-    }
+    PermissionMode::from_mirror_code(value)
 }
 
 /// Read-only handle to the live permission mode held by a
@@ -2115,7 +2098,7 @@ impl PermissionManager {
             if matches!(self.mode, PermissionMode::Plan | PermissionMode::Deny) {
                 return Some(ApprovalDecision::Deny);
             }
-            if self.mode == PermissionMode::Bypass {
+            if self.mode.skips_human_approval_prompts() {
                 return Some(ApprovalDecision::Allow);
             }
             if self.mode == PermissionMode::Auto {
@@ -2137,39 +2120,59 @@ impl PermissionManager {
         }
 
         if quiet {
-            return Some(match self.mode {
-                PermissionMode::Auto | PermissionMode::Bypass => ApprovalDecision::Allow,
-                PermissionMode::Plan => ApprovalDecision::Deny,
-                PermissionMode::AcceptEdits
+            if self.mode.auto_resolves_approval_prompts() {
+                return Some(ApprovalDecision::Allow);
+            }
+            let manual_policy = self
+                .mode
+                .manual_approval_policy()
+                .expect("auto-resolving permission modes returned before quiet match");
+            return Some(match manual_policy {
+                ManualApprovalPolicy::Plan => ApprovalDecision::Deny,
+                ManualApprovalPolicy::AcceptEdits
                     if accept_edits_auto_allows_cloud_request(tool, detail) =>
                 {
                     ApprovalDecision::Allow
                 }
-                PermissionMode::AcceptEdits | PermissionMode::Prompt | PermissionMode::Deny => {
-                    ApprovalDecision::Deny
-                }
+                ManualApprovalPolicy::AcceptEdits
+                | ManualApprovalPolicy::Prompt
+                | ManualApprovalPolicy::Deny => ApprovalDecision::Deny,
             });
         }
 
         if Self::cloud_approval_is_explicit(approval_kind) {
-            return match self.mode {
-                PermissionMode::Auto | PermissionMode::Bypass => Some(ApprovalDecision::Allow),
-                PermissionMode::Plan => Some(ApprovalDecision::Deny),
-                PermissionMode::AcceptEdits => None,
-                PermissionMode::Deny => Some(ApprovalDecision::Deny),
-                PermissionMode::Prompt => None,
+            if self.mode.auto_resolves_approval_prompts() {
+                return Some(ApprovalDecision::Allow);
+            }
+            let manual_policy = self
+                .mode
+                .manual_approval_policy()
+                .expect("auto-resolving permission modes returned before explicit match");
+            return match manual_policy {
+                ManualApprovalPolicy::Plan => Some(ApprovalDecision::Deny),
+                ManualApprovalPolicy::AcceptEdits => None,
+                ManualApprovalPolicy::Deny => Some(ApprovalDecision::Deny),
+                ManualApprovalPolicy::Prompt => None,
             };
         }
 
-        match self.mode {
-            PermissionMode::Auto | PermissionMode::Bypass => return Some(ApprovalDecision::Allow),
-            PermissionMode::Plan => return Some(ApprovalDecision::Deny),
-            PermissionMode::AcceptEdits if accept_edits_auto_allows_cloud_request(tool, detail) => {
+        if self.mode.auto_resolves_approval_prompts() {
+            return Some(ApprovalDecision::Allow);
+        }
+        let manual_policy = self
+            .mode
+            .manual_approval_policy()
+            .expect("auto-resolving permission modes returned before standard match");
+        match manual_policy {
+            ManualApprovalPolicy::Plan => return Some(ApprovalDecision::Deny),
+            ManualApprovalPolicy::AcceptEdits
+                if accept_edits_auto_allows_cloud_request(tool, detail) =>
+            {
                 return Some(ApprovalDecision::Allow);
             }
-            PermissionMode::Deny => return Some(ApprovalDecision::Deny),
-            PermissionMode::Prompt => {}
-            PermissionMode::AcceptEdits => {}
+            ManualApprovalPolicy::Deny => return Some(ApprovalDecision::Deny),
+            ManualApprovalPolicy::Prompt => {}
+            ManualApprovalPolicy::AcceptEdits => {}
         }
 
         // Standard-kind: consult the denial tracker. The session
@@ -2996,7 +2999,7 @@ impl PermissionManager {
                     eprintln!("  {}", "  Git safety violation — blocked".red());
                     return false;
                 }
-                if self.mode == PermissionMode::Bypass {
+                if self.mode.skips_human_approval_prompts() {
                     return true;
                 }
                 // Soft-only violations: respect auto mode and session overrides.
@@ -3033,7 +3036,7 @@ impl PermissionManager {
                 eprintln!("  {}", "  Sensitive path — blocked".red());
                 return false;
             }
-            if self.mode == PermissionMode::Bypass {
+            if self.mode.skips_human_approval_prompts() {
                 return true;
             }
             if self.mode == PermissionMode::Auto {
@@ -3103,22 +3106,28 @@ impl PermissionManager {
         }
 
         // Step 7: Permission mode determines final action.
-        match self.mode {
-            PermissionMode::Auto | PermissionMode::Bypass => return true,
-            PermissionMode::Plan => {
+        if self.mode.auto_resolves_approval_prompts() {
+            return true;
+        }
+        let manual_policy = self
+            .mode
+            .manual_approval_policy()
+            .expect("auto-resolving permission modes returned before final match");
+        match manual_policy {
+            ManualApprovalPolicy::Plan => {
                 let (header, _) = Self::format_tool_display(name, args);
                 eprintln!("  {}", format!("  ✗ {header} — blocked").red());
                 return false;
             }
-            PermissionMode::AcceptEdits if accept_edits_auto_allows_tool_args(name, args) => {
+            ManualApprovalPolicy::AcceptEdits if accept_edits_auto_allows_tool_args(name, args) => {
                 return true;
             }
-            PermissionMode::Deny => {
+            ManualApprovalPolicy::Deny => {
                 let (header, _) = Self::format_tool_display(name, args);
                 eprintln!("  {}", format!("  ✗ {header} — blocked").red());
                 return false;
             }
-            PermissionMode::AcceptEdits | PermissionMode::Prompt => {}
+            ManualApprovalPolicy::AcceptEdits | ManualApprovalPolicy::Prompt => {}
         }
 
         let (header, detail) = Self::format_tool_display(name, args);
@@ -3270,7 +3279,7 @@ impl PermissionManager {
                     GateOutcome::Deny("Sensitive path denied for session".into())
                 };
             }
-            if self.mode == PermissionMode::Bypass {
+            if self.mode.skips_human_approval_prompts() {
                 return GateOutcome::Allow;
             }
             if self.mode == PermissionMode::Auto
@@ -5579,6 +5588,31 @@ mod tests {
         assert!(
             matches!(decision, GateOutcome::Allow),
             "content-specific sensitive path approval should be honored: got {decision:?}"
+        );
+    }
+
+    #[test]
+    fn exact_session_override_uses_path_sensitivity_policy() {
+        use astra_turn_core::approval_fingerprint::ApprovalFingerprint;
+
+        let safe_exact = ApprovalFingerprint::file_op_exact("file_write", Some("src/lib.rs"));
+        assert!(
+            !super::stored_override_allows_sensitive_path(&safe_exact),
+            "exact non-sensitive path approval must not be treated as a sensitive-path override"
+        );
+
+        let skill_exact =
+            ApprovalFingerprint::file_op_exact("file_write", Some(".astra/skills/rust/SKILL.md"));
+        assert!(
+            !super::stored_override_allows_sensitive_path(&skill_exact),
+            "skill content is intentionally normal file content, not sensitive app state"
+        );
+
+        let sensitive_exact =
+            ApprovalFingerprint::file_op_exact("file_write", Some(".astra/config.toml"));
+        assert!(
+            super::stored_override_allows_sensitive_path(&sensitive_exact),
+            "exact sensitive path approval should remain content-specific and reusable"
         );
     }
 

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -536,7 +536,9 @@ fn sensitive_path_match_for_request(tool_name: &str, args: &serde_json::Value) -
 // genuinely different from turn-core's callback decision type
 // (Approve / Deny / Escalate).
 pub(crate) use astra_turn_core::permission::types::PermissionRule;
-pub(crate) use astra_turn_core::permission::types::{ManualApprovalPolicy, PermissionMode};
+pub(crate) use astra_turn_core::permission::types::{
+    ChildPermissionMode, ManualApprovalPolicy, PermissionMode,
+};
 
 /// Atomic encoding of [`PermissionMode`] for the lock-free mirror
 /// the TUI inner-tick path consumes. Keeps the mapping local and
@@ -1630,14 +1632,13 @@ impl PermissionManager {
     ) -> Self {
         // Use inherited mode, but load project settings too
         let mode = match inherited.mode.child_inherited_mode() {
-            astra_runtime::orchestration::PermissionMode::Auto => PermissionMode::Auto,
-            astra_runtime::orchestration::PermissionMode::Bypass => PermissionMode::Bypass,
-            astra_runtime::orchestration::PermissionMode::Plan => PermissionMode::Plan,
-            astra_runtime::orchestration::PermissionMode::AcceptEdits => {
+            astra_runtime::orchestration::ChildPermissionMode::Auto => PermissionMode::Auto,
+            astra_runtime::orchestration::ChildPermissionMode::Plan => PermissionMode::Plan,
+            astra_runtime::orchestration::ChildPermissionMode::AcceptEdits => {
                 PermissionMode::AcceptEdits
             }
-            astra_runtime::orchestration::PermissionMode::Prompt => PermissionMode::Prompt,
-            astra_runtime::orchestration::PermissionMode::Deny => PermissionMode::Deny,
+            astra_runtime::orchestration::ChildPermissionMode::Prompt => PermissionMode::Prompt,
+            astra_runtime::orchestration::ChildPermissionMode::Deny => PermissionMode::Deny,
         };
         let project_outcome = PermissionSettings::try_load(project_root);
         let user_outcome = PermissionSettings::try_load_user();
@@ -1790,12 +1791,11 @@ impl PermissionManager {
         };
 
         let mode = match self.mode.child_inherited_mode() {
-            PermissionMode::Auto => RuntimePermissionMode::Auto,
-            PermissionMode::Bypass => RuntimePermissionMode::Bypass,
-            PermissionMode::Plan => RuntimePermissionMode::Plan,
-            PermissionMode::AcceptEdits => RuntimePermissionMode::AcceptEdits,
-            PermissionMode::Prompt => RuntimePermissionMode::Prompt,
-            PermissionMode::Deny => RuntimePermissionMode::Deny,
+            ChildPermissionMode::Auto => RuntimePermissionMode::Auto,
+            ChildPermissionMode::Plan => RuntimePermissionMode::Plan,
+            ChildPermissionMode::AcceptEdits => RuntimePermissionMode::AcceptEdits,
+            ChildPermissionMode::Prompt => RuntimePermissionMode::Prompt,
+            ChildPermissionMode::Deny => RuntimePermissionMode::Deny,
         };
 
         let mut inherited = self

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -1585,8 +1585,11 @@ impl PermissionManager {
 
     /// Create with inherited permissions from a parent agent.
     ///
-    /// The child agent inherits the parent's permission mode and rules,
-    /// but can still load project-level settings for additional rules.
+    /// The child agent inherits the parent's effective permission mode and
+    /// rules, but can still load project-level settings for additional rules.
+    /// Root-only Bypass is projected to Auto before export so fan-out agents
+    /// do not inherit the parent UI's approval-prompt bypass as a safety
+    /// policy.
     ///
     /// Issue #326 P0 / R1 Major 10 / task #17: if the parent envelope
     /// carries a `fingerprinted_overrides` JSON blob, we deserialize
@@ -1601,7 +1604,7 @@ impl PermissionManager {
         inherited: astra_runtime::orchestration::InheritedPermissions,
     ) -> Self {
         // Use inherited mode, but load project settings too
-        let mode = match inherited.mode {
+        let mode = match inherited.mode.child_inherited_mode() {
             astra_runtime::orchestration::PermissionMode::Auto => PermissionMode::Auto,
             astra_runtime::orchestration::PermissionMode::Bypass => PermissionMode::Bypass,
             astra_runtime::orchestration::PermissionMode::Plan => PermissionMode::Plan,
@@ -1761,7 +1764,7 @@ impl PermissionManager {
             PermissionRule as RuntimePermissionRule,
         };
 
-        let mode = match self.mode {
+        let mode = match self.mode.child_inherited_mode() {
             PermissionMode::Auto => RuntimePermissionMode::Auto,
             PermissionMode::Bypass => RuntimePermissionMode::Bypass,
             PermissionMode::Plan => RuntimePermissionMode::Plan,
@@ -2982,8 +2985,9 @@ impl PermissionManager {
         let side_effect = Self::classify_with_args(name, args);
 
         // Step 2: Git safety approval gate.
-        // Broad overrides cannot skip this gate. Bypass mode can resolve it
-        // without prompting; Auto only resolves soft findings.
+        // Broad overrides cannot skip this gate. Auto/Bypass can resolve soft
+        // findings without prompting; hard findings remain denied/prompted by
+        // mode policy.
         if side_effect == SideEffect::Execute {
             let git_violations = Self::check_git_safety(args);
             if !git_violations.is_empty() {
@@ -3001,6 +3005,10 @@ impl PermissionManager {
                     return false;
                 }
                 if self.mode.skips_human_approval_prompts() {
+                    if has_hard {
+                        eprintln!("  {}", "  Git safety hard violation — blocked".red());
+                        return false;
+                    }
                     return true;
                 }
                 // Soft-only violations: respect auto mode and session overrides.
@@ -6171,6 +6179,20 @@ mod tests {
     }
 
     #[test]
+    fn with_inherited_downgrades_parent_bypass_mode() {
+        use astra_runtime::orchestration::{InheritedPermissions, PermissionMode as RuntimeMode};
+
+        let inherited = InheritedPermissions::new(RuntimeMode::Bypass);
+        let pm = PermissionManager::with_inherited(std::path::Path::new("/tmp"), inherited);
+
+        assert_eq!(
+            pm.mode,
+            PermissionMode::Auto,
+            "child permission managers must not preserve root-only Bypass"
+        );
+    }
+
+    #[test]
     fn with_inherited_checks_parent_allow_rules() {
         use astra_runtime::orchestration::{
             InheritedPermissions, PermissionMode as RuntimeMode, PermissionRule as RuntimeRule,
@@ -6227,6 +6249,23 @@ mod tests {
             "fingerprinted_overrides must be populated; got {:?}",
             inherited.fingerprinted_overrides
         );
+    }
+
+    #[test]
+    fn inherited_permissions_for_child_downgrades_root_bypass_to_auto() {
+        use astra_runtime::orchestration::PermissionMode as RuntimeMode;
+
+        let dir = tempfile::tempdir().unwrap();
+        let pm = PermissionManager::with_project_mode(PermissionMode::Bypass, dir.path());
+
+        let inherited = pm.inherited_permissions_for_child(true);
+
+        assert_eq!(
+            inherited.mode,
+            RuntimeMode::Auto,
+            "Bypass is a root UI interaction mode and must not propagate to child agents"
+        );
+        assert!(inherited.is_background);
     }
 
     #[test]
@@ -6930,17 +6969,19 @@ mod tests {
     }
 
     #[test]
-    fn bypass_mode_skips_git_hard_approval() {
+    fn bypass_mode_denies_git_hard_violation_without_prompt() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Bypass, dir.path());
         let args = serde_json::json!({
             "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
         });
 
-        assert!(matches!(
-            pm.check_nonblocking("bash", &args),
-            GateOutcome::Allow
-        ));
+        match pm.check_nonblocking("bash", &args) {
+            GateOutcome::Deny(reason) => {
+                assert!(reason.contains("Git safety hard violation"), "{reason}");
+            }
+            other => panic!("expected hard git denial in bypass mode, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -449,6 +449,16 @@ fn cloud_detail_is_sensitive(tool: &str, detail: Option<&str>) -> bool {
     }
 }
 
+fn cloud_detail_permission_args(tool: &str, detail: Option<&str>) -> Option<serde_json::Value> {
+    match (cloud_gated_tool_kind(tool), detail) {
+        (Some(CloudGatedToolKind::Execute), Some(cmd)) => {
+            Some(serde_json::json!({ "command": cmd }))
+        }
+        (Some(CloudGatedToolKind::Write), Some(path)) => Some(serde_json::json!({ "path": path })),
+        _ => None,
+    }
+}
+
 fn accept_edits_auto_allows_tool_args(tool: &str, args: &serde_json::Value) -> bool {
     matches!(
         (
@@ -2083,6 +2093,28 @@ impl PermissionManager {
         // workspace-scoped write memory can both match.
         let fps = cloud_detail_lookup_fingerprint_candidates(tool, detail);
         let sensitive_path = cloud_detail_is_sensitive(tool, detail);
+        let mut engine_requires_external_review = false;
+
+        if let Some(args) = cloud_detail_permission_args(tool, detail) {
+            let envelope = self.evaluate_permission_envelope(tool, &args);
+            match envelope.decision {
+                HardDecision::Allow
+                    if !Self::cloud_approval_is_explicit(approval_kind)
+                        || self.mode.auto_resolves_approval_prompts()
+                        || matches!(
+                            envelope.source,
+                            DecisionSource::SessionOverride { allowed: true }
+                        ) =>
+                {
+                    return Some(ApprovalDecision::Allow);
+                }
+                HardDecision::Allow => {}
+                HardDecision::Deny { .. } => return Some(ApprovalDecision::Deny),
+                HardDecision::NeedExternal { .. } => {
+                    engine_requires_external_review = true;
+                }
+            }
+        }
 
         // Session override check — applies to every kind. A matched
         // `Always` means the user has already made an informed
@@ -2116,6 +2148,14 @@ impl PermissionManager {
                     },
                 );
             }
+            return if quiet {
+                Some(ApprovalDecision::Deny)
+            } else {
+                None
+            };
+        }
+
+        if engine_requires_external_review && self.mode.auto_resolves_approval_prompts() {
             return if quiet {
                 Some(ApprovalDecision::Deny)
             } else {
@@ -2338,9 +2378,8 @@ impl PermissionManager {
         }
         // PrivilegeEscalation (sudo, doas, etc.) is handled below as Ask — user can review.
 
-        // Exact substring patterns (original denylist)
-        let exact_patterns = ["rm -rf /", ":(){ :|:& };:", "chmod 777 /"];
-        if exact_patterns.iter().any(|p| lower.contains(p)) {
+        if astra_turn_core::safety_middleware::absolute_dangerous_command_reason(cmd_str).is_some()
+        {
             return ExecuteDecision::Deny;
         }
 
@@ -2513,17 +2552,8 @@ impl PermissionManager {
                 // Execute, a path for Write. Build the allow-rule arg
                 // shape to match so `make_allow_rule` produces the
                 // right pattern (`Bash(argv_prefix="cargo")` vs `write_file`).
-                let kind = cloud_gated_tool_kind(tool);
-                let rule_args = match (kind, detail) {
-                    (Some(CloudGatedToolKind::Execute), Some(cmd)) => {
-                        serde_json::json!({ "command": cmd })
-                    }
-                    (Some(CloudGatedToolKind::Write), Some(p)) => {
-                        serde_json::json!({ "path": p })
-                    }
-                    (Some(CloudGatedToolKind::Write), None) => serde_json::Value::Null,
-                    _ => serde_json::Value::Null,
-                };
+                let rule_args =
+                    cloud_detail_permission_args(tool, detail).unwrap_or(serde_json::Value::Null);
                 let fp = fingerprint_for_match_target(
                     tool,
                     &rule_args,
@@ -3579,8 +3609,12 @@ fn is_word_boundary(c: u8) -> bool {
         || !(c.is_ascii_alphanumeric() || c == b'_' || c == b'-' || c == b'/')
 }
 
-/// Returns true if `rm -rf`/`rm -fr` targets a catastrophic path (root, home, system dirs).
+/// Returns true if `rm -rf`/`rm -fr` targets a catastrophic path.
 fn is_rm_catastrophic_target(lower: &str) -> bool {
+    if astra_turn_core::safety_middleware::absolute_dangerous_command_reason(lower).is_some() {
+        return true;
+    }
+
     // Find the rm target path using find() so compound commands
     // (sudo rm -rf /, cd / && rm -rf *) are caught.
     let rest = lower
@@ -3597,21 +3631,6 @@ fn is_rm_catastrophic_target(lower: &str) -> bool {
     if target.is_empty() {
         // bare `rm -rf` with no arguments — treat as dangerous
         return true;
-    }
-    if matches!(target, "/" | "/*" | "~" | "~/") {
-        return true;
-    }
-    if target.starts_with("$home") {
-        return true;
-    }
-    const SYSTEM_DIRS: &[&str] = &[
-        "/etc", "/usr", "/var", "/bin", "/sbin", "/lib", "/boot", "/dev", "/proc", "/sys", "/opt",
-        "/root", "/tmp", "/home",
-    ];
-    for d in SYSTEM_DIRS {
-        if target == *d || target.starts_with(&format!("{d}/")) {
-            return true;
-        }
     }
     false
 }
@@ -3966,7 +3985,8 @@ mod tests {
 
     #[test]
     fn bypass_vectors_now_blocked() {
-        // doas rm -rf / is still Deny because "rm -rf /" is in exact_patterns
+        // doas rm -rf / is still Deny because wrapper-aware catastrophic
+        // checks strip the privilege wrapper before classifying the segment.
         let doas = serde_json::json!({"command": "doas rm -rf /"});
         assert!(PermissionManager::is_dangerous("bash", &doas));
 
@@ -4091,7 +4111,17 @@ mod tests {
 
     #[test]
     fn rm_rf_root_is_deny() {
-        for cmd_str in &["rm -rf /", "rm -rf /*", "rm -rf ~", "rm -rf ~/", "rm -fr /"] {
+        for cmd_str in &[
+            "rm -rf /",
+            "rm -rf /*",
+            "rm -rf ~",
+            "rm -rf ~/",
+            "rm -fr /",
+            "sudo rm -rf /",
+            "doas rm -rf /",
+            "SUDO -n rm -rf /",
+            "pkexec chmod 777 /",
+        ] {
             let cmd = serde_json::json!({"command": cmd_str});
             let d = PermissionManager::execute_decision("bash", &cmd);
             assert_eq!(d, ExecuteDecision::Deny, "should deny: {cmd_str}");
@@ -4105,6 +4135,10 @@ mod tests {
             "rm -rf node_modules",
             "rm -rf dist/",
             "rm -rf target/debug",
+            "rm -rf /tmp/foo",
+            "sudo rm -rf /tmp/foo",
+            "SUDO rm -rf /home/user/project",
+            "pkexec chmod 777 /tmp/foo",
         ] {
             let cmd = serde_json::json!({"command": cmd_str});
             let d = PermissionManager::execute_decision("bash", &cmd);
@@ -7311,6 +7345,87 @@ mod tests {
             opted_in,
             Some(astra_thin_client::ApprovalDecision::Allow),
             "sensitive cloud writes should allow only after explicit opt-in"
+        );
+    }
+
+    #[test]
+    fn cloud_preflight_reuses_engine_for_hard_git_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut auto = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
+
+        let interactive = auto.preflight_cloud_approval_decision(
+            "bash",
+            Some("git push --force origin main"),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert!(
+            interactive.is_none(),
+            "interactive Auto must route hard git through approval instead of auto-allowing it: {interactive:?}"
+        );
+
+        let quiet = auto.preflight_cloud_approval_decision(
+            "bash",
+            Some("git push --force origin main"),
+            ApprovalKind::Standard,
+            true,
+        );
+        assert_eq!(
+            quiet,
+            Some(astra_thin_client::ApprovalDecision::Deny),
+            "quiet Auto cannot prompt for hard git, so it must fail closed"
+        );
+
+        let mut bypass = PermissionManager::with_project_mode(PermissionMode::Bypass, dir.path());
+        let bypass_decision = bypass.preflight_cloud_approval_decision(
+            "bash",
+            Some("git push --force origin main"),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert_eq!(
+            bypass_decision,
+            Some(astra_thin_client::ApprovalDecision::Deny),
+            "Bypass skips approval prompts, but hard git policy still applies"
+        );
+    }
+
+    #[test]
+    fn cloud_preflight_reuses_engine_for_persistent_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
+
+        pm.settings
+            .deny
+            .push(r#"Bash(argv_prefix="cargo test")"#.to_string());
+        pm.cached_deny = pm.settings.parsed_deny_rules();
+        let denied = pm.preflight_cloud_approval_decision(
+            "bash",
+            Some("cargo test --lib"),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert_eq!(
+            denied,
+            Some(astra_thin_client::ApprovalDecision::Deny),
+            "cloud preflight must honor deny rules before Auto mode"
+        );
+
+        pm.settings.deny.clear();
+        pm.cached_deny = pm.settings.parsed_deny_rules();
+        pm.settings.allow.push("write_file()".to_string());
+        pm.cached_allow = pm.settings.parsed_allow_rules();
+        pm.set_mode(PermissionMode::Prompt);
+        let allowed = pm.preflight_cloud_approval_decision(
+            "write_file",
+            Some("src/lib.rs"),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert_eq!(
+            allowed,
+            Some(astra_thin_client::ApprovalDecision::Allow),
+            "cloud preflight must honor allow rules instead of prompting again"
         );
     }
 

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -1444,7 +1444,7 @@ impl PermissionManager {
     #[cfg(test)]
     pub(crate) fn new(auto_approve: bool) -> Self {
         let mode = if auto_approve {
-            PermissionMode::Auto
+            PermissionMode::Bypass
         } else {
             PermissionMode::Prompt
         };
@@ -1480,7 +1480,7 @@ impl PermissionManager {
     /// Loads `.astra/permissions.json` if it exists, applying persistent allow/deny rules.
     pub(crate) fn with_project(auto_approve: bool, project_root: &Path) -> Self {
         let mode = if auto_approve {
-            PermissionMode::Auto
+            PermissionMode::Bypass
         } else {
             PermissionMode::Prompt
         };
@@ -1503,7 +1503,7 @@ impl PermissionManager {
     /// or changed workspaces apply project deny rules only.
     pub(crate) fn with_workspace_trust(auto_approve: bool, project_root: &Path) -> Self {
         let mode = if auto_approve {
-            PermissionMode::Auto
+            PermissionMode::Bypass
         } else {
             PermissionMode::Prompt
         };
@@ -5626,7 +5626,8 @@ mod tests {
 
     #[test]
     fn explicit_irreversible_actions_auto_allowed_in_auto_mode() {
-        let mut pm = PermissionManager::new(true); // auto mode
+        let mut pm = PermissionManager::new(false);
+        pm.set_mode(PermissionMode::Auto);
         let args = serde_json::json!({"action": "commit", "message": "ship it"});
         let decision = pm.check_nonblocking("git", &args);
         assert!(
@@ -5695,7 +5696,8 @@ mod tests {
     fn broad_session_override_cannot_bypass_git_safety() {
         // CRITICAL: a broad "bash" approval must not cover destructive git.
         // Only an exact command approval can reuse this gate.
-        let mut pm = PermissionManager::new(true); // auto mode
+        let mut pm = PermissionManager::new(false);
+        pm.set_mode(PermissionMode::Auto);
         pm.session_overrides.insert(bare_fp("bash"), true);
         let args = serde_json::json!({
             "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
@@ -5710,7 +5712,8 @@ mod tests {
 
     #[test]
     fn exact_session_override_allows_same_bounded_git_safety_request_only() {
-        let mut pm = PermissionManager::new(true); // auto mode
+        let mut pm = PermissionManager::new(false);
+        pm.set_mode(PermissionMode::Auto);
         let args = serde_json::json!({
             "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
         });
@@ -5750,7 +5753,8 @@ mod tests {
         // Hard boundary: Auto mode never opens an interactive prompt for
         // sensitive paths. Without a content-specific approval or explicit
         // opt-in it fails closed.
-        let mut pm = PermissionManager::new(true);
+        let mut pm = PermissionManager::new(false);
+        pm.set_mode(PermissionMode::Auto);
         pm.session_overrides.insert(bare_fp("write_file"), true);
         let args = serde_json::json!({"path": ".git/config", "content": "bad"});
         let decision = pm.check_nonblocking("write_file", &args);
@@ -5808,7 +5812,8 @@ mod tests {
 
     #[test]
     fn directory_override_cannot_bypass_sensitive_sibling_path() {
-        let mut pm = PermissionManager::new(true);
+        let mut pm = PermissionManager::new(false);
+        pm.set_mode(PermissionMode::Auto);
         let safe = serde_json::json!({"path": "src/deep/main.rs", "content": "ok"});
         let sensitive = serde_json::json!({"path": "src/deep/.env", "content": "SECRET=x"});
 

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -581,10 +581,11 @@ pub(crate) struct PermissionSettings {
     pub allow: Vec<String>,
     #[serde(default)]
     pub deny: Vec<String>,
-    /// Hard-boundary opt-in: allow Auto mode to bypass approval for sensitive
+    /// Hard-boundary opt-in: allow Auto mode to auto-resolve sensitive
     /// file paths (e.g. `.git/`, `.ssh/`, shell configs). Default `false` —
-    /// even in Auto mode, sensitive-path writes require explicit approval
-    /// unless the user sets this to `true` at project or user scope.
+    /// Auto mode fails closed on sensitive-path writes unless the user sets
+    /// this to `true` at project or user scope. Bypass mode skips that prompt
+    /// axis directly; absolute hard-denies still run first.
     #[serde(default)]
     pub allow_sensitive_path_writes: bool,
 }
@@ -2203,7 +2204,7 @@ impl PermissionManager {
         }
     }
 
-    /// Check persistent deny rules (inherited + project + user, bypass-immune).
+    /// Check persistent deny rules (inherited + project + user) before mode shortcuts.
     fn check_deny_rules(&self, name: &str, args: &serde_json::Value) -> bool {
         let ctx = astra_turn_core::permission::types::RuleMatchContext::from_tool_args(name, args);
         // Check inherited deny rules first (from parent agent)
@@ -2972,7 +2973,7 @@ impl PermissionManager {
     /// Only used by tests; production code uses [`check_nonblocking()`].
     #[cfg(test)]
     pub(crate) fn check(&mut self, name: &str, args: &serde_json::Value) -> bool {
-        // Step 1: Deny rules are bypass-immune (checked first, even with auto_approve).
+        // Step 1: Deny rules are checked first, before auto/bypass shortcuts.
         if self.check_deny_rules(name, args) {
             eprintln!("{}", format!("  ✗  Denied by rule: {name}").red());
             return false;
@@ -2980,9 +2981,9 @@ impl PermissionManager {
 
         let side_effect = Self::classify_with_args(name, args);
 
-        // Step 2: Git safety checks.
-        // Hard violations always require explicit approval.
-        // Soft violations (cd+git, commit --amend) respect auto mode and session overrides.
+        // Step 2: Git safety approval gate.
+        // Broad overrides cannot skip this gate. Bypass mode can resolve it
+        // without prompting; Auto only resolves soft findings.
         if side_effect == SideEffect::Execute {
             let git_violations = Self::check_git_safety(args);
             if !git_violations.is_empty() {
@@ -3013,7 +3014,8 @@ impl PermissionManager {
                         return allowed;
                     }
                 }
-                // Hard violations: always require explicit approval.
+                // Hard git findings still require explicit approval in Auto.
+                // Bypass is the explicit "do not interrupt me" mode.
                 if self.mode == PermissionMode::Auto && has_hard {
                     eprintln!(
                         "  {}",
@@ -3029,7 +3031,7 @@ impl PermissionManager {
             }
         }
 
-        // Step 3: Dangerous file path check (bypass-immune).
+        // Step 3: Sensitive path approval gate.
         if let Some(warning) = Self::check_dangerous_path(name, args) {
             eprintln!("  {}", warning.yellow());
             if matches!(self.mode, PermissionMode::Plan | PermissionMode::Deny) {
@@ -3077,8 +3079,9 @@ impl PermissionManager {
             return true;
         }
 
-        // Step 5: Session overrides (AFTER bypass-immune safety checks, BEFORE
-        // explicit-approval and mode gating so a prior approval isn't re-prompted).
+        // Step 5: Session overrides (after safety approval gates, before
+        // explicit-approval and mode gating so a prior exact approval isn't
+        // re-prompted).
         if let Some(allowed) =
             self.check_overrides_any(&approval_lookup_fingerprint_candidates(name, args))
         {
@@ -5006,7 +5009,7 @@ mod tests {
 
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
         let args = serde_json::json!({"command": "rm -rf /"});
-        // Even in auto mode, deny rules are bypass-immune
+        // Even in auto mode, deny rules run before approval shortcuts.
         assert!(!pm.check("bash", &args));
     }
 
@@ -5526,19 +5529,43 @@ mod tests {
     // ── Security: session overrides cannot bypass safety checks ──────────────
 
     #[test]
-    fn session_override_cannot_bypass_git_safety() {
-        // CRITICAL: Even if user previously approved "bash", dangerous git
-        // operations must still require manual approval.
+    fn broad_session_override_cannot_bypass_git_safety() {
+        // CRITICAL: a broad "bash" approval must not cover destructive git.
+        // Only an exact command approval can reuse this gate.
         let mut pm = PermissionManager::new(true); // auto mode
         pm.session_overrides.insert(bare_fp("bash"), true);
         let args = serde_json::json!({
             "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
         });
-        // Must NOT be Allow — git safety is bypass-immune
+        // Must NOT be Allow in Auto; broad overrides are too wide here.
         let decision = pm.check_nonblocking("bash", &args);
         assert!(
             matches!(decision, GateOutcome::NeedApproval { .. }),
-            "session override must not bypass git safety: got {decision:?}"
+            "broad session override must not bypass git safety: got {decision:?}"
+        );
+    }
+
+    #[test]
+    fn exact_session_override_allows_same_bounded_git_safety_request_only() {
+        let mut pm = PermissionManager::new(true); // auto mode
+        let args = serde_json::json!({
+            "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
+        });
+        pm.record_approval_with_match_target("bash", &args, &AllowMatchTarget::Exact, true);
+
+        let decision = pm.check_nonblocking("bash", &args);
+        assert!(
+            matches!(decision, GateOutcome::Allow),
+            "exact git approval should cover the same command: got {decision:?}"
+        );
+
+        let sibling = serde_json::json!({
+            "command": "git restore --staged --worktree rust/crates/foo/src/other.rs"
+        });
+        let sibling_decision = pm.check_nonblocking("bash", &sibling);
+        assert!(
+            matches!(sibling_decision, GateOutcome::NeedApproval { .. }),
+            "exact git approval must not widen to sibling commands: got {sibling_decision:?}"
         );
     }
 
@@ -5676,7 +5703,7 @@ mod tests {
     }
 
     #[test]
-    fn check_session_override_cannot_bypass_git_safety() {
+    fn check_session_override_cannot_bypass_dangerous_command() {
         // Same test for the synchronous check() path
         let mut pm = PermissionManager::new(true);
         pm.session_overrides.insert(bare_fp("bash"), true);

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -2554,49 +2554,106 @@ impl PermissionManager {
                 // right pattern (`Bash(argv_prefix="cargo")` vs `write_file`).
                 let rule_args =
                     cloud_detail_permission_args(tool, detail).unwrap_or(serde_json::Value::Null);
-                let fp = fingerprint_for_match_target(
+                let match_target = default_match_target(tool, &rule_args);
+                let fp = fingerprint_for_match_target(tool, &rule_args, &match_target);
+                let envelope = self.evaluate_permission_envelope(tool, &rule_args);
+                let scope_ctx = astra_turn_core::permission::scope::scope_context_for_tool_request(
                     tool,
                     &rule_args,
-                    &default_match_target(tool, &rule_args),
+                    envelope.risk_tags.clone(),
+                    false,
+                    !self.project_allow_rules_active(),
                 );
-                self.session_overrides.insert(fp, true);
-                let rule = Self::make_allow_rule(tool, &rule_args);
-                let workspace_persistence_available = self.project_root.is_some();
-                let location = if self.project_root.is_some() {
-                    "in this workspace"
-                } else {
-                    "in this session"
+                let always_scope =
+                    astra_turn_core::permission::scope::default_always_scope(&scope_ctx);
+                let location = match always_scope {
+                    astra_turn_core::permission::scope::AllowScope::Project => "in this workspace",
+                    astra_turn_core::permission::scope::AllowScope::User => "for this user",
+                    astra_turn_core::permission::scope::AllowScope::RestOfSession => {
+                        "in this session"
+                    }
+                    astra_turn_core::permission::scope::AllowScope::RestOfTurn => "for this turn",
+                    astra_turn_core::permission::scope::AllowScope::OnceThisCall => "for this call",
                 };
                 let remember_preview = astra_turn_core::permission::match_target::remember_preview(
                     tool, &rule_args, location,
                 );
-                if sensitive_path_match_for_request(tool, &rule_args).is_some() {
-                    eprintln!(
-                        "{}",
-                        cloud_always_feedback_message(
-                            &remember_preview,
-                            workspace_persistence_available,
-                            None,
+                match always_scope {
+                    astra_turn_core::permission::scope::AllowScope::Project => {
+                        self.record_approval_with_match_target(
+                            tool,
+                            &rule_args,
+                            &match_target,
                             true,
-                        )
-                        .dim()
-                    );
-                } else {
-                    self.add_allow_rule(&rule);
-                    let persist_error = self.take_last_save_error();
-                    let feedback = cloud_always_feedback_message(
-                        &remember_preview,
-                        workspace_persistence_available,
-                        persist_error.as_deref(),
-                        false,
-                    );
-                    if persist_error.is_some() {
-                        eprintln!("{}", feedback.yellow());
-                    } else {
-                        eprintln!("{}", feedback.dim());
+                        );
+                        let rule = Self::make_allow_rule_with_match_target(
+                            tool,
+                            &rule_args,
+                            &match_target,
+                        );
+                        self.add_allow_rule(&rule);
+                        let persist_error = self.take_last_save_error();
+                        let feedback = cloud_always_feedback_message(
+                            &remember_preview,
+                            true,
+                            persist_error.as_deref(),
+                            false,
+                        );
+                        if persist_error.is_some() {
+                            eprintln!("{}", feedback.yellow());
+                        } else {
+                            eprintln!("{}", feedback.dim());
+                        }
+                        return ApprovalDecision::AllowSession;
                     }
+                    astra_turn_core::permission::scope::AllowScope::User => {
+                        self.record_approval_with_match_target(
+                            tool,
+                            &rule_args,
+                            &match_target,
+                            true,
+                        );
+                        let rule = Self::make_allow_rule_with_match_target(
+                            tool,
+                            &rule_args,
+                            &match_target,
+                        );
+                        self.add_user_allow_rule(&rule);
+                        let persist_error = self.take_last_save_error();
+                        let feedback = cloud_always_feedback_message(
+                            &remember_preview,
+                            true,
+                            persist_error.as_deref(),
+                            false,
+                        );
+                        if persist_error.is_some() {
+                            eprintln!("{}", feedback.yellow());
+                        } else {
+                            eprintln!("{}", feedback.dim());
+                        }
+                        return ApprovalDecision::AllowSession;
+                    }
+                    astra_turn_core::permission::scope::AllowScope::RestOfSession => {
+                        self.session_overrides.insert(fp, true);
+                        eprintln!(
+                            "{}",
+                            cloud_always_feedback_message(&remember_preview, false, None, true)
+                                .dim()
+                        );
+                        return ApprovalDecision::AllowSession;
+                    }
+                    astra_turn_core::permission::scope::AllowScope::RestOfTurn => {
+                        self.turn_overrides.insert(fp, true);
+                        eprintln!(
+                            "{}",
+                            cloud_always_feedback_message(&remember_preview, false, None, true)
+                                .dim()
+                        );
+                        return ApprovalDecision::Allow;
+                    }
+                    astra_turn_core::permission::scope::AllowScope::OnceThisCall => {}
                 }
-                ApprovalDecision::AllowSession
+                ApprovalDecision::Allow
             }
             '!' => {
                 self.set_mode(PermissionMode::Auto);
@@ -5021,14 +5078,15 @@ mod tests {
     }
 
     #[test]
-    fn cloud_approval_always_sets_session_override() {
+    fn cloud_approval_always_without_detail_is_turn_scoped() {
         let dir = tempfile::tempdir().unwrap();
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
         let decision = pm.apply_cloud_approval_choice("bash", None, 'a');
 
-        assert_eq!(decision, astra_thin_client::ApprovalDecision::AllowSession);
-        assert_eq!(pm.session_overrides.check(&bare_fp("bash")), Some(true));
+        assert_eq!(decision, astra_thin_client::ApprovalDecision::Allow);
+        assert_eq!(pm.turn_overrides.check(&bare_fp("bash")), Some(true));
+        assert_eq!(pm.session_overrides.check(&bare_fp("bash")), None);
     }
 
     #[test]
@@ -6526,7 +6584,7 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
         // Simulate user selecting "always allow this tool" in cloud approval
-        let decision = pm.apply_cloud_approval_choice("write_file", None, 'a');
+        let decision = pm.apply_cloud_approval_choice("write_file", Some("src/lib.rs"), 'a');
         assert_eq!(decision, astra_thin_client::ApprovalDecision::AllowSession);
 
         // Now the local check_nonblocking must auto-allow (no prompt)
@@ -6568,7 +6626,7 @@ mod tests {
         let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
 
         // 1st call: user selects 'a' in cloud approval
-        pm.apply_cloud_approval_choice("write_file", None, 'a');
+        pm.apply_cloud_approval_choice("write_file", Some("src/lib.rs"), 'a');
 
         // 1st call: local check
         let args1 = serde_json::json!({"path": "src/lib.rs", "content": "pub fn one() {}\n"});
@@ -8136,6 +8194,51 @@ mod tests {
         assert!(
             after_restart.is_none(),
             "after restart, sensitive write should prompt again instead of persisting"
+        );
+    }
+
+    #[test]
+    fn cloud_always_git_destructive_stays_session_only_after_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let command = "git restore --staged --worktree rust/crates/foo/src/lib.rs";
+        {
+            let mut pm = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+            let first = pm.apply_cloud_approval_choice("bash", Some(command), 'a');
+            assert_eq!(first, astra_thin_client::ApprovalDecision::AllowSession);
+
+            let same_session = pm.preflight_cloud_approval_decision(
+                "bash",
+                Some(command),
+                ApprovalKind::Standard,
+                false,
+            );
+            assert_eq!(
+                same_session,
+                Some(astra_thin_client::ApprovalDecision::Allow),
+                "same-session git destructive Always should avoid re-prompting"
+            );
+        }
+
+        let settings_path = dir.path().join(".astra").join("permissions.json");
+        if settings_path.exists() {
+            let on_disk = std::fs::read_to_string(&settings_path).unwrap();
+            let saved: PermissionSettings = serde_json::from_str(&on_disk).unwrap();
+            assert!(
+                saved.allow.iter().all(|rule| !rule.contains("git restore")),
+                "git destructive Always must remain session-only: {on_disk}"
+            );
+        }
+
+        let mut reborn = PermissionManager::with_project_mode(PermissionMode::Prompt, dir.path());
+        let after_restart = reborn.preflight_cloud_approval_decision(
+            "bash",
+            Some(command),
+            ApprovalKind::Standard,
+            false,
+        );
+        assert!(
+            after_restart.is_none(),
+            "after restart, git destructive request should prompt again instead of persisting"
         );
     }
 

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -14,7 +14,7 @@ use astra_turn_core::cloud_approval_policy::{
     cloud_gated_tool_kind_with_args,
 };
 use astra_turn_core::permission::engine::{
-    DecisionEnvelope, DecisionSource, HardDecision, allow_rule_preview,
+    DecisionEnvelope, DecisionSource, HardDecision, RiskTag, allow_rule_preview,
     allow_rule_preview_for_match_target,
 };
 use astra_turn_core::permission::match_target::{
@@ -150,17 +150,32 @@ fn persist_permission_mode_to_workspace(session_id: &str, mode: PermissionMode) 
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CloudAlwaysSessionOnlyReason {
+    SensitivePath,
+    BoundedRisk,
+}
+
 fn cloud_always_feedback_message(
     remember_preview: &str,
     workspace_persistence_available: bool,
     persist_error: Option<&str>,
-    sensitive_path: bool,
+    session_only_reason: Option<CloudAlwaysSessionOnlyReason>,
 ) -> String {
-    if sensitive_path {
-        return format!(
-            "  ✓ {remember_preview}: allowed for this session only. \
+    match session_only_reason {
+        Some(CloudAlwaysSessionOnlyReason::SensitivePath) => {
+            return format!(
+                "  ✓ {remember_preview}: allowed for this session only. \
 To auto-allow sensitive paths across sessions, set allow_sensitive_path_writes=true in .astra/permissions.json."
-        );
+            );
+        }
+        Some(CloudAlwaysSessionOnlyReason::BoundedRisk) => {
+            return format!(
+                "  ✓ {remember_preview}: allowed for this session only. \
+This request cannot be remembered safely across sessions."
+            );
+        }
+        None => {}
     }
     if let Some(err) = persist_error {
         return format!(
@@ -2597,7 +2612,7 @@ impl PermissionManager {
                             &remember_preview,
                             true,
                             persist_error.as_deref(),
-                            false,
+                            None,
                         );
                         if persist_error.is_some() {
                             eprintln!("{}", feedback.yellow());
@@ -2624,7 +2639,7 @@ impl PermissionManager {
                             &remember_preview,
                             true,
                             persist_error.as_deref(),
-                            false,
+                            None,
                         );
                         if persist_error.is_some() {
                             eprintln!("{}", feedback.yellow());
@@ -2635,19 +2650,41 @@ impl PermissionManager {
                     }
                     astra_turn_core::permission::scope::AllowScope::RestOfSession => {
                         self.session_overrides.insert(fp, true);
+                        let session_only_reason =
+                            if envelope.risk_tags.contains(&RiskTag::WritesSensitiveFile) {
+                                CloudAlwaysSessionOnlyReason::SensitivePath
+                            } else {
+                                CloudAlwaysSessionOnlyReason::BoundedRisk
+                            };
                         eprintln!(
                             "{}",
-                            cloud_always_feedback_message(&remember_preview, false, None, true)
-                                .dim()
+                            cloud_always_feedback_message(
+                                &remember_preview,
+                                false,
+                                None,
+                                Some(session_only_reason),
+                            )
+                            .dim()
                         );
                         return ApprovalDecision::AllowSession;
                     }
                     astra_turn_core::permission::scope::AllowScope::RestOfTurn => {
                         self.turn_overrides.insert(fp, true);
+                        let session_only_reason =
+                            if envelope.risk_tags.contains(&RiskTag::WritesSensitiveFile) {
+                                CloudAlwaysSessionOnlyReason::SensitivePath
+                            } else {
+                                CloudAlwaysSessionOnlyReason::BoundedRisk
+                            };
                         eprintln!(
                             "{}",
-                            cloud_always_feedback_message(&remember_preview, false, None, true)
-                                .dim()
+                            cloud_always_feedback_message(
+                                &remember_preview,
+                                false,
+                                None,
+                                Some(session_only_reason),
+                            )
+                            .dim()
                         );
                         return ApprovalDecision::Allow;
                     }
@@ -3267,7 +3304,7 @@ impl PermissionManager {
                     &remember_preview,
                     self.project_root.is_some(),
                     persist_error.as_deref(),
-                    false,
+                    None,
                 );
                 if persist_error.is_some() {
                     eprintln!("{}", feedback.yellow());
@@ -3717,9 +3754,9 @@ fn is_read_only_allowlisted(lower_cmd: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApprovalPromptKind, ExecuteDecision, GateOutcome, ModifyError, PermissionLoadPolicy,
-        PermissionManager, PermissionMode, PermissionRule, PermissionSettings,
-        PermissionSettingsLoadError, SideEffect, cloud_always_feedback_message,
+        ApprovalPromptKind, CloudAlwaysSessionOnlyReason, ExecuteDecision, GateOutcome,
+        ModifyError, PermissionLoadPolicy, PermissionManager, PermissionMode, PermissionRule,
+        PermissionSettings, PermissionSettingsLoadError, SideEffect, cloud_always_feedback_message,
         content_aware_fingerprint, decode_mode_for_mirror, encode_mode_for_mirror,
         format_denied_message, is_read_only_allowlisted, parse_sandbox_target_path,
         safe_alternative_for,
@@ -3798,8 +3835,12 @@ mod tests {
 
     #[test]
     fn cloud_always_feedback_message_explains_sensitive_path_session_only() {
-        let out =
-            cloud_always_feedback_message("this file edit in this workspace", true, None, true);
+        let out = cloud_always_feedback_message(
+            "this file edit in this workspace",
+            true,
+            None,
+            Some(CloudAlwaysSessionOnlyReason::SensitivePath),
+        );
         assert!(
             out.contains("session only"),
             "missing session-only hint: {out}"
@@ -3811,12 +3852,34 @@ mod tests {
     }
 
     #[test]
+    fn cloud_always_feedback_message_explains_bounded_risk_without_sensitive_path_guidance() {
+        let out = cloud_always_feedback_message(
+            "this git command in this session",
+            false,
+            None,
+            Some(CloudAlwaysSessionOnlyReason::BoundedRisk),
+        );
+        assert!(
+            out.contains("session only"),
+            "missing session-only hint: {out}"
+        );
+        assert!(
+            out.contains("cannot be remembered safely across sessions"),
+            "missing bounded-risk persistence explanation: {out}"
+        );
+        assert!(
+            !out.contains("allow_sensitive_path_writes"),
+            "git/destructive session-only prompt must not mention sensitive path config: {out}"
+        );
+    }
+
+    #[test]
     fn cloud_always_feedback_message_uses_command_family_language() {
         let out = cloud_always_feedback_message(
             "the `cargo test` command family in this workspace",
             true,
             None,
-            false,
+            None,
         );
         assert_eq!(
             out,
@@ -3831,7 +3894,7 @@ mod tests {
             "the `cargo test` command family in this session",
             false,
             None,
-            false,
+            None,
         );
         assert_eq!(
             out,

--- a/rust/crates/astra-cli/src/cli/permission_manager.rs
+++ b/rust/crates/astra-cli/src/cli/permission_manager.rs
@@ -526,6 +526,7 @@ fn encode_mode_for_mirror(mode: PermissionMode) -> u8 {
         PermissionMode::Plan => 2,
         PermissionMode::AcceptEdits => 3,
         PermissionMode::Deny => 4,
+        PermissionMode::Bypass => 5,
     }
 }
 
@@ -535,6 +536,7 @@ fn decode_mode_for_mirror(value: u8) -> PermissionMode {
         2 => PermissionMode::Plan,
         3 => PermissionMode::AcceptEdits,
         4 => PermissionMode::Deny,
+        5 => PermissionMode::Bypass,
         _ => PermissionMode::Prompt,
     }
 }
@@ -1617,6 +1619,7 @@ impl PermissionManager {
         // Use inherited mode, but load project settings too
         let mode = match inherited.mode {
             astra_runtime::orchestration::PermissionMode::Auto => PermissionMode::Auto,
+            astra_runtime::orchestration::PermissionMode::Bypass => PermissionMode::Bypass,
             astra_runtime::orchestration::PermissionMode::Plan => PermissionMode::Plan,
             astra_runtime::orchestration::PermissionMode::AcceptEdits => {
                 PermissionMode::AcceptEdits
@@ -1776,6 +1779,7 @@ impl PermissionManager {
 
         let mode = match self.mode {
             PermissionMode::Auto => RuntimePermissionMode::Auto,
+            PermissionMode::Bypass => RuntimePermissionMode::Bypass,
             PermissionMode::Plan => RuntimePermissionMode::Plan,
             PermissionMode::AcceptEdits => RuntimePermissionMode::AcceptEdits,
             PermissionMode::Prompt => RuntimePermissionMode::Prompt,
@@ -2111,6 +2115,9 @@ impl PermissionManager {
             if matches!(self.mode, PermissionMode::Plan | PermissionMode::Deny) {
                 return Some(ApprovalDecision::Deny);
             }
+            if self.mode == PermissionMode::Bypass {
+                return Some(ApprovalDecision::Allow);
+            }
             if self.mode == PermissionMode::Auto {
                 return Some(
                     if self.settings.allow_sensitive_path_writes
@@ -2131,7 +2138,7 @@ impl PermissionManager {
 
         if quiet {
             return Some(match self.mode {
-                PermissionMode::Auto => ApprovalDecision::Allow,
+                PermissionMode::Auto | PermissionMode::Bypass => ApprovalDecision::Allow,
                 PermissionMode::Plan => ApprovalDecision::Deny,
                 PermissionMode::AcceptEdits
                     if accept_edits_auto_allows_cloud_request(tool, detail) =>
@@ -2146,7 +2153,7 @@ impl PermissionManager {
 
         if Self::cloud_approval_is_explicit(approval_kind) {
             return match self.mode {
-                PermissionMode::Auto => Some(ApprovalDecision::Allow),
+                PermissionMode::Auto | PermissionMode::Bypass => Some(ApprovalDecision::Allow),
                 PermissionMode::Plan => Some(ApprovalDecision::Deny),
                 PermissionMode::AcceptEdits => None,
                 PermissionMode::Deny => Some(ApprovalDecision::Deny),
@@ -2155,7 +2162,7 @@ impl PermissionManager {
         }
 
         match self.mode {
-            PermissionMode::Auto => return Some(ApprovalDecision::Allow),
+            PermissionMode::Auto | PermissionMode::Bypass => return Some(ApprovalDecision::Allow),
             PermissionMode::Plan => return Some(ApprovalDecision::Deny),
             PermissionMode::AcceptEdits if accept_edits_auto_allows_cloud_request(tool, detail) => {
                 return Some(ApprovalDecision::Allow);
@@ -2989,6 +2996,9 @@ impl PermissionManager {
                     eprintln!("  {}", "  Git safety violation — blocked".red());
                     return false;
                 }
+                if self.mode == PermissionMode::Bypass {
+                    return true;
+                }
                 // Soft-only violations: respect auto mode and session overrides.
                 if all_soft {
                     if self.mode == PermissionMode::Auto {
@@ -3022,6 +3032,9 @@ impl PermissionManager {
             if matches!(self.mode, PermissionMode::Plan | PermissionMode::Deny) {
                 eprintln!("  {}", "  Sensitive path — blocked".red());
                 return false;
+            }
+            if self.mode == PermissionMode::Bypass {
+                return true;
             }
             if self.mode == PermissionMode::Auto {
                 eprintln!("  {}", "  Sensitive path — requires your approval".yellow());
@@ -3091,7 +3104,7 @@ impl PermissionManager {
 
         // Step 7: Permission mode determines final action.
         match self.mode {
-            PermissionMode::Auto => return true,
+            PermissionMode::Auto | PermissionMode::Bypass => return true,
             PermissionMode::Plan => {
                 let (header, _) = Self::format_tool_display(name, args);
                 eprintln!("  {}", format!("  ✗ {header} — blocked").red());
@@ -3256,6 +3269,9 @@ impl PermissionManager {
                 } else {
                     GateOutcome::Deny("Sensitive path denied for session".into())
                 };
+            }
+            if self.mode == PermissionMode::Bypass {
+                return GateOutcome::Allow;
             }
             if self.mode == PermissionMode::Auto
                 && (self.settings.allow_sensitive_path_writes
@@ -4806,6 +4822,14 @@ mod tests {
             "auto".parse::<PermissionMode>().unwrap(),
             PermissionMode::Auto
         );
+        assert_eq!(
+            "bypass".parse::<PermissionMode>().unwrap(),
+            PermissionMode::Bypass
+        );
+        assert_eq!(
+            "skip".parse::<PermissionMode>().unwrap(),
+            PermissionMode::Bypass
+        );
         assert!("yolo".parse::<PermissionMode>().is_err());
         assert!("bypass-safety".parse::<PermissionMode>().is_err());
         assert_eq!(
@@ -4835,6 +4859,7 @@ mod tests {
     #[test]
     fn permission_mode_display() {
         assert_eq!(PermissionMode::Auto.to_string(), "auto");
+        assert_eq!(PermissionMode::Bypass.to_string(), "bypass");
         assert_eq!(PermissionMode::Plan.to_string(), "plan");
         assert_eq!(PermissionMode::AcceptEdits.to_string(), "accept_edits");
         assert_eq!(PermissionMode::Prompt.to_string(), "prompt");
@@ -5497,7 +5522,9 @@ mod tests {
         // operations must still require manual approval.
         let mut pm = PermissionManager::new(true); // auto mode
         pm.session_overrides.insert(bare_fp("bash"), true);
-        let args = serde_json::json!({"command": "git push --force"});
+        let args = serde_json::json!({
+            "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
+        });
         // Must NOT be Allow — git safety is bypass-immune
         let decision = pm.check_nonblocking("bash", &args);
         assert!(
@@ -6824,6 +6851,38 @@ mod tests {
     }
 
     #[test]
+    fn bypass_mode_skips_sensitive_path_approval_but_not_hard_denies() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Bypass, dir.path());
+
+        let sensitive = serde_json::json!({"path": ".ssh/id_rsa", "content": "x"});
+        assert!(matches!(
+            pm.check_nonblocking("write_file", &sensitive),
+            GateOutcome::Allow
+        ));
+
+        let catastrophic = serde_json::json!({"command": "rm -rf /"});
+        assert!(matches!(
+            pm.check_nonblocking("bash", &catastrophic),
+            GateOutcome::Deny(_)
+        ));
+    }
+
+    #[test]
+    fn bypass_mode_skips_git_hard_approval() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Bypass, dir.path());
+        let args = serde_json::json!({
+            "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
+        });
+
+        assert!(matches!(
+            pm.check_nonblocking("bash", &args),
+            GateOutcome::Allow
+        ));
+    }
+
+    #[test]
     fn sensitive_path_gate_ignores_internal_tool_result_pipeline() {
         let dir = tempfile::tempdir().unwrap();
         let sessions_root = dir.path().join("sessions");
@@ -6967,6 +7026,73 @@ mod tests {
             ),
             "shell reads of hidden-home credentials must still gate: {bash_secret_decision:?}"
         );
+    }
+
+    #[test]
+    fn auto_mode_allows_agent_skill_content_but_not_agent_control_or_skill_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pm = PermissionManager::with_project_mode(PermissionMode::Auto, dir.path());
+
+        for path in [
+            ".astra/skills/code-review/SKILL.md",
+            ".claude/skills/code-review/SKILL.md",
+        ] {
+            let write_args = serde_json::json!({"path": path, "content": "# Skill\n"});
+            let write_decision = pm.check_nonblocking("write_file", &write_args);
+            assert!(
+                matches!(write_decision, GateOutcome::Allow),
+                "Auto mode must allow agent skill content edits without approval: {write_decision:?}"
+            );
+
+            let read_args = serde_json::json!({"path": path});
+            let read_decision = pm.check_nonblocking("read_file", &read_args);
+            assert!(
+                matches!(read_decision, GateOutcome::Allow),
+                "Auto mode must allow agent skill content reads without approval: {read_decision:?}"
+            );
+        }
+
+        for path in [
+            ".astra/permissions.json",
+            ".astra/config.toml",
+            ".claude/settings.json",
+        ] {
+            let write_args = serde_json::json!({"path": path, "content": "{}\n"});
+            let decision = pm.check_nonblocking("write_file", &write_args);
+            assert!(
+                matches!(
+                    &decision,
+                    GateOutcome::Deny(reason)
+                        if reason.contains("write-sensitive app/runtime state")
+                ),
+                "agent control files must stay write-sensitive in Auto mode: {decision:?}"
+            );
+        }
+
+        for path in [
+            ".astra/skills/code-review/.env",
+            ".claude/skills/code-review/credentials.json",
+        ] {
+            let read_args = serde_json::json!({"path": path});
+            let read_decision = pm.check_nonblocking("read_file", &read_args);
+            assert!(
+                matches!(
+                    &read_decision,
+                    GateOutcome::Deny(reason) if reason.contains("sensitive credential")
+                ),
+                "skill-local credentials must still be sensitive in Auto mode: {read_decision:?}"
+            );
+
+            let write_args = serde_json::json!({"path": path, "content": "SECRET=x\n"});
+            let write_decision = pm.check_nonblocking("write_file", &write_args);
+            assert!(
+                matches!(
+                    &write_decision,
+                    GateOutcome::Deny(reason) if reason.contains("sensitive credential")
+                ),
+                "skill-local credential writes must still be sensitive in Auto mode: {write_decision:?}"
+            );
+        }
     }
 
     #[test]
@@ -7927,6 +8053,7 @@ mod tests {
         let all_modes = [
             PermissionMode::Prompt,
             PermissionMode::Auto,
+            PermissionMode::Bypass,
             PermissionMode::Plan,
             PermissionMode::AcceptEdits,
             PermissionMode::Deny,
@@ -7953,6 +8080,8 @@ mod tests {
         assert_eq!(mirror.current(), PermissionMode::Plan);
         pm.set_mode(PermissionMode::Auto);
         assert_eq!(mirror.current(), PermissionMode::Auto);
+        pm.set_mode(PermissionMode::Bypass);
+        assert_eq!(mirror.current(), PermissionMode::Bypass);
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/cli/session/session_runtime.rs
+++ b/rust/crates/astra-cli/src/cli/session/session_runtime.rs
@@ -738,7 +738,7 @@ pub(crate) fn initialize_session_state(
     state.perm_manager = match cli_context.permission_mode.as_deref() {
         Some(mode) => PermissionManager::with_workspace_trust_mode(
             mode.parse::<PermissionMode>()
-                .unwrap_or(PermissionMode::Prompt),
+                .unwrap_or_else(|err| panic!("invalid permission mode in CliContext: {err}")),
             &project_root,
         ),
         None => PermissionManager::with_workspace_trust(cli_context.auto_approve, &project_root),

--- a/rust/crates/astra-cli/src/cli/session/session_startup.rs
+++ b/rust/crates/astra-cli/src/cli/session/session_startup.rs
@@ -675,7 +675,12 @@ pub(crate) async fn complete_session_startup(
     if state.perm_manager.mode() == permission_manager::PermissionMode::Auto {
         eprintln!(
             "{}",
-            "  🔓 Auto-approve is ON — tools execute without confirmation.".dim()
+            "  🔓 Auto mode is ON — normal tool risk is auto-approved; hard prompts may still appear.".dim()
+        );
+    } else if state.perm_manager.mode() == permission_manager::PermissionMode::Bypass {
+        eprintln!(
+            "{}",
+            "  🔓 Bypass mode is ON — approval prompts are skipped; hard denies still apply.".dim()
         );
     }
 

--- a/rust/crates/astra-cli/src/cli/session/session_startup.rs
+++ b/rust/crates/astra-cli/src/cli/session/session_startup.rs
@@ -675,12 +675,12 @@ pub(crate) async fn complete_session_startup(
     if state.perm_manager.mode() == permission_manager::PermissionMode::Auto {
         eprintln!(
             "{}",
-            "  🔓 Auto mode is ON — normal tool risk is auto-approved; hard prompts may still appear.".dim()
+            "  🔓 Auto mode is ON — normal tool risk is auto-approved; some git/sensitive gates may still stop.".dim()
         );
     } else if state.perm_manager.mode() == permission_manager::PermissionMode::Bypass {
         eprintln!(
             "{}",
-            "  🔓 Bypass mode is ON — approval prompts are skipped; hard denies still apply.".dim()
+            "  🔓 Bypass mode is ON — approval prompts are skipped; catastrophic and policy hard-denies still apply.".dim()
         );
     }
 

--- a/rust/crates/astra-cli/src/cli/slash/slash_skill.rs
+++ b/rust/crates/astra-cli/src/cli/slash/slash_skill.rs
@@ -618,7 +618,7 @@ Follow these steps:
                         eprintln!(
                             "{}",
                             format!(
-                                "  \u{2717} Skill directory not found for '{name}' (searched .astra/skills, skills/, ~/.astra/skills)"
+                                "  \u{2717} Skill directory not found for '{name}' (searched .astra/skills, .claude/skills, skills/, ~/.astra/skills, ~/.claude/skills)"
                             )
                             .yellow()
                         );
@@ -723,7 +723,8 @@ Follow these steps:
                 }
                 return Ok(());
             }
-            // Search all skill paths (project .astra/skills/, skills/, ~/.astra/skills/)
+            // Search all shared loader paths: project .astra/.claude skills,
+            // cwd skills/, and user-level .astra/.claude skills.
             let search_paths = crate::skill_instructions::skill_search_paths();
             let found = search_paths.iter().find_map(|base| {
                 let dir = base.join(name);
@@ -829,14 +830,14 @@ Follow these steps:
             if !api_ok {
                 eprintln!(
                     "  {}",
-                    "Local view: unified catalog + on-disk paths (.astra/skills, skills/, ~/.astra/skills)."
+                    "Local view: unified catalog + on-disk paths (.astra/skills, .claude/skills, skills/, ~/.astra/skills, ~/.claude/skills)."
                         .dim()
                 );
                 let registry = &state.unified_skill_registry;
                 let mut manifests = registry.all_manifests();
                 if manifests.is_empty() {
                     eprintln!("  {}", "No skills discovered in catalog.".dim());
-                    eprintln!("  {}", "Use /skill new <name> to create one, or add SKILL.md files to .astra/skills/.".dim());
+                    eprintln!("  {}", "Use /skill new <name> to create one, or add SKILL.md files to .astra/skills/ or .claude/skills/.".dim());
                     eprintln!();
                     return Ok(());
                 }
@@ -1315,7 +1316,8 @@ fn parse_skill_info_args(sub_arg: &str) -> (String, bool) {
     (s.to_string(), false)
 }
 
-/// Same resolution order as `/skill dev`: `.astra/skills`, `skills/`, `~/.astra/skills`.
+/// Same resolution order as `/skill dev`: shared loader paths for project,
+/// legacy cwd, and user-level skills.
 fn resolve_skill_dir_on_disk(name: &str) -> Option<std::path::PathBuf> {
     crate::skill_instructions::skill_search_paths()
         .into_iter()

--- a/rust/crates/astra-cli/src/cli/spawn_subrun.rs
+++ b/rust/crates/astra-cli/src/cli/spawn_subrun.rs
@@ -800,6 +800,7 @@ impl SpawnAgentExecutor for CliSpawnAgentExecutor {
         let telemetry = ctx_guard.telemetry();
         let mode = match ctx_guard.mode() {
             astra_runtime::orchestration::PermissionMode::Auto => "auto".to_string(),
+            astra_runtime::orchestration::PermissionMode::Bypass => "bypass".to_string(),
             astra_runtime::orchestration::PermissionMode::Plan => "plan".to_string(),
             astra_runtime::orchestration::PermissionMode::AcceptEdits => "accept_edits".to_string(),
             astra_runtime::orchestration::PermissionMode::Prompt => "prompt".to_string(),

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -2887,7 +2887,15 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                 self.render.tool_done(idx, tool, args, status, 0, &body);
             }
             return self
-                .finish_edge_tool(request_id, tool, args, body, status.to_string(), 0)
+                .finish_edge_tool_with_fields(
+                    request_id,
+                    tool,
+                    args,
+                    body,
+                    Some(crate::edge_tools::noop_or_cached_tool_result_fields()),
+                    status.to_string(),
+                    0,
+                )
                 .await;
         }
 
@@ -2900,7 +2908,15 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                     .tool_done(idx, tool, args, &cached_status, 0, &cached_output);
             }
             return self
-                .finish_edge_tool(request_id, tool, args, cached_output, cached_status, 0)
+                .finish_edge_tool_with_fields(
+                    request_id,
+                    tool,
+                    args,
+                    cached_output,
+                    Some(crate::edge_tools::noop_or_cached_tool_result_fields()),
+                    cached_status,
+                    0,
+                )
                 .await;
         }
 

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -2426,23 +2426,48 @@ impl CliSseStreamHost<'_> {
         } else {
             "Cloud approval required before this tool can run.".to_string()
         };
-        if tx
-            .send(chat_stream::ApprovalRequest::bare(
+        let approval_args = approval_args_from_cloud_detail(tool, detail);
+        let workspace_untrusted = self
+            .perm_manager
+            .as_ref()
+            .is_some_and(|pm| !pm.project_allow_rules_active());
+        let scope_ctx =
+            approval_scope_context_for_tool(tool, &approval_args, false, workspace_untrusted);
+        let always_scope = approval_default_always_scope(&scope_ctx);
+        let mut metadata = crate::tui::approval::queue::ApprovalMetadata::default();
+        metadata.request_key = Some(
+            astra_turn_core::approval_request_key::ApprovalRequestKey::new(
                 tool.to_string(),
-                header,
-                display_label.or(detail).map(ToString::to_string),
-                reason,
-                // Cloud approvals are launched without structured
-                // args in scope (the cloud server already validated
-                // the call). Re-evaluation after a mode pivot will
-                // see Value::Null and fall through unchanged, which
-                // is correct: cloud approvals are bound to the
-                // cloud's own gate, not the local mode.
-                serde_json::Value::Null,
-                resp_tx,
-            ))
-            .is_err()
-        {
+                std::env::current_dir().unwrap_or_default(),
+                &approval_args,
+                None,
+                uuid::Uuid::nil(),
+            ),
+        );
+        metadata.risk_tags = scope_ctx.risk_tags.clone();
+        metadata.workspace_untrusted = scope_ctx.workspace_untrusted;
+        metadata.is_compound_command = scope_ctx.is_compound_command;
+        metadata.has_dynamic_eval = scope_ctx.has_dynamic_eval;
+        metadata.unsafe_rule_shape = scope_ctx.unsafe_rule_shape;
+        metadata.batch_group_key = Some(approval_batch_group_key(
+            tool,
+            &approval_args,
+            &metadata.risk_tags,
+        ));
+        if always_scope == astra_turn_core::permission::scope::AllowScope::Project {
+            metadata.remember_preview = Some(approval_memory_preview(tool, &approval_args, None));
+        }
+
+        let mut request = chat_stream::ApprovalRequest::bare(
+            tool.to_string(),
+            header,
+            display_label.or(detail).map(ToString::to_string),
+            reason,
+            approval_args.clone(),
+            resp_tx,
+        );
+        request.metadata = Some(Box::new(metadata));
+        if tx.send(request).is_err() {
             astra_core::agent_warn!(
                 "permission",
                 "Auto-denied cloud approval for {tool}: TUI approval sink is closed"
@@ -2460,19 +2485,8 @@ impl CliSseStreamHost<'_> {
             resp_rx.await.unwrap_or(ApprovalResponse::Deny)
         };
 
-        let explicit = matches!(approval_kind, astra_thin_client::ApprovalKind::Explicit);
-        let approval_args = approval_args_from_cloud_detail(tool, detail);
-        let always_scope = approval_default_always_scope(&approval_scope_context_for_tool(
-            tool,
-            &approval_args,
-            false,
-            false,
-        ));
         match response {
             ApprovalResponse::AllowOnce => ApprovalDecision::Allow,
-            // Explicit cloud approvals are confirm-once by contract,
-            // so treat Always as AllowOnce for this prompt kind.
-            ApprovalResponse::AlwaysAllow if explicit => ApprovalDecision::Allow,
             ApprovalResponse::AlwaysAllow => {
                 let action = approval_memory_action(&response, always_scope, true);
                 let save_warning_tx = self.stream_event_tx.clone();
@@ -7281,6 +7295,11 @@ mod tests {
             );
             let responder = async {
                 let request = approval_rx.recv().await.expect("approval request");
+                assert_eq!(
+                    request.args["path"].as_str(),
+                    Some("src/main.rs"),
+                    "cloud approval card should carry command args for re-evaluation"
+                );
                 request
                     .response_tx
                     .send(chat_stream::ApprovalResponse::AlwaysAllow)
@@ -7346,6 +7365,18 @@ mod tests {
             );
             let responder = async {
                 let request = approval_rx.recv().await.expect("approval request");
+                assert_eq!(
+                    request.args["path"].as_str(),
+                    Some(".env"),
+                    "cloud approval card should carry command args for re-evaluation"
+                );
+                let metadata = request.metadata.as_ref().expect("approval metadata");
+                assert!(
+                    metadata.risk_tags.contains(
+                        &astra_turn_core::permission::engine::RiskTag::WritesSensitiveFile
+                    ),
+                    "cloud approval card should carry sensitive-path risk metadata"
+                );
                 request
                     .response_tx
                     .send(chat_stream::ApprovalResponse::AlwaysAllow)
@@ -7368,6 +7399,99 @@ mod tests {
             reloaded.check_nonblocking("write_file", &args),
             crate::cli::permission_manager::GateOutcome::NeedApproval { .. }
         ));
+    }
+
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn explicit_cloud_approval_always_git_destructive_is_session_only() {
+        let server = MockServer::start().await;
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).expect("thin client");
+        let temp = tempdir().expect("tempdir");
+        let executor = std::sync::Arc::new(crate::edge_tools::ToolExecutor::new(temp.path()));
+        let mut tool_cache = EdgeToolCache::new(8);
+        let mut pm =
+            crate::cli::permission_manager::PermissionManager::with_project(false, temp.path());
+        let (approval_tx, mut approval_rx) =
+            tokio::sync::mpsc::unbounded_channel::<chat_stream::ApprovalRequest>();
+        let command = "git restore --staged --worktree rust/crates/foo/src/lib.rs";
+
+        let decision = {
+            let mut host = CliSseStreamHost::from_edge_ctx(
+                EdgeSseContext {
+                    api: &api,
+                    token: "tok",
+                    executor_id: "edge-test",
+                    executor,
+                    render_policy: RenderPolicy::Stream,
+                    perm_manager: Some(&mut pm),
+                    cancel_token: None,
+                    stream_event_tx: None,
+                    stream_event_sink: None,
+                    approval_request_tx: Some(approval_tx),
+                    ask_user_request_tx: None,
+                    skill_resolver: None,
+                    skill_continuation: false,
+                    turn_rollback_on_failure: false,
+                    tool_cache: &mut tool_cache,
+                    observability_hub: None,
+                    incremental_state: None,
+                },
+                80,
+                false,
+            );
+            let decision_fut = host.resolve_cloud_approval_via_tui(
+                "bash",
+                Some(command),
+                None,
+                astra_thin_client::ApprovalKind::Explicit,
+            );
+            let responder = async {
+                let request = approval_rx.recv().await.expect("approval request");
+                assert_eq!(
+                    request.args["command"].as_str(),
+                    Some(command),
+                    "cloud approval card should carry command args for re-evaluation"
+                );
+                let metadata = request.metadata.as_ref().expect("approval metadata");
+                assert!(
+                    metadata
+                        .risk_tags
+                        .contains(&astra_turn_core::permission::engine::RiskTag::GitDestructive),
+                    "cloud approval card should carry git-destructive risk metadata"
+                );
+                request
+                    .response_tx
+                    .send(chat_stream::ApprovalResponse::AlwaysAllow)
+                    .expect("send response");
+            };
+            let (decision, ()) = tokio::join!(decision_fut, responder);
+            decision
+        };
+
+        assert_eq!(decision, astra_thin_client::ApprovalDecision::AllowSession);
+        assert_eq!(
+            pm.preflight_cloud_approval_decision(
+                "bash",
+                Some(command),
+                astra_thin_client::ApprovalKind::Explicit,
+                false,
+            ),
+            Some(astra_thin_client::ApprovalDecision::Allow),
+            "same-session explicit git Always should avoid re-prompting"
+        );
+
+        let mut reloaded =
+            crate::cli::permission_manager::PermissionManager::with_project(false, temp.path());
+        assert_eq!(
+            reloaded.preflight_cloud_approval_decision(
+                "bash",
+                Some(command),
+                astra_thin_client::ApprovalKind::Explicit,
+                false,
+            ),
+            None,
+            "explicit git Always must not persist across restarts"
+        );
     }
 
     #[serial_test::serial]

--- a/rust/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/rust/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -176,15 +176,6 @@ fn approval_batch_group_key(
     )
 }
 
-fn push_risk_tag(
-    tags: &mut Vec<astra_turn_core::permission::engine::RiskTag>,
-    tag: astra_turn_core::permission::engine::RiskTag,
-) {
-    if !tags.contains(&tag) {
-        tags.push(tag);
-    }
-}
-
 fn approval_args_from_cloud_detail(tool: &str, detail: Option<&str>) -> Value {
     match (
         astra_turn_core::cloud_approval_policy::cloud_gated_tool_kind(tool),
@@ -206,70 +197,13 @@ fn approval_scope_context_for_tool(
     source_agent_present: bool,
     workspace_untrusted: bool,
 ) -> astra_turn_core::permission::scope::ScopeAvailabilityContext {
-    use astra_turn_core::permission::engine::RiskTag;
-    use astra_turn_core::permission::memory_profile::{
-        PersistentMemoryBlock, permission_memory_profile,
-    };
-
-    let mut ctx = astra_turn_core::permission::scope::ScopeAvailabilityContext {
+    astra_turn_core::permission::scope::scope_context_for_tool_request(
+        tool,
+        args,
+        astra_turn_core::permission::engine::risk_tags_for_request(tool, args),
         source_agent_present,
         workspace_untrusted,
-        ..Default::default()
-    };
-    let memory_profile = permission_memory_profile(tool, args);
-    ctx.unsafe_rule_shape = !memory_profile.has_stable_target
-        || matches!(
-            memory_profile.persistent_block,
-            Some(PersistentMemoryBlock::UnsafeRuleShape)
-        );
-
-    let base_tag = match astra_turn_core::cloud_approval_policy::cloud_gated_tool_kind_with_args(
-        tool,
-        Some(args),
-    ) {
-        Some(astra_turn_core::cloud_approval_policy::CloudGatedToolKind::Execute) => {
-            RiskTag::BashExecute
-        }
-        Some(astra_turn_core::cloud_approval_policy::CloudGatedToolKind::Write) => {
-            RiskTag::WritesOutsidePackage
-        }
-        _ => RiskTag::BashExecute,
-    };
-    push_risk_tag(&mut ctx.risk_tags, base_tag);
-
-    if let Some(path) = args.get("path").and_then(|v| v.as_str())
-        && astra_turn_core::permission::redact::matches_sensitive_path(path)
-    {
-        push_risk_tag(&mut ctx.risk_tags, RiskTag::WritesSensitiveFile);
-    }
-
-    if matches!(tool, "bash" | "powershell")
-        && let Some(cmd) = args.get("command").and_then(|v| v.as_str())
-    {
-        ctx.is_compound_command = matches!(
-            memory_profile.persistent_block,
-            Some(PersistentMemoryBlock::CompoundCommand)
-        );
-        ctx.has_dynamic_eval = matches!(
-            memory_profile.persistent_block,
-            Some(PersistentMemoryBlock::DynamicEval)
-        );
-
-        if tool == "bash" && !astra_runtime::tool_sandbox::validate_git_command(cmd).is_empty() {
-            push_risk_tag(&mut ctx.risk_tags, RiskTag::GitDestructive);
-        }
-    }
-
-    // Issue #326 P5 / R2 Major 5: MCP tools without a registered
-    // ToolCapabilityMetadata default to MCPUnknownCapability. The
-    // server-annotation lookup (slash_mcp's ToolAnnotations →
-    // ApprovalMetadata) can clear this once it is wired.
-    if tool.starts_with("mcp_") {
-        ctx.mcp_unknown_capability = true;
-        push_risk_tag(&mut ctx.risk_tags, RiskTag::MCPUnknownCapability);
-    }
-
-    ctx
+    )
 }
 
 fn approval_has_stable_memory_target(tool: &str, args: &Value) -> bool {
@@ -280,26 +214,7 @@ fn approval_has_stable_memory_target(tool: &str, args: &Value) -> bool {
 fn approval_default_always_scope(
     ctx: &astra_turn_core::permission::scope::ScopeAvailabilityContext,
 ) -> astra_turn_core::permission::scope::AllowScope {
-    use astra_turn_core::permission::scope::{AllowScope, permitted_scopes};
-
-    let scopes = permitted_scopes(ctx);
-    let is_available = |target| {
-        scopes
-            .iter()
-            .any(|entry| entry.scope == target && entry.available)
-    };
-
-    if is_available(AllowScope::Project) {
-        return AllowScope::Project;
-    }
-    if is_available(AllowScope::RestOfSession) {
-        return AllowScope::RestOfSession;
-    }
-    if is_available(AllowScope::RestOfTurn) {
-        return AllowScope::RestOfTurn;
-    }
-
-    AllowScope::OnceThisCall
+    astra_turn_core::permission::scope::default_always_scope(ctx)
 }
 
 fn approval_memory_preview(tool: &str, args: &Value, scope_label: Option<&str>) -> String {

--- a/rust/crates/astra-cli/src/cli/turn/turn_commit.rs
+++ b/rust/crates/astra-cli/src/cli/turn/turn_commit.rs
@@ -496,7 +496,7 @@ mod tests {
         assert_eq!(event.turn, Some(1));
         let metadata = event.metadata.as_ref().expect("turn evaluation metadata");
         assert_eq!(metadata["source"], "cli_repl");
-        assert_eq!(metadata["live_query"], true);
+        assert_eq!(metadata["live_query"], false);
         assert_eq!(metadata["success"], true);
         assert_eq!(metadata["tool_call_count"], 1);
         assert_eq!(metadata["signal_count"], 2);

--- a/rust/crates/astra-cli/src/cli/turn/turn_success.rs
+++ b/rust/crates/astra-cli/src/cli/turn/turn_success.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use astra_turn_core::chat_turn_heuristics::looks_like_live_query_with_context;
 use astra_turn_core::conversation_log::manager::CslManager;
 
 use super::turn_commit::TurnCommitOutcome;
@@ -329,16 +328,6 @@ fn apply_turn_success_sync(
             eprintln!(
                 "{}",
                 format!("  💡 Next prompt: {}  (Tab to accept)", suggestion.text).dim()
-            );
-        }
-
-        if result.tool_calls_count == 0
-            && looks_like_live_query_with_context(line, &state.recent_tools)
-        {
-            eprintln!(
-                "{}",
-                "  ⚠ Warning: This answer was generated without tool calls. Data may be hallucinated."
-                    .yellow()
             );
         }
     }

--- a/rust/crates/astra-cli/src/edge_tools.rs
+++ b/rust/crates/astra-cli/src/edge_tools.rs
@@ -441,6 +441,13 @@ fn cli_tool_output_is_error(output: &str) -> bool {
 
 pub(crate) use astra_tools::git_gix::ToolExecutionOutcome;
 
+pub(crate) fn noop_or_cached_tool_result_fields() -> serde_json::Map<String, Value> {
+    serde_json::Map::from_iter([(
+        "result_class".to_string(),
+        Value::String(astra_services::session_journal::NOOP_OR_CACHED_RESULT_CLASS.to_string()),
+    )])
+}
+
 fn sandbox_denied_outcome_from_output(output: &str) -> Option<ToolExecutionOutcome> {
     let message = crate::sandbox_retry::sandbox_denied_message(output)?.into_owned();
     Some(ToolExecutionOutcome {
@@ -466,6 +473,7 @@ fn tool_execution_outcome_from_output(output: String) -> ToolExecutionOutcome {
 struct EdgeToolRun {
     output: String,
     error_kind: Option<astra_core::ErrorKind>,
+    tool_result_fields: Option<serde_json::Map<String, Value>>,
 }
 
 impl EdgeToolRun {
@@ -473,6 +481,7 @@ impl EdgeToolRun {
         Self {
             output,
             error_kind: None,
+            tool_result_fields: None,
         }
     }
 
@@ -480,6 +489,7 @@ impl EdgeToolRun {
         Self {
             output,
             error_kind: None,
+            tool_result_fields: None,
         }
     }
 
@@ -487,7 +497,13 @@ impl EdgeToolRun {
         Self {
             output,
             error_kind: Some(kind),
+            tool_result_fields: None,
         }
+    }
+
+    fn with_tool_result_fields(mut self, fields: Option<serde_json::Map<String, Value>>) -> Self {
+        self.tool_result_fields = fields;
+        self
     }
 
     fn into_outcome(self) -> ToolExecutionOutcome {
@@ -495,12 +511,24 @@ impl EdgeToolRun {
             return outcome;
         }
 
-        let mut outcome = if self.error_kind.is_some() || cli_tool_output_is_error(&self.output) {
-            ToolExecutionOutcome::error(self.output)
+        let EdgeToolRun {
+            output,
+            error_kind,
+            tool_result_fields,
+        } = self;
+
+        let mut outcome = if error_kind.is_some() || cli_tool_output_is_error(&output) {
+            ToolExecutionOutcome::error(output)
         } else {
-            ToolExecutionOutcome::ok(self.output)
+            ToolExecutionOutcome::ok(output)
         };
-        if let Some(kind) = self.error_kind {
+        if let Some(fields) = tool_result_fields {
+            let metadata = outcome
+                .tool_result_fields
+                .get_or_insert_with(serde_json::Map::new);
+            metadata.extend(fields);
+        }
+        if let Some(kind) = error_kind {
             let metadata = outcome
                 .tool_result_fields
                 .get_or_insert_with(serde_json::Map::new);
@@ -4375,20 +4403,29 @@ impl ToolExecutor {
         if let Some(error) = self.tool_admission_denial(name, args) {
             return error;
         }
-        let output = self.execute_raw(name, args).await;
+        let mut tool_result_fields = None;
+        let output = self.execute_raw(name, args, &mut tool_result_fields).await;
         // Structural error propagation: `execute_raw` returns a plain String,
         // discarding any structured error kind at the source. Recover it here
         // so downstream `tool_work_surface_events` can route on `error_kind`
         // metadata instead of re-deriving it from fragile string matching.
-        if cli_tool_output_is_error(&output) {
+        let is_error = cli_tool_output_is_error(&output);
+        let tool_result_fields = if is_error { None } else { tool_result_fields };
+        if is_error {
             let kind = astra_core::classify_tool_output(&output);
             EdgeToolRun::classified_error(output, kind)
         } else {
             EdgeToolRun::ok(output)
         }
+        .with_tool_result_fields(tool_result_fields)
     }
 
-    async fn execute_raw(&self, name: &str, args: &Value) -> String {
+    async fn execute_raw(
+        &self,
+        name: &str,
+        args: &Value,
+        tool_result_fields: &mut Option<serde_json::Map<String, Value>>,
+    ) -> String {
         let output = if let Err(error) =
             crate::tool_safety_guard::ToolSafetyGuard::check_dispatch(name, args)
         {
@@ -4415,7 +4452,11 @@ impl ToolExecutor {
                     self.record_tool_search_activation_output(&output);
                     output
                 }
-                "read_file" => self.read_file(args),
+                "read_file" => {
+                    let (output, fields) = self.read_file_with_metadata(args);
+                    *tool_result_fields = fields;
+                    output
+                }
                 "write_file" => {
                     // delete=true routes to delete_file handler
                     if args.get("delete").and_then(Value::as_bool).unwrap_or(false) {

--- a/rust/crates/astra-cli/src/edge_tools/fs.rs
+++ b/rust/crates/astra-cli/src/edge_tools/fs.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 
 use super::{
     AGGREGATE_OUTPUT_BUDGET, AGGREGATE_SOFT_LIMIT, ReadCoverage, ReadDedupKey,
-    SANDBOX_DENIED_PREFIX, ToolExecutor, code_intel, fuzzy_replacer, tool_output_limit,
-    truncate_output,
+    SANDBOX_DENIED_PREFIX, ToolExecutor, code_intel, fuzzy_replacer,
+    noop_or_cached_tool_result_fields, tool_output_limit, truncate_output,
 };
 use astra_runtime::tool_sandbox::validate_path;
 use astra_sandbox::is_internal_safe_path;
@@ -30,6 +30,39 @@ fn expand_home_path_arg(path: &str) -> Option<PathBuf> {
         .or_else(|| path.strip_prefix("$HOME/"))
         .or_else(|| path.strip_prefix("${HOME}/"))
         .map(|suffix| home.join(suffix))
+}
+
+fn is_blocked_device_read_path(path_str_lower: &str) -> bool {
+    const BLOCKED_DEVICE_PATHS: &[&str] = &[
+        "/dev/zero",
+        "/dev/random",
+        "/dev/urandom",
+        "/dev/full",
+        "/dev/stdin",
+        "/dev/tty",
+        "/dev/console",
+        "/dev/stdout",
+        "/dev/stderr",
+        "/dev/null",
+    ];
+    BLOCKED_DEVICE_PATHS
+        .iter()
+        .any(|blocked| path_str_lower.starts_with(blocked))
+        || (path_str_lower.starts_with("/proc/") && path_str_lower.contains("/fd/"))
+}
+
+fn is_read_file_image_extension(ext_lower: &str) -> bool {
+    const IMAGE_EXTS: &[&str] = &["png", "jpg", "jpeg", "gif", "bmp", "webp"];
+    IMAGE_EXTS.contains(&ext_lower)
+}
+
+fn is_read_file_binary_extension(ext_lower: &str) -> bool {
+    const BINARY_EXTS: &[&str] = &[
+        "svg", "pdf", "zip", "gz", "tar", "bz2", "xz", "7z", "rar", "exe", "dll", "so", "dylib",
+        "o", "a", "lib", "wasm", "class", "pyc", "pyo", "mp3", "mp4", "avi", "mov", "wav", "flac",
+        "ogg", "ttf", "otf", "woff", "woff2", "eot", "sqlite", "db", "mdb", "ico",
+    ];
+    BINARY_EXTS.contains(&ext_lower)
 }
 
 /// Append the stable [`TOOL_SUCCESS_SENTINEL`] to a human-readable success body.
@@ -183,6 +216,23 @@ impl ToolExecutor {
     }
 
     pub(crate) fn read_file(&self, args: &Value) -> String {
+        self.read_file_with_metadata(args).0
+    }
+
+    pub(crate) fn read_file_with_metadata(
+        &self,
+        args: &Value,
+    ) -> (String, Option<serde_json::Map<String, Value>>) {
+        let mut tool_result_fields = None;
+        let output = self.read_file_impl(args, &mut tool_result_fields);
+        (output, tool_result_fields)
+    }
+
+    fn read_file_impl(
+        &self,
+        args: &Value,
+        tool_result_fields: &mut Option<serde_json::Map<String, Value>>,
+    ) -> String {
         let args = convert_read_file_args(args);
         if let Err(error) = validate_read_file_args(&args) {
             return error;
@@ -202,28 +252,11 @@ impl ToolExecutor {
         // Device file blocking — prevent hangs on infinite/blocking device files
         {
             let path_str_lower = path.to_string_lossy().to_lowercase();
-            const BLOCKED_DEVICE_PATHS: &[&str] = &[
-                "/dev/zero",
-                "/dev/random",
-                "/dev/urandom",
-                "/dev/full",
-                "/dev/stdin",
-                "/dev/tty",
-                "/dev/console",
-                "/dev/stdout",
-                "/dev/stderr",
-                "/dev/null",
-            ];
-            for blocked in BLOCKED_DEVICE_PATHS {
-                if path_str_lower.starts_with(blocked) {
-                    return format!(
-                        "Error: refusing to read device file '{}' (would block or produce infinite output)",
-                        blocked
-                    );
-                }
-            }
-            if path_str_lower.starts_with("/proc/") && path_str_lower.contains("/fd/") {
-                return "Error: refusing to read /proc fd paths (would block)".to_string();
+            if is_blocked_device_read_path(&path_str_lower) {
+                return format!(
+                    "Error: refusing to read device file '{}' (would block or produce infinite output)",
+                    path.display()
+                );
             }
         }
 
@@ -232,8 +265,7 @@ impl ToolExecutor {
             let ext_lower = ext.to_lowercase();
 
             // Image files: return base64 for vision models
-            const IMAGE_EXTS: &[&str] = &["png", "jpg", "jpeg", "gif", "bmp", "webp"];
-            if IMAGE_EXTS.contains(&ext_lower.as_str()) {
+            if is_read_file_image_extension(&ext_lower) {
                 // Check file size before reading — base64 inflates by ~33%
                 if let Ok(meta) = fs::metadata(&path)
                     && meta.len() > 1_500_000
@@ -263,13 +295,7 @@ impl ToolExecutor {
             }
 
             // Other binary files: block
-            const BINARY_EXTS: &[&str] = &[
-                "svg", "pdf", "zip", "gz", "tar", "bz2", "xz", "7z", "rar", "exe", "dll", "so",
-                "dylib", "o", "a", "lib", "wasm", "class", "pyc", "pyo", "mp3", "mp4", "avi",
-                "mov", "wav", "flac", "ogg", "ttf", "otf", "woff", "woff2", "eot", "sqlite", "db",
-                "mdb", "ico",
-            ];
-            if BINARY_EXTS.contains(&ext_lower.as_str()) {
+            if is_read_file_binary_extension(&ext_lower) {
                 return format!(
                     "Error: refusing to read binary file (.{ext}). Use bash with appropriate tools (e.g. file, xxd, strings) for binary analysis."
                 );
@@ -297,6 +323,7 @@ impl ToolExecutor {
 
         // Consecutive identical outline/range request + unchanged file → stub before I/O.
         if !is_internal_artifact_read && self.can_dedup_identical_partial_read(&path, &dedup_key) {
+            *tool_result_fields = Some(noop_or_cached_tool_result_fields());
             return format!(
                 "[Same read_file request as immediately before — file unchanged. \
                  Refer to the earlier read_file result for {path_str}.]"
@@ -311,6 +338,7 @@ impl ToolExecutor {
             let s = start_raw.unwrap_or(1);
             let e = end_raw.unwrap_or(u64::MAX);
             if !is_internal_artifact_read && self.is_range_already_read(&path, s, e) {
+                *tool_result_fields = Some(noop_or_cached_tool_result_fields());
                 return format!(
                     "[Lines {s}–{e} of {path_str} were already read in earlier requests \
                      and the file is unchanged. Refer to those earlier read_file results \
@@ -556,6 +584,7 @@ impl ToolExecutor {
         // changed, return a stub. Later turns may need the content again after
         // prompt compaction, so cross-turn reads still return the file body.
         if !is_internal_artifact_read && self.can_dedup_read(&path) {
+            *tool_result_fields = Some(noop_or_cached_tool_result_fields());
             let msg = if is_ranged {
                 format!(
                     "[File already fully read earlier in this turn and unchanged — \

--- a/rust/crates/astra-cli/src/edge_tools/shell.rs
+++ b/rust/crates/astra-cli/src/edge_tools/shell.rs
@@ -5869,7 +5869,7 @@ mod tests {
         assert!(err.contains("sensitive credential path"), "{err}");
         assert!(
             !err.starts_with(super::SANDBOX_DENIED_PREFIX),
-            "sensitive paths are bypass-immune, not expandable sandbox boundaries: {err}"
+            "sensitive paths are absolute safety guards, not expandable sandbox boundaries: {err}"
         );
     }
 

--- a/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
+++ b/rust/crates/astra-cli/src/edge_tools/tests/executor_core_tests.rs
@@ -272,6 +272,55 @@ async fn execute_with_metadata_bash_empty_result_is_structured_non_error() {
     );
 }
 
+#[tokio::test]
+async fn execute_with_metadata_read_file_reuse_is_structured_noop_or_cached() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("lib.rs"), "fn a() {}\nfn b() {}\n").unwrap();
+    let executor = ToolExecutor::new(temp.path().to_path_buf());
+    let args = json!({"path": "lib.rs", "start_line": 1, "end_line": 1});
+
+    let first = executor.execute_with_metadata("read_file", &args).await;
+    assert!(!first.is_error, "{first:?}");
+    assert!(
+        first
+            .tool_result_fields
+            .as_ref()
+            .and_then(|fields| fields.get("result_class"))
+            .is_none(),
+        "fresh read must not be classified as cached/noop: {first:?}"
+    );
+
+    let second = executor.execute_with_metadata("read_file", &args).await;
+    assert!(!second.is_error, "{second:?}");
+    let fields = second.tool_result_fields.expect("metadata fields");
+    assert_eq!(
+        fields
+            .get("result_class")
+            .and_then(serde_json::Value::as_str),
+        Some(session_journal::NOOP_OR_CACHED_RESULT_CLASS)
+    );
+}
+
+#[tokio::test]
+async fn execute_with_metadata_read_file_error_is_not_structured_noop_or_cached() {
+    let temp = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(temp.path().to_path_buf());
+    let outcome = executor
+        .execute_with_metadata("read_file", &json!({"path": "missing.rs"}))
+        .await;
+
+    assert!(outcome.is_error, "{outcome:?}");
+    assert_ne!(
+        outcome
+            .tool_result_fields
+            .as_ref()
+            .and_then(|fields| fields.get("result_class"))
+            .and_then(serde_json::Value::as_str),
+        Some(session_journal::NOOP_OR_CACHED_RESULT_CLASS),
+        "read_file errors must not be classified as cached/noop: {outcome:?}"
+    );
+}
+
 /// REGRESSION: the consolidated `agent` tool must reject the blocked
 /// delegate action instead of returning a successful placeholder.
 ///

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -2119,7 +2119,7 @@ total_tokens_out: 500
 
     #[test]
     fn permission_mode_roundtrip_parse() {
-        for mode_str in &["auto", "accept_edits", "plan", "prompt", "deny"] {
+        for mode_str in &["auto", "bypass", "accept_edits", "plan", "prompt", "deny"] {
             let mode: permission_manager::PermissionMode = mode_str.parse().unwrap();
             assert_eq!(mode.to_string().to_lowercase(), *mode_str);
         }

--- a/rust/crates/astra-cli/src/main.rs
+++ b/rust/crates/astra-cli/src/main.rs
@@ -2126,7 +2126,7 @@ total_tokens_out: 500
     }
 
     #[test]
-    fn session_state_cli_context_auto_approve_activates_auto_mode() {
+    fn session_state_cli_context_auto_approve_activates_bypass_mode() {
         let state = initialize_session_state(
             None,
             None,
@@ -2144,8 +2144,27 @@ total_tokens_out: 500
         );
         assert_eq!(
             state.perm_manager.mode(),
-            permission_manager::PermissionMode::Auto
+            permission_manager::PermissionMode::Bypass
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid permission mode in CliContext")]
+    fn session_state_invalid_permission_mode_does_not_fallback_to_prompt() {
+        let context = cli::cli_config::cli_context::CliContext::from_launch_options(
+            false,
+            None,
+            &[],
+            &[],
+            &[],
+            false,
+            None,
+            None,
+        )
+        .expect("cli context")
+        .with_permission_mode(Some("bogus".into()));
+
+        let _ = initialize_session_state(None, None, &context);
     }
 
     #[test]

--- a/rust/crates/astra-cli/src/manifest_loader.rs
+++ b/rust/crates/astra-cli/src/manifest_loader.rs
@@ -435,10 +435,10 @@ pub fn register_manifest_tools(skills_dir: &Path, registry: &mut PluginRegistry)
 /// Best-effort skill loading from standard locations.
 ///
 /// Uses [`skill_instructions::skill_search_paths()`] for consistent directory
-/// resolution across the CLI:
-/// 1. `{cwd}/.astra/skills/`
-/// 2. `{cwd}/skills/`
-/// 3. `~/.astra/skills/`
+/// resolution across the CLI. That wrapper delegates to the shared
+/// `astra-skills` loader, so manifest tools and MCP configs see the same
+/// `.astra/skills`, Agent Skills-compatible `.claude/skills`, legacy
+/// `skills/`, and HOME global paths as the runtime skill registry.
 ///
 /// Silently skips if no skills directory exists.
 pub fn load_skills_directory(registry: &mut PluginRegistry) {

--- a/rust/crates/astra-cli/src/skill_instructions.rs
+++ b/rust/crates/astra-cli/src/skill_instructions.rs
@@ -28,9 +28,10 @@
 //!
 //! # Discovery Paths
 //!
-//! Skills are discovered from (highest priority first):
-//! 1. `{cwd}/.astra/skills/` — project-level
-//! 2. `~/.astra/skills/` — user-level global skills
+//! Skills are discovered with the shared `astra-skills` loader. That keeps
+//! legacy CLI manifest/MCP discovery aligned with the runtime skill registry:
+//! cwd walk-up `.astra/skills` and `.claude/skills`, cwd `skills/`, and user
+//! global `.astra/skills` / `.claude/skills`.
 //!
 //! # Three-Level Loading
 //!
@@ -38,30 +39,17 @@
 //! - **Level 2 (Instructions)**: Full SKILL.md content loaded on skill invocation
 //! - **Level 3 (Resources)**: Templates, scripts, references loaded on demand
 
-use std::path::PathBuf;
-
 use serde::{Deserialize, Serialize};
 
 // ── Skill Discovery Paths ─────────────────────────────────────────────────
 
 /// Standard skill directory search order (high → low priority):
 ///
-/// 1. `{cwd}/.astra/skills/`  — project-level
-/// 2. `~/.astra/skills/`      — user-level global skills
-pub fn skill_search_paths() -> Vec<PathBuf> {
-    let mut paths = Vec::with_capacity(2);
-
-    if let Ok(cwd) = std::env::current_dir() {
-        paths.push(cwd.join(".astra").join("skills"));
-    } else {
-        paths.push(PathBuf::from(".astra/skills"));
-    }
-
-    if let Some(home) = dirs::home_dir() {
-        paths.push(home.join(".astra").join("skills"));
-    }
-
-    paths
+/// Delegates to `astra_skills::loader::skill_search_paths()` so all CLI and
+/// runtime skill surfaces agree on `.astra/skills`, Agent Skills-compatible
+/// `.claude/skills`, legacy `skills/`, and HOME-level global paths.
+pub fn skill_search_paths() -> Vec<std::path::PathBuf> {
+    astra_skills::loader::skill_search_paths()
 }
 
 /// Skill instruction parsed from SKILL.md file.
@@ -196,12 +184,9 @@ mod tests {
     use super::skill_search_paths;
 
     #[test]
-    fn skill_search_paths_returns_non_empty() {
+    fn skill_search_paths_delegates_to_shared_loader() {
         let paths = skill_search_paths();
         assert!(!paths.is_empty());
-        // All paths end with .astra/skills
-        for p in &paths {
-            assert!(p.ends_with(".astra/skills"));
-        }
+        assert_eq!(paths, astra_skills::loader::skill_search_paths());
     }
 }

--- a/rust/crates/astra-cli/src/tests/cli_args_tests.rs
+++ b/rust/crates/astra-cli/src/tests/cli_args_tests.rs
@@ -419,6 +419,8 @@ fn cli_chat_subcommand() {
     // Permission modes
     for (input, expected) in [
         ("auto", "auto"),
+        ("bypass", "bypass"),
+        ("skip", "bypass"),
         ("accept_edits", "accept_edits"),
         ("plan", "plan"),
     ] {

--- a/rust/crates/astra-cli/src/tests/cli_args_tests.rs
+++ b/rust/crates/astra-cli/src/tests/cli_args_tests.rs
@@ -443,6 +443,7 @@ fn cli_permissions_subcommand() {
         ("accept_edits", |s| {
             matches!(s, PermissionsSubcommand::AcceptEdits)
         }),
+        ("bypass", |s| matches!(s, PermissionsSubcommand::Bypass)),
         ("plan", |s| matches!(s, PermissionsSubcommand::Plan)),
     ];
     for (mode, check) in cases {

--- a/rust/crates/astra-cli/src/tui/approval/queue.rs
+++ b/rust/crates/astra-cli/src/tui/approval/queue.rs
@@ -327,20 +327,6 @@ impl PendingApproval {
     }
 
     fn always_action_disabled(&self) -> bool {
-        use astra_turn_core::permission::engine::RiskTag;
-
-        if self.source_agent.is_some()
-            || self.is_compound_command
-            || self.has_dynamic_eval
-            || self.unsafe_rule_shape
-            || self.risk_tags.contains(&RiskTag::WritesSensitiveFile)
-            || self.risk_tags.contains(&RiskTag::WritesOutsideWorkspace)
-            || self.risk_tags.contains(&RiskTag::CredentialAccess)
-            || self.risk_tags.contains(&RiskTag::MCPUnknownCapability)
-        {
-            return true;
-        }
-
         [
             AllowScope::RestOfSession,
             AllowScope::Project,
@@ -505,17 +491,32 @@ impl ApprovalQueue {
     where
         F: FnMut(&PendingApproval) -> bool,
     {
+        self.drain_resolved(|entry| {
+            (!still_needs_approval(entry)).then_some(ApprovalResponse::AllowOnce)
+        })
+    }
+
+    /// Drain entries whose request is resolved by a policy change and send the
+    /// corresponding response to all waiters.
+    ///
+    /// Unlike [`drain_now_allowed`], this can resolve to Deny as well as Allow.
+    /// Mode-pivot re-evaluation must preserve that distinction: a request that
+    /// becomes a hard deny under the new mode must not be released as AllowOnce.
+    pub fn drain_resolved<F>(&mut self, mut resolve: F) -> usize
+    where
+        F: FnMut(&PendingApproval) -> Option<ApprovalResponse>,
+    {
         let mut released = 0usize;
         let mut idx = 0usize;
         while idx < self.entries.len() {
-            if still_needs_approval(&self.entries[idx]) {
+            let Some(response) = resolve(&self.entries[idx]) else {
                 idx += 1;
                 continue;
-            }
-            // Take this entry out and broadcast Allow to its waiters.
+            };
+            // Take this entry out and broadcast the policy response to its waiters.
             let mut entry = self.entries.remove(idx).expect("index in range");
             for tx in entry.response_txs.drain(..) {
-                let _ = tx.send(ApprovalResponse::AllowOnce);
+                let _ = tx.send(response.clone());
             }
             released += 1;
             // Don't advance idx: the next entry slid into this slot.
@@ -1385,6 +1386,38 @@ mod tests {
     }
 
     #[test]
+    fn focused_button_action_allows_always_for_sensitive_path_session_only() {
+        use astra_turn_core::permission::engine::RiskTag;
+
+        let mut q = ApprovalQueue::new();
+        let (tx, _rx) = oneshot::channel();
+        q.push_with_metadata(
+            "write_file".into(),
+            ".env".into(),
+            None,
+            "sensitive file".into(),
+            serde_json::json!({"path": ".env", "content": "TOKEN=1"}),
+            tx,
+            ApprovalMetadata::default().with_risk_tags(vec![RiskTag::WritesSensitiveFile]),
+        );
+
+        q.focused_button_move_right();
+        assert_eq!(
+            q.focused_button_action(),
+            Some(super::super::button_row::ButtonAction::Respond(
+                ApprovalResponse::AlwaysAllow
+            )),
+            "sensitive-path requests should keep don't-ask-again available as a session-only override"
+        );
+
+        let view = q.focused_view().expect("pending approval");
+        assert_eq!(
+            view.selection_hint.as_deref(),
+            Some("Don't ask again stays session-only for this request.")
+        );
+    }
+
+    #[test]
     fn focused_button_action_blocks_always_for_unsafe_rule_shape() {
         let mut q = ApprovalQueue::new();
         let (tx, _rx) = oneshot::channel();
@@ -1571,6 +1604,30 @@ mod tests {
         assert_eq!(
             rx_b.try_recv().unwrap(),
             crate::cli::chat_stream::ApprovalResponse::AllowOnce,
+        );
+    }
+
+    #[test]
+    fn drain_resolved_can_broadcast_deny_instead_of_allowing() {
+        let mut q = ApprovalQueue::new();
+        let (tx, mut rx) = oneshot::channel();
+        q.push(
+            "bash".into(),
+            "h".into(),
+            None,
+            "r".into(),
+            serde_json::Value::Null,
+            tx,
+        );
+
+        let released = q.drain_resolved(|_| Some(crate::cli::chat_stream::ApprovalResponse::Deny));
+
+        assert_eq!(released, 1);
+        assert_eq!(q.len(), 0);
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            crate::cli::chat_stream::ApprovalResponse::Deny,
+            "mode pivots must preserve hard denials instead of converting them to AllowOnce",
         );
     }
 }

--- a/rust/crates/astra-cli/src/tui/approval/queue.rs
+++ b/rust/crates/astra-cli/src/tui/approval/queue.rs
@@ -334,7 +334,6 @@ impl PendingApproval {
             || self.has_dynamic_eval
             || self.unsafe_rule_shape
             || self.risk_tags.contains(&RiskTag::WritesSensitiveFile)
-            || self.risk_tags.contains(&RiskTag::GitDestructive)
             || self.risk_tags.contains(&RiskTag::WritesOutsideWorkspace)
             || self.risk_tags.contains(&RiskTag::CredentialAccess)
             || self.risk_tags.contains(&RiskTag::MCPUnknownCapability)
@@ -342,7 +341,13 @@ impl PendingApproval {
             return true;
         }
 
-        !self.workspace_untrusted && !self.scope_available(AllowScope::Project)
+        [
+            AllowScope::RestOfSession,
+            AllowScope::Project,
+            AllowScope::User,
+        ]
+        .into_iter()
+        .all(|scope| !self.scope_available(scope))
     }
 
     fn always_uses_session_fallback(&self) -> bool {
@@ -1318,6 +1323,35 @@ mod tests {
         assert!(
             q.focused_button_action().is_none(),
             "compound shell commands must keep Always disabled"
+        );
+    }
+
+    #[test]
+    fn focused_button_action_allows_always_for_bounded_git_destructive_request() {
+        use astra_turn_core::permission::engine::RiskTag;
+
+        let mut q = ApprovalQueue::new();
+        let (tx, _rx) = oneshot::channel();
+        q.push_with_metadata(
+            "bash".into(),
+            "git restore --staged --worktree rust/crates/foo/src/lib.rs".into(),
+            None,
+            "git destructive".into(),
+            serde_json::json!({
+                "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
+            }),
+            tx,
+            ApprovalMetadata::default()
+                .with_risk_tags(vec![RiskTag::BashExecute, RiskTag::GitDestructive]),
+        );
+
+        q.focused_button_move_right();
+        assert_eq!(
+            q.focused_button_action(),
+            Some(super::super::button_row::ButtonAction::Respond(
+                ApprovalResponse::AlwaysAllow
+            )),
+            "bounded git requests should keep don't-ask-again available"
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/approval/queue.rs
+++ b/rust/crates/astra-cli/src/tui/approval/queue.rs
@@ -351,17 +351,20 @@ impl PendingApproval {
     }
 
     fn always_uses_session_fallback(&self) -> bool {
-        self.workspace_untrusted
-            && !self.always_action_disabled()
+        !self.always_action_disabled()
             && !self.scope_available(AllowScope::Project)
+            && self.scope_available(AllowScope::RestOfSession)
     }
 
     fn selection_hint(&self) -> Option<String> {
         if self.always_uses_session_fallback() {
-            return Some(
-                "Don't ask again stays session-only until you trust this workspace. Choose Trust Workspace or run `/allow trust` to save workspace rules."
-                    .to_string(),
-            );
+            if self.workspace_untrusted {
+                return Some(
+                    "Don't ask again stays session-only until you trust this workspace. Choose Trust Workspace or run `/allow trust` to save workspace rules."
+                        .to_string(),
+                );
+            }
+            return Some("Don't ask again stays session-only for this request.".to_string());
         }
         None
     }
@@ -1352,6 +1355,32 @@ mod tests {
                 ApprovalResponse::AlwaysAllow
             )),
             "bounded git requests should keep don't-ask-again available"
+        );
+    }
+
+    #[test]
+    fn bounded_git_destructive_always_is_session_only_in_view() {
+        use astra_turn_core::permission::engine::RiskTag;
+
+        let mut q = ApprovalQueue::new();
+        let (tx, _rx) = oneshot::channel();
+        q.push_with_metadata(
+            "bash".into(),
+            "git restore --staged --worktree rust/crates/foo/src/lib.rs".into(),
+            None,
+            "git destructive".into(),
+            serde_json::json!({
+                "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
+            }),
+            tx,
+            ApprovalMetadata::default()
+                .with_risk_tags(vec![RiskTag::BashExecute, RiskTag::GitDestructive]),
+        );
+
+        let view = q.focused_view().expect("pending approval");
+        assert_eq!(
+            view.selection_hint.as_deref(),
+            Some("Don't ask again stays session-only for this request.")
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/bottom_pane/approval_integration_tests.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/approval_integration_tests.rs
@@ -8,6 +8,7 @@ use tokio::sync::oneshot;
 
 use super::{ApprovalActivation, BottomPane, BottomPaneAction};
 use crate::cli::chat_stream::ApprovalResponse;
+use crate::cli::permission_manager::PermissionMode;
 use crate::tui::approval::queue::ApprovalMetadata;
 use crate::tui::slash_menu::SlashItem;
 
@@ -243,6 +244,27 @@ fn enter_with_text_in_composer_submits_instead_of_approving() {
         }
         other => panic!("expected SubmitInput, got {other:?}"),
     }
+}
+
+#[test]
+fn mode_pivot_to_deny_resolves_pending_write_as_deny() {
+    let mut bp = BottomPane::new();
+    let (tx, rx) = oneshot::channel();
+    bp.enqueue_approval(
+        "write_file".into(),
+        "write_file needs approval".into(),
+        None,
+        "write".into(),
+        serde_json::json!({"path": "src/lib.rs", "content": "updated"}),
+        tx,
+    );
+
+    let resolved = bp.reevaluate_approvals_for_mode(PermissionMode::Deny);
+
+    assert_eq!(resolved, 1);
+    assert_eq!(bp.footer.pending_approvals, 0);
+    assert!(!bp.has_pending_approvals());
+    assert_eq!(rx.blocking_recv().unwrap(), ApprovalResponse::Deny);
 }
 
 #[test]

--- a/rust/crates/astra-cli/src/tui/bottom_pane/keyboard_tests.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/keyboard_tests.rs
@@ -68,11 +68,10 @@ fn backtab_cycles_mode_when_composer_has_text() {
 
 #[test]
 fn next_mode_cycle_full_loop_skips_deny() {
-    // Prompt → AcceptEdits → Plan → Auto → Bypass → Prompt (wrap).
-    // `Deny` is sticky under the cycle: a bare `/allow` (or Shift+Tab) must
-    // never silently move a session out of the most restrictive mode — it
-    // is only exited by an explicit `/allow <mode>`. Likewise `Deny` is
-    // never a cycle *target*.
+    // Prompt → AcceptEdits → Plan → Auto → Prompt (wrap).
+    // `Bypass` is explicit-only, and `Deny` is sticky under the cycle: a bare
+    // `/allow` (or Shift+Tab) must never silently move into the broadest or out
+    // of the most restrictive mode.
     assert_eq!(
         next_permission_mode_for_cycle(PermissionMode::Prompt),
         PermissionMode::AcceptEdits
@@ -91,7 +90,7 @@ fn next_mode_cycle_full_loop_skips_deny() {
     );
     assert_eq!(
         next_permission_mode_for_cycle(PermissionMode::Auto),
-        PermissionMode::Bypass
+        PermissionMode::Prompt
     );
     assert_eq!(
         next_permission_mode_for_cycle(PermissionMode::Bypass),

--- a/rust/crates/astra-cli/src/tui/bottom_pane/keyboard_tests.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/keyboard_tests.rs
@@ -68,7 +68,7 @@ fn backtab_cycles_mode_when_composer_has_text() {
 
 #[test]
 fn next_mode_cycle_full_loop_skips_deny() {
-    // Prompt → AcceptEdits → Plan → Auto → Prompt (wrap).
+    // Prompt → AcceptEdits → Plan → Auto → Bypass → Prompt (wrap).
     // `Deny` is sticky under the cycle: a bare `/allow` (or Shift+Tab) must
     // never silently move a session out of the most restrictive mode — it
     // is only exited by an explicit `/allow <mode>`. Likewise `Deny` is
@@ -91,6 +91,10 @@ fn next_mode_cycle_full_loop_skips_deny() {
     );
     assert_eq!(
         next_permission_mode_for_cycle(PermissionMode::Auto),
+        PermissionMode::Bypass
+    );
+    assert_eq!(
+        next_permission_mode_for_cycle(PermissionMode::Bypass),
         PermissionMode::Prompt
     );
 }

--- a/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
+++ b/rust/crates/astra-cli/src/tui/bottom_pane/mod.rs
@@ -536,38 +536,36 @@ impl BottomPane {
         id
     }
 
-    /// Re-evaluate every pending approval against `new_mode` and
-    /// auto-approve the ones the new mode would not gate. Used when
-    /// the user pivots permission modes (Shift+Tab, `/permissions`,
-    /// or the `exit_plan_mode` overlay) so the approval queue does
-    /// not lag behind the chip.
+    /// Re-evaluate every pending approval against `new_mode` and resolve the
+    /// ones the new mode can decide without asking. Used when the user pivots
+    /// permission modes (Shift+Tab, `/permissions`, or the `exit_plan_mode`
+    /// overlay) so the approval queue does not lag behind the chip.
     ///
-    /// Returns the number of entries auto-approved. Footer counter
-    /// is refreshed so the chip reads the new pending count.
+    /// Returns the number of entries resolved. Footer counter is refreshed so
+    /// the chip reads the new pending count.
     pub fn reevaluate_approvals_for_mode(
         &mut self,
         new_mode: crate::cli::permission_manager::PermissionMode,
     ) -> usize {
+        use crate::cli::chat_stream::ApprovalResponse;
         use astra_turn_core::permission::engine::{HardDecision, evaluate_permission};
         use astra_turn_core::permission::types::{InheritedPermissions, PermissionSyncContext};
 
         let ctx = PermissionSyncContext::new(InheritedPermissions::new(new_mode));
-        let released = self.approval_queue.drain_now_allowed(|entry| {
-            // Cloud / sandbox-expand entries arrive without args
-            // (Value::Null). We can't safely re-evaluate those —
-            // the cloud path owns its own gate — so leave them in
-            // the queue and let the user resolve them explicitly.
+        let released = self.approval_queue.drain_resolved(|entry| {
+            // Legacy cloud / sandbox-expand entries can arrive
+            // without args (Value::Null). We can't safely
+            // re-evaluate those, so leave them in the queue and let
+            // the original gate resolve them explicitly.
             if entry.args.is_null() {
-                return true;
+                return None;
             }
             let envelope = evaluate_permission(&entry.tool, &entry.args, &ctx);
-            // Keep the entry only if the new mode still needs an
-            // external approval. Allow / Deny outcomes mean "no
-            // user-facing prompt is required any more"; they are
-            // dropped from the queue (Deny is the rarer path —
-            // historically the approval card stayed open even for
-            // a guaranteed-deny call which was just noise).
-            matches!(envelope.decision, HardDecision::NeedExternal { .. })
+            match envelope.decision {
+                HardDecision::Allow => Some(ApprovalResponse::AllowOnce),
+                HardDecision::Deny { .. } => Some(ApprovalResponse::Deny),
+                HardDecision::NeedExternal { .. } => None,
+            }
         });
         self.footer.pending_approvals = self.approval_queue.len();
         released

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -1661,59 +1661,6 @@ pub(crate) async fn run_tui_session(
                                                 );
                                             }
                                         }
-                                        if looks_like_implicit_plan_request(&submit_text) {
-                                        let before = capture_plan_mode_ui_snapshot(&state);
-                                        let Some(token) =
-                                            crate::cli::plan::plan_lifecycle::fresh_token_for_plan(api, profile)
-                                                .await
-                                        else {
-                                            chat_widget.commit_system(
-                                                history_cell::system::SystemCell::error(
-                                                    "Not logged in. Use /login.",
-                                                ),
-                                            );
-                                            refresh_footer_from_state(&mut bottom_pane, &state);
-                                            flush_chat_widget(&mut guard, &mut chat_widget, w);
-                                            frame_requester.schedule_frame();
-                                            continue;
-                                        };
-                                        match crate::cli::plan::plan_lifecycle::enter_remote_plan_mode(
-                                            api,
-                                            profile,
-                                            &token,
-                                            &mut state,
-                                            &submit_text,
-                                        )
-                                        .await
-                                        {
-                                            Ok(_) => {
-                                                commit_plan_transition_notice(
-                                                    &mut chat_widget,
-                                                    &before,
-                                                    &state,
-                                                    true,
-                                                );
-                                                if let Some(ref sid) = state.session_id
-                                                    && chat_widget.session_id() != sid
-                                                {
-                                                    chat_widget.set_session_id(sid.clone());
-                                                    task_board.rebind_session(sid.clone());
-                                                    board_user_pin = None;
-                                                }
-                                                refresh_footer_from_state(&mut bottom_pane, &state);
-                                                flush_chat_widget(&mut guard, &mut chat_widget, w);
-                                            }
-                                            Err(e) => {
-                                                chat_widget.commit_system(
-                                                    history_cell::system::SystemCell::error(e),
-                                                );
-                                                refresh_footer_from_state(&mut bottom_pane, &state);
-                                                flush_chat_widget(&mut guard, &mut chat_widget, w);
-                                                frame_requester.schedule_frame();
-                                                continue;
-                                            }
-                                        }
-                                        }
                                     }
 
                                     bottom_pane.set_task_status(TaskStatus::WaitingModel);
@@ -5406,26 +5353,6 @@ mod tests {
     }
 
     #[test]
-    fn implicit_plan_request_detector_accepts_actionable_prompts() {
-        assert!(looks_like_implicit_plan_request(
-            "帮我计划在/tmp下生成一个报销系统"
-        ));
-        assert!(looks_like_implicit_plan_request(
-            "help me plan how to refactor the auth middleware"
-        ));
-        assert!(looks_like_implicit_plan_request(
-            "please plan how to migrate this service to Axum"
-        ));
-    }
-
-    #[test]
-    fn implicit_plan_request_detector_rejects_meta_plan_questions() {
-        assert!(!looks_like_implicit_plan_request("现在plan是怎么工作的?"));
-        assert!(!looks_like_implicit_plan_request("what is /plan mode?"));
-        assert!(!looks_like_implicit_plan_request("/plan"));
-    }
-
-    #[test]
     fn plan_transition_notice_covers_enter_goal_and_exit() {
         let inactive = PlanModeUiSnapshot::default();
         let entered_empty = PlanModeUiSnapshot {
@@ -5465,7 +5392,7 @@ mod tests {
     }
 
     #[test]
-    fn submit_input_routes_plan_mode_and_implicit_plan_requests_before_chat_turn() {
+    fn submit_input_routes_only_explicit_plan_mode_before_chat_turn() {
         let source = include_str!("event_loop.rs");
         let arm_start = source
             .find("BottomPaneAction::SubmitInput(text) => {")
@@ -5481,31 +5408,14 @@ mod tests {
             "/plan <goal> should pre-enter remote plan mode before the chat turn"
         );
         assert!(
-            arm.contains("looks_like_implicit_plan_request(&submit_text)")
-                && arm.contains("crate::cli::plan::plan_lifecycle::enter_remote_plan_mode("),
-            "plain planning requests should enter remote /plan semantics before normal chat turns"
-        );
-        assert!(
             arm.contains("crate::cli::plan::plan_lifecycle::looks_like_pending_local_plan_entry(")
                 && arm.contains("crate::cli::plan::plan_lifecycle::enter_remote_plan_mode("),
             "the first plain message after bare /plan should bind remote plan mode and continue as chat"
         );
-
-        let implicit_start = arm
-            .find("if looks_like_implicit_plan_request(&submit_text)")
-            .expect("implicit plan request branch must exist");
-        let implicit_ok_start = arm[implicit_start..]
-            .find("Ok(_) => {")
-            .map(|offset| implicit_start + offset)
-            .expect("implicit plan request branch must have a success arm");
-        let implicit_err_start = arm[implicit_ok_start..]
-            .find("Err(e) =>")
-            .map(|offset| implicit_ok_start + offset)
-            .expect("implicit plan request branch must have an error arm");
-        let implicit_success_branch = &arm[implicit_ok_start..implicit_err_start];
         assert!(
-            !implicit_success_branch.contains("continue;"),
-            "successful implicit plan entry must fall through to the chat turn instead of swallowing input"
+            !arm.contains("looks_like_implicit_plan_request")
+                && !arm.contains("if submit_text.to_lowercase().contains(\"plan\")"),
+            "plain natural-language prompts must not toggle plan mode"
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/event_loop.rs
+++ b/rust/crates/astra-cli/src/tui/event_loop.rs
@@ -1067,7 +1067,7 @@ pub(crate) async fn run_tui_session(
                                     chat_widget.commit_system(
                                         crate::tui::history_cell::system::SystemCell::response(
                                             format!(
-                                                "  ✓ {released} pending approval(s) auto-resolved by the new mode",
+                                                "  ✓ {released} pending approval(s) resolved by the new mode",
                                             ),
                                         ),
                                     );
@@ -1786,7 +1786,7 @@ pub(crate) async fn run_tui_session(
                                                                     chat_widget.commit_system(
                                                                         history_cell::system::SystemCell::response(
                                                                             format!(
-                                                                                "  ✓ {released} pending approval(s) auto-resolved by the new mode",
+                                                                                "  ✓ {released} pending approval(s) resolved by the new mode",
                                                                             ),
                                                                         ),
                                                                     );
@@ -3566,15 +3566,15 @@ pub(crate) async fn run_tui_session(
                     // pull_mode_from_mirror after exit_plan_mode
                     // overlay or mid-turn Shift+Tab). Re-evaluate
                     // the approval queue against the new mode so
-                    // any pending entries the new mode would
-                    // auto-approve are released — same machinery
+                    // any pending entries the new mode can resolve
+                    // are released — same machinery
                     // the keystroke paths use.
                     let released = bottom_pane.reevaluate_approvals_for_mode(live_mode_enum);
                     if released > 0 {
                         chat_widget.commit_system(
                             crate::tui::history_cell::system::SystemCell::response(
                                 format!(
-                                    "  ✓ {released} pending approval(s) auto-resolved by the new mode",
+                                    "  ✓ {released} pending approval(s) resolved by the new mode",
                                 ),
                             ),
                         );

--- a/rust/crates/astra-cli/src/tui/history_cell/approval.rs
+++ b/rust/crates/astra-cli/src/tui/history_cell/approval.rs
@@ -280,7 +280,6 @@ impl ApprovalCell {
         for label in &self.risk_tag_labels {
             match label.as_str() {
                 "WritesSensitiveFile" => return Some("sensitive path"),
-                "GitDestructive" => return Some("git destructive"),
                 "WritesOutsideWorkspace" => return Some("outside workspace"),
                 "CredentialAccess" => return Some("credential access"),
                 "MCPUnknownCapability" => return Some("MCP unknown"),
@@ -296,13 +295,26 @@ impl ApprovalCell {
         if self.unsafe_rule_shape {
             return Some("command shape too broad to remember");
         }
+        if !self.has_available_remember_scope() {
+            return Some("no remember scope available");
+        }
         None
     }
 
     fn always_action_disabled(&self) -> bool {
         self.always_disabled_reason().is_some()
-            || (!self.workspace_untrusted
-                && !self.scope_available(astra_turn_core::permission::scope::AllowScope::Project))
+    }
+
+    fn has_available_remember_scope(&self) -> bool {
+        use astra_turn_core::permission::scope::AllowScope;
+
+        [
+            AllowScope::RestOfSession,
+            AllowScope::Project,
+            AllowScope::User,
+        ]
+        .into_iter()
+        .any(|scope| self.scope_available(scope))
     }
 
     fn risk_tags_for_scope(&self) -> Vec<astra_turn_core::permission::engine::RiskTag> {
@@ -935,6 +947,26 @@ mod tests {
     }
 
     #[test]
+    fn always_enabled_for_git_destructive_request_with_bounded_memory() {
+        let cell = ApprovalCell::new(
+            1,
+            "bash".into(),
+            "git restore --staged --worktree rust/crates/foo/src/lib.rs".into(),
+            None,
+            "git destructive".into(),
+            true,
+        )
+        .with_risk_tag_labels(vec!["BashExecute".into(), "GitDestructive".into()]);
+
+        assert_eq!(cell.always_disabled_reason(), None);
+        let rendered = render(&cell);
+        assert!(
+            !rendered.contains("Can't remember"),
+            "bounded git requests should keep don't-ask-again available, got:\n{rendered}"
+        );
+    }
+
+    #[test]
     fn always_enabled_for_untrusted_workspace_benign_request() {
         let cell = ApprovalCell::new(
             1,
@@ -995,16 +1027,16 @@ mod tests {
         let cell = ApprovalCell::new(
             1,
             "bash".into(),
-            "rm -rf /".into(),
+            "edit /etc/hosts".into(),
             None,
             "execute".into(),
             true,
         )
-        .with_risk_tag_labels(vec!["GitDestructive".into()]);
+        .with_risk_tag_labels(vec!["WritesOutsideWorkspace".into()]);
         let rendered = render(&cell);
         assert!(
-            rendered.contains("Can't remember · git destructive"),
-            "destructive cell must advertise the disabled-Always state, got:\n{rendered}"
+            rendered.contains("Can't remember · outside workspace"),
+            "outside-workspace cell must advertise the disabled-Always state, got:\n{rendered}"
         );
     }
 

--- a/rust/crates/astra-cli/src/tui/plan_mode.rs
+++ b/rust/crates/astra-cli/src/tui/plan_mode.rs
@@ -75,51 +75,6 @@ pub(crate) fn commit_plan_transition_notice(
     }
 }
 
-pub(crate) fn looks_like_implicit_plan_request(text: &str) -> bool {
-    let trimmed = text.trim();
-    if trimmed.is_empty() || trimmed.starts_with('/') {
-        return false;
-    }
-
-    let lowered = trimmed.to_lowercase();
-    let meta_queries = [
-        "what is /plan",
-        "how does /plan",
-        "what does /plan",
-        "plan mode",
-        "plan模式",
-        "现在plan是怎么",
-        "什么是/plan",
-        "/plan是什么意思",
-        "怎么进入plan",
-    ];
-    if meta_queries.iter().any(|needle| lowered.contains(needle)) {
-        return false;
-    }
-
-    let planning_requests = [
-        "help me plan",
-        "please plan",
-        "plan how to",
-        "make a plan",
-        "draft a plan",
-        "come up with a plan",
-        "plan out",
-        "帮我计划",
-        "帮我规划",
-        "给我一个计划",
-        "给我个计划",
-        "做个计划",
-        "规划一下",
-        "计划一下",
-        "制定计划",
-        "先计划",
-    ];
-    planning_requests
-        .iter()
-        .any(|needle| lowered.contains(needle))
-}
-
 pub(crate) fn slash_plan_goal(text: &str) -> Option<&str> {
     let rest = text.trim().strip_prefix("/plan")?;
     let goal = rest.trim();

--- a/rust/crates/astra-cli/src/tui/plan_mode.rs
+++ b/rust/crates/astra-cli/src/tui/plan_mode.rs
@@ -1,6 +1,6 @@
 //! Plan-mode UI helpers extracted from `event_loop.rs`.
 //!
-//! Handles plan-mode transitions, implicit plan request detection,
+//! Handles plan-mode transition notices, explicit `/plan <goal>` parsing,
 //! and UI snapshotting when entering/exiting plan mode.
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -1233,7 +1233,7 @@ fn build_permission_mode_picker(
         },
     ];
     ListSelectionView::new(items, Some("Modes".into())).with_footer_hint(
-        "Shift+Tab cycles ask → edits → plan → auto → bypass · /allow rules · /allow trust · /allow trace",
+        "Shift+Tab cycles ask → edits → plan → auto · bypass is explicit · /allow rules · /allow trust · /allow trace",
     )
 }
 
@@ -4117,14 +4117,14 @@ mod view_result_tests {
         );
         assert_eq!(
             next_permission_mode_for_cycle(PermissionMode::Auto),
-            PermissionMode::Bypass
+            PermissionMode::Prompt
         );
         assert_eq!(
             next_permission_mode_for_cycle(PermissionMode::Bypass),
             PermissionMode::Prompt
         );
-        // `Deny` is sticky under the cycle: it must only be exited by an
-        // explicit `/allow <mode>`, never by a bare `/allow`.
+        // `Bypass` is explicit-only, and `Deny` is sticky under the cycle:
+        // neither can be reached by a bare `/allow`.
         assert_eq!(
             next_permission_mode_for_cycle(PermissionMode::Deny),
             PermissionMode::Deny

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -1214,8 +1214,13 @@ fn build_permission_mode_picker(
         },
         SelectionItem {
             name: "Auto".into(),
-            description: Some("All tools auto-approved".into()),
+            description: Some("Auto-approve normal tool risk; hard prompts may still apply".into()),
             is_current: current == crate::cli::permission_manager::PermissionMode::Auto,
+        },
+        SelectionItem {
+            name: "Bypass".into(),
+            description: Some("Skip approval prompts; hard denies still apply".into()),
+            is_current: current == crate::cli::permission_manager::PermissionMode::Bypass,
         },
         SelectionItem {
             name: "Deny".into(),
@@ -1224,7 +1229,7 @@ fn build_permission_mode_picker(
         },
     ];
     ListSelectionView::new(items, Some("Modes".into())).with_footer_hint(
-        "Shift+Tab cycles ask → edits → plan → auto · /allow rules · /allow trust · /allow trace",
+        "Shift+Tab cycles ask → edits → plan → auto → bypass · /allow rules · /allow trust · /allow trace",
     )
 }
 
@@ -1444,6 +1449,14 @@ pub(crate) fn handle_view_result(
                 state,
                 chat_widget,
                 crate::cli::permission_manager::PermissionMode::Auto,
+            );
+            return;
+        }
+        "Bypass" | "Skip" => {
+            apply_permission_mode_selection(
+                state,
+                chat_widget,
+                crate::cli::permission_manager::PermissionMode::Bypass,
             );
             return;
         }
@@ -4007,6 +4020,21 @@ mod view_result_tests {
     }
 
     #[test]
+    fn bypass_selection_updates_state_and_commits_feedback() {
+        let mut state = SessionState::default();
+        let mut bottom_pane = BottomPane::new();
+        let mut chat_widget = ChatWidget::new("");
+
+        handle_view_result("Bypass", &mut state, &mut bottom_pane, &mut chat_widget);
+
+        assert_eq!(state.perm_manager.mode(), PermissionMode::Bypass);
+        assert_eq!(
+            last_system_message(&chat_widget).as_deref(),
+            Some("Mode → Bypass")
+        );
+    }
+
+    #[test]
     fn permission_selection_clears_stale_pending_local_plan_entry() {
         let mut state = SessionState::default();
         state.cloud_plan_mirror = Some(plan::PlanModeState::new(String::new()));
@@ -4085,6 +4113,10 @@ mod view_result_tests {
         );
         assert_eq!(
             next_permission_mode_for_cycle(PermissionMode::Auto),
+            PermissionMode::Bypass
+        );
+        assert_eq!(
+            next_permission_mode_for_cycle(PermissionMode::Bypass),
             PermissionMode::Prompt
         );
         // `Deny` is sticky under the cycle: it must only be exited by an

--- a/rust/crates/astra-cli/src/tui/slash_dispatch.rs
+++ b/rust/crates/astra-cli/src/tui/slash_dispatch.rs
@@ -1214,12 +1214,16 @@ fn build_permission_mode_picker(
         },
         SelectionItem {
             name: "Auto".into(),
-            description: Some("Auto-approve normal tool risk; hard prompts may still apply".into()),
+            description: Some(
+                "Auto-approve normal tool risk; some git/sensitive gates may still stop".into(),
+            ),
             is_current: current == crate::cli::permission_manager::PermissionMode::Auto,
         },
         SelectionItem {
             name: "Bypass".into(),
-            description: Some("Skip approval prompts; hard denies still apply".into()),
+            description: Some(
+                "Skip approval prompts; catastrophic and policy hard-denies still apply".into(),
+            ),
             is_current: current == crate::cli::permission_manager::PermissionMode::Bypass,
         },
         SelectionItem {

--- a/rust/crates/astra-cli/src/tui/status_line/line.rs
+++ b/rust/crates/astra-cli/src/tui/status_line/line.rs
@@ -396,6 +396,14 @@ impl StatusLine {
                         .add_modifier(Modifier::BOLD),
                 ));
             }
+            PermissionMode::Bypass => {
+                out.left.push(Segment::styled(
+                    permission_mode_label(ctx.permission_mode),
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            }
             PermissionMode::Plan => {
                 out.left.push(Segment::styled(
                     permission_mode_label(ctx.permission_mode),

--- a/rust/crates/astra-config/src/user_profile.rs
+++ b/rust/crates/astra-config/src/user_profile.rs
@@ -386,6 +386,13 @@ pub struct TurnIntent {
     /// starting a fresh scenario.
     #[serde(default)]
     pub continuation_mode: TurnContinuationMode,
+    /// Whether the user is correcting or reanchoring the current objective.
+    ///
+    /// This is deliberately separate from `continuation_mode`: a plain
+    /// "continue" keeps working, while a reanchor may reset transient guard
+    /// state that belongs to the previous failed attempt.
+    #[serde(default)]
+    pub reanchors_current_objective: bool,
 }
 
 impl TurnIntent {
@@ -398,6 +405,12 @@ impl TurnIntent {
     #[must_use]
     pub fn with_continuation_mode(mut self, mode: TurnContinuationMode) -> Self {
         self.continuation_mode = mode;
+        self
+    }
+
+    #[must_use]
+    pub fn with_reanchors_current_objective(mut self, reanchors: bool) -> Self {
+        self.reanchors_current_objective = reanchors;
         self
     }
 
@@ -417,6 +430,11 @@ impl TurnIntent {
     #[must_use]
     pub fn continues_current_objective(&self) -> bool {
         self.continuation_mode == TurnContinuationMode::ContinueCurrentObjective
+    }
+
+    #[must_use]
+    pub fn reanchors_current_objective(&self) -> bool {
+        self.reanchors_current_objective
     }
 }
 
@@ -1068,6 +1086,18 @@ mod tests {
 
         assert!(intent.continues_current_objective());
         assert!(!TurnIntent::default().continues_current_objective());
+    }
+
+    #[test]
+    fn turn_intent_reanchor_is_separate_from_continuation() {
+        let continued = TurnIntent::default()
+            .with_continuation_mode(TurnContinuationMode::ContinueCurrentObjective);
+        assert!(continued.continues_current_objective());
+        assert!(!continued.reanchors_current_objective());
+
+        let reanchored = TurnIntent::default().with_reanchors_current_objective(true);
+        assert!(reanchored.reanchors_current_objective());
+        assert!(!reanchored.continues_current_objective());
     }
 
     #[test]

--- a/rust/crates/astra-text-utils/src/semantic_dedup.rs
+++ b/rust/crates/astra-text-utils/src/semantic_dedup.rs
@@ -760,7 +760,7 @@ impl SemanticDedup {
             return String::new();
         }
 
-        let mut files: Vec<&str> = Vec::new();
+        let mut files = std::collections::BTreeSet::new();
         let mut searches: Vec<String> = Vec::new();
         let mut git_ops: Vec<&str> = Vec::new();
         let mut github_ops: Vec<String> = Vec::new();
@@ -771,7 +771,7 @@ impl SemanticDedup {
             match tool.as_str() {
                 "read_file" => {
                     if let Some(path) = read_file_path_from_semantic_key(key) {
-                        files.push(path);
+                        files.insert(path.to_string());
                     }
                 }
                 "grep" => {
@@ -816,7 +816,7 @@ impl SemanticDedup {
 
         if !files.is_empty() {
             let count = files.len();
-            let display: Vec<_> = files.iter().take(5).copied().collect();
+            let display: Vec<_> = files.iter().take(5).map(String::as_str).collect();
             let suffix = if count > 5 {
                 format!(" (+{} more)", count - 5)
             } else {
@@ -1499,6 +1499,27 @@ mod tests {
         assert!(inv.contains("Files:"), "should have Files section");
         assert!(inv.contains("src/main.rs"));
         assert!(inv.contains("src/lib.rs"));
+    }
+
+    #[test]
+    fn context_inventory_counts_read_ranges_as_one_file() {
+        let mut tracker = SemanticDedup::new(0.75);
+        tracker.check_and_record(
+            "read_file",
+            &json!({"path": "src/lib.rs", "start_line": 1, "end_line": 40}),
+            "content",
+            0,
+        );
+        tracker.check_and_record(
+            "read_file",
+            &json!({"path": "src/lib.rs", "start_line": 80, "end_line": 120}),
+            "content",
+            1,
+        );
+
+        let inv = tracker.context_inventory();
+        assert_eq!(inv.matches("src/lib.rs").count(), 1, "{inv}");
+        assert!(!inv.contains("more"), "{inv}");
     }
 
     #[test]

--- a/rust/crates/astra-text-utils/src/semantic_dedup.rs
+++ b/rust/crates/astra-text-utils/src/semantic_dedup.rs
@@ -38,23 +38,7 @@ pub const DEFAULT_SIMILARITY_THRESHOLD: f64 = 0.75;
 pub fn semantic_call_key(tool_name: &str, args: &Value) -> Option<String> {
     match tool_name {
         // File-based tools: key on normalized path + output-critical params
-        "read_file" => {
-            let path = arg_str(args, "path")?;
-            let start = arg_u64(args, "start_line")
-                .map(|v| v.to_string())
-                .unwrap_or_default();
-            let end = arg_u64(args, "end_line")
-                .map(|v| v.to_string())
-                .unwrap_or_default();
-            let outline = arg_bool(args, "outline").unwrap_or(false);
-            Some(format!(
-                "read_file:{}:{}:{}:outline={}",
-                normalize_path(path),
-                start,
-                end,
-                outline,
-            ))
-        }
+        "read_file" => read_file_semantic_key(args),
         "glob" => {
             let pattern = arg_str(args, "pattern").unwrap_or("*");
             let path = arg_str(args, "path").unwrap_or(".");
@@ -186,6 +170,42 @@ fn arg_bool(args: &Value, key: &str) -> Option<bool> {
 
 fn normalize_path(path: &str) -> String {
     path.trim().trim_end_matches('/').to_string()
+}
+
+fn read_file_semantic_key(args: &Value) -> Option<String> {
+    let path = arg_str(args, "path")?;
+    let (start, end) = read_file_effective_line_bounds(args);
+    let outline = arg_bool(args, "outline").unwrap_or(false);
+    Some(format!(
+        "read_file:{}:start={}:end={}:outline={}",
+        normalize_path(path),
+        start.map(|v| v.to_string()).unwrap_or_default(),
+        end.map(|v| v.to_string()).unwrap_or_default(),
+        outline,
+    ))
+}
+
+fn read_file_effective_line_bounds(args: &Value) -> (Option<u64>, Option<u64>) {
+    let mut start = arg_u64(args, "start_line");
+    let mut end = arg_u64(args, "end_line");
+
+    // Mirror astra_tools::fs_ops::convert_read_file_args for the LLM-facing
+    // contract. The schema exposes offset+limit; start_line/end_line are
+    // internal compatibility fields. Dedup must key on the effective range or
+    // offset reads of different sections collapse into the same cache entry.
+    if let Some(offset) = arg_u64(args, "offset") {
+        start = Some(offset);
+        if let Some(limit) = arg_u64(args, "limit") {
+            end = Some(offset.saturating_add(limit.saturating_sub(1)));
+        }
+    }
+
+    (start, end)
+}
+
+fn read_file_path_from_semantic_key(key: &str) -> Option<&str> {
+    key.strip_prefix("read_file:")
+        .and_then(|rest| rest.split_once(":start=").map(|(path, _)| path))
 }
 
 fn normalize_repo(repo: &str) -> String {
@@ -750,7 +770,7 @@ impl SemanticDedup {
         for (key, (_turn, tool, _generation)) in &self.param_cache {
             match tool.as_str() {
                 "read_file" => {
-                    if let Some(path) = key.strip_prefix("read_file:") {
+                    if let Some(path) = read_file_path_from_semantic_key(key) {
                         files.push(path);
                     }
                 }
@@ -883,15 +903,31 @@ mod tests {
     fn read_file_different_line_ranges_differ() {
         let k1 = semantic_call_key(
             "read_file",
-            &json!({"path": "foo.rs", "start_line": 1, "end_line": 120}),
+            &json!({"path": "foo.rs", "offset": 1, "limit": 120}),
         );
         let k2 = semantic_call_key(
             "read_file",
-            &json!({"path": "foo.rs", "start_line": 200, "end_line": 350}),
+            &json!({"path": "foo.rs", "offset": 200, "limit": 151}),
         );
         assert_ne!(
             k1, k2,
-            "different line ranges must produce distinct keys — otherwise agent can't read different regions of the same file"
+            "different offset/limit ranges must produce distinct keys — otherwise agent can't read different regions of the same file"
+        );
+    }
+
+    #[test]
+    fn read_file_offset_limit_matches_internal_line_range_key() {
+        let visible = semantic_call_key(
+            "read_file",
+            &json!({"path": "foo.rs", "offset": 20, "limit": 30}),
+        );
+        let internal = semantic_call_key(
+            "read_file",
+            &json!({"path": "foo.rs", "start_line": 20, "end_line": 49}),
+        );
+        assert_eq!(
+            visible, internal,
+            "LLM-facing offset/limit and internal start/end args must dedup identically"
         );
     }
 
@@ -1337,7 +1373,7 @@ mod tests {
     #[test]
     fn tracker_detects_token_cosine_only_with_same_semantic_key() {
         let mut tracker = SemanticDedup::new(0.7);
-        let args = json!({"path": "src/main.rs", "start_line": 1, "end_line": 80});
+        let args = json!({"path": "src/main.rs", "offset": 1, "limit": 80});
         let sem_key = semantic_call_key("read_file", &args).expect("read_file key");
         let output1 =
             "fn parse_user() {}\nfn parse_team() {}\nfn parse_token() {}\nfn parse_config() {}";
@@ -1364,8 +1400,8 @@ mod tests {
     #[test]
     fn read_file_different_ranges_do_not_trigger_output_similarity_hint() {
         let mut tracker = SemanticDedup::new(0.7);
-        let range1 = json!({"path": "src/lib.rs", "start_line": 1, "end_line": 500});
-        let range2 = json!({"path": "src/lib.rs", "start_line": 501, "end_line": 1000});
+        let range1 = json!({"path": "src/lib.rs", "offset": 1, "limit": 500});
+        let range2 = json!({"path": "src/lib.rs", "offset": 501, "limit": 500});
         let output1 = "pub fn handler_a() {}\npub fn handler_b() {}\npub fn handler_c() {}\npub fn handler_d() {}\n";
         let output2 = "pub fn handler_e() {}\npub fn handler_f() {}\npub fn handler_g() {}\npub fn handler_h() {}\n";
         assert!(
@@ -1388,14 +1424,14 @@ mod tests {
         let mut tracker = SemanticDedup::new(0.75);
         tracker.check_and_record(
             "read_file",
-            &json!({"path": "src/lib.rs", "start_line": 1, "end_line": 500}),
+            &json!({"path": "src/lib.rs", "offset": 1, "limit": 500}),
             "first range content that is long enough to be a useful cached output",
             1,
         );
 
         let block = tracker.pre_check_block(
             "read_file",
-            &json!({"path": "src/lib.rs", "start_line": 501, "end_line": 1000}),
+            &json!({"path": "src/lib.rs", "offset": 501, "limit": 500}),
             2,
         );
         assert!(

--- a/rust/crates/astra-turn-core/src/agentic/turn_ingest.rs
+++ b/rust/crates/astra-turn-core/src/agentic/turn_ingest.rs
@@ -1018,6 +1018,82 @@ mod tests {
     }
 
     #[test]
+    fn factual_retry_is_reachable_from_workspace_evidence_profile() {
+        let snap = AgenticTurnStreamSnapshot {
+            ttft_ms: Some(50),
+            session_id: &None,
+            run_id: &None,
+            full_text: "The latest PR looks green.",
+            tool_calls: &[],
+            prompt_tokens: 100,
+            completion_tokens: 200,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &None,
+            error_kind: None,
+        };
+        let mut pack = Pack::new();
+        pack.task_profile =
+            crate::chat_turn_heuristics::infer_task_execution_profile("show me the latest PR");
+
+        let out = ingest_agentic_turn_stream(
+            &snap,
+            0,
+            |_| String::new(),
+            "show me the latest PR",
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+
+        assert_eq!(out, AgenticTurnIngestOutcome::Continue);
+        assert!(pack.forced_factual_retry);
+        assert_eq!(
+            pack.factual_retry_fallback_text.as_deref(),
+            Some("The latest PR looks green.")
+        );
+    }
+
+    #[test]
+    fn factual_retry_does_not_fire_for_status_line_concept_profile() {
+        let snap = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &None,
+            run_id: &None,
+            full_text: "59% is context usage; 117k is the token count.",
+            tool_calls: &[],
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &None,
+            error_kind: None,
+        };
+        let query = "what do 59% and 117k mean in the status line?";
+        let mut pack = Pack::new();
+        pack.task_profile = crate::chat_turn_heuristics::infer_task_execution_profile(query);
+
+        let out = ingest_agentic_turn_stream(
+            &snap,
+            0,
+            |_| String::new(),
+            query,
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+
+        assert_eq!(out, AgenticTurnIngestOutcome::Break);
+        assert!(!pack.forced_factual_retry);
+        assert_eq!(
+            pack.messages.last().unwrap()["content"],
+            "59% is context usage; 117k is the token count."
+        );
+    }
+
+    #[test]
     fn factual_retry_restores_original_when_no_evidence_retry_drops_the_question() {
         let original = "59% is context usage; 117k is the token count.";
         let query = "what do 59% and 117k mean in the status line?";

--- a/rust/crates/astra-turn-core/src/agentic/turn_ingest.rs
+++ b/rust/crates/astra-turn-core/src/agentic/turn_ingest.rs
@@ -86,6 +86,8 @@ pub struct AgenticTurnIngestMut<'a> {
     pub all_tools_used: &'a mut HashSet<String>,
     pub has_any_usage: &'a mut bool,
     pub forced_factual_retry: &'a mut bool,
+    pub factual_retry_fallback_text: &'a mut Option<String>,
+    pub factual_retry_fallback_decision: Option<FactualRetryFallbackDecision>,
     pub messages: &'a mut Vec<Value>,
     /// See [`crate::agentic_loop_host_types::AgenticLoopState::last_measured_prompt_tokens`].
     pub last_measured_prompt_tokens: &'a mut Option<u64>,
@@ -101,6 +103,119 @@ pub enum AgenticTurnIngestOutcome {
     Continue,
     Fatal(astra_core::ClassifiedError),
     HasToolCalls,
+}
+
+/// Explicit response-selection decision for a factual retry with no real
+/// evidence. This is intentionally an input to ingest, not computed inside it:
+/// only an upstream judge/policy layer may decide that the pre-retry answer is
+/// better than the retry output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FactualRetryFallbackDecision {
+    RestoreFallback,
+    KeepRetry,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FactualRetryFallbackJudgeInput<'a> {
+    pub original_query: &'a str,
+    pub fallback_text: &'a str,
+    pub retry_text: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FactualRetryFallbackJudgeVerdict {
+    pub decision: FactualRetryFallbackDecision,
+    pub confidence: f64,
+    pub reason: Option<String>,
+}
+
+impl FactualRetryFallbackJudgeVerdict {
+    #[must_use]
+    pub fn accepted_decision(&self) -> FactualRetryFallbackDecision {
+        if self.decision == FactualRetryFallbackDecision::RestoreFallback
+            && self.confidence < FACTUAL_RETRY_FALLBACK_MIN_CONFIDENCE
+        {
+            FactualRetryFallbackDecision::KeepRetry
+        } else {
+            self.decision
+        }
+    }
+}
+
+pub const FACTUAL_RETRY_FALLBACK_MIN_CONFIDENCE: f64 = 0.70;
+
+#[must_use]
+pub fn factual_retry_fallback_judge_messages(
+    input: FactualRetryFallbackJudgeInput<'_>,
+) -> Vec<Value> {
+    vec![
+        serde_json::json!({
+            "role": "system",
+            "content": "You are a response-selection judge for an agentic coding assistant. \
+                Choose which assistant answer should be shown to the user after a forced factual retry. \
+                Output only JSON."
+        }),
+        serde_json::json!({
+            "role": "user",
+            "content": format!(
+                "The assistant first answered without tools. The runtime forced a retry, but the retry gathered no real evidence tools.\n\n\
+                 Original user query:\n{original_query}\n\n\
+                 Candidate A: original text-only answer before retry:\n{fallback_text}\n\n\
+                 Candidate B: answer produced by the retry:\n{retry_text}\n\n\
+                 Decide which candidate should be shown.\n\n\
+                 Rules:\n\
+                 - Return restore_fallback only when Candidate A clearly answers the user's actual question and Candidate B does not.\n\
+                 - Return keep_retry when Candidate B answers the question, correctly admits lack of evidence, or when Candidate A makes an unverifiable live-data claim.\n\
+                 - Return keep_retry when uncertain.\n\n\
+                 Output JSON exactly like:\n\
+                 {{\"decision\":\"restore_fallback\"|\"keep_retry\",\"confidence\":0.0,\"reason\":\"short reason\"}}",
+                original_query = input.original_query,
+                fallback_text = input.fallback_text,
+                retry_text = input.retry_text,
+            )
+        }),
+    ]
+}
+
+pub fn parse_factual_retry_fallback_judge_response(
+    raw: &str,
+) -> Result<FactualRetryFallbackJudgeVerdict, String> {
+    let json_text = extract_first_json_object(raw)
+        .ok_or_else(|| format!("judge response did not contain a JSON object: {raw}"))?;
+    let value: Value = serde_json::from_str(json_text)
+        .map_err(|err| format!("judge response was not valid JSON: {err}: {raw}"))?;
+    let decision = match value.get("decision").and_then(Value::as_str) {
+        Some("restore_fallback") => FactualRetryFallbackDecision::RestoreFallback,
+        Some("keep_retry") => FactualRetryFallbackDecision::KeepRetry,
+        other => {
+            return Err(format!(
+                "judge response had invalid decision {other:?}: {raw}"
+            ));
+        }
+    };
+    let confidence = value
+        .get("confidence")
+        .and_then(Value::as_f64)
+        .ok_or_else(|| format!("judge response missing numeric confidence: {raw}"))?
+        .clamp(0.0, 1.0);
+    let reason = value
+        .get("reason")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string);
+
+    Ok(FactualRetryFallbackJudgeVerdict {
+        decision,
+        confidence,
+        reason,
+    })
+}
+
+fn extract_first_json_object(raw: &str) -> Option<&str> {
+    let start = raw.find('{')?;
+    let end = raw.rfind('}')?;
+    (start <= end).then_some(&raw[start..=end])
 }
 
 /// Maps [`AgenticTurnIngestOutcome`] to multi-turn loop control (hosts map break/continue to their enums).
@@ -254,6 +369,26 @@ pub fn ingest_agentic_turn_stream(
     }
 
     if !round_has_edge_work {
+        if *st.forced_factual_retry
+            && *st.total_evidence_tool_calls == 0
+            && st
+                .factual_retry_fallback_text
+                .as_ref()
+                .is_some_and(|text| !text.trim().is_empty())
+            && matches!(
+                st.factual_retry_fallback_decision,
+                Some(FactualRetryFallbackDecision::RestoreFallback)
+            )
+        {
+            let fallback_text = st
+                .factual_retry_fallback_text
+                .take()
+                .expect("fallback presence checked before restore");
+            *st.final_text = fallback_text;
+            persist_final_assistant_message(st.messages, st.final_text.as_str());
+            record_prompt_calibration_success(snap, &mut st);
+            return AgenticTurnIngestOutcome::Break;
+        }
         if should_force_factual_tool_retry(
             st.task_profile,
             message,
@@ -263,8 +398,11 @@ pub fn ingest_agentic_turn_stream(
             &st.turn_policy,
         ) {
             *st.forced_factual_retry = true;
+            if !st.final_text.trim().is_empty() {
+                *st.factual_retry_fallback_text = Some(st.final_text.clone());
+            }
             if !quiet {
-                eprintln!("  ↻ No tool call on a live-data query; forcing one corrective retry…");
+                eprintln!("  ↻ Explicit evidence retry requested; forcing one corrective retry…");
             }
             st.messages.push(openai_factual_tool_retry_user_message(
                 message,
@@ -277,6 +415,7 @@ pub fn ingest_agentic_turn_stream(
         if !snap.full_text.is_empty() {
             persist_final_assistant_message(st.messages, st.final_text.as_str());
         }
+        st.factual_retry_fallback_text.take();
         record_prompt_calibration_success(snap, &mut st);
         return AgenticTurnIngestOutcome::Break;
     }
@@ -333,10 +472,13 @@ mod tests {
         all_tools_used: HashSet<String>,
         has_any_usage: bool,
         forced_factual_retry: bool,
+        factual_retry_fallback_text: Option<String>,
+        factual_retry_fallback_decision: Option<FactualRetryFallbackDecision>,
         messages: Vec<Value>,
         last_measured_prompt_tokens: Option<u64>,
         consecutive_context_window_errors: u32,
         turn_policy: TurnInteractionPolicy,
+        task_profile: TaskExecutionProfile,
     }
 
     impl Pack {
@@ -356,6 +498,8 @@ mod tests {
                 all_tools_used: HashSet::new(),
                 has_any_usage: false,
                 forced_factual_retry: false,
+                factual_retry_fallback_text: None,
+                factual_retry_fallback_decision: None,
                 messages: Vec::new(),
                 last_measured_prompt_tokens: None,
                 consecutive_context_window_errors: 0,
@@ -363,6 +507,7 @@ mod tests {
                     TurnInteractionMode::Deny,
                     vec!["read_file".into()],
                 ),
+                task_profile: TaskExecutionProfile::default(),
             }
         }
 
@@ -375,7 +520,7 @@ mod tests {
             step_persistence_enabled: bool,
         ) -> AgenticTurnIngestMut<'_> {
             AgenticTurnIngestMut {
-                task_profile: TaskExecutionProfile::default(),
+                task_profile: self.task_profile,
                 step_persistence_enabled,
                 first_ttft_ms: &mut self.first_ttft_ms,
                 current_session_id: &mut self.current_session_id,
@@ -391,6 +536,8 @@ mod tests {
                 all_tools_used: &mut self.all_tools_used,
                 has_any_usage: &mut self.has_any_usage,
                 forced_factual_retry: &mut self.forced_factual_retry,
+                factual_retry_fallback_text: &mut self.factual_retry_fallback_text,
+                factual_retry_fallback_decision: self.factual_retry_fallback_decision,
                 messages: &mut self.messages,
                 last_measured_prompt_tokens: &mut self.last_measured_prompt_tokens,
                 consecutive_context_window_errors: &mut self.consecutive_context_window_errors,
@@ -496,6 +643,54 @@ mod tests {
             map_ingest_outcome_to_iteration_control(AgenticTurnIngestOutcome::HasToolCalls),
             AgenticIngestIterationControl::ProceedWithToolCalls
         );
+    }
+
+    #[test]
+    fn factual_retry_fallback_judge_prompt_and_parser_contract() {
+        let messages = factual_retry_fallback_judge_messages(FactualRetryFallbackJudgeInput {
+            original_query: "what do 59% and 117k mean?",
+            fallback_text: "59% is context usage; 117k is token count.",
+            retry_text: "I completed the requested work.",
+        });
+        assert_eq!(messages.len(), 2);
+        let prompt = messages[1]["content"].as_str().unwrap();
+        assert!(prompt.contains("Original user query"));
+        assert!(prompt.contains("Candidate A"));
+        assert!(prompt.contains("Candidate B"));
+        assert!(prompt.contains("\"decision\":\"restore_fallback\"|\"keep_retry\""));
+
+        let verdict = parse_factual_retry_fallback_judge_response(
+            r#"```json
+            {"decision":"restore_fallback","confidence":0.91,"reason":"A answers the question"}
+            ```"#,
+        )
+        .expect("valid judge JSON");
+        assert_eq!(
+            verdict.accepted_decision(),
+            FactualRetryFallbackDecision::RestoreFallback
+        );
+        assert_eq!(verdict.reason.as_deref(), Some("A answers the question"));
+    }
+
+    #[test]
+    fn factual_retry_fallback_judge_low_confidence_restore_fails_closed() {
+        let verdict = parse_factual_retry_fallback_judge_response(
+            r#"{"decision":"restore_fallback","confidence":0.41}"#,
+        )
+        .expect("valid judge JSON");
+        assert_eq!(
+            verdict.accepted_decision(),
+            FactualRetryFallbackDecision::KeepRetry
+        );
+    }
+
+    #[test]
+    fn factual_retry_fallback_judge_rejects_malformed_decisions() {
+        let err = parse_factual_retry_fallback_judge_response(
+            r#"{"decision":"maybe","confidence":0.99}"#,
+        )
+        .expect_err("unknown decisions must fail closed");
+        assert!(err.contains("invalid decision"), "{err}");
     }
 
     #[test]
@@ -775,8 +970,9 @@ mod tests {
 
     #[test]
     fn factual_retry_injects_nudge_and_clears_text() {
-        // When LLM answers a live-data query with zero tool calls,
-        // ingest should inject a retry nudge and return Continue.
+        // When policy explicitly requires factual retry and the LLM produced no
+        // evidence tool calls, ingest should inject a retry nudge and return
+        // Continue.
         let snap = AgenticTurnStreamSnapshot {
             ttft_ms: Some(50),
             session_id: &None,
@@ -792,6 +988,7 @@ mod tests {
             error_kind: None,
         };
         let mut pack = Pack::new();
+        pack.task_profile.allow_factual_retry = true;
         let out = ingest_agentic_turn_stream(
             &snap,
             0,
@@ -803,6 +1000,10 @@ mod tests {
         );
         assert_eq!(out, AgenticTurnIngestOutcome::Continue);
         assert!(pack.forced_factual_retry, "flag should be set");
+        assert_eq!(
+            pack.factual_retry_fallback_text.as_deref(),
+            Some("Here are your recent PRs: ...")
+        );
         assert!(pack.final_text.is_empty(), "text should be cleared");
         assert_eq!(pack.last_measured_prompt_tokens, Some(100));
         assert_eq!(pack.messages.len(), 1, "nudge message should be injected");
@@ -814,6 +1015,240 @@ mod tests {
                 .unwrap()
                 .contains("Runtime correction"),
         );
+    }
+
+    #[test]
+    fn factual_retry_restores_original_when_no_evidence_retry_drops_the_question() {
+        let original = "59% is context usage; 117k is the token count.";
+        let query = "what do 59% and 117k mean in the status line?";
+        let mut pack = Pack::new();
+        pack.forced_factual_retry = true;
+        pack.factual_retry_fallback_text = Some(original.to_string());
+        pack.factual_retry_fallback_decision = Some(FactualRetryFallbackDecision::RestoreFallback);
+
+        let tool_round = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &None,
+            run_id: &None,
+            full_text: "",
+            tool_calls: &[],
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &None,
+            error_kind: None,
+        };
+        let out = ingest_agentic_turn_stream(
+            &tool_round,
+            1,
+            |_| "introspect".to_string(),
+            query,
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+        assert_eq!(out, AgenticTurnIngestOutcome::HasToolCalls);
+        assert_eq!(
+            pack.total_evidence_tool_calls, 0,
+            "introspect is runtime self-observation, not factual evidence"
+        );
+
+        let retry_final = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &None,
+            run_id: &None,
+            full_text: "I completed the requested work and no further action is needed.",
+            tool_calls: &[],
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &None,
+            error_kind: None,
+        };
+        let out = ingest_agentic_turn_stream(
+            &retry_final,
+            0,
+            |_| String::new(),
+            query,
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+        assert_eq!(out, AgenticTurnIngestOutcome::Break);
+        assert_eq!(pack.final_text, original);
+        assert_eq!(pack.factual_retry_fallback_text, None);
+        assert_eq!(pack.messages.last().unwrap()["role"], "assistant");
+        assert_eq!(pack.messages.last().unwrap()["content"], original);
+    }
+
+    #[test]
+    fn factual_retry_accepts_direct_retry_answer_after_control_plane_tools() {
+        let original = "59% is context usage; 117k is the token count.";
+        let query = "what do 59% and 117k mean in the status line?";
+        let corrected = "59% is the context-window usage; 117k is the current token count.";
+        let mut pack = Pack::new();
+        pack.forced_factual_retry = true;
+        pack.factual_retry_fallback_text = Some(original.to_string());
+
+        let tool_round = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &None,
+            run_id: &None,
+            full_text: "",
+            tool_calls: &[],
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &None,
+            error_kind: None,
+        };
+        let out = ingest_agentic_turn_stream(
+            &tool_round,
+            1,
+            |_| "introspect".to_string(),
+            query,
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+        assert_eq!(out, AgenticTurnIngestOutcome::HasToolCalls);
+        assert_eq!(pack.total_evidence_tool_calls, 0);
+
+        let retry_final = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &None,
+            run_id: &None,
+            full_text: corrected,
+            tool_calls: &[],
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &None,
+            error_kind: None,
+        };
+        let out = ingest_agentic_turn_stream(
+            &retry_final,
+            0,
+            |_| String::new(),
+            query,
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+        assert_eq!(out, AgenticTurnIngestOutcome::Break);
+        assert_eq!(pack.final_text, corrected);
+        assert_eq!(pack.factual_retry_fallback_text, None);
+        assert_eq!(pack.messages.last().unwrap()["content"], corrected);
+    }
+
+    #[test]
+    fn factual_retry_does_not_restore_unverified_live_data_answer_without_evidence() {
+        let original = "The latest CI is green.";
+        let query = "latest CI?";
+        let retry = "I could not verify that from the available evidence.";
+        let mut pack = Pack::new();
+        pack.forced_factual_retry = true;
+        pack.factual_retry_fallback_text = Some(original.to_string());
+
+        let retry_final = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &None,
+            run_id: &None,
+            full_text: retry,
+            tool_calls: &[],
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &None,
+            error_kind: None,
+        };
+        let out = ingest_agentic_turn_stream(
+            &retry_final,
+            0,
+            |_| String::new(),
+            query,
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+        assert_eq!(out, AgenticTurnIngestOutcome::Break);
+        assert_eq!(pack.final_text, retry);
+        assert_eq!(pack.factual_retry_fallback_text, None);
+        assert_eq!(pack.messages.last().unwrap()["content"], retry);
+    }
+
+    #[test]
+    fn factual_retry_accepts_retry_answer_after_real_evidence_tool() {
+        let original = "The CI is green.";
+        let query = "最新的一个ci?";
+        let mut pack = Pack::new();
+        pack.forced_factual_retry = true;
+        pack.factual_retry_fallback_text = Some(original.to_string());
+
+        let tool_round = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &None,
+            run_id: &None,
+            full_text: "",
+            tool_calls: &[],
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &None,
+            error_kind: None,
+        };
+        let out = ingest_agentic_turn_stream(
+            &tool_round,
+            1,
+            |_| "github".to_string(),
+            query,
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+        assert_eq!(out, AgenticTurnIngestOutcome::HasToolCalls);
+        assert_eq!(pack.total_evidence_tool_calls, 1);
+
+        let corrected = "The latest CI is failing.";
+        let retry_final = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &None,
+            run_id: &None,
+            full_text: corrected,
+            tool_calls: &[],
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &None,
+            error_kind: None,
+        };
+        let out = ingest_agentic_turn_stream(
+            &retry_final,
+            0,
+            |_| String::new(),
+            query,
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+        assert_eq!(out, AgenticTurnIngestOutcome::Break);
+        assert_eq!(pack.final_text, corrected);
+        assert_eq!(pack.factual_retry_fallback_text, None);
+        assert_eq!(pack.messages.last().unwrap()["content"], corrected);
     }
 
     #[test]
@@ -902,6 +1337,7 @@ mod tests {
             error_kind: None,
         };
         let mut pack = Pack::new();
+        pack.task_profile.allow_factual_retry = true;
         pack.total_tool_calls = 1; // ask_user was called previously
         let out = ingest_agentic_turn_stream(
             &snap,
@@ -955,7 +1391,7 @@ mod tests {
     }
 
     #[test]
-    fn factual_retry_works_for_chinese_workspace_queries() {
+    fn factual_retry_does_not_infer_chinese_workspace_queries_from_text() {
         let snap = AgenticTurnStreamSnapshot {
             ttft_ms: None,
             session_id: &None,
@@ -980,9 +1416,9 @@ mod tests {
             true,
             pack.ingest_mut(),
         );
-        assert_eq!(out, AgenticTurnIngestOutcome::Continue);
-        assert!(pack.forced_factual_retry);
-        assert!(pack.final_text.is_empty());
+        assert_eq!(out, AgenticTurnIngestOutcome::Break);
+        assert!(!pack.forced_factual_retry);
+        assert_eq!(pack.final_text, "代码看起来很好...");
         assert_eq!(pack.messages.len(), 1);
     }
 

--- a/rust/crates/astra-turn-core/src/agentic/turn_ingest.rs
+++ b/rust/crates/astra-turn-core/src/agentic/turn_ingest.rs
@@ -265,15 +265,27 @@ pub fn ingest_agentic_turn_stream(
         *st.current_run_id = snap.run_id.clone();
     }
     let round_has_edge_work = !snap.tool_calls.is_empty() || edge_round_len > 0;
+    let preserve_prior_final_after_runtime_scaffolding_retry = !snap.full_text.is_empty()
+        && !round_has_edge_work
+        && should_preserve_prior_final_after_runtime_scaffolding_retry(
+            st.messages,
+            st.final_text.as_str(),
+        );
 
     // Only text-only responses are final answers. Text that accompanies tool
     // calls is an intermediate preamble; surfacing it as `final_text` makes
     // interrupted/budget-exhausted turns look successfully completed.
-    if !snap.full_text.is_empty() && !round_has_edge_work {
+    if !snap.full_text.is_empty()
+        && !round_has_edge_work
+        && !preserve_prior_final_after_runtime_scaffolding_retry
+    {
         *st.final_text = snap.full_text.to_string();
     }
 
-    if !snap.full_text.is_empty() && !round_has_edge_work {
+    if !snap.full_text.is_empty()
+        && !round_has_edge_work
+        && !preserve_prior_final_after_runtime_scaffolding_retry
+    {
         let guard = apply_response_guards(st.final_text.as_str(), snap.tool_calls, &[], message);
         if let Some(replacement) = guard.replacement {
             agent_warn!("response_guard", "Guard triggered, replacing LLM output");
@@ -412,7 +424,7 @@ pub fn ingest_agentic_turn_stream(
             record_prompt_calibration_success(snap, &mut st);
             return AgenticTurnIngestOutcome::Continue;
         }
-        if !snap.full_text.is_empty() {
+        if !snap.full_text.is_empty() && !preserve_prior_final_after_runtime_scaffolding_retry {
             persist_final_assistant_message(st.messages, st.final_text.as_str());
         }
         st.factual_retry_fallback_text.take();
@@ -447,6 +459,30 @@ fn persist_final_assistant_message(messages: &mut Vec<Value>, final_text: &str) 
         "role": "assistant",
         "content": final_text,
     }));
+}
+
+fn should_preserve_prior_final_after_runtime_scaffolding_retry(
+    messages: &[Value],
+    prior_final_text: &str,
+) -> bool {
+    if prior_final_text.trim().is_empty() {
+        return false;
+    }
+
+    let mut saw_runtime_scaffolding = false;
+    for msg in messages.iter().rev() {
+        let role = msg.get("role").and_then(Value::as_str).unwrap_or("");
+        let content = msg
+            .get("content")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if crate::runtime_scaffolding::is_continuation_scaffolding_for_role(role, content) {
+            saw_runtime_scaffolding = true;
+            continue;
+        }
+        return saw_runtime_scaffolding && role == "assistant" && !content.trim().is_empty();
+    }
+    false
 }
 
 #[cfg(test)]
@@ -964,6 +1000,99 @@ mod tests {
             pack.final_text, "previous stable answer",
             "tool-call preambles are intermediate and must not overwrite the user-visible final answer"
         );
+    }
+
+    #[test]
+    fn no_tool_runtime_scaffolding_retry_preserves_prior_final_answer() {
+        let prior_answer = "Final answer that satisfies the user's request.";
+        let snap = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &None,
+            run_id: &None,
+            full_text: "Runtime follow-up without any new tool evidence.",
+            tool_calls: &[],
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &None,
+            error_kind: None,
+        };
+        let mut pack = Pack::new();
+        pack.final_text = prior_answer.to_string();
+        pack.messages.push(json!({
+            "role": "assistant",
+            "content": prior_answer,
+        }));
+        pack.messages.push(json!({
+            "role": "user",
+            "content": "⚠️ VERIFICATION REQUIRED: Before you finish, run any missing checks",
+        }));
+        pack.messages.push(json!({
+            "role": "user",
+            "content": "## ⚡ Self-Status\nTurn 9/299 | Token pressure: 5% | Cache: 86%",
+        }));
+
+        let out = ingest_agentic_turn_stream(
+            &snap,
+            0,
+            |_| String::new(),
+            "give advice only",
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+
+        assert_eq!(out, AgenticTurnIngestOutcome::Break);
+        assert_eq!(pack.final_text, prior_answer);
+        assert_eq!(
+            pack.messages.len(),
+            3,
+            "no-tool runtime-scaffolding retries must not append or replace the user-visible answer"
+        );
+    }
+
+    #[test]
+    fn no_tool_regular_user_followup_can_replace_prior_final_answer() {
+        let snap = AgenticTurnStreamSnapshot {
+            ttft_ms: None,
+            session_id: &None,
+            run_id: &None,
+            full_text: "Updated answer for the user's follow-up.",
+            tool_calls: &[],
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            has_usage: true,
+            error_message: &None,
+            error_kind: None,
+        };
+        let mut pack = Pack::new();
+        pack.final_text = "Previous answer.".to_string();
+        pack.messages.push(json!({
+            "role": "assistant",
+            "content": "Previous answer.",
+        }));
+        pack.messages.push(json!({
+            "role": "user",
+            "content": "Please adjust the recommendation.",
+        }));
+
+        let out = ingest_agentic_turn_stream(
+            &snap,
+            0,
+            |_| String::new(),
+            "Please adjust the recommendation.",
+            &[],
+            true,
+            pack.ingest_mut(),
+        );
+
+        assert_eq!(out, AgenticTurnIngestOutcome::Break);
+        assert_eq!(pack.final_text, "Updated answer for the user's follow-up.");
+        assert_eq!(pack.messages.len(), 3);
     }
 
     // ─── Factual retry injection tests ──────────────────────────────────────

--- a/rust/crates/astra-turn-core/src/chat_turn_heuristics.rs
+++ b/rust/crates/astra-turn-core/src/chat_turn_heuristics.rs
@@ -186,7 +186,7 @@ impl Default for TaskExecutionProfile {
         Self {
             mutates_workspace: false,
             verification_required: false,
-            allow_factual_retry: true,
+            allow_factual_retry: false,
             exploration_round_window: DEFAULT_EXPLORATION_ROUND_WINDOW,
             stall_window: DEFAULT_STALL_WINDOW,
             complexity: TaskComplexity::Standard,
@@ -228,7 +228,7 @@ pub fn infer_task_execution_profile(input: &str) -> TaskExecutionProfile {
         TaskExecutionProfile {
             mutates_workspace: true,
             verification_required: true,
-            allow_factual_retry: true,
+            allow_factual_retry: false,
             exploration_round_window,
             stall_window,
             complexity,
@@ -239,7 +239,7 @@ pub fn infer_task_execution_profile(input: &str) -> TaskExecutionProfile {
         TaskExecutionProfile {
             mutates_workspace: false,
             verification_required: false,
-            allow_factual_retry: true,
+            allow_factual_retry: false,
             exploration_round_window,
             stall_window,
             complexity,
@@ -251,7 +251,7 @@ pub fn infer_task_execution_profile(input: &str) -> TaskExecutionProfile {
         TaskExecutionProfile {
             mutates_workspace: true,
             verification_required: true,
-            allow_factual_retry: true,
+            allow_factual_retry: false,
             exploration_round_window,
             stall_window,
             complexity,
@@ -343,123 +343,6 @@ pub fn is_session_not_found_error(error: &str) -> bool {
     error.to_lowercase().contains("session not found")
 }
 
-/// Detect queries that refer to the conversation itself rather than
-/// external data.  These should NOT be forced into tool-retry because
-/// the answer is already in the LLM's context window.
-fn references_conversation_context(input: &str) -> bool {
-    let q = input.to_lowercase();
-    [
-        "上面",
-        "上一个",
-        "上个问题",
-        "之前说的",
-        "刚才说的",
-        "前面说的",
-        "你说的",
-        "我说的",
-        "我的问题",
-        "my question",
-        "you said",
-        "i said",
-        "above",
-        "previous message",
-        "previous question",
-        "previous answer",
-    ]
-    .iter()
-    .any(|kw| q.contains(kw))
-}
-
-/// Detect queries that almost certainly need tool calls to answer correctly.
-/// Used for the hallucination guard: if LLM answers these with 0 tool calls,
-/// the response is likely fabricated.
-pub fn looks_like_factual_query(input: &str) -> bool {
-    // Queries about the conversation itself never need tools — the LLM
-    // already has the full chat history in context.
-    if references_conversation_context(input) {
-        return false;
-    }
-
-    let q = input.to_lowercase();
-    // NOTE: bare "问题" removed — it means both "question" and "issue" in
-    // Chinese, causing false positives on conversational queries like
-    // "我上面一个问题？".  "issue" (English) is specific enough.
-    let github_keywords = [
-        "pr",
-        "pull request",
-        "issue",
-        "拉取请求",
-        "commit",
-        "提交",
-        "ci ",
-        " ci?",
-        "ci状态",
-        "最新的一个ci",
-        "workflow",
-        "工作流",
-        "pipeline",
-        "merge",
-        "branch",
-        "分支",
-        "release",
-        "tag",
-        "star",
-        "stars",
-        "多少star",
-    ];
-    let has_github = github_keywords.iter().any(|kw| q.contains(kw));
-    let memory_keywords = ["记忆", "memory", "memories", "存了什么", "记住了什么"];
-    let has_memory = memory_keywords.iter().any(|kw| q.contains(kw));
-    let git_live_keywords = [
-        "git status",
-        "git diff",
-        "改了什么",
-        "有哪些修改",
-        "当前有哪些修改",
-    ];
-    let has_git_live = git_live_keywords.iter().any(|kw| q.contains(kw));
-    let code_keywords = [
-        "read file",
-        "cat ",
-        "show me the code",
-        "what's in",
-        "file content",
-    ];
-    let has_code = code_keywords.iter().any(|kw| q.contains(kw));
-    let web_keywords = ["http", "url", "api ", "endpoint", "fetch", "download"];
-    let has_web = web_keywords.iter().any(|kw| q.contains(kw));
-
-    // Workspace-state queries: anything asking about local changes, diffs,
-    // file contents, or repo state that the model cannot know without tools.
-    // NOTE: bare "看一下" / "看看" removed — they are generic Chinese for
-    // "take a look" and trigger on non-workspace queries like "看看你说的对不对".
-    // They remain in ANALYSIS_TERMS for task-profile classification.
-    let workspace_keywords = [
-        "review",
-        "diff",
-        "changes",
-        "changed",
-        "local",
-        "改动",
-        "修改",
-        "变更",
-        "审查",
-        "审阅",
-        "评审",
-        "什么文件",
-        "哪些文件",
-        "this repo",
-        "this project",
-        "codebase",
-        "这个项目",
-        "这个仓库",
-        "代码库",
-    ];
-    let has_workspace = workspace_keywords.iter().any(|kw| q.contains(kw));
-
-    has_github || has_memory || has_git_live || has_code || has_web || has_workspace
-}
-
 /// Detect requests that are likely to mutate the workspace and therefore
 /// benefit from verification stop hooks before the agent completes.
 ///
@@ -478,14 +361,10 @@ pub fn looks_like_mutating_task(input: &str) -> bool {
     has_mutating
 }
 
-pub fn looks_like_live_query_with_context(input: &str, _recent_tools: &[String]) -> bool {
-    looks_like_factual_query(input)
-}
-
 pub fn should_force_factual_tool_retry(
     profile: TaskExecutionProfile,
-    input: &str,
-    recent_tools: &[String],
+    _input: &str,
+    _recent_tools: &[String],
     total_evidence_tool_calls: u32,
     already_retried: bool,
     policy: &TurnInteractionPolicy,
@@ -494,7 +373,6 @@ pub fn should_force_factual_tool_retry(
         && !already_retried
         && total_evidence_tool_calls == 0
         && policy.has_evidence_tools()
-        && looks_like_live_query_with_context(input, recent_tools)
 }
 
 pub fn factual_tool_retry_message(original_query: &str, policy: &TurnInteractionPolicy) -> String {
@@ -523,12 +401,13 @@ Only call tools from this list to gather evidence — do not use bash to work ar
     format!(
         "Runtime correction: your previous response answered without using any tools. \
         This query requires live data from the workspace, repository, or external sources \
-        that you cannot know from training data alone. Retry from scratch and call tools first.\n\
+        that you cannot know from training data alone. Validate the answer with tools first.\n\
         \n\
         {tools_hint}\n\
         {clarification_hint}\n\
         \n\
-        Discard your previous draft and gather evidence with tools before answering.\n\
+        If the available tools do not provide relevant evidence for the user's actual question, \
+        answer the question directly instead of writing task-progress commentary.\n\
         \n\
         Original user query: {original_query}"
     )
@@ -624,38 +503,6 @@ mod tests {
     use crate::interaction_types::TurnInteractionMode;
 
     #[test]
-    fn factual_query_detects_github_keywords() {
-        assert!(looks_like_factual_query("show me the latest PR"));
-        assert!(looks_like_factual_query("list open issues"));
-        assert!(looks_like_factual_query("check CI status"));
-        assert!(looks_like_factual_query("what's in the commit?"));
-        assert!(looks_like_factual_query("workflow status"));
-        assert!(looks_like_factual_query("最新的一个ci?"));
-        assert!(looks_like_factual_query("多少star了？"));
-        assert!(looks_like_factual_query("pr呢？"));
-    }
-
-    #[test]
-    fn factual_query_detects_file_keywords() {
-        assert!(looks_like_factual_query("read file src/main.rs"));
-        assert!(looks_like_factual_query("cat the config"));
-        assert!(looks_like_factual_query("show me the code in lib.rs"));
-    }
-
-    #[test]
-    fn factual_query_detects_web_keywords() {
-        assert!(looks_like_factual_query("fetch the API endpoint"));
-        assert!(looks_like_factual_query("check http://example.com"));
-    }
-
-    #[test]
-    fn factual_query_detects_memory_and_git_live_queries() {
-        assert!(looks_like_factual_query("我有哪些记忆？"));
-        assert!(looks_like_factual_query("当前有哪些修改？"));
-        assert!(looks_like_factual_query("改了什么，看一眼"));
-    }
-
-    #[test]
     fn mutating_task_detection_distinguishes_read_only_flows() {
         assert!(!looks_like_mutating_task("review 最新的commit"));
         assert!(!looks_like_mutating_task(
@@ -680,13 +527,13 @@ mod tests {
         let review = infer_task_execution_profile("review 最新的commit");
         assert!(!review.mutates_workspace);
         assert!(!review.verification_required);
-        assert!(review.allow_factual_retry);
+        assert!(!review.allow_factual_retry);
         assert_eq!(review.stall_window, DEFAULT_STALL_WINDOW);
 
         let implementation = infer_task_execution_profile("implement the feature");
         assert!(implementation.mutates_workspace);
         assert!(implementation.verification_required);
-        assert!(implementation.allow_factual_retry);
+        assert!(!implementation.allow_factual_retry);
         assert!(
             implementation.agentic_turn_budget.initial_turns
                 > review.agentic_turn_budget.initial_turns
@@ -758,118 +605,44 @@ mod tests {
     }
 
     #[test]
-    fn factual_query_rejects_general_questions() {
-        assert!(!looks_like_factual_query("what is Rust?"));
-        assert!(!looks_like_factual_query("explain monads"));
-        assert!(!looks_like_factual_query("write a function"));
-        assert!(!looks_like_factual_query("hello"));
-    }
-
-    #[test]
-    fn factual_query_rejects_conversation_references() {
-        // Queries about the conversation itself should NOT trigger factual retry
-        // — the answer is already in the LLM's context window.
-        assert!(!looks_like_factual_query("我上面一个问题？"));
-        assert!(!looks_like_factual_query("上一个问题是什么"));
-        assert!(!looks_like_factual_query("之前说的那个"));
-        assert!(!looks_like_factual_query("你说的对吗"));
-        assert!(!looks_like_factual_query("what you said above"));
-        assert!(!looks_like_factual_query("my previous question"));
-    }
-
-    #[test]
-    fn factual_query_rejects_ambiguous_chinese_keywords() {
-        // "问题" alone should NOT trigger (means "question" not just "issue")
-        assert!(!looks_like_factual_query("什么问题？"));
-        assert!(!looks_like_factual_query("你有什么问题？"));
-        assert!(!looks_like_factual_query("这个有问题吗"));
-        // "看一下" / "看看" alone should NOT trigger (too generic)
-        assert!(!looks_like_factual_query("看一下这个公式"));
-        assert!(!looks_like_factual_query("看看你说的对不对"));
-        assert!(!looks_like_factual_query("帮我看看这段话"));
-    }
-
-    #[test]
-    fn force_retry_only_for_first_zero_tool_factual_answer() {
+    fn force_retry_requires_explicit_profile_signal() {
         let none: Vec<String> = vec![];
         let policy = TurnInteractionPolicy::from_visible_tool_names(
             TurnInteractionMode::Deny,
             vec!["github".into()],
         );
+        assert!(!should_force_factual_tool_retry(
+            TaskExecutionProfile::default(),
+            "最新的一个ci?",
+            &none,
+            0,
+            false,
+            &policy,
+        ));
+
+        let explicit = TaskExecutionProfile {
+            allow_factual_retry: true,
+            ..TaskExecutionProfile::default()
+        };
         assert!(should_force_factual_tool_retry(
-            TaskExecutionProfile::default(),
-            "最新的一个ci?",
-            &none,
-            0,
-            false,
-            &policy,
+            explicit, "hello", &none, 0, false, &policy,
         ));
         assert!(!should_force_factual_tool_retry(
-            TaskExecutionProfile::default(),
-            "最新的一个ci?",
-            &none,
-            1,
-            false,
-            &policy,
+            explicit, "hello", &none, 1, false, &policy,
         ));
         assert!(!should_force_factual_tool_retry(
-            TaskExecutionProfile::default(),
-            "最新的一个ci?",
-            &none,
-            0,
-            true,
-            &policy,
-        ));
-        // Analysis tasks now also allow factual retry
-        assert!(should_force_factual_tool_retry(
-            infer_task_execution_profile("review 最新的commit"),
-            "最新的一个ci?",
-            &none,
-            0,
-            false,
-            &policy,
-        ));
-        assert!(!should_force_factual_tool_retry(
-            TaskExecutionProfile::default(),
-            "hello",
-            &none,
-            0,
-            false,
-            &policy,
+            explicit, "hello", &none, 0, true, &policy,
         ));
     }
 
     #[test]
-    fn workspace_queries_detected_as_factual() {
-        // Any query about workspace state should be detected as needing tools
-        assert!(looks_like_factual_query("review local changes"));
-        assert!(looks_like_factual_query("what changed"));
-        assert!(looks_like_factual_query("评审当前修改"));
-        assert!(looks_like_factual_query("看改动"));
-        assert!(looks_like_factual_query("diff the code"));
-        assert!(looks_like_factual_query("what's in this repo"));
-        assert!(looks_like_factual_query("这个项目有什么"));
-        // Generic non-workspace queries should NOT trigger
-        assert!(!looks_like_factual_query("hello"));
-        assert!(!looks_like_factual_query("explain quicksort"));
-        assert!(!looks_like_factual_query("write a poem"));
-    }
-
-    #[test]
-    fn analysis_tasks_allow_factual_retry() {
+    fn heuristic_profiles_do_not_enable_factual_retry() {
         let profile = infer_task_execution_profile("review local changes");
-        assert!(profile.allow_factual_retry);
+        assert!(!profile.allow_factual_retry);
         let profile2 = infer_task_execution_profile("explain this function");
-        assert!(profile2.allow_factual_retry);
-    }
-
-    #[test]
-    fn live_query_detection_ignores_recent_tools_for_short_followups() {
-        let recent = vec!["github".to_string()];
-        assert!(!looks_like_live_query_with_context("最新的", &recent));
-        assert!(looks_like_live_query_with_context("pr呢？", &recent));
-        assert!(!looks_like_live_query_with_context("hello", &recent));
-        assert!(!looks_like_live_query_with_context("然后呢", &recent));
+        assert!(!profile2.allow_factual_retry);
+        let profile3 = infer_task_execution_profile("implement the feature");
+        assert!(!profile3.allow_factual_retry);
     }
 
     #[test]
@@ -881,18 +654,24 @@ mod tests {
         let msg = factual_tool_retry_message("memoria 最新的一个ci?", &policy);
         assert!(msg.contains("mo_query"));
         assert!(msg.contains("cannot pause for user clarification"));
-        assert!(msg.contains("Discard your previous draft"));
+        assert!(msg.contains("If the available tools do not provide relevant evidence"));
+        assert!(!msg.contains("Discard your previous draft"));
     }
 
     #[test]
     fn factual_retry_message_lists_visible_tools_when_provided() {
         let policy = TurnInteractionPolicy::from_visible_tool_names(
             TurnInteractionMode::Deny,
-            vec!["mo_query".to_string(), "read_file".to_string()],
+            vec![
+                "mo_query".to_string(),
+                "introspect".to_string(),
+                "read_file".to_string(),
+            ],
         );
         let msg = factual_tool_retry_message("看session指标", &policy);
         assert!(msg.contains("mo_query"));
         assert!(msg.contains("read_file"));
+        assert!(!msg.contains("introspect"));
         assert!(msg.contains("Only call tools from this list"));
     }
 
@@ -927,8 +706,12 @@ mod tests {
             TurnInteractionMode::Prompt,
             vec!["ask_user".into()],
         );
+        let explicit = TaskExecutionProfile {
+            allow_factual_retry: true,
+            ..TaskExecutionProfile::default()
+        };
         assert!(!should_force_factual_tool_retry(
-            TaskExecutionProfile::default(),
+            explicit,
             "latest CI?",
             &[],
             0,

--- a/rust/crates/astra-turn-core/src/chat_turn_heuristics.rs
+++ b/rust/crates/astra-turn-core/src/chat_turn_heuristics.rs
@@ -57,6 +57,37 @@ const MUTATING_TERMS: &[&str] = &[
     "修正",
 ];
 
+const EXPLICIT_MUTATION_DIRECTIVE_TERMS: &[&str] = &[
+    "fix",
+    "fix issues",
+    "fix failures",
+    "implement",
+    "write",
+    "edit",
+    "update code",
+    "create",
+    "add ",
+    "remove",
+    "delete",
+    "patch",
+    "refactor",
+    "apply",
+    "cleanup",
+    "clean up",
+    "修改代码",
+    "修改文件",
+    "重构",
+    "实现",
+    "新增",
+    "删除",
+    "更新代码",
+    "更新文件",
+    "修复",
+    "修正",
+    "清理",
+    "合理采纳",
+];
+
 const ANALYSIS_TERMS: &[&str] = &[
     "review",
     "code review",
@@ -204,6 +235,8 @@ fn contains_any_keyword(q: &str, keywords: &[&str]) -> bool {
 pub fn infer_task_execution_profile(input: &str) -> TaskExecutionProfile {
     let q = input.to_lowercase();
     let has_mutating = contains_any_keyword(&q, MUTATING_TERMS);
+    let has_explicit_mutation_directive =
+        contains_any_keyword(&q, EXPLICIT_MUTATION_DIRECTIVE_TERMS);
     let has_analysis = contains_any_keyword(&q, ANALYSIS_TERMS);
     let exploratory = contains_any_keyword(&q, EXPLORATION_TERMS);
     let complexity = if contains_any_keyword(&q, COMPLEXITY_TERMS) {
@@ -221,10 +254,12 @@ pub fn infer_task_execution_profile(input: &str) -> TaskExecutionProfile {
     } else {
         DEFAULT_STALL_WINDOW
     };
-    // When both mutating and analysis terms are present, analysis wins —
-    // the user is asking to *review/inspect* something that involves changes,
-    // not asking to *make* changes. E.g. "评审当前修改" = review changes.
-    if has_mutating && !has_analysis {
+    // When both mutating and analysis terms are present, an explicit mutation
+    // directive wins ("review and fix", "评审并修复", "清理过时测试"). Otherwise
+    // analysis wins for object descriptions such as "评审当前修改" / "review
+    // current changes".
+    let should_mutate = has_explicit_mutation_directive || has_mutating && !has_analysis;
+    if should_mutate {
         TaskExecutionProfile {
             mutates_workspace: true,
             verification_required: true,
@@ -245,18 +280,6 @@ pub fn infer_task_execution_profile(input: &str) -> TaskExecutionProfile {
             complexity,
             exploratory_task: exploratory,
             agentic_turn_budget: default_agentic_turn_budget(false, exploratory, complexity),
-        }
-    } else if has_mutating {
-        // Mutating without analysis context
-        TaskExecutionProfile {
-            mutates_workspace: true,
-            verification_required: true,
-            allow_factual_retry: false,
-            exploration_round_window,
-            stall_window,
-            complexity,
-            exploratory_task: exploratory,
-            agentic_turn_budget: default_agentic_turn_budget(true, exploratory, complexity),
         }
     } else {
         TaskExecutionProfile {
@@ -353,12 +376,9 @@ pub fn looks_like_mutating_task(input: &str) -> bool {
     let q = input.to_lowercase();
     let has_mutating = contains_any_keyword(&q, MUTATING_TERMS);
     let has_read_only = contains_any_keyword(&q, ANALYSIS_TERMS);
-    // Analysis context overrides mutating terms — user is reviewing/inspecting
-    // something that involves changes, not requesting changes themselves.
-    if has_read_only {
-        return false;
-    }
-    has_mutating
+    let has_explicit_mutation_directive =
+        contains_any_keyword(&q, EXPLICIT_MUTATION_DIRECTIVE_TERMS);
+    has_explicit_mutation_directive || has_mutating && !has_read_only
 }
 
 pub fn should_force_factual_tool_retry(
@@ -509,10 +529,6 @@ mod tests {
             "what changed in the latest commit?"
         ));
         assert!(!looks_like_mutating_task("explain this diff"));
-        // Analysis context overrides even when mutating terms are present
-        assert!(!looks_like_mutating_task(
-            "review the latest commit and fix any issues"
-        ));
         assert!(!looks_like_mutating_task("评审当前修改"));
         assert!(!looks_like_mutating_task("审查修改"));
         assert!(!looks_like_mutating_task("看一下修改"));
@@ -520,6 +536,16 @@ mod tests {
         assert!(looks_like_mutating_task("implement the feature"));
         assert!(looks_like_mutating_task("fix the bug"));
         assert!(looks_like_mutating_task("修复这个问题"));
+        // Mixed review + explicit mutation should still get a mutating profile.
+        assert!(looks_like_mutating_task(
+            "review the latest commit and fix any issues"
+        ));
+        assert!(looks_like_mutating_task(
+            "review the current changes and fix any issues"
+        ));
+        assert!(looks_like_mutating_task(
+            "多角度review这个分支changes，清理过时测试"
+        ));
     }
 
     #[test]
@@ -595,9 +621,16 @@ mod tests {
     }
 
     #[test]
-    fn analysis_wins_over_mutating_when_both_present() {
-        // "review and fix" → analysis wins (user is reviewing, not just fixing)
+    fn explicit_mutation_wins_over_analysis_when_both_present() {
+        // "review and fix" is a mixed request: inspect first, then mutate.
         let profile = infer_task_execution_profile("review the code and fix issues");
+        assert!(profile.verification_required);
+        assert!(profile.mutates_workspace);
+        let profile = infer_task_execution_profile("多角度review这个分支changes，清理过时测试");
+        assert!(profile.verification_required);
+        assert!(profile.mutates_workspace);
+        // Describing changes as the object of review remains read-only.
+        let profile = infer_task_execution_profile("review current changes");
         assert!(!profile.verification_required);
         // Pure mutating still works
         let profile = infer_task_execution_profile("fix the compilation error");

--- a/rust/crates/astra-turn-core/src/chat_turn_heuristics.rs
+++ b/rust/crates/astra-turn-core/src/chat_turn_heuristics.rs
@@ -29,6 +29,44 @@ const STANDARD_MUTATING_EXPLORATORY_TURN_BUDGET: AgenticTurnBudget =
 const COMPLEX_MUTATING_EXPLORATORY_TURN_BUDGET: AgenticTurnBudget =
     AgenticTurnBudget::new(140, 280, 35, 4);
 
+const WORKSPACE_EVIDENCE_PHRASES: &[&str] = &[
+    "working tree",
+    "local changes",
+    "current changes",
+    "pull request",
+    "test failure",
+    "build failure",
+    "仓库",
+    "工作区",
+    "改动",
+    "修改",
+    "变更",
+    "提交",
+    "分支",
+    "代码",
+    "文件",
+    "函数",
+    "测试失败",
+    "构建失败",
+];
+
+const WORKSPACE_EVIDENCE_WORDS: &[&str] = &[
+    "repo",
+    "repository",
+    "workspace",
+    "changes",
+    "diff",
+    "commit",
+    "branch",
+    "pr",
+    "ci",
+    "github",
+    "codebase",
+    "code",
+    "file",
+    "function",
+];
+
 const MUTATING_TERMS: &[&str] = &[
     "fix",
     "修改代码",
@@ -231,6 +269,18 @@ fn contains_any_keyword(q: &str, keywords: &[&str]) -> bool {
     keywords.iter().any(|kw| q.contains(kw))
 }
 
+fn contains_ascii_word(q: &str, word: &str) -> bool {
+    q.split(|ch: char| !ch.is_ascii_alphanumeric())
+        .any(|part| part == word)
+}
+
+fn contains_workspace_evidence_signal(q: &str) -> bool {
+    contains_any_keyword(q, WORKSPACE_EVIDENCE_PHRASES)
+        || WORKSPACE_EVIDENCE_WORDS
+            .iter()
+            .any(|word| contains_ascii_word(q, word))
+}
+
 #[must_use]
 pub fn infer_task_execution_profile(input: &str) -> TaskExecutionProfile {
     let q = input.to_lowercase();
@@ -259,11 +309,13 @@ pub fn infer_task_execution_profile(input: &str) -> TaskExecutionProfile {
     // analysis wins for object descriptions such as "评审当前修改" / "review
     // current changes".
     let should_mutate = has_explicit_mutation_directive || has_mutating && !has_analysis;
+    let needs_workspace_evidence =
+        should_mutate || exploratory || contains_workspace_evidence_signal(&q);
     if should_mutate {
         TaskExecutionProfile {
             mutates_workspace: true,
             verification_required: true,
-            allow_factual_retry: false,
+            allow_factual_retry: needs_workspace_evidence,
             exploration_round_window,
             stall_window,
             complexity,
@@ -274,7 +326,7 @@ pub fn infer_task_execution_profile(input: &str) -> TaskExecutionProfile {
         TaskExecutionProfile {
             mutates_workspace: false,
             verification_required: false,
-            allow_factual_retry: false,
+            allow_factual_retry: needs_workspace_evidence,
             exploration_round_window,
             stall_window,
             complexity,
@@ -287,6 +339,7 @@ pub fn infer_task_execution_profile(input: &str) -> TaskExecutionProfile {
             stall_window,
             complexity,
             exploratory_task: exploratory,
+            allow_factual_retry: needs_workspace_evidence,
             agentic_turn_budget: default_agentic_turn_budget(false, exploratory, complexity),
             ..TaskExecutionProfile::default()
         }
@@ -553,13 +606,13 @@ mod tests {
         let review = infer_task_execution_profile("review 最新的commit");
         assert!(!review.mutates_workspace);
         assert!(!review.verification_required);
-        assert!(!review.allow_factual_retry);
+        assert!(review.allow_factual_retry);
         assert_eq!(review.stall_window, DEFAULT_STALL_WINDOW);
 
         let implementation = infer_task_execution_profile("implement the feature");
         assert!(implementation.mutates_workspace);
         assert!(implementation.verification_required);
-        assert!(!implementation.allow_factual_retry);
+        assert!(implementation.allow_factual_retry);
         assert!(
             implementation.agentic_turn_budget.initial_turns
                 > review.agentic_turn_budget.initial_turns
@@ -577,6 +630,7 @@ mod tests {
                 >= implementation.agentic_turn_budget.hard_turn_limit
         );
         assert!(exploratory.exploratory_task);
+        assert!(exploratory.allow_factual_retry);
     }
 
     #[test]
@@ -669,13 +723,22 @@ mod tests {
     }
 
     #[test]
-    fn heuristic_profiles_do_not_enable_factual_retry() {
+    fn heuristic_profiles_enable_factual_retry_only_for_workspace_evidence() {
         let profile = infer_task_execution_profile("review local changes");
-        assert!(!profile.allow_factual_retry);
+        assert!(profile.allow_factual_retry);
         let profile2 = infer_task_execution_profile("explain this function");
-        assert!(!profile2.allow_factual_retry);
+        assert!(profile2.allow_factual_retry);
         let profile3 = infer_task_execution_profile("implement the feature");
-        assert!(!profile3.allow_factual_retry);
+        assert!(profile3.allow_factual_retry);
+        let profile4 =
+            infer_task_execution_profile("what do 59% and 117k mean in the status line?");
+        assert!(!profile4.allow_factual_retry);
+        let profile5 = infer_task_execution_profile("what is Rust?");
+        assert!(!profile5.allow_factual_retry);
+        let profile6 = infer_task_execution_profile("explain recursion conceptually");
+        assert!(!profile6.allow_factual_retry);
+        let profile7 = infer_task_execution_profile("explain prompt profile settings");
+        assert!(!profile7.allow_factual_retry);
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/evaluation.rs
+++ b/rust/crates/astra-turn-core/src/evaluation.rs
@@ -12,8 +12,6 @@
 use astra_services::session_journal::{JournalEvent, ToolCallRecord};
 use serde_json::json;
 
-use crate::chat_turn_heuristics::looks_like_live_query_with_context;
-
 /// Signals detected during evaluation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum EvalSignal {
@@ -360,8 +358,8 @@ pub fn evaluate_tool_call_records_with_thresholds(
 
 #[allow(clippy::too_many_arguments)]
 pub fn evaluate_tool_call_records_with_thresholds_and_telemetry(
-    input: &str,
-    recent_tools: &[String],
+    _input: &str,
+    _recent_tools: &[String],
     tool_call_records: &[ToolCallRecord],
     stall_count: usize,
     verdict_warning: bool,
@@ -415,7 +413,7 @@ pub fn evaluate_tool_call_records_with_thresholds_and_telemetry(
             no_op: record.is_noop_or_cached_result(),
         })
         .collect::<Vec<_>>();
-    let is_live_query = looks_like_live_query_with_context(input, recent_tools);
+    let is_live_query = false;
     let mut eval = evaluate_turn(
         &tool_calls,
         stall_count,
@@ -1346,8 +1344,8 @@ pub fn build_turn_evaluation_journal_event(
     session_id: Option<&str>,
     turn: Option<u32>,
     source: &str,
-    input: &str,
-    recent_tools: &[String],
+    _input: &str,
+    _recent_tools: &[String],
     tool_call_records: &[ToolCallRecord],
     stall_count: usize,
     verdict_warning: bool,
@@ -1358,7 +1356,7 @@ pub fn build_turn_evaluation_journal_event(
         session_id,
         turn,
         source,
-        looks_like_live_query_with_context(input, recent_tools),
+        false,
         eval.success,
         eval.quality,
         eval.confidence,
@@ -1590,7 +1588,7 @@ mod tests {
     }
 
     #[test]
-    fn evaluate_tool_call_records_reuses_live_query_heuristic() {
+    fn evaluate_tool_call_records_does_not_infer_live_query_from_text() {
         let eval = evaluate_tool_call_records(
             "Check the latest git status",
             &["git".to_string()],
@@ -1599,8 +1597,8 @@ mod tests {
             false,
             0.2,
         );
-        assert!(!eval.success);
-        assert!(eval.signals.contains(&EvalSignal::NoToolsNeeded));
+        assert!(eval.success);
+        assert!(!eval.signals.contains(&EvalSignal::NoToolsNeeded));
     }
 
     #[test]
@@ -1717,7 +1715,7 @@ mod tests {
         assert_eq!(event.event_type, JournalEventType::TurnEvaluation);
         let metadata = event.metadata.expect("turn evaluation metadata");
         assert_eq!(metadata["source"], "cli_repl");
-        assert_eq!(metadata["live_query"], true);
+        assert_eq!(metadata["live_query"], false);
         assert_eq!(metadata["tool_call_count"], 1);
         assert_eq!(metadata["signal_count"], 2);
         assert_eq!(metadata["signals"][0]["kind"], "tool_error_rate");

--- a/rust/crates/astra-turn-core/src/headless/journal.rs
+++ b/rust/crates/astra-turn-core/src/headless/journal.rs
@@ -1,6 +1,6 @@
 //! `ToolCallRecord` rows for headless early-exit paths.
 
-use astra_services::session_journal::ToolCallRecord;
+use astra_services::session_journal::{NOOP_OR_CACHED_RESULT_CLASS, ToolCallRecord};
 
 #[must_use]
 pub fn journal_record_duplicate_within_turn(
@@ -19,6 +19,7 @@ pub fn journal_record_duplicate_within_turn(
         file_path: None,
         surgically_removed: None,
         original_tool_name: None,
+        result_class: Some(NOOP_OR_CACHED_RESULT_CLASS.to_string()),
         ..Default::default()
     }
 }
@@ -84,6 +85,7 @@ pub fn journal_record_cross_turn_cache_hit(
         file_path: None,
         surgically_removed: None,
         original_tool_name: None,
+        result_class: Some(NOOP_OR_CACHED_RESULT_CLASS.to_string()),
         ..Default::default()
     }
 }
@@ -142,6 +144,7 @@ pub fn journal_record_tool_not_admitted(
         file_path: None,
         surgically_removed: None,
         original_tool_name: None,
+        result_class: Some(NOOP_OR_CACHED_RESULT_CLASS.to_string()),
         ..Default::default()
     }
 }
@@ -190,6 +193,7 @@ pub fn journal_record_suppressed_tool_retry(
         file_path: None,
         surgically_removed: None,
         original_tool_name: None,
+        result_class: Some(NOOP_OR_CACHED_RESULT_CLASS.to_string()),
         ..Default::default()
     }
 }
@@ -259,12 +263,16 @@ mod tests {
         let r = journal_record_duplicate_within_turn("bash".into(), Some("x".into()));
         assert!(r.ok);
         assert_eq!(r.error.as_deref(), Some("duplicate_within_turn"));
+        assert_eq!(r.result_class.as_deref(), Some(NOOP_OR_CACHED_RESULT_CLASS));
+        assert!(r.is_structured_noop_or_cached_result());
     }
 
     #[test]
     fn cache_hit_record_has_output_bytes() {
         let r = journal_record_cross_turn_cache_hit("read_file".into(), 12, None, None);
         assert_eq!(r.output_bytes, Some(12));
+        assert_eq!(r.result_class.as_deref(), Some(NOOP_OR_CACHED_RESULT_CLASS));
+        assert!(r.is_structured_noop_or_cached_result());
     }
 
     #[test]
@@ -440,6 +448,8 @@ mod tests {
         assert!(!r.ok);
         assert_eq!(r.ms, 7);
         assert_eq!(r.error.as_deref(), Some("unknown_tool: nope"));
+        assert_eq!(r.result_class, None);
+        assert!(!r.is_structured_noop_or_cached_result());
     }
 
     #[test]
@@ -460,6 +470,8 @@ mod tests {
                 .is_some_and(|preview| preview.starts_with("Deferred:"))
         );
         assert!(r.is_synthetic_placeholder());
+        assert_eq!(r.result_class.as_deref(), Some(NOOP_OR_CACHED_RESULT_CLASS));
+        assert!(r.is_structured_noop_or_cached_result());
     }
 
     #[test]
@@ -488,6 +500,8 @@ mod tests {
         assert!(r.ok);
         assert_eq!(r.error.as_deref(), Some("nonprogress_retry_deferred"));
         assert!(r.is_synthetic_placeholder());
+        assert_eq!(r.result_class.as_deref(), Some(NOOP_OR_CACHED_RESULT_CLASS));
+        assert!(r.is_structured_noop_or_cached_result());
         assert!(
             !r.was_blocked_by_policy(),
             "retry deferral must not look like a hard policy block"

--- a/rust/crates/astra-turn-core/src/interaction_types.rs
+++ b/rust/crates/astra-turn-core/src/interaction_types.rs
@@ -6,6 +6,8 @@
 use serde_json::Value;
 use std::collections::HashSet;
 
+use crate::tool::registry::meta::{IntentType, tool_meta};
+
 /// Canonical name of the ask-user tool.
 pub const ASK_USER_TOOL_NAME: &str = "ask_user";
 
@@ -140,10 +142,46 @@ pub fn interaction_scoped_tool_restrictions(mode: TurnInteractionMode) -> HashSe
     }
 }
 
-/// Whether a tool invocation counts as factual evidence (all tools except ask_user).
+/// Whether a tool invocation counts as factual evidence for post-hoc live-data retry.
+///
+/// Evidence means the tool observes user/world/workspace data. Control-plane
+/// and runtime-self-observation tools are useful for agent steering, but they
+/// should not make a forced factual retry overwrite a good first answer.
 #[must_use]
 pub fn tool_counts_as_factual_evidence(tool_name: &str) -> bool {
-    tool_name != ASK_USER_TOOL_NAME
+    if tool_name == ASK_USER_TOOL_NAME {
+        return false;
+    }
+    if matches!(
+        tool_name,
+        "introspect"
+            | "tool_search"
+            | "compress_context"
+            | "rollback_session_state"
+            | "enter_plan_mode"
+            | "exit_plan_mode"
+    ) {
+        return false;
+    }
+    if let Some(meta) = tool_meta(tool_name) {
+        if meta.intents.contains(&IntentType::Introspect) {
+            return false;
+        }
+        if !meta.intents.iter().any(|intent| {
+            matches!(
+                intent,
+                IntentType::CodeRead
+                    | IntentType::CodeEdit
+                    | IntentType::Git
+                    | IntentType::GitHub
+                    | IntentType::Memory
+                    | IntentType::Database
+            )
+        }) {
+            return false;
+        }
+    }
+    true
 }
 
 #[cfg(test)]
@@ -202,5 +240,56 @@ mod tests {
         // NOT be the silencing mode. Silencing is opt-in via explicit
         // Auto.
         assert!(!TurnInteractionMode::default().suppresses_loop_nudges());
+    }
+
+    #[test]
+    fn runtime_control_tools_do_not_count_as_factual_evidence() {
+        for name in [
+            ASK_USER_TOOL_NAME,
+            "introspect",
+            "reflect",
+            "session",
+            "tool_search",
+            "compress_context",
+            "rollback_session_state",
+            "enter_plan_mode",
+            "exit_plan_mode",
+        ] {
+            assert!(
+                !tool_counts_as_factual_evidence(name),
+                "{name} must not satisfy factual-retry evidence"
+            );
+        }
+
+        for name in [
+            "read_file",
+            "grep",
+            "glob",
+            "bash",
+            "git",
+            "github",
+            "mo_query",
+        ] {
+            assert!(
+                tool_counts_as_factual_evidence(name),
+                "{name} should count as factual-retry evidence"
+            );
+        }
+    }
+
+    #[test]
+    fn interaction_policy_excludes_control_tools_from_evidence_list() {
+        let policy = TurnInteractionPolicy::from_visible_tool_names(
+            TurnInteractionMode::Auto,
+            vec![
+                "introspect".into(),
+                "read_file".into(),
+                "ask_user".into(),
+                "grep".into(),
+            ],
+        );
+
+        assert_eq!(policy.evidence_tool_names, vec!["read_file", "grep"]);
+        assert!(policy.has_evidence_tools());
     }
 }

--- a/rust/crates/astra-turn-core/src/permission/engine.rs
+++ b/rust/crates/astra-turn-core/src/permission/engine.rs
@@ -1264,6 +1264,19 @@ fn resolve_git_safety_guard(
     }
 
     if ctx.mode().skips_human_approval_prompts() {
+        if has_hard_violation {
+            let reason = format!("Git safety hard violation (bypass denied): {joined_reasons}");
+            return GuardResolution::Return {
+                decision: HardDecision::Deny {
+                    reason: reason.clone(),
+                },
+                source: DecisionSource::GitSafety {
+                    violation: reason.clone(),
+                },
+                detail: reason,
+                skipped_notes,
+            };
+        }
         if ctx.inherited.allowed_tools.is_some() {
             skipped_notes.push(format!(
                 "bypass mode git violation, deferring to allowlist: {joined_reasons}",
@@ -2603,6 +2616,27 @@ mod tests {
     }
 
     #[test]
+    fn structured_git_force_push_feature_branch_is_allowed_in_bypass_mode() {
+        let ctx = crate::permission::types::PermissionSyncContext::root(
+            crate::permission::types::PermissionMode::Bypass,
+        );
+        let envelope = evaluate_permission(
+            "git",
+            &serde_json::json!({
+                "action": "push",
+                "remote": "origin",
+                "branch": "feature/my-branch",
+                "force_with_lease": true
+            }),
+            &ctx,
+        );
+
+        assert!(matches!(envelope.decision, HardDecision::Allow));
+        assert!(matches!(envelope.source, DecisionSource::GitSafety { .. }));
+        assert!(envelope.risk_tags.contains(&RiskTag::GitDestructive));
+    }
+
+    #[test]
     fn structured_git_force_push_protected_branch_requires_approval_in_auto_mode() {
         let ctx = crate::permission::types::PermissionSyncContext::root(
             crate::permission::types::PermissionMode::Auto,
@@ -2627,7 +2661,7 @@ mod tests {
     }
 
     #[test]
-    fn structured_git_force_push_protected_branch_is_allowed_in_bypass_mode() {
+    fn structured_git_force_push_protected_branch_is_denied_in_bypass_mode() {
         let ctx = crate::permission::types::PermissionSyncContext::root(
             crate::permission::types::PermissionMode::Bypass,
         );
@@ -2642,7 +2676,11 @@ mod tests {
             &ctx,
         );
 
-        assert!(matches!(envelope.decision, HardDecision::Allow));
+        assert!(matches!(
+            envelope.decision,
+            HardDecision::Deny { ref reason }
+                if reason.contains("Git safety hard violation")
+        ));
         assert!(matches!(envelope.source, DecisionSource::GitSafety { .. }));
         assert!(envelope.risk_tags.contains(&RiskTag::GitDestructive));
     }
@@ -2804,7 +2842,7 @@ mod tests {
             &serde_json::json!({
                 "action": "push",
                 "remote": "origin",
-                "branch": "main",
+                "branch": "feature/my-branch",
                 "force_with_lease": true
             }),
             &ctx,

--- a/rust/crates/astra-turn-core/src/permission/engine.rs
+++ b/rust/crates/astra-turn-core/src/permission/engine.rs
@@ -438,7 +438,7 @@ pub fn evaluate_permission(
             // are relaxed: the user has delegated trust to the agent.
             // Catastrophic commands (rm -rf /, fork bombs) and destructive SQL
             // (DROP TABLE, etc.) remain hard-denied regardless of mode.
-            if ctx.mode() == PermissionMode::Auto
+            if matches!(ctx.mode(), PermissionMode::Auto | PermissionMode::Bypass)
                 && reason.contains("shell_obfuscation")
                 && !reason.contains("catastrophic")
             {
@@ -495,12 +495,81 @@ pub fn evaluate_permission(
                 risk_tags,
             );
         }
-        if ctx.mode() == PermissionMode::Auto && !has_hard_violation {
+        let mut git_safety_deferred = false;
+        if let Some((stored_override, allowed)) = fingerprinted_override_match(tool_name, args, ctx)
+        {
+            if allowed && !stored_override_allows_git_safety(&stored_override) {
+                push_skipped(
+                    &mut trace,
+                    EvaluationStep::GitSafety,
+                    "broad session override cannot bypass git safety",
+                );
+            } else if ctx.inherited.allowed_tools.is_some() {
+                push_skipped(
+                    &mut trace,
+                    EvaluationStep::GitSafety,
+                    &format!(
+                        "session override matched git violation, deferring to allowlist: {}",
+                        reasons.join(", ")
+                    ),
+                );
+                git_safety_deferred = true;
+            } else {
+                let decision = if allowed {
+                    HardDecision::Allow
+                } else {
+                    HardDecision::Deny {
+                        reason: "Skipped for session".to_string(),
+                    }
+                };
+                push_matched(
+                    &mut trace,
+                    EvaluationStep::GitSafety,
+                    &decision,
+                    "fingerprinted session override matched git safety request",
+                );
+                return envelope(
+                    decision,
+                    DecisionSource::SessionOverride { allowed },
+                    trace,
+                    will_save,
+                    risk_tags,
+                );
+            }
+        }
+        if !git_safety_deferred && ctx.mode() == PermissionMode::Bypass {
+            if ctx.inherited.allowed_tools.is_some() {
+                push_skipped(
+                    &mut trace,
+                    EvaluationStep::GitSafety,
+                    &format!(
+                        "bypass mode git violation, deferring to allowlist: {}",
+                        reasons.join(", ")
+                    ),
+                );
+                git_safety_deferred = true;
+            } else {
+                let reason = format!("Git safety (bypass): {}", reasons.join(", "));
+                let decision = HardDecision::Allow;
+                push_matched(&mut trace, EvaluationStep::GitSafety, &decision, &reason);
+                return envelope(
+                    decision,
+                    DecisionSource::GitSafety { violation: reason },
+                    trace,
+                    will_save,
+                    risk_tags,
+                );
+            }
+        }
+        if git_safety_deferred {
+            // Continue into ToolAllowlist; if allowed there, SessionOverride
+            // or the final Bypass mode decision can allow the exact request.
+        } else if ctx.mode() == PermissionMode::Auto && !has_hard_violation {
             // Soft git violation in auto mode: allow.
             // If there's an explicit allowlist, let ExplicitApprovalGate evaluate
             // whether git is listed.
-            // If a session override exists, defer so SessionOverride can refuse
-            // to bypass git safety.
+            // If a session override exists, defer so SessionOverride can honor
+            // the already-approved exact fingerprint after allowlist policy.
             if ctx.inherited.allowed_tools.is_some() {
                 push_skipped(
                     &mut trace,
@@ -520,7 +589,7 @@ pub fn evaluate_permission(
                         reasons.join(", ")
                     ),
                 );
-                // continue — SessionOverride will refuse to bypass git safety
+                // continue — SessionOverride will apply the bounded decision
             } else {
                 let reason = format!("Git safety (auto-allow): {}", reasons.join(", "));
                 let decision = HardDecision::Allow;
@@ -606,7 +675,74 @@ pub fn evaluate_permission(
                 risk_tags,
             );
         }
-        if ctx.mode() == PermissionMode::Auto {
+        let mut defer_sensitive_to_allowlist = false;
+        if let Some((stored_override, allowed)) = fingerprinted_override_match(tool_name, args, ctx)
+        {
+            if allowed && !stored_override_allows_sensitive_path(&stored_override) {
+                push_skipped(
+                    &mut trace,
+                    EvaluationStep::SensitivePath,
+                    "broad session override cannot bypass sensitive path",
+                );
+            } else if ctx.inherited.allowed_tools.is_some() {
+                push_skipped(
+                    &mut trace,
+                    EvaluationStep::SensitivePath,
+                    "session override matched sensitive path, deferring to allowlist",
+                );
+                defer_sensitive_to_allowlist = true;
+            } else {
+                let decision = if allowed {
+                    HardDecision::Allow
+                } else {
+                    HardDecision::Deny {
+                        reason: "Sensitive path denied for session".to_string(),
+                    }
+                };
+                push_matched(
+                    &mut trace,
+                    EvaluationStep::SensitivePath,
+                    &decision,
+                    "fingerprinted session override matched sensitive path",
+                );
+                return envelope(
+                    decision,
+                    DecisionSource::SessionOverride { allowed },
+                    trace,
+                    will_save,
+                    risk_tags,
+                );
+            }
+        }
+        if !defer_sensitive_to_allowlist && ctx.mode() == PermissionMode::Bypass {
+            if ctx.inherited.allowed_tools.is_some() {
+                push_skipped(
+                    &mut trace,
+                    EvaluationStep::SensitivePath,
+                    "bypass mode sensitive path, deferring to allowlist",
+                );
+                defer_sensitive_to_allowlist = true;
+            } else {
+                let decision = HardDecision::Allow;
+                push_matched(
+                    &mut trace,
+                    EvaluationStep::SensitivePath,
+                    &decision,
+                    "sensitive path allowed by bypass mode",
+                );
+                return envelope(
+                    decision,
+                    DecisionSource::SensitivePath { path },
+                    trace,
+                    will_save,
+                    risk_tags,
+                );
+            }
+        }
+        if defer_sensitive_to_allowlist {
+            // Continue into ToolAllowlist; if allowed there, SessionOverride
+            // or the final Bypass mode decision can allow the exact request.
+        } else if ctx.mode() == PermissionMode::Auto {
             let reason = "Targets a sensitive file path and requires manual approval".to_string();
             let decision = HardDecision::NeedExternal {
                 prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.clone()),
@@ -620,18 +756,20 @@ pub fn evaluate_permission(
                 risk_tags,
             );
         }
-        let reason = "Targets a sensitive file path and requires manual approval".to_string();
-        let decision = HardDecision::NeedExternal {
-            prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.clone()),
-        };
-        push_matched(&mut trace, EvaluationStep::SensitivePath, &decision, &path);
-        return envelope(
-            decision,
-            DecisionSource::SensitivePath { path },
-            trace,
-            will_save,
-            risk_tags,
-        );
+        if !defer_sensitive_to_allowlist {
+            let reason = "Targets a sensitive file path and requires manual approval".to_string();
+            let decision = HardDecision::NeedExternal {
+                prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.clone()),
+            };
+            push_matched(&mut trace, EvaluationStep::SensitivePath, &decision, &path);
+            return envelope(
+                decision,
+                DecisionSource::SensitivePath { path },
+                trace,
+                will_save,
+                risk_tags,
+            );
+        }
     }
     push_skipped(
         &mut trace,
@@ -641,7 +779,7 @@ pub fn evaluate_permission(
 
     if let Some(inner_tool) = tool_name.strip_prefix("sandbox_expand:") {
         return match ctx.mode() {
-            PermissionMode::Auto => {
+            PermissionMode::Auto | PermissionMode::Bypass => {
                 let decision = HardDecision::Allow;
                 push_matched(
                     &mut trace,
@@ -769,23 +907,32 @@ pub fn evaluate_permission(
         .inherited
         .ask_rule_with_context(tool_name, &rule_match_context)
     {
-        let reason = format!("Tool '{tool_name}' requires parent approval");
-        let decision = HardDecision::NeedExternal {
-            prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.clone()),
-        };
-        push_matched(&mut trace, EvaluationStep::AskRules, &decision, &reason);
-        return envelope(
-            decision,
-            DecisionSource::AskRule {
-                rule: rule.to_string(),
-                origin: RuleOrigin::Inherited,
-            },
-            trace,
-            will_save,
-            risk_tags,
-        );
+        if ctx.mode() == PermissionMode::Bypass {
+            push_skipped(
+                &mut trace,
+                EvaluationStep::AskRules,
+                "ask rule skipped by bypass mode",
+            );
+        } else {
+            let reason = format!("Tool '{tool_name}' requires parent approval");
+            let decision = HardDecision::NeedExternal {
+                prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.clone()),
+            };
+            push_matched(&mut trace, EvaluationStep::AskRules, &decision, &reason);
+            return envelope(
+                decision,
+                DecisionSource::AskRule {
+                    rule: rule.to_string(),
+                    origin: RuleOrigin::Inherited,
+                },
+                trace,
+                will_save,
+                risk_tags,
+            );
+        }
+    } else {
+        push_skipped(&mut trace, EvaluationStep::AskRules, "no ask rule matched");
     }
-    push_skipped(&mut trace, EvaluationStep::AskRules, "no ask rule matched");
 
     if explicit_approval_reason(tool_name, args).is_none()
         && is_read_only_tool_with_args(tool_name, Some(args))
@@ -870,32 +1017,6 @@ pub fn evaluate_permission(
     }
 
     if let Some(allowed) = fingerprinted_override(tool_name, args, ctx) {
-        // Session overrides must not bypass git safety. If a git
-        // safety violation is present, refuse the override and
-        // require explicit approval.
-        if allowed && !git_safety_violations_for_request(tool_name, args).is_empty() {
-            let reasons: Vec<String> = git_safety_violations_for_request(tool_name, args)
-                .iter()
-                .map(|v| v.to_string())
-                .collect();
-            let reason = format!("Git safety: {}", reasons.join(", "));
-            let decision = HardDecision::NeedExternal {
-                prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.clone()),
-            };
-            push_matched(
-                &mut trace,
-                EvaluationStep::SessionOverride,
-                &decision,
-                "session override refused — git safety violation present",
-            );
-            return envelope(
-                decision,
-                DecisionSource::GitSafety { violation: reason },
-                trace,
-                will_save,
-                risk_tags,
-            );
-        }
         let decision = if allowed {
             HardDecision::Allow
         } else {
@@ -967,9 +1088,9 @@ pub fn evaluate_permission(
                     risk_tags,
                 )
             }
-            PermissionMode::Auto => {
+            PermissionMode::Auto | PermissionMode::Bypass => {
                 // ToolAllowlist step already denied unlisted tools, so
-                // anything reaching ExplicitApproval in Auto mode is
+                // anything reaching ExplicitApproval in Auto/Bypass mode is
                 // allowed (it's an explicit-approval-gated tool that
                 // the mode auto-approves).
                 let decision = HardDecision::Allow;
@@ -1065,7 +1186,7 @@ pub fn evaluate_permission(
 
     let mode = ctx.mode();
     let (decision, mode_label) = match mode {
-        PermissionMode::Auto => (HardDecision::Allow, mode.to_string()),
+        PermissionMode::Auto | PermissionMode::Bypass => (HardDecision::Allow, mode.to_string()),
         PermissionMode::Plan => (
             HardDecision::Deny {
                 reason: format!("Tool '{tool_name}' denied by permission mode"),
@@ -1329,6 +1450,14 @@ fn fingerprinted_override(
     args: &Value,
     ctx: &PermissionSyncContext,
 ) -> Option<bool> {
+    fingerprinted_override_match(tool_name, args, ctx).map(|(_, allowed)| allowed)
+}
+
+fn fingerprinted_override_match(
+    tool_name: &str,
+    args: &Value,
+    ctx: &PermissionSyncContext,
+) -> Option<(ApprovalFingerprint, bool)> {
     let json = ctx.inherited.fingerprinted_overrides.as_ref()?;
     // Fail-closed: a corrupt overrides blob must NOT silently fall through
     // to broader (potentially permissive) rules. Distinguish "no overrides
@@ -1343,12 +1472,40 @@ fn fingerprinted_override(
                 "fingerprinted_overrides blob is present but undecodable; denying tool {} as fail-closed",
                 tool_name,
             );
-            return Some(false);
+            return Some((ApprovalFingerprint::bare(tool_name), false));
         }
     };
     content_aware_fingerprint_candidates(tool_name, args)
         .into_iter()
-        .find_map(|fp| overrides.check(&fp))
+        .find_map(|fp| {
+            overrides
+                .matching_rule(&fp)
+                .map(|(stored, allowed)| (stored.clone(), *allowed))
+        })
+}
+
+fn stored_override_allows_git_safety(stored: &ApprovalFingerprint) -> bool {
+    stored.command_exact.is_some() || stored.command_prefix.is_some()
+}
+
+fn stored_override_allows_sensitive_path(stored: &ApprovalFingerprint) -> bool {
+    if let Some(command) = stored
+        .command_exact
+        .as_deref()
+        .or(stored.command_prefix.as_deref())
+    {
+        return sensitive_path_match("bash", &serde_json::json!({ "command": command })).is_some();
+    }
+
+    let Some(path) = stored.path_pattern.as_deref() else {
+        return false;
+    };
+
+    if stored.path_match == crate::approval_fingerprint::PathMatchKind::Exact {
+        return true;
+    }
+
+    sensitive_path_match(&stored.tool_name, &serde_json::json!({ "path": path })).is_some()
 }
 
 fn accept_edits_auto_allows(tool_name: &str, args: &Value) -> bool {
@@ -1976,6 +2133,20 @@ mod tests {
     }
 
     #[test]
+    fn evaluate_denies_catastrophic_shell_before_bypass_mode() {
+        let ctx = crate::permission::types::PermissionSyncContext::root(
+            crate::permission::types::PermissionMode::Bypass,
+        );
+        let envelope =
+            evaluate_permission("bash", &serde_json::json!({"command": "rm -rf /"}), &ctx);
+        assert!(matches!(envelope.decision, HardDecision::Deny { .. }));
+        assert!(matches!(
+            envelope.source,
+            DecisionSource::SafetyMiddleware { .. }
+        ));
+    }
+
+    #[test]
     fn evaluate_explicit_approval_precedes_allow_rule_in_prompt_mode() {
         let ctx = crate::permission::types::PermissionSyncContext::new(
             crate::permission::types::InheritedPermissions {
@@ -2016,6 +2187,45 @@ mod tests {
         assert!(matches!(
             envelope.source,
             DecisionSource::SensitivePath { .. }
+        ));
+    }
+
+    #[test]
+    fn evaluate_sensitive_path_is_allowed_in_bypass_mode() {
+        let ctx = crate::permission::types::PermissionSyncContext::root(
+            crate::permission::types::PermissionMode::Bypass,
+        );
+        let envelope = evaluate_permission(
+            "write_file",
+            &serde_json::json!({"path": ".env", "content": "TOKEN=x"}),
+            &ctx,
+        );
+        assert!(matches!(envelope.decision, HardDecision::Allow));
+        assert!(matches!(
+            envelope.source,
+            DecisionSource::SensitivePath { .. }
+        ));
+    }
+
+    #[test]
+    fn evaluate_sensitive_path_session_override_is_honored() {
+        let args = serde_json::json!({"path": ".env", "content": "TOKEN=x"});
+        let mut overrides = FingerprintedOverrides::default();
+        overrides.insert(content_aware_fingerprint("write_file", &args), true);
+        let ctx = crate::permission::types::PermissionSyncContext::new(
+            crate::permission::types::InheritedPermissions {
+                mode: crate::permission::types::PermissionMode::Prompt,
+                fingerprinted_overrides: Some(serde_json::to_value(overrides).unwrap()),
+                ..Default::default()
+            },
+        );
+
+        let envelope = evaluate_permission("write_file", &args, &ctx);
+
+        assert!(matches!(envelope.decision, HardDecision::Allow));
+        assert!(matches!(
+            envelope.source,
+            DecisionSource::SessionOverride { allowed: true }
         ));
     }
 
@@ -2395,6 +2605,27 @@ mod tests {
     }
 
     #[test]
+    fn structured_git_force_push_protected_branch_is_allowed_in_bypass_mode() {
+        let ctx = crate::permission::types::PermissionSyncContext::root(
+            crate::permission::types::PermissionMode::Bypass,
+        );
+        let envelope = evaluate_permission(
+            "git",
+            &serde_json::json!({
+                "action": "push",
+                "remote": "origin",
+                "branch": "main",
+                "force_with_lease": true
+            }),
+            &ctx,
+        );
+
+        assert!(matches!(envelope.decision, HardDecision::Allow));
+        assert!(matches!(envelope.source, DecisionSource::GitSafety { .. }));
+        assert!(envelope.risk_tags.contains(&RiskTag::GitDestructive));
+    }
+
+    #[test]
     fn git_worktree_destructive_bash_requires_approval_in_auto_mode() {
         let ctx = crate::permission::types::PermissionSyncContext::root(
             crate::permission::types::PermissionMode::Auto,
@@ -2417,6 +2648,30 @@ mod tests {
             envelope.source
         );
         assert!(envelope.risk_tags.contains(&RiskTag::GitDestructive));
+    }
+
+    #[test]
+    fn git_worktree_destructive_bash_session_override_is_honored() {
+        let args = serde_json::json!({
+            "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
+        });
+        let mut overrides = FingerprintedOverrides::default();
+        overrides.insert(content_aware_fingerprint("bash", &args), true);
+        let ctx = crate::permission::types::PermissionSyncContext::new(
+            crate::permission::types::InheritedPermissions {
+                mode: crate::permission::types::PermissionMode::Auto,
+                fingerprinted_overrides: Some(serde_json::to_value(overrides).unwrap()),
+                ..Default::default()
+            },
+        );
+
+        let envelope = evaluate_permission("bash", &args, &ctx);
+
+        assert!(matches!(envelope.decision, HardDecision::Allow));
+        assert!(matches!(
+            envelope.source,
+            DecisionSource::SessionOverride { allowed: true }
+        ));
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/permission/engine.rs
+++ b/rust/crates/astra-turn-core/src/permission/engine.rs
@@ -1405,10 +1405,7 @@ fn execute_hard_deny_reason(tool_name: &str, args: &Value) -> Option<String> {
     }
     let command = command_hint_from_args(args)?;
     let lower = command.to_ascii_lowercase();
-    if ["rm -rf /", "rm -fr /", ":(){ :|:& };:", "chmod 777 /"]
-        .iter()
-        .any(|p| lower.contains(p))
-    {
+    if crate::safety_middleware::absolute_dangerous_command_reason(command).is_some() {
         return Some("Dangerous command refused".to_string());
     }
     if lower.contains("shred ") || lower.contains("wipefs") {
@@ -2146,6 +2143,82 @@ mod tests {
         assert!(matches!(
             envelope.source,
             DecisionSource::SafetyMiddleware { .. }
+        ));
+    }
+
+    #[test]
+    fn evaluate_non_catastrophic_rm_requires_approval_not_hard_deny() {
+        let ctx = crate::permission::types::PermissionSyncContext::root(
+            crate::permission::types::PermissionMode::Prompt,
+        );
+        let envelope = evaluate_permission(
+            "bash",
+            &serde_json::json!({"command": "rm -rf /tmp/foo"}),
+            &ctx,
+        );
+
+        assert!(
+            matches!(envelope.decision, HardDecision::NeedExternal { .. }),
+            "bounded destructive rm should be reviewable, got {:?}",
+            envelope.decision
+        );
+        assert!(matches!(
+            envelope.source,
+            DecisionSource::ExplicitApprovalGate { .. }
+        ));
+    }
+
+    #[test]
+    fn evaluate_sudo_root_rm_stays_hard_denied_without_tmp_overmatch() {
+        let ctx = crate::permission::types::PermissionSyncContext::root(
+            crate::permission::types::PermissionMode::Prompt,
+        );
+        let root = evaluate_permission(
+            "bash",
+            &serde_json::json!({"command": "SUDO -n rm -rf /"}),
+            &ctx,
+        );
+        assert!(
+            matches!(root.decision, HardDecision::Deny { .. }),
+            "sudo root rm must be hard denied even through wrapper options, got {:?}",
+            root.decision
+        );
+
+        let tmp = evaluate_permission(
+            "bash",
+            &serde_json::json!({"command": "sudo rm -rf /tmp/foo"}),
+            &ctx,
+        );
+        assert!(
+            matches!(tmp.decision, HardDecision::NeedExternal { .. }),
+            "sudo rm under /tmp should be reviewable, got {:?}",
+            tmp.decision
+        );
+        assert!(matches!(
+            tmp.source,
+            DecisionSource::ExplicitApprovalGate { .. }
+        ));
+    }
+
+    #[test]
+    fn execute_hard_deny_root_chmod_does_not_overmatch_tmp_paths() {
+        let ctx = crate::permission::types::PermissionSyncContext::root(
+            crate::permission::types::PermissionMode::Prompt,
+        );
+        let envelope = evaluate_permission(
+            "bash",
+            &serde_json::json!({"command": "chmod 777 /tmp/foo"}),
+            &ctx,
+        );
+
+        assert!(
+            matches!(envelope.decision, HardDecision::NeedExternal { .. }),
+            "chmod under /tmp should be reviewable, got {:?}",
+            envelope.decision
+        );
+        assert!(matches!(
+            envelope.source,
+            DecisionSource::ExplicitApprovalGate { .. }
         ));
     }
 

--- a/rust/crates/astra-turn-core/src/permission/engine.rs
+++ b/rust/crates/astra-turn-core/src/permission/engine.rs
@@ -1593,7 +1593,8 @@ fn push_unique_fingerprint(
     }
 }
 
-fn risk_tags_for_request(tool_name: &str, args: &Value) -> Vec<RiskTag> {
+#[must_use]
+pub fn risk_tags_for_request(tool_name: &str, args: &Value) -> Vec<RiskTag> {
     let mut tags = Vec::new();
     let has_git_safety_violation = !git_safety_violations_for_request(tool_name, args).is_empty();
     if tool_name.starts_with("sandbox_expand:") {
@@ -1609,7 +1610,9 @@ fn risk_tags_for_request(tool_name: &str, args: &Value) -> Vec<RiskTag> {
         Some(CloudGatedToolKind::Write) if sensitive_path_match(tool_name, args).is_some() => {
             push_risk_tag(&mut tags, RiskTag::WritesSensitiveFile);
         }
-        Some(CloudGatedToolKind::Write) => {}
+        Some(CloudGatedToolKind::Write) => {
+            push_risk_tag(&mut tags, RiskTag::WritesOutsidePackage);
+        }
         None => {}
     }
     if has_git_safety_violation {

--- a/rust/crates/astra-turn-core/src/permission/engine.rs
+++ b/rust/crates/astra-turn-core/src/permission/engine.rs
@@ -376,10 +376,10 @@ pub(crate) fn plan_mode_denial_reason(tool_name: &str) -> String {
 /// context.
 ///
 /// This is the shared pure evaluator for runtime/sub-agent permission checks:
-/// it runs the same bypass-immune guards before any relaxable rule or mode
-/// branch, and returns `NeedExternal` instead of deciding how to ask the user.
-/// Callers are responsible for routing that prompt to a TUI sink, parent
-/// mailbox, or headless fail-closed path.
+/// it runs absolute safety and policy guards before any relaxable rule or
+/// mode branch, and returns `NeedExternal` instead of deciding how to ask the
+/// user. Callers are responsible for routing that prompt to a TUI sink,
+/// parent mailbox, or headless fail-closed path.
 #[must_use]
 pub fn evaluate_permission(
     tool_name: &str,
@@ -1479,7 +1479,7 @@ fn fingerprinted_override_match(
 }
 
 fn stored_override_allows_git_safety(stored: &ApprovalFingerprint) -> bool {
-    stored.command_exact.is_some() || stored.command_prefix.is_some()
+    stored.command_exact.is_some()
 }
 
 fn stored_override_allows_sensitive_path(stored: &ApprovalFingerprint) -> bool {
@@ -2723,6 +2723,40 @@ mod tests {
                 .note
                 .contains("broad session override cannot bypass git safety")),
             "ignored broad override should stay visible in trace: {:?}",
+            envelope.trace
+        );
+    }
+
+    #[test]
+    fn git_worktree_destructive_prefix_session_override_does_not_fall_through() {
+        let args = serde_json::json!({
+            "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
+        });
+        let mut overrides = FingerprintedOverrides::default();
+        overrides.insert(
+            ApprovalFingerprint::shell_prefix("bash", "git restore", false),
+            true,
+        );
+        let ctx = crate::permission::types::PermissionSyncContext::new(
+            crate::permission::types::InheritedPermissions {
+                mode: crate::permission::types::PermissionMode::Auto,
+                fingerprinted_overrides: Some(serde_json::to_value(overrides).unwrap()),
+                ..Default::default()
+            },
+        );
+
+        let envelope = evaluate_permission("bash", &args, &ctx);
+
+        assert!(matches!(
+            envelope.decision,
+            HardDecision::NeedExternal { .. }
+        ));
+        assert!(matches!(envelope.source, DecisionSource::GitSafety { .. }));
+        assert!(
+            envelope.trace.iter().any(|step| step
+                .note
+                .contains("broad session override cannot bypass git safety")),
+            "ignored prefix override should stay visible in trace: {:?}",
             envelope.trace
         );
     }

--- a/rust/crates/astra-turn-core/src/permission/engine.rs
+++ b/rust/crates/astra-turn-core/src/permission/engine.rs
@@ -60,7 +60,7 @@ use crate::permission::match_target::{
 };
 use crate::permission::memory_profile::resolved_write_path;
 use crate::permission::path_sensitivity::sensitive_path_token_for_tool_args;
-use crate::permission::types::{PermissionMode, PermissionSyncContext};
+use crate::permission::types::{ManualApprovalPolicy, PermissionMode, PermissionSyncContext};
 use crate::safety_middleware::{SafetyMiddlewareDecision, evaluate_tool_safety_request};
 use crate::tool::args::hints::{
     command_hint_from_args, path_hint_from_args, permission_prompt_primary_detail,
@@ -438,7 +438,7 @@ pub fn evaluate_permission(
             // are relaxed: the user has delegated trust to the agent.
             // Catastrophic commands (rm -rf /, fork bombs) and destructive SQL
             // (DROP TABLE, etc.) remain hard-denied regardless of mode.
-            if matches!(ctx.mode(), PermissionMode::Auto | PermissionMode::Bypass)
+            if ctx.mode().relaxes_soft_shell_obfuscation()
                 && reason.contains("shell_obfuscation")
                 && !reason.contains("catastrophic")
             {
@@ -475,146 +475,31 @@ pub fn evaluate_permission(
     if !git_violations.is_empty() {
         let reasons: Vec<String> = git_violations.iter().map(ToString::to_string).collect();
         let has_hard_violation = git_violations.iter().any(|v| !is_soft_violation(v));
-        if ctx.mode() == PermissionMode::Deny {
-            let decision = HardDecision::Deny {
-                reason: "Git safety violation (deny mode)".to_string(),
-            };
-            push_matched(
-                &mut trace,
-                EvaluationStep::GitSafety,
-                &decision,
-                &reasons.join(", "),
-            );
-            return envelope(
+        match resolve_git_safety_guard(
+            tool_name,
+            args,
+            ctx,
+            &reasons,
+            has_hard_violation,
+            &risk_tags,
+        ) {
+            GuardResolution::Continue(notes) => {
+                for note in notes {
+                    push_skipped(&mut trace, EvaluationStep::GitSafety, &note);
+                }
+            }
+            GuardResolution::Return {
                 decision,
-                DecisionSource::GitSafety {
-                    violation: reasons.join(", "),
-                },
-                trace,
-                will_save,
-                risk_tags,
-            );
-        }
-        let mut git_safety_deferred = false;
-        if let Some((stored_override, allowed)) = fingerprinted_override_match(tool_name, args, ctx)
-        {
-            if allowed && !stored_override_allows_git_safety(&stored_override) {
-                push_skipped(
-                    &mut trace,
-                    EvaluationStep::GitSafety,
-                    "broad session override cannot bypass git safety",
-                );
-            } else if ctx.inherited.allowed_tools.is_some() {
-                push_skipped(
-                    &mut trace,
-                    EvaluationStep::GitSafety,
-                    &format!(
-                        "session override matched git violation, deferring to allowlist: {}",
-                        reasons.join(", ")
-                    ),
-                );
-                git_safety_deferred = true;
-            } else {
-                let decision = if allowed {
-                    HardDecision::Allow
-                } else {
-                    HardDecision::Deny {
-                        reason: "Skipped for session".to_string(),
-                    }
-                };
-                push_matched(
-                    &mut trace,
-                    EvaluationStep::GitSafety,
-                    &decision,
-                    "fingerprinted session override matched git safety request",
-                );
-                return envelope(
-                    decision,
-                    DecisionSource::SessionOverride { allowed },
-                    trace,
-                    will_save,
-                    risk_tags,
-                );
+                source,
+                detail,
+                skipped_notes,
+            } => {
+                for note in skipped_notes {
+                    push_skipped(&mut trace, EvaluationStep::GitSafety, &note);
+                }
+                push_matched(&mut trace, EvaluationStep::GitSafety, &decision, &detail);
+                return envelope(decision, source, trace, will_save, risk_tags);
             }
-        }
-        if !git_safety_deferred && ctx.mode() == PermissionMode::Bypass {
-            if ctx.inherited.allowed_tools.is_some() {
-                push_skipped(
-                    &mut trace,
-                    EvaluationStep::GitSafety,
-                    &format!(
-                        "bypass mode git violation, deferring to allowlist: {}",
-                        reasons.join(", ")
-                    ),
-                );
-                git_safety_deferred = true;
-            } else {
-                let reason = format!("Git safety (bypass): {}", reasons.join(", "));
-                let decision = HardDecision::Allow;
-                push_matched(&mut trace, EvaluationStep::GitSafety, &decision, &reason);
-                return envelope(
-                    decision,
-                    DecisionSource::GitSafety { violation: reason },
-                    trace,
-                    will_save,
-                    risk_tags,
-                );
-            }
-        }
-        if git_safety_deferred {
-            // Continue into ToolAllowlist; if allowed there, SessionOverride
-            // or the final Bypass mode decision can allow the exact request.
-        } else if ctx.mode() == PermissionMode::Auto && !has_hard_violation {
-            // Soft git violation in auto mode: allow.
-            // If there's an explicit allowlist, let ExplicitApprovalGate evaluate
-            // whether git is listed.
-            // If a session override exists, defer so SessionOverride can honor
-            // the already-approved exact fingerprint after allowlist policy.
-            if ctx.inherited.allowed_tools.is_some() {
-                push_skipped(
-                    &mut trace,
-                    EvaluationStep::GitSafety,
-                    &format!(
-                        "auto mode soft violation, deferring to allowlist: {}",
-                        reasons.join(", ")
-                    ),
-                );
-                // continue to ExplicitApprovalGate
-            } else if fingerprinted_override(tool_name, args, ctx).is_some() {
-                push_skipped(
-                    &mut trace,
-                    EvaluationStep::GitSafety,
-                    &format!(
-                        "auto mode soft violation, deferring for session override: {}",
-                        reasons.join(", ")
-                    ),
-                );
-                // continue — SessionOverride will apply the bounded decision
-            } else {
-                let reason = format!("Git safety (auto-allow): {}", reasons.join(", "));
-                let decision = HardDecision::Allow;
-                push_matched(&mut trace, EvaluationStep::GitSafety, &decision, &reason);
-                return envelope(
-                    decision,
-                    DecisionSource::GitSafety { violation: reason },
-                    trace,
-                    will_save,
-                    risk_tags,
-                );
-            }
-        } else {
-            let reason = format!("Git safety: {}", reasons.join(", "));
-            let decision = HardDecision::NeedExternal {
-                prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.clone()),
-            };
-            push_matched(&mut trace, EvaluationStep::GitSafety, &decision, &reason);
-            return envelope(
-                decision,
-                DecisionSource::GitSafety { violation: reason },
-                trace,
-                will_save,
-                risk_tags,
-            );
         }
     }
     push_skipped(&mut trace, EvaluationStep::GitSafety, git_safety_skip_note);
@@ -662,113 +547,29 @@ pub fn evaluate_permission(
     );
 
     if let Some(path) = sensitive_path_match(tool_name, args) {
-        if ctx.mode() == PermissionMode::Deny {
-            let decision = HardDecision::Deny {
-                reason: "Sensitive path (deny mode)".to_string(),
-            };
-            push_matched(&mut trace, EvaluationStep::SensitivePath, &decision, &path);
-            return envelope(
+        match resolve_sensitive_path_guard(tool_name, args, ctx, &path, &risk_tags) {
+            GuardResolution::Continue(notes) => {
+                for note in notes {
+                    push_skipped(&mut trace, EvaluationStep::SensitivePath, &note);
+                }
+            }
+            GuardResolution::Return {
                 decision,
-                DecisionSource::SensitivePath { path },
-                trace,
-                will_save,
-                risk_tags,
-            );
-        }
-        let mut defer_sensitive_to_allowlist = false;
-        if let Some((stored_override, allowed)) = fingerprinted_override_match(tool_name, args, ctx)
-        {
-            if allowed && !stored_override_allows_sensitive_path(&stored_override) {
-                push_skipped(
-                    &mut trace,
-                    EvaluationStep::SensitivePath,
-                    "broad session override cannot bypass sensitive path",
-                );
-            } else if ctx.inherited.allowed_tools.is_some() {
-                push_skipped(
-                    &mut trace,
-                    EvaluationStep::SensitivePath,
-                    "session override matched sensitive path, deferring to allowlist",
-                );
-                defer_sensitive_to_allowlist = true;
-            } else {
-                let decision = if allowed {
-                    HardDecision::Allow
-                } else {
-                    HardDecision::Deny {
-                        reason: "Sensitive path denied for session".to_string(),
-                    }
-                };
+                source,
+                detail,
+                skipped_notes,
+            } => {
+                for note in skipped_notes {
+                    push_skipped(&mut trace, EvaluationStep::SensitivePath, &note);
+                }
                 push_matched(
                     &mut trace,
                     EvaluationStep::SensitivePath,
                     &decision,
-                    "fingerprinted session override matched sensitive path",
+                    &detail,
                 );
-                return envelope(
-                    decision,
-                    DecisionSource::SessionOverride { allowed },
-                    trace,
-                    will_save,
-                    risk_tags,
-                );
+                return envelope(decision, source, trace, will_save, risk_tags);
             }
-        }
-        if !defer_sensitive_to_allowlist && ctx.mode() == PermissionMode::Bypass {
-            if ctx.inherited.allowed_tools.is_some() {
-                push_skipped(
-                    &mut trace,
-                    EvaluationStep::SensitivePath,
-                    "bypass mode sensitive path, deferring to allowlist",
-                );
-                defer_sensitive_to_allowlist = true;
-            } else {
-                let decision = HardDecision::Allow;
-                push_matched(
-                    &mut trace,
-                    EvaluationStep::SensitivePath,
-                    &decision,
-                    "sensitive path allowed by bypass mode",
-                );
-                return envelope(
-                    decision,
-                    DecisionSource::SensitivePath { path },
-                    trace,
-                    will_save,
-                    risk_tags,
-                );
-            }
-        }
-        if defer_sensitive_to_allowlist {
-            // Continue into ToolAllowlist; if allowed there, SessionOverride
-            // or the final Bypass mode decision can allow the exact request.
-        } else if ctx.mode() == PermissionMode::Auto {
-            let reason = "Targets a sensitive file path and requires manual approval".to_string();
-            let decision = HardDecision::NeedExternal {
-                prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.clone()),
-            };
-            push_matched(&mut trace, EvaluationStep::SensitivePath, &decision, &path);
-            return envelope(
-                decision,
-                DecisionSource::SensitivePath { path },
-                trace,
-                will_save,
-                risk_tags,
-            );
-        }
-        if !defer_sensitive_to_allowlist {
-            let reason = "Targets a sensitive file path and requires manual approval".to_string();
-            let decision = HardDecision::NeedExternal {
-                prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.clone()),
-            };
-            push_matched(&mut trace, EvaluationStep::SensitivePath, &decision, &path);
-            return envelope(
-                decision,
-                DecisionSource::SensitivePath { path },
-                trace,
-                will_save,
-                risk_tags,
-            );
         }
     }
     push_skipped(
@@ -778,24 +579,28 @@ pub fn evaluate_permission(
     );
 
     if let Some(inner_tool) = tool_name.strip_prefix("sandbox_expand:") {
-        return match ctx.mode() {
-            PermissionMode::Auto | PermissionMode::Bypass => {
-                let decision = HardDecision::Allow;
-                push_matched(
-                    &mut trace,
-                    EvaluationStep::SandboxExpand,
-                    &decision,
-                    "sandbox expansion allowed by mode",
-                );
-                envelope(
-                    decision,
-                    DecisionSource::SandboxExpansion,
-                    trace,
-                    will_save,
-                    risk_tags,
-                )
-            }
-            PermissionMode::Plan => {
+        let mode = ctx.mode();
+        if mode.auto_resolves_approval_prompts() {
+            let decision = HardDecision::Allow;
+            push_matched(
+                &mut trace,
+                EvaluationStep::SandboxExpand,
+                &decision,
+                "sandbox expansion allowed by mode",
+            );
+            return envelope(
+                decision,
+                DecisionSource::SandboxExpansion,
+                trace,
+                will_save,
+                risk_tags,
+            );
+        }
+        let manual_policy = mode
+            .manual_approval_policy()
+            .expect("auto-resolving permission modes returned before sandbox match");
+        return match manual_policy {
+            ManualApprovalPolicy::Plan => {
                 let decision = HardDecision::Deny {
                     reason: "Sandbox expansion denied (plan mode)".to_string(),
                 };
@@ -813,7 +618,7 @@ pub fn evaluate_permission(
                     risk_tags,
                 )
             }
-            PermissionMode::AcceptEdits | PermissionMode::Prompt => {
+            ManualApprovalPolicy::AcceptEdits | ManualApprovalPolicy::Prompt => {
                 let reason = args
                     .get("reason")
                     .and_then(Value::as_str)
@@ -843,7 +648,7 @@ pub fn evaluate_permission(
                     risk_tags,
                 )
             }
-            PermissionMode::Deny => {
+            ManualApprovalPolicy::Deny => {
                 let decision = HardDecision::Deny {
                     reason: "Sandbox expansion denied (deny mode)".to_string(),
                 };
@@ -907,7 +712,7 @@ pub fn evaluate_permission(
         .inherited
         .ask_rule_with_context(tool_name, &rule_match_context)
     {
-        if ctx.mode() == PermissionMode::Bypass {
+        if ctx.mode().skips_human_approval_prompts() {
             push_skipped(
                 &mut trace,
                 EvaluationStep::AskRules,
@@ -1047,8 +852,32 @@ pub fn evaluate_permission(
     if let Some(policy_reason) = explicit_approval_reason(tool_name, args) {
         let prompt_reason =
             primary_approval_reason(tool_name, args).unwrap_or_else(|| policy_reason.clone());
-        return match ctx.mode() {
-            PermissionMode::Plan => {
+        let mode = ctx.mode();
+        if mode.auto_resolves_approval_prompts() {
+            // ToolAllowlist step already denied unlisted tools, so anything
+            // reaching ExplicitApproval in an auto-resolving mode is allowed.
+            let decision = HardDecision::Allow;
+            push_matched(
+                &mut trace,
+                EvaluationStep::ExplicitApproval,
+                &decision,
+                "explicit approval auto-allowed by mode",
+            );
+            return envelope(
+                decision,
+                DecisionSource::ExplicitApprovalGate {
+                    reason: policy_reason,
+                },
+                trace,
+                will_save,
+                risk_tags,
+            );
+        }
+        let manual_policy = mode
+            .manual_approval_policy()
+            .expect("auto-resolving permission modes returned before approval match");
+        return match manual_policy {
+            ManualApprovalPolicy::Plan => {
                 let decision = HardDecision::Deny {
                     reason: "Explicit approval required (plan mode)".to_string(),
                 };
@@ -1068,7 +897,7 @@ pub fn evaluate_permission(
                     risk_tags,
                 )
             }
-            PermissionMode::Deny => {
+            ManualApprovalPolicy::Deny => {
                 let decision = HardDecision::Deny {
                     reason: "Explicit approval required (deny mode)".to_string(),
                 };
@@ -1088,29 +917,7 @@ pub fn evaluate_permission(
                     risk_tags,
                 )
             }
-            PermissionMode::Auto | PermissionMode::Bypass => {
-                // ToolAllowlist step already denied unlisted tools, so
-                // anything reaching ExplicitApproval in Auto/Bypass mode is
-                // allowed (it's an explicit-approval-gated tool that
-                // the mode auto-approves).
-                let decision = HardDecision::Allow;
-                push_matched(
-                    &mut trace,
-                    EvaluationStep::ExplicitApproval,
-                    &decision,
-                    "explicit approval auto-allowed by mode",
-                );
-                envelope(
-                    decision,
-                    DecisionSource::ExplicitApprovalGate {
-                        reason: policy_reason,
-                    },
-                    trace,
-                    will_save,
-                    risk_tags,
-                )
-            }
-            PermissionMode::AcceptEdits => {
+            ManualApprovalPolicy::AcceptEdits => {
                 // ToolAllowlist step already denied unlisted tools.
                 let decision = HardDecision::NeedExternal {
                     prompt: approval_prompt(tool_name, args, prompt_reason, risk_tags.clone()),
@@ -1131,7 +938,7 @@ pub fn evaluate_permission(
                     risk_tags,
                 )
             }
-            PermissionMode::Prompt => {
+            ManualApprovalPolicy::Prompt => {
                 let decision = HardDecision::NeedExternal {
                     prompt: approval_prompt(tool_name, args, prompt_reason, risk_tags.clone()),
                 };
@@ -1185,48 +992,54 @@ pub fn evaluate_permission(
     );
 
     let mode = ctx.mode();
-    let (decision, mode_label) = match mode {
-        PermissionMode::Auto | PermissionMode::Bypass => (HardDecision::Allow, mode.to_string()),
-        PermissionMode::Plan => (
-            HardDecision::Deny {
-                reason: format!("Tool '{tool_name}' denied by permission mode"),
-            },
-            mode.to_string(),
-        ),
-        PermissionMode::AcceptEdits => {
-            if accept_edits_auto_allows(tool_name, args) {
-                (HardDecision::Allow, mode.to_string())
-            } else {
-                (
-                    HardDecision::NeedExternal {
-                        prompt: approval_prompt(
-                            tool_name,
-                            args,
-                            "Write/execute tool requires approval".to_string(),
-                            risk_tags.clone(),
-                        ),
-                    },
-                    mode.to_string(),
-                )
+    let (decision, mode_label) = if mode.auto_resolves_approval_prompts() {
+        (HardDecision::Allow, mode.to_string())
+    } else {
+        let manual_policy = mode
+            .manual_approval_policy()
+            .expect("auto-resolving permission modes returned before mode match");
+        match manual_policy {
+            ManualApprovalPolicy::Plan => (
+                HardDecision::Deny {
+                    reason: format!("Tool '{tool_name}' denied by permission mode"),
+                },
+                mode.to_string(),
+            ),
+            ManualApprovalPolicy::AcceptEdits => {
+                if accept_edits_auto_allows(tool_name, args) {
+                    (HardDecision::Allow, mode.to_string())
+                } else {
+                    (
+                        HardDecision::NeedExternal {
+                            prompt: approval_prompt(
+                                tool_name,
+                                args,
+                                "Write/execute tool requires approval".to_string(),
+                                risk_tags.clone(),
+                            ),
+                        },
+                        mode.to_string(),
+                    )
+                }
             }
+            ManualApprovalPolicy::Deny => (
+                HardDecision::Deny {
+                    reason: format!("Tool '{tool_name}' denied by permission mode"),
+                },
+                mode.to_string(),
+            ),
+            ManualApprovalPolicy::Prompt => (
+                HardDecision::NeedExternal {
+                    prompt: approval_prompt(
+                        tool_name,
+                        args,
+                        "Write/execute tool requires approval".to_string(),
+                        risk_tags.clone(),
+                    ),
+                },
+                mode.to_string(),
+            ),
         }
-        PermissionMode::Deny => (
-            HardDecision::Deny {
-                reason: format!("Tool '{tool_name}' denied by permission mode"),
-            },
-            mode.to_string(),
-        ),
-        PermissionMode::Prompt => (
-            HardDecision::NeedExternal {
-                prompt: approval_prompt(
-                    tool_name,
-                    args,
-                    "Write/execute tool requires approval".to_string(),
-                    risk_tags.clone(),
-                ),
-            },
-            mode.to_string(),
-        ),
     };
     push_matched(&mut trace, EvaluationStep::Mode, &decision, &mode_label);
     envelope(
@@ -1392,6 +1205,187 @@ fn sensitive_path_match(tool_name: &str, args: &Value) -> Option<String> {
     sensitive_path_token_for_tool_args(tool_name, args)
 }
 
+enum GuardResolution {
+    Continue(Vec<String>),
+    Return {
+        decision: HardDecision,
+        source: DecisionSource,
+        detail: String,
+        skipped_notes: Vec<String>,
+    },
+}
+
+fn resolve_git_safety_guard(
+    tool_name: &str,
+    args: &Value,
+    ctx: &PermissionSyncContext,
+    reasons: &[String],
+    has_hard_violation: bool,
+    risk_tags: &[RiskTag],
+) -> GuardResolution {
+    let joined_reasons = reasons.join(", ");
+    let mut skipped_notes = Vec::new();
+    if ctx.mode() == PermissionMode::Deny {
+        return GuardResolution::Return {
+            decision: HardDecision::Deny {
+                reason: "Git safety violation (deny mode)".to_string(),
+            },
+            source: DecisionSource::GitSafety {
+                violation: joined_reasons.clone(),
+            },
+            detail: joined_reasons,
+            skipped_notes,
+        };
+    }
+
+    if let Some((stored_override, allowed)) = fingerprinted_override_match(tool_name, args, ctx) {
+        if allowed && !stored_override_allows_git_safety(&stored_override) {
+            skipped_notes.push("broad session override cannot bypass git safety".to_string());
+        } else if ctx.inherited.allowed_tools.is_some() {
+            skipped_notes.push(format!(
+                "session override matched git violation, deferring to allowlist: {joined_reasons}",
+            ));
+            return GuardResolution::Continue(skipped_notes);
+        } else {
+            let decision = if allowed {
+                HardDecision::Allow
+            } else {
+                HardDecision::Deny {
+                    reason: "Skipped for session".to_string(),
+                }
+            };
+            return GuardResolution::Return {
+                decision,
+                source: DecisionSource::SessionOverride { allowed },
+                detail: "fingerprinted session override matched git safety request".to_string(),
+                skipped_notes,
+            };
+        }
+    }
+
+    if ctx.mode().skips_human_approval_prompts() {
+        if ctx.inherited.allowed_tools.is_some() {
+            skipped_notes.push(format!(
+                "bypass mode git violation, deferring to allowlist: {joined_reasons}",
+            ));
+            return GuardResolution::Continue(skipped_notes);
+        }
+        let reason = format!("Git safety (bypass): {joined_reasons}");
+        return GuardResolution::Return {
+            decision: HardDecision::Allow,
+            source: DecisionSource::GitSafety {
+                violation: reason.clone(),
+            },
+            detail: reason,
+            skipped_notes,
+        };
+    }
+
+    if ctx.mode().auto_allows_soft_git_policy() && !has_hard_violation {
+        if ctx.inherited.allowed_tools.is_some() {
+            skipped_notes.push(format!(
+                "auto mode soft violation, deferring to allowlist: {joined_reasons}",
+            ));
+            return GuardResolution::Continue(skipped_notes);
+        }
+        let reason = format!("Git safety (auto-allow): {joined_reasons}");
+        return GuardResolution::Return {
+            decision: HardDecision::Allow,
+            source: DecisionSource::GitSafety {
+                violation: reason.clone(),
+            },
+            detail: reason,
+            skipped_notes,
+        };
+    }
+
+    let reason = format!("Git safety: {joined_reasons}");
+    GuardResolution::Return {
+        decision: HardDecision::NeedExternal {
+            prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.to_vec()),
+        },
+        source: DecisionSource::GitSafety {
+            violation: reason.clone(),
+        },
+        detail: reason,
+        skipped_notes,
+    }
+}
+
+fn resolve_sensitive_path_guard(
+    tool_name: &str,
+    args: &Value,
+    ctx: &PermissionSyncContext,
+    path: &str,
+    risk_tags: &[RiskTag],
+) -> GuardResolution {
+    let mut skipped_notes = Vec::new();
+    if ctx.mode() == PermissionMode::Deny {
+        return GuardResolution::Return {
+            decision: HardDecision::Deny {
+                reason: "Sensitive path (deny mode)".to_string(),
+            },
+            source: DecisionSource::SensitivePath {
+                path: path.to_string(),
+            },
+            detail: path.to_string(),
+            skipped_notes,
+        };
+    }
+
+    if let Some((stored_override, allowed)) = fingerprinted_override_match(tool_name, args, ctx) {
+        if allowed && !stored_override_allows_sensitive_path(&stored_override) {
+            skipped_notes.push("broad session override cannot bypass sensitive path".to_string());
+        } else if ctx.inherited.allowed_tools.is_some() {
+            skipped_notes.push(
+                "session override matched sensitive path, deferring to allowlist".to_string(),
+            );
+            return GuardResolution::Continue(skipped_notes);
+        } else {
+            let decision = if allowed {
+                HardDecision::Allow
+            } else {
+                HardDecision::Deny {
+                    reason: "Sensitive path denied for session".to_string(),
+                }
+            };
+            return GuardResolution::Return {
+                decision,
+                source: DecisionSource::SessionOverride { allowed },
+                detail: "fingerprinted session override matched sensitive path".to_string(),
+                skipped_notes,
+            };
+        }
+    }
+
+    if ctx.mode().skips_human_approval_prompts() {
+        if ctx.inherited.allowed_tools.is_some() {
+            skipped_notes.push("bypass mode sensitive path, deferring to allowlist".to_string());
+            return GuardResolution::Continue(skipped_notes);
+        }
+        return GuardResolution::Return {
+            decision: HardDecision::Allow,
+            source: DecisionSource::SensitivePath {
+                path: path.to_string(),
+            },
+            detail: "sensitive path allowed by bypass mode".to_string(),
+            skipped_notes,
+        };
+    }
+
+    let reason = "Targets a sensitive file path and requires manual approval".to_string();
+    GuardResolution::Return {
+        decision: HardDecision::NeedExternal {
+            prompt: approval_prompt(tool_name, args, reason.clone(), risk_tags.to_vec()),
+        },
+        source: DecisionSource::SensitivePath {
+            path: path.to_string(),
+        },
+        detail: path.to_string(),
+        skipped_notes,
+    }
+}
+
 fn execute_hard_deny_reason(tool_name: &str, args: &Value) -> Option<String> {
     if !is_execute_tool(tool_name, args) {
         return None;
@@ -1500,10 +1494,6 @@ fn stored_override_allows_sensitive_path(stored: &ApprovalFingerprint) -> bool {
     let Some(path) = stored.path_pattern.as_deref() else {
         return false;
     };
-
-    if stored.path_match == crate::approval_fingerprint::PathMatchKind::Exact {
-        return true;
-    }
 
     sensitive_path_match(&stored.tool_name, &serde_json::json!({ "path": path })).is_some()
 }
@@ -2230,6 +2220,38 @@ mod tests {
     }
 
     #[test]
+    fn evaluate_sensitive_path_broad_session_override_does_not_fall_through() {
+        let args = serde_json::json!({"path": ".env", "content": "TOKEN=x"});
+        let mut overrides = FingerprintedOverrides::default();
+        overrides.insert(ApprovalFingerprint::bare("write_file"), true);
+        let ctx = crate::permission::types::PermissionSyncContext::new(
+            crate::permission::types::InheritedPermissions {
+                mode: crate::permission::types::PermissionMode::Auto,
+                fingerprinted_overrides: Some(serde_json::to_value(overrides).unwrap()),
+                ..Default::default()
+            },
+        );
+
+        let envelope = evaluate_permission("write_file", &args, &ctx);
+
+        assert!(matches!(
+            envelope.decision,
+            HardDecision::NeedExternal { .. }
+        ));
+        assert!(matches!(
+            envelope.source,
+            DecisionSource::SensitivePath { .. }
+        ));
+        assert!(
+            envelope.trace.iter().any(|step| step
+                .note
+                .contains("broad session override cannot bypass sensitive path")),
+            "ignored broad override should remain visible in trace: {:?}",
+            envelope.trace
+        );
+    }
+
+    #[test]
     fn evaluate_reading_session_tool_result_artifact_is_allowed_in_auto_mode() {
         let ctx = crate::permission::types::PermissionSyncContext::root(
             crate::permission::types::PermissionMode::Auto,
@@ -2675,6 +2697,37 @@ mod tests {
     }
 
     #[test]
+    fn git_worktree_destructive_broad_session_override_does_not_fall_through() {
+        let args = serde_json::json!({
+            "command": "git restore --staged --worktree rust/crates/foo/src/lib.rs"
+        });
+        let mut overrides = FingerprintedOverrides::default();
+        overrides.insert(ApprovalFingerprint::bare("bash"), true);
+        let ctx = crate::permission::types::PermissionSyncContext::new(
+            crate::permission::types::InheritedPermissions {
+                mode: crate::permission::types::PermissionMode::Auto,
+                fingerprinted_overrides: Some(serde_json::to_value(overrides).unwrap()),
+                ..Default::default()
+            },
+        );
+
+        let envelope = evaluate_permission("bash", &args, &ctx);
+
+        assert!(matches!(
+            envelope.decision,
+            HardDecision::NeedExternal { .. }
+        ));
+        assert!(matches!(envelope.source, DecisionSource::GitSafety { .. }));
+        assert!(
+            envelope.trace.iter().any(|step| step
+                .note
+                .contains("broad session override cannot bypass git safety")),
+            "ignored broad override should stay visible in trace: {:?}",
+            envelope.trace
+        );
+    }
+
+    #[test]
     fn structured_git_force_push_respects_auto_allowlist() {
         let ctx = crate::permission::types::PermissionSyncContext::new(
             crate::permission::types::InheritedPermissions {
@@ -2689,6 +2742,35 @@ mod tests {
                 "action": "push",
                 "remote": "origin",
                 "branch": "feature/my-branch",
+                "force_with_lease": true
+            }),
+            &ctx,
+        );
+
+        assert!(matches!(envelope.decision, HardDecision::Deny { .. }));
+        assert_eq!(
+            envelope.source,
+            DecisionSource::Mode {
+                mode: "agent policy allowlist".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn bypass_mode_git_violation_still_respects_child_allowlist() {
+        let ctx = crate::permission::types::PermissionSyncContext::new(
+            crate::permission::types::InheritedPermissions {
+                mode: crate::permission::types::PermissionMode::Bypass,
+                allowed_tools: Some(std::collections::HashSet::from(["read_file".to_string()])),
+                ..Default::default()
+            },
+        );
+        let envelope = evaluate_permission(
+            "git",
+            &serde_json::json!({
+                "action": "push",
+                "remote": "origin",
+                "branch": "main",
                 "force_with_lease": true
             }),
             &ctx,

--- a/rust/crates/astra-turn-core/src/permission/memory_profile.rs
+++ b/rust/crates/astra-turn-core/src/permission/memory_profile.rs
@@ -1,6 +1,8 @@
 use serde_json::Value;
 use std::path::{Component, Path, PathBuf};
 
+use astra_sandbox::validate_git_command;
+
 use crate::cloud::approval_policy::{CloudGatedToolKind, cloud_gated_tool_kind};
 use crate::parallel_tool_exec::is_read_only_tool_with_args;
 use crate::permission::compound_command::{
@@ -64,6 +66,10 @@ fn execute_memory_profile(tool_name: &str, args: &Value) -> PermissionMemoryProf
 }
 
 fn command_match_target(command: &str) -> AllowMatchTarget {
+    if !validate_git_command(command).is_empty() {
+        return AllowMatchTarget::Exact;
+    }
+
     let prefix = normalized_argv_prefix(command);
     if prefix.is_empty() {
         AllowMatchTarget::Exact
@@ -306,5 +312,20 @@ mod tests {
             profile.persistent_block,
             Some(PersistentMemoryBlock::DynamicEval)
         );
+    }
+
+    #[test]
+    fn git_safety_commands_stay_exact() {
+        for command in [
+            "git restore --staged --worktree rust/crates/foo/src/lib.rs",
+            "git push --force-with-lease origin main",
+            "cd /repo && git diff origin/main...HEAD --stat",
+        ] {
+            let args = serde_json::json!({"command": command});
+            let profile = permission_memory_profile("bash", &args);
+            assert_eq!(profile.match_target, AllowMatchTarget::Exact, "{command}");
+            assert_eq!(profile.persistent_block, None, "{command}");
+            assert!(profile.has_stable_target, "{command}");
+        }
     }
 }

--- a/rust/crates/astra-turn-core/src/permission/path_sensitivity.rs
+++ b/rust/crates/astra-turn-core/src/permission/path_sensitivity.rs
@@ -56,6 +56,9 @@ pub fn classify_path_sensitivity(path: &str) -> PathSensitivity {
     if is_read_sensitive_path(path) {
         return PathSensitivity::Sensitive;
     }
+    if is_agent_skill_content_path(path) {
+        return PathSensitivity::Normal;
+    }
     if is_write_sensitive_path(path) {
         return PathSensitivity::WriteSensitive;
     }
@@ -76,6 +79,31 @@ fn is_write_sensitive_path(path: &str) -> bool {
         || is_dangerous_file_path(&expanded.to_string_lossy())
         || is_tilde_hidden_home_app_state_path(path)
         || is_hidden_home_app_state_path(&expanded)
+}
+
+fn is_agent_skill_content_path(path: &str) -> bool {
+    let expanded = expand_home_path(path);
+    is_agent_skill_content_path_components(Path::new(path))
+        || is_agent_skill_content_path_components(&expanded)
+}
+
+fn is_agent_skill_content_path_components(path: &Path) -> bool {
+    let components = normal_component_strings(path);
+    components.windows(2).any(|window| {
+        matches!(window, [agent_dir, skills_dir]
+            if matches!(agent_dir.as_str(), ".astra" | ".claude")
+                && skills_dir == "skills")
+    })
+}
+
+fn normal_component_strings(path: &Path) -> Vec<String> {
+    normalize_lexical_path(path)
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => Some(value.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect()
 }
 
 fn is_tilde_hidden_home_app_state_path(path: &str) -> bool {
@@ -861,6 +889,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(path_sensitivity_home)]
     fn classifies_legacy_global_tool_results_as_read_only_artifacts() {
         let (_temp, _guard, artifact_path) = create_legacy_tool_result();
         let artifact_path = artifact_path.to_string_lossy();
@@ -1033,6 +1062,110 @@ mod tests {
             .expect("mutating hidden home app state should gate");
         assert_eq!(shell_write.sensitivity, PathSensitivity::WriteSensitive);
         assert_eq!(shell_write.access, PathAccess::Write);
+    }
+
+    #[test]
+    #[serial_test::serial(path_sensitivity_home)]
+    fn agent_skill_content_is_editable_hidden_app_content() {
+        let temp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard::set("HOME", temp.path());
+        let absolute_astra = temp
+            .path()
+            .join(".astra/skills/code-review/SKILL.md")
+            .to_string_lossy()
+            .to_string();
+
+        for path in [
+            ".astra/skills/code-review/SKILL.md",
+            "./.claude/skills/code-review/SKILL.md",
+            "~/.astra/skills/code-review/SKILL.md",
+            "$HOME/.claude/skills/code-review/SKILL.md",
+            absolute_astra.as_str(),
+        ] {
+            assert_eq!(
+                classify_path_sensitivity(path),
+                PathSensitivity::Normal,
+                "{path}"
+            );
+            assert!(
+                path_requires_sensitive_gate(path, PathAccess::Write).is_none(),
+                "{path}"
+            );
+
+            let write_args = serde_json::json!({ "path": path, "content": "# Skill\n" });
+            assert_eq!(
+                sensitive_path_match_for_tool_args("write_file", &write_args),
+                None,
+                "{path}"
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(path_sensitivity_home)]
+    fn agent_skill_credentials_and_control_files_remain_sensitive() {
+        let temp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard::set("HOME", temp.path());
+
+        for path in [
+            "~/.astra/skills/code-review/.env",
+            "~/.claude/skills/code-review/credentials.json",
+        ] {
+            assert_eq!(
+                classify_path_sensitivity(path),
+                PathSensitivity::Sensitive,
+                "{path}"
+            );
+            assert!(
+                path_requires_sensitive_gate(path, PathAccess::Read).is_some(),
+                "{path}"
+            );
+            assert!(
+                path_requires_sensitive_gate(path, PathAccess::Write).is_some(),
+                "{path}"
+            );
+        }
+
+        for path in [
+            "~/.astra/permissions.json",
+            "~/.astra/config.toml",
+            "~/.claude/settings.json",
+        ] {
+            assert_eq!(
+                classify_path_sensitivity(path),
+                PathSensitivity::WriteSensitive,
+                "{path}"
+            );
+            assert!(
+                path_requires_sensitive_gate(path, PathAccess::Read).is_none(),
+                "{path}"
+            );
+            assert!(
+                path_requires_sensitive_gate(path, PathAccess::Write).is_some(),
+                "{path}"
+            );
+        }
+    }
+
+    #[test]
+    fn shell_writes_to_agent_skill_content_do_not_trip_sensitive_gate() {
+        assert_eq!(
+            sensitive_path_match_for_shell_command(
+                "cat > ~/.astra/skills/code-review/SKILL.md <<'EOF'\n# Skill\nEOF"
+            ),
+            None
+        );
+        assert_eq!(
+            sensitive_path_match_for_shell_command(
+                "mkdir -p .claude/skills/code-review && touch .claude/skills/code-review/SKILL.md"
+            ),
+            None
+        );
+
+        let hit = sensitive_path_match_for_shell_command("cat ~/.claude/skills/code-review/.env")
+            .expect("credential file under a skill must still gate");
+        assert_eq!(hit.sensitivity, PathSensitivity::Sensitive);
+        assert_eq!(hit.access, PathAccess::Read);
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/permission/scope.rs
+++ b/rust/crates/astra-turn-core/src/permission/scope.rs
@@ -23,6 +23,7 @@
 //! `permitted_scopes(...)` to know which entries to grey out.
 
 use crate::permission::engine::RiskTag;
+use crate::permission::memory_profile::{PersistentMemoryBlock, permission_memory_profile};
 
 /// Allowed-rule scope. Mirrors the dropdown choices in the
 /// approval card.
@@ -101,6 +102,74 @@ pub struct ScopeAvailability {
     pub scope: AllowScope,
     pub available: bool,
     pub reason: Option<ScopeUnavailableReason>,
+}
+
+/// Build the scope policy input for one concrete tool request.
+///
+/// Risk classification is supplied by the permission engine so callers do not
+/// duplicate git/path/MCP risk detection. This function owns the orthogonal
+/// memory-shape facts: whether the request has a stable target and whether
+/// that target is too broad to remember beyond the current turn.
+#[must_use]
+pub fn scope_context_for_tool_request(
+    tool: &str,
+    args: &serde_json::Value,
+    risk_tags: Vec<RiskTag>,
+    source_agent_present: bool,
+    workspace_untrusted: bool,
+) -> ScopeAvailabilityContext {
+    let memory_profile = permission_memory_profile(tool, args);
+    let mut ctx = ScopeAvailabilityContext {
+        risk_tags,
+        source_agent_present,
+        workspace_untrusted,
+        unsafe_rule_shape: !memory_profile.has_stable_target
+            || matches!(
+                memory_profile.persistent_block,
+                Some(PersistentMemoryBlock::UnsafeRuleShape)
+            ),
+        is_compound_command: matches!(
+            memory_profile.persistent_block,
+            Some(PersistentMemoryBlock::CompoundCommand)
+        ),
+        has_dynamic_eval: matches!(
+            memory_profile.persistent_block,
+            Some(PersistentMemoryBlock::DynamicEval)
+        ),
+        ..Default::default()
+    };
+
+    if tool.starts_with("mcp_") {
+        ctx.mcp_unknown_capability = true;
+        if !ctx.risk_tags.contains(&RiskTag::MCPUnknownCapability) {
+            ctx.risk_tags.push(RiskTag::MCPUnknownCapability);
+        }
+    }
+
+    ctx
+}
+
+/// Pick the strongest safe default scope for the "Always" button.
+#[must_use]
+pub fn default_always_scope(ctx: &ScopeAvailabilityContext) -> AllowScope {
+    let scopes = permitted_scopes(ctx);
+    let is_available = |target| {
+        scopes
+            .iter()
+            .any(|entry| entry.scope == target && entry.available)
+    };
+
+    if is_available(AllowScope::Project) {
+        return AllowScope::Project;
+    }
+    if is_available(AllowScope::RestOfSession) {
+        return AllowScope::RestOfSession;
+    }
+    if is_available(AllowScope::RestOfTurn) {
+        return AllowScope::RestOfTurn;
+    }
+
+    AllowScope::OnceThisCall
 }
 
 /// Compute the scope picker state.

--- a/rust/crates/astra-turn-core/src/permission/sync.rs
+++ b/rust/crates/astra-turn-core/src/permission/sync.rs
@@ -292,8 +292,8 @@ impl PermissionRequestHandler {
 
         // Check mode
         match ctx.mode() {
-            PermissionMode::Auto => {
-                // Auto approves at this layer. Bypass-immune safety guards
+            PermissionMode::Auto | PermissionMode::Bypass => {
+                // Auto/Bypass approve at this layer. Bypass-immune safety guards
                 // (catastrophic-command circuit breaker, sensitive-path
                 // checks) live earlier in the pipeline; by the time we reach
                 // permission_sync those have already had their say.

--- a/rust/crates/astra-turn-core/src/permission/sync.rs
+++ b/rust/crates/astra-turn-core/src/permission/sync.rs
@@ -293,10 +293,9 @@ impl PermissionRequestHandler {
         // Check mode
         let mode = ctx.mode();
         if mode.auto_resolves_approval_prompts() {
-            // Auto/Bypass approve at this layer. Bypass-immune safety guards
-            // (catastrophic-command circuit breaker, sensitive-path
-            // checks) live earlier in the pipeline; by the time we reach
-            // permission_sync those have already had their say.
+            // Auto/Bypass approve at this layer. Absolute safety guards
+            // and policy denies live earlier in the pipeline; by the time
+            // we reach permission_sync those have already had their say.
             let response = if let Some(ref rule_str) = request.suggested_rule {
                 PermissionResponse::approve()
                     .with_update(PermissionUpdate::allow(PermissionRule::parse(rule_str)))

--- a/rust/crates/astra-turn-core/src/permission/sync.rs
+++ b/rust/crates/astra-turn-core/src/permission/sync.rs
@@ -291,12 +291,35 @@ impl PermissionRequestHandler {
         }
 
         // Check mode
-        match ctx.mode() {
-            PermissionMode::Auto | PermissionMode::Bypass => {
-                // Auto/Bypass approve at this layer. Bypass-immune safety guards
-                // (catastrophic-command circuit breaker, sensitive-path
-                // checks) live earlier in the pipeline; by the time we reach
-                // permission_sync those have already had their say.
+        let mode = ctx.mode();
+        if mode.auto_resolves_approval_prompts() {
+            // Auto/Bypass approve at this layer. Bypass-immune safety guards
+            // (catastrophic-command circuit breaker, sensitive-path
+            // checks) live earlier in the pipeline; by the time we reach
+            // permission_sync those have already had their say.
+            let response = if let Some(ref rule_str) = request.suggested_rule {
+                PermissionResponse::approve()
+                    .with_update(PermissionUpdate::allow(PermissionRule::parse(rule_str)))
+            } else {
+                PermissionResponse::approve()
+            };
+
+            // Apply updates to our context
+            drop(ctx);
+            if !response.updates.is_empty() {
+                let mut ctx_mut = self.sync_context.write().await;
+                ctx_mut.apply_response(&response);
+            }
+
+            return response;
+        }
+
+        let manual_policy = mode
+            .manual_approval_policy()
+            .expect("auto-resolving permission modes returned before mode match");
+
+        match manual_policy {
+            ManualApprovalPolicy::AcceptEdits if accept_edits_auto_allows_request(request) => {
                 let response = if let Some(ref rule_str) = request.suggested_rule {
                     PermissionResponse::approve()
                         .with_update(PermissionUpdate::allow(PermissionRule::parse(rule_str)))
@@ -304,7 +327,6 @@ impl PermissionRequestHandler {
                     PermissionResponse::approve()
                 };
 
-                // Apply updates to our context
                 drop(ctx);
                 if !response.updates.is_empty() {
                     let mut ctx_mut = self.sync_context.write().await;
@@ -313,27 +335,11 @@ impl PermissionRequestHandler {
 
                 response
             }
-            PermissionMode::AcceptEdits if accept_edits_auto_allows_request(request) => {
-                let response = if let Some(ref rule_str) = request.suggested_rule {
-                    PermissionResponse::approve()
-                        .with_update(PermissionUpdate::allow(PermissionRule::parse(rule_str)))
-                } else {
-                    PermissionResponse::approve()
-                };
-
-                drop(ctx);
-                if !response.updates.is_empty() {
-                    let mut ctx_mut = self.sync_context.write().await;
-                    ctx_mut.apply_response(&response);
-                }
-
-                response
-            }
-            PermissionMode::Deny => {
+            ManualApprovalPolicy::Deny => {
                 // Deny mode: reject without escalation
                 PermissionResponse::deny("permission mode is deny")
             }
-            PermissionMode::Plan => {
+            ManualApprovalPolicy::Plan => {
                 if crate::tool::schema::prune::PLAN_MODE_REQUIRED_TOOLS
                     .contains(&request.tool_name.as_str())
                 {
@@ -344,7 +350,7 @@ impl PermissionRequestHandler {
                     ))
                 }
             }
-            PermissionMode::AcceptEdits | PermissionMode::Prompt => {
+            ManualApprovalPolicy::AcceptEdits | ManualApprovalPolicy::Prompt => {
                 // Prompt mode: use callback or default logic
                 drop(ctx);
 

--- a/rust/crates/astra-turn-core/src/permission/types.rs
+++ b/rust/crates/astra-turn-core/src/permission/types.rs
@@ -38,7 +38,74 @@ pub enum PermissionMode {
     Deny,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ManualApprovalPolicy {
+    Plan,
+    AcceptEdits,
+    Prompt,
+    Deny,
+}
+
 impl PermissionMode {
+    /// True when ordinary approval prompts should be skipped.
+    ///
+    /// This is the approval-interaction axis, not the safety-policy axis:
+    /// hard denies and explicit deny/allowlist policy can still apply.
+    pub fn auto_resolves_approval_prompts(self) -> bool {
+        matches!(self, Self::Auto | Self::Bypass)
+    }
+
+    /// True for the explicit "do not interrupt me for approval" mode.
+    pub fn skips_human_approval_prompts(self) -> bool {
+        matches!(self, Self::Bypass)
+    }
+
+    /// True when soft, noisy shell-obfuscation guards are treated as advisory.
+    pub fn relaxes_soft_shell_obfuscation(self) -> bool {
+        matches!(self, Self::Auto | Self::Bypass)
+    }
+
+    /// True when soft git policy findings may be auto-allowed.
+    pub fn auto_allows_soft_git_policy(self) -> bool {
+        matches!(self, Self::Auto)
+    }
+
+    pub fn manual_approval_policy(self) -> Option<ManualApprovalPolicy> {
+        match self {
+            Self::Auto => None,
+            Self::Bypass => None,
+            Self::Plan => Some(ManualApprovalPolicy::Plan),
+            Self::AcceptEdits => Some(ManualApprovalPolicy::AcceptEdits),
+            Self::Prompt => Some(ManualApprovalPolicy::Prompt),
+            Self::Deny => Some(ManualApprovalPolicy::Deny),
+        }
+    }
+
+    /// Stable compact encoding used by CLI/TUI atomic mirrors.
+    pub fn mirror_code(self) -> u8 {
+        match self {
+            Self::Prompt => 0,
+            Self::Auto => 1,
+            Self::Plan => 2,
+            Self::AcceptEdits => 3,
+            Self::Deny => 4,
+            Self::Bypass => 5,
+        }
+    }
+
+    /// Decode the compact CLI/TUI mirror encoding. Unknown values fail closed
+    /// to Prompt rather than inheriting an accidentally permissive mode.
+    pub fn from_mirror_code(value: u8) -> Self {
+        match value {
+            1 => Self::Auto,
+            2 => Self::Plan,
+            3 => Self::AcceptEdits,
+            4 => Self::Deny,
+            5 => Self::Bypass,
+            _ => Self::Prompt,
+        }
+    }
+
     /// Human label for the status-line mode chip.
     pub fn chip_text(self) -> &'static str {
         match self {
@@ -1199,6 +1266,54 @@ mod tests {
         assert_eq!(
             "skip".parse::<PermissionMode>().unwrap(),
             PermissionMode::Bypass
+        );
+    }
+
+    #[test]
+    fn permission_mode_policy_helpers_are_explicit_axes() {
+        assert!(PermissionMode::Auto.auto_resolves_approval_prompts());
+        assert!(PermissionMode::Bypass.auto_resolves_approval_prompts());
+        assert!(!PermissionMode::Auto.skips_human_approval_prompts());
+        assert!(PermissionMode::Bypass.skips_human_approval_prompts());
+        assert!(PermissionMode::Auto.auto_allows_soft_git_policy());
+        assert!(!PermissionMode::Bypass.auto_allows_soft_git_policy());
+        assert!(!PermissionMode::Prompt.auto_resolves_approval_prompts());
+
+        assert_eq!(PermissionMode::Auto.manual_approval_policy(), None);
+        assert_eq!(PermissionMode::Bypass.manual_approval_policy(), None);
+        assert_eq!(
+            PermissionMode::Plan.manual_approval_policy(),
+            Some(ManualApprovalPolicy::Plan)
+        );
+        assert_eq!(
+            PermissionMode::AcceptEdits.manual_approval_policy(),
+            Some(ManualApprovalPolicy::AcceptEdits)
+        );
+        assert_eq!(
+            PermissionMode::Prompt.manual_approval_policy(),
+            Some(ManualApprovalPolicy::Prompt)
+        );
+        assert_eq!(
+            PermissionMode::Deny.manual_approval_policy(),
+            Some(ManualApprovalPolicy::Deny)
+        );
+    }
+
+    #[test]
+    fn permission_mode_mirror_code_roundtrip() {
+        for mode in [
+            PermissionMode::Prompt,
+            PermissionMode::Auto,
+            PermissionMode::Bypass,
+            PermissionMode::Plan,
+            PermissionMode::AcceptEdits,
+            PermissionMode::Deny,
+        ] {
+            assert_eq!(PermissionMode::from_mirror_code(mode.mirror_code()), mode);
+        }
+        assert_eq!(
+            PermissionMode::from_mirror_code(u8::MAX),
+            PermissionMode::Prompt
         );
     }
 

--- a/rust/crates/astra-turn-core/src/permission/types.rs
+++ b/rust/crates/astra-turn-core/src/permission/types.rs
@@ -25,6 +25,8 @@ use std::path::{Path, PathBuf};
 pub enum PermissionMode {
     /// Auto-approve all tools (except bypass-immune safety checks).
     Auto,
+    /// Skip human approval prompts; hard safety denies and policy allowlists still apply.
+    Bypass,
     /// Read-only investigation/planning mode: allow read tools, deny mutations.
     Plan,
     /// Auto-approve safe workspace-local edit/write operations only.
@@ -41,6 +43,7 @@ impl PermissionMode {
     pub fn chip_text(self) -> &'static str {
         match self {
             Self::Auto => "Auto",
+            Self::Bypass => "Bypass",
             Self::Plan => "Plan",
             Self::AcceptEdits => "Edits",
             Self::Prompt => "Ask",
@@ -51,9 +54,11 @@ impl PermissionMode {
     /// Color hint for the status-line mode chip.
     /// Returns `(red, green, blue)` for a ratatui-style `Color::Rgb`.
     pub fn chip_color_rgb(self) -> (u8, u8, u8) {
-        // Blue for plan, cyan for edit, yellow for auto, red for deny, white for default.
+        // Blue for plan, cyan for edit, yellow for auto, magenta for bypass,
+        // red for deny, white for default.
         match self {
             Self::Auto => (255, 255, 0),
+            Self::Bypass => (255, 0, 255),
             Self::Plan => (100, 149, 237),
             Self::AcceptEdits => (0, 255, 255),
             Self::Prompt => (255, 255, 255),
@@ -66,6 +71,7 @@ impl std::fmt::Display for PermissionMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Auto => write!(f, "auto"),
+            Self::Bypass => write!(f, "bypass"),
             Self::Plan => write!(f, "plan"),
             Self::AcceptEdits => write!(f, "accept_edits"),
             Self::Prompt => write!(f, "prompt"),
@@ -79,12 +85,13 @@ impl std::str::FromStr for PermissionMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "auto" => Ok(Self::Auto),
+            "bypass" | "skip" => Ok(Self::Bypass),
             "plan" => Ok(Self::Plan),
             "accept_edits" => Ok(Self::AcceptEdits),
             "prompt" => Ok(Self::Prompt),
             "deny" => Ok(Self::Deny),
             _ => Err(format!(
-                "invalid permission mode '{s}': expected auto, plan, accept_edits, prompt, or deny"
+                "invalid permission mode '{s}': expected auto, bypass, plan, accept_edits, prompt, or deny"
             )),
         }
     }
@@ -1181,6 +1188,18 @@ mod tests {
         let parsed = "plan".parse::<PermissionMode>().unwrap();
         assert_eq!(parsed, PermissionMode::Plan);
         assert_eq!(parsed.to_string(), "plan");
+    }
+
+    #[test]
+    fn permission_mode_roundtrip_includes_bypass() {
+        let parsed = "bypass".parse::<PermissionMode>().unwrap();
+        assert_eq!(parsed, PermissionMode::Bypass);
+        assert_eq!(parsed.to_string(), "bypass");
+        assert_eq!(parsed.chip_text(), "Bypass");
+        assert_eq!(
+            "skip".parse::<PermissionMode>().unwrap(),
+            PermissionMode::Bypass
+        );
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/permission/types.rs
+++ b/rust/crates/astra-turn-core/src/permission/types.rs
@@ -46,6 +46,34 @@ pub enum ManualApprovalPolicy {
     Deny,
 }
 
+/// Permission mode safe for child-agent inheritance.
+///
+/// `Bypass` is intentionally excluded: root-user interaction choices
+/// must not become transitive child-agent safety policy. The compiler
+/// guarantees that no match on this type can ever receive a Bypass
+/// variant, unlike the previous approach where an `unreachable!()` arm
+/// served the same guarantee at runtime.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ChildPermissionMode {
+    Auto,
+    Plan,
+    AcceptEdits,
+    Prompt,
+    Deny,
+}
+
+impl From<ChildPermissionMode> for PermissionMode {
+    fn from(m: ChildPermissionMode) -> Self {
+        match m {
+            ChildPermissionMode::Auto => Self::Auto,
+            ChildPermissionMode::Plan => Self::Plan,
+            ChildPermissionMode::AcceptEdits => Self::AcceptEdits,
+            ChildPermissionMode::Prompt => Self::Prompt,
+            ChildPermissionMode::Deny => Self::Deny,
+        }
+    }
+}
+
 impl PermissionMode {
     /// True when ordinary approval prompts can be resolved without blocking.
     ///
@@ -79,11 +107,18 @@ impl PermissionMode {
     /// the current UI session. It must not become a transitive child-agent
     /// safety policy because spawned/fan-out agents have no direct user in the
     /// loop and should not inherit the root session's broad prompt bypass.
+    ///
+    /// Returns a [`ChildPermissionMode`] that cannot represent Bypass,
+    /// making the downgrade a compile-time guarantee.
     #[must_use]
-    pub fn child_inherited_mode(self) -> Self {
+    pub fn child_inherited_mode(self) -> ChildPermissionMode {
         match self {
-            Self::Bypass => Self::Auto,
-            other => other,
+            Self::Bypass => ChildPermissionMode::Auto,
+            Self::Auto => ChildPermissionMode::Auto,
+            Self::Plan => ChildPermissionMode::Plan,
+            Self::AcceptEdits => ChildPermissionMode::AcceptEdits,
+            Self::Prompt => ChildPermissionMode::Prompt,
+            Self::Deny => ChildPermissionMode::Deny,
         }
     }
 
@@ -714,7 +749,8 @@ impl std::fmt::Display for PermissionRule {
 /// Contains the parent's effective permission mode and rules that the child
 /// should honor. Child agents cannot escalate permissions beyond what parent
 /// allows. Root-only interaction choices such as `Bypass` are projected to the
-/// child-safe execution mode by [`PermissionMode::child_inherited_mode`].
+/// child-safe execution mode by [`PermissionMode::child_inherited_mode`], which returns
+/// a [`ChildPermissionMode`] that cannot represent `Bypass`.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct InheritedPermissions {
     /// Permission mode inherited from parent.
@@ -1157,7 +1193,7 @@ impl PermissionSyncContext {
     /// Create inherited permissions for a child agent.
     pub fn for_child(&self, is_background: bool) -> InheritedPermissions {
         let mut inherited = self.inherited.clone();
-        inherited.mode = inherited.mode.child_inherited_mode();
+        inherited.mode = PermissionMode::from(inherited.mode.child_inherited_mode());
         inherited.is_background = is_background;
         // Add session rules to inherited rules for child
         for rule in &self.session_allow {
@@ -1299,11 +1335,11 @@ mod tests {
         assert!(!PermissionMode::Bypass.auto_allows_soft_git_policy());
         assert!(!PermissionMode::Prompt.auto_resolves_approval_prompts());
         assert_eq!(
-            PermissionMode::Bypass.child_inherited_mode(),
+            PermissionMode::from(PermissionMode::Bypass.child_inherited_mode()),
             PermissionMode::Auto
         );
         assert_eq!(
-            PermissionMode::Prompt.child_inherited_mode(),
+            PermissionMode::from(PermissionMode::Prompt.child_inherited_mode()),
             PermissionMode::Prompt
         );
 

--- a/rust/crates/astra-turn-core/src/permission/types.rs
+++ b/rust/crates/astra-turn-core/src/permission/types.rs
@@ -23,9 +23,9 @@ use std::path::{Path, PathBuf};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionMode {
-    /// Auto-approve all tools (except bypass-immune safety checks).
+    /// Auto-resolve ordinary approval prompts; git/sensitive gates may still stop.
     Auto,
-    /// Skip human approval prompts; hard safety denies and policy allowlists still apply.
+    /// Skip human approval prompts; absolute safety denies and policy allowlists still apply.
     Bypass,
     /// Read-only investigation/planning mode: allow read tools, deny mutations.
     Plan,
@@ -47,7 +47,7 @@ pub enum ManualApprovalPolicy {
 }
 
 impl PermissionMode {
-    /// True when ordinary approval prompts should be skipped.
+    /// True when ordinary approval prompts can be resolved without blocking.
     ///
     /// This is the approval-interaction axis, not the safety-policy axis:
     /// hard denies and explicit deny/allowlist policy can still apply.
@@ -56,6 +56,9 @@ impl PermissionMode {
     }
 
     /// True for the explicit "do not interrupt me for approval" mode.
+    ///
+    /// This skips git/sensitive approval gates, but not absolute safety
+    /// denies, explicit deny rules, or child-agent allowlists.
     pub fn skips_human_approval_prompts(self) -> bool {
         matches!(self, Self::Bypass)
     }

--- a/rust/crates/astra-turn-core/src/permission/types.rs
+++ b/rust/crates/astra-turn-core/src/permission/types.rs
@@ -73,6 +73,20 @@ impl PermissionMode {
         matches!(self, Self::Auto)
     }
 
+    /// Permission mode to export into child agents.
+    ///
+    /// `Bypass` is a root user-interaction choice: skip approval prompts in
+    /// the current UI session. It must not become a transitive child-agent
+    /// safety policy because spawned/fan-out agents have no direct user in the
+    /// loop and should not inherit the root session's broad prompt bypass.
+    #[must_use]
+    pub fn child_inherited_mode(self) -> Self {
+        match self {
+            Self::Bypass => Self::Auto,
+            other => other,
+        }
+    }
+
     pub fn manual_approval_policy(self) -> Option<ManualApprovalPolicy> {
         match self {
             Self::Auto => None,
@@ -697,8 +711,10 @@ impl std::fmt::Display for PermissionRule {
 
 /// Permission context inherited from parent to child agent.
 ///
-/// Contains the parent's permission mode and rules that the child should honor.
-/// Child agents cannot escalate permissions beyond what parent allows.
+/// Contains the parent's effective permission mode and rules that the child
+/// should honor. Child agents cannot escalate permissions beyond what parent
+/// allows. Root-only interaction choices such as `Bypass` are projected to the
+/// child-safe execution mode by [`PermissionMode::child_inherited_mode`].
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct InheritedPermissions {
     /// Permission mode inherited from parent.
@@ -1141,6 +1157,7 @@ impl PermissionSyncContext {
     /// Create inherited permissions for a child agent.
     pub fn for_child(&self, is_background: bool) -> InheritedPermissions {
         let mut inherited = self.inherited.clone();
+        inherited.mode = inherited.mode.child_inherited_mode();
         inherited.is_background = is_background;
         // Add session rules to inherited rules for child
         for rule in &self.session_allow {
@@ -1281,6 +1298,14 @@ mod tests {
         assert!(PermissionMode::Auto.auto_allows_soft_git_policy());
         assert!(!PermissionMode::Bypass.auto_allows_soft_git_policy());
         assert!(!PermissionMode::Prompt.auto_resolves_approval_prompts());
+        assert_eq!(
+            PermissionMode::Bypass.child_inherited_mode(),
+            PermissionMode::Auto
+        );
+        assert_eq!(
+            PermissionMode::Prompt.child_inherited_mode(),
+            PermissionMode::Prompt
+        );
 
         assert_eq!(PermissionMode::Auto.manual_approval_policy(), None);
         assert_eq!(PermissionMode::Bypass.manual_approval_policy(), None);
@@ -1598,6 +1623,16 @@ mod tests {
         assert!(child_perms.is_background);
         assert!(child_perms.is_allowed("bash", Some("git status")));
         assert!(child_perms.is_allowed("bash", Some("npm install")));
+    }
+
+    #[test]
+    fn permission_sync_context_downgrades_bypass_for_child() {
+        let ctx = PermissionSyncContext::root(PermissionMode::Bypass);
+
+        let child_perms = ctx.for_child(true);
+
+        assert_eq!(child_perms.mode, PermissionMode::Auto);
+        assert!(child_perms.is_background);
     }
 
     #[tokio::test]

--- a/rust/crates/astra-turn-core/src/prompt_facing.rs
+++ b/rust/crates/astra-turn-core/src/prompt_facing.rs
@@ -432,6 +432,7 @@ mod tests {
             json!({"role": "assistant", "content": "working"}),
             json!({"role": "user", "content": "⚠️ VERIFICATION REQUIRED: Before you finish, run any missing checks"}),
             json!({"role": "user", "content": "🔄 ERROR BUDGET EXHAUSTED: You've hit Unknown errors 3 turns in a row"}),
+            json!({"role": "user", "content": "## ⚡ Self-Status\nTurn 9/299 | Token pressure: 5% | Cache: 86%"}),
             json!({"role": "assistant", "content": "Tools used: bash, grep, read_file"}),
             json!({"role": "assistant", "content": "done"}),
         ];
@@ -453,6 +454,7 @@ mod tests {
         );
         assert!(!joined.contains("VERIFICATION REQUIRED"));
         assert!(!joined.contains("ERROR BUDGET"));
+        assert!(!joined.contains("Self-Status"));
         assert!(!joined.contains("Tools used:"));
     }
 

--- a/rust/crates/astra-turn-core/src/prompt_facing.rs
+++ b/rust/crates/astra-turn-core/src/prompt_facing.rs
@@ -426,6 +426,37 @@ mod tests {
     }
 
     #[test]
+    fn drops_persisted_runtime_scaffolding_directives() {
+        let messages = vec![
+            json!({"role": "user", "content": "continue"}),
+            json!({"role": "assistant", "content": "working"}),
+            json!({"role": "user", "content": "⚠️ VERIFICATION REQUIRED: Before you finish, run any missing checks"}),
+            json!({"role": "user", "content": "🔄 ERROR BUDGET EXHAUSTED: You've hit Unknown errors 3 turns in a row"}),
+            json!({"role": "assistant", "content": "Tools used: bash, grep, read_file"}),
+            json!({"role": "assistant", "content": "done"}),
+        ];
+
+        let got = sanitize_prompt_facing_messages(messages);
+        let joined = got
+            .iter()
+            .filter_map(|msg| msg["content"].as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(
+            got,
+            vec![
+                json!({"role": "user", "content": "continue"}),
+                json!({"role": "assistant", "content": "working"}),
+                json!({"role": "assistant", "content": "done"}),
+            ]
+        );
+        assert!(!joined.contains("VERIFICATION REQUIRED"));
+        assert!(!joined.contains("ERROR BUDGET"));
+        assert!(!joined.contains("Tools used:"));
+    }
+
+    #[test]
     fn anthropic_style_tool_blocks_are_compacted_without_provider_frames() {
         let messages = vec![
             json!({"role": "user", "content": "inspect"}),

--- a/rust/crates/astra-turn-core/src/routing.rs
+++ b/rust/crates/astra-turn-core/src/routing.rs
@@ -1,18 +1,4 @@
-use std::sync::OnceLock;
-
-use regex::Regex;
 use serde_json::{Map, Value};
-
-pub fn detect_correction(query: &str) -> bool {
-    static CORRECTION_PATTERN: OnceLock<Regex> = OnceLock::new();
-    let pattern = CORRECTION_PATTERN.get_or_init(|| {
-        Regex::new(
-            r"不对|错了|不是这样|你搞错|不正确|wrong|incorrect|that's not|no,\s|actually,?\s",
-        )
-        .expect("correction regex should compile")
-    });
-    pattern.is_match(query.trim())
-}
 
 pub fn build_skipped_routing_metadata(reason: &str) -> Map<String, Value> {
     Map::from_iter([
@@ -24,52 +10,6 @@ pub fn build_skipped_routing_metadata(reason: &str) -> Map<String, Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ── detect_correction ──
-
-    #[test]
-    fn detect_correction_positive_en() {
-        assert!(detect_correction("wrong, that's not what I meant"));
-        assert!(detect_correction("that's not right"));
-    }
-
-    #[test]
-    fn detect_correction_positive_cn() {
-        assert!(detect_correction("不对，重新来"));
-        assert!(detect_correction("你搞错了"));
-    }
-
-    #[test]
-    fn detect_correction_negative() {
-        assert!(!detect_correction("looks good, merge it"));
-        assert!(!detect_correction("list the files"));
-    }
-
-    // --- edge cases ---
-
-    #[test]
-    fn detect_correction_empty_string() {
-        assert!(!detect_correction(""));
-    }
-
-    #[test]
-    fn detect_correction_whitespace_only() {
-        assert!(!detect_correction("   \t  "));
-    }
-
-    #[test]
-    fn detect_correction_case_sensitivity() {
-        // The regex uses lowercase, so "Wrong" won't match (case sensitive)
-        assert!(!detect_correction("Wrong answer"));
-        // but "wrong" will
-        assert!(detect_correction("wrong answer"));
-    }
-
-    #[test]
-    fn detect_correction_actually_with_comma() {
-        assert!(detect_correction("actually, I meant something else"));
-        assert!(detect_correction("actually I meant something else"));
-    }
 
     #[test]
     fn build_skipped_routing_fields() {

--- a/rust/crates/astra-turn-core/src/runtime_scaffolding.rs
+++ b/rust/crates/astra-turn-core/src/runtime_scaffolding.rs
@@ -9,6 +9,9 @@ pub enum RuntimeScaffoldingKind {
     CrossSessionProjectContext,
     PreviousRoundSummary,
     SequentialToolCallsWarning,
+    VerificationRequired,
+    ErrorBudgetDirective,
+    GenericRuntimeScaffolding,
 }
 
 pub const SYSTEM_REMINDER_WRAPPER_PREFIX: &str = "<system-reminder>";
@@ -20,6 +23,8 @@ pub const ALREADY_FETCHED_PREFIX: &str = "## Already Fetched";
 pub const CROSS_SESSION_PROJECT_CONTEXT_PREFIX: &str = "## Cross-Session Project Context";
 pub const PREVIOUS_ROUND_PREFIX: &str = "✓ Previous round:";
 pub const SEQUENTIAL_TOOL_CALLS_PREFIX: &str = "## ⚠ Sequential Tool Calls Detected";
+pub const VERIFICATION_REQUIRED_PREFIX: &str = "⚠️ VERIFICATION REQUIRED";
+pub const ERROR_BUDGET_PREFIX: &str = "🔄 ERROR BUDGET";
 
 pub fn detect_runtime_scaffolding(content: &str) -> Option<RuntimeScaffoldingKind> {
     let trimmed = content.trim_start();
@@ -41,38 +46,21 @@ pub fn detect_runtime_scaffolding(content: &str) -> Option<RuntimeScaffoldingKin
         Some(RuntimeScaffoldingKind::PreviousRoundSummary)
     } else if trimmed.starts_with(SEQUENTIAL_TOOL_CALLS_PREFIX) {
         Some(RuntimeScaffoldingKind::SequentialToolCallsWarning)
+    } else if trimmed.starts_with(VERIFICATION_REQUIRED_PREFIX) {
+        Some(RuntimeScaffoldingKind::VerificationRequired)
+    } else if trimmed.starts_with(ERROR_BUDGET_PREFIX) {
+        Some(RuntimeScaffoldingKind::ErrorBudgetDirective)
+    } else if astra_turn_types::scaffolding_body_prefixes_for_filtering()
+        .any(|prefix| trimmed.starts_with(prefix))
+    {
+        Some(RuntimeScaffoldingKind::GenericRuntimeScaffolding)
     } else {
         None
     }
 }
 
 pub fn is_continuation_scaffolding_for_role(role: &str, content: &str) -> bool {
-    matches!(
-        (role, detect_runtime_scaffolding(content)),
-        (
-            "user",
-            Some(
-                RuntimeScaffoldingKind::SystemReminderWrapper
-                    | RuntimeScaffoldingKind::AttentionManifest
-                    | RuntimeScaffoldingKind::WorkingSetManifest
-                    | RuntimeScaffoldingKind::SessionAnchor
-                    | RuntimeScaffoldingKind::ObsoleteActiveTaskAttachment
-                    | RuntimeScaffoldingKind::PreviousRoundSummary
-                    | RuntimeScaffoldingKind::SequentialToolCallsWarning,
-            ),
-        ) | (
-            "system",
-            Some(
-                RuntimeScaffoldingKind::AttentionManifest
-                    | RuntimeScaffoldingKind::WorkingSetManifest
-                    | RuntimeScaffoldingKind::SessionAnchor
-                    | RuntimeScaffoldingKind::ObsoleteActiveTaskAttachment
-                    | RuntimeScaffoldingKind::AlreadyFetchedInventory
-                    | RuntimeScaffoldingKind::CrossSessionProjectContext
-                    | RuntimeScaffoldingKind::PreviousRoundSummary,
-            ),
-        )
-    )
+    matches!(role, "user" | "assistant" | "system") && detect_runtime_scaffolding(content).is_some()
 }
 
 pub fn is_trailing_user_runtime_scaffolding(content: &str) -> bool {
@@ -112,6 +100,50 @@ mod tests {
             Some(RuntimeScaffoldingKind::AlreadyFetchedInventory)
         );
         assert_eq!(detect_runtime_scaffolding("plain user message"), None);
+    }
+
+    #[test]
+    fn detects_stop_hook_and_error_budget_directives() {
+        assert_eq!(
+            detect_runtime_scaffolding(
+                "⚠️ VERIFICATION REQUIRED: Before you finish, run missing checks"
+            ),
+            Some(RuntimeScaffoldingKind::VerificationRequired)
+        );
+        assert_eq!(
+            detect_runtime_scaffolding("🔄 ERROR BUDGET EXHAUSTED: You've hit Unknown errors"),
+            Some(RuntimeScaffoldingKind::ErrorBudgetDirective)
+        );
+    }
+
+    #[test]
+    fn falls_back_to_turn_types_scaffolding_prefixes() {
+        assert_eq!(
+            detect_runtime_scaffolding("Tools used: bash, grep, read_file"),
+            Some(RuntimeScaffoldingKind::GenericRuntimeScaffolding)
+        );
+        assert_eq!(
+            detect_runtime_scaffolding("[compact session=sess-1 turn=4]\nsummary"),
+            Some(RuntimeScaffoldingKind::GenericRuntimeScaffolding)
+        );
+    }
+
+    #[test]
+    fn continuation_scaffolding_is_filtered_for_prompt_facing_roles() {
+        for role in ["user", "assistant", "system"] {
+            assert!(is_continuation_scaffolding_for_role(
+                role,
+                "⚠️ VERIFICATION REQUIRED: Before you finish"
+            ));
+            assert!(is_continuation_scaffolding_for_role(
+                role,
+                "Tools used: bash"
+            ));
+        }
+        assert!(!is_continuation_scaffolding_for_role(
+            "tool",
+            "Tools used: bash"
+        ));
     }
 
     #[test]

--- a/rust/crates/astra-turn-core/src/safety_middleware.rs
+++ b/rust/crates/astra-turn-core/src/safety_middleware.rs
@@ -507,7 +507,7 @@ pub fn check_shell_command_safety(command: &str) -> Option<String> {
     check_shell_command_safety_with_mode(command, TrustMode::Strict)
 }
 
-/// Catastrophic command circuit breaker — bypass-immune, not configurable.
+/// Catastrophic command circuit breaker — absolute safety guard, not configurable.
 ///
 /// These specific patterns must always be denied. They are unrecoverable
 /// (delete the user's home, the whole disk, fork-bomb the machine).
@@ -603,7 +603,7 @@ pub fn catastrophic_command_reason(command: &str) -> Option<String> {
 /// configurable.
 #[must_use]
 pub fn check_shell_command_safety_with_mode(command: &str, mode: TrustMode) -> Option<String> {
-    // 0. Catastrophic command circuit breaker — bypass-immune and not
+    // 0. Catastrophic command circuit breaker — absolute safety guard and not
     //    configurable.
     if let Some(reason) = catastrophic_command_reason(command) {
         return Some(reason);

--- a/rust/crates/astra-turn-core/src/safety_middleware.rs
+++ b/rust/crates/astra-turn-core/src/safety_middleware.rs
@@ -538,6 +538,18 @@ pub fn catastrophic_command_reason(command: &str) -> Option<String> {
         "rm -rf /*",
         "rm -fr /*",
         // home-equivalent paths
+        "rm -rf /home",
+        "rm -fr /home",
+        "rm -r -f /home",
+        "rm -f -r /home",
+        "rm -rf /home/",
+        "rm -fr /home/",
+        "rm -rf /root",
+        "rm -fr /root",
+        "rm -r -f /root",
+        "rm -f -r /root",
+        "rm -rf /root/",
+        "rm -fr /root/",
         "rm -rf ~",
         "rm -fr ~",
         "rm -rf ~/",
@@ -586,6 +598,73 @@ pub fn catastrophic_command_reason(command: &str) -> Option<String> {
         }
     }
 
+    None
+}
+
+/// Absolute, non-configurable command danger guard used by permission gates.
+///
+/// This wraps [`catastrophic_command_reason`] with shell-list segmentation and
+/// common privilege/dispatch wrapper stripping, so `sudo rm -rf /` is treated
+/// the same as `rm -rf /` without overmatching bounded targets like
+/// `sudo rm -rf /tmp/foo`.
+#[must_use]
+pub fn absolute_dangerous_command_reason(command: &str) -> Option<String> {
+    command
+        .split([';', '\n'])
+        .flat_map(|segment| segment.split("&&"))
+        .flat_map(|segment| segment.split("||"))
+        .map(strip_common_shell_wrappers)
+        .find_map(|segment| {
+            catastrophic_command_reason(segment).or_else(|| chmod_777_root_reason(segment))
+        })
+}
+
+fn strip_common_shell_wrappers(segment: &str) -> &str {
+    let mut rest = segment.trim();
+    loop {
+        let Some((head, tail)) = rest.split_once(char::is_whitespace) else {
+            return rest;
+        };
+        let head_lower = head.to_ascii_lowercase();
+        if matches!(
+            head_lower.as_str(),
+            "sudo" | "doas" | "pkexec" | "command" | "builtin"
+        ) {
+            rest = tail.trim_start();
+            if matches!(head_lower.as_str(), "sudo" | "doas" | "pkexec") {
+                rest = strip_leading_wrapper_options(rest);
+            }
+            continue;
+        }
+        return rest;
+    }
+}
+
+fn strip_leading_wrapper_options(segment: &str) -> &str {
+    let mut rest = segment.trim_start();
+    loop {
+        let Some((head, tail)) = rest.split_once(char::is_whitespace) else {
+            return rest;
+        };
+        if head == "--" || head.starts_with('-') {
+            rest = tail.trim_start();
+            continue;
+        }
+        return rest;
+    }
+}
+
+fn chmod_777_root_reason(command: &str) -> Option<String> {
+    let normalized = command
+        .to_ascii_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if normalized == "chmod 777 /" || normalized.starts_with("chmod 777 / ") {
+        return Some(format!(
+            "catastrophic command refused (circuit breaker): `{command}` makes the root directory world-writable"
+        ));
+    }
     None
 }
 
@@ -1995,6 +2074,8 @@ mod tests {
             ("rm -rf ~/", "circuit breaker"),
             ("rm -rf $HOME", "circuit breaker"),
             ("rm -rf ${HOME}", "circuit breaker"),
+            ("rm -fr /home", "circuit breaker"),
+            ("rm -rf /root", "circuit breaker"),
             (":(){ :|:& };:", "fork bomb"),
             ("dd if=/dev/zero of=/dev/sda", "circuit breaker"),
             ("dd if=/dev/zero of=/dev/disk0", "circuit breaker"),
@@ -2021,6 +2102,7 @@ mod tests {
             "rm -rf ./build",
             "rm -rf target/debug",
             "rm /tmp/foo",
+            "rm -rf /home/user/project",
             "rm -rf node_modules",
             "rm -rf $(mktemp -d)",
             "dd if=/dev/zero of=/tmp/zeros bs=1M count=1",
@@ -2030,6 +2112,39 @@ mod tests {
             assert!(
                 catastrophic_command_reason(cmd).is_none(),
                 "circuit breaker must NOT block safe rm: `{cmd}`"
+            );
+        }
+    }
+
+    #[test]
+    fn absolute_dangerous_command_reason_strips_common_wrappers_without_tmp_overmatch() {
+        let blocked: &[&str] = &[
+            "sudo rm -rf /",
+            "SUDO rm -rf /",
+            "sudo -n rm -rf /",
+            "sudo -- rm -rf /",
+            "DOAS rm -fr /home",
+            "pkexec chmod 777 /",
+            "command rm -rf /root",
+            "builtin rm -rf ~",
+        ];
+        for cmd in blocked {
+            assert!(
+                absolute_dangerous_command_reason(cmd).is_some(),
+                "absolute danger guard must reject wrapper form: `{cmd}`"
+            );
+        }
+
+        let allowed: &[&str] = &[
+            "sudo rm -rf /tmp/foo",
+            "SUDO rm -rf /home/user/project",
+            "pkexec chmod 777 /tmp/foo",
+            "command rm -rf ./build",
+        ];
+        for cmd in allowed {
+            assert!(
+                absolute_dangerous_command_reason(cmd).is_none(),
+                "absolute danger guard must not overmatch bounded target: `{cmd}`"
             );
         }
     }

--- a/rust/crates/astra-turn-core/src/tool/registry/meta.rs
+++ b/rust/crates/astra-turn-core/src/tool/registry/meta.rs
@@ -317,7 +317,7 @@ pub static TOOL_CATALOG: &[ToolMeta] = &[
             "状态",
             "健康度",
         ],
-        intents: &[IntentType::CodeRead],
+        intents: &[IntentType::Introspect],
         scope: Scope::Local,
         requires: &[],
         binding_validation: RuntimeBindingValidation::None,
@@ -921,7 +921,7 @@ mod tests {
 
     #[test]
     fn catalog_includes_top_level_session_state_tools() {
-        for name in ["compress_context", "rollback_session_state"] {
+        for name in ["introspect", "compress_context", "rollback_session_state"] {
             let tool = TOOL_CATALOG
                 .iter()
                 .find(|tool| tool.name == name)

--- a/rust/crates/astra-turn-types/src/runtime_scaffolding.rs
+++ b/rust/crates/astra-turn-types/src/runtime_scaffolding.rs
@@ -40,6 +40,7 @@ pub const SCAFFOLDING_BODY_PREFIXES: &[&str] = &[
     "✓ Previous round:",
     "♻ Duplicate calls detected",
     // Runtime directives
+    "## ⚡ Self-Status",
     "⚠️ VERIFICATION REQUIRED",
     "🔄 ERROR BUDGET",
     "<system-reminder>",
@@ -157,6 +158,14 @@ mod tests {
         assert!(is_runtime_scaffolding_message(&msg(
             "user",
             "🔄 ERROR BUDGET EXHAUSTED: hit Unknown errors 3 turns in a row"
+        )));
+    }
+
+    #[test]
+    fn self_status_directive_is_scaffolding() {
+        assert!(is_runtime_scaffolding_message(&msg(
+            "user",
+            "## ⚡ Self-Status\nTurn 9/299 | Token pressure: 5% | Cache: 86%"
         )));
     }
 

--- a/rust/crates/core/src/observation.rs
+++ b/rust/crates/core/src/observation.rs
@@ -136,6 +136,10 @@ fn is_workspace_mutation_tool(tool_name: &str, family: ToolFamily) -> bool {
     }
 }
 
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
 impl TurnMetrics {
     /// Build metrics from lightweight `ToolCallSample` records.
     pub fn from_samples(
@@ -181,7 +185,7 @@ impl TurnMetrics {
                                     1,
                                     sample
                                         .error
-                                        .map(|e| e[..e.len().min(200)].to_string())
+                                        .map(|e| truncate_chars(e, 200))
                                         .unwrap_or_default(),
                                 ),
                             );
@@ -190,7 +194,7 @@ impl TurnMetrics {
                         // Different tool failed — start new streak for this tool
                         let first_err = sample
                             .error
-                            .map(|e| e[..e.len().min(200)].to_string())
+                            .map(|e| truncate_chars(e, 200))
                             .unwrap_or_default();
                         streak_map.insert(lower.clone(), (1, first_err));
                     }
@@ -198,7 +202,7 @@ impl TurnMetrics {
                     // First failure in turn
                     let first_err = sample
                         .error
-                        .map(|e| e[..e.len().min(200)].to_string())
+                        .map(|e| truncate_chars(e, 200))
                         .unwrap_or_default();
                     streak_map.insert(lower.clone(), (1, first_err));
                 }
@@ -1298,6 +1302,25 @@ mod tests {
         let metrics = TurnMetrics::from_samples(&samples, 2, 100);
         assert_eq!(metrics.mutation_count, 2);
         assert_eq!(metrics.rounds_since_last_mutation, 0);
+    }
+
+    #[test]
+    fn error_streak_preview_truncates_on_utf8_char_boundary() {
+        let error = format!("{}⚠ task returned an error", "x".repeat(199));
+        let samples = [ToolCallSample {
+            name: "task.create",
+            ok: false,
+            round: Some(1),
+            file_path: None,
+            error: Some(&error),
+        }];
+
+        let metrics = TurnMetrics::from_samples(&samples, 1, 100);
+
+        assert_eq!(metrics.error_streaks.len(), 1);
+        let first_error = &metrics.error_streaks[0].first_error;
+        assert_eq!(first_error.chars().count(), 200);
+        assert!(first_error.ends_with('⚠'));
     }
 
     #[test]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -312,7 +312,7 @@ pub use astra_turn_core::{
     retrieval::{
         RETRIEVAL_BUDGET_CHARS, enhanced_extraction, format_retrieved_events, rule_based_extraction,
     },
-    routing::{build_skipped_routing_metadata, detect_correction},
+    routing::build_skipped_routing_metadata,
     stall::{
         DIVERGENCE_CORRECTION, DivergenceStatus, SERVER_STALL_WINDOW, canonical_tool_args,
         detect_divergence, detect_server_stall, record_server_tool_signatures,

--- a/rust/crates/runtime/src/orchestration/mod.rs
+++ b/rust/crates/runtime/src/orchestration/mod.rs
@@ -44,10 +44,10 @@ pub mod permission_sync {
 }
 pub use fork_cache_probe::{ForkCacheProbeState, maybe_emit_fork_cache_probe};
 pub use permission_sync::{
-    InheritedPermissions, PermissionAction, PermissionCallback, PermissionDecision, PermissionMode,
-    PermissionRequest, PermissionRequestHandler, PermissionRequestMessaging, PermissionResponse,
-    PermissionResponseMessaging, PermissionRule, PermissionSyncContext, PermissionSyncHandle,
-    PermissionUpdate,
+    ChildPermissionMode, InheritedPermissions, PermissionAction, PermissionCallback,
+    PermissionDecision, PermissionMode, PermissionRequest, PermissionRequestHandler,
+    PermissionRequestMessaging, PermissionResponse, PermissionResponseMessaging, PermissionRule,
+    PermissionSyncContext, PermissionSyncHandle, PermissionUpdate,
 };
 pub use spawner::{
     AgentHistoryRecord, AgentStatus, DynamicAgentSpawner, InheritedChildPrefix, PermissionSummary,

--- a/rust/crates/runtime/src/orchestration/spawner.rs
+++ b/rust/crates/runtime/src/orchestration/spawner.rs
@@ -399,7 +399,7 @@ pub enum WaitForAgentOutcome {
 /// Permission summary for display purposes.
 #[derive(Debug, Clone, Default)]
 pub struct PermissionSummary {
-    /// Permission mode (auto, plan, accept_edits, prompt, deny).
+    /// Permission mode (auto, bypass, plan, accept_edits, prompt, deny).
     pub mode: String,
     /// Number of explicit allow rules.
     pub allow_rules: u32,

--- a/rust/crates/runtime/src/orchestration/spawner.rs
+++ b/rust/crates/runtime/src/orchestration/spawner.rs
@@ -2887,6 +2887,7 @@ fn build_permission_summary(context: &SpawnContext) -> PermissionSummary {
     let inherited = &context.inherited_permissions;
     summary.mode = match inherited.mode {
         super::permission_sync::PermissionMode::Auto => "auto".to_string(),
+        super::permission_sync::PermissionMode::Bypass => "bypass".to_string(),
         super::permission_sync::PermissionMode::Plan => "plan".to_string(),
         super::permission_sync::PermissionMode::AcceptEdits => "accept_edits".to_string(),
         super::permission_sync::PermissionMode::Prompt => "prompt".to_string(),

--- a/rust/crates/runtime/src/prompts/system.rs
+++ b/rust/crates/runtime/src/prompts/system.rs
@@ -621,11 +621,11 @@ fn safety_section() -> &'static str {
 /// stack (~60 lines of repetition) with a tight 18-line contract.
 fn planning_section() -> &'static str {
     "\n## Plan, Batch, Execute\n\
-     1. **Plan first** (3+ tool calls): state goal + numbered steps in a <think> block, then act.\n\
-     2. **Batch independent reads** into ONE turn (≤5 parallel). Only serialize when one result feeds the next call's args.\n\
+     1. **Plan first** (3+ tool calls): state goal + numbered steps in a <think> block, then act. If blocked or surprised, re-plan before retrying.\n\
+     2. **Batch independent reads** into ONE turn (≤5 parallel): multi-file reads, multi-grep, or known list_dir + known read_file. Only serialize when one result feeds the next call's args.\n\
      3. **Reuse history**: if context was already fetched this session, reference it — don't re-fetch.\n\
      4. **Discover before reading**: use list_dir/glob to confirm paths. Never guess.\n\
-     5. **Targeted reads**: prefer line ranges + outline=true over full files. Use glob before grep.\n\
+     5. **Progressive reads**: structure first (outline=true or list), signal next (grep/files-with-matches), then targeted ranges. Full-file reads only for small files or when full context is needed.\n\
      6. **Never batch writes**: write_file / str_replace / bash / git execute sequentially.\n\
      7. **Build/test only AFTER your writes** — not for exploration, review, or Q&A.\n\
      8. **Open-ended loops** (\"keep going\", \"as many as you can\"): do one useful pass, then stop.\n\
@@ -1176,9 +1176,10 @@ fn search_strategy_section(tool_names: &[&str]) -> String {
              - {first_step} for filenames/dirs, then grep only that subset for content.\n\
              - For broad exploration that clearly needs >3 searches, consider an explore agent if available.\n\
              - Start narrow. Prefer likely roots first: src, crates, app, lib, packages, cmd, internal, tests.\n\
+             - Rank by signal density before reading: API entry points → core logic → domain/types → config only if relevant → examples/docs only if asked.\n\
              - For code review, search changed files or adjacent modules before the whole repo.\n\
-             - Skip generated or bulky trees unless the task explicitly targets them: build, dist, target, coverage, htmlcov, node_modules, vendor.\n\
-             - After grep finds candidates, switch to targeted reads instead of repeating more broad searches.\n\
+             - Skip generated, bulky, or low-signal files unless targeted: build, dist, target, coverage, htmlcov, node_modules, vendor, *.example.*, fixtures, docs.\n\
+             - After grep finds candidates, switch to outline/range reads instead of repeating more broad searches.\n\
              - If grep is slow or noisy, tighten path, extension, or literal term — do NOT repeat the same broad search.\n\
              - Use `symbols` for code symbols only when visible or activated; keep grep for content searches.\n"
         )
@@ -1188,9 +1189,10 @@ fn search_strategy_section(tool_names: &[&str]) -> String {
              - Use visible layout/file tools first for filenames/dirs, then targeted reads for exact context.\n\
              - For broad exploration that clearly needs >3 searches, consider an explore agent if available.\n\
              - Start narrow. Prefer likely roots first: src, crates, app, lib, packages, cmd, internal, tests.\n\
+             - Rank by signal density before reading: API entry points → core logic → domain/types → config only if relevant → examples/docs only if asked.\n\
              - For code review, inspect changed files or adjacent modules before the whole repo.\n\
-             - Skip generated or bulky trees unless the task explicitly targets them: build, dist, target, coverage, htmlcov, node_modules, vendor.\n\
-             - After locating candidates, switch to targeted reads instead of repeating broad searches.\n",
+             - Skip generated, bulky, or low-signal files unless targeted: build, dist, target, coverage, htmlcov, node_modules, vendor, *.example.*, fixtures, docs.\n\
+             - After locating candidates, switch to outline/range reads instead of repeating broad searches.\n",
         );
         if tool_visible(tool_names, "tool_search") {
             body.push_str(
@@ -2305,10 +2307,13 @@ mod tests {
         // Parallel tool calls
         assert!(p.contains("Batch independent reads"));
         assert!(p.contains("ONE turn"));
+        assert!(p.contains("multi-file reads"));
+        assert!(p.contains("Only serialize when one result feeds the next call's args"));
 
         // Token efficiency
-        assert!(p.contains("Targeted reads"));
-        assert!(p.contains("line ranges"));
+        assert!(p.contains("Progressive reads"));
+        assert!(p.contains("structure first"));
+        assert!(p.contains("targeted ranges"));
 
         // Build/test guidance
         assert!(p.contains("Build/test only AFTER your writes"));
@@ -2423,6 +2428,10 @@ mod tests {
         let p_search = build_main_system_prompt(&["glob", "grep", "read_file"], "", None);
         assert!(p_search.contains("Search Strategy"));
         assert!(p_search.contains("Use glob first"));
+        assert!(p_search.contains("Rank by signal density"));
+        assert!(p_search.contains("API entry points"));
+        assert!(p_search.contains("*.example.*"));
+        assert!(p_search.contains("outline/range reads"));
 
         // Search strategy → absent without search tools
         let p_no_search = build_main_system_prompt(&["bash"], "", None);

--- a/rust/crates/runtime/src/server/bridge_prep.rs
+++ b/rust/crates/runtime/src/server/bridge_prep.rs
@@ -331,6 +331,10 @@ fn validate_explicit_turn_identity(
     }))
 }
 
+fn inferred_force_intent_for_bridge_user_query(_user_query: &str) -> Option<String> {
+    None
+}
+
 pub(super) async fn prepare_chat_turn_bridge_body(
     state: &AppState,
     user: &AuthUserRecord,
@@ -444,7 +448,7 @@ pub(super) async fn prepare_chat_turn_bridge_body(
         let meta = serde_json::Value::Object(build_skipped_routing_metadata("selected_model"));
         URL_SAFE.encode(serde_json::to_string(&meta).unwrap_or_default().as_bytes())
     });
-    let force_intent = detect_correction(&user_query).then_some("question".to_string());
+    let force_intent = inferred_force_intent_for_bridge_user_query(&user_query);
     let execution_state_b64 = request
         .execution_state_obj()
         .map(normalize_execution_state)
@@ -1313,6 +1317,17 @@ mod tests {
         );
         assert_eq!(state.get("history"), Some(&json!(["turn1", "turn2"])));
         assert_eq!(state.get("turn_count"), Some(&json!(0)));
+    }
+
+    #[test]
+    fn bridge_prep_does_not_infer_force_intent_from_correction_text() {
+        for query in [
+            "wrong, that's not what I meant",
+            "不对，你搞错了",
+            "actually, I meant the runtime branch",
+        ] {
+            assert_eq!(inferred_force_intent_for_bridge_user_query(query), None);
+        }
     }
 
     // ── trim_edge_tools_for_result_turn ─────────────────────────────

--- a/rust/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/rust/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -8799,8 +8799,8 @@ mod tests {
     #[test]
     fn correction_keywords_trigger_was_corrected_via_implicit_feedback() {
         // Sanity-check that the detect_implicit_feedback_signal contract used in
-        // record_server_loop_learning_outcome produces a "correction" signal
-        // for the Chinese-language corrections listed in routing::detect_correction.
+        // record_server_loop_learning_outcome still recognizes Chinese-language
+        // user corrections.
         let signal = astra_turn_types::detect_implicit_feedback_signal(
             "不对，你搞错了",
             Some("previous assistant reply"),
@@ -10848,7 +10848,7 @@ mod tests {
         assert_eq!(event.turn, None);
         let metadata = event.metadata.expect("turn evaluation metadata");
         assert_eq!(metadata["source"], "server_runtime");
-        assert_eq!(metadata["live_query"], true);
+        assert_eq!(metadata["live_query"], false);
         assert_eq!(metadata["stall_count"], 1);
         assert_eq!(metadata["verdict_warning"], true);
         assert_eq!(metadata["tool_call_count"], 1);

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -440,6 +440,43 @@ impl astra_turn_core::cloud_summary::SummaryLlmClient for RequestAwareSummaryCli
     }
 }
 
+impl RequestAwareSummaryClient {
+    fn from_resolved_config(llm_cfg: &ResolvedTurnLlmConfig, max_output_tokens: usize) -> Self {
+        Self {
+            model_name: llm_cfg.model_name.clone(),
+            wire_model_name: llm_cfg.wire_model_name.clone(),
+            api_key: llm_cfg.api_key.clone(),
+            base_url: llm_cfg.base_url.clone(),
+            provider: llm_cfg.provider.clone(),
+            max_output_tokens,
+            header_overrides: llm_cfg.header_overrides.clone(),
+            request_body_overrides: llm_cfg.request_body_overrides.clone(),
+            completions_url_override: llm_cfg.completions_url_override.clone(),
+            request_timeout: llm_cfg.request_timeout,
+        }
+    }
+}
+
+struct SummaryClientTurnIntentJudge {
+    client: Box<dyn astra_turn_core::cloud_summary::SummaryLlmClient>,
+}
+
+#[async_trait]
+impl astra_services::TurnIntentJudge for SummaryClientTurnIntentJudge {
+    async fn judge(
+        &self,
+        ctx: &astra_services::TurnIntentJudgeContext,
+    ) -> Result<astra_config::user_profile::TurnIntent, astra_services::TurnIntentJudgeError> {
+        let messages = astra_services::turn_intent_judge_messages(ctx);
+        let response = self
+            .client
+            .summarize(&messages)
+            .await
+            .map_err(astra_services::TurnIntentJudgeError::Transport)?;
+        astra_services::parse_turn_intent_response(response.text.as_str())
+    }
+}
+
 fn normalize_request_model(preferred_model: Option<&str>) -> Option<String> {
     preferred_model
         .map(str::trim)
@@ -818,6 +855,10 @@ pub struct ServerAgenticLoopHost {
     /// Used by `summary_client()` to construct the compact-summary client
     /// without re-resolving (model resolution requires async DB call).
     resolved_llm_params: Option<astra_turn_core::cloud_summary::LlmConnParams>,
+    /// Full resolved config from the last successful model resolution.
+    /// Summary-classifier calls need completion overrides and forwarded
+    /// headers, which `LlmConnParams` intentionally does not carry.
+    resolved_llm_config: Option<ResolvedTurnLlmConfig>,
 
     // ── Context ──
     edge_tools: Vec<Value>,
@@ -1317,6 +1358,7 @@ impl ServerAgenticLoopHostBuilder {
             llm_token_service: self.llm_token_service,
             resolved_model_name: None,
             resolved_llm_params: None,
+            resolved_llm_config: None,
             edge_tools,
             capabilities: self.capabilities,
             edge_profile: self.edge_profile,
@@ -1434,6 +1476,71 @@ impl ServerAgenticLoopHost {
     /// intent.
     pub fn set_turn_intent_judge(&mut self, judge: Arc<dyn astra_services::TurnIntentJudge>) {
         self.turn_intent_judge = Some(judge);
+    }
+
+    async fn resolve_llm_config_for_state(
+        &self,
+        state: &AgenticLoopState,
+    ) -> Result<ResolvedTurnLlmConfig, String> {
+        // Skill-level model override takes precedence over the host-level one.
+        let effective_model_override = state
+            .skills
+            .model_override
+            .as_deref()
+            .or(self.model_override.as_deref());
+        let pool_ref = self.shared_pool.as_ref().map(|sp| sp.get());
+        resolve_llm_model_for_turn(
+            &self.matrixone,
+            self.encryptor.as_ref(),
+            effective_model_override,
+            pool_ref,
+            self.llm_token_service.as_ref(),
+            &state.hooks.forward_headers,
+        )
+        .await
+    }
+
+    fn remember_resolved_llm_config(&mut self, llm_cfg: &ResolvedTurnLlmConfig) {
+        self.resolved_model_name = Some(llm_cfg.model_name.clone());
+        self.resolved_llm_params = Some(astra_turn_core::cloud_summary::LlmConnParams {
+            model_name: llm_cfg.model_name.clone(),
+            api_key: llm_cfg.api_key.clone(),
+            base_url: llm_cfg.base_url.clone(),
+            provider: llm_cfg.provider.clone(),
+            max_output_tokens: 4096,
+        });
+        self.resolved_llm_config = Some(llm_cfg.clone());
+    }
+
+    async fn turn_intent_summary_client(
+        &mut self,
+        state: &AgenticLoopState,
+    ) -> Option<Box<dyn astra_turn_core::cloud_summary::SummaryLlmClient>> {
+        if let Some(config) = self.resolved_llm_config.as_ref() {
+            return Some(Box::new(RequestAwareSummaryClient::from_resolved_config(
+                config, 256,
+            )));
+        }
+
+        if self.resolved_llm_params.is_none() {
+            let llm_cfg = match self.resolve_llm_config_for_state(state).await {
+                Ok(config) => config,
+                Err(error) => {
+                    tracing::debug!(
+                        target: "astra::turn_intent",
+                        error = %error,
+                        "turn intent judge skipped because model resolution is unavailable"
+                    );
+                    return None;
+                }
+            };
+            self.remember_resolved_llm_config(&llm_cfg);
+            return Some(Box::new(RequestAwareSummaryClient::from_resolved_config(
+                &llm_cfg, 256,
+            )));
+        }
+
+        self.summary_client()
     }
 
     /// Install runtime MCP tool schemas into the LLM tool surface.
@@ -3143,27 +3250,36 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
         &mut self,
         state: &AgenticLoopState,
     ) -> Option<astra_config::user_profile::TurnIntent> {
-        match self.turn_intent_judge.as_ref() {
-            Some(judge) => {
-                let has_prior_assistant_turn = state
-                    .messages
-                    .iter()
-                    .rev()
-                    .any(|m| m.get("role").and_then(|r| r.as_str()) == Some("assistant"));
-                // Use 1-based turn count: llm_rounds_completed counts
-                // *prior* rounds, so the current user turn is +1.
-                let turn_count = state.llm_rounds_completed.saturating_add(1);
-                crate::turn::agentic::turn_intent::judge_turn_intent_with_llm(
-                    judge.as_ref(),
-                    &state.message,
-                    turn_count,
-                    &state.recent_tools,
-                    has_prior_assistant_turn,
-                )
-                .await
-            }
-            None => None,
+        let has_prior_assistant_turn = state
+            .messages
+            .iter()
+            .rev()
+            .any(|m| m.get("role").and_then(|r| r.as_str()) == Some("assistant"));
+        // Use 1-based turn count: llm_rounds_completed counts *prior* rounds,
+        // so the current user turn is +1.
+        let turn_count = state.llm_rounds_completed.saturating_add(1);
+
+        if let Some(judge) = self.turn_intent_judge.as_ref() {
+            return crate::turn::agentic::turn_intent::judge_turn_intent_with_llm(
+                judge.as_ref(),
+                &state.message,
+                turn_count,
+                &state.recent_tools,
+                has_prior_assistant_turn,
+            )
+            .await;
         }
+
+        let client = self.turn_intent_summary_client(state).await?;
+        let judge = SummaryClientTurnIntentJudge { client };
+        crate::turn::agentic::turn_intent::judge_turn_intent_with_llm(
+            &judge,
+            &state.message,
+            turn_count,
+            &state.recent_tools,
+            has_prior_assistant_turn,
+        )
+        .await
     }
 
     async fn judge_factual_retry_fallback(
@@ -3287,23 +3403,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
         }
 
         // ── 1. Resolve LLM model ────────────────────────────────────────
-        // Skill-level model override takes precedence over the host-level one.
-        let effective_model_override = state
-            .skills
-            .model_override
-            .as_deref()
-            .or(self.model_override.as_deref());
-        let pool_ref = self.shared_pool.as_ref().map(|sp| sp.get());
-        let mut llm_cfg = match resolve_llm_model_for_turn(
-            &self.matrixone,
-            self.encryptor.as_ref(),
-            effective_model_override,
-            pool_ref,
-            self.llm_token_service.as_ref(),
-            &state.hooks.forward_headers,
-        )
-        .await
-        {
+        let mut llm_cfg = match self.resolve_llm_config_for_state(state).await {
             Ok(m) => m,
             Err(e) => {
                 return Err(astra_core::ClassifiedError::new(
@@ -3330,6 +3430,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 let enc = self.encryptor.as_ref();
                 let lts = self.llm_token_service.as_ref();
                 let fwd = &state.hooks.forward_headers;
+                let pool_ref = self.shared_pool.as_ref().map(|sp| sp.get());
                 match try_resolve_fallback(
                     cooldown,
                     &llm_cfg.fallback_chain,
@@ -3403,14 +3504,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
             &llm_cfg.provider,
             &llm_cfg.model_name,
         );
-        self.resolved_model_name = Some(llm_cfg.model_name.clone());
-        self.resolved_llm_params = Some(astra_turn_core::cloud_summary::LlmConnParams {
-            model_name: llm_cfg.model_name.clone(),
-            api_key: llm_cfg.api_key.clone(),
-            base_url: llm_cfg.base_url.clone(),
-            provider: llm_cfg.provider.clone(),
-            max_output_tokens: 4096,
-        });
+        self.remember_resolved_llm_config(&llm_cfg);
 
         // ── 2b. Run the context pipeline ─────────────────────────────────
         // Pipeline is the single source of truth for:
@@ -4147,9 +4241,16 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
     }
 
     fn summary_client(&self) -> Option<Box<dyn astra_turn_core::cloud_summary::SummaryLlmClient>> {
-        // LLM config is resolved per-turn inside execute_turn. We cache it in
-        // `resolved_llm_params` after first successful resolution so the trait
-        // method can construct the client without re-resolving.
+        // LLM config is resolved per-turn inside execute_turn. Prefer the full
+        // config because gateway completion overrides and forwarded auth
+        // headers are part of the runtime contract for all auxiliary LLM calls.
+        if let Some(config) = self.resolved_llm_config.as_ref() {
+            return Some(Box::new(RequestAwareSummaryClient::from_resolved_config(
+                config, 4096,
+            )));
+        }
+
+        // Older tests can still seed the minimal params directly.
         let params = self.resolved_llm_params.as_ref()?;
         Some(Box::new(
             astra_turn_core::cloud_summary::HttpSummaryClient::new(params.clone()),
@@ -10167,8 +10268,10 @@ mod tests {
     // judge is absent or fails.
     mod turn_intent_judge_wiring {
         use super::*;
-        use astra_config::user_profile::{TurnContinuationMode, TurnIntent};
-        use astra_services::{TurnIntentJudge, TurnIntentJudgeContext, TurnIntentJudgeError};
+        use astra_config::user_profile::{Scenario, TurnContinuationMode, TurnIntent};
+        use astra_services::{
+            LlmTokenServiceConfig, TurnIntentJudge, TurnIntentJudgeContext, TurnIntentJudgeError,
+        };
         use async_trait::async_trait;
 
         struct ScriptedJudge {
@@ -10282,6 +10385,131 @@ mod tests {
             state.message = "please inspect the current changes".to_string();
 
             assert_eq!(host.judge_turn_intent(&state).await, None);
+        }
+
+        #[tokio::test]
+        async fn judge_turn_intent_uses_gateway_llm_when_no_judge_is_injected() {
+            use axum::{Router, extract::State, routing::post};
+            use tokio::net::TcpListener;
+
+            #[derive(Default)]
+            struct RequestCapture {
+                authorization: tokio::sync::Mutex<Option<String>>,
+                workspace_id: tokio::sync::Mutex<Option<String>>,
+                body: tokio::sync::Mutex<Option<Value>>,
+            }
+
+            async fn handler(
+                State(capture): State<Arc<RequestCapture>>,
+                headers: axum::http::HeaderMap,
+                request: axum::extract::Request,
+            ) -> axum::Json<Value> {
+                *capture.authorization.lock().await = headers
+                    .get("authorization")
+                    .and_then(|value| value.to_str().ok())
+                    .map(String::from);
+                *capture.workspace_id.lock().await = headers
+                    .get("x-workspace-id")
+                    .and_then(|value| value.to_str().ok())
+                    .map(String::from);
+
+                let bytes = axum::body::to_bytes(request.into_body(), usize::MAX)
+                    .await
+                    .expect("read request body");
+                *capture.body.lock().await =
+                    Some(serde_json::from_slice(&bytes).expect("json body"));
+
+                axum::Json(json!({
+                    "choices": [
+                        {
+                            "message": {
+                                "content": "{\"requested_scenario\":\"refactoring\",\"prohibited_scenarios\":[],\"continuation_mode\":\"continue_current_objective\",\"reanchors_current_objective\":true}"
+                            },
+                            "finish_reason": "stop"
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+                }))
+            }
+
+            let capture = Arc::new(RequestCapture::default());
+            let app = Router::new()
+                .route("/gateway/chat/completions", post(handler))
+                .with_state(capture.clone());
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind listener");
+            let addr = listener.local_addr().expect("listener addr");
+            let server = tokio::spawn(async move {
+                axum::serve(listener, app)
+                    .await
+                    .expect("test server should run");
+            });
+
+            let mut host = ServerAgenticLoopHostBuilder::new(
+                mock_matrixone(),
+                mock_encryptor(),
+                "u".to_string(),
+                "s".to_string(),
+            )
+            .with_llm_token_service(Some(LlmTokenServiceConfig {
+                url: format!("http://{addr}/gateway/chat/completions"),
+                timeout_ms: Some(2_000),
+            }))
+            .build();
+
+            let mut state = crate::turn::agentic_loop::host::tests::make_state();
+            state.message = "不对，我要的是系统性修复，不是临时补丁".to_string();
+            state.messages = vec![
+                serde_json::json!({"role": "user", "content": "earlier"}),
+                serde_json::json!({"role": "assistant", "content": "ok"}),
+            ];
+            state.hooks.forward_headers.insert(
+                "authorization".to_string(),
+                "Bearer forwarded-token".to_string(),
+            );
+            state
+                .hooks
+                .forward_headers
+                .insert("x-workspace-id".to_string(), "ws-judge".to_string());
+
+            let intent = host
+                .judge_turn_intent(&state)
+                .await
+                .expect("gateway judge should return intent");
+
+            assert_eq!(intent.requested_scenario, Some(Scenario::Refactoring));
+            assert_eq!(
+                intent.continuation_mode,
+                TurnContinuationMode::ContinueCurrentObjective
+            );
+            assert!(
+                intent.reanchors_current_objective,
+                "judge response should drive reanchor behavior"
+            );
+            assert_eq!(
+                capture.authorization.lock().await.as_deref(),
+                Some("Bearer forwarded-token")
+            );
+            assert_eq!(
+                capture.workspace_id.lock().await.as_deref(),
+                Some("ws-judge")
+            );
+
+            let body = capture.body.lock().await.clone().expect("judge request");
+            let messages = body["messages"].as_array().expect("messages");
+            assert_eq!(messages.len(), 2);
+            let prompt = messages[1]["content"].as_str().expect("user prompt");
+            assert!(
+                prompt.contains("reanchors_current_objective"),
+                "judge prompt must request the structured reanchor field"
+            );
+            assert!(
+                prompt.contains("不对，我要的是系统性修复，不是临时补丁"),
+                "judge prompt must include the current user message as data"
+            );
+
+            server.abort();
         }
     }
 }

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -36,8 +36,8 @@ use crate::server::tool_transport::{
 };
 use crate::turn::agentic::headless_round::HeadlessStderrStyle;
 use crate::turn::agentic_loop::host::{
-    AgenticLoopHost, AgenticLoopState, HostTurnResult, TurnInteractionMode, TurnInteractionPolicy,
-    interaction_scoped_tool_restrictions,
+    AgenticLoopHost, AgenticLoopState, FactualRetryFallbackJudgeContext, HostTurnResult,
+    TurnInteractionMode, TurnInteractionPolicy, interaction_scoped_tool_restrictions,
 };
 use crate::turn::agentic_loop::tool_support::edge_tool_status_exit_code;
 use crate::turn::bridge::llm_stream::rate_limit_cooldown;
@@ -55,6 +55,10 @@ use astra_services::multi_agent::EdgeDispatchService;
 use astra_services::runs::RequestedTurnInteractionMode;
 use astra_turn_core::agent_live_event::{
     AgentLiveEvent, AgentLiveEventKind, SharedAgentLiveEventSink,
+};
+use astra_turn_core::agentic_turn_ingest::{
+    FactualRetryFallbackDecision, FactualRetryFallbackJudgeInput,
+    factual_retry_fallback_judge_messages, parse_factual_retry_fallback_judge_response,
 };
 use astra_turn_core::bridge_rate_limit_cooldown::{
     FallbackOutcome, RateLimitAction, try_resolve_fallback,
@@ -3159,6 +3163,40 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 .await
             }
             None => None,
+        }
+    }
+
+    async fn judge_factual_retry_fallback(
+        &mut self,
+        ctx: FactualRetryFallbackJudgeContext<'_>,
+    ) -> Option<FactualRetryFallbackDecision> {
+        let client = self.summary_client()?;
+        let messages = factual_retry_fallback_judge_messages(FactualRetryFallbackJudgeInput {
+            original_query: ctx.original_query,
+            fallback_text: ctx.fallback_text,
+            retry_text: ctx.retry_text,
+        });
+        let response = match client.summarize(&messages).await {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::warn!(
+                    target: "astra::factual_retry_judge",
+                    error = %error,
+                    "factual retry fallback judge unavailable; keeping retry output"
+                );
+                return None;
+            }
+        };
+        match parse_factual_retry_fallback_judge_response(response.text.as_str()) {
+            Ok(verdict) => Some(verdict.accepted_decision()),
+            Err(error) => {
+                tracing::warn!(
+                    target: "astra::factual_retry_judge",
+                    error = %error,
+                    "factual retry fallback judge returned malformed output; keeping retry output"
+                );
+                None
+            }
         }
     }
 
@@ -8849,6 +8887,87 @@ mod tests {
             capture.path.lock().await.as_deref(),
             Some("/gateway/chat/completions")
         );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn factual_retry_fallback_judge_uses_llm_response_selection() {
+        use axum::{Router, extract::State, routing::post};
+        use tokio::net::TcpListener;
+
+        #[derive(Default)]
+        struct RequestCapture {
+            body: tokio::sync::Mutex<Option<Value>>,
+        }
+
+        async fn handler(
+            State(capture): State<Arc<RequestCapture>>,
+            request: axum::extract::Request,
+        ) -> axum::Json<Value> {
+            let bytes = axum::body::to_bytes(request.into_body(), usize::MAX)
+                .await
+                .expect("read request body");
+            *capture.body.lock().await = Some(serde_json::from_slice(&bytes).expect("json body"));
+            axum::Json(json!({
+                "choices": [
+                    {
+                        "message": {
+                            "content": "{\"decision\":\"restore_fallback\",\"confidence\":0.94,\"reason\":\"candidate A answers the UI question\"}"
+                        },
+                        "finish_reason": "stop"
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            }))
+        }
+
+        let capture = Arc::new(RequestCapture::default());
+        let app = Router::new()
+            .route("/gateway/chat/completions", post(handler))
+            .with_state(capture.clone());
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("test server should run");
+        });
+
+        let mut host = ServerAgenticLoopHostBuilder::new(
+            mock_matrixone(),
+            mock_encryptor(),
+            "user-judge".to_string(),
+            "session-judge".to_string(),
+        )
+        .build();
+        host.resolved_llm_params = Some(astra_turn_core::cloud_summary::LlmConnParams {
+            model_name: "gpt-4o-mini".to_string(),
+            api_key: String::new(),
+            base_url: format!("http://{addr}/gateway"),
+            provider: "openai".to_string(),
+            max_output_tokens: 128,
+        });
+
+        let decision = host
+            .judge_factual_retry_fallback(FactualRetryFallbackJudgeContext {
+                original_query: "what do 59% and 117k mean?",
+                fallback_text: "59% is context usage; 117k is token count.",
+                retry_text: "I completed the requested work.",
+            })
+            .await;
+
+        assert_eq!(
+            decision,
+            Some(FactualRetryFallbackDecision::RestoreFallback)
+        );
+        let body = capture.body.lock().await.clone().expect("judge request");
+        let messages = body["messages"].as_array().expect("messages");
+        let prompt = messages[1]["content"].as_str().expect("user prompt");
+        assert!(prompt.contains("Candidate A"));
+        assert!(prompt.contains("Candidate B"));
 
         server.abort();
     }

--- a/rust/crates/runtime/src/turn/agentic/turn_intent.rs
+++ b/rust/crates/runtime/src/turn/agentic/turn_intent.rs
@@ -1,4 +1,4 @@
-use astra_config::user_profile::{Scenario, TurnContinuationMode, TurnIntent};
+use astra_config::user_profile::TurnIntent;
 use astra_services::{TurnIntentJudge, TurnIntentJudgeContext, TurnIntentJudgeError};
 
 /// Judge the user's turn using the supplied LLM judge, falling back to the
@@ -32,6 +32,7 @@ pub(crate) async fn judge_turn_intent_with_llm(
                 source = "llm_judge",
                 requested = ?intent.requested_scenario,
                 continuation = ?intent.continuation_mode,
+                reanchors = intent.reanchors_current_objective,
                 "turn intent judged"
             );
             Some(intent)
@@ -68,98 +69,6 @@ pub(crate) async fn judge_turn_intent_with_llm(
             None
         }
     }
-}
-
-/// Structural fallback used when the LLM judge is unavailable, errors, or
-/// returns a malformed response. Without this, every judge failure collapses
-/// to `None` and downstream code loses *all* intent signal — scenario routing,
-/// continuation routing, and adaptive profiles all degrade to defaults. This
-/// keeps the loop functional under judge outages.
-///
-/// First-principles: the fallback must never *fabricate* a scenario it cannot
-/// derive from structural evidence. It infers only what the tool history and
-/// message shape support, and otherwise returns a minimal intent that signals
-/// "unknown scenario, continue if context suggests it".
-pub(crate) fn fallback_turn_intent(
-    message: &str,
-    recent_tools: &[String],
-    has_prior_assistant_turn: bool,
-) -> TurnIntent {
-    use astra_turn_core::input_classifier::is_correction_signal;
-
-    // 1. Correction signal → user is redirecting the *current* objective,
-    //    not starting a new one. High-precision keyword signal we still trust.
-    if is_correction_signal(message) {
-        return TurnIntent::default()
-            .with_continuation_mode(TurnContinuationMode::ContinueCurrentObjective);
-    }
-
-    // 2. Short follow-up after an assistant turn with no new objective
-    //    language → treat as continuation. Avoids the failure mode where a
-    //    bare "yes" / "继续" / "go ahead" resets the scenario to Unknown.
-    let trimmed = message.trim();
-    let is_short_followup = trimmed.chars().count() <= 24 && has_prior_assistant_turn;
-    if is_short_followup {
-        return TurnIntent::default()
-            .with_continuation_mode(TurnContinuationMode::ContinueCurrentObjective);
-    }
-
-    // 3. Infer scenario from recent tool history. Tool choices are a strong,
-    //    honest signal of what the user is actually doing — stronger than
-    //    message keywords. Map the dominant tool family to a scenario.
-    let inferred = infer_scenario_from_tools(recent_tools);
-    let mut intent = TurnIntent::default();
-    if let Some(scenario) = inferred {
-        intent = intent.with_requested_scenario(scenario);
-    }
-    // 4. If there is prior assistant context and we couldn't classify, prefer
-    //    continuation over NewObjective — a wrong NewObjective resets budgets
-    //    and adaptive state mid-task, which is the more costly error.
-    if has_prior_assistant_turn && intent.requested_scenario.is_none() {
-        intent = intent.with_continuation_mode(TurnContinuationMode::ContinueCurrentObjective);
-    }
-    intent
-}
-
-/// Map a tool history profile to the single most-likely scenario. Returns
-/// `None` when the tool mix is empty or ambiguous — the caller decides the
-/// default, not this heuristic.
-fn infer_scenario_from_tools(recent_tools: &[String]) -> Option<Scenario> {
-    if recent_tools.is_empty() {
-        return None;
-    }
-    let mut edit = 0usize;
-    let mut inspect = 0usize;
-    let mut search = 0usize;
-    let mut test = 0usize;
-    for t in recent_tools {
-        let t = t.as_str();
-        if matches!(
-            t,
-            "edit" | "str_replace" | "write_file" | "create" | "apply_patch"
-        ) {
-            edit += 1;
-        } else if matches!(t, "bash" | "view" | "read_file") {
-            inspect += 1;
-        } else if matches!(t, "grep" | "glob" | "web_search" | "list_dir") {
-            search += 1;
-        } else if matches!(t, "test" | "cargo_test" | "pytest" | "jest") {
-            test += 1;
-        }
-    }
-    if test > 0 && test >= edit {
-        return Some(Scenario::Testing);
-    }
-    if edit >= inspect && edit > 0 {
-        return Some(Scenario::Implementation);
-    }
-    if search > inspect && search > 0 {
-        return Some(Scenario::Exploration);
-    }
-    if inspect > 0 {
-        return Some(Scenario::Debugging);
-    }
-    None
 }
 
 #[cfg(test)]
@@ -246,115 +155,5 @@ mod tests {
         let judge = FixedJudge::err(TurnIntentJudgeError::Rejected("no model".into()));
         let out = judge_turn_intent_with_llm(&judge, message, 1, &[], false).await;
         assert!(out.is_none(), "judge failure must return None, got {out:?}");
-    }
-
-    // --- fallback_turn_intent direct coverage ---
-    //
-    // The judge path above returns `None` on failure; `fallback_turn_intent`
-    // is what keeps the loop functional under judge outages. It must infer
-    // only from structural evidence and never fabricate a scenario.
-
-    use super::{fallback_turn_intent, infer_scenario_from_tools};
-    use astra_config::user_profile::Scenario;
-
-    #[test]
-    fn fallback_correction_signal_forces_continue_current() {
-        // "不对" / "stop" style redirections must route to continuation of the
-        // current objective, not a fresh NewObjective that resets budgets.
-        let intent =
-            fallback_turn_intent("不对，刚才那个改错了", &["str_replace".to_string()], true);
-        assert_eq!(
-            intent.continuation_mode,
-            TurnContinuationMode::ContinueCurrentObjective
-        );
-    }
-
-    #[test]
-    fn fallback_short_followup_after_assistant_continues() {
-        // A bare "继续" / "yes" / "go" right after an assistant turn should not
-        // be treated as a new objective — that would wipe adaptive state.
-        let intent = fallback_turn_intent("继续", &[], true);
-        assert_eq!(
-            intent.continuation_mode,
-            TurnContinuationMode::ContinueCurrentObjective
-        );
-        assert!(
-            intent.requested_scenario.is_none(),
-            "no tool evidence → no fabricated scenario"
-        );
-    }
-
-    #[test]
-    fn fallback_short_followup_without_prior_assistant_does_not_continue() {
-        // First turn of a session: even a short message has nothing to continue.
-        let intent = fallback_turn_intent("hi", &[], false);
-        assert_ne!(
-            intent.continuation_mode,
-            TurnContinuationMode::ContinueCurrentObjective
-        );
-    }
-
-    // --- infer_scenario_from_tools: direct coverage ---
-    //
-    // Scenario inference is a pure function over tool history. Testing it
-    // directly avoids the short-followup early-return in `fallback_turn_intent`
-    // (messages ≤24 chars with a prior assistant turn never reach the
-    // inference path). The fallback behavioral tests above cover that branch.
-
-    #[test]
-    fn infer_scenario_edit_tools_yield_implementation() {
-        assert_eq!(
-            infer_scenario_from_tools(&["str_replace".to_string(), "write_file".to_string()]),
-            Some(Scenario::Implementation)
-        );
-    }
-
-    #[test]
-    fn infer_scenario_test_wins_over_edit_on_tie() {
-        // `test >= edit` → testing takes priority: the user has moved past
-        // implementation into verification.
-        assert_eq!(
-            infer_scenario_from_tools(&["str_replace".to_string(), "cargo_test".to_string()]),
-            Some(Scenario::Testing)
-        );
-    }
-
-    #[test]
-    fn infer_scenario_search_tools_yield_exploration() {
-        assert_eq!(
-            infer_scenario_from_tools(&["grep".to_string(), "glob".to_string()]),
-            Some(Scenario::Exploration)
-        );
-    }
-
-    #[test]
-    fn infer_scenario_inspect_tools_yield_debugging() {
-        assert_eq!(
-            infer_scenario_from_tools(&["read_file".to_string(), "bash".to_string()]),
-            Some(Scenario::Debugging)
-        );
-    }
-
-    #[test]
-    fn infer_scenario_edit_wins_tie_over_inspect() {
-        // `edit >= inspect` (not strict `>`) — on a tie, implementation wins.
-        assert_eq!(
-            infer_scenario_from_tools(&["str_replace".to_string(), "read_file".to_string()]),
-            Some(Scenario::Implementation)
-        );
-    }
-
-    #[test]
-    fn infer_scenario_empty_tools_is_none() {
-        assert_eq!(infer_scenario_from_tools(&[]), None);
-    }
-
-    #[test]
-    fn infer_scenario_unmatched_tools_is_none() {
-        // Tools matching no known family produce no confident scenario claim.
-        assert_eq!(
-            infer_scenario_from_tools(&["unknown_tool".to_string()]),
-            None
-        );
     }
 }

--- a/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -2,8 +2,9 @@ use std::time::Instant;
 
 use super::super::agentic::headless_round::HeadlessStderrStyle;
 use super::host::{
-    AgenticLoopHost, AgenticLoopOutcome, AgenticLoopState, DeferredInputState, HostTurnResult,
-    TaskBoardSnapshot, finalize_and_render, finalize_turn_trace, try_write_heavy_checkpoint,
+    AgenticLoopHost, AgenticLoopOutcome, AgenticLoopState, DeferredInputState,
+    FactualRetryFallbackJudgeContext, HostTurnResult, TaskBoardSnapshot, finalize_and_render,
+    finalize_turn_trace, try_write_heavy_checkpoint,
 };
 use super::lifecycle::{
     TurnIterationPrep, current_agentic_step, interruption_diagnosis_summary,
@@ -13,8 +14,8 @@ use astra_core::render_compact_status;
 use astra_services::{ContextManifestWrite, DatabaseContextManifestStore};
 use astra_turn_core::agentic_turn_ingest::{
     AgenticIngestIterationControl, AgenticTurnIngestMut, AgenticTurnIngestOutcome,
-    agentic_turn_stream_snapshot_with_kind, ingest_agentic_turn_stream,
-    map_ingest_outcome_to_iteration_control,
+    FactualRetryFallbackDecision, agentic_turn_stream_snapshot_with_kind,
+    ingest_agentic_turn_stream, map_ingest_outcome_to_iteration_control,
 };
 use astra_turn_core::compaction_types::{CompactionEvent, CompactionKind, CompactionTier};
 use astra_turn_core::interaction_types::TurnInteractionMode;
@@ -432,6 +433,32 @@ fn circuit_breaker_introspection_message(
          Tools remain available.",
         llm_rounds_completed, consecutive_read_only
     )
+}
+
+async fn maybe_judge_factual_retry_fallback<H: AgenticLoopHost>(
+    host: &mut H,
+    state: &AgenticLoopState,
+    retry_text: &str,
+    round_has_edge_work: bool,
+) -> Option<FactualRetryFallbackDecision> {
+    if round_has_edge_work
+        || !state.stall.forced_factual_retry
+        || state.total_evidence_tool_calls != 0
+        || retry_text.trim().is_empty()
+    {
+        return None;
+    }
+    let fallback_text = state.stall.factual_retry_fallback_text.as_deref()?;
+    if fallback_text.trim().is_empty() {
+        return None;
+    }
+
+    host.judge_factual_retry_fallback(FactualRetryFallbackJudgeContext {
+        original_query: state.message.as_str(),
+        fallback_text,
+        retry_text,
+    })
+    .await
 }
 
 pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
@@ -1205,6 +1232,9 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
     update_turn_trace_collector(state, &turn_result);
 
     let edge_len = turn_result.edge_tool_round.len();
+    let round_has_edge_work = edge_len > 0 || !snap.tool_calls.is_empty();
+    let factual_retry_fallback_decision =
+        maybe_judge_factual_retry_fallback(host, state, snap.full_text, round_has_edge_work).await;
     let ingest_outcome = ingest_agentic_turn_stream(
         &snap,
         edge_len,
@@ -1229,6 +1259,8 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
             all_tools_used: &mut state.telemetry.all_tools_used,
             has_any_usage: &mut state.has_any_usage,
             forced_factual_retry: &mut state.stall.forced_factual_retry,
+            factual_retry_fallback_text: &mut state.stall.factual_retry_fallback_text,
+            factual_retry_fallback_decision,
             messages: &mut state.messages,
             last_measured_prompt_tokens: &mut state.last_measured_prompt_tokens,
             consecutive_context_window_errors: &mut state.consecutive_context_window_errors,
@@ -3367,6 +3399,95 @@ mod tests {
                 release_failures: Mutex::new(release_failures),
             }
         }
+    }
+
+    struct JudgeOnlyHost {
+        decision: Option<FactualRetryFallbackDecision>,
+        calls: Vec<(String, String, String)>,
+        valid_tools: HashSet<String>,
+    }
+
+    #[async_trait]
+    impl AgenticLoopHost for JudgeOnlyHost {
+        async fn execute_turn(
+            &mut self,
+            _state: &mut AgenticLoopState,
+        ) -> Result<HostTurnResult, astra_core::ClassifiedError> {
+            Err(astra_core::ClassifiedError::new(
+                astra_core::ErrorKind::Unknown,
+                "not used",
+            ))
+        }
+
+        async fn judge_factual_retry_fallback(
+            &mut self,
+            ctx: FactualRetryFallbackJudgeContext<'_>,
+        ) -> Option<FactualRetryFallbackDecision> {
+            self.calls.push((
+                ctx.original_query.to_string(),
+                ctx.fallback_text.to_string(),
+                ctx.retry_text.to_string(),
+            ));
+            self.decision
+        }
+
+        fn emit_headless_line(&mut self, _style: HeadlessStderrStyle, _line: String) {}
+
+        fn is_quiet(&self) -> bool {
+            true
+        }
+
+        fn valid_tool_names(&self) -> &HashSet<String> {
+            &self.valid_tools
+        }
+    }
+
+    #[tokio::test]
+    async fn factual_retry_fallback_judge_called_only_for_no_evidence_retry_final() {
+        let mut host = JudgeOnlyHost {
+            decision: Some(FactualRetryFallbackDecision::RestoreFallback),
+            calls: Vec::new(),
+            valid_tools: HashSet::new(),
+        };
+        let mut state = make_state();
+        state.message = "what do 59% and 117k mean?".to_string();
+        state.stall.forced_factual_retry = true;
+        state.stall.factual_retry_fallback_text =
+            Some("59% is context usage; 117k is token count.".to_string());
+        state.total_evidence_tool_calls = 0;
+
+        let decision =
+            maybe_judge_factual_retry_fallback(&mut host, &state, "I completed the work.", false)
+                .await;
+
+        assert_eq!(
+            decision,
+            Some(FactualRetryFallbackDecision::RestoreFallback)
+        );
+        assert_eq!(host.calls.len(), 1);
+        assert_eq!(host.calls[0].0, "what do 59% and 117k mean?");
+    }
+
+    #[tokio::test]
+    async fn factual_retry_fallback_judge_not_called_when_evidence_exists_or_fallback_missing() {
+        let mut host = JudgeOnlyHost {
+            decision: Some(FactualRetryFallbackDecision::RestoreFallback),
+            calls: Vec::new(),
+            valid_tools: HashSet::new(),
+        };
+        let mut state = make_state();
+        state.stall.forced_factual_retry = true;
+        state.stall.factual_retry_fallback_text = Some("original".to_string());
+        state.total_evidence_tool_calls = 1;
+
+        let decision = maybe_judge_factual_retry_fallback(&mut host, &state, "retry", false).await;
+        assert_eq!(decision, None);
+
+        state.total_evidence_tool_calls = 0;
+        state.stall.factual_retry_fallback_text = None;
+        let decision = maybe_judge_factual_retry_fallback(&mut host, &state, "retry", false).await;
+        assert_eq!(decision, None);
+        assert!(host.calls.is_empty());
     }
 
     #[async_trait]

--- a/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -2058,7 +2058,8 @@ fn should_skip_auto_verify_stop_hooks(state: &AgenticLoopState) -> bool {
     {
         return false;
     }
-    has_successful_verification_after_latest_mutation(state)
+    !has_concrete_workspace_mutation(state)
+        || has_successful_verification_after_latest_mutation(state)
 }
 
 fn is_auto_verify_changes_hook(hook: &astra_turn_core::stop_hooks::StopHook) -> bool {
@@ -4108,6 +4109,28 @@ mod tests {
                     .into(),
             ),
             result_preview: Some("✓ cargo | 426 passed, 0 failed".into()),
+            ..Default::default()
+        });
+
+        assert!(should_skip_auto_verify_stop_hooks(&state));
+    }
+
+    #[test]
+    fn auto_verify_stop_hook_skips_when_no_workspace_mutation_happened() {
+        let mut state = make_state();
+        state.hooks.stop_hooks = vec![auto_verify_hook()];
+        state.final_text = "Here is the advice you asked for.".into();
+        state.stall.tool_call_records.push(ToolCallRecord {
+            name: "read_file".into(),
+            ok: true,
+            args_full: Some(r#"{"path":"src/lib.rs"}"#.into()),
+            ..Default::default()
+        });
+        state.stall.tool_call_records.push(ToolCallRecord {
+            name: "bash".into(),
+            ok: true,
+            args_full: Some(r#"{"command":"git diff --stat"}"#.into()),
+            result_preview: Some("no changes".into()),
             ..Default::default()
         });
 

--- a/rust/crates/runtime/src/turn/agentic_loop/finalization.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/finalization.rs
@@ -927,6 +927,7 @@ fn append_interruption_detail(
 
 fn reset_per_turn_corrective_state(state: &mut AgenticLoopState) {
     state.stall.forced_factual_retry = false;
+    state.stall.factual_retry_fallback_text = None;
     state.stall.forced_execution_retry = false;
     state.stall.forced_execution_escalation = false;
     state.stall.forced_parallel_batching = false;
@@ -1280,6 +1281,7 @@ mod tests {
             }),
         ]);
         state.stall.forced_factual_retry = true;
+        state.stall.factual_retry_fallback_text = Some("old factual retry answer".into());
         state.stall.forced_execution_retry = true;
         state.stall.forced_execution_escalation = true;
         state.stall.forced_parallel_batching = true;
@@ -1320,6 +1322,7 @@ mod tests {
             state.messages
         );
         assert!(!state.stall.forced_factual_retry);
+        assert!(state.stall.factual_retry_fallback_text.is_none());
         assert!(!state.stall.forced_execution_retry);
         assert!(!state.stall.forced_execution_escalation);
         assert!(!state.stall.forced_parallel_batching);

--- a/rust/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/host.rs
@@ -66,6 +66,7 @@ use astra_pipeline::step_protocol::{InMemoryIdempotencyCache, StepCheckpoint};
 use astra_pipeline::step_recorder::StepRecorder;
 use astra_text_utils::semantic_dedup::SemanticDedup;
 use astra_tools::task_mgmt::{SessionTask, TaskManager};
+use astra_turn_core::agentic_turn_ingest::FactualRetryFallbackDecision;
 use astra_turn_core::chat_turn_heuristics::TaskExecutionProfile;
 use astra_turn_core::chat_turn_sse_dispatch::ChatTurnSseAccum;
 use astra_turn_core::compaction_types::{CompactionEvent, CompactionTier};
@@ -136,6 +137,13 @@ pub struct HostTurnResult {
     pub error_kind: Option<astra_core::ErrorKind>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct FactualRetryFallbackJudgeContext<'a> {
+    pub original_query: &'a str,
+    pub fallback_text: &'a str,
+    pub retry_text: &'a str,
+}
+
 pub enum ControlToolRecovery {
     Unsupported,
     Missing,
@@ -178,15 +186,22 @@ pub trait AgenticLoopHost: Send {
 
     /// Optional semantic judge for the current user turn.
     ///
-    /// The default implementation provides a deterministic baseline from the
-    /// current message plus `TaskExecutionProfile`; hosts can override it with a
-    /// higher-fidelity classifier if they have one.
-    async fn judge_turn_intent(&mut self, state: &AgenticLoopState) -> Option<TurnIntent> {
-        Some(crate::turn::agentic::turn_intent::fallback_turn_intent(
-            &state.message,
-            &state.recent_tools,
-            state.has_prior_assistant_turn,
-        ))
+    /// The default implementation returns no semantic intent. Hosts that have
+    /// an LLM judge or another explicit structured signal should override this;
+    /// runtime defaults must not infer natural-language intent from keyword
+    /// lists.
+    async fn judge_turn_intent(&mut self, _state: &AgenticLoopState) -> Option<TurnIntent> {
+        None
+    }
+
+    /// Optional LLM response-selection judge for factual retries that gathered
+    /// no real evidence. The runtime must not fall back to lexical similarity
+    /// here; absence or failure means "keep retry".
+    async fn judge_factual_retry_fallback(
+        &mut self,
+        _ctx: FactualRetryFallbackJudgeContext<'_>,
+    ) -> Option<FactualRetryFallbackDecision> {
+        None
     }
 
     /// Whether the host already injects round budget guidance into the system
@@ -841,6 +856,10 @@ pub struct StallTrackingState {
     pub tool_call_records: Vec<ToolCallRecord>,
     /// Whether a factual-retry was forced this loop.
     pub forced_factual_retry: bool,
+    /// Original text-only answer saved before a forced factual retry. It is
+    /// restored only when an upstream response-selection judge explicitly
+    /// chooses it after a no-evidence retry.
+    pub factual_retry_fallback_text: Option<String>,
     /// Whether an execution-retry was forced after a mutating/confirmed task
     /// attempted to finish without applying any concrete workspace mutation.
     pub forced_execution_retry: bool,
@@ -3044,14 +3063,8 @@ pub(crate) mod tests {
             Ok(result)
         }
 
-        async fn judge_turn_intent(&mut self, state: &AgenticLoopState) -> Option<TurnIntent> {
-            self.turn_intent.clone().or_else(|| {
-                Some(crate::turn::agentic::turn_intent::fallback_turn_intent(
-                    &state.message,
-                    &state.recent_tools,
-                    state.has_prior_assistant_turn,
-                ))
-            })
+        async fn judge_turn_intent(&mut self, _state: &AgenticLoopState) -> Option<TurnIntent> {
+            self.turn_intent.clone()
         }
 
         fn emit_headless_line(&mut self, _style: HeadlessStderrStyle, line: String) {

--- a/rust/crates/runtime/src/turn/agentic_loop/lifecycle.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/lifecycle.rs
@@ -967,7 +967,6 @@ pub(crate) async fn run_loop_preamble<H: AgenticLoopHost>(
     host: &mut H,
     state: &mut AgenticLoopState,
 ) {
-    apply_user_correction_reanchor(state);
     maybe_inject_task_board_start_gate(host, state).await;
 
     if state
@@ -1019,8 +1018,8 @@ pub(crate) async fn run_loop_preamble<H: AgenticLoopHost>(
     // See `context_pipeline_adapter::build_session_context` + `bind_project_context`.
 }
 
-fn apply_user_correction_reanchor(state: &mut AgenticLoopState) -> bool {
-    if !astra_turn_core::input_classifier::is_correction_signal(&state.message) {
+fn apply_structured_user_reanchor(state: &mut AgenticLoopState) -> bool {
+    if state.message.trim().is_empty() {
         return false;
     }
 
@@ -1464,6 +1463,9 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
     let judged_turn_intent = host.judge_turn_intent(state).await;
     if let Some(intent) = judged_turn_intent.as_ref() {
         apply_judged_turn_intent_to_observability_session(state, intent);
+        if intent.reanchors_current_objective() {
+            apply_structured_user_reanchor(state);
+        }
     }
     // Turn intent not yet wired to adaptive execution profiles — observation
     // plane records scenario signals without mutating runtime config.
@@ -3285,7 +3287,7 @@ mod tests {
     }
 
     #[test]
-    fn user_correction_reanchors_working_memory_before_turn() {
+    fn structured_reanchor_updates_working_memory_before_turn() {
         let mut state = make_state();
         state.pipeline_session = Some(astra_turn_core::pipeline_session::PipelineSession::new(
             astra_turn_core::pipeline_config::PipelineConfig::default(),
@@ -3302,7 +3304,7 @@ mod tests {
             memory.set_next_action("retry stale path");
         }
 
-        assert!(apply_user_correction_reanchor(&mut state));
+        assert!(apply_structured_user_reanchor(&mut state));
 
         let rendered = state
             .pipeline_session
@@ -3319,13 +3321,15 @@ mod tests {
         assert!(rendered.contains("server-side executor"));
     }
 
-    #[test]
-    fn ordinary_followup_does_not_reanchor_working_memory() {
+    #[tokio::test]
+    async fn prepare_turn_without_judged_reanchor_does_not_reanchor_working_memory() {
+        let mut host = MockHost::new(Vec::new());
         let mut state = make_state();
         state.pipeline_session = Some(astra_turn_core::pipeline_session::PipelineSession::new(
             astra_turn_core::pipeline_config::PipelineConfig::default(),
         ));
-        state.message = "continue with the implementation".into();
+        state.message = "No, that's wrong; use the server-side executor.".into();
+        state.messages = vec![json!({"role": "user", "content": state.message.clone()})];
         {
             let memory = state
                 .pipeline_session
@@ -3336,7 +3340,11 @@ mod tests {
             memory.set_next_action("continue current path");
         }
 
-        assert!(!apply_user_correction_reanchor(&mut state));
+        let prepared = prepare_turn_iteration(&mut host, &mut state, 0)
+            .await
+            .expect("turn should prepare");
+
+        assert!(matches!(prepared, PreparedTurnIteration::Ready(_)));
 
         let rendered = state
             .pipeline_session
@@ -3374,7 +3382,7 @@ mod tests {
         state.restricted_tools.insert("bash".into());
         state.boosted_tools.insert("grep".into());
 
-        assert!(apply_user_correction_reanchor(&mut state));
+        assert!(apply_structured_user_reanchor(&mut state));
 
         assert_eq!(state.turn_guard.nudge_count, 0);
         assert!(state.turn_guard.tool_sigs.is_empty());
@@ -3394,6 +3402,48 @@ mod tests {
         assert!(
             state.widen_selection_pending,
             "the next assembly should expose the full tool catalogue once"
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_turn_applies_structured_reanchor_from_judge() {
+        let intent = TurnIntent::default().with_reanchors_current_objective(true);
+        let mut host = MockHost::new(Vec::new()).with_turn_intent(intent);
+        let mut state = make_state();
+        state.pipeline_session = Some(astra_turn_core::pipeline_session::PipelineSession::new(
+            astra_turn_core::pipeline_config::PipelineConfig::default(),
+        ));
+        state.message = "不是修修补补，我要的是第一性原则系统性修复。".into();
+        state.messages = vec![json!({"role": "user", "content": state.message.clone()})];
+
+        state.turn_guard.nudge_count = 2;
+        state.restricted_tools.insert("bash".into());
+        state.boosted_tools.insert("grep".into());
+        state
+            .pipeline_session
+            .as_mut()
+            .expect("pipeline session")
+            .working_memory_mut()
+            .set_next_action("stale path");
+
+        let prepared = prepare_turn_iteration(&mut host, &mut state, 0)
+            .await
+            .expect("turn should prepare");
+
+        assert!(matches!(prepared, PreparedTurnIteration::Ready(_)));
+        assert_eq!(state.turn_guard.nudge_count, 0);
+        assert!(state.restricted_tools.is_empty());
+        assert!(state.boosted_tools.is_empty());
+        assert!(state.widen_selection_pending);
+        let rendered = state
+            .pipeline_session
+            .as_ref()
+            .expect("pipeline session")
+            .working_memory()
+            .render_prompt_section();
+        assert!(!rendered.contains("stale path"));
+        assert!(
+            rendered.contains("Latest user correction overrides conflicting prior working memory")
         );
     }
 

--- a/rust/crates/runtime/src/turn/permission_gate.rs
+++ b/rust/crates/runtime/src/turn/permission_gate.rs
@@ -995,7 +995,7 @@ mod tests {
         let inherited = InheritedPermissions {
             mode: PermissionMode::Prompt,
             allow_rules: vec![],
-            deny_rules: vec![PermissionRule::parse("bash(rm -rf:*)")],
+            deny_rules: vec![PermissionRule::parse(r#"Bash(argv_prefix="rm -rf")"#)],
             ask_rules: vec![],
             allowed_tools: None,
             is_background: false,

--- a/rust/crates/runtime/tests/system_matrix_http_e2e/journey_session_artifacts_matrix.rs
+++ b/rust/crates/runtime/tests/system_matrix_http_e2e/journey_session_artifacts_matrix.rs
@@ -7,7 +7,7 @@ use futures_util::StreamExt;
 use serde_json::json;
 use sqlx::Row;
 use std::sync::{
-    Arc,
+    Arc, Mutex,
     atomic::{AtomicU32, Ordering},
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -185,6 +185,74 @@ fn assert_presigned_artifact_download(
 struct RawTransportServerHits {
     stream_hits: Arc<AtomicU32>,
     nonstream_hits: Arc<AtomicU32>,
+    connectivity_probe_hits: Arc<AtomicU32>,
+    turn_intent_judge_hits: Arc<AtomicU32>,
+    primary_nonstream_fallback_hits: Arc<AtomicU32>,
+    primary_nonstream_fallback_requests: Arc<Mutex<Vec<String>>>,
+}
+
+impl RawTransportServerHits {
+    fn new() -> Self {
+        Self {
+            stream_hits: Arc::new(AtomicU32::new(0)),
+            nonstream_hits: Arc::new(AtomicU32::new(0)),
+            connectivity_probe_hits: Arc::new(AtomicU32::new(0)),
+            turn_intent_judge_hits: Arc::new(AtomicU32::new(0)),
+            primary_nonstream_fallback_hits: Arc::new(AtomicU32::new(0)),
+            primary_nonstream_fallback_requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn record_stream(&self) {
+        self.stream_hits.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn record_nonstream(&self, req: &str) -> u32 {
+        let previous = self.nonstream_hits.fetch_add(1, Ordering::SeqCst);
+        if is_connectivity_probe_request(req) {
+            self.connectivity_probe_hits.fetch_add(1, Ordering::SeqCst);
+        } else if is_turn_intent_judge_request(req) {
+            self.turn_intent_judge_hits.fetch_add(1, Ordering::SeqCst);
+        } else {
+            self.primary_nonstream_fallback_hits
+                .fetch_add(1, Ordering::SeqCst);
+            self.primary_nonstream_fallback_requests
+                .lock()
+                .expect("primary nonstream fallback request log lock")
+                .push(summarize_provider_request(req));
+        }
+        previous
+    }
+
+    fn primary_nonstream_fallback_request_summary(&self) -> String {
+        let requests = self
+            .primary_nonstream_fallback_requests
+            .lock()
+            .expect("primary nonstream fallback request log lock");
+        if requests.is_empty() {
+            return "<none>".to_string();
+        }
+        requests.join(" | ")
+    }
+}
+
+fn is_connectivity_probe_request(req: &str) -> bool {
+    req.contains("\"max_tokens\":1")
+        && req.contains("\"content\":\"hi\"")
+        && !req.contains("\"stream\":true")
+}
+
+fn is_turn_intent_judge_request(req: &str) -> bool {
+    req.contains("turn intent classifier") && req.contains("continuation_mode")
+}
+
+fn summarize_provider_request(req: &str) -> String {
+    let body = req
+        .split("\r\n\r\n")
+        .nth(1)
+        .unwrap_or(req)
+        .replace('\n', " ");
+    body.chars().take(260).collect()
 }
 
 type StreamIdleEnvGuard = astra_runtime::turn::stream_idle_test_hooks::StreamIdleTimeoutGuard;
@@ -224,6 +292,19 @@ fn assert_nonstream_hits_in_range(actual: u32, min: u32, max: u32, message: &str
     );
 }
 
+fn assert_no_primary_nonstream_fallback(hits: &RawTransportServerHits, message: &str) {
+    let actual = hits.primary_nonstream_fallback_hits.load(Ordering::SeqCst);
+    assert_eq!(
+        actual,
+        0,
+        "{message}: expected 0 primary non-stream fallback hits, got {actual}; total_nonstream={}, connectivity_probes={}, turn_intent_judges={}; fallback_requests={}",
+        hits.nonstream_hits.load(Ordering::SeqCst),
+        hits.connectivity_probe_hits.load(Ordering::SeqCst),
+        hits.turn_intent_judge_hits.load(Ordering::SeqCst),
+        hits.primary_nonstream_fallback_request_summary()
+    );
+}
+
 async fn spawn_raw_partial_transport_server(
     partial_text: &str,
     fallback_status: u16,
@@ -233,10 +314,7 @@ async fn spawn_raw_partial_transport_server(
         .await
         .expect("bind raw mock llm listener");
     let addr = listener.local_addr().expect("raw local_addr");
-    let hits = RawTransportServerHits {
-        stream_hits: Arc::new(AtomicU32::new(0)),
-        nonstream_hits: Arc::new(AtomicU32::new(0)),
-    };
+    let hits = RawTransportServerHits::new();
     let hits_task = hits.clone();
     let partial_text = partial_text.to_string();
     tokio::spawn(async move {
@@ -250,7 +328,7 @@ async fn spawn_raw_partial_transport_server(
                 let req = read_full_http_request(&mut socket).await;
                 let is_stream = req.contains("\"stream\":true");
                 if is_stream {
-                    hits.stream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_stream();
                     let partial = format!(
                         "data: {}\n\n",
                         json!({"choices":[{"delta":{"content": partial_text}}]})
@@ -265,7 +343,7 @@ async fn spawn_raw_partial_transport_server(
                         .expect("write partial stream response");
                     let _ = socket.shutdown().await;
                 } else {
-                    let nonstream_ix = hits.nonstream_hits.fetch_add(1, Ordering::SeqCst);
+                    let nonstream_ix = hits.record_nonstream(&req);
                     let (status, body) = if nonstream_ix == 0 {
                         (
                             200,
@@ -306,10 +384,7 @@ async fn spawn_raw_idle_after_progress_server(
         .await
         .expect("bind idle mock llm listener");
     let addr = listener.local_addr().expect("idle local_addr");
-    let hits = RawTransportServerHits {
-        stream_hits: Arc::new(AtomicU32::new(0)),
-        nonstream_hits: Arc::new(AtomicU32::new(0)),
-    };
+    let hits = RawTransportServerHits::new();
     let hits_task = hits.clone();
     let partial_text = partial_text.to_string();
     tokio::spawn(async move {
@@ -323,7 +398,7 @@ async fn spawn_raw_idle_after_progress_server(
                 let req = read_full_http_request(&mut socket).await;
                 let is_stream = req.contains("\"stream\":true");
                 if is_stream {
-                    hits.stream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_stream();
                     let partial = format!(
                         "data: {}\n\n",
                         json!({"choices":[{"delta":{"content": partial_text}}]})
@@ -339,7 +414,7 @@ async fn spawn_raw_idle_after_progress_server(
                     tokio::time::sleep(stall_for).await;
                     let _ = socket.shutdown().await;
                 } else {
-                    let nonstream_ix = hits.nonstream_hits.fetch_add(1, Ordering::SeqCst);
+                    let nonstream_ix = hits.record_nonstream(&req);
                     let (status, body) = if nonstream_ix == 0 {
                         (
                             200,
@@ -378,10 +453,7 @@ async fn spawn_raw_stream_rate_limit_server(
         .await
         .expect("bind rate-limit mock llm listener");
     let addr = listener.local_addr().expect("rate-limit local_addr");
-    let hits = RawTransportServerHits {
-        stream_hits: Arc::new(AtomicU32::new(0)),
-        nonstream_hits: Arc::new(AtomicU32::new(0)),
-    };
+    let hits = RawTransportServerHits::new();
     let hits_task = hits.clone();
     tokio::spawn(async move {
         loop {
@@ -393,7 +465,7 @@ async fn spawn_raw_stream_rate_limit_server(
                 let req = read_full_http_request(&mut socket).await;
                 let is_stream = req.contains("\"stream\":true");
                 if is_stream {
-                    hits.stream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_stream();
                     let retry_after_header = retry_after
                         .map(|value| format!("Retry-After: {value}\r\n"))
                         .unwrap_or_default();
@@ -407,7 +479,7 @@ async fn spawn_raw_stream_rate_limit_server(
                         .expect("write rate-limit stream response");
                     let _ = socket.shutdown().await;
                 } else {
-                    hits.nonstream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_nonstream(&req);
                     let body = r#"{"choices":[{"message":{"content":"probe ok"}}]}"#;
                     let response = format!(
                         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
@@ -435,10 +507,7 @@ async fn spawn_raw_stream_rate_limit_then_sse_server(
     let addr = listener
         .local_addr()
         .expect("rate-limit recovery local_addr");
-    let hits = RawTransportServerHits {
-        stream_hits: Arc::new(AtomicU32::new(0)),
-        nonstream_hits: Arc::new(AtomicU32::new(0)),
-    };
+    let hits = RawTransportServerHits::new();
     let hits_task = hits.clone();
     let success_text = success_text.to_string();
     tokio::spawn(async move {
@@ -474,7 +543,7 @@ async fn spawn_raw_stream_rate_limit_then_sse_server(
                         .expect("write rate-limit recovery stream response");
                     let _ = socket.shutdown().await;
                 } else {
-                    hits.nonstream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_nonstream(&req);
                     let body = r#"{"choices":[{"message":{"content":"probe ok"}}]}"#;
                     let response = format!(
                         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
@@ -500,10 +569,7 @@ async fn spawn_raw_tool_call_block_parse_recovery_server() -> (String, RawTransp
     let addr = listener
         .local_addr()
         .expect("tool-call block-parse local_addr");
-    let hits = RawTransportServerHits {
-        stream_hits: Arc::new(AtomicU32::new(0)),
-        nonstream_hits: Arc::new(AtomicU32::new(0)),
-    };
+    let hits = RawTransportServerHits::new();
     let hits_task = hits.clone();
     tokio::spawn(async move {
         loop {
@@ -515,7 +581,7 @@ async fn spawn_raw_tool_call_block_parse_recovery_server() -> (String, RawTransp
                 let req = read_full_http_request(&mut socket).await;
                 let is_stream = req.contains("\"stream\":true");
                 if is_stream {
-                    hits.stream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_stream();
                     let part1 = json!({
                         "choices": [{
                             "delta": {
@@ -556,7 +622,7 @@ async fn spawn_raw_tool_call_block_parse_recovery_server() -> (String, RawTransp
                         .expect("write tool-call block-parse stream response");
                     let _ = socket.shutdown().await;
                 } else {
-                    hits.nonstream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_nonstream(&req);
                     let body = json!({
                         "choices": [{
                             "message": {
@@ -601,10 +667,7 @@ async fn spawn_raw_server_loop_block_parse_recovery_server(
     let addr = listener
         .local_addr()
         .expect("server-loop block-parse recovery local_addr");
-    let hits = RawTransportServerHits {
-        stream_hits: Arc::new(AtomicU32::new(0)),
-        nonstream_hits: Arc::new(AtomicU32::new(0)),
-    };
+    let hits = RawTransportServerHits::new();
     let hits_task = hits.clone();
     let partial_text = partial_text.to_string();
     let recovered_text = recovered_text.to_string();
@@ -620,7 +683,7 @@ async fn spawn_raw_server_loop_block_parse_recovery_server(
                 let req = read_full_http_request(&mut socket).await;
                 let is_stream = req.contains("\"stream\":true");
                 if is_stream {
-                    hits.stream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_stream();
                     let partial = json!({"choices":[{"delta":{"content": partial_text}}]});
                     let body = format!("data: {partial}\n\ndata: not-json\n\n");
                     let response = format!(
@@ -633,7 +696,7 @@ async fn spawn_raw_server_loop_block_parse_recovery_server(
                         .expect("write server-loop block-parse stream response");
                     let _ = socket.shutdown().await;
                 } else {
-                    hits.nonstream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_nonstream(&req);
                     let body = json!({
                         "choices": [{
                             "message": { "content": recovered_text },
@@ -668,10 +731,7 @@ async fn spawn_raw_server_loop_block_parse_failure_server(
     let addr = listener
         .local_addr()
         .expect("server-loop block-parse failure local_addr");
-    let hits = RawTransportServerHits {
-        stream_hits: Arc::new(AtomicU32::new(0)),
-        nonstream_hits: Arc::new(AtomicU32::new(0)),
-    };
+    let hits = RawTransportServerHits::new();
     let hits_task = hits.clone();
     let partial_text = partial_text.to_string();
     tokio::spawn(async move {
@@ -685,7 +745,7 @@ async fn spawn_raw_server_loop_block_parse_failure_server(
                 let req = read_full_http_request(&mut socket).await;
                 let is_stream = req.contains("\"stream\":true");
                 if is_stream {
-                    hits.stream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_stream();
                     let partial = json!({"choices":[{"delta":{"content": partial_text}}]});
                     let body = format!("data: {partial}\n\ndata: not-json\n\n");
                     let response = format!(
@@ -698,7 +758,7 @@ async fn spawn_raw_server_loop_block_parse_failure_server(
                         .expect("write server-loop block-parse failure stream response");
                     let _ = socket.shutdown().await;
                 } else {
-                    hits.nonstream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_nonstream(&req);
                     let body = "fallback exploded";
                     let response = format!(
                         "HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
@@ -722,10 +782,7 @@ async fn spawn_raw_hanging_stream_server(partial_text: &str) -> (String, RawTran
         .await
         .expect("bind hanging mock llm listener");
     let addr = listener.local_addr().expect("hanging local_addr");
-    let hits = RawTransportServerHits {
-        stream_hits: Arc::new(AtomicU32::new(0)),
-        nonstream_hits: Arc::new(AtomicU32::new(0)),
-    };
+    let hits = RawTransportServerHits::new();
     let hits_task = hits.clone();
     let partial_text = partial_text.to_string();
     tokio::spawn(async move {
@@ -739,7 +796,7 @@ async fn spawn_raw_hanging_stream_server(partial_text: &str) -> (String, RawTran
                 let req = read_full_http_request(&mut socket).await;
                 let is_stream = req.contains("\"stream\":true");
                 if is_stream {
-                    hits.stream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_stream();
                     let partial = format!(
                         "data: {}\n\n",
                         json!({"choices":[{"delta":{"content": partial_text}}]})
@@ -755,7 +812,7 @@ async fn spawn_raw_hanging_stream_server(partial_text: &str) -> (String, RawTran
                     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
                     let _ = socket.shutdown().await;
                 } else {
-                    hits.nonstream_hits.fetch_add(1, Ordering::SeqCst);
+                    hits.record_nonstream(&req);
                     let body = r#"{"choices":[{"message":{"content":"probe ok"}}]}"#;
                     let response = format!(
                         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
@@ -2816,11 +2873,9 @@ pub async fn run_server_loop_rate_limit_failure_session_artifact_latest_and_down
         4,
         "expected one initial stream attempt plus three retries before failure"
     );
-    assert_nonstream_hits_in_range(
-        hits.nonstream_hits.load(Ordering::SeqCst),
-        0,
-        1,
-        "repeated stream 429s plus cooldown reject should not issue a non-stream fallback beyond any optional connectivity probe",
+    assert_no_primary_nonstream_fallback(
+        &hits,
+        "repeated stream 429s plus cooldown reject should not issue a non-stream fallback",
     );
 
     let _ = sqlx::query("DELETE FROM session_artifacts WHERE session_id = ?")
@@ -2946,11 +3001,9 @@ pub async fn run_server_loop_rate_limit_retry_success_session_artifact_latest_an
         2,
         "expected one 429 stream attempt and one successful retry stream"
     );
-    assert_nonstream_hits_in_range(
-        hits.nonstream_hits.load(Ordering::SeqCst),
-        0,
-        1,
-        "successful stream retry should not require a non-stream fallback beyond any optional connectivity probe",
+    assert_no_primary_nonstream_fallback(
+        &hits,
+        "successful stream retry should not require a non-stream fallback",
     );
 
     let _ = sqlx::query("DELETE FROM session_artifacts WHERE session_id = ?")
@@ -3706,11 +3759,9 @@ pub async fn run_bridge_rate_limit_failure_session_artifact_latest_and_download_
         4,
         "expected one initial stream attempt plus three retries before failure"
     );
-    assert_nonstream_hits_in_range(
-        hits.nonstream_hits.load(Ordering::SeqCst),
-        0,
-        1,
-        "repeated stream 429s plus cooldown reject should not issue a non-stream fallback beyond any optional connectivity probe",
+    assert_no_primary_nonstream_fallback(
+        &hits,
+        "repeated stream 429s plus cooldown reject should not issue a non-stream fallback",
     );
 
     let _ = sqlx::query("DELETE FROM session_artifacts WHERE session_id = ?")
@@ -3836,11 +3887,9 @@ pub async fn run_bridge_rate_limit_retry_success_session_artifact_latest_and_dow
         2,
         "expected one 429 stream attempt and one successful retry stream"
     );
-    assert_nonstream_hits_in_range(
-        hits.nonstream_hits.load(Ordering::SeqCst),
-        0,
-        1,
-        "successful stream retry should not require a non-stream fallback beyond any optional connectivity probe",
+    assert_no_primary_nonstream_fallback(
+        &hits,
+        "successful stream retry should not require a non-stream fallback",
     );
 
     let _ = sqlx::query("DELETE FROM session_artifacts WHERE session_id = ?")

--- a/rust/crates/services/src/lib.rs
+++ b/rust/crates/services/src/lib.rs
@@ -320,7 +320,7 @@ pub use triggers::{
 };
 pub use turn_intent_judge::{
     TurnIntentJudge, TurnIntentJudgeContext, TurnIntentJudgeError, build_turn_intent_prompt,
-    parse_turn_intent_response,
+    parse_turn_intent_response, turn_intent_judge_messages,
 };
 pub use workflows::{
     UnconfiguredWorkflowService, WorkflowDefRecord, WorkflowListItem, WorkflowRunRecord,

--- a/rust/crates/services/src/session_journal.rs
+++ b/rust/crates/services/src/session_journal.rs
@@ -945,6 +945,7 @@ pub struct ToolCallRecord {
 /// optimizations — **not** tool failures — and are filtered out of
 /// evaluation/analytics by [`ToolCallRecord::is_synthetic_placeholder`].
 pub const SURGICAL_REMOVAL_TOOL_NAME: &str = "(surgically_removed)";
+pub const NOOP_OR_CACHED_RESULT_CLASS: &str = "noop_or_cached";
 
 impl ToolCallRecord {
     /// Synthetic placeholders are audit-only records emitted when skill routing
@@ -989,6 +990,9 @@ impl ToolCallRecord {
     /// "successful execution with fresh evidence" from cache hits, duplicate
     /// suppressions, and unchanged-result stubs.
     pub fn is_noop_or_cached_result(&self) -> bool {
+        if self.is_structured_noop_or_cached_result() {
+            return true;
+        }
         self.error
             .as_deref()
             .is_some_and(is_noop_or_cached_result_text)
@@ -1000,6 +1004,20 @@ impl ToolCallRecord {
                 .result_full
                 .as_deref()
                 .is_some_and(is_noop_or_cached_result_text)
+    }
+
+    /// Structured no-op/cache classification for current journal records.
+    /// Prefer this for new analytics. `is_noop_or_cached_result` keeps the
+    /// legacy text fallback for old local journals.
+    pub fn is_structured_noop_or_cached_result(&self) -> bool {
+        self.result_class.as_deref() == Some(NOOP_OR_CACHED_RESULT_CLASS)
+            || matches!(
+                self.error.as_deref(),
+                Some("cached_cross_turn" | "duplicate_within_turn")
+            )
+            || self.surgically_removed == Some(true)
+            || self.skill_reentry_count.is_some()
+            || self.skill_locked_out == Some(true)
     }
 }
 
@@ -7041,11 +7059,29 @@ mod tests {
                 ToolCallRecord {
                     name: "read_file".to_string(),
                     ok: true,
+                    result_class: Some(NOOP_OR_CACHED_RESULT_CLASS.to_string()),
+                    ..Default::default()
+                }
+                .is_structured_noop_or_cached_result()
+            );
+            assert!(
+                ToolCallRecord {
+                    name: "read_file".to_string(),
+                    ok: true,
                     error: Some("cached_cross_turn".into()),
                     result_preview: Some("[cached_cross_turn: reused 200 bytes]".into()),
                     ..Default::default()
                 }
                 .is_noop_or_cached_result()
+            );
+            assert!(
+                !(ToolCallRecord {
+                    name: "nope".to_string(),
+                    ok: false,
+                    error: Some("unknown_tool: nope".to_string()),
+                    ..Default::default()
+                }
+                .is_structured_noop_or_cached_result())
             );
             assert!(
                 base_tool_record(

--- a/rust/crates/services/src/turn_intent_judge.rs
+++ b/rust/crates/services/src/turn_intent_judge.rs
@@ -106,7 +106,8 @@ pub fn build_turn_intent_prompt(ctx: &TurnIntentJudgeContext) -> String {
          {\n  \
             \"requested_scenario\": <scenario | null>,\n  \
             \"prohibited_scenarios\": [<scenario>, ...],   // may be empty\n  \
-            \"continuation_mode\": \"continue_current_objective\" | \"new_objective\" | \"unknown\"\n\
+            \"continuation_mode\": \"continue_current_objective\" | \"new_objective\" | \"unknown\",\n  \
+            \"reanchors_current_objective\": <boolean>\n\
          }\n\
          \n\
          scenario must be one of:\n\
@@ -120,20 +121,24 @@ pub fn build_turn_intent_prompt(ctx: &TurnIntentJudgeContext) -> String {
              * \"continue_current_objective\" only when the user explicitly asks to proceed, apply, fix, run, or continue prior work (e.g. \"go on\", \"fix it\", \"继续\").\n  \
              * \"new_objective\" when starting an unrelated task.\n  \
              * \"unknown\" for status/progress/why/what-remains questions unless the user also explicitly asks to execute more work.\n\
+         - reanchors_current_objective: true only when the user corrects, redirects, or supersedes the current approach/objective; false for ordinary continuation.\n\
          - Return ONLY the JSON. No prose, no markdown fences.\n\
          \n\
          Examples:\n\
          User: \"please inspect the current changes\"\n\
-         {\"requested_scenario\":\"code_review\",\"prohibited_scenarios\":[],\"continuation_mode\":\"unknown\"}\n\
+         {\"requested_scenario\":\"code_review\",\"prohibited_scenarios\":[],\"continuation_mode\":\"unknown\",\"reanchors_current_objective\":false}\n\
          \n\
          User: \"fix it\" (after assistant proposed an implementation)\n\
-         {\"requested_scenario\":null,\"prohibited_scenarios\":[],\"continuation_mode\":\"continue_current_objective\"}\n\
+         {\"requested_scenario\":null,\"prohibited_scenarios\":[],\"continuation_mode\":\"continue_current_objective\",\"reanchors_current_objective\":false}\n\
          \n\
          User: \"还有什么？\" (after assistant was working on a task)\n\
-         {\"requested_scenario\":\"quick_answer\",\"prohibited_scenarios\":[],\"continuation_mode\":\"unknown\"}\n\
+         {\"requested_scenario\":\"quick_answer\",\"prohibited_scenarios\":[],\"continuation_mode\":\"unknown\",\"reanchors_current_objective\":false}\n\
+         \n\
+         User: \"不对，我要的是系统性修复，不是临时补丁\"\n\
+         {\"requested_scenario\":\"refactoring\",\"prohibited_scenarios\":[],\"continuation_mode\":\"continue_current_objective\",\"reanchors_current_objective\":true}\n\
          \n\
          User: \"don't review this, just continue the implementation\"\n\
-         {\"requested_scenario\":\"implementation\",\"prohibited_scenarios\":[\"code_review\"],\"continuation_mode\":\"continue_current_objective\"}\n\
+         {\"requested_scenario\":\"implementation\",\"prohibited_scenarios\":[\"code_review\"],\"continuation_mode\":\"continue_current_objective\",\"reanchors_current_objective\":false}\n\
          \n",
     );
 
@@ -255,6 +260,19 @@ pub fn parse_turn_intent_response(raw: &str) -> Result<TurnIntent, TurnIntentJud
             })?;
     }
 
+    // reanchors_current_objective: optional, defaults to false. A missing
+    // value is fail-closed for the strong runtime reanchor behavior.
+    if let Some(reanchors) = value.get("reanchors_current_objective")
+        && !reanchors.is_null()
+    {
+        intent.reanchors_current_objective =
+            reanchors
+                .as_bool()
+                .ok_or_else(|| TurnIntentJudgeError::Malformed {
+                    raw: format!("reanchors_current_objective not a boolean: {reanchors}"),
+                })?;
+    }
+
     Ok(intent)
 }
 
@@ -315,6 +333,8 @@ mod tests {
         assert!(prompt.contains("Turn: 3"));
         assert!(prompt.contains("Has prior assistant turn: yes"));
         assert!(prompt.contains("read_file, bash"));
+        assert!(prompt.contains("\"reanchors_current_objective\": <boolean>"));
+        assert!(prompt.contains("false for ordinary continuation"));
     }
 
     #[test]
@@ -364,7 +384,8 @@ mod tests {
         let raw = r#"{
           "requested_scenario": "implementation",
           "prohibited_scenarios": ["code_review"],
-          "continuation_mode": "continue_current_objective"
+          "continuation_mode": "continue_current_objective",
+          "reanchors_current_objective": false
         }"#;
         let intent = parse_turn_intent_response(raw).unwrap();
         assert_eq!(intent.requested_scenario, Some(Scenario::Implementation));
@@ -373,6 +394,21 @@ mod tests {
             intent.continuation_mode,
             TurnContinuationMode::ContinueCurrentObjective
         );
+        assert!(!intent.reanchors_current_objective());
+    }
+
+    #[test]
+    fn parses_structured_reanchor_separately_from_continuation() {
+        let raw = r#"{
+          "requested_scenario": "refactoring",
+          "prohibited_scenarios": [],
+          "continuation_mode": "continue_current_objective",
+          "reanchors_current_objective": true
+        }"#;
+        let intent = parse_turn_intent_response(raw).unwrap();
+        assert_eq!(intent.requested_scenario, Some(Scenario::Refactoring));
+        assert!(intent.continues_current_objective());
+        assert!(intent.reanchors_current_objective());
     }
 
     #[test]
@@ -445,6 +481,14 @@ mod tests {
         assert!(intent.requested_scenario.is_none());
         assert!(intent.prohibited_scenarios.is_empty());
         assert_eq!(intent.continuation_mode, TurnContinuationMode::Unknown);
+        assert!(!intent.reanchors_current_objective());
+    }
+
+    #[test]
+    fn non_boolean_reanchor_returns_malformed() {
+        let raw = r#"{"requested_scenario":null,"prohibited_scenarios":[],"continuation_mode":"unknown","reanchors_current_objective":"true"}"#;
+        let err = parse_turn_intent_response(raw).unwrap_err();
+        assert!(matches!(err, TurnIntentJudgeError::Malformed { .. }));
     }
 
     #[test]

--- a/rust/crates/services/src/turn_intent_judge.rs
+++ b/rust/crates/services/src/turn_intent_judge.rs
@@ -34,6 +34,7 @@
 
 use astra_config::user_profile::{Scenario, TurnContinuationMode, TurnIntent};
 use async_trait::async_trait;
+use serde_json::{Value, json};
 
 /// Context passed to the turn intent judge.
 #[derive(Debug, Clone, Default)]
@@ -167,6 +168,24 @@ pub fn build_turn_intent_prompt(ctx: &TurnIntentJudgeContext) -> String {
     prompt.push_str(&format!("\nUser: \"{}\"\n", sanitized));
 
     prompt
+}
+
+/// Build the chat messages sent to the turn-intent judge.
+///
+/// Keep this centralized so CLI/server judge implementations cannot drift in
+/// system wording, prompt shape, or output contract.
+#[must_use]
+pub fn turn_intent_judge_messages(ctx: &TurnIntentJudgeContext) -> Vec<Value> {
+    vec![
+        json!({
+            "role": "system",
+            "content": "You output ONLY a JSON object as described in the user message. No prose. No markdown fences."
+        }),
+        json!({
+            "role": "user",
+            "content": build_turn_intent_prompt(ctx),
+        }),
+    ]
 }
 
 // ─── Response parser ────────────────────────────────────────────────────────

--- a/skills/README.md
+++ b/skills/README.md
@@ -49,37 +49,38 @@ cp -r .claude/skills/some-skill .astra/skills/some-skill
 
 ### Frontmatter compatibility
 
-| Field | Agent Skills standard | Claude Code | Astra |
-|-------|----------------------|-------------|-------|
-| `name` | ✅ required | ✅ | ✅ |
-| `description` | ✅ required | ✅ | ✅ |
-| `allowed-tools` / `allowed_tools` | ✅ optional | ✅ | ✅ (both forms) |
-| `user-invocable` / `user_invocable` | — | ✅ | ✅ (both forms) |
-| `when_to_use` | — | — | ✅ astra extension |
-| `arguments` | — | via `$ARGUMENTS` | ✅ structured |
-| `context: fork` | — | ✅ | ✅ |
-| `disable-model-invocation` | — | ✅ | — (use `user_invocable: false`) |
-| `hooks` | — | ✅ | ✅ |
-| `paths` | — | ✅ | ✅ |
-| `model` | — | ✅ | ✅ |
-| `effort` | — | ✅ | ✅ |
+| Field                               | Agent Skills standard | Claude Code      | Astra                           |
+| ----------------------------------- | --------------------- | ---------------- | ------------------------------- |
+| `name`                              | ✅ required           | ✅               | ✅                              |
+| `description`                       | ✅ required           | ✅               | ✅                              |
+| `allowed-tools` / `allowed_tools`   | ✅ optional           | ✅               | ✅ (both forms)                 |
+| `user-invocable` / `user_invocable` | —                     | ✅               | ✅ (both forms)                 |
+| `when_to_use`                       | —                     | —                | ✅ astra extension              |
+| `arguments`                         | —                     | via `$ARGUMENTS` | ✅ structured                   |
+| `context: fork`                     | —                     | ✅               | ✅                              |
+| `disable-model-invocation`          | —                     | ✅               | — (use `user_invocable: false`) |
+| `hooks`                             | —                     | ✅               | ✅                              |
+| `paths`                             | —                     | ✅               | ✅                              |
+| `model`                             | —                     | ✅               | ✅                              |
+| `effort`                            | —                     | ✅               | ✅                              |
 
 ## Skills in this repo
 
-| Skill | Purpose |
-|-------|---------|
-| `analyze_session` | Diagnostic analysis and debugging of astra sessions (includes stall/escalation forensics) |
-| `audit_cloud_sync` | Audit edge-cloud sync: events, learning, checkpoints, tasks |
-| `evaluate_session` | Evaluate session performance metrics and optimization |
-| `optimize_prompt` | Analyze and optimize LLM prompt assembly and token usage |
-| `review_changes` | Context-aware code review with git diffs + code intelligence |
-| `trace_delegation` | Trace multi-agent delegation flows and verification gates |
-| `verify_task` | Verify task completion using the 8-type verification engine |
-| **`github_ci_check`** | Check CI/CD status, analyze failures, diagnose root causes |
-| **`github_pre_pr`** | Pre-PR checklist: make check, format, clippy, tests |
-| **`github_create_pr`** | Create PRs with gh CLI, auto-generate body from changes |
-| **`github_create_issue`** | Create issues with gh CLI, structured templates |
-| **`github_pr_review`** | Review PR comments, address feedback, draft responses |
+| Skill                     | Purpose                                                                                                                                              |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `analyze_session`         | Diagnostic analysis and debugging of astra sessions (includes stall/escalation forensics)                                                            |
+| `audit_cloud_sync`        | Audit edge-cloud sync: events, learning, checkpoints, tasks                                                                                          |
+| `evaluate_session`        | Evaluate session performance metrics and optimization                                                                                                |
+| `optimize_prompt`         | Analyze and optimize LLM prompt assembly and token usage                                                                                             |
+| `review_changes`          | Context-aware code review with git diffs + code intelligence                                                                                         |
+| `trace_delegation`        | Trace multi-agent delegation flows and verification gates                                                                                            |
+| `verify_task`             | Verify task completion using the 8-type verification engine                                                                                          |
+| **`github_ci_check`**     | Check CI/CD status, analyze failures, diagnose root causes                                                                                           |
+| **`github_pre_pr`**       | Pre-PR checklist: make check, format, clippy, tests                                                                                                  |
+| **`github_create_pr`**    | Create PRs with gh CLI, auto-generate body from changes                                                                                              |
+| **`github_create_issue`** | Create issues with gh CLI, structured templates                                                                                                      |
+| `github_pr_review`        | Review PR comments, address feedback, draft responses                                                                                                |
+| `unhappy_path_audit`      | Reachability-driven unhappy-path audit (R0→R3): dead code, misclassification, error-propagation breaks, state inconsistency, resource leaks/hung/OOM |
 
 ## Skill structure
 

--- a/skills/github_create_pr/SKILL.md
+++ b/skills/github_create_pr/SKILL.md
@@ -11,7 +11,7 @@ arguments:
     description: "PR body/description. If omitted, generated from diff."
     required: false
   - name: BASE
-    description: "Base branch (default: main)."
+    description: "Base branch. If omitted, use upstream tracking branch; fallback to main."
     required: false
   - name: LABELS
     description: "Comma-separated labels."
@@ -22,11 +22,10 @@ arguments:
 allowed_tools:
   - bash
   - git
-  - git
   - git_log
   - github
-  - github
 ---
+
 # GitHub Create PR
 
 Create a pull request. No native create-PR tool exists, so this skill uses `gh` CLI.
@@ -40,36 +39,64 @@ $ARGUMENTS
 ## Phase 1: Pre-flight Checks
 
 ### 1.1 Verify `gh` CLI is available and authenticated
+
 ```bash
-gh auth status 2>&1
+gh auth status --hostname github.com 2>&1 || true
 ```
-If not authenticated or not installed, stop and tell the user:
-- Not installed → `sudo apt install gh` or see https://cli.github.com
-- Not authenticated → `gh auth login`
-- Authenticated but wrong account → show current account, ask user to switch
+
+**Interpretation**:
+
+- Exit 0 with "Logged in to github.com" → authenticated, continue.
+- Exit 1 but output still contains "Logged in to" → partial success (multi-account, one token expired). Use the account listed as "Logged in"; this is non-blocking.
+- "not authenticated" or "not found" → stop and tell the user:
+  - Not installed → `sudo apt install gh` or see https://cli.github.com
+  - Not authenticated → `gh auth login`
+  - Authenticated but wrong account → show current account, ask user to switch
 
 ### 1.2 Check current branch
+
 ```bash
 git branch --show-current
 ```
+
 If on `main` or the base branch, stop — nothing to create a PR from.
 
+### 1.2.5 Auto-detect base branch from upstream tracking
+
+If no `BASE` argument is provided, detect the upstream tracking branch instead of assuming `main`:
+
+```bash
+upstream=$(git rev-parse --abbrev-ref @{upstream} 2>/dev/null || true)
+if [ -n "$upstream" ]; then
+  base="${upstream#*/}"
+else
+  base="main"
+fi
+printf '%s\n' "$base"
+```
+
+Use the printed value as `BASE` throughout. Only fall back to `main` if upstream tracking is not configured.
+
 ### 1.3 Check for uncommitted changes
+
 Use `git {action: "status"}`. If dirty, ask if user wants to commit first.
 
 ### 1.4 Verify the branch actually has commits to PR (empty-diff guard)
 
 Before calling `gh pr create`, confirm the branch diverges from the base.
-Use the `BASE` argument if the user supplied one; otherwise default to
-`main`:
+Use the `BASE` argument if the user supplied one; otherwise use the
+upstream-detected base from step 1.2.5:
 
 ```bash
-base="${BASE:-main}"
-git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0
+base="${BASE:-$(git rev-parse --abbrev-ref @{upstream} 2>/dev/null | sed 's|^[^/]*/||')}"
+base="${base:-main}"
+base_ref=$(git rev-parse "origin/${base}" 2>/dev/null || git rev-parse "${base}" 2>/dev/null || echo "")
+git rev-list --count "${base_ref}..HEAD" 2>/dev/null || echo 0
 ```
 
 If the count is `0` (or the command errors because the base ref is
 unresolved), **STOP**:
+
 - Tell the user the branch has no commits ahead of `${base}` — there is
   nothing to PR.
 - Do not invoke `gh pr create` on an empty diff. GitHub will reject it with
@@ -79,29 +106,47 @@ unresolved), **STOP**:
   different target branch.
 
 ### 1.5 Check for existing PR from this branch
+
 Use `github {action: "list_prs"}` with `state: "open"` to check. If a PR already exists from this branch, show it and ask whether to update or create a new one.
 
 ## Phase 2: Generate PR Content
 
 ### Title
+
 If not provided, generate from recent commit messages:
+
+If the user did NOT supply a `BASE` argument, run:
+
 ```bash
-git log main..HEAD --oneline
+detected_base=$(git rev-parse --abbrev-ref @{upstream} 2>/dev/null | sed 's|^[^/]*/||')
+detected_base="${detected_base:-main}"
+git log "${detected_base}"..HEAD --oneline
 ```
+
+Otherwise use the supplied `BASE`:
+
+```bash
+git log "${BASE}"..HEAD --oneline
+```
+
 Use conventional commit prefix if applicable: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`.
 
 ### Body
+
 If not provided, generate from diff summary using `git {action: "diff"}` with `stat_only: true`:
 
 ```markdown
 ## Summary
+
 {what changed and why}
 
 ## Changes
+
 - {key change 1}
 - {key change 2}
 
 ## Testing
+
 {how it was tested}
 ```
 
@@ -119,6 +164,7 @@ gh pr create \
 Omit `--label` / `--reviewer` flags if not provided (empty flags cause errors).
 
 **If creation fails:**
+
 - "not found" or 403 → user may not have push access to the remote
 - "already exists" → show existing PR URL
 - Network error → suggest retry
@@ -126,6 +172,7 @@ Omit `--label` / `--reviewer` flags if not provided (empty flags cause errors).
 ## Phase 4: Post-Creation
 
 After successful creation:
+
 1. Show the PR URL
 2. Suggest running pre-PR checks if not already done (reference `github-pre-pr` skill)
 3. Suggest checking CI status after push (reference `github-ci-check` skill)

--- a/skills/unhappy_path_audit/SKILL.md
+++ b/skills/unhappy_path_audit/SKILL.md
@@ -1,0 +1,406 @@
+---
+name: unhappy-path-audit
+description: "Unhappy-path audit: reachability-driven causal tracing. Validate that every changed code path is (1) reachable, (2) logically correct, (3) consistent in error propagation and state. Covers resource safety (Q1-Q3: leak/hung/OOM) as a subset. Produces structured risk reports keyed to actual astra crates."
+user_invocable: true
+when_to_use: "When the user explicitly asks to audit failure behavior: 'unhappy path audit', 'unhappy path', 'failure path', 'error handling audit', 'reachability audit', 'dead code audit', 'resource leak audit', 'hung/OOM audit', or 'resource safety audit'. Do not trigger for generic 'review the diff' or ordinary code review."
+arguments:
+  - name: TARGET
+    description: "Target module(s), crate(s), or branch to audit (e.g. 'astra-turn-core', 'runtime', 'HEAD~3..HEAD'). Default: uncommitted changes or current branch diff."
+    required: false
+  - name: FOCUS
+    description: "Audit dimension: 'reachability', 'classification', 'error-propagation', 'state', 'resource' (Q1-Q3), or 'all' (default: all)"
+    required: false
+allowed_tools:
+  - read_file
+  - grep
+  - glob
+  - bash
+  - git
+---
+
+# Unhappy Path Audit Skill — astra
+
+## First Principles
+
+**Unhappy path auditing = verifying 3 things about every code path, IN ORDER:**
+
+| #   | Gate                      | Question                                                                                           | Failure Mode                |
+| --- | ------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------- |
+| R0  | **What changed?**         | What is the actual diff? Which code paths were added, removed, or altered?                         | Analyzing stale code        |
+| R1  | **Is it reachable?**      | Given all gating conditions (flags, mode switches, feature gates, config), does this path execute? | **Dead code**, false safety |
+| R2  | **Is the logic correct?** | When it executes, does it produce correct results? Classification, error handling, state machine.  | **Misclassification**, bug  |
+| R3  | **What actually breaks?** | Given it's wrong AND reachable, what is the concrete consequence? Not "might break" but "breaks".  | **Severity misassignment**  |
+
+**This ordering is non-negotiable.** R0 before R1 before R2 before R3. A bug that is unreachable (R1 fail) is NOT a finding — it's a note. A bug whose consequences are misjudged (R3 skip) produces wrong severity.
+
+**Resource safety (leak/hung/OOM) is Q1-Q3, a specialization within R2:**
+
+| Q   | Proposition                                              | Maps to |
+| --- | -------------------------------------------------------- | ------- |
+| Q1  | Every resource creation has a guaranteed destruction     | R2      |
+| Q2  | Every blocking wait has a guaranteed release             | R2      |
+| Q3  | Every accumulation has an upper bound or recycling point | R2      |
+
+But Q1-Q3 is ONLY applied to resources that actually exist in the R0 diff. Do NOT audit the entire crate's resource lifecycle — only the resources touched by the change set.
+
+---
+
+## Critical Rule: Reachability First, Always
+
+> **The most common and most expensive audit error is filing a finding without confirming reachability.**
+
+Before ANY finding enters the report, run this check:
+
+```
+grep for the gating condition (flag, mode, feature) → trace ALL call sites → confirm at least one call site reaches the code in the current configuration
+```
+
+**Anti-pattern (actual failure, 53-tool audit):**
+
+```
+1. Saw `allow_factual_retry: false` changed from `true` → filed as 🟡 "might weaken retry"
+2. Did NOT grep for `allow_factual_retry` consumers → missed that the +119-line judge system is entirely gated by this flag
+3. Actual finding: ALL new judge code is DEAD CODE → 🔴, not 🟡
+4. Root cause: skipped R1
+```
+
+**Correct workflow:**
+
+```
+1. See `allow_factual_retry: false` (R0)
+2. grep `allow_factual_retry` → find `should_attempt_factual_retry()` (R1 start)
+3. grep `should_attempt_factual_retry` → find all call sites → confirm reachability (R1 complete)
+4. grep `FactualRetryFallbackJudgeVerdict` → find the gated code → assess impact (R2)
+5. Conclusion: dead code if flag is never true (R3)
+```
+
+---
+
+## Audit Workflow
+
+### Phase 0 — Establish the Change Set
+
+```
+1. git diff --stat (or git log for multi-commit)
+2. Identify the minimal set of functions/paths that changed
+3. Do NOT expand beyond the change set unless a changed path calls into unchanged code that is now affected
+```
+
+**Output**: a list of `<file:function>` that the audit will cover.
+
+### Phase 1 — Per-Path Reachability (R1)
+
+For each changed code path from Phase 0:
+
+```
+1. Identify all gating conditions:
+   - Boolean flags (allow_factual_retry, verification_required)
+   - Mode switches (Bypass/Auto/ApprovalRequired, child_inherited_mode)
+   - Feature gates (#[cfg(feature = "...")])
+   - Config values (from profiles, runtime config)
+   - Error-path guards (if let Err(_) = ..., ?)
+
+2. grep for each gating condition's consumers and callers
+
+3. Trace the FULL call chain from entry point to changed code:
+   - Entry: where does execution start that COULD reach this code?
+   - Every if/match branch on the path: can it reach the changed code?
+   - Terminal: does the path actually terminate at the changed code?
+
+4. Verdict per path:
+   - REACHABLE: at least one concrete scenario reaches it
+   - DEAD: no configuration reaches it → NOTE, not finding
+   - CONDITIONAL: reaches only under specific config → document the condition
+```
+
+**Stop rule**: if R1 returns DEAD, do NOT proceed to R2. Record as a note and move on.
+
+### Phase 2 — Logic Correctness (R2)
+
+For each REACHABLE or CONDITIONAL path:
+
+**Sub-dimensions to check (apply only those relevant):**
+
+| Dimension              | Check                                                                                   | Common patterns in astra                                                                     |
+| ---------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| **Classification**     | Does the classification logic correctly categorize inputs?                              | `contains_any_keyword` substring matching, `split_whitespace().join(" ")` normalization gaps |
+| **Error propagation**  | When this code produces/forwards an error, is context preserved?                        | `ErrorKind` stripped by `map_err(\|e\| format!(...))`, retry info lost                       |
+| **State consistency**  | After partial success or error, is state consistent?                                    | Partial writes before error return, state machine stuck in intermediate state                |
+| **Resource (Q1-Q3)**   | For changed resource operations: creation→destruction, wait→release, accumulation→bound | `tokio::spawn` without abort, `Vec::push` without clear, `Mutex` without timeout             |
+| **Gating correctness** | Is the gating condition itself correct?                                                 | Mode comparison using `==` when `>=` is needed, inverted boolean                             |
+
+**Resource Q1-Q3 drill-down (only for paths touching resources):**
+
+```
+Entry function
+  └→ Layer 1: Execute Q1-Q3 on every resource/wait/accumulation point in the DIFF
+      ├─ Termination satisfied at this layer → ✅
+      └─ Termination depends on lower layer → ⬇ drill down
+          └→ Recurse with Q1-Q3
+```
+
+**Anti-false-positive rule for Q2**: exhaust all release paths (Drop impl, AbortHandle, CancellationToken, timeout branch, channel close) before ruling hung.
+
+### Phase 3 — Deduplication and Causal Grouping
+
+```
+1. Group findings by causal root, not by location:
+   - Finding A (dead code) and Finding B (JSON parse bug in dead code) → ONE entry: "A blocks B"
+   - Finding C (flag change) is the PRIMARY finding; B is a sub-note
+
+2. Remove subordinate findings that are unreachable unless the primary is fixed
+
+3. For each group, identify the PRIMARY finding (the one that, if fixed, resolves others)
+```
+
+**Anti-pattern (actual failure):**
+
+```
+❌ Listed as 3 independent findings:
+   1. allow_factual_retry disabled (🟡)
+   2. extract_first_json_object matches markdown fences (🟡)
+   3. looks_like_factual_query deleted (🟡)
+
+✅ Correct:
+   1. allow_factual_retry disabled → ALL factual retry judge code is dead (🔴)
+      - If re-enabled: extract_first_json_object has markdown fence bug (sub-note)
+      - looks_like_factual_query removal is part of the same transition (sub-note)
+```
+
+### Phase 4 — Severity Calibration (R3)
+
+**Assign severity ONLY after ALL findings are confirmed and deduplicated.**
+
+| Severity | Definition                                                         |
+| -------- | ------------------------------------------------------------------ |
+| 🔴       | Reachable AND causes definite incorrect behavior in current config |
+| 🟡       | Reachable under specific config AND causes incorrect behavior      |
+| 🟢       | Reachable but low-impact, OR unreachable but important design note |
+
+**Calibration: for every finding, state the concrete scenario that triggers it.** If you cannot write "when user does X, system does Y instead of Z", the finding is not concrete enough.
+
+---
+
+## Output Format
+
+### Phase 0 Output: Change Set
+
+```
+## Change Set
+| # | File | Function/Path | Change Type |
+|---|------|---------------|-------------|
+| 1 | chat_turn_heuristics.rs | TaskExecutionProfile::default() | Modified: flag changed |
+| 2 | turn_ingest.rs | parse_factual_retry_fallback_judge_response | Added: new function |
+```
+
+### Final Report
+
+```
+## Unhappy Path Audit: [target]
+
+### 🔴 Critical (N)
+| # | Finding | Reachability | Consequence |
+|---|---------|-------------|-------------|
+| 1 | [description] | Always | [concrete scenario] |
+
+### 🟡 Medium (N)
+...
+
+### 🟢 Low / Notes (N)
+...
+
+### Causal Groups
+- Finding #1 blocks #2, #3 → primary is #1
+
+### Verified-OK
+- [design decision]: confirmed correct because [reason]
+```
+
+---
+
+## Bug Claim Verification Gates (G1-G5)
+
+**Applied during Phase 2→3 transition. EVERY finding must pass ALL gates before entering the final report.**
+
+| #   | Gate               | Action                                                                                                     | Anti-Pattern (actual failures)                                                                            |
+| --- | ------------------ | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| G1  | **FULL-GRAPH**     | Trace resource ownership to ALL terminal nodes. Do not stop at the next hop.                               | Traced `Arc::clone → worker` but stopped; missed `worker.Drop → AbortHandle` → task cancel                |
+| G2  | **CAN-FAIL**       | Open the alleged failure function body; confirm it CAN actually panic/error/block.                         | Assumed `serde_json::to_string()` could hang; it's CPU-bound. Only `from_str` can fail on malformed input |
+| G3  | **SYMMETRY**       | For growth claims (push/insert): grep the variable name + `clear()`/`truncate()`. Confirm NO reset exists. | Saw `events.push(...)`, missed `events.clear()` in `flush_batch()`                                        |
+| G4  | **LINE-REREAD**    | Re-read every cited line AFTER forming the hypothesis. Do not trust memory.                                | Asserted state doesn't transition on error; re-read shows `state = State::Done` is unconditional          |
+| G5  | **CALIBRATE-LAST** | Severity assigned ONLY after G1-G4 pass AND all findings are deduplicated.                                 | Filed as Medium before confirming reachability; finding was unreachable → severity meaningless            |
+
+**Any finding failing G1-G4 is discarded, not downgraded.** G5 is a global gate applied after the full bug list is finalized.
+
+---
+
+## Common Failure Patterns (astra-specific)
+
+### Pattern 1: Flag Gating → Dead Code
+
+**Symptom**: a boolean flag change makes downstream code unreachable.
+**Detection**: grep the flag name → find all consumers → trace call chains.
+**Example**: `allow_factual_retry: false` → `should_attempt_factual_retry()` returns false → `FactualRetryFallbackJudgeVerdict` never instantiated.
+
+### Pattern 2: Substring Matching Without Word Boundaries
+
+**Symptom**: `"fix"` matches `"prefix"`. Classification logic over-triggers.
+**Detection**: for every keyword in a matching list, grep the codebase for words that contain it as a substring.
+**Example**: `EXPLICIT_MUTATION_DIRECTIVE_TERMS` — `"fix"` matches "prefix", "suffix", "fixation". `"create"` matches "recreate".
+
+### Pattern 3: ErrorKind Stripping in map_err
+
+**Symptom**: `map_err(|e| format!("... {}", e))` converts typed ErrorKind to String, losing retry policy.
+**Detection**: grep `map_err(|` near `?` or `.await` in changed code.
+**Example**: `core::ErrorKind::Retryable` → `format!("failed: {}", e)` → caller cannot check `is_retryable()`.
+
+### Pattern 4: Partial State After Error Return
+
+**Symptom**: `vec.push(x); f()?;` — x is pushed, f fails, function returns, vec has partial state.
+**Detection**: look for any mutable operation BEFORE `?` in the same scope.
+**Example**: message queued to channel, then `db.write()?` fails → message already sent but not persisted.
+
+### Pattern 5: JoinHandle Drop Without AbortHandle
+
+**Symptom**: `tokio::spawn(task)` with no corresponding `AbortHandle::abort()`.
+**Detection**: grep `tokio::spawn(` → check if JoinHandle is stored and aborted on Drop/error path.
+**Example**: spawned task outlives the scope that created it, continues running with stale references.
+
+### Pattern 6: Mode/Enum Comparison Gaps
+
+**Symptom**: new enum variant added but comparison logic uses `==` instead of exhaustive match, or uses `<`/`>` that doesn't account for new ordering.
+**Detection**: for any enum change, grep all `==` comparisons against that enum.
+**Example**: `PermissionMode::Bypass` added — `if mode == Auto` no longer covers all non-ApprovalRequired modes (Bypass is now a gap).
+
+
+---
+
+## Appendix A: astra Module Threat Model Reference
+
+When auditing a specific crate, use this reference to focus on the most likely failure modes.
+
+### A.0 — `core` (error foundation)
+
+**ErrorKind** (`error_kind.rs`, 21 variants):
+- Classification correctness: every `?` site that creates/converts an error must assign the correct ErrorKind
+- `is_retryable()`: retry policy must match actual retry-worthiness
+- `retry_delay_ms()`: backoff strategy must be correct
+- `classify_tool_output()`: downgrade classifier must not misclassify transient vs permanent
+
+**Audit focus**: grep `ErrorKind::` in changed code → verify variant choice → trace `is_retryable()` consumer impact
+
+### A.1 — `astra-turn-core`
+
+**Turn processing** (`agentic/`):
+- Turn lifecycle: extraction → execution → verification → completion
+- Factual retry judge: gated by `allow_factual_retry` → verify reachability
+- Verification stop hook: gated by `verification_required` → verify no infinite wait
+
+**Permission engine** (`permission/`):
+- Mode transitions: Bypass → Auto downgrade in child agent fork
+- Allowlist matching: AllowRules step after Guard
+- Safety middleware: catastrophic command detection, `chmod 777 /` patterns
+
+**Chat turn heuristics** (`chat_turn_heuristics.rs`):
+- `EXPLICIT_MUTATION_DIRECTIVE_TERMS`: keyword matching correctness
+- Profile assignment: mutating vs analysis vs default → affects verification, retry
+
+**Audit focus**: flag gating reachability, keyword substring matching, mode transition correctness
+
+### A.2 — `runtime`
+
+**HTTP server**: connection pool exhaustion, request timeout, graceful shutdown
+**WebSocket bridge**: reconnection, message loss on disconnect, backpressure
+**DB pool**: connection leak, transaction rollback after partial writes
+**Orchestration**: turn scheduling, agent lifecycle, pause/resume state
+
+**Audit focus**: Q1 (connection/pool lifecycle), Q2 (shutdown wait ordering), state consistency after agent failure
+
+### A.3 — `services`
+
+**Event ingestion**: batching, retry on write failure, deduplication
+**Sync engine**: conflict resolution, checkpoint recovery, partial sync state
+**Durable tasks**: task lifecycle, retry-after-failure, orphaned tasks
+**Cost ledger**: accumulation, flush interval, loss on crash
+
+**Audit focus**: Q3 (batch accumulation bound), state consistency after partial sync, error propagation fidelity
+
+### A.4 — `astra-messaging`
+
+**Transport**: connection lifecycle, reconnect backoff, message serialization failure
+**Delegation**: fan-out completion tracking, partial results aggregation
+**Ack tracking**: ack timeout, duplicate ack, missing ack → retry storm
+**Dead letter**: overflow, no consumer, disk fill
+
+**Audit focus**: Q2 (ack wait timeout), Q3 (dead letter queue bound), Q1 (connection lifecycle)
+
+### A.5 — `astra-pipeline`
+
+**Checkpoint**: write failure during checkpoint, partial checkpoint recovery
+**Crash recovery**: state reconstruction from incomplete journal
+**Trace retention**: accumulation bound, eviction policy
+
+**Audit focus**: Q3 (trace unbounded growth), state consistency after crash recovery
+
+### A.6 — `astra-sandbox`
+
+**Process isolation**: child process lifecycle, orphan processes, signal handling
+**Bash execution**: timeout enforcement, output capture bound, stdin pipe closure
+**Resource limits**: CPU/memory cgroup limits, disk quota
+
+**Audit focus**: Q1 (child process reaping), Q2 (timeout guarantees), Q3 (output buffer bound)
+
+### A.7 — `astra-cli`
+
+**Edge tools**: local process lifecycle, file watcher, cache management
+**TUI**: render loop, input handling, terminal resize recovery
+**MCP client**: connection management, tool list caching, sandbox retry
+
+**Audit focus**: Q1 (local process lifecycle), Q2 (MCP connection timeout), state consistency in TUI
+
+### A.8 — `web/`
+
+**Next.js frontend**: API call retry, loading state, error boundary
+**Rendering**: partial render on data fetch failure, hydration mismatch
+
+**Audit focus**: error propagation to user, retry on transient failures
+
+---
+
+## Appendix B: Rust/Tokio Wait Termination Model
+
+When auditing Q2 (wait → termination) in async Rust, check these patterns:
+
+| Wait Mechanism               | Release Mechanism                          | Must Verify                                                     |
+| ---------------------------- | ------------------------------------------ | --------------------------------------------------------------- |
+| `tokio::spawn(task)`         | `AbortHandle::abort()` or `CancellationToken` | AbortHandle stored and called in Drop or error path             |
+| `rx.recv()` (tokio channel)  | All `tx` clones dropped or channel closed  | Sender count reaches 0 on ALL code paths (including error)      |
+| `Mutex::lock().await`        | Lock released at end of scope (RAII)       | No `std::mem::forget` or leak of MutexGuard                     |
+| `select! {}`                 | Every branch terminates                    | At least one branch fires; if `else` branch, default fires      |
+| `CancellationToken::cancelled()` | `CancellationToken::cancel()`          | cancel() called in Drop or error path of owner                  |
+| `Notify::notified()`         | `Notify::notify_one()` or `notify_waiters()`| Notify call guaranteed to fire after notified() is awaited      |
+| `Semaphore::acquire()`       | `Semaphore::add_permits()` or Drop         | Permits returned on ALL paths; check for leak                   |
+| `Barrier::wait()`            | Enough waiters arrive                      | Can the required count ever be reached on error paths?          |
+| I/O (`read`, `write`)        | Timeout or peer close                      | `tokio::time::timeout` wrapping the I/O future                  |
+| HTTP request                 | Response, timeout, or connection close     | Timeout set on client; connection pool has eviction             |
+| DB query                     | Result, timeout, or pool shutdown          | Statement timeout; pool shutdown drains in-flight queries       |
+
+**Drill-down rule**: for each wait, identify the release mechanism in the SAME scope first. If not found, drill down to the owner scope. If owner scope is unbounded (static, global), that's a finding.
+
+---
+
+## Appendix C: False Positive Patterns
+
+Common patterns that LOOK like bugs but are NOT. Check these before filing.
+
+| Pattern                                  | Why It's NOT a Bug                                                      |
+| ---------------------------------------- | ----------------------------------------------------------------------- |
+| `tokio::spawn` without visible abort     | JoinHandle stored in struct that has Drop impl calling abort            |
+| `Vec::push` without clear in same function | Variable passed to `flush_batch()` which calls `.clear()`             |
+| `Arc::clone` without visible drop        | Arc is stored in a bounded collection that is drained                   |
+| `?` before side-effect cleanup           | Earlier operation is idempotent, or cleanup happens in Drop             |
+| `unwrap()` on async result               | Invariant guaranteed by caller; may need `.expect()` with reason        |
+| `panic!` in Drop impl                    | Only on already-panicking path (guarded by `std::thread::panicking()`)  |
+| Channel send without recv                | Channel is `broadcast` with `max_receive_count = 0` allowed             |
+| `JoinSet` with spawned tasks not awaited | `JoinSet::shutdown().await` in Drop or main                             |
+| `Weak::upgrade()` fails silently         | Strong ref lifecycle is bounded by owning struct; Weak is for cycle breaking |


### PR DESCRIPTION
## Summary
- add a Bypass permission mode / skip alias that suppresses approval prompts while keeping hard safety denies
- allow agent skill content under .astra/skills and .claude/skills without treating it as sensitive app state, while keeping credentials/control files protected
- keep bounded don't-ask-again available for Git-destructive approval prompts instead of disabling remember entirely

## Validation
- make test-offline
- make test-online
- make check