### PR TITLE
ci: publish release images through IDC runner

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -57,25 +57,30 @@ jobs:
           echo "latest=${latest}" >> "${GITHUB_OUTPUT}"
 
   build:
-    name: Build ${{ matrix.platform }}
+    name: Build & Push DockerHub and IDC Images
     needs: version
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            slug: linux-amd64
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            slug: linux-arm64
+    runs-on: amd64-mo-shanghai-dind
+    timeout-minutes: 240
+    env:
+      http_proxy: http://proxy-service.proxy.svc.cluster.local:8001
+      https_proxy: http://proxy-service.proxy.svc.cluster.local:8001
+      no_proxy: .local,.cn,.gitee.com,.tencent.com,.tencentyun.com,.aliyun.com,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,localhost,127.0.0.0/8,.qq.com,169.254.0.0/16,.myqcloud.com,.matrixone.tech,.aliyuncs.com,.digicert.com,.microsoft.com,.visualstudio.com,.symcb.com,0.0.0.0
 
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+          cache-image: false
+
       - uses: docker/setup-buildx-action@v3
+        id: buildx
+        with:
+          driver-opts: |
+            env.https_proxy=${{ env.https_proxy }}
+            env.http_proxy=${{ env.http_proxy }}
+            "env.no_proxy=${{ env.no_proxy }}"
 
       - uses: docker/login-action@v3
         with:
@@ -91,7 +96,9 @@ jobs:
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.IMAGE_NAME }}
+            ${{ env.IDC_IMAGE_NAME }}
           flavor: |
             latest=false
           tags: |
@@ -100,123 +107,34 @@ jobs:
             type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
 
       - uses: docker/build-push-action@v6
-        id: build
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: Dockerfile
-          platforms: ${{ matrix.platform }}
-          tags: |
-            ${{ env.IMAGE_NAME }}
-            ${{ env.IDC_IMAGE_NAME }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             IMAGE_VERSION=${{ needs.version.outputs.image_version }}
             IMAGE_REVISION=${{ github.sha }}
             IMAGE_BRANCH=${{ github.ref_name }}
-          cache-from: type=gha,scope=docker-${{ matrix.slug }}
-          cache-to: type=gha,scope=docker-${{ matrix.slug }},mode=max
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+            http_proxy=${{ env.http_proxy }}
+            https_proxy=${{ env.https_proxy }}
+            no_proxy=${{ env.no_proxy }}
+            HTTP_PROXY=${{ env.http_proxy }}
+            HTTPS_PROXY=${{ env.https_proxy }}
+            NO_PROXY=${{ env.no_proxy }}
+          cache-from: type=gha,scope=release-docker
+          cache-to: type=gha,scope=release-docker,mode=max
           provenance: mode=max
           sbom: true
 
-      - name: Export digest
+      - name: Verify published manifests
         shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ matrix.slug }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    name: Merge & Push Docker Manifest
-    needs:
-      - version
-      - build
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: digests-*
-          path: /tmp/digests
-          merge-multiple: true
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.IDC_REGISTRY }}
-          username: ${{ secrets.IDC_REGISTRY_USERNAME }}
-          password: ${{ secrets.IDC_REGISTRY_PASSWORD }}
-
-      - uses: docker/metadata-action@v5
-        id: meta
-        with:
-          images: ${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            type=semver,pattern={{version}},value=${{ needs.version.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.latest == 'true' }}
-            type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
-
-      - uses: docker/metadata-action@v5
-        id: idc-meta
-        with:
-          images: ${{ env.IDC_IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            type=semver,pattern={{version}},value=${{ needs.version.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.latest == 'true' }}
-            type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
-
-      - name: Create Docker manifest lists
-        shell: bash
-        working-directory: /tmp/digests
         env:
-          DOCKERHUB_IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          DOCKERHUB_METADATA_JSON: ${{ steps.meta.outputs.json }}
-          IDC_IMAGE_NAME: ${{ env.IDC_IMAGE_NAME }}
-          IDC_METADATA_JSON: ${{ steps.idc-meta.outputs.json }}
+          IMAGE_VERSION: ${{ needs.version.outputs.image_version }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
-
-          create_manifest_list() {
-            local image_name="$1"
-            local metadata_json="$2"
-            local -a tag_args=()
-            local -a sources=()
-
-            mapfile -t tag_args < <(jq -r '.tags[] | "-t", .' <<< "${metadata_json}")
-            if [ "${#tag_args[@]}" -eq 0 ]; then
-              echo "No Docker tags were generated for ${image_name}" >&2
-              exit 1
-            fi
-
-            for digest in *; do
-              sources+=("${image_name}@sha256:${digest}")
-            done
-            if [ "${#sources[@]}" -eq 0 ]; then
-              echo "No platform image digests were downloaded" >&2
-              exit 1
-            fi
-
-            docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
-          }
-
-          create_manifest_list "${DOCKERHUB_IMAGE_NAME}" "${DOCKERHUB_METADATA_JSON}"
-          create_manifest_list "${IDC_IMAGE_NAME}" "${IDC_METADATA_JSON}"
+          docker buildx imagetools inspect "${IMAGE_NAME}:${IMAGE_VERSION}" >/dev/null
+          docker buildx imagetools inspect "${IDC_IMAGE_NAME}:${IMAGE_VERSION}" >/dev/null

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -57,48 +57,35 @@ jobs:
           echo "latest=${latest}" >> "${GITHUB_OUTPUT}"
 
   build:
-    name: Build & Push DockerHub and IDC Images
+    name: Build ${{ matrix.platform }}
     needs: version
-    runs-on: amd64-mo-shanghai-dind
-    timeout-minutes: 240
-    env:
-      http_proxy: http://proxy-service.proxy.svc.cluster.local:8001
-      https_proxy: http://proxy-service.proxy.svc.cluster.local:8001
-      no_proxy: .local,.cn,.gitee.com,.tencent.com,.tencentyun.com,.aliyun.com,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,localhost,127.0.0.0/8,.qq.com,169.254.0.0/16,.myqcloud.com,.matrixone.tech,.aliyuncs.com,.digicert.com,.microsoft.com,.visualstudio.com,.symcb.com,0.0.0.0
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            slug: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            slug: linux-arm64
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-          cache-image: false
-
       - uses: docker/setup-buildx-action@v3
-        id: buildx
-        with:
-          driver-opts: |
-            env.https_proxy=${{ env.https_proxy }}
-            env.http_proxy=${{ env.http_proxy }}
-            "env.no_proxy=${{ env.no_proxy }}"
 
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.IDC_REGISTRY }}
-          username: ${{ secrets.IDC_REGISTRY_USERNAME }}
-          password: ${{ secrets.IDC_REGISTRY_PASSWORD }}
-
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: |
-            ${{ env.IMAGE_NAME }}
-            ${{ env.IDC_IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
           flavor: |
             latest=false
           tags: |
@@ -107,34 +94,144 @@ jobs:
             type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
 
       - uses: docker/build-push-action@v6
+        id: build
         with:
-          builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             IMAGE_VERSION=${{ needs.version.outputs.image_version }}
             IMAGE_REVISION=${{ github.sha }}
             IMAGE_BRANCH=${{ github.ref_name }}
-            http_proxy=${{ env.http_proxy }}
-            https_proxy=${{ env.https_proxy }}
-            no_proxy=${{ env.no_proxy }}
-            HTTP_PROXY=${{ env.http_proxy }}
-            HTTPS_PROXY=${{ env.https_proxy }}
-            NO_PROXY=${{ env.no_proxy }}
-          cache-from: type=gha,scope=release-docker
-          cache-to: type=gha,scope=release-docker,mode=max
+          cache-from: type=gha,scope=docker-${{ matrix.slug }}
+          cache-to: type=gha,scope=docker-${{ matrix.slug }},mode=max
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           provenance: mode=max
           sbom: true
 
-      - name: Verify published manifests
+      - name: Export digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Publish DockerHub Manifest
+    needs:
+      - version
+      - build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.latest == 'true' }}
+            type=raw,value=latest,enable=${{ needs.version.outputs.latest == 'true' }}
+
+      - name: Create DockerHub manifest list
+        shell: bash
+        working-directory: /tmp/digests
+        env:
+          DOCKERHUB_IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERHUB_METADATA_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          mapfile -t tag_args < <(jq -r '.tags[] | "-t", .' <<< "${DOCKERHUB_METADATA_JSON}")
+          if [ "${#tag_args[@]}" -eq 0 ]; then
+            echo "No DockerHub tags were generated" >&2
+            exit 1
+          fi
+
+          sources=()
+          for digest in *; do
+            sources+=("${DOCKERHUB_IMAGE_NAME}@sha256:${digest}")
+          done
+          if [ "${#sources[@]}" -eq 0 ]; then
+            echo "No platform image digests were downloaded" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+
+  idc:
+    name: Publish IDC Manifest
+    needs:
+      - version
+      - merge
+    runs-on: amd64-mo-shanghai-dind
+    timeout-minutes: 45
+    env:
+      http_proxy: http://proxy-service.proxy.svc.cluster.local:8001
+      https_proxy: http://proxy-service.proxy.svc.cluster.local:8001
+      no_proxy: .local,.cn,.gitee.com,.tencent.com,.tencentyun.com,.aliyun.com,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,localhost,127.0.0.0/8,.qq.com,169.254.0.0/16,.myqcloud.com,.matrixone.tech,.aliyuncs.com,.digicert.com,.microsoft.com,.visualstudio.com,.symcb.com,0.0.0.0
+
+    steps:
+      - name: Install crane
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          curl -fsSL \
+            -o "${RUNNER_TEMP}/go-containerregistry.tar.gz" \
+            "https://github.com/google/go-containerregistry/releases/download/v0.20.6/go-containerregistry_Linux_x86_64.tar.gz"
+          tar -xzf "${RUNNER_TEMP}/go-containerregistry.tar.gz" -C "${RUNNER_TEMP}/bin" crane
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+          "${RUNNER_TEMP}/bin/crane" version
+
+      - name: Copy DockerHub manifest to IDC
         shell: bash
         env:
           IMAGE_VERSION: ${{ needs.version.outputs.image_version }}
+          PUBLISH_LATEST: ${{ needs.version.outputs.latest }}
+          SOURCE_IMAGE: ${{ env.IMAGE_NAME }}
+          TARGET_IMAGE: ${{ env.IDC_IMAGE_NAME }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          IDC_USERNAME: ${{ secrets.IDC_REGISTRY_USERNAME }}
+          IDC_PASSWORD: ${{ secrets.IDC_REGISTRY_PASSWORD }}
         run: |
           set -euo pipefail
-          docker buildx imagetools inspect "${IMAGE_NAME}:${IMAGE_VERSION}" >/dev/null
-          docker buildx imagetools inspect "${IDC_IMAGE_NAME}:${IMAGE_VERSION}" >/dev/null
+          printf '%s' "${DOCKERHUB_TOKEN}" | crane auth login index.docker.io -u "${DOCKERHUB_USERNAME}" --password-stdin
+          printf '%s' "${IDC_PASSWORD}" | crane auth login "${IDC_REGISTRY}" -u "${IDC_USERNAME}" --password-stdin
+
+          tags=("${IMAGE_VERSION}")
+          if [ "${PUBLISH_LATEST}" = "true" ]; then
+            tags+=("${IMAGE_VERSION%.*}" "latest")
+          fi
+          for tag in "${tags[@]}"; do
+            crane copy --platform=all --jobs 2 \
+              "docker.io/${SOURCE_IMAGE}:${IMAGE_VERSION}" \
+              "${TARGET_IMAGE}:${tag}"
+          done
+          crane manifest "${TARGET_IMAGE}:${IMAGE_VERSION}" >/dev/null

--- a/crates/astra-cli/src/cli/cli_config/cli_formatting.rs
+++ b/crates/astra-cli/src/cli/cli_config/cli_formatting.rs
@@ -91,7 +91,7 @@ pub fn colorize_diff_summary(diff: &str) -> String {
             old_line += 1;
             new_line += 1;
             let prefix = format!("{:>4}   ", new_line);
-            parts.push(format!("{}{}", prefix.dim(), &line[1..].dim()));
+            parts.push(format!("{}{}", prefix.dim(), line[1..].dim()));
             continue;
         }
         parts.push(format!("{}", line.dim()));

--- a/crates/astra-cli/src/cli/slash/slash_team.rs
+++ b/crates/astra-cli/src/cli/slash/slash_team.rs
@@ -1618,7 +1618,7 @@ pub(crate) async fn handle_team_command(
                 "    {} Use '/team restore {} {}' to restore.",
                 "💡".dim(),
                 name,
-                &snapshot_id,
+                snapshot_id,
             );
             eprintln!();
         }

--- a/crates/astra-cli/src/cli/turn/turn_entry.rs
+++ b/crates/astra-cli/src/cli/turn/turn_entry.rs
@@ -51,10 +51,9 @@ pub(crate) fn classify_shell_passthrough(line: &str) -> Option<ShellPassthroughD
     let trimmed = line.trim_start();
     let (override_high_risk, body) = if let Some(rest) = trimmed.strip_prefix("!!") {
         (true, rest)
-    } else if let Some(rest) = trimmed.strip_prefix('!') {
-        (false, rest)
     } else {
-        return None;
+        let rest = trimmed.strip_prefix('!')?;
+        (false, rest)
     };
     let cmd = body.trim();
     if cmd.is_empty() {

--- a/crates/astra-cli/src/cli/turn/turn_failure_reporting.rs
+++ b/crates/astra-cli/src/cli/turn/turn_failure_reporting.rs
@@ -25,7 +25,7 @@ pub(crate) fn report_turn_failure(
         ui.show_error(&format!(
             "  {} {}",
             crate::cli::theme::icon_err(),
-            &failure.error
+            failure.error
         ));
     }
 

--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -2428,9 +2428,9 @@ impl ToolExecutor {
         // the old-format (pure JSON) and new-format (summary + JSON)
         // responses. Pre-prefix responses still work — `find('{')` on
         // a pure-JSON string returns 0 and we parse the whole string.
-        let json_body = match output.find('{') {
-            Some(pos) => &output[pos..],
-            None => return None,
+        let json_body = {
+            let pos = output.find('{')?;
+            &output[pos..]
         };
         serde_json::from_str::<Value>(json_body).ok()
     }

--- a/crates/astra-cli/src/tui/approval/queue.rs
+++ b/crates/astra-cli/src/tui/approval/queue.rs
@@ -790,7 +790,7 @@ mod tests {
             tx,
             ApprovalMetadata::default().with_mcp_capability(meta.clone()),
         );
-        let entries_dbg = format!("{:?}", &q.entries);
+        let entries_dbg = format!("{:?}", q.entries);
         assert!(entries_dbg.contains("mcp_capability_known: Some(true)"));
     }
 

--- a/crates/astra-cli/src/tui/bottom_pane/info_view.rs
+++ b/crates/astra-cli/src/tui/bottom_pane/info_view.rs
@@ -77,7 +77,7 @@ impl BottomPaneView for InfoView {
 
         // Title
         if y < area.bottom() {
-            let line = Line::from(Span::styled(format!("  {}", &self.title), title_style));
+            let line = Line::from(Span::styled(format!("  {}", self.title), title_style));
             Widget::render(line, Rect::new(area.x, y, area.width, 1), buf);
             y += 1;
         }

--- a/crates/astra-cli/src/tui/bottom_pane/list_selection_view.rs
+++ b/crates/astra-cli/src/tui/bottom_pane/list_selection_view.rs
@@ -137,14 +137,14 @@ impl BottomPaneView for ListSelectionView {
                     Span::styled("  ", sel_style),
                     Span::styled(marker, sel_style),
                     Span::styled(num, sel_style),
-                    Span::styled(format!("{}{}", &item.name, current_tag), sel_style),
+                    Span::styled(format!("{}{}", item.name, current_tag), sel_style),
                 ]
             } else {
                 vec![
                     Span::raw("  "),
                     Span::raw(marker),
                     Span::raw(num),
-                    Span::raw(format!("{}{}", &item.name, current_tag)),
+                    Span::raw(format!("{}{}", item.name, current_tag)),
                 ]
             };
 

--- a/crates/astra-cli/src/tui/history_cell/tool.rs
+++ b/crates/astra-cli/src/tui/history_cell/tool.rs
@@ -857,13 +857,7 @@ pub(super) fn humanize_tool_name(name: &str) -> String {
 }
 
 fn non_empty_tool_text(value: Option<String>) -> Option<String> {
-    value.and_then(|text| {
-        if text.trim().is_empty() {
-            None
-        } else {
-            Some(text)
-        }
-    })
+    value.filter(|text| !text.trim().is_empty())
 }
 
 fn failure_detail_fallback(name: &str, description: &str) -> String {

--- a/crates/astra-tools/src/memoria.rs
+++ b/crates/astra-tools/src/memoria.rs
@@ -1234,10 +1234,9 @@ impl MemoriaClient {
             .and_then(|tail| tail.strip_suffix("/feedback"))
         {
             format!("{cloud_base}/memory/feedback/{memory_id}")
-        } else if let Some(memory_id) = direct_endpoint.strip_prefix("/v1/memories/") {
-            format!("{cloud_base}/memory/expand/{memory_id}")
         } else {
-            return None;
+            let memory_id = direct_endpoint.strip_prefix("/v1/memories/")?;
+            format!("{cloud_base}/memory/expand/{memory_id}")
         };
         Some((endpoint, payload, method))
     }

--- a/crates/astra-turn-core/src/cache.rs
+++ b/crates/astra-turn-core/src/cache.rs
@@ -35,9 +35,9 @@ impl SessionCache {
 
     pub fn get(&mut self, key: &str, now: f64) -> Option<Map<String, Value>> {
         let key = key.to_string();
-        let expired = match self.entries.get(&key) {
-            Some(entry) => now - entry.touched_at > self.ttl,
-            None => return None,
+        let expired = {
+            let entry = self.entries.get(&key)?;
+            now - entry.touched_at > self.ttl
         };
 
         if expired {

--- a/crates/runtime/src/orchestration/spawner.rs
+++ b/crates/runtime/src/orchestration/spawner.rs
@@ -1532,9 +1532,9 @@ impl DynamicAgentSpawner {
         let agent_name = input
             .name
             .clone()
-            .unwrap_or_else(|| format!("{}_{}", input.agent_type, &Uuid::new_v4().to_string()));
+            .unwrap_or_else(|| format!("{}_{}", input.agent_type, Uuid::new_v4()));
         let run_id = Uuid::new_v4().to_string();
-        let agent_id = format!("{}@{}", agent_name, &run_id);
+        let agent_id = format!("{}@{}", agent_name, run_id);
 
         // 3. Determine model and turns
         let model = input

--- a/crates/runtime/src/server/delegation/engine.rs
+++ b/crates/runtime/src/server/delegation/engine.rs
@@ -691,7 +691,7 @@ impl DelegationTracker {
                     run_id: run_id.clone(),
                     parent_run_id: parent_id.clone(),
                     agent_type: "delegated".to_string(),
-                    description: format!("Sub-run for delegation {}", &delegation_id),
+                    description: format!("Sub-run for delegation {}", delegation_id),
                     fanout_slot: None,
                 },
                 timestamp_epoch_ms: std::time::SystemTime::now()

--- a/crates/runtime/src/turn/agentic/tool_interception.rs
+++ b/crates/runtime/src/turn/agentic/tool_interception.rs
@@ -859,11 +859,10 @@ pub(crate) fn extract_repo_name_from_url(url: &str) -> Option<String> {
     let path = url.trim_end_matches('/');
     let segment = if let Some(idx) = path.rfind('/') {
         &path[idx + 1..]
-    } else if let Some(idx) = path.rfind(':') {
+    } else {
+        let idx = path.rfind(':')?;
         let after_colon = &path[idx + 1..];
         after_colon.rsplit('/').next().unwrap_or(after_colon)
-    } else {
-        return None;
     };
     let name = segment.strip_suffix(".git").unwrap_or(segment);
     if name.is_empty() {

--- a/crates/runtime/src/turn/headless_tool_pipeline/record.rs
+++ b/crates/runtime/src/turn/headless_tool_pipeline/record.rs
@@ -179,7 +179,7 @@ impl<'a, E: EdgeToolRoundRow> HeadlessToolExecutionPipeline<'a, E> {
                 if let Some(rec) = self.ctx.tool_call_records.last() {
                     let error_msg = format!(
                         "tool '{}' failed: {}",
-                        &execution.name,
+                        execution.name,
                         truncate_tool_error(&execution.result_str)
                     );
                     let event = astra_services::session_journal::JournalEvent::tool_call_error(

--- a/web/__tests__/components/app/message-bubble.test.tsx
+++ b/web/__tests__/components/app/message-bubble.test.tsx
@@ -142,7 +142,7 @@ describe("MessageBubble", () => {
       );
     });
     expect(
-      screen.getByRole("button", { name: "Response copied" }),
+      await screen.findByRole("button", { name: "Response copied" }),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

- Build `linux/amd64` and `linux/arm64` independently on their native GitHub-hosted runners, in parallel.
- Push only immutable, platform-specific image digests to Docker Hub from those build jobs.
- Assemble the final multi-architecture Docker Hub manifest from those digests.
- Run the sole IDC Harbor write on `amd64-mo-shanghai-dind`: it copies the completed Docker Hub manifest with `crane copy --platform=all`.
- Remove `continue-on-error`: an IDC publication failure fails the release workflow.
- Resolve all Rust 1.97 Clippy warnings exposed by this branch: `question_mark`, formatting borrows, `to_string_in_format_args`, and `manual_filter`. Each source change is an equivalent mechanical rewrite with no intended behavior change.
- Stabilize the web copy-response test by awaiting the asynchronous accessible-name update after the clipboard operation.

## Why

The first implementation built arm64 through QEMU on the single amd64 IDC runner. Its verification run was cancelled after 1h43m, before publication, because emulated Rust release compilation is not acceptable for a release workflow.

This design keeps native compilation parallel while ensuring no GitHub-hosted runner uploads image layers to IDC Harbor:

```
GitHub amd64 runner -> Docker Hub platform digest
GitHub arm64 runner -> Docker Hub platform digest
GitHub manifest job -> Docker Hub multi-arch release tag
IDC runner -> copy that manifest and its layers to IDC Harbor
```

The IDC copy still uploads to Harbor, but it originates on the IDC runner rather than across the GitHub-to-IDC network boundary.

Docker Hub and Harbor cannot be committed atomically. The workflow fails if Harbor publication fails; a rerun is required to complete the release.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-docker.yml"); puts "yaml ok"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.8 -ignore 'label "amd64-mo-shanghai-dind" is unknown' .github/workflows/release-docker.yml`
- `cargo +1.97.0 fmt --all -- --check`
- `cargo +1.97.0 clippy --all-targets -- -D warnings`
- `make lint CARGO='cargo +1.97.0'`
- `cargo +1.97.0 test -p astra-turn-core -p astra-tools -p astra-runtime -p astra-cli --lib` — 3750 passed, 0 failed.
- `packages/sdk: npm ci && npm run build`
- `web: npm ci && npm test -- __tests__/components/app/message-bubble.test.tsx && npm run ci` — 332 passed, 0 failed; typecheck and production build passed.
- Workflow-dispatch `0.0.5-do-not-pull-me`: [successful Docker Hub and IDC multi-architecture publication](https://github.com/matrixorigin/astra/actions/runs/29069027323).

The prerelease verification published only `0.0.5-do-not-pull-me`; it did not move `latest` or `0.0`.
