### PR TITLE
fix(runtime): harden owner-scoped recovery boundaries

### DIFF
--- a/crates/astra-cli/src/cli/edge_lifecycle.rs
+++ b/crates/astra-cli/src/cli/edge_lifecycle.rs
@@ -4,25 +4,18 @@ use std::cell::Cell;
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use crate::cli::chat_stream::edge_executor_instance_id;
-use crate::cli::session::session_runtime::{
-    attempt_token_refresh, current_access_token, fresh_access_token,
-};
+use crate::cli::session::session_runtime::{attempt_token_refresh, current_access_token};
 use astra_thin_client::edge::edge_runtime_environment_capabilities;
-use astra_thin_client::{EdgeHeartbeatRequest, EdgeRegisterRequest, ThinClient, ThinClientError};
-use tokio_util::sync::CancellationToken;
+use astra_thin_client::{
+    EdgeHeartbeatRequest, EdgeHeartbeatResponse, EdgeRegisterRequest, ThinClient, ThinClientError,
+};
 
 /// Maximum number of completed request IDs to track for deduplication.
 const MAX_COMPLETED_REQUEST_IDS: usize = 256;
-const REPLAY_TOOL_TIMEOUT: Duration = Duration::from_secs(300);
-#[derive(Default)]
-struct ReplayExecutorRegistration {
-    executor: Option<std::sync::Weak<crate::edge_tools::ToolExecutor>>,
-    cancel_token: Option<CancellationToken>,
-}
 
 /// Process-scoped edge lifecycle state shared by the heartbeat loop and all
 /// edge-side SSE hosts within this CLI process.
@@ -30,9 +23,15 @@ struct ReplayExecutorRegistration {
 struct EdgeLifecycleContext {
     completed_request_ids: Mutex<VecDeque<String>>,
     pending_tool_requests: AtomicU32,
-    replay_in_flight: AtomicBool,
     registered_worktree_path: Mutex<Option<PathBuf>>,
-    replay_registration: Mutex<ReplayExecutorRegistration>,
+    last_reconciliation_signature: Mutex<Option<HeartbeatReconciliationSignature>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HeartbeatReconciliationSignature {
+    replay_policy: astra_thin_client::EdgeHeartbeatReplayPolicy,
+    unresolved_request_ids: Vec<String>,
+    legacy_pending_request_ids: Vec<String>,
 }
 
 impl EdgeLifecycleContext {
@@ -74,6 +73,7 @@ impl EdgeLifecycleContext {
         }
     }
 
+    #[cfg(test)]
     fn registered_worktree_path(&self) -> Option<PathBuf> {
         self.registered_worktree_path
             .lock()
@@ -81,31 +81,34 @@ impl EdgeLifecycleContext {
             .and_then(|guard| guard.clone())
     }
 
-    fn register_replay_executor(
-        &self,
-        executor: &std::sync::Arc<crate::edge_tools::ToolExecutor>,
-        cancel_token: Option<&CancellationToken>,
-    ) {
-        if let Ok(mut guard) = self.replay_registration.lock() {
-            guard.executor = Some(std::sync::Arc::downgrade(executor));
-            guard.cancel_token = cancel_token.cloned();
+    fn reconciliation_changed(&self, response: &EdgeHeartbeatResponse) -> bool {
+        let mut unresolved_request_ids = response.unresolved_request_ids.clone();
+        unresolved_request_ids.sort();
+        unresolved_request_ids.dedup();
+        let mut legacy_pending_request_ids: Vec<String> = response
+            .legacy_pending_requests
+            .iter()
+            .map(|request| request.request_id.clone())
+            .collect();
+        legacy_pending_request_ids.sort();
+        legacy_pending_request_ids.dedup();
+
+        let next = response
+            .requires_reconciliation()
+            .then_some(HeartbeatReconciliationSignature {
+                replay_policy: response.replay_policy,
+                unresolved_request_ids,
+                legacy_pending_request_ids,
+            });
+        let Ok(mut previous) = self.last_reconciliation_signature.lock() else {
+            // A poisoned diagnostics lock must not hide a correctness warning.
+            return next.is_some();
+        };
+        if *previous == next {
+            return false;
         }
-    }
-
-    fn registered_replay_executor(
-        &self,
-    ) -> Option<std::sync::Arc<crate::edge_tools::ToolExecutor>> {
-        self.replay_registration
-            .lock()
-            .ok()
-            .and_then(|guard| guard.executor.as_ref().and_then(std::sync::Weak::upgrade))
-    }
-
-    fn registered_replay_cancel_token(&self) -> Option<CancellationToken> {
-        self.replay_registration
-            .lock()
-            .ok()
-            .and_then(|guard| guard.cancel_token.clone())
+        *previous = next;
+        previous.is_some()
     }
 
     fn jitter(&self, delay: Duration) -> Duration {
@@ -135,25 +138,17 @@ impl EdgeLifecycleContext {
         delay + Duration::from_millis(jitter_ms)
     }
 
-    fn try_acquire_replay_guard(&self) -> Option<ReplayInFlightGuard<'_>> {
-        self.replay_in_flight
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .ok()
-            .map(|_| ReplayInFlightGuard { ctx: self })
-    }
-
     #[cfg(test)]
     fn reset_for_test(&self) {
         if let Ok(mut ids) = self.completed_request_ids.lock() {
             ids.clear();
         }
         self.pending_tool_requests.store(0, Ordering::Relaxed);
-        self.replay_in_flight.store(false, Ordering::Relaxed);
         if let Ok(mut guard) = self.registered_worktree_path.lock() {
             *guard = None;
         }
-        if let Ok(mut guard) = self.replay_registration.lock() {
-            *guard = ReplayExecutorRegistration::default();
+        if let Ok(mut signature) = self.last_reconciliation_signature.lock() {
+            *signature = None;
         }
     }
 }
@@ -189,29 +184,6 @@ impl PendingToolRequestGuard<'static> {
 impl Drop for PendingToolRequestGuard<'_> {
     fn drop(&mut self) {
         self.ctx.dec_pending_tool_requests();
-    }
-}
-
-pub(crate) fn register_replay_executor(
-    executor: &std::sync::Arc<crate::edge_tools::ToolExecutor>,
-    cancel_token: Option<&CancellationToken>,
-) {
-    edge_lifecycle().register_replay_executor(executor, cancel_token);
-}
-
-struct ReplayInFlightGuard<'a> {
-    ctx: &'a EdgeLifecycleContext,
-}
-
-impl ReplayInFlightGuard<'static> {
-    fn try_acquire() -> Option<Self> {
-        edge_lifecycle().try_acquire_replay_guard()
-    }
-}
-
-impl Drop for ReplayInFlightGuard<'_> {
-    fn drop(&mut self) {
-        self.ctx.replay_in_flight.store(false, Ordering::Release);
     }
 }
 
@@ -307,7 +279,7 @@ pub async fn register_edge_once(api: &ThinClient, token: &str) -> Result<(), Thi
 async fn send_heartbeat(
     api: &ThinClient,
     token: &str,
-) -> Result<Option<Vec<serde_json::Value>>, ThinClientError> {
+) -> Result<Option<EdgeHeartbeatResponse>, ThinClientError> {
     if !edge_cloud_registry_enabled() {
         return Ok(None);
     }
@@ -317,16 +289,11 @@ async fn send_heartbeat(
         pending_request_count: edge_lifecycle().pending_tool_request_count(),
         last_seen_request_ids: completed_request_ids_snapshot(),
     };
-    let resp = api
+    let response = api
         .post_agents_edge_heartbeat(Some(token), Some(id), &hb)
         .await?;
 
-    // Parse pending_requests from heartbeat response (reconnection dedup)
-    let pending = resp
-        .get("pending_requests")
-        .and_then(|v| v.as_array())
-        .cloned();
-    Ok(pending)
+    Ok(Some(response))
 }
 
 pub fn spawn_edge_heartbeat(
@@ -343,27 +310,32 @@ pub fn spawn_edge_heartbeat(
         loop {
             interval.tick().await;
             match send_heartbeat(&api, &token).await {
-                Ok(Some(pending_requests)) => {
+                Ok(Some(reconciliation)) => {
                     failures = 0;
-                    // ── Reconnection dedup: re-execute pending tools ──
-                    if !pending_requests.is_empty()
-                        && let Some(replay_guard) = ReplayInFlightGuard::try_acquire()
-                    {
-                        let client = api.clone();
-                        let t = token.clone();
-                        let replay_profile = profile.clone();
-                        let id = edge_executor_instance_id().to_string();
-                        tokio::spawn(async move {
-                            let _replay_guard = replay_guard;
-                            reexecute_pending_requests(
-                                &client,
-                                &t,
-                                replay_profile.as_deref(),
-                                &id,
-                                &pending_requests,
-                            )
-                            .await;
-                        });
+                    if reconciliation.requires_reconciliation() {
+                        let legacy_pending_request_ids: Vec<&str> = reconciliation
+                            .legacy_pending_requests
+                            .iter()
+                            .map(|request| request.request_id.as_str())
+                            .collect();
+                        if edge_lifecycle().reconciliation_changed(&reconciliation) {
+                            tracing::error!(
+                                target: "astra.edge.reconnect",
+                                unresolved_request_ids = ?reconciliation.unresolved_request_ids,
+                                legacy_pending_request_ids = ?legacy_pending_request_ids,
+                                replay_policy = ?reconciliation.replay_policy,
+                                "edge heartbeat reported unresolved invocations; automatic tool re-execution is forbidden without durable result evidence"
+                            );
+                        } else {
+                            tracing::trace!(
+                                target: "astra.edge.reconnect",
+                                unresolved_count = reconciliation.unresolved_request_ids.len(),
+                                legacy_pending_count = legacy_pending_request_ids.len(),
+                                "edge heartbeat reconciliation state is unchanged"
+                            );
+                        }
+                    } else {
+                        edge_lifecycle().reconciliation_changed(&reconciliation);
                     }
                 }
                 Ok(None) => {
@@ -393,198 +365,6 @@ pub fn spawn_edge_heartbeat(
             }
         }
     }))
-}
-
-/// Re-execute pending tool requests that the cloud returned after reconnection.
-///
-/// This is the dedup mechanism: when an edge reconnects, the cloud heartbeat
-/// response includes any `pending_requests` that were dispatched while the
-/// edge was disconnected. The edge re-executes them and posts results back.
-///
-/// Reuses the active SSE executor when available so replay inherits the live
-/// sandbox state, approval expansions, and cancellation token.
-async fn reexecute_pending_requests(
-    api: &ThinClient,
-    _token: &str,
-    profile: Option<&str>,
-    executor_id: &str,
-    pending: &[serde_json::Value],
-) {
-    let executor = if let Some(executor) = edge_lifecycle().registered_replay_executor() {
-        executor
-    } else {
-        let project_root = edge_lifecycle()
-            .registered_worktree_path()
-            .or_else(|| std::env::current_dir().ok())
-            .unwrap_or_else(|| PathBuf::from("."));
-        std::sync::Arc::new(crate::edge_tools::ToolExecutor::new(&project_root))
-    };
-    let cancel_token = edge_lifecycle().registered_replay_cancel_token();
-    let Some(mut replay_token) = fresh_access_token(api, profile).await else {
-        tracing::warn!(
-            target: "astra.edge.reconnect",
-            "reconnection: skipped pending tool replay because no fresh access token is available"
-        );
-        return;
-    };
-
-    for req in pending {
-        let session_id = match req.get("session_id").and_then(|v| v.as_str()) {
-            Some(id) if !id.trim().is_empty() => id.to_string(),
-            _ => {
-                tracing::error!(
-                    target: "astra.edge.reconnect",
-                    "reconnection: skipped pending tool replay without session_id"
-                );
-                continue;
-            }
-        };
-        let run_id = match req.get("run_id").and_then(|v| v.as_str()) {
-            Some(id) if !id.trim().is_empty() => id.to_string(),
-            _ => {
-                tracing::error!(
-                    target: "astra.edge.reconnect",
-                    "reconnection: skipped pending tool replay without run_id"
-                );
-                continue;
-            }
-        };
-        let turn_chain_id = match req.get("turn_chain_id").and_then(|v| v.as_str()) {
-            Some(id) if !id.trim().is_empty() => id.to_string(),
-            _ => {
-                tracing::error!(
-                    target: "astra.edge.reconnect",
-                    "reconnection: skipped pending tool replay without turn_chain_id"
-                );
-                continue;
-            }
-        };
-        let request_id = match req.get("request_id").and_then(|v| v.as_str()) {
-            Some(id) => id.to_string(),
-            None => continue,
-        };
-        let tool_name = match req.get("tool_name").and_then(|v| v.as_str()) {
-            Some(n) => n,
-            None => continue,
-        };
-        let args = req.get("args").cloned().unwrap_or(serde_json::Value::Null);
-
-        tracing::info!(
-            target: "astra.edge.reconnect",
-            request_id = %request_id,
-            tool = tool_name,
-            "reconnection: re-executing pending tool"
-        );
-
-        // Execute the tool locally and post the result back to cloud.
-        let replay_cancel = cancel_token.clone().unwrap_or_default();
-        let execution_cancel = replay_cancel.child_token();
-        let timeout_cancel = execution_cancel.clone();
-        let outcome = match tokio::time::timeout(
-            REPLAY_TOOL_TIMEOUT,
-            crate::cli::stream::stream_render::execute_with_metadata_responsive(
-                std::sync::Arc::clone(&executor),
-                tool_name.to_string(),
-                args,
-                Some(execution_cancel),
-            ),
-        )
-        .await
-        {
-            Ok(outcome) => outcome,
-            Err(_) => {
-                timeout_cancel.cancel();
-                crate::edge_tools::ToolExecutionOutcome {
-                    output: format!(
-                        "Error: replayed tool execution timed out after {} seconds",
-                        REPLAY_TOOL_TIMEOUT.as_secs()
-                    ),
-                    tool_result_fields: None,
-                    is_error: true,
-                }
-            }
-        };
-
-        let tool_result_fields = outcome.tool_result_fields;
-        let output = outcome.output;
-        let status = if outcome.is_error {
-            "error"
-        } else {
-            "completed"
-        };
-
-        let body = astra_thin_client::ToolResultRequest::new_with_hash(
-            astra_thin_client::ToolResultRequestParts {
-                session_id,
-                run_id,
-                turn_chain_id,
-                request_id: request_id.clone(),
-                edge_agent_id: executor_id.to_string(),
-                status: status.to_string(),
-                output,
-                duration_ms: 0, // reconnection re-execution doesn't track timing
-                tool_result_fields,
-            },
-        );
-
-        match post_replayed_tool_result(api, profile, &mut replay_token, executor_id, &body).await {
-            Ok(_) => {
-                tracing::info!(
-                    target: "astra.edge.reconnect",
-                    request_id = %request_id,
-                    "reconnection: pending tool result posted successfully"
-                );
-                record_completed_request(request_id);
-            }
-            Err(e) => {
-                tracing::warn!(
-                    target: "astra.edge.reconnect",
-                    request_id = %request_id,
-                    error = %e,
-                    "reconnection: failed to post pending tool result"
-                );
-            }
-        }
-    }
-
-    async fn post_replayed_tool_result(
-        api: &ThinClient,
-        profile: Option<&str>,
-        replay_token: &mut String,
-        executor_id: &str,
-        body: &astra_thin_client::ToolResultRequest,
-    ) -> Result<(), ThinClientError> {
-        let Some(fresh) = fresh_access_token(api, profile).await else {
-            return Err(ThinClientError::InvalidInput(format!(
-                "refusing to post replayed tool result '{}' without a fresh access token",
-                body.request_id
-            )));
-        };
-        *replay_token = fresh;
-
-        match api
-            .post_tool_result(Some(replay_token.as_str()), Some(executor_id), body)
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(err) if is_unauthorized(&err) => {
-                if !attempt_token_refresh(api, profile).await {
-                    return Err(err);
-                }
-                let Some(fresh) = fresh_access_token(api, profile).await else {
-                    return Err(ThinClientError::InvalidInput(format!(
-                        "token refresh completed but no fresh access token is available for replayed tool result '{}'",
-                        body.request_id
-                    )));
-                };
-                *replay_token = fresh;
-                api.post_tool_result(Some(replay_token.as_str()), Some(executor_id), body)
-                    .await
-                    .map(|_| ())
-            }
-            Err(err) => Err(err),
-        }
-    }
 }
 
 /// Register with the cloud (best-effort) and start a background heartbeat task.
@@ -650,12 +430,15 @@ fn print_skip_notice(_e: &ThinClientError) {
 #[cfg(test)]
 mod tests {
     use super::{
-        PendingToolRequestGuard, ReplayInFlightGuard, attach_runtime_environment_capabilities,
+        EdgeLifecycleContext, PendingToolRequestGuard, attach_runtime_environment_capabilities,
         backoff_delay, completed_request_ids_snapshot, edge_cloud_registry_enabled, edge_lifecycle,
         enrich_register_body, heartbeat_period, jitter, record_completed_request,
-        reexecute_pending_requests, register_edge_once, send_heartbeat,
+        register_edge_once, send_heartbeat,
     };
-    use astra_thin_client::{ASTRA_EDGE_ID_HEADER, EdgeRegisterRequest, ThinClient};
+    use astra_thin_client::{
+        ASTRA_EDGE_ID_HEADER, EdgeHeartbeatReplayPolicy, EdgeHeartbeatResponse,
+        EdgeRegisterRequest, LegacyEdgePendingRequest, ThinClient,
+    };
     use serial_test::serial;
     use std::sync::atomic::Ordering;
     use std::time::Duration;
@@ -856,7 +639,15 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/agents/edge/heartbeat"))
             .and(header_exists("authorization"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "user_id": "user-1",
+                "edge_id": "transport-1",
+                "edge_agent_id": "edge-1",
+                "unresolved_request_ids": [],
+                "replay_policy": "durable_result_reconciliation_required",
+                "ack_request_ids": []
+            })))
             .mount(&server)
             .await;
 
@@ -881,38 +672,73 @@ mod tests {
         ctx.pending_tool_requests.store(0, Ordering::Relaxed);
     }
 
-    #[tokio::test]
-    #[serial]
-    async fn replay_skips_pending_tools_when_no_fresh_token_is_available() {
-        let prev_token = std::env::var("ASTRA_ACCESS_TOKEN").ok();
-        env_remove("ASTRA_ACCESS_TOKEN");
+    #[test]
+    fn heartbeat_reconciliation_never_treats_pending_payloads_as_replay_authority() {
+        let reconciliation = EdgeHeartbeatResponse {
+            ok: true,
+            user_id: "user-1".to_string(),
+            edge_id: "transport-1".to_string(),
+            edge_agent_id: "edge-1".to_string(),
+            unresolved_request_ids: vec!["invocation-new".to_string()],
+            replay_policy:
+                EdgeHeartbeatReplayPolicy::LegacyPendingPayloadRequiresManualReconciliation,
+            ack_request_ids: Vec::new(),
+            legacy_pending_requests: vec![LegacyEdgePendingRequest {
+                request_id: "legacy-request".to_string(),
+            }],
+        };
 
-        let server = MockServer::start().await;
-        let api = ThinClient::new(&server.uri(), None).expect("url");
-        let pending = vec![serde_json::json!({
-            "request_id": "req-stale-replay",
-            "tool_name": "bash",
-            "args": {"cmd": "echo should-not-run"}
-        })];
+        assert_eq!(
+            reconciliation.unresolved_request_ids,
+            vec!["invocation-new"]
+        );
+        assert_eq!(
+            reconciliation.legacy_pending_requests,
+            vec![LegacyEdgePendingRequest {
+                request_id: "legacy-request".to_string(),
+            }]
+        );
+        assert!(reconciliation.requires_reconciliation());
+    }
 
-        reexecute_pending_requests(
-            &api,
-            "stale-token-from-old-sse-loop",
-            Some("__missing_edge_replay_profile__"),
-            "edge-test",
-            &pending,
-        )
-        .await;
+    #[test]
+    fn reconciliation_errors_only_when_the_unresolved_state_changes() {
+        let ctx = EdgeLifecycleContext::default();
+        let unresolved = EdgeHeartbeatResponse {
+            ok: true,
+            user_id: "user-1".to_string(),
+            edge_id: "transport-1".to_string(),
+            edge_agent_id: "edge-1".to_string(),
+            unresolved_request_ids: vec!["invocation-2".to_string(), "invocation-1".to_string()],
+            replay_policy: EdgeHeartbeatReplayPolicy::DurableResultReconciliationRequired,
+            ack_request_ids: Vec::new(),
+            legacy_pending_requests: Vec::new(),
+        };
 
+        assert!(ctx.reconciliation_changed(&unresolved));
         assert!(
-            server.received_requests().await.unwrap().is_empty(),
-            "edge replay must not reuse the old SSE token argument as a posting credential"
+            !ctx.reconciliation_changed(&EdgeHeartbeatResponse {
+                unresolved_request_ids: vec![
+                    "invocation-1".to_string(),
+                    "invocation-2".to_string()
+                ],
+                ..unresolved.clone()
+            }),
+            "ordering-only differences must not amplify the same error"
         );
 
-        match prev_token {
-            Some(value) => env_set("ASTRA_ACCESS_TOKEN", &value),
-            None => env_remove("ASTRA_ACCESS_TOKEN"),
-        }
+        let resolved = EdgeHeartbeatResponse {
+            unresolved_request_ids: Vec::new(),
+            ..unresolved.clone()
+        };
+        assert!(
+            !ctx.reconciliation_changed(&resolved),
+            "recovery clears diagnostics state without emitting an error"
+        );
+        assert!(
+            ctx.reconciliation_changed(&unresolved),
+            "a recurrence after recovery must be visible"
+        );
     }
 
     #[test]
@@ -943,18 +769,6 @@ mod tests {
             assert_eq!(ctx.pending_tool_requests.load(Ordering::Acquire), 1);
         }
         assert_eq!(ctx.pending_tool_requests.load(Ordering::Acquire), 0);
-    }
-
-    #[test]
-    #[serial]
-    fn replay_guard_is_single_flight() {
-        let ctx = edge_lifecycle();
-        ctx.replay_in_flight.store(false, Ordering::Relaxed);
-        let guard = ReplayInFlightGuard::try_acquire().expect("first acquisition");
-        assert!(ReplayInFlightGuard::try_acquire().is_none());
-        drop(guard);
-        assert!(ReplayInFlightGuard::try_acquire().is_some());
-        ctx.replay_in_flight.store(false, Ordering::Relaxed);
     }
 
     #[test]

--- a/crates/astra-cli/src/cli/http_team_store.rs
+++ b/crates/astra-cli/src/cli/http_team_store.rs
@@ -271,6 +271,13 @@ impl HttpTeamStore {
 
 #[async_trait]
 impl TeamPersistenceService for HttpTeamStore {
+    async fn ensure_builtins(&self, user_id: &str) -> Result<(), String> {
+        // The authenticated server endpoint owns idempotent materialization.
+        // Reading the collection exercises that owner-scoped boundary without
+        // duplicating builtin definitions in the CLI.
+        self.list_teams(user_id).await.map(|_| ())
+    }
+
     async fn save_team(&self, team: &TeamDefinition) -> Result<(), String> {
         let body = UpsertTeamRequest {
             name: &team.name,

--- a/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -939,7 +939,6 @@ impl<'a> CliSseStreamHost<'a> {
         // The thinking spinner and tool status lines still stream normally,
         // so the terminal is never blank during generation.
         let buffer_from_start = true;
-        crate::cli::edge_lifecycle::register_replay_executor(&ctx.executor, ctx.cancel_token);
         let streaming_tool_exec = build_streaming_tool_exec(std::sync::Arc::clone(&ctx.executor));
         Self {
             api: ctx.api,

--- a/crates/astra-pipeline/src/feedback_store.rs
+++ b/crates/astra-pipeline/src/feedback_store.rs
@@ -38,7 +38,7 @@ pub struct FeedbackStore {
 
 struct StoreInner {
     sessions: HashMap<String, SessionRules>,
-    /// Insertion-order tracking for LRU eviction of sessions.
+    /// Least-recently-used order, oldest at the front.
     order: VecDeque<String>,
 }
 
@@ -49,6 +49,11 @@ struct SessionRules {
 }
 
 impl FeedbackStore {
+    fn touch_session(inner: &mut StoreInner, session_id: &str) {
+        inner.order.retain(|existing| existing != session_id);
+        inner.order.push_back(session_id.to_string());
+    }
+
     pub fn new() -> Self {
         Self {
             inner: Mutex::new(StoreInner {
@@ -62,15 +67,14 @@ impl FeedbackStore {
     pub async fn add(&self, session_id: &str, feedback: StructuredFeedback) {
         let mut inner = self.inner.lock().await;
 
-        // LRU eviction of oldest session if at capacity
-        if !inner.sessions.contains_key(session_id) {
-            if inner.order.len() >= MAX_SESSIONS
-                && let Some(oldest) = inner.order.pop_front()
-            {
-                inner.sessions.remove(&oldest);
-            }
-            inner.order.push_back(session_id.to_string());
+        // LRU eviction of the least recently used session if at capacity.
+        if !inner.sessions.contains_key(session_id)
+            && inner.order.len() >= MAX_SESSIONS
+            && let Some(oldest) = inner.order.pop_front()
+        {
+            inner.sessions.remove(&oldest);
         }
+        Self::touch_session(&mut inner, session_id);
 
         let entry = inner
             .sessions
@@ -133,6 +137,9 @@ impl FeedbackStore {
         user_message: Option<&str>,
     ) -> String {
         let mut inner = self.inner.lock().await;
+        if inner.sessions.contains_key(session_id) {
+            Self::touch_session(&mut inner, session_id);
+        }
         let Some(entry) = inner.sessions.get_mut(session_id) else {
             return String::new();
         };
@@ -500,6 +507,27 @@ mod tests {
         // Oldest sessions should be evicted
         assert!(store.is_empty("s0").await);
         assert!(!store.is_empty(&format!("s{}", MAX_SESSIONS + 4)).await);
+    }
+
+    #[tokio::test]
+    async fn active_session_is_retained_by_lru_eviction() {
+        let store = FeedbackStore::new();
+        for i in 0..MAX_SESSIONS {
+            store.add(&format!("s{i}"), make_fb("rule")).await;
+        }
+
+        assert!(store.build_injection("s0").await.contains("rule"));
+        store.add("new-session", make_fb("new rule")).await;
+
+        assert!(
+            !store.is_empty("s0").await,
+            "reading a session must refresh its LRU position"
+        );
+        assert!(
+            store.is_empty("s1").await,
+            "the least recently used session should be evicted"
+        );
+        assert!(!store.is_empty("new-session").await);
     }
 
     // ── Injection format ──

--- a/crates/astra-thin-client/src/client.rs
+++ b/crates/astra-thin-client/src/client.rs
@@ -19,10 +19,10 @@ use crate::edge::ASTRA_EDGE_ID_HEADER;
 use crate::error::ThinClientError;
 use crate::paths;
 use crate::protocol::{
-    ApprovalRespondRequest, ChatStreamRequest, EdgeHeartbeatRequest, EdgeRegisterRequest,
-    RunUserIntentRequest, RunUserIntentResponse, SessionCreateRequest, SessionTranscriptPage,
-    SessionTranscriptReadScope, SessionUpdateRequest, StreamEvent, TaskLeaseMutationRequest,
-    ToolResultRequest, UserPromptRespondRequest,
+    ApprovalRespondRequest, ChatStreamRequest, EdgeHeartbeatRequest, EdgeHeartbeatResponse,
+    EdgeRegisterRequest, RunUserIntentRequest, RunUserIntentResponse, SessionCreateRequest,
+    SessionTranscriptPage, SessionTranscriptReadScope, SessionUpdateRequest, StreamEvent,
+    TaskLeaseMutationRequest, ToolResultRequest, UserPromptRespondRequest,
 };
 use crate::sse::SseParser;
 
@@ -1677,7 +1677,7 @@ impl ThinClient {
         bearer_override: Option<&str>,
         edge_transport_id: Option<&str>,
         body: &EdgeHeartbeatRequest,
-    ) -> Result<Value, ThinClientError> {
+    ) -> Result<EdgeHeartbeatResponse, ThinClientError> {
         let url = self.url(paths::AGENTS_EDGE_HEARTBEAT)?;
         let mut req = self
             .http
@@ -1690,7 +1690,7 @@ impl ThinClient {
             req = req.header(ASTRA_EDGE_ID_HEADER, v);
         }
         let resp = req.send().await?;
-        Self::json_or_error(resp).await
+        Self::typed_json_or_error(resp).await
     }
     /// `POST /agent-jobs/{task_id}/lease/claim`
     pub async fn post_agent_job_lease_claim(
@@ -2735,6 +2735,55 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(v["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn wiremock_agents_edge_heartbeat_round_trips_typed_reconciliation_contract() {
+        let srv = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/agents/edge/heartbeat"))
+            .and(header("authorization", "Bearer t"))
+            .and(header("x-astra-edge-id", "transport-1"))
+            .and(body_json(serde_json::json!({
+                "edge_agent_id": "edge-1",
+                "pending_request_count": 2,
+                "last_seen_request_ids": ["invocation-2"]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "user_id": "user-1",
+                "edge_id": "transport-1",
+                "edge_agent_id": "edge-1",
+                "unresolved_request_ids": ["invocation-1"],
+                "replay_policy": "durable_result_reconciliation_required",
+                "ack_request_ids": ["invocation-2"]
+            })))
+            .mount(&srv)
+            .await;
+
+        let client = ThinClient::new(&srv.uri(), None).unwrap();
+        let response = client
+            .post_agents_edge_heartbeat(
+                Some("t"),
+                Some("transport-1"),
+                &EdgeHeartbeatRequest {
+                    edge_agent_id: "edge-1".to_string(),
+                    pending_request_count: 2,
+                    last_seen_request_ids: vec!["invocation-2".to_string()],
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.replay_policy,
+            crate::protocol::EdgeHeartbeatReplayPolicy::DurableResultReconciliationRequired
+        );
+        assert_eq!(
+            response.unresolved_request_ids,
+            vec!["invocation-1".to_string()]
+        );
+        assert_eq!(response.ack_request_ids, vec!["invocation-2".to_string()]);
     }
 
     #[tokio::test]

--- a/crates/astra-thin-client/src/lib.rs
+++ b/crates/astra-thin-client/src/lib.rs
@@ -29,8 +29,9 @@ pub use edge::{
 pub use error::ThinClientError;
 pub use protocol::{
     ApprovalDecision, ApprovalKind, ApprovalRespondRequest, ChatStreamRequest,
-    EdgeHeartbeatRequest, EdgeRegisterRequest, RunUserIntentRequest, RunUserIntentResponse,
-    SessionCreateRequest, SessionTranscriptItem, SessionTranscriptPage, SessionTranscriptPageRef,
+    EdgeHeartbeatReplayPolicy, EdgeHeartbeatRequest, EdgeHeartbeatResponse, EdgeRegisterRequest,
+    LegacyEdgePendingRequest, RunUserIntentRequest, RunUserIntentResponse, SessionCreateRequest,
+    SessionTranscriptItem, SessionTranscriptPage, SessionTranscriptPageRef,
     SessionTranscriptReadScope, SessionTranscriptToolCall, SessionTranscriptToolResult,
     SessionUpdateRequest, StreamEvent, TaskLeaseMutationRequest, ToolResultRequest,
     ToolResultRequestParts, UserPromptRespondRequest, classify_stream_event,

--- a/crates/astra-thin-client/src/protocol.rs
+++ b/crates/astra-thin-client/src/protocol.rs
@@ -404,6 +404,66 @@ pub struct EdgeHeartbeatRequest {
     pub last_seen_request_ids: Vec<String>,
 }
 
+/// Server policy for invocations that remain unresolved across an Edge
+/// heartbeat. Pending transport state is not proof that a side effect is safe
+/// to execute again.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeHeartbeatReplayPolicy {
+    /// Older servers returned executable `pending_requests` without durable
+    /// result evidence. Clients must surface these entries and must not replay
+    /// them automatically.
+    #[default]
+    LegacyPendingPayloadRequiresManualReconciliation,
+    /// The server returns identities only. Reconciliation must use the
+    /// canonical durable invocation/result protocol.
+    DurableResultReconciliationRequired,
+    /// A newer server policy unknown to this client. Unknown policy never
+    /// grants replay authority; the client surfaces it for reconciliation.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Minimal shape accepted from the retired executable-pending heartbeat
+/// response. Extra legacy payload fields are intentionally ignored: they are
+/// diagnostic evidence, never execution authority.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LegacyEdgePendingRequest {
+    pub request_id: String,
+}
+
+/// `POST /agents/edge/heartbeat` response shared by Server and thin clients.
+///
+/// The response never authorizes tool execution. A non-empty unresolved or
+/// legacy pending set requires durable reconciliation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EdgeHeartbeatResponse {
+    pub ok: bool,
+    pub user_id: String,
+    pub edge_id: String,
+    pub edge_agent_id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unresolved_request_ids: Vec<String>,
+    #[serde(default)]
+    pub replay_policy: EdgeHeartbeatReplayPolicy,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ack_request_ids: Vec<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        rename = "pending_requests"
+    )]
+    pub legacy_pending_requests: Vec<LegacyEdgePendingRequest>,
+}
+
+impl EdgeHeartbeatResponse {
+    pub fn requires_reconciliation(&self) -> bool {
+        !self.unresolved_request_ids.is_empty()
+            || !self.legacy_pending_requests.is_empty()
+            || self.replay_policy == EdgeHeartbeatReplayPolicy::Unknown
+    }
+}
+
 /// `POST /agent-jobs/{id}/lease/{claim,release,renew}` — matches server lease handlers.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct TaskLeaseMutationRequest {
@@ -894,6 +954,73 @@ where
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn heartbeat_response_decodes_current_identity_only_contract() {
+        let response: EdgeHeartbeatResponse = serde_json::from_value(json!({
+            "ok": true,
+            "user_id": "user-1",
+            "edge_id": "transport-1",
+            "edge_agent_id": "edge-1",
+            "unresolved_request_ids": ["invocation-1"],
+            "replay_policy": "durable_result_reconciliation_required",
+            "ack_request_ids": ["invocation-2"]
+        }))
+        .expect("current heartbeat response");
+
+        assert!(response.requires_reconciliation());
+        assert_eq!(
+            response.replay_policy,
+            EdgeHeartbeatReplayPolicy::DurableResultReconciliationRequired
+        );
+        assert!(response.legacy_pending_requests.is_empty());
+    }
+
+    #[test]
+    fn heartbeat_response_decodes_legacy_pending_payload_as_non_executable_evidence() {
+        let response: EdgeHeartbeatResponse = serde_json::from_value(json!({
+            "ok": true,
+            "user_id": "user-1",
+            "edge_id": "transport-1",
+            "edge_agent_id": "edge-1",
+            "pending_requests": [{
+                "request_id": "legacy-request",
+                "tool_name": "bash",
+                "args": {"cmd": "echo must-not-run"}
+            }]
+        }))
+        .expect("legacy heartbeat response");
+
+        assert!(response.requires_reconciliation());
+        assert_eq!(
+            response.replay_policy,
+            EdgeHeartbeatReplayPolicy::LegacyPendingPayloadRequiresManualReconciliation
+        );
+        assert_eq!(
+            response.legacy_pending_requests,
+            vec![LegacyEdgePendingRequest {
+                request_id: "legacy-request".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn heartbeat_response_unknown_policy_fails_safe_without_breaking_heartbeat() {
+        let response: EdgeHeartbeatResponse = serde_json::from_value(json!({
+            "ok": true,
+            "user_id": "user-1",
+            "edge_id": "transport-1",
+            "edge_agent_id": "edge-1",
+            "replay_policy": "future_provider_attested_reconciliation"
+        }))
+        .expect("unknown policy must remain forward compatible");
+
+        assert_eq!(response.replay_policy, EdgeHeartbeatReplayPolicy::Unknown);
+        assert!(
+            response.requires_reconciliation(),
+            "unknown policy must never imply automatic replay authority"
+        );
+    }
 
     #[test]
     fn chat_stream_request_serde_roundtrip() {

--- a/crates/core/src/feedback.rs
+++ b/crates/core/src/feedback.rs
@@ -303,15 +303,11 @@ impl FeedbackSignalStore {
         let mut hints = Vec::new();
         let total = signals.len() as f64;
 
-        // Count by signal type
-        let mut type_counts: std::collections::HashMap<&str, u32> =
-            std::collections::HashMap::new();
-        for s in &signals {
-            *type_counts.entry(s.signal_type.type_name()).or_default() += 1;
-        }
-
         // Repeated retries suggest the current approach is failing
-        let retry_count = type_counts.get("Retry").copied().unwrap_or(0);
+        let retry_count = signals
+            .iter()
+            .filter(|signal| matches!(signal.signal_type, SignalType::Retry { .. }))
+            .count();
         if retry_count as f64 / total > 0.3 {
             hints.push(AdaptationHint {
                 kind: "high_retry_rate".to_string(),
@@ -330,7 +326,10 @@ impl FeedbackSignalStore {
         }
 
         // High error rate signals
-        let error_count = type_counts.get("TaskFailure").copied().unwrap_or(0);
+        let error_count = signals
+            .iter()
+            .filter(|signal| matches!(signal.signal_type, SignalType::TaskFailure { .. }))
+            .count();
         if error_count > 0 && error_count as f64 / total > 0.2 {
             hints.push(AdaptationHint {
                 kind: "elevated_failure_rate".to_string(),
@@ -406,6 +405,55 @@ mod tests {
         assert_eq!(signals[0].turn_id.as_deref(), Some("t1"));
         assert_eq!(signals[1].turn_id.as_deref(), Some("t2"));
         assert_eq!(signals[1].signal_type.type_name(), "correction");
+    }
+
+    #[test]
+    fn adaptation_hints_are_derived_from_typed_signals() {
+        let store = FeedbackSignalStore::new();
+        for _ in 0..4 {
+            store.record(FeedbackSignal::new(SignalType::Retry { count: 1 }));
+        }
+        for _ in 0..2 {
+            store.record(FeedbackSignal::new(SignalType::TaskFailure {
+                reason: "provider failed".to_string(),
+            }));
+        }
+
+        let hints = store.adaptation_hints();
+        assert!(
+            hints.iter().any(|hint| hint.kind == "high_retry_rate"),
+            "{hints:?}"
+        );
+        assert!(
+            hints
+                .iter()
+                .any(|hint| hint.kind == "elevated_failure_rate"),
+            "{hints:?}"
+        );
+    }
+
+    #[test]
+    fn adaptation_hints_do_not_trigger_at_exclusive_thresholds() {
+        let store = FeedbackSignalStore::new();
+        store.record(FeedbackSignal::new(SignalType::Retry { count: 1 }));
+        store.record(FeedbackSignal::new(SignalType::TaskFailure {
+            reason: "provider failed".to_string(),
+        }));
+        for _ in 0..3 {
+            store.record(FeedbackSignal::new(SignalType::Acceptance));
+        }
+
+        let hints = store.adaptation_hints();
+        assert!(
+            !hints.iter().any(|hint| hint.kind == "high_retry_rate"),
+            "20% retry rate must stay below the exclusive 30% threshold: {hints:?}"
+        );
+        assert!(
+            !hints
+                .iter()
+                .any(|hint| hint.kind == "elevated_failure_rate"),
+            "20% failure rate is the exclusive threshold and must not trigger: {hints:?}"
+        );
     }
 
     #[test]

--- a/crates/runtime/src/app_state.rs
+++ b/crates/runtime/src/app_state.rs
@@ -183,7 +183,7 @@ pub struct AppState {
     pub memoria_master_key: Option<String>,
     pub memoria_forwarder: Arc<dyn MemoriaForwarder>,
     pub shared_pool: Option<SharedPool>,
-    /// Matrix pool + journal ingestion + [`astra_services::SyncOrchestrator`] (learning/events).
+    /// Owner-neutral Matrix pool, journal ingestion, sync persistence, and shutdown tracking.
     pub(crate) matrix_cloud_runtime: Option<Arc<crate::matrix_cloud_runtime::MatrixCloudRuntime>>,
     /// Edge §5.5 callbacks (`/tools/result`, `/approval/respond`); keys via [`astra_turn_core::edge_ledger`].
     pub(crate) edge_callback_ledger:

--- a/crates/runtime/src/matrix_cloud_runtime.rs
+++ b/crates/runtime/src/matrix_cloud_runtime.rs
@@ -1,18 +1,17 @@
-//! Matrix-backed cloud plumbing in one place: [`SharedPool`], journal ingestion, and
-//! [`SyncOrchestrator`] (learning, events, templates, preferences). Used by `astra-server`
-//! [`AppState`] and by the CLI [`ReplState`] as a single `Arc` attachment.
+//! Matrix-backed cloud plumbing in one place: [`SharedPool`], journal ingestion,
+//! sync persistence, and shutdown tracking. Used by `astra-server` [`AppState`]
+//! and by the CLI [`ReplState`] as a single `Arc` attachment.
 
 use std::collections::{BTreeMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::Mutex as TokioMutex;
 use tokio::task::JoinSet;
 
 use astra_core::{MatrixOneSettings, SharedPool};
 use astra_services::{
-    CloudTransport, SyncOrchestrator, TaskLeaseHoldCache, TaskRecord,
+    TaskLeaseHoldCache, TaskRecord,
     event_ingestion::{self, IngestionConfig, IngestionEvent},
     session_journal::JournalEvent,
     state_sync::MatrixOneSyncService,
@@ -106,7 +105,6 @@ pub struct MatrixCloudRuntime {
     ingestion_stats: Arc<std::sync::Mutex<astra_services::event_ingestion::IngestionStats>>,
     /// Normalized ingestion config used by this runtime instance.
     ingestion_config: astra_services::event_ingestion::IngestionConfig,
-    sync_orchestrator: TokioMutex<SyncOrchestrator>,
     /// Phase 3: shared with HTTP lease handlers (process-local export filter).
     pub lease_hold_cache: Arc<TaskLeaseHoldCache>,
     /// Phase 3: local task mirror.
@@ -125,20 +123,15 @@ pub struct MatrixCloudRuntime {
     /// available, and exposed via
     /// [`Self::clone_memory_extraction_service`].
     memory_extraction_service: Option<Arc<crate::session_memory::MemoryExtractionService>>,
-    /// User ID this runtime was attached for — needed when constructing
-    /// the memory extraction service inside [`Self::with_encryptor`].
-    user_id: Arc<str>,
 }
 
 impl MatrixCloudRuntime {
-    /// Wire ingestion worker to an existing [`SharedPool`]. The
-    /// [`SyncOrchestrator`] is constructed bare (no adapters) since the
-    /// per-domain sync adapters (learning, events, templates, preferences,
-    /// tasks) were removed along with the self-evolution subsystem.
+    /// Wire owner-neutral ingestion and sync infrastructure to an existing
+    /// [`SharedPool`]. Request-owned services are bound later from authenticated
+    /// run context; the process root never invents a user principal.
     pub fn attach(
         shared_pool: SharedPool,
         _profile: &str,
-        user_id: &str,
         lease_hold_cache: Arc<TaskLeaseHoldCache>,
     ) -> Self {
         let edge_agent_id: Arc<str> = std::env::var("ASTRA_EDGE_AGENT_ID")
@@ -156,9 +149,6 @@ impl MatrixCloudRuntime {
             pool,
             audit_flusher.writer.clone(),
         ));
-        let transport: Arc<dyn CloudTransport> = Arc::new(astra_services::NoopTransport);
-        let orch = SyncOrchestrator::new(transport, user_id.to_string());
-
         Self {
             shared_pool,
             ingestion: Mutex::new(Some(sender)),
@@ -167,7 +157,6 @@ impl MatrixCloudRuntime {
             session_sync_tasks: Mutex::new(JoinSet::new()),
             ingestion_stats,
             ingestion_config,
-            sync_orchestrator: TokioMutex::new(orch),
             lease_hold_cache,
             task_mirror,
             task_dirty,
@@ -177,7 +166,6 @@ impl MatrixCloudRuntime {
             audit_flusher_handle: Mutex::new(Some(audit_flusher.join_handle)),
             encryptor: None,
             memory_extraction_service: None,
-            user_id: Arc::from(user_id),
         }
     }
 
@@ -194,8 +182,7 @@ impl MatrixCloudRuntime {
     pub fn with_encryptor(mut self, enc: Arc<astra_services::FernetTokenEncryptor>) -> Self {
         self.encryptor = Some(Arc::clone(&enc));
         let ingestion = self.ingestion.lock().ok().and_then(|g| g.as_ref().cloned());
-        let memoria = crate::turn::cloud::memoria_compact::HttpMemoriaPort::from_env()
-            .map(|client| client.with_owner_user_id(self.user_id.to_string()));
+        let memoria = crate::turn::cloud::memoria_compact::HttpMemoriaPort::from_env();
         if let (Some(ingestion), Some(memoria)) = (ingestion, memoria) {
             let resolver: Arc<dyn crate::session_memory::SelectorParamsResolver> =
                 Arc::new(PoolSelectorResolver {
@@ -205,13 +192,14 @@ impl MatrixCloudRuntime {
             let broker = Arc::new(crate::session_memory::BackgroundActivityBroker::new());
             let memoria_client: Arc<dyn crate::turn::cloud::memoria_compact::MemoriaPort> =
                 Arc::new(memoria);
-            let svc = Arc::new(crate::session_memory::MemoryExtractionService::new(
-                resolver,
-                memoria_client,
-                ingestion,
-                Arc::clone(&self.user_id),
-                broker,
-            ));
+            let svc = Arc::new(
+                crate::session_memory::MemoryExtractionService::new_owner_scoped_template(
+                    resolver,
+                    memoria_client,
+                    ingestion,
+                    broker,
+                ),
+            );
             self.memory_extraction_service = Some(svc);
         }
         self
@@ -484,10 +472,6 @@ impl MatrixCloudRuntime {
                 }
             }
         }
-    }
-
-    pub async fn sync_orchestrator_lock(&self) -> tokio::sync::MutexGuard<'_, SyncOrchestrator> {
-        self.sync_orchestrator.lock().await
     }
 }
 

--- a/crates/runtime/src/server/edge/edge_callback_handlers.rs
+++ b/crates/runtime/src/server/edge/edge_callback_handlers.rs
@@ -12,9 +12,11 @@ use super::*;
 use astra_services::session_journal::{
     ApprovalDecisionAppendOutcome, append_approval_decision_for_run_if_absent, validate_session_id,
 };
-use astra_thin_client::ASTRA_EDGE_ID_HEADER;
+use astra_thin_client::{
+    ASTRA_EDGE_ID_HEADER, EdgeHeartbeatReplayPolicy, EdgeHeartbeatRequest, EdgeHeartbeatResponse,
+    EdgeRegisterRequest,
+};
 use astra_tools::{AskUserAnswers, AskUserPrompt, normalize_ask_user_answers};
-use serde::Deserialize;
 use serde_json::Value;
 
 use astra_turn_core::edge_ledger::{LEDGER_MAX_ENTRIES, approval_callback_key, tool_callback_key};
@@ -869,28 +871,6 @@ pub(crate) async fn post_user_prompt_respond_handler(
     })))
 }
 
-#[derive(Deserialize)]
-pub(crate) struct EdgeRegisterRequest {
-    pub edge_agent_id: String,
-    pub hostname: Option<String>,
-    pub worktree_path: Option<String>,
-    pub capabilities: Option<serde_json::Value>,
-}
-
-#[derive(Deserialize)]
-pub(crate) struct EdgeHeartbeatRequest {
-    pub edge_agent_id: String,
-    /// Number of in-flight tool requests on this edge executor (from thin-client).
-    /// Used to detect stalled edges: pending > 0 but no results for > 2 min → warning.
-    #[serde(default)]
-    pub pending_request_count: u32,
-    /// Recently completed request IDs the edge has processed, for deduplication
-    /// on reconnection. Cloud can cross-reference with its pending tool_requests
-    /// table to avoid re-issuing tool calls already completed by this edge.
-    #[serde(default)]
-    pub last_seen_request_ids: Vec<String>,
-}
-
 /// `POST /agents/edge` — upsert `edge_agent_registry` (Phase 3).
 pub(crate) async fn post_agents_edge_register_handler(
     State(state): State<AppState>,
@@ -930,7 +910,7 @@ pub(crate) async fn post_agents_edge_heartbeat_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(body): Json<EdgeHeartbeatRequest>,
-) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<EdgeHeartbeatResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
     if body.edge_agent_id.trim().is_empty() {
         return Err(error_response(
@@ -954,9 +934,10 @@ pub(crate) async fn post_agents_edge_heartbeat_handler(
             }
         })?;
 
-    // ── Reconnection dedup ──────────────────────────────────────────
-    // 1. Ack completed request IDs: remove from cloud's pending set.
-    //    The edge confirmed these tools were executed, so no re-issue needed.
+    // ── Reconnection reconciliation ─────────────────────────────────
+    // 1. Ack completed request IDs: remove them from the process-local
+    //    delivery tracker. This is cleanup evidence only; it never grants
+    //    authority to execute an invocation.
     //    Server-side scoping: each lookup key is "{user_id}:{request_id}",
     //    so the edge can only remove entries belonging to its authenticated
     //    user. Fabricated IDs for other users have no effect.
@@ -978,19 +959,16 @@ pub(crate) async fn post_agents_edge_heartbeat_handler(
             .ack_completed_for_user(&user.user_id, seen_ids);
     }
 
-    // 2. Return pending requests (those still in the set after ack).
-    //    On reconnection, the edge re-executes these and reports results.
-    let pending_requests: Vec<serde_json::Value> = state
+    // 2. Report unresolved request identities without returning executable
+    //    payloads. A request being pending proves neither that it was never
+    //    executed nor that it is safe to retry. Re-execution is therefore
+    //    forbidden until the Edge can reconcile a durable completed/unknown
+    //    journal entry under the canonical invocation protocol.
+    let unresolved_request_ids: Vec<String> = state
         .edge_connection_pool
         .get_pending_requests_for_user(&user.user_id)
         .into_iter()
-        .map(|req| {
-            serde_json::json!({
-                "request_id": req.request_id,
-                "tool_name": req.tool_name,
-                "args": req.args,
-            })
-        })
+        .map(|request| request.request_id)
         .collect();
 
     // Stale edge detection: warn if edge has pending tool requests with no progress.
@@ -1003,23 +981,25 @@ pub(crate) async fn post_agents_edge_heartbeat_handler(
         );
     }
 
-    if !pending_requests.is_empty() {
-        tracing::info!(
+    if !unresolved_request_ids.is_empty() {
+        tracing::error!(
             user_id = %user.user_id,
             edge_id = %edge_id,
-            count = pending_requests.len(),
-            "reconnection: returning pending requests to edge"
+            unresolved_request_ids = ?unresolved_request_ids,
+            "edge heartbeat found unresolved invocations; automatic replay is disabled pending durable result reconciliation"
         );
     }
 
-    Ok(Json(serde_json::json!({
-        "ok": true,
-        "user_id": user.user_id,
-        "edge_id": edge_id,
-        "edge_agent_id": body.edge_agent_id,
-        "pending_requests": pending_requests,
-        "ack_request_ids": seen_ids,
-    })))
+    Ok(Json(EdgeHeartbeatResponse {
+        ok: true,
+        user_id: user.user_id,
+        edge_id,
+        edge_agent_id: body.edge_agent_id,
+        unresolved_request_ids,
+        replay_policy: EdgeHeartbeatReplayPolicy::DurableResultReconciliationRequired,
+        ack_request_ids: seen_ids.to_vec(),
+        legacy_pending_requests: Vec::new(),
+    }))
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/server/session/session_todo_sweeper.rs
+++ b/crates/runtime/src/server/session/session_todo_sweeper.rs
@@ -175,6 +175,7 @@ pub(crate) async fn run_stale_in_progress_sweep(pool: SharedPool) -> Result<u64,
         "SELECT user_id, session_id, todo_id, metadata FROM session_todos \
          WHERE status = 'in_progress' \
            AND updated_at < DATE_SUB(NOW(6), INTERVAL ? HOUR) \
+         ORDER BY updated_at ASC, user_id ASC, session_id ASC, todo_id ASC \
          LIMIT ? \
          FOR UPDATE",
     )
@@ -300,12 +301,18 @@ async fn run_completed_auto_archive_batch(pool: SharedPool, limit: i64) -> Resul
             .await
             .map_err(|e| format!("completed-auto-archive tx begin: {e}"))?;
 
+        // The process-level sweeper lease is the ordinary single-owner path,
+        // but candidate claiming must still be correct if a lease handoff,
+        // operator-triggered pass, or test overlaps another worker. Lock the
+        // deterministic oldest-first batch inside the mutation transaction so
+        // two workers cannot both select a row and then report false progress.
         let rows: Vec<(String, String, String)> = sqlx::query_as(
             "SELECT user_id, session_id, todo_id FROM session_todos \
              WHERE status IN ('completed', 'failed', 'cancelled') \
                AND updated_at < DATE_SUB(NOW(6), INTERVAL ? DAY) \
-             ORDER BY updated_at ASC \
-             LIMIT ?",
+             ORDER BY updated_at ASC, user_id ASC, session_id ASC, todo_id ASC \
+             LIMIT ? \
+             FOR UPDATE",
         )
         .bind(days)
         .bind(batch_size)
@@ -482,13 +489,17 @@ async fn run_archive_gc_batch(pool: SharedPool, limit: i64) -> Result<u64, Strin
             .await
             .map_err(|e| format!("archive-gc tx begin: {e}"))?;
 
+        // GC uses the same transaction-local claim boundary as auto-archive.
+        // Stable tie-breakers prevent an equal-timestamp backlog from
+        // repeatedly favoring an arbitrary subset.
         let rows: Vec<(String, String, String)> = sqlx::query_as(
             "SELECT user_id, session_id, todo_id FROM session_todos \
              WHERE status = 'archived' \
                AND archived_at IS NOT NULL \
                AND archived_at < DATE_SUB(NOW(6), INTERVAL ? DAY) \
-             ORDER BY archived_at ASC \
-             LIMIT ?",
+             ORDER BY archived_at ASC, user_id ASC, session_id ASC, todo_id ASC \
+             LIMIT ? \
+             FOR UPDATE",
         )
         .bind(days)
         .bind(batch_size)
@@ -1153,7 +1164,7 @@ mod tests {
             "INSERT INTO session_todos (\
                  session_id, todo_id, user_id, ordinal, title, status, blocks, archived_at, created_at, updated_at\
              ) VALUES \
-                 (?, 'task-1', ?, 0, 'old done with corrupt edges', 'completed', 'not-json', NULL, NOW(6), DATE_SUB(NOW(6), INTERVAL 1000 DAY))",
+                 (?, 'task-1', ?, 0, 'old done with corrupt edges', 'completed', 'not-json', NULL, NOW(6), DATE_SUB(NOW(6), INTERVAL 10000 DAY))",
         )
         .bind(&session_id)
         .bind(&user_id)

--- a/crates/runtime/src/server/state_builder/runtime.rs
+++ b/crates/runtime/src/server/state_builder/runtime.rs
@@ -35,12 +35,10 @@ pub(super) async fn build_runtime_wiring(
         )),
         delegation_tracker.clone(),
     ));
-    let user_id = "local";
     let matrix_rt = Arc::new(
         crate::matrix_cloud_runtime::MatrixCloudRuntime::attach(
             shared_pool.clone(),
             "default",
-            user_id,
             Arc::clone(lease_hold_cache),
         )
         .with_encryptor(Arc::clone(run_encryptor)),
@@ -150,7 +148,7 @@ pub(super) async fn build_runtime_wiring(
     #[cfg(feature = "harness")]
     let run_lifecycle = run_lifecycle.with_harness_registry(state.harness_registry.clone());
 
-    let team_store = initialize_team_store(shared_pool, user_id).await;
+    let team_store = initialize_team_store(shared_pool);
     Ok(RuntimeWiring {
         matrix_rt,
         run_lifecycle,
@@ -213,21 +211,12 @@ async fn initialize_resource_governor(
     std::sync::Arc::new(resource_governor)
 }
 
-async fn initialize_team_store(
+fn initialize_team_store(
     shared_pool: &SharedPool,
-    user_id: &str,
 ) -> Arc<dyn astra_services::team_persistence::TeamPersistenceService> {
-    let team_store =
-        astra_services::team_persistence::MatrixOneTeamStore::new(shared_pool.get().clone());
-    if let Err(error) = team_store.ensure_builtins(user_id).await {
-        tracing::warn!(
-            target: "astra_runtime::state_builder",
-            error = %error,
-            user_id = %user_id,
-            "team builtins seed failed"
-        );
-    }
-    Arc::new(team_store)
+    Arc::new(astra_services::team_persistence::MatrixOneTeamStore::new(
+        shared_pool.get().clone(),
+    ))
 }
 
 pub(super) fn default_agent_profile_registry() -> astra_services::AgentProfileRegistry {

--- a/crates/runtime/src/server/team/handlers.rs
+++ b/crates/runtime/src/server/team/handlers.rs
@@ -35,6 +35,25 @@ fn require_team_store(
     })
 }
 
+async fn require_owner_team_store<'a>(
+    state: &'a AppState,
+    user_id: &str,
+) -> Result<&'a Arc<dyn TeamPersistenceService>, (StatusCode, Json<ErrorResponse>)> {
+    let store = require_team_store(state)?;
+    store.ensure_builtins(user_id).await.map_err(|error| {
+        tracing::error!(
+            user_id,
+            error = %error,
+            "failed to initialize owner-scoped built-in teams"
+        );
+        error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "team templates are temporarily unavailable",
+        )
+    })?;
+    Ok(store)
+}
+
 fn require_delegation_engine(
     state: &AppState,
 ) -> Result<
@@ -76,7 +95,7 @@ pub(crate) async fn list_teams_handler(
     headers: HeaderMap,
 ) -> Result<Json<TeamListResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
-    let store = require_team_store(&state)?;
+    let store = require_owner_team_store(&state, &user.user_id).await?;
 
     let teams = store
         .list_teams(&user.user_id)
@@ -95,7 +114,7 @@ pub(crate) async fn get_team_handler(
     headers: HeaderMap,
 ) -> Result<Json<TeamDefinition>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
-    let store = require_team_store(&state)?;
+    let store = require_owner_team_store(&state, &user.user_id).await?;
 
     let team = load_team_by_name_or_id(store, &user.user_id, &name)
         .await?
@@ -113,7 +132,7 @@ pub(crate) async fn upsert_team_handler(
     Json(body): Json<CreateTeamRequest>,
 ) -> Result<Json<TeamDefinition>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
-    let store = require_team_store(&state)?;
+    let store = require_owner_team_store(&state, &user.user_id).await?;
 
     let now = chrono::Utc::now().to_rfc3339();
     let existing = store
@@ -173,7 +192,7 @@ pub(crate) async fn delete_team_handler(
     headers: HeaderMap,
 ) -> Result<Json<DeleteTeamResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
-    let store = require_team_store(&state)?;
+    let store = require_owner_team_store(&state, &user.user_id).await?;
 
     let deleted = store
         .delete_team(&user.user_id, &name)
@@ -265,7 +284,7 @@ pub(crate) async fn list_executions_handler(
     headers: HeaderMap,
 ) -> Result<Json<ExecutionListResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
-    let store = require_team_store(&state)?;
+    let store = require_owner_team_store(&state, &user.user_id).await?;
 
     let team = load_team_by_name_or_id(store, &user.user_id, &name)
         .await?
@@ -303,7 +322,10 @@ pub(crate) async fn execute_team_handler(
     Json(body): Json<ExecuteTeamRequest>,
 ) -> Result<Json<TeamExecuteResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
-    let team_store: Arc<dyn TeamPersistenceService> = require_team_store(&state)?.clone();
+    let team_store: Arc<dyn TeamPersistenceService> =
+        require_owner_team_store(&state, &user.user_id)
+            .await?
+            .clone();
     let engine = require_delegation_engine(&state)?;
 
     let session_id = body
@@ -484,7 +506,7 @@ pub(crate) async fn list_snapshots_handler(
     headers: HeaderMap,
 ) -> Result<Json<SnapshotListResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
-    let store = require_team_store(&state)?;
+    let store = require_owner_team_store(&state, &user.user_id).await?;
     store
         .load_team(&user.user_id, &name)
         .await
@@ -518,7 +540,7 @@ pub(crate) async fn create_snapshot_handler(
     Json(body): Json<CreateSnapshotRequest>,
 ) -> Result<Json<SnapshotEntry>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
-    let store = require_team_store(&state)?;
+    let store = require_owner_team_store(&state, &user.user_id).await?;
     let team = store
         .load_team(&user.user_id, &name)
         .await
@@ -553,7 +575,7 @@ pub(crate) async fn delete_snapshot_handler(
     headers: HeaderMap,
 ) -> Result<Json<DeleteTeamResponse>, (StatusCode, Json<ErrorResponse>)> {
     let user = state.auth_service.current_user(&headers).await?;
-    let store = require_team_store(&state)?;
+    let store = require_owner_team_store(&state, &user.user_id).await?;
     let deleted = store
         .delete_snapshot(&id, &user.user_id)
         .await

--- a/crates/runtime/src/session_memory/request.rs
+++ b/crates/runtime/src/session_memory/request.rs
@@ -28,9 +28,10 @@ pub enum SpawnDecision {
     /// a worker. The service retained the latest request and the current
     /// worker will process it before releasing the session slot.
     Queued,
-    /// Gate rejected the attempt (no session id, below init gate,
-    /// debounced, or an extraction is already in flight). The
-    /// corresponding `SessionMemoryExtraction{outcome="skipped"}` event
-    /// has already been emitted synchronously.
+    /// Gate rejected the attempt (no owner/session id, below init gate,
+    /// debounced, or an extraction is already in flight). Owner-bound gate
+    /// rejections emit a synchronous `SessionMemoryExtraction` skipped event;
+    /// an unbound process template has no legal owner for durable emission and
+    /// instead fails loudly in the runtime log.
     Skipped,
 }

--- a/crates/runtime/src/session_memory/service.rs
+++ b/crates/runtime/src/session_memory/service.rs
@@ -104,7 +104,10 @@ pub struct MemoryExtractionService {
     selector_resolver: Arc<dyn SelectorParamsResolver>,
     memoria_client: Arc<dyn MemoriaPort>,
     ingestion: IngestionSender,
-    user_id: Arc<str>,
+    /// Authenticated owner for an executable service. The process-wide
+    /// template is deliberately unbound and can only create owner-scoped
+    /// services through [`Self::scoped_to_owner`].
+    user_id: Option<Arc<str>>,
     health: Arc<SelectorHealth>,
     memoria_health: Arc<MemoriaHealth>,
     /// Per-session active fingerprint plus one latest-wins queued refresh.
@@ -144,7 +147,7 @@ pub struct MemoryExtractionService {
 impl std::fmt::Debug for MemoryExtractionService {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MemoryExtractionService")
-            .field("user_id", &self.user_id)
+            .field("user_id", &self.user_id.as_deref())
             .field("subscribers", &self.broker.subscriber_count())
             .finish()
     }
@@ -162,11 +165,38 @@ impl MemoryExtractionService {
         user_id: impl Into<Arc<str>>,
         broker: Arc<BackgroundActivityBroker>,
     ) -> Self {
+        Self::new_with_owner(
+            selector_resolver,
+            memoria_client,
+            ingestion,
+            Some(user_id.into()),
+            broker,
+        )
+    }
+
+    /// Build an owner-neutral process template. It cannot execute extraction
+    /// itself; callers must bind it to an authenticated owner first.
+    pub(crate) fn new_owner_scoped_template(
+        selector_resolver: Arc<dyn SelectorParamsResolver>,
+        memoria_client: Arc<dyn MemoriaPort>,
+        ingestion: IngestionSender,
+        broker: Arc<BackgroundActivityBroker>,
+    ) -> Self {
+        Self::new_with_owner(selector_resolver, memoria_client, ingestion, None, broker)
+    }
+
+    fn new_with_owner(
+        selector_resolver: Arc<dyn SelectorParamsResolver>,
+        memoria_client: Arc<dyn MemoriaPort>,
+        ingestion: IngestionSender,
+        user_id: Option<Arc<str>>,
+        broker: Arc<BackgroundActivityBroker>,
+    ) -> Self {
         Self {
             selector_resolver,
             memoria_client,
             ingestion,
-            user_id: user_id.into(),
+            user_id,
             health: Arc::new(SelectorHealth::new()),
             memoria_health: Arc::new(MemoriaHealth::new()),
             work: Arc::new(std::sync::Mutex::new(SessionWorkCoordinator::default())),
@@ -211,7 +241,7 @@ impl MemoryExtractionService {
     /// a bootstrap/default tenant.
     pub fn scoped_to_owner(self: &Arc<Self>, user_id: &str) -> Result<Arc<Self>, String> {
         let scope = astra_memoria::MemoryScope::new(user_id, "owner-binding-validation")?;
-        if self.user_id.as_ref() == scope.user_id.as_str() {
+        if self.user_id.as_deref() == Some(scope.user_id.as_str()) {
             return Ok(Arc::clone(self));
         }
 
@@ -219,6 +249,7 @@ impl MemoryExtractionService {
             .owner_scoped_services
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        scoped.retain(|_, service| service.strong_count() > 0);
         if let Some(existing) = scoped
             .get(&scope.user_id)
             .and_then(std::sync::Weak::upgrade)
@@ -230,7 +261,7 @@ impl MemoryExtractionService {
             selector_resolver: Arc::clone(&self.selector_resolver),
             memoria_client: self.memoria_client.bind_owner(&scope.user_id)?,
             ingestion: self.ingestion.clone(),
-            user_id: Arc::from(scope.user_id.as_str()),
+            user_id: Some(Arc::from(scope.user_id.as_str())),
             health: Arc::clone(&self.health),
             memoria_health: Arc::clone(&self.memoria_health),
             work: Arc::new(std::sync::Mutex::new(SessionWorkCoordinator::default())),
@@ -247,8 +278,8 @@ impl MemoryExtractionService {
     }
 
     #[must_use]
-    pub fn owner_user_id(&self) -> &str {
-        &self.user_id
+    pub fn owner_user_id(&self) -> Option<&str> {
+        self.user_id.as_deref()
     }
 
     fn write_required_local_snapshot(&self, session_id: &str, content: &str) -> Result<(), String> {
@@ -391,6 +422,13 @@ impl MemoryExtractionService {
     ///
     /// **Must run inside a Tokio runtime.**
     pub fn maybe_spawn(self: &Arc<Self>, req: ExtractionRequest) -> SpawnDecision {
+        let Some(user_id) = self.user_id.as_deref() else {
+            tracing::error!(
+                session_id = %req.session_id,
+                "refusing session-memory extraction from an owner-neutral service template"
+            );
+            return SpawnDecision::Skipped;
+        };
         let content_fingerprint = extraction_input_fingerprint(&req);
         // Breadcrumbs for sync-path skip events. `selector_model` and
         // `attempt` only make sense in the async worker after LLM
@@ -482,13 +520,7 @@ impl MemoryExtractionService {
                 } else {
                     Some(req.session_id.as_str())
                 };
-                self.emit_skip_event(
-                    &self.user_id,
-                    sid_opt,
-                    req.turn_number,
-                    reason,
-                    &skip_breadcrumbs,
-                );
+                self.emit_skip_event(user_id, sid_opt, req.turn_number, reason, &skip_breadcrumbs);
                 return SpawnDecision::Skipped;
             }
         }
@@ -523,7 +555,13 @@ impl MemoryExtractionService {
 
     async fn run_one(self: Arc<Self>, req: ExtractionRequest, content_fingerprint: u64) {
         let session_id = req.session_id.clone();
-        let user_id = self.user_id.to_string();
+        let Some(user_id) = self.user_id.as_deref().map(str::to_string) else {
+            tracing::error!(
+                session_id = %session_id,
+                "refusing session-memory worker execution without an authenticated owner"
+            );
+            return;
+        };
         let turn = req.turn_number;
         let messages_count = req.messages.len() as u32;
         let started = Instant::now();
@@ -1271,11 +1309,10 @@ mod tests {
         let port = Arc::new(OwnerBindingMemoria::default());
         let bindings = Arc::clone(&port.bindings);
         let (tx, _rx) = IngestionSender::for_tests(16);
-        let root = Arc::new(MemoryExtractionService::new(
+        let root = Arc::new(MemoryExtractionService::new_owner_scoped_template(
             Arc::new(ConstSelectorResolver(None)),
             port,
             tx,
-            "bootstrap-owner",
             Arc::new(BackgroundActivityBroker::new()),
         ));
 
@@ -1285,14 +1322,46 @@ mod tests {
 
         assert!(Arc::ptr_eq(&alice_a, &alice_b));
         assert!(!Arc::ptr_eq(&alice_a, &bob));
-        assert_eq!(alice_a.owner_user_id(), "alice");
-        assert_eq!(bob.owner_user_id(), "bob");
+        assert_eq!(root.owner_user_id(), None);
+        assert_eq!(alice_a.owner_user_id(), Some("alice"));
+        assert_eq!(bob.owner_user_id(), Some("bob"));
         assert_eq!(&*bindings.lock().unwrap(), &["alice", "bob"]);
 
         alice_a.mark_session_extracted("same-session", 11, 2);
         assert!(alice_a.peek_state("same-session").is_some());
         assert!(bob.peek_state("same-session").is_none());
         assert!(Arc::ptr_eq(&alice_a.pending, &bob.pending));
+    }
+
+    #[test]
+    fn owner_scoped_service_cache_prunes_dead_owner_keys() {
+        let port = Arc::new(OwnerBindingMemoria::default());
+        let (tx, _rx) = IngestionSender::for_tests(16);
+        let root = Arc::new(MemoryExtractionService::new_owner_scoped_template(
+            Arc::new(ConstSelectorResolver(None)),
+            port,
+            tx,
+            Arc::new(BackgroundActivityBroker::new()),
+        ));
+
+        let alice = root.scoped_to_owner("alice").unwrap();
+        assert_eq!(
+            root.owner_scoped_services
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .len(),
+            1
+        );
+        drop(alice);
+
+        let _bob = root.scoped_to_owner("bob").unwrap();
+        let scoped = root
+            .owner_scoped_services
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(scoped.len(), 1, "dead owner keys must not accumulate");
+        assert!(scoped.contains_key("bob"));
+        assert!(!scoped.contains_key("alice"));
     }
 
     async fn spawn_json_server_with_status(
@@ -1370,6 +1439,28 @@ mod tests {
             had_user_correction: false,
             turn_number: 1,
         }
+    }
+
+    #[tokio::test]
+    async fn owner_neutral_template_refuses_direct_extraction() {
+        let memoria = Arc::new(OwnerBindingMemoria::default());
+        let (ingestion, _rx) = IngestionSender::for_tests(16);
+        let template = Arc::new(MemoryExtractionService::new_owner_scoped_template(
+            Arc::new(ConstSelectorResolver(None)),
+            memoria,
+            ingestion,
+            Arc::new(BackgroundActivityBroker::new()),
+        ));
+
+        assert_eq!(
+            template.maybe_spawn(sample_req("session-without-owner", 1_000, false)),
+            SpawnDecision::Skipped
+        );
+        assert_eq!(template.owner_user_id(), None);
+        assert_eq!(
+            template.wait_for_pending(Duration::from_millis(10)).await,
+            0
+        );
     }
 
     fn meaningful_shutdown_req(session_id: &str, _tokens: usize) -> ExtractionRequest {

--- a/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/crates/runtime/src/turn/bridge/inprocess.rs
@@ -259,6 +259,36 @@ where
     Some(snapshot)
 }
 
+async fn record_session_local_heuristic_feedback(
+    feedback_store: &astra_pipeline::feedback_store::FeedbackStore,
+    session_id: &str,
+    user_text: &str,
+    signal: &astra_turn_types::ImplicitSignal,
+) -> bool {
+    if session_id.is_empty()
+        || !matches!(
+            signal.signal_type.as_str(),
+            "correction" | "frustration" | "rephrasing"
+        )
+    {
+        return false;
+    }
+    let Some(feedback) = astra_pipeline::feedback_extraction::heuristic_extract(
+        user_text,
+        &signal.signal_type,
+        signal.confidence,
+    ) else {
+        return false;
+    };
+
+    // Heuristic feedback is an unverified observation. This function
+    // deliberately has access only to the session-scoped store: promotion to
+    // cross-session memory requires a separate durable learning workflow with
+    // consent, evaluation, activation, rollback, and deletion lineage.
+    feedback_store.add(session_id, feedback).await;
+    true
+}
+
 /// Build a prompt section for the CLI-injected skill listing.
 ///
 /// Returns `None` when the CLI didn't include a listing (no skills loaded
@@ -2167,46 +2197,13 @@ impl InProcessChatTurnBridge {
                     signal.signal_type.as_str(),
                     "correction" | "frustration" | "rephrasing"
                 );
-                // Store heuristic-extracted feedback only on correction-like signals
-                // and only when we have a valid session_id (avoid cross-session leakage)
-                if !session_id.is_empty() && is_correction_like {
-                    if let Some(fb) = astra_pipeline::feedback_extraction::heuristic_extract(
-                        user_content_for_signal,
-                        &signal.signal_type,
-                        signal.confidence,
-                    ) {
-                        // Persist feedback rule to Memoria L3 (fire-and-forget).
-                        // Closes the reflect→memory loop: correction detected in
-                        // this turn → stored durably → recalled in future sessions.
-                        if let Some(ref mc) = memoria_client_owned {
-                            use crate::turn::cloud::memoria_compact::MemoriaPort;
-                            if let Some(lesson) =
-                                crate::learning::synthesizer::feedback_rule_to_lesson(&fb)
-                            {
-                                let c = mc.clone();
-                                let sid = session_id.clone();
-                                tokio::spawn(async move {
-                                    match tokio::time::timeout(
-                                        std::time::Duration::from_secs(5),
-                                        c.store(
-                                            &lesson.content,
-                                            lesson.memory_type,
-                                            Some(&sid),
-                                            Some(lesson.trust_tier),
-                                        ),
-                                    )
-                                    .await
-                                    {
-                                        Ok(Ok(_)) => tracing::debug!("Persisted feedback rule to Memoria"),
-                                        Ok(Err(e)) => tracing::debug!("Failed to persist feedback rule: {e}"),
-                                        Err(_) => tracing::debug!("Timed out persisting feedback rule to Memoria"),
-                                    }
-                                });
-                            }
-                        }
-                        feedback_store.add(&session_id, fb).await;
-                    }
-                }
+                record_session_local_heuristic_feedback(
+                    feedback_store.as_ref(),
+                    &session_id,
+                    user_content_for_signal,
+                    &signal,
+                )
+                .await;
                 let hint = crate::turn::implicit_feedback::implicit_feedback_context_injection(&signal)
                     .map(|s| format!("\n\n{s}"))
                     .unwrap_or_default();
@@ -5059,6 +5056,54 @@ mod tests {
         .expect("provider model gateway invocation");
 
         assert_eq!(invocation.model, "qwen3.5-flash");
+    }
+
+    #[tokio::test]
+    async fn heuristic_feedback_remains_session_local_and_requires_a_concrete_rule() {
+        let store = astra_pipeline::feedback_store::FeedbackStore::new();
+        let correction = astra_turn_types::detect_implicit_feedback_signal(
+            "wrong, don't use mocks in integration tests",
+            Some("I'll mock the database"),
+        );
+
+        assert!(
+            record_session_local_heuristic_feedback(
+                &store,
+                "session-a",
+                "wrong, don't use mocks in integration tests",
+                &correction,
+            )
+            .await
+        );
+        assert_eq!(store.len("session-a").await, 1);
+        assert!(
+            store.is_empty("session-b").await,
+            "heuristic feedback must not cross session ownership boundaries"
+        );
+
+        assert!(
+            !record_session_local_heuristic_feedback(
+                &store,
+                "",
+                "wrong, don't use mocks in integration tests",
+                &correction,
+            )
+            .await,
+            "feedback without a session owner must be rejected"
+        );
+
+        let neutral = astra_turn_types::detect_implicit_feedback_signal("tell me about Rust", None);
+        assert!(
+            !record_session_local_heuristic_feedback(
+                &store,
+                "session-a",
+                "tell me about Rust",
+                &neutral,
+            )
+            .await,
+            "non-correction observations must not become learned rules"
+        );
+        assert_eq!(store.len("session-a").await, 1);
     }
 
     #[test]

--- a/crates/runtime/tests/system_matrix_http_e2e/journey_full.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/journey_full.rs
@@ -770,6 +770,14 @@ pub async fn run_product_matrix_full_journey(
     )
     .await;
     assert_eq!(st_hb, StatusCode::OK, "edge heartbeat: {hb}");
+    assert_eq!(
+        hb["replay_policy"], "durable_result_reconciliation_required",
+        "heartbeat must never grant automatic pending-tool replay authority"
+    );
+    assert!(
+        hb.get("pending_requests").is_none(),
+        "heartbeat must not return executable pending tool payloads"
+    );
 
     let (st_tool, tool_j) = post_json(
         app,

--- a/crates/runtime/tests/team_api_integration.rs
+++ b/crates/runtime/tests/team_api_integration.rs
@@ -375,11 +375,11 @@ async fn scenario_full_team_lifecycle() {
         assert!(!body["team_id"].as_str().unwrap().is_empty());
     }
 
-    // ── List: should see all 4 ──
+    // ── List: owner-scoped builtins plus all 4 custom teams ──
     let (status, body) = get(app.clone(), "/teams", user).await;
     assert_eq!(status, StatusCode::OK);
     let team_list = body["teams"].as_array().unwrap();
-    assert_eq!(team_list.len(), 4);
+    assert_eq!(team_list.len(), 7);
     let names: Vec<&str> = team_list
         .iter()
         .map(|t| t["name"].as_str().unwrap())
@@ -388,6 +388,9 @@ async fn scenario_full_team_lifecycle() {
     assert!(names.contains(&"adversarial-review"));
     assert!(names.contains(&"parallel-research"));
     assert!(names.contains(&"db-migration"));
+    assert!(names.contains(&"review"));
+    assert!(names.contains(&"research"));
+    assert!(names.contains(&"dev"));
 
     // Verify budget/max_parallel visible in list summary
     let dev_summary = team_list.iter().find(|t| t["name"] == "dev-cycle").unwrap();
@@ -450,10 +453,10 @@ async fn scenario_full_team_lifecycle() {
     let (status, _) = get(app.clone(), "/teams/db-migration", user).await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 
-    // List should now have 3
+    // List should now have 3 custom teams plus the 3 owner-scoped builtins.
     let (status, body) = get(app.clone(), "/teams", user).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["teams"].as_array().unwrap().len(), 3);
+    assert_eq!(body["teams"].as_array().unwrap().len(), 6);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -475,17 +478,55 @@ async fn scenario_multi_user_isolation() {
     // Each user sees only their own
     let (_, body_a) = get(app.clone(), "/teams", "alice").await;
     let (_, body_b) = get(app.clone(), "/teams", "bob").await;
-    assert_eq!(body_a["teams"].as_array().unwrap().len(), 1);
-    assert_eq!(body_b["teams"].as_array().unwrap().len(), 1);
+    assert_eq!(body_a["teams"].as_array().unwrap().len(), 4);
+    assert_eq!(body_b["teams"].as_array().unwrap().len(), 4);
 
     // Different team_ids
-    let id_a = body_a["teams"][0]["team_id"].as_str().unwrap();
-    let id_b = body_b["teams"][0]["team_id"].as_str().unwrap();
+    let id_a = body_a["teams"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|team| team["name"] == "dev-cycle")
+        .and_then(|team| team["team_id"].as_str())
+        .unwrap();
+    let id_b = body_b["teams"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|team| team["name"] == "dev-cycle")
+        .and_then(|team| team["team_id"].as_str())
+        .unwrap();
     assert_ne!(id_a, id_b);
 
     // User A cannot see user B's team by name (scoped)
     let (s, _) = get(app.clone(), "/teams/dev-cycle", "charlie").await;
     assert_eq!(s, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn scenario_fresh_owner_lazily_receives_isolated_builtin_teams() {
+    let app = build_test_app();
+
+    let (status, alice) = get(app.clone(), "/teams", "alice-new").await;
+    assert_eq!(status, StatusCode::OK);
+    let alice_teams = alice["teams"].as_array().unwrap();
+    assert_eq!(alice_teams.len(), 3);
+    assert_eq!(
+        alice_teams
+            .iter()
+            .map(|team| team["name"].as_str().unwrap())
+            .collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from(["dev", "research", "review"])
+    );
+
+    let (status, review) = get(app.clone(), "/teams/review", "alice-new").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(review["user_id"], "alice-new");
+
+    let (status, bob_review) = get(app, "/teams/review", "bob-new").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(bob_review["user_id"], "bob-new");
+    assert_ne!(review["team_id"], bob_review["team_id"]);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/runtime/tests/team_execute_http_integration.rs
+++ b/crates/runtime/tests/team_execute_http_integration.rs
@@ -657,11 +657,19 @@ async fn http_execute_invalid_json_or_missing_task() {
 #[tokio::test]
 async fn http_execute_team_for_different_user_returns_404() {
     let store = Arc::new(InMemoryTeamStore::with_builtins("test-user"));
+    let mut owner_private_team = store
+        .load_team("test-user", "research")
+        .await
+        .unwrap()
+        .expect("seeded research team");
+    owner_private_team.team_id = "test-user-private-research".to_string();
+    owner_private_team.name = "private-research".to_string();
+    store.save_team(&owner_private_team).await.unwrap();
     let app = build_app_with_delegation(store, Arc::new(StubSubRunExecutor)).await;
 
     let (status, body) = post_json(
         app,
-        "/teams/research/execute",
+        "/teams/private-research/execute",
         "other-user",
         json!({ "task": "t" }),
     )

--- a/crates/services/src/team_persistence.rs
+++ b/crates/services/src/team_persistence.rs
@@ -713,6 +713,13 @@ fn team_snapshot_page_from_records(
 /// CRUD operations for team definitions, execution history, and snapshots.
 #[async_trait]
 pub trait TeamPersistenceService: Send + Sync {
+    /// Materialize the standard team templates for an authenticated owner.
+    ///
+    /// This is intentionally request-owner scoped. Process startup has no
+    /// legitimate user identity and must never seed templates under a fake
+    /// principal.
+    async fn ensure_builtins(&self, user_id: &str) -> Result<(), String>;
+
     async fn save_team(&self, team: &TeamDefinition) -> Result<(), String>;
     async fn load_team(&self, user_id: &str, name: &str) -> Result<Option<TeamDefinition>, String>;
     async fn load_team_by_id(
@@ -854,6 +861,16 @@ impl Default for InMemoryTeamStore {
 
 #[async_trait]
 impl TeamPersistenceService for InMemoryTeamStore {
+    async fn ensure_builtins(&self, user_id: &str) -> Result<(), String> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let mut map = self.teams.write().map_err(|e| e.to_string())?;
+        for team in builtin_teams(user_id, &now) {
+            let key = format!("{}:{}", team.user_id, team.name);
+            map.entry(key).or_insert(team);
+        }
+        Ok(())
+    }
+
     async fn save_team(&self, team: &TeamDefinition) -> Result<(), String> {
         let key = format!("{}:{}", team.user_id, team.name);
         let mut map = self.teams.write().map_err(|e| e.to_string())?;
@@ -1082,21 +1099,79 @@ impl MatrixOneTeamStore {
         Self { pool }
     }
 
-    /// Seed built-in teams for a user if they don't already exist.
+    /// Materialize built-in teams without overwriting an owner's existing
+    /// same-name definition.
+    ///
+    /// This uses insert-only admission rather than `load` followed by
+    /// [`TeamPersistenceService::save_team`]. The latter is an upsert and can
+    /// overwrite a user customization when first-request initialization races
+    /// with an explicit create.
     pub async fn ensure_builtins(&self, user_id: &str) -> Result<(), String> {
         let now = chrono::Utc::now().to_rfc3339();
         for team in builtin_teams(user_id, &now) {
-            let existing = self.load_team(user_id, &team.name).await?;
-            if existing.is_none() {
-                self.save_team(&team).await?;
-            }
+            self.insert_builtin_if_absent(&team).await?;
         }
         Ok(())
+    }
+
+    async fn insert_builtin_if_absent(&self, team: &TeamDefinition) -> Result<(), String> {
+        let coordination_json =
+            serde_json::to_string(&team.coordination).map_err(|e| e.to_string())?;
+        let members_json = serde_json::to_string(&team.members).map_err(|e| e.to_string())?;
+        let context_json = serde_json::to_string(&team.context).map_err(|e| e.to_string())?;
+        let worktree_str = serde_json::to_string(&team.worktree_mode)
+            .map_err(|e| e.to_string())?
+            .trim_matches('"')
+            .to_string();
+        let budget_json = team
+            .budget
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| e.to_string())?;
+
+        match sqlx::query(
+            "INSERT INTO team_definitions \
+             (team_id, user_id, name, description, coordination, members_json, \
+              context_json, worktree_mode, budget_json, max_parallel, \
+              created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6), NOW(6))",
+        )
+        .bind(&team.team_id)
+        .bind(&team.user_id)
+        .bind(&team.name)
+        .bind(&team.description)
+        .bind(&coordination_json)
+        .bind(&members_json)
+        .bind(&context_json)
+        .bind(&worktree_str)
+        .bind(&budget_json)
+        .bind(team.max_parallel)
+        .execute(&self.pool)
+        .await
+        {
+            Ok(_) => Ok(()),
+            Err(error) if is_duplicate_key_error(&error) => {
+                if self.load_team(&team.user_id, &team.name).await?.is_some() {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "builtin team INSERT failed: team_id {} collides with a different team",
+                        team.team_id
+                    ))
+                }
+            }
+            Err(error) => Err(format!("builtin team INSERT failed: {error}")),
+        }
     }
 }
 
 #[async_trait]
 impl TeamPersistenceService for MatrixOneTeamStore {
+    async fn ensure_builtins(&self, user_id: &str) -> Result<(), String> {
+        MatrixOneTeamStore::ensure_builtins(self, user_id).await
+    }
+
     async fn save_team(&self, team: &TeamDefinition) -> Result<(), String> {
         let coordination_json =
             serde_json::to_string(&team.coordination).map_err(|e| e.to_string())?;
@@ -1971,6 +2046,40 @@ mod tests {
         assert!(names.contains(&"review"));
         assert!(names.contains(&"research"));
         assert!(names.contains(&"dev"));
+    }
+
+    #[tokio::test]
+    async fn ensure_builtins_is_owner_scoped_idempotent_and_non_destructive() {
+        let store = InMemoryTeamStore::new();
+        let mut existing_review = test_team();
+        existing_review.team_id = "alice-custom-review".to_string();
+        existing_review.user_id = "alice".to_string();
+        existing_review.name = "review".to_string();
+        existing_review.description = "owner customized review".to_string();
+        store.save_team(&existing_review).await.unwrap();
+
+        store.ensure_builtins("alice").await.unwrap();
+        store.ensure_builtins("alice").await.unwrap();
+        store.ensure_builtins("bob").await.unwrap();
+
+        let alice = store.list_teams("alice").await.unwrap();
+        let bob = store.list_teams("bob").await.unwrap();
+        assert_eq!(alice.len(), 3);
+        assert_eq!(bob.len(), 3);
+        assert_eq!(
+            alice
+                .iter()
+                .find(|team| team.name == "review")
+                .map(|team| (team.team_id.as_str(), team.description.as_str())),
+            Some(("alice-custom-review", "owner customized review")),
+            "lazy initialization must not overwrite an owner's existing definition"
+        );
+        assert!(
+            alice
+                .iter()
+                .all(|team| team.user_id == "alice" && !team.team_id.contains("bob"))
+        );
+        assert!(bob.iter().all(|team| team.user_id == "bob"));
     }
 
     #[tokio::test]

--- a/crates/services/tests/team_persistence_integration.rs
+++ b/crates/services/tests/team_persistence_integration.rs
@@ -502,16 +502,15 @@ async fn ensure_builtins_idempotent() {
     let user_id = format!("it-builtins-{}", Uuid::new_v4());
     let store = MatrixOneTeamStore::new(pool.clone());
 
-    // First call seeds built-in teams
-    store
-        .ensure_builtins(&user_id)
-        .await
-        .expect("ensure_builtins");
-    let list1 = store.list_teams(&user_id).await.unwrap();
-    assert!(
-        list1.len() >= 3,
-        "should have at least review, research, dev"
+    // Concurrent first requests must converge without overwriting or errors.
+    let (first, concurrent) = tokio::join!(
+        store.ensure_builtins(&user_id),
+        store.ensure_builtins(&user_id)
     );
+    first.expect("ensure_builtins");
+    concurrent.expect("concurrent ensure_builtins");
+    let list1 = store.list_teams(&user_id).await.unwrap();
+    assert_eq!(list1.len(), 3, "should have review, research, dev once");
 
     // Second call is idempotent
     store
@@ -524,5 +523,43 @@ async fn ensure_builtins_idempotent() {
     // Cleanup
     for t in &list2 {
         cleanup_team(&pool, &t.team_id).await;
+    }
+}
+
+#[tokio::test]
+#[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
+#[serial]
+async fn ensure_builtins_preserves_existing_owner_customization() {
+    let shared = setup_pool().await;
+    let pool = shared.get().clone();
+    let store = MatrixOneTeamStore::new(pool.clone());
+    let user_id = format!("it-builtins-custom-{}", Uuid::new_v4());
+    let mut customized = test_team("builtin-custom", TeamCoordination::Pipeline);
+    customized.user_id = user_id.clone();
+    customized.name = "review".to_string();
+    customized.description = "owner-defined review workflow".to_string();
+    cleanup_team(&pool, &customized.team_id).await;
+    store
+        .save_team(&customized)
+        .await
+        .expect("save owner customization");
+
+    store
+        .ensure_builtins(&user_id)
+        .await
+        .expect("materialize missing builtins");
+
+    let review = store
+        .load_team(&user_id, "review")
+        .await
+        .expect("load customized review")
+        .expect("customized review remains present");
+    assert_eq!(review.team_id, customized.team_id);
+    assert_eq!(review.description, "owner-defined review workflow");
+    let teams = store.list_teams(&user_id).await.expect("list teams");
+    assert_eq!(teams.len(), 3);
+
+    for team in teams {
+        cleanup_team(&pool, &team.team_id).await;
     }
 }


### PR DESCRIPTION
## Summary

- make Edge heartbeat recovery identity-first: typed reconciliation only, no executable pending payload or automatic tool replay
- restore owner-scoped team materialization and session memory binding without a synthetic `local` principal
- make builtin creation concurrent-safe and non-destructive; prune dead owner cache entries
- harden feedback/session boundaries and deterministic todo sweeper claims

## Verification

- `make check`
- `make test-online` — runtime 52/52, turn-core 12/12, services 178/178, shared integration 310/310, performance 5/5
- `make test-offline` — workspace 24,247/24,247, runtime supplemental 5,088/5,088, SDK 210 passed / 1 skipped, Web 332/332 plus production build

Package lockfiles are intentionally unchanged.