### PR TITLE
ci: push release Docker image to IDC registry

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   IMAGE_NAME: matrixorigin/astra
+  IDC_REGISTRY: shanghai.idc.matrixorigin.cn:30019
+  IDC_IMAGE_NAME: shanghai.idc.matrixorigin.cn:30019/mocloud/astra
 
 jobs:
   version:
@@ -80,6 +82,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IDC_REGISTRY }}
+          username: ${{ secrets.IDC_REGISTRY_USERNAME }}
+          password: ${{ secrets.IDC_REGISTRY_PASSWORD }}
+
       - uses: docker/metadata-action@v5
         id: meta
         with:
@@ -97,7 +105,9 @@ jobs:
           context: .
           file: Dockerfile
           platforms: ${{ matrix.platform }}
-          tags: ${{ env.IMAGE_NAME }}
+          tags: |
+            ${{ env.IMAGE_NAME }}
+            ${{ env.IDC_IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             IMAGE_VERSION=${{ needs.version.outputs.image_version }}
@@ -145,6 +155,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IDC_REGISTRY }}
+          username: ${{ secrets.IDC_REGISTRY_USERNAME }}
+          password: ${{ secrets.IDC_REGISTRY_PASSWORD }}
+
       - uses: docker/metadata-action@v5
         id: meta
         with:
@@ -156,29 +172,51 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.latest == 'true' }}
             type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
 
-      - name: Create manifest list
+      - uses: docker/metadata-action@v5
+        id: idc-meta
+        with:
+          images: ${{ env.IDC_IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.latest == 'true' }}
+            type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
+
+      - name: Create Docker manifest lists
         shell: bash
         working-directory: /tmp/digests
         env:
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          METADATA_JSON: ${{ steps.meta.outputs.json }}
+          DOCKERHUB_IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERHUB_METADATA_JSON: ${{ steps.meta.outputs.json }}
+          IDC_IMAGE_NAME: ${{ env.IDC_IMAGE_NAME }}
+          IDC_METADATA_JSON: ${{ steps.idc-meta.outputs.json }}
         run: |
           set -euo pipefail
           shopt -s nullglob
 
-          mapfile -t tag_args < <(jq -r '.tags[] | "-t", .' <<< "${METADATA_JSON}")
-          if [ "${#tag_args[@]}" -eq 0 ]; then
-            echo "No Docker tags were generated" >&2
-            exit 1
-          fi
+          create_manifest_list() {
+            local image_name="$1"
+            local metadata_json="$2"
+            local -a tag_args=()
+            local -a sources=()
 
-          sources=()
-          for digest in *; do
-            sources+=("${IMAGE_NAME}@sha256:${digest}")
-          done
-          if [ "${#sources[@]}" -eq 0 ]; then
-            echo "No platform image digests were downloaded" >&2
-            exit 1
-          fi
+            mapfile -t tag_args < <(jq -r '.tags[] | "-t", .' <<< "${metadata_json}")
+            if [ "${#tag_args[@]}" -eq 0 ]; then
+              echo "No Docker tags were generated for ${image_name}" >&2
+              exit 1
+            fi
 
-          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+            for digest in *; do
+              sources+=("${image_name}@sha256:${digest}")
+            done
+            if [ "${#sources[@]}" -eq 0 ]; then
+              echo "No platform image digests were downloaded" >&2
+              exit 1
+            fi
+
+            docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+          }
+
+          create_manifest_list "${DOCKERHUB_IMAGE_NAME}" "${DOCKERHUB_METADATA_JSON}"
+          create_manifest_list "${IDC_IMAGE_NAME}" "${IDC_METADATA_JSON}"


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [x] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes #

## What this PR does / why we need it

Updates the release Docker workflow so Astra release images are published to both Docker Hub and the Shanghai IDC Harbor registry.

- Adds `shanghai.idc.matrixorigin.cn:30019/mocloud/astra` as an additional release image target.
- Logs into the IDC registry during per-platform image pushes and manifest publishing.
- Pushes the same per-platform digests to both registries, then creates multi-arch manifest lists for Docker Hub and IDC using the same semver/latest tag policy.

This keeps the existing Docker Hub release behavior unchanged while making tags such as `0.0.4`, `0.0`, and `latest` available from the IDC registry as multi-arch images.

Validation:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-docker.yml")'`
- `git diff --check -- .github/workflows/release-docker.yml`

Required repository secrets before running the workflow:

- `IDC_REGISTRY_USERNAME`
- `IDC_REGISTRY_PASSWORD`
