### PR TITLE
feat(sandbox): MOI sandbox integration — edge auth, proxy, dispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ benchmarks/
 
 investigation/
 tools/
+monorepo/target/
+react-app/target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "futures-util",
  "hostname",
  "reqwest 0.12.28",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -289,6 +290,7 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "tracing",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,8 @@ tracing-opentelemetry = { version = "0.33.0", default-features = false }
 tracing-appender = { version = "0.2", default-features = false }
 http-body-util = "0.1"
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+webpki-roots = "0.26"
 clap = { version = "4", features = ["derive", "env"] }
 hostname = "0.4"
 insta = { version = "1.41", features = ["yaml"] }

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -1,0 +1,73 @@
+# Dockerfile.prebuilt — astra-server runtime image (no Rust compilation)
+#
+# Prerequisites: pre-built binaries must exist at:
+#   rust/target/x86_64-unknown-linux-gnu/release/astra-server
+#   rust/target/x86_64-unknown-linux-gnu/release/astra
+#
+# Build with cargo-zigbuild first:
+#   cd rust
+#   cargo zigbuild --release --no-default-features \
+#     --target x86_64-unknown-linux-gnu \
+#     -p astra-runtime --bin astra-server \
+#     -p astra-cli --bin astra
+#
+# Then build the image:
+#   docker buildx build --platform linux/amd64 -f Dockerfile.prebuilt -t astra-server:TAG .
+
+FROM debian:bookworm-slim
+
+ARG IMAGE_VERSION=dev
+ARG IMAGE_REVISION=unknown
+ARG IMAGE_BRANCH=unknown
+
+LABEL org.opencontainers.image.title="Astra" \
+      org.opencontainers.image.description="Astra API server and CLI runtime image (prebuilt)" \
+      org.opencontainers.image.version="${IMAGE_VERSION}" \
+      org.opencontainers.image.revision="${IMAGE_REVISION}" \
+      org.opencontainers.image.ref.name="${IMAGE_BRANCH}"
+
+ARG DEBIAN_MIRROR
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+# Proxy vars are intentionally kept as build-time ARGs only (used by apt/curl
+# during build). They are NOT promoted to ENV to avoid baking proxy URLs —
+# which may contain credentials — into the image layers. Inject proxy settings
+# at runtime via docker run -e or Kubernetes pod env if needed.
+
+WORKDIR /app
+
+RUN set -eux; \
+    if [ -n "${DEBIAN_MIRROR:-}" ]; then \
+        mirror="${DEBIAN_MIRROR%/}"; \
+        case "${mirror}" in http://*|https://*) ;; *) mirror="https://${mirror}" ;; esac; \
+        find /etc/apt -type f \( -name 'sources.list' -o -name '*.sources' \) -print0 \
+            | xargs -0 -r sed -i -E "s#https?://(deb.debian.org|security.debian.org)#${mirror}#g"; \
+    fi; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl libssl3; \
+    rm -rf /var/lib/apt/lists/*; \
+    groupadd -r appgroup; \
+    useradd --system --create-home --home-dir /home/appuser \
+            --shell /usr/sbin/nologin -g appgroup appuser
+
+COPY rust/target/x86_64-unknown-linux-gnu/release/astra-server /usr/local/bin/astra-server
+COPY rust/target/x86_64-unknown-linux-gnu/release/astra        /usr/local/bin/astra
+
+RUN chown root:appgroup /app && chmod 0770 /app
+
+USER appuser
+
+EXPOSE 17001
+ENV HOME=/home/appuser
+ENV ASTRA_API_HOST=0.0.0.0
+ENV ASTRA_API_PORT=17001
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD curl -fsS http://localhost:17001/health >/dev/null || exit 1
+
+STOPSIGNAL SIGTERM
+CMD ["astra-server"]

--- a/crates/astra-cli/src/cli/http_task_service.rs
+++ b/crates/astra-cli/src/cli/http_task_service.rs
@@ -54,8 +54,8 @@ impl HttpTaskService {
     async fn rpc(&self, method: &str, args: Value) -> Result<Value, String> {
         let url = self.rpc_url();
         let client = reqwest::Client::builder()
-            .no_proxy() // astra server is local/intranet; bypass http_proxy env
             .timeout(std::time::Duration::from_secs(TASK_HTTP_TIMEOUT_SECS))
+            .no_proxy()
             .build()
             .map_err(|e| format!("http client init: {e}"))?;
         let mut req = client
@@ -426,8 +426,8 @@ impl HttpTaskLeaseService {
         edge_id: Option<&str>,
     ) -> Result<Value, String> {
         let client = reqwest::Client::builder()
-            .no_proxy() // astra server is local/intranet; bypass http_proxy env
             .timeout(std::time::Duration::from_secs(TASK_HTTP_TIMEOUT_SECS))
+            .no_proxy()
             .build()
             .map_err(|e| format!("http client init: {e}"))?;
         let mut req = client.post(self.url(path)).json(&body);
@@ -453,8 +453,8 @@ impl HttpTaskLeaseService {
 
     async fn get(&self, path: &str) -> Result<Value, String> {
         let client = reqwest::Client::builder()
-            .no_proxy() // astra server is local/intranet; bypass http_proxy env
             .timeout(std::time::Duration::from_secs(TASK_HTTP_TIMEOUT_SECS))
+            .no_proxy()
             .build()
             .map_err(|e| format!("http client init: {e}"))?;
         let mut req = client.get(self.url(path));

--- a/crates/astra-cli/src/cli/http_team_store.rs
+++ b/crates/astra-cli/src/cli/http_team_store.rs
@@ -158,8 +158,8 @@ impl HttpTeamStore {
             crate::cli::session::session_runtime::current_access_token(self.profile.as_deref())
                 .ok_or(TeamHttpError::AuthenticationRequired)?;
         let client = reqwest::Client::builder()
-            .no_proxy()
             .timeout(std::time::Duration::from_secs(TEAM_HTTP_TIMEOUT_SECS))
+            .no_proxy()
             .build()
             .map_err(|e| TeamHttpError::ClientInit(e.to_string()))?;
         Ok((client, token))

--- a/crates/astra-cli/src/cli/preferences_client.rs
+++ b/crates/astra-cli/src/cli/preferences_client.rs
@@ -31,8 +31,8 @@ fn build_request(
     token: Option<&str>,
 ) -> Result<reqwest::RequestBuilder, String> {
     let client = reqwest::Client::builder()
-        .no_proxy() // astra server is local/intranet; bypass http_proxy env
         .timeout(std::time::Duration::from_secs(PREFS_HTTP_TIMEOUT_SECS))
+        .no_proxy()
         .build()
         .map_err(|e| format!("http client init: {e}"))?;
     let mut req = client.request(method, url);

--- a/crates/astra-cli/src/cli/session/session_runtime.rs
+++ b/crates/astra-cli/src/cli/session/session_runtime.rs
@@ -424,6 +424,7 @@ fn create_pipeline_modules_inner(
 pub(crate) struct ServerModelSelection {
     pub name: String,
     pub context_window: Option<u32>,
+    pub model_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -477,6 +478,10 @@ pub(crate) fn default_model_selection_from_models_response(
             model_list_entry_name(entry).map(|name| ServerModelSelection {
                 name: name.to_string(),
                 context_window: model_list_entry_context_window(entry),
+                model_id: entry
+                    .get("model_id")
+                    .and_then(|v| v.as_str())
+                    .map(ToOwned::to_owned),
             })
         })
 }
@@ -538,21 +543,53 @@ pub(crate) async fn resolve_server_default_model(
     api: &astra_thin_client::ThinClient,
     token: &str,
 ) -> ServerDefaultModel {
+    tracing::debug!(
+        target: "astra_cli::model_selection",
+        "resolve_server_default_model: calling GET /models"
+    );
     let resp = match api
         .get_models_response_timeout(token, std::time::Duration::from_secs(3))
         .await
     {
         Ok(r) if r.status().is_success() => r,
-        _ => return ServerDefaultModel::Unavailable,
+        Ok(r) => {
+            tracing::warn!(
+                target: "astra_cli::model_selection",
+                status = %r.status(),
+                "resolve_server_default_model: GET /models returned non-success status → Unavailable"
+            );
+            return ServerDefaultModel::Unavailable;
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "astra_cli::model_selection",
+                error = %e,
+                "resolve_server_default_model: GET /models request error → Unavailable"
+            );
+            return ServerDefaultModel::Unavailable;
+        }
     };
     let body: serde_json::Value = match resp.json().await {
         Ok(v) => v,
-        Err(_) => return ServerDefaultModel::Unavailable,
+        Err(e) => {
+            tracing::warn!(
+                target: "astra_cli::model_selection",
+                error = %e,
+                "resolve_server_default_model: failed to parse /models JSON → Unavailable"
+            );
+            return ServerDefaultModel::Unavailable;
+        }
     };
-    match default_model_selection_from_models_response(&body) {
+    let result = match default_model_selection_from_models_response(&body) {
         Some(selection) => ServerDefaultModel::Selected(selection),
         None => ServerDefaultModel::NoModels,
-    }
+    };
+    tracing::debug!(
+        target: "astra_cli::model_selection",
+        result = ?result,
+        "resolve_server_default_model: completed"
+    );
+    result
 }
 
 pub(crate) async fn ensure_state_default_model(
@@ -585,6 +622,11 @@ pub(crate) async fn ensure_state_default_model(
     match resolve_server_default_model(api, token).await {
         ServerDefaultModel::Selected(selection) => {
             state.model = Some(selection.name.clone());
+            if selection.model_id.is_some() {
+                crate::cli::slash::slash_config::set_active_model_id_for_request(
+                    selection.model_id.clone(),
+                );
+            }
             if let Some(context_window) = selection.context_window {
                 state.context_budget =
                     astra_runtime::prompts::ContextBudget::from_runtime_config_with_context_window(
@@ -846,8 +888,16 @@ pub(crate) async fn fresh_access_token(
 ) -> Option<String> {
     let now = chrono::Utc::now().timestamp();
     if let Some(token) = active_env_access_token(now) {
+        tracing::debug!(
+            target: "astra_cli::auth",
+            "fresh_access_token: using ASTRA_ACCESS_TOKEN env var (valid, not expired)"
+        );
         return Some(token);
     }
+    tracing::debug!(
+        target: "astra_cli::auth",
+        "fresh_access_token: ASTRA_ACCESS_TOKEN env var absent/expired, falling back to profile credentials"
+    );
 
     let creds = load_credentials();
     let name = profile_name(profile, &creds);
@@ -1193,7 +1243,8 @@ pub(crate) fn print_session_banner(profile: Option<&str>, state: &SessionState) 
     let creds = load_credentials();
     let pname = profile_name(profile, &creds);
     let p = creds.profiles.get(&pname);
-    let logged_in = p.and_then(|p| p.access_token.as_ref()).is_some();
+    let logged_in = p.and_then(|p| p.access_token.as_ref()).is_some()
+        || active_env_access_token(chrono::Utc::now().timestamp()).is_some();
     let model_display = state.model.as_deref().unwrap_or("auto");
     let version = env!("CARGO_PKG_VERSION");
     let skills_count = state.unified_skill_registry.len();
@@ -1317,17 +1368,6 @@ pub(crate) fn print_session_banner(profile: Option<&str>, state: &SessionState) 
     if let Some(line) = pending_recovery_status_line(state) {
         let truncated = trunc_vis(&line, right_col_w);
         right.push(truncated.yellow().bold().to_string());
-    }
-    if let Ok(proxy) = std::env::var("http_proxy").or_else(|_| std::env::var("HTTP_PROXY")) {
-        if !proxy.is_empty() {
-            let max_proxy = right_col_w.saturating_sub(8);
-            let short = if proxy.len() > max_proxy {
-                format!("{}…", &proxy[..max_proxy.saturating_sub(1)])
-            } else {
-                proxy
-            };
-            right.push(format!("proxy: {short}").white().bold().to_string());
-        }
     }
 
     // Equalize heights

--- a/crates/astra-cli/src/cli/session/session_startup.rs
+++ b/crates/astra-cli/src/cli/session/session_startup.rs
@@ -797,6 +797,11 @@ pub(crate) async fn complete_session_startup(
                             Some(&selection.name),
                             selection.context_window,
                         );
+                    if selection.model_id.is_some() {
+                        crate::cli::slash::slash_config::set_active_model_id_for_request(
+                            selection.model_id.clone(),
+                        );
+                    }
                     state.model = Some(selection.name);
                 }
                 session_runtime::ServerDefaultModel::NoModels => {

--- a/crates/astra-cli/src/cli/session/session_todo_client.rs
+++ b/crates/astra-cli/src/cli/session/session_todo_client.rs
@@ -110,8 +110,8 @@ fn build_request(
     token: Option<&str>,
 ) -> Result<reqwest::RequestBuilder, String> {
     let client = reqwest::Client::builder()
-        .no_proxy() // astra server is local/intranet; bypass http_proxy env
         .timeout(std::time::Duration::from_secs(TODOS_HTTP_TIMEOUT_SECS))
+        .no_proxy()
         .build()
         .map_err(|e| format!("http client init: {e}"))?;
     let mut req = client.request(method, url);

--- a/crates/astra-cli/src/cli/turn/turn_stream_runner.rs
+++ b/crates/astra-cli/src/cli/turn/turn_stream_runner.rs
@@ -284,13 +284,6 @@ mod tests {
     use crate::cli::turn::local_run_control::LocalRunControl;
     use std::sync::Arc;
 
-    /// Source-level guard: cancellation paths in `await_stream_with_interrupts`
-    /// MUST notify the server so the durable run does not keep running on the
-    /// backend after the local SSE stream is dropped. Asserting on the source
-    /// is the only stable way to prove this short of a full E2E test against
-    /// a live server — and the regression risk (silent removal during a
-    /// refactor) is exactly the failure mode that produced this bug.
-
     #[tokio::test]
     async fn prepare_turn_stream_state_does_not_inject_task_board_prompt() {
         let state = SessionState::default();

--- a/crates/astra-cli/src/edge_tools/git_gix.rs
+++ b/crates/astra-cli/src/edge_tools/git_gix.rs
@@ -1125,9 +1125,11 @@ mod tests {
 
     #[test]
     fn git_action_show_stat_only() {
-        let root = repo_root();
+        // Use an isolated temp repo so the test is not affected by the
+        // current branch state (e.g. a merge commit at HEAD has no diff stat).
+        let dir = init_temp_repo();
         let result = show(
-            &root,
+            dir.path(),
             &json!({"revision": "HEAD", "stat_only": true}),
             0.0,
             0,
@@ -1381,9 +1383,11 @@ mod tests {
 
     #[test]
     fn git_action_show_stat_only_has_stats() {
-        let root = repo_root();
+        // Use an isolated temp repo so the test is not affected by the
+        // current branch state (e.g. a merge commit at HEAD has no diff stat).
+        let dir = init_temp_repo();
         let result = show(
-            &root,
+            dir.path(),
             &json!({"revision": "HEAD", "stat_only": true}),
             0.0,
             0,

--- a/crates/astra-cli/src/lib.rs
+++ b/crates/astra-cli/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unstable_name_collisions)]
 //! `astra-cli` library crate.
 //!
 //! Provides the CLI application logic shared between the main `astra` binary

--- a/crates/astra-edge/Cargo.toml
+++ b/crates/astra-edge/Cargo.toml
@@ -21,6 +21,8 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["signal", "time"] }
 tokio-tungstenite = { workspace = true }
+rustls = { workspace = true }
+webpki-roots = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 hostname = { workspace = true }

--- a/crates/astra-edge/src/main.rs
+++ b/crates/astra-edge/src/main.rs
@@ -23,7 +23,11 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
-use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_tungstenite::{
+    Connector, MaybeTlsStream, WebSocketStream, client_async_tls_with_config, connect_async,
+    tungstenite::Message,
+};
 use tracing::Instrument;
 
 /// Astra remote edge agent — execute tool calls locally for web sessions.
@@ -240,6 +244,133 @@ fn edge_runtime_environment_capabilities(edge_id: &str, workspace: &Path) -> Val
         .expect("runtime environment advertisement serializes")
 }
 
+// ─── Proxy helpers ───────────────────────────────────────────────────────────
+
+/// Parse `host` and `port` from a WebSocket URL (`ws://` or `wss://`).
+///
+/// Handles IPv6 bracket notation (`[::1]:port`) and strips any path/query
+/// component.  Does not support userinfo — WebSocket URLs with credentials
+/// are not a use-case here.
+fn parse_ws_target(ws_url: &str) -> Option<(String, u16)> {
+    let (rest, default_port) = if let Some(r) = ws_url.strip_prefix("wss://") {
+        (r, 443u16)
+    } else {
+        let r = ws_url.strip_prefix("ws://")?;
+        (r, 80u16)
+    };
+    // Drop path/query/fragment — only the authority matters.
+    let authority = rest.split('/').next()?;
+    parse_host_port(authority, default_port)
+}
+
+/// Parse `host` and `port` from an HTTP(S) proxy URL.
+///
+/// Accepts `http://` and `https://` schemes, strips userinfo (e.g.
+/// `user:pass@`), handles IPv6 bracket notation, and defaults to port 3128
+/// when no explicit port is present.
+fn parse_proxy_addr(proxy_url: &str) -> Option<(String, u16)> {
+    let rest = proxy_url
+        .strip_prefix("http://")
+        .or_else(|| proxy_url.strip_prefix("https://"))?;
+    // Drop path/query/fragment.
+    let authority = rest.split('/').next()?;
+    // Strip optional userinfo (`user:pass@`).
+    let host_port = match authority.rfind('@') {
+        Some(at) => &authority[at + 1..],
+        None => authority,
+    };
+    parse_host_port(host_port, 3128)
+}
+
+/// Parse `host:port` from an authority string, handling IPv6 bracket notation.
+fn parse_host_port(authority: &str, default_port: u16) -> Option<(String, u16)> {
+    if authority.starts_with('[') {
+        // IPv6: `[::1]` or `[::1]:port`
+        let bracket_end = authority.find(']')?;
+        let host = authority.get(1..bracket_end)?.to_string();
+        let port = if authority.as_bytes().get(bracket_end + 1) == Some(&b':') {
+            authority.get(bracket_end + 2..)?.parse().ok()?
+        } else {
+            default_port
+        };
+        Some((host, port))
+    } else if let Some(colon_pos) = authority.rfind(':') {
+        let host = authority[..colon_pos].to_string();
+        let port: u16 = authority[colon_pos + 1..].parse().ok()?;
+        Some((host, port))
+    } else {
+        Some((authority.to_string(), default_port))
+    }
+}
+
+// Connect to the WebSocket server via HTTP CONNECT proxy.
+// Returns the same type as `connect_async` so callers stay uniform.
+async fn connect_via_proxy(
+    ws_url: &str,
+    proxy_url: &str,
+) -> Result<WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>, Box<dyn std::error::Error>> {
+    if proxy_url.starts_with("https://") {
+        return Err(format!(
+            "HTTPS proxies are not supported for WebSocket CONNECT \
+             (the CONNECT handshake is sent in plaintext over a raw TCP connection). \
+             Configure an http:// proxy instead: {proxy_url}"
+        )
+        .into());
+    }
+    let (ws_host, ws_port) =
+        parse_ws_target(ws_url).ok_or_else(|| format!("Cannot parse WebSocket URL: {ws_url}"))?;
+    let (proxy_host, proxy_port) = parse_proxy_addr(proxy_url)
+        .ok_or_else(|| format!("Cannot parse proxy URL: {proxy_url}"))?;
+
+    tracing::info!(proxy = %proxy_url, target = %format!("{ws_host}:{ws_port}"), "CONNECT via proxy");
+
+    let mut tcp = tokio::net::TcpStream::connect(format!("{proxy_host}:{proxy_port}")).await?;
+
+    // HTTP CONNECT handshake
+    let req = format!("CONNECT {ws_host}:{ws_port} HTTP/1.1\r\nHost: {ws_host}:{ws_port}\r\n\r\n");
+    tcp.write_all(req.as_bytes()).await?;
+
+    // Read proxy response headers (200 Connection Established). Read until
+    // end-of-headers (\r\n\r\n) so we don't mis-parse when the status line is
+    // split across TCP packets.
+    let mut buf: Vec<u8> = Vec::new();
+    let mut tmp = [0u8; 1024];
+    while buf.len() < 16 * 1024 {
+        let n = tcp.read(&mut tmp).await?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+    let resp = String::from_utf8_lossy(&buf);
+    if !resp.starts_with("HTTP/1.1 200") && !resp.starts_with("HTTP/1.0 200") {
+        let first_line = resp.lines().next().unwrap_or("(empty)").to_string();
+        return Err(format!("Proxy CONNECT rejected: {first_line}").into());
+    }
+
+    // For wss://, the CONNECT tunnel is plain TCP — we must perform a TLS
+    // handshake inside the tunnel before sending the WebSocket upgrade.
+    // For ws://, no TLS is needed; send the upgrade directly over the tunnel.
+    if ws_url.starts_with("wss://") {
+        let mut root_store = rustls::RootCertStore::empty();
+        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        let tls_config = rustls::ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+        let connector = Connector::Rustls(std::sync::Arc::new(tls_config));
+        let (ws_stream, _) =
+            client_async_tls_with_config(ws_url, tcp, None, Some(connector)).await?;
+        Ok(ws_stream)
+    } else {
+        let (ws_stream, _) =
+            tokio_tungstenite::client_async(ws_url, MaybeTlsStream::Plain(tcp)).await?;
+        Ok(ws_stream)
+    }
+}
+
 // ─── Connection loop ─────────────────────────────────────────────────────────
 
 async fn run_edge_connection(config: &EdgeConfig) -> Result<(), Box<dyn std::error::Error>> {
@@ -247,16 +378,37 @@ async fn run_edge_connection(config: &EdgeConfig) -> Result<(), Box<dyn std::err
 
     tracing::info!(url = %url, edge_id = %config.edge_id, "Connecting to server...");
 
-    let (ws_stream, _) = connect_async(&url).await.map_err(|e| {
-        tracing::error!(
-            target: "astra.edge",
-            edge_id = %config.edge_id,
-            url = %url,
-            error = %e,
-            "WebSocket connect failed"
-        );
-        e
-    })?;
+    // Use HTTP proxy when http_proxy / HTTP_PROXY environment variable is set.
+    let proxy = std::env::var("http_proxy")
+        .or_else(|_| std::env::var("HTTP_PROXY"))
+        .ok()
+        .filter(|p| !p.is_empty());
+
+    let ws_stream = if let Some(ref proxy_url) = proxy {
+        connect_via_proxy(&url, proxy_url).await.map_err(|e| {
+            tracing::error!(
+                target: "astra.edge",
+                edge_id = %config.edge_id,
+                url = %url,
+                proxy = %proxy_url,
+                error = %e,
+                "WebSocket connect via proxy failed"
+            );
+            e
+        })?
+    } else {
+        let (ws, _) = connect_async(&url).await.map_err(|e| {
+            tracing::error!(
+                target: "astra.edge",
+                edge_id = %config.edge_id,
+                url = %url,
+                error = %e,
+                "WebSocket connect failed"
+            );
+            e
+        })?;
+        ws
+    };
     let (mut write, mut read) = ws_stream.split();
 
     tracing::info!("WebSocket connected, authenticating...");
@@ -341,6 +493,10 @@ async fn run_edge_connection(config: &EdgeConfig) -> Result<(), Box<dyn std::err
             msg = read.next() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
+                        tracing::debug!(
+                            frame_len = text.len(),
+                            "edge received server text frame"
+                        );
                         match serde_json::from_str::<EdgeServerMessage>(&text) {
                             Ok(EdgeServerMessage::ToolRequest {
                                 request_id,

--- a/crates/astra-edge/src/main.rs
+++ b/crates/astra-edge/src/main.rs
@@ -322,7 +322,7 @@ async fn connect_via_proxy(
     let (proxy_host, proxy_port) = parse_proxy_addr(proxy_url)
         .ok_or_else(|| format!("Cannot parse proxy URL: {proxy_url}"))?;
 
-    tracing::info!(proxy = %proxy_url, target = %format!("{ws_host}:{ws_port}"), "CONNECT via proxy");
+    tracing::info!(proxy_host = %proxy_host, proxy_port, target = %format!("{ws_host}:{ws_port}"), "CONNECT via proxy");
 
     let mut tcp = tokio::net::TcpStream::connect(format!("{proxy_host}:{proxy_port}")).await?;
 
@@ -390,7 +390,7 @@ async fn run_edge_connection(config: &EdgeConfig) -> Result<(), Box<dyn std::err
                 target: "astra.edge",
                 edge_id = %config.edge_id,
                 url = %url,
-                proxy = %proxy_url,
+                proxy = %proxy_url.rsplit('@').next().unwrap_or(proxy_url),
                 error = %e,
                 "WebSocket connect via proxy failed"
             );

--- a/crates/astra-mcp/src/tools.rs
+++ b/crates/astra-mcp/src/tools.rs
@@ -43,12 +43,21 @@ impl McpToolCallResult {
     }
 }
 
+/// Returns the largest byte index <= `index` that lies on a UTF-8 char boundary.
+fn floor_char_boundary(s: &str, index: usize) -> usize {
+    let index = index.min(s.len());
+    (0..=index)
+        .rev()
+        .find(|&i| s.is_char_boundary(i))
+        .unwrap_or(0)
+}
+
 fn truncate_with_marker(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         return s.to_string();
     }
     let content_budget = max_len.saturating_sub(TRUNCATION_MARKER.len());
-    let end = s.floor_char_boundary(content_budget);
+    let end = floor_char_boundary(s, content_budget);
     format!("{}{TRUNCATION_MARKER}", &s[..end])
 }
 
@@ -354,7 +363,7 @@ pub fn extract_tool_call_result_with_limit(
                 total_len += text.text.len();
                 parts.push(text.text.clone());
             } else {
-                let end = text.text.floor_char_boundary(remaining);
+                let end = floor_char_boundary(&text.text, remaining);
                 parts.push(text.text[..end].to_string());
                 total_len += end;
                 break;

--- a/crates/astra-server-types/src/edge_connection_pool.rs
+++ b/crates/astra-server-types/src/edge_connection_pool.rs
@@ -6,6 +6,7 @@
 //! whether to route tool calls to a remote edge or fall back to the server.
 
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -60,8 +61,17 @@ pub struct EdgeConnection {
     pub hostname: Option<String>,
     pub workspace_dir: Option<String>,
     pub capabilities: Option<Value>,
+    /// Workspace that owns this edge agent, captured at connect time from the
+    /// edge registration token's `provider_scope_id`.  Used to authorize
+    /// cross-user lookups: only workspace members may dispatch to a shared
+    /// edge agent (e.g. a sandbox edge that connected via a service account).
+    pub workspace_id: Option<String>,
     pub sender: EdgeWsSender,
     pub connected_at: std::time::Instant,
+    /// Monotonically increasing generation counter assigned at registration.
+    /// Used by `unregister_if_generation` to guard against stale cleanup
+    /// overwriting a newer connection that replaced this one in the pool.
+    pub generation: u64,
     /// Pending tool call responses: request_id → oneshot sender.
     pending_results: Arc<DashMap<String, oneshot::Sender<EdgeToolResult>>>,
 }
@@ -94,6 +104,10 @@ pub struct EdgeConnectionPool {
     /// Global FIFO of dispatched request IDs for O(1)-amortized eviction when
     /// the pending set reaches capacity. Stale IDs are lazily skipped.
     pending_request_order: Arc<Mutex<VecDeque<String>>>,
+    /// Monotonically increasing counter used to assign a unique generation to
+    /// each registered connection. Guards `unregister_if_generation` against
+    /// stale cleanup overwriting a newer connection.
+    next_generation: Arc<AtomicU64>,
     /// Maximum number of inflight dispatched tool requests. When exceeded,
     /// the oldest entry is evicted before insertion.
     max_pending: usize,
@@ -114,12 +128,14 @@ impl EdgeConnectionPool {
             pending_requests: Arc::new(DashMap::new()),
             pending_request_ids_by_user: Arc::new(DashMap::new()),
             pending_request_order: Arc::new(Mutex::new(VecDeque::new())),
+            next_generation: Arc::new(AtomicU64::new(1)),
             max_pending: MAX_PENDING_REQUESTS,
             max_pending_per_user: MAX_PENDING_REQUESTS_PER_USER,
         }
     }
 
     /// Register a new edge connection. Replaces any existing connection for the same key.
+    /// Returns the generation ID assigned to this connection.
     pub fn register(
         &self,
         user_id: &str,
@@ -127,12 +143,13 @@ impl EdgeConnectionPool {
         hostname: Option<String>,
         workspace_dir: Option<String>,
         sender: EdgeWsSender,
-    ) {
+    ) -> u64 {
         self.register_with_capabilities(
             user_id,
             edge_agent_id,
             hostname,
             workspace_dir,
+            None,
             None,
             sender,
         )
@@ -140,6 +157,12 @@ impl EdgeConnectionPool {
 
     /// Register a new edge connection with its structured runtime capability advertisement.
     /// Replaces any existing connection for the same key.
+    /// Returns the generation ID assigned to this connection for use with
+    /// `unregister_if_generation` during cleanup.
+    ///
+    /// `workspace_id` is the owning workspace, captured from the edge registration
+    /// token's `provider_scope_id`.  Pass `None` for internal (non-moi) tokens.
+    #[allow(clippy::too_many_arguments)]
     pub fn register_with_capabilities(
         &self,
         user_id: &str,
@@ -147,8 +170,10 @@ impl EdgeConnectionPool {
         hostname: Option<String>,
         workspace_dir: Option<String>,
         capabilities: Option<Value>,
+        workspace_id: Option<String>,
         sender: EdgeWsSender,
-    ) {
+    ) -> u64 {
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
         let key = pool_key(user_id, edge_agent_id);
         self.connections.insert(
             key,
@@ -158,11 +183,39 @@ impl EdgeConnectionPool {
                 hostname,
                 workspace_dir,
                 capabilities,
+                workspace_id,
                 sender,
                 connected_at: std::time::Instant::now(),
+                generation,
                 pending_results: Arc::new(DashMap::new()),
             },
         );
+        generation
+    }
+
+    /// Remove an edge connection only if its generation matches `expected_gen`.
+    ///
+    /// Returns `true` if the entry was removed, `false` if the generation did not
+    /// match (meaning a newer connection has already replaced this one in the pool).
+    ///
+    /// Follow-up cleanup is the caller's responsibility. It is safe when
+    /// additionally guarded by a connection-unique identifier (e.g. `edge_id`)
+    /// so that it cannot affect the replacement connection.
+    pub fn unregister_if_generation(
+        &self,
+        user_id: &str,
+        edge_agent_id: &str,
+        expected_gen: u64,
+    ) -> bool {
+        let key = pool_key(user_id, edge_agent_id);
+        if let Some((_, conn)) = self
+            .connections
+            .remove_if(&key, |_, conn| conn.generation == expected_gen)
+        {
+            conn.pending_results.clear();
+            return true;
+        }
+        false
     }
 
     /// Remove an edge connection. Cancels any pending tool requests.
@@ -179,6 +232,53 @@ impl EdgeConnectionPool {
         self.connections
             .iter()
             .any(|entry| entry.value().user_id == user_id && !entry.value().sender.is_closed())
+    }
+
+    /// Find a connected edge agent by its agent ID across all users.
+    ///
+    /// Returns the owner user_id and connection info, or `None` if the agent
+    /// is not connected or the workspace does not match.
+    ///
+    /// `workspace_id` is the requesting workspace.  Workspace isolation is
+    /// fail-closed: a workspace-bound edge (edge.workspace_id is Some) is only
+    /// reachable from a request that carries the matching workspace_id.  A
+    /// request without workspace context can only reach edges that are also
+    /// unscoped (edge.workspace_id is None).  This prevents a request that
+    /// lacks workspace context (e.g. workspace_record: None on a
+    /// provider-authorized turn) from silently resolving a workspace-bound
+    /// sandbox edge.
+    pub fn find_edge_by_agent_id(
+        &self,
+        edge_agent_id: &str,
+        workspace_id: Option<&str>,
+    ) -> Option<(String, EdgeConnectionInfo)> {
+        self.connections
+            .iter()
+            .find(|entry| {
+                let conn = entry.value();
+                if conn.edge_agent_id != edge_agent_id || conn.sender.is_closed() {
+                    return false;
+                }
+                // Fail-closed workspace isolation:
+                //   request has workspace_id  → edge must have the same workspace_id
+                //   request has no workspace_id → edge must also be unscoped (None)
+                match (workspace_id, conn.workspace_id.as_deref()) {
+                    (Some(req_ws), Some(edge_ws)) => req_ws == edge_ws,
+                    (None, None) => true,
+                    _ => false,
+                }
+            })
+            .map(|entry| {
+                let conn = entry.value();
+                let info = EdgeConnectionInfo {
+                    edge_agent_id: conn.edge_agent_id.clone(),
+                    hostname: conn.hostname.clone(),
+                    workspace_dir: conn.workspace_dir.clone(),
+                    capabilities: conn.capabilities.clone(),
+                    connected_at: conn.connected_at,
+                };
+                (conn.user_id.clone(), info)
+            })
     }
 
     /// Get all connected edge agents for a user.
@@ -232,9 +332,21 @@ impl EdgeConnectionPool {
         }
         let key = pool_key(user_id, edge_agent_id);
         let (pending_results, sender) = {
-            let entry = self.connections.get(&key)?;
+            let Some(entry) = self.connections.get(&key) else {
+                tracing::warn!(
+                    target: "astra_runtime::edge_dispatch_diag",
+                    key = %key,
+                    "edge_dispatch: execute_tool_with_cancel no pool entry for key"
+                );
+                return None;
+            };
             let conn = entry.value();
             if conn.sender.is_closed() {
+                tracing::warn!(
+                    target: "astra_runtime::edge_dispatch_diag",
+                    key = %key,
+                    "edge_dispatch: execute_tool_with_cancel pool entry sender already closed"
+                );
                 drop(entry);
                 self.connections.remove(&key);
                 return None;
@@ -262,11 +374,25 @@ impl EdgeConnectionPool {
         };
         self.insert_pending_request(user_id, &request_id, dispatched);
 
-        if sender.send(msg).await.is_err() {
+        if let Err(e) = sender.send(msg).await {
+            tracing::warn!(
+                target: "astra_runtime::edge_dispatch_diag",
+                key = %key,
+                request_id = %request_id,
+                error = %e,
+                "edge_dispatch: execute_tool_with_cancel channel send failed"
+            );
             pending_results.remove(&request_id);
             self.remove_pending_request(&request_id);
             return None;
         }
+        tracing::info!(
+            target: "astra_runtime::edge_dispatch_diag",
+            key = %key,
+            request_id = %request_id,
+            tool = %tool,
+            "edge_dispatch: execute_tool_with_cancel queued tool request into edge channel, awaiting result"
+        );
 
         // Helper: notify the edge that it should abort the in-flight request
         // and drop any partial result. Best-effort: if the send fails (edge
@@ -300,6 +426,13 @@ impl EdgeConnectionPool {
                 // Timed out waiting for the edge. Tell it to abort so the
                 // (possibly still running) tool does not write to a file or
                 // run a destructive command after the caller has given up.
+                tracing::warn!(
+                    target: "astra_runtime::edge_dispatch_diag",
+                    key = %key,
+                    request_id = %request_id,
+                    timeout_secs = EDGE_TOOL_TIMEOUT_SECS,
+                    "edge_dispatch: execute_tool_with_cancel timed out waiting for edge tool result"
+                );
                 cancel_edge();
                 pending_results.remove(&request_id);
                 self.remove_pending_request(&request_id);
@@ -645,6 +778,7 @@ mod tests {
                     "capabilities": {"runtime": {"shell": true, "git": true}}
                 }
             })),
+            None,
             tx,
         );
 
@@ -955,5 +1089,198 @@ mod tests {
         assert!(c1 <= 1);
         assert!(c2 <= 1);
         assert_eq!(pool.connection_count(), 0);
+    }
+
+    // ── generation race condition ─────────────────────────────────────
+
+    /// Register gen-1 then gen-2 for the same edge; cleaning up with gen-1 must
+    /// leave gen-2 intact. Only a subsequent gen-2 cleanup removes the entry.
+    #[test]
+    fn unregister_if_generation_skips_stale_cleanup() {
+        let pool = EdgeConnectionPool::new();
+
+        let (tx1, _rx1) = mpsc::channel(1);
+        let gen1 = pool.register("user-1", "edge-a", None, None, tx1);
+
+        // Second connection replaces the first in the pool.
+        let (tx2, _rx2) = mpsc::channel(1);
+        let gen2 = pool.register("user-1", "edge-a", None, None, tx2);
+
+        assert!(gen2 > gen1, "generations must be strictly increasing");
+
+        // Old connection's cleanup fires with gen-1: must be a no-op.
+        let removed = pool.unregister_if_generation("user-1", "edge-a", gen1);
+        assert!(
+            !removed,
+            "stale gen-1 cleanup must not remove the gen-2 entry"
+        );
+        assert!(
+            pool.has_connected_edge("user-1"),
+            "gen-2 connection must still be in the pool"
+        );
+
+        // Current connection's cleanup fires with gen-2: must remove the entry.
+        let removed = pool.unregister_if_generation("user-1", "edge-a", gen2);
+        assert!(removed, "gen-2 cleanup must remove the entry");
+        assert!(
+            !pool.has_connected_edge("user-1"),
+            "pool must be empty after gen-2 cleanup"
+        );
+    }
+
+    /// A single connection registered and cleaned up with its own generation
+    /// removes the entry normally.
+    #[test]
+    fn unregister_if_generation_removes_own_entry() {
+        let pool = EdgeConnectionPool::new();
+        let (tx, _rx) = mpsc::channel(1);
+        let my_gen = pool.register("user-1", "edge-a", None, None, tx);
+
+        let removed = pool.unregister_if_generation("user-1", "edge-a", my_gen);
+        assert!(removed);
+        assert!(!pool.has_connected_edge("user-1"));
+    }
+
+    /// Three rapid reconnects: gen-1 and gen-2 cleanups must both be no-ops;
+    /// only gen-3 cleanup drains the pool.
+    #[test]
+    fn unregister_if_generation_multiple_replacements() {
+        let pool = EdgeConnectionPool::new();
+
+        let (tx1, _rx1) = mpsc::channel(1);
+        let gen1 = pool.register("user-1", "edge-a", None, None, tx1);
+
+        let (tx2, _rx2) = mpsc::channel(1);
+        let gen2 = pool.register("user-1", "edge-a", None, None, tx2);
+
+        let (tx3, _rx3) = mpsc::channel(1);
+        let gen3 = pool.register("user-1", "edge-a", None, None, tx3);
+
+        assert!(!pool.unregister_if_generation("user-1", "edge-a", gen1));
+        assert!(pool.has_connected_edge("user-1"));
+
+        assert!(!pool.unregister_if_generation("user-1", "edge-a", gen2));
+        assert!(pool.has_connected_edge("user-1"));
+
+        assert!(pool.unregister_if_generation("user-1", "edge-a", gen3));
+        assert!(!pool.has_connected_edge("user-1"));
+    }
+
+    #[test]
+    fn find_edge_by_agent_id_matches_connected_edge() {
+        let pool = EdgeConnectionPool::new();
+        let (tx, _rx) = mpsc::channel(1);
+        pool.register_with_capabilities(
+            "user-a",
+            "edge-x",
+            None,
+            None,
+            None,
+            Some("ws-1".into()),
+            tx,
+        );
+
+        let result = pool.find_edge_by_agent_id("edge-x", Some("ws-1"));
+        assert!(result.is_some());
+        let (owner, info) = result.unwrap();
+        assert_eq!(owner, "user-a");
+        assert_eq!(info.edge_agent_id, "edge-x");
+    }
+
+    #[test]
+    fn find_edge_by_agent_id_workspace_mismatch_returns_none() {
+        let pool = EdgeConnectionPool::new();
+        let (tx, _rx) = mpsc::channel(1);
+        pool.register_with_capabilities(
+            "user-a",
+            "edge-x",
+            None,
+            None,
+            None,
+            Some("ws-1".into()),
+            tx,
+        );
+
+        // Requesting workspace differs from the edge's registered workspace.
+        let result = pool.find_edge_by_agent_id("edge-x", Some("ws-2"));
+        assert!(result.is_none(), "different workspace must not match");
+    }
+
+    #[test]
+    fn find_edge_by_agent_id_workspace_mismatch_request_has_ws_edge_unscoped_returns_none() {
+        let pool = EdgeConnectionPool::new();
+        let (tx, _rx) = mpsc::channel(1);
+        // Unscoped edge (no workspace binding).
+        pool.register_with_capabilities("user-a", "edge-x", None, None, None, None, tx);
+
+        // A request that carries a workspace_id must NOT silently resolve an
+        // unscoped edge — fail-closed prevents workspace confusion.
+        let result = pool.find_edge_by_agent_id("edge-x", Some("ws-any"));
+        assert!(
+            result.is_none(),
+            "scoped request must not resolve an unscoped edge"
+        );
+    }
+
+    #[test]
+    fn find_edge_by_agent_id_no_workspace_context_resolves_unscoped_edge() {
+        let pool = EdgeConnectionPool::new();
+        let (tx, _rx) = mpsc::channel(1);
+        pool.register_with_capabilities("user-a", "edge-x", None, None, None, None, tx);
+
+        // Neither side has workspace_id — legacy / single-tenant path is allowed.
+        let result = pool.find_edge_by_agent_id("edge-x", None);
+        assert!(
+            result.is_some(),
+            "unscoped request must resolve unscoped edge"
+        );
+    }
+
+    #[test]
+    fn find_edge_by_agent_id_no_workspace_context_does_not_resolve_scoped_edge() {
+        let pool = EdgeConnectionPool::new();
+        let (tx, _rx) = mpsc::channel(1);
+        pool.register_with_capabilities(
+            "user-a",
+            "edge-x",
+            None,
+            None,
+            None,
+            Some("ws-sandbox".to_string()),
+            tx,
+        );
+
+        // A request without workspace context must NOT resolve a workspace-bound
+        // sandbox edge (fail-closed: workspace_record: None on provider turn).
+        let result = pool.find_edge_by_agent_id("edge-x", None);
+        assert!(
+            result.is_none(),
+            "unscoped request must not resolve a workspace-bound edge"
+        );
+    }
+
+    /// Cleanups for different edges must be fully independent.
+    #[test]
+    fn unregister_if_generation_different_edges_are_independent() {
+        let pool = EdgeConnectionPool::new();
+
+        let (tx_a1, _rx_a1) = mpsc::channel(1);
+        let gen_a1 = pool.register("user-1", "edge-a", None, None, tx_a1);
+
+        let (tx_a2, _rx_a2) = mpsc::channel(1);
+        let _gen_a2 = pool.register("user-1", "edge-a", None, None, tx_a2);
+
+        let (tx_b, _rx_b) = mpsc::channel(1);
+        let gen_b = pool.register("user-1", "edge-b", None, None, tx_b);
+
+        // Stale cleanup for edge-a must not touch edge-b.
+        assert!(!pool.unregister_if_generation("user-1", "edge-a", gen_a1));
+        assert!(pool.has_connected_edge("user-1")); // edge-b is still present
+
+        // Cleaning up edge-b with its own generation succeeds.
+        assert!(pool.unregister_if_generation("user-1", "edge-b", gen_b));
+
+        // edge-a's gen-2 is still present.
+        assert!(pool.has_connected_edge("user-1"));
     }
 }

--- a/crates/astra-server-types/src/edge_ws_protocol.rs
+++ b/crates/astra-server-types/src/edge_ws_protocol.rs
@@ -110,6 +110,20 @@ pub enum EdgeServerMessage {
     ToolCancel { request_id: String },
 }
 
+impl EdgeServerMessage {
+    /// Short stable label for diagnostic logging (no payload).
+    pub fn diagnostic_kind(&self) -> &'static str {
+        match self {
+            EdgeServerMessage::AuthOk { .. } => "auth_ok",
+            EdgeServerMessage::AuthError { .. } => "auth_error",
+            EdgeServerMessage::ToolRequest { .. } => "tool_request",
+            EdgeServerMessage::Pong => "pong",
+            EdgeServerMessage::Closing { .. } => "closing",
+            EdgeServerMessage::ToolCancel { .. } => "tool_cancel",
+        }
+    }
+}
+
 fn default_tool_timeout_secs() -> u64 {
     EDGE_TOOL_TIMEOUT_SECS
 }

--- a/crates/astra-server-types/src/lib.rs
+++ b/crates/astra-server-types/src/lib.rs
@@ -1197,6 +1197,16 @@ pub fn chat_request_into_data(mut request: ChatRequest) -> ChatRequestData {
         request.plan_subtask_id.take(),
         request.is_plan_subtask,
     );
+    // Prefer an explicit edge_executor_id; fall back to the id carried in
+    // capability_descriptors.edge_agent when moi-core sets the executor via
+    // capability descriptor rather than the legacy field.
+    let edge_executor_id = request.edge_executor_id.take().or_else(|| {
+        request
+            .capability_descriptors
+            .as_ref()
+            .and_then(|cd| cd.edge_agent.as_ref())
+            .map(|ea| ea.id.clone())
+    });
     ChatRequestData {
         message: request.message,
         user_intent: request.user_intent,
@@ -1227,9 +1237,10 @@ pub fn chat_request_into_data(mut request: ChatRequest) -> ChatRequestData {
         runtime_mcp_bindings: request.runtime_mcp_bindings,
         mcp_binding_ids: request.mcp_binding_ids,
         context,
-        edge_executor_id: request.edge_executor_id,
+        edge_executor_id,
         capabilities: request.capabilities,
         forward_headers: std::collections::HashMap::new(),
+        provider_workspace_id: None,
         execution_budget: request.execution_budget,
         execution_policy: request.execution_policy,
         explain: request.explain,

--- a/crates/astra-skills/src/loader.rs
+++ b/crates/astra-skills/src/loader.rs
@@ -7,6 +7,14 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+fn floor_char_boundary(s: &str, index: usize) -> usize {
+    let index = index.min(s.len());
+    (0..=index)
+        .rev()
+        .find(|&i| s.is_char_boundary(i))
+        .unwrap_or(0)
+}
+
 use super::hooks::SkillHooks;
 use super::manifest::{
     ExecutionContext, LoadedSkill, SkillManifest, SkillResources, SkillSourceKind,
@@ -310,7 +318,7 @@ fn validate_skill_name(name: &str) -> Result<(), SkillError> {
         return Err(SkillError::ParseFailed(format!(
             "skill name too long ({} chars, max 128): {}",
             name.len(),
-            &name[..name.floor_char_boundary(32)]
+            &name[..floor_char_boundary(name, 32)]
         )));
     }
     if name.contains('/') || name.contains('\\') || name.contains('\0') {

--- a/crates/astra-thin-client/src/client.rs
+++ b/crates/astra-thin-client/src/client.rs
@@ -77,8 +77,19 @@ fn authed_text_request_timeout() -> Duration {
 }
 
 fn streaming_http_client() -> Result<Client, reqwest::Error> {
+    // Auto-decompression is disabled so that Content-Encoding headers on SSE
+    // responses do not cause reqwest to buffer chunks before handing them to
+    // the caller, which would break streaming.
+    //
+    // NOTE: do NOT call `.no_proxy()` here.  In sandbox environments the
+    // process runs inside an isolated network namespace whose only egress path
+    // is the OpenShell HTTP proxy (HTTP_PROXY / http_proxy env var).  Calling
+    // `.no_proxy()` would cause direct-connect attempts that have no route and
+    // fail silently, breaking both model-selection pre-flight (`/models`) and
+    // the SSE chat-turn stream (`/agents/edge/turns`).  When no proxy is
+    // configured the env vars are empty and the behaviour is identical to
+    // `.no_proxy()`.
     Client::builder()
-        .no_proxy()
         .no_gzip()
         .no_brotli()
         .no_deflate()
@@ -104,7 +115,7 @@ impl ThinClient {
     pub fn new(base: &str, bearer_token: Option<String>) -> Result<Self, ThinClientError> {
         let base =
             Url::parse(base).map_err(|_| ThinClientError::InvalidBaseUrl(base.to_string()))?;
-        let http = Client::builder().no_proxy().build()?;
+        let http = Client::builder().build()?;
         // Bound TCP/TLS handshakes while leaving response body streaming uncapped.
         // Chat turns can run for many minutes after the connection is established.
         let http_stream = streaming_http_client()?;
@@ -415,13 +426,42 @@ impl ThinClient {
         timeout: Duration,
     ) -> Result<Response, ThinClientError> {
         let url = self.url(paths::MODELS)?;
-        Ok(self
+        let http_proxy = std::env::var("HTTP_PROXY")
+            .or_else(|_| std::env::var("http_proxy"))
+            .unwrap_or_else(|_| "(none)".to_string());
+        let no_proxy = std::env::var("NO_PROXY")
+            .or_else(|_| std::env::var("no_proxy"))
+            .unwrap_or_else(|_| "(none)".to_string());
+        tracing::debug!(
+            target: "astra_cli::http_proxy",
+            url = %url,
+            http_proxy = %http_proxy,
+            no_proxy = %no_proxy,
+            token_len = token.len(),
+            "get_models_response_timeout: sending GET /models via self.http (proxy-aware client)"
+        );
+        let result = self
             .http
-            .get(url)
+            .get(url.clone())
             .headers(Self::bearer_headers(token)?)
             .timeout(timeout)
             .send()
-            .await?)
+            .await;
+        match &result {
+            Ok(resp) => tracing::debug!(
+                target: "astra_cli::http_proxy",
+                url = %url,
+                status = %resp.status(),
+                "get_models_response_timeout: response received"
+            ),
+            Err(e) => tracing::warn!(
+                target: "astra_cli::http_proxy",
+                url = %url,
+                error = %e,
+                "get_models_response_timeout: request failed"
+            ),
+        }
+        Ok(result?)
     }
 
     pub async fn get_models_text(&self, token: &str) -> Result<String, ThinClientError> {
@@ -702,6 +742,7 @@ impl ThinClient {
             .get(url)
             .headers(Self::bearer_headers(token)?)
             .query(query)
+            .timeout(authed_text_request_timeout())
             .send()
             .await?;
         Self::text_or_api(resp).await
@@ -719,6 +760,7 @@ impl ThinClient {
             .get(url)
             .headers(Self::bearer_headers(token)?)
             .query(query)
+            .timeout(authed_text_request_timeout())
             .send()
             .await?;
         Self::text_or_api(resp).await
@@ -887,18 +929,38 @@ impl ThinClient {
         payload: &Value,
     ) -> Result<Response, ThinClientError> {
         let url = self.url(paths::CHAT_TURN)?;
+        tracing::debug!(
+            target: "astra_cli::http_proxy",
+            url = %url,
+            "post_chat_turn: sending POST /chat/turn via http_stream (proxy-aware streaming client)"
+        );
         let mut headers = Self::bearer_headers(token)?;
         headers.insert(
             header::ACCEPT,
             HeaderValue::from_static("text/event-stream"),
         );
-        Ok(self
+        let result = self
             .http_stream
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .json(payload)
             .send()
-            .await?)
+            .await;
+        match &result {
+            Ok(resp) => tracing::debug!(
+                target: "astra_cli::http_proxy",
+                url = %url,
+                status = %resp.status(),
+                "post_chat_turn: response received"
+            ),
+            Err(e) => tracing::warn!(
+                target: "astra_cli::http_proxy",
+                url = %url,
+                error = %e,
+                "post_chat_turn: request failed"
+            ),
+        }
+        Ok(result?)
     }
 
     /// Same as [`Self::post_chat_turn`] but with a per-request timeout (e.g. LLM tool-selection probe).
@@ -3070,5 +3132,100 @@ mod tests {
             "attachment; filename=\"\"".parse().unwrap(),
         );
         assert_eq!(attachment_filename(&headers), None);
+    }
+
+    // ── streaming_http_client proxy-transparency guard ────────────────────────
+    //
+    // The SSE chat-turn stream (`post_chat_turn`) and the model-list pre-flight
+    // (`get_models_response_timeout`) both use `http_stream`, which is built by
+    // `streaming_http_client()`.  Inside an OpenShell sandbox the process lives
+    // in an isolated network namespace whose ONLY egress route is the HTTP proxy
+    // injected via the HTTP_PROXY / http_proxy environment variable.  Calling
+    // `.no_proxy()` on the builder bypasses that proxy, making the client
+    // attempt a direct TCP connection that has no route — the request silently
+    // fails and the user sees no LLM response.
+    //
+    // These tests are source-level guards that will break loudly if anyone adds
+    // `.no_proxy()` back to `streaming_http_client`.  They complement the
+    // human-readable comment inside the function itself.
+
+    /// Extract the body of `streaming_http_client` from the source, with
+    /// single-line comments stripped so guard tests are not confused by
+    /// explanatory comment text that mentions `.no_proxy()`.
+    fn streaming_http_client_body_no_comments() -> String {
+        let src = include_str!("client.rs");
+        let fn_start = src
+            .find("fn streaming_http_client()")
+            .expect("streaming_http_client must exist in client.rs");
+        let fn_src = &src[fn_start..];
+        let body_start = fn_src.find('{').expect("function body open brace");
+        let body_src = &fn_src[body_start..];
+        let mut depth = 0usize;
+        let mut body_end = 0usize;
+        for (i, ch) in body_src.char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        body_end = i + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let fn_body = &body_src[..body_end];
+        // Strip single-line comments so guard assertions are not tripped by
+        // comment text that intentionally mentions the forbidden pattern.
+        fn_body
+            .lines()
+            .map(|line| {
+                if let Some(pos) = line.find("//") {
+                    &line[..pos]
+                } else {
+                    line
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn streaming_http_client_does_not_suppress_proxy() {
+        // `streaming_http_client` must not call `.no_proxy()`.
+        // Inside an OpenShell sandbox the only egress route is the HTTP proxy
+        // injected via HTTP_PROXY / http_proxy.  Suppressing it causes silent
+        // connection failures for all SSE chat turns and model-list pre-flight.
+        let code = streaming_http_client_body_no_comments();
+        assert!(
+            !code.contains(".no_proxy()"),
+            "streaming_http_client must NOT call .no_proxy(): \
+             inside an OpenShell sandbox the only egress path is the \
+             HTTP_PROXY env-var proxy; suppressing it causes silent \
+             connection failures for all SSE chat turns.\n\
+             Code (comments stripped):\n{code}"
+        );
+    }
+
+    #[test]
+    fn streaming_http_client_disables_auto_decompression() {
+        // Auto-decompression must stay disabled on `http_stream`.  If
+        // Content-Encoding headers on SSE responses cause reqwest to buffer
+        // chunks, streaming breaks.  This guard prevents accidental re-addition
+        // of `.gzip(true)` / `.brotli(true)` / `.deflate(true)`.
+        let code = streaming_http_client_body_no_comments();
+        assert!(
+            code.contains(".no_gzip()"),
+            "streaming_http_client must call .no_gzip() to disable auto-decompression"
+        );
+        assert!(
+            code.contains(".no_brotli()"),
+            "streaming_http_client must call .no_brotli() to disable auto-decompression"
+        );
+        assert!(
+            code.contains(".no_deflate()"),
+            "streaming_http_client must call .no_deflate() to disable auto-decompression"
+        );
     }
 }

--- a/crates/astra-thin-client/src/client.rs
+++ b/crates/astra-thin-client/src/client.rs
@@ -426,17 +426,11 @@ impl ThinClient {
         timeout: Duration,
     ) -> Result<Response, ThinClientError> {
         let url = self.url(paths::MODELS)?;
-        let http_proxy = std::env::var("HTTP_PROXY")
-            .or_else(|_| std::env::var("http_proxy"))
-            .unwrap_or_else(|_| "(none)".to_string());
-        let no_proxy = std::env::var("NO_PROXY")
-            .or_else(|_| std::env::var("no_proxy"))
-            .unwrap_or_else(|_| "(none)".to_string());
         tracing::debug!(
             target: "astra_cli::http_proxy",
             url = %url,
-            http_proxy = %http_proxy,
-            no_proxy = %no_proxy,
+            http_proxy_set = std::env::var("HTTP_PROXY").or_else(|_| std::env::var("http_proxy")).is_ok(),
+            no_proxy_set = std::env::var("NO_PROXY").or_else(|_| std::env::var("no_proxy")).is_ok(),
             token_len = token.len(),
             "get_models_response_timeout: sending GET /models via self.http (proxy-aware client)"
         );

--- a/crates/astra-tools/src/char_boundary.rs
+++ b/crates/astra-tools/src/char_boundary.rs
@@ -1,0 +1,30 @@
+/// Stable polyfill for the `round_char_boundary` nightly feature (issue #93743).
+///
+/// Provides `floor_char_boundary` and `ceil_char_boundary` as extension methods
+/// on `str`, matching the semantics of the unstable inherent methods so call
+/// sites can be updated transparently.
+pub trait CharBoundaryExt {
+    /// Returns the largest byte index `<= index` that is a valid UTF-8 char boundary.
+    fn floor_char_boundary(&self, index: usize) -> usize;
+    /// Returns the smallest byte index `>= index` that is a valid UTF-8 char boundary.
+    fn ceil_char_boundary(&self, index: usize) -> usize;
+}
+
+impl CharBoundaryExt for str {
+    fn floor_char_boundary(&self, index: usize) -> usize {
+        let index = index.min(self.len());
+        (0..=index)
+            .rev()
+            .find(|&i| self.is_char_boundary(i))
+            .unwrap_or(0)
+    }
+
+    fn ceil_char_boundary(&self, index: usize) -> usize {
+        if index >= self.len() {
+            return self.len();
+        }
+        (index..=self.len())
+            .find(|&i| self.is_char_boundary(i))
+            .unwrap_or(self.len())
+    }
+}

--- a/crates/astra-tools/src/lib.rs
+++ b/crates/astra-tools/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unstable_name_collisions)]
 //! # astra-tools
 //!
 //! Extracted tool execution library for astra-engine. This crate contains the
@@ -8,6 +9,9 @@
 //! on this crate and compose its `DefaultToolExecutor` with their own wrappers.
 
 pub mod agent_tool_contract;
+pub mod char_boundary;
+pub use char_boundary::CharBoundaryExt;
+
 pub mod ask_user;
 pub mod display_sixel;
 pub mod memoria;

--- a/crates/astra-turn-core/src/lib.rs
+++ b/crates/astra-turn-core/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unstable_name_collisions)]
 //! Core turn types, contracts, and pure helpers extracted from the runtime crate.
 //!
 //! This crate contains modules that have no dependency on the runtime's

--- a/crates/runtime/src/app_state.rs
+++ b/crates/runtime/src/app_state.rs
@@ -1205,6 +1205,7 @@ mod tests {
             Some("MacBook Pro".to_string()),
             Some("/Users/test/project".to_string()),
             Some(edge_runtime_environment_advertisement("edge-selected")),
+            None,
             tx,
         );
 

--- a/crates/runtime/src/capabilities.rs
+++ b/crates/runtime/src/capabilities.rs
@@ -366,9 +366,19 @@ impl RemoteSkillCatalogProvider {
             .get_skills_query_text(&token, &params)
             .await
             .map_err(|source| {
-                SkillError::LoadFailed(format!(
-                    "failed to list remote skill catalog page: {source}"
-                ))
+                use std::error::Error;
+                let mut chain = format!("{source}");
+                let mut e: &dyn Error = &source;
+                while let Some(next) = e.source() {
+                    chain.push_str(&format!(" → {next}"));
+                    e = next;
+                }
+                tracing::warn!(
+                    target: "astra_runtime::skill_discovery",
+                    error = %chain,
+                    "skill-discovery: HTTP request failed listing remote skill catalog page"
+                );
+                SkillError::LoadFailed(format!("failed to list remote skill catalog page: {chain}"))
             })?;
         serde_json::from_str(&body).map_err(|source| {
             SkillError::ParseFailed(format!(
@@ -403,13 +413,70 @@ impl SkillProvider for RemoteSkillCatalogProvider {
     async fn discover(&self) -> Result<Vec<SkillManifest>, SkillError> {
         let mut cursor = None;
         let mut manifests = Vec::new();
+        let mut first_page = true;
         loop {
             let remaining = REMOTE_SKILL_MAX_ROWS.saturating_sub(manifests.len() as u32);
             if remaining == 0 {
                 break;
             }
             let limit = remaining.min(REMOTE_SKILL_PAGE_SIZE);
-            let page = self.list_page(limit, cursor).await?;
+            let page = match self.list_page(limit, cursor.clone()).await {
+                Ok(p) => p,
+                // Retry the first page with exponential backoff on transport
+                // failure (e.g. sandbox pod startup race where network routing
+                // isn't fully ready within the first couple of seconds).
+                Err(first_err) if first_page => {
+                    tracing::warn!(
+                        target: "astra_runtime::skill_discovery",
+                        error = %first_err,
+                        "skill-discovery: first page fetch failed; retrying with backoff"
+                    );
+                    let retry_delays_secs: &[u64] = &[2, 5, 10, 20];
+                    let mut recovered = None;
+                    let mut last_err_msg = String::new();
+                    for (attempt, &delay) in retry_delays_secs.iter().enumerate() {
+                        tracing::info!(
+                            target: "astra_runtime::skill_discovery",
+                            attempt = attempt + 1,
+                            attempts = retry_delays_secs.len(),
+                            delay_secs = delay,
+                            "skill-discovery: retrying first page"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+                        match self.list_page(limit, cursor.clone()).await {
+                            Ok(p) => {
+                                tracing::info!(
+                                    target: "astra_runtime::skill_discovery",
+                                    attempt = attempt + 1,
+                                    "skill-discovery: first page retry succeeded"
+                                );
+                                recovered = Some(p);
+                                break;
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    target: "astra_runtime::skill_discovery",
+                                    attempt = attempt + 1,
+                                    error = %e,
+                                    "skill-discovery: first page retry failed"
+                                );
+                                last_err_msg = e.to_string();
+                            }
+                        }
+                    }
+                    match recovered {
+                        Some(p) => p,
+                        None => {
+                            return Err(SkillError::LoadFailed(format!(
+                                "skill discovery failed after {} retries: {last_err_msg}",
+                                retry_delays_secs.len()
+                            )));
+                        }
+                    }
+                }
+                Err(e) => return Err(e),
+            };
+            first_page = false;
             let page_len = page.skills.len() as u32;
             cursor = page.next_cursor.clone();
             manifests.extend(page.skills.into_iter().map(|item| SkillManifest {

--- a/crates/runtime/src/capability_registry.rs
+++ b/crates/runtime/src/capability_registry.rs
@@ -535,6 +535,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
 
         let resolved = reg.resolve(&request).await.unwrap();
@@ -561,6 +562,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
 
         let result = reg.resolve(&request).await;
@@ -596,6 +598,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
 
         let resolved = reg.resolve(&request).await.unwrap();
@@ -639,6 +642,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
 
         // Should pick "with-storage" even though it has higher priority,
@@ -683,6 +687,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
 
         let resolved = reg.resolve(&request).await.unwrap();
@@ -718,6 +723,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
 
         let resolved = reg.resolve(&request).await;
@@ -749,6 +755,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
 
         let resolved = reg.resolve(&request).await;
@@ -783,6 +790,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
         assert!(
             reg.resolve(&task_request).await.is_ok(),
@@ -799,6 +807,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
         assert!(
             matches!(
@@ -834,6 +843,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
 
         let resolved = reg.resolve(&request).await;
@@ -950,6 +960,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
 
         let resolved = reg.resolve(&request).await.unwrap();
@@ -990,6 +1001,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
 
         let result = reg.resolve(&request).await;

--- a/crates/runtime/src/data_layer/models.rs
+++ b/crates/runtime/src/data_layer/models.rs
@@ -46,6 +46,20 @@ pub async fn list_models_handler(
     headers: HeaderMap,
 ) -> Result<Json<Vec<ModelListItemResponse>>, (StatusCode, Json<ErrorResponse>)> {
     let principal = state.auth_service.current_principal(&headers).await?;
+    if principal.is_edge_registration() {
+        let catalog = state
+            .auth_service
+            .external_catalog_by_scope(&principal)
+            .await?;
+        return Ok(Json(
+            catalog
+                .models
+                .into_iter()
+                .map(ModelListItem::from)
+                .map(ModelListItemResponse::from)
+                .collect(),
+        ));
+    }
     let user = principal.user;
     let is_admin = state.admin.authorizer.require_admin(&headers).await.is_ok();
     let models = state

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,4 +1,5 @@
 // Clippy 1.94 tightened several lints; clean up incrementally rather than blocking CI.
+#![allow(unstable_name_collisions)]
 #![allow(
     deprecated,
     clippy::await_holding_lock,

--- a/crates/runtime/src/provider/edge_connection.rs
+++ b/crates/runtime/src/provider/edge_connection.rs
@@ -16,6 +16,7 @@ use crate::server::tool_execution_binding::{
     ExecutorBinding, ExecutorStatus, ToolExecutionRequest, ToolPolicySnapshot, ToolTransportKind,
     WorkspaceAuthority, WorkspaceBinding,
 };
+use astra_runtime_env::WorkspaceRecord;
 
 // ---------------------------------------------------------------------------
 // EdgeConnectionProvider
@@ -139,6 +140,25 @@ impl CapabilityProvider for EdgeConnectionProvider {
         request: ToolRequest,
         cancel_token: Option<&std::sync::Arc<tokio_util::sync::CancellationToken>>,
     ) -> ToolResult {
+        // Synthesise a minimal WorkspaceRecord from the request's workspace_id
+        // so that workspace isolation checks in the edge transport layer work
+        // correctly on the MOI provider-authorized turn path (where the caller's
+        // turn does not carry a full WorkspaceRecord).
+        let workspace_record = request
+            .workspace_id
+            .as_deref()
+            .map(|ws_id| WorkspaceRecord {
+                workspace_id: ws_id.to_string(),
+                owner_scope: astra_runtime_env::WorkspaceOwnerScope::None,
+                kind: astra_runtime_env::WorkspaceBindingKind::None,
+                authority: WorkspaceAuthority::None,
+                root_or_volume_ref: String::new(),
+                source: astra_runtime_env::WorkspaceSource::None,
+                persistence: astra_runtime_env::WorkspacePersistence::None,
+                revision: String::new(),
+                display_name: String::new(),
+            });
+
         // Build a ToolExecutionRequest from the provider's ToolRequest.
         let exec_request = ToolExecutionRequest {
             user_id: request.user_id.clone(),
@@ -149,7 +169,7 @@ impl CapabilityProvider for EdgeConnectionProvider {
             tool_call_id: request.tool_call_id.clone(),
             args: request.parameters.clone(),
             workspace: WorkspaceBinding::edge_workspace("edge", "/", WorkspaceAuthority::None),
-            workspace_record: None,
+            workspace_record,
             executor: ExecutorBinding::edge_agent(
                 "edge-agent",
                 "Edge Agent",
@@ -310,6 +330,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         };
         let result = provider.execute(request, None).await;
         match result {
@@ -400,6 +421,7 @@ mod tests {
                 _hostname: Option<&str>,
                 _worktree_path: Option<&str>,
                 _capabilities: Option<serde_json::Value>,
+                _workspace_id: Option<&str>,
             ) -> Result<astra_services::multi_agent::EdgeAgentRecord, String> {
                 Err("mock".into())
             }
@@ -408,16 +430,29 @@ mod tests {
                 _user_id: &str,
                 _edge_agent_id: &str,
                 _edge_id_header: &str,
-            ) -> Result<(), String> {
+            ) -> Result<(), astra_services::multi_agent::HeartbeatError> {
                 Ok(())
             }
+            async fn find_by_agent_id_and_workspace(
+                &self,
+                _edge_agent_id: &str,
+                _workspace_id: Option<&str>,
+            ) -> Result<Option<astra_services::multi_agent::EdgeAgentRecord>, String> {
+                Ok(None)
+            }
+
             async fn list_by_user(
                 &self,
                 _user_id: &str,
             ) -> Result<Vec<astra_services::multi_agent::EdgeAgentRecord>, String> {
                 Ok(vec![])
             }
-            async fn unregister(&self, _user_id: &str, _edge_agent_id: &str) -> Result<(), String> {
+            async fn unregister(
+                &self,
+                _user_id: &str,
+                _edge_agent_id: &str,
+                _edge_id: &str,
+            ) -> Result<(), String> {
                 Ok(())
             }
         }

--- a/crates/runtime/src/provider/sandbox_runner.rs
+++ b/crates/runtime/src/provider/sandbox_runner.rs
@@ -227,6 +227,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         }
     }
 

--- a/crates/runtime/src/provider/server_builtin.rs
+++ b/crates/runtime/src/provider/server_builtin.rs
@@ -191,6 +191,7 @@ mod tests {
             user_id: "test-user".into(),
             run_id: "test-run".into(),
             session_id: "test-session".into(),
+            workspace_id: None,
         }
     }
 

--- a/crates/runtime/src/provider/traits.rs
+++ b/crates/runtime/src/provider/traits.rs
@@ -40,6 +40,12 @@ pub struct ToolRequest {
     pub run_id: String,
     /// Session-scoped session identifier.
     pub session_id: String,
+    /// Owning workspace identifier (provider_scope_id from edge-registration
+    /// token binding).  Set by the capability registry caller when the turn
+    /// originates from a provider-authorized context so that edge workspace
+    /// isolation checks work correctly even when a full WorkspaceRecord is
+    /// not available on the turn.
+    pub workspace_id: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/runtime/src/server/edge/edge_callback_handlers.rs
+++ b/crates/runtime/src/server/edge/edge_callback_handlers.rs
@@ -915,6 +915,7 @@ pub(crate) async fn post_agents_edge_register_handler(
             body.hostname.as_deref(),
             body.worktree_path.as_deref(),
             body.capabilities,
+            None, // workspace_id not available via REST callback path
         )
         .await
         .map_err(|e| error_response(StatusCode::SERVICE_UNAVAILABLE, e))?;
@@ -943,7 +944,15 @@ pub(crate) async fn post_agents_edge_heartbeat_handler(
         .edge_registry_service
         .heartbeat(&user.user_id, &body.edge_agent_id, &edge_id)
         .await
-        .map_err(|e| error_response(StatusCode::SERVICE_UNAVAILABLE, e))?;
+        .map_err(|e| match e {
+            astra_services::multi_agent::HeartbeatError::Superseded => error_response(
+                StatusCode::CONFLICT,
+                "edge connection superseded by newer registration",
+            ),
+            astra_services::multi_agent::HeartbeatError::StorageFailure(msg) => {
+                error_response(StatusCode::SERVICE_UNAVAILABLE, msg)
+            }
+        })?;
 
     // ── Reconnection dedup ──────────────────────────────────────────
     // 1. Ack completed request IDs: remove from cloud's pending set.

--- a/crates/runtime/src/server/edge/edge_service_status_handler.rs
+++ b/crates/runtime/src/server/edge/edge_service_status_handler.rs
@@ -9,8 +9,9 @@ use super::*;
 const SERVICE_KEY_ENV: &str = "ASTRA_BACKEND_SERVICE_KEY";
 
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    // Fold length difference into diff to avoid early return leaking length info.
-    let mut diff: u8 = (a.len() ^ b.len()) as u8;
+    // Use a boolean inequality so the length mismatch contributes exactly 0 or 1
+    // to diff — XOR-then-cast would truncate to 0 for lengths differing by 256.
+    let mut diff: u8 = (a.len() != b.len()) as u8;
     let max = a.len().max(b.len());
     for i in 0..max {
         let av = *a.get(i).unwrap_or(&0);

--- a/crates/runtime/src/server/edge/edge_service_status_handler.rs
+++ b/crates/runtime/src/server/edge/edge_service_status_handler.rs
@@ -9,12 +9,13 @@ use super::*;
 const SERVICE_KEY_ENV: &str = "ASTRA_BACKEND_SERVICE_KEY";
 
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff: u8 = 0;
-    for i in 0..a.len() {
-        diff |= a[i] ^ b[i];
+    // Fold length difference into diff to avoid early return leaking length info.
+    let mut diff: u8 = (a.len() ^ b.len()) as u8;
+    let max = a.len().max(b.len());
+    for i in 0..max {
+        let av = *a.get(i).unwrap_or(&0);
+        let bv = *b.get(i).unwrap_or(&0);
+        diff |= av ^ bv;
     }
     diff == 0
 }

--- a/crates/runtime/src/server/edge/edge_service_status_handler.rs
+++ b/crates/runtime/src/server/edge/edge_service_status_handler.rs
@@ -1,0 +1,166 @@
+//! `GET /service/edges/status?user_id=xxx` — service-to-service edge status.
+//!
+//! Allows trusted backend services (moi-backend) to query live edge connection
+//! status for any user without needing a user session token. Auth is a static
+//! shared secret configured via ASTRA_BACKEND_SERVICE_KEY environment variable.
+
+use super::*;
+
+const SERVICE_KEY_ENV: &str = "ASTRA_BACKEND_SERVICE_KEY";
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for i in 0..a.len() {
+        diff |= a[i] ^ b[i];
+    }
+    diff == 0
+}
+
+fn check_service_auth(headers: &HeaderMap) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let expected = match std::env::var(SERVICE_KEY_ENV) {
+        Ok(k) if !k.is_empty() => k,
+        _ => {
+            return Err(error_response(
+                StatusCode::FORBIDDEN,
+                "service endpoint not configured (ASTRA_BACKEND_SERVICE_KEY not set)",
+            ));
+        }
+    };
+    let provided = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .unwrap_or("");
+    if !constant_time_eq(provided.as_bytes(), expected.as_bytes()) {
+        return Err(error_response(
+            StatusCode::UNAUTHORIZED,
+            "invalid service key",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+pub(crate) struct ServiceEdgeStatusQuery {
+    pub user_id: String,
+}
+
+/// Heartbeat TTL: DB entries whose `last_heartbeat_at` is older than this are
+/// treated as stale (edge likely disconnected from another pod).
+/// Must be >= 3× EDGE_HEARTBEAT_INTERVAL_SECS (30s) to tolerate tick jitter
+/// and the MissedTickBehavior::Delay policy without false disconnects.
+const HEARTBEAT_TTL_SECS: i64 = 90;
+
+pub(crate) async fn edge_service_status_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(query): Query<ServiceEdgeStatusQuery>,
+) -> Result<Json<edge_status_handler::EdgeStatusResponse>, (StatusCode, Json<ErrorResponse>)> {
+    check_service_auth(&headers)?;
+
+    if query.user_id.trim().is_empty() {
+        return Err(error_response(StatusCode::BAD_REQUEST, "user_id required"));
+    }
+
+    // Build in-memory pool lookup for connected_secs enrichment (this-pod connections).
+    let in_memory_edges = state.edge_connection_pool.get_user_edges(&query.user_id);
+    let in_memory: std::collections::HashMap<String, std::time::Instant> = in_memory_edges
+        .into_iter()
+        .map(|info| (info.edge_agent_id.clone(), info.connected_at))
+        .collect();
+
+    // Primary: query DB registry for cross-pod correctness.
+    // The DB registry is the authoritative source for multi-pod clusters;
+    // falling back to the in-memory pool would return incomplete data and
+    // silently mislead callers. Return 503 on failure so the client can
+    // distinguish between "no edges" and "status unavailable".
+    let db_records = match state
+        .execution
+        .edge_registry_service
+        .list_by_user(&query.user_id)
+        .await
+    {
+        Ok(records) => records,
+        Err(e) => {
+            tracing::warn!(
+                target: "astra_runtime::edge_service_status",
+                user_id = %query.user_id,
+                error = %e,
+                "edge_registry list_by_user failed; returning 503 to signal degraded state"
+            );
+            return Err(error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "edge registry unavailable",
+            ));
+        }
+    };
+
+    // When no DB records are found (unconfigured / single-pod deployment),
+    // synthesise records from the in-memory pool so that callers can see
+    // locally connected edges even without a DB registry.
+    let now = Utc::now();
+    if db_records.is_empty() && !in_memory.is_empty() {
+        let edges: Vec<edge_status_handler::EdgeInfo> = state
+            .edge_connection_pool
+            .get_user_edges(&query.user_id)
+            .into_iter()
+            .map(|info| edge_status_handler::EdgeInfo {
+                connected_secs: info.connected_at.elapsed().as_secs(),
+                capabilities: info.capabilities,
+                edge_agent_id: info.edge_agent_id,
+                hostname: info.hostname,
+                workspace_dir: info.workspace_dir,
+            })
+            .collect();
+        return Ok(Json(edge_status_handler::EdgeStatusResponse { edges }));
+    }
+
+    let edges: Vec<edge_status_handler::EdgeInfo> = db_records
+        .into_iter()
+        .filter_map(|record| {
+            // Apply heartbeat TTL: discard entries whose last heartbeat is too old.
+            // The format from `CAST(last_heartbeat_at AS CHAR)` is "%Y-%m-%d %H:%M:%S%.6f".
+            let heartbeat_naive = chrono::NaiveDateTime::parse_from_str(
+                &record.last_heartbeat_at,
+                "%Y-%m-%d %H:%M:%S%.6f",
+            )
+            .or_else(|_| {
+                chrono::NaiveDateTime::parse_from_str(
+                    &record.last_heartbeat_at,
+                    "%Y-%m-%d %H:%M:%S",
+                )
+            })
+            .ok()?;
+            let heartbeat_at = heartbeat_naive.and_utc();
+            let age_secs = (now - heartbeat_at).num_seconds();
+            if age_secs > HEARTBEAT_TTL_SECS {
+                tracing::debug!(
+                    target: "astra_runtime::edge_service_status",
+                    edge_agent_id = %record.edge_agent_id,
+                    age_secs,
+                    "edge_registry: discarding stale entry"
+                );
+                return None;
+            }
+
+            // Use in-memory connected_at if the edge is also locally tracked.
+            let connected_secs = in_memory
+                .get(&record.edge_agent_id)
+                .map(|connected_at| connected_at.elapsed().as_secs())
+                .unwrap_or(0);
+
+            Some(edge_status_handler::EdgeInfo {
+                edge_agent_id: record.edge_agent_id,
+                hostname: record.hostname,
+                workspace_dir: record.worktree_path,
+                capabilities: record.capabilities,
+                connected_secs,
+            })
+        })
+        .collect();
+
+    Ok(Json(edge_status_handler::EdgeStatusResponse { edges }))
+}

--- a/crates/runtime/src/server/edge/edge_ws_handler.rs
+++ b/crates/runtime/src/server/edge/edge_ws_handler.rs
@@ -169,14 +169,69 @@ async fn handle_edge_connection(
 
     let user_id = user.user_id.clone();
 
-    // Send auth success
-    let _ = send_edge_msg(
-        &ws_sink,
-        EdgeServerMessage::AuthOk {
-            user_id: user_id.clone(),
-        },
-    )
-    .await;
+    // ── Phase 1.5: Verify self-reported edge_agent_id matches token binding ──
+    // For moi-user-token-v1 tokens, ask the provider to confirm which
+    // edge_agent_id the token is bound to. A legitimate edge will always
+    // match; a forged or replayed token with a fabricated edge_agent_id is
+    // rejected here before it can hijack another edge's connection slot.
+    let workspace_id: Option<String> = if token.starts_with("moi-user-token-v1") {
+        match state.auth_service.edge_registration_binding(&token).await {
+            Ok(Some((bound_edge_agent_id, bound_workspace_id))) => {
+                if bound_edge_agent_id != edge_agent_id {
+                    tracing::warn!(
+                        target: "astra_runtime::edge_ws",
+                        edge_agent_id = %edge_agent_id,
+                        bound_edge_agent_id = %bound_edge_agent_id,
+                        "edge WebSocket auth failed: self-reported edge_agent_id does not match token binding"
+                    );
+                    let _ = send_edge_msg(
+                        &ws_sink,
+                        EdgeServerMessage::AuthError {
+                            message: "edge_agent_id does not match token binding".into(),
+                        },
+                    )
+                    .await;
+                    return;
+                }
+                Some(bound_workspace_id)
+            }
+            Ok(None) => {
+                // moi-user-token-v1 tokens must always carry an edge_agent_id binding.
+                // Ok(None) means the provider issued a runtime token (server-to-server),
+                // which must never be accepted on the WebSocket path.
+                tracing::warn!(
+                    target: "astra_runtime::edge_ws",
+                    edge_agent_id = %edge_agent_id,
+                    "edge WebSocket auth failed: moi-user-token-v1 token has no edge_agent_id binding (runtime token on WS path)"
+                );
+                let _ = send_edge_msg(
+                    &ws_sink,
+                    EdgeServerMessage::AuthError {
+                        message: "edge registration token required; runtime token not accepted on WebSocket path".into(),
+                    },
+                )
+                .await;
+                return;
+            }
+            Err(_) => {
+                tracing::warn!(
+                    target: "astra_runtime::edge_ws",
+                    edge_agent_id = %edge_agent_id,
+                    "edge WebSocket auth failed: edge token binding verification failed"
+                );
+                let _ = send_edge_msg(
+                    &ws_sink,
+                    EdgeServerMessage::AuthError {
+                        message: "edge token binding verification failed".into(),
+                    },
+                )
+                .await;
+                return;
+            }
+        }
+    } else {
+        None
+    };
 
     // ── Phase 1a: Validate & sanitize self-reported capabilities ─────
     // Edge nodes self-report their capabilities; a malicious edge could
@@ -196,19 +251,27 @@ async fn handle_edge_connection(
     let (pool_tx, mut pool_rx) = mpsc::channel::<EdgeServerMessage>(
         astra_server_types::edge_connection_pool::EDGE_WS_CHANNEL_CAPACITY,
     );
-    state.edge_connection_pool.register_with_capabilities(
+    // B1: capture generation so cleanup can use unregister_if_generation,
+    // preventing a late-arriving cleanup from removing a newer connection.
+    let pool_generation = state.edge_connection_pool.register_with_capabilities(
         &user_id,
         &edge_agent_id,
         hostname.clone(),
         workspace_dir.clone(),
         capabilities.clone(),
+        workspace_id.clone(),
         pool_tx,
     );
 
     // ── Phase 2a: Register in DB edge registry for cross-pod routing ─
+    // B2: if DB registration fails, roll back the pool entry and reject the
+    // WebSocket connection. This ensures there is no "online in-memory but
+    // invisible to other pods" split-brain state.
+    // B4 counterpart: UnconfiguredEdgeRegistryService always returns Ok here,
+    // so single-pod deployments without a DB registry are unaffected.
     let edge_registry = state.execution.edge_registry_service.clone();
     let edge_id_for_registry = format!("ws-{}", uuid::Uuid::new_v4());
-    let _ = edge_registry
+    if let Err(e) = edge_registry
         .register_or_update(
             &user_id,
             &edge_agent_id,
@@ -216,8 +279,40 @@ async fn handle_edge_connection(
             hostname.as_deref(),
             workspace_dir.as_deref(),
             capabilities,
+            workspace_id.as_deref(),
+        )
+        .await
+    {
+        tracing::warn!(
+            target: "astra_runtime::edge_ws",
+            user_id = %user_id,
+            edge_agent_id = %edge_agent_id,
+            error = %e,
+            "edge WebSocket: DB registry registration failed; rejecting connection"
+        );
+        state.edge_connection_pool.unregister_if_generation(
+            &user_id,
+            &edge_agent_id,
+            pool_generation,
+        );
+        let _ = send_edge_msg(
+            &ws_sink,
+            EdgeServerMessage::AuthError {
+                message: "edge registry registration failed".into(),
+            },
         )
         .await;
+        return;
+    }
+
+    // Auth + pool + DB all succeeded — notify the edge client.
+    let _ = send_edge_msg(
+        &ws_sink,
+        EdgeServerMessage::AuthOk {
+            user_id: user_id.clone(),
+        },
+    )
+    .await;
 
     // ── Phase 2b: Spawn cross-pod dispatch relay polling task ─────────
     let inflight_dispatches = InflightEdgeDispatchTracker::default();
@@ -469,6 +564,37 @@ async fn handle_edge_connection(
                     if send_edge_msg(&ws_sink_write, EdgeServerMessage::Pong).await.is_err() {
                         break;
                     }
+                    // B3: update last_heartbeat_at in DB registry, guarded by
+                    // edge_id so a stale connection cannot refresh a row that a
+                    // newer connection has already claimed.
+                    match edge_registry
+                        .heartbeat(&user_id, &edge_agent_id, &edge_id_for_registry)
+                        .await
+                    {
+                        Ok(()) => {}
+                        Err(astra_services::multi_agent::HeartbeatError::Superseded) => {
+                            tracing::info!(
+                                target: "astra_runtime::edge_ws",
+                                user_id = %user_id,
+                                edge_agent_id = %edge_agent_id,
+                                "edge WebSocket: connection superseded by newer registration; closing"
+                            );
+                            break;
+                        }
+                        Err(astra_services::multi_agent::HeartbeatError::StorageFailure(e)) => {
+                            tracing::warn!(
+                                target: "astra_runtime::edge_ws",
+                                user_id = %user_id,
+                                edge_agent_id = %edge_agent_id,
+                                error = %e,
+                                "edge WebSocket: heartbeat DB failure (transient); connection remains open"
+                            );
+                            // Transient storage failure — do not disconnect. The
+                            // next tick will retry. Persistent failures will
+                            // eventually be caught by the sweeper's stale-record
+                            // expiry, which uses last_heartbeat_at.
+                        }
+                    }
                 }
             }
         }
@@ -495,14 +621,39 @@ async fn handle_edge_connection(
         "edge_ws_disconnected",
     )
     .await;
-    pool_for_cleanup.unregister(&user_id_cleanup, &edge_agent_id_cleanup);
+    // B1: only remove our own pool entry; a faster reconnect may have already
+    // replaced it with a higher-generation entry — leave that intact.
+    let _was_our_entry = pool_for_cleanup.unregister_if_generation(
+        &user_id_cleanup,
+        &edge_agent_id_cleanup,
+        pool_generation,
+    );
 
-    // Unregister from DB edge registry so other pods stop routing to this edge.
-    let _ = state
+    // Always attempt DB unregister, regardless of whether we still owned the
+    // pool slot. The WHERE edge_id = ? guard in the SQL prevents us from
+    // deleting a newer connection's row written by a cross-pod reconnect.
+    // This also covers the gap where a new connection registered in DB but
+    // then failed and rolled back its pool entry — without this call the old
+    // DB row would linger until the sweeper expires it.
+    if let Err(e) = state
         .execution
         .edge_registry_service
-        .unregister(&user_id_cleanup, &edge_agent_id_cleanup)
-        .await;
+        .unregister(
+            &user_id_cleanup,
+            &edge_agent_id_cleanup,
+            &edge_id_for_registry,
+        )
+        .await
+    {
+        tracing::warn!(
+            target: "astra_runtime::edge_ws",
+            user_id = %user_id_cleanup,
+            edge_agent_id = %edge_agent_id_cleanup,
+            edge_id = %edge_id_for_registry,
+            error = %e,
+            "edge WebSocket cleanup: DB unregister failed; sweeper will expire the record"
+        );
+    }
 
     tracing::info!(
         user_id = %user_id_cleanup,

--- a/crates/runtime/src/server/edge/mod.rs
+++ b/crates/runtime/src/server/edge/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) use super::*;
 
 pub mod edge_callback_handlers;
+pub mod edge_service_status_handler;
 pub mod edge_status_handler;
 pub mod edge_ws_handler;

--- a/crates/runtime/src/server/http_helpers.rs
+++ b/crates/runtime/src/server/http_helpers.rs
@@ -18,15 +18,33 @@ pub(super) fn sse_json_response(events: Vec<serde_json::Value>) -> Response {
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn sse_error_response(status: StatusCode, message: impl Into<String>) -> Response {
+    let message = message.into();
+    tracing::warn!(
+        target: "astra_runtime::sse",
+        http_status = status.as_u16(),
+        error_code = status_to_sse_error_code(status),
+        retryable = status_to_sse_retryable(status),
+        message = %message,
+        "sse error response emitted to client",
+    );
     sse_json_response(vec![serde_json::json!({
         "type": "error",
-        "message": message.into(),
+        "message": message,
         "code": status_to_sse_error_code(status),
         "retryable": status_to_sse_retryable(status),
     })])
 }
 
 pub(super) fn sse_error_response_from_error(status: StatusCode, error: ErrorResponse) -> Response {
+    tracing::warn!(
+        target: "astra_runtime::sse",
+        http_status = status.as_u16(),
+        error_code = status_to_sse_error_code(status),
+        retryable = status_to_sse_retryable(status),
+        domain_error_code = error.error_code.as_deref().unwrap_or(""),
+        message = %error.detail,
+        "sse error response emitted to client",
+    );
     let mut event = serde_json::json!({
         "type": "error",
         "message": error.detail,
@@ -119,11 +137,23 @@ pub(super) fn sse_streaming_response(
                     .and_then(|data| data.get("error"))
                     .and_then(serde_json::Value::as_str)
                     .map(ToOwned::to_owned);
+                tracing::warn!(
+                    target: "astra_runtime::sse",
+                    run_id = %run_id,
+                    error = pending_terminal_error.as_deref().unwrap_or(""),
+                    "run failed mid-stream (run_error)",
+                );
             } else if event.get("type").and_then(serde_json::Value::as_str) == Some("error") {
                 pending_terminal_error = event
                     .get("message")
                     .and_then(serde_json::Value::as_str)
                     .map(ToOwned::to_owned);
+                tracing::warn!(
+                    target: "astra_runtime::sse",
+                    run_id = %run_id,
+                    error = pending_terminal_error.as_deref().unwrap_or(""),
+                    "error event emitted mid-stream",
+                );
             }
 
             let events = handlers::transform_stream_run_events_for_client_with_pending(

--- a/crates/runtime/src/server/provider_runtime_context.rs
+++ b/crates/runtime/src/server/provider_runtime_context.rs
@@ -7,23 +7,184 @@ pub(crate) async fn inject_effective_runtime_context(
 ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
     if principal.is_provider_authorized_request() {
         request.provider_runtime_authorized = true;
+        // Thread provider_scope_id into the request so the run lifecycle can
+        // propagate it into ToolExecutionRequest.workspace_record, enabling
+        // workspace isolation checks on the edge transport path even when the
+        // turn carries no full WorkspaceRecord (MOI provider-authorized turns).
+        if let AuthPrincipalOrigin::ProviderAuthorizedRequest(ctx) = &principal.origin {
+            request.provider_workspace_id = Some(ctx.provider_scope_id.clone());
+        }
         return apply_provider_supplied_runtime_context(request);
     }
     reject_unauthorized_capability_descriptors(request)
 }
 
 pub(crate) async fn inject_effective_runtime_context_body(
-    _state: &AppState,
+    state: &AppState,
     principal: &AuthPrincipal,
     body: Bytes,
 ) -> Result<Bytes, (StatusCode, Json<ErrorResponse>)> {
     if principal.is_provider_authorized_request() {
+        if principal.is_edge_registration() {
+            return inject_edge_registration_runtime_context_body(state, principal, body).await;
+        }
         return Ok(body);
     }
     if body_has_capability_descriptors(&body)? {
         return Err(provider_runtime_authorization_required());
     }
     Ok(body)
+}
+
+async fn inject_edge_registration_runtime_context_body(
+    state: &AppState,
+    principal: &AuthPrincipal,
+    body: Bytes,
+) -> Result<Bytes, (StatusCode, Json<ErrorResponse>)> {
+    let mut value: serde_json::Value = serde_json::from_slice(&body).map_err(|error| {
+        error_response(
+            StatusCode::BAD_REQUEST,
+            format!("chat turn request body must be JSON for edge runtime context: {error}"),
+        )
+    })?;
+    let object = value.as_object_mut().ok_or_else(|| {
+        error_response(
+            StatusCode::BAD_REQUEST,
+            "chat turn request body must be a JSON object for edge runtime context",
+        )
+    })?;
+    // Strip any caller-supplied runtime context fields. Edge-registration tokens
+    // are not allowed to provide runtime auth, capability descriptors, or
+    // runtime bindings directly; the provider issues all of these below.
+    object.remove("runtime_auth");
+    object.remove("capability_descriptors");
+    object.remove("llm_token_service");
+    object.remove("runtime_profile");
+    object.remove("runtime_mcp_bindings");
+    object.remove("runtime_skill_binding");
+    object.remove("runtime_system_prompt");
+
+    let requested_model_id = match object
+        .get("selected_model")
+        .and_then(|s| s.get("id"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+    {
+        Some(id) => id,
+        None => {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "edge chat turn request must specify selected_model.id",
+            ));
+        }
+    };
+    // Replace caller-supplied selected_model wholesale with the provider-issued one below.
+    object.remove("selected_model");
+    let requested_tool_ids = string_array_field(object, "allow_tools")?;
+    let requested_skill_ids = string_array_field(object, "allow_skills")?;
+    let t0 = std::time::Instant::now();
+    tracing::info!("astra_timing: issue_runtime_context started (edge-jwt path)");
+    let context = state
+        .auth_service
+        .external_runtime_context_by_scope(
+            principal,
+            astra_services::ExternalRuntimeContextRequestData {
+                requested_model_id,
+                requested_tool_ids,
+                requested_skill_ids: requested_skill_ids.clone(),
+                requested_knowledge_base_ids: Vec::new(),
+            },
+        )
+        .await?;
+    tracing::info!(
+        elapsed_ms = t0.elapsed().as_millis(),
+        "astra_timing: issue_runtime_context completed (edge-jwt path)"
+    );
+    let authorization = context.runtime_auth.authorization.clone();
+    let selected_model = context.selected_model.to_selected_model_request();
+    let runtime_auth = context.runtime_auth.to_runtime_auth_request();
+    if let Some(runtime_system_prompt) = context.runtime_system_prompt {
+        object.insert(
+            "runtime_system_prompt".to_string(),
+            serde_json::Value::String(runtime_system_prompt),
+        );
+    }
+    object.insert(
+        "selected_model".to_string(),
+        serde_json::to_value(&selected_model).map_err(internal_error)?,
+    );
+    object.insert(
+        "runtime_auth".to_string(),
+        serde_json::to_value(&runtime_auth).map_err(internal_error)?,
+    );
+    object.insert(
+        "capability_descriptors".to_string(),
+        serde_json::to_value(context.capability_descriptors.to_request_descriptors())
+            .map_err(internal_error)?,
+    );
+    if let Some(model_gateway) = context.capability_descriptors.model_gateway.as_ref() {
+        object.insert(
+            "llm_token_service".to_string(),
+            serde_json::json!({
+                "url": model_gateway.endpoint_url,
+            }),
+        );
+    }
+    if let Some(mcp) = context.capability_descriptors.mcp {
+        object.insert(
+            "runtime_profile".to_string(),
+            serde_json::Value::String("request_scoped_runtime_mcp".to_string()),
+        );
+        object.insert(
+            "runtime_mcp_bindings".to_string(),
+            serde_json::to_value(vec![mcp.into_runtime_mcp_binding(authorization.clone())])
+                .map_err(internal_error)?,
+        );
+    }
+    if !requested_skill_ids.is_empty() {
+        if let Some(skills) = context.capability_descriptors.skills {
+            object.insert(
+                "runtime_skill_binding".to_string(),
+                serde_json::json!({
+                    "id": skills.id,
+                    "url": skills.endpoint_url,
+                    "authorization": authorization,
+                }),
+            );
+        }
+    }
+    serde_json::to_vec(&value)
+        .map(Bytes::from)
+        .map_err(internal_error)
+}
+
+fn string_array_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<Vec<String>, (StatusCode, Json<ErrorResponse>)> {
+    let Some(value) = object.get(field) else {
+        return Ok(Vec::new());
+    };
+    if value.is_null() {
+        return Ok(Vec::new());
+    }
+    let array = value.as_array().ok_or_else(|| {
+        error_response(
+            StatusCode::BAD_REQUEST,
+            format!("{field} must be an array of string ids"),
+        )
+    })?;
+    array
+        .iter()
+        .map(|item| {
+            item.as_str().map(ToOwned::to_owned).ok_or_else(|| {
+                error_response(
+                    StatusCode::BAD_REQUEST,
+                    format!("{field} must contain only string ids"),
+                )
+            })
+        })
+        .collect()
 }
 
 fn apply_provider_supplied_runtime_context(
@@ -132,4 +293,127 @@ fn body_has_capability_descriptors(
         .as_object()
         .and_then(|object| object.get("capability_descriptors"))
         .is_some_and(|value| !value.is_null()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astra_services::auth::{AuthPrincipalOrigin, AuthProviderAuthorizedRequestContext};
+    use axum::http::StatusCode;
+
+    struct AlwaysHealthy;
+    #[async_trait::async_trait]
+    impl HealthChecker for AlwaysHealthy {
+        async fn database_healthy(&self) -> bool {
+            true
+        }
+    }
+
+    struct StubEdgeAuth;
+    #[async_trait::async_trait]
+    impl AuthService for StubEdgeAuth {
+        async fn register(
+            &self,
+            _req: AuthRegisterRequestData,
+        ) -> Result<AuthUserRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+            unreachable!()
+        }
+        async fn login(
+            &self,
+            _req: AuthLoginRequestData,
+        ) -> Result<AuthTokenRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+            unreachable!()
+        }
+        async fn refresh(
+            &self,
+            _req: AuthRefreshRequestData,
+        ) -> Result<AuthTokenRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+            unreachable!()
+        }
+        async fn logout(
+            &self,
+            _req: AuthRefreshRequestData,
+        ) -> Result<(), (StatusCode, axum::Json<ErrorResponse>)> {
+            unreachable!()
+        }
+        async fn current_user(
+            &self,
+            _headers: &axum::http::HeaderMap,
+        ) -> Result<AuthUserRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+            unreachable!()
+        }
+    }
+
+    fn edge_principal() -> AuthPrincipal {
+        AuthPrincipal {
+            user: AuthUserRecord {
+                user_id: "u1".to_string(),
+                username: "edge".to_string(),
+                email: "edge@test".to_string(),
+                display_name: None,
+            },
+            session_id: None,
+            origin: AuthPrincipalOrigin::ProviderAuthorizedRequest(
+                AuthProviderAuthorizedRequestContext {
+                    provider_id: "p1".to_string(),
+                    external_subject: "s1".to_string(),
+                    provider_scope_id: "ws-1".to_string(),
+                    request_authorization_id: "r1".to_string(),
+                    edge_agent_id: Some("edge-test".to_string()),
+                },
+            ),
+        }
+    }
+
+    fn test_state() -> AppState {
+        AppState::new(
+            ServiceInfo::new("prc-test", "0.0.0-test", ""),
+            std::sync::Arc::new(AlwaysHealthy),
+        )
+        .with_auth_service(std::sync::Arc::new(StubEdgeAuth))
+    }
+
+    #[tokio::test]
+    async fn missing_selected_model_id_returns_400() {
+        let state = test_state();
+        let principal = edge_principal();
+        let body = Bytes::from_static(b"{}");
+
+        let err = inject_edge_registration_runtime_context_body(&state, &principal, body)
+            .await
+            .unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(
+            err.1.0.detail.contains("selected_model.id"),
+            "error message must mention selected_model.id: {:?}",
+            err.1.0.detail
+        );
+    }
+
+    #[tokio::test]
+    async fn injected_runtime_auth_and_capability_descriptors_are_stripped_before_model_id_check() {
+        let state = test_state();
+        let principal = edge_principal();
+        // Attacker injects both reserved fields but omits selected_model.id.
+        // The handler must strip the injected fields without error and then
+        // fail on the missing model id — not on unexpected field presence.
+        let body = Bytes::from(
+            serde_json::json!({
+                "runtime_auth": {"authorization": "attacker-token"},
+                "capability_descriptors": {"mcp": {"id": "evil"}},
+                "selected_model": {}
+            })
+            .to_string(),
+        );
+
+        let err = inject_edge_registration_runtime_context_body(&state, &principal, body)
+            .await
+            .unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(
+            err.1.0.detail.contains("selected_model.id"),
+            "must fail on missing selected_model.id, not on injected fields: {:?}",
+            err.1.0.detail
+        );
+    }
 }

--- a/crates/runtime/src/server/router_builder/realtime.rs
+++ b/crates/runtime/src/server/router_builder/realtime.rs
@@ -153,6 +153,10 @@ pub(super) fn add_routes(router: Router<AppState>) -> Router<AppState> {
             get(edge::edge_status_handler::edge_status_handler),
         )
         .route(
+            "/service/edges/status",
+            get(edge::edge_service_status_handler::edge_service_status_handler),
+        )
+        .route(
             "/chat/runs/{run_id}",
             get(crate::server::run::handlers::get_run_status_handler)
                 .delete(crate::server::run::handlers::cancel_run_handler),

--- a/crates/runtime/src/server/run/binding_resolution.rs
+++ b/crates/runtime/src/server/run/binding_resolution.rs
@@ -37,6 +37,27 @@ pub(crate) fn request_uses_server_workspace(
     }
 }
 
+/// MOI runner chat supplies `allow_tools` with executor_binding.transport=edge_ws.
+/// ServerToolExecutor still needs an internal scratch workspace even though tool
+/// execution is routed to the connected edge agent.
+#[allow(dead_code)]
+pub(crate) fn request_needs_edge_bound_server_executor(
+    request: &astra_services::runs::ChatRequestData,
+    execution_bindings: Option<&ExecutionBindingSnapshot>,
+) -> bool {
+    let has_allow_tools = request
+        .allow_tools
+        .as_ref()
+        .is_some_and(|tools| !tools.is_empty());
+    if !has_allow_tools {
+        return false;
+    }
+    execution_bindings.is_some_and(|snapshot| {
+        matches!(snapshot.executor.kind, ExecutorBindingKind::EdgeAgent)
+            && matches!(snapshot.executor.transport, ToolTransportKind::EdgeWs)
+    })
+}
+
 pub(crate) fn resolve_request_execution_bindings_without_server_workspace(
     request: &astra_services::runs::ChatRequestData,
     edge_profile: &Map<String, Value>,
@@ -251,6 +272,14 @@ pub(crate) fn executor_binding_from_request(
 ) -> ExecutorBinding {
     match workspace.kind {
         WorkspaceBindingKind::ServerSandbox => {
+            // When the caller explicitly requests an edge agent executor (e.g. a sandbox
+            // connected via WebSocket), honour that kind instead of forcing server_local.
+            if matches!(
+                binding,
+                Some(b) if b.kind == astra_services::runs::ExecutorBindingRequestKind::EdgeAgent
+            ) {
+                return edge_executor_binding_from_request(binding);
+            }
             let mut executor = ExecutorBinding::server_local();
             if let Some(binding) = binding {
                 if let Some(executor_id) = non_empty_string(binding.executor_id.as_deref()) {
@@ -562,6 +591,7 @@ mod tests {
             explain: false,
             interaction_mode: None,
             interactive_client: false,
+            provider_workspace_id: None,
         }
     }
 

--- a/crates/runtime/src/server/run/engine.rs
+++ b/crates/runtime/src/server/run/engine.rs
@@ -3020,6 +3020,7 @@ mod tests {
             explain: false,
             interaction_mode: None,
             interactive_client: false,
+            provider_workspace_id: None,
         };
         let context = crate::server::run::binding_resolution::run_start_context_from_request(
             &request, None, None,

--- a/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -6534,6 +6534,31 @@ fn cloud_workspace_provision_error(
     }
 }
 
+/// Returns the effective WorkspaceRecord for tool execution:
+/// - If a cloud workspace record is present, use it (standard path).
+/// - Otherwise, if the request carries a provider_workspace_id (from the
+///   edge-registration token's provider_scope_id on MOI provider-authorized
+///   turns), synthesise a minimal WorkspaceRecord so that edge workspace
+///   isolation checks in the transport layer work correctly.
+fn provider_effective_workspace_record(
+    cloud: Option<&astra_runtime_env::WorkspaceRecord>,
+    provider_workspace_id: Option<&str>,
+) -> Option<astra_runtime_env::WorkspaceRecord> {
+    cloud.cloned().or_else(|| {
+        provider_workspace_id.map(|ws_id| astra_runtime_env::WorkspaceRecord {
+            workspace_id: ws_id.to_string(),
+            owner_scope: astra_runtime_env::WorkspaceOwnerScope::None,
+            kind: astra_runtime_env::WorkspaceBindingKind::None,
+            authority: astra_runtime_env::WorkspaceAuthority::None,
+            root_or_volume_ref: String::new(),
+            source: astra_runtime_env::WorkspaceSource::None,
+            persistence: astra_runtime_env::WorkspacePersistence::None,
+            revision: String::new(),
+            display_name: String::new(),
+        })
+    })
+}
+
 fn workspace_record_store_error(
     error: WorkspaceRecordStoreError,
 ) -> (StatusCode, Json<ErrorResponse>) {
@@ -6966,7 +6991,10 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             let agent_working_dir =
                 agent_working_dir_for_bindings(execution_bindings.as_ref(), workspace.as_path());
             executor.set_execution_binding_snapshot(binding_snapshot);
-            executor.set_workspace_record(cloud_workspace_record.clone());
+            executor.set_workspace_record(provider_effective_workspace_record(
+                cloud_workspace_record.as_ref(),
+                request.provider_workspace_id.as_deref(),
+            ));
             host.set_execution_metadata(executor.binding_metadata());
 
             self.wire_server_dynamic_agent_tools(
@@ -8059,7 +8087,10 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             let agent_working_dir =
                 agent_working_dir_for_bindings(execution_bindings.as_ref(), workspace.as_path());
             executor.set_execution_binding_snapshot(binding_snapshot);
-            executor.set_workspace_record(cloud_workspace_record.clone());
+            executor.set_workspace_record(provider_effective_workspace_record(
+                cloud_workspace_record.as_ref(),
+                request.provider_workspace_id.as_deref(),
+            ));
             host.set_execution_metadata(executor.binding_metadata());
             executor.set_work_surface_event_tx(event_tx.clone());
             self.wire_server_dynamic_agent_tools(

--- a/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -6793,6 +6793,18 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             host.install_runtime_tool_schemas(bundle.schemas.clone(), bundle.control_tools.clone());
             host.install_runtime_stop_after_success_tools(bundle.stop_after_success_tools.clone());
         }
+        // In agent-binding mode with an EdgeAgent executor, the host only installs
+        // MCP schemas by default. Merge edge-builtin tool schemas (bash, read_file, …)
+        // for any tools explicitly listed in allow_tools so the model can see and call
+        // them via the edge dispatch path.
+        if let Some(snapshot) = execution_bindings.as_ref() {
+            if snapshot.executor.kind == ExecutorBindingKind::EdgeAgent {
+                if let Some(allow_tools) = request.allow_tools.as_deref() {
+                    let tools: Vec<String> = allow_tools.iter().map(|s| s.to_string()).collect();
+                    host.merge_allowlisted_edge_tool_schemas(&tools);
+                }
+            }
+        }
         let mut loop_state = self.build_initial_state_inner(
             &user_id,
             &request,
@@ -7857,6 +7869,18 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         if let Some(ref bundle) = runtime_capabilities.mcp_bundle {
             host.install_runtime_tool_schemas(bundle.schemas.clone(), bundle.control_tools.clone());
             host.install_runtime_stop_after_success_tools(bundle.stop_after_success_tools.clone());
+        }
+        // In agent-binding mode with an EdgeAgent executor, the host only installs
+        // MCP schemas by default. Merge edge-builtin tool schemas (bash, read_file, …)
+        // for any tools explicitly listed in allow_tools so the model can see and call
+        // them via the edge dispatch path.
+        if let Some(snapshot) = execution_bindings.as_ref() {
+            if snapshot.executor.kind == ExecutorBindingKind::EdgeAgent {
+                if let Some(allow_tools) = request.allow_tools.as_deref() {
+                    let tools: Vec<String> = allow_tools.iter().map(|s| s.to_string()).collect();
+                    host.merge_allowlisted_edge_tool_schemas(&tools);
+                }
+            }
         }
 
         // Guard: reject if this session already has a blocking run.

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -2943,6 +2943,7 @@ fn test_request(message: &str) -> ChatRequestData {
         explain: false,
         interaction_mode: None,
         interactive_client: false,
+        provider_workspace_id: None,
     }
 }
 
@@ -4610,6 +4611,7 @@ async fn validate_request_constraints_accepts_provider_descriptor_without_regist
             )),
             mcp: None,
             skills: None,
+            edge_agent: None,
         });
 
     service
@@ -4651,6 +4653,7 @@ async fn validate_request_constraints_rejects_provider_descriptor_with_selected_
             )),
             mcp: None,
             skills: None,
+            edge_agent: None,
         });
 
     let err = service
@@ -4685,6 +4688,7 @@ async fn validate_request_constraints_rejects_descriptor_without_provider_author
             )),
             mcp: None,
             skills: None,
+            edge_agent: None,
         });
 
     let err = service
@@ -7208,6 +7212,7 @@ fn extract_edge_tools_from_context() {
         explain: false,
         interaction_mode: None,
         interactive_client: false,
+        provider_workspace_id: None,
     };
     let tools = AgenticRunLifecycleService::extract_edge_tools(&req).expect("edge tools");
     assert_eq!(tools.len(), 1);
@@ -7378,6 +7383,7 @@ fn extract_edge_profile_from_context() {
         explain: false,
         interaction_mode: None,
         interactive_client: false,
+        provider_workspace_id: None,
     };
     let profile = AgenticRunLifecycleService::extract_edge_profile(&req).expect("edge profile");
     assert_eq!(profile["cwd"], "/tmp");
@@ -8117,6 +8123,7 @@ async fn agent_binding_runtime_ignores_legacy_endpoint_urls() {
                 "skills",
                 &format!("http://{addr}/skills"),
             )),
+            edge_agent: None,
         });
 
     let capabilities = service

--- a/crates/runtime/src/server/runtime_tool_executor.rs
+++ b/crates/runtime/src/server/runtime_tool_executor.rs
@@ -374,6 +374,8 @@ pub struct RuntimeToolExecutor {
     progress_callback: Option<Arc<dyn astra_tools::ToolProgressCallback>>,
     /// Optional auxiliary event writer for ask_user-specific audit events.
     auxiliary_event_writer: Option<Arc<dyn crate::TurnAuxiliaryEventWriter>>,
+    /// Tool names explicitly admitted for edge dispatch (bypass capability check).
+    edge_admitted_tools: HashSet<String>,
 }
 
 impl RuntimeToolExecutor {
@@ -456,6 +458,7 @@ impl RuntimeToolExecutor {
             control_plane_tools_enabled: true,
             invocation_ledger: None,
             semantic_read_observation_store: None,
+            edge_admitted_tools: HashSet::new(),
         }
     }
 
@@ -614,6 +617,24 @@ impl RuntimeToolExecutor {
 
     pub fn with_server_service_tools_disabled(mut self) -> Self {
         self.server_service_tools_enabled = false;
+        self
+    }
+
+    /// Mark explicit tool names as admitted for edge dispatch.  These tools
+    /// bypass the capability surface check so the model sees them in its tool
+    /// list even when server builtin tools are disabled (agent-binding mode).
+    /// Execution is still routed through `ToolExecutionService` to the edge
+    /// agent via WebSocket — server-local execution is never attempted.
+    pub fn with_edge_admitted_tools(mut self, tools: &[String]) -> Self {
+        self.edge_admitted_tools = tools
+            .iter()
+            .map(|t| t.trim().to_ascii_lowercase())
+            .filter(|t| !t.is_empty())
+            .collect();
+        tracing::debug!(
+            edge_admitted_tools = ?self.edge_admitted_tools,
+            "edge_tool_schema: ServerToolExecutor::with_edge_admitted_tools"
+        );
         self
     }
 
@@ -1007,6 +1028,18 @@ impl RuntimeToolExecutor {
         let runtime_registry_knows_tool = runtime_registry.get(name).is_some();
         if let Some(denial) = self.runtime_environment_tool_denial(name, args) {
             return ExecutorToolReadiness::RuntimeEnvironmentDenied(denial);
+        }
+
+        // Tools explicitly admitted for edge dispatch bypass the server
+        // capability surface check.  The capability filter was already applied
+        // upstream (merge_allowlisted_edge_tool_schemas) and execution is routed
+        // to the connected edge agent, not executed server-local.
+        if self
+            .edge_admitted_tools
+            .contains(&name.to_ascii_lowercase())
+        {
+            tracing::debug!(tool_name = %name, "edge_tool_schema: tool_admission: edge_admitted → Ready");
+            return ExecutorToolReadiness::Ready;
         }
 
         let Some(meta) = astra_turn_core::tool::registry::meta::tool_meta(name) else {
@@ -5594,6 +5627,7 @@ esac
             _hostname: Option<&str>,
             _worktree_path: Option<&str>,
             _capabilities: Option<serde_json::Value>,
+            _workspace_id: Option<&str>,
         ) -> Result<astra_services::multi_agent::EdgeAgentRecord, String> {
             Err("MCP tools must not update edge registry".to_string())
         }
@@ -5603,8 +5637,18 @@ esac
             _user_id: &str,
             _edge_agent_id: &str,
             _edge_id_header: &str,
-        ) -> Result<(), String> {
-            Err("MCP tools must not heartbeat edge registry".to_string())
+        ) -> Result<(), astra_services::multi_agent::HeartbeatError> {
+            Err(astra_services::multi_agent::HeartbeatError::StorageFailure(
+                "MCP tools must not heartbeat edge registry".to_string(),
+            ))
+        }
+
+        async fn find_by_agent_id_and_workspace(
+            &self,
+            _edge_agent_id: &str,
+            _workspace_id: Option<&str>,
+        ) -> Result<Option<astra_services::multi_agent::EdgeAgentRecord>, String> {
+            Ok(None)
         }
 
         async fn list_by_user(
@@ -5614,7 +5658,12 @@ esac
             Err("MCP tools must not list edge registry".to_string())
         }
 
-        async fn unregister(&self, _user_id: &str, _edge_agent_id: &str) -> Result<(), String> {
+        async fn unregister(
+            &self,
+            _user_id: &str,
+            _edge_agent_id: &str,
+            _edge_id: &str,
+        ) -> Result<(), String> {
             Err("MCP tools must not unregister edge registry".to_string())
         }
     }
@@ -5745,6 +5794,7 @@ esac
             _hostname: Option<&str>,
             _worktree_path: Option<&str>,
             _capabilities: Option<serde_json::Value>,
+            _workspace_id: Option<&str>,
         ) -> Result<astra_services::multi_agent::EdgeAgentRecord, String> {
             Err("not needed for this test".to_string())
         }
@@ -5754,8 +5804,35 @@ esac
             _user_id: &str,
             _edge_agent_id: &str,
             _edge_id_header: &str,
-        ) -> Result<(), String> {
+        ) -> Result<(), astra_services::multi_agent::HeartbeatError> {
             Ok(())
+        }
+
+        async fn find_by_agent_id_and_workspace(
+            &self,
+            edge_agent_id: &str,
+            workspace_id: Option<&str>,
+        ) -> Result<Option<astra_services::multi_agent::EdgeAgentRecord>, String> {
+            if edge_agent_id != self.edge_agent_id {
+                return Ok(None);
+            }
+            // This registry has no workspace scope (workspace_id = None).
+            // Fail-closed: only match unscoped requests.
+            if workspace_id.is_some() {
+                return Ok(None);
+            }
+            Ok(Some(astra_services::multi_agent::EdgeAgentRecord {
+                registry_id: format!("registry-{}", self.edge_agent_id),
+                user_id: "test-user".to_string(),
+                edge_agent_id: self.edge_agent_id.clone(),
+                edge_id: format!("edge-id-{}", self.edge_agent_id),
+                hostname: Some("MacBook Pro".to_string()),
+                worktree_path: Some("/Users/test/project".to_string()),
+                capabilities: Some(edge_runtime_environment_advertisement(&self.edge_agent_id)),
+                workspace_id: None,
+                registered_at: "2026-06-11T00:00:00Z".to_string(),
+                last_heartbeat_at: "2026-06-11T00:00:00Z".to_string(),
+            }))
         }
 
         async fn list_by_user(
@@ -5770,12 +5847,18 @@ esac
                 hostname: Some("MacBook Pro".to_string()),
                 worktree_path: Some("/Users/test/project".to_string()),
                 capabilities: Some(edge_runtime_environment_advertisement(&self.edge_agent_id)),
+                workspace_id: None,
                 registered_at: "2026-06-11T00:00:00Z".to_string(),
                 last_heartbeat_at: "2026-06-11T00:00:00Z".to_string(),
             }])
         }
 
-        async fn unregister(&self, _user_id: &str, _edge_agent_id: &str) -> Result<(), String> {
+        async fn unregister(
+            &self,
+            _user_id: &str,
+            _edge_agent_id: &str,
+            _edge_id: &str,
+        ) -> Result<(), String> {
             Ok(())
         }
     }

--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -38,9 +38,10 @@ use crate::server::tool_transport::{
     ExecutionBindingSnapshot, ExecutorBinding, ExecutorBindingKind, ExecutorStatus,
     SelectedToolOfferSnapshot, ToolExecutionRequest, ToolPolicySnapshot, ToolTransportKind,
     WorkspaceAuthority, WorkspaceBinding, WorkspaceBindingKind, binding_event_fields,
+    capability_filter_edge_provided_tool_schemas_for_binding,
     capability_filter_edge_provided_tool_schemas_for_binding_with_context,
-    capability_filtered_server_tool_schemas_with_context, projected_tool_end_event_fields,
-    projected_tool_start_event_fields,
+    capability_filtered_server_tool_schemas, capability_filtered_server_tool_schemas_with_context,
+    projected_tool_end_event_fields, projected_tool_start_event_fields,
 };
 use crate::turn::agentic::headless_round::HeadlessStderrStyle;
 use crate::turn::agentic_loop::host::{
@@ -2152,6 +2153,130 @@ impl ServerAgenticLoopHost {
         tools: crate::turn::tool_completion::RuntimeStopAfterSuccessToolSnapshot,
     ) {
         self.runtime_stop_after_success_tools = tools;
+    }
+
+    fn tool_schema_visible_for_current_binding(&self, schema: &Value) -> bool {
+        !capability_filter_edge_provided_tool_schemas_for_binding(
+            vec![schema.clone()],
+            &self.workspace_binding,
+            &self.executor_binding,
+            self.runtime_binding.as_ref(),
+        )
+        .is_empty()
+    }
+
+    fn install_admissible_tool_schema(&mut self, schema: Value, admit_as_extra: bool) -> bool {
+        let Some(name) = tool_schema_name(&schema).map(str::to_string) else {
+            tracing::warn!(
+                "install_admissible_tool_schema: rejected malformed schema (no valid function name)"
+            );
+            return false;
+        };
+        if !self.tool_schema_visible_for_current_binding(&schema) {
+            tracing::debug!(
+                tool_name = %name,
+                executor_kind = ?self.executor_binding.kind,
+                executor_status = ?self.executor_binding.status,
+                workspace_kind = ?self.workspace_binding.kind,
+                "edge_tool_schema: install_admissible_tool_schema: schema rejected — not visible for current binding"
+            );
+            return false;
+        }
+        tracing::debug!(tool_name = %name, "edge_tool_schema: install_admissible_tool_schema: admitted");
+
+        self.valid_tools.insert(name.clone());
+        if admit_as_extra && !self.admissible_extras.iter().any(|extra| extra == &name) {
+            self.admissible_extras.push(name.clone());
+        }
+        if let Some(existing) = self
+            .tool_schemas
+            .iter_mut()
+            .find(|tool| tool_schema_name(tool) == Some(name.as_str()))
+        {
+            *existing = schema;
+        } else {
+            self.tool_schemas.push(schema);
+        }
+        true
+    }
+
+    /// Merge edge-resident builtin tool schemas when MOI (or similar) callers
+    /// supply `allow_tools` together with an explicit edge executor binding.
+    /// Agent-binding mode only installs MCP schemas by default; without this
+    /// merge the model never sees bash/read_file even though dispatch targets
+    /// the selected edge agent.
+    ///
+    /// `allow_tools` is treated strictly as an explicit tool-name allowlist and
+    /// is intersected with the edge's capability-filtered tool set: the effective
+    /// set is `allow_tools ∩ capability_set`. There is no wildcard — a caller
+    /// cannot expand tool admission beyond the names it enumerates, so a mistaken
+    /// or malicious capability declaration cannot by itself grant a tool.
+    pub fn merge_allowlisted_edge_tool_schemas(&mut self, allow_tools: &[String]) {
+        if allow_tools.is_empty()
+            || !matches!(self.executor_binding.kind, ExecutorBindingKind::EdgeAgent)
+        {
+            tracing::debug!(
+                allow_tools_empty = allow_tools.is_empty(),
+                executor_kind = ?self.executor_binding.kind,
+                "edge_tool_schema: merge_allowlisted_edge_tool_schemas: guard failed, returning early"
+            );
+            return;
+        }
+        let allow_set: std::collections::HashSet<String> = allow_tools
+            .iter()
+            .map(|tool| tool.trim().to_ascii_lowercase())
+            .filter(|tool| !tool.is_empty() && tool != "*")
+            .collect();
+        if allow_set.is_empty() {
+            tracing::debug!(
+                "edge_tool_schema: merge_allowlisted_edge_tool_schemas: allow_set is empty after normalization"
+            );
+            return;
+        }
+        let candidates = capability_filtered_server_tool_schemas(
+            &self.capabilities,
+            &self.workspace_binding,
+            &self.executor_binding,
+            self.runtime_binding.as_ref(),
+        );
+        tracing::debug!(
+            allow_set = ?allow_set,
+            candidates_count = candidates.len(),
+            workspace_kind = ?self.workspace_binding.kind,
+            workspace_cwd = ?self.workspace_binding.cwd,
+            executor_kind = ?self.executor_binding.kind,
+            executor_status = ?self.executor_binding.status,
+            executor_transport = ?self.executor_binding.transport,
+            "edge_tool_schema: merge_allowlisted_edge_tool_schemas: candidates filtered"
+        );
+        let merged: Vec<Value> = candidates
+            .into_iter()
+            .filter(|schema| {
+                tool_schema_name(schema)
+                    .map(|name| allow_set.contains(&name.to_ascii_lowercase()))
+                    .unwrap_or(false)
+            })
+            .collect();
+        let merged_count = merged.len();
+        tracing::debug!(
+            merged_count,
+            "edge_tool_schema: merge_allowlisted_edge_tool_schemas: merged {} tools",
+            merged_count
+        );
+        for schema in merged {
+            self.install_admissible_tool_schema(schema, true);
+        }
+        // MOI runner chat sends `allow_tools` + executor_binding.transport=edge_ws.
+        // Those tools must execute via ServerToolExecutor → edge websocket, not the
+        // browser ledger path (which blocks up to 300s waiting for POST /tools/result).
+        if merged_count > 0
+            && matches!(
+                self.executor_binding.transport,
+                crate::server::tool_transport::ToolTransportKind::EdgeWs
+            )
+        {
+            self.server_side_tools = true;
+        }
     }
 
     fn read_plan_resume_hint(&self) -> Option<String> {
@@ -4821,6 +4946,13 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
         } else {
             None
         };
+        tracing::debug!(
+            target: "astra_runtime::server_loop",
+            session_id = %self.session_id,
+            turn = state.session_turn,
+            has_session_memory = initial_session_memory_entry.is_some(),
+            "turn pipeline: session memory loaded"
+        );
         let turn_pipeline = self.run_turn_pipeline_with_cache_capability_and_session_memory(
             state,
             &visible_tools,
@@ -7376,6 +7508,75 @@ mod tests {
                 "server-service tool {hidden} must not leak when server-service capacity is disabled: {names:?}"
             );
         }
+    }
+
+    #[test]
+    fn merge_allowlisted_edge_tool_schemas_adds_edge_builtins_after_mcp_install() {
+        let mut host = ServerAgenticLoopHostBuilder::new(
+            mock_matrixone(),
+            mock_encryptor(),
+            "u1".to_string(),
+            "s1".to_string(),
+        )
+        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
+            false, false,
+        ))
+        .with_server_service_tool_catalog_enabled(false)
+        .with_static_tool_catalog_admissible(false)
+        .with_execution_binding_snapshot(edge_runtime_snapshot())
+        .build();
+
+        host.install_runtime_tool_schemas(
+            vec![json!({
+                "type": "function",
+                "function": {
+                    "name": "mcp__catalog__read_artifact",
+                    "description": "MOI catalog MCP tool",
+                    "parameters": { "type": "object", "properties": {} }
+                }
+            })],
+            Default::default(),
+        );
+
+        host.merge_allowlisted_edge_tool_schemas(&["bash".to_string(), "read_file".to_string()]);
+
+        assert!(
+            host.valid_tool_names()
+                .contains("mcp__catalog__read_artifact")
+        );
+        assert!(host.valid_tool_names().contains("bash"));
+        assert!(host.valid_tool_names().contains("read_file"));
+        assert!(
+            host.server_side_tools,
+            "edge_ws allow_tools must route through ServerToolExecutor, not edge ledger"
+        );
+    }
+
+    #[test]
+    fn merge_allowlisted_edge_tool_schemas_enables_server_side_tools_without_mcp() {
+        let mut host = ServerAgenticLoopHostBuilder::new(
+            mock_matrixone(),
+            mock_encryptor(),
+            "u1".to_string(),
+            "s1".to_string(),
+        )
+        .with_capabilities(crate::capabilities::lifecycle_server_capabilities(
+            false, false,
+        ))
+        .with_server_service_tool_catalog_enabled(false)
+        .with_static_tool_catalog_admissible(false)
+        .with_execution_binding_snapshot(edge_runtime_snapshot())
+        .build();
+
+        assert!(!host.server_side_tools);
+
+        host.merge_allowlisted_edge_tool_schemas(&["bash".to_string()]);
+
+        assert!(host.valid_tool_names().contains("bash"));
+        assert!(
+            host.server_side_tools,
+            "MOI runner allow_tools without MCP must not use edge ledger delivery"
+        );
     }
 
     fn schema_names(tools: &[Value]) -> HashSet<String> {

--- a/crates/runtime/src/server/state_builder.rs
+++ b/crates/runtime/src/server/state_builder.rs
@@ -23,6 +23,7 @@ pub async fn build_server_state(
 ) -> Result<AppState, Box<dyn std::error::Error>> {
     ensure_core_schema(&settings.matrixone, &settings.database_bootstrap_catalog).await?;
     let shared_pool = SharedPool::new(&settings.matrixone).await?;
+
     let lease_hold_cache = Arc::new(TaskLeaseHoldCache::default());
     let shared_encryptor = Arc::new(
         FernetTokenEncryptor::from_key(settings.token_encryption_key.as_deref())

--- a/crates/runtime/src/server/state_builder/core.rs
+++ b/crates/runtime/src/server/state_builder/core.rs
@@ -221,11 +221,11 @@ pub(super) fn install_execution_services(
         .with_task_service(Arc::new(MatrixOneTaskService::from_shared(shared_pool)))
         .with_edge_registry_service(edge_registry_service)
         .with_edge_dispatch_service(edge_dispatch_service)
-        .with_tool_execution_service(tool_execution_service)
         .with_task_lease_service(Arc::new(
             DatabaseTaskLeaseService::from_shared(shared_pool, Arc::clone(lease_hold_cache))
                 .with_metrics(metrics),
         ))
+        .with_tool_execution_service(tool_execution_service)
 }
 
 fn build_shared_tool_execution_service(
@@ -327,6 +327,7 @@ mod tests {
             Some("MacBook Pro".to_string()),
             Some("/Users/test/project".to_string()),
             Some(edge_runtime_environment_advertisement("edge-selected")),
+            None,
             tx,
         );
 

--- a/crates/runtime/src/server/tool_edge_transport.rs
+++ b/crates/runtime/src/server/tool_edge_transport.rs
@@ -186,13 +186,64 @@ async fn try_edge_websocket(
         ) {
             Ok(Some(edge)) => (edge.clone(), request.user_id.clone()),
             Ok(None) => {
-                tracing::warn!(
-                    target: "astra_runtime::edge_dispatch_diag",
-                    tool = %request.tool_name,
-                    selected_executor_id = ?plan.selected_executor_id(),
-                    "edge_dispatch: try_edge_websocket no capable connected edge matched (Unavailable)"
-                );
-                return EdgeTransportAttempt::Unavailable;
+                // The pinned executor was not found among this user's edges.
+                // Fall back to a cross-user lookup — this handles the sandbox
+                // case where the edge agent connects under a service-account
+                // user ID different from the workspace user issuing the request.
+                if let Some(agent_id) = plan.selected_executor_id() {
+                    match pool.find_edge_by_agent_id(agent_id, requesting_workspace_id) {
+                        Some((owner_user_id, found_edge)) => {
+                            match select_capable_connected_edge(
+                                std::slice::from_ref(&found_edge),
+                                Some(agent_id),
+                                request,
+                                tool_registry,
+                            ) {
+                                Ok(Some(_)) => {}
+                                Ok(None) => {
+                                    tracing::warn!(
+                                        target: "astra_runtime::edge_dispatch_diag",
+                                        tool = %request.tool_name,
+                                        selected_executor_id = ?plan.selected_executor_id(),
+                                        "edge_dispatch: try_edge_websocket cross-user edge found but capability check failed (Unavailable)"
+                                    );
+                                    return EdgeTransportAttempt::Unavailable;
+                                }
+                                Err(ref err) => {
+                                    return EdgeTransportAttempt::Delivered(
+                                        capability_denied_result(request, &err.0, err.1.clone()),
+                                    );
+                                }
+                            }
+                            tracing::info!(
+                                target: "astra_runtime::edge_dispatch_diag",
+                                tool = %request.tool_name,
+                                edge_agent_id = %found_edge.edge_agent_id,
+                                owner_user_id = %owner_user_id,
+                                requester_user_id = %request.user_id,
+                                "edge_dispatch: try_edge_websocket cross-user edge found (user had other edges)"
+                            );
+                            (found_edge, owner_user_id)
+                        }
+                        None => {
+                            tracing::warn!(
+                                target: "astra_runtime::edge_dispatch_diag",
+                                tool = %request.tool_name,
+                                selected_executor_id = ?plan.selected_executor_id(),
+                                "edge_dispatch: try_edge_websocket no capable connected edge matched (Unavailable)"
+                            );
+                            return EdgeTransportAttempt::Unavailable;
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        target: "astra_runtime::edge_dispatch_diag",
+                        tool = %request.tool_name,
+                        selected_executor_id = ?plan.selected_executor_id(),
+                        "edge_dispatch: try_edge_websocket no capable connected edge matched (Unavailable)"
+                    );
+                    return EdgeTransportAttempt::Unavailable;
+                }
             }
             Err(ref err) => {
                 return EdgeTransportAttempt::Delivered(capability_denied_result(

--- a/crates/runtime/src/server/tool_edge_transport.rs
+++ b/crates/runtime/src/server/tool_edge_transport.rs
@@ -33,6 +33,20 @@ pub(crate) async fn execute_edge_bound(
     }
     let plan = EdgeBoundExecutionPlan::from_request_with_binding(&request, binding);
 
+    tracing::info!(
+        target: "astra_runtime::edge_dispatch_diag",
+        tool = %request.tool_name,
+        user_id = %request.user_id,
+        selected_executor_id = ?plan.selected_executor_id(),
+        executor_transport = ?request.executor.transport,
+        executor_status = ?request.executor.status,
+        connected_edges = edge_connection_pool
+            .as_ref()
+            .map(|p| p.get_user_edges(&request.user_id).len())
+            .unwrap_or(0),
+        "edge_dispatch: begin edge-bound tool execution"
+    );
+
     let mut diagnostics = Vec::new();
     match try_edge_websocket(
         &request,
@@ -95,31 +109,123 @@ async fn try_edge_websocket(
         return EdgeTransportAttempt::Unavailable;
     };
     let edges = pool.get_user_edges(&request.user_id);
-    let edge = match select_capable_connected_edge(
-        &edges,
-        plan.selected_executor_id(),
-        request,
-        tool_registry,
-    ) {
-        Ok(Some(edge)) => edge,
-        Ok(None) => return EdgeTransportAttempt::Unavailable,
-        Err(ref err) => {
-            return EdgeTransportAttempt::Delivered(capability_denied_result(
-                request,
-                &err.0,
-                err.1.clone(),
-            ));
+    tracing::info!(
+        target: "astra_runtime::edge_dispatch_diag",
+        tool = %request.tool_name,
+        selected_executor_id = ?plan.selected_executor_id(),
+        edge_ids = ?edges.iter().map(|e| e.edge_agent_id.as_str()).collect::<Vec<_>>(),
+        "edge_dispatch: try_edge_websocket connected edges for user"
+    );
+
+    // When the user-scoped lookup returns nothing but a specific executor is
+    // requested, attempt a cross-user lookup by agent ID.  This handles the
+    // case where a sandbox edge agent connects using a service-account user ID
+    // that is different from the workspace user issuing the chat request.
+    // The requesting workspace_id is passed so that the pool can enforce that
+    // the edge agent belongs to the same workspace (workspace-level authorization).
+    let requesting_workspace_id = request
+        .workspace_record
+        .as_ref()
+        .map(|w| w.workspace_id.as_str());
+    let (edge, edge_owner_user_id) = if edges.is_empty() {
+        if let Some(agent_id) = plan.selected_executor_id() {
+            match pool.find_edge_by_agent_id(agent_id, requesting_workspace_id) {
+                Some((owner_user_id, found_edge)) => {
+                    // Enforce capability surface checks even on cross-user lookups.
+                    match select_capable_connected_edge(
+                        std::slice::from_ref(&found_edge),
+                        Some(agent_id),
+                        request,
+                        tool_registry,
+                    ) {
+                        Ok(Some(_)) => {}
+                        Ok(None) => return EdgeTransportAttempt::Unavailable,
+                        Err(ref err) => {
+                            return EdgeTransportAttempt::Delivered(capability_denied_result(
+                                request,
+                                &err.0,
+                                err.1.clone(),
+                            ));
+                        }
+                    }
+                    tracing::info!(
+                        target: "astra_runtime::edge_dispatch_diag",
+                        tool = %request.tool_name,
+                        edge_agent_id = %found_edge.edge_agent_id,
+                        owner_user_id = %owner_user_id,
+                        requester_user_id = %request.user_id,
+                        "edge_dispatch: try_edge_websocket cross-user edge found"
+                    );
+                    (found_edge, owner_user_id)
+                }
+                None => {
+                    tracing::warn!(
+                        target: "astra_runtime::edge_dispatch_diag",
+                        tool = %request.tool_name,
+                        selected_executor_id = ?plan.selected_executor_id(),
+                        "edge_dispatch: try_edge_websocket no capable connected edge matched (Unavailable)"
+                    );
+                    return EdgeTransportAttempt::Unavailable;
+                }
+            }
+        } else {
+            tracing::warn!(
+                target: "astra_runtime::edge_dispatch_diag",
+                tool = %request.tool_name,
+                selected_executor_id = ?plan.selected_executor_id(),
+                "edge_dispatch: try_edge_websocket no capable connected edge matched (Unavailable)"
+            );
+            return EdgeTransportAttempt::Unavailable;
+        }
+    } else {
+        match select_capable_connected_edge(
+            &edges,
+            plan.selected_executor_id(),
+            request,
+            tool_registry,
+        ) {
+            Ok(Some(edge)) => (edge.clone(), request.user_id.clone()),
+            Ok(None) => {
+                tracing::warn!(
+                    target: "astra_runtime::edge_dispatch_diag",
+                    tool = %request.tool_name,
+                    selected_executor_id = ?plan.selected_executor_id(),
+                    "edge_dispatch: try_edge_websocket no capable connected edge matched (Unavailable)"
+                );
+                return EdgeTransportAttempt::Unavailable;
+            }
+            Err(ref err) => {
+                return EdgeTransportAttempt::Delivered(capability_denied_result(
+                    request,
+                    &err.0,
+                    err.1.clone(),
+                ));
+            }
         }
     };
+
+    tracing::info!(
+        target: "astra_runtime::edge_dispatch_diag",
+        tool = %request.tool_name,
+        edge_agent_id = %edge.edge_agent_id,
+        "edge_dispatch: try_edge_websocket selected edge, sending tool request over WS"
+    );
     let edge_result = pool
         .execute_tool_with_cancel(
-            plan.user_id(),
+            &edge_owner_user_id,
             &edge.edge_agent_id,
             &request.tool_name,
             &request.args,
             cancel_token,
         )
         .await;
+    tracing::info!(
+        target: "astra_runtime::edge_dispatch_diag",
+        tool = %request.tool_name,
+        edge_agent_id = %edge.edge_agent_id,
+        got_result = edge_result.is_some(),
+        "edge_dispatch: try_edge_websocket execute_tool_with_cancel returned"
+    );
     if cancel_token.is_some_and(CancellationToken::is_cancelled) {
         return EdgeTransportAttempt::Delivered(cancelled_runtime_tool_result(
             request,
@@ -162,39 +268,85 @@ async fn try_edge_dispatch(
             false,
         ));
     }
-    let list_agents = registry.list_by_user(&request.user_id);
-    let agents_result = if let Some(token) = cancel_token.as_ref() {
-        tokio::select! {
-            _ = token.cancelled() => {
-                return EdgeTransportAttempt::Delivered(cancelled_runtime_tool_result(
-                    request,
-                    binding,
-                    ToolTransportKind::EdgeLedger,
-                    false,
-                ));
+    // Cross-user dispatch: if the plan names a specific executor (sandbox edge),
+    // look it up directly by agent_id so we find a service-account-owned edge
+    // even when the tool request comes from a different (real) user.
+    // Workspace filtering prevents cross-workspace agent hijacking.
+    // Fallback to list_by_user when no executor is pinned (same-user dispatch).
+    let requesting_workspace_id = request
+        .workspace_record
+        .as_ref()
+        .map(|w| w.workspace_id.as_str());
+    let agent = if let Some(executor_id) = plan.selected_executor_id() {
+        let find_agent =
+            registry.find_by_agent_id_and_workspace(executor_id, requesting_workspace_id);
+        let agent_result = if let Some(token) = cancel_token.as_ref() {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    return EdgeTransportAttempt::Delivered(cancelled_runtime_tool_result(
+                        request,
+                        binding,
+                        ToolTransportKind::EdgeLedger,
+                        false,
+                    ));
+                }
+                result = find_agent => result,
             }
-            result = list_agents => result,
+        } else {
+            find_agent.await
+        };
+        match agent_result {
+            Ok(Some(agent)) => {
+                match select_capable_edge_agent(
+                    std::slice::from_ref(&agent),
+                    None,
+                    request,
+                    tool_registry,
+                ) {
+                    Ok(Some(_)) => agent,
+                    Ok(None) => return EdgeTransportAttempt::Unavailable,
+                    Err(ref err) => {
+                        return EdgeTransportAttempt::Delivered(capability_denied_result(
+                            request,
+                            &err.0,
+                            err.1.clone(),
+                        ));
+                    }
+                }
+            }
+            Ok(None) => return EdgeTransportAttempt::Unavailable,
+            Err(_) => return EdgeTransportAttempt::Unavailable,
         }
     } else {
-        list_agents.await
-    };
-    let Ok(agents) = agents_result else {
-        return EdgeTransportAttempt::Unavailable;
-    };
-    let agent = match select_capable_edge_agent(
-        &agents,
-        plan.selected_executor_id(),
-        request,
-        tool_registry,
-    ) {
-        Ok(Some(agent)) => agent,
-        Ok(None) => return EdgeTransportAttempt::Unavailable,
-        Err(ref err) => {
-            return EdgeTransportAttempt::Delivered(capability_denied_result(
-                request,
-                &err.0,
-                err.1.clone(),
-            ));
+        let list_agents = registry.list_by_user(&request.user_id);
+        let agents_result = if let Some(token) = cancel_token.as_ref() {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    return EdgeTransportAttempt::Delivered(cancelled_runtime_tool_result(
+                        request,
+                        binding,
+                        ToolTransportKind::EdgeLedger,
+                        false,
+                    ));
+                }
+                result = list_agents => result,
+            }
+        } else {
+            list_agents.await
+        };
+        let Ok(agents) = agents_result else {
+            return EdgeTransportAttempt::Unavailable;
+        };
+        match select_capable_edge_agent(&agents, None, request, tool_registry) {
+            Ok(Some(agent)) => agent.clone(),
+            Ok(None) => return EdgeTransportAttempt::Unavailable,
+            Err(ref err) => {
+                return EdgeTransportAttempt::Delivered(capability_denied_result(
+                    request,
+                    &err.0,
+                    err.1.clone(),
+                ));
+            }
         }
     };
     if cancel_token
@@ -209,8 +361,12 @@ async fn try_edge_dispatch(
         ));
     }
     let request_id = plan.dispatch_request_id().to_string();
+    // Use the edge owner's user_id (from the registry record) for the dispatch
+    // identity, not the request user_id. The edge relay polls its own user_id,
+    // so sandbox service-account edges would never see rows keyed to the real
+    // user. request.user_id is preserved in session/run/turn fields for tracing.
     let identity = astra_services::multi_agent::EdgeDispatchIdentity::new(
-        &request.user_id,
+        &agent.user_id,
         &request.session_id,
         &request.run_id,
         &request.turn_chain_id,

--- a/crates/runtime/src/server/tool_transport/tests.rs
+++ b/crates/runtime/src/server/tool_transport/tests.rs
@@ -719,6 +719,7 @@ impl astra_services::multi_agent::EdgeRegistryService for StaticEdgeRegistry {
         _hostname: Option<&str>,
         _worktree_path: Option<&str>,
         _capabilities: Option<serde_json::Value>,
+        _workspace_id: Option<&str>,
     ) -> Result<astra_services::multi_agent::EdgeAgentRecord, String> {
         Err("not needed for this test".to_string())
     }
@@ -728,8 +729,28 @@ impl astra_services::multi_agent::EdgeRegistryService for StaticEdgeRegistry {
         _user_id: &str,
         _edge_agent_id: &str,
         _edge_id_header: &str,
-    ) -> Result<(), String> {
+    ) -> Result<(), astra_services::multi_agent::HeartbeatError> {
         Ok(())
+    }
+
+    async fn find_by_agent_id_and_workspace(
+        &self,
+        edge_agent_id: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<Option<astra_services::multi_agent::EdgeAgentRecord>, String> {
+        let record = self
+            .agents
+            .iter()
+            .find(|a| {
+                a.edge_agent_id == edge_agent_id
+                    && match (workspace_id, a.workspace_id.as_deref()) {
+                        (Some(req), Some(edge)) => req == edge,
+                        (None, None) => true,
+                        _ => false,
+                    }
+            })
+            .cloned();
+        Ok(record)
     }
 
     async fn list_by_user(
@@ -739,7 +760,12 @@ impl astra_services::multi_agent::EdgeRegistryService for StaticEdgeRegistry {
         Ok(self.agents.clone())
     }
 
-    async fn unregister(&self, _user_id: &str, _edge_agent_id: &str) -> Result<(), String> {
+    async fn unregister(
+        &self,
+        _user_id: &str,
+        _edge_agent_id: &str,
+        _edge_id: &str,
+    ) -> Result<(), String> {
         Ok(())
     }
 }
@@ -753,6 +779,7 @@ fn edge_agent_record(edge_agent_id: &str) -> astra_services::multi_agent::EdgeAg
         hostname: Some("MacBook Pro".to_string()),
         worktree_path: Some("/Users/test/project".to_string()),
         capabilities: Some(edge_runtime_environment_advertisement(edge_agent_id)),
+        workspace_id: None,
         registered_at: "2026-06-11T00:00:00Z".to_string(),
         last_heartbeat_at: "2026-06-11T00:00:00Z".to_string(),
     }
@@ -2558,6 +2585,7 @@ async fn edge_ws_result_preserves_tool_result_fields() {
         Some("MacBook Pro".to_string()),
         Some("/Users/test/project".to_string()),
         Some(edge_runtime_environment_advertisement("edge-selected")),
+        None,
         tx,
     );
     let service = ToolExecutionService::builder()

--- a/crates/runtime/src/server/tool_transport_plan.rs
+++ b/crates/runtime/src/server/tool_transport_plan.rs
@@ -17,6 +17,7 @@ pub(crate) enum EdgeTransportAttempt {
 
 #[derive(Debug, Clone)]
 pub(crate) struct EdgeBoundExecutionPlan {
+    #[allow(dead_code)]
     user_id: String,
     selected_executor_id: Option<String>,
     dispatch_request_id: String,
@@ -68,6 +69,7 @@ impl EdgeBoundExecutionPlan {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn user_id(&self) -> &str {
         &self.user_id
     }

--- a/crates/runtime/src/server/ws_handler.rs
+++ b/crates/runtime/src/server/ws_handler.rs
@@ -1250,6 +1250,7 @@ fn build_ws_chat_request(
         edge_executor_id: None,
         capabilities: Vec::new(),
         forward_headers: std::collections::HashMap::new(),
+        provider_workspace_id: None,
         execution_budget,
         execution_policy: Default::default(),
         explain,

--- a/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -1125,7 +1125,21 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
     // Increment the LLM-round counter regardless of outcome so retry/error
     // paths don't see a stale count (the counter tracks *attempted* LLM
     // calls for guidance-threshold purposes, not just successful ones).
+    let t_llm_start = std::time::Instant::now();
+    tracing::debug!(
+        target: "astra_timing",
+        llm_round = llm_attempt_index,
+        messages = pre_llm_messages.len(),
+        "LLM call started"
+    );
     let turn_result = host.execute_turn(state).await;
+    tracing::debug!(
+        target: "astra_timing",
+        llm_round = llm_attempt_index,
+        elapsed_ms = t_llm_start.elapsed().as_millis(),
+        ok = turn_result.is_ok(),
+        "LLM call completed"
+    );
     state.llm_rounds_completed += 1;
     // Capture finish_reason before the match consumes turn_result.
     // Used by textless-stop retry (loop level) and ensure_terminal_text

--- a/crates/runtime/src/turn/agentic_loop/lifecycle.rs
+++ b/crates/runtime/src/turn/agentic_loop/lifecycle.rs
@@ -1401,8 +1401,12 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
     }
 
     let turn_start_time = Instant::now();
-
-    // Initialize turn event buffer for fine-grained observability (once per turn).
+    tracing::debug!(
+        target: "astra_timing",
+        turn_index = turn_index,
+        session_turn = session_turn_number(state),
+        "agentic turn started"
+    );
     if state.turn_event_buffer.is_none() {
         state.turn_event_buffer = Some(
             astra_services::session_journal::TurnEventBuffer::begin_turn(

--- a/crates/runtime/src/turn/agentic_loop/tool_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/tool_phase.rs
@@ -1915,6 +1915,16 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
                     tool_execution_ms: tool_exec_ms,
                     total_ms,
                 };
+                tracing::debug!(
+                    target: "astra_timing",
+                    session_turn = timing.turn,
+                    total_ms = timing.total_ms,
+                    ctx_assembly_ms = timing.context_assembly_ms,
+                    ttft_ms = timing.ttft_ms,
+                    llm_ms = timing.llm_total_ms,
+                    tool_exec_ms = timing.tool_execution_ms,
+                    "turn completed"
+                );
                 let mut session_guard = astra_core::sync_poison::recover_rwlock_write(session);
                 crate::observability::on_turn_end(hub, &mut session_guard, timing);
             }

--- a/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/crates/runtime/src/turn/bridge/inprocess.rs
@@ -1512,6 +1512,7 @@ impl InProcessChatTurnBridge {
         turn_session_activity_writer: Arc<dyn TurnSessionActivityWriter>,
         client_cancel: Option<Arc<CancellationToken>>,
     ) -> Result<Response, (StatusCode, String)> {
+        tracing::debug!(target: "astra_timing", "bridge forward() called (pre-stream)");
         // Extract trusted context injected by dispatch_chat_turn_bridge
         let user_id = required_bridge_header(headers, "x-mo-user-id")?;
         let session_id = required_bridge_header(headers, "x-mo-session-id")?;
@@ -1689,6 +1690,7 @@ impl InProcessChatTurnBridge {
                 .as_ref()
                 .map(|t| crate::turn::llm::client::CancelOnClientDisconnect::new(t.clone()));
             let turn_started = Instant::now();
+            tracing::debug!(target: "astra_timing", "bridge stream started");
             let run_id = uuid::Uuid::new_v4().to_string();
             let mut turn_event_buffer = bridge_should_create_turn_event_buffer(
                 full_llm_capture,
@@ -2051,6 +2053,12 @@ impl InProcessChatTurnBridge {
                         .as_ref()
                         .map(|s| s.fetch_ms)
                         .unwrap_or(0);
+                tracing::debug!(
+                    target: "astra_timing",
+                    elapsed_ms = turn_started.elapsed().as_millis(),
+                    memory_fetch_ms = memory_fetch_ms,
+                    "memoria prefetch done"
+                );
 
                 let mut recall_entries = cached_session_start
                     .as_ref()
@@ -2697,6 +2705,7 @@ impl InProcessChatTurnBridge {
                 let mut loop_reasoning = String::new();
                 let mut loop_reasoning_signature = String::new();
                 let mut attempt_in_round = 0_u32;
+                let mut ttft_logged = false;
                 let request_capture_model = if resolved_model.is_empty() {
                     model_name.clone()
                 } else {
@@ -3050,6 +3059,13 @@ impl InProcessChatTurnBridge {
                         &breakdown,
                         Some(&bridge_manifest_trace_json),
                     ));
+                    tracing::debug!(
+                        target: "astra_timing",
+                        elapsed_ms = turn_started.elapsed().as_millis(),
+                        memory_fetch_ms = memory_fetch_ms,
+                        model = %model_name,
+                        "context assembled, starting LLM call"
+                    );
                     let mut client_stopped = false;
                     let llm_stream = if let Some(blocks) = bridge_e2e_stream_blocks
                         .clone()
@@ -3487,6 +3503,14 @@ impl InProcessChatTurnBridge {
                                             for b in chunks {
                                                 if terminal_error_event.is_none() {
                                                     terminal_error_event = forwarded_sse_error_event(&b);
+                                                }
+                                                if !ttft_logged && !loop_text.is_empty() {
+                                                    tracing::debug!(
+                                                        target: "astra_timing",
+                                                        elapsed_ms = turn_started.elapsed().as_millis(),
+                                                        "first text token (TTFT from stream start)"
+                                                    );
+                                                    ttft_logged = true;
                                                 }
                                                 yield b;
                                             }
@@ -4145,6 +4169,13 @@ impl InProcessChatTurnBridge {
 
 
             let llm_duration_ms = llm_started.elapsed().as_millis() as i64;
+            tracing::debug!(
+                target: "astra_timing",
+                total_turn_ms = turn_started.elapsed().as_millis(),
+                llm_phase_ms = llm_duration_ms,
+                memory_fetch_ms = memory_fetch_ms,
+                "bridge turn completed"
+            );
 
             // Persist events (fire-and-forget)
             let user_content = latest_user_message_text(&messages).map(ToString::to_string);

--- a/crates/runtime/tests/capability_registry_integration.rs
+++ b/crates/runtime/tests/capability_registry_integration.rs
@@ -149,6 +149,7 @@ async fn priority_routing_lower_wins() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await.unwrap();
@@ -186,6 +187,7 @@ async fn priority_routing_three_providers() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await.unwrap();
@@ -223,6 +225,7 @@ async fn cross_kind_priority_routing() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await.unwrap();
@@ -249,6 +252,7 @@ async fn server_builtin_default_does_not_overclaim_lsp_symbols_category() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let result = reg.resolve(&request).await;
@@ -296,6 +300,7 @@ async fn storage_unavailable_returns_not_capable() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await.unwrap();
@@ -328,6 +333,7 @@ async fn no_storage_request_matches_all() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await.unwrap();
@@ -360,6 +366,7 @@ async fn server_builtin_rejects_storage_request_for_agent() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let result = reg.resolve(&request).await;
@@ -408,6 +415,7 @@ async fn isolation_filters_out_insufficient_providers() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await.unwrap();
@@ -453,6 +461,7 @@ async fn isolation_container_only_sandbox_qualifies() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await.unwrap();
@@ -482,6 +491,7 @@ async fn isolation_sandbox_only_highest_qualifies() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await.unwrap();
@@ -511,6 +521,7 @@ async fn isolation_none_available_returns_error() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let result = reg.resolve(&request).await;
@@ -543,6 +554,7 @@ async fn empty_registry_returns_not_capable() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let result = reg.resolve(&request).await;
@@ -585,6 +597,7 @@ async fn capability_match_but_isolation_excludes() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let result = reg.resolve(&request).await;
@@ -630,6 +643,7 @@ async fn named_capability_matches_category_provider() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await.unwrap();
@@ -696,6 +710,7 @@ async fn combined_storage_isolation_priority() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await.unwrap();
@@ -726,6 +741,7 @@ async fn combined_capability_match_but_isolation_excluded() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let result = reg.resolve(&request).await;
@@ -828,6 +844,7 @@ async fn all_providers_unhealthy_health_check_reports_all_down() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
     let resolved = reg.resolve(&request).await;
     assert!(
@@ -870,6 +887,7 @@ async fn resolve_rejects_when_all_providers_are_degraded() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await;

--- a/crates/runtime/tests/edge_ws_e2e.rs
+++ b/crates/runtime/tests/edge_ws_e2e.rs
@@ -744,3 +744,375 @@ async fn edge_deliver_result_for_unknown_request_returns_false() {
 
     server.abort();
 }
+
+// ── Edge agent id binding enforcement ────────────────────────────────
+
+/// Auth service that authenticates the token and reports a fixed edge_agent_id
+/// binding, exercising the edge WS handler's self-reported-id verification.
+#[derive(Clone)]
+struct BindingAuthService {
+    bound_edge_agent_id: String,
+}
+
+#[async_trait]
+impl AuthService for BindingAuthService {
+    async fn register(
+        &self,
+        _req: AuthRegisterRequestData,
+    ) -> Result<AuthUserRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+        unreachable!()
+    }
+    async fn login(
+        &self,
+        _req: AuthLoginRequestData,
+    ) -> Result<astra_runtime::AuthTokenRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+        unreachable!()
+    }
+    async fn refresh(
+        &self,
+        _req: AuthRefreshRequestData,
+    ) -> Result<astra_runtime::AuthTokenRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+        unreachable!()
+    }
+    async fn logout(
+        &self,
+        _req: AuthRefreshRequestData,
+    ) -> Result<(), (StatusCode, axum::Json<ErrorResponse>)> {
+        unreachable!()
+    }
+    async fn current_user(
+        &self,
+        _headers: &HeaderMap,
+    ) -> Result<AuthUserRecord, (StatusCode, axum::Json<ErrorResponse>)> {
+        Ok(AuthUserRecord {
+            user_id: "test-user-1".to_string(),
+            username: "edgeuser".to_string(),
+            email: "edge@test.local".to_string(),
+            display_name: None,
+        })
+    }
+    async fn edge_registration_binding(
+        &self,
+        _token: &str,
+    ) -> Result<Option<(String, String)>, (StatusCode, axum::Json<ErrorResponse>)> {
+        Ok(Some((
+            self.bound_edge_agent_id.clone(),
+            "test-workspace".to_string(),
+        )))
+    }
+}
+
+async fn spawn_binding_server(
+    bound_edge_agent_id: &str,
+) -> (std::net::SocketAddr, AppState, tokio::task::JoinHandle<()>) {
+    let state = AppState::new(
+        ServiceInfo::new("edge-bind-test", "0.0.0-test", ""),
+        Arc::new(StubHealthChecker),
+    )
+    .with_auth_service(Arc::new(BindingAuthService {
+        bound_edge_agent_id: bound_edge_agent_id.to_string(),
+    }));
+    let state_clone = state.clone();
+    let app = build_app(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind to ephemeral port");
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, state_clone, handle)
+}
+
+async fn edge_auth_result(addr: std::net::SocketAddr, edge_id: &str) -> serde_json::Value {
+    let url = format!("ws://{addr}/edge/ws");
+    let (mut ws, _) = connect_async(&url).await.expect("WS connect");
+    let auth_msg = json!({
+        "type": "edge_auth",
+        "token": "moi-user-token-v1.payload.sig",
+        "edge_agent_id": edge_id,
+        "hostname": "host",
+        "workspace_dir": "/home/test/project"
+    });
+    ws.send(Message::Text(auth_msg.to_string().into()))
+        .await
+        .unwrap();
+    let resp = ws.next().await.unwrap().unwrap();
+    serde_json::from_str(&resp.into_text().unwrap()).unwrap()
+}
+
+#[tokio::test]
+async fn edge_ws_rejects_mismatched_edge_agent_id() {
+    let (addr, state, server) = spawn_binding_server("runner-bound").await;
+
+    // Self-reported id differs from the token binding → must be rejected.
+    let resp = edge_auth_result(addr, "runner-impersonated").await;
+    assert_eq!(resp["type"], "edge_auth_error");
+    assert!(!state.edge_connection_pool.has_connected_edge("test-user-1"));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn edge_ws_accepts_matching_edge_agent_id() {
+    let (addr, state, server) = spawn_binding_server("runner-bound").await;
+
+    // Self-reported id matches the token binding → accepted and registered.
+    let resp = edge_auth_result(addr, "runner-bound").await;
+    assert_eq!(resp["type"], "edge_auth_ok");
+    assert!(state.edge_connection_pool.has_connected_edge("test-user-1"));
+
+    server.abort();
+}
+
+// ── B2: DB registration failure rejects WS connection ────────────────
+
+struct FailingEdgeRegistry;
+
+#[async_trait]
+impl astra_services::multi_agent::EdgeRegistryService for FailingEdgeRegistry {
+    async fn register_or_update(
+        &self,
+        _user_id: &str,
+        _edge_agent_id: &str,
+        _edge_id_header: &str,
+        _hostname: Option<&str>,
+        _worktree_path: Option<&str>,
+        _capabilities: Option<serde_json::Value>,
+        _workspace_id: Option<&str>,
+    ) -> Result<astra_services::multi_agent::EdgeAgentRecord, String> {
+        Err("simulated DB failure".to_string())
+    }
+
+    async fn heartbeat(
+        &self,
+        _user_id: &str,
+        _edge_agent_id: &str,
+        _edge_id_header: &str,
+    ) -> Result<(), astra_services::multi_agent::HeartbeatError> {
+        Ok(())
+    }
+
+    async fn find_by_agent_id_and_workspace(
+        &self,
+        _edge_agent_id: &str,
+        _workspace_id: Option<&str>,
+    ) -> Result<Option<astra_services::multi_agent::EdgeAgentRecord>, String> {
+        Ok(None)
+    }
+
+    async fn list_by_user(
+        &self,
+        _user_id: &str,
+    ) -> Result<Vec<astra_services::multi_agent::EdgeAgentRecord>, String> {
+        Ok(Vec::new())
+    }
+
+    async fn unregister(
+        &self,
+        _user_id: &str,
+        _edge_agent_id: &str,
+        _edge_id: &str,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn edge_ws_rejects_connection_when_db_registration_fails() {
+    let state = AppState::new(
+        ServiceInfo::new("edge-b2-test", "0.0.0-test", ""),
+        Arc::new(StubHealthChecker),
+    )
+    .with_auth_service(Arc::new(StubAuthService))
+    .with_edge_registry_service(Arc::new(FailingEdgeRegistry));
+    let state_clone = state.clone();
+    let app = astra_runtime::build_app(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let url = format!("ws://{addr}/edge/ws");
+    let (mut ws, _) = connect_async(&url).await.expect("WS connect");
+    ws.send(Message::Text(
+        json!({
+            "type": "edge_auth",
+            "token": "test-edge-token",
+            "edge_agent_id": "edge-b2",
+            "hostname": "host",
+            "workspace_dir": "/workspace"
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    let resp: serde_json::Value =
+        serde_json::from_str(&ws.next().await.unwrap().unwrap().into_text().unwrap()).unwrap();
+    assert_eq!(
+        resp["type"], "edge_auth_error",
+        "DB failure must reject the connection: {resp}"
+    );
+    assert!(
+        !state_clone
+            .edge_connection_pool
+            .has_connected_edge("test-user-1")
+    );
+
+    server.abort();
+}
+
+// ── B3: heartbeat tick updates DB registry ────────────────────────────
+
+#[derive(Default)]
+struct RecordingEdgeRegistry {
+    heartbeats: std::sync::Mutex<Vec<(String, String, String)>>,
+    notify: tokio::sync::Notify,
+}
+
+#[async_trait]
+impl astra_services::multi_agent::EdgeRegistryService for RecordingEdgeRegistry {
+    async fn register_or_update(
+        &self,
+        user_id: &str,
+        edge_agent_id: &str,
+        edge_id_header: &str,
+        hostname: Option<&str>,
+        _worktree_path: Option<&str>,
+        _capabilities: Option<serde_json::Value>,
+        _workspace_id: Option<&str>,
+    ) -> Result<astra_services::multi_agent::EdgeAgentRecord, String> {
+        Ok(astra_services::multi_agent::EdgeAgentRecord {
+            registry_id: "test-registry-id".to_string(),
+            user_id: user_id.to_string(),
+            edge_agent_id: edge_agent_id.to_string(),
+            edge_id: edge_id_header.to_string(),
+            hostname: hostname.map(str::to_string),
+            worktree_path: None,
+            capabilities: None,
+            workspace_id: None,
+            registered_at: "2024-01-01T00:00:00".to_string(),
+            last_heartbeat_at: "2024-01-01T00:00:00".to_string(),
+        })
+    }
+
+    async fn heartbeat(
+        &self,
+        user_id: &str,
+        edge_agent_id: &str,
+        edge_id_header: &str,
+    ) -> Result<(), astra_services::multi_agent::HeartbeatError> {
+        self.heartbeats.lock().unwrap().push((
+            user_id.to_string(),
+            edge_agent_id.to_string(),
+            edge_id_header.to_string(),
+        ));
+        self.notify.notify_waiters();
+        Ok(())
+    }
+
+    async fn find_by_agent_id_and_workspace(
+        &self,
+        _edge_agent_id: &str,
+        _workspace_id: Option<&str>,
+    ) -> Result<Option<astra_services::multi_agent::EdgeAgentRecord>, String> {
+        Ok(None)
+    }
+
+    async fn list_by_user(
+        &self,
+        _user_id: &str,
+    ) -> Result<Vec<astra_services::multi_agent::EdgeAgentRecord>, String> {
+        Ok(Vec::new())
+    }
+
+    async fn unregister(
+        &self,
+        _user_id: &str,
+        _edge_agent_id: &str,
+        _edge_id: &str,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn edge_ws_heartbeat_tick_updates_db_registry() {
+    let registry = Arc::new(RecordingEdgeRegistry::default());
+    let registry_clone = Arc::clone(&registry);
+
+    let state = AppState::new(
+        ServiceInfo::new("edge-b3-test", "0.0.0-test", ""),
+        Arc::new(StubHealthChecker),
+    )
+    .with_auth_service(Arc::new(StubAuthService))
+    .with_edge_registry_service(registry_clone);
+    let app = astra_runtime::build_app(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    // Yield to let axum's accept loop start before we attempt to connect.
+    // In current_thread+start_paused mode there is no real sleep; we just
+    // need the server task to reach its accept().await before we send the
+    // auth message.
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+    }
+
+    // Connect and auth normally.
+    let _ws = ws_auth(addr, "edge-b3", "host-b3").await;
+
+    // Advance mock clock past one heartbeat interval (30 s) so the ticker fires.
+    // start_paused = true means time is already frozen; advance() moves it forward
+    // and yields to let the server's heartbeat task run.
+    tokio::time::advance(std::time::Duration::from_secs(31)).await;
+    // Yield a few more times to let the server task process the tick.
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+    }
+
+    let beats = registry.heartbeats.lock().unwrap().clone();
+    assert!(
+        beats
+            .iter()
+            .any(|(uid, eid, _)| uid == "test-user-1" && eid == "edge-b3"),
+        "heartbeat must be called after advancing mock clock 31s: {beats:?}"
+    );
+
+    server.abort();
+}
+
+// ── F5: workspace_id from binding is stored in edge connection pool ───
+
+#[tokio::test]
+async fn edge_ws_stores_workspace_id_in_connection_pool() {
+    let (addr, state, server) = spawn_binding_server("ws-edge-agent").await;
+
+    // BindingAuthService returns workspace_id = "test-workspace".
+    let resp = edge_auth_result(addr, "ws-edge-agent").await;
+    assert_eq!(resp["type"], "edge_auth_ok", "auth must succeed: {resp}");
+
+    // Pool must record the workspace_id from the binding so workspace-scoped
+    // dispatch can route to this edge.
+    let found = state
+        .edge_connection_pool
+        .find_edge_by_agent_id("ws-edge-agent", Some("test-workspace"));
+    assert!(
+        found.is_some(),
+        "edge must be findable by workspace_id 'test-workspace'"
+    );
+
+    // A different workspace_id must not match (workspace authorization guard).
+    let wrong_ws = state
+        .edge_connection_pool
+        .find_edge_by_agent_id("ws-edge-agent", Some("other-workspace"));
+    assert!(
+        wrong_ws.is_none(),
+        "edge must not be accessible from a different workspace"
+    );
+
+    server.abort();
+}

--- a/crates/runtime/tests/executor_unhappy_path.rs
+++ b/crates/runtime/tests/executor_unhappy_path.rs
@@ -181,6 +181,7 @@ async fn all_unhealthy_providers_resolve_returns_unhealthy() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
     let resolved = reg.resolve(&request).await;
     assert!(matches!(resolved, Err(ProviderError::Unhealthy(_))));
@@ -199,6 +200,7 @@ async fn empty_registry_not_capable_vs_all_unhealthy() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
     let result = reg.resolve(&request).await;
     assert!(matches!(result, Err(ProviderError::NotCapable { .. })));
@@ -317,6 +319,7 @@ async fn provider_degrades_between_resolve_and_execute() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
 
     let resolved = reg.resolve(&request).await.unwrap();
@@ -367,6 +370,7 @@ async fn lease_expired_provider_is_rejected_by_resolve() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
     let resolved = reg.resolve(&request).await;
     assert!(matches!(resolved, Err(ProviderError::Unhealthy(_))));
@@ -402,6 +406,7 @@ async fn all_providers_lease_expired_resolve_returns_unhealthy() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
     let resolved = reg.resolve(&request).await;
     assert!(
@@ -442,6 +447,7 @@ async fn hung_transport_times_out_at_caller_level() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
     let resolved = reg.resolve(&request).await.unwrap();
 
@@ -478,6 +484,7 @@ async fn network_partition_all_providers_hung() {
         user_id: "test-user".into(),
         run_id: "test-run".into(),
         session_id: "test-session".into(),
+        workspace_id: None,
     };
     let resolved = reg.resolve(&request).await.unwrap();
 

--- a/crates/runtime/tests/system_matrix_http_e2e/journey_saas_negative_matrix.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/journey_saas_negative_matrix.rs
@@ -988,7 +988,7 @@ pub async fn run_saas_edges_status_smoke() {
 /// GET /service/edges/status: verifies auth gate and response shape.
 ///
 /// Covers:
-/// 1. Missing key → 403 (endpoint not configured when env var absent).
+/// 1. Missing Authorization header (env var set) → 401.
 /// 2. Invalid key → 401.
 /// 3. Valid key → 200 with `edges` array.
 pub async fn run_saas_service_edges_status_smoke() {
@@ -1003,7 +1003,7 @@ pub async fn run_saas_service_edges_status_smoke() {
     let app = &ctx.app;
     let user_id = &b.ctx.user_id;
 
-    // 1. No Authorization header → 403 (env var set but no key provided).
+    // 1. No Authorization header → 401 (env var set but no key provided).
     let (st_no_key, j_no_key) = get_json(
         app,
         &format!("/service/edges/status?user_id={user_id}"),

--- a/crates/runtime/tests/system_matrix_http_e2e/journey_saas_negative_matrix.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/journey_saas_negative_matrix.rs
@@ -985,6 +985,73 @@ pub async fn run_saas_edges_status_smoke() {
     ctx.pool.close().await;
 }
 
+/// GET /service/edges/status: verifies auth gate and response shape.
+///
+/// Covers:
+/// 1. Missing key → 403 (endpoint not configured when env var absent).
+/// 2. Invalid key → 401.
+/// 3. Valid key → 200 with `edges` array.
+pub async fn run_saas_service_edges_status_smoke() {
+    const SERVICE_KEY: &str = "test-service-key-e2e";
+    // Safety: test-only env mutation, isolated to this process.
+    unsafe {
+        std::env::set_var("ASTRA_BACKEND_SERVICE_KEY", SERVICE_KEY);
+    }
+
+    let b = bootstrap().await;
+    let ctx = &b.ctx;
+    let app = &ctx.app;
+    let user_id = &b.ctx.user_id;
+
+    // 1. No Authorization header → 403 (env var set but no key provided).
+    let (st_no_key, j_no_key) = get_json(
+        app,
+        &format!("/service/edges/status?user_id={user_id}"),
+        None,
+        &[],
+    )
+    .await;
+    assert_eq!(
+        st_no_key,
+        StatusCode::UNAUTHORIZED,
+        "missing key should be 401: {j_no_key}"
+    );
+
+    // 2. Wrong key → 401.
+    let (st_bad, j_bad) = get_json(
+        app,
+        &format!("/service/edges/status?user_id={user_id}"),
+        Some("Bearer wrong-key"),
+        &[],
+    )
+    .await;
+    assert_eq!(
+        st_bad,
+        StatusCode::UNAUTHORIZED,
+        "invalid key should be 401: {j_bad}"
+    );
+
+    // 3. Valid key → 200 with edges array (may be empty; no live WS in this test).
+    let valid_auth = format!("Bearer {SERVICE_KEY}");
+    let (st_ok, ok_j) = get_json(
+        app,
+        &format!("/service/edges/status?user_id={user_id}"),
+        Some(&valid_auth),
+        &[],
+    )
+    .await;
+    assert_eq!(st_ok, StatusCode::OK, "valid key should be 200: {ok_j}");
+    assert!(
+        ok_j["edges"].is_array(),
+        "edges field must be array: {ok_j}"
+    );
+
+    unsafe {
+        std::env::remove_var("ASTRA_BACKEND_SERVICE_KEY");
+    }
+    ctx.pool.close().await;
+}
+
 /// Valid approval respond commits one owner-scoped durable interaction decision.
 pub async fn run_saas_approval_respond_success_path() {
     let b = bootstrap().await;

--- a/crates/runtime/tests/system_matrix_http_e2e/main.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/main.rs
@@ -698,7 +698,7 @@ async fn e2e_matrix_saas_edges_status_smoke() {
     journey_saas_negative_matrix::run_saas_edges_status_smoke().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tokio::test(flavor = "current_thread")]
 #[ignore = "live MatrixOne + full secrets; ASTRA_TEST_DB_IT=1 — SaaS platform §4.2 service/edges/status auth gate"]
 async fn e2e_matrix_saas_service_edges_status_smoke() {
     require_system_e2e_env();

--- a/crates/runtime/tests/system_matrix_http_e2e/main.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/main.rs
@@ -699,6 +699,13 @@ async fn e2e_matrix_saas_edges_status_smoke() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live MatrixOne + full secrets; ASTRA_TEST_DB_IT=1 — SaaS platform §4.2 service/edges/status auth gate"]
+async fn e2e_matrix_saas_service_edges_status_smoke() {
+    require_system_e2e_env();
+    journey_saas_negative_matrix::run_saas_service_edges_status_smoke().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "live MatrixOne + full secrets; ASTRA_TEST_DB_IT=1 — SaaS platform §4.2 approval callback"]
 async fn e2e_matrix_saas_approval_respond_success_path() {
     require_system_e2e_env();

--- a/crates/services/src/auth/external.rs
+++ b/crates/services/src/auth/external.rs
@@ -1,0 +1,1699 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use astra_core::{ErrorResponse, error_response, error_response_coded, internal_error};
+
+#[derive(Clone, Debug)]
+pub struct ExternalAuthProviderConfig {
+    pub id: String,
+    pub display_name: String,
+    pub external_auth_endpoint: String,
+}
+use async_trait::async_trait;
+use axum::{Json, http::StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::models::ModelListItem;
+use crate::runs::{
+    RuntimeAuthRequest, RuntimeCapabilityDescriptorRequest, RuntimeCapabilityDescriptorsRequest,
+    RuntimeMcpBindingRequest, RuntimeSkillBindingRequest, SelectedModelRequest,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExternalProviderPublicRecord {
+    pub id: String,
+    pub display_name: String,
+    pub credential_type: String,
+}
+
+impl From<&ExternalAuthProviderConfig> for ExternalProviderPublicRecord {
+    fn from(value: &ExternalAuthProviderConfig) -> Self {
+        Self {
+            id: value.id.clone(),
+            display_name: value.display_name.clone(),
+            credential_type: "password".to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExternalLoginRequestData {
+    pub provider_id: String,
+    pub username: String,
+    pub password: String,
+    pub scope_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExternalAuthorizeRequestData {
+    pub provider_id: String,
+    pub token: String,
+    pub request: ExternalRequestDescriptor,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalRequestDescriptor {
+    pub method: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body_digest: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExternalRuntimeContextRequestData {
+    pub requested_model_id: String,
+    pub requested_tool_ids: Vec<String>,
+    pub requested_skill_ids: Vec<String>,
+    pub requested_knowledge_base_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExternalSessionRecord {
+    pub external_session_id: String,
+    pub provider_id: String,
+    pub astra_user_id: String,
+    pub external_subject: String,
+    pub provider_scope_id: String,
+    pub provider_scope_display_name: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalProviderScope {
+    pub id: String,
+    pub workspace_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub account_name: Option<String>,
+    #[serde(default)]
+    pub is_default: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalProviderAuthResponse {
+    pub external_subject: ExternalSubject,
+    pub display_info: ExternalDisplayInfo,
+    pub workspace_scopes: Vec<ExternalProviderScope>,
+    pub selected_scope: ExternalProviderScope,
+    pub default_scope: ExternalProviderScope,
+    pub provider_session_handle: String,
+    pub expires_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalSubject {
+    pub id: String,
+    pub provider: String,
+    pub kind: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalDisplayInfo {
+    pub username: String,
+    #[serde(default)]
+    pub nickname: Option<String>,
+    #[serde(default)]
+    pub email: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalCatalogModel {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    pub model_name: String,
+    #[serde(default)]
+    pub provider_ref: Option<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub parameters: Map<String, Value>,
+    #[serde(default)]
+    pub limits: Map<String, Value>,
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+}
+
+impl ExternalCatalogModel {
+    fn into_model_list_item(self) -> ModelListItem {
+        ModelListItem {
+            model_id: self.id,
+            name: self.display_name.unwrap_or(self.name),
+            provider: self.provider_ref.unwrap_or_default(),
+            description: string_value(&self.metadata, "description"),
+            is_active: true,
+            context_window: i32_value(&self.limits, "context_window").unwrap_or_default(),
+            max_completion_tokens: i32_value(&self.limits, "max_completion_tokens"),
+            architecture: string_value(&self.metadata, "architecture"),
+            thinking_capability: None,
+        }
+    }
+}
+
+fn string_value(values: &Map<String, Value>, key: &str) -> Option<String> {
+    values
+        .get(key)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn i32_value(values: &Map<String, Value>, key: &str) -> Option<i32> {
+    let value = values.get(key)?;
+    if let Some(raw) = value.as_i64() {
+        return i32::try_from(raw).ok();
+    }
+    value.as_u64().and_then(|raw| i32::try_from(raw).ok())
+}
+
+impl From<ExternalCatalogModel> for ModelListItem {
+    fn from(value: ExternalCatalogModel) -> Self {
+        value.into_model_list_item()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalCatalogTool {
+    pub id: String,
+    pub name: String,
+    pub kind: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub side_effect_class: String,
+    #[serde(default)]
+    pub input_schema: Map<String, Value>,
+    #[serde(default)]
+    pub output_schema: Map<String, Value>,
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalCatalogSkill {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub version: i32,
+    #[serde(default)]
+    pub routing_summary: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub requirements: Map<String, Value>,
+    #[serde(default)]
+    pub parameters_schema: Map<String, Value>,
+    #[serde(default)]
+    pub output_contract: Map<String, Value>,
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalCatalogKnowledgeBase {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub visibility: String,
+    pub index_status: String,
+    #[serde(default)]
+    pub catalog_asset_refs: Vec<Map<String, Value>>,
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalCatalogResponse {
+    #[serde(default)]
+    pub models: Vec<ExternalCatalogModel>,
+    #[serde(default)]
+    pub tools: Vec<ExternalCatalogTool>,
+    #[serde(default)]
+    pub skills: Vec<ExternalCatalogSkill>,
+    #[serde(default)]
+    pub knowledge_bases: Vec<ExternalCatalogKnowledgeBase>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalAuthorizeRequestResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub external_subject: Option<String>,
+    #[serde(default)]
+    pub provider_scope_id: Option<String>,
+    #[serde(default)]
+    pub request_authorization_id: Option<String>,
+    #[serde(default)]
+    pub reason: Option<String>,
+    /// Populated by the provider when the verified token is an edge-registration
+    /// token. Astra edge auth verifies the self-reported edge id against this.
+    #[serde(default)]
+    pub edge_agent_id: Option<String>,
+}
+
+impl ExternalAuthorizeRequestResponse {
+    pub fn into_authorization(
+        self,
+        provider_id: &str,
+    ) -> Result<ExternalAuthorizedRequest, (StatusCode, Json<ErrorResponse>)> {
+        if !self.ok {
+            return Err(error_response_coded(
+                StatusCode::FORBIDDEN,
+                self.reason
+                    .unwrap_or_else(|| "external provider denied request".to_string()),
+                "external_request_denied",
+            ));
+        }
+        let external_subject = self.external_subject.ok_or_else(|| {
+            error_response_coded(
+                StatusCode::BAD_GATEWAY,
+                format!(
+                    "external provider '{}' authorize_request omitted external_subject",
+                    provider_id
+                ),
+                "external_provider_response_invalid",
+            )
+        })?;
+        let provider_scope_id = self.provider_scope_id.ok_or_else(|| {
+            error_response_coded(
+                StatusCode::BAD_GATEWAY,
+                format!(
+                    "external provider '{}' authorize_request omitted provider_scope_id",
+                    provider_id
+                ),
+                "external_provider_response_invalid",
+            )
+        })?;
+        let request_authorization_id = self.request_authorization_id.ok_or_else(|| {
+            error_response_coded(
+                StatusCode::BAD_GATEWAY,
+                format!(
+                    "external provider '{}' authorize_request omitted request_authorization_id",
+                    provider_id
+                ),
+                "external_provider_response_invalid",
+            )
+        })?;
+        Ok(ExternalAuthorizedRequest {
+            provider_id: provider_id.to_string(),
+            external_subject,
+            provider_scope_id,
+            request_authorization_id,
+            edge_agent_id: self.edge_agent_id,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExternalAuthorizedRequest {
+    pub provider_id: String,
+    pub external_subject: String,
+    pub provider_scope_id: String,
+    pub request_authorization_id: String,
+    /// Present when the token is an edge-registration token; the bound edge
+    /// agent id that Astra must match against the self-reported value.
+    pub edge_agent_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalRuntimeCapabilityDescriptor {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub descriptor_type: String,
+    pub transport: String,
+    pub endpoint_url: String,
+    pub protocol: String,
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+}
+
+impl ExternalRuntimeCapabilityDescriptor {
+    pub fn to_request_descriptor(&self) -> RuntimeCapabilityDescriptorRequest {
+        RuntimeCapabilityDescriptorRequest {
+            id: self.id.clone(),
+            descriptor_type: self.descriptor_type.clone(),
+            transport: self.transport.clone(),
+            endpoint_url: self.endpoint_url.clone(),
+            protocol: self.protocol.clone(),
+            metadata: self.metadata.clone(),
+        }
+    }
+
+    pub fn into_runtime_mcp_binding(self, authorization: String) -> RuntimeMcpBindingRequest {
+        RuntimeMcpBindingRequest {
+            id: self.id,
+            transport: self.transport,
+            url: self.endpoint_url,
+            auth_token: Some(authorization),
+            headers: std::collections::HashMap::new(),
+        }
+    }
+
+    pub fn into_runtime_skill_binding(self, authorization: String) -> RuntimeSkillBindingRequest {
+        RuntimeSkillBindingRequest {
+            id: self.id,
+            url: self.endpoint_url,
+            authorization,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalRuntimeCapabilityDescriptors {
+    #[serde(default)]
+    pub model_gateway: Option<ExternalRuntimeCapabilityDescriptor>,
+    #[serde(default)]
+    pub mcp: Option<ExternalRuntimeCapabilityDescriptor>,
+    #[serde(default)]
+    pub skills: Option<ExternalRuntimeCapabilityDescriptor>,
+}
+
+impl ExternalRuntimeCapabilityDescriptors {
+    pub fn to_request_descriptors(&self) -> RuntimeCapabilityDescriptorsRequest {
+        RuntimeCapabilityDescriptorsRequest {
+            model_gateway: self
+                .model_gateway
+                .as_ref()
+                .map(ExternalRuntimeCapabilityDescriptor::to_request_descriptor),
+            mcp: self
+                .mcp
+                .as_ref()
+                .map(ExternalRuntimeCapabilityDescriptor::to_request_descriptor),
+            skills: self
+                .skills
+                .as_ref()
+                .map(ExternalRuntimeCapabilityDescriptor::to_request_descriptor),
+            edge_agent: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalRuntimeContextResponse {
+    pub selected_model: ExternalSelectedModelResponse,
+    pub runtime_auth: ExternalRuntimeAuthResponse,
+    #[serde(default)]
+    pub capability_descriptors: ExternalRuntimeCapabilityDescriptors,
+    pub runtime_scope: ExternalRuntimeScopeResponse,
+    #[serde(default)]
+    pub runtime_system_prompt: Option<String>,
+    pub task_id: String,
+    pub manifest_id: String,
+    pub provider_scope_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalSelectedModelResponse {
+    pub id: String,
+    pub model: String,
+}
+
+impl ExternalSelectedModelResponse {
+    pub fn to_selected_model_request(&self) -> SelectedModelRequest {
+        SelectedModelRequest {
+            id: Some(self.id.clone()),
+            model: self.model.clone(),
+            gateway: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalRuntimeAuthResponse {
+    #[serde(rename = "type")]
+    pub auth_type: String,
+    pub authorization: String,
+    pub expires_at: String,
+}
+
+impl ExternalRuntimeAuthResponse {
+    pub fn to_runtime_auth_request(&self) -> RuntimeAuthRequest {
+        RuntimeAuthRequest {
+            authorization: self.authorization.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalRuntimeScopeResponse {
+    pub allowed_model_id: String,
+    #[serde(default)]
+    pub allowed_tools: Vec<ExternalCatalogTool>,
+    #[serde(default)]
+    pub allowed_skills: Vec<ExternalCatalogSkill>,
+    #[serde(default)]
+    pub allowed_knowledge_bases: Vec<ExternalCatalogKnowledgeBase>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ExternalProviderSessionHandle {
+    pub provider_session_handle: String,
+    pub provider_scope_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalRefreshSessionResponse {
+    pub provider_session_handle: String,
+    pub provider_scope_id: String,
+    pub expires_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalLogoutResponse {
+    pub provider_session_handle: String,
+    pub logged_out: bool,
+}
+
+#[async_trait]
+pub trait ExternalProviderClient: Send + Sync {
+    async fn authorize_request(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        request: ExternalAuthorizeRequestData,
+    ) -> Result<ExternalAuthorizedRequest, (StatusCode, Json<ErrorResponse>)>;
+
+    async fn authenticate(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        request: ExternalLoginRequestData,
+    ) -> Result<ExternalProviderAuthResponse, (StatusCode, Json<ErrorResponse>)>;
+
+    async fn list_catalog(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        session: ExternalProviderSessionHandle,
+    ) -> Result<ExternalCatalogResponse, (StatusCode, Json<ErrorResponse>)>;
+
+    async fn issue_runtime_context(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        session: ExternalProviderSessionHandle,
+        request: ExternalRuntimeContextRequestData,
+    ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)>;
+
+    async fn refresh_session(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        session: ExternalProviderSessionHandle,
+    ) -> Result<ExternalRefreshSessionResponse, (StatusCode, Json<ErrorResponse>)>;
+
+    async fn logout(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        session: ExternalProviderSessionHandle,
+    ) -> Result<ExternalLogoutResponse, (StatusCode, Json<ErrorResponse>)>;
+
+    /// List the catalog for an authorized-request principal using provider_scope_id and
+    /// external_subject directly, without a session handle. Used for edge-JWT principals.
+    async fn list_catalog_by_scope(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        provider_scope_id: String,
+        external_subject: String,
+    ) -> Result<ExternalCatalogResponse, (StatusCode, Json<ErrorResponse>)>;
+
+    /// Issue a runtime context for an authorized-request principal using provider_scope_id
+    /// and external_subject directly, without a session handle. Used for edge-JWT principals.
+    async fn issue_runtime_context_by_scope(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        provider_scope_id: String,
+        external_subject: String,
+        request: ExternalRuntimeContextRequestData,
+    ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)>;
+}
+
+#[derive(Clone)]
+pub struct HttpExternalProviderClient {
+    client: reqwest::Client,
+}
+
+impl Default for HttpExternalProviderClient {
+    fn default() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .no_proxy()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("external provider HTTP client configuration is static"),
+        }
+    }
+}
+
+impl HttpExternalProviderClient {
+    pub fn shared() -> Arc<dyn ExternalProviderClient> {
+        Arc::new(Self::default())
+    }
+
+    async fn post_action<T, R>(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        action: &'static str,
+        payload: T,
+    ) -> Result<R, (StatusCode, Json<ErrorResponse>)>
+    where
+        T: Serialize + Send,
+        R: for<'de> Deserialize<'de>,
+    {
+        let request = ExternalProviderActionRequest {
+            action,
+            provider_id: &provider.id,
+            payload,
+        };
+        let response = self
+            .client
+            .post(&provider.external_auth_endpoint)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|error| {
+                error_response_coded(
+                    StatusCode::BAD_GATEWAY,
+                    format!(
+                        "external provider '{}' action '{}' request failed: {error}",
+                        provider.id, action
+                    ),
+                    "external_provider_request_failed",
+                )
+            })?;
+        let status = response.status();
+        let body = response.text().await.map_err(|error| {
+            error_response_coded(
+                StatusCode::BAD_GATEWAY,
+                format!(
+                    "external provider '{}' action '{}' response read failed: {error}",
+                    provider.id, action
+                ),
+                "external_provider_response_invalid",
+            )
+        })?;
+        if !status.is_success() {
+            return Err(map_provider_error_status(
+                &provider.id,
+                action,
+                status,
+                &body,
+            ));
+        }
+        let envelope = serde_json::from_str::<ProviderSuccessEnvelope>(&body).map_err(|error| {
+            error_response_coded(
+                StatusCode::BAD_GATEWAY,
+                format!(
+                    "external provider '{}' action '{}' response envelope is invalid: {error}",
+                    provider.id, action
+                ),
+                "external_provider_response_invalid",
+            )
+        })?;
+        if envelope.code != 0 {
+            return Err(error_response_coded(
+                StatusCode::BAD_GATEWAY,
+                format!(
+                    "external provider '{}' action '{}' returned provider error: {}",
+                    provider.id,
+                    action,
+                    envelope
+                        .message
+                        .unwrap_or_else(|| format!("code {}", envelope.code))
+                ),
+                format!("external_provider_code_{}", envelope.code),
+            ));
+        }
+        serde_json::from_value::<R>(envelope.data).map_err(|error| {
+            error_response_coded(
+                StatusCode::BAD_GATEWAY,
+                format!(
+                    "external provider '{}' action '{}' response data is invalid: {error}",
+                    provider.id, action
+                ),
+                "external_provider_response_invalid",
+            )
+        })
+    }
+}
+
+#[async_trait]
+impl ExternalProviderClient for HttpExternalProviderClient {
+    async fn authorize_request(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        request: ExternalAuthorizeRequestData,
+    ) -> Result<ExternalAuthorizedRequest, (StatusCode, Json<ErrorResponse>)> {
+        let response: ExternalAuthorizeRequestResponse = self
+            .post_action(
+                provider,
+                "authorize_request",
+                AuthorizeRequestActionPayload {
+                    token: request.token,
+                    request: request.request,
+                },
+            )
+            .await?;
+        response.into_authorization(&provider.id)
+    }
+
+    async fn authenticate(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        request: ExternalLoginRequestData,
+    ) -> Result<ExternalProviderAuthResponse, (StatusCode, Json<ErrorResponse>)> {
+        self.post_action(
+            provider,
+            "authenticate",
+            AuthenticateActionPayload {
+                username: request.username,
+                password: request.password,
+                provider_scope_id: request.scope_id,
+            },
+        )
+        .await
+    }
+
+    async fn list_catalog(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        session: ExternalProviderSessionHandle,
+    ) -> Result<ExternalCatalogResponse, (StatusCode, Json<ErrorResponse>)> {
+        self.post_action(
+            provider,
+            "list_catalog",
+            SessionActionPayload::from(session),
+        )
+        .await
+    }
+
+    async fn issue_runtime_context(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        session: ExternalProviderSessionHandle,
+        request: ExternalRuntimeContextRequestData,
+    ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)> {
+        self.post_action(
+            provider,
+            "issue_runtime_context",
+            IssueRuntimeContextActionPayload {
+                session: SessionActionPayload::from(session),
+                requested_model_id: request.requested_model_id,
+                requested_tool_ids: request.requested_tool_ids,
+                requested_skill_ids: request.requested_skill_ids,
+                requested_knowledge_base_ids: request.requested_knowledge_base_ids,
+            },
+        )
+        .await
+    }
+
+    async fn refresh_session(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        session: ExternalProviderSessionHandle,
+    ) -> Result<ExternalRefreshSessionResponse, (StatusCode, Json<ErrorResponse>)> {
+        self.post_action(
+            provider,
+            "refresh_session",
+            SessionActionPayload::from(session),
+        )
+        .await
+    }
+
+    async fn logout(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        session: ExternalProviderSessionHandle,
+    ) -> Result<ExternalLogoutResponse, (StatusCode, Json<ErrorResponse>)> {
+        self.post_action(provider, "logout", SessionActionPayload::from(session))
+            .await
+    }
+
+    async fn list_catalog_by_scope(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        provider_scope_id: String,
+        external_subject: String,
+    ) -> Result<ExternalCatalogResponse, (StatusCode, Json<ErrorResponse>)> {
+        self.post_action(
+            provider,
+            "list_catalog_by_scope",
+            ScopeActionPayload {
+                provider_scope_id,
+                external_subject,
+            },
+        )
+        .await
+    }
+
+    async fn issue_runtime_context_by_scope(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        provider_scope_id: String,
+        external_subject: String,
+        request: ExternalRuntimeContextRequestData,
+    ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)> {
+        self.post_action(
+            provider,
+            "issue_runtime_context_by_scope",
+            ScopeRuntimeContextActionPayload {
+                scope: ScopeActionPayload {
+                    provider_scope_id,
+                    external_subject,
+                },
+                requested_model_id: request.requested_model_id,
+                requested_tool_ids: request.requested_tool_ids,
+                requested_skill_ids: request.requested_skill_ids,
+                requested_knowledge_base_ids: request.requested_knowledge_base_ids,
+            },
+        )
+        .await
+    }
+}
+
+#[derive(Serialize)]
+struct ExternalProviderActionRequest<'a, T> {
+    action: &'static str,
+    provider_id: &'a str,
+    #[serde(flatten)]
+    payload: T,
+}
+
+#[derive(Serialize)]
+struct AuthorizeRequestActionPayload {
+    token: String,
+    request: ExternalRequestDescriptor,
+}
+
+#[derive(Serialize)]
+struct AuthenticateActionPayload {
+    username: String,
+    password: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider_scope_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct SessionActionPayload {
+    provider_session_handle: String,
+    provider_scope_id: String,
+}
+
+impl From<ExternalProviderSessionHandle> for SessionActionPayload {
+    fn from(value: ExternalProviderSessionHandle) -> Self {
+        Self {
+            provider_session_handle: value.provider_session_handle,
+            provider_scope_id: value.provider_scope_id,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct IssueRuntimeContextActionPayload {
+    #[serde(flatten)]
+    session: SessionActionPayload,
+    requested_model_id: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    requested_tool_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    requested_skill_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    requested_knowledge_base_ids: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct ScopeActionPayload {
+    provider_scope_id: String,
+    external_subject: String,
+}
+
+#[derive(Serialize)]
+struct ScopeRuntimeContextActionPayload {
+    #[serde(flatten)]
+    scope: ScopeActionPayload,
+    requested_model_id: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    requested_tool_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    requested_skill_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    requested_knowledge_base_ids: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct ProviderSuccessEnvelope {
+    code: i32,
+    #[serde(default)]
+    message: Option<String>,
+    data: Value,
+}
+
+#[derive(Deserialize)]
+struct ProviderErrorEnvelope {
+    error: ProviderErrorBody,
+}
+
+#[derive(Deserialize)]
+struct ProviderErrorBody {
+    code: String,
+    message: String,
+}
+
+#[derive(Deserialize)]
+struct ProviderApiErrorEnvelope {
+    code: i32,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+fn map_provider_error_status(
+    provider_id: &str,
+    action: &str,
+    status: reqwest::StatusCode,
+    body: &str,
+) -> (StatusCode, Json<ErrorResponse>) {
+    let mapped_status = match status {
+        reqwest::StatusCode::UNAUTHORIZED => StatusCode::UNAUTHORIZED,
+        reqwest::StatusCode::FORBIDDEN => StatusCode::FORBIDDEN,
+        reqwest::StatusCode::CONFLICT => StatusCode::CONFLICT,
+        reqwest::StatusCode::BAD_REQUEST => StatusCode::BAD_REQUEST,
+        _ => StatusCode::BAD_GATEWAY,
+    };
+    if let Ok(envelope) = serde_json::from_str::<ProviderApiErrorEnvelope>(body)
+        && envelope.code != 0
+    {
+        let message = envelope
+            .message
+            .unwrap_or_else(|| format!("provider error code {}", envelope.code));
+        return error_response_coded(
+            mapped_status,
+            format!(
+                "external provider '{}' action '{}' failed: {}",
+                provider_id, action, message
+            ),
+            format!("external_provider_code_{}", envelope.code),
+        );
+    }
+    if let Ok(envelope) = serde_json::from_str::<ProviderErrorEnvelope>(body) {
+        return error_response_coded(
+            mapped_status,
+            format!(
+                "external provider '{}' action '{}' failed: {}",
+                provider_id, action, envelope.error.message
+            ),
+            envelope.error.code,
+        );
+    }
+    error_response_coded(
+        mapped_status,
+        format!(
+            "external provider '{}' action '{}' failed with HTTP {}",
+            provider_id, action, status
+        ),
+        "external_provider_action_failed",
+    )
+}
+
+pub fn validate_provider_runtime_context(
+    provider: &ExternalAuthProviderConfig,
+    requested_model_id: &str,
+    context: &ExternalRuntimeContextResponse,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if context.selected_model.id != requested_model_id {
+        return Err(error_response_coded(
+            StatusCode::FORBIDDEN,
+            "requested model is not visible in the selected external scope",
+            "external_model_not_visible",
+        ));
+    }
+    if context.runtime_scope.allowed_model_id != requested_model_id {
+        return Err(provider_context_conflict(format!(
+            "external provider '{}' returned runtime scope for model '{}' while '{}' was requested",
+            provider.id, context.runtime_scope.allowed_model_id, requested_model_id
+        )));
+    }
+    validate_bearer_authorization(&context.runtime_auth.authorization)?;
+    if context.runtime_auth.auth_type != "moi_runtime_grant" {
+        return Err(provider_context_invalid(
+            "runtime_auth.type must be moi_runtime_grant",
+        ));
+    }
+    let model_gateway = context
+        .capability_descriptors
+        .model_gateway
+        .as_ref()
+        .ok_or_else(|| {
+            provider_context_invalid("capability_descriptors.model_gateway is required")
+        })?;
+    validate_capability_descriptor(provider, model_gateway, "model_gateway")?;
+    if let Some(mcp) = context.capability_descriptors.mcp.as_ref() {
+        validate_capability_descriptor(provider, mcp, "mcp")?;
+    }
+    if let Some(skills) = context.capability_descriptors.skills.as_ref() {
+        validate_capability_descriptor(provider, skills, "skills")?;
+    }
+    Ok(())
+}
+
+fn validate_bearer_authorization(
+    authorization: &str,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let mut parts = authorization.split_ascii_whitespace();
+    let scheme = parts.next();
+    let token = parts.next();
+    if scheme != Some("Bearer") || token.is_none() || parts.next().is_some() {
+        return Err(provider_context_invalid(
+            "runtime_auth.authorization must contain exactly one Bearer token",
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_runtime_capability_descriptor(
+    descriptor: &RuntimeCapabilityDescriptorRequest,
+    expected_type: &str,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    validate_descriptor_strings(
+        &descriptor.id,
+        &descriptor.descriptor_type,
+        &descriptor.transport,
+        &descriptor.endpoint_url,
+        &descriptor.protocol,
+        expected_type,
+    )
+}
+
+fn validate_capability_descriptor(
+    provider: &ExternalAuthProviderConfig,
+    descriptor: &ExternalRuntimeCapabilityDescriptor,
+    expected_type: &str,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    validate_descriptor_strings(
+        &descriptor.id,
+        &descriptor.descriptor_type,
+        &descriptor.transport,
+        &descriptor.endpoint_url,
+        &descriptor.protocol,
+        expected_type,
+    )
+    .map_err(|(status, error)| {
+        error_response_coded(
+            status,
+            format!(
+                "external provider '{}' returned invalid capability descriptor '{}': {}",
+                provider.id, descriptor.id, error.detail
+            ),
+            error
+                .error_code
+                .clone()
+                .unwrap_or_else(|| "external_provider_runtime_context_invalid".to_string()),
+        )
+    })
+}
+
+fn validate_descriptor_strings(
+    id: &str,
+    descriptor_type: &str,
+    transport: &str,
+    endpoint_url: &str,
+    protocol: &str,
+    expected_type: &str,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    validate_exact_descriptor_string("capability_descriptors[].id", id)?;
+    validate_exact_descriptor_string("capability_descriptors[].type", descriptor_type)?;
+    validate_exact_descriptor_string("capability_descriptors[].transport", transport)?;
+    validate_exact_descriptor_string("capability_descriptors[].protocol", protocol)?;
+    if descriptor_type != expected_type {
+        return Err(provider_context_invalid(format!(
+            "capability descriptor type must be {expected_type}"
+        )));
+    }
+    validate_endpoint_url(endpoint_url)
+}
+
+fn validate_exact_descriptor_string(
+    field: &str,
+    value: &str,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if value.is_empty() || value.trim() != value || value.chars().any(char::is_control) {
+        return Err(provider_context_invalid(format!(
+            "{field} must be a non-empty exact string"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_endpoint_url(url: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    validate_exact_descriptor_string("capability_descriptors[].endpoint_url", url)?;
+    let parsed = reqwest::Url::parse(url).map_err(|error| {
+        provider_context_invalid(format!(
+            "capability descriptor endpoint_url is invalid: {error}"
+        ))
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return Err(provider_context_invalid(
+            "capability descriptor endpoint_url must be an absolute http or https URL",
+        ));
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() || parsed.fragment().is_some() {
+        return Err(provider_context_invalid(
+            "capability descriptor endpoint_url must not contain userinfo or fragment",
+        ));
+    }
+    Ok(())
+}
+
+fn provider_context_invalid(detail: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
+    error_response_coded(
+        StatusCode::BAD_GATEWAY,
+        detail,
+        "external_provider_runtime_context_invalid",
+    )
+}
+
+fn provider_context_conflict(detail: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
+    error_response_coded(
+        StatusCode::CONFLICT,
+        detail,
+        "external_provider_runtime_context_disallowed",
+    )
+}
+
+pub fn resolve_selected_scope(
+    requested_scope_id: Option<&str>,
+    response: &ExternalProviderAuthResponse,
+) -> Result<ExternalProviderScope, (StatusCode, Json<ErrorResponse>)> {
+    let visible_selected = response
+        .workspace_scopes
+        .iter()
+        .find(|scope| scope.id == response.selected_scope.id)
+        .cloned()
+        .ok_or_else(|| {
+            error_response_coded(
+                StatusCode::FORBIDDEN,
+                "provider selected scope is not visible",
+                "external_scope_not_visible",
+            )
+        })?;
+
+    if let Some(scope_id) = requested_scope_id {
+        let visible_requested = response
+            .workspace_scopes
+            .iter()
+            .find(|scope| scope.id == scope_id)
+            .cloned()
+            .ok_or_else(|| {
+                error_response_coded(
+                    StatusCode::FORBIDDEN,
+                    "external scope is missing or no longer visible",
+                    "external_scope_not_visible",
+                )
+            })?;
+        if visible_selected.id != visible_requested.id {
+            return Err(error_response_coded(
+                StatusCode::FORBIDDEN,
+                "provider selected scope does not match requested external scope",
+                "external_scope_not_visible",
+            ));
+        }
+        return Ok(visible_selected);
+    }
+
+    let default_scopes = response
+        .workspace_scopes
+        .iter()
+        .filter(|scope| scope.is_default)
+        .cloned()
+        .collect::<Vec<_>>();
+    match default_scopes.as_slice() {
+        [scope] if scope.id == visible_selected.id => Ok(visible_selected),
+        [scope] => Err(error_response_coded(
+            StatusCode::FORBIDDEN,
+            format!(
+                "provider selected scope '{}' does not match default scope '{}'",
+                visible_selected.id, scope.id
+            ),
+            "external_scope_not_visible",
+        )),
+        [] => Err(error_response_coded(
+            StatusCode::FORBIDDEN,
+            "external scope must be selected",
+            "external_scope_required",
+        )),
+        _ => Err(error_response_coded(
+            StatusCode::FORBIDDEN,
+            "external provider returned multiple default scopes",
+            "external_scope_ambiguous",
+        )),
+    }
+}
+
+pub fn decrypt_provider_session_handle(
+    encryptor: &super::FernetTokenEncryptor,
+    encrypted: &str,
+) -> Result<String, (StatusCode, Json<ErrorResponse>)> {
+    encryptor.decrypt(encrypted).map_err(internal_error)
+}
+
+pub fn encrypt_provider_session_handle(
+    encryptor: &super::FernetTokenEncryptor,
+    handle: &str,
+) -> Result<String, (StatusCode, Json<ErrorResponse>)> {
+    if handle.is_empty() {
+        return Err(error_response(
+            StatusCode::BAD_GATEWAY,
+            "external provider session handle must not be empty",
+        ));
+    }
+    encryptor.encrypt(handle).map_err(internal_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, extract::State, routing::post};
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    fn provider(endpoint: String) -> ExternalAuthProviderConfig {
+        ExternalAuthProviderConfig {
+            id: "moi".to_string(),
+            display_name: "MOI".to_string(),
+            external_auth_endpoint: endpoint,
+        }
+    }
+
+    #[tokio::test]
+    async fn http_provider_client_uses_moi_external_auth_contract() {
+        let captured = Arc::new(Mutex::new(Vec::<Value>::new()));
+        async fn handler(
+            State(captured): State<Arc<Mutex<Vec<Value>>>>,
+            Json(body): Json<Value>,
+        ) -> Json<Value> {
+            captured.lock().await.push(body.clone());
+            match body["action"].as_str() {
+                Some("authorize_request") => Json(authorize_request_fixture()),
+                Some("authenticate") => Json(authenticate_fixture()),
+                Some("list_catalog") => Json(list_catalog_fixture()),
+                Some("issue_runtime_context") => Json(issue_runtime_context_fixture()),
+                Some("refresh_session") => Json(refresh_session_fixture()),
+                Some("logout") => Json(logout_fixture()),
+                action => Json(json!({
+                    "code": 3,
+                    "message": format!("unexpected action {action:?}")
+                })),
+            }
+        }
+        let app = Router::new()
+            .route("/external-auth", post(handler))
+            .with_state(captured.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let endpoint = format!("http://{}/external-auth", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve test provider");
+        });
+
+        let client = HttpExternalProviderClient::default();
+        let authorized = client
+            .authorize_request(
+                &provider(endpoint.clone()),
+                ExternalAuthorizeRequestData {
+                    provider_id: "moi".to_string(),
+                    token: "Bearer provider-token".to_string(),
+                    request: ExternalRequestDescriptor {
+                        method: "POST".to_string(),
+                        path: "/chat/stream".to_string(),
+                        route: Some("/chat/stream".to_string()),
+                        request_id: Some("trace-1".to_string()),
+                        body_digest: None,
+                    },
+                },
+            )
+            .await
+            .expect("authorize_request should succeed");
+        assert_eq!(authorized.provider_id, "moi");
+        assert_eq!(authorized.external_subject, "moi-user-1");
+
+        let response = client
+            .authenticate(
+                &provider(endpoint.clone()),
+                ExternalLoginRequestData {
+                    provider_id: "moi".to_string(),
+                    username: "admin".to_string(),
+                    password: "secret".to_string(),
+                    scope_id: None,
+                },
+            )
+            .await
+            .expect("authenticate should succeed");
+
+        assert_eq!(response.external_subject.id, "moi-user-1");
+        assert_eq!(response.display_info.username, "admin");
+        assert_eq!(response.selected_scope.id, "ws-1");
+        assert_eq!(response.provider_session_handle, "provider-session-secret");
+
+        let catalog = client
+            .list_catalog(
+                &provider(endpoint.clone()),
+                ExternalProviderSessionHandle {
+                    provider_session_handle: "provider-session-secret".to_string(),
+                    provider_scope_id: "ws-1".to_string(),
+                },
+            )
+            .await
+            .expect("list_catalog should parse MOI catalog");
+        assert_eq!(catalog.models[0].id, "model-qwen");
+        let model = ModelListItem::from(catalog.models.into_iter().next().unwrap());
+        assert_eq!(model.model_id, "model-qwen");
+        assert_eq!(model.name, "Qwen 2.5");
+
+        let runtime_context = client
+            .issue_runtime_context(
+                &provider(endpoint.clone()),
+                ExternalProviderSessionHandle {
+                    provider_session_handle: "provider-session-secret".to_string(),
+                    provider_scope_id: "ws-1".to_string(),
+                },
+                ExternalRuntimeContextRequestData {
+                    requested_model_id: "model-qwen".to_string(),
+                    requested_tool_ids: vec!["tool-search".to_string()],
+                    requested_skill_ids: Vec::new(),
+                    requested_knowledge_base_ids: Vec::new(),
+                },
+            )
+            .await
+            .expect("issue_runtime_context should parse MOI runtime context");
+        assert_eq!(runtime_context.selected_model.id, "model-qwen");
+        assert_eq!(
+            runtime_context
+                .capability_descriptors
+                .mcp
+                .as_ref()
+                .expect("mcp server")
+                .transport,
+            "streamable_http"
+        );
+        assert_eq!(runtime_context.runtime_scope.allowed_model_id, "model-qwen");
+
+        let refresh = client
+            .refresh_session(
+                &provider(endpoint.clone()),
+                ExternalProviderSessionHandle {
+                    provider_session_handle: "provider-session-secret".to_string(),
+                    provider_scope_id: "ws-1".to_string(),
+                },
+            )
+            .await
+            .expect("refresh_session should parse MOI response");
+        assert_eq!(refresh.provider_session_handle, "provider-session-secret-2");
+        assert_eq!(refresh.provider_scope_id, "ws-1");
+
+        let logout = client
+            .logout(
+                &provider(endpoint),
+                ExternalProviderSessionHandle {
+                    provider_session_handle: "provider-session-secret-2".to_string(),
+                    provider_scope_id: "ws-1".to_string(),
+                },
+            )
+            .await
+            .expect("logout should parse MOI response");
+        assert!(logout.logged_out);
+
+        let bodies = captured.lock().await.clone();
+        assert_eq!(bodies[0]["action"], "authorize_request");
+        assert_eq!(bodies[0]["provider_id"], "moi");
+        assert_eq!(bodies[0]["token"], "Bearer provider-token");
+        assert_eq!(bodies[0]["request"]["method"], "POST");
+        assert_eq!(bodies[0]["request"]["path"], "/chat/stream");
+        assert_eq!(bodies[0]["request"]["route"], "/chat/stream");
+        assert_eq!(bodies[0]["request"]["request_id"], "trace-1");
+        assert!(bodies[0]["request"].get("summary").is_none());
+        assert!(bodies[0].get("has_agent_binding").is_none());
+        assert!(bodies[0].get("has_runtime_auth").is_none());
+        assert!(bodies[0].get("selected_model_gateway").is_none());
+        assert_eq!(bodies[1]["action"], "authenticate");
+        assert_eq!(bodies[1]["provider_id"], "moi");
+        assert_eq!(bodies[1]["username"], "admin");
+        assert_eq!(bodies[1]["password"], "secret");
+        assert!(bodies[1].get("provider_session_handle").is_none());
+        assert_eq!(bodies[2]["action"], "list_catalog");
+        assert_eq!(
+            bodies[2]["provider_session_handle"],
+            "provider-session-secret"
+        );
+        assert_eq!(bodies[2]["provider_scope_id"], "ws-1");
+        assert!(bodies[2].get("external_session_handle").is_none());
+        assert_eq!(bodies[3]["action"], "issue_runtime_context");
+        assert_eq!(bodies[3]["requested_model_id"], "model-qwen");
+        assert_eq!(bodies[3]["requested_tool_ids"], json!(["tool-search"]));
+        assert!(bodies[3].get("requested_model").is_none());
+        assert_eq!(bodies[4]["action"], "refresh_session");
+        assert_eq!(
+            bodies[4]["provider_session_handle"],
+            "provider-session-secret"
+        );
+        assert_eq!(bodies[4]["provider_scope_id"], "ws-1");
+        assert_eq!(bodies[5]["action"], "logout");
+        assert_eq!(
+            bodies[5]["provider_session_handle"],
+            "provider-session-secret-2"
+        );
+        assert_eq!(bodies[5]["provider_scope_id"], "ws-1");
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn http_provider_client_logout_failure_returns_error() {
+        async fn handler(Json(_body): Json<Value>) -> (StatusCode, Json<Value>) {
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({
+                    "code": 14,
+                    "message": "provider logout failed"
+                })),
+            )
+        }
+        let app = Router::new().route("/external-auth", post(handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let endpoint = format!("http://{}/external-auth", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve test provider");
+        });
+
+        let client = HttpExternalProviderClient::default();
+        let err = client
+            .logout(
+                &provider(endpoint),
+                ExternalProviderSessionHandle {
+                    provider_session_handle: "provider-session-secret".to_string(),
+                    provider_scope_id: "ws-1".to_string(),
+                },
+            )
+            .await
+            .expect_err("provider logout failure must be explicit");
+
+        assert_eq!(err.0, StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            err.1.error_code.as_deref(),
+            Some("external_provider_code_14")
+        );
+        server.abort();
+    }
+
+    #[test]
+    fn runtime_context_requires_model_gateway_descriptor() {
+        let context = ExternalRuntimeContextResponse {
+            selected_model: ExternalSelectedModelResponse {
+                id: "model-qwen".to_string(),
+                model: "qwen".to_string(),
+            },
+            runtime_auth: ExternalRuntimeAuthResponse {
+                auth_type: "moi_runtime_grant".to_string(),
+                authorization: "Bearer runtime-grant".to_string(),
+                expires_at: "2026-01-01T00:00:00Z".to_string(),
+            },
+            capability_descriptors: ExternalRuntimeCapabilityDescriptors::default(),
+            runtime_scope: ExternalRuntimeScopeResponse {
+                allowed_model_id: "model-qwen".to_string(),
+                allowed_tools: Vec::new(),
+                allowed_skills: Vec::new(),
+                allowed_knowledge_bases: Vec::new(),
+            },
+            runtime_system_prompt: None,
+            task_id: "task-1".to_string(),
+            manifest_id: "manifest-1".to_string(),
+            provider_scope_id: "ws-1".to_string(),
+        };
+
+        let err = validate_provider_runtime_context(
+            &provider("http://127.0.0.1/external-auth".to_string()),
+            "model-qwen",
+            &context,
+        )
+        .expect_err("model gateway descriptor is required");
+
+        assert_eq!(err.0, StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            err.1.error_code.as_deref(),
+            Some("external_provider_runtime_context_invalid")
+        );
+    }
+
+    #[test]
+    fn resolve_selected_scope_requires_visible_scope() {
+        let scope = ExternalProviderScope {
+            id: "ws-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+            name: "Workspace".to_string(),
+            account_name: None,
+            is_default: true,
+        };
+        let response = ExternalProviderAuthResponse {
+            external_subject: ExternalSubject {
+                id: "subject".to_string(),
+                provider: "moi".to_string(),
+                kind: "user".to_string(),
+            },
+            display_info: ExternalDisplayInfo {
+                username: "user".to_string(),
+                nickname: None,
+                email: None,
+            },
+            workspace_scopes: vec![scope.clone()],
+            selected_scope: scope.clone(),
+            default_scope: scope,
+            provider_session_handle: "handle".to_string(),
+            expires_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+
+        let err = resolve_selected_scope(Some("missing"), &response)
+            .expect_err("requested scope must be visible");
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+        assert_eq!(
+            err.1.error_code.as_deref(),
+            Some("external_scope_not_visible")
+        );
+    }
+
+    #[test]
+    fn runtime_context_accepts_complete_capability_descriptors() {
+        let value = json!({
+            "selected_model": {
+                "id": "model-qwen",
+                "model": "qwen2.5"
+            },
+            "runtime_auth": {
+                "type": "moi_runtime_grant",
+                "authorization": "Bearer runtime-grant",
+                "expires_at": "2026-01-01T00:00:00Z"
+            },
+            "capability_descriptors": {
+                "model_gateway": {
+                    "id": "moi-model-gateway",
+                    "type": "model_gateway",
+                    "transport": "http",
+                    "endpoint_url": "http://127.0.0.1/api/v1/models/openai/chat/completions",
+                    "protocol": "openai_responses",
+                    "metadata": {}
+                }
+            },
+            "runtime_scope": {
+                "allowed_model_id": "model-qwen",
+                "allowed_tools": [],
+                "allowed_skills": [],
+                "allowed_knowledge_bases": []
+            },
+            "task_id": "task-1",
+            "manifest_id": "manifest-1",
+            "provider_scope_id": "ws-1"
+        });
+
+        let context: ExternalRuntimeContextResponse =
+            serde_json::from_value(value).expect("MOI runtime context should parse");
+        let model_gateway = context
+            .capability_descriptors
+            .model_gateway
+            .expect("model gateway");
+        assert_eq!(model_gateway.protocol, "openai_responses");
+        assert_eq!(
+            model_gateway.endpoint_url,
+            "http://127.0.0.1/api/v1/models/openai/chat/completions"
+        );
+    }
+
+    fn authenticate_fixture() -> Value {
+        JsonFixture(json!({
+            "external_subject": {"id": "moi-user-1", "provider": "moi", "kind": "user"},
+            "display_info": {"username": "admin", "nickname": "Admin", "email": "admin@example.com"},
+            "workspace_scopes": [{
+                "id": "ws-1",
+                "workspace_id": "workspace-1",
+                "name": "Default Workspace",
+                "account_name": "default",
+                "is_default": true
+            }],
+            "selected_scope": {
+                "id": "ws-1",
+                "workspace_id": "workspace-1",
+                "name": "Default Workspace",
+                "account_name": "default",
+                "is_default": true
+            },
+            "default_scope": {
+                "id": "ws-1",
+                "workspace_id": "workspace-1",
+                "name": "Default Workspace",
+                "account_name": "default",
+                "is_default": true
+            },
+            "provider_session_handle": "provider-session-secret",
+            "expires_at": "2026-01-01T00:00:00Z"
+        }))
+        .success()
+    }
+
+    fn authorize_request_fixture() -> Value {
+        JsonFixture(json!({
+            "ok": true,
+            "external_subject": "moi-user-1",
+            "provider_scope_id": "ws-1",
+            "request_authorization_id": "authz-1"
+        }))
+        .success()
+    }
+
+    fn list_catalog_fixture() -> Value {
+        JsonFixture(json!({
+            "models": [{
+                "id": "model-qwen",
+                "name": "qwen",
+                "display_name": "Qwen 2.5",
+                "model_name": "qwen2.5",
+                "provider_ref": "moi",
+                "capabilities": ["chat"],
+                "parameters": {"temperature": true},
+                "limits": {"context_window": 32768, "max_completion_tokens": 4096},
+                "metadata": {"description": "MOI model", "architecture": "transformer"}
+            }],
+            "tools": [{
+                "id": "tool-search",
+                "name": "search",
+                "kind": "mcp",
+                "description": "Search",
+                "side_effect_class": "read",
+                "input_schema": {},
+                "output_schema": {},
+                "metadata": {}
+            }],
+            "skills": [],
+            "knowledge_bases": []
+        }))
+        .success()
+    }
+
+    fn issue_runtime_context_fixture() -> Value {
+        JsonFixture(json!({
+            "selected_model": {
+                "id": "model-qwen",
+                "model": "qwen2.5"
+            },
+            "runtime_auth": {
+                "type": "moi_runtime_grant",
+                "authorization": "Bearer runtime-grant",
+                "expires_at": "2026-01-01T00:00:00Z"
+            },
+            "capability_descriptors": {
+                "model_gateway": {
+                    "id": "moi-model-gateway",
+                    "type": "model_gateway",
+                    "transport": "http",
+                    "endpoint_url": "http://127.0.0.1/api/v1/models/openai/chat/completions",
+                    "protocol": "openai_responses",
+                    "metadata": {}
+                },
+                "mcp": {
+                    "id": "moi-tools",
+                    "type": "mcp",
+                    "transport": "streamable_http",
+                    "endpoint_url": "http://127.0.0.1/api/v1/mcp/http",
+                    "protocol": "mcp",
+                    "metadata": {}
+                }
+            },
+            "runtime_scope": {
+                "allowed_model_id": "model-qwen",
+                "allowed_tools": [{
+                    "id": "tool-search",
+                    "name": "search",
+                    "kind": "mcp",
+                    "description": "Search",
+                    "side_effect_class": "read",
+                    "input_schema": {},
+                    "output_schema": {},
+                    "metadata": {}
+                }],
+                "allowed_skills": [],
+                "allowed_knowledge_bases": []
+            },
+            "runtime_system_prompt": "Use MOI runtime grant.",
+            "task_id": "task-1",
+            "manifest_id": "manifest-1",
+            "provider_scope_id": "ws-1"
+        }))
+        .success()
+    }
+
+    fn refresh_session_fixture() -> Value {
+        JsonFixture(json!({
+            "provider_session_handle": "provider-session-secret-2",
+            "provider_scope_id": "ws-1",
+            "expires_at": "2026-01-01T01:00:00Z"
+        }))
+        .success()
+    }
+
+    fn logout_fixture() -> Value {
+        JsonFixture(json!({
+            "provider_session_handle": "provider-session-secret-2",
+            "logged_out": true
+        }))
+        .success()
+    }
+
+    struct JsonFixture(Value);
+
+    impl JsonFixture {
+        fn success(self) -> Value {
+            json!({"code": 0, "data": self.0})
+        }
+    }
+}

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -38,6 +38,7 @@ use uuid::Uuid;
 
 mod admin;
 mod encryption;
+pub mod external;
 mod jwt;
 pub mod provider_request;
 pub mod session;
@@ -55,6 +56,15 @@ pub use admin::{
 };
 pub use encryption::FernetTokenEncryptor;
 use encryption::sha256_hex;
+pub use external::{
+    ExternalAuthProviderConfig, ExternalAuthorizeRequestData, ExternalAuthorizedRequest,
+    ExternalCatalogResponse, ExternalLoginRequestData, ExternalProviderClient,
+    ExternalProviderPublicRecord, ExternalRequestDescriptor, ExternalRuntimeContextRequestData,
+    ExternalRuntimeContextResponse, ExternalSessionRecord, HttpExternalProviderClient,
+};
+use external::{
+    encrypt_provider_session_handle, resolve_selected_scope, validate_provider_runtime_context,
+};
 use jwt::{JwtTokenClaims, create_jwt_token, decode_jwt_claims, decode_jwt_claims_with_detail};
 pub use provider_request::{ProviderAuthorizedRequest, ProviderRequestDescriptor};
 pub use session::UnconfiguredSessionService;
@@ -316,6 +326,90 @@ pub trait AuthService: Send + Sync {
     ) -> Result<AuthPrincipal, (StatusCode, Json<ErrorResponse>)> {
         self.current_principal(headers).await
     }
+
+    /// Resolve the edge binding for the presented credential when it is an
+    /// edge-registration token.  Returns `Ok(Some((edge_agent_id, workspace_id)))`
+    /// on success, `Ok(None)` when the token carries no binding (internal tokens,
+    /// backends without external-provider edge support), and `Err` when the
+    /// credential is rejected (revoked or invalid).
+    ///
+    /// The `workspace_id` in the tuple is the owning workspace (`provider_scope_id`
+    /// from the external auth response).  Callers store it in the edge connection
+    /// pool for workspace-level authorization of cross-user lookups.
+    ///
+    /// The default returns `Ok(None)` so backends and test stubs that do not
+    /// support edge registration impose no binding.
+    async fn edge_registration_binding(
+        &self,
+        _token: &str,
+    ) -> Result<Option<(String, String)>, (StatusCode, Json<ErrorResponse>)> {
+        Ok(None)
+    }
+
+    async fn external_providers(
+        &self,
+    ) -> Result<Vec<ExternalProviderPublicRecord>, (StatusCode, Json<ErrorResponse>)> {
+        Err(error_response(
+            StatusCode::NOT_IMPLEMENTED,
+            "External auth providers are not configured",
+        ))
+    }
+
+    async fn external_login(
+        &self,
+        _request: ExternalLoginRequestData,
+    ) -> Result<AuthTokenRecord, (StatusCode, Json<ErrorResponse>)> {
+        Err(error_response(
+            StatusCode::NOT_IMPLEMENTED,
+            "External auth providers are not configured",
+        ))
+    }
+
+    async fn external_catalog(
+        &self,
+        _principal: &AuthPrincipal,
+    ) -> Result<ExternalCatalogResponse, (StatusCode, Json<ErrorResponse>)> {
+        Err(error_response(
+            StatusCode::NOT_IMPLEMENTED,
+            "External runtime catalog is not configured",
+        ))
+    }
+
+    async fn external_runtime_context(
+        &self,
+        _principal: &AuthPrincipal,
+        _request: ExternalRuntimeContextRequestData,
+    ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)> {
+        Err(error_response(
+            StatusCode::NOT_IMPLEMENTED,
+            "External runtime context is not configured",
+        ))
+    }
+
+    /// List catalog for an authorized-request principal (edge-JWT) using scope and subject
+    /// directly, without a session handle.
+    async fn external_catalog_by_scope(
+        &self,
+        _principal: &AuthPrincipal,
+    ) -> Result<ExternalCatalogResponse, (StatusCode, Json<ErrorResponse>)> {
+        Err(error_response(
+            StatusCode::NOT_IMPLEMENTED,
+            "External runtime catalog (by scope) is not configured",
+        ))
+    }
+
+    /// Issue runtime context for an authorized-request principal (edge-JWT) using scope and
+    /// subject directly, without a session handle.
+    async fn external_runtime_context_by_scope(
+        &self,
+        _principal: &AuthPrincipal,
+        _request: ExternalRuntimeContextRequestData,
+    ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)> {
+        Err(error_response(
+            StatusCode::NOT_IMPLEMENTED,
+            "External runtime context (by scope) is not configured",
+        ))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -367,6 +461,16 @@ impl AuthPrincipal {
             AuthPrincipalOrigin::ProviderAuthorizedRequest(_)
         )
     }
+
+    /// Returns true when the principal was authenticated via an edge-registration
+    /// token (i.e. a long-lived token bound to a specific edge_agent_id, issued
+    /// by moi-backend). False for runtime tokens (short-lived, server-to-server).
+    pub fn is_edge_registration(&self) -> bool {
+        matches!(
+            &self.origin,
+            AuthPrincipalOrigin::ProviderAuthorizedRequest(ctx) if ctx.edge_agent_id.is_some()
+        )
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -381,6 +485,10 @@ pub struct AuthProviderAuthorizedRequestContext {
     pub external_subject: String,
     pub provider_scope_id: String,
     pub request_authorization_id: String,
+    /// Present when the token is an edge-registration token; the bound edge
+    /// agent id verified by Phase 1.5 of edge WebSocket auth. `None` for
+    /// runtime tokens (matrixflow server-to-server calls).
+    pub edge_agent_id: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -397,6 +505,8 @@ pub struct DatabaseAuthService {
     pool: Option<SharedPool>,
     jwt: JwtSettings,
     encryptor: Option<FernetTokenEncryptor>,
+    ext_providers: Vec<ExternalAuthProviderConfig>,
+    external_client: std::sync::Arc<dyn ExternalProviderClient>,
     provider_request_auth: Vec<ProviderRequestAuthConfig>,
     provider_request_replay_cache: Arc<Mutex<HashMap<String, i64>>>,
 }
@@ -460,6 +570,8 @@ impl DatabaseAuthService {
             jwt,
             pool: None,
             encryptor: None,
+            ext_providers: Vec::new(),
+            external_client: HttpExternalProviderClient::shared(),
             provider_request_auth: Vec::new(),
             provider_request_replay_cache: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -628,6 +740,36 @@ impl DatabaseAuthService {
         self
     }
 
+    pub fn with_external_providers(mut self, providers: Vec<ExternalAuthProviderConfig>) -> Self {
+        self.ext_providers = providers;
+        self
+    }
+
+    #[allow(dead_code)]
+    fn encryptor(&self) -> Result<&FernetTokenEncryptor, (StatusCode, Json<ErrorResponse>)> {
+        self.encryptor.as_ref().ok_or_else(|| {
+            error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "External auth session encryption is not configured",
+            )
+        })
+    }
+
+    fn external_provider_config(
+        &self,
+        provider_id: &str,
+    ) -> Result<&ExternalAuthProviderConfig, (StatusCode, Json<ErrorResponse>)> {
+        self.ext_providers
+            .iter()
+            .find(|p| p.id == provider_id)
+            .ok_or_else(|| {
+                error_response(
+                    StatusCode::NOT_FOUND,
+                    format!("External provider '{provider_id}' not configured"),
+                )
+            })
+    }
+
     pub fn with_provider_request_auth(mut self, auth: Vec<ProviderRequestAuthConfig>) -> Self {
         self.provider_request_auth = auth;
         self
@@ -787,6 +929,255 @@ impl DatabaseAuthService {
             )),
         }
     }
+
+    #[allow(dead_code)]
+    fn parse_provider_expires_at(
+        &self,
+        raw: &str,
+    ) -> Result<String, (StatusCode, Json<ErrorResponse>)> {
+        chrono::DateTime::parse_from_rfc3339(raw)
+            .map(|dt| {
+                dt.with_timezone(&Utc)
+                    .format("%Y-%m-%d %H:%M:%S")
+                    .to_string()
+            })
+            .map_err(|error| {
+                error_response_coded(
+                    StatusCode::BAD_GATEWAY,
+                    format!("external provider session expiry is invalid: {error}"),
+                    "external_provider_response_invalid",
+                )
+            })
+    }
+
+    #[allow(dead_code)]
+    async fn complete_external_auth(
+        &self,
+        provider: &ExternalAuthProviderConfig,
+        requested_scope_id: Option<&str>,
+        response: external::ExternalProviderAuthResponse,
+    ) -> Result<AuthTokenRecord, (StatusCode, Json<ErrorResponse>)> {
+        let selected_scope = resolve_selected_scope(requested_scope_id, &response)?;
+        let encrypted_handle =
+            encrypt_provider_session_handle(self.encryptor()?, &response.provider_session_handle)?;
+        let external_subject = response.external_subject.id.clone();
+        let external_username = response.display_info.username.clone();
+        let external_email = response.display_info.email.clone();
+        let external_display_name = response.display_info.nickname.clone();
+        let pool = self
+            .get_pool()
+            .await
+            .map_err(|e| map_auth_sqlx(e, "auth.get_pool", None))?;
+        let now = Utc::now();
+        let external_expires_at = self.parse_provider_expires_at(&response.expires_at)?;
+        let astra_session_id = Uuid::new_v4().to_string();
+        let astra_user_id = Uuid::new_v4().to_string();
+        let internal_username = format!("ext_{}", astra_user_id.replace('-', ""));
+        let internal_email = format!("{internal_username}@external.astra.invalid");
+
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|e| map_auth_sqlx(e, "external.begin_tx", Some(&pool)))?;
+        let existing_identity = query(
+            "SELECT astra_user_id FROM auth_external_identities \
+             WHERE provider_id = ? AND external_subject = ? LIMIT 1",
+        )
+        .bind(&provider.id)
+        .bind(&external_subject)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| map_auth_sqlx(e, "external.fetch_identity", Some(&pool)))?;
+
+        let astra_user_id = if let Some(row) = existing_identity {
+            let existing_user_id: String = row.try_get("astra_user_id").unwrap_or_default();
+            query(
+                "UPDATE auth_external_identities \
+                 SET username = ?, email = ?, display_name = ?, updated_at = NOW() \
+                 WHERE provider_id = ? AND external_subject = ?",
+            )
+            .bind(&external_username)
+            .bind(&external_email)
+            .bind(&external_display_name)
+            .bind(&provider.id)
+            .bind(&external_subject)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| map_auth_sqlx(e, "external.update_identity", Some(&pool)))?;
+            existing_user_id
+        } else {
+            query(
+                "INSERT INTO auth_users \
+                 (user_id, username, email, password_hash, display_name, is_active) \
+                 VALUES (?, ?, ?, '', ?, 1)",
+            )
+            .bind(&astra_user_id)
+            .bind(&internal_username)
+            .bind(&internal_email)
+            .bind(&external_display_name)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| map_auth_sqlx(e, "external.insert_auth_user", Some(&pool)))?;
+            query(
+                "INSERT INTO auth_external_identities \
+                 (provider_id, external_subject, astra_user_id, username, email, display_name) \
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&provider.id)
+            .bind(&external_subject)
+            .bind(&astra_user_id)
+            .bind(&external_username)
+            .bind(&external_email)
+            .bind(&external_display_name)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| map_auth_sqlx(e, "external.insert_identity", Some(&pool)))?;
+            astra_user_id
+        };
+
+        query(
+            "INSERT INTO auth_external_sessions \
+             (external_session_id, provider_id, astra_user_id, external_subject, \
+              provider_scope_id, provider_scope_display_name, encrypted_provider_session_handle, \
+              status, expires_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?)",
+        )
+        .bind(&astra_session_id)
+        .bind(&provider.id)
+        .bind(&astra_user_id)
+        .bind(&external_subject)
+        .bind(&selected_scope.id)
+        .bind(&selected_scope.name)
+        .bind(&encrypted_handle)
+        .bind(&external_expires_at)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| map_auth_sqlx(e, "external.insert_session", Some(&pool)))?;
+
+        let access_token = self
+            .create_access_token(
+                &astra_user_id,
+                &external_username,
+                &astra_session_id,
+                "external",
+            )
+            .map_err(internal_error)?;
+        let refresh_token = self
+            .create_refresh_token(&astra_user_id, &astra_session_id, "external")
+            .map_err(internal_error)?;
+        let refresh_token_hash = sha256_hex(&refresh_token);
+        let refresh_expires_at = self.refresh_token_expires_at_string(now);
+
+        query(
+            "INSERT INTO auth_refresh_tokens \
+             (token_id, user_id, session_id, token_hash, expires_at, is_revoked) \
+             VALUES (?, ?, ?, ?, ?, 0)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(&astra_user_id)
+        .bind(&astra_session_id)
+        .bind(&refresh_token_hash)
+        .bind(refresh_expires_at)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| map_auth_sqlx(e, "external.insert_refresh_token", Some(&pool)))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| map_auth_sqlx(e, "external.commit_tx", Some(&pool)))?;
+
+        Ok(AuthTokenRecord {
+            access_token,
+            refresh_token,
+            token_type: "bearer".to_string(),
+            expires_in: self.access_token_expires_in_seconds(),
+        })
+    }
+
+    /// Resolve an [`AuthPrincipal`] from a moi-backend edge-registration token
+    /// (`moi-user-token-v1.*`) via the external auth provider.  Called from
+    /// [`current_principal`] when the Bearer token is not an astra session JWT.
+    async fn principal_from_edge_token(
+        &self,
+        token: &str,
+    ) -> Result<AuthPrincipal, (StatusCode, Json<ErrorResponse>)> {
+        let provider = self
+            .ext_providers
+            .iter()
+            .find(|p| p.id == "moi")
+            .or_else(|| self.ext_providers.first())
+            .ok_or_else(|| {
+                error_response(
+                    StatusCode::UNAUTHORIZED,
+                    "No external provider configured for edge token auth",
+                )
+            })?
+            .clone();
+        let authorized = self
+            .external_client
+            .authorize_request(
+                &provider,
+                ExternalAuthorizeRequestData {
+                    provider_id: provider.id.clone(),
+                    token: format!("Bearer {token}"),
+                    request: ExternalRequestDescriptor {
+                        method: "GET".to_string(),
+                        path: "/api".to_string(),
+                        route: Some("/api".to_string()),
+                        request_id: None,
+                        body_digest: None,
+                    },
+                },
+            )
+            .await?;
+        tracing::debug!(
+            target: "astra_services::auth",
+            provider_id = %authorized.provider_id,
+            external_subject = %authorized.external_subject,
+            "principal_from_edge_token: edge token authorized for HTTP API"
+        );
+        let user_id = format!(
+            "external_authorized:{}:{}",
+            authorized.provider_id, authorized.external_subject
+        );
+        Ok(AuthPrincipal {
+            user: AuthUserRecord {
+                user_id,
+                username: authorized.external_subject.clone(),
+                email: String::new(),
+                display_name: None,
+            },
+            session_id: None,
+            origin: AuthPrincipalOrigin::ProviderAuthorizedRequest(
+                AuthProviderAuthorizedRequestContext {
+                    provider_id: authorized.provider_id,
+                    external_subject: authorized.external_subject,
+                    provider_scope_id: authorized.provider_scope_id,
+                    request_authorization_id: authorized.request_authorization_id,
+                    edge_agent_id: authorized.edge_agent_id,
+                },
+            ),
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+struct ExternalSessionDbRecord {
+    session: ExternalSessionRecord,
+    provider_expires_at: String,
+    encrypted_provider_session_handle: String,
+    external_username: String,
+    external_email: Option<String>,
+    external_display_name: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+struct ExternalSessionRefreshUpdate {
+    encrypted_provider_session_handle: String,
+    provider_scope_id: String,
+    expires_at: String,
 }
 
 fn header_exact(
@@ -1198,6 +1589,14 @@ impl AuthService for DatabaseAuthService {
         headers: &HeaderMap,
     ) -> Result<AuthPrincipal, (StatusCode, Json<ErrorResponse>)> {
         let token = bearer_token(headers)?;
+        // Edge-registration tokens (moi-user-token-v1.*) are issued by
+        // moi-backend and cannot be decoded with the astra JWT secret.
+        // Verify them via the external auth provider instead so that astra CLI
+        // running inside a sandbox can access HTTP APIs with the same token
+        // it uses for the WebSocket /chat/stream connection.
+        if token.starts_with("moi-user-token-v1") {
+            return self.principal_from_edge_token(token).await;
+        }
         let claims = decode_jwt_claims(token, &self.jwt)?;
 
         if claims.token_type.as_deref() != Some("access") {
@@ -1298,9 +1697,147 @@ impl AuthService for DatabaseAuthService {
                     external_subject: authorized.external_subject,
                     provider_scope_id: authorized.provider_scope_id,
                     request_authorization_id: authorized.request_authorization_id,
+                    // Provider-request (HMAC server-to-server) calls carry no edge binding.
+                    edge_agent_id: None,
                 },
             ),
         })
+    }
+
+    async fn edge_registration_binding(
+        &self,
+        token: &str,
+    ) -> Result<Option<(String, String)>, (StatusCode, Json<ErrorResponse>)> {
+        // Only moi-issued tokens carry an edge_agent_id binding. Anything else
+        // (e.g. an Astra JWT used by a managed sandbox) imposes no binding and
+        // keeps its existing identity resolution untouched.
+        const MOI_USER_TOKEN_PREFIX: &str = "moi-user-token-v1";
+        if !token.starts_with(MOI_USER_TOKEN_PREFIX) {
+            return Ok(None);
+        }
+        // Resolve the MOI external provider. Without one configured we cannot
+        // verify the binding via authorize_request; impose none rather than
+        // failing closed (matches deployments where external auth is disabled).
+        let provider = match self
+            .ext_providers
+            .iter()
+            .find(|p| p.id == "moi")
+            .or_else(|| self.ext_providers.first())
+        {
+            Some(provider) => provider.clone(),
+            None => {
+                tracing::warn!(
+                    target: "astra_services::auth",
+                    "edge_registration_binding: no external provider configured; cannot verify edge binding"
+                );
+                return Ok(None);
+            }
+        };
+        // authorize_request verifies the token (signature, expiry, jti
+        // revocation) and returns the bound edge_agent_id and provider_scope_id
+        // (workspace_id). A revoked or invalid edge token yields an Err here,
+        // which the caller treats as a denial.
+        tracing::debug!(
+            target: "astra_services::auth",
+            provider_id = %provider.id,
+            "edge_registration_binding: verifying moi edge token via provider authorize_request"
+        );
+        let authorized = match self
+            .external_client
+            .authorize_request(
+                &provider,
+                ExternalAuthorizeRequestData {
+                    provider_id: provider.id.clone(),
+                    token: format!("Bearer {token}"),
+                    request: ExternalRequestDescriptor {
+                        method: "GET".to_string(),
+                        path: "/edge/ws".to_string(),
+                        route: Some("/edge/ws".to_string()),
+                        request_id: None,
+                        body_digest: None,
+                    },
+                },
+            )
+            .await
+        {
+            Ok(authorized) => authorized,
+            Err((status, err)) => {
+                tracing::warn!(
+                    target: "astra_services::auth",
+                    provider_id = %provider.id,
+                    status = %status,
+                    error = ?err,
+                    "edge_registration_binding: provider rejected edge token (revoked/invalid/expired)"
+                );
+                return Err((status, err));
+            }
+        };
+        tracing::debug!(
+            target: "astra_services::auth",
+            provider_id = %provider.id,
+            edge_agent_id = ?authorized.edge_agent_id,
+            workspace_id = %authorized.provider_scope_id,
+            "edge_registration_binding: provider accepted edge token"
+        );
+        Ok(authorized
+            .edge_agent_id
+            .map(|eid| (eid, authorized.provider_scope_id)))
+    }
+
+    async fn external_providers(
+        &self,
+    ) -> Result<Vec<ExternalProviderPublicRecord>, (StatusCode, Json<ErrorResponse>)> {
+        Ok(self
+            .ext_providers
+            .iter()
+            .map(ExternalProviderPublicRecord::from)
+            .collect())
+    }
+
+    async fn external_catalog_by_scope(
+        &self,
+        principal: &AuthPrincipal,
+    ) -> Result<ExternalCatalogResponse, (StatusCode, Json<ErrorResponse>)> {
+        let AuthPrincipalOrigin::ProviderAuthorizedRequest(context) = &principal.origin else {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "ExternalAuthorizedRequest principal is required for catalog by scope",
+            ));
+        };
+        let provider = self.external_provider_config(&context.provider_id)?.clone();
+        self.external_client
+            .list_catalog_by_scope(
+                &provider,
+                context.provider_scope_id.clone(),
+                context.external_subject.clone(),
+            )
+            .await
+    }
+
+    async fn external_runtime_context_by_scope(
+        &self,
+        principal: &AuthPrincipal,
+        request: ExternalRuntimeContextRequestData,
+    ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)> {
+        let AuthPrincipalOrigin::ProviderAuthorizedRequest(context) = &principal.origin else {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "ExternalAuthorizedRequest principal is required for runtime context by scope",
+            ));
+        };
+        let provider = self.external_provider_config(&context.provider_id)?.clone();
+        let requested_model_id = request.requested_model_id.clone();
+        let runtime_context = self
+            .external_client
+            .issue_runtime_context_by_scope(
+                &provider,
+                context.provider_scope_id.clone(),
+                context.external_subject.clone(),
+                request,
+            )
+            .await?;
+        validate_provider_runtime_context(&provider, &requested_model_id, &runtime_context)?;
+        Ok(runtime_context)
     }
 }
 
@@ -1410,7 +1947,11 @@ impl AuthService for StubAuthService {
 
 #[cfg(test)]
 mod tests {
+    use super::external::{
+        ExternalLogoutResponse, ExternalProviderAuthResponse, ExternalRefreshSessionResponse,
+    };
     use super::*;
+    use crate::auth::external::ExternalProviderSessionHandle;
     use astra_core::ProviderRequestAuthConfig;
     use chrono::Utc;
     use serde_json::json;
@@ -1418,6 +1959,99 @@ mod tests {
     const TEST_PROVIDER_HMAC_KEY: &str = "test-provider-hmac-key";
     const GOLDEN_PROVIDER_HMAC_KEY: &str = "WrE2irtwGEq1Ih2stZUtgFfLFNv2gVhOAwsBD999QLI";
     const GOLDEN_PROVIDER_TOKEN: &str = "moi-provider-v1.eyJzdWIiOiJ1c2VyXzEiLCJzY29wZSI6IndvcmtzcGFjZV8xIiwicHJvdmlkZXIiOiJtb2kiLCJpYXQiOjQxMDI0NDQ1MDAsImV4cCI6NDEwMjQ0NDgwMH0.wZS9mRKasIEmreqhzGheguYYPbq1URTYkJoSK3nfW3M";
+
+    #[allow(dead_code)]
+    struct AuthorizingProviderClient;
+
+    #[async_trait]
+    impl ExternalProviderClient for AuthorizingProviderClient {
+        async fn authorize_request(
+            &self,
+            provider: &ExternalAuthProviderConfig,
+            request: ExternalAuthorizeRequestData,
+        ) -> Result<ExternalAuthorizedRequest, (StatusCode, Json<ErrorResponse>)> {
+            assert_eq!(provider.id, "moi");
+            assert_eq!(request.token, "Bearer provider-token");
+            assert_eq!(request.request.method, "POST");
+            assert_eq!(request.request.path, "/chat/stream");
+            assert!(request.request.body_digest.is_none());
+            Ok(ExternalAuthorizedRequest {
+                provider_id: "moi".to_string(),
+                external_subject: "moi-user-1".to_string(),
+                provider_scope_id: "workspace-1".to_string(),
+                request_authorization_id: "authz-1".to_string(),
+                edge_agent_id: None,
+            })
+        }
+
+        async fn authenticate(
+            &self,
+            _provider: &ExternalAuthProviderConfig,
+            _request: ExternalLoginRequestData,
+        ) -> Result<ExternalProviderAuthResponse, (StatusCode, Json<ErrorResponse>)> {
+            unimplemented!("AuthorizingProviderClient stub: authenticate not used in these tests")
+        }
+
+        async fn list_catalog(
+            &self,
+            _provider: &ExternalAuthProviderConfig,
+            _session: ExternalProviderSessionHandle,
+        ) -> Result<ExternalCatalogResponse, (StatusCode, Json<ErrorResponse>)> {
+            unimplemented!("AuthorizingProviderClient stub: list_catalog not used in these tests")
+        }
+
+        async fn issue_runtime_context(
+            &self,
+            _provider: &ExternalAuthProviderConfig,
+            _session: ExternalProviderSessionHandle,
+            _request: ExternalRuntimeContextRequestData,
+        ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)> {
+            unimplemented!(
+                "AuthorizingProviderClient stub: issue_runtime_context not used in these tests"
+            )
+        }
+
+        async fn refresh_session(
+            &self,
+            _provider: &ExternalAuthProviderConfig,
+            _session: ExternalProviderSessionHandle,
+        ) -> Result<ExternalRefreshSessionResponse, (StatusCode, Json<ErrorResponse>)> {
+            unimplemented!(
+                "AuthorizingProviderClient stub: refresh_session not used in these tests"
+            )
+        }
+
+        async fn logout(
+            &self,
+            _provider: &ExternalAuthProviderConfig,
+            _session: ExternalProviderSessionHandle,
+        ) -> Result<ExternalLogoutResponse, (StatusCode, Json<ErrorResponse>)> {
+            unimplemented!("AuthorizingProviderClient stub: logout not used in these tests")
+        }
+
+        async fn list_catalog_by_scope(
+            &self,
+            _provider: &ExternalAuthProviderConfig,
+            _provider_scope_id: String,
+            _external_subject: String,
+        ) -> Result<ExternalCatalogResponse, (StatusCode, Json<ErrorResponse>)> {
+            unimplemented!(
+                "AuthorizingProviderClient stub: list_catalog_by_scope not used in these tests"
+            )
+        }
+
+        async fn issue_runtime_context_by_scope(
+            &self,
+            _provider: &ExternalAuthProviderConfig,
+            _provider_scope_id: String,
+            _external_subject: String,
+            _request: ExternalRuntimeContextRequestData,
+        ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)> {
+            unimplemented!(
+                "AuthorizingProviderClient stub: issue_runtime_context_by_scope not used in these tests"
+            )
+        }
+    }
 
     fn hmac_provider_token(
         subject: &str,

--- a/crates/services/src/lib.rs
+++ b/crates/services/src/lib.rs
@@ -139,13 +139,17 @@ pub use astra_core::composite_snapshot::{
     SnapshotSpec,
 };
 pub use auth::{
-    AuthLoginRequestData, AuthPrincipal, AuthPrincipalOrigin, AuthRefreshRequestData,
-    AuthRegisterRequestData, AuthService, AuthTokenRecord, AuthUserRecord,
+    AuthLoginRequestData, AuthPrincipal, AuthPrincipalOrigin, AuthProviderAuthorizedRequestContext,
+    AuthRefreshRequestData, AuthRegisterRequestData, AuthService, AuthTokenRecord, AuthUserRecord,
     DatabaseAdminAuditReader, DatabaseAdminAuthorizer, DatabaseAdminFeedbackStatsReader,
     DatabaseAdminInitializer, DatabaseAdminTokenReader, DatabaseAdminTokenWriter,
     DatabaseAdminUserRoleManager, DatabaseAuthService, DatabaseSessionService,
-    FernetTokenEncryptor, ProviderRequestDescriptor, SessionCreateRequestData, SessionListFilter,
-    SessionListRecord, SessionRecord, SessionService, SessionUpdateRequestData,
+    ExternalAuthProviderConfig, ExternalAuthorizeRequestData, ExternalAuthorizedRequest,
+    ExternalCatalogResponse, ExternalLoginRequestData, ExternalProviderClient,
+    ExternalProviderPublicRecord, ExternalRequestDescriptor, ExternalRuntimeContextRequestData,
+    ExternalRuntimeContextResponse, ExternalSessionRecord, FernetTokenEncryptor,
+    HttpExternalProviderClient, ProviderRequestDescriptor, SessionCreateRequestData,
+    SessionListFilter, SessionListRecord, SessionRecord, SessionService, SessionUpdateRequestData,
 };
 pub use branches::{BranchService, DatabaseBranchService, UnconfiguredBranchService};
 pub use context::{
@@ -244,7 +248,7 @@ pub use models::{
 pub use multi_agent::{
     DatabaseEdgeDispatchService, DatabaseEdgeRegistryService, DatabaseTaskLeaseService,
     EdgeAgentRecord, EdgeDispatchIdentity, EdgeDispatchRow, EdgeDispatchService,
-    EdgeRegistryService, LeaseClaimResult, LeaseRenewalConfig, LeaseRenewalTask,
+    EdgeRegistryService, HeartbeatError, LeaseClaimResult, LeaseRenewalConfig, LeaseRenewalTask,
     NextClaimableLeaseClaimResult, TaskLeaseHoldCache, TaskLeaseService, TaskLeaseView,
     TasksPackPushResult, UnconfiguredEdgeDispatchService, UnconfiguredEdgeRegistryService,
     UnconfiguredTaskLeaseService,

--- a/crates/services/src/multi_agent/edge_dispatch.rs
+++ b/crates/services/src/multi_agent/edge_dispatch.rs
@@ -381,6 +381,27 @@ impl EdgeDispatchService for DatabaseEdgeDispatchService {
         user_id: &str,
         edge_agent_id: &str,
     ) -> Result<Vec<EdgeDispatchRow>, String> {
+        // Fast path: non-locking COUNT before opening any transaction.
+        // MatrixOne can acquire a table-level lock on SELECT FOR UPDATE even
+        // when the result set is empty, adding significant latency (seconds)
+        // per 2-second poll cycle when there is nothing to claim. Skipping
+        // the transaction when the count is zero avoids that entirely. The
+        // tiny TOCTOU window (a new row arriving between COUNT and FOR UPDATE)
+        // is benign: we will pick it up in the next poll interval.
+        let fast_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM edge_pending_dispatch \
+             WHERE user_id = ? AND edge_agent_id = ? AND status = 'pending'",
+        )
+        .bind(user_id)
+        .bind(edge_agent_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| format!("edge_dispatch poll COUNT: {e}"))?;
+
+        if fast_count == 0 {
+            return Ok(vec![]);
+        }
+
         // Atomically claim pending dispatches using SELECT FOR UPDATE
         // within a transaction. This eliminates the race window between
         // poll and mark — two pods polling simultaneously cannot both

--- a/crates/services/src/multi_agent/edge_registry.rs
+++ b/crates/services/src/multi_agent/edge_registry.rs
@@ -19,12 +19,42 @@ pub struct EdgeAgentRecord {
     pub hostname: Option<String>,
     pub worktree_path: Option<String>,
     pub capabilities: Option<serde_json::Value>,
+    /// Owning workspace (provider_scope_id from edge-registration token binding).
+    /// None for legacy rows written before this field was added.
+    pub workspace_id: Option<String>,
     pub registered_at: String,
     pub last_heartbeat_at: String,
 }
 
+/// Structured error for `EdgeRegistryService::heartbeat`.
+///
+/// Callers must treat these two variants differently:
+/// - `Superseded`: this connection's `edge_id` no longer owns the DB row — a
+///   newer connection has taken over. Close the WebSocket immediately.
+/// - `StorageFailure`: transient DB problem (network blip, pool exhaustion).
+///   Log and allow a limited number of retries before closing.
+#[derive(Debug)]
+pub enum HeartbeatError {
+    /// A newer connection has replaced this one in the registry.
+    Superseded,
+    /// Transient storage failure; the connection may still be valid.
+    StorageFailure(String),
+}
+
+impl std::fmt::Display for HeartbeatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HeartbeatError::Superseded => {
+                write!(f, "edge connection superseded by newer registration")
+            }
+            HeartbeatError::StorageFailure(e) => write!(f, "edge heartbeat storage failure: {e}"),
+        }
+    }
+}
+
 #[async_trait]
 pub trait EdgeRegistryService: Send + Sync {
+    #[allow(clippy::too_many_arguments)]
     async fn register_or_update(
         &self,
         user_id: &str,
@@ -33,6 +63,7 @@ pub trait EdgeRegistryService: Send + Sync {
         hostname: Option<&str>,
         worktree_path: Option<&str>,
         capabilities: Option<serde_json::Value>,
+        workspace_id: Option<&str>,
     ) -> Result<EdgeAgentRecord, String>;
 
     async fn heartbeat(
@@ -40,13 +71,38 @@ pub trait EdgeRegistryService: Send + Sync {
         user_id: &str,
         edge_agent_id: &str,
         edge_id_header: &str,
-    ) -> Result<(), String>;
+    ) -> Result<(), HeartbeatError>;
+
+    /// Find the most-recently-active registry record for a given edge_agent_id,
+    /// scoped to a workspace when `workspace_id` is `Some`.  Used by the
+    /// cross-pod dispatch path to locate a sandbox edge registered under a
+    /// service-account user.
+    ///
+    /// Workspace isolation is fail-closed:
+    /// - `Some(ws)` only matches rows with the same `workspace_id = ws`.
+    /// - `None` only matches legacy/unscoped rows where `workspace_id IS NULL`.
+    ///
+    /// A request without workspace context cannot resolve a workspace-bound
+    /// sandbox edge; pass `Some` whenever workspace context is available.
+    async fn find_by_agent_id_and_workspace(
+        &self,
+        edge_agent_id: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<Option<EdgeAgentRecord>, String>;
 
     /// List all registered edge agents for a user (for cross-pod dispatch routing).
     async fn list_by_user(&self, user_id: &str) -> Result<Vec<EdgeAgentRecord>, String>;
 
     /// Remove an edge agent from the registry (on disconnect).
-    async fn unregister(&self, user_id: &str, edge_agent_id: &str) -> Result<(), String>;
+    /// Only removes the row if `edge_id` matches the registered connection's
+    /// edge_id, so a stale cleanup on pod A cannot delete a fresh registration
+    /// that pod B created during a cross-pod reconnect.
+    async fn unregister(
+        &self,
+        user_id: &str,
+        edge_agent_id: &str,
+        edge_id: &str,
+    ) -> Result<(), String>;
 }
 
 pub struct DatabaseEdgeRegistryService {
@@ -110,6 +166,9 @@ fn decode_edge_agent_record(row: &impl EdgeRegistryDbRow) -> Result<EdgeAgentRec
             .optional_string_column("worktree_path")
             .map_err(|e| edge_registry_decode_error("list_by_user row", "worktree_path", e))?,
         capabilities,
+        workspace_id: row
+            .optional_string_column("workspace_id")
+            .map_err(|e| edge_registry_decode_error("list_by_user row", "workspace_id", e))?,
         registered_at: row
             .string_column("registered_at")
             .map_err(|e| edge_registry_decode_error("list_by_user row", "registered_at", e))?,
@@ -130,6 +189,7 @@ impl EdgeRegistryService for DatabaseEdgeRegistryService {
         hostname: Option<&str>,
         worktree_path: Option<&str>,
         capabilities: Option<serde_json::Value>,
+        workspace_id: Option<&str>,
     ) -> Result<EdgeAgentRecord, String> {
         let capabilities_for_record = capabilities.clone();
         let cap_json = capabilities
@@ -174,13 +234,16 @@ impl EdgeRegistryService for DatabaseEdgeRegistryService {
                 let n = sqlx::query(
                     "UPDATE edge_agent_registry \
                      SET edge_id = ?, hostname = ?, worktree_path = ?, \
-                         capabilities_json = ?, last_heartbeat_at = NOW(6) \
+                         capabilities_json = ?, \
+                         workspace_id = COALESCE(?, workspace_id), \
+                         last_heartbeat_at = NOW(6) \
                      WHERE user_id = ? AND registry_id = ?",
                 )
                 .bind(edge_id_header)
                 .bind(hostname)
                 .bind(worktree_path)
                 .bind(&cap_json)
+                .bind(workspace_id)
                 .bind(user_id)
                 .bind(&reg_id)
                 .execute(&self.pool)
@@ -201,6 +264,7 @@ impl EdgeRegistryService for DatabaseEdgeRegistryService {
                     hostname: hostname.map(|s| s.to_string()),
                     worktree_path: worktree_path.map(|s| s.to_string()),
                     capabilities: capabilities_for_record.clone(),
+                    workspace_id: workspace_id.map(|s| s.to_string()),
                     registered_at,
                     last_heartbeat_at: now,
                 });
@@ -211,8 +275,8 @@ impl EdgeRegistryService for DatabaseEdgeRegistryService {
             match sqlx::query(
                 "INSERT INTO edge_agent_registry \
                  (registry_id, user_id, edge_agent_id, edge_id, hostname, worktree_path, \
-                  capabilities_json, registered_at, last_heartbeat_at) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?, NOW(6), NOW(6))",
+                  capabilities_json, workspace_id, registered_at, last_heartbeat_at) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW(6), NOW(6))",
             )
             .bind(&registry_id)
             .bind(user_id)
@@ -221,6 +285,7 @@ impl EdgeRegistryService for DatabaseEdgeRegistryService {
             .bind(hostname)
             .bind(worktree_path)
             .bind(&cap_json)
+            .bind(workspace_id)
             .execute(&self.pool)
             .await
             {
@@ -245,6 +310,7 @@ impl EdgeRegistryService for DatabaseEdgeRegistryService {
                         hostname: hostname.map(|s| s.to_string()),
                         worktree_path: worktree_path.map(|s| s.to_string()),
                         capabilities: capabilities_for_record.clone(),
+                        workspace_id: workspace_id.map(|s| s.to_string()),
                         registered_at,
                         last_heartbeat_at,
                     });
@@ -268,40 +334,97 @@ impl EdgeRegistryService for DatabaseEdgeRegistryService {
         user_id: &str,
         edge_agent_id: &str,
         edge_id_header: &str,
-    ) -> Result<(), String> {
+    ) -> Result<(), HeartbeatError> {
+        // Guard on edge_id so a stale connection cannot refresh (or resurrect)
+        // the row after a newer connection has replaced it. register_or_update
+        // already set edge_id to the current connection's value, so we only
+        // touch last_heartbeat_at and never rewrite edge_id here. If a newer
+        // connection has taken over (edge_id differs), this matches 0 rows and
+        // the stale connection's heartbeat correctly returns Superseded.
         let n = sqlx::query(
-            "UPDATE edge_agent_registry SET edge_id = ?, last_heartbeat_at = NOW(6) \
-             WHERE user_id = ? AND edge_agent_id = ?",
+            "UPDATE edge_agent_registry SET last_heartbeat_at = NOW(6) \
+             WHERE user_id = ? AND edge_agent_id = ? AND edge_id = ?",
         )
-        .bind(edge_id_header)
         .bind(user_id)
         .bind(edge_agent_id)
+        .bind(edge_id_header)
         .execute(&self.pool)
         .await
-        .map_err(|e| format!("edge heartbeat: {e}"))?
+        .map_err(|e| HeartbeatError::StorageFailure(format!("edge heartbeat: {e}")))?
         .rows_affected();
         if n == 0 {
-            tracing::warn!("edge_registry: heartbeat for unregistered agent");
-            return Err("edge agent not registered".to_string());
+            // The row is gone or belongs to a newer connection — this connection
+            // has been superseded and must not keep the DB entry alive.
+            tracing::warn!(
+                edge_id = %edge_id_header,
+                "edge_registry: heartbeat matched no row (unregistered or superseded by newer connection)"
+            );
+            return Err(HeartbeatError::Superseded);
         }
         Ok(())
     }
-    #[tracing::instrument(skip(self), fields(user_id = %user_id, edge_agent_id = %edge_agent_id))]
-    async fn unregister(&self, user_id: &str, edge_agent_id: &str) -> Result<(), String> {
-        sqlx::query("DELETE FROM edge_agent_registry WHERE user_id = ? AND edge_agent_id = ?")
-            .bind(user_id)
-            .bind(edge_agent_id)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| format!("edge_registry unregister: {e}"))?;
+    #[tracing::instrument(skip(self), fields(user_id = %user_id, edge_agent_id = %edge_agent_id, edge_id = %edge_id))]
+    async fn unregister(
+        &self,
+        user_id: &str,
+        edge_agent_id: &str,
+        edge_id: &str,
+    ) -> Result<(), String> {
+        // Guard on edge_id to prevent a stale pod A cleanup from deleting a
+        // fresh row created by pod B during a cross-pod reconnect.
+        sqlx::query(
+            "DELETE FROM edge_agent_registry \
+             WHERE user_id = ? AND edge_agent_id = ? AND edge_id = ?",
+        )
+        .bind(user_id)
+        .bind(edge_agent_id)
+        .bind(edge_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| format!("edge_registry unregister: {e}"))?;
         Ok(())
+    }
+
+    #[tracing::instrument(skip(self), fields(edge_agent_id = %edge_agent_id))]
+    async fn find_by_agent_id_and_workspace(
+        &self,
+        edge_agent_id: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<Option<EdgeAgentRecord>, String> {
+        // Fail-closed workspace isolation:
+        //   request has workspace_id  → edge.workspace_id must match exactly
+        //   request has no workspace_id → only reach edges that are also unscoped (workspace_id IS NULL)
+        // This prevents a request without workspace context from resolving a
+        // workspace-bound sandbox edge (e.g. when workspace_record is None on
+        // the MOI provider-authorized path).
+        let row = sqlx::query(
+            "SELECT registry_id, user_id, edge_agent_id, edge_id, hostname, worktree_path, \
+             capabilities_json, workspace_id, \
+             CAST(registered_at AS CHAR) AS registered_at, \
+             CAST(last_heartbeat_at AS CHAR) AS last_heartbeat_at \
+             FROM edge_agent_registry \
+             WHERE edge_agent_id = ? \
+               AND ((? IS NOT NULL AND workspace_id = ?) OR (? IS NULL AND workspace_id IS NULL)) \
+             ORDER BY last_heartbeat_at DESC LIMIT 1",
+        )
+        .bind(edge_agent_id)
+        .bind(workspace_id)
+        .bind(workspace_id)
+        .bind(workspace_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| format!("edge_registry find_by_agent_id_and_workspace: {e}"))?;
+
+        row.as_ref().map(decode_edge_agent_record).transpose()
     }
 
     #[tracing::instrument(skip(self), fields(user_id = %user_id))]
     async fn list_by_user(&self, user_id: &str) -> Result<Vec<EdgeAgentRecord>, String> {
         let rows = sqlx::query(
-            "SELECT registry_id, user_id, edge_agent_id, edge_id, hostname, worktree_path, capabilities_json, \
-             CAST(registered_at AS CHAR) AS registered_at, CAST(last_heartbeat_at AS CHAR) AS last_heartbeat_at \
+            "SELECT registry_id, user_id, edge_agent_id, edge_id, hostname, worktree_path, \
+             capabilities_json, workspace_id, \
+             CAST(registered_at AS CHAR) AS registered_at, \
+             CAST(last_heartbeat_at AS CHAR) AS last_heartbeat_at \
              FROM edge_agent_registry WHERE user_id = ? ORDER BY last_heartbeat_at DESC",
         )
         .bind(user_id)
@@ -317,33 +440,68 @@ pub struct UnconfiguredEdgeRegistryService;
 
 #[async_trait]
 impl EdgeRegistryService for UnconfiguredEdgeRegistryService {
+    /// When no cross-pod registry is configured (single-pod deployment), edge
+    /// registration is a successful no-op: the connection is tracked in the
+    /// in-memory pool and there is no cross-pod source of truth to fail. This is
+    /// distinct from a *configured* registry (e.g. DB-backed) whose failure
+    /// returns an error and — per the edge WS handler — rejects the connection.
     async fn register_or_update(
         &self,
-        _user_id: &str,
-        _edge_agent_id: &str,
-        _edge_id_header: &str,
-        _hostname: Option<&str>,
-        _worktree_path: Option<&str>,
-        _capabilities: Option<serde_json::Value>,
+        user_id: &str,
+        edge_agent_id: &str,
+        edge_id_header: &str,
+        hostname: Option<&str>,
+        worktree_path: Option<&str>,
+        capabilities: Option<serde_json::Value>,
+        workspace_id: Option<&str>,
     ) -> Result<EdgeAgentRecord, String> {
-        Err("edge registry service not configured".to_string())
+        let now = chrono::Utc::now()
+            .format("%Y-%m-%d %H:%M:%S%.6f")
+            .to_string();
+        Ok(EdgeAgentRecord {
+            registry_id: edge_id_header.to_string(),
+            user_id: user_id.to_string(),
+            edge_agent_id: edge_agent_id.to_string(),
+            edge_id: edge_id_header.to_string(),
+            hostname: hostname.map(|s| s.to_string()),
+            worktree_path: worktree_path.map(|s| s.to_string()),
+            capabilities,
+            workspace_id: workspace_id.map(|s| s.to_string()),
+            registered_at: now.clone(),
+            last_heartbeat_at: now,
+        })
     }
 
+    async fn find_by_agent_id_and_workspace(
+        &self,
+        _edge_agent_id: &str,
+        _workspace_id: Option<&str>,
+    ) -> Result<Option<EdgeAgentRecord>, String> {
+        Ok(None)
+    }
+
+    /// No-op success: there is no cross-pod row to refresh.
     async fn heartbeat(
         &self,
         _user_id: &str,
         _edge_agent_id: &str,
         _edge_id_header: &str,
-    ) -> Result<(), String> {
-        Err("edge registry service not configured".to_string())
+    ) -> Result<(), HeartbeatError> {
+        Ok(())
     }
 
     async fn list_by_user(&self, _user_id: &str) -> Result<Vec<EdgeAgentRecord>, String> {
-        Err("edge registry service not configured".to_string())
+        Ok(Vec::new())
     }
 
-    async fn unregister(&self, _user_id: &str, _edge_agent_id: &str) -> Result<(), String> {
-        Err("edge registry service not configured".to_string())
+    /// No-op success: nothing was persisted, so nothing to remove.
+    async fn unregister(
+        &self,
+        _user_id: &str,
+        _edge_agent_id: &str,
+        _edge_id: &str,
+    ) -> Result<(), String> {
+        Ok(())
     }
 }
 
@@ -419,6 +577,7 @@ mod tests {
                 "hostname" => self.hostname,
                 "worktree_path" => self.worktree_path,
                 "capabilities_json" => self.capabilities_json,
+                "workspace_id" => None,
                 _ => return Err(sqlx::Error::ColumnNotFound(column.to_string())),
             }
             .map(str::to_string))

--- a/crates/services/src/multi_agent/mod.rs
+++ b/crates/services/src/multi_agent/mod.rs
@@ -19,7 +19,7 @@ pub use edge_dispatch::{
     UnconfiguredEdgeDispatchService, refresh_edge_dispatch_backlog_metrics,
 };
 pub use edge_registry::{
-    DatabaseEdgeRegistryService, EdgeAgentRecord, EdgeRegistryService,
+    DatabaseEdgeRegistryService, EdgeAgentRecord, EdgeRegistryService, HeartbeatError,
     UnconfiguredEdgeRegistryService,
 };
 pub use hold_cache::TaskLeaseHoldCache;

--- a/crates/services/src/multi_agent/task_lease.rs
+++ b/crates/services/src/multi_agent/task_lease.rs
@@ -1154,14 +1154,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unconfigured_edge_registry_errors() {
+    async fn unconfigured_edge_registry_is_noop_success() {
+        // With no cross-pod registry configured (single-pod), all mutating
+        // operations and list_by_user are successful no-ops so edge connections
+        // are never rejected and callers get empty results rather than errors.
         let s = UnconfiguredEdgeRegistryService;
         let r = s
-            .register_or_update("u", "e1", "hdr", None, None, None)
-            .await;
-        assert!(r.is_err());
-        let h = s.heartbeat("u", "e1", "hdr").await;
-        assert!(h.is_err());
+            .register_or_update("u", "e1", "hdr", None, None, None, None)
+            .await
+            .expect("unconfigured register_or_update is a no-op success");
+        assert_eq!(r.edge_agent_id, "e1");
+        assert_eq!(r.edge_id, "hdr");
+        assert!(s.heartbeat("u", "e1", "hdr").await.is_ok());
+        assert!(s.unregister("u", "e1", "hdr").await.is_ok());
+        let listed = s
+            .list_by_user("u")
+            .await
+            .expect("unconfigured list_by_user is a no-op returning empty vec");
+        assert!(listed.is_empty());
     }
 
     #[tokio::test]

--- a/crates/services/src/runs.rs
+++ b/crates/services/src/runs.rs
@@ -479,6 +479,11 @@ pub struct RuntimeCapabilityDescriptorsRequest {
     pub mcp: Option<RuntimeCapabilityDescriptorRequest>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skills: Option<RuntimeCapabilityDescriptorRequest>,
+    // edge_agent: astra-edge executor descriptor injected by moi-core catalog when
+    // a sandbox or runner is selected. The astra-server routes tool callbacks to
+    // the edge agent identified by id via the existing edge WebSocket registry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub edge_agent: Option<RuntimeCapabilityDescriptorRequest>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -565,6 +570,12 @@ pub struct ChatRequestData {
     pub edge_executor_id: Option<String>,
     pub capabilities: Vec<String>,
     pub forward_headers: std::collections::HashMap<String, String>,
+    /// Owning workspace from the provider-authorized turn's edge-registration
+    /// token (`provider_scope_id`).  Injected at the request-injection layer
+    /// and propagated into `ToolExecutionRequest.workspace_record` by the run
+    /// lifecycle so that edge workspace isolation checks work correctly on the
+    /// MOI provider-authorized turn path.
+    pub provider_workspace_id: Option<String>,
     pub execution_budget: Option<ExecutionBudget>,
     pub execution_policy: ExecutionPolicyRequest,
     pub explain: bool,
@@ -10045,6 +10056,7 @@ mod tests {
             explain: false,
             interaction_mode: None,
             interactive_client: false,
+            provider_workspace_id: None,
         };
 
         let rendered = format!("{request:?}");
@@ -10111,6 +10123,7 @@ mod tests {
             explain: false,
             interaction_mode: None,
             interactive_client: false,
+            provider_workspace_id: None,
         };
 
         let rendered = format!("{request:?}");
@@ -10196,6 +10209,7 @@ mod tests {
                     explain: false,
                     interaction_mode: None,
                     interactive_client: false,
+                    provider_workspace_id: None,
                 },
             )
             .await

--- a/crates/services/src/storage.rs
+++ b/crates/services/src/storage.rs
@@ -3779,12 +3779,14 @@ pub async fn ensure_core_schema(
             edge_id VARCHAR(128) NOT NULL,
             hostname VARCHAR(255) NULL,
             worktree_path VARCHAR(512) NULL,
-            capabilities_json JSON NULL,
+            capabilities_json TEXT NULL,
+            workspace_id VARCHAR(512) NULL,
             registered_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
             last_heartbeat_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
             PRIMARY KEY (user_id, registry_id),
             UNIQUE KEY uq_edge_registry_user_agent (user_id, edge_agent_id),
-            INDEX idx_edge_registry_user_heartbeat (user_id, last_heartbeat_at)
+            INDEX idx_edge_registry_user_heartbeat (user_id, last_heartbeat_at),
+            INDEX idx_edge_registry_agent_workspace (edge_agent_id, workspace_id)
         )",
     )
     .execute(&pool)
@@ -3795,6 +3797,22 @@ pub async fn ensure_core_schema(
         "edge_agent_registry",
         &["user_id", "registry_id"],
         "ALTER TABLE edge_agent_registry ADD PRIMARY KEY (user_id, registry_id)",
+    )
+    .await?;
+    add_column_if_missing(
+        &pool,
+        &settings.database,
+        "edge_agent_registry",
+        "workspace_id",
+        "ALTER TABLE edge_agent_registry ADD COLUMN workspace_id VARCHAR(512) NULL",
+    )
+    .await?;
+    add_index_if_missing(
+        &pool,
+        &settings.database,
+        "edge_agent_registry",
+        "idx_edge_registry_agent_workspace",
+        "ALTER TABLE edge_agent_registry ADD INDEX idx_edge_registry_agent_workspace (edge_agent_id, workspace_id)",
     )
     .await?;
 

--- a/crates/services/tests/edge_dispatch_db_it.rs
+++ b/crates/services/tests/edge_dispatch_db_it.rs
@@ -438,7 +438,15 @@ async fn edge_registry_register_list_unregister() {
 
     // Register
     let record = svc
-        .register_or_update(&user_id, &edge_agent_id, &edge_id_header, None, None, None)
+        .register_or_update(
+            &user_id,
+            &edge_agent_id,
+            &edge_id_header,
+            None,
+            None,
+            None,
+            None,
+        )
         .await
         .expect("register");
     assert_eq!(record.user_id, user_id);
@@ -450,8 +458,8 @@ async fn edge_registry_register_list_unregister() {
     assert_eq!(list.len(), 1);
     assert_eq!(list[0].edge_agent_id, edge_agent_id);
 
-    // Unregister
-    svc.unregister(&user_id, &edge_agent_id)
+    // Unregister (guarded by edge_id so cross-pod stale cleanup cannot delete a newer row)
+    svc.unregister(&user_id, &edge_agent_id, &edge_id_header)
         .await
         .expect("unregister");
 
@@ -474,8 +482,10 @@ async fn edge_registry_heartbeat_unregistered() {
     let result = svc
         .heartbeat(&user_id, &edge_agent_id, &edge_id_header)
         .await;
-    assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), "edge agent not registered");
+    assert!(matches!(
+        result.unwrap_err(),
+        astra_services::HeartbeatError::Superseded
+    ));
 }
 
 #[tokio::test]
@@ -493,8 +503,8 @@ async fn edge_registry_concurrent_register() {
 
     // Concurrent registration with same key
     let (r1, r2) = tokio::join!(
-        svc1.register_or_update(&user_id, &edge_agent_id, &edge_id1, None, None, None),
-        svc2.register_or_update(&user_id, &edge_agent_id, &edge_id2, None, None, None)
+        svc1.register_or_update(&user_id, &edge_agent_id, &edge_id1, None, None, None, None),
+        svc2.register_or_update(&user_id, &edge_agent_id, &edge_id2, None, None, None, None)
     );
 
     let rec1 = r1.expect("register1");
@@ -525,7 +535,15 @@ async fn edge_registry_register_twice_updates() {
 
     // First register
     let rec1 = svc
-        .register_or_update(&user_id, &edge_agent_id, &edge_id1, hostname1, None, None)
+        .register_or_update(
+            &user_id,
+            &edge_agent_id,
+            &edge_id1,
+            hostname1,
+            None,
+            None,
+            None,
+        )
         .await
         .expect("register1");
     assert_eq!(rec1.edge_id, edge_id1);
@@ -533,7 +551,15 @@ async fn edge_registry_register_twice_updates() {
 
     // Second register updates
     let rec2 = svc
-        .register_or_update(&user_id, &edge_agent_id, &edge_id2, hostname2, None, None)
+        .register_or_update(
+            &user_id,
+            &edge_agent_id,
+            &edge_id2,
+            hostname2,
+            None,
+            None,
+            None,
+        )
         .await
         .expect("register2");
     assert_eq!(rec2.edge_id, edge_id2);

--- a/crates/services/tests/multi_agent_integration.rs
+++ b/crates/services/tests/multi_agent_integration.rs
@@ -162,6 +162,7 @@ async fn edge_registry_register_twice_keeps_registry_id() {
             Some("h1"),
             Some("/tmp/a"),
             Some(serde_json::json!({ "k": 1 })),
+            Some("ws-1"),
         )
         .await
         .expect("register 1");
@@ -175,6 +176,7 @@ async fn edge_registry_register_twice_keeps_registry_id() {
             Some("h2"),
             Some("/tmp/b"),
             Some(serde_json::json!({ "k": 2 })),
+            Some("ws-1"),
         )
         .await
         .expect("register 2");

--- a/docs/design/moi-sandbox-integration.md
+++ b/docs/design/moi-sandbox-integration.md
@@ -1,0 +1,584 @@
+# MOI Sandbox Integration
+
+> **Code Review 文档**  
+> 本文档描述本 PR 为支持 MOI sandbox 场景引入的主要改动点与设计取舍，供 code review 使用。  
+> 文档内容以 PR 当前 diff 为准；若与实现不一致，请以代码为准。
+
+---
+
+## 背景
+
+MOI sandbox 是在 Kubernetes pod 内运行的隔离执行环境。每个 sandbox pod 内置一个 `astra-edge` 进程，通过 WebSocket 连接到 astra-server，将 AI agent 的 tool call（bash、read_file 等）代理到 pod 内本地执行。
+
+```
+用户浏览器
+    │
+    ▼
+moi-backend / moi-core (matrixflow)
+    │  HTTP POST /agents/turns
+    │  Authorization: Bearer moi-user-token-v1.xxx        ← runtime token
+    │  X-Astra-External-Provider: moi
+    │  X-Astra-External-Action: authorize_request
+    ▼
+astra-server
+    │  WebSocket /edge/ws  ←────────────────────────────────────────────────┐
+    │                                                                         │
+    │  工具分发 (DB edge dispatch / in-memory pool)                           │
+    │                                                                         │
+    └─► astra-edge (运行在 sandbox pod 内)                                   │
+            │  Authorization: Bearer moi-user-token-v1.xxx   ← edge-registration token
+            └───────────────────────────────────────────────────────────────►┘
+```
+
+astra-server 目前（github/main）已有 **server-to-server** 认证路径（matrixflow 用 HTTP header 调用 astra），本次改动在此基础上新增 **edge WebSocket 认证路径**，并修复与多 pod 部署相关的若干 bug。
+
+---
+
+## Token 类型说明
+
+本次改动涉及两种格式相同、但用途不同的 `moi-user-token-v1.*` token：
+
+| 类型 | 发行方 | TTL | 用途 | `purpose` 字段 | `edge_agent_id` |
+|------|--------|-----|------|----------------|-----------------|
+| **Runtime token** | moi-catalog | 10 min | matrixflow → astra HTTP API 调用（已有） | `"runtime"` | 无 |
+| **Edge-registration token** | moi-backend | 30 天 | astra-edge → astra-server WebSocket 注册（本次新增） | `"edge_registration"` | 绑定 edge id |
+
+两类 token 格式相同，通过 `purpose` 字段和 `edge_agent_id` 字段区分。Edge-registration token 还携带 `jti` 用于撤销。
+
+---
+
+## 改动总览
+
+| 编号 | 类型 | 标题 | 核心文件 |
+|------|------|------|---------|
+| F1 | Feature | MOI edge-registration token WebSocket 认证 | `auth/mod.rs`, `edge_ws_handler.rs` |
+| F2 | Feature | Upstream HTTP proxy 支持 | `astra-edge/main.rs`, `astra-thin-client/client.rs` |
+| F3 | Feature | ExternalAuthorizedRequest runtime context 按 token 类型分流 | `external_runtime_context.rs`, `auth/mod.rs` |
+| F4 | Feature | Edge agent allow_tools schema 动态注入 | `server_loop_host.rs`, `lifecycle/mod.rs` |
+| F5 | Feature | 跨用户 edge dispatch（sandbox 服务账号场景） | `tool_edge_transport.rs`, `edge_connection_pool.rs` |
+| F6 | Feature | list_catalog / issue_runtime_context by scope | `auth/external.rs`, `auth/mod.rs` |
+| F7 | Feature | `edge_agent` CapabilityDescriptor 字段 | `services/src/runs.rs` |
+| F8 | Feature | EdgeWs transport 路由强制走 EdgeBound | `tool_route_selection.rs` |
+| B1 | Bug Fix | 连接池 generation 防竞态清理 | `edge_connection_pool.rs` |
+| B2 | Bug Fix | DB 注册失败拒绝 WebSocket 连接 | `edge_ws_handler.rs` |
+| B3 | Bug Fix | heartbeat 按 edge_id 隔离，防旧连接刷新 | `edge_registry.rs` |
+| B4 | Bug Fix | UnconfiguredEdgeRegistryService 改为 no-op 成功 | `edge_registry.rs` |
+| B5 | Bug Fix | edge_dispatch poll 快路径（MatrixOne FOR UPDATE 慢查询） | `edge_dispatch.rs` |
+
+---
+
+## 详细说明
+
+### F1 — MOI edge-registration token WebSocket 认证
+
+**文件：** `rust/crates/services/src/auth/mod.rs`, `rust/crates/runtime/src/server/edge/edge_ws_handler.rs`
+
+#### 问题
+
+astra-edge 在 sandbox pod 内启动后，需要通过 WebSocket `/edge/ws` 向 astra-server 注册。注册时需要出示凭证。astra-server 的 `current_principal()` 只能解码 astra 自己签发的 JWT，无法验证 moi-backend 签发的 `moi-user-token-v1` 格式的 edge-registration token。
+
+#### 改动
+
+**`auth/mod.rs`：**
+
+```rust
+// current_principal() 新增前置分支
+if token.starts_with("moi-user-token-v1") {
+    return self.principal_from_edge_token(token).await;
+}
+// 之后原有的 JWT decode 路径不变
+```
+
+`principal_from_edge_token()` 通过已配置的 external provider（id = `"moi"` 或 first）调用 `authorize_request`，将 token 送到 matrixflow 验证，成功后构造 `ExternalAuthorizedRequest` principal。
+
+新增 `edge_registration_binding()` trait 方法：
+
+```rust
+async fn edge_registration_binding(
+    &self,
+    token: &str,
+) -> Result<Option<(String, String)>, ...>
+// Ok(Some((edge_agent_id, workspace_id))) — 有绑定，必须匹配
+// Ok(None) — 无绑定（内部 JWT），跳过检查
+// Err(_) — token 被拒绝（已撤销/无效）
+```
+
+`DatabaseAuthService` 实现再次调用 `authorize_request`，读取响应里的 `edge_agent_id` 和 `provider_scope_id`（workspace_id）。默认实现返回 `Ok(None)`，使不支持 external auth 的部署不受影响。
+
+**`edge_ws_handler.rs`（Phase 1.5）：**
+
+astra-edge 在 Auth 消息里自报 `edge_agent_id`。Phase 1.5 在 Auth 成功之后、Pool 注册之前，验证自报值与 token 绑定值是否一致：
+
+```
+Phase 1  : 解析 Auth 消息，current_principal() 验证 token
+Phase 1.5: edge_registration_binding() 取 token 绑定的 edge_agent_id
+           比对自报值，不一致 → 发 AuthError 并关闭
+Phase 2  : 注册进 EdgeConnectionPool（携带 workspace_id）
+Phase 2a : 写入 DB edge registry
+Phase 2b : 启动 cross-pod dispatch relay
+```
+
+**防护目的：** 同一 token 的持有者不能冒充不同的 edge id。
+
+#### 影响范围
+
+现有 astra JWT 不以 `"moi-user-token-v1"` 开头，`current_principal()` 的原有路径完全不变。`edge_registration_binding()` 默认返回 `Ok(None)`，未实现 external auth 的部署无需修改。
+
+---
+
+### F2 — Upstream HTTP proxy 支持
+
+**文件：** `rust/crates/astra-edge/src/main.rs`, `rust/crates/astra-thin-client/src/client.rs`
+
+#### 问题
+
+IDC 部署的 sandbox pod 运行在受限网络 namespace 中，唯一出口是 HTTP 代理（`HTTP_PROXY` / `http_proxy` 环境变量）。原有代码在两处显式调用 `.no_proxy()`，绕过了系统代理：
+
+1. `astra-edge` 连接 astra-server WebSocket 时使用 `connect_async()`，不走代理
+2. `astra-thin-client` 的 `streaming_http_client()` 和 `ThinClient::new()` 均调用 `.no_proxy()`
+
+#### 改动
+
+**`astra-edge/src/main.rs`：**
+
+新增 `connect_via_proxy()` 函数，实现 HTTP CONNECT 隧道：
+1. 读取 `http_proxy` / `HTTP_PROXY` 环境变量
+2. TCP 连接到代理地址
+3. 发送 `CONNECT target:port HTTP/1.1` 握手
+4. 读取 `200 Connection Established` 响应
+5. 在隧道上执行 WebSocket upgrade
+
+连接入口统一为：
+```rust
+let ws_stream = if let Some(proxy_url) = proxy {
+    connect_via_proxy(&url, &proxy_url).await?
+} else {
+    let (ws, _) = connect_async(&url).await?;
+    ws
+};
+```
+
+**`astra-thin-client/src/client.rs`：**
+
+- `streaming_http_client()`：移除 `.no_proxy()`，保留注释说明禁止恢复的原因（sandbox 网络隔离）
+- `ThinClient::new()`：`Client::builder()` 移除 `.no_proxy()`
+
+同时添加了 `no_proxy` guard 测试，从源码层面阻止任何人误加回 `.no_proxy()`：
+```rust
+fn streaming_http_client_body_no_comments() -> String { ... }
+
+#[test]
+fn streaming_http_client_does_not_call_no_proxy() {
+    let body = streaming_http_client_body_no_comments();
+    assert!(!body.contains(".no_proxy()"), ...);
+}
+```
+
+#### 影响范围
+
+无代理环境（`HTTP_PROXY` 为空）：行为与原来完全等价。有代理环境：请求现在经过代理路由，这是修正而非破坏。
+
+---
+
+### F3 — ExternalAuthorizedRequest runtime context 按 token 类型分流
+
+**文件：** `rust/crates/runtime/src/server/external_runtime_context.rs`, `rust/crates/services/src/auth/mod.rs`
+
+#### 背景
+
+`inject_effective_runtime_context_body()` 在 streaming chat 端点被调用，负责向请求 body 注入 runtime context（model gateway、MCP、skills 地址等）。
+
+github/main 对 `ExternalAuthorizedRequest` principal 的处理是直接透传 body，因为 matrixflow 调用 astra 时已在 JSON body 里携带了 `capability_descriptors`，astra 无需再做注入。
+
+但 astra-edge 以 edge-registration token 调用 astra HTTP API 时，同样产生 `ExternalAuthorizedRequest` principal，却没有 session，body 里也没有 capability descriptors。它需要通过 `_by_scope` 路径向 matrixflow 获取 runtime context。
+
+#### `AuthExternalAuthorizedRequestContext` 结构变更
+
+```rust
+pub struct AuthExternalAuthorizedRequestContext {
+    pub provider_id: String,
+    pub external_subject: String,
+    pub provider_scope_id: String,
+    pub request_authorization_id: String,
+    // 新增：edge-registration token 携带此字段，runtime token 为 None
+    pub edge_agent_id: Option<String>,
+}
+```
+
+`AuthPrincipal` 新增方法：
+```rust
+pub fn is_edge_registration(&self) -> bool {
+    matches!(
+        &self.origin,
+        AuthPrincipalOrigin::ExternalAuthorizedRequest(ctx) if ctx.edge_agent_id.is_some()
+    )
+}
+```
+
+两个构造 `AuthExternalAuthorizedRequestContext` 的位置：
+- `current_principal_for_request()`（server-to-server 路径）：`edge_agent_id: None`
+- `principal_from_edge_token()`（edge WebSocket 路径）：`edge_agent_id: authorized.edge_agent_id`
+
+#### 分流逻辑
+
+```rust
+// external_runtime_context.rs
+if principal.is_external_authorized_request() {
+    if principal.is_edge_registration() {
+        // edge-registration token：无 session，通过 by_scope 获取 runtime context
+        return inject_authorized_request_runtime_context_body(state, principal, body).await;
+    }
+    // runtime token（matrixflow server-to-server）：body 已有 descriptors，直接透传
+    return Ok(body);
+}
+```
+
+#### 影响范围
+
+分流逻辑确保：
+- matrixflow server-to-server 调用（runtime token）：行为与 github/main 完全一致（透传）
+- astra-edge HTTP 调用（edge-registration token）：新路径，获取并注入 runtime context
+
+---
+
+### F4 — Edge agent allow_tools schema 动态注入
+
+**文件：** `rust/crates/runtime/src/server/server_loop_host.rs`, `rust/crates/runtime/src/server/run/lifecycle/mod.rs`, `rust/crates/runtime/src/server/run/binding_resolution.rs`
+
+#### 问题
+
+当 chat 请求指定 `executor_binding.kind = EdgeAgent` 时（agent-binding 模式），`ServerAgenticLoopHost` 默认只安装 MCP schema，不安装 edge builtin tools（bash、read_file 等）。MOI 调用方在请求里带 `allow_tools: ["bash", "read_file"]` 时，模型看不到这些工具，tool call 失败。
+
+#### 改动
+
+**`server_loop_host.rs`：**
+
+新增 `merge_allowlisted_edge_tool_schemas()` 方法：
+1. 只在 `executor_binding.kind == EdgeAgent` 时有效
+2. 取 `allow_tools` 中枚举的工具名与 capability-filtered 工具集的**交集**
+3. 将交集中的工具 schema 注入到 host 的 `edge_tools` 列表
+
+严格白名单：`allow_tools` 里必须显式列出工具名，不支持通配符，不允许调用方声明超过 capability set 的工具。
+
+**`binding_resolution.rs`：**
+
+新增 `request_needs_edge_bound_server_executor()` 函数：当请求携带 `allow_tools` 且 executor binding 类型为 `EdgeWs` 时，返回 true，触发 server executor 初始化（agent-binding 模式下也需要初始化 ServerToolExecutor 作为 scratch workspace）。
+
+**`lifecycle/mod.rs`：**
+
+在 run lifecycle 启动时调用 `merge_request_scoped_edge_tool_schemas()`，将 allow_tools 的交集 schema 合并到 host。
+
+#### 影响范围
+
+仅当 `executor_binding.kind == EdgeAgent` 且请求携带非空 `allow_tools` 时触发，现有路径不受影响。
+
+---
+
+### F5 — 跨用户 edge dispatch（sandbox 服务账号场景）
+
+**文件：** `rust/crates/runtime/src/server/tool_edge_transport.rs`, `rust/crates/astra-server-types/src/edge_connection_pool.rs`
+
+#### 问题
+
+sandbox 中的 astra-edge 使用 moi-backend 发行的 edge-registration token 连入，该 token 的 `sub` 字段是 moi-backend 的服务账号（形如 `external_authorized:moi:svc-xxx`）。但发起 chat turn 的是工作区用户（形如 `external_authorized:moi:user-yyy`）。
+
+原有 `try_edge_websocket()` 只在**当前用户**的 pool entries 里查找 edge，找不到 → `Unavailable`，导致 sandbox tool call 失败。
+
+#### 改动
+
+**`edge_connection_pool.rs`：**
+
+`EdgeConnection` 新增字段：
+```rust
+pub workspace_id: Option<String>,   // 来自 edge-registration token 的 provider_scope_id
+pub generation: u64,                // 单调递增，用于防竞态清理（见 B1）
+```
+
+`register_with_capabilities()` 新增参数 `workspace_id: Option<String>`，返回 `u64`（generation）。
+
+新增 `find_edge_by_agent_id()` 方法：
+```rust
+pub fn find_edge_by_agent_id(
+    &self,
+    edge_agent_id: &str,
+    workspace_id: Option<&str>,
+) -> Option<(String, EdgeConnectionInfo)>
+```
+
+workspace 授权规则：若请求方和 edge 都有 `workspace_id`，二者必须相等；任一方为 None 时跳过检查（向后兼容内部 token）。
+
+**`tool_edge_transport.rs`：**
+
+`try_edge_websocket()` 新增 fallback 逻辑：
+1. 先在当前用户的 pool entries 查找（原逻辑）
+2. 若为空且 `plan.selected_executor_id()` 有值，调用 `find_edge_by_agent_id()` 跨用户查找
+3. 找到则以找到的 `owner_user_id` 发起 dispatch
+
+#### 影响范围
+
+fallback 仅在当前用户没有 edge 连接时触发，且需要明确指定 `executor_id`；现有走 user-scoped 查找的路径不变。
+
+---
+
+### F6 — list_catalog / issue_runtime_context by scope
+
+**文件：** `rust/crates/services/src/auth/external.rs`, `rust/crates/services/src/auth/mod.rs`
+
+#### 问题
+
+`external_catalog()` 和 `external_runtime_context()` 都需要 session 句柄。Edge-registration token 产生的 `ExternalAuthorizedRequest` principal 没有 session，无法调用这两个接口。
+
+#### 改动
+
+**`auth/external.rs`：**
+
+`ExternalProviderClient` trait 新增两个方法：
+```rust
+async fn list_catalog_by_scope(
+    &self,
+    provider: &ExternalAuthProviderConfig,
+    provider_scope_id: String,
+    external_subject: String,
+) -> Result<ExternalCatalogResponse, ...>
+
+async fn issue_runtime_context_by_scope(
+    &self,
+    provider: &ExternalAuthProviderConfig,
+    provider_scope_id: String,
+    external_subject: String,
+    request: ExternalRuntimeContextRequestData,
+) -> Result<ExternalRuntimeContextResponse, ...>
+```
+
+`HttpExternalProviderClient` 实现分别 POST 到 provider 的 `list_catalog_by_scope` / `issue_runtime_context_by_scope` action endpoint（需要 matrixflow 侧同步实现这两个 action）。
+
+`ExternalAuthorizeRequestResponse` 新增字段：
+```rust
+pub edge_agent_id: Option<String>,
+```
+Provider 在验证 edge-registration token 时，将 token payload 中绑定的 `edge_agent_id` 写入此字段，astra edge WebSocket handler 从中提取后做 Phase 1.5 校验。
+
+**`auth/mod.rs`：**
+
+`AuthService` trait 新增两个方法（默认返回 NOT_IMPLEMENTED）：
+```rust
+async fn external_catalog_by_scope(&self, principal: &AuthPrincipal) -> ...
+async fn external_runtime_context_by_scope(&self, principal: &AuthPrincipal, request: ...) -> ...
+```
+
+`DatabaseAuthService` 实现从 `ExternalAuthorizedRequest` context 中提取 `provider_scope_id` + `external_subject`，转发给 `external_client`。
+
+#### 影响范围
+
+新增 trait 方法有默认实现（返回 NOT_IMPLEMENTED），不实现 external auth 的 stub 零成本兼容。`_by_scope` 接口只在 F3 的 edge-registration token 分支下被调用。
+
+---
+
+### F7 — `edge_agent` CapabilityDescriptor 字段
+
+**文件：** `rust/crates/services/src/runs.rs`
+
+`RuntimeCapabilityDescriptorsRequest` 新增可选字段：
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub edge_agent: Option<RuntimeCapabilityDescriptorRequest>,
+```
+
+该字段由 moi-core catalog 在选定 sandbox executor 时填入，携带 edge agent id 和 transport 类型。astra-server 读取后在 `binding_resolution.rs` 中建立 `ExecutorBinding(EdgeAgent)`，将 tool dispatch 路由到对应 edge agent。
+
+---
+
+### F8 — EdgeWs transport 路由强制走 EdgeBound
+
+**文件：** `rust/crates/runtime/src/server/tool_route_selection.rs`
+
+#### 问题
+
+`routing_decision()` 在 `WorkspaceBindingKind::ServerSandbox` 时将 RuntimeExecutor 工具路由到 `ServerLocal`。但当 executor transport 为 `EdgeWs` 时，意味着已经有 edge agent 连接，工具必须派发到该 agent；`ServerLocal` 路由在 agent-binding 模式下找不到本地适配器，导致 bash/read_file 等工具调用失败。
+
+#### 改动
+
+在 `routing_decision()` 的 workspace 判断之前，先检查 transport：
+
+```rust
+if matches!(request.executor.transport, ToolTransportKind::EdgeWs) {
+    return ToolExecutionRouteKind::EdgeBound;
+}
+```
+
+新增测试覆盖 `ServerSandbox` 和 `EdgeWorkspace` 两种 workspace 在 `EdgeWs` transport 下均路由到 `EdgeBound`。
+
+---
+
+### B1 — 连接池 generation 防竞态清理
+
+**文件：** `rust/crates/astra-server-types/src/edge_connection_pool.rs`, `rust/crates/runtime/src/server/edge/edge_ws_handler.rs`
+
+#### 问题
+
+edge WebSocket 断开时，handler 调用 `pool.unregister()` 清理 pool entry。若同一 edge agent 在断开期间立即重连（例如因网络抖动重试），新连接先写入 pool，随后旧连接的 cleanup 代码将新 entry 也一并删除，导致新连接对其他 pod 不可见。
+
+#### 改动
+
+`EdgeConnectionPool` 新增：
+```rust
+next_generation: Arc<AtomicU64>,  // 单调递增计数器
+
+pub fn register_with_capabilities(...) -> u64  // 返回分配的 generation
+
+pub fn unregister_if_generation(
+    &self,
+    user_id: &str,
+    edge_agent_id: &str,
+    expected_gen: u64,
+) -> bool  // 仅在 generation 匹配时删除
+```
+
+`EdgeConnection` 新增 `generation: u64` 字段。
+
+`edge_ws_handler.rs`：
+- `register_with_capabilities()` 的返回值存入 `pool_generation`
+- cleanup 时改用 `unregister_if_generation(pool_generation)`
+- DB unregister 只在 `was_our_entry == true` 时执行
+
+---
+
+### B2 — DB 注册失败拒绝 WebSocket 连接
+
+**文件：** `rust/crates/runtime/src/server/edge/edge_ws_handler.rs`
+
+#### 问题
+
+原代码：
+```rust
+let _ = edge_registry.register_or_update(...).await;
+```
+`let _ =` 忽略了错误。若 DB 注册失败，edge 在本 pod 的 in-memory pool 里可见，但其他 pod 无法通过 DB registry 路由到它，状态为"在线"但 cross-pod dispatch 实际不工作。
+
+#### 改动
+
+```rust
+if let Err(e) = edge_registry.register_or_update(...).await {
+    // 回滚 pool entry（若 generation 匹配）
+    state.edge_connection_pool.unregister_if_generation(..., pool_generation);
+    // 向 edge 发 AuthError 并关闭 WebSocket
+    send_edge_msg(&ws_sink, EdgeServerMessage::AuthError { ... }).await;
+    return;
+}
+```
+
+**注意：B2 必须与 B4 同时存在。** B4 将 `UnconfiguredEdgeRegistryService` 从返回错误改为 no-op 成功，确保没有配置 DB registry 的单节点部署不会因 B2 拒绝所有 edge 连接。
+
+---
+
+### B3 — heartbeat 按 edge_id 隔离，防旧连接刷新
+
+**文件：** `rust/crates/services/src/multi_agent/edge_registry.rs`
+
+#### 问题
+
+heartbeat 的 UPDATE 语句：
+```sql
+UPDATE edge_agent_registry
+SET edge_id = ?, last_heartbeat_at = NOW(6)
+WHERE user_id = ? AND edge_agent_id = ?
+```
+
+新连接建立后 `edge_id` 变化，旧连接的 heartbeat 仍然匹配（`edge_id` 条件不存在），持续更新 `last_heartbeat_at`，导致旧连接的 DB 行存活，其他 pod 可能路由到已断开的旧连接。
+
+#### 改动
+
+```sql
+UPDATE edge_agent_registry
+SET last_heartbeat_at = NOW(6)
+WHERE user_id = ? AND edge_agent_id = ? AND edge_id = ?
+```
+
+旧连接的 heartbeat 匹配 0 行 → 返回错误 → `edge_ws_handler.rs` 对 heartbeat 错误的处理（warn log）会触发连接关闭流程。`edge_id` 字段不再在 heartbeat 时更新，只由 `register_or_update` 写入。
+
+---
+
+### B4 — UnconfiguredEdgeRegistryService 改为 no-op 成功
+
+**文件：** `rust/crates/services/src/multi_agent/edge_registry.rs`
+
+#### 问题
+
+未配置 DB edge registry 的部署（例如单节点测试环境），`UnconfiguredEdgeRegistryService` 的 `register_or_update`、`heartbeat`、`unregister` 全部返回 `Err`。结合 B2（注册失败拒绝连接），会导致**所有 edge WebSocket 连接都被拒绝**。
+
+#### 改动
+
+```rust
+// 修改前
+async fn register_or_update(...) -> Result<EdgeAgentRecord, String> {
+    Err("edge registry service not configured".to_string())
+}
+
+// 修改后：构造一个内存态的 EdgeAgentRecord 返回，模拟成功
+async fn register_or_update(...) -> Result<EdgeAgentRecord, String> {
+    Ok(EdgeAgentRecord { ... })
+}
+```
+
+`heartbeat` 和 `unregister` 同样改为 `Ok(())`。`list_by_user` 保留返回 `Err`（跨 pod 查询在无 DB 时是预期不可用的）。
+
+---
+
+### B5 — edge_dispatch poll 快路径（MatrixOne FOR UPDATE 慢查询）
+
+**文件：** `rust/crates/services/src/multi_agent/edge_dispatch.rs`
+
+#### 问题
+
+`poll_pending()` 每 2 秒调用一次，每次都使用 `BEGIN` + `SELECT FOR UPDATE` 事务查询 pending dispatch。MatrixOne 对空结果集的 `FOR UPDATE` 也会获取表/页级锁，耗时 8-20 秒，导致即使无 tool call 在途，每次 poll 也极慢，工具响应延迟严重。
+
+#### 改动
+
+在事务查询前加非锁定 COUNT 快路径：
+
+```rust
+let fast_count: i64 = sqlx::query_scalar(
+    "SELECT COUNT(*) FROM edge_pending_dispatch \
+     WHERE user_id = ? AND edge_agent_id = ? AND status = 'pending'",
+)
+.bind(user_id)
+.bind(edge_agent_id)
+.fetch_one(&self.pool)
+.await?;
+
+if fast_count == 0 {
+    return Ok(vec![]);  // 跳过 FOR UPDATE 事务
+}
+// 后续原有的 SELECT FOR UPDATE 逻辑不变
+```
+
+**竞态分析：** COUNT 与 FOR UPDATE 之间如果有新 dispatch 到达，最多延迟 1 个 2s poll 周期，不影响正确性。
+
+---
+
+## 测试覆盖
+
+| 测试位置 | 覆盖内容 |
+|---------|---------|
+| `runtime/tests/edge_ws_e2e.rs` | Phase 1.5 binding 校验：token 绑定的 edge_agent_id 与自报值不一致时连接被拒绝 |
+| `services/src/multi_agent/edge_registry.rs` | `UnconfiguredEdgeRegistryService` 改为 no-op 后的行为验证 |
+| `runtime/src/server/tool_route_selection.rs` | EdgeWs transport 在 ServerSandbox / EdgeWorkspace 下均路由到 EdgeBound |
+| `astra-thin-client/src/client.rs` | `streaming_http_client` 中 `.no_proxy()` 不存在（源码级 guard 测试）|
+
+---
+
+## 未解决问题 / 已知缺口
+
+| 编号 | 描述 | 风险 |
+|------|------|------|
+| GAP-1 | Edge-registration token TTL 为 30 天，astra 无法主动撤销（jti 撤销需要 matrixflow 侧 jti blocklist 接口，未实现）| 🟡 中 |
+| GAP-2 | `_by_scope` 接口（F6）需要 matrixflow 侧同步实现 `list_catalog_by_scope` / `issue_runtime_context_by_scope` 两个 action，否则 edge HTTP 调用 runtime context 时返回错误 | 🔴 阻塞 |
+| GAP-3 | `edge_agent` CapabilityDescriptor（F7）的填充逻辑在 matrixflow 侧（moi-core catalog），本仓库只消费，不产生，需配套改动同步上线 | 🟡 中 |
+
+---
+
+## 合入前置条件
+
+1. **B2 + B4 必须同时合入**，单独合入 B2 会导致没有 DB 的部署拒绝所有 edge 连接
+2. **F6 的 `_by_scope` action** 需要 matrixflow 侧同步实现，否则 astra-edge HTTP 调用 runtime context 返回 501 NOT_IMPLEMENTED
+3. **F7 的 `edge_agent` descriptor** 需要 matrixflow 侧（moi-core catalog）在签发 runtime context 时填充该字段

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -50,7 +50,7 @@
         "postcss": "^8.5.15",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
-        "vitest": "^4.1.8"
+        "vitest": "^4.1.10"
       }
     },
     "../packages/sdk": {
@@ -3413,16 +3413,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -3431,13 +3431,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3458,9 +3458,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3471,13 +3471,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3485,14 +3485,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3501,9 +3501,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3511,13 +3511,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -9025,7 +9025,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11211,19 +11210,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -11251,12 +11250,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -64,6 +64,6 @@
     "postcss": "^8.5.15",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.10"
   }
 }

--- a/web/test.setup.ts
+++ b/web/test.setup.ts
@@ -33,15 +33,28 @@ if (
   };
   const descriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
   if (descriptor && !descriptor.configurable) {
-    throw new Error(
-      "test.setup.ts: window.localStorage is non-configurable in this environment. " +
-        "The fakeStorage mock cannot be installed. " +
-        "Check your Node/jsdom version or update the workaround in test.setup.ts."
-    );
+    // Property is non-configurable (Node 25 WinterCG): cannot replace wholesale.
+    // Patch missing methods on the existing object so tests can proceed.
+    try {
+      const ls = window.localStorage as unknown as Record<string, unknown>;
+      if (typeof ls["clear"] !== "function")
+        ls["clear"] = fakeStorage.clear.bind(fakeStorage);
+      if (typeof ls["getItem"] !== "function")
+        ls["getItem"] = fakeStorage.getItem.bind(fakeStorage);
+      if (typeof ls["setItem"] !== "function")
+        ls["setItem"] = fakeStorage.setItem.bind(fakeStorage);
+      if (typeof ls["removeItem"] !== "function")
+        ls["removeItem"] = fakeStorage.removeItem.bind(fakeStorage);
+      if (typeof ls["key"] !== "function")
+        ls["key"] = fakeStorage.key.bind(fakeStorage);
+    } catch {
+      // Ignore: if patching also fails, individual tests will surface the issue.
+    }
+  } else {
+    Object.defineProperty(window, "localStorage", {
+      value: fakeStorage,
+      writable: true,
+      configurable: true,
+    });
   }
-  Object.defineProperty(window, "localStorage", {
-    value: fakeStorage,
-    writable: true,
-    configurable: true,
-  });
 }

--- a/web/test.setup.ts
+++ b/web/test.setup.ts
@@ -1,1 +1,47 @@
 import "@testing-library/jest-dom/vitest";
+
+// Node 25 ships a built-in globalThis.localStorage (WinterCG) whose properties
+// are non-configurable. In vitest's jsdom environment it leaks onto `window`
+// and shadows the spec-compliant jsdom Storage, breaking window.localStorage.clear().
+// Replace window.localStorage wholesale when .clear is missing.
+if (
+  typeof window !== "undefined" &&
+  typeof window.localStorage?.clear !== "function"
+) {
+  const store: Record<string, string> = {};
+  const fakeStorage: Storage = {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear() {
+      Object.keys(store).forEach((k) => delete store[k]);
+    },
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(store, key)
+        ? store[key]
+        : null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value);
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    key(index: number) {
+      return Object.keys(store)[index] ?? null;
+    },
+  };
+  const descriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+  if (descriptor && !descriptor.configurable) {
+    throw new Error(
+      "test.setup.ts: window.localStorage is non-configurable in this environment. " +
+        "The fakeStorage mock cannot be installed. " +
+        "Check your Node/jsdom version or update the workaround in test.setup.ts."
+    );
+  }
+  Object.defineProperty(window, "localStorage", {
+    value: fakeStorage,
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
  - [x] feat (new feature)
  - [x] fix (bug fix)
  - [x] test (adding or updating tests)

  Which issue(s) this PR fixes

  Fixes # https://github.com/matrixorigin/astra/issues/563

  What this PR does / why we need it

  Background

  MOI needs to run astra-edge inside K8s sandbox pods that connect to astra-server via WebSocket. Sandbox network
  topology differs from regular edge nodes: outbound traffic must route through an HTTP proxy, and edge identity
  must be bound to a MOI-issued token to prevent spoofing.

  Changes

  1. Two-token model (crates/services/src/auth/)

  New external.rs implements ExternalAuthService:
  - Registration token (30-day): binds edge_agent_id + provider_scope_id, used for WebSocket handshake
  - Runtime token (10-min): issued by the server to the edge for calling astra-server APIs

  2. workspace_id isolation (crates/services/src/multi_agent/edge_registry.rs)

  New find_by_agent_id_and_workspace with fail-closed matching:
  - (None, None) → allow
  - (Some(a), Some(b)) if a == b → allow
  - anything else → deny

  3. Edge WebSocket auth hardening (crates/runtime/src/server/edge/edge_ws_handler.rs)

  New Phase 1.5: for moi-user-token-v1 tokens, verify the edge_agent_id binding with the provider before accepting
  the connection, preventing token replay or fabrication.

  4. Capability check on pinned-executor path (crates/runtime/src/server/tool_edge_transport.rs)

  Security fix: the pinned-executor path (via find_by_agent_id_and_workspace) previously skipped
  select_capable_edge_agent. Both dispatch paths now enforce capability validation.

  5. Proxy-aware HTTP client for sandbox (crates/astra-thin-client/src/client.rs)

  Sandbox processes run in an isolated network namespace where outbound traffic must go through an HTTP proxy.
  streaming_http_client (used for LLM /chat/turn calls) must not call .no_proxy(). Added detailed comments and
  debug logging to surface proxy configuration for troubleshooting.


  6. Typed HeartbeatError (crates/services/src/multi_agent/edge_registry.rs)

  heartbeat() return type changed from Result<(), String> to Result<(), HeartbeatError>, distinguishing Superseded
  (connection replaced by a newer one) from StorageFailure(String) (transient DB error).

  7. Web test fix (web/test.setup.ts)

  Node 25 ships a built-in WinterCG globalThis.localStorage with non-configurable properties, causing
  window.localStorage.clear() to be missing in vitest's jsdom environment. Added a polyfill that replaces
  window.localStorage wholesale when .clear is absent.

  Testing

  New integration tests:
  - crates/runtime/tests/edge_ws_e2e.rs: WebSocket auth, connection pool, workspace_id storage, heartbeat,
  cross-pod dispatch
  - crates/services/tests/edge_dispatch_db_it.rs: DB-layer edge dispatch paths
  - crates/services/tests/multi_agent_integration.rs: workspace_id fail-closed isolation

  make check and make test pass. The 5 failing tui_pty_journey tests are pre-existing failures introduced in
  upstream #564 and are unrelated to this PR.