### PR TITLE
fix: align release Dockerfile with root Rust workspace

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -195,48 +195,60 @@ jobs:
 
   idc:
     name: Push IDC image
-    needs: version
+    needs:
+      - version
+      - merge
     runs-on: amd64-mo-shanghai-dind
-    timeout-minutes: 45
+    timeout-minutes: 20
     continue-on-error: true
+    env:
+      http_proxy: http://proxy-service.proxy.svc.cluster.local:8001
+      https_proxy: http://proxy-service.proxy.svc.cluster.local:8001
+      no_proxy: .local,.cn,.gitee.com,.tencent.com,.tencentyun.com,.aliyun.com,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,localhost,127.0.0.0/8,.qq.com,169.254.0.0/16,.myqcloud.com,.matrixone.tech,.aliyuncs.com,.digicert.com,.microsoft.com,.visualstudio.com,.symcb.com,0.0.0.0
+      HTTP_PROXY: http://proxy-service.proxy.svc.cluster.local:8001
+      HTTPS_PROXY: http://proxy-service.proxy.svc.cluster.local:8001
+      NO_PROXY: .local,.cn,.gitee.com,.tencent.com,.tencentyun.com,.aliyun.com,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,localhost,127.0.0.0/8,.qq.com,169.254.0.0/16,.myqcloud.com,.matrixone.tech,.aliyuncs.com,.digicert.com,.microsoft.com,.visualstudio.com,.symcb.com,0.0.0.0
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - name: Install crane
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          curl -fsSL \
+            -o "${RUNNER_TEMP}/go-containerregistry.tar.gz" \
+            "https://github.com/google/go-containerregistry/releases/download/v0.20.6/go-containerregistry_Linux_x86_64.tar.gz"
+          tar -xzf "${RUNNER_TEMP}/go-containerregistry.tar.gz" -C "${RUNNER_TEMP}/bin" crane
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+          "${RUNNER_TEMP}/bin/crane" version
 
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.IDC_REGISTRY }}
-          username: ${{ secrets.IDC_REGISTRY_USERNAME }}
-          password: ${{ secrets.IDC_REGISTRY_PASSWORD }}
-
-      - uses: docker/metadata-action@v5
-        id: idc-meta
-        with:
-          images: ${{ env.IDC_IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            type=semver,pattern={{version}},value=${{ needs.version.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.latest == 'true' }}
-            type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
-
-      - uses: docker/build-push-action@v6
-        id: idc-build
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.idc-meta.outputs.tags }}
-          labels: ${{ steps.idc-meta.outputs.labels }}
-          build-args: |
-            IMAGE_VERSION=${{ needs.version.outputs.image_version }}
-            IMAGE_REVISION=${{ github.sha }}
-            IMAGE_BRANCH=${{ github.ref_name }}
-          cache-from: type=registry,ref=${{ env.IDC_IMAGE_NAME }}:cache
-          cache-to: type=registry,ref=${{ env.IDC_IMAGE_NAME }}:cache,mode=max,oci-mediatypes=true,image-manifest=true,ignore-error=true
+      - name: Mirror DockerHub image to IDC
+        shell: bash
+        env:
+          IMAGE_VERSION: ${{ needs.version.outputs.image_version }}
+          PUBLISH_LATEST: ${{ needs.version.outputs.latest }}
+          SOURCE_IMAGE: ${{ env.IMAGE_NAME }}
+          TARGET_IMAGE: ${{ env.IDC_IMAGE_NAME }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          IDC_USERNAME: ${{ secrets.IDC_REGISTRY_USERNAME }}
+          IDC_PASSWORD: ${{ secrets.IDC_REGISTRY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${DOCKERHUB_TOKEN}" | crane auth login index.docker.io -u "${DOCKERHUB_USERNAME}" --password-stdin
+          printf '%s' "${IDC_PASSWORD}" | crane auth login "${IDC_REGISTRY}" -u "${IDC_USERNAME}" --password-stdin
+          tags=("${IMAGE_VERSION}")
+          if [ "${PUBLISH_LATEST}" = "true" ]; then
+            tags+=("${IMAGE_VERSION%.*}" "latest")
+          fi
+          for tag in "${tags[@]}"; do
+            crane copy --platform=all --jobs 2 \
+              "docker.io/${SOURCE_IMAGE}:${IMAGE_VERSION}" \
+              "${TARGET_IMAGE}:${tag}"
+          done
+          crane manifest "${TARGET_IMAGE}:${IMAGE_VERSION}" >/dev/null
 
       - name: Write IDC summary
         if: always()
@@ -246,6 +258,8 @@ jobs:
             echo "## IDC image publish"
             echo
             echo "- Target: \`${{ env.IDC_IMAGE_NAME }}\`"
+            echo "- Source: \`${{ env.IMAGE_NAME }}:${{ needs.version.outputs.image_version }}\`"
+            echo "- Mode: multi-arch registry mirror after DockerHub manifest publish."
             echo "- DockerHub release jobs do not depend on this optional IDC job."
-            echo "- This job is capped at 45 minutes to avoid long registry retry loops."
+            echo "- This job is capped at 20 minutes to avoid long registry retry loops."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -57,7 +57,7 @@ jobs:
           echo "latest=${latest}" >> "${GITHUB_OUTPUT}"
 
   build:
-    name: Build ${{ matrix.platform }}
+    name: Build DockerHub ${{ matrix.platform }}
     needs: version
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
@@ -82,12 +82,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.IDC_REGISTRY }}
-          username: ${{ secrets.IDC_REGISTRY_USERNAME }}
-          password: ${{ secrets.IDC_REGISTRY_PASSWORD }}
-
       - uses: docker/metadata-action@v5
         id: meta
         with:
@@ -105,9 +99,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: ${{ matrix.platform }}
-          tags: |
-            ${{ env.IMAGE_NAME }}
-            ${{ env.IDC_IMAGE_NAME }}
+          tags: ${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             IMAGE_VERSION=${{ needs.version.outputs.image_version }}
@@ -135,7 +127,7 @@ jobs:
           retention-days: 1
 
   merge:
-    name: Merge & Push Docker Manifest
+    name: Merge & Push DockerHub Manifest
     needs:
       - version
       - build
@@ -155,12 +147,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.IDC_REGISTRY }}
-          username: ${{ secrets.IDC_REGISTRY_USERNAME }}
-          password: ${{ secrets.IDC_REGISTRY_PASSWORD }}
-
       - uses: docker/metadata-action@v5
         id: meta
         with:
@@ -172,25 +158,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.latest == 'true' }}
             type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
 
-      - uses: docker/metadata-action@v5
-        id: idc-meta
-        with:
-          images: ${{ env.IDC_IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            type=semver,pattern={{version}},value=${{ needs.version.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.latest == 'true' }}
-            type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
-
-      - name: Create Docker manifest lists
+      - name: Create DockerHub manifest list
         shell: bash
         working-directory: /tmp/digests
         env:
           DOCKERHUB_IMAGE_NAME: ${{ env.IMAGE_NAME }}
           DOCKERHUB_METADATA_JSON: ${{ steps.meta.outputs.json }}
-          IDC_IMAGE_NAME: ${{ env.IDC_IMAGE_NAME }}
-          IDC_METADATA_JSON: ${{ steps.idc-meta.outputs.json }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -219,4 +192,60 @@ jobs:
           }
 
           create_manifest_list "${DOCKERHUB_IMAGE_NAME}" "${DOCKERHUB_METADATA_JSON}"
-          create_manifest_list "${IDC_IMAGE_NAME}" "${IDC_METADATA_JSON}"
+
+  idc:
+    name: Push IDC image
+    needs: version
+    runs-on: amd64-mo-shanghai-dind
+    timeout-minutes: 45
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IDC_REGISTRY }}
+          username: ${{ secrets.IDC_REGISTRY_USERNAME }}
+          password: ${{ secrets.IDC_REGISTRY_PASSWORD }}
+
+      - uses: docker/metadata-action@v5
+        id: idc-meta
+        with:
+          images: ${{ env.IDC_IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.latest == 'true' }}
+            type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
+
+      - uses: docker/build-push-action@v6
+        id: idc-build
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.idc-meta.outputs.tags }}
+          labels: ${{ steps.idc-meta.outputs.labels }}
+          build-args: |
+            IMAGE_VERSION=${{ needs.version.outputs.image_version }}
+            IMAGE_REVISION=${{ github.sha }}
+            IMAGE_BRANCH=${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ env.IDC_IMAGE_NAME }}:cache
+          cache-to: type=registry,ref=${{ env.IDC_IMAGE_NAME }}:cache,mode=max,oci-mediatypes=true,image-manifest=true,ignore-error=true
+
+      - name: Write IDC summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## IDC image publish"
+            echo
+            echo "- Target: \`${{ env.IDC_IMAGE_NAME }}\`"
+            echo "- DockerHub release jobs do not depend on this optional IDC job."
+            echo "- This job is capped at 45 minutes to avoid long registry retry loops."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -205,9 +205,6 @@ jobs:
       http_proxy: http://proxy-service.proxy.svc.cluster.local:8001
       https_proxy: http://proxy-service.proxy.svc.cluster.local:8001
       no_proxy: .local,.cn,.gitee.com,.tencent.com,.tencentyun.com,.aliyun.com,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,localhost,127.0.0.0/8,.qq.com,169.254.0.0/16,.myqcloud.com,.matrixone.tech,.aliyuncs.com,.digicert.com,.microsoft.com,.visualstudio.com,.symcb.com,0.0.0.0
-      HTTP_PROXY: http://proxy-service.proxy.svc.cluster.local:8001
-      HTTPS_PROXY: http://proxy-service.proxy.svc.cluster.local:8001
-      NO_PROXY: .local,.cn,.gitee.com,.tencent.com,.tencentyun.com,.aliyun.com,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,localhost,127.0.0.0/8,.qq.com,169.254.0.0/16,.myqcloud.com,.matrixone.tech,.aliyuncs.com,.digicert.com,.microsoft.com,.visualstudio.com,.symcb.com,0.0.0.0
 
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,14 +49,15 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM chef AS planner
 
-WORKDIR /app/rust
-COPY rust/ ./
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ ./crates/
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 
-WORKDIR /app/rust
-COPY --from=planner /app/rust/recipe.json recipe.json
+WORKDIR /app
+COPY --from=planner /app/recipe.json recipe.json
 # Runtime image intentionally ships the API server plus the single public CLI.
 # Test-only mock_mcp_server and the standalone astra-edge daemon are excluded.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -66,7 +67,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
         -p astra-runtime --bin astra-server \
         -p astra-cli --bin astra
 
-COPY rust/ ./
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ ./crates/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target \


### PR DESCRIPTION
## Summary
- Update the release Dockerfile to build from the repository-root Rust workspace layout.
- Replace stale `WORKDIR /app/rust` / `COPY rust/ ./` paths with root `Cargo.toml`, `Cargo.lock`, and `crates/` copies.
- Decouple DockerHub release publishing from IDC Harbor publishing.
- Publish DockerHub as the primary multi-arch release path.
- Mirror the completed DockerHub multi-arch image to IDC from an optional `amd64-mo-shanghai-dind` job using `crane copy --platform=all`.
- Cap the optional IDC mirror job at 20 minutes so IDC/DockerHub registry problems do not create long blocking retry loops.

## Root Cause
Release image builds for tag `v0.0.5` failed because commit `cfdb56875` moved the Rust workspace from `rust/` to the repository root, but the Dockerfile still copied `rust/` during the planner and builder stages.

Observed failure:

```text
ERROR: failed to calculate checksum ... "/rust": not found
```

After the Dockerfile fix, the temporary release run reached image export but IDC Harbor returned repeated server-side 500s while committing blobs. The old workflow pushed DockerHub and IDC in the same buildx export, so IDC registry instability could block DockerHub publication.

A follow-up attempt to build directly on the Shanghai runner failed resolving DockerHub base image metadata. The IDC job now mirrors the already-published DockerHub multi-arch image with proxy settings instead of rebuilding from Dockerfile.

## Workflow Behavior
- DockerHub multi-arch release remains the primary release path.
- DockerHub build jobs push only `matrixorigin/astra` by digest.
- DockerHub manifest creation only creates DockerHub tags.
- IDC publishing is best-effort by workflow design: its job has `continue-on-error: true` and `timeout-minutes: 20`.
- IDC waits for the DockerHub manifest, then copies the multi-arch image to `shanghai.idc.matrixorigin.cn:30019/mocloud/astra`.
- Stable releases mirror the version tag, major/minor tag, and `latest`; prereleases mirror only the prerelease tag.

## Validation
- `git diff --check -- .github/workflows/release-docker.yml Dockerfile`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-docker.yml"); puts "yaml ok"'`
- `cargo metadata --no-deps --format-version 1`
- `cargo check --locked -p astra-runtime --bin astra-server -p astra-cli --bin astra`

I also attempted `docker build --target planner`, but local Docker could not fetch the base image metadata because Docker Hub token auth repeatedly timed out before reaching the Dockerfile stages.