### PR TITLE
fix(runtime): allow provider selected model without id

### DIFF
--- a/rust/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/rust/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -2464,7 +2464,7 @@ impl AgenticRunLifecycleService {
         if let Some(gateway_id) = selected_model.gateway.as_deref() {
             self.load_active_selected_model_gateway(gateway_id).await?;
         } else if provider_model_descriptor.is_some() {
-            Self::validate_provider_selected_model(request, selected_model)?;
+            Self::validate_provider_runtime_authorized(request)?;
         } else {
             self.validate_selected_native_model(&selected_model.model)
                 .await?;
@@ -2713,22 +2713,14 @@ impl AgenticRunLifecycleService {
         Ok(Some(model_gateway))
     }
 
-    fn validate_provider_selected_model(
+    fn validate_provider_runtime_authorized(
         request: &ChatRequestData,
-        selected_model: &SelectedModelRequest,
     ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
         if !request.provider_runtime_authorized {
             return Err(error_response_coded(
                 StatusCode::BAD_REQUEST,
                 "provider runtime descriptors require provider-authorized request authentication",
                 "external_runtime_context_required",
-            ));
-        }
-        if selected_model.id.as_deref().is_none() {
-            return Err(error_response_coded(
-                StatusCode::BAD_REQUEST,
-                "provider-issued selected_model.id is required with capability_descriptors",
-                "selected_model_invalid",
             ));
         }
         Ok(())
@@ -10903,7 +10895,7 @@ mod tests {
         let mut request = test_request("hello");
         request.provider_runtime_authorized = true;
         request.selected_model = Some(SelectedModelRequest {
-            id: Some("model-qwen".to_string()),
+            id: None,
             model: "qwen3.7-max".to_string(),
             gateway: None,
         });

--- a/rust/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/rust/crates/runtime/src/turn/bridge/inprocess.rs
@@ -102,11 +102,6 @@ fn provider_model_gateway_invocation_from_payload(
         .ok_or_else(|| {
             "selected_model is required with capability_descriptors.model_gateway".to_string()
         })?;
-    if selected_model.get("id").and_then(Value::as_str).is_none() {
-        return Err(
-            "provider-issued selected_model.id is required with capability_descriptors".to_string(),
-        );
-    }
     let model = selected_model
         .get("model")
         .and_then(Value::as_str)
@@ -4963,8 +4958,8 @@ mod tests {
     }
 
     #[test]
-    fn provider_model_gateway_invocation_requires_provider_model_id() {
-        let error = provider_model_gateway_invocation_from_payload(&json!({
+    fn provider_model_gateway_invocation_allows_missing_provider_model_id() {
+        let invocation = provider_model_gateway_invocation_from_payload(&json!({
             "selected_model": {"model": "qwen3.5-flash"},
             "runtime_auth": {"authorization": "Bearer runtime-grant"},
             "capability_descriptors": {
@@ -4973,9 +4968,10 @@ mod tests {
                 }
             }
         }))
-        .expect_err("provider model id is required");
+        .expect("valid provider runtime context")
+        .expect("provider model gateway invocation");
 
-        assert!(error.contains("selected_model.id"), "{error}");
+        assert_eq!(invocation.model, "qwen3.5-flash");
     }
 
     #[test]


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [x] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

N/A

## What this PR does / why we need it

- Allows provider-authorized model gateway requests to omit `selected_model.id`.
- Keeps `selected_model.model`, provider authorization, runtime auth, and descriptor validation as the contract.
- Updates the in-process bridge and lifecycle validation tests for provider-issued selected models without ids.

## Tests

- `cargo test -p astra-runtime validate_request_constraints_accepts_provider_descriptor_without_registered_gateway`
- `cargo test -p astra-runtime provider_model_gateway_invocation_allows_missing_provider_model_id`