### PR TITLE
fix(runtime): keep terminal task diagnostics reachable

### DIFF
--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -3729,6 +3729,9 @@ impl ToolExecutor {
                         "pattern must be at most 512 characters",
                     );
                 }
+                if pattern.contains(['\r', '\n']) {
+                    return format_background_task_argument_error("pattern must be a single line");
+                }
                 Some(pattern.to_string())
             }
             Some(_) => {
@@ -7122,6 +7125,20 @@ mod tests {
                 "{output}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn task_output_pattern_rejects_multiline_literal() {
+        let executor = test_executor();
+        let output = executor
+            .task_output(&serde_json::json!({
+                "task_id": "bg-shell-1",
+                "pattern": "failure\npanic"
+            }))
+            .await;
+        let result = parse_control_result(&output);
+        assert_eq!(result["status"], "invalid_argument", "{output}");
+        assert_eq!(result["error"], "pattern must be a single line", "{output}");
     }
 
     #[tokio::test]

--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -647,6 +647,18 @@ pub struct BgTaskOutputSnapshot {
     pub output_ref: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct BgTaskOutputSearchSnapshot {
+    pub kind: String,
+    pub title: Option<String>,
+    pub output: String,
+    pub matching_lines: u64,
+    pub truncated: bool,
+    pub status: String,
+    pub terminal: bool,
+    pub output_ref: String,
+}
+
 pub(crate) enum BgTaskCommand {
     Kill {
         task_id: String,
@@ -657,6 +669,14 @@ pub(crate) enum BgTaskCommand {
         offset: u64,
         max_bytes: usize,
         reply: tokio::sync::oneshot::Sender<Result<BgTaskOutputSnapshot, BackgroundTaskError>>,
+    },
+    SearchOutput {
+        task_id: String,
+        pattern: String,
+        context_lines: usize,
+        max_bytes: usize,
+        reply:
+            tokio::sync::oneshot::Sender<Result<BgTaskOutputSearchSnapshot, BackgroundTaskError>>,
     },
     List {
         reply: tokio::sync::oneshot::Sender<String>,
@@ -701,6 +721,36 @@ async fn request_background_task_output_snapshot(
         commands.push(BgTaskCommand::GetOutputSince {
             task_id: task_id.to_string(),
             offset,
+            max_bytes,
+            reply: tx,
+        });
+    }
+    match await_bg_task_command_reply(rx, reply_timeout).await {
+        Ok(Ok(snapshot)) => Ok(snapshot),
+        Ok(Err(error)) => Err(format_background_task_error(&error)),
+        Err(BgTaskReplyError::Closed) => Err(format_background_task_registry_closed(Some(task_id))),
+        Err(BgTaskReplyError::TimedOut) => Err(format_background_task_output_registry_timeout(
+            task_id,
+            reply_timeout,
+        )),
+    }
+}
+
+async fn request_background_task_output_search(
+    bg_commands: &std::sync::Arc<std::sync::Mutex<Vec<BgTaskCommand>>>,
+    task_id: &str,
+    pattern: &str,
+    context_lines: usize,
+    max_bytes: usize,
+    reply_timeout: Duration,
+) -> Result<BgTaskOutputSearchSnapshot, String> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    {
+        let mut commands = bg_commands.lock_recover();
+        commands.push(BgTaskCommand::SearchOutput {
+            task_id: task_id.to_string(),
+            pattern: pattern.to_string(),
+            context_lines,
             max_bytes,
             reply: tx,
         });
@@ -951,6 +1001,10 @@ fn format_background_task_output(
     if !snapshot.output_ref.trim().is_empty() {
         metadata_parts.push(format!("output_ref {}", snapshot.output_ref));
     }
+    if kind == "shell" && snapshot.status == "failed" {
+        metadata_parts.push("failure_cause unverified".to_string());
+        metadata_parts.push("diagnostic_search_available true".to_string());
+    }
     if let Some(title) = snapshot
         .title
         .as_deref()
@@ -979,14 +1033,77 @@ fn format_background_task_output(
             (_, "unavailable") => "Unavailable · stale handle or unsupported runner",
             _ => "No output yet",
         };
-        return format!("{header}\n{state} · {metadata}");
+        let diagnosis = (kind == "shell" && snapshot.status == "failed").then_some(
+            "\nFailure diagnosis is still open. Search this task's captured output with task_output(pattern=...) before assigning a cause; a failed status alone is not evidence that a test is flaky.",
+        );
+        return format!("{header}\n{state} · {metadata}{}", diagnosis.unwrap_or(""));
     }
 
     let chunk = snapshot.output.trim_end();
     let line_count = chunk.lines().count();
+    let diagnosis = (kind == "shell" && snapshot.status == "failed").then_some(
+        "\nFailure diagnosis is still open. Search this task's captured output with task_output(pattern=...) before assigning a cause; a failed status alone is not evidence that a test is flaky.",
+    );
     format!(
         "{header}\n{line_count} new {} · {metadata} · {status_label}\nOutput chunk:\n{chunk}",
         if line_count == 1 { "line" } else { "lines" }
+    ) + diagnosis.unwrap_or("")
+}
+
+fn format_background_task_output_search(
+    task_id: &str,
+    pattern: &str,
+    context_lines: usize,
+    snapshot: &BgTaskOutputSearchSnapshot,
+) -> String {
+    let kind = snapshot.kind.trim();
+    let kind = if kind.is_empty() { "shell" } else { kind };
+    let status_label = match snapshot.status.as_str() {
+        "pending" => "pending",
+        "running" => "still running",
+        "waiting_for_input" => "needs input",
+        "completed" => "completed",
+        "failed" => "failed",
+        "killed" => "killed",
+        other => other,
+    };
+    let title = snapshot
+        .title
+        .as_deref()
+        .filter(|title| !title.trim().is_empty())
+        .map(|title| format!(" · title {}", title.trim()))
+        .unwrap_or_default();
+    let output_ref = if snapshot.output_ref.trim().is_empty() {
+        String::new()
+    } else {
+        format!(" · output_ref {}", snapshot.output_ref)
+    };
+    let truncation = if snapshot.truncated {
+        " · result_truncated true"
+    } else {
+        ""
+    };
+    let header = format!(
+        "Search {kind} output {task_id}\npattern {pattern:?} · {} matching {} · context_lines {context_lines} · terminal {} · {status_label}{truncation}{title}{output_ref}",
+        snapshot.matching_lines,
+        if snapshot.matching_lines == 1 {
+            "line"
+        } else {
+            "lines"
+        },
+        snapshot.terminal,
+    );
+    let evidence_contract = if snapshot.status == "failed" {
+        "\nDiagnostic search returns evidence, not a classification. Call a test flaky only after a controlled rerun succeeds or equivalent repeatability evidence exists."
+    } else {
+        ""
+    };
+    if snapshot.output.trim().is_empty() {
+        return format!("{header}\nNo matching output lines.{evidence_contract}");
+    }
+    format!(
+        "{header}\nMatched output:\n{}{evidence_contract}",
+        snapshot.output.trim_end()
     )
 }
 
@@ -1024,6 +1141,26 @@ fn background_task_output_result_fields(
             "status": snapshot.status,
             "terminal": snapshot.terminal,
             "mode": observation_mode,
+        }),
+    )])
+}
+
+fn background_task_output_search_result_fields(
+    task_id: &str,
+    pattern: &str,
+    snapshot: &BgTaskOutputSearchSnapshot,
+) -> serde_json::Map<String, Value> {
+    serde_json::Map::from_iter([(
+        "background_task_observation".to_string(),
+        serde_json::json!({
+            "task_id": task_id,
+            "task_kind": snapshot.kind,
+            "status": snapshot.status,
+            "terminal": snapshot.terminal,
+            "mode": "diagnostic",
+            "pattern": pattern,
+            "matching_lines": snapshot.matching_lines,
+            "truncated": snapshot.truncated,
         }),
     )])
 }
@@ -3580,6 +3717,29 @@ impl ToolExecutor {
         };
         let block = args.get("block").and_then(Value::as_bool).unwrap_or(false);
         let requested_offset = args.get("offset").and_then(Value::as_u64);
+        let pattern = match args.get("pattern") {
+            None => None,
+            Some(Value::String(pattern)) => {
+                let pattern = pattern.trim();
+                if pattern.is_empty() {
+                    return format_background_task_argument_error("pattern must not be empty");
+                }
+                if pattern.chars().count() > 512 {
+                    return format_background_task_argument_error(
+                        "pattern must be at most 512 characters",
+                    );
+                }
+                Some(pattern.to_string())
+            }
+            Some(_) => {
+                return format_background_task_argument_error("pattern must be a string");
+            }
+        };
+        if pattern.is_some() && (block || requested_offset.is_some()) {
+            return format_background_task_argument_error(
+                "pattern cannot be combined with block or offset",
+            );
+        }
         let read_mode = if requested_offset.is_some() {
             BgTaskOutputReadMode::Historical
         } else {
@@ -3589,24 +3749,31 @@ impl ToolExecutor {
             .get("max_bytes")
             .and_then(Value::as_u64)
             .unwrap_or(8_192)
-            .min(65_536) as usize;
+            .clamp(1, 65_536) as usize;
         let timeout_ms = args
             .get("timeout_ms")
             .and_then(Value::as_u64)
             .unwrap_or(30_000)
             .clamp(1, 300_000);
+        let context_lines = args
+            .get("context_lines")
+            .and_then(Value::as_u64)
+            .unwrap_or(3)
+            .min(20) as usize;
 
-        if let Some(output) = self
-            .fanout_group_task_output_response(
-                &task_id,
-                requested_offset.unwrap_or(0),
-                max_bytes,
-                read_mode,
-                None,
-            )
-            .await
-        {
-            return output;
+        if pattern.is_none() {
+            if let Some(output) = self
+                .fanout_group_task_output_response(
+                    &task_id,
+                    requested_offset.unwrap_or(0),
+                    max_bytes,
+                    read_mode,
+                    None,
+                )
+                .await
+            {
+                return output;
+            }
         }
 
         let Some(ref bg_commands) = self.bg_task_commands else {
@@ -3614,6 +3781,31 @@ impl ToolExecutor {
         };
 
         let reply_timeout = background_task_reply_timeout(timeout_ms);
+        if let Some(pattern) = pattern.as_deref() {
+            return match request_background_task_output_search(
+                bg_commands,
+                &task_id,
+                pattern,
+                context_lines,
+                max_bytes,
+                reply_timeout,
+            )
+            .await
+            {
+                Ok(snapshot) => {
+                    *tool_result_fields = Some(background_task_output_search_result_fields(
+                        &task_id, pattern, &snapshot,
+                    ));
+                    format_background_task_output_search(
+                        &task_id,
+                        pattern,
+                        context_lines,
+                        &snapshot,
+                    )
+                }
+                Err(error) => error,
+            };
+        }
         if !block {
             return match background_task_output_view(
                 bg_commands,
@@ -6017,10 +6209,10 @@ impl astra_tools::ToolExecutor for ToolExecutor {
 #[cfg(test)]
 mod tests {
     use super::{
-        AGGREGATE_SOFT_LIMIT, BgTaskCommand, BgTaskOutputReadMode, BgTaskOutputSnapshot,
-        PERSIST_THRESHOLD, ToolExecutor, all_tool_schemas, cli_tool_output_is_error,
-        detect_git_remote_repos, extract_github_owner_repo, file_checkpoint_dir_for,
-        format_background_task_error, format_background_task_output,
+        AGGREGATE_SOFT_LIMIT, BgTaskCommand, BgTaskOutputReadMode, BgTaskOutputSearchSnapshot,
+        BgTaskOutputSnapshot, PERSIST_THRESHOLD, ToolExecutor, all_tool_schemas,
+        cli_tool_output_is_error, detect_git_remote_repos, extract_github_owner_repo,
+        file_checkpoint_dir_for, format_background_task_error, format_background_task_output,
         format_background_task_output_wait_timeout, format_background_task_stop_error,
         git_stash_sub_action_args, memoria, parse_memory_search_contents, utf16_col_to_char_idx,
     };
@@ -6843,6 +7035,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn task_output_pattern_uses_typed_bounded_diagnostic_search() {
+        let commands = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let executor = test_executor().with_bg_task_commands(commands.clone());
+        let args = serde_json::json!({
+            "task_id": "bg-shell-1",
+            "pattern": "failing_test_name",
+            "context_lines": 5,
+            "max_bytes": 4096,
+            "timeout_ms": 10_000
+        });
+        let mut result_fields = None;
+        let output = tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            let output_fut = executor.task_output_with_fields(&args, &mut result_fields);
+            tokio::pin!(output_fut);
+            loop {
+                tokio::select! {
+                    output = &mut output_fut => break output,
+                    _ = tokio::time::sleep(std::time::Duration::from_millis(1)) => {
+                        if let Some(BgTaskCommand::SearchOutput {
+                            task_id,
+                            pattern,
+                            context_lines,
+                            max_bytes,
+                            reply,
+                        }) = commands.lock_recover().pop()
+                        {
+                            assert_eq!(task_id, "bg-shell-1");
+                            assert_eq!(pattern, "failing_test_name");
+                            assert_eq!(context_lines, 5);
+                            assert_eq!(max_bytes, 4096);
+                            let _ = reply.send(Ok(BgTaskOutputSearchSnapshot {
+                                kind: "shell".to_string(),
+                                title: Some("cargo test".to_string()),
+                                output: "[stdout lines 40-42]\n41: panic detail\n".to_string(),
+                                matching_lines: 1,
+                                truncated: false,
+                                status: "failed".to_string(),
+                                terminal: true,
+                                output_ref: "stdout: /tmp/bg-shell-1.stdout".to_string(),
+                            }));
+                        }
+                    }
+                }
+            }
+        })
+        .await
+        .expect("diagnostic search should return promptly");
+
+        assert!(
+            output.contains("Search shell output bg-shell-1"),
+            "{output}"
+        );
+        assert!(output.contains("pattern \"failing_test_name\""), "{output}");
+        assert!(output.contains("panic detail"), "{output}");
+        assert!(output.contains("not a classification"), "{output}");
+        let observation = result_fields
+            .as_ref()
+            .and_then(|fields| fields.get("background_task_observation"))
+            .expect("diagnostic search observation must be structured");
+        assert_eq!(observation["mode"], "diagnostic");
+        assert_eq!(observation["terminal"], true);
+        assert_eq!(observation["matching_lines"], 1);
+    }
+
+    #[tokio::test]
+    async fn task_output_pattern_rejects_cursor_or_wait_combinations() {
+        let executor = test_executor();
+        for args in [
+            serde_json::json!({
+                "task_id": "bg-shell-1",
+                "pattern": "failure",
+                "offset": 0
+            }),
+            serde_json::json!({
+                "task_id": "bg-shell-1",
+                "pattern": "failure",
+                "block": true
+            }),
+        ] {
+            let output = executor.task_output(&args).await;
+            let result = parse_control_result(&output);
+            assert_eq!(result["status"], "invalid_argument", "{output}");
+            assert_eq!(
+                result["error"], "pattern cannot be combined with block or offset",
+                "{output}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn task_output_blocking_waits_for_terminal_not_ordinary_output_growth() {
         let commands = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let executor = test_executor().with_bg_task_commands(commands.clone());
@@ -7421,6 +7703,12 @@ mod tests {
         assert!(killed.contains("Stopped with no output"), "{killed}");
         assert!(!failed.contains("Completed with no output"), "{failed}");
         assert!(!killed.contains("Completed with no output"), "{killed}");
+        assert!(failed.contains("failure_cause unverified"), "{failed}");
+        assert!(failed.contains("task_output(pattern=...)"), "{failed}");
+        assert!(
+            failed.contains("not evidence that a test is flaky"),
+            "{failed}"
+        );
     }
 
     #[test]

--- a/crates/astra-cli/src/edge_tools/shell.rs
+++ b/crates/astra-cli/src/edge_tools/shell.rs
@@ -5244,6 +5244,7 @@ mod tests {
                 "{command} -> {result}"
             );
             assert!(result.contains("task_output"), "{command} -> {result}");
+            assert!(result.contains("pattern"), "{command} -> {result}");
         }
         assert!(
             executor

--- a/crates/astra-cli/src/tui/background_tasks.rs
+++ b/crates/astra-cli/src/tui/background_tasks.rs
@@ -10,7 +10,7 @@
 //!   per occurrence
 //! - Factual no-recent-output advisory without guessing process intent
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
@@ -2079,49 +2079,126 @@ fn search_combined_output(
         if !path.exists() || file_len(path) == 0 {
             continue;
         }
-        let bytes = std::fs::read(path)
-            .map_err(|error| format!("cannot read {}: {error}", path.display()))?;
-        let text = String::from_utf8_lossy(&bytes);
-        let lines: Vec<&str> = text.lines().collect();
-        let hits: Vec<usize> = lines
-            .iter()
-            .enumerate()
-            .filter_map(|(index, line)| line.contains(pattern).then_some(index))
-            .collect();
-        matching_lines = matching_lines.saturating_add(hits.len() as u64);
+        search_output_source(
+            label,
+            path,
+            pattern,
+            context_lines,
+            max_bytes,
+            &mut output,
+            &mut matching_lines,
+            &mut truncated,
+        )?;
+    }
 
-        let mut ranges: Vec<(usize, usize)> = Vec::new();
-        for hit in hits {
-            let start = hit.saturating_sub(context_lines);
-            let end = hit
-                .saturating_add(context_lines)
-                .saturating_add(1)
-                .min(lines.len());
-            if let Some((_, previous_end)) = ranges.last_mut()
-                && start <= *previous_end
-            {
-                *previous_end = (*previous_end).max(end);
-            } else {
-                ranges.push((start, end));
-            }
+    Ok((output, matching_lines, truncated))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn search_output_source(
+    label: &str,
+    path: &Path,
+    pattern: &str,
+    context_lines: usize,
+    max_bytes: usize,
+    output: &mut String,
+    matching_lines: &mut u64,
+    truncated: &mut bool,
+) -> Result<(), String> {
+    use std::io::BufRead;
+
+    let file = std::fs::File::open(path)
+        .map_err(|error| format!("cannot read {}: {error}", path.display()))?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut bytes = Vec::new();
+    let mut prior_lines = VecDeque::<(u64, String)>::with_capacity(context_lines);
+    let mut following_context = 0_usize;
+    let mut line_number = 0_u64;
+
+    loop {
+        bytes.clear();
+        let read = reader
+            .read_until(b'\n', &mut bytes)
+            .map_err(|error| format!("cannot read {}: {error}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        line_number = line_number.saturating_add(1);
+        let line = String::from_utf8_lossy(&bytes);
+        let line = line.trim_end_matches(&['\r', '\n'][..]);
+        let is_match = line.contains(pattern);
+        if is_match {
+            *matching_lines = matching_lines.saturating_add(1);
         }
 
-        for (start, end) in ranges {
-            if output.len() >= max_bytes {
-                truncated = true;
+        // Once the bounded response is full, keep scanning only to return an
+        // accurate match count. In particular, do not retain per-line state:
+        // captured shell output can contain millions of very short lines.
+        if *truncated {
+            continue;
+        }
+
+        if is_match {
+            if following_context == 0 {
+                if !output.is_empty() && append_utf8_bounded(output, "\n", max_bytes) {
+                    *truncated = true;
+                    continue;
+                }
+                let header = format!("[{label} context near line {line_number}]\n");
+                if append_utf8_bounded(output, &header, max_bytes) {
+                    *truncated = true;
+                    continue;
+                }
+                for (number, prior) in prior_lines.drain(..) {
+                    if append_numbered_search_line(output, number, &prior, max_bytes) {
+                        *truncated = true;
+                        break;
+                    }
+                }
+                if *truncated {
+                    continue;
+                }
+            } else {
+                prior_lines.clear();
+            }
+            if append_numbered_search_line(output, line_number, line, max_bytes) {
+                *truncated = true;
                 continue;
             }
-            let mut block = format!("[{label} lines {}-{}]\n", start + 1, end);
-            for (index, line) in lines[start..end].iter().enumerate() {
-                block.push_str(&format!("{}: {line}\n", start + index + 1));
+            following_context = context_lines;
+        } else if following_context > 0 {
+            if append_numbered_search_line(output, line_number, line, max_bytes) {
+                *truncated = true;
+                continue;
             }
-            if append_utf8_bounded(&mut output, &block, max_bytes) {
-                truncated = true;
+            following_context -= 1;
+        } else if context_lines > 0 {
+            // A retained context line can never contribute more than the
+            // response byte budget, so cap it before storing it in the ring.
+            let mut end = line.len().min(max_bytes);
+            while end > 0 && !line.is_char_boundary(end) {
+                end -= 1;
+            }
+            prior_lines.push_back((line_number, line[..end].to_string()));
+            if prior_lines.len() > context_lines {
+                prior_lines.pop_front();
             }
         }
     }
 
-    Ok((output, matching_lines, truncated))
+    Ok(())
+}
+
+fn append_numbered_search_line(
+    output: &mut String,
+    line_number: u64,
+    line: &str,
+    max_bytes: usize,
+) -> bool {
+    let prefix = format!("{line_number}: ");
+    append_utf8_bounded(output, &prefix, max_bytes)
+        || append_utf8_bounded(output, line, max_bytes)
+        || append_utf8_bounded(output, "\n", max_bytes)
 }
 
 /// Append as much UTF-8 text as fits and report whether any bytes were omitted.
@@ -3015,10 +3092,10 @@ mod tests {
 
         assert_eq!(matching_lines, 3, "{output}");
         assert!(!truncated, "{output}");
-        assert!(output.contains("[stdout lines 1-6]"), "{output}");
+        assert!(output.contains("[stdout context near line 2]"), "{output}");
         assert!(output.contains("1: before one"), "{output}");
         assert!(output.contains("5: failing_test_name again"), "{output}");
-        assert!(output.contains("[stderr lines 1-1]"), "{output}");
+        assert!(output.contains("[stderr context near line 1]"), "{output}");
     }
 
     #[test]
@@ -3030,12 +3107,34 @@ mod tests {
         std::fs::write(&stderr, "").unwrap();
 
         let (output, matching_lines, truncated) =
-            search_combined_output(&stdout, &stderr, "needle", 0, 24)
+            search_combined_output(&stdout, &stderr, "needle", 0, 43)
                 .expect("bounded search captured output");
 
         assert_eq!(matching_lines, 1);
         assert!(truncated, "{output}");
-        assert!(output.len() <= 24, "{} bytes: {output}", output.len());
+        assert!(output.len() <= 43, "{} bytes: {output}", output.len());
+        assert!(std::str::from_utf8(output.as_bytes()).is_ok(), "{output:?}");
+    }
+
+    #[test]
+    fn output_search_counts_late_matches_after_result_is_full() {
+        let tmp = crate::tests::test_temp_dir();
+        let stdout = tmp.path().join("stdout.log");
+        let stderr = tmp.path().join("stderr.log");
+        std::fs::write(
+            &stdout,
+            "needle one\nignored\nneedle two\nignored\nneedle three\n",
+        )
+        .unwrap();
+        std::fs::write(&stderr, "needle four\n").unwrap();
+
+        let (output, matching_lines, truncated) =
+            search_combined_output(&stdout, &stderr, "needle", 0, 16)
+                .expect("bounded search captured output");
+
+        assert_eq!(matching_lines, 4, "{output}");
+        assert!(truncated, "{output}");
+        assert!(output.len() <= 16, "{} bytes: {output}", output.len());
     }
 
     #[test]

--- a/crates/astra-cli/src/tui/background_tasks.rs
+++ b/crates/astra-cli/src/tui/background_tasks.rs
@@ -923,6 +923,50 @@ impl BackgroundTaskRegistry {
         })?
     }
 
+    pub async fn search_combined_output_async(
+        &mut self,
+        id: &str,
+        pattern: &str,
+        context_lines: usize,
+        max_bytes: usize,
+    ) -> Result<(String, u64, bool), BackgroundTaskError> {
+        self.drain_join_set();
+        let handle = self
+            .tasks
+            .get(id)
+            .ok_or_else(|| BackgroundTaskError::not_found(id))?;
+        let stdout_path = handle.stdout_path.clone();
+        let stderr_path = handle.stderr_path.clone();
+        let terminal = handle.status().is_terminal();
+        let task_id = id.to_string();
+        let pattern = pattern.to_string();
+        tokio::task::spawn_blocking(move || {
+            let stdout_missing = !stdout_path.exists();
+            let stderr_has_output = file_len(&stderr_path) > 0;
+            if terminal && stdout_missing && !stderr_has_output {
+                return Err(BackgroundTaskError::output_artifact_missing(
+                    &task_id,
+                    &stdout_path,
+                ));
+            }
+            search_combined_output(
+                &stdout_path,
+                &stderr_path,
+                &pattern,
+                context_lines,
+                max_bytes,
+            )
+            .map_err(|detail| BackgroundTaskError::output_unavailable(&task_id, detail))
+        })
+        .await
+        .map_err(|error| {
+            BackgroundTaskError::output_unavailable(
+                id,
+                format!("background output search task failed: {error}"),
+            )
+        })?
+    }
+
     /// Read stderr from a task.
     pub fn get_stderr(
         &self,
@@ -2020,6 +2064,81 @@ fn read_combined_from_str(
     ))
 }
 
+fn search_combined_output(
+    stdout_path: &Path,
+    stderr_path: &Path,
+    pattern: &str,
+    context_lines: usize,
+    max_bytes: usize,
+) -> Result<(String, u64, bool), String> {
+    let mut output = String::new();
+    let mut matching_lines = 0_u64;
+    let mut truncated = false;
+
+    for (label, path) in [("stdout", stdout_path), ("stderr", stderr_path)] {
+        if !path.exists() || file_len(path) == 0 {
+            continue;
+        }
+        let bytes = std::fs::read(path)
+            .map_err(|error| format!("cannot read {}: {error}", path.display()))?;
+        let text = String::from_utf8_lossy(&bytes);
+        let lines: Vec<&str> = text.lines().collect();
+        let hits: Vec<usize> = lines
+            .iter()
+            .enumerate()
+            .filter_map(|(index, line)| line.contains(pattern).then_some(index))
+            .collect();
+        matching_lines = matching_lines.saturating_add(hits.len() as u64);
+
+        let mut ranges: Vec<(usize, usize)> = Vec::new();
+        for hit in hits {
+            let start = hit.saturating_sub(context_lines);
+            let end = hit
+                .saturating_add(context_lines)
+                .saturating_add(1)
+                .min(lines.len());
+            if let Some((_, previous_end)) = ranges.last_mut()
+                && start <= *previous_end
+            {
+                *previous_end = (*previous_end).max(end);
+            } else {
+                ranges.push((start, end));
+            }
+        }
+
+        for (start, end) in ranges {
+            if output.len() >= max_bytes {
+                truncated = true;
+                continue;
+            }
+            let mut block = format!("[{label} lines {}-{}]\n", start + 1, end);
+            for (index, line) in lines[start..end].iter().enumerate() {
+                block.push_str(&format!("{}: {line}\n", start + index + 1));
+            }
+            if append_utf8_bounded(&mut output, &block, max_bytes) {
+                truncated = true;
+            }
+        }
+    }
+
+    Ok((output, matching_lines, truncated))
+}
+
+/// Append as much UTF-8 text as fits and report whether any bytes were omitted.
+fn append_utf8_bounded(output: &mut String, text: &str, max_bytes: usize) -> bool {
+    let remaining = max_bytes.saturating_sub(output.len());
+    if text.len() <= remaining {
+        output.push_str(text);
+        return false;
+    }
+    let mut end = remaining.min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    output.push_str(&text[..end]);
+    true
+}
+
 fn count_file_lines(path: &Path) -> Result<u64, String> {
     use std::io::Read;
     let mut file =
@@ -2876,6 +2995,47 @@ mod tests {
                 .0
                 .contains("completed output")
         );
+    }
+
+    #[test]
+    fn output_search_returns_literal_matches_with_bounded_context() {
+        let tmp = crate::tests::test_temp_dir();
+        let stdout = tmp.path().join("stdout.log");
+        let stderr = tmp.path().join("stderr.log");
+        std::fs::write(
+            &stdout,
+            "before one\nfailing_test_name\nafter one\nunrelated\nfailing_test_name again\nafter two\n",
+        )
+        .unwrap();
+        std::fs::write(&stderr, "panic detail for failing_test_name\n").unwrap();
+
+        let (output, matching_lines, truncated) =
+            search_combined_output(&stdout, &stderr, "failing_test_name", 1, 4096)
+                .expect("search captured output");
+
+        assert_eq!(matching_lines, 3, "{output}");
+        assert!(!truncated, "{output}");
+        assert!(output.contains("[stdout lines 1-6]"), "{output}");
+        assert!(output.contains("1: before one"), "{output}");
+        assert!(output.contains("5: failing_test_name again"), "{output}");
+        assert!(output.contains("[stderr lines 1-1]"), "{output}");
+    }
+
+    #[test]
+    fn output_search_enforces_utf8_safe_result_bound() {
+        let tmp = crate::tests::test_temp_dir();
+        let stdout = tmp.path().join("stdout.log");
+        let stderr = tmp.path().join("stderr.log");
+        std::fs::write(&stdout, "needle 中文中文中文中文中文中文\n").unwrap();
+        std::fs::write(&stderr, "").unwrap();
+
+        let (output, matching_lines, truncated) =
+            search_combined_output(&stdout, &stderr, "needle", 0, 24)
+                .expect("bounded search captured output");
+
+        assert_eq!(matching_lines, 1);
+        assert!(truncated, "{output}");
+        assert!(output.len() <= 24, "{} bytes: {output}", output.len());
     }
 
     #[test]

--- a/crates/astra-cli/src/tui/bg_task_proxy.rs
+++ b/crates/astra-cli/src/tui/bg_task_proxy.rs
@@ -219,11 +219,29 @@ pub(crate) fn export_background_local_agent_task_projections_from_snapshot(
 }
 
 pub(crate) fn background_task_output_dir(session_id: Option<&str>) -> std::path::PathBuf {
-    std::env::temp_dir().join("astra").join("bg_tasks").join(
-        session_id
-            .filter(|sid| !sid.is_empty())
-            .unwrap_or("default"),
-    )
+    static UNBOUND_PROCESS_SCOPE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    let scope = session_id.filter(|sid| !sid.is_empty()).map_or_else(
+        || {
+            UNBOUND_PROCESS_SCOPE
+                .get_or_init(|| {
+                    let started_at = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_nanos();
+                    format!("unbound-{}-{started_at:x}", std::process::id())
+                })
+                .as_str()
+        },
+        |session_id| session_id,
+    );
+    // A TUI can launch work before the server assigns its durable session id.
+    // Give that pre-binding window a process-unique owner: the old shared
+    // `default/bg-shell-1.stdout` path let a second Astra process overwrite
+    // the first session's only failure evidence.
+    std::env::temp_dir()
+        .join("astra")
+        .join("bg_tasks")
+        .join(scope)
 }
 
 pub(crate) async fn restore_background_task_projections(
@@ -466,6 +484,45 @@ pub(crate) async fn background_task_output_snapshot(
         end_offset,
         total_bytes,
         total_lines,
+        status,
+        terminal,
+        output_ref,
+    })
+}
+
+pub(crate) async fn background_task_output_search_snapshot(
+    background_registry: &mut super::background_tasks::BackgroundTaskRegistry,
+    task_id: &str,
+    pattern: &str,
+    context_lines: usize,
+    max_bytes: usize,
+) -> Result<crate::edge_tools::BgTaskOutputSearchSnapshot, BackgroundTaskError> {
+    background_registry.drain_join_set();
+    let (status, title, output_ref) = {
+        let handle = background_registry
+            .get(task_id)
+            .ok_or_else(|| BackgroundTaskError::not_found(task_id))?;
+        (
+            handle.projected_status().to_string(),
+            handle.description.clone(),
+            format!(
+                "stdout: {} · stderr: {}",
+                handle.stdout_path.display(),
+                handle.stderr_path.display()
+            ),
+        )
+    };
+    let terminal = background_task_status_is_terminal(&status);
+    let (output, matching_lines, truncated) = background_registry
+        .search_combined_output_async(task_id, pattern, context_lines, max_bytes)
+        .await?;
+
+    Ok(crate::edge_tools::BgTaskOutputSearchSnapshot {
+        kind: "shell".to_string(),
+        title: Some(title),
+        output,
+        matching_lines,
+        truncated,
         status,
         terminal,
         output_ref,
@@ -733,7 +790,30 @@ pub(crate) fn background_task_event_system_messages(
 
 #[cfg(test)]
 mod tests {
-    use super::background_task_status_is_terminal;
+    use super::{background_task_output_dir, background_task_status_is_terminal};
+
+    #[test]
+    fn unbound_background_output_scope_is_process_owned_not_shared_default() {
+        let first = background_task_output_dir(None);
+        let second = background_task_output_dir(None);
+
+        assert_eq!(first, second, "one process must keep one provisional owner");
+        let scope = first
+            .file_name()
+            .and_then(|scope| scope.to_str())
+            .expect("UTF-8 provisional scope");
+        assert!(scope.starts_with("unbound-"), "{scope}");
+        assert_ne!(scope, "default");
+    }
+
+    #[test]
+    fn bound_background_output_scope_uses_durable_session_identity() {
+        let path = background_task_output_dir(Some("session-123"));
+        assert_eq!(
+            path.file_name().and_then(|scope| scope.to_str()),
+            Some("session-123")
+        );
+    }
 
     #[test]
     fn terminal_status_is_a_lifecycle_fact_not_an_availability_guess() {

--- a/crates/astra-cli/src/tui/bg_task_proxy.rs
+++ b/crates/astra-cli/src/tui/bg_task_proxy.rs
@@ -513,6 +513,14 @@ pub(crate) async fn background_task_output_search_snapshot(
         )
     };
     let terminal = background_task_status_is_terminal(&status);
+    if !terminal {
+        return Err(BackgroundTaskError::output_unavailable(
+            task_id,
+            format!(
+                "diagnostic search requires a terminal shell task; current status is {status}. Use one current task_output snapshot and wait for the automatic completion notification."
+            ),
+        ));
+    }
     let (output, matching_lines, truncated) = background_registry
         .search_combined_output_async(task_id, pattern, context_lines, max_bytes)
         .await?;
@@ -790,7 +798,34 @@ pub(crate) fn background_task_event_system_messages(
 
 #[cfg(test)]
 mod tests {
-    use super::{background_task_output_dir, background_task_status_is_terminal};
+    use super::{
+        background_task_output_dir, background_task_output_search_snapshot,
+        background_task_status_is_terminal,
+    };
+
+    #[tokio::test]
+    async fn diagnostic_search_rejects_live_shell_output() {
+        let temp = crate::tests::test_temp_dir();
+        let mut registry =
+            super::super::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
+        let task_id = registry.spawn_shell("sleep 5", "long test");
+
+        let error =
+            background_task_output_search_snapshot(&mut registry, &task_id, "failure", 3, 8192)
+                .await
+                .expect_err("live output must not be treated as stable diagnostic evidence");
+
+        assert!(
+            matches!(
+                error,
+                crate::background_task_error::BackgroundTaskError::OutputUnavailable {
+                    ref detail,
+                    ..
+                } if detail.contains("requires a terminal shell task")
+            ),
+            "{error}"
+        );
+    }
 
     #[test]
     fn unbound_background_output_scope_is_process_owned_not_shared_default() {

--- a/crates/astra-cli/src/tui/event_loop.rs
+++ b/crates/astra-cli/src/tui/event_loop.rs
@@ -1305,6 +1305,24 @@ async fn drain_background_task_commands(
                     .await,
                 );
             }
+            crate::edge_tools::BgTaskCommand::SearchOutput {
+                task_id,
+                pattern,
+                context_lines,
+                max_bytes,
+                reply,
+            } => {
+                let _ = reply.send(
+                    background_task_output_search_snapshot(
+                        background_registry,
+                        &task_id,
+                        &pattern,
+                        context_lines,
+                        max_bytes,
+                    )
+                    .await,
+                );
+            }
             crate::edge_tools::BgTaskCommand::List { reply } => {
                 let rendered = render_background_task_list_xml_with_agents(
                     background_registry,
@@ -10059,6 +10077,54 @@ mod tests {
             .expect("foreground tick must answer command")
             .expect("background output must be readable");
         assert_eq!(snapshot.output, "progress\n");
+        assert!(snapshot.terminal);
+        assert!(commands.lock_recover().is_empty());
+    }
+
+    #[tokio::test]
+    async fn foreground_tick_services_background_output_search_commands() {
+        let temp = crate::tests::test_temp_dir();
+        let mut registry =
+            crate::tui::background_tasks::BackgroundTaskRegistry::new(temp.path().join("bg"));
+        let task_id = registry.spawn_shell(
+            "printf 'before\\nfailing_test_name\\npanic detail\\n'",
+            "failing test",
+        );
+        for _ in 0..100 {
+            registry.poll_completions();
+            if registry
+                .get(&task_id)
+                .is_some_and(|task| task.status().as_str() != "running")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        let commands = Arc::new(std::sync::Mutex::new(vec![
+            crate::edge_tools::BgTaskCommand::SearchOutput {
+                task_id: task_id.clone(),
+                pattern: "failing_test_name".to_string(),
+                context_lines: 1,
+                max_bytes: 8192,
+                reply: reply_tx,
+            },
+        ]));
+        let list_cache = Arc::new(tokio::sync::RwLock::new(String::new()));
+
+        drain_background_task_commands(&commands, &mut registry, None, &[], &list_cache).await;
+
+        let snapshot = reply_rx
+            .await
+            .expect("foreground tick must answer search command")
+            .expect("background output must be searchable");
+        assert_eq!(snapshot.matching_lines, 1);
+        assert!(
+            snapshot.output.contains("panic detail"),
+            "{}",
+            snapshot.output
+        );
         assert!(snapshot.terminal);
         assert!(commands.lock_recover().is_empty());
     }

--- a/crates/astra-tools/src/schemas.rs
+++ b/crates/astra-tools/src/schemas.rs
@@ -1152,7 +1152,7 @@ fn all_tool_schemas_core() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "task_output",
-                "description": "Observe one specific typed background task and return its task kind/status. For an append-only shell task, omitting offset returns one bounded latest-tail status snapshot; do this at most once per task in a turn and do not chase live progress with a cursor. For a terminal shell failure, set pattern to search the captured output with bounded context instead of reading its files through Bash; terminal diagnostics remain available after a status snapshot. Agent-result tasks may return a cursor when their semantic result is larger than one bounded response. Set block=true once when the user explicitly asks to wait: the runtime waits for terminal completion, required input, or timeout without spending additional model rounds. Supply an explicit offset only when the user asked to read historical shell output, then use next_offset for bounded pagination. Requires the exact task_id so the model and UI refer to the same task.",
+                "description": "Observe one specific typed background task and return its task kind/status. For an append-only shell task, omitting offset returns one bounded latest-tail status snapshot; do this at most once per task in a turn and do not chase live progress with a cursor. For a terminal shell task, especially a failure, set pattern to search the captured output with bounded context instead of reading its files through Bash; terminal diagnostics remain available after a status snapshot. Agent-result tasks may return a cursor when their semantic result is larger than one bounded response. Set block=true once when the user explicitly asks to wait: the runtime waits for terminal completion, required input, or timeout without spending additional model rounds. Supply an explicit offset only when the user asked to read historical shell output, then use next_offset for bounded pagination. Requires the exact task_id so the model and UI refer to the same task.",
                 "parameters": {
                     "type": "object",
                     "additionalProperties": false,
@@ -1172,7 +1172,9 @@ fn all_tool_schemas_core() -> Vec<Value> {
                         },
                         "pattern": {
                             "type": "string",
-                            "description": "Literal text to find in a terminal shell task's captured stdout/stderr. Returns bounded matching lines with context. Use an exact failing test, error, or panic fragment from the terminal summary. Cannot be combined with block or offset. A failed status alone is not evidence that a test is flaky."
+                            "minLength": 1,
+                            "maxLength": 512,
+                            "description": "Single-line literal text to find in a terminal shell task's captured stdout/stderr. Returns bounded matching lines with context. Use an exact failing test, error, or panic fragment from the terminal summary. Cannot be combined with block or offset. A failed status alone is not evidence that a test is flaky."
                         },
                         "context_lines": {
                             "type": "integer",
@@ -1183,10 +1185,13 @@ fn all_tool_schemas_core() -> Vec<Value> {
                         "max_bytes": {
                             "type": "integer",
                             "minimum": 1,
+                            "maximum": 65536,
                             "description": "Maximum bytes to return from the current offset. Default 8192, max 65536."
                         },
                         "timeout_ms": {
                             "type": "integer",
+                            "minimum": 1,
+                            "maximum": 300000,
                             "description": "Max ms to wait when block=true, and max registry response wait when block=false. Default 30000, max 300000."
                         }
                     },

--- a/crates/astra-tools/src/schemas.rs
+++ b/crates/astra-tools/src/schemas.rs
@@ -1152,7 +1152,7 @@ fn all_tool_schemas_core() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "task_output",
-                "description": "Observe one specific typed background task and return its task kind/status. For an append-only shell task, omitting offset returns one bounded latest-tail status snapshot; do this at most once per task in a turn and do not chase live progress with a cursor. Agent-result tasks may return a cursor when their semantic result is larger than one bounded response. Set block=true once when the user explicitly asks to wait: the runtime waits for terminal completion, required input, or timeout without spending additional model rounds. Supply an explicit offset only when the user asked to read historical shell output, then use next_offset for bounded pagination. Requires the exact task_id so the model and UI refer to the same task.",
+                "description": "Observe one specific typed background task and return its task kind/status. For an append-only shell task, omitting offset returns one bounded latest-tail status snapshot; do this at most once per task in a turn and do not chase live progress with a cursor. For a terminal shell failure, set pattern to search the captured output with bounded context instead of reading its files through Bash; terminal diagnostics remain available after a status snapshot. Agent-result tasks may return a cursor when their semantic result is larger than one bounded response. Set block=true once when the user explicitly asks to wait: the runtime waits for terminal completion, required input, or timeout without spending additional model rounds. Supply an explicit offset only when the user asked to read historical shell output, then use next_offset for bounded pagination. Requires the exact task_id so the model and UI refer to the same task.",
                 "parameters": {
                     "type": "object",
                     "additionalProperties": false,
@@ -1169,6 +1169,16 @@ fn all_tool_schemas_core() -> Vec<Value> {
                             "type": "integer",
                             "minimum": 0,
                             "description": "Explicit output cursor. For shell tasks, omit it for one current latest-tail status snapshot and set it only when the user asked to page historical output. For bounded agent results, reuse the returned next_offset to continue the semantic result."
+                        },
+                        "pattern": {
+                            "type": "string",
+                            "description": "Literal text to find in a terminal shell task's captured stdout/stderr. Returns bounded matching lines with context. Use an exact failing test, error, or panic fragment from the terminal summary. Cannot be combined with block or offset. A failed status alone is not evidence that a test is flaky."
+                        },
+                        "context_lines": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 20,
+                            "description": "Lines before and after each literal match. Used only with pattern. Default 3, max 20."
                         },
                         "max_bytes": {
                             "type": "integer",

--- a/crates/astra-tools/src/shell_ops.rs
+++ b/crates/astra-tools/src/shell_ops.rs
@@ -59,6 +59,8 @@ pub fn background_task_output_dir_read_error(command: &str) -> Option<String> {
     Some(
         "Error: bash cannot read background task output files directly. \
          Call the `task_output` tool with the task_id (e.g. `bg-shell-1`) instead. \
+         For a terminal failure, use its `pattern` argument to search an exact test or error \
+         with bounded context. \
          The runtime delivers a <task_notification> when the task terminates; \
          polling the on-disk files via bash returns stale partial bytes and \
          bypasses terminal-status reporting."
@@ -4845,6 +4847,7 @@ printf 'probe.txt:1:needle\n'
                 "{command}: {error}"
             );
             assert!(error.contains("task_output"), "{command}: {error}");
+            assert!(error.contains("pattern"), "{command}: {error}");
         }
         assert!(
             validate_execute_bash_command("echo bg_tasks is not a path here").is_ok(),

--- a/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/crates/runtime/src/turn/agentic_loop/host.rs
@@ -1080,9 +1080,10 @@ pub struct StallTrackingState {
     /// short running acknowledgement; a second attempt closes the loop with
     /// a runtime-owned acknowledgement instead of burning dozens of rounds.
     pub same_turn_detached_poll_attempts: u32,
-    /// Shell background tasks already observed through a current `task_output`
-    /// snapshot or runtime-owned wait in this turn. These are status
-    /// observations, not requests to page through the task's full log.
+    /// Non-terminal shell background tasks already observed through
+    /// `task_output` in this turn. These are live-status observations, not
+    /// requests to page through the task's full log. Terminal observations
+    /// are intentionally excluded so failure diagnosis remains available.
     pub observed_background_task_snapshots: BTreeSet<String>,
     /// Repeated attempts to page a task after a current snapshot was already
     /// returned. The first attempt is corrected; the second closes the
@@ -3929,14 +3930,24 @@ pub(crate) mod tests {
         mode: &str,
         output: &str,
     ) -> EdgeToolExecResult {
+        make_shell_task_output_observation_with_status(task_id, mode, "running", false, output)
+    }
+
+    fn make_shell_task_output_observation_with_status(
+        task_id: &str,
+        mode: &str,
+        status: &str,
+        terminal: bool,
+        output: &str,
+    ) -> EdgeToolExecResult {
         let mut fields = edge_runtime_environment_fields();
         fields.insert(
             "background_task_observation".to_string(),
             json!({
                 "task_id": task_id,
                 "task_kind": "shell",
-                "status": "running",
-                "terminal": false,
+                "status": status,
+                "terminal": terminal,
                 "mode": mode,
             }),
         );
@@ -5636,6 +5647,60 @@ pub(crate) mod tests {
                     && message.contains("Do not page historical output")
             }),
             "a cursor follow-up after a current snapshot must be intercepted"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_background_snapshot_keeps_same_turn_diagnostics_available() {
+        let mut host = MockHost::new(vec![
+            edge_tool_result(
+                vec![make_shell_task_output_observation_with_status(
+                    "bg-shell-1",
+                    "current",
+                    "failed",
+                    true,
+                    "test summary names one failure",
+                )],
+                10,
+                5,
+                None,
+            ),
+            edge_tool_result(
+                vec![make_edge_tool_with_args(
+                    "task_output",
+                    json!({
+                        "task_id": "bg-shell-1",
+                        "pattern": "failing_test_name"
+                    }),
+                    "diagnostic match with panic context",
+                )],
+                10,
+                5,
+                None,
+            ),
+            text_result("The failure is now supported by diagnostics.", 10, 5, None),
+        ])
+        .with_valid_tools(&["task_output"]);
+        let mut state = make_state();
+
+        let outcome = run_agentic_loop_with_host(&mut host, &mut state).await;
+
+        assert!(
+            matches!(outcome, Ok(AgenticLoopOutcome::Completed)),
+            "{outcome:?}"
+        );
+        assert_eq!(host.turn_count(), 3);
+        assert_eq!(state.total_tool_calls, 2);
+        assert!(
+            state.stall.observed_background_task_snapshots.is_empty(),
+            "terminal observations must not arm the live-poll guard"
+        );
+        assert_eq!(state.stall.repeated_background_task_snapshot_attempts, 0);
+        assert!(
+            state.messages.iter().all(|message| !message
+                .to_string()
+                .contains("already has a current status snapshot")),
+            "terminal failure diagnostics must execute instead of being treated as live polling"
         );
     }
 

--- a/crates/runtime/src/turn/agentic_loop/tool_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/tool_phase.rs
@@ -125,7 +125,7 @@ fn background_task_id_from_map(map: &serde_json::Map<String, Value>) -> Option<S
         .map(ToString::to_string)
 }
 
-fn current_shell_background_task_observation_id(
+fn live_shell_background_task_observation_id(
     result: &astra_turn_core::sse_stream_host::EdgeToolExecResult,
 ) -> Option<String> {
     let tool_name = astra_turn_core::tool_allowlist::normalize_tool_name(&result.tool)?;
@@ -139,7 +139,8 @@ fn current_shell_background_task_observation_id(
         .as_object()?;
     let mode = observation.get("mode").and_then(Value::as_str)?;
     if observation.get("task_kind").and_then(Value::as_str)? != "shell"
-        || !matches!(mode, "current" | "wait")
+        || observation.get("terminal").and_then(Value::as_bool) != Some(false)
+        || !matches!(mode, "current" | "wait" | "diagnostic")
     {
         return None;
     }
@@ -1627,7 +1628,7 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
         state.stall.same_turn_detached_task_ids.insert(task_id);
     }
     for result in &edge_tool_round {
-        if let Some(task_id) = current_shell_background_task_observation_id(result) {
+        if let Some(task_id) = live_shell_background_task_observation_id(result) {
             state
                 .stall
                 .observed_background_task_snapshots


### PR DESCRIPTION
## Summary

- distinguish non-terminal progress observation from terminal failure diagnosis in the runtime polling guard
- add bounded literal search with context to task_output for captured shell stdout/stderr
- give pre-session background output a process-unique owner and expose evidence requirements for flaky classification

## Validation

- targeted astra-runtime background snapshot tests
- targeted astra-cli task output/search/registry tests
- targeted PTY reproduction: ctrl_o_replays_tool_history_after_a_real_tool_turn
- make check