### PR TITLE
fix(runtime): preserve web deferred user inputs in transcript and persistence

### DIFF
--- a/rust/.cargo/audit.toml
+++ b/rust/.cargo/audit.toml
@@ -7,5 +7,9 @@
 # REVIEW_BY: 2026-10-18 — calendar re-check: run `cargo audit`, confirm whether rsa/sqlx resolved;
 # remove this ignore if a fixed dependency graph is available.
 
+# RUSTSEC-2026-0194 / RUSTSEC-2026-0195 (quick-xml): pulled via plist → syntect → two-face.
+# quick-xml 0.39.3 is the version required by plist 1.9.0; there is no patched release in the
+# transitive dependency chain yet. Revisit when syntect/two-face upgrades plist.
+# REVIEW_BY: 2026-09-02
 [advisories]
-ignore = ["RUSTSEC-2023-0071"]
+ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2026-0194", "RUSTSEC-2026-0195"]

--- a/rust/crates/runtime/src/server/run/lifecycle/persistence.rs
+++ b/rust/crates/runtime/src/server/run/lifecycle/persistence.rs
@@ -831,7 +831,10 @@ async fn persist_server_loop_core_events_impl(
     state: &AgenticLoopState,
     model_name: Option<&str>,
 ) -> Result<(), String> {
-    if user_message.is_empty() && state.final_text.is_empty() {
+    if user_message.is_empty()
+        && state.final_text.is_empty()
+        && state.deferred_input.delivered_user_inputs().is_empty()
+    {
         return Ok(());
     }
 
@@ -877,6 +880,32 @@ async fn persist_server_loop_core_events_impl(
         None
     };
 
+    let deferred_user_message_events = state
+        .deferred_input
+        .delivered_user_inputs()
+        .iter()
+        .map(|input| {
+            let event_index = input.event_index.to_string();
+            let mut event = TraceEvent::new(
+                trace_event_id("deferred_user", &[run_id, &event_index]),
+                session_id,
+                user_id,
+                "user_message",
+                "turn",
+            )
+            .with_turn_context(&trace);
+            event.run_id = Some(run_id.to_string());
+            event.parent_run_id = parent_run_id.map(ToString::to_string);
+            event.agent_id = Some(agent_id.unwrap_or("root-agent").to_string());
+            event.parent_agent_id = parent_agent_id.map(ToString::to_string);
+            event.content = Some(input.content.clone());
+            event.parent_event_id = user_query_event
+                .as_ref()
+                .map(|event| event.event_id.clone());
+            event
+        })
+        .collect::<Vec<_>>();
+
     let llm_response_event = if !state.final_text.is_empty() {
         let usage = lifecycle_token_usage_json(
             state.total_prompt,
@@ -908,10 +937,11 @@ async fn persist_server_loop_core_events_impl(
         None
     };
 
-    let mut events = Vec::with_capacity(2);
+    let mut events = Vec::with_capacity(2 + deferred_user_message_events.len());
     if let Some(event) = user_query_event.clone() {
         events.push(event);
     }
+    events.extend(deferred_user_message_events.iter().cloned());
     if let Some(event) = llm_response_event.clone() {
         events.push(event);
     }
@@ -953,7 +983,8 @@ async fn persist_server_loop_core_events_impl(
             }),
         snapshot_link_plan: None,
     };
-    let transcript_items = transcript_items_from_core_plan(&plan, run_id);
+    let transcript_items =
+        transcript_items_from_core_plan(&plan, run_id, &deferred_user_message_events);
 
     match external_tx {
         Some(tx) => {
@@ -1005,13 +1036,22 @@ pub(crate) struct TranscriptPersistItem {
 fn transcript_items_from_core_plan(
     plan: &TurnCorePersistPlan,
     run_id: &str,
+    deferred_user_message_events: &[TraceEvent],
 ) -> Vec<TranscriptPersistItem> {
-    let mut items = Vec::with_capacity(2);
+    let mut items = Vec::with_capacity(2 + deferred_user_message_events.len());
     if let Some(event) = &plan.user_query_event {
         items.push(TranscriptPersistItem {
             run_id: run_id.to_string(),
             role: "user",
             content: event.content.clone(),
+            source_event_id: event.event_id.clone(),
+        });
+    }
+    for event in deferred_user_message_events {
+        items.push(TranscriptPersistItem {
+            run_id: run_id.to_string(),
+            role: "user",
+            content: event.content.clone().unwrap_or_default(),
             source_event_id: event.event_id.clone(),
         });
     }
@@ -1515,18 +1555,17 @@ pub(crate) async fn persist_session_transcript_items_inner_in_tx(
 
     for item in items {
         let existing = sqlx::query(
-            "SELECT COUNT(*) AS count
+            "SELECT 1 AS existing
              FROM session_transcript_items
-             WHERE session_id = ? AND user_id = ? AND run_id = ? AND role = ?",
+             WHERE session_id = ? AND user_id = ? AND source_event_id = ?
+             LIMIT 1",
         )
         .bind(session_id)
         .bind(user_id)
-        .bind(&item.run_id)
-        .bind(item.role)
-        .fetch_one(&mut **tx)
-        .await?
-        .try_get::<i64, _>("count")?;
-        if existing > 0 {
+        .bind(&item.source_event_id)
+        .fetch_optional(&mut **tx)
+        .await?;
+        if existing.is_some() {
             continue;
         }
 
@@ -2335,6 +2374,172 @@ mod tests {
             .expect("cleanup transcript fixture agent_sessions");
     }
 
+    async fn cleanup_core_persist_fixture_for_owner(
+        db: &sqlx::Pool<sqlx::MySql>,
+        session_id: &str,
+        user_id: &str,
+    ) {
+        sqlx::query("DELETE FROM transcript_pages WHERE session_id = ? AND user_id = ?")
+            .bind(session_id)
+            .bind(user_id)
+            .execute(db)
+            .await
+            .expect("cleanup core persist transcript_pages");
+        sqlx::query("DELETE FROM session_transcript_items WHERE session_id = ? AND user_id = ?")
+            .bind(session_id)
+            .bind(user_id)
+            .execute(db)
+            .await
+            .expect("cleanup core persist session_transcript_items");
+        sqlx::query("DELETE FROM agent_event_edges WHERE session_id = ? AND user_id = ?")
+            .bind(session_id)
+            .bind(user_id)
+            .execute(db)
+            .await
+            .expect("cleanup core persist agent_event_edges");
+        sqlx::query("DELETE FROM agent_events WHERE session_id = ? AND user_id = ?")
+            .bind(session_id)
+            .bind(user_id)
+            .execute(db)
+            .await
+            .expect("cleanup core persist agent_events");
+        sqlx::query("DELETE FROM agent_sessions WHERE session_id = ? AND user_id = ?")
+            .bind(session_id)
+            .bind(user_id)
+            .execute(db)
+            .await
+            .expect("cleanup core persist agent_sessions");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires MatrixOne; run with ASTRA_TEST_DB_IT=1"]
+    async fn core_persistence_records_deferred_inputs_without_splitting_audit_turns() {
+        let pool = setup_pool().await;
+        let db = pool.get().clone();
+        let matrixone = MatrixOneSettings::from_env();
+        let session_id = Uuid::new_v4().to_string();
+        let user_id = Uuid::new_v4().to_string();
+        let run_id = Uuid::new_v4().to_string();
+
+        cleanup_core_persist_fixture_for_owner(&db, &session_id, &user_id).await;
+        sqlx::query(
+            "INSERT INTO agent_sessions (session_id, user_id, title, status, event_count)
+             VALUES (?, ?, 'core-persist-deferred-it', 'active', 0)",
+        )
+        .bind(&session_id)
+        .bind(&user_id)
+        .execute(&db)
+        .await
+        .expect("insert owner session");
+
+        let mut state = crate::turn::agentic_loop::host::make_test_loop_state();
+        state.session_turn = 7;
+        state.final_text = "assistant final".to_string();
+        state.deferred_input.record_delivered_user_inputs(&[
+            crate::turn::agentic_loop::host::DeferredUserInputRecord {
+                event_index: 3,
+                content: "queued two".to_string(),
+            },
+            crate::turn::agentic_loop::host::DeferredUserInputRecord {
+                event_index: 4,
+                content: "queued three".to_string(),
+            },
+        ]);
+
+        persist_server_loop_core_events_impl(
+            &matrixone,
+            Some(&pool),
+            None,
+            &user_id,
+            &session_id,
+            &run_id,
+            None,
+            None,
+            None,
+            None,
+            "initial one",
+            &state,
+            Some("test-model"),
+        )
+        .await
+        .expect("persist core events");
+
+        let event_rows = sqlx::query(
+            "SELECT event_id, event_type, content, parent_event_id
+             FROM agent_events
+             WHERE session_id = ? AND user_id = ?
+             ORDER BY created_at ASC, event_id ASC",
+        )
+        .bind(&session_id)
+        .bind(&user_id)
+        .fetch_all(&db)
+        .await
+        .expect("agent events");
+        let user_query_rows = event_rows
+            .iter()
+            .filter(|row| row.try_get::<String, _>("event_type").unwrap() == "user_query")
+            .collect::<Vec<_>>();
+        let user_message_rows = event_rows
+            .iter()
+            .filter(|row| row.try_get::<String, _>("event_type").unwrap() == "user_message")
+            .collect::<Vec<_>>();
+        let response_rows = event_rows
+            .iter()
+            .filter(|row| row.try_get::<String, _>("event_type").unwrap() == "llm_response")
+            .collect::<Vec<_>>();
+        assert_eq!(user_query_rows.len(), 1, "run must have one audit turn");
+        assert_eq!(user_message_rows.len(), 2, "deferred inputs are messages");
+        assert_eq!(response_rows.len(), 1, "run must have one final response");
+        let root_event_id = user_query_rows[0].try_get::<String, _>("event_id").unwrap();
+        assert_eq!(
+            response_rows[0]
+                .try_get::<Option<String>, _>("parent_event_id")
+                .unwrap()
+                .as_deref(),
+            Some(root_event_id.as_str()),
+            "final response must remain attached to the audit turn root"
+        );
+        assert!(user_message_rows.iter().all(|row| {
+            row.try_get::<Option<String>, _>("parent_event_id")
+                .unwrap()
+                .as_deref()
+                == Some(root_event_id.as_str())
+        }));
+
+        let transcript_rows = sqlx::query(
+            "SELECT role, content
+             FROM session_transcript_items
+             WHERE session_id = ? AND user_id = ?
+             ORDER BY item_seq ASC",
+        )
+        .bind(&session_id)
+        .bind(&user_id)
+        .fetch_all(&db)
+        .await
+        .expect("transcript rows");
+        let transcript_items = transcript_rows
+            .iter()
+            .map(|row| {
+                (
+                    row.try_get::<String, _>("role").unwrap(),
+                    row.try_get::<String, _>("content").unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            transcript_items,
+            vec![
+                ("user".to_string(), "initial one".to_string()),
+                ("user".to_string(), "queued two".to_string()),
+                ("user".to_string(), "queued three".to_string()),
+                ("assistant".to_string(), "assistant final".to_string()),
+            ],
+            "transcript remains the ordered user-facing conversation"
+        );
+
+        cleanup_core_persist_fixture_for_owner(&db, &session_id, &user_id).await;
+    }
+
     #[tokio::test]
     #[ignore = "requires MatrixOne; run with ASTRA_TEST_DB_IT=1"]
     async fn transcript_persistence_writes_owner_scoped_pages_and_rejects_wrong_owner() {
@@ -2389,6 +2594,12 @@ mod tests {
             },
             TranscriptPersistItem {
                 run_id: run_id.clone(),
+                role: "user",
+                content: "second input".to_string(),
+                source_event_id: Uuid::new_v4().to_string(),
+            },
+            TranscriptPersistItem {
+                run_id: run_id.clone(),
                 role: "assistant",
                 content: "world".to_string(),
                 source_event_id: Uuid::new_v4().to_string(),
@@ -2417,8 +2628,38 @@ mod tests {
         .expect("owner transcript page");
         assert_eq!(page.try_get::<String, _>("user_id").unwrap(), owner_user_id);
         assert_eq!(page.try_get::<i64, _>("start_item_seq").unwrap(), 1);
-        assert_eq!(page.try_get::<i64, _>("end_item_seq").unwrap(), 2);
-        assert_eq!(page.try_get::<i64, _>("item_count").unwrap(), 2);
+        assert_eq!(page.try_get::<i64, _>("end_item_seq").unwrap(), 3);
+        assert_eq!(page.try_get::<i64, _>("item_count").unwrap(), 3);
+
+        let owner_rows = sqlx::query(
+            "SELECT role, content
+             FROM session_transcript_items
+             WHERE user_id = ? AND session_id = ?
+             ORDER BY item_seq ASC",
+        )
+        .bind(&owner_user_id)
+        .bind(&session_id)
+        .fetch_all(&db)
+        .await
+        .expect("owner transcript rows");
+        let owner_items = owner_rows
+            .iter()
+            .map(|row| {
+                (
+                    row.try_get::<String, _>("role").unwrap(),
+                    row.try_get::<String, _>("content").unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            owner_items,
+            vec![
+                ("user".to_string(), "hello".to_string()),
+                ("user".to_string(), "second input".to_string()),
+                ("assistant".to_string(), "world".to_string()),
+            ],
+            "transcript must preserve multiple user inputs in one run"
+        );
 
         let same_item_seq_rows = sqlx::query(
             "SELECT COUNT(*) AS c

--- a/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -116,7 +116,7 @@ pub(crate) fn deferred_user_input_text(input: &serde_json::Value) -> Option<Stri
 
 fn render_deferred_user_input(content: &str) -> String {
     format!(
-        "A newer user message arrived during execution and now supersedes the previous plan.\n\nLatest user message:\n{content}\n\nRequired behavior:\n- Treat this as the newest user instruction.\n- Address it before making more tool calls.\n- Do not continue the previous plan blindly.\n- Only make another tool call if it is directly necessary to satisfy this newest user message."
+        "Newer user message(s) arrived during execution and now supersede the previous plan.\n\nNew user message(s):\n{content}\n\nRequired behavior:\n- Treat the last new user message as the newest user instruction.\n- Address it before making more tool calls.\n- Do not continue the previous plan blindly.\n- Only make another tool call if it is directly necessary to satisfy the newest user message."
     )
 }
 
@@ -163,13 +163,25 @@ pub(crate) async fn inject_polled_deferred_user_inputs<H: AgenticLoopHost>(
     }
 
     if !observed.contents.is_empty() {
-        let combined = observed.contents.join("\n\n");
+        let combined = observed
+            .contents
+            .iter()
+            .map(|input| input.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n");
         if !combined.is_empty() {
             state.messages.push(serde_json::json!({
                 "role": "user",
                 "content": combined.clone(),
             }));
-            state.message = combined.clone();
+            state.message = observed
+                .contents
+                .last()
+                .map(|input| input.content.clone())
+                .unwrap_or_default();
+            state
+                .deferred_input
+                .record_delivered_user_inputs(&observed.contents);
             state.push_volatile(
                 super::host::VolatileKind::DeferredUserInput,
                 render_deferred_user_input(&combined),
@@ -3386,7 +3398,8 @@ mod tests {
     use crate::observability::ObservabilityHub;
     use crate::turn::agentic_loop::host::tests::{MockHost, make_state, text_result};
     use crate::turn::agentic_loop::host::{
-        AgenticLoopHost, AgenticLoopState, VolatileKind, run_agentic_loop_with_host,
+        AgenticLoopHost, AgenticLoopState, DeferredUserInputRecord, VolatileKind,
+        run_agentic_loop_with_host,
     };
     use crate::turn::run_control::{RunInputProvider, RunQueuedInputPoll, RunStatusProvider};
     use astra_turn_core::chat_turn_sse_dispatch::ChatTurnSseAccum;
@@ -5404,6 +5417,13 @@ mod tests {
         assert_eq!(*provider.released.lock().await, vec![1]);
         assert_eq!(state.message, "Switch to writing tests first.");
         assert_eq!(
+            state.deferred_input.delivered_user_inputs(),
+            &[DeferredUserInputRecord {
+                event_index: 1,
+                content: "Switch to writing tests first.".to_string(),
+            }]
+        );
+        assert_eq!(
             state
                 .messages
                 .last()
@@ -5415,6 +5435,66 @@ mod tests {
             entry.kind == VolatileKind::DeferredUserInput
                 && entry.content.contains("Switch to writing tests first.")
         }));
+    }
+
+    #[tokio::test]
+    async fn deferred_user_input_records_multiple_inputs_without_consecutive_user_messages() {
+        let mut state = make_state();
+        state.current_run_id = Some("run-queued-many".into());
+        state.context_manifest_user_id = Some("user-deferred".into());
+        let provider = Arc::new(StubRunControlProvider::new(vec![RunQueuedInputPoll {
+            next_cursor: 3,
+            inputs: vec![
+                crate::turn::run_control::QueuedRunInputEvent {
+                    event_index: 1,
+                    input: serde_json::json!({"content": "first queued input"}),
+                },
+                crate::turn::run_control::QueuedRunInputEvent {
+                    event_index: 2,
+                    input: serde_json::json!({"content": "second queued input"}),
+                },
+            ],
+            error: None,
+        }]));
+        state.run_control = Some(provider.clone());
+        let mut host = MockHost::new(vec![]);
+
+        inject_polled_deferred_user_inputs(&mut host, &mut state)
+            .await
+            .unwrap();
+
+        assert_eq!(state.deferred_input.deferred_user_input_cursor(), 3);
+        assert_eq!(*provider.released.lock().await, vec![1, 2]);
+        assert_eq!(state.message, "second queued input");
+        assert_eq!(
+            state.deferred_input.delivered_user_inputs(),
+            &[
+                DeferredUserInputRecord {
+                    event_index: 1,
+                    content: "first queued input".to_string(),
+                },
+                DeferredUserInputRecord {
+                    event_index: 2,
+                    content: "second queued input".to_string(),
+                },
+            ]
+        );
+        assert_eq!(
+            state
+                .messages
+                .last()
+                .and_then(|message| message.get("content"))
+                .and_then(|content| content.as_str()),
+            Some("first queued input\n\nsecond queued input")
+        );
+        assert!(
+            !state.messages.windows(2).any(|window| {
+                window.iter().all(|message| {
+                    message.get("role").and_then(|role| role.as_str()) == Some("user")
+                })
+            }),
+            "deferred input injection must keep prompt history provider-safe"
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/rust/crates/runtime/src/turn/agentic_loop/host.rs
@@ -1046,6 +1046,12 @@ impl StallTrackingState {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeferredUserInputRecord {
+    pub event_index: usize,
+    pub content: String,
+}
+
 #[derive(Default)]
 pub struct DeferredInputState {
     /// Durable event cursor for deferred user-input polling.
@@ -1053,11 +1059,15 @@ pub struct DeferredInputState {
     /// Event indices already delivered to the model but not yet durably marked
     /// as released. Retried on later poll points without re-injecting content.
     pending_release_event_indices: Vec<usize>,
+    /// User messages that were appended to the prompt while this run was
+    /// already active. These must be persisted as transcript items after the
+    /// loop finishes, otherwise session history diverges from prompt history.
+    delivered_user_inputs: Vec<DeferredUserInputRecord>,
 }
 
 pub(crate) struct ObservedDeferredUserInputs {
     pub(crate) raw_inputs: Vec<Value>,
-    pub(crate) contents: Vec<String>,
+    pub(crate) contents: Vec<DeferredUserInputRecord>,
     pub(crate) released_event_indices: Vec<usize>,
     pub(crate) next_cursor: usize,
 }
@@ -1065,6 +1075,14 @@ pub(crate) struct ObservedDeferredUserInputs {
 impl DeferredInputState {
     pub fn deferred_user_input_cursor(&self) -> usize {
         self.deferred_user_input_cursor
+    }
+
+    pub fn delivered_user_inputs(&self) -> &[DeferredUserInputRecord] {
+        &self.delivered_user_inputs
+    }
+
+    pub(crate) fn record_delivered_user_inputs(&mut self, inputs: &[DeferredUserInputRecord]) {
+        self.delivered_user_inputs.extend_from_slice(inputs);
     }
 
     pub(crate) fn release_event_indices_to_ack(&self, observed: &[usize]) -> Vec<usize> {
@@ -1108,7 +1126,10 @@ impl DeferredInputState {
             let Some(content) = content_from_input(&event.input) else {
                 continue;
             };
-            contents.push(content);
+            contents.push(DeferredUserInputRecord {
+                event_index: event.event_index,
+                content,
+            });
         }
 
         ObservedDeferredUserInputs {

--- a/rust/crates/services/src/storage.rs
+++ b/rust/crates/services/src/storage.rs
@@ -1705,7 +1705,8 @@ pub async fn ensure_core_schema(
             content_hash VARCHAR(128) NOT NULL,
             created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
             PRIMARY KEY (user_id, session_id, item_seq),
-            INDEX idx_transcript_owner_run_event (user_id, run_id, source_event_idx)
+            INDEX idx_transcript_owner_run_event (user_id, run_id, source_event_idx),
+            INDEX idx_transcript_owner_session_source_event (user_id, session_id, source_event_id)
         )",
     )
     .execute(&pool)
@@ -1725,6 +1726,15 @@ pub async fn ensure_core_schema(
         "idx_transcript_owner_run_event",
         &["user_id", "run_id", "source_event_idx"],
         "ALTER TABLE session_transcript_items ADD INDEX idx_transcript_owner_run_event (user_id, run_id, source_event_idx)",
+    )
+    .await?;
+    ensure_index_shape(
+        &pool,
+        &settings.database,
+        "session_transcript_items",
+        "idx_transcript_owner_session_source_event",
+        &["user_id", "session_id", "source_event_id"],
+        "ALTER TABLE session_transcript_items ADD INDEX idx_transcript_owner_session_source_event (user_id, session_id, source_event_id)",
     )
     .await?;
     query(

--- a/rust/crates/services/tests/schema_assertions.rs
+++ b/rust/crates/services/tests/schema_assertions.rs
@@ -1290,6 +1290,17 @@ async fn phase2_web_hydration_schema_contract() {
         ["user_id", "run_id", "source_event_idx"],
         "transcript source event lookups must be owner-bound"
     );
+    assert_eq!(
+        index_columns(
+            &pool,
+            &schema,
+            "session_transcript_items",
+            "idx_transcript_owner_session_source_event"
+        )
+        .await,
+        ["user_id", "session_id", "source_event_id"],
+        "transcript source-event idempotency lookups must be owner/session-bound"
+    );
     let transcript_page_columns = column_names(&pool, &schema, "transcript_pages").await;
     assert!(
         transcript_page_columns

--- a/web/lib/api/web-store.ts
+++ b/web/lib/api/web-store.ts
@@ -890,13 +890,16 @@ export async function sendMessage(
     chat.model = payload.options.model;
   }
 
+  const backendSessionId = await ensureChatBackendSession(ownerUserId, chat.id, {
+    model: payload.options?.model ?? chat.model,
+  });
   const agentResult = await callBackendAgent({
-    sessionId: chat.id,
+    sessionId: backendSessionId,
     text: payload.content,
     model: selectedWebModel(payload.options?.model ?? chat.model),
     activeSkills: payload.options?.activeSkills,
   });
-  assertBackendSessionMatchesChat(chat.id, agentResult.sessionId);
+  assertBackendSessionMatchesChat(backendSessionId, agentResult.sessionId);
   const assistantMessage = appendAssistantMessage(
     chat,
     agentResult.assistantText,


### PR DESCRIPTION
## Why
- Fix missing chat context continuity when users send follow-up questions during an active run.
- Distinguish audit-turn user_query from user_message rows for deferred inputs.
- Persist deferred user inputs into session transcript without splitting audit turns.
- Keep provider prompts valid (no consecutive role=user injections).
- Ensure frontend sends correct backend session id.

## What changed
- runtime: split deferred input tracking by event_index/content and include in core persistence output.
- runtime: inject deferred inputs as a single combined user message into prompt state and track as delivered inputs.
- services: add transcript index on source_event_id and schema assertion.
- web: ensure sendMessage uses runtime session id from ensureChatBackendSession.

## Testing
- cargo test and integration tests for core persistence/trancript behavior were run before commit.