### PR TITLE
refactor: context pipe components for the paper experiments

### DIFF
--- a/crates/astra-turn-core/src/context/budget.rs
+++ b/crates/astra-turn-core/src/context/budget.rs
@@ -17,6 +17,30 @@ pub const PRESSURE_COMPACT_HISTORY: f64 = 0.75;
 /// Pressure threshold above which aggressive pruning engages.
 pub const PRESSURE_AGGRESSIVE_PRUNE: f64 = 0.90;
 
+/// Pressure thresholds at which each compaction tier activates.
+///
+/// Defaults to the shared constants (`PRESSURE_TRIM_SCHEMAS`,
+/// `PRESSURE_COMPACT_HISTORY`, `PRESSURE_AGGRESSIVE_PRUNE`). Configurable
+/// through `PipelineConfig::plan_policy` so threshold-policy experiments can
+/// shift the ladder without touching the selection logic.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TierThresholds {
+    pub trim_schemas: f64,
+    pub compact_history: f64,
+    pub aggressive_prune: f64,
+}
+
+impl Default for TierThresholds {
+    fn default() -> Self {
+        Self {
+            trim_schemas: PRESSURE_TRIM_SCHEMAS,
+            compact_history: PRESSURE_COMPACT_HISTORY,
+            aggressive_prune: PRESSURE_AGGRESSIVE_PRUNE,
+        }
+    }
+}
+
 /// Select the compaction tier from a raw or predictive pressure value.
 ///
 /// Thresholds are defined as constants (`PRESSURE_TRIM_SCHEMAS`,
@@ -24,11 +48,17 @@ pub const PRESSURE_AGGRESSIVE_PRUNE: f64 = 0.90;
 /// the microcompact layer to eliminate comment-only alignment.
 #[must_use]
 pub fn select_compaction_tier(pressure: f64) -> CompactionTier {
-    if pressure >= PRESSURE_AGGRESSIVE_PRUNE {
+    select_compaction_tier_with(&TierThresholds::default(), pressure)
+}
+
+/// Tier selection against an explicit threshold ladder.
+#[must_use]
+pub fn select_compaction_tier_with(thresholds: &TierThresholds, pressure: f64) -> CompactionTier {
+    if pressure >= thresholds.aggressive_prune {
         CompactionTier::AggressivePrune
-    } else if pressure >= PRESSURE_COMPACT_HISTORY {
+    } else if pressure >= thresholds.compact_history {
         CompactionTier::CompactHistory
-    } else if pressure >= PRESSURE_TRIM_SCHEMAS {
+    } else if pressure >= thresholds.trim_schemas {
         CompactionTier::TrimSchemas
     } else {
         CompactionTier::Normal
@@ -40,8 +70,22 @@ pub fn select_compaction_tier(pressure: f64) -> CompactionTier {
 /// a temporarily inflated reserve estimate from under-compacting.
 #[must_use]
 pub fn select_tier_gated(raw_pressure: f64, predictive_pressure: f64) -> CompactionTier {
-    let raw_tier = select_compaction_tier(raw_pressure);
-    let predictive_tier = select_compaction_tier(predictive_pressure);
+    select_tier_gated_with(
+        &TierThresholds::default(),
+        raw_pressure,
+        predictive_pressure,
+    )
+}
+
+/// Gated tier selection against an explicit threshold ladder.
+#[must_use]
+pub fn select_tier_gated_with(
+    thresholds: &TierThresholds,
+    raw_pressure: f64,
+    predictive_pressure: f64,
+) -> CompactionTier {
+    let raw_tier = select_compaction_tier_with(thresholds, raw_pressure);
+    let predictive_tier = select_compaction_tier_with(thresholds, predictive_pressure);
     raw_tier.max(predictive_tier)
 }
 
@@ -205,6 +249,40 @@ mod tests {
         // Gated should escalate to CompactHistory
         let tier2 = select_tier_gated(0.55, 0.80);
         assert_eq!(tier2, CompactionTier::CompactHistory);
+    }
+
+    #[test]
+    fn custom_thresholds_shift_the_ladder() {
+        let shifted = TierThresholds {
+            trim_schemas: 0.50,
+            compact_history: 0.65,
+            aggressive_prune: 0.80,
+        };
+        // 0.55 is Normal on the default ladder but TrimSchemas on the shifted one.
+        assert_eq!(select_compaction_tier(0.55), CompactionTier::Normal);
+        assert_eq!(
+            select_compaction_tier_with(&shifted, 0.55),
+            CompactionTier::TrimSchemas
+        );
+        // 0.82 is CompactHistory by default, AggressivePrune when shifted.
+        assert_eq!(select_compaction_tier(0.82), CompactionTier::CompactHistory);
+        assert_eq!(
+            select_compaction_tier_with(&shifted, 0.82),
+            CompactionTier::AggressivePrune
+        );
+        // Gated variant honors the same ladder and never de-escalates.
+        assert_eq!(
+            select_tier_gated_with(&shifted, 0.55, 0.40),
+            CompactionTier::TrimSchemas
+        );
+    }
+
+    #[test]
+    fn default_thresholds_match_shared_constants() {
+        let t = TierThresholds::default();
+        assert_eq!(t.trim_schemas, PRESSURE_TRIM_SCHEMAS);
+        assert_eq!(t.compact_history, PRESSURE_COMPACT_HISTORY);
+        assert_eq!(t.aggressive_prune, PRESSURE_AGGRESSIVE_PRUNE);
     }
 
     #[test]

--- a/crates/astra-turn-core/src/context/pipeline.rs
+++ b/crates/astra-turn-core/src/context/pipeline.rs
@@ -10,13 +10,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::compaction_types::CompactionTier;
 use crate::context_binder::bind_all;
-use crate::context_optimizer::{ContextOptimized, optimize_with_spill};
-use crate::context_planner::{ContextPlan, PlanInput, plan_turn};
+use crate::context_optimizer::{ContextOptimized, SkippedOptimization, optimize_with_spill};
+use crate::context_planner::{ContextPlan, PlanInput, plan_turn_with_policy};
 use crate::context_pressure::ContextPressure;
 use crate::context_serializer::{SerializedProviderRequest, serialize_provider_request};
 use crate::context_sources::ContextSources;
 use crate::optimize_limits::OptimizeLimits;
-use crate::pipeline_config::PipelineConfig;
+use crate::pipeline_config::{AssemblerMode, PipelineConfig};
 use crate::recovery_state::RecoveryState;
 use crate::session_latches::SessionLatches;
 use crate::spill_backend::SpillBackend;
@@ -99,7 +99,7 @@ impl ContextPipeline {
             model_id: input.model_id,
             query_source: input.query_source,
         };
-        let plan = plan_turn(&plan_input);
+        let plan = plan_turn_with_policy(&plan_input, &self.config.plan_policy);
         timings.push(PipelinePhaseTiming::elapsed("plan", started));
 
         let started = Instant::now();
@@ -109,15 +109,36 @@ impl ContextPipeline {
         let started = Instant::now();
         let spill_backend: Option<&dyn SpillBackend> =
             input.sources.external.spill_backend.as_deref();
-        let optimized = optimize_with_spill(
+        // Flat baseline: every gate forced closed regardless of caller limits,
+        // so sections keep bind order and no transformation runs.
+        let flat_mode = self.config.assembler_mode == AssemblerMode::Flat;
+        let flat_limits = OptimizeLimits::all_closed();
+        let effective_limits = if flat_mode {
+            &flat_limits
+        } else {
+            input.optimize_limits
+        };
+        let mut optimized = optimize_with_spill(
             &plan,
             bound,
             input.latches,
             provider_policy,
-            input.optimize_limits,
+            effective_limits,
             input.sources.turn.turn_index,
             spill_backend,
         );
+        if flat_mode {
+            // A naive assembler emits no cache markers; record the suppression
+            // so the trace shows what the structured path would have placed.
+            let suppressed = optimized.cache_markers.len();
+            optimized.cache_markers.clear();
+            optimized.stats.skipped.push(SkippedOptimization {
+                step: "assembler_mode".into(),
+                reason: format!(
+                    "flat mode: gates forced closed, {suppressed} cache marker(s) suppressed"
+                ),
+            });
+        }
         timings.push(PipelinePhaseTiming::elapsed("optimize", started));
 
         let started = Instant::now();
@@ -130,6 +151,7 @@ impl ContextPipeline {
             pressure: plan.pressure,
             compact_tier: plan.compact_tier,
             skipped_optimizations: optimized.stats.skipped.len() as u32,
+            ptl_errors_total: input.sources.stats.ptl_errors_total,
         };
 
         Ok(PipelineRunOutput {
@@ -168,6 +190,9 @@ pub struct PipelineExplain {
     pub pressure: ContextPressure,
     pub compact_tier: CompactionTier,
     pub skipped_optimizations: u32,
+    /// Cumulative prompt-too-long errors for the session as of this turn.
+    #[serde(default)]
+    pub ptl_errors_total: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -199,6 +224,13 @@ pub struct PipelineRunMetrics {
     pub cache_markers: u32,
     pub tokens_cleared: u32,
     pub avg_cache_hit_ratio: f64,
+    /// Sections spilled to the spill backend this turn.
+    #[serde(default)]
+    pub spilled: u32,
+    /// Cumulative API responses recorded before this turn (explicit call
+    /// counter — no longer inferred from capture files).
+    #[serde(default)]
+    pub api_calls_total: u64,
 }
 
 impl PipelineRunMetrics {
@@ -220,6 +252,8 @@ impl PipelineRunMetrics {
             cache_markers: optimized.cache_markers.len() as u32,
             tokens_cleared: optimized.stats.tokens_cleared,
             avg_cache_hit_ratio: input.sources.stats.avg_cache_hit_ratio,
+            spilled: optimized.spilled.len() as u32,
+            api_calls_total: input.sources.stats.api_calls,
         }
     }
 }

--- a/crates/astra-turn-core/src/context/planner.rs
+++ b/crates/astra-turn-core/src/context/planner.rs
@@ -8,10 +8,10 @@
 use serde::{Deserialize, Serialize};
 
 use crate::compaction_types::CompactionTier;
-use crate::context_budget::{TokenBudget, select_tier_gated};
+use crate::context_budget::{TokenBudget, select_compaction_tier_with, select_tier_gated_with};
 use crate::context_pressure::{ContextPressure, ContextReserves};
 use crate::microcompact::PromptCacheProtocol;
-use crate::pipeline_config::ProviderCachePolicy;
+use crate::pipeline_config::{PlanPolicy, PressureMode, ProviderCachePolicy};
 use crate::pipeline_stats::PipelineStats;
 use crate::recovery_state::RecoveryState;
 use crate::section_types::{
@@ -59,14 +59,26 @@ pub struct PlanInput<'a> {
 /// Plan a turn: compute pressure, select tier, allocate budgets, choose cache strategy.
 ///
 /// This is a pure function with no I/O. It produces a `ContextPlan` that
-/// the Bind and Optimize phases will execute.
+/// the Bind and Optimize phases will execute. Uses the default
+/// [`PlanPolicy`] (predictive pressure, production thresholds/percentiles).
 #[must_use]
 pub fn plan_turn(input: &PlanInput<'_>) -> ContextPlan {
+    plan_turn_with_policy(input, &PlanPolicy::default())
+}
+
+/// Plan a turn under an explicit decision policy.
+///
+/// The policy carries the deterministic knobs (pressure mode, tier
+/// thresholds, reserve percentiles); the input carries the observed state.
+/// `plan_turn(input)` is equivalent to passing `PlanPolicy::default()`.
+#[must_use]
+pub fn plan_turn_with_policy(input: &PlanInput<'_>, policy: &PlanPolicy) -> ContextPlan {
     // 1. Compute reserves from historical response data
-    let reserves = input.stats.response_token_estimates.reserve_for(
+    let reserves = input.stats.response_token_estimates.reserve_for_with(
         input.model_id,
         input.query_source,
         input.recovery,
+        policy.reserve_percentiles,
     );
 
     // 2. Compute raw and predictive pressure
@@ -76,9 +88,18 @@ pub fn plan_turn(input: &PlanInput<'_>) -> ContextPlan {
         reserves,
     );
 
-    // 3. Select compaction tier (gated: predictive can escalate, not de-escalate)
-    let tier =
-        select_tier_gated(pressure.raw, pressure.value).escalate_for_recovery(input.recovery);
+    // 3. Select compaction tier. Predictive mode gates on max(raw, predictive)
+    //    so prediction can escalate but never de-escalate; reactive mode reads
+    //    raw pressure only (predictive is still computed and traced).
+    let ungated = match policy.pressure_mode {
+        PressureMode::Predictive => {
+            select_tier_gated_with(&policy.tier_thresholds, pressure.raw, pressure.value)
+        }
+        PressureMode::Reactive => {
+            select_compaction_tier_with(&policy.tier_thresholds, pressure.raw)
+        }
+    };
+    let tier = ungated.escalate_for_recovery(input.recovery);
 
     // 4. Allocate token budgets per section
     let section_history = input.stats.section_token_history();
@@ -298,6 +319,73 @@ mod tests {
         let input = make_plan_input(&tokens, &recovery, &latches, &stats, &policy);
         let plan = plan_turn(&input);
         assert!(plan.compact_tier >= CompactionTier::CompactHistory);
+    }
+
+    #[test]
+    fn reactive_mode_ignores_predictive_escalation() {
+        use crate::context_feedback::ContextFeedback;
+        use crate::pipeline_config::PlanPolicy;
+
+        // Large observed completions make the reserve estimate big enough
+        // that predictive pressure crosses TrimSchemas while raw stays Normal.
+        let (mut tokens, recovery, latches, mut stats, policy) = default_input();
+        for _ in 0..10 {
+            let fb = ContextFeedback::from_usage(1_000, 0, 0, 30_000, false);
+            stats
+                .response_token_estimates
+                .record("test-model", "repl", &fb);
+        }
+        tokens.prompt = 55_000; // raw = 0.55 (Normal)
+        let input = make_plan_input(&tokens, &recovery, &latches, &stats, &policy);
+
+        let predictive_plan = plan_turn(&input); // default policy = Predictive
+        assert!(
+            predictive_plan.pressure.value >= 0.60,
+            "test setup must push predictive pressure over the TrimSchemas threshold, got {}",
+            predictive_plan.pressure.value
+        );
+        assert!(
+            predictive_plan.compact_tier > CompactionTier::Normal,
+            "predictive mode should escalate on predicted pressure"
+        );
+
+        let reactive = PlanPolicy {
+            pressure_mode: PressureMode::Reactive,
+            ..PlanPolicy::default()
+        };
+        let reactive_plan = plan_turn_with_policy(&input, &reactive);
+        assert_eq!(
+            reactive_plan.compact_tier,
+            CompactionTier::Normal,
+            "reactive mode must select the tier from raw pressure only"
+        );
+        // Predictive pressure is still computed for the trace.
+        assert!(reactive_plan.pressure.value >= 0.60);
+        assert_eq!(reactive_plan.pressure.raw, predictive_plan.pressure.raw);
+    }
+
+    #[test]
+    fn plan_policy_custom_thresholds_apply() {
+        use crate::context_budget::TierThresholds;
+        use crate::pipeline_config::PlanPolicy;
+
+        let (mut tokens, recovery, latches, stats, policy) = default_input();
+        tokens.prompt = 55_000; // raw = 0.55: Normal by default ladder
+        let input = make_plan_input(&tokens, &recovery, &latches, &stats, &policy);
+
+        let shifted = PlanPolicy {
+            tier_thresholds: TierThresholds {
+                trim_schemas: 0.50,
+                compact_history: 0.65,
+                aggressive_prune: 0.80,
+            },
+            ..PlanPolicy::default()
+        };
+        let plan = plan_turn_with_policy(&input, &shifted);
+        assert!(
+            plan.compact_tier >= CompactionTier::TrimSchemas,
+            "shifted ladder should activate TrimSchemas at 0.55 raw pressure"
+        );
     }
 
     #[test]

--- a/crates/astra-turn-core/src/context/sources.rs
+++ b/crates/astra-turn-core/src/context/sources.rs
@@ -64,6 +64,11 @@ pub struct ContextChannelPolicy {
     pub suppressed: std::collections::HashSet<&'static str>,
     /// Minimum turn index before any channel activates (global gate).
     pub min_turn: Option<u32>,
+    /// Skip the stable/dynamic cache-scope partition: every section is
+    /// returned in provider-registration (arrival) order through the dynamic
+    /// lane. Sections keep their declared scope and bucket. Ablation arm for
+    /// ordering experiments; `false` in production.
+    pub arrival_order: bool,
 }
 
 impl ContextChannelPolicy {
@@ -103,7 +108,9 @@ impl ChannelAssembler {
 
     /// Collect sections from all allowed providers.
     ///
-    /// Returns `(stable_sections, dynamic_sections)` partitioned by cache scope.
+    /// Returns `(stable_sections, dynamic_sections)` partitioned by cache
+    /// scope. When the policy sets `arrival_order`, the partition is skipped:
+    /// all sections come back in the dynamic lane in registration order.
     #[must_use]
     pub fn assemble(&self, turn_index: u32) -> (Vec<PromptSection>, Vec<PromptSection>) {
         let mut stable = Vec::new();
@@ -116,6 +123,10 @@ impl ChannelAssembler {
                 // Provider declares scope; override section's scope + bucket
                 section.scope = provider.cache_scope();
                 section.token_bucket = provider.token_bucket();
+                if self.policy.arrival_order {
+                    dynamic.push(section);
+                    continue;
+                }
                 match provider.cache_scope() {
                     CacheScope::Global | CacheScope::Session => stable.push(section),
                     CacheScope::None => dynamic.push(section),

--- a/crates/astra-turn-core/src/emergent_context.rs
+++ b/crates/astra-turn-core/src/emergent_context.rs
@@ -36,6 +36,10 @@ pub struct EmergentContext {
     pub tool_summaries: Vec<EmergentItem<ToolUseSummary>>,
     /// Attachment-style context from tool execution side-effects. Cap: 16.
     pub attachments: Vec<EmergentItem<Attachment>>,
+    /// Cumulative items dropped because a list was at capacity. Feeds the
+    /// `emergent_overflow` alert rule via `PipelineStats`.
+    #[serde(default)]
+    pub cap_evictions_total: u64,
 }
 
 const SKILL_CAP: usize = 4;
@@ -45,19 +49,23 @@ const ATTACHMENT_CAP: usize = 16;
 
 impl EmergentContext {
     pub fn push_skill(&mut self, item: EmergentItem<DiscoveredSkill>) {
-        push_with_dedup_and_cap(&mut self.discovered_skills, item, SKILL_CAP);
+        let evicted = push_with_dedup_and_cap(&mut self.discovered_skills, item, SKILL_CAP);
+        self.cap_evictions_total = self.cap_evictions_total.saturating_add(evicted);
     }
 
     pub fn push_memory(&mut self, item: EmergentItem<PrefetchedMemory>) {
-        push_with_dedup_and_cap(&mut self.prefetched_memory, item, MEMORY_CAP);
+        let evicted = push_with_dedup_and_cap(&mut self.prefetched_memory, item, MEMORY_CAP);
+        self.cap_evictions_total = self.cap_evictions_total.saturating_add(evicted);
     }
 
     pub fn push_summary(&mut self, item: EmergentItem<ToolUseSummary>) {
-        push_with_dedup_and_cap(&mut self.tool_summaries, item, SUMMARY_CAP);
+        let evicted = push_with_dedup_and_cap(&mut self.tool_summaries, item, SUMMARY_CAP);
+        self.cap_evictions_total = self.cap_evictions_total.saturating_add(evicted);
     }
 
     pub fn push_attachment(&mut self, item: EmergentItem<Attachment>) {
-        push_with_dedup_and_cap(&mut self.attachments, item, ATTACHMENT_CAP);
+        let evicted = push_with_dedup_and_cap(&mut self.attachments, item, ATTACHMENT_CAP);
+        self.cap_evictions_total = self.cap_evictions_total.saturating_add(evicted);
     }
 
     /// Drain items within TTL, clearing consumed items from this context.
@@ -71,6 +79,9 @@ impl EmergentContext {
             prefetched_memory: drain_live_items(&mut self.prefetched_memory, current_turn, max_age),
             tool_summaries: drain_live_items(&mut self.tool_summaries, current_turn, max_age),
             attachments: drain_live_items(&mut self.attachments, current_turn, max_age),
+            // Session-cumulative; stays on `self` and rides along in the
+            // returned snapshot for observability.
+            cap_evictions_total: self.cap_evictions_total,
         }
     }
 
@@ -84,20 +95,29 @@ impl EmergentContext {
     }
 }
 
-fn push_with_dedup_and_cap<T>(list: &mut Vec<EmergentItem<T>>, item: EmergentItem<T>, cap: usize) {
+/// Push with dedup + cap enforcement. Returns the number of items evicted
+/// to make room (0 when the item was deduped or the list had capacity).
+fn push_with_dedup_and_cap<T>(
+    list: &mut Vec<EmergentItem<T>>,
+    item: EmergentItem<T>,
+    cap: usize,
+) -> u64 {
     // Dedup: reject if same hash already exists
     if list
         .iter()
         .any(|existing| existing.content_hash == item.content_hash)
     {
-        return;
+        return 0;
     }
     // Cap: drop oldest if at capacity. Caps are deliberately tiny (<=16), so
     // Vec::remove(0) keeps the API simple without material runtime cost.
+    let mut evicted = 0u64;
     while list.len() >= cap {
         list.remove(0);
+        evicted += 1;
     }
     list.push(item);
+    evicted
 }
 
 fn drain_live_items<T: Clone>(
@@ -179,6 +199,32 @@ mod tests {
         // Oldest (skill_0) should have been dropped
         assert_eq!(ctx.discovered_skills[0].value.skill_name, "skill_1");
         assert_eq!(ctx.discovered_skills[3].value.skill_name, "skill_4");
+    }
+
+    #[test]
+    fn cap_evictions_are_counted_and_dedup_is_not() {
+        let mut ctx = EmergentContext::default();
+        for i in 0..5 {
+            ctx.push_skill(make_skill(&format!("skill_{i}"), 1, i as u64));
+        }
+        assert_eq!(ctx.cap_evictions_total, 1, "one item over the cap of 4");
+
+        // Duplicate hash is rejected without counting as an eviction.
+        ctx.push_skill(make_skill("dup", 1, 4));
+        assert_eq!(ctx.cap_evictions_total, 1);
+
+        // Summary cap is 1, so every additional summary evicts.
+        for i in 0..3 {
+            ctx.push_summary(make_item(
+                ToolUseSummary {
+                    summary: format!("s{i}"),
+                    tool_calls_covered: 1,
+                },
+                1,
+                100 + i as u64,
+            ));
+        }
+        assert_eq!(ctx.cap_evictions_total, 3);
     }
 
     #[test]

--- a/crates/astra-turn-core/src/lib.rs
+++ b/crates/astra-turn-core/src/lib.rs
@@ -225,6 +225,7 @@ pub use pipeline::metrics as pipeline_metrics;
 pub use pipeline::session as pipeline_session;
 pub use pipeline::session_serde as pipeline_session_serde;
 pub use pipeline::stats as pipeline_stats;
+pub use pipeline::trace_export as pipeline_trace_export;
 
 // Re-exports: fork_* → fork::*
 pub use fork::cache_event as fork_cache_event;

--- a/crates/astra-turn-core/src/pipeline/config.rs
+++ b/crates/astra-turn-core/src/pipeline/config.rs
@@ -2,7 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::context_budget::TierThresholds;
 use crate::microcompact::{CompactStrategy, PromptCacheProtocol};
+use crate::optimize_limits::OptimizeLimits;
+use crate::pipeline_stats::ReservePercentiles;
 
 /// Provider-level cache policy consumed by the optimizer.
 ///
@@ -61,11 +64,61 @@ impl ProviderCachePolicy {
     }
 }
 
+/// How the planner turns pressure into a compaction tier.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PressureMode {
+    /// Tier from `max(raw, predictive)` pressure — prediction can only
+    /// escalate (production default).
+    #[default]
+    Predictive,
+    /// Tier from raw pressure only. Predictive pressure is still computed
+    /// and traced, but does not influence tier selection. Ablation arm for
+    /// the predictive-vs-reactive experiment.
+    Reactive,
+}
+
+/// How the pipeline arranges and transforms sections.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AssemblerMode {
+    /// Full pipeline: tier-gated compaction, spill, cache-marker placement
+    /// (production default).
+    #[default]
+    Structured,
+    /// Naive stable-prefix-then-append baseline: every optimizer gate is
+    /// forced closed and no cache markers are emitted. Sections keep their
+    /// bind order. Baseline arm for controlled assembler comparisons.
+    Flat,
+}
+
+/// Planner decision policy — the deterministic knobs the Plan phase reads.
+///
+/// Every field defaults to the production constants, so `PlanPolicy::default()`
+/// reproduces current behavior exactly. Experiments override individual knobs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PlanPolicy {
+    /// Predictive (gated) vs reactive (raw-only) tier selection.
+    pub pressure_mode: PressureMode,
+    /// Pressure ladder for compaction-tier selection.
+    pub tier_thresholds: TierThresholds,
+    /// Percentiles the reserve estimator reads (steady / recovery).
+    pub reserve_percentiles: ReservePercentiles,
+}
+
 /// Top-level pipeline configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct PipelineConfig {
     /// Provider cache policy for the current session.
     pub provider_policy: ProviderCachePolicy,
+    /// Planner decision policy (pressure mode, thresholds, percentiles).
+    pub plan_policy: PlanPolicy,
+    /// Structured pipeline vs flat baseline assembly.
+    pub assembler_mode: AssemblerMode,
+    /// When set, replaces tier-derived `OptimizeLimits` in
+    /// `cascade_aware_limits` (cascade suppression still applies on top).
+    /// Experiment hook for optimizer-knob sweeps; `None` in production.
+    pub limits_override: Option<OptimizeLimits>,
 }
 
 #[cfg(test)]
@@ -77,6 +130,29 @@ mod tests {
         let c = PipelineConfig::default();
         assert_eq!(c.provider_policy.max_markers, 0);
         assert!(!c.provider_policy.supports_global_scope);
+    }
+
+    #[test]
+    fn default_plan_policy_reproduces_production_constants() {
+        let c = PipelineConfig::default();
+        assert_eq!(c.plan_policy.pressure_mode, PressureMode::Predictive);
+        assert_eq!(c.assembler_mode, AssemblerMode::Structured);
+        assert!(c.limits_override.is_none());
+        assert_eq!(c.plan_policy.tier_thresholds.trim_schemas, 0.60);
+        assert_eq!(c.plan_policy.tier_thresholds.compact_history, 0.75);
+        assert_eq!(c.plan_policy.tier_thresholds.aggressive_prune, 0.90);
+        assert_eq!(c.plan_policy.reserve_percentiles.steady, 0.75);
+        assert_eq!(c.plan_policy.reserve_percentiles.recovery, 0.95);
+    }
+
+    #[test]
+    fn legacy_config_json_without_new_fields_deserializes() {
+        // Configs persisted before PlanPolicy/AssemblerMode existed must load.
+        let policy_json = serde_json::to_string(&ProviderCachePolicy::default()).unwrap();
+        let json = format!(r#"{{"provider_policy":{policy_json}}}"#);
+        let c: PipelineConfig = serde_json::from_str(&json).expect("legacy config should load");
+        assert_eq!(c.plan_policy.pressure_mode, PressureMode::Predictive);
+        assert_eq!(c.assembler_mode, AssemblerMode::Structured);
     }
 
     #[test]

--- a/crates/astra-turn-core/src/pipeline/journal.rs
+++ b/crates/astra-turn-core/src/pipeline/journal.rs
@@ -33,6 +33,11 @@ pub struct PipelineJournalEvent {
     pub cache_hit_ratio: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_tokens: Option<u64>,
+    /// Prompt tokens not served from cache (`prompt - cache_read`), the
+    /// "fresh/miss" quantity used in billed-cost decomposition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub fresh_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_read_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -43,6 +48,10 @@ pub struct PipelineJournalEvent {
     pub model_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_break_reason: Option<String>,
+    /// Cumulative API responses recorded for this session (explicit counter).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub api_calls_total: Option<u64>,
 
     // Alert fields
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -70,6 +79,12 @@ impl PipelineJournalEvent {
             turn,
             cache_hit_ratio: Some(feedback.cache_hit_ratio),
             prompt_tokens: Some(feedback.tokens.prompt),
+            fresh_tokens: Some(
+                feedback
+                    .tokens
+                    .prompt
+                    .saturating_sub(feedback.tokens.cache_read),
+            ),
             cache_read_tokens: Some(feedback.tokens.cache_read),
             cache_creation_tokens: Some(feedback.tokens.cache_creation),
             completion_tokens: Some(feedback.tokens.completion),
@@ -78,6 +93,7 @@ impl PipelineJournalEvent {
                 .cache_break_detected
                 .as_ref()
                 .map(ToString::to_string),
+            api_calls_total: None,
             alert_rule: None,
             alert_severity: None,
             alert_message: None,
@@ -85,6 +101,13 @@ impl PipelineJournalEvent {
             items_affected: None,
             tokens_freed: None,
         }
+    }
+
+    /// Attach the session's cumulative API-call counter to a feedback event.
+    #[must_use]
+    pub fn with_api_calls_total(mut self, api_calls_total: u64) -> Self {
+        self.api_calls_total = Some(api_calls_total);
+        self
     }
 
     /// Create an alert event from a trace alert.
@@ -95,11 +118,13 @@ impl PipelineJournalEvent {
             turn: alert.turn,
             cache_hit_ratio: None,
             prompt_tokens: None,
+            fresh_tokens: None,
             cache_read_tokens: None,
             cache_creation_tokens: None,
             completion_tokens: None,
             model_id: None,
             cache_break_reason: None,
+            api_calls_total: None,
             alert_rule: Some(alert.rule.clone()),
             alert_severity: Some(format!("{:?}", alert.severity)),
             alert_message: Some(alert.message.clone()),
@@ -122,11 +147,13 @@ impl PipelineJournalEvent {
             turn,
             cache_hit_ratio: None,
             prompt_tokens: None,
+            fresh_tokens: None,
             cache_read_tokens: None,
             cache_creation_tokens: None,
             completion_tokens: None,
             model_id: None,
             cache_break_reason: None,
+            api_calls_total: None,
             alert_rule: None,
             alert_severity: None,
             alert_message: None,
@@ -152,6 +179,19 @@ mod tests {
         assert_eq!(evt.cache_creation_tokens, Some(200));
         assert_eq!(evt.completion_tokens, Some(500));
         assert_eq!(evt.model_id.as_deref(), Some("claude"));
+        assert_eq!(
+            evt.fresh_tokens,
+            Some(200),
+            "fresh = prompt(1000) - cache_read(800)"
+        );
+        assert_eq!(evt.api_calls_total, None);
+    }
+
+    #[test]
+    fn feedback_event_carries_api_call_counter() {
+        let fb = ContextFeedback::from_usage(1000, 800, 200, 500, false);
+        let evt = PipelineJournalEvent::from_feedback(3, "claude", &fb).with_api_calls_total(42);
+        assert_eq!(evt.api_calls_total, Some(42));
     }
 
     #[test]

--- a/crates/astra-turn-core/src/pipeline/mod.rs
+++ b/crates/astra-turn-core/src/pipeline/mod.rs
@@ -4,3 +4,4 @@ pub mod metrics;
 pub mod session;
 pub mod session_serde;
 pub mod stats;
+pub mod trace_export;

--- a/crates/astra-turn-core/src/pipeline/session.rs
+++ b/crates/astra-turn-core/src/pipeline/session.rs
@@ -219,6 +219,10 @@ impl PipelineSession {
             metrics,
         } = self.pipeline.run(run_input)?;
 
+        // Track predictive pressure across turns for spike detection
+        // (feeds the `pressure_spike` alert rule).
+        self.stats.record_plan_pressure(plan.pressure.value);
+
         let output = TurnOutput {
             plan,
             optimized,
@@ -316,6 +320,10 @@ impl PipelineSession {
         }
 
         self.stats.record(model_id, query_source, feedback);
+        // Sync emergent-context cap evictions so the `emergent_overflow`
+        // alert rule sees the per-turn delta.
+        self.stats
+            .note_emergent_evictions(self.emergent.cap_evictions_total);
         self.recovery.process_feedback(feedback.was_truncated);
 
         if feedback.was_truncated
@@ -350,6 +358,7 @@ impl PipelineSession {
     /// Record a prompt-too-long error (no successful response).
     pub fn record_ptl_error(&mut self) {
         self.recovery.record_ptl_error();
+        self.stats.record_ptl_error();
     }
 
     /// Record that a reactive compaction was attempted.
@@ -393,9 +402,21 @@ impl PipelineSession {
 
     /// Build optimize limits that respond to compaction cascade detection.
     /// When a cascade is active, suppress tool_result_clearing to break the loop.
+    ///
+    /// Precedence: flat assembler mode forces `all_closed()`; an explicit
+    /// `limits_override` in the config replaces the tier-derived limits;
+    /// otherwise limits derive from the current pressure tier. Cascade
+    /// suppression applies on top of override/tier limits.
     #[must_use]
     pub fn cascade_aware_limits(&self, model_limit: u32) -> OptimizeLimits {
-        let mut limits = OptimizeLimits::for_tier(self.current_pressure_tier(), model_limit);
+        let config = self.pipeline.config();
+        if config.assembler_mode == crate::pipeline_config::AssemblerMode::Flat {
+            return OptimizeLimits::all_closed();
+        }
+        let mut limits = match &config.limits_override {
+            Some(overridden) => overridden.clone(),
+            None => OptimizeLimits::for_tier(self.current_pressure_tier(), model_limit),
+        };
         if self.stats.has_compaction_cascade() {
             limits.allow_tool_result_clearing = false;
         }
@@ -750,6 +771,151 @@ mod tests {
         let output = sess.run_turn(input).expect("should not abort");
         assert_eq!(output.metrics.turn_index, 1);
         assert!(output.explain.phase_timings.len() == 4);
+    }
+
+    #[test]
+    fn flat_mode_forces_gates_closed_and_suppresses_markers() {
+        use crate::pipeline_config::AssemblerMode;
+
+        let statics = test_statics();
+        let agent = AgentContext::default();
+        let session = test_session_context(); // anthropic policy → markers
+        let external = test_external();
+        let limits = OptimizeLimits::default();
+
+        let run = |sess: &mut PipelineSession| {
+            let turn = test_turn_state(1);
+            let input = TurnInput {
+                statics: &statics,
+                agent: &agent,
+                session: &session,
+                turn: &turn,
+                external: &external,
+                optimize_limits: &limits,
+                model_id: "claude-sonnet-4-6",
+                query_source: "repl",
+            };
+            sess.run_turn(input).expect("should not abort")
+        };
+
+        let mut structured = PipelineSession::new(PipelineConfig::default());
+        let structured_out = run(&mut structured);
+        assert!(
+            !structured_out.optimized.cache_markers.is_empty(),
+            "anthropic policy should place markers on the structured path"
+        );
+
+        let mut flat = PipelineSession::new(PipelineConfig {
+            assembler_mode: AssemblerMode::Flat,
+            ..Default::default()
+        });
+        let flat_out = run(&mut flat);
+        assert!(
+            flat_out.optimized.cache_markers.is_empty(),
+            "flat mode must emit no cache markers"
+        );
+        assert_eq!(flat_out.metrics.cache_markers, 0);
+        assert!(
+            flat_out
+                .optimized
+                .stats
+                .skipped
+                .iter()
+                .any(|s| s.step == "assembler_mode"),
+            "marker suppression must be visible in the skipped-optimization trace"
+        );
+        // cascade_aware_limits (the adaptive entry's limit source) collapses
+        // to all_closed under flat mode.
+        assert!(!flat.cascade_aware_limits(200_000).any_open());
+    }
+
+    #[test]
+    fn ptl_counter_is_cumulative_across_recovery_resets() {
+        let mut sess = PipelineSession::new(PipelineConfig::default());
+        sess.record_ptl_error();
+
+        // Successful feedback clears consecutive errors but not the total.
+        let mut feedback = ContextFeedback::from_usage(1000, 800, 200, 500, false);
+        sess.record_feedback("model", "repl", &mut feedback, None);
+        assert_eq!(sess.recovery.consecutive_ptl_errors, 0);
+
+        sess.record_ptl_error();
+        assert_eq!(sess.recovery.consecutive_ptl_errors, 1);
+        assert_eq!(sess.stats.ptl_errors_total, 2);
+
+        let statics = test_statics();
+        let agent = AgentContext::default();
+        let session = test_session_context();
+        let turn = test_turn_state(2);
+        let external = test_external();
+        let limits = OptimizeLimits::default();
+        let input = TurnInput {
+            statics: &statics,
+            agent: &agent,
+            session: &session,
+            turn: &turn,
+            external: &external,
+            optimize_limits: &limits,
+            model_id: "claude-sonnet-4-6",
+            query_source: "repl",
+        };
+        let output = sess.run_turn(input).expect("should not abort");
+        assert_eq!(
+            output.explain.ptl_errors_total, 2,
+            "explain must carry the cumulative PTL counter"
+        );
+    }
+
+    #[test]
+    fn api_call_counter_increments_and_flows_to_metrics() {
+        let mut sess = PipelineSession::new(PipelineConfig::default());
+        for _ in 0..2 {
+            let mut feedback = ContextFeedback::from_usage(1000, 800, 200, 500, false);
+            sess.record_feedback("model", "repl", &mut feedback, None);
+        }
+        assert_eq!(sess.stats.api_calls, 2);
+
+        let statics = test_statics();
+        let agent = AgentContext::default();
+        let session = test_session_context();
+        let turn = test_turn_state(3);
+        let external = test_external();
+        let limits = OptimizeLimits::default();
+        let input = TurnInput {
+            statics: &statics,
+            agent: &agent,
+            session: &session,
+            turn: &turn,
+            external: &external,
+            optimize_limits: &limits,
+            model_id: "claude-sonnet-4-6",
+            query_source: "repl",
+        };
+        let output = sess.run_turn(input).expect("should not abort");
+        assert_eq!(
+            output.metrics.api_calls_total, 2,
+            "metrics must expose the explicit call counter"
+        );
+    }
+
+    #[test]
+    fn limits_override_replaces_tier_limits() {
+        let custom = OptimizeLimits {
+            allow_reorder: true,
+            max_reorder_moves: 7,
+            ..OptimizeLimits::all_closed()
+        };
+        let sess = PipelineSession::new(PipelineConfig {
+            limits_override: Some(custom),
+            ..Default::default()
+        });
+        let limits = sess.cascade_aware_limits(200_000);
+        assert!(limits.allow_reorder);
+        assert_eq!(limits.max_reorder_moves, 7);
+        assert!(
+            !limits.allow_spill,
+            "override taken verbatim, not tier-derived"
+        );
     }
 
     #[test]

--- a/crates/astra-turn-core/src/pipeline/stats.rs
+++ b/crates/astra-turn-core/src/pipeline/stats.rs
@@ -114,6 +114,27 @@ mod estimator_buckets_serde {
     }
 }
 
+/// Percentiles the reserve estimator reads in steady state vs. recovery.
+///
+/// Defaults to p75 steady / p95 recovery. Configurable through
+/// `PipelineConfig::plan_policy` so reserve-percentile sweeps can vary the
+/// policy without touching estimator state.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ReservePercentiles {
+    pub steady: f64,
+    pub recovery: f64,
+}
+
+impl Default for ReservePercentiles {
+    fn default() -> Self {
+        Self {
+            steady: 0.75,
+            recovery: 0.95,
+        }
+    }
+}
+
 impl ResponseTokenEstimator {
     /// Create with a default floor reserve.
     #[must_use]
@@ -143,14 +164,26 @@ impl ResponseTokenEstimator {
         source: &str,
         recovery: &RecoveryState,
     ) -> ContextReserves {
+        self.reserve_for_with(model, source, recovery, ReservePercentiles::default())
+    }
+
+    /// Compute reserves for the next turn against an explicit percentile policy.
+    #[must_use]
+    pub fn reserve_for_with(
+        &self,
+        model: &str,
+        source: &str,
+        recovery: &RecoveryState,
+        percentiles: ReservePercentiles,
+    ) -> ContextReserves {
         let key = EstimatorKey {
             model_id: model.to_string(),
             query_source: source.to_string(),
         };
         let p = if recovery.is_in_recovery() {
-            0.95
+            percentiles.recovery
         } else {
-            0.75
+            percentiles.steady
         };
         let output_tokens = self
             .buckets
@@ -199,6 +232,21 @@ pub struct PipelineStats {
     /// Count of observed content changes per section kind.
     #[serde(with = "section_churn_serde")]
     pub section_churns: HashMap<crate::section_types::SectionKind, u32>,
+    /// Cumulative API responses recorded (one per `record()` call). Unlike
+    /// `turns_executed` this is an explicit call counter for cost accounting,
+    /// not a pressure-tier denominator.
+    pub api_calls: u64,
+    /// Cumulative prompt-too-long errors across the session (never reset,
+    /// unlike `RecoveryState::consecutive_ptl_errors`).
+    pub ptl_errors_total: u64,
+    /// Predictive pressure of recent turns (ring, newest last). Feeds the
+    /// `pressure_spike` alert rule.
+    pub recent_pressures: Vec<f64>,
+    /// Emergent-context cap evictions observed as of the last feedback sync.
+    pub emergent_evictions_seen: u64,
+    /// Emergent-context cap evictions that occurred since the previous
+    /// feedback sync. Feeds the `emergent_overflow` alert rule.
+    pub emergent_evictions_last_turn: u64,
 }
 
 mod section_ema_serde {
@@ -303,7 +351,49 @@ impl Default for PipelineStats {
             section_usage_ema: HashMap::new(),
             section_fingerprints: HashMap::new(),
             section_churns: HashMap::new(),
+            api_calls: 0,
+            ptl_errors_total: 0,
+            recent_pressures: Vec::new(),
+            emergent_evictions_seen: 0,
+            emergent_evictions_last_turn: 0,
         }
+    }
+}
+
+impl PipelineStats {
+    /// Maximum retained recent pressure samples (spike detection needs 2).
+    const MAX_RECENT_PRESSURES: usize = 8;
+
+    /// Record the predictive pressure the planner computed for this turn.
+    /// Called once per `run_turn`, before feedback arrives.
+    pub fn record_plan_pressure(&mut self, predictive: f64) {
+        if self.recent_pressures.len() >= Self::MAX_RECENT_PRESSURES {
+            self.recent_pressures.remove(0);
+        }
+        self.recent_pressures.push(predictive);
+    }
+
+    /// The two most recent predictive pressures as (previous, current),
+    /// if at least two turns have been planned.
+    #[must_use]
+    pub fn pressure_delta_pair(&self) -> Option<(f64, f64)> {
+        let n = self.recent_pressures.len();
+        if n < 2 {
+            return None;
+        }
+        Some((self.recent_pressures[n - 2], self.recent_pressures[n - 1]))
+    }
+
+    /// Record a prompt-too-long error (cumulative; never reset).
+    pub fn record_ptl_error(&mut self) {
+        self.ptl_errors_total = self.ptl_errors_total.saturating_add(1);
+    }
+
+    /// Sync the emergent-context cap-eviction counter, computing the delta
+    /// since the previous sync. Called once per feedback cycle.
+    pub fn note_emergent_evictions(&mut self, total: u64) {
+        self.emergent_evictions_last_turn = total.saturating_sub(self.emergent_evictions_seen);
+        self.emergent_evictions_seen = total;
     }
 }
 
@@ -311,6 +401,7 @@ impl PipelineStats {
     /// Record feedback from a completed turn.
     pub fn record(&mut self, model: &str, source: &str, feedback: &ContextFeedback) {
         self.turns_executed += 1;
+        self.api_calls = self.api_calls.saturating_add(1);
 
         // Exponential moving average for cache hit ratio
         let alpha = if self.turns_executed <= 1 { 1.0 } else { 0.1 };

--- a/crates/astra-turn-core/src/pipeline/trace_export.rs
+++ b/crates/astra-turn-core/src/pipeline/trace_export.rs
@@ -1,0 +1,215 @@
+//! Session trace exporter — renders per-turn pipeline records into the
+//! compact trace-table format used in EXPLAIN ANALYZE reports and papers:
+//! one row per turn with pressure, tier, cache behavior, event, and spills.
+//!
+//! The exporter is presentation-only: rows are built from records the
+//! pipeline already emits (`PipelineRunMetrics` per turn, `ContextFeedback`
+//! after the API response, `TraceAlert`s from rule evaluation). No new
+//! instrumentation is required to produce a table.
+
+use serde::{Deserialize, Serialize};
+
+use crate::compaction_types::CompactionTier;
+use crate::context_feedback::ContextFeedback;
+use crate::context_pipeline::PipelineRunMetrics;
+use crate::trace_alert::TraceAlert;
+
+/// One row of the exported trace table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceRow {
+    pub turn: u32,
+    pub raw_pressure: f64,
+    pub predictive_pressure: f64,
+    pub tier: CompactionTier,
+    /// Cache-hit ratio from post-execution feedback; `None` before feedback.
+    pub cache_hit_ratio: Option<f64>,
+    /// Event label for the turn (alert rules fired, recovery escalations…).
+    /// Empty when the turn was uneventful.
+    pub event: String,
+    /// Sections spilled to the spill backend this turn.
+    pub spilled: u32,
+}
+
+impl TraceRow {
+    /// Build a row from a turn's pre-execution metrics, optional
+    /// post-execution feedback, and the alerts that fired on the turn.
+    #[must_use]
+    pub fn from_turn(
+        metrics: &PipelineRunMetrics,
+        feedback: Option<&ContextFeedback>,
+        alerts: &[TraceAlert],
+    ) -> Self {
+        let event = alerts
+            .iter()
+            .map(|a| a.rule.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        Self {
+            turn: metrics.turn_index,
+            raw_pressure: metrics.raw_pressure,
+            predictive_pressure: metrics.predictive_pressure,
+            tier: metrics.compact_tier,
+            cache_hit_ratio: feedback.map(|f| f.cache_hit_ratio),
+            event,
+            spilled: metrics.spilled,
+        }
+    }
+}
+
+/// Render rows as a GitHub-flavored markdown table.
+#[must_use]
+pub fn render_markdown(rows: &[TraceRow]) -> String {
+    let mut out = String::from(
+        "| turn | P_raw | P_pred | tier | cache hit | event | spilled |\n\
+         |---:|---:|---:|:--|---:|:--|---:|\n",
+    );
+    for row in rows {
+        out.push_str(&format!(
+            "| {} | {:.2} | {:.2} | {} | {} | {} | {} |\n",
+            row.turn,
+            row.raw_pressure,
+            row.predictive_pressure,
+            tier_label(row.tier),
+            hit_label(row.cache_hit_ratio),
+            if row.event.is_empty() {
+                "-"
+            } else {
+                &row.event
+            },
+            row.spilled,
+        ));
+    }
+    out
+}
+
+/// Render rows as CSV (header + one line per turn).
+#[must_use]
+pub fn render_csv(rows: &[TraceRow]) -> String {
+    let mut out =
+        String::from("turn,raw_pressure,predictive_pressure,tier,cache_hit,event,spilled\n");
+    for row in rows {
+        out.push_str(&format!(
+            "{},{:.4},{:.4},{},{},{},{}\n",
+            row.turn,
+            row.raw_pressure,
+            row.predictive_pressure,
+            tier_label(row.tier),
+            row.cache_hit_ratio
+                .map(|h| format!("{h:.4}"))
+                .unwrap_or_default(),
+            csv_escape(&row.event),
+            row.spilled,
+        ));
+    }
+    out
+}
+
+fn tier_label(tier: CompactionTier) -> &'static str {
+    match tier {
+        CompactionTier::Normal => "Normal",
+        CompactionTier::TrimSchemas => "TrimSchemas",
+        CompactionTier::CompactHistory => "CompactHistory",
+        CompactionTier::AggressivePrune => "AggressivePrune",
+    }
+}
+
+fn hit_label(hit: Option<f64>) -> String {
+    match hit {
+        Some(h) => format!("{:.0}%", h * 100.0),
+        None => "-".to_string(),
+    }
+}
+
+fn csv_escape(value: &str) -> String {
+    if value.contains(',') || value.contains('"') || value.contains('\n') {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trace_alert::AlertSeverity;
+
+    fn row(turn: u32, tier: CompactionTier, hit: Option<f64>, event: &str) -> TraceRow {
+        TraceRow {
+            turn,
+            raw_pressure: 0.42,
+            predictive_pressure: 0.61,
+            tier,
+            cache_hit_ratio: hit,
+            event: event.to_string(),
+            spilled: 1,
+        }
+    }
+
+    #[test]
+    fn markdown_renders_one_line_per_turn_with_header() {
+        let rows = vec![
+            row(1, CompactionTier::Normal, None, ""),
+            row(2, CompactionTier::TrimSchemas, Some(0.87), "pressure_spike"),
+        ];
+        let md = render_markdown(&rows);
+        let lines: Vec<&str> = md.lines().collect();
+        assert_eq!(lines.len(), 4, "header + separator + 2 rows");
+        assert!(lines[2].contains("| 1 |"));
+        assert!(lines[2].contains("Normal"));
+        assert!(lines[2].contains("| - |"), "no feedback → hit placeholder");
+        assert!(lines[3].contains("87%"));
+        assert!(lines[3].contains("pressure_spike"));
+    }
+
+    #[test]
+    fn csv_escapes_multi_event_rows() {
+        let rows = vec![row(
+            3,
+            CompactionTier::CompactHistory,
+            Some(0.5),
+            "recovery_loop, compaction_cascade",
+        )];
+        let csv = render_csv(&rows);
+        assert!(csv.contains("\"recovery_loop, compaction_cascade\""));
+        assert!(csv.starts_with("turn,raw_pressure"));
+    }
+
+    #[test]
+    fn from_turn_joins_alert_rules_into_event() {
+        let metrics = PipelineRunMetrics {
+            turn_index: 7,
+            input_tokens: 1000,
+            output_reserve_tokens: 500,
+            raw_pressure: 0.55,
+            predictive_pressure: 0.72,
+            compact_tier: CompactionTier::TrimSchemas,
+            sections: 5,
+            messages: 3,
+            tool_schemas: 2,
+            cache_markers: 2,
+            tokens_cleared: 0,
+            avg_cache_hit_ratio: 0.8,
+            spilled: 0,
+            api_calls_total: 6,
+        };
+        let feedback = ContextFeedback::from_usage(1000, 800, 200, 100, false);
+        let alerts = vec![
+            TraceAlert {
+                severity: AlertSeverity::Warning,
+                rule: "pressure_spike".into(),
+                message: String::new(),
+                turn: 7,
+            },
+            TraceAlert {
+                severity: AlertSeverity::Warning,
+                rule: "emergent_overflow".into(),
+                message: String::new(),
+                turn: 7,
+            },
+        ];
+        let row = TraceRow::from_turn(&metrics, Some(&feedback), &alerts);
+        assert_eq!(row.turn, 7);
+        assert_eq!(row.event, "pressure_spike, emergent_overflow");
+        assert!((row.cache_hit_ratio.unwrap() - 0.8).abs() < 1e-9);
+    }
+}

--- a/crates/astra-turn-core/src/trace_alert.rs
+++ b/crates/astra-turn-core/src/trace_alert.rs
@@ -127,8 +127,45 @@ pub fn evaluate_alerts(
         }
     }
 
+    // Rule 7: Pressure spike — predictive pressure jumped >= 0.20 in one turn.
+    // A single turn adding a fifth of the window usually means an oversized
+    // tool result or attachment slipped in; worth surfacing before the
+    // compaction ladder has to absorb it.
+    if let Some((previous, current)) = stats.pressure_delta_pair() {
+        let delta = current - previous;
+        if delta >= PRESSURE_SPIKE_DELTA {
+            alerts.push(TraceAlert {
+                severity: AlertSeverity::Warning,
+                rule: "pressure_spike".into(),
+                message: format!(
+                    "Predictive pressure jumped {:.2} -> {:.2} (+{:.2}) in one turn.",
+                    previous, current, delta,
+                ),
+                turn,
+            });
+        }
+    }
+
+    // Rule 8: Emergent overflow — the TTL+dedup+cap guardrails evicted items
+    // since the last feedback cycle, i.e. Execute produced more emergent
+    // context than the caps admit; the next Bind silently lost candidates.
+    if stats.emergent_evictions_last_turn > 0 {
+        alerts.push(TraceAlert {
+            severity: AlertSeverity::Warning,
+            rule: "emergent_overflow".into(),
+            message: format!(
+                "{} emergent item(s) evicted at list cap since the previous turn.",
+                stats.emergent_evictions_last_turn,
+            ),
+            turn,
+        });
+    }
+
     alerts
 }
+
+/// One-turn predictive-pressure jump that fires the `pressure_spike` rule.
+pub const PRESSURE_SPIKE_DELTA: f64 = 0.20;
 
 #[cfg(test)]
 mod tests {
@@ -241,5 +278,64 @@ mod tests {
         let recovery = RecoveryState::default();
         let alerts = evaluate_alerts(4, &f, &stats, &recovery);
         assert!(alerts.iter().any(|a| a.rule == "predictive_miss"));
+    }
+
+    #[test]
+    fn pressure_spike_alert_on_one_turn_jump() {
+        let f = make_feedback(800, 200);
+        let mut stats = PipelineStats {
+            turns_executed: 5,
+            avg_cache_hit_ratio: 0.75,
+            ..Default::default()
+        };
+        stats.record_plan_pressure(0.45);
+        stats.record_plan_pressure(0.70); // +0.25 in one turn
+        let alerts = evaluate_alerts(6, &f, &stats, &RecoveryState::default());
+        assert!(alerts.iter().any(|a| a.rule == "pressure_spike"));
+    }
+
+    #[test]
+    fn no_pressure_spike_on_gradual_growth() {
+        let f = make_feedback(800, 200);
+        let mut stats = PipelineStats {
+            turns_executed: 5,
+            avg_cache_hit_ratio: 0.75,
+            ..Default::default()
+        };
+        stats.record_plan_pressure(0.45);
+        stats.record_plan_pressure(0.55); // +0.10 — below the spike delta
+        let alerts = evaluate_alerts(6, &f, &stats, &RecoveryState::default());
+        assert!(!alerts.iter().any(|a| a.rule == "pressure_spike"));
+    }
+
+    #[test]
+    fn no_pressure_spike_with_fewer_than_two_samples() {
+        let f = make_feedback(800, 200);
+        let mut stats = PipelineStats {
+            turns_executed: 1,
+            avg_cache_hit_ratio: 0.75,
+            ..Default::default()
+        };
+        stats.record_plan_pressure(0.90);
+        let alerts = evaluate_alerts(1, &f, &stats, &RecoveryState::default());
+        assert!(!alerts.iter().any(|a| a.rule == "pressure_spike"));
+    }
+
+    #[test]
+    fn emergent_overflow_alert_on_cap_evictions() {
+        let f = make_feedback(800, 200);
+        let mut stats = PipelineStats {
+            turns_executed: 5,
+            avg_cache_hit_ratio: 0.75,
+            ..Default::default()
+        };
+        stats.note_emergent_evictions(3); // 3 new evictions since last sync
+        let alerts = evaluate_alerts(6, &f, &stats, &RecoveryState::default());
+        assert!(alerts.iter().any(|a| a.rule == "emergent_overflow"));
+
+        // Next cycle with no new evictions must not re-alert.
+        stats.note_emergent_evictions(3);
+        let alerts = evaluate_alerts(7, &f, &stats, &RecoveryState::default());
+        assert!(!alerts.iter().any(|a| a.rule == "emergent_overflow"));
     }
 }

--- a/crates/astra-turn-core/tests/context_pipeline_contract.rs
+++ b/crates/astra-turn-core/tests/context_pipeline_contract.rs
@@ -129,6 +129,7 @@ fn context_pipeline_serializes_provider_request_and_metrics() {
     };
     let pipeline = ContextPipeline::new(PipelineConfig {
         provider_policy: session.provider_policy.clone(),
+        ..Default::default()
     });
     let run = pipeline
         .run(PipelineRunInput {
@@ -327,6 +328,7 @@ fn pipeline_aborts_on_consecutive_ptl_errors() {
     };
     let pipeline = ContextPipeline::new(PipelineConfig {
         provider_policy: session.provider_policy.clone(),
+        ..Default::default()
     });
     let result = pipeline.run(PipelineRunInput {
         sources: &sources,
@@ -364,6 +366,7 @@ fn serialized_output_format_system_blocks_are_well_structured() {
     };
     let pipeline = ContextPipeline::new(PipelineConfig {
         provider_policy: session.provider_policy.clone(),
+        ..Default::default()
     });
     let run = pipeline
         .run(PipelineRunInput {

--- a/crates/astra-turn-core/tests/pipeline_adapter_phase14.rs
+++ b/crates/astra-turn-core/tests/pipeline_adapter_phase14.rs
@@ -143,6 +143,7 @@ fn pipeline_output_flattened_matches_concatenation_of_blocks() {
 
     let mut sess = PipelineSession::new(PipelineConfig {
         provider_policy: ProviderCachePolicy::anthropic(),
+        ..Default::default()
     });
 
     let input = TurnInput {
@@ -184,6 +185,7 @@ fn pipeline_to_anthropic_message_format() {
 
     let mut sess = PipelineSession::new(PipelineConfig {
         provider_policy: ProviderCachePolicy::anthropic(),
+        ..Default::default()
     });
 
     let input = TurnInput {

--- a/crates/astra-turn-core/tests/pipeline_observability_phase13.rs
+++ b/crates/astra-turn-core/tests/pipeline_observability_phase13.rs
@@ -29,6 +29,7 @@ fn pipeline_explain_serializes_to_trace_compatible_json() {
         },
         compact_tier: CompactionTier::TrimSchemas,
         skipped_optimizations: 2,
+        ptl_errors_total: 0,
     };
 
     let json = serde_json::to_value(&explain).unwrap();

--- a/crates/astra-turn-core/tests/pipeline_session_lifecycle.rs
+++ b/crates/astra-turn-core/tests/pipeline_session_lifecycle.rs
@@ -76,6 +76,7 @@ fn make_turn_state(turn_index: u32, message_count: usize) -> TurnState {
 fn ten_turn_session_lifecycle() {
     let config = PipelineConfig {
         provider_policy: ProviderCachePolicy::anthropic(),
+        ..Default::default()
     };
     let mut sess = PipelineSession::new(config);
     let statics = StaticSections::test_default();
@@ -133,6 +134,7 @@ fn ten_turn_session_lifecycle() {
 fn warm_start_from_serialized_stats() {
     let config = PipelineConfig {
         provider_policy: ProviderCachePolicy::anthropic(),
+        ..Default::default()
     };
 
     let mut first_session = PipelineSession::new(config.clone());
@@ -193,6 +195,7 @@ fn ptl_error_recovery_and_abort() {
 fn shadow_mode_produces_deterministic_output() {
     let config = PipelineConfig {
         provider_policy: ProviderCachePolicy::anthropic(),
+        ..Default::default()
     };
     let mut sess = PipelineSession::new(config);
     let statics = StaticSections::test_default();
@@ -270,6 +273,7 @@ fn full_lifecycle_with_emergent_and_latches() {
 
     let config = PipelineConfig {
         provider_policy: ProviderCachePolicy::anthropic(),
+        ..Default::default()
     };
     let mut sess = PipelineSession::new(config);
 

--- a/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -1495,7 +1495,8 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                 let feedback_evt =
                     astra_turn_core::pipeline_journal::PipelineJournalEvent::from_feedback(
                         turn, &model_id, &feedback,
-                    );
+                    )
+                    .with_api_calls_total(pipeline_sess.stats.api_calls);
                 if let Ok(payload) = serde_json::to_value(&feedback_evt) {
                     buf.record(
                         astra_services::session_journal::JournalEvent::pipeline_feedback(

--- a/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/crates/runtime/src/turn/bridge/inprocess.rs
@@ -4129,7 +4129,8 @@ impl InProcessChatTurnBridge {
                             current_turn,
                             capture_model,
                             &feedback,
-                        );
+                        )
+                        .with_api_calls_total(bridge_pipeline_baseline.stats.api_calls);
                     if let Ok(payload) = serde_json::to_value(&feedback_evt) {
                         buf.record(
                             astra_services::session_journal::JournalEvent::pipeline_feedback(

--- a/crates/runtime/src/turn/context_pipeline_adapter.rs
+++ b/crates/runtime/src/turn/context_pipeline_adapter.rs
@@ -1233,6 +1233,7 @@ mod tests {
 
         let mut sess = PipelineSession::new(PipelineConfig {
             provider_policy: ci.session.provider_policy.clone(),
+            ..Default::default()
         });
         let output = sess
             .run_turn_adaptive(AdaptiveTurnInput {
@@ -1284,6 +1285,7 @@ mod tests {
 
         let mut sess = PipelineSession::new(PipelineConfig {
             provider_policy: ci.session.provider_policy.clone(),
+            ..Default::default()
         });
         let output = sess
             .run_turn_adaptive(AdaptiveTurnInput {
@@ -1332,6 +1334,7 @@ mod tests {
 
         let mut sess = PipelineSession::new(PipelineConfig {
             provider_policy: ci.session.provider_policy.clone(),
+            ..Default::default()
         });
         let output = sess
             .run_turn_adaptive(AdaptiveTurnInput {
@@ -1374,6 +1377,7 @@ mod tests {
 
         let mut sess = PipelineSession::new(PipelineConfig {
             provider_policy: ci.session.provider_policy.clone(),
+            ..Default::default()
         });
         let output = sess
             .run_turn_adaptive(AdaptiveTurnInput {
@@ -1442,6 +1446,7 @@ mod tests {
         let ci = build_composite_inputs(&state, &ep_with, "anthropic", "claude-sonnet-4-6", "hi");
         let mut sess = PipelineSession::new(PipelineConfig {
             provider_policy: ci.session.provider_policy.clone(),
+            ..Default::default()
         });
         let out_with = sess
             .run_turn_adaptive(AdaptiveTurnInput {
@@ -1468,6 +1473,7 @@ mod tests {
             build_composite_inputs(&state, &ep_without, "anthropic", "claude-sonnet-4-6", "hi");
         let mut sess2 = PipelineSession::new(PipelineConfig {
             provider_policy: ci2.session.provider_policy.clone(),
+            ..Default::default()
         });
         let out_without = sess2
             .run_turn_adaptive(AdaptiveTurnInput {
@@ -1966,6 +1972,36 @@ mod tests {
             2,
             "turn_budget + active_skill_names → 2 dynamic"
         );
+    }
+
+    #[test]
+    fn assembler_arrival_order_skips_partition_and_preserves_registration_order() {
+        // Same mixed-scope providers as the partitioning test, interleaved
+        // Session/None so ordering is observable.
+        let providers: Vec<Box<dyn astra_turn_core::context_sources::ContextChannelProvider>> = vec![
+            Box::new(super::SkillListingProvider {
+                content: "skills".into(),
+            }), // Session
+            Box::new(super::TurnBudgetProvider {
+                remaining_turns: 5,
+                max_turns: 10,
+            }), // None
+            Box::new(super::CacheStrategyProvider), // Session
+        ];
+        let policy = ContextChannelPolicy {
+            arrival_order: true,
+            ..ContextChannelPolicy::default()
+        };
+        let assembler = ChannelAssembler::new(providers, policy);
+        let (stable, dynamic) = assembler.assemble(0);
+        assert!(stable.is_empty(), "arrival order bypasses the stable lane");
+        assert_eq!(dynamic.len(), 3, "all sections flow through dynamic");
+        assert!(dynamic[0].text.contains("skills"));
+        assert!(dynamic[1].text.contains("5"), "turn budget second");
+        assert!(dynamic[2].text.contains("Execution Strategy"));
+        // Scope declarations survive even though the partition is skipped.
+        assert_eq!(dynamic[0].scope, CacheScope::Session);
+        assert_eq!(dynamic[1].scope, CacheScope::None);
     }
 
     #[test]

--- a/crates/runtime/src/turn/prompt_cache.rs
+++ b/crates/runtime/src/turn/prompt_cache.rs
@@ -522,6 +522,7 @@ pub(crate) fn assemble_bridge_pipeline_outcome(
     // is the right lifecycle. Stats/recovery/latches all start at default.
     let mut session = PipelineSession::new(PipelineConfig {
         provider_policy: provider_policy.clone(),
+        ..Default::default()
     });
     let input = AdaptiveTurnInput {
         statics: &statics,


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [x] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## What this PR does / why we need it

Code changes for ContextPipe paper

All proposed code changes (C1–C6) are implemented in Astra, tested, and green. Here's the delivery report.

**C1 — Predictive vs. reactive pressure (ablation X2a/A1).** `PipelineConfig.plan_policy.pressure_mode` selects how the planner turns pressure into a compaction tier: `Predictive` (default, unchanged: `max(raw, predictive)`, escalate-only) or `Reactive` (tier from raw pressure only — predictive is still computed and traced, so the explain shows what prediction *would* have done). The cumulative `prompt_too_long` count now survives recovery resets: `PipelineStats.ptl_errors_total` feeds a new `PipelineExplain.ptl_errors_total` field — the primary metric of the ablation.

**C2 — Flat baseline assembler (experiment E2/X1a).** `PipelineConfig.assembler_mode = Flat` turns the same `run_turn` entry point into a naive stable-prefix-then-append builder: every optimizer gate forced closed, zero cache markers (suppression recorded in the skipped-optimization trace, so audits show what the structured path would have placed), and `cascade_aware_limits` collapses to `all_closed()`. For X1a's arm B, `ContextChannelPolicy.arrival_order = true` bypasses the stable/dynamic partition and returns channel sections in registration order.

**C3 — Parameterized knobs (sweep X2b/X2c).** `TierThresholds` (default 0.60/0.75/0.90) threads through new `select_compaction_tier_with`/`select_tier_gated_with`; `ReservePercentiles` (default p75/p95) through `reserve_for_with`; both ride in `PlanPolicy`. `PipelineConfig.limits_override` replaces tier-derived `OptimizeLimits` verbatim for optimizer-knob sweeps. The old function signatures remain as default-policy wrappers, which is why all 28 existing `PlanInput` sites and 30 `plan_turn` callers needed no changes.

**C4 — Honest cost accounting.** `PipelineStats.api_calls` is an explicit counter (the paper previously had to infer call counts from capture files — reviewers flagged this); it flows into `PipelineRunMetrics.api_calls_total` and journal feedback events, which now also carry `fresh_tokens` (prompt − cache_read, the billed-cost decomposition quantity). Wired at both production journal emitters (`execution_phase.rs`, `bridge/inprocess.rs`).

**C5 — Trace exporter.** New `pipeline/trace_export.rs`: `TraceRow::from_turn(metrics, feedback, alerts)` plus markdown/CSV renderers producing exactly the paper's trace-table shape (turn, P_raw, P_pred, tier, cache hit, event, spilled) from records the pipeline already emits.

**C6 — The two missing alert rules.** `evaluate_alerts` now implements all 8 rules the paper's §6 promises: added `pressure_spike` (predictive pressure jumps ≥ 0.20 in one turn, via a small pressure ring in stats) and `emergent_overflow` (cap evictions since the last feedback sync, counted by the new `EmergentContext.cap_evictions_total`). Signature unchanged — both rules read from `PipelineStats`, so all existing callers get them for free.

Every config addition is `#[serde(default)]`-guarded, so persisted sessions and legacy configs load unchanged, and `PlanPolicy::default()` reproduces production behavior bit-for-bit.

## Verification

| Gate | Result |
|---|---|
| `cargo check --workspace --all-targets` | clean |
| `cargo test -p astra-turn-core` | 3,751 lib tests + 31 suites, all pass (includes 15 new tests: reactive-vs-predictive, shifted ladders, Flat markers/gates, PTL cumulativity, api_calls flow, eviction counting, both new alert rules, exporter rendering, legacy-config serde) |
| `cargo test -p astra-runtime --lib context_pipeline_adapter` / `prompt_cache` | 81 + 53 pass (includes new arrival-order test) |
| `cargo fmt --check`, `cargo clippy` (turn-core all-targets, runtime lib) | clean, 0 warnings |

**One pre-existing flake found, not caused by this work**: `parallel_tool_exec::tool_admission_metrics_record_wait_time` fails when its module runs together but passes alone — I verified it reproduces on the pristine tree via stash. I've flagged it as a separate task chip rather than mixing the fix into this change set.

## Residual risk / skipped

- Changes are uncommitted in `~/workspace/astra` (20 files) — I didn't commit since you may want to review or split; say the word and I'll commit with a conventional message.
- The full `astra-runtime` integration test suite wasn't run end-to-end (only the two touched modules, per the focused-gate policy); workspace check covers compilation everywhere.
- C7 (trace retention defaults) resolved paper-side per plan: the paper should describe the configurable 30-day default — no code change.

💡 **Next steps**
1. Fix the abstract (W1) — still the cheapest reviewer-flip item, untouched in the paper tree.
2. Locate the external SWE-bench runner and wire `plan_policy`/`assembler_mode` into its config to launch X2a (predictive-vs-reactive) and E2 (Flat-vs-Structured).
3. X1a can start immediately with zero API cost: recorded snapshots + `run_turn_shadow` byte-diff against the Flat/arrival-order arms.