### PR TITLE
[codex] Drop legacy transcript secondary index

### DIFF
--- a/rust/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/rust/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -1977,6 +1977,21 @@ impl AgenticRunLifecycleService {
         Some(Arc::new(store))
     }
 
+    fn install_restored_csl_history_for_current_turn(
+        loop_state: &mut AgenticLoopState,
+        mut restored_messages: Vec<Value>,
+    ) -> usize {
+        let turn_start_message_count = restored_messages.len();
+        if restored_messages.is_empty() {
+            return turn_start_message_count;
+        }
+        if !loop_state.messages.is_empty() {
+            restored_messages.push(loop_state.messages.remove(0));
+        }
+        loop_state.messages = restored_messages;
+        turn_start_message_count
+    }
+
     async fn restore_csl_history(
         &self,
         user_id: &str,
@@ -1998,11 +2013,11 @@ impl AgenticRunLifecycleService {
         };
         mgr.set_trace_id(run_id.to_string());
 
-        let mut restored_messages = Vec::new();
+        let mut restored_messages = None;
 
         match mgr.load().await {
             Ok(Some(mat)) => {
-                restored_messages = mat.messages;
+                restored_messages = Some(mat.messages);
                 restore_session_state_compact(mat.session_state, loop_state);
             }
             Ok(None) => {
@@ -2048,14 +2063,14 @@ impl AgenticRunLifecycleService {
             }
         }
 
-        if !restored_messages.is_empty() {
-            if !loop_state.messages.is_empty() {
-                restored_messages.push(loop_state.messages.remove(0));
-            }
-            loop_state.messages = restored_messages;
+        if let Some(restored_messages) = restored_messages {
+            let turn_start_message_count =
+                Self::install_restored_csl_history_for_current_turn(loop_state, restored_messages);
+            mgr.mark_turn_start(turn_start_message_count);
+        } else {
+            mgr.mark_turn_start(loop_state.messages.len());
         }
 
-        mgr.mark_turn_start(loop_state.messages.len());
         Some(mgr)
     }
 
@@ -7858,6 +7873,45 @@ mod tests {
             blocks: vec![],
             blocked_by: vec![],
         }
+    }
+
+    #[test]
+    fn restored_csl_turn_start_excludes_current_user_message() {
+        let mut state = crate::turn::agentic_loop::host::make_test_loop_state();
+        state.messages = vec![json!({"role": "user", "content": "current question"})];
+
+        let turn_start = AgenticRunLifecycleService::install_restored_csl_history_for_current_turn(
+            &mut state,
+            vec![
+                json!({"role": "user", "content": "old question"}),
+                json!({"role": "assistant", "content": "old answer"}),
+            ],
+        );
+
+        assert_eq!(turn_start, 2);
+        assert_eq!(state.messages.len(), 3);
+        assert_eq!(state.messages[0]["content"], "old question");
+        assert_eq!(state.messages[2]["content"], "current question");
+        let appended: Vec<&str> = state.messages[turn_start..]
+            .iter()
+            .filter_map(|message| message["content"].as_str())
+            .collect();
+        assert_eq!(appended, vec!["current question"]);
+    }
+
+    #[test]
+    fn empty_restored_csl_turn_still_treats_current_user_as_new() {
+        let mut state = crate::turn::agentic_loop::host::make_test_loop_state();
+        state.messages = vec![json!({"role": "user", "content": "current question"})];
+
+        let turn_start = AgenticRunLifecycleService::install_restored_csl_history_for_current_turn(
+            &mut state,
+            Vec::new(),
+        );
+
+        assert_eq!(turn_start, 0);
+        assert_eq!(state.messages.len(), 1);
+        assert_eq!(state.messages[0]["content"], "current question");
     }
 
     fn test_agent_progress_event(

--- a/rust/crates/services/src/storage.rs
+++ b/rust/crates/services/src/storage.rs
@@ -1710,6 +1710,16 @@ pub async fn ensure_core_schema(
     )
     .execute(&pool)
     .await?;
+    // MatrixOne #25377: legacy secondary indexes that explicitly include the
+    // full transcript primary key can have empty hidden index tables and return
+    // wrong results for transcript sequence allocation.
+    drop_index_if_present(
+        &pool,
+        &settings.database,
+        "session_transcript_items",
+        "idx_transcript_user_session_seq",
+    )
+    .await?;
     ensure_primary_key_shape(
         &pool,
         &settings.database,
@@ -5311,6 +5321,34 @@ mod tests {
         assert!(
             !insert_body.contains("INSERT IGNORE INTO agent_event_edges"),
             "agent_event_edges must not hide ordering conflicts with INSERT IGNORE"
+        );
+    }
+
+    #[test]
+    fn transcript_items_schema_drops_legacy_matrixone_bad_index() {
+        let source = include_str!("storage.rs");
+        let create_ddl = source
+            .split("CREATE TABLE IF NOT EXISTS session_transcript_items")
+            .nth(1)
+            .and_then(|rest| rest.split(")\"").next())
+            .expect("session_transcript_items DDL");
+        assert!(
+            !create_ddl.contains("idx_transcript_user_session_seq"),
+            "fresh transcript tables must not recreate the MatrixOne-broken legacy index"
+        );
+
+        let transcript_bootstrap = source
+            .split("CREATE TABLE IF NOT EXISTS session_transcript_items")
+            .nth(1)
+            .and_then(|rest| {
+                rest.split("CREATE TABLE IF NOT EXISTS transcript_pages")
+                    .next()
+            })
+            .expect("session_transcript_items bootstrap block");
+        assert!(
+            transcript_bootstrap.contains("drop_index_if_present(")
+                && transcript_bootstrap.contains("\"idx_transcript_user_session_seq\""),
+            "schema bootstrap must drop the MatrixOne-broken legacy transcript index"
         );
     }
 

--- a/rust/crates/services/tests/schema_assertions.rs
+++ b/rust/crates/services/tests/schema_assertions.rs
@@ -1290,6 +1290,17 @@ async fn phase2_web_hydration_schema_contract() {
         ["user_id", "run_id", "source_event_idx"],
         "transcript source event lookups must be owner-bound"
     );
+    assert!(
+        index_columns(
+            &pool,
+            &schema,
+            "session_transcript_items",
+            "idx_transcript_user_session_seq"
+        )
+        .await
+        .is_empty(),
+        "session_transcript_items must drop MatrixOne-broken legacy index idx_transcript_user_session_seq"
+    );
     let transcript_page_columns = column_names(&pool, &schema, "transcript_pages").await;
     assert!(
         transcript_page_columns


### PR DESCRIPTION
## Summary

- Drop the legacy `idx_transcript_user_session_seq` index from `session_transcript_items` during schema bootstrap.
- Add source-level and MatrixOne schema assertions so fresh and existing databases do not keep recreating or retaining the MatrixOne-broken index.

## Root Cause

MatrixOne issue matrixorigin/matrixone#25377 shows secondary indexes that explicitly include the full primary key can have empty hidden index tables and return wrong results. On MatrixOne 3.0.15, the legacy transcript index caused transcript sequence allocation queries to miss existing rows and compute `MAX(item_seq)+1` as `1`.

## Impact

Existing data is preserved. Fresh databases do not create this legacy index, and existing databases drop it if present. The current owner/run/source-event index remains unchanged.

## Validation

- Verified against `8.0.30-MatrixOne-v3.0.15`: the legacy hidden index table was empty and `MAX(item_seq)+1` used the bad index path in the old schema.
- `cargo test -p astra-services transcript_items_schema_drops_legacy_matrixone_bad_index`
- `ASTRA_TEST_DB_IT=1 ASTRA_AUTO_CREATE_DATABASE=1 ASTRA_DATABASE=astra_runtime_test ASTRA_DATABASE_PREFIX=codex_transcript_ cargo test -p astra-services --test schema_assertions phase2_web_hydration_schema_contract -- --ignored --nocapture`
- `cargo clippy -p astra-services --all-targets -- -D warnings`