### PR TITLE
fix(runtime): gate reflect on configured service

### DIFF
--- a/rust/crates/astra-turn-core/src/capability.rs
+++ b/rust/crates/astra-turn-core/src/capability.rs
@@ -28,9 +28,25 @@ pub enum Capability {
     PlanLifecycle,
     /// Local/edge background task registry and projection control.
     LocalBackgroundTasks,
+    /// Persisted session reflection service used by `reflect`.
+    ReflectService,
 }
 
 impl Capability {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Capability::AgentSpawner => "agent_spawner",
+            Capability::MemoryService => "memory_service",
+            Capability::Database => "database",
+            Capability::SkillsCatalog => "skills_catalog",
+            Capability::GitHubAuth => "github_auth",
+            Capability::LSPServer => "lsp_server",
+            Capability::PlanLifecycle => "plan_lifecycle",
+            Capability::LocalBackgroundTasks => "local_background_tasks",
+            Capability::ReflectService => "reflect_service",
+        }
+    }
+
     /// Whether this capability requires a runtime executor binding.
     ///
     /// An executor-gated capability cannot be satisfied by a service or static
@@ -62,6 +78,7 @@ impl CapabilitySet {
             .with(Capability::GitHubAuth)
             .with(Capability::LSPServer)
             .with(Capability::PlanLifecycle)
+            .with(Capability::ReflectService)
         // NOTE: LocalBackgroundTasks is intentionally excluded — it is an
         // edge-only capability (typed background tasks like bg-shell).
         // Server-side ToolEngine has no handlers for task_output / task_stop
@@ -129,6 +146,7 @@ mod tests {
             Capability::GitHubAuth,
             Capability::LSPServer,
             Capability::PlanLifecycle,
+            Capability::ReflectService,
         ] {
             assert!(caps.has(capability), "missing {capability:?}");
         }

--- a/rust/crates/astra-turn-core/src/tool/registry/meta.rs
+++ b/rust/crates/astra-turn-core/src/tool/registry/meta.rs
@@ -341,7 +341,7 @@ pub static TOOL_CATALOG: &[ToolMeta] = &[
         ],
         intents: &[IntentType::Introspect, IntentType::CodeRead],
         scope: Scope::Local,
-        requires: &[],
+        requires: &[Capability::ReflectService],
         binding_validation: RuntimeBindingValidation::None,
         schema_tokens: 45,
     },
@@ -946,6 +946,7 @@ mod tests {
             ("skill", Capability::SkillsCatalog),
             ("enter_plan_mode", Capability::PlanLifecycle),
             ("exit_plan_mode", Capability::PlanLifecycle),
+            ("reflect", Capability::ReflectService),
         ];
         for (name, expected) in cases {
             let tool = TOOL_CATALOG

--- a/rust/crates/runtime/src/capabilities.rs
+++ b/rust/crates/runtime/src/capabilities.rs
@@ -136,6 +136,7 @@ pub fn full_server_capabilities_for_tests() -> astra_turn_core::capability::Capa
 /// Production-truth `CapabilitySet` for an agentic-run lifecycle.
 pub fn lifecycle_server_capabilities(
     database_pool_present: bool,
+    reflect_service_configured: bool,
 ) -> astra_turn_core::capability::CapabilitySet {
     use astra_turn_core::capability::{Capability, CapabilitySet};
     CapabilitySet::empty()
@@ -145,13 +146,17 @@ pub fn lifecycle_server_capabilities(
         .with(Capability::SkillsCatalog)
         .with(Capability::GitHubAuth)
         .with(Capability::PlanLifecycle)
+        .with_if(reflect_service_configured, Capability::ReflectService)
 }
 
 /// Production-truth server `CapabilitySet` derived from [`crate::app_state::AppState`].
 pub fn server_capabilities_from(
     state: &crate::app_state::AppState,
 ) -> astra_turn_core::capability::CapabilitySet {
-    lifecycle_server_capabilities(state.shared_pool.is_some())
+    lifecycle_server_capabilities(
+        state.shared_pool.is_some(),
+        state.reflect_service.is_configured(),
+    )
 }
 
 /// Tool schemas for Web agent / server-executed turns.
@@ -647,7 +652,7 @@ mod tests {
         );
 
         // ── Background task tools: local-only ──
-        let server_caps = lifecycle_server_capabilities(true);
+        let server_caps = lifecycle_server_capabilities(true, true);
         let local_caps = CapabilitySet::empty()
             .with(Capability::MemoryService)
             .with(Capability::SkillsCatalog)
@@ -680,7 +685,7 @@ mod tests {
 
     #[test]
     fn server_executed_tool_descriptions_do_not_reference_unavailable_job_tool() {
-        let caps = lifecycle_server_capabilities(true);
+        let caps = lifecycle_server_capabilities(true, true);
         let server_tools = server_runtime_tool_schemas(&caps);
         let remote_tools = cli_remote_tool_schemas(Vec::new(), &caps);
 
@@ -756,19 +761,35 @@ mod tests {
     }
 
     #[test]
+    fn server_executed_surfaces_hide_reflect_without_reflect_service_capability() {
+        let caps = lifecycle_server_capabilities(true, false);
+        let web = names(server_runtime_tool_schemas(&caps));
+        let remote = names(cli_remote_tool_schemas(Vec::new(), &caps));
+
+        for (surface, names) in [("web", web), ("remote", remote)] {
+            assert!(
+                !names.contains(&"reflect".to_string()),
+                "{surface} must not advertise reflect until the reflect service is configured: {names:?}"
+            );
+        }
+    }
+
+    #[test]
     fn server_lifecycle_capabilities() {
         use astra_turn_core::capability::Capability;
 
         // AgentSpawner is always included
-        let caps = lifecycle_server_capabilities(true);
+        let caps = lifecycle_server_capabilities(true, true);
         assert!(
             caps.has(Capability::AgentSpawner),
             "server lifecycle must include AgentSpawner"
         );
 
         // Database is gated on pool availability
-        assert!(!lifecycle_server_capabilities(false).has(Capability::Database));
+        assert!(!lifecycle_server_capabilities(false, true).has(Capability::Database));
         assert!(caps.has(Capability::Database));
+        assert!(!lifecycle_server_capabilities(true, false).has(Capability::ReflectService));
+        assert!(caps.has(Capability::ReflectService));
 
         // Web resolve with lifecycle caps advertises agent tool
         let tool_names = names(server_runtime_tool_schemas(&caps));

--- a/rust/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/rust/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -159,6 +159,13 @@ fn wire_executor_into_state(
     state.server_tool_executor = Some(executor);
 }
 
+fn wire_reflect_service_into_executor(
+    executor: server_tool_executor::ServerToolExecutor,
+    service: &Arc<dyn astra_services::ReflectService>,
+) -> server_tool_executor::ServerToolExecutor {
+    executor.with_reflect_service(Arc::clone(service))
+}
+
 struct NonInteractiveApprovalGate;
 
 #[async_trait]
@@ -613,6 +620,7 @@ fn build_server_skill_executor(
     request_constraints: RequestConstraints,
     inherited_permissions: InheritedPermissions,
     skill_resolver: Option<Arc<dyn crate::turn::skill_tool::SkillResolver>>,
+    reflect_service: Arc<dyn astra_services::ReflectService>,
     session_id: &str,
     edge_connection_pool: Option<&astra_server_types::edge_connection_pool::EdgeConnectionPool>,
     cancel_token: Option<Arc<tokio_util::sync::CancellationToken>>,
@@ -638,6 +646,7 @@ fn build_server_skill_executor(
     .with_request_constraints(request_constraints)
     .with_inherited_permissions(inherited_permissions)
     .with_skill_resolver(skill_resolver)
+    .with_reflect_service(reflect_service)
     .with_cancel_token(cancel_token);
     if let Some(snapshot) = execution_bindings {
         subrun_executor = subrun_executor.with_execution_binding_snapshot(snapshot.clone());
@@ -1485,6 +1494,8 @@ pub struct AgenticRunLifecycleService {
     memory_extraction_service: Option<Arc<crate::session_memory::MemoryExtractionService>>,
     /// Shared ToolExecutionService so executors share the same disabled_tools set.
     tool_execution_service: Option<ToolExecutionService>,
+    /// Shared persisted-reflection service used by the visible `reflect` tool.
+    reflect_service: Arc<dyn astra_services::ReflectService>,
 }
 
 impl AgenticRunLifecycleService {
@@ -1532,6 +1543,7 @@ impl AgenticRunLifecycleService {
             harness_registry: None,
             memory_extraction_service: None,
             tool_execution_service: None,
+            reflect_service: Arc::new(astra_services::UnconfiguredReflectService),
         }
     }
 
@@ -1600,6 +1612,14 @@ impl AgenticRunLifecycleService {
 
     pub fn with_tool_execution_service(mut self, service: ToolExecutionService) -> Self {
         self.tool_execution_service = Some(service);
+        self
+    }
+
+    pub fn with_reflect_service(
+        mut self,
+        service: Arc<dyn astra_services::ReflectService>,
+    ) -> Self {
+        self.reflect_service = service;
         self
     }
 
@@ -1810,7 +1830,8 @@ impl AgenticRunLifecycleService {
             .with_pool(self.shared_pool.clone())
             .with_edge_connection_pool(self.edge_connection_pool.clone())
             .with_skill_service(self.skill_service.clone())
-            .with_memory_extraction_service(self.memory_extraction_service.clone()),
+            .with_memory_extraction_service(self.memory_extraction_service.clone())
+            .with_reflect_service(Arc::clone(&self.reflect_service)),
         );
         let executor_for_spawner: Arc<dyn SpawnAgentExecutor> = executor.clone();
         let mut spawner = DynamicAgentSpawner::with_broadcaster(
@@ -3128,6 +3149,7 @@ impl AgenticRunLifecycleService {
         .with_static_tool_catalog_admissible(static_tool_catalog_admissible)
         .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
             self.shared_pool.is_some(),
+            self.reflect_service.is_configured(),
         ))
         .with_edge_profile(edge_profile)
         .with_edge_callback_ledger(self.edge_callback_ledger.clone())
@@ -3406,6 +3428,7 @@ impl AgenticRunLifecycleService {
             request_constraints.clone(),
             root_permissions.clone(),
             skill_resolver.clone(),
+            Arc::clone(&self.reflect_service),
             session_id,
             self.edge_connection_pool.as_ref(),
             cancel_token,
@@ -4844,15 +4867,18 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 session_id.clone(),
                 memoria_base,
                 None,
-            )
-            .with_cancel_token(loop_state.cancellation.token.clone())
-            .with_task_store(task_store);
+            );
+            executor = wire_reflect_service_into_executor(executor, &self.reflect_service)
+                .with_cancel_token(loop_state.cancellation.token.clone())
+                .with_task_store(task_store);
             if agent_binding_mode {
                 executor = executor.with_server_builtin_tools_disabled();
             } else {
-                executor = executor.with_capabilities(
-                    crate::capabilities::lifecycle_server_capabilities(self.shared_pool.is_some()),
-                );
+                executor =
+                    executor.with_capabilities(crate::capabilities::lifecycle_server_capabilities(
+                        self.shared_pool.is_some(),
+                        self.reflect_service.is_configured(),
+                    ));
             }
 
             // Enable exactly-once tool execution for crash recovery dedup.
@@ -5670,15 +5696,18 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 session_id.clone(),
                 memoria_base,
                 None,
-            )
-            .with_cancel_token(state.cancellation.token.clone())
-            .with_task_store(task_store);
+            );
+            executor = wire_reflect_service_into_executor(executor, &self.reflect_service)
+                .with_cancel_token(state.cancellation.token.clone())
+                .with_task_store(task_store);
             if agent_binding_mode {
                 executor = executor.with_server_builtin_tools_disabled();
             } else {
-                executor = executor.with_capabilities(
-                    crate::capabilities::lifecycle_server_capabilities(self.shared_pool.is_some()),
-                );
+                executor =
+                    executor.with_capabilities(crate::capabilities::lifecycle_server_capabilities(
+                        self.shared_pool.is_some(),
+                        self.reflect_service.is_configured(),
+                    ));
             }
 
             // Enable exactly-once tool execution for crash recovery dedup.
@@ -6707,6 +6736,7 @@ pub struct ServerSpawnAgentExecutor {
     edge_registry_service: Option<Arc<dyn astra_services::multi_agent::EdgeRegistryService>>,
     skill_service: Option<Arc<dyn SkillService>>,
     memory_extraction_service: Option<Arc<crate::session_memory::MemoryExtractionService>>,
+    reflect_service: Arc<dyn astra_services::ReflectService>,
     runtime_contexts: Arc<RwLock<HashMap<String, ServerSpawnRuntimeContext>>>,
 }
 
@@ -6726,6 +6756,7 @@ impl ServerSpawnAgentExecutor {
             edge_registry_service: None,
             skill_service: None,
             memory_extraction_service: None,
+            reflect_service: Arc::new(astra_services::UnconfiguredReflectService),
             runtime_contexts: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -6769,6 +6800,14 @@ impl ServerSpawnAgentExecutor {
         svc: Option<Arc<crate::session_memory::MemoryExtractionService>>,
     ) -> Self {
         self.memory_extraction_service = svc;
+        self
+    }
+
+    pub fn with_reflect_service(
+        mut self,
+        service: Arc<dyn astra_services::ReflectService>,
+    ) -> Self {
+        self.reflect_service = service;
         self
     }
 
@@ -6831,6 +6870,7 @@ impl ServerSpawnAgentExecutor {
         if let Some(svc) = self.memory_extraction_service.clone() {
             executor = executor.with_memory_extraction_service(svc);
         }
+        executor = executor.with_reflect_service(Arc::clone(&self.reflect_service));
         executor
     }
 }
@@ -7095,6 +7135,7 @@ pub struct ServerSubRunExecutor {
     edge_registry_service: Option<Arc<dyn astra_services::multi_agent::EdgeRegistryService>>,
     skill_service: Option<Arc<dyn SkillService>>,
     memory_extraction_service: Option<Arc<crate::session_memory::MemoryExtractionService>>,
+    reflect_service: Arc<dyn astra_services::ReflectService>,
     inherited_permissions: InheritedPermissions,
     /// Shared ToolExecutionService so executors share the same disabled_tools set.
     pub tool_execution_service: Option<ToolExecutionService>,
@@ -7118,6 +7159,7 @@ impl ServerSubRunExecutor {
             edge_registry_service: None,
             skill_service: None,
             memory_extraction_service: None,
+            reflect_service: Arc::new(astra_services::UnconfiguredReflectService),
             inherited_permissions: InheritedPermissions::auto_approve(),
             tool_execution_service: None,
             #[cfg(feature = "bridge-e2e-hooks")]
@@ -7143,6 +7185,14 @@ impl ServerSubRunExecutor {
         inherited_permissions: InheritedPermissions,
     ) -> Self {
         self.inherited_permissions = inherited_permissions;
+        self
+    }
+
+    pub fn with_reflect_service(
+        mut self,
+        service: Arc<dyn astra_services::ReflectService>,
+    ) -> Self {
+        self.reflect_service = service;
         self
     }
 
@@ -7273,6 +7323,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
         .with_llm_token_service(config.llm_token_service.clone())
         .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
             self.shared_pool.is_some(),
+            self.reflect_service.is_configured(),
         ))
         .with_edge_profile(edge_profile)
         .with_edge_callback_ledger(self.edge_callback_ledger.clone());
@@ -7525,12 +7576,14 @@ impl SubRunExecutor for ServerSubRunExecutor {
                 config.session_id.clone(),
                 memoria_base,
                 None,
-            )
-            .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
-                self.shared_pool.is_some(),
-            ))
-            .with_cancel_token(config.cancel_token.clone())
-            .with_task_store(task_store);
+            );
+            executor = wire_reflect_service_into_executor(executor, &self.reflect_service)
+                .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
+                    self.shared_pool.is_some(),
+                    self.reflect_service.is_configured(),
+                ))
+                .with_cancel_token(config.cancel_token.clone())
+                .with_task_store(task_store);
 
             // Enable exactly-once tool execution for crash recovery dedup.
             // This prevents side-effect tools (github_create_issue, task create, etc.)
@@ -14364,6 +14417,52 @@ mod tests {
         assert!(
             fn_body.contains("with_inherited_permissions"),
             "build_server_skill_executor must pass request-level permissions to server skill sub-runs"
+        );
+    }
+
+    #[test]
+    fn build_server_skill_executor_wires_reflect_service() {
+        let source = include_str!("mod.rs");
+        let fn_start = source
+            .find("fn build_server_skill_executor(")
+            .expect("build_server_skill_executor must exist");
+        let fn_end = source[fn_start..]
+            .find("\npub(crate) fn ")
+            .or_else(|| source[fn_start..].find("\nfn "))
+            .map(|p| fn_start + p)
+            .unwrap_or(source.len());
+        let fn_body = &source[fn_start..fn_end];
+        assert!(
+            fn_body.contains("reflect_service: Arc<dyn astra_services::ReflectService>"),
+            "build_server_skill_executor must accept the shared reflect service"
+        );
+        assert!(
+            fn_body.contains(".with_reflect_service(reflect_service)"),
+            "build_server_skill_executor must pass reflect service to server skill sub-runs"
+        );
+    }
+
+    #[test]
+    fn lifecycle_executor_construction_wires_reflect_service() {
+        let source = include_str!("mod.rs");
+        let production = source
+            .split("\n#[cfg(test)]\nmod tests")
+            .next()
+            .expect("production lifecycle source");
+        let root_wires = production
+            .matches("wire_reflect_service_into_executor(executor, &self.reflect_service)")
+            .count();
+        assert!(
+            root_wires >= 3,
+            "root/resume/sub-run ServerToolExecutor construction must all inject the shared reflect service"
+        );
+        assert!(
+            production.contains(".with_reflect_service(Arc::clone(&self.reflect_service))"),
+            "dynamic agent spawner/sub-run builders must inherit the shared reflect service"
+        );
+        assert!(
+            production.contains("self.reflect_service.is_configured()"),
+            "capability construction must derive reflect visibility from reflect service readiness"
         );
     }
 

--- a/rust/crates/runtime/src/server/server_loop_host.rs
+++ b/rust/crates/runtime/src/server/server_loop_host.rs
@@ -2670,6 +2670,29 @@ impl ServerAgenticLoopHost {
         filter_tool_schemas_by_excluded_names(self.edge_tools.clone(), restricted_tools)
     }
 
+    fn runtime_ready_turn_tools(&self, tools: Vec<Value>, state: &AgenticLoopState) -> Vec<Value> {
+        let Some(executor) = state.server_tool_executor.as_deref() else {
+            return tools;
+        };
+        tools
+            .into_iter()
+            .filter(|tool| {
+                tool.get("function")
+                    .and_then(|function| function.get("name"))
+                    .and_then(Value::as_str)
+                    .is_some_and(|name| executor.tool_runtime_ready(name))
+            })
+            .collect()
+    }
+
+    fn filtered_runtime_ready_turn_tools(
+        &self,
+        restricted_tools: &HashSet<String>,
+        state: &AgenticLoopState,
+    ) -> Vec<Value> {
+        self.runtime_ready_turn_tools(self.filtered_turn_tools(restricted_tools), state)
+    }
+
     fn runtime_allowlist_restrictions(&self, state: &AgenticLoopState) -> HashSet<String> {
         let disabled: HashSet<String> = self
             .disabled_tools
@@ -2908,7 +2931,7 @@ impl ServerAgenticLoopHost {
     #[cfg(test)]
     fn visible_turn_tools(&mut self, state: &mut AgenticLoopState) -> Vec<Value> {
         let effective_restricted = self.compute_effective_restricted(state, true);
-        let visible = self.filtered_turn_tools(&effective_restricted);
+        let visible = self.filtered_runtime_ready_turn_tools(&effective_restricted, state);
         self.sync_valid_tools_to_wire_surface_for_state(&visible, state);
         visible
     }
@@ -3386,7 +3409,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
             .to_string();
 
         let effective_restricted = self.compute_effective_restricted(state, true);
-        let visible_tools = self.filtered_turn_tools(&effective_restricted);
+        let visible_tools = self.filtered_runtime_ready_turn_tools(&effective_restricted, state);
 
         // Latch prompt cache config from provider info (once per turn is fine;
         // provider doesn't change within a turn).
@@ -4047,7 +4070,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
             .to_string();
 
         let effective_restricted = self.compute_effective_restricted(state, false);
-        let visible_tools = self.filtered_turn_tools(&effective_restricted);
+        let visible_tools = self.filtered_runtime_ready_turn_tools(&effective_restricted, state);
         // We only need the system messages here — the inline summary call
         // reuses the main turn's system prefix, not its tools.
         let system_messages = match self.run_turn_pipeline(
@@ -4791,7 +4814,9 @@ mod tests {
             "u1".to_string(),
             "s1".to_string(),
         )
-        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(false))
+        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
+            false, false,
+        ))
         .build();
 
         assert!(host.server_side_tools);
@@ -4809,7 +4834,9 @@ mod tests {
             "u1".to_string(),
             "s1".to_string(),
         )
-        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(false))
+        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
+            false, false,
+        ))
         .with_server_tool_catalog_enabled(false)
         .build();
 
@@ -4828,7 +4855,9 @@ mod tests {
             "u1".to_string(),
             "s1".to_string(),
         )
-        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(false))
+        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
+            false, false,
+        ))
         .with_server_tool_catalog_enabled(false)
         .with_static_tool_catalog_admissible(false)
         .build();
@@ -4856,7 +4885,9 @@ mod tests {
             "u1".to_string(),
             "s1".to_string(),
         )
-        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(false))
+        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
+            false, false,
+        ))
         .with_server_tool_catalog_enabled(false)
         .with_static_tool_catalog_admissible(false)
         .build();
@@ -4887,7 +4918,9 @@ mod tests {
             "u1".to_string(),
             "s1".to_string(),
         )
-        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(false))
+        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
+            false, false,
+        ))
         .with_edge_tools(sample_edge_tools())
         .with_execution_binding_snapshot(edge_runtime_snapshot())
         .build();
@@ -7060,6 +7093,66 @@ mod tests {
             "soft health must not mutate hard restricted_tools"
         );
         assert!(state.restricted_tools.contains("read_file"));
+    }
+
+    #[test]
+    fn visible_turn_tools_filters_executor_service_unready_tools() {
+        let dir = tempfile::TempDir::new().expect("temp workspace");
+        let mut host = ServerAgenticLoopHostBuilder::new(
+            mock_matrixone(),
+            mock_encryptor(),
+            "u".to_string(),
+            "s".to_string(),
+        )
+        .with_server_sandbox_workspace(dir.path())
+        .build();
+        let raw_names = astra_turn_core::tool::schema::tool_names_from_schemas(&host.edge_tools);
+        assert!(
+            raw_names.contains("reflect"),
+            "capability-only server surface starts with reflect before executor readiness filtering"
+        );
+
+        let mut state = create_test_state();
+        state.server_tool_executor = Some(Arc::new(
+            crate::server::server_tool_executor::ServerToolExecutor::new(
+                dir.path().to_path_buf(),
+                "u".to_string(),
+                "s".to_string(),
+                None,
+                None,
+            ),
+        ));
+
+        let visible = host.visible_turn_tools(&mut state);
+        let names = astra_turn_core::tool::schema::tool_names_from_schemas(&visible);
+        assert!(
+            !names.contains("reflect"),
+            "service-unready tools must not be visible to the model: {names:?}"
+        );
+        assert!(
+            names.contains("introspect"),
+            "ready observation tools should remain visible"
+        );
+    }
+
+    #[test]
+    fn builder_hides_reflect_without_reflect_service_capability() {
+        let host = ServerAgenticLoopHostBuilder::new(
+            mock_matrixone(),
+            mock_encryptor(),
+            "u".to_string(),
+            "s".to_string(),
+        )
+        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
+            true, false,
+        ))
+        .build();
+
+        let names = astra_turn_core::tool::schema::tool_names_from_schemas(&host.edge_tools);
+        assert!(
+            !names.contains("reflect"),
+            "builder must fail closed before executor filtering when the reflect service is unconfigured: {names:?}"
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/server/server_skill_subrun.rs
+++ b/rust/crates/runtime/src/server/server_skill_subrun.rs
@@ -17,7 +17,7 @@ use tokio::sync::Mutex as TokioMutex;
 
 use astra_core::SharedPool;
 use astra_runtime_env::validate_workspace_id;
-use astra_services::LlmTokenServiceConfig;
+use astra_services::{LlmTokenServiceConfig, ReflectService, UnconfiguredReflectService};
 
 use crate::FernetTokenEncryptor;
 use crate::MatrixOneSettings;
@@ -89,6 +89,8 @@ pub struct ServerSkillSubRunExecutor {
     /// from the parent lifecycle service. `None` → no extraction in
     /// skill sub-runs (rarely surfaces user-relevant memory).
     memory_extraction_service: Option<Arc<crate::session_memory::MemoryExtractionService>>,
+    /// Shared persisted-reflection service inherited from the parent run.
+    reflect_service: Arc<dyn ReflectService>,
     /// Request-level permissions inherited from the parent server run.
     inherited_permissions: crate::orchestration::InheritedPermissions,
 }
@@ -119,6 +121,7 @@ impl ServerSkillSubRunExecutor {
             #[cfg(feature = "harness")]
             harness_sink: None,
             memory_extraction_service: None,
+            reflect_service: Arc::new(UnconfiguredReflectService),
             inherited_permissions: crate::orchestration::InheritedPermissions::auto_approve(),
         }
     }
@@ -128,6 +131,11 @@ impl ServerSkillSubRunExecutor {
         svc: Arc<crate::session_memory::MemoryExtractionService>,
     ) -> Self {
         self.memory_extraction_service = Some(svc);
+        self
+    }
+
+    pub fn with_reflect_service(mut self, service: Arc<dyn ReflectService>) -> Self {
+        self.reflect_service = service;
         self
     }
 
@@ -309,6 +317,7 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
         .with_edge_tools(self.edge_tools.clone())
         .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
             self.shared_pool.is_some(),
+            self.reflect_service.is_configured(),
         ))
         .with_edge_profile(self.edge_profile.clone())
         .with_edge_callback_ledger(Arc::new(TokioMutex::new(HashMap::new())));
@@ -555,8 +564,10 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
                 memoria_base,
                 None,
             )
+            .with_reflect_service(Arc::clone(&self.reflect_service))
             .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
                 self.shared_pool.is_some(),
+                self.reflect_service.is_configured(),
             ))
             .with_cancel_token(self.cancel_token.clone())
             .with_tool_execution_service(builder.build());
@@ -593,6 +604,7 @@ mod tests {
     use crate::server::tool_transport::{
         ExecutorBinding, ExecutorStatus, ToolTransportKind, WorkspaceAuthority, WorkspaceBinding,
     };
+    use async_trait::async_trait;
 
     fn mock_matrixone() -> MatrixOneSettings {
         MatrixOneSettings::mock()
@@ -619,6 +631,24 @@ mod tests {
         )
     }
 
+    struct ReadyReflectService;
+
+    #[async_trait]
+    impl ReflectService for ReadyReflectService {
+        fn is_configured(&self) -> bool {
+            true
+        }
+
+        async fn build_evidence(
+            &self,
+            _user_id: &str,
+            _session_id: &str,
+            _request: astra_services::reflect::ReflectRequest,
+        ) -> astra_services::reflect::ServiceResult<astra_services::ReflectReport> {
+            unreachable!("server skill subrun tests only inspect service readiness")
+        }
+    }
+
     #[test]
     fn server_skill_subrun_executor_builds() {
         let executor = ServerSkillSubRunExecutor::new(
@@ -632,6 +662,10 @@ mod tests {
         assert_eq!(
             executor.inherited_permissions.mode,
             crate::orchestration::PermissionMode::Auto
+        );
+        assert!(
+            !executor.reflect_service.is_configured(),
+            "skill sub-runs must fail closed until the parent reflect service is injected"
         );
     }
 
@@ -656,6 +690,18 @@ mod tests {
         assert!(executor.llm_token_service.is_some());
         assert_eq!(executor.edge_tools.len(), 1);
         assert!(executor.cancel_token.is_some());
+    }
+
+    #[test]
+    fn server_skill_subrun_executor_keeps_reflect_service() {
+        let executor = ServerSkillSubRunExecutor::new(
+            mock_matrixone(),
+            mock_encryptor(),
+            "test-session".to_string(),
+        )
+        .with_reflect_service(Arc::new(ReadyReflectService));
+
+        assert!(executor.reflect_service.is_configured());
     }
 
     #[test]

--- a/rust/crates/runtime/src/server/server_tool_executor.rs
+++ b/rust/crates/runtime/src/server/server_tool_executor.rs
@@ -89,6 +89,14 @@ fn resolved_server_tool_names(
         .collect()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ToolAdmission {
+    Ready,
+    MissingRuntimeBinding,
+    MissingCapability(Capability),
+    MissingService(Capability),
+}
+
 /// Per-turn mutation accounting for self-modifying session config tools.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SessionConfigInner {
@@ -521,6 +529,9 @@ impl ServerToolExecutor {
             let mut activatable_pool =
                 crate::capabilities::server_runtime_tool_schemas(&self.capabilities);
             retain_tool_schemas_by_names(&mut activatable_pool, &activatable);
+            activatable_pool.retain(|schema| {
+                tool_schema_name(schema).is_some_and(|name| self.tool_runtime_ready(name))
+            });
             extend_tool_schema_pool_unique(&mut pool, activatable_pool);
         }
         pool.extend(self.external_schemas_snapshot("external_schemas_tool_search"));
@@ -670,7 +681,7 @@ impl ServerToolExecutor {
             self.execution_binding.executor(),
             self.execution_binding.runtime(),
         );
-        supported_names.contains(tool) && self.tool_has_runtime_binding(tool)
+        supported_names.contains(tool) && self.tool_runtime_ready(tool)
     }
 
     fn capability_filtered_server_tool_schemas(&self) -> Vec<Value> {
@@ -684,7 +695,7 @@ impl ServerToolExecutor {
             self.execution_binding.runtime(),
         );
         schemas.retain(|schema| {
-            tool_schema_name(schema).is_some_and(|name| self.tool_has_runtime_binding(name))
+            tool_schema_name(schema).is_some_and(|name| self.tool_runtime_ready(name))
         });
         schemas
     }
@@ -695,8 +706,48 @@ impl ServerToolExecutor {
 
     pub(crate) fn runtime_bound_tool_names(&self, names: HashSet<String>) -> HashSet<String> {
         astra_turn_core::tool::deferred_activation::runtime_bound_tool_names(names, |name| {
-            self.tool_has_runtime_binding(name)
+            self.tool_runtime_ready(name)
         })
+    }
+
+    pub(crate) fn tool_runtime_ready(&self, name: &str) -> bool {
+        matches!(self.tool_admission(name), ToolAdmission::Ready)
+    }
+
+    fn tool_admission(&self, name: &str) -> ToolAdmission {
+        if name.starts_with("mcp__") {
+            return if self.mcp_tool_has_runtime_binding(name) {
+                ToolAdmission::Ready
+            } else {
+                ToolAdmission::MissingRuntimeBinding
+            };
+        }
+
+        let Some(meta) = astra_turn_core::tool::registry::meta::tool_meta(name) else {
+            return if self.tool_engine.contains(name) || self.plugin_schema_has_name(name) {
+                ToolAdmission::Ready
+            } else {
+                ToolAdmission::MissingRuntimeBinding
+            };
+        };
+
+        for capability in meta.requires {
+            if !self.capabilities.has(*capability) {
+                return if self.capability_is_service_dependency(*capability) {
+                    ToolAdmission::MissingService(*capability)
+                } else {
+                    ToolAdmission::MissingCapability(*capability)
+                };
+            }
+            if !self.capability_has_runtime_binding(*capability) {
+                return ToolAdmission::MissingRuntimeBinding;
+            }
+            if !self.capability_service_dependency_ready(*capability) {
+                return ToolAdmission::MissingService(*capability);
+            }
+        }
+
+        ToolAdmission::Ready
     }
 
     fn tool_has_runtime_binding(&self, name: &str) -> bool {
@@ -743,6 +794,17 @@ impl ServerToolExecutor {
         }
     }
 
+    fn capability_is_service_dependency(&self, capability: Capability) -> bool {
+        matches!(capability, Capability::ReflectService)
+    }
+
+    fn capability_service_dependency_ready(&self, capability: Capability) -> bool {
+        match capability {
+            Capability::ReflectService => self.reflect_service.is_configured(),
+            _ => true,
+        }
+    }
+
     fn tool_can_validate_without_runtime_binding(&self, name: &str, args: &Value) -> bool {
         let action = args.get("action").and_then(Value::as_str);
         astra_turn_core::tool::registry::meta::tool_allows_validation_without_runtime_binding(
@@ -773,17 +835,68 @@ impl ServerToolExecutor {
         )
     }
 
+    fn capability_unavailable_error_result(
+        &self,
+        name: &str,
+        capability: Capability,
+    ) -> astra_tools::ToolResult {
+        let error = format!(
+            "Tool `{name}` is not available in this turn because required runtime capability `{}` is not configured.",
+            capability.as_str()
+        );
+        tool_result_from_output(
+            json!({
+                "status": "failed",
+                "error": error,
+                "error_kind": astra_core::ErrorKind::ToolUnavailable.as_str(),
+                "retryable": false,
+            })
+            .to_string(),
+        )
+    }
+
+    fn service_dependency_error_result(
+        &self,
+        name: &str,
+        capability: Capability,
+    ) -> astra_tools::ToolResult {
+        let error = format!(
+            "Tool `{name}` is not available in this turn because required service `{}` is not configured.",
+            capability.as_str()
+        );
+        tool_result_from_output(
+            json!({
+                "status": "failed",
+                "error": error,
+                "error_kind": astra_core::ErrorKind::ToolUnavailable.as_str(),
+                "retryable": false,
+            })
+            .to_string(),
+        )
+    }
+
     fn tool_binding_preflight_result(
         &self,
         name: &str,
         args: &Value,
     ) -> Option<astra_tools::ToolResult> {
-        if self.tool_has_runtime_binding(name)
-            || self.tool_can_validate_without_runtime_binding(name, args)
-        {
-            return None;
+        match self.tool_admission(name) {
+            ToolAdmission::Ready => None,
+            ToolAdmission::MissingRuntimeBinding
+                if self.tool_can_validate_without_runtime_binding(name, args) =>
+            {
+                None
+            }
+            ToolAdmission::MissingRuntimeBinding => {
+                Some(self.runtime_binding_error_result(name, args))
+            }
+            ToolAdmission::MissingCapability(capability) => {
+                Some(self.capability_unavailable_error_result(name, capability))
+            }
+            ToolAdmission::MissingService(capability) => {
+                Some(self.service_dependency_error_result(name, capability))
+            }
         }
-        Some(self.runtime_binding_error_result(name, args))
     }
 
     /// Inject the plan repository so plan-mode tools and the write-tool guard
@@ -1298,6 +1411,52 @@ mod tests {
             .collect()
     }
 
+    struct ReadyReflectService;
+
+    #[async_trait]
+    impl astra_services::ReflectService for ReadyReflectService {
+        fn is_configured(&self) -> bool {
+            true
+        }
+
+        async fn build_evidence(
+            &self,
+            _user_id: &str,
+            session_id: &str,
+            request: astra_services::reflect::ReflectRequest,
+        ) -> astra_services::reflect::ServiceResult<astra_services::ReflectReport> {
+            let data_coverage = astra_core::ObservationDataCoverage {
+                overall: "fresh".to_string(),
+                source: "test".to_string(),
+                events: 0,
+                decisions: 0,
+                providers: Default::default(),
+                warnings: Vec::new(),
+            };
+            Ok(astra_services::ReflectReport {
+                schema_version: 1,
+                tool: "reflect".to_string(),
+                session_id: session_id.to_string(),
+                analysis_view: request.analysis_view,
+                topic: request.topic.as_str().to_string(),
+                facet: request.facet.as_str().to_string(),
+                depth: request.depth.as_str().to_string(),
+                horizon: request.horizon.as_str().to_string(),
+                source_policy: request.source_policy.as_str().to_string(),
+                include_context: request.include_context,
+                data_coverage,
+                view: None,
+                summary: "reflect ready".to_string(),
+                observations: Vec::new(),
+                evidence: Vec::new(),
+                action_hints: Vec::new(),
+                failure_clusters: Vec::new(),
+                graph_slice: Default::default(),
+                budget_result: Default::default(),
+            })
+        }
+    }
+
     #[test]
     fn tool_schemas_hide_project_tools_without_workspace_runtime() {
         let (mut exec, _dir) = test_executor();
@@ -1359,6 +1518,57 @@ mod tests {
             !exec.supports_server_tool_name("bash"),
             "project tools must not remain supported after binding changes to no-runtime"
         );
+    }
+
+    #[tokio::test]
+    async fn service_unready_tools_are_not_advertised_or_executable() {
+        let (exec, _dir) = test_executor();
+
+        assert!(
+            exec.has_runtime_binding("reflect"),
+            "reflect does not need an executor binding; service readiness is a separate admission gate"
+        );
+        assert!(
+            !exec.tool_runtime_ready("reflect"),
+            "reflect must not be runtime-ready without a configured reflect service"
+        );
+        let names = schema_name_set(exec.tool_schemas());
+        assert!(
+            !names.contains("reflect"),
+            "prompt-visible schema must not include service-unready tools: {names:?}"
+        );
+
+        let result = exec
+            .execute_with_metadata("reflect", &json!({"topic": "execution"}))
+            .await;
+        assert!(result.is_error, "{result:?}");
+        assert!(
+            result.output.contains("reflect_service"),
+            "{}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn service_ready_tools_are_advertised_and_execute_through_shared_admission() {
+        let (exec, _dir) = test_executor();
+        let exec = exec.with_reflect_service(Arc::new(ReadyReflectService));
+
+        assert!(
+            exec.tool_runtime_ready("reflect"),
+            "configured reflect service should make reflect runtime-ready"
+        );
+        let names = schema_name_set(exec.tool_schemas());
+        assert!(
+            names.contains("reflect"),
+            "runtime-ready reflect should remain prompt-visible"
+        );
+
+        let result = exec
+            .execute_with_metadata("reflect", &json!({"topic": "execution"}))
+            .await;
+        assert!(!result.is_error, "{result:?}");
+        assert!(result.output.contains("reflect ready"), "{}", result.output);
     }
 
     #[tokio::test]
@@ -1802,7 +2012,7 @@ mod tests {
 
     #[test]
     fn tool_engine_handlers_are_schema_and_runtime_registry_backed() {
-        let (exec, _dir) = test_executor_with_agent_context();
+        let (exec, _dir) = test_executor_with_agent_context_and_reflect_service();
         let schema_names = schema_name_set(exec.tool_schemas());
         let registry = astra_runtime_env::ToolRegistry::builtins();
 
@@ -1840,7 +2050,7 @@ mod tests {
             is_server_control_plane_tool, is_server_runtime_tool,
         };
 
-        let (exec, _dir) = test_executor_with_agent_context();
+        let (exec, _dir) = test_executor_with_agent_context_and_reflect_service();
         let schema_names = schema_name_set(exec.tool_schemas());
 
         // 1. Every control_plane tool must have a handler.
@@ -2196,6 +2406,14 @@ esac
         let (mut exec, dir) = test_executor();
         exec.set_agent_tool_context(test_agent_tool_context(dir.path()));
         (exec, dir)
+    }
+
+    fn test_executor_with_agent_context_and_reflect_service() -> (ServerToolExecutor, TempDir) {
+        let (exec, dir) = test_executor_with_agent_context();
+        (
+            exec.with_reflect_service(Arc::new(ReadyReflectService)),
+            dir,
+        )
     }
 
     fn test_agent_tool_context(work_dir: &Path) -> AgentToolContext {
@@ -4080,7 +4298,7 @@ esac
     /// is the right pool.
     #[tokio::test]
     async fn server_tool_search_resolves_deferred_via_activatable_set() {
-        let (exec, _dir) = test_executor();
+        let (exec, _dir) = test_executor_with_agent_context();
         exec.set_current_searchable_tool_schemas(&[
             json!({"type": "function", "function": {"name": "bash"}}),
             json!({"type": "function", "function": {"name": "tool_search"}}),

--- a/rust/crates/runtime/src/server/state_builder/runtime.rs
+++ b/rust/crates/runtime/src/server/state_builder/runtime.rs
@@ -50,7 +50,8 @@ pub(super) async fn build_runtime_wiring(
         )
         .with_pool(shared_pool.clone())
         .with_edge_connection_pool(state.edge_connection_pool.clone())
-        .with_skill_service(state.skill_service.clone());
+        .with_skill_service(state.skill_service.clone())
+        .with_reflect_service(state.reflect_service.clone());
         if let Some(svc) = memory_extraction_service.as_ref() {
             exec = exec.with_memory_extraction_service(Arc::clone(svc));
         }
@@ -89,6 +90,7 @@ pub(super) async fn build_runtime_wiring(
     .with_mcp_registry_service(state.mcp_registry_service.clone())
     .with_agent_binding_service(state.agent_binding_service.clone())
     .with_model_gateway_service(state.model_gateway_service.clone())
+    .with_reflect_service(state.reflect_service.clone())
     .with_allow_implicit_request_scoped_mcp(
         astra_config::runtime_config::RuntimeConfig::cached().allow_implicit_request_scoped_mcp,
     )

--- a/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
+++ b/rust/crates/runtime/src/turn/headless_tool_pipeline/policy.rs
@@ -685,16 +685,16 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                 exec.current_activatable_tool_names_snapshot()
                     .contains(&execution.name)
             });
-            let has_runtime_binding = |name: &str| {
+            let tool_runtime_ready = |name: &str| {
                 self.ctx
                     .server_tool_executor
-                    .is_some_and(|exec| exec.has_runtime_binding(name))
+                    .is_some_and(|exec| exec.tool_runtime_ready(name))
             };
             let action = execution.args.get("action").and_then(Value::as_str);
             let (err_msg, skip_reason) = match classify_direct_deferred_call(
                 &execution.name,
                 is_activatable_deferred,
-                has_runtime_binding,
+                tool_runtime_ready,
             ) {
                 DirectDeferredCallAdmission::Activate { name } => {
                     if let Some(exec) = self.ctx.server_tool_executor {
@@ -725,7 +725,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                 }
                 DirectDeferredCallAdmission::Unknown => {
                     if is_prompt_deferred {
-                        if has_runtime_binding(&execution.name) {
+                        if tool_runtime_ready(&execution.name) {
                             (
                                 deferred_tool_not_activatable_message(&execution.name),
                                 "tool_not_admitted",

--- a/rust/crates/services/src/reflect.rs
+++ b/rust/crates/services/src/reflect.rs
@@ -468,6 +468,8 @@ fn evidence_event_from_row(row: &impl ReflectRow) -> ServiceResult<EvidenceEvent
 
 #[async_trait]
 pub trait ReflectService: Send + Sync {
+    fn is_configured(&self) -> bool;
+
     async fn build_evidence(
         &self,
         user_id: &str,
@@ -898,6 +900,10 @@ fn filter_evidence_events_for_graph(
 
 #[async_trait]
 impl ReflectService for DatabaseReflectService {
+    fn is_configured(&self) -> bool {
+        self.pool.is_some()
+    }
+
     async fn build_evidence(
         &self,
         user_id: &str,
@@ -1305,6 +1311,10 @@ pub struct UnconfiguredReflectService;
 
 #[async_trait]
 impl ReflectService for UnconfiguredReflectService {
+    fn is_configured(&self) -> bool {
+        false
+    }
+
     async fn build_evidence(
         &self,
         _: &str,


### PR DESCRIPTION
## Summary
- gate reflect availability on configured ReflectService
- propagate reflect service through runtime lifecycle, loop host, subruns, and spawned agents
- update runtime tool readiness handling and tests

## Tests
- make test-offline
- make test-online
- make check